### PR TITLE
fix: pin all dependencies to exact versions for Scorecard compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install ruff
-        run: pip install --no-cache-dir 'ruff>=0.12,<1'
+        run: pip install --no-cache-dir ruff==0.12.4
       - name: Lint ${{ matrix.package }}
         run: ruff check packages/${{ matrix.package }}/src/ --select E,F,W --ignore E501
         continue-on-error: true
@@ -47,7 +47,7 @@ jobs:
         working-directory: packages/${{ matrix.package }}
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .
-          pip install --no-cache-dir 'pytest>=8,<9' 'pytest-asyncio>=1,<2' 2>/dev/null || true
+          pip install --no-cache-dir pytest==8.4.1 pytest-asyncio==1.1.0 2>/dev/null || true
       - name: Test ${{ matrix.package }}
         working-directory: packages/${{ matrix.package }}
         run: pytest tests/ -x -q --tb=short 2>/dev/null || echo "No tests found"
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install safety
-        run: pip install --no-cache-dir 'safety>=3,<4'
+        run: pip install --no-cache-dir safety==3.2.1
       - name: Check dependencies
         run: |
           for pkg in agent-os agent-mesh agent-hypervisor agent-sre agent-compliance; do

--- a/.github/workflows/policy-validation.yml
+++ b/.github/workflows/policy-validation.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: packages/agent-os
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .
-          pip install --no-cache-dir 'pyyaml>=6,<7'
+          pip install --no-cache-dir pyyaml==6.0.2
 
       - name: Find and validate policy files
         run: |
@@ -58,7 +58,7 @@ jobs:
         working-directory: packages/agent-os
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .
-          pip install --no-cache-dir 'pyyaml>=6,<7' 'pytest>=8,<9'
+          pip install --no-cache-dir pyyaml==6.0.2 pytest==8.4.1
 
       - name: Run policy CLI tests
         working-directory: packages/agent-os

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install build tools
-        run: pip install --no-cache-dir 'build>=1,<2'
+        run: pip install --no-cache-dir build==1.2.1
 
       - name: Build ${{ matrix.package }}
         working-directory: packages/${{ matrix.package }}

--- a/packages/agent-hypervisor/examples/docker-compose/Dockerfile
+++ b/packages/agent-hypervisor/examples/docker-compose/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install the hypervisor package and API dependencies (pinned for reproducibility)
 RUN pip install --no-cache-dir \
-    "agent-hypervisor[api]>=0.1.0,<1.0.0" \
+    "agent-hypervisor[api]==0.1.0" \
     redis==5.2.1 \
     pyyaml==6.0.2 \
     httpx==0.28.1

--- a/packages/agent-os/extensions/github-cli/gh-agent-os
+++ b/packages/agent-os/extensions/github-cli/gh-agent-os
@@ -30,7 +30,7 @@ case "$COMMAND" in
     # Check if agent-os is installed
     if ! python -c "import agent_os" 2>/dev/null; then
       echo "Installing agent-os..."
-      pip install --no-cache-dir "agent-os>=0.1.0,<2" --quiet
+      pip install --no-cache-dir "agent-os==0.1.0" --quiet
     fi
     
     python -c "

--- a/packages/agent-os/modules/caas/requirements.txt
+++ b/packages/agent-os/modules/caas/requirements.txt
@@ -1,11 +1,11 @@
-fastapi>=0.115.0,<1.0.0  # pinned
-uvicorn[standard]>=0.27.0,<1.0.0  # pinned
-pydantic>=2.5.0,<3.0.0  # pinned
-pypdf>=6.0.0,<7.0.0  # pinned — CVE fix: multiple DoS/infinite-loop vulnerabilities
-beautifulsoup4>=4.12.2,<5.0.0  # pinned
-lxml>=4.9.3,<6.0.0  # pinned
-python-multipart>=0.0.22,<1.0.0  # pinned
-tiktoken>=0.5.1,<1.0.0  # pinned
-numpy>=1.26.2,<2.0.0  # pinned
-scikit-learn>=1.6.1,<2.0.0  # pinned
-aiofiles>=23.2.1,<24.0.0  # pinned
+fastapi==0.115.0
+uvicorn[standard]==0.27.0
+pydantic==2.10.3
+pypdf==6.0.0  # CVE fix: multiple DoS/infinite-loop vulnerabilities
+beautifulsoup4==4.12.2
+lxml==5.3.0
+python-multipart==0.0.22
+tiktoken==0.8.0
+numpy==1.26.4
+scikit-learn==1.6.1
+aiofiles==23.2.1

--- a/packages/agent-os/modules/cmvk/requirements.txt
+++ b/packages/agent-os/modules/cmvk/requirements.txt
@@ -4,10 +4,10 @@
 # Last updated: 2026-01-23
 
 # Core dependencies (allowed only)
-numpy>=1.24.0,<2.0.0  # pinned
+numpy==1.26.4
 
 # Optional: Enhanced statistical functions
-scipy>=1.11.0,<2.0.0  # pinned
+scipy==1.14.0
 docker==7.1.0
 
 # For Hugging Face dataset upload (optional)

--- a/packages/agent-os/modules/iatp/requirements.txt
+++ b/packages/agent-os/modules/iatp/requirements.txt
@@ -1,6 +1,6 @@
-fastapi>=0.109.1,<1.0.0  # pinned
+fastapi==0.115.0
 uvicorn==0.27.0
 pydantic==2.5.3
 httpx==0.26.0
 python-dateutil==2.8.2
-agent-primitives>=0.1.0,<1.0.0  # pinned
+agent-primitives==0.1.0

--- a/packages/agent-os/modules/scak/requirements.txt
+++ b/packages/agent-os/modules/scak/requirements.txt
@@ -3,9 +3,9 @@
 # =============================================================================
 
 # Core Dependencies (required)
-pydantic>=2.0.0,<3.0.0  # pinned
-pyyaml>=6.0,<7.0.0  # pinned
-agent-primitives>=0.1.0,<1.0.0  # pinned: Layer 1: Shared failure models
+pydantic==2.10.3
+pyyaml==6.0.2
+agent-primitives==0.1.0  # Layer 1: Shared failure models
 
 # =============================================================================
 # Layer 4 Integration Dependencies (optional)
@@ -21,26 +21,26 @@ agent-primitives>=0.1.0,<1.0.0  # pinned: Layer 1: Shared failure models
 # LLM Client Dependencies (optional)
 # =============================================================================
 # For Shadow Teacher and production LLM calls
-openai>=1.0.0,<2.0.0  # pinned: For OpenAI API integration
-anthropic>=0.7.0,<1.0.0  # pinned: For Claude API integration
+openai==1.58.0  # For OpenAI API integration
+anthropic==0.39.0  # For Claude API integration
 
 # =============================================================================
 # Testing and Development
 # =============================================================================
-pytest>=7.4.0,<9.0.0  # pinned
-pytest-asyncio>=0.21.0,<1.0.0  # pinned
+pytest==8.4.1
+pytest-asyncio==1.1.0
 
 # =============================================================================
 # Optional Dependencies
 # =============================================================================
 
 # Visualization and Developer Tools
-streamlit>=1.37.0,<2.0.0  # pinned: For telemetry dashboard
-jupyter>=1.0.0,<2.0.0  # pinned: For interactive notebooks
+streamlit==1.41.0  # For telemetry dashboard
+jupyter==1.1.1  # For interactive notebooks
 
 # LangChain Integration
-langchain>=0.3.0,<1.0.0  # pinned: For LangChain integration
-langchain-core>=1.2.11,<2.0.0  # pinned — CVE fix: SSRF via image_url token counting
+langchain==0.3.14  # For LangChain integration
+langchain-core==1.2.11  # CVE fix: SSRF via image_url token counting
 
 # Distributed Computing (uncomment as needed)
 # ray>=2.8.0  # For distributed execution

--- a/packages/agent-os/scripts/quickstart.sh
+++ b/packages/agent-os/scripts/quickstart.sh
@@ -21,7 +21,7 @@ echo "✅ Found Python $PYTHON_VERSION"
 # Install Agent OS
 echo ""
 echo "📦 Installing Agent OS..."
-pip3 install --no-cache-dir --quiet "agent-os>=0.1.0,<2"
+pip3 install --no-cache-dir --quiet "agent-os==0.1.0"
 
 echo "✅ Agent OS installed"
 

--- a/packages/agent-os/services/cloud-board/requirements.txt
+++ b/packages/agent-os/services/cloud-board/requirements.txt
@@ -2,15 +2,15 @@
 # Requirements for the Agent Trust Exchange
 
 # Web Framework
-fastapi>=0.109.0,<1.0.0  # pinned
-uvicorn[standard]>=0.27.0,<1.0.0  # pinned
+fastapi==0.115.0
+uvicorn[standard]==0.27.1
 
 # Async HTTP
-aiohttp>=3.13.3,<4.0.0  # pinned
-httpx>=0.26.0,<1.0.0  # pinned
+aiohttp==3.13.3
+httpx==0.27.0
 
 # Data Validation
-pydantic>=2.5.0,<3.0.0  # pinned
+pydantic==2.10.3
 
 # Database (production)
 # asyncpg>=0.29.0
@@ -22,22 +22,21 @@ pydantic>=2.5.0,<3.0.0  # pinned
 # aiocache>=0.12.0
 
 # Cryptography
-cryptography>=46.0.5,<48.0.0  # pinned — CVE fix: subgroup attack on SECT curves
-pynacl>=1.5.0,<2.0.0  # pinned
+cryptography==46.0.5  # CVE fix: subgroup attack on SECT curves
+pynacl==1.5.0
 
 # Observability
-opentelemetry-api>=1.22.0,<2.0.0  # pinned
-opentelemetry-sdk>=1.22.0,<2.0.0  # pinned
-opentelemetry-instrumentation-fastapi>=0.43b0,<1.0  # pinned
-structlog>=24.1.0,<25.0.0  # pinned
+opentelemetry-api==1.29.0
+opentelemetry-sdk==1.29.0
+opentelemetry-instrumentation-fastapi==0.50b0
+structlog==24.4.0
 
 # Testing
-pytest>=7.4.0,<9.0.0  # pinned
-pytest-asyncio>=0.23.0,<1.0.0  # pinned
-pytest-cov>=4.1.0,<6.0.0  # pinned
-httpx>=0.26.0,<1.0.0  # pinned
+pytest==8.4.1
+pytest-asyncio==1.1.0
+pytest-cov==5.0.0
 
 # Development
-black>=24.3.0,<25.0.0  # pinned
-ruff>=0.1.0,<1.0.0  # pinned
-mypy>=1.8.0,<2.0.0  # pinned
+black==24.10.0
+ruff==0.12.4
+mypy==1.14.0


### PR DESCRIPTION
## Summary

Converts all pip dependency version ranges to exact == pins for OpenSSF Scorecard PinnedDependenciesID compliance.

### Changes

**CI Workflows (3 files)**
- ci.yml: ruff==0.12.4, pytest==8.4.1, pytest-asyncio==1.1.0, safety==3.2.1
- publish.yml: build==1.2.1
- policy-validation.yml: pyyaml==6.0.2, pytest==8.4.1

**Requirements.txt (5 files)**
- caas: 11 packages pinned (fastapi, uvicorn, pydantic, pypdf, numpy, etc.)
- cmvk: 2 packages pinned (numpy, scipy)
- scak: 11 packages pinned (pydantic, pyyaml, openai, langchain-core, etc.)
- iatp: 2 packages pinned (fastapi, agent-primitives)
- cloud-board: 14 packages pinned (cryptography, aiohttp, otel, structlog, etc.)

**Dockerfiles and Scripts (3 files)**
- agent-hypervisor Dockerfile: agent-hypervisor[api]==0.1.0
- quickstart.sh, gh-agent-os: agent-os==0.1.0

### Remaining Alerts (unfixable via code)
- pip install -e . (local editable installs) - inherently unpinnable
- 6 repo-level alerts (BranchProtection, CII, CodeReview, Fuzzing, Maintained, SAST)