### PR TITLE
docs: add requirements files for example directories

### DIFF
--- a/packages/agent-compliance/examples/README.md
+++ b/packages/agent-compliance/examples/README.md
@@ -12,7 +12,7 @@ Runnable examples showing the unified governance stack in action.
 ## Prerequisites
 
 ```bash
-pip install agent-governance-toolkit[full]
+pip install -r requirements.txt
 ```
 
 ## Running

--- a/packages/agent-compliance/examples/requirements.txt
+++ b/packages/agent-compliance/examples/requirements.txt
@@ -1,0 +1,1 @@
+agent-governance-toolkit[full]>=2.2.0

--- a/packages/agent-hypervisor/examples/demo.py
+++ b/packages/agent-hypervisor/examples/demo.py
@@ -13,7 +13,7 @@ Demonstrates the full lifecycle of the Agent Hypervisor:
 
 Run:
     cd modules/hypervisor
-    pip install -e .
+    pip install -r examples/requirements.txt
     python examples/demo.py
 """
 

--- a/packages/agent-hypervisor/examples/requirements.txt
+++ b/packages/agent-hypervisor/examples/requirements.txt
@@ -1,0 +1,1 @@
+agent-hypervisor>=2.2.0

--- a/packages/agent-mesh/examples/00-registration-hello-world/README.md
+++ b/packages/agent-mesh/examples/00-registration-hello-world/README.md
@@ -42,7 +42,7 @@ This example simulates an agent registering with AgentMesh for the first time:
 ## Prerequisites
 
 ```bash
-pip install agentmesh-platform
+pip install -r requirements.txt
 ```
 
 ## Running the Example

--- a/packages/agent-mesh/examples/00-registration-hello-world/requirements.txt
+++ b/packages/agent-mesh/examples/00-registration-hello-world/requirements.txt
@@ -1,0 +1,3 @@
+agentmesh-platform>=2.2.0
+cryptography>=45.0.3
+rich>=13.0.0


### PR DESCRIPTION
Fixes #333

## Summary
- add requirements.txt files for the agent-compliance, agent-mesh hello-world, and agent-hypervisor example directories
- point the nearby example docs at those local requirements files instead of inline install commands
- keep the change scoped to 3 example directories as suggested in the issue

## Verification
- reviewed each example's imports against the package metadata before listing dependencies
- checked the updated example docs and usage text for consistency
