### PR TITLE
feat: add GitHub Pages site for project docs #347

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Deploy Documentation
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install mkdocs-material
+      - name: Build and Deploy
+        run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: AI Agent Governance Toolkit
+nav:
+  - Home: index.md
+  - Architecture: architecture.md
+  - Governance: packages/agent-compliance/README.md
+  - Identity: packages/agent-mesh/README.md
+theme:
+  name: material


### PR DESCRIPTION
This PR introduces a GitHub Pages deployment workflow using `MkDocs Material` (#347).

### Changes:
- Added `.github/workflows/docs.yml` for automated deployment on push to main.
- Included `mkdocs.yml` configuration with structured navigation.
- Enables a polished public documentation entry point for the toolkit.

/claim #347