### PR TITLE
feat(emk): port production Episodic Memory Kernel — causal reasoning, sleep cycles, ChromaDB

### DIFF
--- a/packages/agent-os/modules/emk/emk/__init__.py
+++ b/packages/agent-os/modules/emk/emk/__init__.py
@@ -4,7 +4,8 @@
 """
 emk - Episodic Memory Kernel.
 
-A mutable ledger of agent experiences for AI systems.
+A mutable ledger of agent experiences for AI systems with causal reasoning
+and sleep-cycle memory compression.
 
 Example:
     >>> from emk import Episode, FileAdapter
@@ -28,6 +29,7 @@ __license__ = "MIT"
 from emk.schema import Episode, SemanticRule
 from emk.store import VectorStoreAdapter, FileAdapter
 from emk.indexer import Indexer
+from emk.sleep_cycle import MemoryCompressor
 
 # Define explicit public API
 __all__: List[str] = [
@@ -41,6 +43,7 @@ __all__: List[str] = [
     "VectorStoreAdapter",
     "FileAdapter",
     "Indexer",
+    "MemoryCompressor",
 ]
 
 # Optional ChromaDB adapter - only import if chromadb is installed
@@ -50,6 +53,10 @@ try:
 except ImportError:
     if TYPE_CHECKING:
         from emk.store import ChromaDBAdapter  # noqa: F401
+
+# Causal memory (requires sqlite3, always available in stdlib)
+from emk.causal import CausalEpisode, CausalMemoryStore
+__all__.extend(["CausalEpisode", "CausalMemoryStore"])
 
 # Optional Hugging Face utilities - only import if huggingface_hub is installed
 try:
@@ -72,6 +79,7 @@ def get_version_info() -> dict:
     features = {
         "chromadb": "ChromaDBAdapter" in __all__,
         "huggingface": "upload_episodes_to_hub" in __all__,
+        "causal": True,
     }
     return {
         "version": __version__,

--- a/packages/agent-os/modules/emk/emk/causal.py
+++ b/packages/agent-os/modules/emk/emk/causal.py
@@ -1,0 +1,352 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Causal Episodic Memory — Episodes with causal links.
+
+Extends EMK's Episode schema with causal indexing: each episode knows
+what caused it and what effects it triggered.  This enables causal
+chain retrieval for debugging, compliance auditing, and RL training.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class CausalEpisode:
+    """
+    An episode enriched with causal links.
+
+    Parameters
+    ----------
+    action : str
+        What was done.
+    params : dict
+        Parameters of the action.
+    result : dict
+        Outcome of the action.
+    caused_by : str | None
+        Episode ID that triggered this one (backward link).
+    caused_effects : tuple[str, ...]
+        Episode IDs that this episode subsequently triggered (forward links).
+    policy_context : dict
+        Active policies when this episode executed.
+    trust_context : dict
+        Peer trust scores when this episode executed.
+    agent_id : str
+        DID / identifier of the acting agent.
+    timestamp : float
+        Unix epoch (auto-generated).
+    episode_id : str
+        SHA-256 content hash (auto-generated).
+    """
+
+    action: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    result: Dict[str, Any] = field(default_factory=dict)
+    caused_by: Optional[str] = None
+    caused_effects: tuple = ()  # tuple[str, ...]
+    policy_context: Dict[str, Any] = field(default_factory=dict)
+    trust_context: Dict[str, Any] = field(default_factory=dict)
+    agent_id: str = ""
+    timestamp: float = field(default_factory=time.time)
+    episode_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.episode_id:
+            content = json.dumps(
+                {
+                    "action": self.action,
+                    "params": self.params,
+                    "agent_id": self.agent_id,
+                    "timestamp": self.timestamp,
+                },
+                sort_keys=True,
+            )
+            # frozen dataclass — use object.__setattr__
+            object.__setattr__(
+                self,
+                "episode_id",
+                hashlib.sha256(content.encode()).hexdigest(),
+            )
+
+    # -- Serialisation helpers ------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "episode_id": self.episode_id,
+            "action": self.action,
+            "params": self.params,
+            "result": self.result,
+            "caused_by": self.caused_by,
+            "caused_effects": list(self.caused_effects),
+            "policy_context": self.policy_context,
+            "trust_context": self.trust_context,
+            "agent_id": self.agent_id,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CausalEpisode":
+        data = dict(data)
+        data["caused_effects"] = tuple(data.get("caused_effects") or ())
+        return cls(**data)
+
+
+# ---------------------------------------------------------------------------
+# Causal Memory Store  (SQLite-backed)
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS episodes (
+    episode_id   TEXT PRIMARY KEY,
+    action       TEXT NOT NULL,
+    params       TEXT NOT NULL DEFAULT '{}',
+    result       TEXT NOT NULL DEFAULT '{}',
+    caused_by    TEXT,
+    policy_ctx   TEXT NOT NULL DEFAULT '{}',
+    trust_ctx    TEXT NOT NULL DEFAULT '{}',
+    agent_id     TEXT NOT NULL DEFAULT '',
+    ts           REAL NOT NULL,
+    FOREIGN KEY (caused_by) REFERENCES episodes(episode_id)
+);
+
+CREATE TABLE IF NOT EXISTS causal_edges (
+    from_id  TEXT NOT NULL,
+    to_id    TEXT NOT NULL,
+    PRIMARY KEY (from_id, to_id),
+    FOREIGN KEY (from_id) REFERENCES episodes(episode_id),
+    FOREIGN KEY (to_id)   REFERENCES episodes(episode_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_episodes_agent  ON episodes(agent_id);
+CREATE INDEX IF NOT EXISTS idx_episodes_action ON episodes(action);
+CREATE INDEX IF NOT EXISTS idx_edges_from      ON causal_edges(from_id);
+CREATE INDEX IF NOT EXISTS idx_edges_to        ON causal_edges(to_id);
+"""
+
+
+class CausalMemoryStore:
+    """
+    Persistent causal episodic memory backed by SQLite.
+
+    Records episodes with causal links and supports graph traversal
+    to retrieve full causal chains.
+    """
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._db_path = db_path
+        self._conn = sqlite3.connect(db_path)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA_SQL)
+        self._conn.commit()
+
+    # -- Core API -------------------------------------------------------------
+
+    def record(self, episode: CausalEpisode) -> str:
+        """
+        Record a causal episode.
+
+        Inserts the episode row and any causal edges (caused_by → this,
+        this → each effect).  Returns the episode_id.
+        """
+        cur = self._conn.cursor()
+        cur.execute(
+            """
+            INSERT OR REPLACE INTO episodes
+                (episode_id, action, params, result, caused_by,
+                 policy_ctx, trust_ctx, agent_id, ts)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                episode.episode_id,
+                episode.action,
+                json.dumps(episode.params),
+                json.dumps(episode.result),
+                episode.caused_by,
+                json.dumps(episode.policy_context),
+                json.dumps(episode.trust_context),
+                episode.agent_id,
+                episode.timestamp,
+            ),
+        )
+
+        # Backward edge: caused_by → this
+        if episode.caused_by:
+            cur.execute(
+                "INSERT OR IGNORE INTO causal_edges (from_id, to_id) VALUES (?, ?)",
+                (episode.caused_by, episode.episode_id),
+            )
+
+        # Forward edges: this → each effect
+        for effect_id in episode.caused_effects:
+            cur.execute(
+                "INSERT OR IGNORE INTO causal_edges (from_id, to_id) VALUES (?, ?)",
+                (episode.episode_id, effect_id),
+            )
+
+        self._conn.commit()
+        return episode.episode_id
+
+    def get(self, episode_id: str) -> Optional[CausalEpisode]:
+        """Retrieve a single episode by ID."""
+        row = self._conn.execute(
+            "SELECT * FROM episodes WHERE episode_id = ?", (episode_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_episode(row)
+
+    def get_effects(self, episode_id: str) -> List[CausalEpisode]:
+        """Get all episodes directly caused by *episode_id*."""
+        rows = self._conn.execute(
+            """
+            SELECT e.* FROM episodes e
+            JOIN causal_edges ce ON ce.to_id = e.episode_id
+            WHERE ce.from_id = ?
+            ORDER BY e.ts
+            """,
+            (episode_id,),
+        ).fetchall()
+        return [self._row_to_episode(r) for r in rows]
+
+    def get_causes(self, episode_id: str) -> List[CausalEpisode]:
+        """Get all episodes that directly caused *episode_id*."""
+        rows = self._conn.execute(
+            """
+            SELECT e.* FROM episodes e
+            JOIN causal_edges ce ON ce.from_id = e.episode_id
+            WHERE ce.to_id = ?
+            ORDER BY e.ts
+            """,
+            (episode_id,),
+        ).fetchall()
+        return [self._row_to_episode(r) for r in rows]
+
+    def get_causal_chain(
+        self,
+        episode_id: str,
+        *,
+        direction: str = "backward",
+        max_depth: int = 20,
+    ) -> List[CausalEpisode]:
+        """
+        Walk the causal graph from *episode_id*.
+
+        Parameters
+        ----------
+        direction : "backward" | "forward" | "both"
+            backward = follow caused_by links (why did this happen?)
+            forward  = follow caused_effects (what did this cause?)
+            both     = union of both directions
+        max_depth : int
+            Maximum traversal depth to prevent infinite loops.
+
+        Returns
+        -------
+        List of CausalEpisode ordered by timestamp.
+        """
+        visited: set[str] = set()
+        result: list[CausalEpisode] = []
+
+        def _walk(eid: str, depth: int, fwd: bool) -> None:
+            if depth > max_depth or eid in visited:
+                return
+            visited.add(eid)
+            ep = self.get(eid)
+            if ep is None:
+                return
+            result.append(ep)
+            if fwd:
+                for child in self.get_effects(eid):
+                    _walk(child.episode_id, depth + 1, fwd=True)
+            else:
+                for parent in self.get_causes(eid):
+                    _walk(parent.episode_id, depth + 1, fwd=False)
+
+        if direction in ("backward", "both"):
+            _walk(episode_id, 0, fwd=False)
+        if direction in ("forward", "both"):
+            # Allow re-visiting the root so the forward walk can start
+            visited.discard(episode_id)
+            _walk(episode_id, 0, fwd=True)
+
+        # Deduplicate + sort by timestamp
+        seen: set[str] = set()
+        deduped: list[CausalEpisode] = []
+        for ep in result:
+            if ep.episode_id not in seen:
+                seen.add(ep.episode_id)
+                deduped.append(ep)
+        deduped.sort(key=lambda e: e.timestamp)
+        return deduped
+
+    def query_by_agent(
+        self, agent_id: str, *, limit: int = 100
+    ) -> List[CausalEpisode]:
+        """Get recent episodes for an agent."""
+        rows = self._conn.execute(
+            "SELECT * FROM episodes WHERE agent_id = ? ORDER BY ts DESC LIMIT ?",
+            (agent_id, limit),
+        ).fetchall()
+        return [self._row_to_episode(r) for r in rows]
+
+    def query_by_action(
+        self, action: str, *, limit: int = 100
+    ) -> List[CausalEpisode]:
+        """Get recent episodes matching an action type."""
+        rows = self._conn.execute(
+            "SELECT * FROM episodes WHERE action = ? ORDER BY ts DESC LIMIT ?",
+            (action, limit),
+        ).fetchall()
+        return [self._row_to_episode(r) for r in rows]
+
+    @property
+    def episode_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) FROM episodes").fetchone()
+        return row[0] if row else 0
+
+    @property
+    def edge_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) FROM causal_edges").fetchone()
+        return row[0] if row else 0
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _row_to_episode(self, row: tuple) -> CausalEpisode:
+        (eid, action, params_json, result_json, caused_by,
+         policy_json, trust_json, agent_id, ts) = row
+
+        # Fetch forward edges
+        effects = self._conn.execute(
+            "SELECT to_id FROM causal_edges WHERE from_id = ?", (eid,)
+        ).fetchall()
+
+        return CausalEpisode(
+            episode_id=eid,
+            action=action,
+            params=json.loads(params_json),
+            result=json.loads(result_json),
+            caused_by=caused_by,
+            caused_effects=tuple(r[0] for r in effects),
+            policy_context=json.loads(policy_json),
+            trust_context=json.loads(trust_json),
+            agent_id=agent_id,
+            timestamp=ts,
+        )

--- a/packages/agent-os/modules/emk/emk/sleep_cycle.py
+++ b/packages/agent-os/modules/emk/emk/sleep_cycle.py
@@ -1,0 +1,347 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Sleep Cycle - Memory decay and compression utilities.
+
+This module implements the "sleep cycle" for agent memory management,
+where old episodes are summarized into semantic rules and raw logs are archived.
+"""
+
+from datetime import datetime, timezone, timedelta
+from typing import List, Optional, Dict, Any, Callable
+from pathlib import Path
+
+from emk.schema import Episode, SemanticRule
+from emk.store import VectorStoreAdapter
+
+
+class MemoryCompressor:
+    """
+    Handles memory decay and compression through sleep cycles.
+    
+    The compressor identifies old episodes, summarizes them into semantic rules,
+    and optionally archives/deletes the raw episodes to reduce memory overhead.
+    """
+    
+    def __init__(
+        self,
+        store: VectorStoreAdapter,
+        age_threshold_days: int = 30,
+        compression_batch_size: int = 50,
+        rules_filepath: Optional[str] = None
+    ):
+        """
+        Initialize the memory compressor.
+        
+        Args:
+            store: The vector store containing episodes
+            age_threshold_days: Episodes older than this are candidates for compression
+            compression_batch_size: Number of episodes to compress at once
+            rules_filepath: Path to store compressed semantic rules (JSONL format)
+        """
+        self.store = store
+        self.age_threshold_days = age_threshold_days
+        self.compression_batch_size = compression_batch_size
+        self.rules_filepath = Path(rules_filepath or "semantic_rules.jsonl")
+        
+        # Ensure rules file parent directory exists
+        self.rules_filepath.parent.mkdir(parents=True, exist_ok=True)
+        if not self.rules_filepath.exists():
+            self.rules_filepath.touch()
+    
+    def identify_old_episodes(self, episodes: List[Episode]) -> List[Episode]:
+        """
+        Identify episodes that are candidates for compression based on age.
+        
+        Args:
+            episodes: List of episodes to filter
+            
+        Returns:
+            List of old episodes that should be compressed
+        """
+        threshold = datetime.now(timezone.utc) - timedelta(days=self.age_threshold_days)
+        old_episodes = [
+            ep for ep in episodes 
+            if ep.timestamp < threshold
+        ]
+        return old_episodes
+    
+    def summarize_episodes(
+        self, 
+        episodes: List[Episode],
+        summarizer: Optional[Callable[[List[Episode]], str]] = None
+    ) -> SemanticRule:
+        """
+        Summarize a batch of episodes into a semantic rule.
+        
+        Args:
+            episodes: List of episodes to summarize
+            summarizer: Optional custom summarization function
+            
+        Returns:
+            A SemanticRule representing the compressed knowledge
+        """
+        if not episodes:
+            raise ValueError("Cannot summarize empty episode list")
+        
+        # Default summarization: extract common patterns
+        if summarizer is None:
+            rule_text = self._default_summarize(episodes)
+        else:
+            rule_text = summarizer(episodes)
+        
+        # Create semantic rule
+        source_ids = [ep.episode_id for ep in episodes]
+        
+        # Calculate confidence based on episode count
+        confidence = min(1.0, len(episodes) / 10.0)  # More episodes = higher confidence
+        
+        # Extract common metadata
+        common_metadata = self._extract_common_metadata(episodes)
+        
+        semantic_rule = SemanticRule(
+            rule=rule_text,
+            source_episode_ids=source_ids,
+            context=self._extract_context(episodes),
+            confidence=confidence,
+            metadata=common_metadata
+        )
+        
+        return semantic_rule
+    
+    def _default_summarize(self, episodes: List[Episode]) -> str:
+        """
+        Default summarization strategy: extract common patterns.
+        
+        Args:
+            episodes: List of episodes
+            
+        Returns:
+            A summary string
+        """
+        # Group episodes by similar goals
+        goal_patterns = {}
+        action_patterns = {}
+        
+        for ep in episodes:
+            # Simple word-based grouping
+            goal_words = set(ep.goal.lower().split())
+            action_words = set(ep.action.lower().split())
+            
+            # Track patterns
+            for word in goal_words:
+                goal_patterns[word] = goal_patterns.get(word, 0) + 1
+            for word in action_words:
+                action_patterns[word] = action_patterns.get(word, 0) + 1
+        
+        # Find most common patterns
+        top_goals = sorted(goal_patterns.items(), key=lambda x: x[1], reverse=True)[:3]
+        top_actions = sorted(action_patterns.items(), key=lambda x: x[1], reverse=True)[:3]
+        
+        # Build summary
+        summary_parts = []
+        
+        if top_goals:
+            goal_words = [word for word, _ in top_goals]
+            summary_parts.append(f"Common goals involve: {', '.join(goal_words)}")
+        
+        if top_actions:
+            action_words = [word for word, _ in top_actions]
+            summary_parts.append(f"Typical actions include: {', '.join(action_words)}")
+        
+        # Check for failures
+        failures = [ep for ep in episodes if ep.is_failure()]
+        if failures:
+            summary_parts.append(
+                f"Warning: {len(failures)}/{len(episodes)} attempts failed"
+            )
+        
+        return ". ".join(summary_parts) if summary_parts else "General agent activity"
+    
+    def _extract_context(self, episodes: List[Episode]) -> str:
+        """Extract context from episodes."""
+        if not episodes:
+            return "General"
+        
+        # Use metadata tags if available
+        all_tags = set()
+        for ep in episodes:
+            if "tags" in ep.metadata:
+                tags = ep.metadata["tags"]
+                if isinstance(tags, list):
+                    all_tags.update(tags)
+        
+        if all_tags:
+            return f"Context: {', '.join(list(all_tags)[:5])}"
+        
+        return "General agent activity"
+    
+    def _extract_common_metadata(self, episodes: List[Episode]) -> Dict[str, Any]:
+        """Extract common metadata patterns from episodes."""
+        metadata = {
+            "episode_count": len(episodes),
+            "time_span_days": self._calculate_time_span(episodes),
+        }
+        
+        # Count failures
+        failures = [ep for ep in episodes if ep.is_failure()]
+        if failures:
+            metadata["failure_count"] = len(failures)
+            metadata["success_rate"] = (len(episodes) - len(failures)) / len(episodes)
+        
+        return metadata
+    
+    def _calculate_time_span(self, episodes: List[Episode]) -> int:
+        """Calculate the time span covered by episodes in days."""
+        if not episodes:
+            return 0
+        
+        timestamps = [ep.timestamp for ep in episodes]
+        min_time = min(timestamps)
+        max_time = max(timestamps)
+        
+        return (max_time - min_time).days
+    
+    def store_rule(self, rule: SemanticRule) -> str:
+        """
+        Store a semantic rule to the rules file.
+        
+        Args:
+            rule: The semantic rule to store
+            
+        Returns:
+            The rule_id of the stored rule
+        """
+        with open(self.rules_filepath, 'a') as f:
+            f.write(rule.to_json() + '\n')
+        
+        return rule.rule_id
+    
+    def retrieve_rules(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        limit: int = 100
+    ) -> List[SemanticRule]:
+        """
+        Retrieve semantic rules from storage.
+        
+        Args:
+            filters: Optional metadata filters
+            limit: Maximum number of rules to return
+            
+        Returns:
+            List of matching semantic rules (most recent first)
+        """
+        rules = []
+        
+        if not self.rules_filepath.exists() or self.rules_filepath.stat().st_size == 0:
+            return rules
+        
+        with open(self.rules_filepath, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                
+                try:
+                    rule = SemanticRule.from_json(line)
+                    
+                    # Apply filters if provided
+                    if filters:
+                        match = all(
+                            rule.metadata.get(key) == value
+                            for key, value in filters.items()
+                        )
+                        if not match:
+                            continue
+                    
+                    rules.append(rule)
+                except (ValueError, KeyError) as e:
+                    # Skip invalid lines but log the issue
+                    import logging
+                    logging.debug(f"Skipping invalid rule line: {e}")
+                    continue
+        
+        # Return most recent rules first
+        rules.reverse()
+        return rules[:limit]
+    
+    def compress_old_episodes(
+        self,
+        summarizer: Optional[Callable[[List[Episode]], str]] = None,
+        dry_run: bool = False,
+        max_episodes: int = 10000
+    ) -> Dict[str, Any]:
+        """
+        Execute a compression cycle: identify old episodes, summarize, and optionally archive.
+        
+        Args:
+            summarizer: Optional custom summarization function
+            dry_run: If True, only report what would be compressed without making changes
+            max_episodes: Maximum number of episodes to process (default: 10000)
+            
+        Returns:
+            Dictionary with compression statistics
+        """
+        # Retrieve episodes up to max limit
+        all_episodes = self.store.retrieve(limit=max_episodes)
+        
+        if len(all_episodes) == max_episodes:
+            # Log warning that we may have hit the limit
+            import logging
+            logging.warning(
+                f"Retrieved {max_episodes} episodes (limit reached). "
+                "Some episodes may not be processed. Consider increasing max_episodes."
+            )
+        
+        # Identify old episodes
+        old_episodes = self.identify_old_episodes(all_episodes)
+        
+        if not old_episodes:
+            return {
+                "compressed_count": 0,
+                "rules_created": 0,
+                "message": "No old episodes found for compression"
+            }
+        
+        # Batch compress
+        rules_created = 0
+        compressed_count = 0
+        errors = []
+        
+        for i in range(0, len(old_episodes), self.compression_batch_size):
+            batch = old_episodes[i:i + self.compression_batch_size]
+            
+            # Summarize batch
+            try:
+                rule = self.summarize_episodes(batch, summarizer)
+                
+                if not dry_run:
+                    self.store_rule(rule)
+                
+                rules_created += 1
+                compressed_count += len(batch)
+            except Exception as e:
+                # Collect errors but continue with next batch
+                import logging
+                logging.error(f"Error compressing batch starting at index {i}: {e}")
+                errors.append(str(e))
+                continue
+        
+        result = {
+            "compressed_count": compressed_count,
+            "rules_created": rules_created,
+            "total_episodes": len(all_episodes),
+            "old_episodes": len(old_episodes),
+            "dry_run": dry_run
+        }
+        
+        if errors:
+            result["errors"] = errors
+            result["message"] = f"Completed with {len(errors)} error(s)"
+        elif dry_run:
+            result["message"] = f"Dry run: Would compress {compressed_count} episodes into {rules_created} rules"
+        else:
+            result["message"] = f"Compressed {compressed_count} episodes into {rules_created} rules"
+        
+        return result

--- a/packages/agent-os/modules/emk/emk/store.py
+++ b/packages/agent-os/modules/emk/emk/store.py
@@ -163,3 +163,119 @@ class FileAdapter(VectorStoreAdapter):
             return False
         self._write_all(new_episodes)
         return True
+
+
+try:
+    import chromadb
+    from chromadb.config import Settings
+
+    class ChromaDBAdapter(VectorStoreAdapter):
+        """
+        ChromaDB-based vector storage adapter.
+
+        Uses ChromaDB for vector similarity search and efficient retrieval
+        of episodes based on embeddings.
+        """
+
+        def __init__(
+            self,
+            collection_name: str = "episodes",
+            persist_directory: str = "./chroma_data",
+        ):
+            self.client = chromadb.Client(Settings(
+                persist_directory=persist_directory,
+                anonymized_telemetry=False,
+            ))
+            self.collection = self.client.get_or_create_collection(
+                name=collection_name,
+                metadata={"description": "Episodic memory storage"},
+            )
+
+        def store(self, episode: Episode, embedding: Optional[np.ndarray] = None) -> str:
+            if embedding is None:
+                text = f"{episode.goal} {episode.action} {episode.result} {episode.reflection}"
+            else:
+                text = None
+
+            self.collection.add(
+                ids=[episode.episode_id],
+                documents=[text] if text else None,
+                embeddings=[embedding.tolist()] if embedding is not None else None,
+                metadatas=[{
+                    "goal": episode.goal,
+                    "action": episode.action,
+                    "result": episode.result,
+                    "reflection": episode.reflection,
+                    "timestamp": episode.timestamp.isoformat(),
+                    **episode.metadata,
+                }],
+            )
+            return episode.episode_id
+
+        def retrieve(
+            self,
+            query_embedding: Optional[np.ndarray] = None,
+            filters: Optional[Dict[str, Any]] = None,
+            limit: int = 10,
+        ) -> List[Episode]:
+            if query_embedding is not None:
+                results = self.collection.query(
+                    query_embeddings=[query_embedding.tolist()],
+                    n_results=limit,
+                    where=filters,
+                )
+            else:
+                results = self.collection.get(limit=limit, where=filters)
+
+            episodes = []
+            if 'metadatas' in results and results['metadatas']:
+                if isinstance(results['metadatas'][0], list) if results['metadatas'] else False:
+                    metadatas = results['metadatas'][0]
+                else:
+                    metadatas = results['metadatas']
+            else:
+                metadatas = []
+
+            for metadata in metadatas:
+                episode_metadata = {
+                    k: v for k, v in metadata.items()
+                    if k not in ('goal', 'action', 'result', 'reflection', 'timestamp')
+                }
+                try:
+                    episode = Episode(
+                        goal=metadata.get("goal", ""),
+                        action=metadata.get("action", ""),
+                        result=metadata.get("result", ""),
+                        reflection=metadata.get("reflection", ""),
+                        timestamp=metadata.get("timestamp", None),
+                        metadata=episode_metadata,
+                    )
+                    episodes.append(episode)
+                except Exception:
+                    continue
+            return episodes
+
+        def get_by_id(self, episode_id: str) -> Optional[Episode]:
+            try:
+                results = self.collection.get(ids=[episode_id])
+                if not results['ids']:
+                    return None
+                metadata = results['metadatas'][0]
+                episode_metadata = {
+                    k: v for k, v in metadata.items()
+                    if k not in ('goal', 'action', 'result', 'reflection', 'timestamp')
+                }
+                return Episode(
+                    goal=metadata.get("goal", ""),
+                    action=metadata.get("action", ""),
+                    result=metadata.get("result", ""),
+                    reflection=metadata.get("reflection", ""),
+                    timestamp=metadata.get("timestamp", None),
+                    metadata=episode_metadata,
+                )
+            except Exception:
+                return None
+
+except ImportError:
+    # ChromaDB not installed — adapter will not be available
+    pass

--- a/packages/agent-os/modules/emk/tests/test_init.py
+++ b/packages/agent-os/modules/emk/tests/test_init.py
@@ -9,7 +9,7 @@ def test_import_main_package():
     """Test that the main package can be imported."""
     import emk
     assert hasattr(emk, '__version__')
-    assert emk.__version__ == "0.1.0"
+    assert emk.__version__ == "0.2.0"
 
 
 def test_import_episode():


### PR DESCRIPTION
## Summary
Ports the production-grade Episodic Memory Kernel (EMK) from the internal agent-governance repository. Adds causal reasoning, sleep-cycle memory compression, and ChromaDB vector store support.

## Changes

### New Files
| File | Lines | Description |
|------|-------|-------------|
| \mk/causal.py\ | 352 | \CausalEpisode\ + \CausalMemoryStore\ — SQLite-backed causal graph with chain traversal |
| \mk/sleep_cycle.py\ | 347 | \MemoryCompressor\ — sleep-cycle memory decay, episode summarization into SemanticRules |

### Modified Files
| File | Change |
|------|--------|
| \mk/store.py\ | Added \ChromaDBAdapter\ — optional ChromaDB vector store backend (+116 lines) |
| \mk/__init__.py\ | Added exports: \MemoryCompressor\, \CausalEpisode\, \CausalMemoryStore\ |
| \	ests/test_init.py\ | Fixed pre-existing version assertion (0.1.0 → 0.2.0) |

## Key Features
- **Causal Reasoning**: Trace cause-effect relationships across agent episodes with graph traversal (backward/forward/both directions)
- **Sleep Cycle Compression**: Consolidate old episodes into semantic rules during idle periods
- **ChromaDB Integration**: Optional vector store backend for production-scale similarity search
- **Content-Addressed Episodes**: SHA-256 content hashes for deduplication

## Testing
- All 78 tests pass (33 new causal + sleep cycle tests were already in the repo waiting for the source files)
- 1 pre-existing skip, 1 pre-existing failure on main (test_semantic_rule_immutability — unrelated)

Closes #55