### PR TITLE
docs: add missing README files for integrations and examples

### DIFF
--- a/examples/policies/README.md
+++ b/examples/policies/README.md
@@ -1,0 +1,31 @@
+# Policies Example
+
+Sample YAML governance policy files for AgentMesh. Each file provides an example configuration covering a specific security or compliance scenario. 
+
+## Policies
+ 
+| File | Description |
+|------|-------------|
+| `adk-governance.yaml` | Tool restrictions and delegation controls for Google ADK agents |
+| `cli-security-rules.yaml` | Blocks dangerous shell and CLI patterns |
+| `conversation-guardian.yaml` | Content safety rules for conversational agents |
+| `mcp-security.yaml` | Security controls for MCP tool usage |
+| `pii-detection.yaml` | Detects and blocks personally identifiable information |
+| `prompt-injection-safety.yaml` | Guards against prompt injection attacks |
+| `sandbox-safety.yaml` | Restrictions for sandboxed agent execution |
+| `semantic-policy.yaml` | Semantic similarity-based policy enforcement |
+| `sql-readonly.yaml` | Restricts agents to read-only SQL operations |
+| `sql-safety.yaml` | Blocks destructive SQL patterns |
+| `sql-strict.yaml` | Strict SQL allowlist for production databases |
+
+## How to Use
+ 
+These policy files can be applied to agent workflows to enforce governance rules.
+ 
+```bash
+scripts/check-policy.sh --action "web_search" --tokens 1500 --policy examples/policies/sql-safety.yaml
+```
+
+## Related
+ 
+- [Quickstart](../quickstart/) - Runnable examples that use these policies

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,38 @@
+# Quickstart Examples
+
+Runnable examples showing AgentMesh governance enforcement across five major agent frameworks. Each script demonstrates a real policy violation being caught and a compliant call succeeding, with a printed audit trail.
+
+Refer to the individual scripts for framework-specific implementations.
+
+## Prerequisites
+
+- Python 3.x
+- OpenAI API key (for LangChain, AutoGen, OpenAI Agents examples)
+- Google ADK credentials (for ADK example)
+
+```bash
+pip install agent-governance-toolkit[full]
+```
+
+## How to Run
+
+```bash
+# LangChain
+python examples/quickstart/langchain_governed.py
+
+# CrewAI
+python examples/quickstart/crewai_governed.py
+
+# AutoGen
+python examples/quickstart/autogen_governed.py
+
+# Google ADK
+python examples/quickstart/google_adk_governed.py
+
+# OpenAI Agents
+python examples/quickstart/openai_agents_governed.py
+```
+
+## Related
+
+- [Policies](../policies/) — Sample YAML governance policies to use with these examples

--- a/packages/agentmesh-integrations/moltbook/README.md
+++ b/packages/agentmesh-integrations/moltbook/README.md
@@ -1,0 +1,26 @@
+# Moltbook - AgentMesh Skill
+
+## What This Is
+
+AgentMesh governance skill for Moltbook agents, enabling identity verification, trust-based access control, and audit logging.
+
+## Files
+
+- `skill.json` — Skill manifest (name, version, capabilities)
+- `skill.md` — Skill specification and behavior description
+- `heartbeat.md` — Health check definition
+
+## Usage
+
+Register this skill with your Moltbook agent:
+
+```bash
+mkdir -p ~/.moltbot/skills/agentmesh
+curl -s https://agentmesh-api.vercel.app/skill.md > ~/.moltbot/skills/agentmesh/SKILL.md
+curl -s https://agentmesh-api.vercel.app/heartbeat.md > ~/.moltbot/skills/agentmesh/HEARTBEAT.md
+curl -s https://agentmesh-api.vercel.app/skill.json > ~/.moltbot/skills/agentmesh/skill.json
+```
+
+## Related
+
+- Agent Marketplace

--- a/packages/agentmesh-integrations/openclaw-skill/README.md
+++ b/packages/agentmesh-integrations/openclaw-skill/README.md
@@ -1,0 +1,35 @@
+# OpenClaw - AgentMesh Skill
+
+## What This Is
+
+Zero-trust governance skill for OpenClaw agents, enabling policy enforcement, identity verification, and trust scoring.
+
+## Files
+
+- `skill.md` — Skill specification and behavior description
+- `scripts/` — Supporting scripts for the skill
+
+## Usage
+
+Register this skill with your OpenClaw agent:
+
+```bash
+pip install agentmesh-governance
+```
+
+Then use the scripts in `scripts/` to enforce governance from your agent:
+
+```bash
+# Check policy before a tool call
+scripts/check-policy.sh --action "web_search" --tokens 1500 --policy policy.yaml
+
+# Verify a peer agent's identity
+scripts/verify-identity.sh --did "did:mesh:abc123" --message "hello" --signature "base64sig"
+
+# Check trust score before delegation
+scripts/trust-score.sh --agent "research-agent"
+```
+
+## Related
+
+- Agent Marketplace


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes in this PR -->
This PR adds missing README files for skill-based integrations and example directories to improve discoverability and usability.

I checked the integrations directory and found that most packages already have README files. I focused on adding README files for skill-based integrations and missing example directories.

Changes include:
- Added README for `moltbook` and `openclaw-skill` integrations using the skill-based documentation format
- Added README for `examples/policies` with descriptions of available YAML policy files and usage examples
- Added README for `examples/quickstart` with setup instructions and runnable examples

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
Fixes #318 
