### PR TITLE
fix: align MAF Message stub with agent-framework API

### DIFF
--- a/packages/agent-os/src/agent_os/integrations/maf_adapter.py
+++ b/packages/agent-os/src/agent_os/integrations/maf_adapter.py
@@ -82,13 +82,13 @@ except ImportError:  # pragma: no cover
             self.messages = messages or []
 
     class Message:  # type: ignore[no-redef]
-        def __init__(self, role: str, content: list[str] | None = None) -> None:
+        def __init__(self, role: str, contents: list[str] | None = None) -> None:
             self.role = role
-            self.content = content or []
+            self.contents = contents or []
 
         @property
         def text(self) -> str:
-            return self.content[0] if self.content else ""
+            return str(self.contents[0]) if self.contents else ""
 
     class MiddlewareTermination(Exception):  # type: ignore[no-redef]
         """Local fallback when agent_framework is not installed."""

--- a/packages/agent-os/tests/test_e2e_governance_pipeline.py
+++ b/packages/agent-os/tests/test_e2e_governance_pipeline.py
@@ -99,11 +99,11 @@ class MockMessage:
     """Mock MAF Message."""
     def __init__(self, role: str = "user", content: str = ""):
         self.role = role
-        self.content = [content] if content else []
+        self.contents = [content] if content else []
 
     @property
     def text(self):
-        return self.content[0] if self.content else ""
+        return str(self.contents[0]) if self.contents else ""
 
 
 # ============================================================================
@@ -180,7 +180,7 @@ defaults:
 
         assert call_next_called is False
         assert ctx.result is not None
-        assert "Policy violation" in ctx.result.messages[0].content[0]
+        assert "Policy violation" in str(ctx.result.messages[0].contents[0])
 
         # Audit log should record the denial
         entries = audit_log.get_entries_for_agent("researcher")


### PR DESCRIPTION
Fixes Message.content vs Message.contents mismatch with real agent-framework. Updates stub and tests.