### PR TITLE
feat(ci): add PR review orchestrator — collapse agents, post unified summary

### DIFF
--- a/.github/actions/ai-agent-runner/action.yml
+++ b/.github/actions/ai-agent-runner/action.yml
@@ -248,39 +248,87 @@ runs:
           return { content, tokensUsed };
         }
 
+        // ── Helpers for comment upsert & collapsing ─────────────────────
+        function extractOneLiner(text) {
+          // Try to find a ### heading line first
+          const headingMatch = text.match(/^###\s+(.+)$/m);
+          if (headingMatch) return headingMatch[1].trim();
+          // Then look for a line containing "Summary"
+          const summaryMatch = text.match(/^.*Summary.*$/mi);
+          if (summaryMatch) return summaryMatch[0].replace(/^#+\s*/, "").trim();
+          // Fallback
+          return "View details";
+        }
+
+        async function findExistingComment(owner, repo, issueNumber, marker) {
+          // Paginate through comments to find one matching our marker
+          let page = 1;
+          while (true) {
+            const comments = await ghApi(
+              `/repos/${owner}/${repo}/issues/${issueNumber}/comments?per_page=100&page=${page}`
+            );
+            if (!comments.length) break;
+            const found = comments.find((c) => c.body && c.body.includes(marker));
+            if (found) return found;
+            if (comments.length < 100) break;
+            page++;
+          }
+          return null;
+        }
+
+        async function upsertComment(owner, repo, issueNumber, marker, body) {
+          const existing = await findExistingComment(owner, repo, issueNumber, marker);
+          if (existing) {
+            // Update (PATCH) the existing comment
+            await ghApi(`/repos/${owner}/${repo}/issues/comments/${existing.id}`, {
+              method: "PATCH",
+              body: JSON.stringify({ body }),
+            });
+            console.log(`   Updated existing comment ${existing.id}`);
+          } else {
+            // Create a new comment
+            await ghApi(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+              method: "POST",
+              body: JSON.stringify({ body }),
+            });
+            console.log(`   Created new comment`);
+          }
+        }
+
         // ── Post results ─────────────────────────────────────────────────
         async function postResults(outputMode, context, response) {
           const [owner, repo] = env("GITHUB_REPOSITORY").split("/");
+          const agentType = env("INPUT_AGENT_TYPE");
+          const marker = `<!-- ai-agent:${agentType} -->`;
 
           if (outputMode === "pr-comment" && context.prNumber) {
-            await ghApi(`/repos/${owner}/${repo}/issues/${context.prNumber}/comments`, {
-              method: "POST",
-              body: JSON.stringify({
-                body: `## 🤖 AI Agent: ${env("INPUT_AGENT_TYPE")}\n\n${response}`,
-              }),
-            });
+            const oneLiner = extractOneLiner(response);
+            const body = [
+              marker,
+              `<details>`,
+              `<summary>🤖 AI Agent: ${agentType} — ${oneLiner}</summary>`,
+              ``,
+              response,
+              ``,
+              `</details>`,
+            ].join("\n");
+            await upsertComment(owner, repo, context.prNumber, marker, body);
           }
 
           if (outputMode === "pr-review" && context.prNumber) {
+            // Reviews cannot be collapsed or updated — post as-is
             await ghApi(`/repos/${owner}/${repo}/pulls/${context.prNumber}/reviews`, {
               method: "POST",
               body: JSON.stringify({
                 event: "COMMENT",
-                body: `## 🤖 AI Agent: ${env("INPUT_AGENT_TYPE")}\n\n${response}`,
+                body: `## 🤖 AI Agent: ${agentType}\n\n${response}`,
               }),
             });
           }
 
           if (outputMode === "issue-comment" && context.issueNumber) {
-            await ghApi(
-              `/repos/${owner}/${repo}/issues/${context.issueNumber}/comments`,
-              {
-                method: "POST",
-                body: JSON.stringify({
-                  body: `## 🤖 AI Agent: ${env("INPUT_AGENT_TYPE")}\n\n${response}`,
-                }),
-              }
-            );
+            const body = `${marker}\n## 🤖 AI Agent: ${agentType}\n\n${response}`;
+            await upsertComment(owner, repo, context.issueNumber, marker, body);
           }
 
           if (outputMode === "artifact") {

--- a/.github/workflows/ai-pr-summary.yml
+++ b/.github/workflows/ai-pr-summary.yml
@@ -1,0 +1,197 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# AI PR Summary — Consolidates all AI agent feedback into one clean verdict
+# ──────────────────────────────────────────────────────────────────────────────
+# Triggered after each AI agent workflow completes. Fetches all agent comments
+# on the PR, parses verdicts, and posts/updates a single summary table.
+# Uses an HTML marker (<!-- ai-pr-summary -->) for idempotent upserts.
+# ──────────────────────────────────────────────────────────────────────────────
+name: AI PR Summary
+
+on:
+  workflow_run:
+    workflows:
+      - "AI Code Review"
+      - "AI Security Scan"
+      - "AI Breaking Change Detector"
+      - "AI Docs Sync Check"
+      - "AI Test Generator"
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  summarize:
+    name: Post unified summary
+    runs-on: ubuntu-latest
+    # Only run when the triggering workflow was for a PR
+    if: >-
+      github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'pull_request_target'
+    steps:
+      - name: Get PR number from triggering workflow
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // The workflow_run event contains the head SHA; find the PR for it
+            const runId = context.payload.workflow_run.id;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headSha = context.payload.workflow_run.head_sha;
+            const headBranch = context.payload.workflow_run.head_branch;
+
+            // Try to find PR by head branch
+            const { data: prs } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${headBranch}`,
+              per_page: 5,
+            });
+
+            let prNumber = null;
+            if (prs.length > 0) {
+              prNumber = prs[0].number;
+            } else {
+              // Fallback: search by commit SHA
+              const { data: searchPrs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha: headSha,
+              });
+              const openPr = searchPrs.find(p => p.state === 'open');
+              if (openPr) prNumber = openPr.number;
+            }
+
+            if (!prNumber) {
+              core.info('No open PR found for this workflow run — skipping summary.');
+              core.setOutput('found', 'false');
+              return;
+            }
+
+            core.info(`Found PR #${prNumber}`);
+            core.setOutput('found', 'true');
+            core.setOutput('number', String(prNumber));
+
+      - name: Collect agent comments and post summary
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+            const SUMMARY_MARKER = '<!-- ai-pr-summary -->';
+
+            // ── Agent registry ──────────────────────────────────────────
+            // Maps agent-type marker to display info
+            const AGENTS = [
+              { marker: '<!-- ai-agent:code-reviewer -->',    icon: '🔍', label: 'Code Review' },
+              { marker: '<!-- ai-agent:security-scanner -->',  icon: '🛡️', label: 'Security Scan' },
+              { marker: '<!-- ai-agent:breaking-change -->',   icon: '🔄', label: 'Breaking Changes' },
+              { marker: '<!-- ai-agent:docs-sync -->',         icon: '📝', label: 'Docs Sync' },
+              { marker: '<!-- ai-agent:test-generator -->',    icon: '🧪', label: 'Test Coverage' },
+            ];
+
+            // ── Fetch all comments on the PR ────────────────────────────
+            let allComments = [];
+            let page = 1;
+            while (true) {
+              const { data: batch } = await github.rest.issues.listComments({
+                owner, repo, issue_number: prNumber, per_page: 100, page,
+              });
+              if (!batch.length) break;
+              allComments = allComments.concat(batch);
+              if (batch.length < 100) break;
+              page++;
+            }
+
+            // ── Parse each agent's verdict ──────────────────────────────
+            function parseVerdict(body) {
+              if (!body) return { status: '⏳', statusLabel: 'Pending', detail: 'Awaiting results' };
+              const lower = body.toLowerCase();
+
+              // Check for critical / error first
+              if (/critical|error|vulnerabilit(y|ies)\s+found|high\s+severity/i.test(body)) {
+                // Try to extract a useful detail line
+                const detailMatch = body.match(/^###\s+(.+)$/m) || body.match(/^.*(?:critical|error|vulnerab).*$/mi);
+                return { status: '❌', statusLabel: 'Failed', detail: detailMatch ? detailMatch[1] || detailMatch[0] : 'Issues detected' };
+              }
+
+              // Warnings
+              if (/warning|⚠️|potential|breaking\s+change|minor/i.test(body)) {
+                const warnMatch = body.match(/(\d+)\s*warning/i);
+                const detailMatch = body.match(/^###\s+(.+)$/m) || body.match(/^.*(?:warning|⚠️|potential|breaking).*$/mi);
+                const count = warnMatch ? warnMatch[1] : '';
+                const label = count ? `${count} Warning${count === '1' ? '' : 's'}` : 'Warning';
+                return { status: '⚠️', statusLabel: label, detail: detailMatch ? (detailMatch[1] || detailMatch[0]).replace(/^#+\s*/, '').trim() : 'See details' };
+              }
+
+              // Suggestions / info
+              if (/suggest|consider|recommend|ℹ️|info/i.test(body)) {
+                const detailMatch = body.match(/^###\s+(.+)$/m) || body.match(/^.*(?:suggest|consider|recommend).*$/mi);
+                return { status: 'ℹ️', statusLabel: 'Suggestion', detail: detailMatch ? (detailMatch[1] || detailMatch[0]).replace(/^#+\s*/, '').trim() : 'See suggestions' };
+              }
+
+              // Passed / clean
+              if (/no issues|pass(ed)?|clean|no vulnerabilit|up.to.date|no breaking|all good|looks good|lgtm/i.test(body)) {
+                const detailMatch = body.match(/^.*(?:no issues|pass|clean|no vulnerab|up.to.date|no breaking|all good|looks good).*$/mi);
+                return { status: '✅', statusLabel: 'Passed', detail: detailMatch ? detailMatch[0].replace(/^#+\s*/, '').trim().slice(0, 80) : 'No issues found' };
+              }
+
+              // Default: completed but unclear verdict
+              return { status: '✅', statusLabel: 'Completed', detail: 'Analysis complete' };
+            }
+
+            // Build rows
+            const rows = AGENTS.map(agent => {
+              const comment = allComments.find(c => c.body && c.body.includes(agent.marker));
+              const verdict = comment ? parseVerdict(comment.body) : { status: '⏳', statusLabel: 'Pending', detail: 'Awaiting results' };
+              return `| ${agent.icon} ${agent.label} | ${verdict.status} ${verdict.statusLabel} | ${verdict.detail} |`;
+            });
+
+            // ── Determine overall verdict ───────────────────────────────
+            const allVerdicts = rows.join('\n');
+            let overallVerdict;
+            if (allVerdicts.includes('❌')) {
+              overallVerdict = '**Verdict: ❌ Changes needed — see failures above**';
+            } else if (allVerdicts.includes('⚠️')) {
+              overallVerdict = '**Verdict: ⚠️ Ready for human review — see warnings above**';
+            } else if (allVerdicts.includes('⏳')) {
+              overallVerdict = '**Verdict: ⏳ Still running — some checks have not completed yet**';
+            } else {
+              overallVerdict = '**Verdict: ✅ Ready for human review**';
+            }
+
+            // ── Build summary body ──────────────────────────────────────
+            const summaryBody = [
+              SUMMARY_MARKER,
+              '## ✅ PR Review Summary',
+              '',
+              '| Check | Status | Details |',
+              '|-------|--------|---------|',
+              ...rows,
+              '',
+              overallVerdict,
+              '',
+              '> 💡 Individual agent reports are collapsed below for reference.',
+            ].join('\n');
+
+            // ── Upsert summary comment ──────────────────────────────────
+            const existing = allComments.find(c => c.body && c.body.includes(SUMMARY_MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body: summaryBody,
+              });
+              core.info(`Updated existing summary comment ${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body: summaryBody,
+              });
+              core.info('Created new summary comment');
+            }


### PR DESCRIPTION
## Problem

Contributors opening a 3-line fix get bombarded with 5-7 separate bot comments (code-reviewer, security-scanner, breaking-change-detector, docs-sync, test-generator, contributor-guide). This is overwhelming — especially for first-time contributors.

## Solution

### 1. Collapsed agent comments
Individual agent comments are now wrapped in \<details>\ tags — collapsed by default with a one-line summary visible:

\\\
▶ 🤖 AI Agent: security-scanner — No vulnerabilities detected
\\\

Click to expand for full details.

### 2. Unified summary table
A new \i-pr-summary.yml\ workflow runs after all agents complete and posts ONE clean verdict:

| Check | Status | Details |
|-------|--------|---------|
| 🔍 Code Review | ✅ Passed | No issues found |
| 🛡️ Security | ✅ Passed | No vulnerabilities |
| 🔄 Breaking Changes | ⚠️ Warning | API signature change |
| 📝 Docs Sync | ✅ Passed | Up to date |
| 🧪 Tests | ℹ️ Suggestion | Consider adding tests |

**Verdict: Ready for human review**

### 3. Idempotent comments
Agent comments now upsert (update existing, don't duplicate) — re-pushes update the same comment instead of posting new ones.

### Files changed
- \.github/actions/ai-agent-runner/action.yml\ — collapse + upsert logic
- \.github/workflows/ai-pr-summary.yml\ — new orchestrator workflow

### Before/After
**Before:** 5-7 separate expanded bot comments cluttering the PR
**After:** 1 summary table + 5-7 collapsed details (one-liner visible)