### PR TITLE
docs: multi-language SDK readiness restructure

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # Performance Benchmarks
 
-> **Last updated:** March 2026 · **VADP version:** 0.3.x · **Python:** 3.13 · **OS:** Windows 11 (AMD64)
+> **Last updated:** March 2026 · **Toolkit version:** 1.1.x · **Python:** 3.13 · **OS:** Windows 11 (AMD64)
 >
 > All benchmarks use `time.perf_counter()` with 10,000 iterations (unless noted).
 > Numbers are from a development workstation — CI runs on `ubuntu-latest` GitHub-hosted runners.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Get from zero to governed AI agents in under 10 minutes.
 
-> **Prerequisites:** Python 3.10+ and pip installed.
+> **Prerequisites:** Python 3.10+ / Node.js 18+ / .NET 8.0+ (any one or more).
 
 ## Architecture Overview
 
@@ -37,6 +37,18 @@ pip install agent-sre              # SLOs, error budgets, chaos testing
 pip install agent-runtime          # Execution supervisor + privilege rings
 pip install agent-marketplace      # Plugin lifecycle management
 pip install agent-lightning        # RL training governance
+```
+
+### TypeScript / Node.js
+
+```bash
+npm install @agentmesh/sdk
+```
+
+### .NET
+
+```bash
+dotnet add package Microsoft.AgentGovernance
 ```
 
 ## 2. Verify Your Installation
@@ -88,6 +100,45 @@ Run it:
 
 ```bash
 python governed_agent.py
+```
+
+### Your First Governed Agent — TypeScript
+
+Create a file called `governed_agent.ts`:
+
+```typescript
+import { PolicyEngine, AgentIdentity, AuditLogger } from "@agentmesh/sdk";
+
+const identity = AgentIdentity.generate("my-agent", ["web_search", "read_file"]);
+
+const engine = new PolicyEngine([
+  { action: "web_search", effect: "allow" },
+  { action: "delete_file", effect: "deny" },
+]);
+
+console.log(engine.evaluate("web_search"));  // "allow"
+console.log(engine.evaluate("delete_file")); // "deny"
+```
+
+### Your First Governed Agent — .NET
+
+Create a file called `GovernedAgent.cs`:
+
+```csharp
+using AgentGovernance;
+using AgentGovernance.Policy;
+
+var kernel = new GovernanceKernel(new GovernanceOptions
+{
+    PolicyPaths = new() { "policies/default.yaml" },
+    EnablePromptInjectionDetection = true,
+});
+
+var result = kernel.EvaluateToolCall("did:mesh:agent-1", "web_search", new() { ["query"] = "AI news" });
+Console.WriteLine($"Allowed: {result.Allowed}");  // True (if policy permits)
+
+result = kernel.EvaluateToolCall("did:mesh:agent-1", "delete_file", new() { ["path"] = "/etc/passwd" });
+Console.WriteLine($"Allowed: {result.Allowed}");  // False
 ```
 
 ## 4. Wrap an Existing Framework
@@ -144,7 +195,9 @@ agent-governance integrity --manifest integrity.json
 
 | What | Where |
 |------|-------|
-| Full API reference | [packages/agent-os/README.md](packages/agent-os/README.md) |
+| Full API reference (Python) | [packages/agent-os/README.md](packages/agent-os/README.md) |
+| TypeScript SDK docs | [packages/agent-mesh/sdks/typescript/README.md](packages/agent-mesh/sdks/typescript/README.md) |
+| .NET SDK docs | [packages/agent-governance-dotnet/README.md](packages/agent-governance-dotnet/README.md) |
 | OWASP coverage map | [docs/OWASP-COMPLIANCE.md](docs/OWASP-COMPLIANCE.md) |
 | Framework integrations | [packages/agent-os/src/agent_os/integrations/](packages/agent-os/src/agent_os/integrations/) |
 | Example applications | [packages/agent-os/examples/](packages/agent-os/examples/) |

--- a/README.md
+++ b/README.md
@@ -5,36 +5,52 @@
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-npm_%40agentmesh%2Fsdk-blue?logo=typescript)](packages/agent-mesh/sdks/typescript/)
+[![.NET 8.0+](https://img.shields.io/badge/.NET_8.0+-NuGet-blue?logo=dotnet)](https://www.nuget.org/packages/Microsoft.AgentGovernance)
 [![OWASP Agentic Top 10](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10_Covered-blue)](docs/OWASP-COMPLIANCE.md)
 [![OpenSSF Best Practices](https://img.shields.io/cii/percentage/12085?label=OpenSSF%20Best%20Practices&logo=opensourcesecurity)](https://www.bestpractices.dev/projects/12085)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/microsoft/agent-governance-toolkit/badge)](https://scorecard.dev/viewer/?uri=github.com/microsoft/agent-governance-toolkit)
 
-Runtime governance for AI agents — the only toolkit covering all **10 OWASP Agentic risks** with **6,100+ tests**. Governs what agents *do*, not just what they say — deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE — one `pip install`.
+Runtime governance for AI agents — the only toolkit covering all **10 OWASP Agentic risks** with **6,100+ tests**. Governs what agents *do*, not just what they say — deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE — **Python · TypeScript · .NET**
 
 ## 📋 Getting Started
 
 ### 📦 Installation
 
+**Python** (PyPI)
 ```bash
 pip install agent-governance[full]
-# This will install all sub-packages, see `packages/` for individual packages.
 ```
 
-Or install individual packages:
+**TypeScript / Node.js** (npm)
+```bash
+npm install @agentmesh/sdk
+```
+
+**.NET** (NuGet)
+```bash
+dotnet add package Microsoft.AgentGovernance
+```
+
+<details>
+<summary>Install individual Python packages</summary>
 
 ```bash
-pip install agent-os-kernel    # Policy engine
-pip install agentmesh           # Trust mesh
-pip install agent-runtime       # Runtime supervisor
-pip install agent-sre           # SRE toolkit
-pip install agent-governance    # Compliance & attestation
-pip install agent-marketplace   # Plugin marketplace
-pip install agent-lightning     # RL training governance
+pip install agent-os-kernel        # Policy engine
+pip install agentmesh-platform     # Trust mesh
+pip install agent-runtime          # Runtime supervisor
+pip install agent-sre              # SRE toolkit
+pip install agent-governance       # Compliance & attestation
+pip install agent-marketplace      # Plugin marketplace
+pip install agent-lightning        # RL training governance
 ```
+</details>
 
 ### 📚 Documentation
 
-- **[Quick Start](QUICKSTART.md)** — Get from zero to governed agents in 10 minutes
+- **[Quick Start](QUICKSTART.md)** — Get from zero to governed agents in 10 minutes (Python · TypeScript · .NET)
+- **[TypeScript SDK](packages/agent-mesh/sdks/typescript/README.md)** — npm package with identity, trust, policy, and audit
+- **[.NET SDK](packages/agent-governance-dotnet/README.md)** — NuGet package with full OWASP coverage
 - **[Tutorials](docs/tutorials/)** — Step-by-step guides for policy, identity, integrations, compliance, SRE, and sandboxing
 - **[Azure Deployment](docs/deployment/README.md)** — AKS, Azure AI Foundry, Container Apps, OpenClaw sidecar
 - **[OWASP Compliance](docs/OWASP-COMPLIANCE.md)** — Full ASI-01 through ASI-10 mapping
@@ -48,7 +64,7 @@ Still have questions? File a [GitHub issue](https://github.com/microsoft/agent-g
 - **Deterministic Policy Enforcement**: Every agent action evaluated against policy *before* execution at sub-millisecond latency (<0.1 ms)
   - [Policy Engine](packages/agent-os/) | [Benchmarks](BENCHMARKS.md)
 - **Zero-Trust Agent Identity**: Ed25519 cryptographic credentials, SPIFFE/SVID support, trust scoring on a 0–1000 scale
-  - [AgentMesh](packages/agent-mesh/) | [Trust Scoring docs](packages/agent-mesh/docs/TRUST-SCORING.md)
+  - [AgentMesh](packages/agent-mesh/) | [Trust Scoring](packages/agent-mesh/)
 - **Execution Sandboxing**: 4-tier privilege rings, saga orchestration, termination control, kill switch
   - [Agent Runtime](packages/agent-runtime/) | [Agent Hypervisor](packages/agent-hypervisor/)
 - **Agent SRE**: SLOs, error budgets, replay debugging, chaos engineering, circuit breakers, progressive delivery
@@ -85,6 +101,39 @@ if decision.allowed:
     ...
 ```
 
+### Enforce a policy — TypeScript
+
+```typescript
+import { PolicyEngine } from "@agentmesh/sdk";
+
+const engine = new PolicyEngine([
+  { action: "web_search", effect: "allow" },
+  { action: "shell_exec", effect: "deny" },
+]);
+
+const decision = engine.evaluate("web_search"); // "allow"
+```
+
+### Enforce a policy — .NET
+
+```csharp
+using AgentGovernance;
+using AgentGovernance.Policy;
+
+var kernel = new GovernanceKernel(new GovernanceOptions
+{
+    PolicyPaths = new() { "policies/default.yaml" },
+});
+
+var result = kernel.EvaluateToolCall(
+    agentId: "did:mesh:researcher-1",
+    toolName: "web_search",
+    args: new() { ["query"] = "latest AI news" }
+);
+
+if (result.Allowed) { /* proceed */ }
+```
+
 ## More Examples & Samples
 
 - **[Framework Quickstarts](examples/quickstart/)** — One-file governed agents for LangChain, CrewAI, AutoGen, OpenAI Agents, Google ADK
@@ -95,7 +144,17 @@ if decision.allowed:
 - **[Tutorial 5: Agent Reliability](docs/tutorials/05-agent-reliability.md)** — SLOs, error budgets, chaos testing
 - **[Tutorial 6: Execution Sandboxing](docs/tutorials/06-execution-sandboxing.md)** — Privilege rings and termination
 
-## Packages
+## SDKs & Packages
+
+### Multi-Language SDKs
+
+| Language | Package | Install |
+|----------|---------|---------|
+| **Python** | [`agent-governance[full]`](https://pypi.org/project/agent-governance/) | `pip install agent-governance[full]` |
+| **TypeScript** | [`@agentmesh/sdk`](packages/agent-mesh/sdks/typescript/) | `npm install @agentmesh/sdk` |
+| **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
+
+### Python Packages (PyPI)
 
 | Package | PyPI | Description |
 |---------|------|-------------|
@@ -114,11 +173,13 @@ Works with **12+ agent frameworks** including:
 | Framework | Stars | Integration |
 |-----------|-------|-------------|
 | [**Microsoft Agent Framework**](https://github.com/microsoft/agent-framework) | 7.6K+ ⭐ | **Native Middleware** |
+| [**Semantic Kernel**](https://github.com/microsoft/semantic-kernel) | 24K+ ⭐ | **Native (.NET + Python)** |
 | [Dify](https://github.com/langgenius/dify) | 65K+ ⭐ | Plugin |
 | [LlamaIndex](https://github.com/run-llama/llama_index) | 47K+ ⭐ | Middleware |
 | [LangGraph](https://github.com/langchain-ai/langgraph) | 24K+ ⭐ | Adapter |
 | [Microsoft AutoGen](https://github.com/microsoft/autogen) | 42K+ ⭐ | Adapter |
 | [CrewAI](https://github.com/crewAIInc/crewAI) | 28K+ ⭐ | Adapter |
+| [Azure AI Foundry](https://learn.microsoft.com/azure/ai-studio/) | — | Deployment Guide |
 | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | — | Middleware |
 | [Google ADK](https://github.com/google/adk-python) | — | Adapter |
 | [Haystack](https://github.com/deepset-ai/haystack) | 22K+ ⭐ | Pipeline |

--- a/demo/maf_governance_demo.py
+++ b/demo/maf_governance_demo.py
@@ -42,8 +42,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-mesh" / "src"))
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-sre" / "src"))
-# agent-hypervisor is the legacy name; the package is now called agent-runtime
-sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-hypervisor" / "src"))
+sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-runtime" / "src"))
 
 # Suppress library-level log messages to keep terminal output clean.
 import logging

--- a/examples/quickstart/autogen_governed.py
+++ b/examples/quickstart/autogen_governed.py
@@ -4,7 +4,7 @@
 AutoGen Agents with Trust Verification — Quickstart
 ====================================================
 
-pip install ai-agent-compliance[full] pyautogen
+pip install agent-governance[full] pyautogen
 python examples/quickstart/autogen_governed.py
 
 Shows a real policy violation being caught during message routing,

--- a/examples/quickstart/crewai_governed.py
+++ b/examples/quickstart/crewai_governed.py
@@ -4,7 +4,7 @@
 CrewAI Crew with Governance Middleware — Quickstart
 ====================================================
 
-pip install ai-agent-compliance[full] crewai
+pip install agent-governance[full] crewai
 python examples/quickstart/crewai_governed.py
 
 Shows a real policy violation being caught, then a compliant run succeeding,

--- a/examples/quickstart/google_adk_governed.py
+++ b/examples/quickstart/google_adk_governed.py
@@ -4,7 +4,7 @@
 Google ADK Agent with Policy Gates — Quickstart
 ================================================
 
-pip install ai-agent-compliance[full] google-adk
+pip install agent-governance[full] google-adk
 python examples/quickstart/google_adk_governed.py
 
 Shows real policy violations being caught by ADK governance callbacks,

--- a/examples/quickstart/langchain_governed.py
+++ b/examples/quickstart/langchain_governed.py
@@ -4,7 +4,7 @@
 LangChain Agent with Policy Enforcement — Quickstart
 =====================================================
 
-pip install ai-agent-compliance[full] langchain langchain-openai
+pip install agent-governance[full] langchain langchain-openai
 python examples/quickstart/langchain_governed.py
 
 Shows a real policy violation being caught, then a compliant call succeeding,

--- a/examples/quickstart/openai_agents_governed.py
+++ b/examples/quickstart/openai_agents_governed.py
@@ -4,7 +4,7 @@
 OpenAI Agents SDK with Guardrails — Quickstart
 ===============================================
 
-pip install ai-agent-compliance[full] openai-agents
+pip install agent-governance[full] openai-agents
 python examples/quickstart/openai_agents_governed.py
 
 Shows a real policy violation being caught by a tool guard, then a compliant

--- a/packages/agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj
@@ -7,6 +7,14 @@
     <Version>1.1.0</Version>
     <Description>Agent Governance Toolkit — .NET SDK for policy enforcement, rate limiting, zero-trust identity, OpenTelemetry metrics, and audit logging for autonomous AI agents. Compatible with Microsoft Agent Framework and Semantic Kernel.</Description>
     <PackageId>Microsoft.AgentGovernance</PackageId>
+    <Authors>Microsoft</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/microsoft/agent-governance-toolkit</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/microsoft/agent-governance-toolkit.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>agent;governance;policy;security;owasp;ai;trust;identity</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Copyright>Copyright (c) Microsoft Corporation</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/agent-mesh/sdks/typescript/package.json
+++ b/packages/agent-mesh/sdks/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentmesh/sdk",
   "version": "0.1.0",
-  "description": "TypeScript SDK for AgentMesh — agent identity, trust scoring, policy evaluation, and audit logging",
+  "description": "TypeScript SDK for AgentMesh \u2014 agent identity, trust scoring, policy evaluation, and audit logging",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -11,7 +11,8 @@
     "build": "tsc",
     "test": "jest --config jest.config.js",
     "lint": "eslint src/ tests/ --ext .ts",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "agentmesh",
@@ -23,11 +24,11 @@
     "audit"
   ],
   "author": "AgentMesh Contributors",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/agent-governance-toolkit.git",
-    "directory": "sdks/typescript"
+    "directory": "packages/agent-mesh/sdks/typescript"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
@@ -46,5 +47,13 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "homepage": "https://github.com/microsoft/agent-governance-toolkit/tree/main/packages/agent-mesh/sdks/typescript"
 }


### PR DESCRIPTION
## Summary

Restructure repo docs to surface all three SDKs (Python, TypeScript, .NET) as first-class citizens.

### Changes

**README.md**
- Added TypeScript (npm) + .NET (NuGet) install sections and badges
- Added TypeScript + .NET quickstart code examples
- Added multi-SDK packages table alongside PyPI packages
- Added Semantic Kernel + Azure AI Foundry to integration table
- Fixed broken trust-scoring doc link
- Fixed stale agentmesh package name (should be agentmesh-platform)

**QUICKSTART.md**
- Added TypeScript + .NET prerequisites and install sections
- Added governed agent examples in TypeScript + .NET
- Updated Next Steps table with SDK-specific doc links

**Examples**
- Fixed all 5 quickstart files: ai-agent-compliance[full] -> agent-governance[full]

**TypeScript SDK (package.json)**
- Fixed repository.directory path
- Added exports field for proper ESM/CJS support
- Added prepublishOnly build hook
- Changed license to MIT (matching repo)

**.NET SDK (csproj)**
- Added NuGet metadata: Authors, License, RepositoryUrl, Tags, ReadmeFile

**Other**
- BENCHMARKS.md: fixed stale VADP version reference
- Demo: fixed legacy agent-hypervisor path -> agent-runtime