### PR TITLE
feat: Policy conflict resolution with 4 declared strategies

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/governance/__init__.py
@@ -8,6 +8,13 @@ Append-only audit logs with optional external sinks.
 """
 
 from .policy import PolicyEngine, Policy, PolicyRule, PolicyDecision
+from .conflict_resolution import (
+    ConflictResolutionStrategy,
+    PolicyScope,
+    PolicyConflictResolver,
+    CandidateDecision,
+    ResolutionResult,
+)
 from .compliance import ComplianceEngine, ComplianceFramework, ComplianceReport
 from .audit import AuditLog, AuditEntry, AuditChain
 from .audit_backends import (
@@ -37,6 +44,11 @@ __all__ = [
     "Policy",
     "PolicyRule",
     "PolicyDecision",
+    "ConflictResolutionStrategy",
+    "PolicyScope",
+    "PolicyConflictResolver",
+    "CandidateDecision",
+    "ResolutionResult",
     "ComplianceEngine",
     "ComplianceFramework",
     "ComplianceReport",

--- a/packages/agent-mesh/src/agentmesh/governance/conflict_resolution.py
+++ b/packages/agent-mesh/src/agentmesh/governance/conflict_resolution.py
@@ -1,0 +1,269 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Policy Conflict Resolution.
+
+When multiple policies apply to the same agent action, the conflict
+resolution strategy determines which decision wins.
+
+Strategies
+----------
+- **DENY_OVERRIDES** (safest): If ANY matching rule denies, the action
+  is denied regardless of what other rules say. Standard in XACML and
+  most enterprise policy systems.
+- **ALLOW_OVERRIDES**: If ANY matching rule allows, the action is
+  allowed. Useful for exception-based governance where you want
+  explicit allow-rules to punch through default-deny policies.
+- **PRIORITY_FIRST_MATCH** (current default): Rules are sorted by
+  priority (highest first), and the first matching rule wins. This
+  preserves backward compatibility with the existing PolicyEngine.
+- **MOST_SPECIFIC_WINS**: Agent-scoped rules override tenant-scoped,
+  which override global-scoped. Within the same scope, priority breaks
+  ties. Models the intuition that "closer policies override distant ones."
+
+Scopes
+------
+Each ``Policy`` can declare a ``scope`` that indicates its breadth:
+
+- ``global``: Organization-wide default policies
+- ``tenant``: Applied to a specific tenant or team
+- ``agent``: Applied to a specific agent instance
+
+When ``MOST_SPECIFIC_WINS`` is active, scope determines precedence.
+When other strategies are active, scope is informational metadata.
+
+Usage::
+
+    from agentmesh.governance.conflict_resolution import (
+        ConflictResolutionStrategy,
+        PolicyScope,
+        PolicyConflictResolver,
+    )
+
+    resolver = PolicyConflictResolver(ConflictResolutionStrategy.DENY_OVERRIDES)
+    final = resolver.resolve(candidate_decisions)
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class ConflictResolutionStrategy(str, Enum):
+    """Strategy for resolving conflicts between competing policy decisions."""
+
+    DENY_OVERRIDES = "deny_overrides"
+    ALLOW_OVERRIDES = "allow_overrides"
+    PRIORITY_FIRST_MATCH = "priority_first_match"
+    MOST_SPECIFIC_WINS = "most_specific_wins"
+
+
+class PolicyScope(str, Enum):
+    """Breadth of a policy's applicability.
+
+    Specificity order (most → least): AGENT > TENANT > GLOBAL.
+    """
+
+    GLOBAL = "global"
+    TENANT = "tenant"
+    AGENT = "agent"
+
+
+# Specificity rank: higher = more specific
+_SCOPE_SPECIFICITY: dict[PolicyScope, int] = {
+    PolicyScope.GLOBAL: 0,
+    PolicyScope.TENANT: 1,
+    PolicyScope.AGENT: 2,
+}
+
+
+class CandidateDecision(BaseModel):
+    """A single policy decision candidate awaiting conflict resolution.
+
+    Groups a decision with its originating policy metadata so the
+    resolver can apply scope- and priority-aware strategies.
+
+    Attributes:
+        action: The action the rule dictates (allow, deny, warn, etc.).
+        priority: Numeric priority from the matched rule.
+        scope: Scope of the policy that produced this decision.
+        policy_name: Name of the originating policy.
+        rule_name: Name of the matched rule.
+        reason: Human-readable explanation.
+        approvers: Required approvers for ``require_approval`` actions.
+    """
+
+    action: str
+    priority: int = 0
+    scope: PolicyScope = PolicyScope.GLOBAL
+    policy_name: str = ""
+    rule_name: str = ""
+    reason: str = ""
+    approvers: list[str] = Field(default_factory=list)
+
+    @property
+    def is_deny(self) -> bool:
+        return self.action == "deny"
+
+    @property
+    def is_allow(self) -> bool:
+        return self.action == "allow"
+
+    @property
+    def specificity(self) -> int:
+        return _SCOPE_SPECIFICITY.get(self.scope, 0)
+
+
+class ResolutionResult(BaseModel):
+    """Outcome of conflict resolution.
+
+    Attributes:
+        winning_decision: The decision that prevailed.
+        strategy_used: Which strategy resolved the conflict.
+        candidates_evaluated: How many candidates were considered.
+        conflict_detected: Whether genuinely conflicting decisions existed.
+        resolution_trace: Human-readable trace of the resolution logic.
+    """
+
+    winning_decision: CandidateDecision
+    strategy_used: ConflictResolutionStrategy
+    candidates_evaluated: int = 0
+    conflict_detected: bool = False
+    resolution_trace: list[str] = Field(default_factory=list)
+
+
+class PolicyConflictResolver:
+    """Resolves conflicts between competing policy decisions.
+
+    Args:
+        strategy: The conflict resolution strategy to apply.
+    """
+
+    def __init__(
+        self,
+        strategy: ConflictResolutionStrategy = ConflictResolutionStrategy.PRIORITY_FIRST_MATCH,
+    ) -> None:
+        self.strategy = strategy
+
+    def resolve(self, candidates: list[CandidateDecision]) -> ResolutionResult:
+        """Resolve a list of candidate decisions into a single winner.
+
+        Args:
+            candidates: One or more candidate decisions from matching rules.
+
+        Returns:
+            A ``ResolutionResult`` containing the winning decision and
+            a trace of the resolution logic.
+
+        Raises:
+            ValueError: If ``candidates`` is empty.
+        """
+        if not candidates:
+            raise ValueError("Cannot resolve conflict with zero candidates")
+
+        if len(candidates) == 1:
+            return ResolutionResult(
+                winning_decision=candidates[0],
+                strategy_used=self.strategy,
+                candidates_evaluated=1,
+                conflict_detected=False,
+                resolution_trace=[f"Single candidate: {candidates[0].rule_name} → {candidates[0].action}"],
+            )
+
+        # Detect genuine conflict (mix of allow and deny)
+        actions = {c.action for c in candidates}
+        conflict_detected = "allow" in actions and "deny" in actions
+
+        dispatch = {
+            ConflictResolutionStrategy.DENY_OVERRIDES: self._deny_overrides,
+            ConflictResolutionStrategy.ALLOW_OVERRIDES: self._allow_overrides,
+            ConflictResolutionStrategy.PRIORITY_FIRST_MATCH: self._priority_first_match,
+            ConflictResolutionStrategy.MOST_SPECIFIC_WINS: self._most_specific_wins,
+        }
+
+        winner, trace = dispatch[self.strategy](candidates)
+
+        return ResolutionResult(
+            winning_decision=winner,
+            strategy_used=self.strategy,
+            candidates_evaluated=len(candidates),
+            conflict_detected=conflict_detected,
+            resolution_trace=trace,
+        )
+
+    # ── Strategy implementations ────────────────────────────
+
+    def _deny_overrides(
+        self, candidates: list[CandidateDecision]
+    ) -> tuple[CandidateDecision, list[str]]:
+        """DENY_OVERRIDES: any deny wins. Among denies, highest priority wins."""
+        trace = []
+        denies = [c for c in candidates if c.is_deny]
+        if denies:
+            denies.sort(key=lambda c: c.priority, reverse=True)
+            winner = denies[0]
+            trace.append(f"DENY_OVERRIDES: {len(denies)} deny rule(s) found")
+            trace.append(f"Winner: {winner.rule_name} (priority={winner.priority}, scope={winner.scope.value})")
+            return winner, trace
+
+        # No denies — pick highest-priority allow
+        candidates_sorted = sorted(candidates, key=lambda c: c.priority, reverse=True)
+        winner = candidates_sorted[0]
+        trace.append("DENY_OVERRIDES: no deny rules, selecting highest-priority allow")
+        trace.append(f"Winner: {winner.rule_name} (priority={winner.priority})")
+        return winner, trace
+
+    def _allow_overrides(
+        self, candidates: list[CandidateDecision]
+    ) -> tuple[CandidateDecision, list[str]]:
+        """ALLOW_OVERRIDES: any allow wins. Among allows, highest priority wins."""
+        trace = []
+        allows = [c for c in candidates if c.is_allow]
+        if allows:
+            allows.sort(key=lambda c: c.priority, reverse=True)
+            winner = allows[0]
+            trace.append(f"ALLOW_OVERRIDES: {len(allows)} allow rule(s) found")
+            trace.append(f"Winner: {winner.rule_name} (priority={winner.priority}, scope={winner.scope.value})")
+            return winner, trace
+
+        # No allows — pick highest-priority deny
+        candidates_sorted = sorted(candidates, key=lambda c: c.priority, reverse=True)
+        winner = candidates_sorted[0]
+        trace.append("ALLOW_OVERRIDES: no allow rules, selecting highest-priority deny")
+        trace.append(f"Winner: {winner.rule_name} (priority={winner.priority})")
+        return winner, trace
+
+    def _priority_first_match(
+        self, candidates: list[CandidateDecision]
+    ) -> tuple[CandidateDecision, list[str]]:
+        """PRIORITY_FIRST_MATCH: highest priority wins regardless of action."""
+        sorted_candidates = sorted(candidates, key=lambda c: c.priority, reverse=True)
+        winner = sorted_candidates[0]
+        trace = [
+            f"PRIORITY_FIRST_MATCH: {len(candidates)} candidates",
+            f"Winner: {winner.rule_name} (priority={winner.priority}, action={winner.action})",
+        ]
+        return winner, trace
+
+    def _most_specific_wins(
+        self, candidates: list[CandidateDecision]
+    ) -> tuple[CandidateDecision, list[str]]:
+        """MOST_SPECIFIC_WINS: agent > tenant > global. Priority breaks ties."""
+        sorted_candidates = sorted(
+            candidates,
+            key=lambda c: (c.specificity, c.priority),
+            reverse=True,
+        )
+        winner = sorted_candidates[0]
+        trace = [
+            f"MOST_SPECIFIC_WINS: {len(candidates)} candidates",
+            f"Specificity ranking: {[(c.rule_name, c.scope.value, c.specificity) for c in sorted_candidates]}",
+            f"Winner: {winner.rule_name} (scope={winner.scope.value}, priority={winner.priority}, action={winner.action})",
+        ]
+        return winner, trace

--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -154,6 +154,12 @@ class Policy(BaseModel):
     agent: Optional[str] = Field(None, description="Agent this policy applies to")
     agents: list[str] = Field(default_factory=list, description="Multiple agents")
     
+    # Scope for conflict resolution
+    scope: str = Field(
+        default="global",
+        description="Policy scope: global, tenant, or agent",
+    )
+    
     # Rules
     rules: list[PolicyRule] = Field(default_factory=list)
     
@@ -298,14 +304,31 @@ class PolicyEngine:
     - 100% deterministic across runs
     - Rate limiting support
     - Approval workflows
+    - Configurable conflict resolution strategy
     """
     
     MAX_EVAL_MS = 5  # Target: <5ms evaluation
     
-    def __init__(self):
+    def __init__(self, conflict_strategy: str = "priority_first_match"):
+        """Initialize the policy engine.
+
+        Args:
+            conflict_strategy: How to resolve conflicts when multiple
+                rules match. One of ``"deny_overrides"``,
+                ``"allow_overrides"``, ``"priority_first_match"``
+                (default, preserves v1.0 behavior), or
+                ``"most_specific_wins"``.
+        """
+        from agentmesh.governance.conflict_resolution import (
+            ConflictResolutionStrategy,
+            PolicyConflictResolver,
+        )
+
         self._policies: dict[str, Policy] = {}
         self._rate_limits: dict[str, dict] = {}  # rule_name -> {count, reset_at}
         self._rego_evaluators: list[tuple[str, Any]] = []  # [(package, OPAEvaluator)]
+        self._conflict_strategy = ConflictResolutionStrategy(conflict_strategy)
+        self._resolver = PolicyConflictResolver(self._conflict_strategy)
     
     def load_policy(self, policy: Policy) -> None:
         """Load a policy into the engine.
@@ -526,10 +549,15 @@ class PolicyEngine:
     ) -> PolicyDecision:
         """Evaluate all applicable policies for an agent action.
 
-        YAML/JSON rules are checked first (sorted by priority,
-        highest first). If no YAML rule matches, registered Rego
-        policies are consulted. If nothing matches, the default
-        action of the first applicable policy is used.
+        Collects ALL matching rules across all applicable policies,
+        then resolves conflicts using the configured strategy:
+
+        - ``priority_first_match``: Highest-priority matching rule wins
+          (v1.0 behavior).
+        - ``deny_overrides``: Any deny wins, regardless of priority.
+        - ``allow_overrides``: Any allow wins, regardless of priority.
+        - ``most_specific_wins``: Agent-scoped > tenant > global;
+          priority breaks ties within the same scope.
 
         Args:
             agent_did: Decentralized identifier of the acting agent.
@@ -539,25 +567,74 @@ class PolicyEngine:
             A ``PolicyDecision`` indicating whether the action is allowed
             and which rule (if any) matched.
         """
+        from agentmesh.governance.conflict_resolution import (
+            CandidateDecision,
+            PolicyScope,
+        )
+
         start = datetime.utcnow()
 
         # 1. Check YAML/JSON policies first
         applicable = [p for p in self._policies.values() if p.applies_to(agent_did)]
 
         if applicable:
-            all_rules = []
+            candidates: list[CandidateDecision] = []
             for policy in applicable:
+                # Map policy scope string to enum
+                try:
+                    scope = PolicyScope(policy.scope)
+                except ValueError:
+                    scope = PolicyScope.GLOBAL
+
                 for rule in policy.rules:
-                    all_rules.append((policy, rule))
+                    if rule.enabled and rule.evaluate(context):
+                        candidates.append(CandidateDecision(
+                            action=rule.action,
+                            priority=rule.priority,
+                            scope=scope,
+                            policy_name=policy.name,
+                            rule_name=rule.name,
+                            reason=rule.description or f"Rule {rule.name} matched",
+                            approvers=rule.approvers,
+                        ))
 
-            all_rules.sort(key=lambda x: x[1].priority, reverse=True)
+            if candidates:
+                result = self._resolver.resolve(candidates)
+                winner = result.winning_decision
+                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
 
-            for policy, rule in all_rules:
-                if rule.evaluate(context):
-                    decision = self._apply_rule(rule, policy, context)
-                    elapsed = (datetime.utcnow() - start).total_seconds() * 1000
-                    decision.evaluation_ms = elapsed
-                    return decision
+                # Apply rate limiting for the winning rule
+                matched_rule = None
+                for policy in applicable:
+                    for rule in policy.rules:
+                        if rule.name == winner.rule_name:
+                            matched_rule = rule
+                            break
+                    if matched_rule:
+                        break
+
+                if matched_rule and matched_rule.limit:
+                    if self._is_rate_limited(matched_rule):
+                        return PolicyDecision(
+                            allowed=False,
+                            action="deny",
+                            matched_rule=matched_rule.name,
+                            policy_name=winner.policy_name,
+                            reason=f"Rate limited: {matched_rule.limit}",
+                            evaluated_at=start,
+                            evaluation_ms=elapsed,
+                        )
+
+                return PolicyDecision(
+                    allowed=(winner.action == "allow"),
+                    action=winner.action,
+                    matched_rule=winner.rule_name,
+                    policy_name=winner.policy_name,
+                    reason=winner.reason,
+                    approvers=winner.approvers,
+                    evaluated_at=start,
+                    evaluation_ms=elapsed,
+                )
 
         # 2. Check Rego policies
         for package, evaluator in self._rego_evaluators:

--- a/packages/agent-mesh/tests/test_conflict_resolution.py
+++ b/packages/agent-mesh/tests/test_conflict_resolution.py
@@ -1,0 +1,304 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for policy conflict resolution strategies."""
+
+import pytest
+
+from agentmesh.governance.conflict_resolution import (
+    CandidateDecision,
+    ConflictResolutionStrategy,
+    PolicyConflictResolver,
+    PolicyScope,
+    ResolutionResult,
+)
+from agentmesh.governance.policy import Policy, PolicyEngine, PolicyRule
+
+
+# ── Resolver unit tests ─────────────────────────────────────
+
+
+class TestConflictResolutionStrategy:
+    def test_enum_values(self):
+        assert ConflictResolutionStrategy.DENY_OVERRIDES == "deny_overrides"
+        assert ConflictResolutionStrategy.ALLOW_OVERRIDES == "allow_overrides"
+        assert ConflictResolutionStrategy.PRIORITY_FIRST_MATCH == "priority_first_match"
+        assert ConflictResolutionStrategy.MOST_SPECIFIC_WINS == "most_specific_wins"
+
+
+class TestPolicyScope:
+    def test_specificity_ordering(self):
+        agent = CandidateDecision(action="deny", scope=PolicyScope.AGENT, rule_name="a")
+        tenant = CandidateDecision(action="deny", scope=PolicyScope.TENANT, rule_name="t")
+        global_ = CandidateDecision(action="deny", scope=PolicyScope.GLOBAL, rule_name="g")
+
+        assert agent.specificity > tenant.specificity > global_.specificity
+
+
+class TestDenyOverrides:
+    def setup_method(self):
+        self.resolver = PolicyConflictResolver(ConflictResolutionStrategy.DENY_OVERRIDES)
+
+    def test_deny_wins_over_allow(self):
+        candidates = [
+            CandidateDecision(action="allow", priority=100, rule_name="permissive"),
+            CandidateDecision(action="deny", priority=1, rule_name="strict"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.action == "deny"
+        assert result.winning_decision.rule_name == "strict"
+        assert result.conflict_detected is True
+
+    def test_highest_priority_deny_wins(self):
+        candidates = [
+            CandidateDecision(action="deny", priority=10, rule_name="low-deny"),
+            CandidateDecision(action="deny", priority=50, rule_name="high-deny"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "high-deny"
+
+    def test_no_denies_falls_to_highest_allow(self):
+        candidates = [
+            CandidateDecision(action="allow", priority=5, rule_name="low"),
+            CandidateDecision(action="allow", priority=20, rule_name="high"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "high"
+        assert result.conflict_detected is False
+
+
+class TestAllowOverrides:
+    def setup_method(self):
+        self.resolver = PolicyConflictResolver(ConflictResolutionStrategy.ALLOW_OVERRIDES)
+
+    def test_allow_wins_over_deny(self):
+        candidates = [
+            CandidateDecision(action="deny", priority=100, rule_name="strict"),
+            CandidateDecision(action="allow", priority=1, rule_name="exception"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.action == "allow"
+        assert result.winning_decision.rule_name == "exception"
+        assert result.conflict_detected is True
+
+    def test_highest_priority_allow_wins(self):
+        candidates = [
+            CandidateDecision(action="allow", priority=5, rule_name="low-allow"),
+            CandidateDecision(action="allow", priority=50, rule_name="high-allow"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "high-allow"
+
+    def test_no_allows_falls_to_highest_deny(self):
+        candidates = [
+            CandidateDecision(action="deny", priority=5, rule_name="low"),
+            CandidateDecision(action="deny", priority=20, rule_name="high"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "high"
+
+
+class TestPriorityFirstMatch:
+    def setup_method(self):
+        self.resolver = PolicyConflictResolver(ConflictResolutionStrategy.PRIORITY_FIRST_MATCH)
+
+    def test_highest_priority_wins(self):
+        candidates = [
+            CandidateDecision(action="allow", priority=5, rule_name="low"),
+            CandidateDecision(action="deny", priority=50, rule_name="high"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "high"
+        assert result.winning_decision.action == "deny"
+
+    def test_preserves_v1_behavior(self):
+        """Priority-first-match is the same as the old sort-by-priority logic."""
+        candidates = [
+            CandidateDecision(action="deny", priority=10, rule_name="r1"),
+            CandidateDecision(action="allow", priority=5, rule_name="r2"),
+            CandidateDecision(action="deny", priority=1, rule_name="r3"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "r1"
+
+
+class TestMostSpecificWins:
+    def setup_method(self):
+        self.resolver = PolicyConflictResolver(ConflictResolutionStrategy.MOST_SPECIFIC_WINS)
+
+    def test_agent_scope_overrides_global(self):
+        candidates = [
+            CandidateDecision(
+                action="deny", priority=100, scope=PolicyScope.GLOBAL, rule_name="global-deny"
+            ),
+            CandidateDecision(
+                action="allow", priority=1, scope=PolicyScope.AGENT, rule_name="agent-allow"
+            ),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "agent-allow"
+        assert result.winning_decision.action == "allow"
+
+    def test_tenant_overrides_global(self):
+        candidates = [
+            CandidateDecision(
+                action="deny", priority=50, scope=PolicyScope.GLOBAL, rule_name="global"
+            ),
+            CandidateDecision(
+                action="allow", priority=10, scope=PolicyScope.TENANT, rule_name="tenant"
+            ),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "tenant"
+
+    def test_priority_breaks_same_scope_tie(self):
+        candidates = [
+            CandidateDecision(
+                action="deny", priority=5, scope=PolicyScope.TENANT, rule_name="low-tenant"
+            ),
+            CandidateDecision(
+                action="allow", priority=50, scope=PolicyScope.TENANT, rule_name="high-tenant"
+            ),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "high-tenant"
+
+    def test_full_hierarchy(self):
+        """Agent > tenant > global, with priority as tiebreaker."""
+        candidates = [
+            CandidateDecision(action="deny", priority=100, scope=PolicyScope.GLOBAL, rule_name="g"),
+            CandidateDecision(action="deny", priority=50, scope=PolicyScope.TENANT, rule_name="t"),
+            CandidateDecision(action="allow", priority=1, scope=PolicyScope.AGENT, rule_name="a"),
+        ]
+        result = self.resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "a"
+        assert result.winning_decision.action == "allow"
+
+
+class TestResolverEdgeCases:
+    def test_single_candidate(self):
+        resolver = PolicyConflictResolver(ConflictResolutionStrategy.DENY_OVERRIDES)
+        result = resolver.resolve([
+            CandidateDecision(action="allow", rule_name="only")
+        ])
+        assert result.winning_decision.rule_name == "only"
+        assert result.conflict_detected is False
+        assert result.candidates_evaluated == 1
+
+    def test_empty_candidates_raises(self):
+        resolver = PolicyConflictResolver()
+        with pytest.raises(ValueError, match="zero candidates"):
+            resolver.resolve([])
+
+    def test_resolution_trace_populated(self):
+        resolver = PolicyConflictResolver(ConflictResolutionStrategy.DENY_OVERRIDES)
+        result = resolver.resolve([
+            CandidateDecision(action="allow", priority=10, rule_name="a"),
+            CandidateDecision(action="deny", priority=5, rule_name="b"),
+        ])
+        assert len(result.resolution_trace) > 0
+        assert "DENY_OVERRIDES" in result.resolution_trace[0]
+
+
+# ── PolicyEngine integration tests ──────────────────────────
+
+
+class TestPolicyEngineConflictResolution:
+    """Test that PolicyEngine correctly delegates to the resolver."""
+
+    def _make_policy(self, name, rules, scope="global", agents=None):
+        return Policy(
+            name=name,
+            scope=scope,
+            agents=agents or ["*"],
+            rules=[PolicyRule(**r) for r in rules],
+            default_action="deny",
+        )
+
+    def test_default_strategy_is_priority_first_match(self):
+        engine = PolicyEngine()
+        assert engine._conflict_strategy == ConflictResolutionStrategy.PRIORITY_FIRST_MATCH
+
+    def test_deny_overrides_strategy(self):
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        # Global policy allows with high priority
+        engine.load_policy(self._make_policy("permissive", [
+            {"name": "allow-all", "condition": "action.type == 'read'", "action": "allow", "priority": 100},
+        ], scope="global"))
+        # Agent policy denies with low priority
+        engine.load_policy(self._make_policy("restrictive", [
+            {"name": "deny-reads", "condition": "action.type == 'read'", "action": "deny", "priority": 1},
+        ], scope="agent"))
+
+        result = engine.evaluate("agent-1", {"action": {"type": "read"}})
+        assert result.allowed is False
+        assert result.matched_rule == "deny-reads"
+
+    def test_allow_overrides_strategy(self):
+        engine = PolicyEngine(conflict_strategy="allow_overrides")
+        engine.load_policy(self._make_policy("restrictive", [
+            {"name": "deny-all", "condition": "action.type == 'write'", "action": "deny", "priority": 100},
+        ]))
+        engine.load_policy(self._make_policy("exception", [
+            {"name": "allow-write", "condition": "action.type == 'write'", "action": "allow", "priority": 1},
+        ]))
+
+        result = engine.evaluate("agent-1", {"action": {"type": "write"}})
+        assert result.allowed is True
+        assert result.matched_rule == "allow-write"
+
+    def test_most_specific_wins_strategy(self):
+        engine = PolicyEngine(conflict_strategy="most_specific_wins")
+        engine.load_policy(self._make_policy("global-deny", [
+            {"name": "block-shell", "condition": "tool == 'shell'", "action": "deny", "priority": 100},
+        ], scope="global"))
+        engine.load_policy(self._make_policy("agent-allow", [
+            {"name": "permit-shell", "condition": "tool == 'shell'", "action": "allow", "priority": 1},
+        ], scope="agent"))
+
+        result = engine.evaluate("agent-1", {"tool": "shell"})
+        assert result.allowed is True
+        assert result.matched_rule == "permit-shell"
+
+    def test_backward_compat_priority_first_match(self):
+        """Default strategy matches v1.0 behavior: highest priority wins."""
+        engine = PolicyEngine()
+        engine.load_policy(self._make_policy("p1", [
+            {"name": "high-deny", "condition": "action.type == 'export'", "action": "deny", "priority": 50},
+        ]))
+        engine.load_policy(self._make_policy("p2", [
+            {"name": "low-allow", "condition": "action.type == 'export'", "action": "allow", "priority": 10},
+        ]))
+
+        result = engine.evaluate("agent-1", {"action": {"type": "export"}})
+        assert result.allowed is False
+        assert result.matched_rule == "high-deny"
+
+    def test_no_matching_rules_uses_default(self):
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_policy(self._make_policy("strict", [
+            {"name": "r1", "condition": "never_matches", "action": "deny"},
+        ]))
+
+        result = engine.evaluate("agent-1", {"action": {"type": "read"}})
+        assert result.reason == "No matching rules, using default"
+
+    def test_policy_scope_in_yaml(self):
+        """Scope field survives YAML round-trip."""
+        yaml_content = """
+apiVersion: governance.toolkit/v1
+name: tenant-policy
+scope: tenant
+agents: ["*"]
+rules:
+  - name: tenant-rule
+    condition: "data.contains_pii"
+    action: deny
+    priority: 10
+"""
+        engine = PolicyEngine()
+        policy = engine.load_yaml(yaml_content)
+        assert policy.scope == "tenant"
+
+    def test_scope_defaults_to_global(self):
+        policy = Policy(name="test")
+        assert policy.scope == "global"


### PR DESCRIPTION
## Summary

Closes #91 — Declares an explicit, documented, and testable conflict resolution model for the policy engine.

### Problem
When multiple policies apply to the same agent action, the existing engine uses implicit priority-based first-match-wins with no declared precedence model. This is the hardest unsolved problem in every policy engine (XACML, OPA, Cedar) and was entirely undocumented.

### Solution

**New module: \conflict_resolution.py\**

4 conflict resolution strategies:

| Strategy | Behavior | Use Case |
|---|---|---|
| \DENY_OVERRIDES\ | Any deny wins, regardless of priority | Safety-critical (healthcare, finance) |
| \ALLOW_OVERRIDES\ | Any allow wins, regardless of priority | Exception-based governance |
| \PRIORITY_FIRST_MATCH\ | Highest priority rule wins (v1.0 default) | Backward compatibility |
| \MOST_SPECIFIC_WINS\ | Agent > Tenant > Global scope | Multi-tenant deployments |

**Policy scope field:**
- Added \scope\ to \Policy\ model: \global\, \	enant\, or \gent\
- Drives \MOST_SPECIFIC_WINS\ strategy; informational metadata for other strategies

**Resolution trace:**
- Every resolution produces a human-readable trace for audit/debug
- \conflict_detected\ flag indicates when genuinely conflicting decisions existed

### Breaking Changes
None. Default strategy is \PRIORITY_FIRST_MATCH\ which preserves v1.0 behavior. The \scope\ field defaults to \global\.

### Tests
- **25 new tests**: All 4 strategies, edge cases, engine integration, YAML round-trip
- **54 existing policy tests**: All pass unchanged