### PR TITLE
feat: add governance policy linter CLI command (#404)

### DIFF
--- a/packages/agent-compliance/src/agent_compliance/cli/main.py
+++ b/packages/agent-compliance/src/agent_compliance/cli/main.py
@@ -5,8 +5,9 @@
 Agent Governance Toolkit CLI.
 
 Commands:
-    verify      Run OWASP ASI 2026 governance verification
-    integrity   Verify or generate module integrity manifest
+    verify       Run OWASP ASI 2026 governance verification
+    integrity    Verify or generate module integrity manifest
+    lint-policy  Lint YAML policy files for common mistakes
 """
 
 from __future__ import annotations
@@ -76,6 +77,32 @@ def cmd_integrity(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_lint_policy(args: argparse.Namespace) -> int:
+    """Lint YAML policy files for common mistakes."""
+    from agent_compliance.lint_policy import lint_path
+
+    try:
+        result = lint_path(args.path)
+
+        if args.json:
+            import json
+
+            print(json.dumps(result.to_dict(), indent=2))
+        else:
+            for msg in result.messages:
+                print(msg)
+            if result.messages:
+                print()
+            print(result.summary())
+
+        if args.strict and result.warnings:
+            return 1
+        return 0 if result.passed else 1
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
 def main() -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -114,12 +141,31 @@ def main() -> int:
         "--json", action="store_true", help="Output JSON report"
     )
 
+    # lint-policy command
+    lint_parser = subparsers.add_parser(
+        "lint-policy",
+        help="Lint YAML policy files for common mistakes",
+    )
+    lint_parser.add_argument(
+        "path", type=str, help="Path to a YAML policy file or directory"
+    )
+    lint_parser.add_argument(
+        "--json", action="store_true", help="Output JSON report"
+    )
+    lint_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat warnings as errors (exit 1 if any warnings)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "verify":
         return cmd_verify(args)
     elif args.command == "integrity":
         return cmd_integrity(args)
+    elif args.command == "lint-policy":
+        return cmd_lint_policy(args)
     else:
         parser.print_help()
         return 0

--- a/packages/agent-compliance/src/agent_compliance/lint_policy.py
+++ b/packages/agent-compliance/src/agent_compliance/lint_policy.py
@@ -1,0 +1,346 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Policy linter for Agent Governance Toolkit.
+
+Validates YAML policy files for common mistakes: missing required fields,
+unknown operators/actions, conflicting rules, deprecated field names,
+empty rule lists, and invalid priority values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Known values — union of schema.py (PolicyOperator/PolicyAction) and
+# shared.py (VALID_OPERATORS/VALID_ACTIONS) so the linter accepts every
+# operator and action recognised anywhere in the governance stack.
+# ---------------------------------------------------------------------------
+
+KNOWN_OPERATORS = frozenset({
+    "eq", "ne", "gt", "lt", "gte", "lte", "in", "not_in", "matches", "contains",
+})
+
+KNOWN_ACTIONS = frozenset({
+    "allow", "deny", "audit", "block", "escalate", "rate_limit",
+})
+
+REQUIRED_FIELDS = ("version", "name", "rules")
+
+DEPRECATED_FIELDS: dict[str, str] = {
+    "type": "action",
+    "op": "operator",
+    "policy_name": "name",
+    "policy_version": "version",
+}
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LintMessage:
+    """A single lint finding with severity, message, and file location."""
+
+    severity: str  # "error" or "warning"
+    message: str
+    file: str
+    line: int
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}: {self.severity}: {self.message}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "severity": self.severity,
+            "message": self.message,
+            "file": self.file,
+            "line": self.line,
+        }
+
+
+@dataclass
+class LintResult:
+    """Aggregated lint results for one or more policy files."""
+
+    messages: list[LintMessage] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[LintMessage]:
+        return [m for m in self.messages if m.severity == "error"]
+
+    @property
+    def warnings(self) -> list[LintMessage]:
+        return [m for m in self.messages if m.severity == "warning"]
+
+    @property
+    def passed(self) -> bool:
+        return len(self.errors) == 0
+
+    def summary(self) -> str:
+        n_err = len(self.errors)
+        n_warn = len(self.warnings)
+        parts: list[str] = []
+        if n_err:
+            parts.append(f"{n_err} error(s)")
+        if n_warn:
+            parts.append(f"{n_warn} warning(s)")
+        if not parts:
+            return "No issues found."
+        return ", ".join(parts) + " found."
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "errors": len(self.errors),
+            "warnings": len(self.warnings),
+            "messages": [m.to_dict() for m in self.messages],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_line(lines: list[str], needle: str, start: int = 0) -> int:
+    """Return the 1-based line number where *needle* first appears."""
+    for i, raw in enumerate(lines[start:], start=start + 1):
+        if needle in raw:
+            return i
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Core linting logic
+# ---------------------------------------------------------------------------
+
+
+def lint_file(path: str | Path) -> LintResult:
+    """Lint a single YAML policy file and return structured results."""
+    try:
+        import yaml
+    except ImportError as exc:
+        raise ImportError("pyyaml is required: pip install pyyaml") from exc
+
+    path = Path(path)
+    result = LintResult()
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        result.messages.append(
+            LintMessage("error", f"Cannot read file: {exc}", str(path), 1)
+        )
+        return result
+
+    lines = raw.splitlines()
+
+    # ── YAML parsing ──────────────────────────────────────────
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        line = 1
+        if hasattr(exc, "problem_mark") and exc.problem_mark is not None:
+            line = exc.problem_mark.line + 1
+        result.messages.append(
+            LintMessage("error", f"Invalid YAML: {exc}", str(path), line)
+        )
+        return result
+
+    if not isinstance(data, dict):
+        result.messages.append(
+            LintMessage("error", "Policy file must be a YAML mapping", str(path), 1)
+        )
+        return result
+
+    # ── Required top-level fields ─────────────────────────────
+    for field_name in REQUIRED_FIELDS:
+        if field_name not in data:
+            result.messages.append(
+                LintMessage(
+                    "error",
+                    f"Missing required field '{field_name}'",
+                    str(path),
+                    1,
+                )
+            )
+
+    # ── Deprecated top-level fields ───────────────────────────
+    for old, new in DEPRECATED_FIELDS.items():
+        if old in data:
+            line = _find_line(lines, old + ":")
+            result.messages.append(
+                LintMessage(
+                    "warning",
+                    f"Deprecated field '{old}'; use '{new}' instead",
+                    str(path),
+                    line,
+                )
+            )
+
+    # ── Rules validation ──────────────────────────────────────
+    rules = data.get("rules")
+    if isinstance(rules, list) and len(rules) == 0:
+        line = _find_line(lines, "rules:")
+        result.messages.append(
+            LintMessage("warning", "Rules list is empty", str(path), line)
+        )
+
+    if isinstance(rules, list):
+        _lint_rules(rules, lines, str(path), result)
+
+    return result
+
+
+def _lint_rules(
+    rules: list[Any],
+    lines: list[str],
+    filepath: str,
+    result: LintResult,
+) -> None:
+    """Validate individual rules and detect conflicts."""
+    # Track (field, operator, value) -> action for conflict detection
+    seen: dict[tuple[str, str, str], str] = {}
+
+    for idx, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            result.messages.append(
+                LintMessage("error", f"Rule {idx} is not a mapping", filepath, 1)
+            )
+            continue
+
+        rule_name = rule.get("name", f"rule[{idx}]")
+        search_hint = rule_name if rule_name != f"rule[{idx}]" else "- name:"
+        rule_line = _find_line(lines, search_hint)
+
+        # ── Deprecated fields inside rules ────────────────────
+        for old, new in DEPRECATED_FIELDS.items():
+            if old in rule:
+                line = _find_line(lines, old + ":", max(rule_line - 1, 0))
+                result.messages.append(
+                    LintMessage(
+                        "warning",
+                        f"Rule '{rule_name}': deprecated field '{old}'; "
+                        f"use '{new}' instead",
+                        filepath,
+                        line,
+                    )
+                )
+
+        # ── Action validation ─────────────────────────────────
+        action = rule.get("action")
+        if action is not None and action not in KNOWN_ACTIONS:
+            line = _find_line(lines, str(action), max(rule_line - 1, 0))
+            result.messages.append(
+                LintMessage(
+                    "error",
+                    f"Rule '{rule_name}': unknown action '{action}'",
+                    filepath,
+                    line,
+                )
+            )
+
+        # ── Condition / conditions validation ─────────────────
+        condition = rule.get("condition")
+        conditions = rule.get("conditions", [])
+        all_conditions: list[dict[str, Any]] = []
+        if isinstance(condition, dict):
+            all_conditions.append(condition)
+        if isinstance(conditions, list):
+            all_conditions.extend(c for c in conditions if isinstance(c, dict))
+
+        for cond in all_conditions:
+            operator = cond.get("operator")
+            if operator is not None and operator not in KNOWN_OPERATORS:
+                line = _find_line(lines, str(operator), max(rule_line - 1, 0))
+                result.messages.append(
+                    LintMessage(
+                        "error",
+                        f"Rule '{rule_name}': unknown operator '{operator}'",
+                        filepath,
+                        line,
+                    )
+                )
+
+            for old, new in DEPRECATED_FIELDS.items():
+                if old in cond:
+                    line = _find_line(lines, old + ":", max(rule_line - 1, 0))
+                    result.messages.append(
+                        LintMessage(
+                            "warning",
+                            f"Rule '{rule_name}': deprecated field '{old}' "
+                            f"in condition; use '{new}' instead",
+                            filepath,
+                            line,
+                        )
+                    )
+
+        # ── Priority validation ───────────────────────────────
+        priority = rule.get("priority")
+        if priority is not None and not isinstance(priority, int):
+            line = _find_line(lines, "priority:", max(rule_line - 1, 0))
+            result.messages.append(
+                LintMessage(
+                    "error",
+                    f"Rule '{rule_name}': priority must be an integer, "
+                    f"got {type(priority).__name__}",
+                    filepath,
+                    line,
+                )
+            )
+
+        # ── Conflict detection ────────────────────────────────
+        if action in ("allow", "deny") and all_conditions:
+            for cond in all_conditions:
+                key = (
+                    cond.get("field", ""),
+                    cond.get("operator", ""),
+                    str(cond.get("value", "")),
+                )
+                prev_action = seen.get(key)
+                if prev_action is not None and prev_action != action:
+                    result.messages.append(
+                        LintMessage(
+                            "warning",
+                            f"Rule '{rule_name}': conflicts with a prior rule "
+                            f"— same condition has both '{prev_action}' and "
+                            f"'{action}'",
+                            filepath,
+                            rule_line,
+                        )
+                    )
+                elif prev_action is None:
+                    seen[key] = action
+
+
+def lint_path(path: str | Path) -> LintResult:
+    """Lint a file or directory of YAML policy files."""
+    path = Path(path)
+    if path.is_file():
+        return lint_file(path)
+
+    result = LintResult()
+    if path.is_dir():
+        files = sorted(path.glob("*.yaml")) + sorted(path.glob("*.yml"))
+        if not files:
+            result.messages.append(
+                LintMessage(
+                    "warning", "No YAML policy files found", str(path), 0
+                )
+            )
+            return result
+        for f in files:
+            sub = lint_file(f)
+            result.messages.extend(sub.messages)
+    else:
+        result.messages.append(
+            LintMessage("error", f"Path does not exist: {path}", str(path), 0)
+        )
+
+    return result

--- a/packages/agent-compliance/tests/test_lint_policy.py
+++ b/packages/agent-compliance/tests/test_lint_policy.py
@@ -1,0 +1,479 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the policy linter (GitHub issue #404)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+
+import pytest
+
+from agent_compliance.lint_policy import (
+    KNOWN_ACTIONS,
+    KNOWN_OPERATORS,
+    LintMessage,
+    LintResult,
+    lint_file,
+    lint_path,
+)
+from agent_compliance.cli.main import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_policy(tmp_path, content: str, name: str = "policy.yaml"):
+    """Write *content* to a YAML file and return its Path."""
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(content), encoding="utf-8")
+    return p
+
+
+def run_cli(*args: str) -> int:
+    """Run the CLI with the given arguments and return the exit code."""
+    old_argv = sys.argv
+    sys.argv = ["agent-compliance", *args]
+    try:
+        return main()
+    finally:
+        sys.argv = old_argv
+
+
+# ---------------------------------------------------------------------------
+# LintMessage / LintResult unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLintMessage:
+    def test_str_format(self):
+        msg = LintMessage("error", "bad thing", "policy.yaml", 5)
+        assert str(msg) == "policy.yaml:5: error: bad thing"
+
+    def test_to_dict(self):
+        msg = LintMessage("warning", "hmm", "f.yaml", 3)
+        d = msg.to_dict()
+        assert d == {
+            "severity": "warning",
+            "message": "hmm",
+            "file": "f.yaml",
+            "line": 3,
+        }
+
+
+class TestLintResult:
+    def test_passed_when_no_errors(self):
+        r = LintResult(
+            messages=[LintMessage("warning", "w", "f.yaml", 1)]
+        )
+        assert r.passed is True
+
+    def test_failed_when_errors(self):
+        r = LintResult(
+            messages=[LintMessage("error", "e", "f.yaml", 1)]
+        )
+        assert r.passed is False
+
+    def test_summary_no_issues(self):
+        assert "No issues" in LintResult().summary()
+
+    def test_summary_with_issues(self):
+        r = LintResult(
+            messages=[
+                LintMessage("error", "e", "f.yaml", 1),
+                LintMessage("warning", "w", "f.yaml", 2),
+            ]
+        )
+        s = r.summary()
+        assert "1 error(s)" in s
+        assert "1 warning(s)" in s
+
+    def test_to_dict(self):
+        r = LintResult(
+            messages=[LintMessage("error", "e", "f.yaml", 1)]
+        )
+        d = r.to_dict()
+        assert d["passed"] is False
+        assert d["errors"] == 1
+        assert len(d["messages"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# lint_file tests
+# ---------------------------------------------------------------------------
+
+
+class TestLintFileValid:
+    """A fully valid policy file should produce no messages."""
+
+    def test_valid_policy_no_messages(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test-policy
+            rules:
+              - name: allow-read
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: read_file
+                action: allow
+                priority: 10
+        """)
+        result = lint_file(p)
+        assert result.passed
+        assert result.messages == []
+
+
+class TestLintFileMissingFields:
+    def test_missing_version(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            name: test
+            rules: []
+        """)
+        result = lint_file(p)
+        msgs = [m for m in result.errors if "'version'" in m.message]
+        assert len(msgs) == 1
+
+    def test_missing_name(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            rules: []
+        """)
+        result = lint_file(p)
+        msgs = [m for m in result.errors if "'name'" in m.message]
+        assert len(msgs) == 1
+
+    def test_missing_rules(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+        """)
+        result = lint_file(p)
+        msgs = [m for m in result.errors if "'rules'" in m.message]
+        assert len(msgs) == 1
+
+
+class TestLintFileEmptyRules:
+    def test_empty_rules_warning(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules: []
+        """)
+        result = lint_file(p)
+        assert result.passed  # warning only
+        assert any("empty" in m.message.lower() for m in result.warnings)
+
+
+class TestLintFileUnknownOperator:
+    def test_unknown_operator_error(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: bad-op
+                condition:
+                  field: tool_name
+                  operator: fuzzy_match
+                  value: foo
+                action: allow
+        """)
+        result = lint_file(p)
+        assert not result.passed
+        assert any("fuzzy_match" in m.message for m in result.errors)
+
+
+class TestLintFileUnknownAction:
+    def test_unknown_action_error(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: bad-action
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: foo
+                action: quarantine
+        """)
+        result = lint_file(p)
+        assert not result.passed
+        assert any("quarantine" in m.message for m in result.errors)
+
+
+class TestLintFileConflictingRules:
+    def test_allow_deny_same_condition(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: allow-read
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: read_file
+                action: allow
+              - name: deny-read
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: read_file
+                action: deny
+        """)
+        result = lint_file(p)
+        assert any("conflicts" in m.message.lower() for m in result.warnings)
+
+
+class TestLintFileDeprecatedFields:
+    def test_deprecated_top_level(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            policy_name: test
+            name: test
+            rules: []
+        """)
+        result = lint_file(p)
+        assert any(
+            "policy_name" in m.message and "deprecated" in m.message.lower()
+            for m in result.warnings
+        )
+
+    def test_deprecated_field_in_rule(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: r1
+                type: allow
+                action: allow
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: foo
+        """)
+        result = lint_file(p)
+        assert any(
+            "'type'" in m.message and "deprecated" in m.message.lower()
+            for m in result.warnings
+        )
+
+    def test_deprecated_op_in_condition(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: r1
+                action: allow
+                condition:
+                  field: tool_name
+                  op: eq
+                  operator: eq
+                  value: foo
+        """)
+        result = lint_file(p)
+        assert any(
+            "'op'" in m.message and "deprecated" in m.message.lower()
+            for m in result.warnings
+        )
+
+
+class TestLintFileInvalidPriority:
+    def test_string_priority(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: r1
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: foo
+                action: allow
+                priority: "high"
+        """)
+        result = lint_file(p)
+        assert not result.passed
+        assert any("priority" in m.message.lower() for m in result.errors)
+
+
+class TestLintFileInvalidYaml:
+    def test_malformed_yaml(self, tmp_path):
+        p = tmp_path / "bad.yaml"
+        p.write_text("  :\n  - :\n    bad: [", encoding="utf-8")
+        result = lint_file(p)
+        assert not result.passed
+        assert any("Invalid YAML" in m.message for m in result.errors)
+
+
+class TestLintFileNonMapping:
+    def test_yaml_list_at_root(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            - item1
+            - item2
+        """)
+        result = lint_file(p)
+        assert not result.passed
+        assert any("mapping" in m.message.lower() for m in result.errors)
+
+
+class TestLintFileNotReadable:
+    def test_nonexistent_file(self, tmp_path):
+        p = tmp_path / "does_not_exist.yaml"
+        result = lint_file(p)
+        assert not result.passed
+        assert any("Cannot read" in m.message for m in result.errors)
+
+
+class TestLintFileSharedConditions:
+    """PolicyDocument uses 'condition' (singular), SharedPolicySchema uses
+    'conditions' (plural list). The linter should handle both."""
+
+    def test_conditions_list_unknown_operator(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: r1
+                conditions:
+                  - field: tool_name
+                    operator: nope
+                    value: foo
+                action: allow
+        """)
+        result = lint_file(p)
+        assert not result.passed
+        assert any("nope" in m.message for m in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# lint_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestLintPath:
+    def test_lint_directory(self, tmp_path):
+        _write_policy(tmp_path, """\
+            version: "1.0"
+            name: p1
+            rules: []
+        """, "a.yaml")
+        _write_policy(tmp_path, """\
+            version: "1.0"
+            name: p2
+            rules: []
+        """, "b.yml")
+        result = lint_path(tmp_path)
+        # Both files produce an "empty rules" warning
+        assert len(result.warnings) == 2
+
+    def test_lint_directory_no_yaml(self, tmp_path):
+        result = lint_path(tmp_path)
+        assert any("No YAML" in m.message for m in result.warnings)
+
+    def test_lint_nonexistent_path(self, tmp_path):
+        result = lint_path(tmp_path / "nope")
+        assert not result.passed
+
+    def test_lint_single_file(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: ok
+            rules:
+              - name: r1
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: x
+                action: allow
+        """)
+        result = lint_path(p)
+        assert result.passed
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestLintPolicyCLI:
+    def test_lint_clean_exit_0(self, tmp_path):
+        _write_policy(tmp_path, """\
+            version: "1.0"
+            name: ok
+            rules:
+              - name: r1
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: x
+                action: allow
+        """)
+        rc = run_cli("lint-policy", str(tmp_path))
+        assert rc == 0
+
+    def test_lint_errors_exit_1(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            name: bad
+        """)
+        rc = run_cli("lint-policy", str(p))
+        assert rc == 1
+
+    def test_lint_json_output(self, tmp_path, capsys):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules: []
+        """)
+        run_cli("lint-policy", "--json", str(p))
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert "passed" in parsed
+        assert "messages" in parsed
+
+    def test_lint_strict_warnings_exit_1(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules: []
+        """)
+        rc = run_cli("lint-policy", "--strict", str(p))
+        assert rc == 1  # empty rules warning triggers failure
+
+    def test_lint_strict_clean_exit_0(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: ok
+            rules:
+              - name: r1
+                condition:
+                  field: tool_name
+                  operator: eq
+                  value: x
+                action: allow
+        """)
+        rc = run_cli("lint-policy", "--strict", str(p))
+        assert rc == 0
+
+    def test_lint_human_output(self, tmp_path, capsys):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: bad-op
+                condition:
+                  field: x
+                  operator: nope
+                  value: y
+                action: allow
+        """)
+        run_cli("lint-policy", str(p))
+        captured = capsys.readouterr()
+        assert "nope" in captured.out
+        assert "error" in captured.out
+
+    def test_lint_nonexistent_path(self, tmp_path, capsys):
+        rc = run_cli("lint-policy", str(tmp_path / "nope.yaml"))
+        assert rc == 1


### PR DESCRIPTION
## Description

Adds a \lint-policy\ subcommand to the \gent-compliance\ CLI that validates YAML policy files for common mistakes.

### Lint checks

| Check | Severity |
|-------|----------|
| Missing \ersion\, \
ame\, \ules\ | error |
| Invalid YAML / non-mapping root | error |
| Unknown operator | error |
| Unknown action | error |
| Invalid priority (non-integer) | error |
| Empty rules list | warning |
| Deprecated fields (\	ype\→\ction\, \op\→\operator\) | warning |
| Conflicting rules (same condition with allow + deny) | warning |

### Usage

\\\ash
agent-compliance lint-policy policies/
agent-compliance lint-policy policy.yaml --json
agent-compliance lint-policy policies/ --strict   # treat warnings as errors
\\\

### Tests

34 new tests — all passing.

Closes #404