### PR TITLE
fix: dep confusion + pydantic dependency (post-merge review)

### DIFF
--- a/packages/agent-compliance/pyproject.toml
+++ b/packages/agent-compliance/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = [
     "agent-os-kernel>=1.0.0",
     "agentmesh-platform>=1.0.0",
+    "pydantic>=2.4.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/agentmesh-integrations/openclaw-skill/README.md
+++ b/packages/agentmesh-integrations/openclaw-skill/README.md
@@ -14,7 +14,7 @@ Zero-trust governance skill for OpenClaw agents, enabling policy enforcement, id
 Register this skill with your OpenClaw agent:
 
 ```bash
-pip install agentmesh-governance
+pip install agent-governance-toolkit
 ```
 
 Then use the scripts in `scripts/` to enforce governance from your agent:


### PR DESCRIPTION
2 files, 2 actual changes:
- openclaw-skill README: agentmesh-governance → agent-governance-toolkit
- agent-compliance pyproject.toml: add pydantic>=2.4.0