### PR TITLE
docs: expand quickstart guide and enhance verification script

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,8 +1,139 @@
-# 10-Minute Quick Start Guide
+# 🚀 10-Minute Quick Start Guide
 
-Setup and verify your agent governance stack.
+Get from zero to governed AI agents in under 10 minutes.
+
+> **Prerequisites:** Python 3.10+ and pip installed.
 
 ## 1. Installation
-Install the core toolkit and dependencies:
+
+Install the governance toolkit:
+
 ```bash
-pip install -r requirements.txt
+pip install ai-agent-compliance[full]
+```
+
+Or install individual packages:
+
+```bash
+pip install agent-os-kernel        # Policy enforcement + framework integrations
+pip install agentmesh-platform     # Zero-trust identity + trust cards
+pip install ai-agent-compliance    # OWASP ASI verification + integrity CLI
+pip install agent-sre              # SLOs, error budgets, chaos testing
+pip install agent-hypervisor       # Execution sandboxing + privilege rings
+```
+
+## 2. Verify Your Installation
+
+Run the included verification script:
+
+```bash
+python scripts/check_gov.py
+```
+
+Or use the governance CLI directly:
+
+```bash
+agent-compliance verify
+agent-compliance verify --badge
+```
+
+## 3. Your First Governed Agent
+
+Create a file called `governed_agent.py`:
+
+```python
+from agent_os.policy import PolicyEngine, CapabilityModel, PolicyScope
+
+# Define what your agent is allowed to do
+capabilities = CapabilityModel(
+    allowed_tools=["web_search", "read_file", "send_email"],
+    blocked_tools=["execute_code", "delete_file"],
+    blocked_patterns=[r"\b\d{3}-\d{2}-\d{4}\b"],  # Block SSN patterns
+    require_human_approval=True,
+    max_tool_calls=10,
+)
+
+# Create a policy engine
+engine = PolicyEngine(capabilities=capabilities)
+
+# Every agent action goes through the policy engine
+result = engine.evaluate(action="web_search", input_text="latest AI news")
+print(f"Action allowed: {result.allowed}")
+print(f"Reason: {result.reason}")
+
+# This will be blocked
+result = engine.evaluate(action="delete_file", input_text="/etc/passwd")
+print(f"Action allowed: {result.allowed}")  # False
+print(f"Reason: {result.reason}")           # "Tool 'delete_file' is blocked"
+```
+
+Run it:
+
+```bash
+python governed_agent.py
+```
+
+## 4. Wrap an Existing Framework
+
+The toolkit integrates with all major agent frameworks. Here's a LangChain example:
+
+```python
+from agent_os import KernelSpace
+from agent_os.policy import CapabilityModel
+
+# Initialize with governance
+kernel = KernelSpace(
+    capabilities=CapabilityModel(
+        allowed_tools=["web_search", "calculator"],
+        max_tool_calls=5,
+    )
+)
+
+# Wrap your LangChain agent — every tool call is now governed
+governed_agent = kernel.wrap(your_langchain_agent)
+```
+
+Supported frameworks: **LangChain**, **OpenAI Agents SDK**, **AutoGen**, **CrewAI**,
+**Google ADK**, **Semantic Kernel**, **LlamaIndex**, **Anthropic**, **Mistral**, **Gemini**, and more.
+
+## 5. Check OWASP ASI 2026 Coverage
+
+Verify your deployment covers the OWASP Agentic Security Threats:
+
+```bash
+# Text summary
+agent-compliance verify
+
+# JSON for CI/CD pipelines
+agent-compliance verify --json
+
+# Badge for your README
+agent-compliance verify --badge
+```
+
+## 6. Verify Module Integrity
+
+Ensure no governance modules have been tampered with:
+
+```bash
+# Generate a baseline integrity manifest
+agent-compliance integrity --generate integrity.json
+
+# Verify against the manifest later
+agent-compliance integrity --manifest integrity.json
+```
+
+## Next Steps
+
+| What | Where |
+|------|-------|
+| Full API reference | [packages/agent-os/README.md](packages/agent-os/README.md) |
+| OWASP coverage map | [docs/OWASP-COMPLIANCE.md](docs/OWASP-COMPLIANCE.md) |
+| Framework integrations | [packages/agent-os/src/agent_os/integrations/](packages/agent-os/src/agent_os/integrations/) |
+| Example applications | [packages/agent-os/examples/](packages/agent-os/examples/) |
+| Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Changelog | [CHANGELOG.md](CHANGELOG.md) |
+
+---
+
+*Based on the initial quickstart contribution by [@davidequarracino](https://github.com/davidequarracino) ([#106](https://github.com/microsoft/agent-governance-toolkit/pull/106)).*

--- a/scripts/check_gov.py
+++ b/scripts/check_gov.py
@@ -1,17 +1,86 @@
-import cryptography
-import langchain_core
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Governance stack installation checker.
+
+Validates that the Agent Governance Toolkit core packages and
+critical dependencies are installed and importable.
+
+Usage:
+    python scripts/check_gov.py
+"""
+
 import sys
 
-def verify_installation():
-    print("--- Agent Governance Toolkit: Installation Check ---")
+
+def _check(label: str, import_path: str) -> bool:
+    """Try to import a module and report success/failure."""
     try:
-        # Verifichiamo le dipendenze critiche aggiornate da Imran (Issue #103, #104)
-        print(f"[OK] Cryptography version: {cryptography.__version__}")
-        print(f"[OK] Langchain-Core version: {langchain_core.__version__}")
-        print("[SUCCESS] Governance stack is ready.")
-    except Exception as e:
-        print(f"[ERROR] Stack verification failed: {e}")
-        sys.exit(1)
+        mod = __import__(import_path)
+        version = getattr(mod, "__version__", "ok")
+        print(f"  ✅  {label:.<40s} {version}")
+        return True
+    except ImportError:
+        print(f"  ❌  {label:.<40s} not installed")
+        return False
+
+
+def verify_installation() -> int:
+    """Check all governance toolkit packages and critical dependencies."""
+    print()
+    print("╔══════════════════════════════════════════════════════╗")
+    print("║   Agent Governance Toolkit — Installation Check     ║")
+    print("╚══════════════════════════════════════════════════════╝")
+    print()
+
+    results: list[bool] = []
+
+    # Core packages
+    print("Core Packages:")
+    results.append(_check("agent-os-kernel", "agent_os"))
+    results.append(_check("agentmesh-platform", "agentmesh"))
+    results.append(_check("ai-agent-compliance", "agent_compliance"))
+    results.append(_check("agent-sre", "agent_sre"))
+    print()
+
+    # Critical security dependencies
+    print("Security Dependencies:")
+    results.append(_check("cryptography", "cryptography"))
+    results.append(_check("pynacl", "nacl"))
+    print()
+
+    # AI/ML dependencies
+    print("AI/ML Dependencies:")
+    _check("langchain-core", "langchain_core")  # optional
+    _check("openai", "openai")  # optional
+    print()
+
+    # Governance CLI
+    print("Governance CLI:")
+    try:
+        from agent_compliance.cli.main import cmd_verify  # noqa: F401
+        print("  ✅  agent-compliance verify............ available")
+        results.append(True)
+    except ImportError:
+        print("  ❌  agent-compliance verify............ not available")
+        results.append(False)
+    print()
+
+    passed = sum(results)
+    total = len(results)
+    status = "READY" if all(results) else "INCOMPLETE"
+
+    print(f"Result: {passed}/{total} checks passed — {status}")
+    print()
+
+    if not all(results):
+        print("To install missing packages:")
+        print("  pip install ai-agent-compliance[full]")
+        print()
+        return 1
+
+    return 0
+
 
 if __name__ == "__main__":
-    verify_installation()
+    sys.exit(verify_installation())


### PR DESCRIPTION
## Summary

Expands the quickstart guide and verification script from #106 (our first community contribution by @davidequarracino) into a comprehensive 10-minute tutorial.

### QUICKSTART.md (8 lines -> 120 lines)
- Full 6-section tutorial: Install, Verify, First Policy, Framework Wrapping, OWASP Check, Integrity
- Real pip install commands matching our published PyPI packages
- Working code examples with PolicyEngine and KernelSpace
- Next steps table linking to all key docs
- Attribution to the original contributor

### scripts/check_gov.py (17 lines -> 85 lines)
- Checks all 4 core packages + security deps + optional AI/ML deps
- Verifies governance CLI availability
- Proper exit codes (0=ready, 1=incomplete) for CI usage
- Visual formatting with pass/fail indicators

Builds on #106 | Partially addresses #47