### PR TITLE
feat: implement behavioral anomaly detection in RingBreachDetector

### DIFF
--- a/packages/agent-hypervisor/src/hypervisor/rings/breach_detector.py
+++ b/packages/agent-hypervisor/src/hypervisor/rings/breach_detector.py
@@ -1,15 +1,26 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Community Edition — basic implementation
 """
-Ring Breach Detector — stub implementation.
+Ring Breach Detector — behavioral anomaly detection for rogue agents.
 
-Community edition: breach detection is not available.
-All methods return safe defaults.
+Detects two classes of anomaly:
+
+1. **Tool-call frequency spikes** — an agent's call rate inside a sliding
+   window exceeds a configurable baseline by a severity-dependent multiplier.
+2. **Privilege-escalation attempts** — a low-privilege agent (Ring 3)
+   repeatedly calls into higher-privilege rings (Ring 0/1).  The *ring
+   distance* amplifies the anomaly score so that sandbox→root jumps are
+   scored more aggressively than standard→privileged ones.
+
+When a HIGH or CRITICAL breach is detected the internal circuit-breaker
+trips and ``is_breaker_tripped()`` returns ``True`` until explicitly reset
+via ``reset_breaker()``.
 """
 
 from __future__ import annotations
 
+import time
+from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
@@ -23,6 +34,15 @@ class BreachSeverity(str, Enum):
     MEDIUM = "medium"
     HIGH = "high"
     CRITICAL = "critical"
+
+
+# Multiplier thresholds: actual_rate / baseline_rate
+_SEVERITY_THRESHOLDS: list[tuple[float, BreachSeverity]] = [
+    (20.0, BreachSeverity.CRITICAL),
+    (10.0, BreachSeverity.HIGH),
+    (5.0, BreachSeverity.MEDIUM),
+    (2.0, BreachSeverity.LOW),
+]
 
 
 @dataclass
@@ -40,12 +60,45 @@ class BreachEvent:
     details: str = ""
 
 
-class RingBreachDetector:
-    """Breach detector stub (community edition: no detection)."""
+def _agent_key(agent_did: str, session_id: str) -> str:
+    """Internal composite key for per-agent tracking."""
+    return f"{agent_did}::{session_id}"
 
-    def __init__(self, window_seconds: int = 60) -> None:
-        self._breach_history: list[BreachEvent] = []
+
+class RingBreachDetector:
+    """Behavioural anomaly detector for rogue-agent ring abuse.
+
+    Parameters
+    ----------
+    window_seconds:
+        Sliding window (in seconds) over which call rates are measured.
+    baseline_rate:
+        Expected calls-per-second within the window.  Rates above multiples
+        of this value trigger breach events of increasing severity.
+    max_events_per_agent:
+        Maximum call timestamps retained per agent (bounded ``deque``).
+    """
+
+    def __init__(
+        self,
+        window_seconds: int = 60,
+        baseline_rate: float = 10.0,
+        max_events_per_agent: int = 1_000,
+    ) -> None:
         self.window_seconds = window_seconds
+        self.baseline_rate = baseline_rate
+        self.max_events_per_agent = max_events_per_agent
+
+        # Per-agent sliding-window timestamps
+        self._call_windows: dict[str, deque[float]] = {}
+        # Per-agent circuit-breaker flag
+        self._tripped: dict[str, bool] = {}
+        # Global breach history
+        self._breach_history: list[BreachEvent] = []
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def record_call(
         self,
@@ -54,14 +107,88 @@ class RingBreachDetector:
         agent_ring: ExecutionRing,
         called_ring: ExecutionRing,
     ) -> BreachEvent | None:
-        """Record a ring call (community edition: no-op, never detects breach)."""
-        return None
+        """Record a ring call and return a ``BreachEvent`` if anomalous.
+
+        Returns ``None`` when the call is within normal parameters.
+        """
+        key = _agent_key(agent_did, session_id)
+        now = time.monotonic()
+
+        # --- 1. Track timestamp in bounded deque ---
+        if key not in self._call_windows:
+            self._call_windows[key] = deque(maxlen=self.max_events_per_agent)
+        window = self._call_windows[key]
+        window.append(now)
+
+        # --- 2. Prune timestamps outside the sliding window ---
+        cutoff = now - self.window_seconds
+        while window and window[0] < cutoff:
+            window.popleft()
+
+        # --- 3. Compute actual rate (calls / second) ---
+        call_count = len(window)
+        actual_rate = call_count / self.window_seconds if self.window_seconds > 0 else 0.0
+
+        # --- 4. Ring-distance amplifier ---
+        #   Upward calls (low value = higher privilege) are escalations.
+        #   ExecutionRing values: 0=root, 1=priv, 2=std, 3=sandbox.
+        #   ring_distance > 0 means privilege escalation.
+        ring_distance = int(agent_ring) - int(called_ring)
+        amplifier = max(ring_distance, 1)  # at least 1× (no reduction)
+
+        # --- 5. Score = (actual / baseline) × amplifier ---
+        if self.baseline_rate <= 0:
+            ratio = 0.0
+        else:
+            ratio = actual_rate / self.baseline_rate
+        anomaly_score = ratio * amplifier
+
+        # --- 6. Map score → severity ---
+        severity = BreachSeverity.NONE
+        for threshold, sev in _SEVERITY_THRESHOLDS:
+            if anomaly_score >= threshold:
+                severity = sev
+                break
+
+        if severity == BreachSeverity.NONE:
+            return None
+
+        # --- 7. Build event ---
+        event = BreachEvent(
+            agent_did=agent_did,
+            session_id=session_id,
+            severity=severity,
+            anomaly_score=round(anomaly_score, 4),
+            call_count_window=call_count,
+            expected_rate=self.baseline_rate,
+            actual_rate=round(actual_rate, 4),
+            details=(
+                f"rate={actual_rate:.2f}/s (baseline={self.baseline_rate:.2f}/s), "
+                f"ring_distance={ring_distance}, amplifier={amplifier}×, "
+                f"score={anomaly_score:.2f}"
+            ),
+        )
+        self._breach_history.append(event)
+
+        # --- 8. Trip circuit-breaker on HIGH / CRITICAL ---
+        if severity in (BreachSeverity.HIGH, BreachSeverity.CRITICAL):
+            self._tripped[key] = True
+
+        return event
 
     def is_breaker_tripped(self, agent_did: str, session_id: str) -> bool:
-        return False
+        """Return ``True`` if the circuit-breaker is tripped for this agent."""
+        return self._tripped.get(_agent_key(agent_did, session_id), False)
 
     def reset_breaker(self, agent_did: str, session_id: str) -> None:
-        pass
+        """Reset the circuit-breaker and clear the call window for this agent."""
+        key = _agent_key(agent_did, session_id)
+        self._tripped.pop(key, None)
+        self._call_windows.pop(key, None)
+
+    # ------------------------------------------------------------------
+    # Read-only accessors
+    # ------------------------------------------------------------------
 
     @property
     def breach_history(self) -> list[BreachEvent]:

--- a/packages/agent-hypervisor/tests/test_breach_detector.py
+++ b/packages/agent-hypervisor/tests/test_breach_detector.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Tests for ring breach detector."""
+"""Tests for ring breach detector — behavioral anomaly detection."""
 
 from datetime import UTC, datetime
 
@@ -69,6 +69,7 @@ class TestRingBreachDetector:
     def test_init_defaults(self):
         detector = RingBreachDetector()
         assert detector.window_seconds == 60
+        assert detector.baseline_rate == 10.0
         assert detector.breach_count == 0
         assert detector.breach_history == []
 
@@ -76,25 +77,135 @@ class TestRingBreachDetector:
         detector = RingBreachDetector(window_seconds=120)
         assert detector.window_seconds == 120
 
-    def test_record_call_returns_none(self):
-        """Community edition never detects a breach."""
-        detector = RingBreachDetector()
+    def test_normal_rate_no_breach(self):
+        """Calls below baseline threshold produce no breach event."""
+        detector = RingBreachDetector(window_seconds=60, baseline_rate=10.0)
         result = detector.record_call(
             agent_did="did:example:agent1",
             session_id="sess-1",
-            agent_ring=ExecutionRing.RING_3_SANDBOX,
-            called_ring=ExecutionRing.RING_0_ROOT,
+            agent_ring=ExecutionRing.RING_2_STANDARD,
+            called_ring=ExecutionRing.RING_2_STANDARD,
         )
         assert result is None
+        assert detector.breach_count == 0
 
-    def test_is_breaker_tripped_always_false(self):
-        detector = RingBreachDetector()
+    def test_high_frequency_triggers_breach(self):
+        """Rapid calls exceeding baseline trigger a breach event."""
+        detector = RingBreachDetector(
+            window_seconds=60, baseline_rate=0.1, max_events_per_agent=500
+        )
+
+        breach = None
+        for _ in range(30):
+            result = detector.record_call(
+                agent_did="did:example:agent1",
+                session_id="sess-1",
+                agent_ring=ExecutionRing.RING_2_STANDARD,
+                called_ring=ExecutionRing.RING_2_STANDARD,
+            )
+            if result is not None:
+                breach = result
+
+        assert breach is not None
+        assert breach.severity in (
+            BreachSeverity.LOW,
+            BreachSeverity.MEDIUM,
+            BreachSeverity.HIGH,
+            BreachSeverity.CRITICAL,
+        )
+        assert breach.actual_rate > detector.baseline_rate
+        assert breach.anomaly_score >= 2.0
+        assert detector.breach_count >= 1
+
+    def test_privilege_escalation_amplifies_severity(self):
+        """Ring 3 → Ring 0 (distance 3) amplifies anomaly score vs same-ring."""
+        detector_same = RingBreachDetector(
+            window_seconds=60, baseline_rate=0.05
+        )
+        detector_escalate = RingBreachDetector(
+            window_seconds=60, baseline_rate=0.05
+        )
+
+        breach_same = None
+        breach_escalate = None
+        for _ in range(20):
+            r1 = detector_same.record_call(
+                "did:example:a", "s1",
+                ExecutionRing.RING_2_STANDARD,
+                ExecutionRing.RING_2_STANDARD,
+            )
+            r2 = detector_escalate.record_call(
+                "did:example:a", "s1",
+                ExecutionRing.RING_3_SANDBOX,
+                ExecutionRing.RING_0_ROOT,
+            )
+            if r1 is not None:
+                breach_same = r1
+            if r2 is not None:
+                breach_escalate = r2
+
+        assert breach_same is not None
+        assert breach_escalate is not None
+        assert breach_escalate.anomaly_score > breach_same.anomaly_score
+
+    def test_breaker_trips_on_high_severity(self):
+        """Circuit-breaker trips when HIGH or CRITICAL breach detected."""
+        detector = RingBreachDetector(
+            window_seconds=60, baseline_rate=0.01
+        )
+
         assert detector.is_breaker_tripped("did:example:a", "s1") is False
 
-    def test_reset_breaker_no_op(self):
-        detector = RingBreachDetector()
+        for _ in range(50):
+            detector.record_call(
+                "did:example:a", "s1",
+                ExecutionRing.RING_3_SANDBOX,
+                ExecutionRing.RING_0_ROOT,
+            )
+
+        assert detector.is_breaker_tripped("did:example:a", "s1") is True
+
+    def test_breaker_reset(self):
+        """reset_breaker() clears the trip and the call window."""
+        detector = RingBreachDetector(
+            window_seconds=60, baseline_rate=0.01
+        )
+
+        for _ in range(50):
+            detector.record_call(
+                "did:example:a", "s1",
+                ExecutionRing.RING_3_SANDBOX,
+                ExecutionRing.RING_0_ROOT,
+            )
+        assert detector.is_breaker_tripped("did:example:a", "s1") is True
+
         detector.reset_breaker("did:example:a", "s1")
-        assert detector.breach_count == 0
+        assert detector.is_breaker_tripped("did:example:a", "s1") is False
+
+        result = detector.record_call(
+            "did:example:a", "s1",
+            ExecutionRing.RING_2_STANDARD,
+            ExecutionRing.RING_2_STANDARD,
+        )
+        assert result is None
+        assert detector.is_breaker_tripped("did:example:a", "s1") is False
+
+    def test_breach_history_populated(self):
+        """Breach events are stored in breach_history."""
+        detector = RingBreachDetector(
+            window_seconds=60, baseline_rate=0.01
+        )
+        for _ in range(20):
+            detector.record_call(
+                "did:example:a", "s1",
+                ExecutionRing.RING_3_SANDBOX,
+                ExecutionRing.RING_0_ROOT,
+            )
+
+        history = detector.breach_history
+        assert len(history) >= 1
+        assert all(isinstance(e, BreachEvent) for e in history)
+        assert history is not detector._breach_history
 
     def test_breach_history_returns_copy(self):
         detector = RingBreachDetector()
@@ -102,15 +213,40 @@ class TestRingBreachDetector:
         assert history == []
         assert history is not detector._breach_history
 
-    def test_multiple_record_calls_still_safe(self):
-        """Multiple calls should all return None in community edition."""
-        detector = RingBreachDetector()
-        for _ in range(100):
-            result = detector.record_call(
-                agent_did="did:example:agent1",
-                session_id="s1",
-                agent_ring=ExecutionRing.RING_2_STANDARD,
-                called_ring=ExecutionRing.RING_1_PRIVILEGED,
+    def test_bounded_event_storage(self):
+        """Per-agent call window is bounded by max_events_per_agent."""
+        detector = RingBreachDetector(
+            window_seconds=3600,
+            baseline_rate=100.0,
+            max_events_per_agent=50,
+        )
+        for _ in range(200):
+            detector.record_call(
+                "did:example:a", "s1",
+                ExecutionRing.RING_2_STANDARD,
+                ExecutionRing.RING_2_STANDARD,
             )
-            assert result is None
+        key = "did:example:a::s1"
+        assert len(detector._call_windows[key]) <= 50
+
+    def test_multiple_agents_independent(self):
+        """Each agent has independent tracking and breaker state."""
+        detector = RingBreachDetector(
+            window_seconds=60, baseline_rate=0.01
+        )
+
+        for _ in range(50):
+            detector.record_call(
+                "did:example:agent1", "s1",
+                ExecutionRing.RING_3_SANDBOX,
+                ExecutionRing.RING_0_ROOT,
+            )
+
+        assert detector.is_breaker_tripped("did:example:agent1", "s1") is True
+        assert detector.is_breaker_tripped("did:example:agent2", "s1") is False
+
+    def test_reset_breaker_no_op_when_not_tripped(self):
+        """Resetting a never-tripped breaker is a safe no-op."""
+        detector = RingBreachDetector()
+        detector.reset_breaker("did:example:a", "s1")
         assert detector.breach_count == 0


### PR DESCRIPTION
## Summary
Resubmitted per maintainer request in #237 — hypervisor code only, no README changes.
Replaces the `RingBreachDetector` stub (all methods returned `None`/`False`) with real behavioral anomaly detection:
### Detection signals
1. **Tool-call frequency analysis** — per-agent sliding-window rate tracking via bounded `deque(maxlen=N)`. Severity escalates as rate exceeds baseline: `>2x` = LOW, `>5x` = MEDIUM, `>10x` = HIGH, `>20x` = CRITICAL.
2. **Ring-crossing amplification** — privilege escalation attempts (e.g. Ring 3 → Ring 0) amplify the anomaly score by the ring distance, so sandbox→root is flagged 3× more aggressively than same-ring abuse.
### Circuit-breaker
When HIGH or CRITICAL breach is detected, the per-agent circuit-breaker trips automatically. Stays tripped until explicitly cleared via `reset_breaker()`, giving operators time to investigate.
### Files changed
| File | Change |
|------|--------|
| `packages/agent-hypervisor/src/hypervisor/rings/breach_detector.py` | Stub → real behavioral detection |
| `packages/agent-hypervisor/tests/test_breach_detector.py` | 17 behavioral tests |
### Test results
- 17/17 breach detector tests passed
-  Ruff clean