### PR TITLE
ci: add Copilot auto-review on new PRs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -16,6 +16,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --add-reviewer "copilot"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+            -f "reviewers[]=copilot"


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically requests Copilot as a reviewer when PRs are opened or marked ready for review. Draft PRs are skipped.

Once merged, every new PR will get an automatic Copilot code review.