### PR TITLE
feat: add .NET governance SDK for Microsoft Agent Framework integration

### DIFF
--- a/packages/agent-governance-dotnet/AgentGovernance.sln
+++ b/packages/agent-governance-dotnet/AgentGovernance.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentGovernance", "src\AgentGovernance\AgentGovernance.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentGovernance.Tests", "tests\AgentGovernance.Tests\AgentGovernance.Tests.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/packages/agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>AgentGovernance</RootNamespace>
+    <AssemblyName>AgentGovernance</AssemblyName>
+    <Version>1.0.0</Version>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft</Company>
+    <Description>Agent Governance Toolkit — .NET SDK for policy enforcement, zero-trust identity, and audit logging for autonomous AI agents. Compatible with Microsoft Agent Framework.</Description>
+    <PackageId>Microsoft.AgentGovernance</PackageId>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>ai;agents;governance;security;policy;owasp</PackageTags>
+    <RepositoryUrl>https://github.com/microsoft/agent-governance-toolkit</RepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Audit/AuditEmitter.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Audit/AuditEmitter.cs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+
+namespace AgentGovernance.Audit;
+
+/// <summary>
+/// Thread-safe pub-sub audit event system for the governance engine.
+/// Consumers subscribe to specific <see cref="GovernanceEventType"/> values
+/// and receive callbacks when matching events are emitted.
+/// </summary>
+public sealed class AuditEmitter
+{
+    /// <summary>
+    /// Handlers registered per event type.
+    /// </summary>
+    private readonly ConcurrentDictionary<GovernanceEventType, ConcurrentBag<Action<GovernanceEvent>>> _handlers = new();
+
+    /// <summary>
+    /// Wildcard handlers that receive all events regardless of type.
+    /// </summary>
+    private readonly ConcurrentBag<Action<GovernanceEvent>> _wildcardHandlers = new();
+
+    /// <summary>
+    /// Subscribes a handler to a specific governance event type.
+    /// </summary>
+    /// <param name="type">The event type to listen for.</param>
+    /// <param name="handler">The callback to invoke when a matching event is emitted.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="handler"/> is <c>null</c>.</exception>
+    public void On(GovernanceEventType type, Action<GovernanceEvent> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var bag = _handlers.GetOrAdd(type, _ => new ConcurrentBag<Action<GovernanceEvent>>());
+        bag.Add(handler);
+    }
+
+    /// <summary>
+    /// Subscribes a handler that receives all governance events (wildcard subscription).
+    /// </summary>
+    /// <param name="handler">The callback to invoke for every emitted event.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="handler"/> is <c>null</c>.</exception>
+    public void OnAll(Action<GovernanceEvent> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        _wildcardHandlers.Add(handler);
+    }
+
+    /// <summary>
+    /// Emits a pre-constructed <see cref="GovernanceEvent"/> to all matching subscribers.
+    /// </summary>
+    /// <param name="governanceEvent">The event to emit.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="governanceEvent"/> is <c>null</c>.</exception>
+    public void Emit(GovernanceEvent governanceEvent)
+    {
+        ArgumentNullException.ThrowIfNull(governanceEvent);
+
+        // Notify type-specific handlers.
+        if (_handlers.TryGetValue(governanceEvent.Type, out var handlers))
+        {
+            foreach (var handler in handlers)
+            {
+                InvokeSafe(handler, governanceEvent);
+            }
+        }
+
+        // Notify wildcard handlers.
+        foreach (var handler in _wildcardHandlers)
+        {
+            InvokeSafe(handler, governanceEvent);
+        }
+    }
+
+    /// <summary>
+    /// Constructs and emits a <see cref="GovernanceEvent"/> from individual parameters.
+    /// This is a convenience overload for callers that don't need to pre-build the event.
+    /// </summary>
+    /// <param name="type">The event type.</param>
+    /// <param name="agentId">The agent's DID.</param>
+    /// <param name="sessionId">The session identifier.</param>
+    /// <param name="data">Optional data dictionary to attach to the event.</param>
+    /// <param name="policyName">Optional name of the policy that triggered this event.</param>
+    public void Emit(
+        GovernanceEventType type,
+        string agentId,
+        string sessionId,
+        Dictionary<string, object>? data = null,
+        string? policyName = null)
+    {
+        var governanceEvent = new GovernanceEvent
+        {
+            Type = type,
+            AgentId = agentId,
+            SessionId = sessionId,
+            Data = data ?? new Dictionary<string, object>(),
+            PolicyName = policyName
+        };
+
+        Emit(governanceEvent);
+    }
+
+    /// <summary>
+    /// Returns the number of handlers registered for a specific event type.
+    /// Useful for diagnostics and testing.
+    /// </summary>
+    /// <param name="type">The event type to query.</param>
+    /// <returns>The number of registered handlers (excludes wildcard handlers).</returns>
+    public int HandlerCount(GovernanceEventType type)
+    {
+        return _handlers.TryGetValue(type, out var handlers) ? handlers.Count : 0;
+    }
+
+    /// <summary>
+    /// Returns the total number of wildcard handlers registered.
+    /// </summary>
+    public int WildcardHandlerCount => _wildcardHandlers.Count;
+
+    /// <summary>
+    /// Safely invokes a handler, catching and swallowing any exceptions
+    /// to prevent one faulty handler from disrupting other subscribers.
+    /// </summary>
+    private static void InvokeSafe(Action<GovernanceEvent> handler, GovernanceEvent governanceEvent)
+    {
+        try
+        {
+            handler(governanceEvent);
+        }
+        catch
+        {
+            // Swallow handler exceptions to maintain event bus stability.
+            // In production, consider logging handler errors.
+        }
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Audit/GovernanceEvent.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Audit/GovernanceEvent.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace AgentGovernance.Audit;
+
+/// <summary>
+/// Types of governance events emitted during agent operations.
+/// </summary>
+public enum GovernanceEventType
+{
+    /// <summary>A policy check was performed.</summary>
+    PolicyCheck,
+
+    /// <summary>A policy violation was detected (request denied).</summary>
+    PolicyViolation,
+
+    /// <summary>A tool call was blocked by the governance engine.</summary>
+    ToolCallBlocked,
+
+    /// <summary>A governance checkpoint was created.</summary>
+    CheckpointCreated,
+
+    /// <summary>A configuration or policy drift was detected.</summary>
+    DriftDetected,
+
+    /// <summary>An agent identity was verified.</summary>
+    TrustVerified,
+
+    /// <summary>An agent identity verification failed.</summary>
+    TrustFailed,
+
+    /// <summary>An agent was registered in the governance system.</summary>
+    AgentRegistered
+}
+
+/// <summary>
+/// Represents a single governance event emitted by the governance engine
+/// or its components. Events are used for audit logging, monitoring,
+/// and triggering downstream reactions via the <see cref="AuditEmitter"/>.
+/// </summary>
+public sealed class GovernanceEvent
+{
+    /// <summary>
+    /// The type of governance event.
+    /// </summary>
+    public GovernanceEventType Type { get; init; }
+
+    /// <summary>
+    /// UTC timestamp of when the event occurred.
+    /// </summary>
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// The decentralised identifier of the agent involved (e.g., "did:mesh:abc123").
+    /// </summary>
+    public required string AgentId { get; init; }
+
+    /// <summary>
+    /// The session identifier for correlating events within a single agent session.
+    /// </summary>
+    public required string SessionId { get; init; }
+
+    /// <summary>
+    /// The name of the policy that produced this event, if applicable.
+    /// </summary>
+    public string? PolicyName { get; init; }
+
+    /// <summary>
+    /// A unique identifier for this event instance.
+    /// </summary>
+    public string EventId { get; init; } = $"evt-{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Arbitrary data associated with this event.
+    /// Keys and values depend on the <see cref="Type"/>.
+    /// </summary>
+    public Dictionary<string, object> Data { get; init; } = new();
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        $"[{Timestamp:O}] {Type} agent={AgentId} session={SessionId} policy={PolicyName ?? "(none)"}";
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/GovernanceKernel.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/GovernanceKernel.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Audit;
+using AgentGovernance.Integration;
+using AgentGovernance.Policy;
+
+namespace AgentGovernance;
+
+/// <summary>
+/// Configuration options for the <see cref="GovernanceKernel"/>.
+/// </summary>
+public sealed class GovernanceOptions
+{
+    /// <summary>
+    /// List of file paths to YAML policy files to load at initialisation.
+    /// </summary>
+    public List<string> PolicyPaths { get; init; } = new();
+
+    /// <summary>
+    /// The conflict resolution strategy for the policy engine.
+    /// Defaults to <see cref="ConflictResolutionStrategy.PriorityFirstMatch"/>.
+    /// </summary>
+    public ConflictResolutionStrategy ConflictStrategy { get; init; } =
+        ConflictResolutionStrategy.PriorityFirstMatch;
+
+    /// <summary>
+    /// Whether to enable audit event emission.
+    /// When <c>false</c>, the <see cref="AuditEmitter"/> is still created but events
+    /// are not emitted from the middleware. Defaults to <c>true</c>.
+    /// </summary>
+    public bool EnableAudit { get; init; } = true;
+}
+
+/// <summary>
+/// Main entry point and facade for the Agent Governance system.
+/// Provides a simplified API that wires together the <see cref="PolicyEngine"/>,
+/// <see cref="AuditEmitter"/>, and <see cref="GovernanceMiddleware"/>.
+/// </summary>
+/// <remarks>
+/// <b>Quick start:</b>
+/// <code>
+/// var kernel = new GovernanceKernel(new GovernanceOptions
+/// {
+///     PolicyPaths = new() { "policies/default.yaml" },
+///     ConflictStrategy = ConflictResolutionStrategy.DenyOverrides
+/// });
+///
+/// var result = kernel.EvaluateToolCall("did:mesh:abc123", "file_write", new() { ["path"] = "/etc" });
+/// if (!result.Allowed)
+/// {
+///     Console.WriteLine($"Blocked: {result.Reason}");
+/// }
+/// </code>
+/// </remarks>
+public sealed class GovernanceKernel
+{
+    /// <summary>
+    /// The policy evaluation engine used by this kernel.
+    /// </summary>
+    public PolicyEngine PolicyEngine { get; }
+
+    /// <summary>
+    /// The audit event emitter used by this kernel.
+    /// </summary>
+    public AuditEmitter AuditEmitter { get; }
+
+    /// <summary>
+    /// The governance middleware that integrates the policy engine with agent tool calls.
+    /// </summary>
+    public GovernanceMiddleware Middleware { get; }
+
+    /// <summary>
+    /// Whether audit events are enabled.
+    /// </summary>
+    public bool AuditEnabled { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="GovernanceKernel"/> with optional configuration.
+    /// Loads any policy files specified in <see cref="GovernanceOptions.PolicyPaths"/>.
+    /// </summary>
+    /// <param name="options">
+    /// Configuration options. When <c>null</c>, uses default settings.
+    /// </param>
+    public GovernanceKernel(GovernanceOptions? options = null)
+    {
+        var opts = options ?? new GovernanceOptions();
+
+        PolicyEngine = new PolicyEngine
+        {
+            ConflictStrategy = opts.ConflictStrategy
+        };
+
+        AuditEmitter = new AuditEmitter();
+        AuditEnabled = opts.EnableAudit;
+        Middleware = new GovernanceMiddleware(PolicyEngine, AuditEmitter);
+
+        // Load any initial policy files.
+        foreach (var path in opts.PolicyPaths)
+        {
+            PolicyEngine.LoadYamlFile(path);
+        }
+    }
+
+    /// <summary>
+    /// Loads a governance policy from a YAML file.
+    /// </summary>
+    /// <param name="yamlPath">Path to the YAML policy file.</param>
+    public void LoadPolicy(string yamlPath)
+    {
+        PolicyEngine.LoadYamlFile(yamlPath);
+    }
+
+    /// <summary>
+    /// Loads a governance policy from a YAML string.
+    /// </summary>
+    /// <param name="yaml">YAML content representing a policy document.</param>
+    public void LoadPolicyFromYaml(string yaml)
+    {
+        PolicyEngine.LoadYaml(yaml);
+    }
+
+    /// <summary>
+    /// Evaluates whether a tool call is permitted under the current governance policies.
+    /// This is the primary method agents should call before executing any tool.
+    /// </summary>
+    /// <param name="agentId">The DID of the agent requesting the tool call.</param>
+    /// <param name="toolName">The name of the tool being called.</param>
+    /// <param name="args">Optional arguments to the tool call.</param>
+    /// <returns>A <see cref="ToolCallResult"/> indicating whether the call is allowed.</returns>
+    public ToolCallResult EvaluateToolCall(
+        string agentId,
+        string toolName,
+        Dictionary<string, object>? args = null)
+    {
+        return Middleware.EvaluateToolCall(agentId, toolName, args);
+    }
+
+    /// <summary>
+    /// Subscribes to a specific governance event type.
+    /// </summary>
+    /// <param name="type">The event type to listen for.</param>
+    /// <param name="handler">The callback to invoke when a matching event is emitted.</param>
+    public void OnEvent(GovernanceEventType type, Action<GovernanceEvent> handler)
+    {
+        AuditEmitter.On(type, handler);
+    }
+
+    /// <summary>
+    /// Subscribes to all governance events (wildcard).
+    /// </summary>
+    /// <param name="handler">The callback to invoke for every emitted event.</param>
+    public void OnAllEvents(Action<GovernanceEvent> handler)
+    {
+        AuditEmitter.OnAll(handler);
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Integration/GovernanceMiddleware.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Integration/GovernanceMiddleware.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Audit;
+using AgentGovernance.Policy;
+
+namespace AgentGovernance.Integration;
+
+/// <summary>
+/// The result of evaluating a tool call through the governance middleware.
+/// </summary>
+public sealed class ToolCallResult
+{
+    /// <summary>
+    /// Whether the tool call is allowed to proceed.
+    /// </summary>
+    public bool Allowed { get; init; }
+
+    /// <summary>
+    /// Human-readable reason for the decision.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    /// <summary>
+    /// The governance event generated for this evaluation (for audit logging).
+    /// </summary>
+    public required GovernanceEvent AuditEntry { get; init; }
+
+    /// <summary>
+    /// The underlying policy decision, if available.
+    /// </summary>
+    public PolicyDecision? PolicyDecision { get; init; }
+}
+
+/// <summary>
+/// Middleware for integrating the governance engine with the Microsoft Agent Framework.
+/// Agents call <see cref="EvaluateToolCall"/> before executing any tool to enforce
+/// governance policies and emit audit events.
+/// </summary>
+/// <remarks>
+/// <b>Usage with Microsoft Agent Framework:</b>
+/// <code>
+/// var middleware = new GovernanceMiddleware(engine, emitter);
+/// var result = middleware.EvaluateToolCall("did:mesh:abc123", "file_write", new() { ["path"] = "/etc/config" });
+/// if (!result.Allowed)
+/// {
+///     // Block the tool call and log the reason.
+///     logger.Warn(result.Reason);
+///     return;
+/// }
+/// // Proceed with the tool call.
+/// </code>
+/// </remarks>
+public sealed class GovernanceMiddleware
+{
+    private readonly PolicyEngine _policyEngine;
+    private readonly AuditEmitter _auditEmitter;
+
+    /// <summary>
+    /// Initializes a new <see cref="GovernanceMiddleware"/> instance.
+    /// </summary>
+    /// <param name="policyEngine">The policy engine to evaluate requests against.</param>
+    /// <param name="auditEmitter">The audit emitter for publishing governance events.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="policyEngine"/> or <paramref name="auditEmitter"/> is <c>null</c>.
+    /// </exception>
+    public GovernanceMiddleware(PolicyEngine policyEngine, AuditEmitter auditEmitter)
+    {
+        ArgumentNullException.ThrowIfNull(policyEngine);
+        ArgumentNullException.ThrowIfNull(auditEmitter);
+
+        _policyEngine = policyEngine;
+        _auditEmitter = auditEmitter;
+    }
+
+    /// <summary>
+    /// Evaluates whether a tool call is permitted under the current governance policies.
+    /// Emits the appropriate audit events.
+    /// </summary>
+    /// <param name="agentId">The DID of the agent requesting the tool call.</param>
+    /// <param name="toolName">The name of the tool being called (e.g., "file_write", "http_request").</param>
+    /// <param name="arguments">Optional arguments to the tool call, exposed to policy conditions.</param>
+    /// <returns>A <see cref="ToolCallResult"/> indicating whether the call is allowed and why.</returns>
+    public ToolCallResult EvaluateToolCall(
+        string agentId,
+        string toolName,
+        Dictionary<string, object>? arguments = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(agentId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
+
+        // Build the evaluation context from the tool call parameters.
+        var context = BuildContext(agentId, toolName, arguments);
+
+        // Generate a session ID for correlating audit events.
+        var sessionId = $"session-{Guid.NewGuid():N}"[..24];
+
+        // Evaluate against the policy engine.
+        var decision = _policyEngine.Evaluate(agentId, context);
+
+        // Determine event type based on the decision.
+        var eventType = decision.Allowed
+            ? GovernanceEventType.PolicyCheck
+            : GovernanceEventType.ToolCallBlocked;
+
+        // Build the audit event.
+        var auditEvent = new GovernanceEvent
+        {
+            Type = eventType,
+            AgentId = agentId,
+            SessionId = sessionId,
+            PolicyName = decision.MatchedRule,
+            Data = new Dictionary<string, object>
+            {
+                ["tool_name"] = toolName,
+                ["allowed"] = decision.Allowed,
+                ["action"] = decision.Action,
+                ["reason"] = decision.Reason,
+                ["evaluation_ms"] = decision.EvaluationMs
+            }
+        };
+
+        // Add arguments to audit data if present.
+        if (arguments is not null)
+        {
+            auditEvent.Data["arguments"] = arguments;
+        }
+
+        // Emit the audit event.
+        _auditEmitter.Emit(auditEvent);
+
+        // If denied, also emit a PolicyViolation event.
+        if (!decision.Allowed)
+        {
+            _auditEmitter.Emit(
+                GovernanceEventType.PolicyViolation,
+                agentId,
+                sessionId,
+                new Dictionary<string, object>
+                {
+                    ["tool_name"] = toolName,
+                    ["matched_rule"] = decision.MatchedRule ?? "(default deny)",
+                    ["reason"] = decision.Reason
+                },
+                decision.MatchedRule);
+        }
+
+        return new ToolCallResult
+        {
+            Allowed = decision.Allowed,
+            Reason = decision.Reason,
+            AuditEntry = auditEvent,
+            PolicyDecision = decision
+        };
+    }
+
+    /// <summary>
+    /// Builds the evaluation context dictionary from tool call parameters.
+    /// The context includes the tool name, agent ID, and any additional arguments
+    /// so that policy conditions can reference them.
+    /// </summary>
+    private static Dictionary<string, object> BuildContext(
+        string agentId,
+        string toolName,
+        Dictionary<string, object>? arguments)
+    {
+        var context = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["tool_name"] = toolName,
+            ["agent_did"] = agentId
+        };
+
+        // Merge arguments into the context so policy conditions can reference them directly.
+        if (arguments is not null)
+        {
+            foreach (var (key, value) in arguments)
+            {
+                context.TryAdd(key, value);
+            }
+        }
+
+        return context;
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Policy/ConflictResolution.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Policy/ConflictResolution.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace AgentGovernance.Policy;
+
+/// <summary>
+/// Strategies for resolving conflicts when multiple policy rules match a single request.
+/// </summary>
+public enum ConflictResolutionStrategy
+{
+    /// <summary>
+    /// Any deny wins over any allow. Among denies, the highest priority wins.
+    /// This is the safest strategy for security-critical environments.
+    /// </summary>
+    DenyOverrides,
+
+    /// <summary>
+    /// Any allow wins over any deny. Among allows, the highest priority wins.
+    /// Use when permissiveness is preferred.
+    /// </summary>
+    AllowOverrides,
+
+    /// <summary>
+    /// The rule with the highest priority wins, regardless of its action.
+    /// This is the default strategy.
+    /// </summary>
+    PriorityFirstMatch,
+
+    /// <summary>
+    /// The most specific scope wins (Agent > Tenant > Global).
+    /// Ties within the same scope are broken by priority.
+    /// </summary>
+    MostSpecificWins
+}
+
+/// <summary>
+/// Scope of a governance policy, ordered from broadest to most specific.
+/// </summary>
+public enum PolicyScope
+{
+    /// <summary>Applies to all agents in the system.</summary>
+    Global = 0,
+
+    /// <summary>Applies to agents within a specific tenant.</summary>
+    Tenant = 1,
+
+    /// <summary>Applies to a specific agent.</summary>
+    Agent = 2
+}
+
+/// <summary>
+/// Resolves conflicts between multiple matching policy rules using a configured strategy.
+/// </summary>
+public static class PolicyConflictResolver
+{
+    /// <summary>
+    /// Resolves a list of candidate rule/decision pairs into a single winning decision.
+    /// </summary>
+    /// <param name="candidates">
+    /// Matching rules paired with their corresponding decisions and the scope of the policy they belong to.
+    /// </param>
+    /// <param name="strategy">The conflict resolution strategy to use.</param>
+    /// <returns>The winning <see cref="PolicyDecision"/>, or <c>null</c> if no candidates were provided.</returns>
+    public static PolicyDecision? Resolve(
+        IReadOnlyList<CandidateDecision> candidates,
+        ConflictResolutionStrategy strategy)
+    {
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0].Decision;
+        }
+
+        return strategy switch
+        {
+            ConflictResolutionStrategy.DenyOverrides => ResolveDenyOverrides(candidates),
+            ConflictResolutionStrategy.AllowOverrides => ResolveAllowOverrides(candidates),
+            ConflictResolutionStrategy.PriorityFirstMatch => ResolvePriorityFirstMatch(candidates),
+            ConflictResolutionStrategy.MostSpecificWins => ResolveMostSpecificWins(candidates),
+            _ => ResolvePriorityFirstMatch(candidates)
+        };
+    }
+
+    /// <summary>
+    /// Any deny wins. Among denies, highest priority wins.
+    /// If there are no denies, pick the highest priority allow.
+    /// </summary>
+    private static PolicyDecision ResolveDenyOverrides(IReadOnlyList<CandidateDecision> candidates)
+    {
+        var denies = candidates.Where(c => !c.Decision.Allowed).ToList();
+        if (denies.Count > 0)
+        {
+            return denies.OrderByDescending(c => c.Rule.Priority).First().Decision;
+        }
+
+        return candidates.OrderByDescending(c => c.Rule.Priority).First().Decision;
+    }
+
+    /// <summary>
+    /// Any allow wins. Among allows, highest priority wins.
+    /// If there are no allows, pick the highest priority deny.
+    /// </summary>
+    private static PolicyDecision ResolveAllowOverrides(IReadOnlyList<CandidateDecision> candidates)
+    {
+        var allows = candidates.Where(c => c.Decision.Allowed).ToList();
+        if (allows.Count > 0)
+        {
+            return allows.OrderByDescending(c => c.Rule.Priority).First().Decision;
+        }
+
+        return candidates.OrderByDescending(c => c.Rule.Priority).First().Decision;
+    }
+
+    /// <summary>
+    /// Highest priority wins regardless of action type.
+    /// </summary>
+    private static PolicyDecision ResolvePriorityFirstMatch(IReadOnlyList<CandidateDecision> candidates)
+    {
+        return candidates.OrderByDescending(c => c.Rule.Priority).First().Decision;
+    }
+
+    /// <summary>
+    /// Most specific scope wins (Agent > Tenant > Global).
+    /// Ties within the same scope are broken by priority.
+    /// </summary>
+    private static PolicyDecision ResolveMostSpecificWins(IReadOnlyList<CandidateDecision> candidates)
+    {
+        return candidates
+            .OrderByDescending(c => (int)c.Scope)
+            .ThenByDescending(c => c.Rule.Priority)
+            .First()
+            .Decision;
+    }
+
+    /// <summary>
+    /// Parses a <see cref="PolicyScope"/> from a string value.
+    /// </summary>
+    /// <param name="value">The scope string (e.g., "global", "tenant", "agent").</param>
+    /// <returns>The parsed <see cref="PolicyScope"/>.</returns>
+    public static PolicyScope ParseScope(string? value)
+    {
+        return value?.ToLowerInvariant() switch
+        {
+            "tenant" => PolicyScope.Tenant,
+            "agent" => PolicyScope.Agent,
+            _ => PolicyScope.Global
+        };
+    }
+}
+
+/// <summary>
+/// A candidate decision produced by evaluating a single rule, annotated with
+/// the rule, its decision, and the scope of the policy it belongs to.
+/// </summary>
+/// <param name="Rule">The matched rule.</param>
+/// <param name="Decision">The decision produced by the rule.</param>
+/// <param name="Scope">The scope of the policy that contains this rule.</param>
+public sealed record CandidateDecision(PolicyRule Rule, PolicyDecision Decision, PolicyScope Scope);

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Policy/Policy.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Policy/Policy.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace AgentGovernance.Policy;
+
+/// <summary>
+/// Represents a complete governance policy document loaded from YAML.
+/// A policy contains metadata and an ordered list of <see cref="PolicyRule"/> entries
+/// that are evaluated against agent requests.
+/// </summary>
+public sealed class Policy
+{
+    /// <summary>
+    /// Supported API versions for policy schema validation.
+    /// </summary>
+    private static readonly HashSet<string> SupportedApiVersions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "governance.toolkit/v1"
+    };
+
+    /// <summary>
+    /// The API version of the policy schema (e.g., "governance.toolkit/v1").
+    /// </summary>
+    public string ApiVersion { get; init; } = "governance.toolkit/v1";
+
+    /// <summary>
+    /// The version of this policy document (e.g., "1.0").
+    /// </summary>
+    public string Version { get; init; } = "1.0";
+
+    /// <summary>
+    /// Unique name of the policy.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Optional human-readable description of the policy.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// The scope of this policy used for conflict resolution.
+    /// </summary>
+    public PolicyScope Scope { get; init; } = PolicyScope.Global;
+
+    /// <summary>
+    /// The default action to take when no rules match.
+    /// </summary>
+    public PolicyAction DefaultAction { get; init; } = PolicyAction.Deny;
+
+    /// <summary>
+    /// Ordered list of policy rules to evaluate.
+    /// </summary>
+    public List<PolicyRule> Rules { get; init; } = new();
+
+    /// <summary>
+    /// Deserializes a <see cref="Policy"/> from a YAML string.
+    /// </summary>
+    /// <param name="yaml">The YAML content representing a policy document.</param>
+    /// <returns>A new <see cref="Policy"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when the YAML is invalid or the API version is unsupported.</exception>
+    public static Policy FromYaml(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        var raw = deserializer.Deserialize<YamlPolicyDocument>(yaml)
+            ?? throw new ArgumentException("Failed to parse YAML policy document.");
+
+        // Validate API version.
+        var apiVersion = raw.ApiVersion ?? "governance.toolkit/v1";
+        if (!SupportedApiVersions.Contains(apiVersion))
+        {
+            throw new ArgumentException(
+                $"Unsupported policy API version: '{apiVersion}'. " +
+                $"Supported: {string.Join(", ", SupportedApiVersions)}");
+        }
+
+        var scope = PolicyConflictResolver.ParseScope(raw.Scope);
+        var defaultAction = ParseDefaultAction(raw.DefaultAction);
+
+        var rules = new List<PolicyRule>();
+        if (raw.Rules is not null)
+        {
+            foreach (var ruleDoc in raw.Rules)
+            {
+                rules.Add(new PolicyRule
+                {
+                    Name = ruleDoc.Name ?? throw new ArgumentException("Every rule must have a 'name'."),
+                    Condition = ruleDoc.Condition ?? throw new ArgumentException($"Rule '{ruleDoc.Name}' is missing a 'condition'."),
+                    Action = PolicyRule.ParseAction(ruleDoc.Action ?? "deny"),
+                    Priority = ruleDoc.Priority ?? 0,
+                    Enabled = ruleDoc.Enabled ?? true,
+                    Approvers = ruleDoc.Approvers ?? new List<string>(),
+                    Limit = ruleDoc.Limit,
+                    Description = ruleDoc.Description
+                });
+            }
+        }
+
+        return new Policy
+        {
+            ApiVersion = apiVersion,
+            Version = raw.Version ?? "1.0",
+            Name = raw.Name ?? throw new ArgumentException("Policy must have a 'name'."),
+            Description = raw.Description,
+            Scope = scope,
+            DefaultAction = defaultAction,
+            Rules = rules
+        };
+    }
+
+    /// <summary>
+    /// Loads a <see cref="Policy"/> from a YAML file on disk.
+    /// </summary>
+    /// <param name="path">Absolute or relative path to the YAML policy file.</param>
+    /// <returns>A new <see cref="Policy"/> instance.</returns>
+    /// <exception cref="FileNotFoundException">Thrown when the file does not exist.</exception>
+    public static Policy FromYamlFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Policy file not found: '{path}'", path);
+        }
+
+        var yaml = File.ReadAllText(path);
+        return FromYaml(yaml);
+    }
+
+    /// <summary>
+    /// Parses the default_action field from YAML into a <see cref="PolicyAction"/>.
+    /// Defaults to <see cref="PolicyAction.Deny"/> when not specified.
+    /// </summary>
+    private static PolicyAction ParseDefaultAction(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return PolicyAction.Deny;
+        }
+
+        return PolicyRule.ParseAction(value);
+    }
+
+    // ── Internal YAML deserialization models ──────────────────────────────
+
+    /// <summary>
+    /// Internal model for YAML deserialization of a policy document.
+    /// Uses snake_case naming convention via YamlDotNet.
+    /// </summary>
+    internal sealed class YamlPolicyDocument
+    {
+        [YamlMember(Alias = "apiVersion", ApplyNamingConventions = false)]
+        public string? ApiVersion { get; set; }
+        public string? Version { get; set; }
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? Scope { get; set; }
+        public string? DefaultAction { get; set; }
+        public List<YamlRuleDocument>? Rules { get; set; }
+    }
+
+    /// <summary>
+    /// Internal model for YAML deserialization of a policy rule.
+    /// </summary>
+    internal sealed class YamlRuleDocument
+    {
+        public string? Name { get; set; }
+        public string? Description { get; set; }
+        public string? Condition { get; set; }
+        public string? Action { get; set; }
+        public int? Priority { get; set; }
+        public bool? Enabled { get; set; }
+        public List<string>? Approvers { get; set; }
+        public string? Limit { get; set; }
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyDecision.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyDecision.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace AgentGovernance.Policy;
+
+/// <summary>
+/// Represents the result of evaluating a request against one or more governance policies.
+/// </summary>
+public sealed class PolicyDecision
+{
+    /// <summary>
+    /// Whether the request is allowed to proceed.
+    /// </summary>
+    public bool Allowed { get; init; }
+
+    /// <summary>
+    /// The resulting action string (e.g., "allow", "deny", "warn", "require_approval").
+    /// </summary>
+    public required string Action { get; init; }
+
+    /// <summary>
+    /// Name of the rule that produced this decision, or <c>null</c> if the decision
+    /// was derived from the policy default action.
+    /// </summary>
+    public string? MatchedRule { get; init; }
+
+    /// <summary>
+    /// Human-readable reason explaining why this decision was made.
+    /// </summary>
+    public required string Reason { get; init; }
+
+    /// <summary>
+    /// List of approvers required when the action is <c>require_approval</c>.
+    /// Empty when not applicable.
+    /// </summary>
+    public List<string> Approvers { get; init; } = new();
+
+    /// <summary>
+    /// Indicates whether the request was rate-limited.
+    /// </summary>
+    public bool RateLimited { get; init; }
+
+    /// <summary>
+    /// Time in milliseconds taken to evaluate the policy decision.
+    /// </summary>
+    public double EvaluationMs { get; init; }
+
+    /// <summary>
+    /// Creates a default "allowed" decision (used when no rules match and default is allow).
+    /// </summary>
+    /// <param name="evaluationMs">Evaluation duration in milliseconds.</param>
+    /// <returns>A new <see cref="PolicyDecision"/> indicating the request is allowed.</returns>
+    public static PolicyDecision AllowDefault(double evaluationMs = 0) => new()
+    {
+        Allowed = true,
+        Action = "allow",
+        Reason = "No matching rules; default action is allow.",
+        EvaluationMs = evaluationMs
+    };
+
+    /// <summary>
+    /// Creates a default "denied" decision (used when no rules match and default is deny).
+    /// </summary>
+    /// <param name="evaluationMs">Evaluation duration in milliseconds.</param>
+    /// <returns>A new <see cref="PolicyDecision"/> indicating the request is denied.</returns>
+    public static PolicyDecision DenyDefault(double evaluationMs = 0) => new()
+    {
+        Allowed = false,
+        Action = "deny",
+        Reason = "No matching rules; default action is deny.",
+        EvaluationMs = evaluationMs
+    };
+
+    /// <summary>
+    /// Creates a decision from a matched <see cref="PolicyRule"/>.
+    /// </summary>
+    /// <param name="rule">The rule that matched.</param>
+    /// <param name="evaluationMs">Evaluation duration in milliseconds.</param>
+    /// <returns>A new <see cref="PolicyDecision"/> derived from the rule.</returns>
+    public static PolicyDecision FromRule(PolicyRule rule, double evaluationMs = 0)
+    {
+        var action = rule.Action;
+        return new PolicyDecision
+        {
+            Allowed = action is PolicyAction.Allow or PolicyAction.Warn or PolicyAction.Log,
+            Action = action.ToString().ToLowerInvariant(),
+            MatchedRule = rule.Name,
+            Reason = $"Matched rule '{rule.Name}' with action '{action}'.",
+            Approvers = action == PolicyAction.RequireApproval ? new List<string>(rule.Approvers) : new(),
+            RateLimited = action == PolicyAction.RateLimit,
+            EvaluationMs = evaluationMs
+        };
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace AgentGovernance.Policy;
+
+/// <summary>
+/// Main governance policy evaluation engine. Loads one or more <see cref="Policy"/>
+/// documents, evaluates agent requests against all loaded rules, and resolves
+/// conflicts when multiple rules match.
+/// <para>
+/// This class is thread-safe. Policies are stored in a lock-protected list and
+/// evaluation is side-effect free.
+/// </para>
+/// </summary>
+public sealed class PolicyEngine
+{
+    private readonly List<Policy> _policies = new();
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// The conflict resolution strategy to use when multiple rules match.
+    /// Defaults to <see cref="ConflictResolutionStrategy.PriorityFirstMatch"/>.
+    /// </summary>
+    public ConflictResolutionStrategy ConflictStrategy { get; set; } =
+        ConflictResolutionStrategy.PriorityFirstMatch;
+
+    /// <summary>
+    /// Loads a pre-parsed <see cref="Policy"/> into the engine.
+    /// </summary>
+    /// <param name="policy">The policy to load.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="policy"/> is <c>null</c>.</exception>
+    public void LoadPolicy(Policy policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+
+        lock (_lock)
+        {
+            _policies.Add(policy);
+        }
+    }
+
+    /// <summary>
+    /// Parses a YAML string into a <see cref="Policy"/> and loads it into the engine.
+    /// </summary>
+    /// <param name="yaml">YAML content representing a policy document.</param>
+    public void LoadYaml(string yaml)
+    {
+        var policy = Policy.FromYaml(yaml);
+        LoadPolicy(policy);
+    }
+
+    /// <summary>
+    /// Loads a policy from a YAML file on disk.
+    /// </summary>
+    /// <param name="path">Path to the YAML policy file.</param>
+    public void LoadYamlFile(string path)
+    {
+        var policy = Policy.FromYamlFile(path);
+        LoadPolicy(policy);
+    }
+
+    /// <summary>
+    /// Returns a read-only snapshot of all loaded policies.
+    /// </summary>
+    /// <returns>An immutable list of loaded policies.</returns>
+    public IReadOnlyList<Policy> ListPolicies()
+    {
+        lock (_lock)
+        {
+            return _policies.ToList().AsReadOnly();
+        }
+    }
+
+    /// <summary>
+    /// Removes all loaded policies from the engine.
+    /// </summary>
+    public void ClearPolicies()
+    {
+        lock (_lock)
+        {
+            _policies.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Evaluates an agent request against all loaded policies.
+    /// </summary>
+    /// <param name="agentDid">
+    /// The decentralised identifier of the agent making the request (e.g., "did:mesh:abc123").
+    /// This is injected into the evaluation context as <c>agent_did</c>.
+    /// </param>
+    /// <param name="context">
+    /// A dictionary of contextual values for condition evaluation.
+    /// Common keys include <c>tool_name</c>, <c>action.type</c>, etc.
+    /// </param>
+    /// <returns>
+    /// A <see cref="PolicyDecision"/> representing the outcome.
+    /// If no policies are loaded, the request is allowed by default.
+    /// </returns>
+    public PolicyDecision Evaluate(string agentDid, Dictionary<string, object> context)
+    {
+        var sw = Stopwatch.StartNew();
+
+        // Snapshot policies under lock.
+        List<Policy> snapshot;
+        lock (_lock)
+        {
+            snapshot = _policies.ToList();
+        }
+
+        if (snapshot.Count == 0)
+        {
+            sw.Stop();
+            return PolicyDecision.AllowDefault(sw.Elapsed.TotalMilliseconds);
+        }
+
+        // Inject agent DID into context so rules can reference it.
+        var evalContext = new Dictionary<string, object>(context, StringComparer.OrdinalIgnoreCase)
+        {
+            ["agent_did"] = agentDid
+        };
+
+        // Collect all candidate decisions from all policies.
+        var candidates = new List<CandidateDecision>();
+        PolicyAction lastDefaultAction = PolicyAction.Deny;
+
+        foreach (var policy in snapshot)
+        {
+            lastDefaultAction = policy.DefaultAction;
+
+            foreach (var rule in policy.Rules)
+            {
+                if (!rule.Enabled)
+                {
+                    continue;
+                }
+
+                if (rule.Evaluate(evalContext))
+                {
+                    var decision = PolicyDecision.FromRule(rule, sw.Elapsed.TotalMilliseconds);
+                    candidates.Add(new CandidateDecision(rule, decision, policy.Scope));
+                }
+            }
+        }
+
+        sw.Stop();
+        var elapsed = sw.Elapsed.TotalMilliseconds;
+
+        // No rules matched — return the default action.
+        if (candidates.Count == 0)
+        {
+            return lastDefaultAction == PolicyAction.Allow
+                ? PolicyDecision.AllowDefault(elapsed)
+                : PolicyDecision.DenyDefault(elapsed);
+        }
+
+        // Resolve conflicts and return the winning decision.
+        var resolved = PolicyConflictResolver.Resolve(candidates, ConflictStrategy);
+        if (resolved is not null)
+        {
+            // Update evaluation time to include conflict resolution.
+            return new PolicyDecision
+            {
+                Allowed = resolved.Allowed,
+                Action = resolved.Action,
+                MatchedRule = resolved.MatchedRule,
+                Reason = resolved.Reason,
+                Approvers = resolved.Approvers,
+                RateLimited = resolved.RateLimited,
+                EvaluationMs = elapsed
+            };
+        }
+
+        return PolicyDecision.DenyDefault(elapsed);
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace AgentGovernance.Policy;
+
+/// <summary>
+/// Supported actions for a governance policy rule.
+/// </summary>
+public enum PolicyAction
+{
+    /// <summary>Allow the request.</summary>
+    Allow,
+
+    /// <summary>Deny the request.</summary>
+    Deny,
+
+    /// <summary>Warn but still allow the request.</summary>
+    Warn,
+
+    /// <summary>Require explicit approval before proceeding.</summary>
+    RequireApproval,
+
+    /// <summary>Log the request for audit purposes only.</summary>
+    Log,
+
+    /// <summary>Apply rate-limiting to the request.</summary>
+    RateLimit
+}
+
+/// <summary>
+/// Represents a single governance policy rule that can be evaluated against a context.
+/// </summary>
+public sealed class PolicyRule
+{
+    // Regex patterns for simple expression evaluation (mirrors Python implementation).
+    private static readonly Regex EqualityPattern =
+        new(@"^(\w+(?:\.\w+)*)\s*==\s*['""]([^'""]+)['""]$", RegexOptions.Compiled);
+
+    private static readonly Regex InequalityPattern =
+        new(@"^(\w+(?:\.\w+)*)\s*!=\s*['""]([^'""]+)['""]$", RegexOptions.Compiled);
+
+    private static readonly Regex NumericComparisonPattern =
+        new(@"^(\w+(?:\.\w+)*)\s*(>=|<=|>|<)\s*(\d+(?:\.\d+)?)$", RegexOptions.Compiled);
+
+    private static readonly Regex InListPattern =
+        new(@"^(\w+(?:\.\w+)*)\s+in\s+(\w+(?:\.\w+)*)$", RegexOptions.Compiled);
+
+    private static readonly Regex BooleanFieldPattern =
+        new(@"^(\w+(?:\.\w+)*)$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Unique name of the rule within a policy.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Condition expression to evaluate (e.g., "tool_name in blocked_tools").
+    /// Supports equality, inequality, numeric comparisons, <c>in</c> list checks,
+    /// boolean fields, and compound <c>and</c>/<c>or</c> operators.
+    /// </summary>
+    public required string Condition { get; init; }
+
+    /// <summary>
+    /// Action to take when the condition matches.
+    /// </summary>
+    public PolicyAction Action { get; init; } = PolicyAction.Deny;
+
+    /// <summary>
+    /// Priority of the rule. Higher values are evaluated first during conflict resolution.
+    /// </summary>
+    public int Priority { get; init; }
+
+    /// <summary>
+    /// Whether the rule is active. Disabled rules are skipped during evaluation.
+    /// </summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>
+    /// Optional list of approver identifiers (e.g., email addresses) required
+    /// when <see cref="Action"/> is <see cref="PolicyAction.RequireApproval"/>.
+    /// </summary>
+    public List<string> Approvers { get; init; } = new();
+
+    /// <summary>
+    /// Optional rate-limit expression (e.g., "100/hour") when
+    /// <see cref="Action"/> is <see cref="PolicyAction.RateLimit"/>.
+    /// </summary>
+    public string? Limit { get; init; }
+
+    /// <summary>
+    /// Optional human-readable description of what this rule does.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Evaluates the rule condition against the provided context dictionary.
+    /// </summary>
+    /// <param name="context">
+    /// A dictionary of contextual values (e.g., tool_name, action.type, data.contains_pii).
+    /// Supports nested keys via dot notation.
+    /// </param>
+    /// <returns><c>true</c> if the condition matches; otherwise <c>false</c>.</returns>
+    public bool Evaluate(IReadOnlyDictionary<string, object> context)
+    {
+        if (!Enabled)
+        {
+            return false;
+        }
+
+        try
+        {
+            return EvaluateExpression(Condition.Trim(), context);
+        }
+        catch
+        {
+            // Safe-fail: if evaluation errors, the rule does not match.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Recursively evaluates a condition expression string.
+    /// Supports compound operators (<c>and</c>, <c>or</c>) and atomic conditions.
+    /// </summary>
+    private static bool EvaluateExpression(string expression, IReadOnlyDictionary<string, object> context)
+    {
+        // Handle compound 'or' (lowest precedence).
+        var orParts = SplitCompound(expression, " or ");
+        if (orParts.Count > 1)
+        {
+            foreach (var part in orParts)
+            {
+                if (EvaluateExpression(part.Trim(), context))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Handle compound 'and'.
+        var andParts = SplitCompound(expression, " and ");
+        if (andParts.Count > 1)
+        {
+            foreach (var part in andParts)
+            {
+                if (!EvaluateExpression(part.Trim(), context))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Atomic condition evaluation.
+        return EvaluateAtomic(expression, context);
+    }
+
+    /// <summary>
+    /// Splits an expression on a compound keyword, respecting that the keyword
+    /// must be surrounded by whitespace (not inside a quoted string).
+    /// </summary>
+    private static List<string> SplitCompound(string expression, string keyword)
+    {
+        var parts = new List<string>();
+        int idx;
+        var remaining = expression;
+
+        while ((idx = remaining.IndexOf(keyword, StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            parts.Add(remaining[..idx]);
+            remaining = remaining[(idx + keyword.Length)..];
+        }
+
+        parts.Add(remaining);
+        return parts;
+    }
+
+    /// <summary>
+    /// Evaluates a single atomic condition (equality, inequality, numeric comparison,
+    /// <c>in</c> list membership, or boolean field).
+    /// </summary>
+    private static bool EvaluateAtomic(string expression, IReadOnlyDictionary<string, object> context)
+    {
+        // Equality: field == 'value'
+        var match = EqualityPattern.Match(expression);
+        if (match.Success)
+        {
+            var fieldValue = ResolveField(match.Groups[1].Value, context);
+            return string.Equals(fieldValue?.ToString(), match.Groups[2].Value, StringComparison.Ordinal);
+        }
+
+        // Inequality: field != 'value'
+        match = InequalityPattern.Match(expression);
+        if (match.Success)
+        {
+            var fieldValue = ResolveField(match.Groups[1].Value, context);
+            return !string.Equals(fieldValue?.ToString(), match.Groups[2].Value, StringComparison.Ordinal);
+        }
+
+        // Numeric comparison: field > 10, field <= 100
+        match = NumericComparisonPattern.Match(expression);
+        if (match.Success)
+        {
+            var fieldValue = ResolveField(match.Groups[1].Value, context);
+            if (fieldValue is not null && double.TryParse(fieldValue.ToString(), out var left)
+                && double.TryParse(match.Groups[3].Value, out var right))
+            {
+                return match.Groups[2].Value switch
+                {
+                    ">" => left > right,
+                    ">=" => left >= right,
+                    "<" => left < right,
+                    "<=" => left <= right,
+                    _ => false
+                };
+            }
+            return false;
+        }
+
+        // In-list: field in list_field
+        match = InListPattern.Match(expression);
+        if (match.Success)
+        {
+            var itemValue = ResolveField(match.Groups[1].Value, context);
+            var listValue = ResolveField(match.Groups[2].Value, context);
+
+            if (itemValue is not null && listValue is IEnumerable<object> list)
+            {
+                var itemStr = itemValue.ToString();
+                return list.Any(x => string.Equals(x?.ToString(), itemStr, StringComparison.Ordinal));
+            }
+
+            // Also support comma-separated string lists.
+            if (itemValue is not null && listValue is string csvList)
+            {
+                var itemStr = itemValue.ToString();
+                return csvList.Split(',').Select(s => s.Trim()).Contains(itemStr);
+            }
+
+            return false;
+        }
+
+        // Boolean field: data.contains_pii (truthiness check).
+        match = BooleanFieldPattern.Match(expression);
+        if (match.Success)
+        {
+            var fieldValue = ResolveField(match.Groups[1].Value, context);
+            return IsTruthy(fieldValue);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves a possibly dot-notated field path against the context dictionary.
+    /// Supports nested dictionaries (e.g., "data.contains_pii" resolves
+    /// context["data"]["contains_pii"]).
+    /// </summary>
+    internal static object? ResolveField(string path, IReadOnlyDictionary<string, object> context)
+    {
+        var segments = path.Split('.');
+        object? current = null;
+
+        // Try the full key first (some contexts use dotted keys directly).
+        if (context.TryGetValue(path, out var directValue))
+        {
+            return directValue;
+        }
+
+        // Walk nested dictionaries.
+        if (!context.TryGetValue(segments[0], out current))
+        {
+            return null;
+        }
+
+        for (int i = 1; i < segments.Length; i++)
+        {
+            if (current is IReadOnlyDictionary<string, object> roDict)
+            {
+                if (!roDict.TryGetValue(segments[i], out current))
+                {
+                    return null;
+                }
+            }
+            else if (current is IDictionary<string, object> dict)
+            {
+                if (!dict.TryGetValue(segments[i], out current))
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        return current;
+    }
+
+    /// <summary>
+    /// Determines the truthiness of a value using Python-like semantics.
+    /// </summary>
+    private static bool IsTruthy(object? value) => value switch
+    {
+        null => false,
+        bool b => b,
+        int i => i != 0,
+        long l => l != 0,
+        double d => d != 0.0,
+        string s => !string.IsNullOrEmpty(s) && !s.Equals("false", StringComparison.OrdinalIgnoreCase),
+        _ => true
+    };
+
+    /// <summary>
+    /// Parses a <see cref="PolicyAction"/> from a YAML/string value.
+    /// </summary>
+    /// <param name="value">The string representation (e.g., "deny", "require_approval").</param>
+    /// <returns>The parsed <see cref="PolicyAction"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when the value is not a recognised action.</exception>
+    public static PolicyAction ParseAction(string value)
+    {
+        return value.ToLowerInvariant().Replace("_", "") switch
+        {
+            "allow" => PolicyAction.Allow,
+            "deny" => PolicyAction.Deny,
+            "warn" => PolicyAction.Warn,
+            "requireapproval" => PolicyAction.RequireApproval,
+            "log" => PolicyAction.Log,
+            "ratelimit" => PolicyAction.RateLimit,
+            _ => throw new ArgumentException($"Unknown policy action: '{value}'", nameof(value))
+        };
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Trust/AgentIdentity.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Trust/AgentIdentity.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AgentGovernance.Trust;
+
+/// <summary>
+/// Represents an agent identity with cryptographic signing and verification capabilities.
+/// <para>
+/// Uses HMAC-SHA256 as a portable signing mechanism for .NET 8.0 compatibility.
+/// When targeting .NET 9.0+, this should be migrated to the native
+/// <c>System.Security.Cryptography.Ed25519</c> API for proper Ed25519 support.
+/// The DID format follows the AgentMesh convention: <c>did:mesh:{unique-id}</c>.
+/// </para>
+/// </summary>
+/// <remarks>
+/// <b>Migration note (.NET 9+):</b> Replace HMAC-SHA256 with Ed25519:
+/// <code>
+/// // .NET 9+ Ed25519 example:
+/// using var key = Ed25519.Create();
+/// byte[] signature = key.SignData(data);
+/// bool valid = key.VerifyData(data, signature);
+/// </code>
+/// </remarks>
+public sealed class AgentIdentity
+{
+    /// <summary>
+    /// The key size in bytes used for HMAC-SHA256 signing keys.
+    /// Matches the Ed25519 key size (32 bytes) for forward-compatible serialisation.
+    /// </summary>
+    private const int KeySizeBytes = 32;
+
+    /// <summary>
+    /// The decentralised identifier for this agent (e.g., "did:mesh:a1b2c3d4").
+    /// </summary>
+    public string Did { get; }
+
+    /// <summary>
+    /// The public key bytes. In the HMAC-SHA256 fallback, this is a 32-byte
+    /// truncated SHA-256 hash of the private key. With Ed25519, this would be
+    /// the actual Ed25519 public key.
+    /// </summary>
+    public byte[] PublicKey { get; }
+
+    /// <summary>
+    /// The private key bytes used for signing. <c>null</c> for verification-only identities.
+    /// </summary>
+    public byte[]? PrivateKey { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="AgentIdentity"/> with the specified DID and key material.
+    /// </summary>
+    /// <param name="did">The decentralised identifier.</param>
+    /// <param name="publicKey">The public key bytes.</param>
+    /// <param name="privateKey">The private key bytes, or <c>null</c> for verification-only identities.</param>
+    public AgentIdentity(string did, byte[] publicKey, byte[]? privateKey = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(did);
+        ArgumentNullException.ThrowIfNull(publicKey);
+
+        Did = did;
+        PublicKey = publicKey;
+        PrivateKey = privateKey;
+    }
+
+    /// <summary>
+    /// Creates a new agent identity with a freshly generated key pair.
+    /// The DID is derived from the agent name using the <c>did:mesh:</c> method.
+    /// </summary>
+    /// <param name="name">A human-readable name for the agent (used to derive the DID).</param>
+    /// <returns>A new <see cref="AgentIdentity"/> with both public and private keys.</returns>
+    public static AgentIdentity Create(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        // Generate a deterministic-format DID from the name + random component.
+        var uniqueId = GenerateUniqueId(name);
+        var did = $"did:mesh:{uniqueId}";
+
+        // Generate a random 32-byte private key.
+        var privateKey = RandomNumberGenerator.GetBytes(KeySizeBytes);
+
+        // Derive public key: SHA-256 hash of the private key (HMAC-SHA256 fallback).
+        var publicKey = DerivePublicKey(privateKey);
+
+        return new AgentIdentity(did, publicKey, privateKey);
+    }
+
+    /// <summary>
+    /// Signs the provided data using this identity's private key.
+    /// </summary>
+    /// <param name="data">The data to sign.</param>
+    /// <returns>A 32-byte HMAC-SHA256 signature.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when this identity does not have a private key (verification-only).
+    /// </exception>
+    public byte[] Sign(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        if (PrivateKey is null)
+        {
+            throw new InvalidOperationException(
+                "Cannot sign data: this identity does not have a private key.");
+        }
+
+        using var hmac = new HMACSHA256(PrivateKey);
+        return hmac.ComputeHash(data);
+    }
+
+    /// <summary>
+    /// Signs a string message using this identity's private key.
+    /// </summary>
+    /// <param name="message">The message to sign.</param>
+    /// <returns>A 32-byte HMAC-SHA256 signature.</returns>
+    public byte[] Sign(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        return Sign(Encoding.UTF8.GetBytes(message));
+    }
+
+    /// <summary>
+    /// Verifies a signature against data using this identity's public key.
+    /// </summary>
+    /// <param name="data">The data that was signed.</param>
+    /// <param name="signature">The signature to verify.</param>
+    /// <returns><c>true</c> if the signature is valid; otherwise <c>false</c>.</returns>
+    /// <remarks>
+    /// In the HMAC-SHA256 fallback, verification requires the private key to
+    /// recompute the HMAC. This is a known limitation; with Ed25519, verification
+    /// uses only the public key.
+    /// </remarks>
+    public bool Verify(byte[] data, byte[] signature)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentNullException.ThrowIfNull(signature);
+
+        if (PrivateKey is null)
+        {
+            // Without Ed25519, we cannot verify with only the public key.
+            // In production with .NET 9+, use Ed25519 public-key verification.
+            return false;
+        }
+
+        var expected = Sign(data);
+        return CryptographicOperations.FixedTimeEquals(expected, signature);
+    }
+
+    /// <summary>
+    /// Verifies a signature using a standalone public key and private key pair.
+    /// This static overload is provided for cross-agent verification scenarios.
+    /// </summary>
+    /// <param name="publicKey">The public key of the signer.</param>
+    /// <param name="data">The signed data.</param>
+    /// <param name="signature">The signature to verify.</param>
+    /// <param name="privateKey">
+    /// The private key for HMAC recomputation (required for HMAC-SHA256 fallback;
+    /// not needed with Ed25519 on .NET 9+).
+    /// </param>
+    /// <returns><c>true</c> if the signature is valid; otherwise <c>false</c>.</returns>
+    public static bool VerifySignature(byte[] publicKey, byte[] data, byte[] signature, byte[]? privateKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(publicKey);
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentNullException.ThrowIfNull(signature);
+
+        if (privateKey is null)
+        {
+            // Cannot verify without private key in HMAC-SHA256 mode.
+            // With Ed25519 (.NET 9+), this would use the public key directly.
+            return false;
+        }
+
+        using var hmac = new HMACSHA256(privateKey);
+        var expected = hmac.ComputeHash(data);
+        return CryptographicOperations.FixedTimeEquals(expected, signature);
+    }
+
+    /// <summary>
+    /// Generates a unique identifier component for a DID based on the agent name.
+    /// Combines the name hash with random bytes for uniqueness.
+    /// </summary>
+    private static string GenerateUniqueId(string name)
+    {
+        // Hash the name for a deterministic prefix, append random bytes for uniqueness.
+        var nameBytes = Encoding.UTF8.GetBytes(name);
+        var hash = SHA256.HashData(nameBytes);
+        var randomBytes = RandomNumberGenerator.GetBytes(4);
+
+        // Take first 4 bytes of name hash + 4 random bytes = 8 hex chars each.
+        return Convert.ToHexString(hash[..4]).ToLowerInvariant()
+             + Convert.ToHexString(randomBytes).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Derives a public key from the private key using SHA-256.
+    /// This is a placeholder for Ed25519 key derivation.
+    /// </summary>
+    private static byte[] DerivePublicKey(byte[] privateKey)
+    {
+        return SHA256.HashData(privateKey)[..KeySizeBytes];
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => Did;
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentGovernance.Tests.csproj
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentGovernance.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgentGovernance\AgentGovernance.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentIdentityTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentIdentityTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Trust;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class AgentIdentityTests
+{
+    [Fact]
+    public void Create_GeneratesValidIdentity()
+    {
+        var identity = AgentIdentity.Create("test-agent");
+
+        Assert.StartsWith("did:mesh:", identity.Did);
+        Assert.NotNull(identity.PublicKey);
+        Assert.NotNull(identity.PrivateKey);
+        Assert.Equal(32, identity.PublicKey.Length);
+        Assert.Equal(32, identity.PrivateKey!.Length);
+    }
+
+    [Fact]
+    public void Create_DifferentNames_ProduceDifferentDids()
+    {
+        var id1 = AgentIdentity.Create("agent-alpha");
+        var id2 = AgentIdentity.Create("agent-beta");
+
+        // DIDs should be different (they contain random components).
+        Assert.NotEqual(id1.Did, id2.Did);
+    }
+
+    [Fact]
+    public void Sign_ProducesConsistentSignature()
+    {
+        var identity = AgentIdentity.Create("signer");
+        var data = "Hello, governance!"u8.ToArray();
+
+        var sig1 = identity.Sign(data);
+        var sig2 = identity.Sign(data);
+
+        Assert.Equal(sig1, sig2);
+        Assert.Equal(32, sig1.Length); // HMAC-SHA256 produces 32-byte output.
+    }
+
+    [Fact]
+    public void Sign_StringOverload_Works()
+    {
+        var identity = AgentIdentity.Create("signer");
+        var sig = identity.Sign("test message");
+
+        Assert.NotNull(sig);
+        Assert.Equal(32, sig.Length);
+    }
+
+    [Fact]
+    public void Verify_ValidSignature_ReturnsTrue()
+    {
+        var identity = AgentIdentity.Create("verifier");
+        var data = "some data to sign"u8.ToArray();
+
+        var signature = identity.Sign(data);
+        Assert.True(identity.Verify(data, signature));
+    }
+
+    [Fact]
+    public void Verify_TamperedData_ReturnsFalse()
+    {
+        var identity = AgentIdentity.Create("verifier");
+        var data = "original data"u8.ToArray();
+        var signature = identity.Sign(data);
+
+        var tampered = "tampered data"u8.ToArray();
+        Assert.False(identity.Verify(tampered, signature));
+    }
+
+    [Fact]
+    public void Verify_TamperedSignature_ReturnsFalse()
+    {
+        var identity = AgentIdentity.Create("verifier");
+        var data = "some data"u8.ToArray();
+        var signature = identity.Sign(data);
+
+        // Flip a byte in the signature.
+        var tampered = (byte[])signature.Clone();
+        tampered[0] ^= 0xFF;
+        Assert.False(identity.Verify(data, tampered));
+    }
+
+    [Fact]
+    public void Verify_VerificationOnlyIdentity_ReturnsFalse()
+    {
+        // An identity with no private key cannot verify in HMAC mode.
+        var identity = AgentIdentity.Create("full");
+        var verifyOnly = new AgentIdentity(identity.Did, identity.PublicKey);
+
+        var data = "test"u8.ToArray();
+        var sig = identity.Sign(data);
+
+        Assert.False(verifyOnly.Verify(data, sig));
+    }
+
+    [Fact]
+    public void Sign_WithoutPrivateKey_ThrowsInvalidOperationException()
+    {
+        var identity = new AgentIdentity("did:mesh:test", new byte[32]);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            identity.Sign("test"u8.ToArray()));
+    }
+
+    [Fact]
+    public void VerifySignature_Static_WithPrivateKey_Works()
+    {
+        var identity = AgentIdentity.Create("static-test");
+        var data = "static verification"u8.ToArray();
+        var signature = identity.Sign(data);
+
+        Assert.True(AgentIdentity.VerifySignature(
+            identity.PublicKey, data, signature, identity.PrivateKey));
+    }
+
+    [Fact]
+    public void VerifySignature_Static_WithoutPrivateKey_ReturnsFalse()
+    {
+        var identity = AgentIdentity.Create("static-test");
+        var data = "test"u8.ToArray();
+        var signature = identity.Sign(data);
+
+        Assert.False(AgentIdentity.VerifySignature(
+            identity.PublicKey, data, signature));
+    }
+
+    [Fact]
+    public void ToString_ReturnsDid()
+    {
+        var identity = AgentIdentity.Create("display-test");
+        Assert.Equal(identity.Did, identity.ToString());
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AuditEmitterTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AuditEmitterTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Audit;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class AuditEmitterTests
+{
+    [Fact]
+    public void Emit_TypeSpecificHandler_ReceivesMatchingEvents()
+    {
+        var emitter = new AuditEmitter();
+        GovernanceEvent? received = null;
+
+        emitter.On(GovernanceEventType.PolicyCheck, e => received = e);
+
+        emitter.Emit(GovernanceEventType.PolicyCheck, "did:mesh:test", "session-1");
+
+        Assert.NotNull(received);
+        Assert.Equal(GovernanceEventType.PolicyCheck, received!.Type);
+        Assert.Equal("did:mesh:test", received.AgentId);
+        Assert.Equal("session-1", received.SessionId);
+    }
+
+    [Fact]
+    public void Emit_TypeSpecificHandler_DoesNotReceiveOtherEventTypes()
+    {
+        var emitter = new AuditEmitter();
+        GovernanceEvent? received = null;
+
+        emitter.On(GovernanceEventType.PolicyCheck, e => received = e);
+
+        emitter.Emit(GovernanceEventType.PolicyViolation, "did:mesh:test", "session-1");
+
+        Assert.Null(received);
+    }
+
+    [Fact]
+    public void Emit_WildcardHandler_ReceivesAllEvents()
+    {
+        var emitter = new AuditEmitter();
+        var events = new List<GovernanceEvent>();
+
+        emitter.OnAll(e => events.Add(e));
+
+        emitter.Emit(GovernanceEventType.PolicyCheck, "did:mesh:test", "s1");
+        emitter.Emit(GovernanceEventType.PolicyViolation, "did:mesh:test", "s2");
+        emitter.Emit(GovernanceEventType.ToolCallBlocked, "did:mesh:test", "s3");
+
+        Assert.Equal(3, events.Count);
+    }
+
+    [Fact]
+    public void Emit_MultipleHandlers_AllReceiveEvent()
+    {
+        var emitter = new AuditEmitter();
+        int callCount = 0;
+
+        emitter.On(GovernanceEventType.DriftDetected, _ => callCount++);
+        emitter.On(GovernanceEventType.DriftDetected, _ => callCount++);
+        emitter.On(GovernanceEventType.DriftDetected, _ => callCount++);
+
+        emitter.Emit(GovernanceEventType.DriftDetected, "did:mesh:test", "session-1");
+
+        Assert.Equal(3, callCount);
+    }
+
+    [Fact]
+    public void Emit_PrebuiltEvent_PassedCorrectly()
+    {
+        var emitter = new AuditEmitter();
+        GovernanceEvent? received = null;
+
+        emitter.On(GovernanceEventType.CheckpointCreated, e => received = e);
+
+        var evt = new GovernanceEvent
+        {
+            Type = GovernanceEventType.CheckpointCreated,
+            AgentId = "did:mesh:test",
+            SessionId = "session-42",
+            PolicyName = "test-policy",
+            Data = new Dictionary<string, object> { ["key"] = "value" }
+        };
+
+        emitter.Emit(evt);
+
+        Assert.NotNull(received);
+        Assert.Equal("did:mesh:test", received!.AgentId);
+        Assert.Equal("session-42", received.SessionId);
+        Assert.Equal("test-policy", received.PolicyName);
+        Assert.Equal("value", received.Data["key"]);
+    }
+
+    [Fact]
+    public void Emit_FaultyHandler_DoesNotBreakOtherHandlers()
+    {
+        var emitter = new AuditEmitter();
+        bool secondHandlerCalled = false;
+
+        emitter.On(GovernanceEventType.PolicyCheck, _ => throw new InvalidOperationException("boom"));
+        emitter.On(GovernanceEventType.PolicyCheck, _ => secondHandlerCalled = true);
+
+        // Should not throw.
+        emitter.Emit(GovernanceEventType.PolicyCheck, "did:mesh:test", "session-1");
+
+        Assert.True(secondHandlerCalled);
+    }
+
+    [Fact]
+    public void HandlerCount_ReturnsCorrectCount()
+    {
+        var emitter = new AuditEmitter();
+
+        Assert.Equal(0, emitter.HandlerCount(GovernanceEventType.PolicyCheck));
+
+        emitter.On(GovernanceEventType.PolicyCheck, _ => { });
+        emitter.On(GovernanceEventType.PolicyCheck, _ => { });
+
+        Assert.Equal(2, emitter.HandlerCount(GovernanceEventType.PolicyCheck));
+        Assert.Equal(0, emitter.HandlerCount(GovernanceEventType.DriftDetected));
+    }
+
+    [Fact]
+    public void WildcardHandlerCount_ReturnsCorrectCount()
+    {
+        var emitter = new AuditEmitter();
+
+        Assert.Equal(0, emitter.WildcardHandlerCount);
+
+        emitter.OnAll(_ => { });
+        Assert.Equal(1, emitter.WildcardHandlerCount);
+    }
+
+    [Fact]
+    public void GovernanceEvent_HasUniqueEventId()
+    {
+        var e1 = new GovernanceEvent { AgentId = "a", SessionId = "s" };
+        var e2 = new GovernanceEvent { AgentId = "a", SessionId = "s" };
+
+        Assert.NotEqual(e1.EventId, e2.EventId);
+        Assert.StartsWith("evt-", e1.EventId);
+    }
+
+    [Fact]
+    public void GovernanceEvent_TimestampIsUtc()
+    {
+        var evt = new GovernanceEvent { AgentId = "a", SessionId = "s" };
+        Assert.Equal(TimeSpan.Zero, evt.Timestamp.Offset);
+    }
+
+    [Fact]
+    public void GovernanceEvent_ToString_IncludesKey()
+    {
+        var evt = new GovernanceEvent
+        {
+            Type = GovernanceEventType.PolicyViolation,
+            AgentId = "did:mesh:test",
+            SessionId = "s-1",
+            PolicyName = "my-policy"
+        };
+
+        var str = evt.ToString();
+        Assert.Contains("PolicyViolation", str);
+        Assert.Contains("did:mesh:test", str);
+        Assert.Contains("my-policy", str);
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/ConflictResolutionTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/ConflictResolutionTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class ConflictResolutionTests
+{
+    private static PolicyRule MakeRule(string name, PolicyAction action, int priority) =>
+        new() { Name = name, Condition = "true_field", Action = action, Priority = priority };
+
+    [Fact]
+    public void DenyOverrides_DenyWinsOverAllow()
+    {
+        var candidates = new List<CandidateDecision>
+        {
+            new(MakeRule("allow-rule", PolicyAction.Allow, 5),
+                PolicyDecision.FromRule(MakeRule("allow-rule", PolicyAction.Allow, 5)),
+                PolicyScope.Global),
+            new(MakeRule("deny-rule", PolicyAction.Deny, 3),
+                PolicyDecision.FromRule(MakeRule("deny-rule", PolicyAction.Deny, 3)),
+                PolicyScope.Global)
+        };
+
+        var result = PolicyConflictResolver.Resolve(candidates, ConflictResolutionStrategy.DenyOverrides);
+
+        Assert.NotNull(result);
+        Assert.False(result!.Allowed);
+        Assert.Equal("deny-rule", result.MatchedRule);
+    }
+
+    [Fact]
+    public void AllowOverrides_AllowWinsOverDeny()
+    {
+        var candidates = new List<CandidateDecision>
+        {
+            new(MakeRule("deny-rule", PolicyAction.Deny, 10),
+                PolicyDecision.FromRule(MakeRule("deny-rule", PolicyAction.Deny, 10)),
+                PolicyScope.Global),
+            new(MakeRule("allow-rule", PolicyAction.Allow, 3),
+                PolicyDecision.FromRule(MakeRule("allow-rule", PolicyAction.Allow, 3)),
+                PolicyScope.Global)
+        };
+
+        var result = PolicyConflictResolver.Resolve(candidates, ConflictResolutionStrategy.AllowOverrides);
+
+        Assert.NotNull(result);
+        Assert.True(result!.Allowed);
+        Assert.Equal("allow-rule", result.MatchedRule);
+    }
+
+    [Fact]
+    public void PriorityFirstMatch_HighestPriorityWins()
+    {
+        var candidates = new List<CandidateDecision>
+        {
+            new(MakeRule("low-priority", PolicyAction.Allow, 1),
+                PolicyDecision.FromRule(MakeRule("low-priority", PolicyAction.Allow, 1)),
+                PolicyScope.Global),
+            new(MakeRule("high-priority", PolicyAction.Deny, 100),
+                PolicyDecision.FromRule(MakeRule("high-priority", PolicyAction.Deny, 100)),
+                PolicyScope.Global)
+        };
+
+        var result = PolicyConflictResolver.Resolve(candidates, ConflictResolutionStrategy.PriorityFirstMatch);
+
+        Assert.NotNull(result);
+        Assert.False(result!.Allowed);
+        Assert.Equal("high-priority", result.MatchedRule);
+    }
+
+    [Fact]
+    public void MostSpecificWins_AgentScopeBeatsGlobal()
+    {
+        var candidates = new List<CandidateDecision>
+        {
+            new(MakeRule("global-deny", PolicyAction.Deny, 100),
+                PolicyDecision.FromRule(MakeRule("global-deny", PolicyAction.Deny, 100)),
+                PolicyScope.Global),
+            new(MakeRule("agent-allow", PolicyAction.Allow, 1),
+                PolicyDecision.FromRule(MakeRule("agent-allow", PolicyAction.Allow, 1)),
+                PolicyScope.Agent)
+        };
+
+        var result = PolicyConflictResolver.Resolve(candidates, ConflictResolutionStrategy.MostSpecificWins);
+
+        Assert.NotNull(result);
+        Assert.True(result!.Allowed);
+        Assert.Equal("agent-allow", result.MatchedRule);
+    }
+
+    [Fact]
+    public void MostSpecificWins_TenantBeatGlobal_AgentBeatsTenant()
+    {
+        var candidates = new List<CandidateDecision>
+        {
+            new(MakeRule("global-rule", PolicyAction.Deny, 10),
+                PolicyDecision.FromRule(MakeRule("global-rule", PolicyAction.Deny, 10)),
+                PolicyScope.Global),
+            new(MakeRule("tenant-rule", PolicyAction.Allow, 5),
+                PolicyDecision.FromRule(MakeRule("tenant-rule", PolicyAction.Allow, 5)),
+                PolicyScope.Tenant),
+            new(MakeRule("agent-rule", PolicyAction.Deny, 1),
+                PolicyDecision.FromRule(MakeRule("agent-rule", PolicyAction.Deny, 1)),
+                PolicyScope.Agent)
+        };
+
+        var result = PolicyConflictResolver.Resolve(candidates, ConflictResolutionStrategy.MostSpecificWins);
+
+        Assert.NotNull(result);
+        Assert.Equal("agent-rule", result.MatchedRule);
+    }
+
+    [Fact]
+    public void Resolve_EmptyList_ReturnsNull()
+    {
+        var result = PolicyConflictResolver.Resolve(
+            new List<CandidateDecision>(),
+            ConflictResolutionStrategy.DenyOverrides);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Resolve_SingleCandidate_ReturnsThatDecision()
+    {
+        var candidates = new List<CandidateDecision>
+        {
+            new(MakeRule("only-rule", PolicyAction.Allow, 5),
+                PolicyDecision.FromRule(MakeRule("only-rule", PolicyAction.Allow, 5)),
+                PolicyScope.Global)
+        };
+
+        var result = PolicyConflictResolver.Resolve(candidates, ConflictResolutionStrategy.DenyOverrides);
+
+        Assert.NotNull(result);
+        Assert.Equal("only-rule", result!.MatchedRule);
+    }
+
+    [Fact]
+    public void ParseScope_ValidValues_ParseCorrectly()
+    {
+        Assert.Equal(PolicyScope.Global, PolicyConflictResolver.ParseScope("global"));
+        Assert.Equal(PolicyScope.Tenant, PolicyConflictResolver.ParseScope("tenant"));
+        Assert.Equal(PolicyScope.Agent, PolicyConflictResolver.ParseScope("agent"));
+        Assert.Equal(PolicyScope.Global, PolicyConflictResolver.ParseScope(null));
+        Assert.Equal(PolicyScope.Global, PolicyConflictResolver.ParseScope("unknown"));
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceKernelTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceKernelTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Audit;
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class GovernanceKernelTests
+{
+    private const string TestPolicy = @"
+apiVersion: governance.toolkit/v1
+name: kernel-test-policy
+default_action: deny
+rules:
+  - name: allow-safe-tools
+    condition: ""tool_name == 'read'""
+    action: allow
+    priority: 10
+  - name: block-writes
+    condition: ""tool_name == 'write'""
+    action: deny
+    priority: 5
+";
+
+    [Fact]
+    public void Constructor_DefaultOptions_CreatesKernel()
+    {
+        var kernel = new GovernanceKernel();
+
+        Assert.NotNull(kernel.PolicyEngine);
+        Assert.NotNull(kernel.AuditEmitter);
+        Assert.NotNull(kernel.Middleware);
+        Assert.True(kernel.AuditEnabled);
+    }
+
+    [Fact]
+    public void LoadPolicyFromYaml_LoadsSuccessfully()
+    {
+        var kernel = new GovernanceKernel();
+        kernel.LoadPolicyFromYaml(TestPolicy);
+
+        var policies = kernel.PolicyEngine.ListPolicies();
+        Assert.Single(policies);
+        Assert.Equal("kernel-test-policy", policies[0].Name);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_AllowedTool_ReturnsAllowed()
+    {
+        var kernel = new GovernanceKernel();
+        kernel.LoadPolicyFromYaml(TestPolicy);
+
+        var result = kernel.EvaluateToolCall("did:mesh:test", "read");
+        Assert.True(result.Allowed);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_BlockedTool_ReturnsDenied()
+    {
+        var kernel = new GovernanceKernel();
+        kernel.LoadPolicyFromYaml(TestPolicy);
+
+        var result = kernel.EvaluateToolCall("did:mesh:test", "write");
+        Assert.False(result.Allowed);
+    }
+
+    [Fact]
+    public void OnEvent_ReceivesEmittedEvents()
+    {
+        var kernel = new GovernanceKernel();
+        kernel.LoadPolicyFromYaml(TestPolicy);
+
+        GovernanceEvent? received = null;
+        kernel.OnEvent(GovernanceEventType.ToolCallBlocked, e => received = e);
+
+        kernel.EvaluateToolCall("did:mesh:test", "write");
+
+        Assert.NotNull(received);
+        Assert.Equal(GovernanceEventType.ToolCallBlocked, received!.Type);
+    }
+
+    [Fact]
+    public void OnAllEvents_ReceivesAllEventTypes()
+    {
+        var kernel = new GovernanceKernel();
+        kernel.LoadPolicyFromYaml(TestPolicy);
+
+        var events = new List<GovernanceEvent>();
+        kernel.OnAllEvents(e => events.Add(e));
+
+        kernel.EvaluateToolCall("did:mesh:test", "read");
+        kernel.EvaluateToolCall("did:mesh:test", "write");
+
+        Assert.True(events.Count >= 2);
+    }
+
+    [Fact]
+    public void Options_ConflictStrategy_IsRespected()
+    {
+        var kernel = new GovernanceKernel(new GovernanceOptions
+        {
+            ConflictStrategy = ConflictResolutionStrategy.DenyOverrides
+        });
+
+        Assert.Equal(ConflictResolutionStrategy.DenyOverrides, kernel.PolicyEngine.ConflictStrategy);
+    }
+
+    [Fact]
+    public void Options_EnableAuditFalse_SetsFlag()
+    {
+        var kernel = new GovernanceKernel(new GovernanceOptions
+        {
+            EnableAudit = false
+        });
+
+        Assert.False(kernel.AuditEnabled);
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceMiddlewareTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceMiddlewareTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Audit;
+using AgentGovernance.Integration;
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class GovernanceMiddlewareTests
+{
+    private static GovernanceMiddleware CreateMiddleware(string yaml)
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(yaml);
+        var emitter = new AuditEmitter();
+        return new GovernanceMiddleware(engine, emitter);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_BlockedTool_ReturnsDenied()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: block-policy
+default_action: allow
+rules:
+  - name: block-rm
+    condition: ""tool_name == 'rm'""
+    action: deny
+    priority: 10
+";
+        var middleware = CreateMiddleware(yaml);
+
+        var result = middleware.EvaluateToolCall("did:mesh:agent1", "rm");
+
+        Assert.False(result.Allowed);
+        Assert.Contains("deny", result.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(result.AuditEntry);
+        Assert.Equal(GovernanceEventType.ToolCallBlocked, result.AuditEntry.Type);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_AllowedTool_ReturnsAllowed()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: allow-policy
+default_action: allow
+rules: []
+";
+        var middleware = CreateMiddleware(yaml);
+
+        var result = middleware.EvaluateToolCall("did:mesh:agent1", "file_read");
+
+        Assert.True(result.Allowed);
+        Assert.NotNull(result.AuditEntry);
+        Assert.Equal(GovernanceEventType.PolicyCheck, result.AuditEntry.Type);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_EmitsAuditEvents()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: audit-test
+default_action: allow
+rules:
+  - name: block-delete
+    condition: ""tool_name == 'delete'""
+    action: deny
+    priority: 10
+";
+        var engine = new PolicyEngine();
+        engine.LoadYaml(yaml);
+        var emitter = new AuditEmitter();
+        var middleware = new GovernanceMiddleware(engine, emitter);
+
+        var events = new List<GovernanceEvent>();
+        emitter.OnAll(e => events.Add(e));
+
+        middleware.EvaluateToolCall("did:mesh:test", "delete");
+
+        // Should emit both a ToolCallBlocked and PolicyViolation event.
+        Assert.Contains(events, e => e.Type == GovernanceEventType.ToolCallBlocked);
+        Assert.Contains(events, e => e.Type == GovernanceEventType.PolicyViolation);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_IncludesToolNameInAuditData()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: data-test
+default_action: allow
+rules: []
+";
+        var middleware = CreateMiddleware(yaml);
+
+        var result = middleware.EvaluateToolCall("did:mesh:test", "my_tool",
+            new Dictionary<string, object> { ["path"] = "/tmp/file.txt" });
+
+        Assert.Equal("my_tool", result.AuditEntry.Data["tool_name"]);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_ArgumentsMergedIntoContext()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: args-test
+default_action: allow
+rules:
+  - name: block-secret-path
+    condition: ""path == '/etc/secrets'""
+    action: deny
+    priority: 10
+";
+        var middleware = CreateMiddleware(yaml);
+
+        var result = middleware.EvaluateToolCall("did:mesh:test", "read",
+            new Dictionary<string, object> { ["path"] = "/etc/secrets" });
+
+        Assert.False(result.Allowed);
+    }
+
+    [Fact]
+    public void EvaluateToolCall_PolicyDecisionIsAttached()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: decision-test
+default_action: deny
+rules: []
+";
+        var middleware = CreateMiddleware(yaml);
+
+        var result = middleware.EvaluateToolCall("did:mesh:test", "anything");
+
+        Assert.NotNull(result.PolicyDecision);
+        Assert.False(result.PolicyDecision!.Allowed);
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyEngineTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyEngineTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class PolicyEngineTests
+{
+    private const string DenyPolicy = @"
+apiVersion: governance.toolkit/v1
+name: security-policy
+scope: global
+default_action: deny
+rules:
+  - name: block-rm
+    condition: ""tool_name == 'rm'""
+    action: deny
+    priority: 10
+  - name: allow-read
+    condition: ""tool_name == 'read'""
+    action: allow
+    priority: 5
+  - name: warn-write
+    condition: ""tool_name == 'write'""
+    action: warn
+    priority: 3
+";
+
+    [Fact]
+    public void Evaluate_NoPoliciesLoaded_AllowsByDefault()
+    {
+        var engine = new PolicyEngine();
+        var decision = engine.Evaluate("did:mesh:test", new Dictionary<string, object>());
+
+        Assert.True(decision.Allowed);
+        Assert.Equal("allow", decision.Action);
+    }
+
+    [Fact]
+    public void Evaluate_DenyRuleMatches_ReturnsDeny()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object> { ["tool_name"] = "rm" });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("deny", decision.Action);
+        Assert.Equal("block-rm", decision.MatchedRule);
+    }
+
+    [Fact]
+    public void Evaluate_AllowRuleMatches_ReturnsAllow()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object> { ["tool_name"] = "read" });
+
+        Assert.True(decision.Allowed);
+        Assert.Equal("allow", decision.Action);
+        Assert.Equal("allow-read", decision.MatchedRule);
+    }
+
+    [Fact]
+    public void Evaluate_WarnRuleMatches_ReturnsAllowedWithWarn()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object> { ["tool_name"] = "write" });
+
+        Assert.True(decision.Allowed);
+        Assert.Equal("warn", decision.Action);
+    }
+
+    [Fact]
+    public void Evaluate_NoRulesMatch_ReturnsDefaultAction()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object> { ["tool_name"] = "unknown_tool" });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("deny", decision.Action);
+        Assert.Null(decision.MatchedRule);
+    }
+
+    [Fact]
+    public void Evaluate_AllowDefault_NoRulesMatch_AllowsByDefault()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: permissive
+default_action: allow
+rules: []
+";
+        var engine = new PolicyEngine();
+        engine.LoadYaml(yaml);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object> { ["tool_name"] = "anything" });
+
+        Assert.True(decision.Allowed);
+    }
+
+    [Fact]
+    public void Evaluate_InListCondition_DeniesBlockedTool()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: blocklist-policy
+default_action: allow
+rules:
+  - name: blocklist
+    condition: ""tool_name in blocked_tools""
+    action: deny
+    priority: 10
+";
+        var engine = new PolicyEngine();
+        engine.LoadYaml(yaml);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object>
+            {
+                ["tool_name"] = "rm",
+                ["blocked_tools"] = new List<object> { "rm", "format", "shutdown" }
+            });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("blocklist", decision.MatchedRule);
+    }
+
+    [Fact]
+    public void ListPolicies_ReturnsLoadedPolicies()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+
+        var policies = engine.ListPolicies();
+        Assert.Single(policies);
+        Assert.Equal("security-policy", policies[0].Name);
+    }
+
+    [Fact]
+    public void ClearPolicies_RemovesAllPolicies()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+        Assert.Single(engine.ListPolicies());
+
+        engine.ClearPolicies();
+        Assert.Empty(engine.ListPolicies());
+    }
+
+    [Fact]
+    public void Evaluate_RecordsEvaluationTime()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object> { ["tool_name"] = "rm" });
+
+        Assert.True(decision.EvaluationMs >= 0);
+    }
+
+    [Fact]
+    public void Evaluate_InjectsAgentDid()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: agent-check
+default_action: allow
+rules:
+  - name: block-specific-agent
+    condition: ""agent_did == 'did:mesh:blocked'""
+    action: deny
+    priority: 10
+";
+        var engine = new PolicyEngine();
+        engine.LoadYaml(yaml);
+
+        // Should match the blocked agent.
+        var decision1 = engine.Evaluate("did:mesh:blocked",
+            new Dictionary<string, object> { ["tool_name"] = "anything" });
+        Assert.False(decision1.Allowed);
+
+        // Should not match a different agent.
+        var decision2 = engine.Evaluate("did:mesh:other",
+            new Dictionary<string, object> { ["tool_name"] = "anything" });
+        Assert.True(decision2.Allowed);
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class PolicyRuleTests
+{
+    [Fact]
+    public void Evaluate_EqualityCondition_MatchesWhenEqual()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-equality",
+            Condition = "tool_name == 'file_write'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object> { ["tool_name"] = "file_write" };
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_EqualityCondition_DoesNotMatchWhenDifferent()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-equality-miss",
+            Condition = "tool_name == 'file_write'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object> { ["tool_name"] = "file_read" };
+        Assert.False(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_InequalityCondition_Matches()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-inequality",
+            Condition = "role != 'admin'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object> { ["role"] = "user" };
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_NumericGreaterThan_Matches()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-gt",
+            Condition = "request_count > 100",
+            Action = PolicyAction.RateLimit
+        };
+
+        var context = new Dictionary<string, object> { ["request_count"] = 150 };
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_NumericLessThanOrEqual_DoesNotMatch()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-lte-miss",
+            Condition = "request_count > 100",
+            Action = PolicyAction.RateLimit
+        };
+
+        var context = new Dictionary<string, object> { ["request_count"] = 50 };
+        Assert.False(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_InListCondition_MatchesWhenInList()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-in-list",
+            Condition = "tool_name in blocked_tools",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["tool_name"] = "rm",
+            ["blocked_tools"] = new List<object> { "rm", "format", "shutdown" }
+        };
+
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_InListCondition_DoesNotMatchWhenNotInList()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-in-list-miss",
+            Condition = "tool_name in blocked_tools",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["tool_name"] = "file_read",
+            ["blocked_tools"] = new List<object> { "rm", "format", "shutdown" }
+        };
+
+        Assert.False(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_BooleanFieldCondition_MatchesWhenTrue()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-bool",
+            Condition = "contains_pii",
+            Action = PolicyAction.RequireApproval
+        };
+
+        var context = new Dictionary<string, object> { ["contains_pii"] = true };
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_BooleanFieldCondition_DoesNotMatchWhenFalse()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-bool-false",
+            Condition = "contains_pii",
+            Action = PolicyAction.RequireApproval
+        };
+
+        var context = new Dictionary<string, object> { ["contains_pii"] = false };
+        Assert.False(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_CompoundAndCondition_BothMustMatch()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-and",
+            Condition = "tool_name == 'export' and contains_pii",
+            Action = PolicyAction.RequireApproval
+        };
+
+        // Both conditions true.
+        var context1 = new Dictionary<string, object>
+        {
+            ["tool_name"] = "export",
+            ["contains_pii"] = true
+        };
+        Assert.True(rule.Evaluate(context1));
+
+        // One condition false.
+        var context2 = new Dictionary<string, object>
+        {
+            ["tool_name"] = "export",
+            ["contains_pii"] = false
+        };
+        Assert.False(rule.Evaluate(context2));
+    }
+
+    [Fact]
+    public void Evaluate_CompoundOrCondition_EitherCanMatch()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-or",
+            Condition = "tool_name == 'rm' or tool_name == 'format'",
+            Action = PolicyAction.Deny
+        };
+
+        var context1 = new Dictionary<string, object> { ["tool_name"] = "rm" };
+        Assert.True(rule.Evaluate(context1));
+
+        var context2 = new Dictionary<string, object> { ["tool_name"] = "format" };
+        Assert.True(rule.Evaluate(context2));
+
+        var context3 = new Dictionary<string, object> { ["tool_name"] = "read" };
+        Assert.False(rule.Evaluate(context3));
+    }
+
+    [Fact]
+    public void Evaluate_DisabledRule_NeverMatches()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-disabled",
+            Condition = "tool_name == 'anything'",
+            Action = PolicyAction.Deny,
+            Enabled = false
+        };
+
+        var context = new Dictionary<string, object> { ["tool_name"] = "anything" };
+        Assert.False(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_NestedDotNotation_ResolvesCorrectly()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-nested",
+            Condition = "data.classification == 'secret'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["data"] = new Dictionary<string, object> { ["classification"] = "secret" }
+        };
+
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_MissingField_ReturnsFalseSafely()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "test-missing",
+            Condition = "nonexistent_field == 'value'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object>();
+        Assert.False(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void ParseAction_ValidValues_ParseCorrectly()
+    {
+        Assert.Equal(PolicyAction.Allow, PolicyRule.ParseAction("allow"));
+        Assert.Equal(PolicyAction.Deny, PolicyRule.ParseAction("deny"));
+        Assert.Equal(PolicyAction.Warn, PolicyRule.ParseAction("warn"));
+        Assert.Equal(PolicyAction.RequireApproval, PolicyRule.ParseAction("require_approval"));
+        Assert.Equal(PolicyAction.Log, PolicyRule.ParseAction("log"));
+        Assert.Equal(PolicyAction.RateLimit, PolicyRule.ParseAction("rate_limit"));
+    }
+
+    [Fact]
+    public void ParseAction_InvalidValue_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => PolicyRule.ParseAction("invalid"));
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Policy;
+using Xunit;
+using GovernancePolicy = AgentGovernance.Policy.Policy;
+
+namespace AgentGovernance.Tests;
+
+public class PolicyTests
+{
+    private const string ValidYaml = @"
+apiVersion: governance.toolkit/v1
+version: '1.0'
+name: test-policy
+description: A test policy
+scope: global
+default_action: deny
+rules:
+  - name: block-dangerous-tools
+    condition: ""tool_name in blocked_tools""
+    action: deny
+    priority: 10
+    enabled: true
+  - name: require-approval-for-exports
+    condition: ""tool_name == 'export'""
+    action: require_approval
+    priority: 5
+    approvers:
+      - compliance@org.com
+      - admin@org.com
+  - name: log-reads
+    condition: ""tool_name == 'read'""
+    action: log
+    priority: 1
+";
+
+    [Fact]
+    public void FromYaml_ValidPolicy_ParsesCorrectly()
+    {
+        var policy = GovernancePolicy.FromYaml(ValidYaml);
+
+        Assert.Equal("governance.toolkit/v1", policy.ApiVersion);
+        Assert.Equal("1.0", policy.Version);
+        Assert.Equal("test-policy", policy.Name);
+        Assert.Equal("A test policy", policy.Description);
+        Assert.Equal(PolicyScope.Global, policy.Scope);
+        Assert.Equal(PolicyAction.Deny, policy.DefaultAction);
+        Assert.Equal(3, policy.Rules.Count);
+    }
+
+    [Fact]
+    public void FromYaml_ParsesRuleProperties()
+    {
+        var policy = GovernancePolicy.FromYaml(ValidYaml);
+
+        var blockRule = policy.Rules[0];
+        Assert.Equal("block-dangerous-tools", blockRule.Name);
+        Assert.Equal("tool_name in blocked_tools", blockRule.Condition);
+        Assert.Equal(PolicyAction.Deny, blockRule.Action);
+        Assert.Equal(10, blockRule.Priority);
+        Assert.True(blockRule.Enabled);
+    }
+
+    [Fact]
+    public void FromYaml_ParsesApprovers()
+    {
+        var policy = GovernancePolicy.FromYaml(ValidYaml);
+
+        var approvalRule = policy.Rules[1];
+        Assert.Equal(PolicyAction.RequireApproval, approvalRule.Action);
+        Assert.Equal(2, approvalRule.Approvers.Count);
+        Assert.Contains("compliance@org.com", approvalRule.Approvers);
+        Assert.Contains("admin@org.com", approvalRule.Approvers);
+    }
+
+    [Fact]
+    public void FromYaml_TenantScope_ParsesCorrectly()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: tenant-policy
+scope: tenant
+default_action: allow
+rules: []
+";
+        var policy = GovernancePolicy.FromYaml(yaml);
+        Assert.Equal(PolicyScope.Tenant, policy.Scope);
+        Assert.Equal(PolicyAction.Allow, policy.DefaultAction);
+    }
+
+    [Fact]
+    public void FromYaml_AgentScope_ParsesCorrectly()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: agent-policy
+scope: agent
+default_action: deny
+rules: []
+";
+        var policy = GovernancePolicy.FromYaml(yaml);
+        Assert.Equal(PolicyScope.Agent, policy.Scope);
+    }
+
+    [Fact]
+    public void FromYaml_UnsupportedApiVersion_ThrowsArgumentException()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v99
+name: bad-policy
+rules: []
+";
+        var ex = Assert.Throws<ArgumentException>(() => GovernancePolicy.FromYaml(yaml));
+        Assert.Contains("Unsupported", ex.Message);
+    }
+
+    [Fact]
+    public void FromYaml_MissingName_ThrowsArgumentException()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+rules: []
+";
+        Assert.Throws<ArgumentException>(() => GovernancePolicy.FromYaml(yaml));
+    }
+
+    [Fact]
+    public void FromYaml_NullOrEmpty_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => GovernancePolicy.FromYaml(""));
+        Assert.Throws<ArgumentException>(() => GovernancePolicy.FromYaml("   "));
+    }
+
+    [Fact]
+    public void FromYaml_DefaultsToAllowAction()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: default-allow
+default_action: allow
+rules: []
+";
+        var policy = GovernancePolicy.FromYaml(yaml);
+        Assert.Equal(PolicyAction.Allow, policy.DefaultAction);
+    }
+
+    [Fact]
+    public void FromYaml_DefaultsWhenFieldsMissing()
+    {
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: minimal-policy
+rules:
+  - name: simple-rule
+    condition: ""tool_name == 'test'""
+";
+        var policy = GovernancePolicy.FromYaml(yaml);
+
+        Assert.Equal(PolicyScope.Global, policy.Scope);
+        Assert.Equal(PolicyAction.Deny, policy.DefaultAction);
+
+        var rule = policy.Rules[0];
+        Assert.Equal(PolicyAction.Deny, rule.Action);
+        Assert.Equal(0, rule.Priority);
+        Assert.True(rule.Enabled);
+        Assert.Empty(rule.Approvers);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a .NET 8.0 governance SDK that brings the Agent Governance Toolkit to the Microsoft Agent Framework and .NET enterprise ecosystem. Same YAML policy schema works cross-language.

### Architecture

```
packages/agent-governance-dotnet/
  src/AgentGovernance/
    Policy/          PolicyEngine, Policy, PolicyRule, ConflictResolution
    Trust/           AgentIdentity (did:mesh:, HMAC-SHA256 signing)
    Audit/           AuditEmitter (thread-safe pub-sub), GovernanceEvent
    Integration/     GovernanceMiddleware (MAF tool call governance)
    GovernanceKernel.cs  (facade entry point)
  tests/AgentGovernance.Tests/  (82 tests)
```

### Core Components

| Component | Description | Python Equivalent |
|-----------|-------------|------------------|
| PolicyEngine | YAML policy loading + rule evaluation | agentmesh.governance.policy |
| ConflictResolver | 4 strategies: deny/allow overrides, priority, specificity | agentmesh.governance.conflict_resolution |
| AgentIdentity | did:mesh: format, HMAC-SHA256 signing (.NET 8), Ed25519 path for .NET 9+ | agentmesh.trust.handshake |
| AuditEmitter | Thread-safe pub-sub with wildcard subscriptions | agent_os.integrations.base (event system) |
| GovernanceMiddleware | Tool call evaluation + audit for MAF agents | agent_os.integrations (framework wrappers) |
| GovernanceKernel | Facade wiring all components | agent_os.KernelSpace |

### Usage

```csharp
var kernel = new GovernanceKernel(new GovernanceOptions
{
    PolicyPaths = new List<string> { "policies/production.yaml" },
    ConflictStrategy = ConflictResolutionStrategy.DenyOverrides,
});

// Evaluate every tool call before execution
var result = kernel.EvaluateToolCall("did:mesh:agent-1", "web_search", args);
if (!result.Allowed)
    throw new GovernanceViolationException(result.Reason);
```

### Testing
- 82 unit tests across 8 test suites
- All passing on .NET 8.0
- Covers: rule evaluation, YAML parsing, conflict resolution, identity signing, audit emission, middleware

### What's Next
- NuGet package publishing
- gRPC client for cross-language policy evaluation
- Native Ed25519 support (when targeting .NET 9+)
- Microsoft Agent Framework IAgentMiddleware adapter

Closes #80