### PR TITLE
fix: repair welcome and copilot-review CI workflows

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,7 +1,7 @@
 name: Copilot Auto-Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review]
 
 permissions:
@@ -21,4 +21,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-            -f "reviewers[]=copilot"
+            -f "reviewers[]=copilot" || echo "::warning::Could not request Copilot review (expected for fork PRs)"

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - uses: actions/first-interaction@a1db7729b356323c7988c20ed6f0d33fe31297be # v1.3.0
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          issue-message: |
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          issue_message: |
             Welcome to the Agent Governance Toolkit! Thanks for opening your first issue.
             A maintainer will review this shortly. Check our [Contributing Guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/CONTRIBUTING.md).
             For security issues, use [private vulnerability reporting](https://github.com/microsoft/agent-governance-toolkit/security/advisories/new).
-          pr-message: |
+          pr_message: |
             Welcome to the Agent Governance Toolkit! Thanks for your first pull request.
             Please ensure tests pass, code follows style (ruff check), and you have signed the [CLA](https://cla.opensource.microsoft.com/).
             See our [Contributing Guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Changes

### welcome.yml
- \ctions/first-interaction\ v1.3.0 requires underscore input names (\epo_token\, \issue_message\, \pr_message\), not kebab-case
- The kebab-case variants were silently ignored, causing 'Input required and not supplied: issue_message' error on every new contributor PR/issue

### copilot-review.yml
- Switch from \pull_request\ to \pull_request_target\ so the workflow gets write permissions on fork PRs
- Add \|| echo\ fallback so the job doesn't fail with HTTP 403 when Copilot review can't be requested

Fixes CI failures seen in #117.