### PR TITLE
feat(security): add dependency confusion pre-commit hook + weekly audit CI

### DIFF
--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -1,0 +1,112 @@
+name: Weekly Security Audit
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Monday 8:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  dependency-confusion-check:
+    name: Dependency Confusion Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Scan for unregistered pip install targets
+        id: dep-check
+        run: |
+          # Find all pip install commands and check package names
+          python scripts/check_dependency_confusion.py \
+            $(find . -name "*.md" -o -name "*.py" -o -name "*.ts" -o -name "*.txt" -o -name "*.yaml" -o -name "*.svg" -o -name "*.ipynb" \
+              | grep -v node_modules | grep -v .git | grep -v __pycache__ | grep -v .venv) \
+            > dep-confusion-report.txt 2>&1 || true
+          if [ -s dep-confusion-report.txt ]; then
+            echo "has-findings=true" >> "$GITHUB_OUTPUT"
+            echo "### ⚠️ Dependency Confusion Findings" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat dep-confusion-report.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has-findings=false" >> "$GITHUB_OUTPUT"
+            echo "### ✅ No dependency confusion findings" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  security-skills-scan:
+    name: Security Skills Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Run security skills scan
+        continue-on-error: true
+        run: |
+          python scripts/security_scan.py packages/ \
+            --exclude-tests \
+            --min-severity high \
+            --format text | tee security-report.txt
+
+      - name: Generate JSON report
+        if: always()
+        run: |
+          python scripts/security_scan.py packages/ \
+            --exclude-tests \
+            --format json > weekly-security-report.json || true
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6db9a6b7e75b195db6a6b2be22da8 # v4.6.2
+        with:
+          name: weekly-security-audit
+          path: |
+            weekly-security-report.json
+            dep-confusion-report.txt
+          retention-days: 90
+
+  weak-crypto-check:
+    name: Weak Cryptography Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Check for MD5/SHA1 in non-test code
+        run: |
+          echo "### Weak Cryptography Check" >> "$GITHUB_STEP_SUMMARY"
+          FINDINGS=$(grep -rn "hashlib\.md5\|hashlib\.sha1" --include="*.py" packages/ \
+            | grep -v "test_" | grep -v "text_tool" | grep -v "security_skills" \
+            | grep -v "example" | grep -v "benchmark" | grep -v "red_team" || true)
+          if [ -n "$FINDINGS" ]; then
+            echo "⚠️ MD5/SHA1 found in production code:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$FINDINGS" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ No weak cryptography in production code" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Check for pickle in non-test code
+        run: |
+          FINDINGS=$(grep -rn "pickle\.load" --include="*.py" packages/ \
+            | grep -v "test_" | grep -v "security_skills" | grep -v "# " || true)
+          if [ -n "$FINDINGS" ]; then
+            echo "⚠️ pickle usage found:" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$FINDINGS" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "✅ No pickle deserialization in production code" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Pre-commit hook: detect unregistered PyPI package names in pip install commands.
+
+Scans staged files for `pip install <name>` where <name> is not a known
+registered package. Prevents dependency confusion attacks.
+
+Usage:
+    # Install as pre-commit hook
+    cp scripts/check_dependency_confusion.py .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+
+    # Or run manually
+    python scripts/check_dependency_confusion.py [files...]
+"""
+
+import re
+import subprocess
+import sys
+
+# Known registered PyPI package names for this project
+REGISTERED_PACKAGES = {
+    # Core packages (on PyPI)
+    "agent-os-kernel",
+    "agentmesh-platform",
+    "agent-hypervisor",
+    "agent-runtime",
+    "agent-sre",
+    "agent-governance-toolkit",
+    "agent-lightning",
+    "agent-marketplace",
+    # Common dependencies
+    "pydantic", "pyyaml", "cryptography", "pynacl", "httpx", "aiohttp",
+    "fastapi", "uvicorn", "structlog", "click", "rich", "numpy", "scipy",
+    "pytest", "pytest-asyncio", "pytest-cov", "ruff", "mypy", "build",
+    "openai", "anthropic", "langchain", "langchain-core", "crewai",
+    "redis", "sqlalchemy", "asyncpg", "chromadb", "pinecone-client",
+    "sentence-transformers", "prometheus-client", "opentelemetry-api",
+    "opentelemetry-sdk", "fhir.resources", "hl7apy", "zenpy", "freshdesk",
+    "google-adk", "safety", "jupyter", "vitest", "tsup", "typescript",
+    # With extras (base name is what matters)
+}
+
+# Patterns that are always safe
+SAFE_PATTERNS = {
+    "-e", "--editable", "-r", "--requirement", "--upgrade", "--no-cache-dir",
+    "--quiet", "--require-hashes", "--hash", ".", "..", "../..",
+}
+
+PIP_INSTALL_RE = re.compile(
+    r'pip\s+install\s+(.+?)(?:\s*\\?\s*$|(?=\s*&&|\s*\||\s*;|\s*#))',
+    re.MULTILINE,
+)
+
+
+def extract_package_names(install_args: str) -> list[str]:
+    """Extract package names from a pip install argument string."""
+    packages = []
+    for token in install_args.split():
+        # Skip flags
+        if token.startswith("-") or token in SAFE_PATTERNS:
+            continue
+        if token.startswith((".", "/", "\\", "http", "git+")):
+            continue
+        # Strip extras: package[extra] -> package
+        base = re.sub(r'\[.*\]', '', token)
+        # Strip version specifiers: package>=1.0 -> package
+        base = re.split(r'[><=!~]', base)[0]
+        # Strip markdown/quote artifacts
+        base = base.strip('`"\'(){}')
+        if base and base not in SAFE_PATTERNS:
+            packages.append(base)
+    return packages
+
+
+def check_file(filepath: str) -> list[str]:
+    """Check a file for potentially unregistered pip install targets."""
+    findings = []
+    try:
+        with open(filepath, encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError):
+        return findings
+
+    for match in PIP_INSTALL_RE.finditer(content):
+        line_num = content[:match.start()].count("\n") + 1
+        packages = extract_package_names(match.group(1))
+        for pkg in packages:
+            if pkg.lower() not in {p.lower() for p in REGISTERED_PACKAGES}:
+                findings.append(
+                    f"  {filepath}:{line_num}: "
+                    f"'{pkg}' may not be registered on PyPI"
+                )
+    return findings
+
+
+def main() -> int:
+    # Get files to check
+    if len(sys.argv) > 1:
+        files = sys.argv[1:]
+    else:
+        # Pre-commit mode: check staged files
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+            capture_output=True, text=True,
+        )
+        files = [
+            f for f in result.stdout.strip().split("\n")
+            if f.endswith((".md", ".py", ".ts", ".txt", ".yaml", ".yml", ".ipynb", ".svg"))
+        ]
+
+    all_findings = []
+    for f in files:
+        all_findings.extend(check_file(f))
+
+    if all_findings:
+        print("⚠️  Potential dependency confusion detected:")
+        print()
+        for finding in all_findings:
+            print(finding)
+        print()
+        print("If the package IS registered on PyPI, add it to REGISTERED_PACKAGES")
+        print("in scripts/check_dependency_confusion.py")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Proactive security tooling from audit recommendations:

- **\scripts/check_dependency_confusion.py\**: Pre-commit hook that scans for \pip install\ commands referencing unregistered PyPI packages. Maintains allowlist of known packages.
- **\weekly-security-audit.yml\**: Weekly CI job running dependency confusion scan, security skills scan, and weak crypto check. Reports uploaded as 90-day artifacts.