### PR TITLE
fix(security): harden pull_request_target workflows against fork RCE [MSRC-111178]

### DIFF
--- a/.github/workflows/ai-breaking-change-detector.yml
+++ b/.github/workflows/ai-breaking-change-detector.yml
@@ -3,6 +3,9 @@
 # changed function signatures, modified exports in __init__.py, and changed
 # exception types. Posts findings as a PR comment with severity ratings.
 name: AI Breaking Change Detector
+# SECURITY: Uses pull_request_target for write access to post PR comments.
+# All checkouts pin to BASE ref (never HEAD) to prevent RCE via modified
+# composite actions in fork PRs. See MSRC Case 111178.
 
 on:
   pull_request_target:
@@ -25,12 +28,14 @@ jobs:
       github.actor != 'dependabot[bot]'
     continue-on-error: true
     steps:
+      - name: Fork safety check
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Running on fork PR — composite action resolved from base branch (safe)"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # SECURITY: pull_request_target — checkout base branch (default), NOT
-          # the PR head. The composite action fetches the diff via GitHub API,
-          # so checking out HEAD is unnecessary and would let a malicious PR
-          # modify .github/actions/ code that runs with elevated GITHUB_TOKEN.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Run breaking change analysis

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -2,8 +2,10 @@
 # Analyzes PR diffs for security issues, policy engine correctness,
 # trust/identity flaws, sandbox escape vectors, and API compatibility.
 # Uses GitHub Models API (gpt-4o) via the ai-agent-runner composite action.
-# Fork PRs are supported via pull_request_target with explicit HEAD SHA checkout.
 name: AI Code Review
+# SECURITY: Uses pull_request_target for write access to post PR comments.
+# All checkouts pin to BASE ref (never HEAD) to prevent RCE via modified
+# composite actions in fork PRs. See MSRC Case 111178.
 
 on:
   pull_request_target:
@@ -26,13 +28,15 @@ jobs:
       github.actor != 'github-actions[bot]'
     continue-on-error: true
     steps:
+      - name: Fork safety check
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Running on fork PR — composite action resolved from base branch (safe)"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # SECURITY: pull_request_target — checkout base branch (default), NOT
-          # the PR head. The composite action fetches the diff via GitHub API,
-          # so checking out HEAD is unnecessary and would let a malicious PR
-          # modify .github/actions/ code that runs with elevated GITHUB_TOKEN.
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 1
 
       - name: Run AI code review
         id: review

--- a/.github/workflows/ai-contributor-guide.yml
+++ b/.github/workflows/ai-contributor-guide.yml
@@ -4,6 +4,9 @@
 # - For PRs: provides a friendly first-PR review with extra guidance
 # Builds OSS community by making the contribution experience welcoming.
 name: AI Contributor Guide
+# SECURITY: Uses pull_request_target for write access to post PR comments.
+# All checkouts pin to BASE ref (never HEAD) to prevent RCE via modified
+# composite actions in fork PRs. See MSRC Case 111178.
 
 on:
   issues:
@@ -32,6 +35,9 @@ jobs:
     # is fetched via GitHub API. Permissions are scoped to minimum needed.
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
 
       - name: Guide contributor on issue
         uses: ./.github/actions/ai-agent-runner
@@ -81,7 +87,14 @@ jobs:
     # Permissions scoped to minimum: contents:read for base checkout, pr:write
     # for posting the welcome comment.
     steps:
+      - name: Fork safety check
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Running on fork PR — composite action resolved from base branch (safe)"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - name: Guide PR author
         uses: ./.github/actions/ai-agent-runner

--- a/.github/workflows/ai-docs-sync.yml
+++ b/.github/workflows/ai-docs-sync.yml
@@ -3,6 +3,9 @@
 # documentation is updated — flags missing docstrings, stale READMEs,
 # and changed behavior without CHANGELOG entries.
 name: AI Docs Sync Check
+# SECURITY: Uses pull_request_target for write access to post PR comments.
+# All checkouts pin to BASE ref (never HEAD) to prevent RCE via modified
+# composite actions in fork PRs. See MSRC Case 111178.
 
 on:
   pull_request_target:
@@ -25,13 +28,15 @@ jobs:
       github.actor != 'dependabot[bot]'
     continue-on-error: true
     steps:
+      - name: Fork safety check
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Running on fork PR — composite action resolved from base branch (safe)"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # SECURITY: pull_request_target — checkout base branch (default), NOT
-          # the PR head. The composite action fetches the diff via GitHub API,
-          # so checking out HEAD is unnecessary and would let a malicious PR
-          # modify .github/actions/ code that runs with elevated GITHUB_TOKEN.
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 1
 
       - name: Check documentation freshness
         uses: ./.github/actions/ai-agent-runner

--- a/.github/workflows/ai-security-scan.yml
+++ b/.github/workflows/ai-security-scan.yml
@@ -7,6 +7,9 @@
 # - PR scan: non-blocking analysis on every pull request
 # - Weekly full scan: comprehensive audit posted as a GitHub issue
 name: AI Security Scan
+# SECURITY: Uses pull_request_target for write access to post PR comments.
+# All checkouts pin to BASE ref (never HEAD) to prevent RCE via modified
+# composite actions in fork PRs. See MSRC Case 111178.
 
 on:
   pull_request_target:
@@ -32,13 +35,15 @@ jobs:
       github.actor != 'dependabot[bot]'
     continue-on-error: true
     steps:
+      - name: Fork safety check
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Running on fork PR — composite action resolved from base branch (safe)"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # SECURITY: pull_request_target — checkout base branch (default), NOT
-          # the PR head. The composite action fetches the diff via GitHub API,
-          # so checking out HEAD is unnecessary and would let a malicious PR
-          # modify .github/actions/ code that runs with elevated GITHUB_TOKEN.
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 1
 
       - name: Run AI security scan
         uses: ./.github/actions/ai-agent-runner
@@ -77,7 +82,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
 
       - name: Run full security audit
         id: audit

--- a/.github/workflows/ai-test-generator.yml
+++ b/.github/workflows/ai-test-generator.yml
@@ -3,6 +3,9 @@
 # and suggests domain-specific test cases — especially edge cases for policy
 # evaluation, trust scoring, chaos experiments, and concurrency.
 name: AI Test Generator
+# SECURITY: Uses pull_request_target for write access to post PR comments.
+# All checkouts pin to BASE ref (never HEAD) to prevent RCE via modified
+# composite actions in fork PRs. See MSRC Case 111178.
 
 on:
   pull_request_target:
@@ -25,13 +28,15 @@ jobs:
       github.actor != 'dependabot[bot]'
     continue-on-error: true
     steps:
+      - name: Fork safety check
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "::notice::Running on fork PR — composite action resolved from base branch (safe)"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # SECURITY: pull_request_target — checkout base branch (default), NOT
-          # the PR head. The composite action fetches the diff via GitHub API,
-          # so checking out HEAD is unnecessary and would let a malicious PR
-          # modify .github/actions/ code that runs with elevated GITHUB_TOKEN.
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          fetch-depth: 1
 
       - name: Identify changed source files
         id: changes


### PR DESCRIPTION
Defense-in-depth hardening for all 6 AI agent workflows using pull_request_target.

**Changes across 6 workflow files:**
- Explicit ref: base.sha on all 8 checkout steps (was implicit default)
- persist-credentials: false on all checkouts
- Fork safety check step on all PR-triggered jobs
- Shallow clone (fetch-depth: 1) where full history not needed
- Security header comments referencing MSRC case

The core vulnerability (ref: head.sha checkout enabling fork RCE) was already removed in PR #303. These changes add defense-in-depth per MSRC requirements.

Ref: MSRC Case 111178