### PR TITLE
feat(agent-sre): enforce org_monthly_budget in CostGuard.check_task()

### DIFF
--- a/packages/agent-sre/src/agent_sre/cost/guard.py
+++ b/packages/agent-sre/src/agent_sre/cost/guard.py
@@ -176,6 +176,13 @@ class CostGuard:
         if budget.spent_today_usd + estimated_cost > budget.daily_limit_usd:
             return False, f"Would exceed daily budget (${budget.remaining_today_usd:.2f} remaining)"
 
+        if self.org_monthly_budget > 0:
+            if self._org_spent_month + estimated_cost > self.org_monthly_budget:
+                return False, (
+                    f"Would exceed org monthly budget "
+                    f"(${self.org_remaining_month:.2f} remaining)"
+                )
+
         return True, "ok"
 
     def record_cost(
@@ -250,6 +257,28 @@ class CostGuard:
                 threshold=budget.daily_limit_usd * 0.85,
                 action=BudgetAction.THROTTLE,
             ))
+
+        # Org budget kill alert
+        if self.auto_throttle and self.org_monthly_budget > 0:
+            org_util = self._org_spent_month / self.org_monthly_budget
+            prev_org_util = (
+                (self._org_spent_month - cost_usd) / self.org_monthly_budget
+                if self.org_monthly_budget > 0 else 0.0
+            )
+            if prev_org_util < self.kill_switch_threshold <= org_util:
+                for b in self._budgets.values():
+                    b.killed = True
+                alerts.append(CostAlert(
+                    severity=CostAlertSeverity.CRITICAL,
+                    message=(
+                        f"Org budget kill switch triggered -- "
+                        f"{org_util * 100:.0f}% of monthly budget consumed"
+                    ),
+                    agent_id=agent_id,
+                    current_value=self._org_spent_month,
+                    threshold=self.org_monthly_budget * self.kill_switch_threshold,
+                    action=BudgetAction.KILL,
+                ))
 
         # Anomaly detection
         if self.anomaly_detection and len(self._cost_history) >= 10:

--- a/packages/agent-sre/tests/unit/test_cost.py
+++ b/packages/agent-sre/tests/unit/test_cost.py
@@ -125,3 +125,232 @@ class TestCostGuard:
         s = guard.summary()
         assert s["total_records"] == 1
         assert "bot-1" in s["agents"]
+
+    def test_check_task_exceeds_org_budget(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=50.0,
+        )
+        guard.record_cost("bot-1", "t1", 30.0)
+        guard.record_cost("bot-2", "t2", 15.0)
+        # 45 spent, trying to add 10 -> 55 > 50
+        allowed, reason = guard.check_task("bot-3", estimated_cost=10.0)
+        assert allowed is False
+        assert "org monthly budget" in reason.lower()
+
+    def test_check_task_within_org_budget(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=100.0,
+        )
+        guard.record_cost("bot-1", "t1", 30.0)
+        allowed, reason = guard.check_task("bot-2", estimated_cost=10.0)
+        assert allowed is True
+
+    def test_org_budget_kill_alert(self) -> None:
+        guard = CostGuard(
+            per_task_limit=1000.0,
+            per_agent_daily_limit=10000.0,
+            org_monthly_budget=100.0,
+            auto_throttle=True,
+            kill_switch_threshold=0.95,
+        )
+        alerts = guard.record_cost("bot-1", "t1", 96.0)  # 96% of org budget
+        kill_alerts = [a for a in alerts if "org budget" in a.message.lower() and "kill" in a.message.lower()]
+        assert len(kill_alerts) >= 1
+
+    def test_org_budget_multi_agent_aggregate(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=100.0,
+            org_monthly_budget=50.0,
+        )
+        # Each agent within daily limit, but org total exceeds
+        guard.record_cost("bot-1", "t1", 20.0)
+        guard.record_cost("bot-2", "t2", 20.0)
+        guard.record_cost("bot-3", "t3", 15.0)
+        # 55 total > 50 org budget; bot-4 should be blocked
+        allowed, reason = guard.check_task("bot-4", estimated_cost=1.0)
+        assert allowed is False
+        assert "org monthly budget" in reason.lower()
+
+
+import pytest
+
+
+class TestCostGuardOrgBudgetAdversarial:
+    """Adversarial tests for org_monthly_budget enforcement."""
+
+    # Rule 11: Boundary Triple (limit-1, limit, limit+1)
+    # NOTE: Implementation uses strict inequality (spent + estimated > budget),
+    # so estimated==budget with spent==0 is allowed (equal is not exceeding).
+    # The boundary that denies is any value strictly above the budget.
+    @pytest.mark.parametrize("estimated,expected", [
+        (49.99, True),   # below limit -- allowed
+        (50.00, True),   # at limit exactly -- allowed (0 + 50.0 > 50.0 is False)
+        (50.01, False),  # above limit -- denied
+    ])
+    def test_org_budget_boundary_triple(self, estimated: float, expected: bool) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=50.0,
+        )
+        allowed, _ = guard.check_task("bot-1", estimated_cost=estimated)
+        assert allowed is expected
+
+    # Rule 17: NaN/Inf bypass -- org_monthly_budget as bad value
+    # nan > 0 is False in IEEE 754, so org check is skipped entirely -> allowed
+    # inf > 0 is True, but spent + cost > inf is always False -> allowed
+    # -inf > 0 is False, so org check is skipped -> allowed
+    @pytest.mark.parametrize("bad_budget", [float("nan"), float("inf"), float("-inf")])
+    def test_nan_inf_budget_does_not_crash(self, bad_budget: float) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=bad_budget,
+        )
+        # Must not raise; behavior may vary but no crash
+        allowed, reason = guard.check_task("bot-1", estimated_cost=1.0)
+        assert isinstance(allowed, bool)
+        assert isinstance(reason, str)
+
+    # Rule 17: NaN/Inf bypass -- estimated_cost as bad value
+    # nan > per_task_limit is False, nan comparisons are always False -> check_task allows nan
+    # inf > per_task_limit(100) is True -> denied at per-task check (not org)
+    # -inf passes all greater-than checks -> allowed
+    @pytest.mark.parametrize("bad_cost", [float("nan"), float("inf"), float("-inf")])
+    def test_nan_inf_estimated_cost_does_not_crash(self, bad_cost: float) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=50.0,
+        )
+        allowed, reason = guard.check_task("bot-1", estimated_cost=bad_cost)
+        assert isinstance(allowed, bool)
+        assert isinstance(reason, str)
+
+    # Rule 23: Zero-semantics (0 = unlimited, not zero budget)
+    # Implementation: `if self.org_monthly_budget > 0` gates the org check.
+    # org_monthly_budget=0.0 means the guard is disabled, not "zero budget allowed".
+    def test_zero_org_budget_means_no_limit(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=10000.0,
+            org_monthly_budget=0.0,
+        )
+        guard.record_cost("bot-1", "t1", 99999.0)
+        allowed, _ = guard.check_task("bot-2", estimated_cost=1.0)
+        # org_monthly_budget=0 means disabled (guard checks > 0), so org check is skipped
+        assert allowed is True
+
+    # Rule 6: Compound state (per-agent killed + org budget exceeded simultaneously)
+    # When agent is killed, the kill check fires first in check_task.
+    def test_agent_killed_and_org_exceeded(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=10.0,
+            org_monthly_budget=50.0,
+            auto_throttle=True,
+            kill_switch_threshold=0.95,
+        )
+        guard.record_cost("bot-1", "t1", 9.6)  # 96% daily -> killed
+        guard.record_cost("bot-2", "t2", 45.0)  # org total = 54.6 > 50
+        # bot-1 denied for agent kill, not org budget -- kill check runs first
+        allowed, reason = guard.check_task("bot-1", estimated_cost=0.01)
+        assert allowed is False
+        assert "killed" in reason.lower()
+
+    # Rule 7: Side-effect verification
+    # record_cost must update both org_spent_month and org_remaining_month.
+    def test_record_cost_updates_org_spent(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=100.0,
+        )
+        guard.record_cost("bot-1", "t1", 10.0)
+        guard.record_cost("bot-2", "t2", 20.0)
+        assert guard.org_spent_month == 30.0
+        assert guard.org_remaining_month == 70.0
+
+    # Rule 14: Concurrent access
+    # Multiple threads recording costs simultaneously must not corrupt state or crash.
+    def test_concurrent_record_cost_no_crash(self) -> None:
+        import threading
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=10000.0,
+            org_monthly_budget=10000.0,
+        )
+        errors: list[str] = []
+
+        def spend(agent_id: str) -> None:
+            try:
+                for i in range(100):
+                    guard.record_cost(agent_id, f"t{i}", 0.01)
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [threading.Thread(target=spend, args=(f"bot-{i}",)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert errors == []
+        # 10 threads x 100 records x $0.01 = $10.00 (allow 1.0 float drift from races)
+        assert abs(guard.org_spent_month - 10.0) < 1.0
+
+    # Boundary: negative org budget
+    # Implementation: `if self.org_monthly_budget > 0` -- negative fails this check,
+    # so the org gate is skipped entirely and the task is allowed.
+    def test_negative_org_budget_treated_as_disabled(self) -> None:
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=1000.0,
+            org_monthly_budget=-1.0,
+        )
+        allowed, _ = guard.check_task("bot-1", estimated_cost=1.0)
+        # Negative budget: guard checks > 0, so org check skipped -> allowed
+        assert allowed is True
+
+    # Kill alert fires exactly once across threshold
+    # Implementation uses: prev_org_util < threshold <= org_util
+    # After first crossing, prev_org_util is already above threshold, so condition is False.
+    def test_org_kill_alert_fires_once(self) -> None:
+        guard = CostGuard(
+            per_task_limit=1000.0,
+            per_agent_daily_limit=10000.0,
+            org_monthly_budget=100.0,
+            auto_throttle=True,
+            kill_switch_threshold=0.95,
+        )
+        # First call crosses threshold (0.0 -> 0.96, crosses 0.95)
+        alerts1 = guard.record_cost("bot-1", "t1", 96.0)
+        kill1 = [a for a in alerts1 if "org budget" in a.message.lower() and "kill" in a.message.lower()]
+        # Second call is already above threshold (0.96 -> 0.97, prev >= threshold -> no crossing)
+        alerts2 = guard.record_cost("bot-1", "t2", 1.0)
+        kill2 = [a for a in alerts2 if "org budget" in a.message.lower() and "kill" in a.message.lower()]
+        assert len(kill1) >= 1
+        assert len(kill2) == 0  # must not fire again
+
+    # WARN-2 fix: org kill must set budget.killed on all agents
+    def test_org_kill_sets_killed_on_all_agents(self) -> None:
+        guard = CostGuard(
+            per_task_limit=1000.0,
+            per_agent_daily_limit=10000.0,
+            org_monthly_budget=100.0,
+            auto_throttle=True,
+            kill_switch_threshold=0.95,
+        )
+        guard.record_cost("bot-1", "t1", 50.0)
+        guard.record_cost("bot-2", "t2", 46.0)  # org total = 96% -> kill
+        # Both registered agents should be killed
+        assert guard.get_budget("bot-1").killed is True
+        assert guard.get_budget("bot-2").killed is True
+        # Killed agents are blocked via check_task (agent kill gate)
+        allowed_1, reason_1 = guard.check_task("bot-1", estimated_cost=0.01)
+        assert allowed_1 is False
+        assert "killed" in reason_1.lower()


### PR DESCRIPTION
## Description

`check_task()` now rejects tasks that would exceed `org_monthly_budget`.
`record_cost()` emits a kill alert and sets `budget.killed` on all agents
when org spend crosses `kill_switch_threshold`.

Previously the budget was tracked but never checked -- 50 agents at $100/day
blow a $5k monthly budget on day one.

Per maintainer feedback on #238:
> Would welcome a PR. The tests in test_cost.py already cover per-agent
> budgets so the pattern is established -- just extend to org-level.

Pre-existing issues found during testing (out of scope, see #238 comment):
NaN/Inf input bypass, `_org_spent_month` thread safety, negative cost_usd.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Package(s) Affected
- [x] agent-sre

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest) -- 34 passed
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues
Closes #238