### PR TITLE
fix: hardcode service connection name in ESRP pipelines

### DIFF
--- a/pipelines/npm-publish.yml
+++ b/pipelines/npm-publish.yml
@@ -51,13 +51,14 @@ parameters:
     default: false
 
 # -------------------------------------------------------
-# ESRP Configuration — All values sourced from pipeline variables/secrets
-# Configure these in ADO pipeline variables (mark sensitive ones as secret):
-#   ESRP_SERVICE_CONNECTION, ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER,
+# ESRP Configuration
+# Service connection name is hardcoded (required at compile time by ADO).
+# All other values sourced from ADO pipeline variables (mark as secret):
+#   ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER,
 #   ESRP_CLIENT_ID, ESRP_DOMAIN_TENANT_ID, ESRP_OWNERS, ESRP_APPROVERS
 # -------------------------------------------------------
 variables:
-  esrpServiceConnection: $(ESRP_SERVICE_CONNECTION)
+  esrpServiceConnection: 'Agent Governance Toolkit'
   esrpKeyVaultName: $(ESRP_KEYVAULT_NAME)
   esrpSignCertName: $(ESRP_CERT_IDENTIFIER)
   esrpClientId: $(ESRP_CLIENT_ID)

--- a/pipelines/pypi-publish.yml
+++ b/pipelines/pypi-publish.yml
@@ -51,13 +51,14 @@ parameters:
     default: false
 
 # -------------------------------------------------------
-# ESRP Configuration — All values sourced from GitHub Secrets
-# Configure these secrets in the ADO pipeline or GitHub repo:
-#   ESRP_SERVICE_CONNECTION, ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER,
+# ESRP Configuration
+# Service connection name is hardcoded (required at compile time by ADO).
+# All other values sourced from ADO pipeline variables (mark as secret):
+#   ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER,
 #   ESRP_CLIENT_ID, ESRP_DOMAIN_TENANT_ID, ESRP_OWNERS, ESRP_APPROVERS
 # -------------------------------------------------------
 variables:
-  esrpServiceConnection: $(ESRP_SERVICE_CONNECTION)
+  esrpServiceConnection: 'Agent Governance Toolkit'
   esrpKeyVaultName: $(ESRP_KEYVAULT_NAME)
   esrpSignCertName: $(ESRP_CERT_IDENTIFIER)
   esrpClientId: $(ESRP_CLIENT_ID)


### PR DESCRIPTION
ADO requires service connection names at compile time for task authorization — runtime variables don't work for \connectedservicename\. Hardcodes the name \Agent Governance Toolkit\ directly in both pipelines.

- \pipelines/pypi-publish.yml\
- \pipelines/npm-publish.yml\

\ESRP_SERVICE_CONNECTION\ pipeline variable is no longer needed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>