### PR TITLE
docs: add README files to three example directories

### DIFF
--- a/packages/agent-mesh/examples/06-trust-score-dashboard/README.md
+++ b/packages/agent-mesh/examples/06-trust-score-dashboard/README.md
@@ -1,0 +1,45 @@
+# Trust Score Dashboard
+
+A Streamlit dashboard for monitoring agent trust networks, credential lifecycles, protocol traffic, and compliance posture across an AgentMesh deployment.
+
+## What It Does
+
+This example launches an interactive dashboard with five tabs:
+
+1. **Trust Network** — Force-directed graph of agent relationships, colored and sized by trust score. Hover for DID, protocol, and score details.
+2. **Trust Scores** — Leaderboard, per-agent radar breakdown across five dimensions (Competence, Integrity, Availability, Security, Compliance), historical score timeline, and trust decay simulation showing projected score erosion without activity.
+3. **Credential Lifecycle** — Status table of all agent credentials (x509-mTLS, VC-JWT, DID-Auth, OAuth2, API-Key), TTL countdown gauges, expiry distribution, and rotation timeline.
+4. **Protocol Traffic** — Message throughput by protocol (A2A, MCP, IATP), distribution breakdown, trust verification pass/fail rates, and top communication pairs by trust weight.
+5. **Compliance** — Framework status (EU AI Act, SOC 2, HIPAA, GDPR), per-agent compliance checklist, audit log with severity levels, audit chain verification, and compliance score heatmap.
+
+The dashboard uses simulated data to demonstrate the visualization patterns. Replace the data generators with live AgentMesh queries for production use.
+
+## Prerequisites
+
+- Python 3.10+
+- Dependencies listed in `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Key packages: `streamlit`, `plotly`, `pandas`, `numpy`, `networkx`.
+
+## How to Run
+
+```bash
+cd packages/agent-mesh/examples/06-trust-score-dashboard
+streamlit run trust_dashboard.py
+```
+
+The dashboard opens at `http://localhost:8501`. Use the sidebar to filter by agent, time range, and protocol.
+
+## Expected Output
+
+A dark-themed multi-tab dashboard showing:
+- 10 simulated agents with W3C DIDs (`did:web:*.mesh.io`)
+- Trust scores from 0-1000 on a red-yellow-green gradient
+- 15 trust relationships with weighted edges
+- Credential status (active/expired/expiring-soon)
+- Protocol traffic across A2A, MCP, and IATP
+- Compliance scores across four regulatory frameworks

--- a/packages/agent-os/examples/demo-app/README.md
+++ b/packages/agent-os/examples/demo-app/README.md
@@ -1,0 +1,43 @@
+# Demo App — Your First Governed Agent
+
+A minimal example showing how to run an agent task through the Agent OS kernel with policy enforcement.
+
+## What It Does
+
+Creates a `StatelessKernel` (no external dependencies), defines a simple agent function that processes a task through the kernel under a `read_only` policy, and prints the result. This is the simplest possible Agent OS example — one agent, one policy, one task.
+
+The kernel intercepts the `process_task` action, checks it against the declared policy, and either allows or blocks execution. This demonstrates the core Agent OS pattern: all agent actions flow through the kernel, where governance policies are enforced before execution.
+
+## Prerequisites
+
+- Python 3.10+
+- Agent OS installed:
+
+```bash
+pip install -e "packages/agent-os[dev]"
+```
+
+## How to Run
+
+```bash
+cd packages/agent-os/examples/demo-app
+python agent.py
+```
+
+## Expected Output
+
+```
+[Agent OS] Demo
+========================================
+[OK] Result: Processed: HELLO, AGENT OS!
+
+Success! Your agent ran safely under kernel governance!
+
+The kernel checked the 'read_only' policy before execution.
+```
+
+## Next Steps
+
+- Add more policies from `packages/agent-os/examples/shared-policies/`
+- Try the `self-evaluating` example for agents that assess their own output quality
+- See the `governed-chatbot` example for a conversational agent with full policy enforcement

--- a/packages/agent-sre/examples/README.md
+++ b/packages/agent-sre/examples/README.md
@@ -1,0 +1,46 @@
+# Agent-SRE Examples
+
+Examples demonstrating SLO monitoring, cost guardrails, incident detection, and reliability engineering for AI agents.
+
+## Quickstart
+
+The fastest way to see Agent-SRE in action:
+
+```bash
+pip install -e "packages/agent-sre[dev]"
+python packages/agent-sre/examples/quickstart.py
+```
+
+This simulates 100 agent tasks with a 93% success rate (below the 95% target) and 8% hallucination rate (above the 5% target), then shows SLO status, error budget consumption, cost tracking, and burn rate alerts.
+
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| `quickstart.py` | SLOs, cost budgets, and incidents in 30 lines |
+| `slo_alerting.py` | Multi-window burn rate alerting (1h, 6h, 24h, 72h) |
+| `cost_guard.py` | Per-task, per-agent, and org-wide cost limits |
+| `cost_guardrails.py` | Cost guardrails with automatic throttling |
+| `canary_rollout.py` | Canary deployment for model upgrades with automatic rollback |
+| `chaos_test.py` | Chaos testing — inject failures and measure agent resilience |
+| `langchain_monitor.py` | LangChain callback integration for SLO tracking |
+| `dashboard/` | Streamlit SRE dashboard for real-time monitoring |
+| `chaos/` | Extended chaos engineering scenarios |
+| `chaos-chatbot/` | Chaos testing for conversational agents |
+| `canary-model-upgrade/` | Full canary pipeline for swapping underlying models |
+| `langchain-monitoring/` | LangChain integration with custom metrics |
+| `docker-compose/` | Docker setup for running the monitoring stack |
+
+## Key Concepts
+
+- **SLO (Service Level Objective):** Define reliability targets for your agent — success rate, cost per task, hallucination rate. Agent-SRE measures compliance continuously.
+- **Error Budget:** A fixed allowance for failures. When exhausted, deployments should freeze. Burn rate alerts fire when the budget is being consumed too fast.
+- **Cost Guard:** Per-task, per-agent, and organization-wide spending limits. Tasks that would exceed the budget are blocked before execution.
+- **Incident Detection:** Correlates signals (budget exhaustion, SLO breaches, anomalies) into incidents with severity classification.
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install -e "packages/agent-sre[dev]"`
+- For the dashboard: `pip install streamlit plotly`
+- For LangChain examples: `pip install langchain`


### PR DESCRIPTION
## Summary
- Add README to `packages/agent-mesh/examples/06-trust-score-dashboard/` — documents the Streamlit trust dashboard (5 tabs, 10 simulated agents, trust network visualization, credential lifecycle, protocol traffic, compliance heatmaps)
- Add README to `packages/agent-os/examples/demo-app/` — documents the minimal governed agent example (kernel, policy, single task)
- Add README to `packages/agent-sre/examples/` — index of all 13 SRE examples with descriptions, key concepts, and prerequisites

Each README follows the format requested in #335: what it does, prerequisites, how to run, expected output. Covers 3 of the 5 priority directories listed in the issue.

Partial fix for #335.

## Test plan
- [x] Verified all three examples exist and match the README descriptions
- [x] Confirmed no existing READMEs were overwritten
- [x] Checked `self-evaluating` example already has README (skipped per issue)

Generated with [Claude Code](https://claude.com/claude-code)