### PR TITLE
fix(security): add SECURITY.md to all packages, harden langchain crypto fallback

### DIFF
--- a/packages/agent-compliance/SECURITY.md
+++ b/packages/agent-compliance/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-governance-dotnet/SECURITY.md
+++ b/packages/agent-governance-dotnet/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-hypervisor/SECURITY.md
+++ b/packages/agent-hypervisor/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-lightning/SECURITY.md
+++ b/packages/agent-lightning/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-marketplace/SECURITY.md
+++ b/packages/agent-marketplace/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-mesh/SECURITY.md
+++ b/packages/agent-mesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-os/SECURITY.md
+++ b/packages/agent-os/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-runtime/SECURITY.md
+++ b/packages/agent-runtime/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agent-sre/SECURITY.md
+++ b/packages/agent-sre/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/a2a-protocol/SECURITY.md
+++ b/packages/agentmesh-integrations/a2a-protocol/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/adk-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/adk-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/copilot-governance/SECURITY.md
+++ b/packages/agentmesh-integrations/copilot-governance/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/crewai-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/crewai-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/dify-plugin/SECURITY.md
+++ b/packages/agentmesh-integrations/dify-plugin/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/dify/SECURITY.md
+++ b/packages/agentmesh-integrations/dify/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/flowise-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/flowise-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/haystack-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/haystack-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/langchain-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/langchain-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/identity.py
+++ b/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/identity.py
@@ -21,6 +21,15 @@ try:
     CRYPTO_AVAILABLE = True
 except ImportError:
     CRYPTO_AVAILABLE = False
+    import warnings
+
+    warnings.warn(
+        "cryptography package not installed — using INSECURE simulation mode. "
+        "Signatures are NOT cryptographically verified. Install cryptography: "
+        "pip install 'langchain-agentmesh[crypto]' or pip install cryptography>=44.0.0",
+        SecurityWarning,
+        stacklevel=2,
+    )
 
 
 @dataclass
@@ -157,7 +166,8 @@ class VerificationIdentity:
             signature_bytes = private_key_obj.sign(data.encode("utf-8"))
             signature_b64 = base64.b64encode(signature_bytes).decode("ascii")
         else:
-            # Fallback simulation
+            # SECURITY WARNING: Fallback simulation — NOT cryptographically secure.
+            # Only for demo/development when cryptography package is unavailable.
             sig_input = f"{data}:{self.private_key}"
             signature_b64 = base64.b64encode(
                 hashlib.sha256(sig_input.encode()).digest()
@@ -193,7 +203,8 @@ class VerificationIdentity:
             except (InvalidSignature, ValueError):
                 return False
         else:
-            # Fallback verification (less secure, for demo only)
+            # SECURITY WARNING: Fallback verification — NOT cryptographically secure.
+            # Accepts any non-empty signature. Only for demo/development.
             return len(signature.signature) > 0
 
     def to_dict(self) -> Dict[str, Any]:

--- a/packages/agentmesh-integrations/langflow-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/langflow-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/langgraph-trust/SECURITY.md
+++ b/packages/agentmesh-integrations/langgraph-trust/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/llamaindex-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/llamaindex-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/mastra-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/mastra-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/mcp-trust-proxy/SECURITY.md
+++ b/packages/agentmesh-integrations/mcp-trust-proxy/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/moltbook/SECURITY.md
+++ b/packages/agentmesh-integrations/moltbook/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/nostr-wot/SECURITY.md
+++ b/packages/agentmesh-integrations/nostr-wot/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/openai-agents-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/openai-agents-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/openai-agents-trust/SECURITY.md
+++ b/packages/agentmesh-integrations/openai-agents-trust/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/openclaw-skill/SECURITY.md
+++ b/packages/agentmesh-integrations/openclaw-skill/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/pydantic-ai-governance/SECURITY.md
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.


### PR DESCRIPTION
Add SECURITY.md to all 29 subpackages linking to root security reporting guidance. Harden langchain-agentmesh crypto fallback with SecurityWarning when running in simulation mode. 30 files changed.