### PR TITLE
feat(agent-sre): enforce org_monthly_budget in CostGuard.check_task()

### DIFF
--- a/packages/agent-sre/src/agent_sre/cost/guard.py
+++ b/packages/agent-sre/src/agent_sre/cost/guard.py
@@ -176,6 +176,14 @@ class CostGuard:
         if budget.spent_today_usd + estimated_cost > budget.daily_limit_usd:
             return False, f"Would exceed daily budget (${budget.remaining_today_usd:.2f} remaining)"
 
+
+        if self.org_monthly_budget > 0:
+            if self._org_spent_month + estimated_cost > self.org_monthly_budget:
+                return False, (
+                    f"Would exceed org monthly budget "
+                    f"(${self.org_remaining_month:.2f} remaining)"
+                )
+
         return True, "ok"
 
     def record_cost(
@@ -250,6 +258,26 @@ class CostGuard:
                 threshold=budget.daily_limit_usd * 0.85,
                 action=BudgetAction.THROTTLE,
             ))
+
+        # Org budget kill alert
+        if self.auto_throttle and self.org_monthly_budget > 0:
+            org_util = self._org_spent_month / self.org_monthly_budget
+            prev_org_util = (
+                (self._org_spent_month - cost_usd) / self.org_monthly_budget
+                if self.org_monthly_budget > 0 else 0.0
+            )
+            if prev_org_util < self.kill_switch_threshold <= org_util:
+                alerts.append(CostAlert(
+                    severity=CostAlertSeverity.CRITICAL,
+                    message=(
+                        f"Org budget kill switch triggered -- "
+                        f"{org_util * 100:.0f}% of monthly budget consumed"
+                    ),
+                    agent_id=agent_id,
+                    current_value=self._org_spent_month,
+                    threshold=self.org_monthly_budget * self.kill_switch_threshold,
+                    action=BudgetAction.KILL,
+                ))
 
         # Anomaly detection
         if self.anomaly_detection and len(self._cost_history) >= 10:

--- a/packages/agent-sre/tests/unit/test_cost.py
+++ b/packages/agent-sre/tests/unit/test_cost.py
@@ -125,3 +125,53 @@ class TestCostGuard:
         s = guard.summary()
         assert s["total_records"] == 1
         assert "bot-1" in s["agents"]
+
+    def test_check_task_exceeds_org_budget(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=50.0,
+        )
+        guard.record_cost("bot-1", "t1", 30.0)
+        guard.record_cost("bot-2", "t2", 15.0)
+        # 45 spent, trying to add 10 -> 55 > 50
+        allowed, reason = guard.check_task("bot-3", estimated_cost=10.0)
+        assert allowed is False
+        assert "org monthly budget" in reason.lower()
+
+    def test_check_task_within_org_budget(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=100.0,
+        )
+        guard.record_cost("bot-1", "t1", 30.0)
+        allowed, reason = guard.check_task("bot-2", estimated_cost=10.0)
+        assert allowed is True
+
+    def test_org_budget_kill_alert(self) -> None:
+        guard = CostGuard(
+            per_task_limit=1000.0,
+            per_agent_daily_limit=10000.0,
+            org_monthly_budget=100.0,
+            auto_throttle=True,
+            kill_switch_threshold=0.95,
+        )
+        alerts = guard.record_cost("bot-1", "t1", 96.0)  # 96% of org budget
+        kill_alerts = [a for a in alerts if "org budget" in a.message.lower() and "kill" in a.message.lower()]
+        assert len(kill_alerts) >= 1
+
+    def test_org_budget_multi_agent_aggregate(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=100.0,
+            org_monthly_budget=50.0,
+        )
+        # Each agent within daily limit, but org total exceeds
+        guard.record_cost("bot-1", "t1", 20.0)
+        guard.record_cost("bot-2", "t2", 20.0)
+        guard.record_cost("bot-3", "t3", 15.0)
+        # 55 total > 50 org budget; bot-4 should be blocked
+        allowed, reason = guard.check_task("bot-4", estimated_cost=1.0)
+        assert allowed is False
+        assert "org monthly budget" in reason.lower()


### PR DESCRIPTION
## Description

`CostGuard.check_task()` now enforces `org_monthly_budget`. Previously, the budget was tracked in `record_cost()` but never gated in `check_task()` -- 50 agents at $100/day could blow a $5,000 monthly budget on day one.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Package(s) Affected
- [x] agent-sre

## Changes

**`check_task()`**: Rejects tasks when `_org_spent_month + estimated_cost > org_monthly_budget`.

**`record_cost()`**: Emits `CRITICAL` / `BudgetAction.KILL` alert when org spend crosses `kill_switch_threshold`, matching the existing per-agent kill pattern. Uses `prev_org_util < threshold <= org_util` to fire exactly once.

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues

Closes #238