### PR TITLE
fix(security): enforce maintainer approval for all external PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
 # CODEOWNERS — Default reviewers for microsoft/agent-governance-toolkit
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# POLICY: Every PR from a non-member MUST be approved by a CODEOWNER.
+# No bypass. No AI-only approval. Human maintainer review required.
+# See: docs/CONTRIBUTING.md and .github/workflows/require-maintainer-approval.yml
 
 # Default owners for everything in the repo
 * @imran-siddique
@@ -10,9 +14,18 @@
 /packages/agent-hypervisor/  @imran-siddique
 /packages/agent-sre/         @imran-siddique
 /packages/agent-compliance/  @imran-siddique
+/packages/agent-marketplace/ @imran-siddique
+/packages/agent-runtime/     @imran-siddique
+/packages/agentmesh-integrations/ @imran-siddique
 
-# CI/CD and GitHub configuration
+# Security-sensitive paths — require maintainer review, no exceptions
 /.github/                    @imran-siddique
+/.github/workflows/          @imran-siddique
+/.github/actions/            @imran-siddique
+/packages/*/src/**/sandbox*  @imran-siddique
+/packages/*/src/**/trust*    @imran-siddique
+/packages/*/src/**/identity* @imran-siddique
+/packages/*/src/**/crypto*   @imran-siddique
 
 # Documentation
 /docs/                       @imran-siddique

--- a/.github/workflows/require-maintainer-approval.yml
+++ b/.github/workflows/require-maintainer-approval.yml
@@ -1,0 +1,54 @@
+# Blocks merge of external contributor PRs unless a maintainer has approved.
+# AI-only approvals do NOT count. Bot approvals do NOT count.
+# This is a safety net — branch protection rules should also enforce this.
+#
+# Context: PRs #357 and #362 were auto-merged without maintainer review,
+# reintroducing shell=True (CWE-78) that we fixed for MSRC Case 111178.
+
+name: Require Maintainer Approval
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-approval:
+    name: Maintainer approval gate
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'OWNER'
+    steps:
+      - name: Check for maintainer approval
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const MAINTAINERS = ['imran-siddique'];
+
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const maintainerApproval = reviews.data.find(
+              (r) =>
+                r.state === 'APPROVED' &&
+                MAINTAINERS.includes(r.user.login) &&
+                r.user.type === 'User'  // Exclude bot approvals
+            );
+
+            if (!maintainerApproval) {
+              core.setFailed(
+                `❌ This PR requires approval from a maintainer (${MAINTAINERS.join(', ')}) before merge.\n` +
+                `AI and bot approvals do not satisfy this requirement.\n` +
+                `This policy exists because PRs #357/#362 reintroduced security vulnerabilities when auto-merged without human review.`
+              );
+            } else {
+              core.info(`✅ Maintainer @${maintainerApproval.user.login} approved this PR.`);
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,29 @@ pytest tests/ -x -q
 - Use `--no-cache-dir` for pip installs in Dockerfiles.
 - Pin dependencies to specific versions in `pyproject.toml`.
 
+### Merge Policy
+
+> **All PRs from external contributors MUST be approved by a maintainer before merge.**
+> AI-only approvals and bot approvals do NOT satisfy this requirement.
+
+This policy is enforced by:
+1. **CODEOWNERS** — every file requires review from `@imran-siddique`
+2. **`require-maintainer-approval.yml`** — CI check that blocks merge without human maintainer approval
+3. **Branch protection** — CODEOWNERS review required on `main`
+
+**Why this policy exists:** PRs #357 and #362 were auto-merged without maintainer review and reintroduced a command injection vulnerability (`subprocess.run(shell=True)`) that had been fixed for MSRC Case 111178 just days earlier. AI code review agents did not catch the security regression.
+
+**What counts as maintainer approval:**
+- ✅ A GitHub "Approve" review from a listed CODEOWNER
+- ❌ AI/bot approval (Copilot, Sourcery, etc.) — does not count
+- ❌ Author self-approval — does not count
+- ❌ Admin bypass — should not be used for external PRs
+
+**Security-sensitive paths** (extra scrutiny required):
+- `.github/workflows/` and `.github/actions/` — CI/CD configuration
+- Any file containing `subprocess`, `eval`, `exec`, `pickle`, `shell=True`
+- Trust, identity, and cryptography modules
+
 ## Licensing
 
 By contributing to this project, you agree that your contributions will be licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Adds enforcement that all PRs from non-members require human maintainer approval. AI/bot approvals do not count. No bypass.

Changes: expanded CODEOWNERS with security-sensitive paths, new require-maintainer-approval.yml CI gate, Merge Policy section in CONTRIBUTING.md.

Context: PRs #357/#362 auto-merged without review, reintroducing shell=True (CWE-78) fixed in MSRC-111178.