### PR TITLE
chore: add CODEOWNERS and SBOM generation for CELA compliance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS — Default reviewers for microsoft/agent-governance-toolkit
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @imran-siddique
+
+# Package-specific ownership
+/packages/agent-os/          @imran-siddique
+/packages/agent-mesh/        @imran-siddique
+/packages/agent-hypervisor/  @imran-siddique
+/packages/agent-sre/         @imran-siddique
+/packages/agent-compliance/  @imran-siddique
+
+# CI/CD and GitHub configuration
+/.github/                    @imran-siddique
+
+# Documentation
+/docs/                       @imran-siddique
+*.md                         @imran-siddique

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,54 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: SBOM Generation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.18.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: sbom.spdx.json
+          artifact-name: sbom-spdx
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.18.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          artifact-name: sbom-cyclonedx
+
+      - name: Attest SBOM
+        if: github.event_name == 'release'
+        uses: actions/attest-sbom@115c3be05ff3974bcbd0b9f9ef62b1aaad0cae2b # v2.2.0
+        with:
+          subject-path: sbom.spdx.json
+          sbom-format: spdx+json
+
+      - name: Upload SBOMs to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            sbom.spdx.json \
+            sbom.cdx.json \
+            --clobber


### PR DESCRIPTION
## CELA Release Checklist — Compliance Gaps

Addresses two gaps identified in the pre-launch compliance audit:

### CODEOWNERS
- `@imran-siddique` as default reviewer for all paths
- Package-specific ownership for `/packages/*`
- CI/CD and docs ownership defined

### SBOM Workflow (`sbom.yml`)
- Generates **SPDX** and **CycloneDX** SBOMs on every release
- Uses `anchore/sbom-action` (pinned SHA) for generation
- Uses `actions/attest-sbom` for GitHub attestation (supply chain security)
- Uploads both SBOMs as release assets
- Also supports `workflow_dispatch` for manual runs

### Remaining manual items
- [ ] Install Microsoft CLA bot on this repo
- [ ] Enable private vulnerability reporting (Settings > Security)
- [ ] Confirm RAI review not required with RAI Champ