### PR TITLE
fix: .NET bug sweep — 6 issues (thread safety, error surfacing, caching, disposal)

### DIFF
--- a/packages/agent-governance-dotnet/src/AgentGovernance/Audit/AuditEmitter.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Audit/AuditEmitter.cs
@@ -22,6 +22,12 @@ public sealed class AuditEmitter
     private readonly ConcurrentBag<Action<GovernanceEvent>> _wildcardHandlers = new();
 
     /// <summary>
+    /// Optional callback invoked when a handler throws an exception.
+    /// Allows callers to log or monitor handler failures without disrupting other subscribers.
+    /// </summary>
+    public Action<Exception, GovernanceEvent>? HandlerError { get; init; }
+
+    /// <summary>
     /// Subscribes a handler to a specific governance event type.
     /// </summary>
     /// <param name="type">The event type to listen for.</param>
@@ -116,19 +122,19 @@ public sealed class AuditEmitter
     public int WildcardHandlerCount => _wildcardHandlers.Count;
 
     /// <summary>
-    /// Safely invokes a handler, catching and swallowing any exceptions
-    /// to prevent one faulty handler from disrupting other subscribers.
+    /// Safely invokes a handler, catching exceptions to prevent one faulty
+    /// handler from disrupting other subscribers. Exceptions are surfaced
+    /// through the <see cref="HandlerError"/> callback when configured.
     /// </summary>
-    private static void InvokeSafe(Action<GovernanceEvent> handler, GovernanceEvent governanceEvent)
+    private void InvokeSafe(Action<GovernanceEvent> handler, GovernanceEvent governanceEvent)
     {
         try
         {
             handler(governanceEvent);
         }
-        catch
+        catch (Exception ex)
         {
-            // Swallow handler exceptions to maintain event bus stability.
-            // In production, consider logging handler errors.
+            HandlerError?.Invoke(ex, governanceEvent);
         }
     }
 }

--- a/packages/agent-governance-dotnet/src/AgentGovernance/GovernanceKernel.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/GovernanceKernel.cs
@@ -102,7 +102,7 @@ public sealed class GovernanceOptions
 /// }
 /// </code>
 /// </remarks>
-public sealed class GovernanceKernel
+public sealed class GovernanceKernel : IDisposable
 {
     /// <summary>
     /// The policy evaluation engine used by this kernel.
@@ -261,4 +261,14 @@ public sealed class GovernanceKernel
     {
         AuditEmitter.OnAll(handler);
     }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        (Metrics as IDisposable)?.Dispose();
+    }
+
+    private bool _disposed;
 }

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Hypervisor/SagaOrchestrator.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Hypervisor/SagaOrchestrator.cs
@@ -75,6 +75,11 @@ public sealed class Saga
     public List<SagaStep> Steps { get; } = new();
     public List<string> FailedCompensations { get; } = new();
     public DateTime CreatedUtc { get; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Per-saga lock for synchronizing state mutations during execution and compensation.
+    /// </summary>
+    internal object SyncRoot { get; } = new();
 }
 
 /// <summary>
@@ -122,11 +127,11 @@ public sealed class SagaOrchestrator
     public async Task<bool> ExecuteAsync(Saga saga, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(saga);
-        saga.State = SagaState.Executing;
+        lock (saga.SyncRoot) { saga.State = SagaState.Executing; }
 
         foreach (var step in saga.Steps)
         {
-            var success = await ExecuteStepAsync(step, cancellationToken).ConfigureAwait(false);
+            var success = await ExecuteStepAsync(saga, step, cancellationToken).ConfigureAwait(false);
             if (!success)
             {
                 await CompensateAsync(saga, cancellationToken).ConfigureAwait(false);
@@ -134,7 +139,7 @@ public sealed class SagaOrchestrator
             }
         }
 
-        saga.State = SagaState.Committed;
+        lock (saga.SyncRoot) { saga.State = SagaState.Committed; }
         return true;
     }
 
@@ -149,32 +154,30 @@ public sealed class SagaOrchestrator
         }
     }
 
-    private async Task<bool> ExecuteStepAsync(SagaStep step, CancellationToken cancellationToken)
+    private async Task<bool> ExecuteStepAsync(Saga saga, SagaStep step, CancellationToken cancellationToken)
     {
         for (int attempt = 0; attempt < step.MaxRetries; attempt++)
         {
-            step.State = StepState.Executing;
-            step.Error = null;
+            lock (saga.SyncRoot) { step.State = StepState.Executing; step.Error = null; }
 
             try
             {
                 using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 cts.CancelAfter(step.Timeout);
 
-                step.Result = await step.Execute(cts.Token).ConfigureAwait(false);
-                step.State = StepState.Committed;
+                var result = await step.Execute(cts.Token).ConfigureAwait(false);
+                lock (saga.SyncRoot) { step.Result = result; step.State = StepState.Committed; }
                 return true;
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
-                step.Error = $"Step '{step.ActionId}' timed out after {step.Timeout.TotalSeconds}s.";
+                lock (saga.SyncRoot) { step.Error = $"Step '{step.ActionId}' timed out after {step.Timeout.TotalSeconds}s."; }
             }
             catch (Exception ex)
             {
-                step.Error = $"Step '{step.ActionId}' failed: {ex.Message}";
+                lock (saga.SyncRoot) { step.Error = $"Step '{step.ActionId}' failed: {ex.Message}"; }
             }
 
-            // Exponential backoff before retry.
             if (attempt + 1 < step.MaxRetries)
             {
                 var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
@@ -182,25 +185,27 @@ public sealed class SagaOrchestrator
             }
         }
 
-        step.State = StepState.Failed;
+        lock (saga.SyncRoot) { step.State = StepState.Failed; }
         return false;
     }
 
     private async Task CompensateAsync(Saga saga, CancellationToken cancellationToken)
     {
-        saga.State = SagaState.Compensating;
-
-        // Compensate in reverse order of committed steps.
-        var committedSteps = saga.Steps
-            .Where(s => s.State == StepState.Committed)
-            .Reverse()
-            .ToList();
+        List<SagaStep> committedSteps;
+        lock (saga.SyncRoot)
+        {
+            saga.State = SagaState.Compensating;
+            committedSteps = saga.Steps
+                .Where(s => s.State == StepState.Committed)
+                .Reverse()
+                .ToList();
+        }
 
         foreach (var step in committedSteps)
         {
             if (step.Compensate is null)
             {
-                step.State = StepState.Compensated;
+                lock (saga.SyncRoot) { step.State = StepState.Compensated; }
                 continue;
             }
 
@@ -210,18 +215,24 @@ public sealed class SagaOrchestrator
                 cts.CancelAfter(step.Timeout);
 
                 await step.Compensate(cts.Token).ConfigureAwait(false);
-                step.State = StepState.Compensated;
+                lock (saga.SyncRoot) { step.State = StepState.Compensated; }
             }
             catch (Exception ex)
             {
-                step.State = StepState.CompensationFailed;
-                step.Error = $"Compensation for '{step.ActionId}' failed: {ex.Message}";
-                saga.FailedCompensations.Add(step.ActionId);
+                lock (saga.SyncRoot)
+                {
+                    step.State = StepState.CompensationFailed;
+                    step.Error = $"Compensation for '{step.ActionId}' failed: {ex.Message}";
+                    saga.FailedCompensations.Add(step.ActionId);
+                }
             }
         }
 
-        saga.State = saga.FailedCompensations.Count > 0
-            ? SagaState.Escalated
-            : SagaState.Aborted;
+        lock (saga.SyncRoot)
+        {
+            saga.State = saga.FailedCompensations.Count > 0
+                ? SagaState.Escalated
+                : SagaState.Aborted;
+        }
     }
 }

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Integration/GovernanceMiddleware.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Integration/GovernanceMiddleware.cs
@@ -58,6 +58,8 @@ public sealed class GovernanceMiddleware
 {
     private readonly PolicyEngine _policyEngine;
     private readonly AuditEmitter _auditEmitter;
+    private Dictionary<string, PolicyRule>? _ruleLookupCache;
+    private int _cachedPolicyCount = -1;
     private readonly RateLimiter? _rateLimiter;
     private readonly GovernanceMetrics? _metrics;
     private readonly RingEnforcer? _ringEnforcer;
@@ -296,18 +298,28 @@ public sealed class GovernanceMiddleware
     }
 
     /// <summary>
-    /// Searches loaded policies for a rule by name.
+    /// Searches loaded policies for a rule by name using a cached lookup.
+    /// Cache is invalidated when the policy count changes.
     /// </summary>
     private PolicyRule? FindMatchingRule(string ruleName)
     {
-        foreach (var policy in _policyEngine.ListPolicies())
+        var policies = _policyEngine.ListPolicies();
+        var currentCount = policies.Count;
+
+        if (_ruleLookupCache is null || _cachedPolicyCount != currentCount)
         {
-            foreach (var rule in policy.Rules)
+            var cache = new Dictionary<string, PolicyRule>(StringComparer.Ordinal);
+            foreach (var policy in policies)
             {
-                if (string.Equals(rule.Name, ruleName, StringComparison.Ordinal))
-                    return rule;
+                foreach (var rule in policy.Rules)
+                {
+                    cache.TryAdd(rule.Name, rule);
+                }
             }
+            _ruleLookupCache = cache;
+            _cachedPolicyCount = currentCount;
         }
-        return null;
+
+        return _ruleLookupCache.TryGetValue(ruleName, out var cached) ? cached : null;
     }
 }

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Trust/AgentIdentity.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Trust/AgentIdentity.cs
@@ -121,16 +121,16 @@ public sealed class AgentIdentity
     }
 
     /// <summary>
-    /// Verifies a signature against data using this identity's public key.
+    /// Verifies a signature against data using this identity's key material.
     /// </summary>
     /// <param name="data">The data that was signed.</param>
     /// <param name="signature">The signature to verify.</param>
     /// <returns><c>true</c> if the signature is valid; otherwise <c>false</c>.</returns>
-    /// <remarks>
-    /// In the HMAC-SHA256 fallback, verification requires the private key to
-    /// recompute the HMAC. This is a known limitation; with Ed25519, verification
-    /// uses only the public key.
-    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when this identity does not have a private key. HMAC-SHA256
+    /// verification requires the signing key. For public-key verification,
+    /// migrate to Ed25519 on .NET 9+.
+    /// </exception>
     public bool Verify(byte[] data, byte[] signature)
     {
         ArgumentNullException.ThrowIfNull(data);
@@ -138,9 +138,9 @@ public sealed class AgentIdentity
 
         if (PrivateKey is null)
         {
-            // Without Ed25519, we cannot verify with only the public key.
-            // In production with .NET 9+, use Ed25519 public-key verification.
-            return false;
+            throw new InvalidOperationException(
+                "Cannot verify signature: HMAC-SHA256 requires the private key. " +
+                "For cross-agent verification with only a public key, migrate to Ed25519 (.NET 9+).");
         }
 
         var expected = Sign(data);
@@ -148,17 +148,21 @@ public sealed class AgentIdentity
     }
 
     /// <summary>
-    /// Verifies a signature using a standalone public key and private key pair.
+    /// Verifies a signature using a standalone key pair.
     /// This static overload is provided for cross-agent verification scenarios.
     /// </summary>
-    /// <param name="publicKey">The public key of the signer.</param>
+    /// <param name="publicKey">The public key of the signer (unused in HMAC mode; reserved for Ed25519).</param>
     /// <param name="data">The signed data.</param>
     /// <param name="signature">The signature to verify.</param>
     /// <param name="privateKey">
-    /// The private key for HMAC recomputation (required for HMAC-SHA256 fallback;
-    /// not needed with Ed25519 on .NET 9+).
+    /// The private key for HMAC recomputation. Required for HMAC-SHA256;
+    /// will not be needed with Ed25519 on .NET 9+.
     /// </param>
     /// <returns><c>true</c> if the signature is valid; otherwise <c>false</c>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="privateKey"/> is <c>null</c> because HMAC-SHA256
+    /// cannot verify without the signing key.
+    /// </exception>
     public static bool VerifySignature(byte[] publicKey, byte[] data, byte[] signature, byte[]? privateKey = null)
     {
         ArgumentNullException.ThrowIfNull(publicKey);
@@ -167,9 +171,9 @@ public sealed class AgentIdentity
 
         if (privateKey is null)
         {
-            // Cannot verify without private key in HMAC-SHA256 mode.
-            // With Ed25519 (.NET 9+), this would use the public key directly.
-            return false;
+            throw new InvalidOperationException(
+                "Cannot verify signature: HMAC-SHA256 requires the private key. " +
+                "For public-key-only verification, migrate to Ed25519 (.NET 9+).");
         }
 
         using var hmac = new HMACSHA256(privateKey);

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Trust/FileTrustStore.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Trust/FileTrustStore.cs
@@ -16,6 +16,7 @@ public sealed class FileTrustStore : IDisposable
     private readonly object _ioLock = new();
     private readonly double _defaultScore;
     private readonly double _decayRate;
+    private readonly Action<Exception, string>? _loadErrorHandler;
     private bool _disposed;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -34,12 +35,17 @@ public sealed class FileTrustStore : IDisposable
     /// Trust decay rate per hour of inactivity (0–1000). Defaults to 10.
     /// Agents that have not had positive signals lose trust over time.
     /// </param>
-    public FileTrustStore(string filePath, double defaultScore = 500.0, double decayRate = 10.0)
+    /// <param name="loadErrorHandler">
+    /// Optional callback invoked when the trust store file is corrupted.
+    /// Receives the exception and file path. When null, corruption is handled silently.
+    /// </param>
+    public FileTrustStore(string filePath, double defaultScore = 500.0, double decayRate = 10.0, Action<Exception, string>? loadErrorHandler = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
         _filePath = filePath;
         _defaultScore = Math.Clamp(defaultScore, 0, 1000);
         _decayRate = Math.Max(0, decayRate);
+        _loadErrorHandler = loadErrorHandler;
 
         Load();
     }
@@ -179,9 +185,20 @@ public sealed class FileTrustStore : IDisposable
                     }
                 }
             }
-            catch (JsonException)
+            catch (JsonException ex)
             {
-                // Corrupted file — start fresh.
+                // Preserve corrupted file for forensics.
+                try
+                {
+                    var corruptPath = _filePath + ".corrupt";
+                    File.Copy(_filePath, corruptPath, overwrite: true);
+                }
+                catch
+                {
+                    // Best-effort backup; ignore if it fails.
+                }
+
+                _loadErrorHandler?.Invoke(ex, _filePath);
             }
         }
     }

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentIdentityTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentIdentityTests.cs
@@ -87,16 +87,16 @@ public class AgentIdentityTests
     }
 
     [Fact]
-    public void Verify_VerificationOnlyIdentity_ReturnsFalse()
+    public void Verify_VerificationOnlyIdentity_ThrowsInvalidOperationException()
     {
-        // An identity with no private key cannot verify in HMAC mode.
+        // An identity with no private key cannot verify in HMAC mode — throws to make the limitation explicit.
         var identity = AgentIdentity.Create("full");
         var verifyOnly = new AgentIdentity(identity.Did, identity.PublicKey);
 
         var data = "test"u8.ToArray();
         var sig = identity.Sign(data);
 
-        Assert.False(verifyOnly.Verify(data, sig));
+        Assert.Throws<InvalidOperationException>(() => verifyOnly.Verify(data, sig));
     }
 
     [Fact]
@@ -120,14 +120,14 @@ public class AgentIdentityTests
     }
 
     [Fact]
-    public void VerifySignature_Static_WithoutPrivateKey_ReturnsFalse()
+    public void VerifySignature_Static_WithoutPrivateKey_ThrowsInvalidOperationException()
     {
         var identity = AgentIdentity.Create("static-test");
         var data = "test"u8.ToArray();
         var signature = identity.Sign(data);
 
-        Assert.False(AgentIdentity.VerifySignature(
-            identity.PublicKey, data, signature));
+        Assert.Throws<InvalidOperationException>(() =>
+            AgentIdentity.VerifySignature(identity.PublicKey, data, signature));
     }
 
     [Fact]


### PR DESCRIPTION
## .NET SDK Bug Sweep

Fixes 6 open issues in the .NET governance SDK:

| Issue | Fix |
|-------|-----|
| #147 AuditEmitter swallows exceptions | Added \HandlerError\ callback property — exceptions surfaced, not lost |
| #145 SagaOrchestrator compensation races | Added per-saga \SyncRoot\ lock guarding all state mutations |
| #148 FindMatchingRule O(n*m) | Cached rule lookups in dictionary, invalidated on policy count change |
| #150 GovernanceKernel not IDisposable | Implements \IDisposable\, disposes Metrics |
| #141 AgentIdentity silent false on verify | Throws \InvalidOperationException\ — makes HMAC limitation explicit |
| #152 FileTrustStore ignores corrupted JSON | Preserves \.corrupt\ backup + \loadErrorHandler\ callback |

**Tests:** 385 passed, 0 failed (.NET 8.0)
**Build:** 0 warnings, 0 errors

Closes #141, #145, #147, #148, #150, #152