### PR TITLE
feat: observability integrations — Prometheus, OTel, PagerDuty, Grafana (#49)

### DIFF
--- a/packages/agent-hypervisor/pyproject.toml
+++ b/packages/agent-hypervisor/pyproject.toml
@@ -60,6 +60,12 @@ dev = [
 blockchain = [
     "web3>=6.0.0",  # Reserved for future blockchain anchoring — not yet used
 ]
+observability = [
+    "agent-sre>=1.1.0",  # PrometheusExporter bridge for RingMetricsCollector
+]
+otel = [
+    "opentelemetry-api>=1.20",  # OTel span creation for SagaSpanExporter
+]
 
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"

--- a/packages/agent-hypervisor/src/hypervisor/observability/__init__.py
+++ b/packages/agent-hypervisor/src/hypervisor/observability/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Observability module — structured event bus and causal tracing."""
+"""Observability module — structured event bus, causal tracing, and metrics."""
 
 from hypervisor.observability.causal_trace import CausalTraceId
 from hypervisor.observability.event_bus import (
@@ -8,10 +8,20 @@ from hypervisor.observability.event_bus import (
     HypervisorEvent,
     HypervisorEventBus,
 )
+from hypervisor.observability.prometheus_collector import RingMetricsCollector
+from hypervisor.observability.saga_span_exporter import (
+    SagaSpanExporter,
+    SagaSpanRecord,
+    SpanSink,
+)
 
 __all__ = [
     "EventType",
     "HypervisorEvent",
     "HypervisorEventBus",
     "CausalTraceId",
+    "RingMetricsCollector",
+    "SagaSpanExporter",
+    "SagaSpanRecord",
+    "SpanSink",
 ]

--- a/packages/agent-hypervisor/src/hypervisor/observability/prometheus_collector.py
+++ b/packages/agent-hypervisor/src/hypervisor/observability/prometheus_collector.py
@@ -1,0 +1,248 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Prometheus metrics collector for Hypervisor ring transitions.
+
+Subscribes to the HypervisorEventBus and maintains in-memory counters
+for ring-related events (transitions, breaches, elevations). Metrics
+follow the ``agent_hypervisor_ring_*`` prefix convention.
+
+No external dependencies — works standalone or exports to the
+``agent-sre`` PrometheusExporter via dependency injection.
+
+Usage::
+
+    from hypervisor.observability import RingMetricsCollector, HypervisorEventBus
+
+    bus = HypervisorEventBus()
+    collector = RingMetricsCollector(bus)
+
+    # ... hypervisor operates, ring events flow through the bus ...
+
+    snapshot = collector.collect()
+    # {"agent_hypervisor_ring_transitions_total": {"ring.assigned": 5, ...}, ...}
+
+    # Optional: export to agent-sre PrometheusExporter
+    from agent_sre.integrations.prometheus import PrometheusExporter
+    prom = PrometheusExporter()
+    collector.export_to_prometheus(prom)
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Any, Protocol
+
+from hypervisor.observability.event_bus import EventType, HypervisorEvent, HypervisorEventBus
+
+# Ring event types that represent transitions
+_RING_TRANSITION_EVENTS = frozenset({
+    EventType.RING_ASSIGNED,
+    EventType.RING_ELEVATED,
+    EventType.RING_DEMOTED,
+    EventType.RING_ELEVATION_EXPIRED,
+})
+
+_RING_BREACH_EVENTS = frozenset({
+    EventType.RING_BREACH_DETECTED,
+})
+
+_ALL_RING_EVENTS = _RING_TRANSITION_EVENTS | _RING_BREACH_EVENTS
+
+
+class PrometheusExporterProtocol(Protocol):
+    """Protocol for Prometheus exporters — avoids hard dep on agent-sre."""
+
+    def set_gauge(
+        self, name: str, value: float,
+        labels: dict[str, str] | None = None,
+        help_text: str = "",
+    ) -> None: ...
+
+    def inc_counter(
+        self, name: str, value: float = 1.0,
+        labels: dict[str, str] | None = None,
+        help_text: str = "",
+    ) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Metric name constants
+# ---------------------------------------------------------------------------
+
+METRIC_RING_TRANSITIONS_TOTAL = "agent_hypervisor_ring_transitions_total"
+METRIC_RING_BREACHES_TOTAL = "agent_hypervisor_ring_breaches_total"
+METRIC_RING_CURRENT = "agent_hypervisor_ring_current"
+METRIC_RING_ELEVATION_DURATION = "agent_hypervisor_ring_elevation_duration_seconds"
+
+
+class RingMetricsCollector:
+    """Collects Prometheus-compatible metrics from hypervisor ring events.
+
+    Subscribes to the ``HypervisorEventBus`` for ring transition and breach
+    events. Maintains in-memory counters and gauges that can be exported
+    to any :class:`PrometheusExporterProtocol`-compatible exporter.
+
+    Attributes:
+        _bus: The event bus this collector is subscribed to.
+        _transition_counts: Counter per ``(event_type, agent_did, session_id)``.
+        _breach_counts: Counter per ``(agent_did, session_id)``.
+        _current_rings: Current ring gauge per ``agent_did``.
+        _elevation_start: Timestamp when an agent entered elevated state.
+        _elevation_durations: Last known elevation duration per ``agent_did``.
+    """
+
+    def __init__(self, bus: HypervisorEventBus) -> None:
+        self._bus = bus
+
+        # Counters: (event_type_value, agent_did, session_id) -> count
+        self._transition_counts: dict[tuple[str, str, str], int] = defaultdict(int)
+
+        # Breach counter: (agent_did, session_id) -> count
+        self._breach_counts: dict[tuple[str, str], int] = defaultdict(int)
+
+        # Current ring per agent: agent_did -> ring_value (int)
+        self._current_rings: dict[str, int] = {}
+
+        # Elevation tracking: agent_did -> start timestamp
+        self._elevation_start: dict[str, float] = {}
+
+        # Last elevation duration: agent_did -> seconds (float)
+        self._elevation_durations: dict[str, float] = {}
+
+        # Total events processed
+        self._events_processed: int = 0
+
+        # Subscribe to all ring events
+        for event_type in _ALL_RING_EVENTS:
+            bus.subscribe(event_type=event_type, handler=self._handle_event)
+
+    def _handle_event(self, event: HypervisorEvent) -> None:
+        """Process a ring-related event from the bus."""
+        agent_did = event.agent_did or "unknown"
+        session_id = event.session_id or "unknown"
+        self._events_processed += 1
+
+        if event.event_type in _RING_TRANSITION_EVENTS:
+            key = (event.event_type.value, agent_did, session_id)
+            self._transition_counts[key] += 1
+
+            # Track current ring from payload
+            to_ring = event.payload.get("to_ring") or event.payload.get("ring")
+            if to_ring is not None:
+                self._current_rings[agent_did] = (
+                    to_ring if isinstance(to_ring, int) else int(to_ring)
+                )
+
+            # Track elevation timing
+            if event.event_type == EventType.RING_ELEVATED:
+                self._elevation_start[agent_did] = event.timestamp.timestamp()
+            elif event.event_type in (
+                EventType.RING_DEMOTED,
+                EventType.RING_ELEVATION_EXPIRED,
+            ):
+                start = self._elevation_start.pop(agent_did, None)
+                if start is not None:
+                    self._elevation_durations[agent_did] = (
+                        event.timestamp.timestamp() - start
+                    )
+
+        elif event.event_type in _RING_BREACH_EVENTS:
+            self._breach_counts[(agent_did, session_id)] += 1
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def collect(self) -> dict[str, Any]:
+        """Return a snapshot of all metrics as a framework-agnostic dict.
+
+        Returns:
+            Dictionary with metric names as keys and nested dicts/values:
+
+            - ``agent_hypervisor_ring_transitions_total``:
+              ``{(event_type, agent, session): count}``
+            - ``agent_hypervisor_ring_breaches_total``:
+              ``{(agent, session): count}``
+            - ``agent_hypervisor_ring_current``:
+              ``{agent: ring_value}``
+            - ``agent_hypervisor_ring_elevation_duration_seconds``:
+              ``{agent: seconds}``
+        """
+        return {
+            METRIC_RING_TRANSITIONS_TOTAL: dict(self._transition_counts),
+            METRIC_RING_BREACHES_TOTAL: dict(self._breach_counts),
+            METRIC_RING_CURRENT: dict(self._current_rings),
+            METRIC_RING_ELEVATION_DURATION: dict(self._elevation_durations),
+            "events_processed": self._events_processed,
+        }
+
+    def export_to_prometheus(self, exporter: PrometheusExporterProtocol) -> None:
+        """Write all current metrics into a Prometheus-compatible exporter.
+
+        Args:
+            exporter: Any object implementing :class:`PrometheusExporterProtocol`
+                (e.g. ``agent_sre.integrations.prometheus.PrometheusExporter``).
+        """
+        # Transition counters
+        for (event_type, agent_did, session_id), count in self._transition_counts.items():
+            exporter.inc_counter(
+                METRIC_RING_TRANSITIONS_TOTAL,
+                float(count),
+                labels={
+                    "event_type": event_type,
+                    "agent_did": agent_did,
+                    "session_id": session_id,
+                },
+                help_text="Total ring transition events by type",
+            )
+
+        # Breach counters
+        for (agent_did, session_id), count in self._breach_counts.items():
+            exporter.inc_counter(
+                METRIC_RING_BREACHES_TOTAL,
+                float(count),
+                labels={
+                    "agent_did": agent_did,
+                    "session_id": session_id,
+                },
+                help_text="Total ring breach events detected",
+            )
+
+        # Current ring gauge
+        for agent_did, ring_value in self._current_rings.items():
+            exporter.set_gauge(
+                METRIC_RING_CURRENT,
+                float(ring_value),
+                labels={"agent_did": agent_did},
+                help_text="Current execution ring for each agent (0=root, 3=sandbox)",
+            )
+
+        # Elevation duration gauge
+        for agent_did, duration in self._elevation_durations.items():
+            exporter.set_gauge(
+                METRIC_RING_ELEVATION_DURATION,
+                duration,
+                labels={"agent_did": agent_did},
+                help_text="Duration of the last ring elevation in seconds",
+            )
+
+        # Also export any currently-active elevations
+        now = time.time()
+        for agent_did, start_ts in self._elevation_start.items():
+            exporter.set_gauge(
+                METRIC_RING_ELEVATION_DURATION,
+                now - start_ts,
+                labels={"agent_did": agent_did},
+                help_text="Duration of the last ring elevation in seconds",
+            )
+
+    def reset(self) -> None:
+        """Reset all counters (for testing)."""
+        self._transition_counts.clear()
+        self._breach_counts.clear()
+        self._current_rings.clear()
+        self._elevation_start.clear()
+        self._elevation_durations.clear()
+        self._events_processed = 0

--- a/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py
+++ b/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py
@@ -1,0 +1,341 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+OpenTelemetry-compatible span exporter for Saga orchestration steps.
+
+Subscribes to the HypervisorEventBus for saga lifecycle events and
+produces span records that can be forwarded to any tracing backend
+via the ``SpanSink`` protocol.
+
+No external dependencies — the hypervisor stays standalone.  A concrete
+``OTelSpanSink`` adapter lives in ``agent-sre`` and bridges into the
+existing ``TraceExporter``.
+
+Usage::
+
+    from hypervisor.observability import SagaSpanExporter, HypervisorEventBus
+
+    bus = HypervisorEventBus()
+    exporter = SagaSpanExporter(bus)
+
+    # Optionally attach a sink (e.g. OTelSpanSink from agent-sre)
+    exporter.attach_sink(my_sink)
+
+    # ... saga events flow through the bus ...
+
+    # Or inspect buffered spans directly
+    spans = exporter.completed_spans
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from hypervisor.observability.event_bus import EventType, HypervisorEvent, HypervisorEventBus
+
+# Saga event types we subscribe to
+_SAGA_LIFECYCLE_EVENTS = frozenset({
+    EventType.SAGA_CREATED,
+    EventType.SAGA_STEP_STARTED,
+    EventType.SAGA_STEP_COMMITTED,
+    EventType.SAGA_STEP_FAILED,
+    EventType.SAGA_COMPENSATING,
+    EventType.SAGA_COMPLETED,
+    EventType.SAGA_ESCALATED,
+})
+
+
+# ---------------------------------------------------------------------------
+# SpanSink protocol — no hard OTel dependency in hypervisor
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SpanSink(Protocol):
+    """Protocol for receiving completed span records.
+
+    Any object implementing this interface can receive spans from the
+    ``SagaSpanExporter``.  The ``agent-sre`` package ships an
+    ``OTelSpanSink`` adapter that bridges into the native OTel SDK.
+    """
+
+    def record_span(
+        self,
+        name: str,
+        start_time: float,
+        end_time: float,
+        attributes: dict[str, Any],
+        status: str,
+    ) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Span record dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SagaSpanRecord:
+    """An immutable record of a completed saga span."""
+
+    name: str
+    saga_id: str
+    step_id: str
+    step_action: str
+    start_time: float
+    end_time: float
+    status: str  # "ok", "error", "compensating"
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.end_time - self.start_time
+
+
+# ---------------------------------------------------------------------------
+# SagaSpanExporter
+# ---------------------------------------------------------------------------
+
+
+class SagaSpanExporter:
+    """Exports OpenTelemetry-compatible spans for saga orchestration steps.
+
+    Subscribes to the ``HypervisorEventBus`` for saga lifecycle events.
+    On each step completion (committed, failed, escalated), records a span
+    with timing, saga context, and status information.
+
+    Completed spans are:
+    1. Buffered internally in ``completed_spans``
+    2. Forwarded to an attached ``SpanSink`` (if any)
+
+    Attributes:
+        _bus: The event bus this exporter is subscribed to.
+        _sink: Optional SpanSink for forwarding completed spans.
+        _step_starts: Tracks step start times: ``(saga_id, step_id) -> timestamp``.
+        _saga_starts: Tracks saga creation times: ``saga_id -> timestamp``.
+        _completed_spans: Buffer of completed span records.
+    """
+
+    def __init__(self, bus: HypervisorEventBus, sink: SpanSink | None = None) -> None:
+        self._bus = bus
+        self._sink = sink
+
+        # In-flight tracking: (saga_id, step_id) -> start timestamp
+        self._step_starts: dict[tuple[str, str], float] = {}
+
+        # Saga-level tracking: saga_id -> creation timestamp
+        self._saga_starts: dict[str, float] = {}
+
+        # Completed span buffer
+        self._completed_spans: list[SagaSpanRecord] = []
+
+        # Total events processed
+        self._events_processed: int = 0
+
+        # Subscribe to all saga lifecycle events
+        for event_type in _SAGA_LIFECYCLE_EVENTS:
+            bus.subscribe(event_type=event_type, handler=self._handle_event)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def attach_sink(self, sink: SpanSink) -> None:
+        """Attach a SpanSink to receive completed spans in real time."""
+        self._sink = sink
+
+    def detach_sink(self) -> None:
+        """Detach the current SpanSink."""
+        self._sink = None
+
+    @property
+    def completed_spans(self) -> list[SagaSpanRecord]:
+        """Return a copy of all completed span records."""
+        return list(self._completed_spans)
+
+    @property
+    def events_processed(self) -> int:
+        """Total saga events processed."""
+        return self._events_processed
+
+    def reset(self) -> None:
+        """Reset all internal state (for testing)."""
+        self._step_starts.clear()
+        self._saga_starts.clear()
+        self._completed_spans.clear()
+        self._events_processed = 0
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+
+    def _handle_event(self, event: HypervisorEvent) -> None:
+        """Process a saga lifecycle event from the bus."""
+        self._events_processed += 1
+        payload = event.payload
+        saga_id = payload.get("saga_id", event.causal_trace_id or "unknown")
+        step_id = payload.get("step_id", "")
+        step_action = payload.get("action", payload.get("step_action", ""))
+
+        if event.event_type == EventType.SAGA_CREATED:
+            self._saga_starts[saga_id] = event.timestamp.timestamp()
+
+        elif event.event_type == EventType.SAGA_STEP_STARTED:
+            key = (saga_id, step_id or step_action)
+            self._step_starts[key] = event.timestamp.timestamp()
+
+        elif event.event_type == EventType.SAGA_STEP_COMMITTED:
+            self._complete_step(
+                saga_id=saga_id,
+                step_id=step_id or step_action,
+                step_action=step_action,
+                end_time=event.timestamp.timestamp(),
+                status="ok",
+                extra_attrs=payload,
+                agent_did=event.agent_did,
+                session_id=event.session_id,
+            )
+
+        elif event.event_type == EventType.SAGA_STEP_FAILED:
+            self._complete_step(
+                saga_id=saga_id,
+                step_id=step_id or step_action,
+                step_action=step_action,
+                end_time=event.timestamp.timestamp(),
+                status="error",
+                extra_attrs=payload,
+                agent_did=event.agent_did,
+                session_id=event.session_id,
+            )
+
+        elif event.event_type == EventType.SAGA_COMPENSATING:
+            # Compensation is a span in its own right
+            self._record_span(
+                name=f"saga.compensate.{step_action or step_id}",
+                saga_id=saga_id,
+                step_id=step_id or "compensation",
+                step_action=step_action or "compensate",
+                start_time=event.timestamp.timestamp(),
+                end_time=event.timestamp.timestamp(),  # instantaneous marker
+                status="compensating",
+                extra_attrs=payload,
+                agent_did=event.agent_did,
+                session_id=event.session_id,
+            )
+
+        elif event.event_type == EventType.SAGA_COMPLETED:
+            # Record a saga-level span from creation to completion
+            start = self._saga_starts.pop(saga_id, None)
+            if start is not None:
+                self._record_span(
+                    name=f"saga.completed.{saga_id}",
+                    saga_id=saga_id,
+                    step_id="",
+                    step_action="complete",
+                    start_time=start,
+                    end_time=event.timestamp.timestamp(),
+                    status="ok",
+                    extra_attrs=payload,
+                    agent_did=event.agent_did,
+                    session_id=event.session_id,
+                )
+
+        elif event.event_type == EventType.SAGA_ESCALATED:
+            start = self._saga_starts.pop(saga_id, None)
+            if start is not None:
+                self._record_span(
+                    name=f"saga.escalated.{saga_id}",
+                    saga_id=saga_id,
+                    step_id="",
+                    step_action="escalate",
+                    start_time=start,
+                    end_time=event.timestamp.timestamp(),
+                    status="error",
+                    extra_attrs=payload,
+                    agent_did=event.agent_did,
+                    session_id=event.session_id,
+                )
+
+    def _complete_step(
+        self,
+        saga_id: str,
+        step_id: str,
+        step_action: str,
+        end_time: float,
+        status: str,
+        extra_attrs: dict[str, Any],
+        agent_did: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Complete an in-flight step span."""
+        key = (saga_id, step_id)
+        start_time = self._step_starts.pop(key, None)
+        if start_time is None:
+            # Step started before we subscribed, use end_time as fallback
+            start_time = end_time
+
+        self._record_span(
+            name=f"saga.step.{step_action or step_id}",
+            saga_id=saga_id,
+            step_id=step_id,
+            step_action=step_action,
+            start_time=start_time,
+            end_time=end_time,
+            status=status,
+            extra_attrs=extra_attrs,
+            agent_did=agent_did,
+            session_id=session_id,
+        )
+
+    def _record_span(
+        self,
+        name: str,
+        saga_id: str,
+        step_id: str,
+        step_action: str,
+        start_time: float,
+        end_time: float,
+        status: str,
+        extra_attrs: dict[str, Any] | None = None,
+        agent_did: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Create a span record, buffer it, and forward to sink if attached."""
+        attrs: dict[str, Any] = {
+            "agent.saga.id": saga_id,
+            "agent.saga.step_id": step_id,
+            "agent.saga.step_action": step_action,
+            "agent.saga.state": status,
+        }
+        if agent_did:
+            attrs["agent.did"] = agent_did
+        if session_id:
+            attrs["session.id"] = session_id
+        if extra_attrs:
+            # Include select payload fields as span attributes
+            for key in ("error", "reason", "result"):
+                if key in extra_attrs:
+                    attrs[f"agent.saga.{key}"] = str(extra_attrs[key])
+
+        record = SagaSpanRecord(
+            name=name,
+            saga_id=saga_id,
+            step_id=step_id,
+            step_action=step_action,
+            start_time=start_time,
+            end_time=end_time,
+            status=status,
+            attributes=attrs,
+        )
+        self._completed_spans.append(record)
+
+        # Forward to sink if attached
+        if self._sink is not None:
+            self._sink.record_span(
+                name=record.name,
+                start_time=record.start_time,
+                end_time=record.end_time,
+                attributes=record.attributes,
+                status=record.status,
+            )

--- a/packages/agent-hypervisor/tests/unit/test_prometheus_collector.py
+++ b/packages/agent-hypervisor/tests/unit/test_prometheus_collector.py
@@ -1,0 +1,226 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the Prometheus ring metrics collector."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from hypervisor.observability.event_bus import (
+    EventType,
+    HypervisorEvent,
+    HypervisorEventBus,
+)
+from hypervisor.observability.prometheus_collector import (
+    METRIC_RING_BREACHES_TOTAL,
+    METRIC_RING_CURRENT,
+    METRIC_RING_ELEVATION_DURATION,
+    METRIC_RING_TRANSITIONS_TOTAL,
+    RingMetricsCollector,
+)
+
+
+class _FakePrometheusExporter:
+    """Minimal fake matching PrometheusExporterProtocol."""
+
+    def __init__(self) -> None:
+        self.gauges: list[tuple[str, float, dict]] = []
+        self.counters: list[tuple[str, float, dict]] = []
+
+    def set_gauge(
+        self, name: str, value: float,
+        labels: dict[str, str] | None = None,
+        help_text: str = "",
+    ) -> None:
+        self.gauges.append((name, value, labels or {}))
+
+    def inc_counter(
+        self, name: str, value: float = 1.0,
+        labels: dict[str, str] | None = None,
+        help_text: str = "",
+    ) -> None:
+        self.counters.append((name, value, labels or {}))
+
+
+class TestRingMetricsCollector:
+    def test_subscribe_ring_events(self):
+        """Emitting ring events into EventBus increments collector counters."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ASSIGNED,
+            agent_did="agent-1",
+            session_id="sess-1",
+            payload={"ring": 2},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ASSIGNED,
+            agent_did="agent-2",
+            session_id="sess-1",
+            payload={"ring": 3},
+        ))
+
+        snapshot = collector.collect()
+        transitions = snapshot[METRIC_RING_TRANSITIONS_TOTAL]
+        assert ("ring.assigned", "agent-1", "sess-1") in transitions
+        assert transitions[("ring.assigned", "agent-1", "sess-1")] == 1
+        assert snapshot["events_processed"] == 2
+
+    def test_metric_labels(self):
+        """Verify agent/session/event_type labels are attached to exports."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ELEVATED,
+            agent_did="agent-a",
+            session_id="sess-x",
+            payload={"to_ring": 1},
+        ))
+
+        exporter = _FakePrometheusExporter()
+        collector.export_to_prometheus(exporter)
+
+        # Should have transition counter + current ring gauge + elevation duration
+        counter_names = [c[0] for c in exporter.counters]
+        assert METRIC_RING_TRANSITIONS_TOTAL in counter_names
+
+        # Check labels on the counter
+        tc = next(c for c in exporter.counters if c[0] == METRIC_RING_TRANSITIONS_TOTAL)
+        assert tc[2]["agent_did"] == "agent-a"
+        assert tc[2]["session_id"] == "sess-x"
+        assert tc[2]["event_type"] == "ring.elevated"
+
+    def test_export_to_prometheus(self):
+        """Verify export_to_prometheus() writes correct metrics."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ASSIGNED,
+            agent_did="a1",
+            session_id="s1",
+            payload={"ring": 2},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ASSIGNED,
+            agent_did="a1",
+            session_id="s1",
+            payload={"ring": 2},
+        ))
+
+        exporter = _FakePrometheusExporter()
+        collector.export_to_prometheus(exporter)
+
+        # Check the counter has the accumulated count
+        tc = next(c for c in exporter.counters if c[0] == METRIC_RING_TRANSITIONS_TOTAL)
+        assert tc[1] == 2.0
+
+        # Check current ring gauge
+        gauge_names = [g[0] for g in exporter.gauges]
+        assert METRIC_RING_CURRENT in gauge_names
+        rg = next(g for g in exporter.gauges if g[0] == METRIC_RING_CURRENT)
+        assert rg[1] == 2.0
+        assert rg[2]["agent_did"] == "a1"
+
+    def test_breach_counter(self):
+        """Verify breach events increment a separate counter."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_BREACH_DETECTED,
+            agent_did="bad-agent",
+            session_id="sess-1",
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_BREACH_DETECTED,
+            agent_did="bad-agent",
+            session_id="sess-1",
+        ))
+
+        snapshot = collector.collect()
+        breaches = snapshot[METRIC_RING_BREACHES_TOTAL]
+        assert breaches[("bad-agent", "sess-1")] == 2
+
+        exporter = _FakePrometheusExporter()
+        collector.export_to_prometheus(exporter)
+        bc = next(c for c in exporter.counters if c[0] == METRIC_RING_BREACHES_TOTAL)
+        assert bc[1] == 2.0
+
+    def test_elevation_duration_tracking(self):
+        """Verify elevation duration is tracked between elevated/demoted events."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        now = datetime.now(UTC)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ELEVATED,
+            agent_did="agent-1",
+            session_id="s1",
+            timestamp=now,
+            payload={"to_ring": 1},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_DEMOTED,
+            agent_did="agent-1",
+            session_id="s1",
+            timestamp=now + timedelta(seconds=30),
+            payload={"to_ring": 2},
+        ))
+
+        snapshot = collector.collect()
+        durations = snapshot[METRIC_RING_ELEVATION_DURATION]
+        assert "agent-1" in durations
+        assert abs(durations["agent-1"] - 30.0) < 1.0
+
+    def test_current_ring_updates(self):
+        """Current ring gauge updates on each transition."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ASSIGNED,
+            agent_did="a1",
+            payload={"ring": 3},
+        ))
+        assert collector.collect()[METRIC_RING_CURRENT]["a1"] == 3
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ELEVATED,
+            agent_did="a1",
+            payload={"to_ring": 1},
+        ))
+        assert collector.collect()[METRIC_RING_CURRENT]["a1"] == 1
+
+    def test_reset(self):
+        """Reset clears all metrics."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_ASSIGNED,
+            agent_did="a1",
+            payload={"ring": 2},
+        ))
+        assert collector.collect()["events_processed"] == 1
+
+        collector.reset()
+        snapshot = collector.collect()
+        assert snapshot["events_processed"] == 0
+        assert len(snapshot[METRIC_RING_TRANSITIONS_TOTAL]) == 0
+
+    def test_unknown_agent_defaults(self):
+        """Events without agent_did/session_id use 'unknown' labels."""
+        bus = HypervisorEventBus()
+        collector = RingMetricsCollector(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.RING_BREACH_DETECTED,
+        ))
+
+        snapshot = collector.collect()
+        assert ("unknown", "unknown") in snapshot[METRIC_RING_BREACHES_TOTAL]

--- a/packages/agent-hypervisor/tests/unit/test_saga_span_exporter.py
+++ b/packages/agent-hypervisor/tests/unit/test_saga_span_exporter.py
@@ -1,0 +1,242 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the SagaSpanExporter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from hypervisor.observability.event_bus import (
+    EventType,
+    HypervisorEvent,
+    HypervisorEventBus,
+)
+from hypervisor.observability.saga_span_exporter import (
+    SagaSpanExporter,
+    SagaSpanRecord,
+    SpanSink,
+)
+
+
+class _MockSpanSink:
+    """Mock sink implementing SpanSink protocol."""
+
+    def __init__(self) -> None:
+        self.spans: list[dict[str, Any]] = []
+
+    def record_span(
+        self,
+        name: str,
+        start_time: float,
+        end_time: float,
+        attributes: dict[str, Any],
+        status: str,
+    ) -> None:
+        self.spans.append({
+            "name": name,
+            "start_time": start_time,
+            "end_time": end_time,
+            "attributes": attributes,
+            "status": status,
+        })
+
+
+class TestSagaSpanExporter:
+    def test_saga_step_creates_span(self):
+        """Emit start + committed events → span appears in buffer."""
+        bus = HypervisorEventBus()
+        exporter = SagaSpanExporter(bus)
+
+        now = datetime.now(UTC)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_STARTED,
+            agent_did="agent-1",
+            session_id="sess-1",
+            timestamp=now,
+            payload={"saga_id": "saga-abc", "step_id": "step-1", "action": "validate"},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_COMMITTED,
+            agent_did="agent-1",
+            session_id="sess-1",
+            timestamp=now + timedelta(seconds=2),
+            payload={"saga_id": "saga-abc", "step_id": "step-1", "action": "validate"},
+        ))
+
+        spans = exporter.completed_spans
+        assert len(spans) == 1
+        assert spans[0].saga_id == "saga-abc"
+        assert spans[0].step_id == "step-1"
+        assert spans[0].status == "ok"
+        assert abs(spans[0].duration_seconds - 2.0) < 1.0
+
+    def test_protocol_sink(self):
+        """Mock SpanSink receives correct arguments when attached."""
+        bus = HypervisorEventBus()
+        sink = _MockSpanSink()
+        exporter = SagaSpanExporter(bus, sink=sink)
+
+        now = datetime.now(UTC)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_STARTED,
+            timestamp=now,
+            payload={"saga_id": "s1", "step_id": "st1", "action": "execute"},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_COMMITTED,
+            timestamp=now + timedelta(seconds=5),
+            payload={"saga_id": "s1", "step_id": "st1", "action": "execute"},
+        ))
+
+        assert len(sink.spans) == 1
+        span = sink.spans[0]
+        assert span["status"] == "ok"
+        assert span["attributes"]["agent.saga.id"] == "s1"
+        assert span["attributes"]["agent.saga.step_action"] == "execute"
+
+    def test_compensation_span(self):
+        """Compensation events create spans with 'compensating' status."""
+        bus = HypervisorEventBus()
+        sink = _MockSpanSink()
+        exporter = SagaSpanExporter(bus, sink=sink)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_COMPENSATING,
+            payload={"saga_id": "s1", "step_id": "rollback-1", "action": "undo"},
+        ))
+
+        assert len(sink.spans) == 1
+        assert sink.spans[0]["status"] == "compensating"
+        assert "compensate" in sink.spans[0]["name"]
+
+    def test_failed_step_creates_error_span(self):
+        """Failed saga steps produce spans with 'error' status."""
+        bus = HypervisorEventBus()
+        exporter = SagaSpanExporter(bus)
+
+        now = datetime.now(UTC)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_STARTED,
+            timestamp=now,
+            payload={"saga_id": "s2", "step_id": "st2", "action": "deploy"},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_FAILED,
+            timestamp=now + timedelta(seconds=1),
+            payload={"saga_id": "s2", "step_id": "st2", "action": "deploy", "error": "timeout"},
+        ))
+
+        spans = exporter.completed_spans
+        assert len(spans) == 1
+        assert spans[0].status == "error"
+        assert spans[0].attributes["agent.saga.error"] == "timeout"
+
+    def test_saga_without_sink(self):
+        """Spans buffer internally when no sink is attached."""
+        bus = HypervisorEventBus()
+        exporter = SagaSpanExporter(bus)  # no sink
+
+        now = datetime.now(UTC)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_STARTED,
+            timestamp=now,
+            payload={"saga_id": "s3", "step_id": "st3"},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_STEP_COMMITTED,
+            timestamp=now + timedelta(seconds=1),
+            payload={"saga_id": "s3", "step_id": "st3"},
+        ))
+
+        assert len(exporter.completed_spans) == 1
+        assert exporter.events_processed == 2
+
+    def test_saga_completed_creates_saga_level_span(self):
+        """SAGA_CREATED + SAGA_COMPLETED produces a saga-level span."""
+        bus = HypervisorEventBus()
+        exporter = SagaSpanExporter(bus)
+
+        now = datetime.now(UTC)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_CREATED,
+            timestamp=now,
+            payload={"saga_id": "saga-full"},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_COMPLETED,
+            timestamp=now + timedelta(seconds=10),
+            payload={"saga_id": "saga-full"},
+        ))
+
+        saga_spans = [s for s in exporter.completed_spans if "completed" in s.name]
+        assert len(saga_spans) == 1
+        assert abs(saga_spans[0].duration_seconds - 10.0) < 1.0
+
+    def test_saga_escalated_creates_error_span(self):
+        """SAGA_ESCALATED produces a saga-level span with error status."""
+        bus = HypervisorEventBus()
+        exporter = SagaSpanExporter(bus)
+
+        now = datetime.now(UTC)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_CREATED,
+            timestamp=now,
+            payload={"saga_id": "saga-esc"},
+        ))
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_ESCALATED,
+            timestamp=now + timedelta(seconds=3),
+            payload={"saga_id": "saga-esc", "reason": "max retries"},
+        ))
+
+        saga_spans = [s for s in exporter.completed_spans if "escalated" in s.name]
+        assert len(saga_spans) == 1
+        assert saga_spans[0].status == "error"
+
+    def test_attach_detach_sink(self):
+        """Attaching and detaching sinks works correctly."""
+        bus = HypervisorEventBus()
+        sink = _MockSpanSink()
+        exporter = SagaSpanExporter(bus)
+
+        # No sink — spans buffer only
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_COMPENSATING,
+            payload={"saga_id": "s1"},
+        ))
+        assert len(sink.spans) == 0
+        assert len(exporter.completed_spans) == 1
+
+        # Attach sink — new spans go to sink
+        exporter.attach_sink(sink)
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_COMPENSATING,
+            payload={"saga_id": "s2"},
+        ))
+        assert len(sink.spans) == 1
+
+        # Detach — back to buffer only
+        exporter.detach_sink()
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_COMPENSATING,
+            payload={"saga_id": "s3"},
+        ))
+        assert len(sink.spans) == 1  # still 1
+
+    def test_reset(self):
+        """Reset clears all internal state."""
+        bus = HypervisorEventBus()
+        exporter = SagaSpanExporter(bus)
+
+        bus.emit(HypervisorEvent(
+            event_type=EventType.SAGA_COMPENSATING,
+            payload={"saga_id": "s1"},
+        ))
+        assert exporter.events_processed == 1
+
+        exporter.reset()
+        assert exporter.events_processed == 0
+        assert len(exporter.completed_spans) == 0

--- a/packages/agent-sre/dashboards/grafana/agent-slo-dashboard.json
+++ b/packages/agent-sre/dashboards/grafana/agent-slo-dashboard.json
@@ -1,0 +1,412 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Dedicated SLO health dashboard — error budgets, burn rates, ring transitions, and PagerDuty breach timeline for AI agents",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Agent SRE Overview",
+      "tooltip": "Back to the main SRE overview dashboard",
+      "type": "link",
+      "url": "/d/agent-sre-overview"
+    }
+  ],
+  "panels": [
+    {
+      "title": "SLO Status Overview",
+      "description": "Current SLO health status per SLO (0=healthy, 1=warning, 2=critical, 3=exhausted)",
+      "type": "stat",
+      "id": 1,
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "agent_sre_slo_status{slo=~\"$slo_name\", agent_id=~\"$agent_id\"}",
+          "legendFormat": "{{slo}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "HEALTHY", "color": "green" },
+                "1": { "text": "WARNING", "color": "yellow" },
+                "2": { "text": "CRITICAL", "color": "orange" },
+                "3": { "text": "EXHAUSTED", "color": "red" },
+                "-1": { "text": "UNKNOWN", "color": "gray" }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 1, "color": "yellow" },
+              { "value": 2, "color": "orange" },
+              { "value": 3, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      }
+    },
+    {
+      "title": "Error Budget Remaining",
+      "description": "Remaining error budget as a percentage per SLO",
+      "type": "gauge",
+      "id": 2,
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "agent_sre_slo_budget_remaining{slo=~\"$slo_name\", agent_id=~\"$agent_id\"}",
+          "legendFormat": "{{slo}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "red" },
+              { "value": 0.1, "color": "orange" },
+              { "value": 0.5, "color": "yellow" },
+              { "value": 0.8, "color": "green" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      }
+    },
+    {
+      "title": "Active Burn Rate",
+      "description": "Current error budget burn rate (>1 means consuming faster than planned)",
+      "type": "stat",
+      "id": 3,
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "agent_sre_slo_burn_rate{slo=~\"$slo_name\", agent_id=~\"$agent_id\"}",
+          "legendFormat": "{{slo}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 2, "color": "yellow" },
+              { "value": 10, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      }
+    },
+    {
+      "title": "Burn Rate Over Time",
+      "description": "Error budget burn rate with 5m and 1h windows",
+      "type": "timeseries",
+      "id": 4,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "agent_sre_slo_burn_rate{slo=~\"$slo_name\", agent_id=~\"$agent_id\"}",
+          "legendFormat": "{{slo}} — current",
+          "refId": "A"
+        },
+        {
+          "expr": "avg_over_time(agent_sre_slo_burn_rate{slo=~\"$slo_name\"}[1h])",
+          "legendFormat": "{{slo}} — 1h avg",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 2, "color": "yellow" },
+              { "value": 10, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Budget Consumption Rate",
+      "description": "Rate of change of error budget remaining",
+      "type": "timeseries",
+      "id": 5,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "deriv(agent_sre_slo_budget_remaining{slo=~\"$slo_name\", agent_id=~\"$agent_id\"}[5m])",
+          "legendFormat": "{{slo}} — consumption/s",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "lineWidth": 2
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Ring Transitions",
+      "description": "Rate of hypervisor ring transitions per 5-minute window",
+      "type": "timeseries",
+      "id": 6,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "rate(agent_hypervisor_ring_transitions_total{agent_did=~\"$agent_id\"}[5m])",
+          "legendFormat": "{{event_type}} — {{agent_did}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Ring Breaches",
+      "description": "Total ring breach events detected",
+      "type": "stat",
+      "id": 7,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "agent_hypervisor_ring_breaches_total{agent_did=~\"$agent_id\"}",
+          "legendFormat": "{{agent_did}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "value": null, "color": "green" },
+              { "value": 1, "color": "orange" },
+              { "value": 5, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      }
+    },
+    {
+      "title": "SLO Breach Alerts Timeline",
+      "description": "Annotation overlay of PagerDuty incidents triggered by SLO breaches",
+      "type": "timeseries",
+      "id": 8,
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 22 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "changes(agent_sre_slo_status{slo=~\"$slo_name\"}[5m])",
+          "legendFormat": "{{slo}} status changes",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "lineWidth": 1
+          },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Per-Agent SLO Compliance",
+      "description": "Table view of SLO status grouped by agent",
+      "type": "table",
+      "id": 9,
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 22 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        {
+          "expr": "agent_sre_slo_status{slo=~\"$slo_name\", agent_id=~\"$agent_id\"}",
+          "legendFormat": "",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": { "text": "HEALTHY", "color": "green" },
+                "1": { "text": "WARNING", "color": "yellow" },
+                "2": { "text": "CRITICAL", "color": "orange" },
+                "3": { "text": "EXHAUSTED", "color": "red" },
+                "-1": { "text": "UNKNOWN", "color": "gray" }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Value", "desc": true }]
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["agent-sre", "slo", "ai-agents", "observability", "error-budget", "burn-rate"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(agent_sre_slo_status, slo)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "SLO Name",
+        "multi": true,
+        "name": "slo_name",
+        "options": [],
+        "query": "label_values(agent_sre_slo_status, slo)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "definition": "label_values(agent_sre_slo_status, agent_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Agent ID",
+        "multi": true,
+        "name": "agent_id",
+        "options": [],
+        "query": "label_values(agent_sre_slo_status, agent_id)",
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Agent SLO Dashboard",
+  "uid": "agent-slo-dashboard",
+  "version": 1,
+  "refresh": "15s"
+}

--- a/packages/agent-sre/dashboards/grafana/agent-sre-overview.json
+++ b/packages/agent-sre/dashboards/grafana/agent-sre-overview.json
@@ -17,7 +17,20 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "SLO Dashboard",
+      "tooltip": "Detailed SLO health, burn rates, and ring metrics",
+      "type": "link",
+      "url": "/d/agent-slo-dashboard"
+    }
+  ],
   "panels": [
     {
       "title": "SLO Health — Budget Remaining",

--- a/packages/agent-sre/src/agent_sre/integrations/otel/saga_sink.py
+++ b/packages/agent-sre/src/agent_sre/integrations/otel/saga_sink.py
@@ -1,0 +1,97 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+OTel adapter for hypervisor SagaSpanExporter.
+
+Bridges the hypervisor's ``SpanSink`` protocol into the native
+OpenTelemetry SDK via the existing ``TraceExporter.export_span_simple()``.
+
+Usage::
+
+    from agent_sre.integrations.otel.saga_sink import OTelSpanSink
+    from agent_sre.integrations.otel.traces import TraceExporter
+    from hypervisor.observability import SagaSpanExporter, HypervisorEventBus
+
+    bus = HypervisorEventBus()
+    trace_exporter = TraceExporter(service_name="my-agent")
+    sink = OTelSpanSink(trace_exporter, agent_id="agent-1")
+
+    saga_exporter = SagaSpanExporter(bus, sink=sink)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from agent_sre.replay.capture import SpanKind, SpanStatus
+
+if TYPE_CHECKING:
+    from agent_sre.integrations.otel.traces import TraceExporter
+
+# Map saga span status strings to SRE SpanStatus
+_STATUS_MAP: dict[str, SpanStatus] = {
+    "ok": SpanStatus.OK,
+    "error": SpanStatus.ERROR,
+    "compensating": SpanStatus.ERROR,
+}
+
+
+class OTelSpanSink:
+    """Concrete SpanSink adapter that bridges into the OTel TraceExporter.
+
+    Implements the ``SpanSink`` protocol defined in
+    ``hypervisor.observability.saga_span_exporter`` without importing it
+    (structural subtyping via Protocol).
+
+    Each call to ``record_span()`` creates a native OTel span via
+    ``TraceExporter.export_span_simple()``.
+    """
+
+    def __init__(
+        self,
+        trace_exporter: TraceExporter,
+        agent_id: str = "",
+    ) -> None:
+        self._trace_exporter = trace_exporter
+        self._agent_id = agent_id
+        self._spans_exported: int = 0
+
+    def record_span(
+        self,
+        name: str,
+        start_time: float,
+        end_time: float,
+        attributes: dict[str, Any],
+        status: str,
+    ) -> None:
+        """Record a completed saga span as a native OTel span.
+
+        Args:
+            name: Span name (e.g. ``saga.step.validate``).
+            start_time: Unix timestamp when the step started.
+            end_time: Unix timestamp when the step completed.
+            attributes: Saga-specific attributes (``agent.saga.*``).
+            status: One of ``"ok"``, ``"error"``, ``"compensating"``.
+        """
+        sre_status = _STATUS_MAP.get(status, SpanStatus.OK)
+
+        # Merge saga attributes with agent ID
+        merged_attrs: dict[str, Any] = dict(attributes)
+        if self._agent_id and "agent.id" not in merged_attrs:
+            merged_attrs["agent.id"] = self._agent_id
+
+        self._trace_exporter.export_span_simple(
+            name=name,
+            kind=SpanKind.INTERNAL,
+            agent_id=self._agent_id or merged_attrs.get("agent.did", "unknown"),
+            start_time=start_time,
+            end_time=end_time,
+            status=sre_status,
+            attributes=merged_attrs,
+        )
+        self._spans_exported += 1
+
+    @property
+    def spans_exported(self) -> int:
+        """Total number of spans sent to OTel."""
+        return self._spans_exported

--- a/packages/agent-sre/src/agent_sre/integrations/pagerduty.py
+++ b/packages/agent-sre/src/agent_sre/integrations/pagerduty.py
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+PagerDuty integration for SLO breach alerting.
+
+Provides ``PagerDutyAlertConfig`` — a helper that registers a PagerDuty
+channel with the ``AlertManager`` and watches SLOs for status transitions.
+On breach (CRITICAL / EXHAUSTED) it fires PagerDuty alerts; on recovery
+(HEALTHY) it sends resolve events.
+
+No external dependencies — uses the existing ``AlertManager`` http-based
+delivery (stdlib ``urllib``).
+
+Usage::
+
+    from agent_sre.integrations.pagerduty import PagerDutyAlertConfig
+    from agent_sre.alerts import AlertManager
+    from agent_sre.slo.objectives import SLO
+
+    manager = AlertManager()
+    pd = PagerDutyAlertConfig(
+        alert_manager=manager,
+        routing_key="R0XXXXXXXXXXXXXXXXXXXXXXXXX",
+    )
+
+    slo = SLO(name="latency-p99", indicators=[...], agent_id="agent-1")
+    pd.watch_slo(slo)  # fires if SLO is breached, resolves on recovery
+"""
+
+from __future__ import annotations
+
+from agent_sre.alerts import (
+    Alert,
+    AlertChannel,
+    AlertManager,
+    AlertSeverity,
+    ChannelConfig,
+)
+from agent_sre.slo.objectives import SLO, SLOStatus
+
+# PagerDuty Events API v2 endpoint
+PAGERDUTY_EVENTS_URL = "https://events.pagerduty.com/v2/enqueue"
+
+# Default severity mapping
+_DEFAULT_SEVERITY_MAP: dict[SLOStatus, AlertSeverity] = {
+    SLOStatus.CRITICAL: AlertSeverity.CRITICAL,
+    SLOStatus.EXHAUSTED: AlertSeverity.CRITICAL,
+    SLOStatus.WARNING: AlertSeverity.WARNING,
+}
+
+# Statuses that trigger an alert
+_ALERT_STATUSES = frozenset({SLOStatus.CRITICAL, SLOStatus.EXHAUSTED})
+
+
+class PagerDutyAlertConfig:
+    """Connects SLO evaluations to PagerDuty incident management.
+
+    Registers a PagerDuty channel with the ``AlertManager`` and provides
+    ``watch_slo()`` to evaluate an SLO and fire/resolve PagerDuty alerts
+    based on status transitions.
+
+    Features:
+    - Automatic dedup via ``{slo.name}:{agent_id}`` keys
+    - Resolve events on recovery to HEALTHY
+    - Configurable severity mapping
+    - Tracks last-known status per SLO to avoid redundant alerts
+
+    Attributes:
+        _alert_manager: The AlertManager to send alerts through.
+        _routing_key: PagerDuty integration/routing key.
+        _channel_name: Name of the registered PagerDuty channel.
+        _severity_map: Maps SLOStatus to AlertSeverity.
+        _last_statuses: Tracks last-known status per SLO name.
+    """
+
+    def __init__(
+        self,
+        alert_manager: AlertManager,
+        routing_key: str,
+        channel_name: str = "pagerduty-slo",
+        severity_map: dict[SLOStatus, AlertSeverity] | None = None,
+        url: str = PAGERDUTY_EVENTS_URL,
+    ) -> None:
+        self._alert_manager = alert_manager
+        self._routing_key = routing_key
+        self._channel_name = channel_name
+        self._severity_map = severity_map or dict(_DEFAULT_SEVERITY_MAP)
+        self._last_statuses: dict[str, SLOStatus] = {}
+
+        # Register PagerDuty channel with the AlertManager
+        self._alert_manager.add_channel(ChannelConfig(
+            channel_type=AlertChannel.PAGERDUTY,
+            name=channel_name,
+            url=url,
+            token=routing_key,
+            min_severity=AlertSeverity.WARNING,
+            enabled=True,
+        ))
+
+    @property
+    def channel_name(self) -> str:
+        return self._channel_name
+
+    @property
+    def last_statuses(self) -> dict[str, SLOStatus]:
+        """Last-known SLO statuses (read-only copy)."""
+        return dict(self._last_statuses)
+
+    def watch_slo(
+        self,
+        slo: SLO,
+        agent_id: str = "",
+    ) -> SLOStatus:
+        """Evaluate an SLO and fire/resolve PagerDuty alerts as needed.
+
+        Call this periodically (e.g. after each ``slo.record_event()``)
+        or on a schedule.
+
+        Args:
+            slo: The SLO to evaluate.
+            agent_id: Agent identifier for dedup and alert context.
+
+        Returns:
+            The current SLO status after evaluation.
+        """
+        agent_id = agent_id or getattr(slo, "_agent_id", "") or ""
+        status = slo.evaluate()
+        prev_status = self._last_statuses.get(slo.name)
+        dedup_key = self._make_dedup_key(slo.name, agent_id)
+
+        if status in _ALERT_STATUSES and prev_status != status:
+            # Breach — fire alert
+            severity = self._severity_map.get(status, AlertSeverity.CRITICAL)
+            self._alert_manager.send(Alert(
+                title=f"SLO Breach: {slo.name}",
+                message=(
+                    f"SLO '{slo.name}' status changed to {status.value}. "
+                    f"Error budget remaining: {slo.error_budget.remaining_percent:.1f}%"
+                ),
+                severity=severity,
+                source="pagerduty-slo-watcher",
+                agent_id=agent_id,
+                slo_name=slo.name,
+                dedup_key=dedup_key,
+                metadata={
+                    "slo_name": slo.name,
+                    "status": status.value,
+                    "remaining_percent": slo.error_budget.remaining_percent,
+                    "burn_rate": slo.error_budget.burn_rate(),
+                },
+            ))
+        elif (
+            status == SLOStatus.HEALTHY
+            and prev_status is not None
+            and prev_status != SLOStatus.HEALTHY
+        ):
+            # Recovery — send resolve
+            self._alert_manager.send(Alert(
+                title=f"SLO Recovered: {slo.name}",
+                message=f"SLO '{slo.name}' recovered to healthy.",
+                severity=AlertSeverity.RESOLVED,
+                source="pagerduty-slo-watcher",
+                agent_id=agent_id,
+                slo_name=slo.name,
+                dedup_key=dedup_key,
+                metadata={
+                    "slo_name": slo.name,
+                    "status": status.value,
+                    "remaining_percent": slo.error_budget.remaining_percent,
+                },
+            ))
+
+        self._last_statuses[slo.name] = status
+        return status
+
+    def remove(self) -> None:
+        """Unregister the PagerDuty channel from the AlertManager."""
+        self._alert_manager.remove_channel(self._channel_name)
+
+    @staticmethod
+    def _make_dedup_key(slo_name: str, agent_id: str) -> str:
+        """Generate a stable dedup key for PagerDuty."""
+        return f"{slo_name}:{agent_id}" if agent_id else slo_name

--- a/packages/agent-sre/tests/test_otel_saga_sink.py
+++ b/packages/agent-sre/tests/test_otel_saga_sink.py
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the OTelSpanSink adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_sre.integrations.otel.saga_sink import OTelSpanSink
+
+
+class TestOTelSpanSink:
+    def _make_mock_trace_exporter(self) -> MagicMock:
+        """Create a mock TraceExporter with export_span_simple."""
+        mock = MagicMock()
+        mock.export_span_simple = MagicMock(return_value=MagicMock())
+        return mock
+
+    def test_otel_span_attributes(self):
+        """Verify saga attributes are set on the OTel span."""
+        mock_exporter = self._make_mock_trace_exporter()
+        sink = OTelSpanSink(trace_exporter=mock_exporter, agent_id="agent-42")
+
+        attrs = {
+            "agent.saga.id": "saga-123",
+            "agent.saga.step_id": "step-1",
+            "agent.saga.step_action": "validate",
+            "agent.saga.state": "ok",
+        }
+
+        sink.record_span(
+            name="saga.step.validate",
+            start_time=1000.0,
+            end_time=1002.5,
+            attributes=attrs,
+            status="ok",
+        )
+
+        mock_exporter.export_span_simple.assert_called_once()
+        call_kwargs = mock_exporter.export_span_simple.call_args
+        passed_attrs = call_kwargs.kwargs.get("attributes") or call_kwargs[1].get("attributes")
+
+        # Check saga-specific attributes were forwarded
+        assert passed_attrs["agent.saga.id"] == "saga-123"
+        assert passed_attrs["agent.saga.step_action"] == "validate"
+        assert passed_attrs["agent.id"] == "agent-42"
+
+    def test_span_timing(self):
+        """Verify start/end time are passed correctly (TraceExporter converts to ns)."""
+        mock_exporter = self._make_mock_trace_exporter()
+        sink = OTelSpanSink(trace_exporter=mock_exporter, agent_id="agent-1")
+
+        sink.record_span(
+            name="saga.step.deploy",
+            start_time=1700000000.0,
+            end_time=1700000002.5,
+            attributes={"agent.saga.id": "s1"},
+            status="ok",
+        )
+
+        call_kwargs = mock_exporter.export_span_simple.call_args
+        # extract positional or keyword args
+        kw = call_kwargs.kwargs if call_kwargs.kwargs else {}
+        assert kw.get("start_time") == 1700000000.0
+        assert kw.get("end_time") == 1700000002.5
+
+    def test_error_status_mapping(self):
+        """Error status maps to SpanStatus.ERROR."""
+        mock_exporter = self._make_mock_trace_exporter()
+        sink = OTelSpanSink(trace_exporter=mock_exporter, agent_id="agent-1")
+
+        sink.record_span(
+            name="saga.step.fail",
+            start_time=1000.0,
+            end_time=1001.0,
+            attributes={"agent.saga.id": "s1"},
+            status="error",
+        )
+
+        call_kwargs = mock_exporter.export_span_simple.call_args
+        from agent_sre.replay.capture import SpanStatus
+        assert call_kwargs.kwargs.get("status") == SpanStatus.ERROR
+
+    def test_spans_exported_counter(self):
+        """spans_exported increments on each record_span call."""
+        mock_exporter = self._make_mock_trace_exporter()
+        sink = OTelSpanSink(trace_exporter=mock_exporter, agent_id="agent-1")
+
+        assert sink.spans_exported == 0
+
+        sink.record_span(
+            name="test",
+            start_time=0.0,
+            end_time=1.0,
+            attributes={},
+            status="ok",
+        )
+        assert sink.spans_exported == 1
+
+        sink.record_span(
+            name="test2",
+            start_time=1.0,
+            end_time=2.0,
+            attributes={},
+            status="ok",
+        )
+        assert sink.spans_exported == 2

--- a/packages/agent-sre/tests/test_pagerduty_slo.py
+++ b/packages/agent-sre/tests/test_pagerduty_slo.py
@@ -1,0 +1,208 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for PagerDuty SLO integration."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_sre.alerts import (
+    Alert,
+    AlertChannel,
+    AlertManager,
+    AlertSeverity,
+    ChannelConfig,
+)
+from agent_sre.integrations.pagerduty import PagerDutyAlertConfig
+from agent_sre.slo.objectives import ErrorBudget, SLO, SLOStatus
+
+
+def _make_slo(
+    name: str = "latency-p99",
+    agent_id: str = "agent-1",
+    budget_total: float = 0.01,
+) -> SLO:
+    """Create a minimal SLO for testing (no SLIs needed for status forcing)."""
+    budget = ErrorBudget(total=budget_total, consumed=0.0)
+    sli_mock = MagicMock()
+    sli_mock.target = 0.99
+    sli_mock.current_value.return_value = 0.999
+    sli_mock.to_dict.return_value = {"name": "mock-sli", "target": 0.99}
+    return SLO(
+        name=name,
+        indicators=[sli_mock],
+        error_budget=budget,
+        agent_id=agent_id,
+    )
+
+
+class TestPagerDutyAlertConfig:
+    def test_registers_pagerduty_channel(self):
+        """PagerDutyAlertConfig registers a PagerDuty channel with AlertManager."""
+        manager = AlertManager()
+        pd = PagerDutyAlertConfig(
+            alert_manager=manager,
+            routing_key="test-key",
+        )
+
+        assert pd.channel_name in manager.list_channels()
+
+    def test_slo_breach_triggers_alert(self):
+        """SLO transitioning to CRITICAL fires a PagerDuty alert."""
+        sent_alerts: list[Alert] = []
+        manager = AlertManager()
+
+        # Use a callback channel to capture alerts
+        manager.add_channel(ChannelConfig(
+            channel_type=AlertChannel.CALLBACK,
+            name="test-capture",
+            callback=lambda a: sent_alerts.append(a),
+            min_severity=AlertSeverity.WARNING,
+        ))
+
+        pd = PagerDutyAlertConfig(
+            alert_manager=manager,
+            routing_key="test-key",
+        )
+
+        slo = _make_slo()
+
+        # Exhaust the error budget to force CRITICAL/EXHAUSTED
+        for _ in range(100):
+            slo.error_budget.record_event(good=False)
+
+        status = pd.watch_slo(slo, agent_id="agent-1")
+        assert status in (SLOStatus.CRITICAL, SLOStatus.EXHAUSTED)
+
+        # Should have fired at least one alert
+        breach_alerts = [a for a in sent_alerts if "Breach" in a.title]
+        assert len(breach_alerts) >= 1
+        assert breach_alerts[0].severity in (AlertSeverity.CRITICAL, AlertSeverity.WARNING)
+
+    def test_slo_recovery_resolves(self):
+        """SLO recovering to HEALTHY sends a resolve event."""
+        sent_alerts: list[Alert] = []
+        manager = AlertManager()
+        manager.add_channel(ChannelConfig(
+            channel_type=AlertChannel.CALLBACK,
+            name="test-capture",
+            callback=lambda a: sent_alerts.append(a),
+            min_severity=AlertSeverity.INFO,
+        ))
+
+        pd = PagerDutyAlertConfig(
+            alert_manager=manager,
+            routing_key="test-key",
+        )
+
+        slo = _make_slo(budget_total=0.01)
+
+        # Force into EXHAUSTED state
+        for _ in range(100):
+            slo.error_budget.record_event(good=False)
+        pd.watch_slo(slo, agent_id="agent-1")
+
+        # Now "recover" — reset budget
+        slo.error_budget.consumed = 0.0
+        slo.error_budget._events.clear()
+        slo._last_status = None  # reset SLO's own status tracking
+
+        status = pd.watch_slo(slo, agent_id="agent-1")
+        assert status == SLOStatus.HEALTHY
+
+        # Should have a RESOLVED alert
+        resolved = [a for a in sent_alerts if a.severity == AlertSeverity.RESOLVED]
+        assert len(resolved) >= 1
+        assert "Recovered" in resolved[0].title
+
+    def test_dedup_key_prevents_duplicates(self):
+        """Same SLO breach doesn't re-fire alerts within dedup window."""
+        sent_alerts: list[Alert] = []
+        manager = AlertManager(dedup_window_seconds=300.0)
+        manager.add_channel(ChannelConfig(
+            channel_type=AlertChannel.CALLBACK,
+            name="test-capture",
+            callback=lambda a: sent_alerts.append(a),
+            min_severity=AlertSeverity.WARNING,
+        ))
+
+        pd = PagerDutyAlertConfig(
+            alert_manager=manager,
+            routing_key="test-key",
+        )
+
+        slo = _make_slo(budget_total=0.01)
+        for _ in range(100):
+            slo.error_budget.record_event(good=False)
+
+        # First watch fires
+        pd.watch_slo(slo, agent_id="agent-1")
+        first_count = len(sent_alerts)
+        assert first_count >= 1
+
+        # Force status change tracking to pretend we haven't seen this status
+        # but the AlertManager dedup should suppress the re-send
+        pd._last_statuses.pop(slo.name, None)
+        pd.watch_slo(slo, agent_id="agent-1")
+
+        # The alert manager's dedup should suppress the duplicate
+        assert manager.suppressed_count >= 1
+
+    def test_resolve_event_format(self):
+        """Verify the resolve payload uses event_action: 'resolve'."""
+        from agent_sre.alerts import format_pagerduty
+
+        resolve_alert = Alert(
+            title="SLO Recovered: test-slo",
+            message="SLO recovered to healthy",
+            severity=AlertSeverity.RESOLVED,
+            agent_id="agent-1",
+            slo_name="test-slo",
+            dedup_key="test-slo:agent-1",
+        )
+
+        payload = format_pagerduty(resolve_alert)
+        assert payload["event_action"] == "resolve"
+        assert payload["dedup_key"] == "test-slo:agent-1"
+
+    def test_watch_slo_returns_healthy_for_good_slo(self):
+        """A healthy SLO returns HEALTHY and doesn't fire."""
+        sent_alerts: list[Alert] = []
+        manager = AlertManager()
+        manager.add_channel(ChannelConfig(
+            channel_type=AlertChannel.CALLBACK,
+            name="test-capture",
+            callback=lambda a: sent_alerts.append(a),
+            min_severity=AlertSeverity.WARNING,
+        ))
+
+        pd = PagerDutyAlertConfig(
+            alert_manager=manager,
+            routing_key="test-key",
+        )
+
+        slo = _make_slo()
+        # Record good events only
+        for _ in range(10):
+            slo.error_budget.record_event(good=True)
+
+        status = pd.watch_slo(slo, agent_id="agent-1")
+        assert status == SLOStatus.HEALTHY
+        # No breach alerts should have fired
+        breach_alerts = [a for a in sent_alerts if "Breach" in a.title]
+        assert len(breach_alerts) == 0
+
+    def test_remove_channel(self):
+        """remove() unregisters the PagerDuty channel."""
+        manager = AlertManager()
+        pd = PagerDutyAlertConfig(
+            alert_manager=manager,
+            routing_key="test-key",
+        )
+        assert pd.channel_name in manager.list_channels()
+
+        pd.remove()
+        assert pd.channel_name not in manager.list_channels()


### PR DESCRIPTION
## Summary

 observability integrations for the Agent Governance Toolkit. Closes #49.

### What's included

| Component | Package | Description |
|-----------|---------|-------------|
| **Prometheus ring metrics** | `agent-hypervisor` | [RingMetricsCollector](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/prometheus_collector.py:79:0-247:34) subscribes to EventBus ring events, exposes `agent_hypervisor_ring_*` metrics via Protocol-based [PrometheusExporterProtocol](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/prometheus_collector.py:53:0-66:18) |
| **OTel saga span export** | `agent-hypervisor` + `agent-sre` | [SagaSpanExporter](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py:100:0-340:13) + [SpanSink](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py:53:0-69:18) protocol (no OTel dep in hypervisor), [OTelSpanSink](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/src/agent_sre/integrations/otel/saga_sink.py:36:0-94:35) adapter bridges into existing `TraceExporter.export_span_simple()` |
| **PagerDuty SLO alerts** | `agent-sre` | [PagerDutyAlertConfig](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/src/agent_sre/integrations/pagerduty.py:54:0-182:65) watches SLOs, fires on CRITICAL/EXHAUSTED, auto-resolves on HEALTHY recovery, dedup via `{slo_name}:{agent_id}` keys |
| **Grafana SLO dashboard** | `agent-sre` | 9-panel dashboard with SLO status, error budget, burn rate, ring transitions, breach timeline. 3 template variables (`DS_PROMETHEUS`, `slo_name`, `agent_id`) |

### Architecture

- **Zero new core dependencies** in `agent-hypervisor` — all integrations use Protocol-based duck typing
- [SpanSink](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py:53:0-69:18) protocol decouples hypervisor from OTel SDK; concrete adapter lives in `agent-sre`
- PagerDuty uses existing [AlertManager](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/src/agent_sre/alerts/__init__.py:244:0-408:29) + [format_pagerduty()](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/src/agent_sre/alerts/__init__.py:136:0-162:18) (already supports resolve events)
- Optional extras added: `[observability]` for `agent-sre` bridge, `[otel]` for OpenTelemetry

### Files changed

**New files (9):**
- [packages/agent-hypervisor/src/hypervisor/observability/prometheus_collector.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/prometheus_collector.py:0:0-0:0)
- [packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py:0:0-0:0)
- [packages/agent-hypervisor/tests/unit/test_prometheus_collector.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/tests/unit/test_prometheus_collector.py:0:0-0:0)
- [packages/agent-hypervisor/tests/unit/test_saga_span_exporter.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/tests/unit/test_saga_span_exporter.py:0:0-0:0)
- [packages/agent-sre/src/agent_sre/integrations/otel/saga_sink.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/src/agent_sre/integrations/otel/saga_sink.py:0:0-0:0)
- [packages/agent-sre/src/agent_sre/integrations/pagerduty.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/src/agent_sre/integrations/pagerduty.py:0:0-0:0)
- [packages/agent-sre/dashboards/grafana/agent-slo-dashboard.json](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/dashboards/grafana/agent-slo-dashboard.json:0:0-0:0)
- [packages/agent-sre/tests/test_otel_saga_sink.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/tests/test_otel_saga_sink.py:0:0-0:0)
- [packages/agent-sre/tests/test_pagerduty_slo.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/tests/test_pagerduty_slo.py:0:0-0:0)

**Modified files (3):**
- [packages/agent-hypervisor/src/hypervisor/observability/__init__.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/__init__.py:0:0-0:0) — re-exports [SagaSpanExporter](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py:100:0-340:13), [SpanSink](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py:53:0-69:18), [SagaSpanRecord](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/src/hypervisor/observability/saga_span_exporter.py:77:0-92:46)
- [packages/agent-hypervisor/pyproject.toml](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-hypervisor/pyproject.toml:0:0-0:0) — `[observability]` and `[otel]` optional extras
- [packages/agent-sre/dashboards/grafana/agent-sre-overview.json](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-sre/dashboards/grafana/agent-sre-overview.json:0:0-0:0) — cross-link to SLO dashboard

### Test results

```
agent-hypervisor: 579 passed, 60 skipped, 0 failures
agent-sre:         11 passed,  0 failures
Grafana JSON:      9 panels, 3 template vars — structurally valid
```
### outputs:- 
<img width="1908" height="908" alt="image" src="https://github.com/user-attachments/assets/f97b402f-9627-4dd3-b513-caba9adfdca0" />
<img width="1918" height="765" alt="image" src="https://github.com/user-attachments/assets/fe5eb626-88d9-41e6-bb48-3b1f352a161f" />
<img width="1919" height="782" alt="image" src="https://github.com/user-attachments/assets/943dcbd5-48b9-4c8e-a062-ffd7286ce130" />
<img width="1919" height="662" alt="image" src="https://github.com/user-attachments/assets/19fe85d6-1a88-42ee-9674-587b9cf6970c" />
<img width="1918" height="197" alt="image" src="https://github.com/user-attachments/assets/bc78dfeb-1164-4139-886c-07f59e5a1454" />
