### PR TITLE
feat: add GitHub Actions action for governance verification (#423)

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -1,0 +1,116 @@
+# Agent Governance Verify — GitHub Action
+
+A GitHub Action that runs governance verification and plugin validation from the
+[Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+Add governance as a required CI check with minimal configuration.
+
+## Quick Start
+
+```yaml
+- uses: microsoft/agent-governance-toolkit/action@v2
+```
+
+That's it — runs `agent-compliance verify` against your repo.
+
+## Usage Examples
+
+### Governance verification (OWASP ASI compliance)
+
+```yaml
+- name: Governance Check
+  uses: microsoft/agent-governance-toolkit/action@v2
+  with:
+    command: governance-verify
+    output-format: json
+```
+
+### Plugin manifest validation
+
+```yaml
+- name: Verify Plugin
+  uses: microsoft/agent-governance-toolkit/action@v2
+  with:
+    command: marketplace-verify
+    manifest-path: plugins/my-plugin/plugin.json
+```
+
+### Policy evaluation
+
+```yaml
+- name: Evaluate Policy
+  uses: microsoft/agent-governance-toolkit/action@v2
+  with:
+    command: policy-evaluate
+    policy-path: policies/
+    context-json: '{"tool_name": "web_search", "agent_id": "agent-1"}'
+```
+
+### Full suite (all checks)
+
+```yaml
+- name: Full Governance Suite
+  uses: microsoft/agent-governance-toolkit/action@v2
+  with:
+    command: all
+    manifest-path: plugins/my-plugin/plugin.json
+    policy-path: policies/
+```
+
+### Plugin marketplace PR workflow
+
+```yaml
+name: Plugin Governance
+on:
+  pull_request:
+    paths: ['plugins/**']
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify plugin manifest
+        uses: microsoft/agent-governance-toolkit/action@v2
+        id: verify
+        with:
+          command: marketplace-verify
+          manifest-path: plugins/${{ github.event.pull_request.title }}/plugin.json
+
+      - name: Governance compliance
+        uses: microsoft/agent-governance-toolkit/action@v2
+        with:
+          command: governance-verify
+          output-format: json
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `command` | Verification to run: `governance-verify`, `marketplace-verify`, `policy-evaluate`, `all` | No | `governance-verify` |
+| `policy-path` | Path to YAML policy file(s) | No | |
+| `manifest-path` | Path to plugin manifest | No | |
+| `context-json` | JSON evaluation context for `policy-evaluate` | No | |
+| `output-format` | Output format: `text`, `json`, `badge` | No | `text` |
+| `fail-on-warning` | Fail on warnings (not just errors) | No | `false` |
+| `python-version` | Python version to use | No | `3.12` |
+| `toolkit-version` | Toolkit version to install (default: latest) | No | |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `status` | `pass` or `fail` |
+| `controls-passed` | Controls passed (governance-verify) |
+| `controls-total` | Total controls checked (governance-verify) |
+| `violations` | Violation count (policy-evaluate) |
+| `output` | Full command output |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All checks passed |
+| `1` | One or more checks failed |

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,226 @@
+name: 'Agent Governance Verify'
+description: 'Run governance verification and plugin validation from the Agent Governance Toolkit'
+author: 'Microsoft'
+branding:
+  icon: 'shield'
+  color: 'blue'
+
+inputs:
+  command:
+    description: >
+      Which verification to run.
+      Options: governance-verify, marketplace-verify, policy-evaluate, all
+    required: false
+    default: 'governance-verify'
+  policy-path:
+    description: 'Path to YAML policy file(s) for policy-evaluate command'
+    required: false
+    default: ''
+  manifest-path:
+    description: 'Path to plugin manifest for marketplace-verify command'
+    required: false
+    default: ''
+  context-json:
+    description: 'JSON string of evaluation context for policy-evaluate (e.g. {"tool_name": "web_search"})'
+    required: false
+    default: ''
+  output-format:
+    description: 'Output format: text, json, badge'
+    required: false
+    default: 'text'
+  fail-on-warning:
+    description: 'Fail the check if warnings are found (not just errors)'
+    required: false
+    default: 'false'
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.12'
+  toolkit-version:
+    description: 'Agent Governance Toolkit version to install (default: latest)'
+    required: false
+    default: ''
+
+outputs:
+  status:
+    description: 'Compliance status: pass or fail'
+    value: ${{ steps.run.outputs.status }}
+  controls-passed:
+    description: 'Number of governance controls passed (governance-verify only)'
+    value: ${{ steps.run.outputs.controls_passed }}
+  controls-total:
+    description: 'Total number of governance controls checked (governance-verify only)'
+    value: ${{ steps.run.outputs.controls_total }}
+  violations:
+    description: 'Number of policy violations found (policy-evaluate only)'
+    value: ${{ steps.run.outputs.violations }}
+  output:
+    description: 'Full command output (JSON when output-format is json)'
+    value: ${{ steps.run.outputs.output }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Agent Governance Toolkit
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.toolkit-version }}" ]; then
+          pip install --quiet "agent-governance-toolkit[full]==${{ inputs.toolkit-version }}"
+        else
+          pip install --quiet "agent-governance-toolkit[full]"
+        fi
+
+    - name: Run governance check
+      id: run
+      shell: bash
+      run: |
+        set +e
+        COMMAND="${{ inputs.command }}"
+        FORMAT="${{ inputs.output-format }}"
+        STATUS="pass"
+        EXIT_CODE=0
+        OUTPUT=""
+
+        case "$COMMAND" in
+          governance-verify)
+            echo "🛡️ Running governance verification..."
+            if [ "$FORMAT" = "json" ]; then
+              OUTPUT=$(python -m agent_compliance.cli.main verify --json 2>&1)
+            elif [ "$FORMAT" = "badge" ]; then
+              OUTPUT=$(python -m agent_compliance.cli.main verify --badge 2>&1)
+            else
+              OUTPUT=$(python -m agent_compliance.cli.main verify 2>&1)
+            fi
+            EXIT_CODE=$?
+
+            # Extract controls info from JSON output
+            if [ "$FORMAT" = "json" ]; then
+              PASSED=$(echo "$OUTPUT" | python -c "import sys,json; d=json.load(sys.stdin); print(d.get('controls_passed',0))" 2>/dev/null || echo "0")
+              TOTAL=$(echo "$OUTPUT" | python -c "import sys,json; d=json.load(sys.stdin); print(d.get('controls_total',0))" 2>/dev/null || echo "0")
+              echo "controls_passed=$PASSED" >> "$GITHUB_OUTPUT"
+              echo "controls_total=$TOTAL" >> "$GITHUB_OUTPUT"
+            fi
+            ;;
+
+          marketplace-verify)
+            MANIFEST="${{ inputs.manifest-path }}"
+            if [ -z "$MANIFEST" ]; then
+              echo "::error::manifest-path is required for marketplace-verify command"
+              exit 1
+            fi
+            echo "📦 Verifying plugin manifest: $MANIFEST"
+            OUTPUT=$(python -m agent_marketplace.cli_commands verify "$MANIFEST" 2>&1)
+            EXIT_CODE=$?
+            ;;
+
+          policy-evaluate)
+            POLICY="${{ inputs.policy-path }}"
+            CONTEXT='${{ inputs.context-json }}'
+            if [ -z "$POLICY" ]; then
+              echo "::error::policy-path is required for policy-evaluate command"
+              exit 1
+            fi
+            echo "📋 Evaluating policy: $POLICY"
+            OUTPUT=$(python -c "
+        import json, sys
+        from agent_os.policies import PolicyEvaluator
+
+        evaluator = PolicyEvaluator()
+        evaluator.load_policies('$POLICY')
+
+        context = json.loads('$CONTEXT') if '$CONTEXT' else {}
+        decision = evaluator.evaluate(context)
+
+        result = {
+            'allowed': decision.allowed,
+            'action': decision.action,
+            'reason': decision.reason,
+            'matched_rule': decision.matched_rule,
+        }
+        print(json.dumps(result, indent=2))
+        sys.exit(0 if decision.allowed else 1)
+        " 2>&1)
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -ne 0 ]; then
+              echo "violations=1" >> "$GITHUB_OUTPUT"
+            else
+              echo "violations=0" >> "$GITHUB_OUTPUT"
+            fi
+            ;;
+
+          all)
+            echo "🛡️ Running full governance suite..."
+            RESULTS=""
+            FAIL=0
+
+            # 1. Governance verify
+            echo "--- Governance Verification ---"
+            GV_OUT=$(python -m agent_compliance.cli.main verify --json 2>&1)
+            GV_EXIT=$?
+            echo "$GV_OUT"
+            [ $GV_EXIT -ne 0 ] && FAIL=1
+
+            # 2. Marketplace verify (if manifest provided)
+            MANIFEST="${{ inputs.manifest-path }}"
+            if [ -n "$MANIFEST" ]; then
+              echo "--- Marketplace Verification ---"
+              MV_OUT=$(python -m agent_marketplace.cli_commands verify "$MANIFEST" 2>&1)
+              MV_EXIT=$?
+              echo "$MV_OUT"
+              [ $MV_EXIT -ne 0 ] && FAIL=1
+            fi
+
+            # 3. Policy evaluate (if policy provided)
+            POLICY="${{ inputs.policy-path }}"
+            if [ -n "$POLICY" ]; then
+              echo "--- Policy Evaluation ---"
+              PE_OUT=$(python -c "
+        import json, sys
+        from agent_os.policies import PolicyEvaluator
+        evaluator = PolicyEvaluator()
+        evaluator.load_policies('$POLICY')
+        context = json.loads('${{ inputs.context-json }}') if '${{ inputs.context-json }}' else {}
+        decision = evaluator.evaluate(context)
+        print(json.dumps({'allowed': decision.allowed, 'action': decision.action, 'reason': decision.reason}, indent=2))
+        sys.exit(0 if decision.allowed else 1)
+        " 2>&1)
+              PE_EXIT=$?
+              echo "$PE_OUT"
+              [ $PE_EXIT -ne 0 ] && FAIL=1
+            fi
+
+            EXIT_CODE=$FAIL
+            OUTPUT="Full suite completed. Exit: $EXIT_CODE"
+            ;;
+
+          *)
+            echo "::error::Unknown command: $COMMAND. Use: governance-verify, marketplace-verify, policy-evaluate, or all"
+            exit 1
+            ;;
+        esac
+
+        # Set outputs
+        if [ $EXIT_CODE -ne 0 ]; then
+          STATUS="fail"
+        fi
+        echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+        # Store output (handle multiline)
+        {
+          echo "output<<GOVEOF"
+          echo "$OUTPUT"
+          echo "GOVEOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "$OUTPUT"
+
+        # Determine final exit
+        if [ "$STATUS" = "fail" ]; then
+          echo "::error::Governance check failed"
+          exit 1
+        fi


### PR DESCRIPTION
## Description

Adds a composite GitHub Action at \ction/action.yml\ so teams can add governance as a required CI check with minimal configuration.

### Usage

\\\yaml
- uses: microsoft/agent-governance-toolkit/action@v2
\\\

### Supported commands

| Command | What it does |
|---------|-------------|
| \governance-verify\ | OWASP ASI compliance check via \gent-compliance verify\ |
| \marketplace-verify\ | Plugin manifest validation via \gent-marketplace verify\ |
| \policy-evaluate\ | Policy evaluation against a JSON context |
| \ll\ | Full governance suite (all of the above) |

### Inputs & Outputs

Configurable inputs: policy path, manifest path, context JSON, output format (text/json/badge), toolkit version, Python version.

Structured outputs: status (pass/fail), controls-passed, controls-total, violations, full output.

### Includes

- \ction/action.yml\ — composite action definition
- \ction/README.md\ — usage docs with examples for plugin marketplace PR workflows

Closes #423