### PR TITLE
test: add pytest markers for slow and integration tests

### DIFF
--- a/packages/agent-hypervisor/pyproject.toml
+++ b/packages/agent-hypervisor/pyproject.toml
@@ -90,6 +90,10 @@ packages = ["src/hypervisor"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "-v --tb=short"
+markers = [
+    "slow: long-running tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
+]
 
 [tool.ruff]
 target-version = "py311"

--- a/packages/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
+++ b/packages/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
@@ -32,6 +32,7 @@ from hypervisor.models import ActionDescriptor
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestFullLifecycle:
     """End-to-end session lifecycle: create → join → activate → terminate."""
 
@@ -113,6 +114,7 @@ class TestFullLifecycle:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestRingEnforcementIntegration:
     """Test ring assignment with real sessions and sponsorship."""
 
@@ -168,6 +170,7 @@ class TestRingEnforcementIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestVouchingSlashingIntegration:
     """Test sponsorship with exposure limits and penalty cascades."""
 
@@ -229,6 +232,7 @@ class TestVouchingSlashingIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestSagaIntegration:
     """Test saga orchestration with real timeout and retry behavior."""
 
@@ -382,6 +386,7 @@ class TestSagaIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestAuditTrailIntegration:
     """Test delta audit engine in context of full sessions."""
 
@@ -455,6 +460,7 @@ class TestAuditTrailIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestGCIntegration:
     """Test garbage collection with real VFS and delta engines."""
 
@@ -499,6 +505,7 @@ class TestGCIntegration:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 class TestEdgeCases:
     """Edge cases and security boundaries."""
 

--- a/packages/agent-mesh/pyproject.toml
+++ b/packages/agent-mesh/pyproject.toml
@@ -165,4 +165,5 @@ markers = [
     "fuzz: fuzzing tests with malformed inputs",
     "benchmark: crypto operation benchmarks",
     "slow: long-running load tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
 ]

--- a/packages/agent-mesh/tests/test_credential_lifecycle.py
+++ b/packages/agent-mesh/tests/test_credential_lifecycle.py
@@ -103,6 +103,7 @@ class TestCredentialCreation:
 # ===================================================================
 
 
+@pytest.mark.slow
 class TestTTLExpiry:
     """Verify credentials expire after their time-to-live window."""
 
@@ -418,6 +419,7 @@ class TestChainOfTrust:
 # ===================================================================
 
 
+@pytest.mark.slow
 class TestExpiredCleanup:
     """Verify expired credential garbage collection."""
 

--- a/packages/agent-mesh/tests/test_handshake_timeout.py
+++ b/packages/agent-mesh/tests/test_handshake_timeout.py
@@ -59,6 +59,7 @@ class TestHandshakeTimeoutBehavior:
     """Tests for timeout behavior during handshake."""
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_timeout_raises_handshake_timeout_error(self):
         """Slow handshake raises HandshakeTimeoutError."""
         agent_a = _make_identity("timeout-a")

--- a/packages/agent-mesh/tests/test_key_rotation.py
+++ b/packages/agent-mesh/tests/test_key_rotation.py
@@ -29,6 +29,7 @@ def _create_identity() -> AgentIdentity:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 class TestKeyRotationManager:
     """Tests for KeyRotationManager."""
 

--- a/packages/agent-mesh/tests/test_revocation.py
+++ b/packages/agent-mesh/tests/test_revocation.py
@@ -33,6 +33,7 @@ class TestRevocationEntry:
         assert entry.expires_at is not None
 
 
+@pytest.mark.slow
 class TestRevocationList:
     def test_revoke_and_check(self):
         rl = RevocationList()

--- a/packages/agent-os/pyproject.toml
+++ b/packages/agent-os/pyproject.toml
@@ -211,6 +211,8 @@ asyncio_mode = "auto"
 addopts = "-v --tb=short"
 markers = [
     "benchmark: performance benchmark tests",
+    "slow: long-running tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
 ]
 
 # ============================================================================

--- a/packages/agent-os/tests/test_adapter_quality.py
+++ b/packages/agent-os/tests/test_adapter_quality.py
@@ -115,6 +115,7 @@ def test_langchain_kernel_default_timeout():
     assert kernel.timeout_seconds == 300.0
 
 
+@pytest.mark.slow
 async def test_langchain_ainvoke_timeout():
     """ainvoke should raise TimeoutError when the operation exceeds timeout."""
     chain = MagicMock()

--- a/packages/agent-os/tests/test_policy_decisions.py
+++ b/packages/agent-os/tests/test_policy_decisions.py
@@ -164,6 +164,7 @@ class TestEnforcePolicyDefer:
         assert "deny" in result.error.lower()
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_defer_timeout(self, agent):
         async def _slow(action, params):
             await asyncio.sleep(10)
@@ -175,6 +176,7 @@ class TestEnforcePolicyDefer:
         assert result.signal == "DEFER_TIMEOUT"
 
     @pytest.mark.asyncio
+    @pytest.mark.slow
     async def test_defer_custom_timeout(self):
         agent = _StubAgent(
             AgentConfig(agent_id="custom-timeout"), defer_timeout=0.1

--- a/packages/agent-sre/pyproject.toml
+++ b/packages/agent-sre/pyproject.toml
@@ -101,6 +101,10 @@ mypy_path = "src"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "slow: long-running tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
+]
 
 [tool.bandit]
 skips = ["B310"]

--- a/packages/agent-sre/tests/integration/test_integration.py
+++ b/packages/agent-sre/tests/integration/test_integration.py
@@ -15,7 +15,9 @@ These tests verify that the major subsystems work together correctly:
 import contextlib
 import time
 
+import pytest
 
+@pytest.mark.integration
 class TestSLOPipeline:
     """SLI recording → SLO evaluation → Error Budget → Dashboard."""
 
@@ -111,6 +113,7 @@ class TestSLOPipeline:
         assert len(snapshots) == 3
 
 
+@pytest.mark.integration
 class TestIncidentFlow:
     """Incident detection → Circuit breaker → Postmortem."""
 
@@ -193,6 +196,7 @@ class TestIncidentFlow:
             assert gen is not None
 
 
+@pytest.mark.integration
 class TestCostPipeline:
     """Cost recording → Anomaly detection → Budget guard."""
 
@@ -236,6 +240,7 @@ class TestCostPipeline:
         assert isinstance(allowed, bool)
 
 
+@pytest.mark.integration
 class TestDeliveryPipeline:
     """Rollout → SLO evaluation → Decision."""
 
@@ -261,6 +266,7 @@ class TestDeliveryPipeline:
             rollout.start()
 
 
+@pytest.mark.integration
 class TestEvalsSLIPipeline:
     """Evaluation engine → SLI feed → SLO tracking."""
 
@@ -306,6 +312,7 @@ class TestEvalsSLIPipeline:
         assert engine.pass_rate() >= 0.0
 
 
+@pytest.mark.integration
 class TestObservabilityIntegrations:
     """OTEL, Langfuse, Arize all feeding into SLIs."""
 
@@ -368,6 +375,7 @@ class TestObservabilityIntegrations:
         assert len(exporter.observations) == 2
 
 
+@pytest.mark.integration
 class TestReplayFlow:
     """Trace capture → Replay → Diff analysis."""
 
@@ -398,6 +406,7 @@ class TestReplayFlow:
         assert trace.task_output == "done"
 
 
+@pytest.mark.integration
 class TestChaosExperiment:
     """Chaos experiment lifecycle."""
 
@@ -436,6 +445,7 @@ class TestChaosExperiment:
         assert experiment.state == ExperimentState.COMPLETED
 
 
+@pytest.mark.integration
 class TestSLIRegistry:
     """SLI type registration and discovery."""
 


### PR DESCRIPTION
Adds `@pytest.mark.slow` and `@pytest.mark.integration` markers across four packages.

## Why this matters

Slow tests block the dev loop. Skip them with `pytest -m "not slow"`. Fast feedback matters.

## Changes

- **pyproject.toml** (4 files): Registered markers in agent-mesh, agent-os, agent-hypervisor, agent-sre
- **agent-mesh** (4 test files): Marked credential, handshake, rotation, revocation tests as slow
- **agent-os** (2 test files): Marked adapter and policy tests as slow
- **agent-hypervisor** (1 file): Marked e2e classes as integration
- **agent-sre** (1 file): Marked integration classes

## Testing

Markers register clean. No warnings.

Fixes #338

This contribution was developed with AI assistance (Claude Code).