### PR TITLE
feat(governance): cross-organizational federation governance model (#93)

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/governance/__init__.py
@@ -46,6 +46,20 @@ from .trust_policy import (
 from .async_policy_evaluator import AsyncTrustPolicyEvaluator
 from .async_policy_evaluator import ConcurrencyStats as TrustConcurrencyStats
 from .policy_evaluator import PolicyEvaluator, TrustPolicyDecision
+from .federation import (
+    PolicyCategory,
+    OrgPolicyRule,
+    DataClassification,
+    OrgPolicy,
+    OrgPolicyDecision,
+    OrgTrustAgreement,
+    PolicyDelegation,
+    FederationDecision,
+    FederationStore,
+    InMemoryFederationStore,
+    FileFederationStore,
+    FederationEngine,
+)
 
 __all__ = [
     "AsyncTrustPolicyEvaluator",
@@ -92,4 +106,18 @@ __all__ = [
     "load_policies",
     "PolicyEvaluator",
     "TrustPolicyDecision",
+    # Federation (issue #93)
+    "PolicyCategory",
+    "OrgPolicyRule",
+    "DataClassification",
+    "OrgPolicy",
+    "OrgPolicyDecision",
+    "OrgTrustAgreement",
+    "PolicyDelegation",
+    "FederationDecision",
+    "FederationStore",
+    "InMemoryFederationStore",
+    "FileFederationStore",
+    "FederationEngine",
 ]
+

--- a/packages/agent-mesh/src/agentmesh/governance/_conflict_resolution_impl.py
+++ b/packages/agent-mesh/src/agentmesh/governance/_conflict_resolution_impl.py
@@ -31,11 +31,12 @@ class ConflictResolutionStrategy(str, Enum):
 class PolicyScope(str, Enum):
     """Breadth of a policy's applicability.
 
-    Specificity order (most → least): AGENT > TENANT > GLOBAL.
+    Specificity order (most → least): AGENT > ORGANIZATION > TENANT > GLOBAL.
     """
 
     GLOBAL = "global"
     TENANT = "tenant"
+    ORGANIZATION = "organization"
     AGENT = "agent"
 
 
@@ -43,7 +44,8 @@ class PolicyScope(str, Enum):
 _SCOPE_SPECIFICITY: dict[Any, int] = {
     PolicyScope.GLOBAL: 0,
     PolicyScope.TENANT: 1,
-    PolicyScope.AGENT: 2,
+    PolicyScope.ORGANIZATION: 2,
+    PolicyScope.AGENT: 3,
 }
 
 

--- a/packages/agent-mesh/src/agentmesh/governance/federation.py
+++ b/packages/agent-mesh/src/agentmesh/governance/federation.py
@@ -1,0 +1,1048 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Cross-Organizational Federation Governance.
+
+Enables mutual policy enforcement, org-level trust establishment,
+and policy delegation between organizations.
+
+When agents from different organizations interact, the federation
+engine evaluates **both** the caller's and callee's org policies,
+checks for bilateral trust agreements, and resolves policy
+delegations — ensuring the most restrictive decision wins.
+
+Closes: https://github.com/microsoft/agent-governance-toolkit/issues/93
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal, Optional, Protocol, runtime_checkable
+
+import yaml
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ── Policy Categories ──────────────────────────────────────────
+
+
+class PolicyCategory(str, Enum):
+    """Extensible taxonomy of governance categories.
+
+    These categories scope what aspects of governance one organization
+    may delegate to another.
+    """
+
+    PII_HANDLING = "pii_handling"
+    DATA_EXPORT = "data_export"
+    DATA_RETENTION = "data_retention"
+    COST_CONTROL = "cost_control"
+    MODEL_SAFETY = "model_safety"
+    AUDIT_LOGGING = "audit_logging"
+    ACCESS_CONTROL = "access_control"
+    COMPLIANCE = "compliance"
+    GENERAL = "general"
+
+
+# ── Org Policy Model ───────────────────────────────────────────
+
+
+class OrgPolicyRule(BaseModel):
+    """A single rule within an organization policy.
+
+    Attributes:
+        name: Unique rule identifier.
+        description: Human-readable description.
+        category: Governance category this rule belongs to.
+        condition: Condition expression (same syntax as PolicyRule).
+        action: Action when the condition matches.
+        priority: Evaluation priority (lower = higher priority).
+        enabled: Whether this rule is active.
+    """
+
+    name: str = Field(..., description="Rule name")
+    description: Optional[str] = Field(None)
+    category: PolicyCategory = Field(
+        default=PolicyCategory.GENERAL,
+        description="Governance category this rule belongs to",
+    )
+    condition: str = Field(..., description="Condition expression")
+    action: Literal["allow", "deny", "warn", "require_approval"] = Field(
+        default="deny",
+    )
+    priority: int = Field(default=100)
+    enabled: bool = Field(default=True)
+
+    def evaluate(self, context: dict) -> bool:
+        """Evaluate rule condition against context.
+
+        Uses the same simple expression evaluation as the core
+        ``PolicyRule``.  Supports ``==``, boolean attributes,
+        ``and``/``or`` compound conditions.
+
+        Args:
+            context: Runtime context dict.
+
+        Returns:
+            ``True`` if enabled and the condition matches.
+        """
+        if not self.enabled:
+            return False
+        try:
+            return _eval_expression(self.condition, context)
+        except Exception:
+            logger.debug(
+                "OrgPolicyRule evaluation failed for '%s'",
+                self.name,
+                exc_info=True,
+            )
+            return False
+
+
+class DataClassification(str, Enum):
+    """Data classification levels for org policy constraints."""
+
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    CONFIDENTIAL = "confidential"
+    RESTRICTED = "restricted"
+
+
+class OrgPolicy(BaseModel):
+    """Organization-level policy document.
+
+    Extends the governance pattern to organizational boundaries.  Each
+    org can define rules that apply to **all** interactions involving
+    its agents — both as caller and callee.
+
+    Attributes:
+        org_id: Unique organization identifier.
+        org_name: Human-readable organization name.
+        version: Policy version string.
+        description: Optional description.
+        rules: Ordered list of org-level policy rules.
+        default_action: Fallback action when no rule matches.
+        max_data_classification: Highest data classification
+            allowed for cross-org transfers.
+        required_min_trust_score: Minimum trust score required
+            for any agent interacting with this org's agents.
+        allowed_partner_orgs: Explicit allowlist of partner org
+            IDs.  Empty list means ''trust agreements only''.
+        blocked_orgs: Explicit blocklist of org IDs.
+        created_at: When this policy was created.
+        updated_at: When this policy was last modified.
+    """
+
+    org_id: str = Field(..., description="Organization identifier")
+    org_name: str = Field(default="", description="Organization name")
+    version: str = Field(default="1.0")
+    description: Optional[str] = Field(None)
+
+    rules: list[OrgPolicyRule] = Field(default_factory=list)
+    default_action: Literal["allow", "deny"] = Field(default="deny")
+
+    # Constraints
+    max_data_classification: DataClassification = Field(
+        default=DataClassification.INTERNAL,
+        description="Highest data classification for cross-org transfers",
+    )
+    required_min_trust_score: int = Field(
+        default=700,
+        ge=0,
+        le=1000,
+        description="Minimum trust score for cross-org interaction",
+    )
+
+    # Org allowlist / blocklist
+    allowed_partner_orgs: list[str] = Field(
+        default_factory=list,
+        description="Explicit allowlist of partner org IDs",
+    )
+    blocked_orgs: list[str] = Field(
+        default_factory=list,
+        description="Blocked org IDs — always deny",
+    )
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    def evaluate(self, context: dict) -> OrgPolicyDecision:
+        """Evaluate all rules against the given context.
+
+        Rules are sorted by priority (lower first = higher priority).
+        The first matching rule wins.
+
+        Args:
+            context: Runtime context dict.
+
+        Returns:
+            An ``OrgPolicyDecision`` with the matched rule and action.
+        """
+        sorted_rules = sorted(
+            [r for r in self.rules if r.enabled],
+            key=lambda r: r.priority,
+        )
+
+        for rule in sorted_rules:
+            if rule.evaluate(context):
+                return OrgPolicyDecision(
+                    allowed=(rule.action == "allow"),
+                    action=rule.action,
+                    matched_rule=rule.name,
+                    org_id=self.org_id,
+                    reason=rule.description or f"Rule '{rule.name}' matched",
+                    category=rule.category,
+                )
+
+        return OrgPolicyDecision(
+            allowed=(self.default_action == "allow"),
+            action=self.default_action,
+            matched_rule=None,
+            org_id=self.org_id,
+            reason="No rules matched, using org default",
+            category=PolicyCategory.GENERAL,
+        )
+
+    @classmethod
+    def from_yaml(cls, yaml_content: str) -> "OrgPolicy":
+        """Load an OrgPolicy from a YAML string.
+
+        Args:
+            yaml_content: Raw YAML string.
+
+        Returns:
+            A fully-constructed ``OrgPolicy``.
+        """
+        data = yaml.safe_load(yaml_content)
+        rules = []
+        for rule_data in data.pop("rules", []):
+            rules.append(OrgPolicyRule(**rule_data))
+        data["rules"] = rules
+        return cls(**data)
+
+    def to_yaml(self) -> str:
+        """Serialize this OrgPolicy to a YAML string.
+
+        Returns:
+            YAML-formatted policy document.
+        """
+        data = self.model_dump(mode="json", exclude_none=True)
+        return yaml.dump(data, default_flow_style=False, sort_keys=False)
+
+
+class OrgPolicyDecision(BaseModel):
+    """Result of evaluating an org-level policy.
+
+    Attributes:
+        allowed: Whether the action is permitted.
+        action: The action taken.
+        matched_rule: Name of the matched rule (if any).
+        org_id: Organization that produced this decision.
+        reason: Human-readable explanation.
+        category: Governance category of the matched rule.
+    """
+
+    allowed: bool
+    action: str
+    matched_rule: Optional[str] = None
+    org_id: str = ""
+    reason: str = ""
+    category: PolicyCategory = PolicyCategory.GENERAL
+
+
+# ── Org Trust Agreement ────────────────────────────────────────
+
+
+class OrgTrustAgreement(BaseModel):
+    """Bilateral trust agreement between two organizations.
+
+    Establishes that org A and org B trust each other (or one-way)
+    for specific governance categories, subject to constraints.
+
+    Attributes:
+        agreement_id: Unique identifier for this agreement.
+        org_a_id: First organization.
+        org_b_id: Second organization.
+        trust_categories: Which governance categories this
+            agreement covers.
+        min_trust_score: Minimum agent trust score required for
+            cross-org interaction under this agreement.
+        mutual: If ``True``, enforcement is bidirectional.
+            If ``False``, only org_a trusts org_b.
+        max_data_classification: Highest data classification
+            allowed under this agreement.
+        created_at: When this agreement was established.
+        expires_at: When this agreement expires.  ``None`` means
+            no expiration.
+        revoked: Whether this agreement has been revoked.
+        revocation_reason: Reason for revocation, if applicable.
+        verification_method: How this agreement was verified
+            (e.g., ``"manual"``, ``"iatp_attestation"``).
+    """
+
+    agreement_id: str = Field(
+        default_factory=lambda: f"agmt_{uuid.uuid4().hex[:16]}",
+    )
+    org_a_id: str = Field(..., description="First organization ID")
+    org_b_id: str = Field(..., description="Second organization ID")
+
+    trust_categories: list[PolicyCategory] = Field(
+        default_factory=lambda: [PolicyCategory.GENERAL],
+        description="Governance categories covered",
+    )
+    min_trust_score: int = Field(
+        default=700,
+        ge=0,
+        le=1000,
+        description="Minimum agent trust score",
+    )
+    mutual: bool = Field(
+        default=True,
+        description="Bidirectional trust",
+    )
+    max_data_classification: DataClassification = Field(
+        default=DataClassification.INTERNAL,
+    )
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    expires_at: Optional[datetime] = Field(None)
+    revoked: bool = Field(default=False)
+    revocation_reason: Optional[str] = Field(None)
+
+    verification_method: str = Field(
+        default="manual",
+        description="How this agreement was verified",
+    )
+
+    def is_active(self) -> bool:
+        """Check if this agreement is active (not expired or revoked)."""
+        if self.revoked:
+            return False
+        if self.expires_at and datetime.utcnow() > self.expires_at:
+            return False
+        return True
+
+    def covers_orgs(self, org_a: str, org_b: str) -> bool:
+        """Check if this agreement covers the given org pair.
+
+        If ``mutual`` is ``True``, order doesn't matter.
+        If ``False``, only org_a trusts org_b (directional).
+
+        Args:
+            org_a: Caller org ID.
+            org_b: Callee org ID.
+
+        Returns:
+            ``True`` if the pair is covered.
+        """
+        if self.mutual:
+            return {self.org_a_id, self.org_b_id} == {org_a, org_b}
+        return self.org_a_id == org_a and self.org_b_id == org_b
+
+    def covers_category(self, category: PolicyCategory) -> bool:
+        """Check if a governance category is covered.
+
+        Args:
+            category: The category to check.
+
+        Returns:
+            ``True`` if the category is covered by this agreement.
+        """
+        if PolicyCategory.GENERAL in self.trust_categories:
+            return True
+        return category in self.trust_categories
+
+    def revoke(self, reason: str) -> None:
+        """Revoke this agreement."""
+        self.revoked = True
+        self.revocation_reason = reason
+
+
+# ── Policy Delegation ──────────────────────────────────────────
+
+
+class PolicyDelegation(BaseModel):
+    """Policy delegation: org A accepts org B's governance attestation
+    for specific categories.
+
+    This enables one org to say: ''I trust that org B's governance
+    is sufficient for PII handling — I don't need to re-evaluate
+    PII rules for their agents.''
+
+    Attributes:
+        delegation_id: Unique identifier.
+        source_org_id: Organization that delegates authority.
+        target_org_id: Organization that receives delegation.
+        delegated_categories: Governance categories being
+            delegated.
+        constraints: Additional constraints on the delegation
+            (e.g., ``{"region": "EU"}`` restricts PII delegation
+            to EU data only).
+        created_at: When created.
+        expires_at: When this delegation expires.
+        active: Whether this delegation is active.
+    """
+
+    delegation_id: str = Field(
+        default_factory=lambda: f"deleg_{uuid.uuid4().hex[:16]}",
+    )
+    source_org_id: str = Field(
+        ..., description="Org that delegates authority"
+    )
+    target_org_id: str = Field(
+        ..., description="Org that receives delegation"
+    )
+    delegated_categories: list[PolicyCategory] = Field(
+        ..., description="Categories being delegated"
+    )
+    constraints: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional constraints",
+    )
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    expires_at: Optional[datetime] = Field(None)
+    active: bool = Field(default=True)
+
+    def is_active(self) -> bool:
+        """Check if delegation is active and not expired."""
+        if not self.active:
+            return False
+        if self.expires_at and datetime.utcnow() > self.expires_at:
+            return False
+        return True
+
+    def covers_category(self, category: PolicyCategory) -> bool:
+        """Check if this delegation covers a category.
+
+        Args:
+            category: The category to check.
+
+        Returns:
+            ``True`` if the category is delegated.
+        """
+        return category in self.delegated_categories
+
+    def check_constraints(self, context: dict) -> bool:
+        """Verify that the context satisfies delegation constraints.
+
+        Each constraint key must be present in the context with a
+        matching value.
+
+        Args:
+            context: Runtime context dict.
+
+        Returns:
+            ``True`` if all constraints are satisfied.
+        """
+        for key, expected in self.constraints.items():
+            actual = context.get(key)
+            if actual != expected:
+                return False
+        return True
+
+
+# ── Federation Decision ────────────────────────────────────────
+
+
+class FederationDecision(BaseModel):
+    """Result of a cross-organizational federation evaluation.
+
+    Attributes:
+        allowed: Whether the cross-org interaction is permitted.
+        caller_decision: Decision from the caller org's policy.
+        callee_decision: Decision from the callee org's policy.
+        trust_agreement_id: ID of the applicable trust agreement.
+        delegations_applied: IDs of delegations that were honored.
+        reason: Human-readable summary.
+        trace: Step-by-step trace of the evaluation logic.
+        evaluated_at: Timestamp of evaluation.
+    """
+
+    allowed: bool
+    caller_decision: Optional[OrgPolicyDecision] = None
+    callee_decision: Optional[OrgPolicyDecision] = None
+    trust_agreement_id: Optional[str] = None
+    delegations_applied: list[str] = Field(default_factory=list)
+    reason: str = ""
+    trace: list[str] = Field(default_factory=list)
+    evaluated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+# ── Persistence Interface ─────────────────────────────────────
+
+
+@runtime_checkable
+class FederationStore(Protocol):
+    """Interface for federation data persistence.
+
+    Implementations may be file-based, SQL-backed, or in-memory.
+    """
+
+    def get_org_policy(self, org_id: str) -> Optional[OrgPolicy]: ...
+    def get_trust_agreements(
+        self, org_a: str, org_b: str
+    ) -> list[OrgTrustAgreement]: ...
+    def get_delegations(
+        self, source_org: str, target_org: str
+    ) -> list[PolicyDelegation]: ...
+
+
+# ── In-Memory Federation Store ────────────────────────────────
+
+
+class InMemoryFederationStore:
+    """Simple in-memory federation store for development and testing.
+
+    For production, implement ``FederationStore`` against a
+    database or distributed config store.
+    """
+
+    def __init__(self) -> None:
+        self._org_policies: dict[str, OrgPolicy] = {}
+        self._trust_agreements: list[OrgTrustAgreement] = []
+        self._delegations: list[PolicyDelegation] = []
+
+    # ── CRUD: Org Policies ─────────────────────────────────
+
+    def add_org_policy(self, policy: OrgPolicy) -> None:
+        """Register or update an org policy."""
+        self._org_policies[policy.org_id] = policy
+        logger.info(
+            "Federation: registered org policy for '%s'",
+            policy.org_id,
+        )
+
+    def remove_org_policy(self, org_id: str) -> bool:
+        """Remove an org policy.  Returns True if found."""
+        if org_id in self._org_policies:
+            del self._org_policies[org_id]
+            return True
+        return False
+
+    def get_org_policy(self, org_id: str) -> Optional[OrgPolicy]:
+        """Retrieve an org policy by org ID."""
+        return self._org_policies.get(org_id)
+
+    def list_org_policies(self) -> list[OrgPolicy]:
+        """List all registered org policies."""
+        return list(self._org_policies.values())
+
+    # ── CRUD: Trust Agreements ─────────────────────────────
+
+    def add_trust_agreement(
+        self, agreement: OrgTrustAgreement
+    ) -> None:
+        """Register a trust agreement."""
+        self._trust_agreements.append(agreement)
+        logger.info(
+            "Federation: registered trust agreement '%s' "
+            "between '%s' and '%s'",
+            agreement.agreement_id,
+            agreement.org_a_id,
+            agreement.org_b_id,
+        )
+
+    def revoke_trust_agreement(
+        self, agreement_id: str, reason: str
+    ) -> bool:
+        """Revoke a trust agreement by ID."""
+        for agmt in self._trust_agreements:
+            if agmt.agreement_id == agreement_id:
+                agmt.revoke(reason)
+                logger.info(
+                    "Federation: revoked agreement '%s': %s",
+                    agreement_id,
+                    reason,
+                )
+                return True
+        return False
+
+    def get_trust_agreements(
+        self, org_a: str, org_b: str
+    ) -> list[OrgTrustAgreement]:
+        """Find active trust agreements covering the given org pair."""
+        return [
+            a
+            for a in self._trust_agreements
+            if a.is_active() and a.covers_orgs(org_a, org_b)
+        ]
+
+    def list_trust_agreements(self) -> list[OrgTrustAgreement]:
+        """List all trust agreements (active and revoked)."""
+        return list(self._trust_agreements)
+
+    # ── CRUD: Delegations ──────────────────────────────────
+
+    def add_delegation(self, delegation: PolicyDelegation) -> None:
+        """Register a policy delegation."""
+        self._delegations.append(delegation)
+        logger.info(
+            "Federation: registered delegation '%s' "
+            "from '%s' to '%s' for %s",
+            delegation.delegation_id,
+            delegation.source_org_id,
+            delegation.target_org_id,
+            [c.value for c in delegation.delegated_categories],
+        )
+
+    def revoke_delegation(self, delegation_id: str) -> bool:
+        """Revoke a delegation by ID."""
+        for d in self._delegations:
+            if d.delegation_id == delegation_id:
+                d.active = False
+                return True
+        return False
+
+    def get_delegations(
+        self, source_org: str, target_org: str
+    ) -> list[PolicyDelegation]:
+        """Find active delegations from source to target org."""
+        return [
+            d
+            for d in self._delegations
+            if d.is_active()
+            and d.source_org_id == source_org
+            and d.target_org_id == target_org
+        ]
+
+    def list_delegations(self) -> list[PolicyDelegation]:
+        """List all delegations."""
+        return list(self._delegations)
+
+
+# ── Federation Engine ──────────────────────────────────────────
+
+
+class FederationEngine:
+    """Cross-organizational federation governance engine.
+
+    Provides **mutual enforcement**: when agents from different
+    organizations interact, both the caller's and callee's org
+    policies are evaluated.  The most restrictive decision wins.
+
+    The engine also handles:
+    - Trust agreement lookup and validation
+    - Policy delegation (org A accepts org B's governance
+      attestation for category X)
+    - Graceful fail-closed semantics (missing policy → deny)
+
+    Args:
+        store: Federation data store.  Defaults to
+            ``InMemoryFederationStore()`` for development.
+    """
+
+    def __init__(
+        self,
+        store: Optional[InMemoryFederationStore] = None,
+    ) -> None:
+        self.store = store or InMemoryFederationStore()
+
+    # ── Primary evaluation ─────────────────────────────────
+
+    def evaluate(
+        self,
+        caller_org_id: str,
+        callee_org_id: str,
+        caller_trust_score: int,
+        context: dict,
+    ) -> FederationDecision:
+        """Evaluate a cross-organizational interaction.
+
+        Steps:
+        1. Same-org shortcut — bypass federation if same org.
+        2. Check blocklists on both sides.
+        3. Look up active trust agreements.
+        4. Evaluate caller org policy (caller-side constraints).
+        5. Evaluate callee org policy (callee-side constraints).
+        6. Apply policy delegations (skip rules for delegated
+           categories).
+        7. Merge decisions — most restrictive wins.
+
+        Args:
+            caller_org_id: Organization ID of the calling agent.
+            callee_org_id: Organization ID of the called agent.
+            caller_trust_score: Trust score of the calling agent.
+            context: Runtime context dict.
+
+        Returns:
+            A ``FederationDecision`` with the merged result.
+        """
+        trace: list[str] = []
+
+        # ── 1. Same-org shortcut ───────────────────────────
+        if caller_org_id == callee_org_id:
+            trace.append(
+                f"Same org ({caller_org_id}): federation bypassed"
+            )
+            return FederationDecision(
+                allowed=True,
+                reason="Same organization — federation not required",
+                trace=trace,
+            )
+
+        trace.append(
+            f"Cross-org interaction: {caller_org_id} → {callee_org_id}"
+        )
+
+        # ── 2. Load org policies ───────────────────────────
+        caller_policy = self.store.get_org_policy(caller_org_id)
+        callee_policy = self.store.get_org_policy(callee_org_id)
+
+        # ── 3. Check blocklists ────────────────────────────
+        if caller_policy and callee_org_id in caller_policy.blocked_orgs:
+            trace.append(
+                f"Caller org '{caller_org_id}' blocks '{callee_org_id}'"
+            )
+            return FederationDecision(
+                allowed=False,
+                reason=(
+                    f"Organization '{callee_org_id}' is blocked by "
+                    f"caller org '{caller_org_id}'"
+                ),
+                trace=trace,
+            )
+
+        if callee_policy and caller_org_id in callee_policy.blocked_orgs:
+            trace.append(
+                f"Callee org '{callee_org_id}' blocks '{caller_org_id}'"
+            )
+            return FederationDecision(
+                allowed=False,
+                reason=(
+                    f"Organization '{caller_org_id}' is blocked by "
+                    f"callee org '{callee_org_id}'"
+                ),
+                trace=trace,
+            )
+
+        # ── 4. Look up trust agreements ────────────────────
+        agreements = self.store.get_trust_agreements(
+            caller_org_id, callee_org_id
+        )
+
+        if not agreements:
+            trace.append("No active trust agreement found")
+            return FederationDecision(
+                allowed=False,
+                reason=(
+                    f"No trust agreement between '{caller_org_id}' "
+                    f"and '{callee_org_id}'"
+                ),
+                trace=trace,
+            )
+
+        agreement = agreements[0]  # Use first active agreement
+        trace.append(
+            f"Trust agreement found: {agreement.agreement_id}"
+        )
+
+        # ── 5. Check trust score ───────────────────────────
+        effective_min = max(
+            agreement.min_trust_score,
+            caller_policy.required_min_trust_score
+            if caller_policy
+            else 0,
+            callee_policy.required_min_trust_score
+            if callee_policy
+            else 0,
+        )
+
+        if caller_trust_score < effective_min:
+            trace.append(
+                f"Trust score {caller_trust_score} < "
+                f"minimum {effective_min}"
+            )
+            return FederationDecision(
+                allowed=False,
+                trust_agreement_id=agreement.agreement_id,
+                reason=(
+                    f"Agent trust score ({caller_trust_score}) below "
+                    f"minimum ({effective_min}) for cross-org interaction"
+                ),
+                trace=trace,
+            )
+
+        trace.append(
+            f"Trust score {caller_trust_score} ≥ {effective_min}: OK"
+        )
+
+        # ── 6. Evaluate org policies (mutual enforcement) ──
+        caller_decision = None
+        callee_decision = None
+        delegations_applied: list[str] = []
+
+        # Caller org policy
+        if caller_policy:
+            # Check for delegations from caller to callee
+            delegations = self.store.get_delegations(
+                caller_org_id, callee_org_id
+            )
+            caller_decision = caller_policy.evaluate(context)
+            trace.append(
+                f"Caller org policy '{caller_org_id}': "
+                f"{caller_decision.action} "
+                f"(rule: {caller_decision.matched_rule})"
+            )
+
+            # If caller denies but the category is delegated,
+            # override to allow
+            if (
+                not caller_decision.allowed
+                and delegations
+            ):
+                for deleg in delegations:
+                    if (
+                        deleg.covers_category(caller_decision.category)
+                        and deleg.check_constraints(context)
+                    ):
+                        trace.append(
+                            f"Delegation '{deleg.delegation_id}' "
+                            f"overrides caller deny for "
+                            f"'{caller_decision.category.value}'"
+                        )
+                        caller_decision = OrgPolicyDecision(
+                            allowed=True,
+                            action="allow",
+                            matched_rule=caller_decision.matched_rule,
+                            org_id=caller_org_id,
+                            reason=(
+                                f"Delegated to '{callee_org_id}' "
+                                f"for '{caller_decision.category.value}'"
+                            ),
+                            category=caller_decision.category,
+                        )
+                        delegations_applied.append(
+                            deleg.delegation_id
+                        )
+                        break
+        else:
+            # No caller policy → fail-closed
+            trace.append(
+                f"No org policy for caller '{caller_org_id}': "
+                f"fail-closed (deny)"
+            )
+            caller_decision = OrgPolicyDecision(
+                allowed=False,
+                action="deny",
+                org_id=caller_org_id,
+                reason=(
+                    f"No org policy defined for '{caller_org_id}'"
+                ),
+            )
+
+        # Callee org policy
+        if callee_policy:
+            callee_decision = callee_policy.evaluate(context)
+            trace.append(
+                f"Callee org policy '{callee_org_id}': "
+                f"{callee_decision.action} "
+                f"(rule: {callee_decision.matched_rule})"
+            )
+        else:
+            trace.append(
+                f"No org policy for callee '{callee_org_id}': "
+                f"fail-closed (deny)"
+            )
+            callee_decision = OrgPolicyDecision(
+                allowed=False,
+                action="deny",
+                org_id=callee_org_id,
+                reason=(
+                    f"No org policy defined for '{callee_org_id}'"
+                ),
+            )
+
+        # ── 7. Merge: most restrictive wins ────────────────
+        both_allowed = (
+            caller_decision.allowed and callee_decision.allowed
+        )
+
+        if both_allowed:
+            reason = (
+                f"Both orgs allow: "
+                f"caller='{caller_org_id}', callee='{callee_org_id}'"
+            )
+            trace.append("Merged result: ALLOWED (both orgs allow)")
+        else:
+            deny_reasons = []
+            if not caller_decision.allowed:
+                deny_reasons.append(
+                    f"caller '{caller_org_id}': {caller_decision.reason}"
+                )
+            if not callee_decision.allowed:
+                deny_reasons.append(
+                    f"callee '{callee_org_id}': {callee_decision.reason}"
+                )
+            reason = (
+                "Cross-org interaction denied — " + "; ".join(deny_reasons)
+            )
+            trace.append(
+                f"Merged result: DENIED ({'; '.join(deny_reasons)})"
+            )
+
+        return FederationDecision(
+            allowed=both_allowed,
+            caller_decision=caller_decision,
+            callee_decision=callee_decision,
+            trust_agreement_id=agreement.agreement_id,
+            delegations_applied=delegations_applied,
+            reason=reason,
+            trace=trace,
+        )
+
+
+# ── File-based Federation Store ────────────────────────────────
+
+
+class FileFederationStore(InMemoryFederationStore):
+    """File-based federation store that loads from a directory.
+
+    Expected directory structure::
+
+        federation/
+        ├── org_policies/
+        │   ├── org_a.yaml
+        │   └── org_b.yaml
+        ├── trust_agreements.yaml
+        └── delegations.yaml
+
+    Falls back to in-memory storage for trust agreements and
+    delegations if the YAML files are not present.
+
+    Args:
+        directory: Path to the federation config directory.
+    """
+
+    def __init__(self, directory: str | Path) -> None:
+        super().__init__()
+        self._directory = Path(directory)
+        self._load()
+
+    def _load(self) -> None:
+        """Load federation data from the directory."""
+        # Load org policies
+        policies_dir = self._directory / "org_policies"
+        if policies_dir.is_dir():
+            for yaml_file in sorted(policies_dir.glob("*.yaml")):
+                with open(yaml_file) as f:
+                    policy = OrgPolicy.from_yaml(f.read())
+                    self.add_org_policy(policy)
+            for yml_file in sorted(policies_dir.glob("*.yml")):
+                with open(yml_file) as f:
+                    policy = OrgPolicy.from_yaml(f.read())
+                    self.add_org_policy(policy)
+
+        # Load trust agreements
+        agmt_file = self._directory / "trust_agreements.yaml"
+        if agmt_file.is_file():
+            with open(agmt_file) as f:
+                data = yaml.safe_load(f)
+                for agmt_data in data.get("agreements", []):
+                    # Convert category strings to enums
+                    if "trust_categories" in agmt_data:
+                        agmt_data["trust_categories"] = [
+                            PolicyCategory(c)
+                            for c in agmt_data["trust_categories"]
+                        ]
+                    if "max_data_classification" in agmt_data:
+                        agmt_data["max_data_classification"] = (
+                            DataClassification(
+                                agmt_data["max_data_classification"]
+                            )
+                        )
+                    self.add_trust_agreement(
+                        OrgTrustAgreement(**agmt_data)
+                    )
+
+        # Load delegations
+        deleg_file = self._directory / "delegations.yaml"
+        if deleg_file.is_file():
+            with open(deleg_file) as f:
+                data = yaml.safe_load(f)
+                for deleg_data in data.get("delegations", []):
+                    if "delegated_categories" in deleg_data:
+                        deleg_data["delegated_categories"] = [
+                            PolicyCategory(c)
+                            for c in deleg_data["delegated_categories"]
+                        ]
+                    self.add_delegation(
+                        PolicyDelegation(**deleg_data)
+                    )
+
+
+# ── Expression evaluator (reuses PolicyRule patterns) ──────────
+
+
+def _eval_expression(expr: str, context: dict) -> bool:
+    """Evaluate a simple policy expression.
+
+    Supports the same syntax as ``PolicyRule._eval_expression``:
+    - ``field == 'value'``
+    - ``field`` (boolean truthy)
+    - ``expr1 and expr2``
+    - ``expr1 or expr2``
+    """
+    import re
+
+    # OR
+    if " or " in expr:
+        parts = expr.split(" or ")
+        return any(_eval_expression(p.strip(), context) for p in parts)
+
+    # AND
+    if " and " in expr:
+        parts = expr.split(" and ")
+        return all(_eval_expression(p.strip(), context) for p in parts)
+
+    # Equality: field == 'value'
+    eq_match = re.match(
+        r"(\w+(?:\.\w+)*)\s*==\s*['\"]([^'\"]+)['\"]", expr
+    )
+    if eq_match:
+        path, value = eq_match.groups()
+        actual = _get_nested(context, path)
+        return actual == value
+
+    # Boolean
+    bool_match = re.match(r"^(\w+(?:\.\w+)*)$", expr)
+    if bool_match:
+        path = bool_match.group(1)
+        return bool(_get_nested(context, path))
+
+    return False
+
+
+def _get_nested(obj: dict, path: str) -> Any:
+    """Resolve a dot-notated path against a dict."""
+    parts = path.split(".")
+    current: Any = obj
+    for part in parts:
+        if isinstance(current, dict):
+            current = current.get(part)
+        else:
+            return None
+    return current
+
+
+# ── Public API ─────────────────────────────────────────────────
+
+__all__ = [
+    "PolicyCategory",
+    "OrgPolicyRule",
+    "DataClassification",
+    "OrgPolicy",
+    "OrgPolicyDecision",
+    "OrgTrustAgreement",
+    "PolicyDelegation",
+    "FederationDecision",
+    "FederationStore",
+    "InMemoryFederationStore",
+    "FileFederationStore",
+    "FederationEngine",
+]

--- a/packages/agent-mesh/tests/test_federation.py
+++ b/packages/agent-mesh/tests/test_federation.py
@@ -1,0 +1,690 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for cross-organizational federation governance (issue #93).
+
+Covers:
+- OrgPolicy model creation and YAML roundtrip
+- OrgTrustAgreement lifecycle (creation, expiration, revocation)
+- PolicyDelegation (category scoping, constraints)
+- FederationEngine mutual enforcement
+- Edge cases (same-org, missing policies, blocklists)
+- ORGANIZATION scope in conflict resolution
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from agentmesh.governance.federation import (
+    DataClassification,
+    FederationDecision,
+    FederationEngine,
+    InMemoryFederationStore,
+    OrgPolicy,
+    OrgPolicyDecision,
+    OrgPolicyRule,
+    OrgTrustAgreement,
+    PolicyCategory,
+    PolicyDelegation,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────
+
+
+def _org_policy(
+    org_id: str,
+    rules: list[OrgPolicyRule] | None = None,
+    default_action: str = "allow",
+    blocked_orgs: list[str] | None = None,
+    min_trust: int = 500,
+) -> OrgPolicy:
+    """Create a test OrgPolicy."""
+    return OrgPolicy(
+        org_id=org_id,
+        org_name=f"Org {org_id}",
+        rules=rules or [],
+        default_action=default_action,
+        blocked_orgs=blocked_orgs or [],
+        required_min_trust_score=min_trust,
+    )
+
+
+def _pii_deny_rule() -> OrgPolicyRule:
+    """Rule that denies PII-containing actions."""
+    return OrgPolicyRule(
+        name="block-pii-export",
+        description="Block cross-org PII export",
+        category=PolicyCategory.PII_HANDLING,
+        condition="data.contains_pii",
+        action="deny",
+        priority=10,
+    )
+
+
+def _export_deny_rule() -> OrgPolicyRule:
+    """Rule that denies data exports."""
+    return OrgPolicyRule(
+        name="block-export",
+        description="Block data export",
+        category=PolicyCategory.DATA_EXPORT,
+        condition="action.type == 'export'",
+        action="deny",
+        priority=20,
+    )
+
+
+def _setup_engine(
+    caller_policy: OrgPolicy | None = None,
+    callee_policy: OrgPolicy | None = None,
+    agreements: list[OrgTrustAgreement] | None = None,
+    delegations: list[PolicyDelegation] | None = None,
+) -> FederationEngine:
+    """Set up a FederationEngine with pre-loaded data."""
+    store = InMemoryFederationStore()
+    if caller_policy:
+        store.add_org_policy(caller_policy)
+    if callee_policy:
+        store.add_org_policy(callee_policy)
+    for agmt in (agreements or []):
+        store.add_trust_agreement(agmt)
+    for deleg in (delegations or []):
+        store.add_delegation(deleg)
+    return FederationEngine(store=store)
+
+
+# ── OrgPolicy Model Tests ─────────────────────────────────────
+
+
+class TestOrgPolicy:
+    """OrgPolicy model creation and evaluation."""
+
+    def test_creation(self):
+        policy = _org_policy("org-microsoft", rules=[_pii_deny_rule()])
+        assert policy.org_id == "org-microsoft"
+        assert policy.org_name == "Org org-microsoft"
+        assert len(policy.rules) == 1
+        assert policy.rules[0].category == PolicyCategory.PII_HANDLING
+
+    def test_evaluate_deny(self):
+        policy = _org_policy("org-a", rules=[_pii_deny_rule()])
+        decision = policy.evaluate({"data": {"contains_pii": True}})
+        assert decision.allowed is False
+        assert decision.action == "deny"
+        assert decision.matched_rule == "block-pii-export"
+        assert decision.org_id == "org-a"
+
+    def test_evaluate_allow_default(self):
+        policy = _org_policy("org-a", rules=[_pii_deny_rule()], default_action="allow")
+        decision = policy.evaluate({"data": {"contains_pii": False}})
+        assert decision.allowed is True
+        assert decision.action == "allow"
+
+    def test_evaluate_deny_default(self):
+        policy = _org_policy("org-a", rules=[], default_action="deny")
+        decision = policy.evaluate({"some": "context"})
+        assert decision.allowed is False
+
+    def test_evaluate_priority_ordering(self):
+        """Lower priority number wins."""
+        high_prio = OrgPolicyRule(
+            name="high-prio-allow",
+            condition="data.contains_pii",
+            action="allow",
+            priority=1,
+        )
+        low_prio = OrgPolicyRule(
+            name="low-prio-deny",
+            condition="data.contains_pii",
+            action="deny",
+            priority=50,
+        )
+        policy = _org_policy("org-a", rules=[low_prio, high_prio])
+        decision = policy.evaluate({"data": {"contains_pii": True}})
+        assert decision.allowed is True
+        assert decision.matched_rule == "high-prio-allow"
+
+    def test_disabled_rule_skipped(self):
+        rule = OrgPolicyRule(
+            name="disabled-rule",
+            condition="data.contains_pii",
+            action="deny",
+            enabled=False,
+        )
+        policy = _org_policy("org-a", rules=[rule], default_action="allow")
+        decision = policy.evaluate({"data": {"contains_pii": True}})
+        assert decision.allowed is True
+
+    def test_yaml_roundtrip(self):
+        policy = _org_policy("org-a", rules=[_pii_deny_rule(), _export_deny_rule()])
+        yaml_str = policy.to_yaml()
+        loaded = OrgPolicy.from_yaml(yaml_str)
+        assert loaded.org_id == "org-a"
+        assert len(loaded.rules) == 2
+        assert loaded.rules[0].name == "block-pii-export"
+        assert loaded.rules[1].name == "block-export"
+
+    def test_data_classification_field(self):
+        policy = OrgPolicy(
+            org_id="org-a",
+            max_data_classification=DataClassification.RESTRICTED,
+        )
+        assert policy.max_data_classification == DataClassification.RESTRICTED
+
+
+# ── OrgTrustAgreement Tests ────────────────────────────────────
+
+
+class TestOrgTrustAgreement:
+    """Trust agreement lifecycle."""
+
+    def test_creation_defaults(self):
+        agmt = OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")
+        assert agmt.is_active()
+        assert agmt.mutual is True
+        assert agmt.min_trust_score == 700
+        assert agmt.agreement_id.startswith("agmt_")
+
+    def test_covers_orgs_mutual(self):
+        agmt = OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b", mutual=True)
+        assert agmt.covers_orgs("org-a", "org-b")
+        assert agmt.covers_orgs("org-b", "org-a")  # bidirectional
+
+    def test_covers_orgs_directional(self):
+        agmt = OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b", mutual=False)
+        assert agmt.covers_orgs("org-a", "org-b")
+        assert not agmt.covers_orgs("org-b", "org-a")  # one-way
+
+    def test_expiration(self):
+        expired = OrgTrustAgreement(
+            org_a_id="org-a",
+            org_b_id="org-b",
+            expires_at=datetime.utcnow() - timedelta(hours=1),
+        )
+        assert expired.is_active() is False
+
+    def test_not_yet_expired(self):
+        valid = OrgTrustAgreement(
+            org_a_id="org-a",
+            org_b_id="org-b",
+            expires_at=datetime.utcnow() + timedelta(days=30),
+        )
+        assert valid.is_active() is True
+
+    def test_revocation(self):
+        agmt = OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")
+        assert agmt.is_active()
+        agmt.revoke("Trust breach detected")
+        assert agmt.is_active() is False
+        assert agmt.revocation_reason == "Trust breach detected"
+
+    def test_covers_category(self):
+        agmt = OrgTrustAgreement(
+            org_a_id="org-a",
+            org_b_id="org-b",
+            trust_categories=[PolicyCategory.PII_HANDLING, PolicyCategory.DATA_EXPORT],
+        )
+        assert agmt.covers_category(PolicyCategory.PII_HANDLING)
+        assert agmt.covers_category(PolicyCategory.DATA_EXPORT)
+        assert not agmt.covers_category(PolicyCategory.COST_CONTROL)
+
+    def test_general_category_covers_all(self):
+        agmt = OrgTrustAgreement(
+            org_a_id="org-a",
+            org_b_id="org-b",
+            trust_categories=[PolicyCategory.GENERAL],
+        )
+        assert agmt.covers_category(PolicyCategory.PII_HANDLING)
+        assert agmt.covers_category(PolicyCategory.COST_CONTROL)
+
+
+# ── PolicyDelegation Tests ─────────────────────────────────────
+
+
+class TestPolicyDelegation:
+    """Policy delegation model tests."""
+
+    def test_creation(self):
+        deleg = PolicyDelegation(
+            source_org_id="org-a",
+            target_org_id="org-b",
+            delegated_categories=[PolicyCategory.PII_HANDLING],
+        )
+        assert deleg.is_active()
+        assert deleg.delegation_id.startswith("deleg_")
+
+    def test_covers_category(self):
+        deleg = PolicyDelegation(
+            source_org_id="org-a",
+            target_org_id="org-b",
+            delegated_categories=[PolicyCategory.PII_HANDLING],
+        )
+        assert deleg.covers_category(PolicyCategory.PII_HANDLING)
+        assert not deleg.covers_category(PolicyCategory.DATA_EXPORT)
+
+    def test_expiration(self):
+        deleg = PolicyDelegation(
+            source_org_id="org-a",
+            target_org_id="org-b",
+            delegated_categories=[PolicyCategory.GENERAL],
+            expires_at=datetime.utcnow() - timedelta(hours=1),
+        )
+        assert deleg.is_active() is False
+
+    def test_constraints(self):
+        deleg = PolicyDelegation(
+            source_org_id="org-a",
+            target_org_id="org-b",
+            delegated_categories=[PolicyCategory.PII_HANDLING],
+            constraints={"region": "EU"},
+        )
+        assert deleg.check_constraints({"region": "EU"})
+        assert not deleg.check_constraints({"region": "US"})
+        assert not deleg.check_constraints({})
+
+    def test_revocation(self):
+        deleg = PolicyDelegation(
+            source_org_id="org-a",
+            target_org_id="org-b",
+            delegated_categories=[PolicyCategory.GENERAL],
+        )
+        assert deleg.is_active()
+        deleg.active = False
+        assert deleg.is_active() is False
+
+
+# ── InMemoryFederationStore Tests ──────────────────────────────
+
+
+class TestInMemoryFederationStore:
+    """CRUD operations on the in-memory store."""
+
+    def test_org_policy_crud(self):
+        store = InMemoryFederationStore()
+        policy = _org_policy("org-a")
+        store.add_org_policy(policy)
+        assert store.get_org_policy("org-a") is policy
+        assert len(store.list_org_policies()) == 1
+        assert store.remove_org_policy("org-a") is True
+        assert store.get_org_policy("org-a") is None
+        assert store.remove_org_policy("nonexistent") is False
+
+    def test_trust_agreement_crud(self):
+        store = InMemoryFederationStore()
+        agmt = OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")
+        store.add_trust_agreement(agmt)
+        found = store.get_trust_agreements("org-a", "org-b")
+        assert len(found) == 1
+        assert found[0].agreement_id == agmt.agreement_id
+        assert store.revoke_trust_agreement(agmt.agreement_id, "test")
+        assert len(store.get_trust_agreements("org-a", "org-b")) == 0
+
+    def test_delegation_crud(self):
+        store = InMemoryFederationStore()
+        deleg = PolicyDelegation(
+            source_org_id="org-a",
+            target_org_id="org-b",
+            delegated_categories=[PolicyCategory.PII_HANDLING],
+        )
+        store.add_delegation(deleg)
+        found = store.get_delegations("org-a", "org-b")
+        assert len(found) == 1
+        assert store.revoke_delegation(deleg.delegation_id)
+        assert len(store.get_delegations("org-a", "org-b")) == 0
+
+
+# ── FederationEngine Tests ─────────────────────────────────────
+
+
+class TestFederationEngine:
+    """Core mutual enforcement engine tests."""
+
+    def test_same_org_bypasses_federation(self):
+        engine = _setup_engine()
+        result = engine.evaluate("org-a", "org-a", 800, {})
+        assert result.allowed is True
+        assert "federation bypassed" in result.trace[0].lower() or "same" in result.trace[0].lower()
+
+    def test_no_trust_agreement_denied(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            callee_policy=_org_policy("org-b"),
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert result.allowed is False
+        assert "no trust agreement" in result.reason.lower()
+
+    def test_mutual_enforcement_both_allow(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert result.allowed is True
+        assert result.trust_agreement_id is not None
+
+    def test_mutual_enforcement_caller_denies(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", rules=[_pii_deny_rule()]),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {"data": {"contains_pii": True}})
+        assert result.allowed is False
+        assert result.caller_decision is not None
+        assert result.caller_decision.allowed is False
+
+    def test_mutual_enforcement_callee_denies(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            callee_policy=_org_policy("org-b", rules=[_export_deny_rule()]),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate(
+            "org-a", "org-b", 800, {"action": {"type": "export"}}
+        )
+        assert result.allowed is False
+        assert result.callee_decision is not None
+        assert result.callee_decision.allowed is False
+
+    def test_mutual_enforcement_both_deny(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", rules=[_pii_deny_rule()]),
+            callee_policy=_org_policy("org-b", rules=[_pii_deny_rule()]),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {"data": {"contains_pii": True}})
+        assert result.allowed is False
+
+    def test_trust_score_below_threshold_denied(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(
+                org_a_id="org-a", org_b_id="org-b", min_trust_score=800
+            )],
+        )
+        result = engine.evaluate("org-a", "org-b", 600, {})
+        assert result.allowed is False
+        assert "trust score" in result.reason.lower()
+
+    def test_trust_score_at_threshold_allowed(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", min_trust=700),
+            callee_policy=_org_policy("org-b", min_trust=700),
+            agreements=[OrgTrustAgreement(
+                org_a_id="org-a", org_b_id="org-b", min_trust_score=700
+            )],
+        )
+        result = engine.evaluate("org-a", "org-b", 700, {})
+        assert result.allowed is True
+
+    def test_expired_agreement_denied(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(
+                org_a_id="org-a",
+                org_b_id="org-b",
+                expires_at=datetime.utcnow() - timedelta(hours=1),
+            )],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert result.allowed is False
+        assert "no trust agreement" in result.reason.lower()
+
+    def test_blocklist_caller_blocks_callee(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", blocked_orgs=["org-b"]),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert result.allowed is False
+        assert "blocked" in result.reason.lower()
+
+    def test_blocklist_callee_blocks_caller(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            callee_policy=_org_policy("org-b", blocked_orgs=["org-a"]),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert result.allowed is False
+        assert "blocked" in result.reason.lower()
+
+    def test_missing_caller_policy_fail_closed(self):
+        engine = _setup_engine(
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert result.allowed is False
+        assert "no org policy" in result.reason.lower()
+
+    def test_missing_callee_policy_fail_closed(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert result.allowed is False
+
+    def test_federation_decision_has_trace(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a"),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {})
+        assert len(result.trace) > 0
+        assert any("cross-org" in t.lower() for t in result.trace)
+        assert result.evaluated_at is not None
+
+
+# ── Policy Delegation in Engine Tests ──────────────────────────
+
+
+class TestFederationDelegation:
+    """Delegation overrides in the federation engine."""
+
+    def test_delegation_overrides_caller_deny(self):
+        """When caller denies PII but has delegated PII to callee, allow."""
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", rules=[_pii_deny_rule()]),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+            delegations=[PolicyDelegation(
+                source_org_id="org-a",
+                target_org_id="org-b",
+                delegated_categories=[PolicyCategory.PII_HANDLING],
+            )],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {"data": {"contains_pii": True}})
+        assert result.allowed is True
+        assert len(result.delegations_applied) > 0
+
+    def test_delegation_wrong_category_no_override(self):
+        """Delegation for DATA_EXPORT doesn't help when PII is denied."""
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", rules=[_pii_deny_rule()]),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+            delegations=[PolicyDelegation(
+                source_org_id="org-a",
+                target_org_id="org-b",
+                delegated_categories=[PolicyCategory.DATA_EXPORT],
+            )],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {"data": {"contains_pii": True}})
+        assert result.allowed is False
+        assert len(result.delegations_applied) == 0
+
+    def test_delegation_with_constraints_met(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", rules=[_pii_deny_rule()]),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+            delegations=[PolicyDelegation(
+                source_org_id="org-a",
+                target_org_id="org-b",
+                delegated_categories=[PolicyCategory.PII_HANDLING],
+                constraints={"region": "EU"},
+            )],
+        )
+        result = engine.evaluate(
+            "org-a", "org-b", 800,
+            {"data": {"contains_pii": True}, "region": "EU"},
+        )
+        assert result.allowed is True
+
+    def test_delegation_with_constraints_not_met(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", rules=[_pii_deny_rule()]),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+            delegations=[PolicyDelegation(
+                source_org_id="org-a",
+                target_org_id="org-b",
+                delegated_categories=[PolicyCategory.PII_HANDLING],
+                constraints={"region": "EU"},
+            )],
+        )
+        result = engine.evaluate(
+            "org-a", "org-b", 800,
+            {"data": {"contains_pii": True}, "region": "US"},
+        )
+        assert result.allowed is False
+
+    def test_expired_delegation_not_applied(self):
+        engine = _setup_engine(
+            caller_policy=_org_policy("org-a", rules=[_pii_deny_rule()]),
+            callee_policy=_org_policy("org-b"),
+            agreements=[OrgTrustAgreement(org_a_id="org-a", org_b_id="org-b")],
+            delegations=[PolicyDelegation(
+                source_org_id="org-a",
+                target_org_id="org-b",
+                delegated_categories=[PolicyCategory.PII_HANDLING],
+                expires_at=datetime.utcnow() - timedelta(hours=1),
+            )],
+        )
+        result = engine.evaluate("org-a", "org-b", 800, {"data": {"contains_pii": True}})
+        assert result.allowed is False
+
+
+# ── ORGANIZATION Scope in Conflict Resolution ──────────────────
+
+
+class TestOrganizationScope:
+    """Verify ORGANIZATION scope ranks correctly in conflict resolution."""
+
+    def test_organization_scope_exists(self):
+        from agentmesh.governance.conflict_resolution import PolicyScope
+        assert hasattr(PolicyScope, "ORGANIZATION")
+        assert PolicyScope.ORGANIZATION.value == "organization"
+
+    def test_organization_scope_specificity(self):
+        from agentmesh.governance.conflict_resolution import (
+            CandidateDecision,
+            PolicyConflictResolver,
+            ConflictResolutionStrategy,
+            PolicyScope,
+        )
+
+        resolver = PolicyConflictResolver(
+            ConflictResolutionStrategy.MOST_SPECIFIC_WINS
+        )
+
+        candidates = [
+            CandidateDecision(
+                action="deny",
+                priority=10,
+                scope=PolicyScope.GLOBAL,
+                rule_name="global-deny",
+            ),
+            CandidateDecision(
+                action="allow",
+                priority=10,
+                scope=PolicyScope.ORGANIZATION,
+                rule_name="org-allow",
+            ),
+        ]
+
+        result = resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "org-allow"
+        assert result.winning_decision.action == "allow"
+
+    def test_agent_overrides_organization(self):
+        from agentmesh.governance.conflict_resolution import (
+            CandidateDecision,
+            PolicyConflictResolver,
+            ConflictResolutionStrategy,
+            PolicyScope,
+        )
+
+        resolver = PolicyConflictResolver(
+            ConflictResolutionStrategy.MOST_SPECIFIC_WINS
+        )
+
+        candidates = [
+            CandidateDecision(
+                action="allow",
+                priority=10,
+                scope=PolicyScope.ORGANIZATION,
+                rule_name="org-allow",
+            ),
+            CandidateDecision(
+                action="deny",
+                priority=10,
+                scope=PolicyScope.AGENT,
+                rule_name="agent-deny",
+            ),
+        ]
+
+        result = resolver.resolve(candidates)
+        assert result.winning_decision.rule_name == "agent-deny"
+        assert result.winning_decision.action == "deny"
+
+    def test_full_specificity_chain(self):
+        """AGENT > ORGANIZATION > TENANT > GLOBAL."""
+        from agentmesh.governance.conflict_resolution import (
+            CandidateDecision,
+            PolicyScope,
+        )
+
+        scopes = [
+            PolicyScope.GLOBAL,
+            PolicyScope.TENANT,
+            PolicyScope.ORGANIZATION,
+            PolicyScope.AGENT,
+        ]
+        candidates = [
+            CandidateDecision(
+                action="deny", scope=s, rule_name=s.value, priority=0
+            )
+            for s in scopes
+        ]
+        specificities = [c.specificity for c in candidates]
+        assert specificities == [0, 1, 2, 3]
+
+
+# ── PolicyCategory Enum Tests ─────────────────────────────────
+
+
+class TestPolicyCategory:
+    """Verify the extensible category taxonomy."""
+
+    def test_all_categories_exist(self):
+        expected = {
+            "pii_handling", "data_export", "data_retention",
+            "cost_control", "model_safety", "audit_logging",
+            "access_control", "compliance", "general",
+        }
+        actual = {c.value for c in PolicyCategory}
+        assert expected == actual
+
+    def test_category_string_roundtrip(self):
+        cat = PolicyCategory("pii_handling")
+        assert cat == PolicyCategory.PII_HANDLING
+        assert cat.value == "pii_handling"

--- a/packages/agent-os/src/agent_os/policies/conflict_resolution.py
+++ b/packages/agent-os/src/agent_os/policies/conflict_resolution.py
@@ -66,11 +66,12 @@ class ConflictResolutionStrategy(str, Enum):
 class PolicyScope(str, Enum):
     """Breadth of a policy's applicability.
 
-    Specificity order (most → least): AGENT > TENANT > GLOBAL.
+    Specificity order (most → least): AGENT > ORGANIZATION > TENANT > GLOBAL.
     """
 
     GLOBAL = "global"
     TENANT = "tenant"
+    ORGANIZATION = "organization"
     AGENT = "agent"
 
 
@@ -78,7 +79,8 @@ class PolicyScope(str, Enum):
 _SCOPE_SPECIFICITY: dict[PolicyScope, int] = {
     PolicyScope.GLOBAL: 0,
     PolicyScope.TENANT: 1,
-    PolicyScope.AGENT: 2,
+    PolicyScope.ORGANIZATION: 2,
+    PolicyScope.AGENT: 3,
 }
 
 


### PR DESCRIPTION
## Summary

Implements cross-organizational federation governance as described in #93. Adds mutual policy enforcement, org-level trust agreements, and policy delegation for cross-organizational agent interactions.

**Zero breaking changes** — federation is a new additive module alongside the existing governance engine.

## Problem

[AgentIdentity](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/identity/agent_id.py:57:0-422:9) has [organization](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/tests/test_federation.py:581:4-584:63) and `organization_id` fields but they are **never used in policy enforcement**. All governance is callee-only — there is no mutual enforcement, no org-scoped policy delegation, and no concept of "org A trusts org B's governance layer."

## What's New

### Core Module: `agentmesh.governance.federation`

| Component | Purpose |
|-----------|---------|
| [OrgPolicy](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:116:0-235:73) | Org-scoped policy document with rules, data classification, trust thresholds, allowlists/blocklists |
| [OrgTrustAgreement](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:261:0-363:39) | Bilateral trust agreement with expiration, revocation, category scoping, mutual/directional flag |
| [PolicyDelegation](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:369:0-446:19) | "Org A accepts org B's governance attestation for category X" with constraint checking |
| [FederationEngine](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:621:0-896:9) | Mutual enforcement — both caller and callee org policies evaluated, most restrictive wins |
| [InMemoryFederationStore](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:498:0-615:38) | In-memory persistence with full CRUD for policies, agreements, and delegations |
| [FileFederationStore](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:902:0-975:21) | File-based persistence loading from YAML directory structure |
| [PolicyCategory](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:34:0-49:23) | Extensible 9-value governance taxonomy (`pii_handling`, `data_export`, `cost_control`, etc.) |
| [FederationDecision](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:452:0-473:67) | Rich decision result with traces from both orgs |

### Scope Hierarchy Update

Added `ORGANIZATION` scope to [PolicyScope](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-os/src/agent_os/policies/conflict_resolution.py:65:0-74:19) enum in both `agent-os` and `agentmesh` conflict resolution:


## Files Changed

| File | Change |
|------|--------|
| [packages/agent-mesh/src/agentmesh/governance/federation.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:0:0-0:0) | **[NEW]** Core federation module |
| [packages/agent-mesh/tests/test_federation.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/tests/test_federation.py:0:0-0:0) | **[NEW]** 49 tests |
| [packages/agent-mesh/src/agentmesh/governance/__init__.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/__init__.py:0:0-0:0) | Export federation types |
| [packages/agent-os/src/agent_os/policies/conflict_resolution.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-os/src/agent_os/policies/conflict_resolution.py:0:0-0:0) | Add `ORGANIZATION` scope |
| [packages/agent-mesh/src/agentmesh/governance/_conflict_resolution_impl.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/_conflict_resolution_impl.py:0:0-0:0) | Add `ORGANIZATION` scope (fallback) |

## Test Results

- **49 new tests** — covers mutual enforcement, trust agreements, delegations, blocklists, fail-closed semantics, expiration, constraints, ORGANIZATION scope ranking, and edge cases
- **79 existing tests** — governance, trust policy, and conflict resolution tests pass with **zero regressions**
- **128 total tests passing**

## Design Decisions

1. **Fail-closed**: Missing org policy → deny. This is the safest default for cross-org interactions.
2. **Most restrictive wins**: When merging caller + callee decisions, any deny from either side blocks the interaction.
3. **Delegation overrides**: A delegation only overrides a deny from the *delegating* org for the *specific category* — it cannot override the other org's policies.
4. **Persistence interface**: [FederationStore](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/federation.py:479:0-492:36) protocol allows future SQL/Redis backends without changing the engine.
5. **No breaking changes**: The federation module is entirely additive. Existing [PolicyEngine](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/governance/policy.py:316:0-809:9), [TrustBridge](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/agent-governance-toolkit/packages/agent-mesh/src/agentmesh/trust/bridge.py:73:0-194:20), and all other components remain untouched.

outputs:- 
<img width="1919" height="619" alt="image" src="https://github.com/user-attachments/assets/1f50c421-8c25-4200-80d7-02e1f1d67496" />
<img width="1913" height="450" alt="image" src="https://github.com/user-attachments/assets/b183f54a-9724-4968-9c5e-41a7b644deee" />

<img width="1919" height="512" alt="image" src="https://github.com/user-attachments/assets/e737e99f-2062-40d4-9bf0-4e9780cda509" />
<img width="1909" height="532" alt="image" src="https://github.com/user-attachments/assets/4731262c-5719-4583-a3e1-7d35f2d0a7f3" />

Closes #93
