### PR TITLE
feat: policy schema versioning + file-backed trust persistence

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -5,17 +5,29 @@ Policy Engine
 
 Declarative policy engine with YAML/JSON policies.
 Policy evaluation latency <5ms with 100% deterministic results.
+
+Supports schema versioning via ``apiVersion`` (e.g.,
+``governance.toolkit/v1``). Older versions emit deprecation
+warnings; unknown versions raise ``ValueError``.
 """
 
 from datetime import datetime
 from typing import Optional, Literal, Any, Callable
 from pydantic import BaseModel, Field
 import logging
+import warnings
 import yaml
 import json
 import re
 
 logger = logging.getLogger(__name__)
+
+# Supported schema versions (newest first)
+CURRENT_API_VERSION = "governance.toolkit/v1"
+SUPPORTED_API_VERSIONS = {
+    "governance.toolkit/v1": {"status": "current"},
+    "1.0": {"status": "deprecated", "migrate_to": "governance.toolkit/v1"},
+}
 
 
 class PolicyRule(BaseModel):
@@ -126,8 +138,14 @@ class Policy(BaseModel):
     Complete policy document.
     
     Policies are defined in YAML/JSON and loaded at runtime.
+    Use ``apiVersion: governance.toolkit/v1`` in YAML files for
+    schema-versioned policies.
     """
     
+    apiVersion: str = Field(
+        default=CURRENT_API_VERSION,
+        description="Schema version (e.g., governance.toolkit/v1)",
+    )
     version: str = Field(default="1.0")
     name: str = Field(...)
     description: Optional[str] = Field(None)
@@ -150,13 +168,20 @@ class Policy(BaseModel):
     def from_yaml(cls, yaml_content: str) -> "Policy":
         """Load a policy from a YAML string.
 
+        Validates the ``apiVersion`` field against supported versions
+        and emits deprecation warnings for older schemas.
+
         Args:
             yaml_content: Raw YAML string containing the policy definition.
 
         Returns:
             A fully-constructed ``Policy`` instance.
+
+        Raises:
+            ValueError: If the ``apiVersion`` is not recognized.
         """
         data = yaml.safe_load(yaml_content)
+        _validate_api_version(data)
         
         # Parse rules
         rules = []
@@ -170,13 +195,20 @@ class Policy(BaseModel):
     def from_json(cls, json_content: str) -> "Policy":
         """Load a policy from a JSON string.
 
+        Validates the ``apiVersion`` field against supported versions
+        and emits deprecation warnings for older schemas.
+
         Args:
             json_content: Raw JSON string containing the policy definition.
 
         Returns:
             A fully-constructed ``Policy`` instance.
+
+        Raises:
+            ValueError: If the ``apiVersion`` is not recognized.
         """
         data = json.loads(json_content)
+        _validate_api_version(data)
         
         rules = []
         for rule_data in data.get("rules", []):
@@ -555,3 +587,146 @@ class PolicyEngine:
             evaluated_at=start,
             evaluation_ms=elapsed,
         )
+
+
+# ── Schema versioning helpers ──────────────────────────────
+
+
+def _validate_api_version(data: dict) -> None:
+    """Validate and warn about the apiVersion field in a policy document.
+
+    Args:
+        data: Parsed policy dict (from YAML/JSON).
+
+    Raises:
+        ValueError: If the ``apiVersion`` is present but not recognized.
+    """
+    api_version = data.get("apiVersion")
+
+    if api_version is None:
+        # Legacy policy without apiVersion — treat as v1.0, inject current
+        legacy_version = data.get("version", "1.0")
+        if legacy_version in SUPPORTED_API_VERSIONS:
+            info = SUPPORTED_API_VERSIONS[legacy_version]
+            if info["status"] == "deprecated":
+                warnings.warn(
+                    f"Policy schema version '{legacy_version}' is deprecated. "
+                    f"Add 'apiVersion: {info['migrate_to']}' to your policy file. "
+                    f"See https://github.com/microsoft/agent-governance-toolkit/docs/policy-migration.md",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+        data["apiVersion"] = CURRENT_API_VERSION
+        return
+
+    if api_version not in SUPPORTED_API_VERSIONS:
+        raise ValueError(
+            f"Unsupported policy apiVersion: '{api_version}'. "
+            f"Supported versions: {list(SUPPORTED_API_VERSIONS.keys())}"
+        )
+
+    info = SUPPORTED_API_VERSIONS[api_version]
+    if info["status"] == "deprecated":
+        warnings.warn(
+            f"Policy apiVersion '{api_version}' is deprecated. "
+            f"Migrate to '{info['migrate_to']}'. "
+            f"See https://github.com/microsoft/agent-governance-toolkit/docs/policy-migration.md",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+
+def migrate_policy(yaml_content: str, target_version: str = CURRENT_API_VERSION) -> str:
+    """Migrate a policy YAML document to the target schema version.
+
+    Currently supports:
+    - ``1.0`` → ``governance.toolkit/v1``: Adds ``apiVersion`` field.
+
+    Args:
+        yaml_content: Raw YAML policy string.
+        target_version: Target apiVersion to migrate to.
+
+    Returns:
+        Updated YAML string with the new apiVersion.
+
+    Raises:
+        ValueError: If the target version is not supported.
+    """
+    if target_version not in SUPPORTED_API_VERSIONS:
+        raise ValueError(f"Unknown target version: {target_version}")
+
+    data = yaml.safe_load(yaml_content)
+    current = data.get("apiVersion", data.get("version", "1.0"))
+
+    if current == target_version:
+        return yaml_content  # Already at target
+
+    # Migration: 1.0 → governance.toolkit/v1
+    if current == "1.0" and target_version == CURRENT_API_VERSION:
+        data["apiVersion"] = CURRENT_API_VERSION
+        if "version" in data:
+            del data["version"]
+        return yaml.dump(data, default_flow_style=False, sort_keys=False)
+
+    logger.warning(
+        "No migration path from '%s' to '%s'", current, target_version
+    )
+    return yaml_content
+
+
+def validate_policy_schema(yaml_content: str) -> list[str]:
+    """Validate a policy YAML document against its declared schema.
+
+    Checks for required fields, valid values, and structural correctness.
+
+    Args:
+        yaml_content: Raw YAML policy string.
+
+    Returns:
+        List of validation error strings. Empty list means valid.
+    """
+    errors: list[str] = []
+    try:
+        data = yaml.safe_load(yaml_content)
+    except yaml.YAMLError as e:
+        return [f"YAML parse error: {e}"]
+
+    if not isinstance(data, dict):
+        return ["Policy must be a YAML mapping"]
+
+    # Check apiVersion
+    api_version = data.get("apiVersion", data.get("version", "1.0"))
+    if api_version not in SUPPORTED_API_VERSIONS:
+        errors.append(f"Unknown apiVersion: '{api_version}'")
+
+    # Check required fields
+    if "name" not in data:
+        errors.append("Missing required field: 'name'")
+
+    # Validate rules
+    rules = data.get("rules", [])
+    if not isinstance(rules, list):
+        errors.append("'rules' must be a list")
+    else:
+        valid_actions = {"allow", "deny", "warn", "require_approval", "log"}
+        for i, rule in enumerate(rules):
+            if not isinstance(rule, dict):
+                errors.append(f"Rule {i}: must be a mapping")
+                continue
+            if "name" not in rule:
+                errors.append(f"Rule {i}: missing required field 'name'")
+            if "condition" not in rule:
+                errors.append(f"Rule {i}: missing required field 'condition'")
+            action = rule.get("action", "deny")
+            if action not in valid_actions:
+                errors.append(
+                    f"Rule {i} ('{rule.get('name', '?')}'): "
+                    f"invalid action '{action}', must be one of {valid_actions}"
+                )
+
+    # Validate default_action
+    default_action = data.get("default_action", "deny")
+    if default_action not in ("allow", "deny"):
+        errors.append(f"Invalid default_action: '{default_action}', must be 'allow' or 'deny'")
+
+    return errors

--- a/packages/agent-mesh/src/agentmesh/storage/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/storage/__init__.py
@@ -11,6 +11,7 @@ from .memory_provider import MemoryStorageProvider
 from .redis_provider import RedisStorageProvider
 from .postgres_provider import PostgresStorageProvider
 from .redis_backend import RedisTrustStore
+from .file_trust_store import FileTrustStore
 
 __all__ = [
     "AbstractStorageProvider",
@@ -19,4 +20,5 @@ __all__ = [
     "RedisStorageProvider",
     "PostgresStorageProvider",
     "RedisTrustStore",
+    "FileTrustStore",
 ]

--- a/packages/agent-mesh/src/agentmesh/storage/file_trust_store.py
+++ b/packages/agent-mesh/src/agentmesh/storage/file_trust_store.py
@@ -1,0 +1,157 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+File-backed Trust Score Store.
+
+Persists trust scores to a JSON file on disk so that scores survive
+agent restarts without requiring Redis or any external dependency.
+
+Usage:
+    from agentmesh.storage.file_trust_store import FileTrustStore
+
+    store = FileTrustStore("./data/trust_scores.json")
+    store.store_trust_score("did:mesh:agent-1", {"score": 850, "level": "high"})
+
+    # After restart:
+    store = FileTrustStore("./data/trust_scores.json")
+    score = store.get_trust_score("did:mesh:agent-1")
+    # score == {"score": 850, "level": "high"}
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class FileTrustStore:
+    """File-backed trust score persistence.
+
+    Stores trust scores in a JSON file on disk. Thread-safe via a
+    reentrant lock. Writes are atomic (write-to-temp then rename)
+    to prevent corruption on crash.
+
+    Args:
+        path: File path for the trust score JSON file.
+        auto_save: If True, persist to disk on every write.
+            If False, call ``save()`` explicitly.
+    """
+
+    def __init__(self, path: str = "./trust_scores.json", auto_save: bool = True) -> None:
+        self._path = Path(path)
+        self._auto_save = auto_save
+        self._lock = threading.RLock()
+        self._scores: dict[str, dict[str, Any]] = {}
+        self._metadata: dict[str, dict[str, str]] = {}
+
+        if self._path.exists():
+            self._load()
+
+    def store_trust_score(self, agent_did: str, score: dict[str, Any]) -> None:
+        """Store or update a trust score for an agent.
+
+        Args:
+            agent_did: DID of the agent.
+            score: Trust score data (arbitrary dict).
+        """
+        with self._lock:
+            self._scores[agent_did] = score
+            self._metadata[agent_did] = {
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+            if self._auto_save:
+                self._save()
+
+    def get_trust_score(self, agent_did: str) -> Optional[dict[str, Any]]:
+        """Retrieve the trust score for an agent.
+
+        Args:
+            agent_did: DID of the agent.
+
+        Returns:
+            Trust score dict, or None if not found.
+        """
+        with self._lock:
+            return self._scores.get(agent_did)
+
+    def delete_trust_score(self, agent_did: str) -> bool:
+        """Remove a trust score.
+
+        Args:
+            agent_did: DID of the agent.
+
+        Returns:
+            True if the score existed and was removed.
+        """
+        with self._lock:
+            if agent_did in self._scores:
+                del self._scores[agent_did]
+                self._metadata.pop(agent_did, None)
+                if self._auto_save:
+                    self._save()
+                return True
+            return False
+
+    def list_agents(self) -> list[str]:
+        """List all agent DIDs with stored trust scores."""
+        with self._lock:
+            return list(self._scores.keys())
+
+    def get_all_scores(self) -> dict[str, dict[str, Any]]:
+        """Return all stored trust scores."""
+        with self._lock:
+            return dict(self._scores)
+
+    def save(self) -> None:
+        """Explicitly persist to disk."""
+        with self._lock:
+            self._save()
+
+    def _save(self) -> None:
+        """Write scores to disk atomically."""
+        data = {
+            "version": "1.0",
+            "saved_at": datetime.now(timezone.utc).isoformat(),
+            "scores": self._scores,
+            "metadata": self._metadata,
+        }
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self._path.with_suffix(".tmp")
+        try:
+            tmp_path.write_text(json.dumps(data, indent=2, default=str))
+            tmp_path.replace(self._path)
+        except Exception:
+            logger.error("Failed to save trust scores to %s", self._path, exc_info=True)
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+    def _load(self) -> None:
+        """Load scores from disk."""
+        try:
+            raw = json.loads(self._path.read_text())
+            self._scores = raw.get("scores", {})
+            self._metadata = raw.get("metadata", {})
+            count = len(self._scores)
+            logger.info(
+                "Loaded %d trust scores from %s", count, self._path
+            )
+        except Exception:
+            logger.warning(
+                "Failed to load trust scores from %s, starting fresh",
+                self._path,
+                exc_info=True,
+            )
+            self._scores = {}
+            self._metadata = {}
+
+    def __len__(self) -> int:
+        return len(self._scores)
+
+    def __contains__(self, agent_did: str) -> bool:
+        return agent_did in self._scores

--- a/packages/agent-mesh/tests/test_file_trust_store.py
+++ b/packages/agent-mesh/tests/test_file_trust_store.py
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for file-backed trust score store."""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from agentmesh.storage.file_trust_store import FileTrustStore
+
+
+@pytest.fixture
+def trust_file(tmp_path):
+    return str(tmp_path / "trust_scores.json")
+
+
+class TestFileTrustStore:
+    def test_store_and_retrieve(self, trust_file):
+        store = FileTrustStore(trust_file)
+        store.store_trust_score("did:mesh:agent-1", {"score": 850, "level": "high"})
+        result = store.get_trust_score("did:mesh:agent-1")
+        assert result == {"score": 850, "level": "high"}
+
+    def test_persistence_across_instances(self, trust_file):
+        store1 = FileTrustStore(trust_file)
+        store1.store_trust_score("did:mesh:agent-1", {"score": 900})
+        store1.store_trust_score("did:mesh:agent-2", {"score": 500})
+        del store1
+
+        store2 = FileTrustStore(trust_file)
+        assert store2.get_trust_score("did:mesh:agent-1") == {"score": 900}
+        assert store2.get_trust_score("did:mesh:agent-2") == {"score": 500}
+
+    def test_update_score(self, trust_file):
+        store = FileTrustStore(trust_file)
+        store.store_trust_score("did:mesh:agent-1", {"score": 500})
+        store.store_trust_score("did:mesh:agent-1", {"score": 900})
+        assert store.get_trust_score("did:mesh:agent-1") == {"score": 900}
+
+    def test_delete_score(self, trust_file):
+        store = FileTrustStore(trust_file)
+        store.store_trust_score("did:mesh:agent-1", {"score": 800})
+        assert store.delete_trust_score("did:mesh:agent-1") is True
+        assert store.get_trust_score("did:mesh:agent-1") is None
+
+    def test_delete_nonexistent(self, trust_file):
+        store = FileTrustStore(trust_file)
+        assert store.delete_trust_score("did:mesh:ghost") is False
+
+    def test_list_agents(self, trust_file):
+        store = FileTrustStore(trust_file)
+        store.store_trust_score("did:mesh:a", {"score": 1})
+        store.store_trust_score("did:mesh:b", {"score": 2})
+        agents = store.list_agents()
+        assert set(agents) == {"did:mesh:a", "did:mesh:b"}
+
+    def test_get_all_scores(self, trust_file):
+        store = FileTrustStore(trust_file)
+        store.store_trust_score("did:mesh:a", {"score": 100})
+        all_scores = store.get_all_scores()
+        assert "did:mesh:a" in all_scores
+
+    def test_len_and_contains(self, trust_file):
+        store = FileTrustStore(trust_file)
+        assert len(store) == 0
+        store.store_trust_score("did:mesh:a", {"score": 1})
+        assert len(store) == 1
+        assert "did:mesh:a" in store
+        assert "did:mesh:b" not in store
+
+    def test_nonexistent_returns_none(self, trust_file):
+        store = FileTrustStore(trust_file)
+        assert store.get_trust_score("did:mesh:ghost") is None
+
+    def test_corrupt_file_starts_fresh(self, trust_file):
+        with open(trust_file, "w") as f:
+            f.write("NOT VALID JSON!!!")
+        store = FileTrustStore(trust_file)
+        assert len(store) == 0
+        store.store_trust_score("did:mesh:a", {"score": 1})
+        assert store.get_trust_score("did:mesh:a") == {"score": 1}
+
+    def test_auto_save_disabled(self, trust_file):
+        store = FileTrustStore(trust_file, auto_save=False)
+        store.store_trust_score("did:mesh:a", {"score": 1})
+        # File should not exist yet
+        assert not os.path.exists(trust_file)
+        store.save()
+        assert os.path.exists(trust_file)
+
+    def test_creates_parent_directories(self, tmp_path):
+        deep_path = str(tmp_path / "a" / "b" / "c" / "scores.json")
+        store = FileTrustStore(deep_path)
+        store.store_trust_score("did:mesh:a", {"score": 1})
+        assert os.path.exists(deep_path)
+
+    def test_file_format(self, trust_file):
+        store = FileTrustStore(trust_file)
+        store.store_trust_score("did:mesh:a", {"score": 42})
+        with open(trust_file) as f:
+            data = json.load(f)
+        assert data["version"] == "1.0"
+        assert "saved_at" in data
+        assert "did:mesh:a" in data["scores"]
+        assert data["scores"]["did:mesh:a"]["score"] == 42

--- a/packages/agent-mesh/tests/test_policy_schema.py
+++ b/packages/agent-mesh/tests/test_policy_schema.py
@@ -1,0 +1,187 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for policy schema versioning and migration."""
+
+import warnings
+
+import pytest
+
+from agentmesh.governance.policy import (
+    CURRENT_API_VERSION,
+    Policy,
+    PolicyEngine,
+    migrate_policy,
+    validate_policy_schema,
+)
+
+
+VALID_V1_YAML = """
+apiVersion: governance.toolkit/v1
+name: test-policy
+description: A test policy
+default_action: deny
+rules:
+  - name: block-exports
+    condition: "action.type == 'export'"
+    action: deny
+    description: Block export actions
+"""
+
+LEGACY_YAML = """
+name: legacy-policy
+version: "1.0"
+default_action: allow
+rules:
+  - name: allow-all
+    condition: "agent.role == 'admin'"
+    action: allow
+"""
+
+UNSUPPORTED_VERSION_YAML = """
+apiVersion: governance.toolkit/v99
+name: future-policy
+default_action: deny
+rules: []
+"""
+
+
+class TestApiVersionValidation:
+    def test_current_version_accepted(self):
+        policy = Policy.from_yaml(VALID_V1_YAML)
+        assert policy.apiVersion == CURRENT_API_VERSION
+        assert policy.name == "test-policy"
+
+    def test_legacy_version_emits_deprecation(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            policy = Policy.from_yaml(LEGACY_YAML)
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+            assert "deprecated" in str(deprecation_warnings[0].message).lower()
+
+    def test_unsupported_version_raises(self):
+        with pytest.raises(ValueError, match="Unsupported policy apiVersion"):
+            Policy.from_yaml(UNSUPPORTED_VERSION_YAML)
+
+    def test_no_version_defaults_to_current(self):
+        yaml_content = """
+name: minimal-policy
+default_action: allow
+rules: []
+"""
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            policy = Policy.from_yaml(yaml_content)
+            assert policy.apiVersion == CURRENT_API_VERSION
+
+    def test_json_version_validation(self):
+        import json
+        data = {
+            "apiVersion": "governance.toolkit/v1",
+            "name": "json-policy",
+            "rules": [],
+        }
+        policy = Policy.from_json(json.dumps(data))
+        assert policy.apiVersion == CURRENT_API_VERSION
+
+    def test_json_unsupported_version_raises(self):
+        import json
+        data = {
+            "apiVersion": "governance.toolkit/v99",
+            "name": "bad-policy",
+            "rules": [],
+        }
+        with pytest.raises(ValueError):
+            Policy.from_json(json.dumps(data))
+
+
+class TestMigration:
+    def test_migrate_legacy_to_v1(self):
+        result = migrate_policy(LEGACY_YAML, CURRENT_API_VERSION)
+        assert "governance.toolkit/v1" in result
+        # version field should be removed
+        import yaml
+        data = yaml.safe_load(result)
+        assert data.get("apiVersion") == CURRENT_API_VERSION
+        assert "version" not in data
+
+    def test_migrate_already_current_is_noop(self):
+        result = migrate_policy(VALID_V1_YAML, CURRENT_API_VERSION)
+        assert result == VALID_V1_YAML
+
+    def test_migrate_to_unknown_version_raises(self):
+        with pytest.raises(ValueError, match="Unknown target version"):
+            migrate_policy(LEGACY_YAML, "governance.toolkit/v99")
+
+
+class TestSchemaValidation:
+    def test_valid_policy(self):
+        errors = validate_policy_schema(VALID_V1_YAML)
+        assert errors == []
+
+    def test_missing_name(self):
+        yaml_content = """
+apiVersion: governance.toolkit/v1
+rules: []
+"""
+        errors = validate_policy_schema(yaml_content)
+        assert any("name" in e for e in errors)
+
+    def test_invalid_action(self):
+        yaml_content = """
+apiVersion: governance.toolkit/v1
+name: bad-action-policy
+rules:
+  - name: rule1
+    condition: "true"
+    action: explode
+"""
+        errors = validate_policy_schema(yaml_content)
+        assert any("invalid action" in e for e in errors)
+
+    def test_missing_rule_condition(self):
+        yaml_content = """
+apiVersion: governance.toolkit/v1
+name: missing-condition
+rules:
+  - name: rule1
+    action: deny
+"""
+        errors = validate_policy_schema(yaml_content)
+        assert any("condition" in e for e in errors)
+
+    def test_invalid_yaml(self):
+        errors = validate_policy_schema("not: valid: yaml: {{}")
+        assert len(errors) > 0
+
+    def test_unknown_api_version(self):
+        yaml_content = """
+apiVersion: unknown/v99
+name: test
+rules: []
+"""
+        errors = validate_policy_schema(yaml_content)
+        assert any("apiVersion" in e for e in errors)
+
+    def test_invalid_default_action(self):
+        yaml_content = """
+apiVersion: governance.toolkit/v1
+name: test
+default_action: maybe
+rules: []
+"""
+        errors = validate_policy_schema(yaml_content)
+        assert any("default_action" in e for e in errors)
+
+
+class TestPolicyEngineWithVersioning:
+    def test_engine_loads_versioned_policy(self):
+        engine = PolicyEngine()
+        policy = engine.load_yaml(VALID_V1_YAML)
+        assert policy.apiVersion == CURRENT_API_VERSION
+        assert engine.get_policy("test-policy") is not None
+
+    def test_engine_rejects_unsupported_version(self):
+        engine = PolicyEngine()
+        with pytest.raises(ValueError):
+            engine.load_yaml(UNSUPPORTED_VERSION_YAML)


### PR DESCRIPTION
## Summary
Addresses two enterprise-readiness gaps:

### Policy Schema Versioning (Closes #87)
The policy schema had a cosmetic \\ersion\\ field that was never validated. Now:
- **apiVersion field**: \\governance.toolkit/v1\\ in Policy model
- **Deprecation warnings**: Legacy \\1.0\\ policies emit \\DeprecationWarning\\
- **Validation**: Unsupported versions raise \\ValueError\\
- **Migration**: \\migrate_policy()\\ converts v1.0 → governance.toolkit/v1
- **Schema validator**: \\alidate_policy_schema()\\ checks structure before load

### File-Backed Trust Persistence (Closes #86)
Trust scores defaulted to in-memory (lost on restart). Now:
- **FileTrustStore**: JSON file-backed, zero external deps
- **Atomic writes**: Write-to-temp then rename (crash-safe)
- **Thread-safe**: RLock for concurrent access
- **Corruption recovery**: Gracefully starts fresh on corrupt files
- **Auto-creates dirs**: Parent directories created on first write

## Tests: 31 new, all passing
- 18 schema versioning (validation, migration, deprecation, engine integration)
- 13 trust store (CRUD, persistence across instances, corruption, auto-save)