### PR TITLE
ci: add markdown link checker workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,26 @@
+# Checks all Markdown files for broken links (internal and external).
+# Uses lychee (https://github.com/lycheeverse/lychee) with configuration
+# from .lychee.toml at the repository root.
+
+name: Link Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --no-progress
+            '**/*.md'
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,41 @@
+# Configuration for lychee link checker
+# https://lychee.cli.rs/configuration/
+
+# General settings
+max_concurrency = 32
+timeout = 30
+max_retries = 3
+retry_wait = 5
+
+# Accept these HTTP status codes as valid
+accept = [200, 429]
+
+# Exclude patterns for known false positives
+exclude = [
+    # Placeholder / example URLs
+    "example\\.com",
+    "example\\.org",
+    "example\\.net",
+
+    # Localhost and private networks
+    "localhost",
+    "127\\.0\\.0\\.1",
+    "0\\.0\\.0\\.0",
+
+    # npm registry (frequently rate-limits CI)
+    "npmjs\\.com",
+
+    # PyPI (frequently rate-limits CI)
+    "pypi\\.org/project",
+
+    # Microsoft login / auth endpoints (require authentication)
+    "login\\.microsoftonline\\.com",
+    "portal\\.azure\\.com",
+
+    # GitHub special URLs that require authentication or don't resolve in CI
+    "github\\.com/.*/compare/",
+    "github\\.com/.*/releases/new",
+]
+
+# Exclude email addresses from checking
+exclude_mail = true


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that checks all Markdown files for broken links on every PR targeting main, using [lychee](https://github.com/lycheeverse/lychee).

## Changes

- `.github/workflows/link-check.yml`: New workflow using `lycheeverse/lychee-action` (SHA-pinned per project convention). Runs on `pull_request` to `main`, checks all `**/*.md` files.
- `.lychee.toml`: Configuration with timeout/retry settings and an allow-list for known-flaky URLs (npm/PyPI registries, localhost, placeholder domains, auth endpoints).

## Testing

The workflow runs automatically on this PR. lychee validates both internal file references and external URLs.

Closes #320

This contribution was developed with AI assistance (Claude Code).