### PR TITLE
fix: bound breach history + CostGuard thread safety (#247, #246)

### DIFF
--- a/packages/agent-hypervisor/src/hypervisor/rings/breach_detector.py
+++ b/packages/agent-hypervisor/src/hypervisor/rings/breach_detector.py
@@ -84,6 +84,7 @@ class RingBreachDetector:
         window_seconds: int = 60,
         baseline_rate: float = 10.0,
         max_events_per_agent: int = 1_000,
+        max_breach_history: int = 10_000,
     ) -> None:
         self.window_seconds = window_seconds
         self.baseline_rate = baseline_rate
@@ -93,8 +94,8 @@ class RingBreachDetector:
         self._call_windows: dict[str, deque[float]] = {}
         # Per-agent circuit-breaker flag
         self._tripped: dict[str, bool] = {}
-        # Global breach history
-        self._breach_history: list[BreachEvent] = []
+        # Global breach history (bounded)
+        self._breach_history: deque[BreachEvent] = deque(maxlen=max_breach_history)
 
     # ------------------------------------------------------------------
     # Public API

--- a/packages/agent-sre/src/agent_sre/cost/guard.py
+++ b/packages/agent-sre/src/agent_sre/cost/guard.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import math
+import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -146,6 +147,7 @@ class CostGuard:
         self._alerts: list[CostAlert] = []
         self._cost_history: deque[float] = deque(maxlen=1000)
         self._org_spent_month: float = 0.0
+        self._lock = threading.Lock()
 
     def get_budget(self, agent_id: str) -> AgentBudget:
         """Get or create budget for an agent."""
@@ -177,11 +179,12 @@ class CostGuard:
             return False, f"Would exceed daily budget (${budget.remaining_today_usd:.2f} remaining)"
 
         if self.org_monthly_budget > 0:
-            if self._org_spent_month + estimated_cost > self.org_monthly_budget:
-                return False, (
-                    f"Would exceed org monthly budget "
-                    f"(${self.org_remaining_month:.2f} remaining)"
-                )
+            with self._lock:
+                if self._org_spent_month + estimated_cost > self.org_monthly_budget:
+                    return False, (
+                        f"Would exceed org monthly budget "
+                        f"(${self.org_remaining_month:.2f} remaining)"
+                    )
 
         return True, "ok"
 
@@ -208,9 +211,10 @@ class CostGuard:
         self._cost_history.append(cost_usd)
 
         # Update budget
-        budget.spent_today_usd += cost_usd
-        budget.task_count_today += 1
-        self._org_spent_month += cost_usd
+        with self._lock:
+            budget.spent_today_usd += cost_usd
+            budget.task_count_today += 1
+            self._org_spent_month += cost_usd
 
         # Per-task limit check
         if cost_usd > self.per_task_limit:


### PR DESCRIPTION
## Fixes

| Issue | Fix |
|-------|-----|
| #247 RingBreachDetector._breach_history unbounded | Changed to \deque(maxlen=10_000)\ with configurable \max_breach_history\ |
| #246 CostGuard._org_spent_month race condition | Added \	hreading.Lock\ protecting read-modify-write in \check_task()\ and \ecord_cost()\ |

**Tests:** hypervisor 380 passed, cost 34 passed

Closes #247, closes #246