### PR TITLE
fix: update vulnerable dependencies — cryptography, langchain-core, pypdf

### DIFF
--- a/packages/agent-os/modules/caas/requirements.txt
+++ b/packages/agent-os/modules/caas/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.115.0,<1.0.0  # pinned
 uvicorn[standard]>=0.27.0,<1.0.0  # pinned
 pydantic>=2.5.0,<3.0.0  # pinned
-pypdf>=4.0.0,<5.0.0  # pinned
+pypdf>=6.0.0,<7.0.0  # pinned — CVE fix: multiple DoS/infinite-loop vulnerabilities
 beautifulsoup4>=4.12.2,<5.0.0  # pinned
 lxml>=4.9.3,<6.0.0  # pinned
 python-multipart>=0.0.22,<1.0.0  # pinned

--- a/packages/agent-os/modules/scak/requirements.txt
+++ b/packages/agent-os/modules/scak/requirements.txt
@@ -39,8 +39,8 @@ streamlit>=1.37.0,<2.0.0  # pinned: For telemetry dashboard
 jupyter>=1.0.0,<2.0.0  # pinned: For interactive notebooks
 
 # LangChain Integration
-langchain>=0.1.0,<1.0.0  # pinned: For LangChain integration
-langchain-core>=0.1.0,<1.0.0  # pinned: Core LangChain abstractions
+langchain>=0.3.0,<1.0.0  # pinned: For LangChain integration
+langchain-core>=1.2.11,<2.0.0  # pinned — CVE fix: SSRF via image_url token counting
 
 # Distributed Computing (uncomment as needed)
 # ray>=2.8.0  # For distributed execution

--- a/packages/agent-os/services/cloud-board/requirements.txt
+++ b/packages/agent-os/services/cloud-board/requirements.txt
@@ -22,7 +22,7 @@ pydantic>=2.5.0,<3.0.0  # pinned
 # aiocache>=0.12.0
 
 # Cryptography
-cryptography>=42.0.0,<45.0.0  # pinned
+cryptography>=46.0.5,<48.0.0  # pinned — CVE fix: subgroup attack on SECT curves
 pynacl>=1.5.0,<2.0.0  # pinned
 
 # Observability


### PR DESCRIPTION
## Summary

Updates 3 vulnerable dependencies to patched versions, resolving all 16 open Dependabot alerts.

### Changes
| Package | Old Range | New Range | Alerts Fixed | CVE |
|---------|-----------|-----------|-------------|-----|
| cryptography | >=42.0.0,<45.0.0 | >=46.0.5,<48.0.0 | #90 | Subgroup attack on SECT curves |
| langchain-core | >=0.1.0,<1.0.0 | >=1.2.11,<2.0.0 | #89 | SSRF via image_url token counting |
| pypdf | >=4.0.0,<5.0.0 | >=6.0.0,<7.0.0 | #75-#88 | 14 DoS/infinite-loop/RAM-exhaustion vulns |

### Files Changed
- packages/agent-os/services/cloud-board/requirements.txt
- packages/agent-os/modules/scak/requirements.txt
- packages/agent-os/modules/caas/requirements.txt