### PR TITLE
feat(esrp): set Key Vault name to learncopilot

### DIFF
--- a/pipelines/npm-publish.yml
+++ b/pipelines/npm-publish.yml
@@ -56,7 +56,7 @@ parameters:
 # -------------------------------------------------------
 variables:
   esrpServiceConnection: 'agt-esrp-release'
-  esrpKeyVaultName: 'agt-esrp-kv'  # TODO: replace with actual KV name
+  esrpKeyVaultName: 'learncopilot'
   esrpSignCertName: 'esrp-sign'  # TODO: replace with actual cert name
   esrpClientId: 'a458522c-0359-4e92-9887-5fee1607c0c7'
   esrpDomainTenantId: '975f013f-7f24-47e8-a7d3-abc4752bf346'

--- a/pipelines/pypi-publish.yml
+++ b/pipelines/pypi-publish.yml
@@ -58,7 +58,7 @@ variables:
   # Azure service connection for ESRP Release
   esrpServiceConnection: 'agt-esrp-release'
   # Azure Key Vault containing PRSS auth + sign certificates
-  esrpKeyVaultName: 'agt-esrp-kv'  # TODO: replace with actual KV name
+  esrpKeyVaultName: 'learncopilot'
   # Code-signing certificate name in Key Vault
   esrpSignCertName: 'esrp-sign'  # TODO: replace with actual cert name
   # AAD App Registration client ID (AME tenant)


### PR DESCRIPTION
Sets \srpKeyVaultName\ to \learncopilot\ in both PyPI and npm publish pipelines.