### PR TITLE
feat: add plugin schema adapters and batch evaluation (#424, #429)

### DIFF
--- a/packages/agent-marketplace/src/agent_marketplace/__init__.py
+++ b/packages/agent-marketplace/src/agent_marketplace/__init__.py
@@ -17,9 +17,19 @@ from agent_marketplace.manifest import (
     save_manifest,
 )
 from agent_marketplace.registry import PluginRegistry
+from agent_marketplace.schema_adapters import (
+    ClaudePluginManifest,
+    CopilotPluginManifest,
+    adapt_to_canonical,
+    detect_manifest_format,
+    extract_capabilities,
+    extract_mcp_servers,
+)
 from agent_marketplace.signing import PluginSigner, verify_signature
 
 __all__ = [
+    "ClaudePluginManifest",
+    "CopilotPluginManifest",
     "MANIFEST_FILENAME",
     "MarketplaceError",
     "PluginInstaller",
@@ -27,6 +37,10 @@ __all__ = [
     "PluginRegistry",
     "PluginSigner",
     "PluginType",
+    "adapt_to_canonical",
+    "detect_manifest_format",
+    "extract_capabilities",
+    "extract_mcp_servers",
     "load_manifest",
     "save_manifest",
     "verify_signature",

--- a/packages/agent-marketplace/src/agent_marketplace/batch.py
+++ b/packages/agent-marketplace/src/agent_marketplace/batch.py
@@ -1,0 +1,430 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Batch Policy Evaluation
+
+Scans a directory of plugin manifests and evaluates each against a
+governance policy, producing a consolidated compliance report.
+
+Usage (programmatic):
+    >>> from agent_marketplace.batch import evaluate_batch, format_report
+    >>> result = evaluate_batch(Path("./plugins"), Path("policy.yaml"))
+    >>> print(format_report(result, "text"))
+
+Integration with CLI (add to cli_commands.py):
+    >>> from agent_marketplace.batch import evaluate_batch_command
+    >>> plugin.add_command(evaluate_batch_command)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+import yaml
+from pydantic import BaseModel, Field
+
+from agent_marketplace.exceptions import MarketplaceError
+from agent_marketplace.manifest import MANIFEST_FILENAME, PluginManifest, load_manifest
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class Violation(BaseModel):
+    """A single policy violation found during evaluation."""
+
+    rule: str = Field(..., description="Rule identifier that was violated")
+    severity: str = Field(..., description="Severity level: high, medium, low")
+    message: str = Field(..., description="Human-readable violation description")
+    remediation: str = Field("", description="Suggested fix for the violation")
+
+
+class PluginResult(BaseModel):
+    """Evaluation result for a single plugin."""
+
+    name: str = Field(..., description="Plugin name")
+    status: str = Field(..., description="compliant or non_compliant")
+    violations: list[Violation] = Field(default_factory=list)
+
+
+class BatchResult(BaseModel):
+    """Consolidated result of batch policy evaluation."""
+
+    total: int = Field(0, description="Total plugins evaluated")
+    compliant: int = Field(0, description="Number of compliant plugins")
+    non_compliant: int = Field(0, description="Number of non-compliant plugins")
+    by_severity: dict[str, int] = Field(
+        default_factory=dict, description="Violation counts by severity"
+    )
+    top_violations: list[str] = Field(
+        default_factory=list, description="Most common violation rules"
+    )
+    plugins: list[PluginResult] = Field(
+        default_factory=list, description="Per-plugin results"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Policy loading and evaluation helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_policy(policy_path: Path) -> dict[str, Any]:
+    """Load policy rules from a YAML file.
+
+    Expected format::
+
+        rules:
+          require_signature: true
+          allowed_types: [integration, agent]
+          min_description_length: 10
+          require_capabilities: true
+          max_dependencies: 10
+    """
+    if not policy_path.exists():
+        raise MarketplaceError(f"Policy file not found: {policy_path}")
+    try:
+        with open(policy_path) as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict) or "rules" not in data:
+            raise MarketplaceError("Policy file must contain a 'rules' key")
+        return data["rules"]
+    except yaml.YAMLError as exc:
+        raise MarketplaceError(f"Invalid policy YAML: {exc}") from exc
+
+
+def _evaluate_manifest(
+    manifest: PluginManifest, rules: dict[str, Any]
+) -> list[Violation]:
+    """Evaluate a single manifest against policy rules."""
+    violations: list[Violation] = []
+
+    if rules.get("require_signature") and not manifest.signature:
+        violations.append(
+            Violation(
+                rule="require_signature",
+                severity="high",
+                message=f"Plugin '{manifest.name}' is not signed",
+                remediation="Sign the plugin with a valid Ed25519 key before publishing",
+            )
+        )
+
+    allowed = rules.get("allowed_types")
+    if allowed and manifest.plugin_type.value not in allowed:
+        violations.append(
+            Violation(
+                rule="allowed_types",
+                severity="high",
+                message=(
+                    f"Plugin type '{manifest.plugin_type.value}' is not allowed "
+                    f"(allowed: {', '.join(allowed)})"
+                ),
+                remediation=f"Change plugin_type to one of: {', '.join(allowed)}",
+            )
+        )
+
+    min_desc = rules.get("min_description_length", 0)
+    if min_desc and len(manifest.description) < min_desc:
+        violations.append(
+            Violation(
+                rule="min_description_length",
+                severity="medium",
+                message=(
+                    f"Description is too short "
+                    f"({len(manifest.description)} chars, minimum {min_desc})"
+                ),
+                remediation=f"Provide a description of at least {min_desc} characters",
+            )
+        )
+
+    if rules.get("require_capabilities") and not manifest.capabilities:
+        violations.append(
+            Violation(
+                rule="require_capabilities",
+                severity="medium",
+                message=f"Plugin '{manifest.name}' declares no capabilities",
+                remediation="Add at least one capability to the manifest",
+            )
+        )
+
+    max_deps = rules.get("max_dependencies")
+    if max_deps is not None and len(manifest.dependencies) > max_deps:
+        violations.append(
+            Violation(
+                rule="max_dependencies",
+                severity="low",
+                message=(
+                    f"Plugin has {len(manifest.dependencies)} dependencies "
+                    f"(max {max_deps})"
+                ),
+                remediation=f"Reduce dependencies to at most {max_deps}",
+            )
+        )
+
+    return violations
+
+
+def _discover_manifests(directory: Path) -> list[Path]:
+    """Find all plugin manifest files in immediate subdirectories."""
+    if not directory.is_dir():
+        raise MarketplaceError(f"Not a directory: {directory}")
+
+    manifests: list[Path] = []
+
+    # Check each immediate subdirectory for a manifest
+    for child in sorted(directory.iterdir()):
+        if child.is_dir():
+            manifest_path = child / MANIFEST_FILENAME
+            if manifest_path.exists():
+                manifests.append(manifest_path)
+
+    # Also check the directory root
+    root_manifest = directory / MANIFEST_FILENAME
+    if root_manifest.exists():
+        manifests.append(root_manifest)
+
+    return manifests
+
+
+# ---------------------------------------------------------------------------
+# Core API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_batch(directory: Path, policy_path: Path) -> BatchResult:
+    """Scan a directory for plugin manifests and evaluate each against a policy.
+
+    Each immediate subdirectory containing an ``agent-plugin.yaml`` is treated
+    as a plugin.  Unparseable manifests are reported as non-compliant with a
+    ``manifest_parse_error`` violation.
+
+    Args:
+        directory: Path to directory containing plugin subdirectories.
+        policy_path: Path to a YAML policy file.
+
+    Returns:
+        Consolidated :class:`BatchResult`.
+
+    Raises:
+        MarketplaceError: If the directory or policy file is invalid.
+    """
+    rules = _load_policy(policy_path)
+    manifest_paths = _discover_manifests(directory)
+
+    plugins: list[PluginResult] = []
+    severity_counts: dict[str, int] = {}
+    violation_counts: dict[str, int] = {}
+
+    for manifest_path in manifest_paths:
+        try:
+            manifest = load_manifest(manifest_path)
+        except MarketplaceError as exc:
+            plugins.append(
+                PluginResult(
+                    name=manifest_path.parent.name,
+                    status="non_compliant",
+                    violations=[
+                        Violation(
+                            rule="manifest_parse_error",
+                            severity="high",
+                            message=str(exc),
+                            remediation=(
+                                "Fix the manifest file so it conforms to "
+                                "the PluginManifest schema"
+                            ),
+                        )
+                    ],
+                )
+            )
+            severity_counts["high"] = severity_counts.get("high", 0) + 1
+            violation_counts["manifest_parse_error"] = (
+                violation_counts.get("manifest_parse_error", 0) + 1
+            )
+            continue
+
+        violations = _evaluate_manifest(manifest, rules)
+        status = "compliant" if not violations else "non_compliant"
+        plugins.append(
+            PluginResult(name=manifest.name, status=status, violations=violations)
+        )
+
+        for v in violations:
+            severity_counts[v.severity] = severity_counts.get(v.severity, 0) + 1
+            violation_counts[v.rule] = violation_counts.get(v.rule, 0) + 1
+
+    total = len(plugins)
+    compliant = sum(1 for p in plugins if p.status == "compliant")
+    non_compliant = total - compliant
+
+    # Top violations sorted by frequency (descending)
+    top_violations = sorted(
+        violation_counts, key=lambda r: violation_counts[r], reverse=True
+    )
+
+    return BatchResult(
+        total=total,
+        compliant=compliant,
+        non_compliant=non_compliant,
+        by_severity=severity_counts,
+        top_violations=top_violations,
+        plugins=plugins,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+
+def format_report(result: BatchResult, fmt: str = "text") -> str:
+    """Format a :class:`BatchResult` as JSON, markdown, or plain text.
+
+    Args:
+        result: The batch evaluation result to format.
+        fmt: Output format — ``"json"``, ``"markdown"``, or ``"text"``.
+
+    Returns:
+        Formatted report string.
+
+    Raises:
+        MarketplaceError: If the format is unknown.
+    """
+    if fmt == "json":
+        return result.model_dump_json(indent=2)
+    elif fmt == "markdown":
+        return _format_markdown(result)
+    elif fmt == "text":
+        return _format_text(result)
+    else:
+        raise MarketplaceError(f"Unknown report format: {fmt}")
+
+
+def _format_markdown(result: BatchResult) -> str:
+    """Format result as a Markdown report."""
+    lines: list[str] = [
+        "# Batch Policy Evaluation Report",
+        "",
+        f"**Total plugins:** {result.total}",
+        f"**Compliant:** {result.compliant}",
+        f"**Non-compliant:** {result.non_compliant}",
+        "",
+    ]
+
+    if result.by_severity:
+        lines.append("## Violations by Severity")
+        lines.append("")
+        for severity, count in sorted(result.by_severity.items()):
+            lines.append(f"- **{severity}**: {count}")
+        lines.append("")
+
+    if result.top_violations:
+        lines.append("## Top Violations")
+        lines.append("")
+        for rule in result.top_violations:
+            lines.append(f"1. `{rule}`")
+        lines.append("")
+
+    lines.append("## Plugin Details")
+    lines.append("")
+    for plugin in result.plugins:
+        icon = "\u2713" if plugin.status == "compliant" else "\u2717"
+        lines.append(f"### {icon} {plugin.name}")
+        lines.append("")
+        lines.append(f"**Status:** {plugin.status}")
+        lines.append("")
+        if plugin.violations:
+            lines.append("| Rule | Severity | Message |")
+            lines.append("|------|----------|---------|")
+            for v in plugin.violations:
+                lines.append(f"| `{v.rule}` | {v.severity} | {v.message} |")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_text(result: BatchResult) -> str:
+    """Format result as plain text."""
+    lines: list[str] = [
+        "Batch Policy Evaluation Report",
+        "=" * 40,
+        (
+            f"Total: {result.total}  "
+            f"Compliant: {result.compliant}  "
+            f"Non-compliant: {result.non_compliant}"
+        ),
+        "",
+    ]
+
+    for plugin in result.plugins:
+        icon = "\u2713" if plugin.status == "compliant" else "\u2717"
+        lines.append(f"  {icon} {plugin.name}: {plugin.status}")
+        for v in plugin.violations:
+            lines.append(f"    [{v.severity}] {v.rule}: {v.message}")
+            if v.remediation:
+                lines.append(f"           Remediation: {v.remediation}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+@click.command("evaluate-batch")
+@click.argument("directory", type=click.Path(exists=True))
+@click.option(
+    "--policy",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to policy YAML file",
+)
+@click.option(
+    "--output",
+    "output_file",
+    default=None,
+    type=click.Path(),
+    help="Write report to file instead of stdout",
+)
+@click.option(
+    "--format",
+    "fmt",
+    default="text",
+    type=click.Choice(["json", "markdown", "text"]),
+    help="Report format",
+)
+def evaluate_batch_command(
+    directory: str, policy: str, output_file: str | None, fmt: str
+) -> None:
+    """Evaluate all plugins in a directory against a governance policy.
+
+    Scans DIRECTORY for plugin subdirectories containing agent-plugin.yaml
+    manifests and evaluates each against the rules in POLICY.
+
+    Exit code 0 if all plugins are compliant, 1 if any violations exist.
+    """
+    try:
+        result = evaluate_batch(Path(directory), Path(policy))
+    except MarketplaceError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    report = format_report(result, fmt)
+
+    if output_file:
+        Path(output_file).write_text(report, encoding="utf-8")
+        click.echo(f"Report written to {output_file}")
+    else:
+        click.echo(report)
+
+    if result.non_compliant > 0:
+        sys.exit(1)

--- a/packages/agent-marketplace/src/agent_marketplace/cli_commands.py
+++ b/packages/agent-marketplace/src/agent_marketplace/cli_commands.py
@@ -31,6 +31,12 @@ from agent_marketplace import (
     PluginType,
     load_manifest,
 )
+from agent_marketplace.schema_adapters import (
+    adapt_to_canonical,
+    detect_manifest_format,
+    extract_capabilities,
+    extract_mcp_servers,
+)
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -125,17 +131,82 @@ def search_plugins(query: str) -> None:
 
 @plugin.command("verify")
 @click.argument("path", type=click.Path(exists=True))
-def verify_plugin(path: str) -> None:
-    """Verify a plugin's signature."""
+@click.option(
+    "--format",
+    "manifest_format",
+    type=click.Choice(["auto", "copilot-plugin", "claude-plugin", "generic"]),
+    default="auto",
+    help="Manifest format (auto-detected by default)",
+)
+def verify_plugin(path: str, manifest_format: str) -> None:
+    """Verify a plugin manifest, with optional format detection for Copilot/Claude plugins."""
+    import json
+
+    import yaml
+
+    plugin_path = Path(path)
+
     try:
-        manifest = load_manifest(Path(path))
-        if not manifest.signature:
-            console.print("[yellow]Plugin has no signature.[/yellow]")
+        # For non-auto generic format or YAML files, use the existing loader
+        if manifest_format == "generic":
+            manifest = load_manifest(plugin_path)
+            _print_verify_result(manifest)
             return
-        console.print(f"[green]✓[/green] Manifest loaded: {manifest.name}@{manifest.version}")
-        console.print("[yellow]Provide a public key to complete verification.[/yellow]")
+
+        # Load raw data for format-aware validation
+        target = plugin_path
+        if target.is_dir():
+            # Try plugin.json first, then fall back to agent-plugin.yaml
+            json_path = target / "plugin.json"
+            yaml_path = target / "agent-plugin.yaml"
+            if json_path.exists():
+                target = json_path
+            elif yaml_path.exists():
+                target = yaml_path
+            else:
+                raise MarketplaceError(f"No manifest found in {target}")
+
+        text = target.read_text(encoding="utf-8")
+        if target.suffix == ".json":
+            data = json.loads(text)
+        else:
+            data = yaml.safe_load(text)
+
+        # Determine format
+        if manifest_format == "auto":
+            fmt = detect_manifest_format(data)
+        elif manifest_format == "copilot-plugin":
+            fmt = "copilot"
+        elif manifest_format == "claude-plugin":
+            fmt = "claude"
+        else:
+            fmt = "generic"
+
+        if fmt == "generic":
+            manifest = load_manifest(plugin_path)
+        else:
+            manifest = adapt_to_canonical(data, fmt)
+
+        console.print(f"[dim]Detected format:[/dim] {fmt}")
+        _print_verify_result(manifest)
+
+        servers = extract_mcp_servers(data)
+        if servers:
+            console.print(f"[dim]MCP servers:[/dim] {', '.join(servers)}")
+
     except MarketplaceError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+
+
+def _print_verify_result(manifest: "PluginManifest") -> None:
+    """Print verification summary for a loaded manifest."""
+    console.print(f"[green]✓[/green] Manifest loaded: {manifest.name}@{manifest.version}")
+    if manifest.capabilities:
+        console.print(f"[dim]Capabilities:[/dim] {', '.join(manifest.capabilities)}")
+    if manifest.signature:
+        console.print("[yellow]Provide a public key to complete verification.[/yellow]")
+    else:
+        console.print("[yellow]Plugin has no signature.[/yellow]")
 
 
 @plugin.command("publish")
@@ -151,3 +222,13 @@ def publish_plugin(path: str) -> None:
         )
     except MarketplaceError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+
+
+# Register batch evaluation command
+try:
+    from agent_marketplace.batch import evaluate_batch_command
+
+    plugin.add_command(evaluate_batch_command)
+except ImportError:
+    pass
+

--- a/packages/agent-marketplace/src/agent_marketplace/schema_adapters.py
+++ b/packages/agent-marketplace/src/agent_marketplace/schema_adapters.py
@@ -1,0 +1,213 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Copilot / Claude Plugin Manifest Schema Adapters
+
+Detects and converts Copilot-style and Claude-style plugin manifests
+(plugin.json with skills, agents, mcps fields) into the canonical
+PluginManifest used by the marketplace validator.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from agent_marketplace.exceptions import MarketplaceError
+from agent_marketplace.manifest import PluginManifest, PluginType
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Sub-models shared by Copilot and Claude manifests
+# ---------------------------------------------------------------------------
+
+
+class SkillDef(BaseModel):
+    """A skill declaration inside a plugin manifest."""
+
+    name: str = Field(..., description="Skill identifier")
+    description: str = Field("", description="Human-readable description")
+
+
+class AgentDef(BaseModel):
+    """An agent declaration inside a plugin manifest."""
+
+    name: str = Field(..., description="Agent identifier")
+    model: str = Field("", description="Model backing this agent")
+    instructions: str = Field("", description="System instructions for the agent")
+
+
+class MCPServerDef(BaseModel):
+    """An MCP server registration inside a plugin manifest."""
+
+    name: str = Field(..., description="Server identifier")
+    url: Optional[str] = Field(None, description="HTTP endpoint for the server")
+    command: Optional[str] = Field(None, description="Local command to launch the server")
+    tools: list[str] = Field(default_factory=list, description="Tools exposed by the server")
+
+    @model_validator(mode="after")
+    def require_url_or_command(self) -> MCPServerDef:
+        if not self.url and not self.command:
+            raise MarketplaceError(
+                f"MCP server '{self.name}' must declare either 'url' or 'command'"
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Copilot plugin manifest
+# ---------------------------------------------------------------------------
+
+
+class CopilotPluginManifest(BaseModel):
+    """Schema for a GitHub Copilot-style plugin manifest (plugin.json)."""
+
+    name: str = Field(..., description="Plugin name")
+    description: str = Field("", description="Plugin description")
+    version: str = Field("1.0.0", description="Semver version string")
+    skills: list[SkillDef] = Field(default_factory=list, description="Skill definitions")
+    agents: list[AgentDef] = Field(default_factory=list, description="Agent definitions")
+    mcps: list[MCPServerDef] = Field(default_factory=list, description="MCP server registrations")
+
+
+# ---------------------------------------------------------------------------
+# Claude plugin manifest
+# ---------------------------------------------------------------------------
+
+
+class ClaudePluginManifest(BaseModel):
+    """Schema for an Anthropic Claude-style plugin manifest (plugin.json)."""
+
+    name: str = Field(..., description="Plugin name")
+    description: str = Field("", description="Plugin description")
+    version: str = Field("1.0.0", description="Semver version string")
+    permissions: list[str] = Field(
+        default_factory=list, description="Permissions requested by the plugin"
+    )
+    allowed_tools: list[str] = Field(
+        default_factory=list, description="Tools the plugin is allowed to invoke"
+    )
+    skills: list[SkillDef] = Field(default_factory=list, description="Skill definitions")
+    agents: list[AgentDef] = Field(default_factory=list, description="Agent definitions")
+    mcps: list[MCPServerDef] = Field(default_factory=list, description="MCP server registrations")
+
+
+# ---------------------------------------------------------------------------
+# Detection and adaptation helpers
+# ---------------------------------------------------------------------------
+
+# Fields that distinguish each format
+_COPILOT_SIGNALS = {"skills", "agents", "mcps"}
+_CLAUDE_SIGNALS = {"permissions", "allowed_tools"}
+
+
+def detect_manifest_format(data: dict) -> str:
+    """Detect whether *data* represents a Copilot, Claude, or generic manifest.
+
+    Returns:
+        ``"copilot"``, ``"claude"``, or ``"generic"``.
+    """
+    keys = set(data.keys())
+    has_claude = bool(keys & _CLAUDE_SIGNALS)
+    has_copilot = bool(keys & _COPILOT_SIGNALS)
+
+    if has_claude:
+        return "claude"
+    if has_copilot:
+        return "copilot"
+    return "generic"
+
+
+def adapt_to_canonical(data: dict, format: str) -> PluginManifest:
+    """Convert a Copilot or Claude manifest dict into a canonical :class:`PluginManifest`.
+
+    For ``"generic"`` format the data is passed straight through.
+
+    Args:
+        data: Raw manifest dictionary.
+        format: One of ``"copilot"``, ``"claude"``, or ``"generic"``.
+
+    Returns:
+        A validated :class:`PluginManifest`.
+
+    Raises:
+        MarketplaceError: On validation failure.
+    """
+    if format == "generic":
+        try:
+            return PluginManifest(**data)
+        except Exception as exc:
+            raise MarketplaceError(f"Invalid generic manifest: {exc}") from exc
+
+    # Validate through the format-specific model first
+    try:
+        if format == "copilot":
+            parsed = CopilotPluginManifest(**data)
+        elif format == "claude":
+            parsed = ClaudePluginManifest(**data)
+        else:
+            raise MarketplaceError(f"Unknown manifest format: {format}")
+    except MarketplaceError:
+        raise
+    except Exception as exc:
+        raise MarketplaceError(f"Invalid {format} manifest: {exc}") from exc
+
+    capabilities = extract_capabilities(data, format)
+
+    return PluginManifest(
+        name=parsed.name,
+        version=parsed.version,
+        description=parsed.description,
+        author=data.get("author", "unknown"),
+        plugin_type=PluginType.AGENT,
+        capabilities=capabilities,
+    )
+
+
+def extract_capabilities(data: dict, format: str) -> list[str]:
+    """Extract declared capabilities from a manifest dict.
+
+    Capabilities are derived from skill names and MCP server tool lists.
+
+    Args:
+        data: Raw manifest dictionary.
+        format: ``"copilot"``, ``"claude"``, or ``"generic"``.
+
+    Returns:
+        Sorted, deduplicated list of capability strings.
+    """
+    if format == "generic":
+        return sorted(set(data.get("capabilities", [])))
+
+    caps: set[str] = set()
+    for skill in data.get("skills", []):
+        if isinstance(skill, dict) and skill.get("name"):
+            caps.add(skill["name"])
+    for mcp in data.get("mcps", []):
+        if isinstance(mcp, dict):
+            for tool in mcp.get("tools", []):
+                caps.add(tool)
+    if format == "claude":
+        for tool in data.get("allowed_tools", []):
+            caps.add(tool)
+    return sorted(caps)
+
+
+def extract_mcp_servers(data: dict) -> list[str]:
+    """Extract MCP server names from any manifest format.
+
+    Args:
+        data: Raw manifest dictionary.
+
+    Returns:
+        List of MCP server name strings.
+    """
+    servers: list[str] = []
+    for mcp in data.get("mcps", []):
+        if isinstance(mcp, dict) and mcp.get("name"):
+            servers.append(mcp["name"])
+    return servers

--- a/packages/agent-marketplace/tests/test_batch.py
+++ b/packages/agent-marketplace/tests/test_batch.py
@@ -1,0 +1,338 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for batch policy evaluation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from agent_marketplace.batch import (
+    BatchResult,
+    PluginResult,
+    Violation,
+    evaluate_batch,
+    evaluate_batch_command,
+    format_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(directory: Path, name: str, **overrides) -> Path:
+    """Create a plugin subdirectory with an agent-plugin.yaml manifest."""
+    plugin_dir = directory / name
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": name,
+        "version": "1.0.0",
+        "description": "A test plugin for evaluation",
+        "author": "test@example.com",
+        "plugin_type": "integration",
+        "capabilities": ["cap-a"],
+        "dependencies": [],
+    }
+    manifest.update(overrides)
+    (plugin_dir / "agent-plugin.yaml").write_text(
+        yaml.dump(manifest), encoding="utf-8"
+    )
+    return plugin_dir
+
+
+def _write_policy(directory: Path, rules: dict) -> Path:
+    """Write a policy YAML file and return its path."""
+    policy_path = directory / "policy.yaml"
+    policy_path.write_text(yaml.dump({"rules": rules}), encoding="utf-8")
+    return policy_path
+
+
+# ---------------------------------------------------------------------------
+# evaluate_batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateBatch:
+    """Tests for the evaluate_batch function."""
+
+    def test_all_compliant(self, tmp_path: Path) -> None:
+        """All plugins pass policy checks."""
+        _write_manifest(tmp_path, "plugin-a", signature="abc123")
+        _write_manifest(tmp_path, "plugin-b", signature="def456")
+        policy = _write_policy(
+            tmp_path, {"require_signature": True, "allowed_types": ["integration"]}
+        )
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.total == 2
+        assert result.compliant == 2
+        assert result.non_compliant == 0
+        assert all(p.status == "compliant" for p in result.plugins)
+
+    def test_mixed_compliance(self, tmp_path: Path) -> None:
+        """Some plugins pass, some fail."""
+        _write_manifest(tmp_path, "good-plugin", signature="abc123")
+        _write_manifest(tmp_path, "unsigned-plugin")  # no signature
+        policy = _write_policy(tmp_path, {"require_signature": True})
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.total == 2
+        assert result.compliant == 1
+        assert result.non_compliant == 1
+        names = {p.name: p.status for p in result.plugins}
+        assert names["good-plugin"] == "compliant"
+        assert names["unsigned-plugin"] == "non_compliant"
+
+    def test_invalid_manifest(self, tmp_path: Path) -> None:
+        """Unparseable manifests are reported as non-compliant."""
+        bad_dir = tmp_path / "bad-plugin"
+        bad_dir.mkdir()
+        # Valid YAML but missing required PluginManifest fields
+        (bad_dir / "agent-plugin.yaml").write_text(
+            "name: bad-plugin\n", encoding="utf-8"
+        )
+        policy = _write_policy(tmp_path, {})
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.total == 1
+        assert result.non_compliant == 1
+        assert result.plugins[0].violations[0].rule == "manifest_parse_error"
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        """No manifests found produces zero-total result."""
+        policy = _write_policy(tmp_path, {})
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.total == 0
+        assert result.compliant == 0
+        assert result.plugins == []
+
+    def test_severity_counts(self, tmp_path: Path) -> None:
+        """by_severity aggregates violation severities correctly."""
+        _write_manifest(tmp_path, "p1", capabilities=[])
+        _write_manifest(tmp_path, "p2", capabilities=[])
+        policy = _write_policy(tmp_path, {"require_capabilities": True})
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.by_severity.get("medium") == 2
+
+    def test_top_violations(self, tmp_path: Path) -> None:
+        """top_violations lists rules ordered by frequency."""
+        _write_manifest(tmp_path, "p1")
+        _write_manifest(tmp_path, "p2")
+        policy = _write_policy(
+            tmp_path, {"require_signature": True, "require_capabilities": True}
+        )
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert "require_signature" in result.top_violations
+
+    def test_allowed_types_violation(self, tmp_path: Path) -> None:
+        """Plugin with a disallowed type fails."""
+        _write_manifest(tmp_path, "agent-p", plugin_type="agent")
+        policy = _write_policy(tmp_path, {"allowed_types": ["integration"]})
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.non_compliant == 1
+        assert result.plugins[0].violations[0].rule == "allowed_types"
+
+    def test_max_dependencies_violation(self, tmp_path: Path) -> None:
+        """Plugin exceeding max dependencies fails."""
+        deps = [f"dep-{i}>=1.0.0" for i in range(5)]
+        _write_manifest(tmp_path, "heavy-plugin", dependencies=deps)
+        policy = _write_policy(tmp_path, {"max_dependencies": 2})
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.non_compliant == 1
+        assert result.plugins[0].violations[0].rule == "max_dependencies"
+
+    def test_min_description_length(self, tmp_path: Path) -> None:
+        """Short descriptions trigger a violation."""
+        _write_manifest(tmp_path, "short-desc", description="Hi")
+        policy = _write_policy(tmp_path, {"min_description_length": 20})
+
+        result = evaluate_batch(tmp_path, policy)
+
+        assert result.non_compliant == 1
+        assert result.plugins[0].violations[0].rule == "min_description_length"
+
+
+# ---------------------------------------------------------------------------
+# format_report tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReport:
+    """Tests for the format_report function."""
+
+    @staticmethod
+    def _sample_result() -> BatchResult:
+        return BatchResult(
+            total=2,
+            compliant=1,
+            non_compliant=1,
+            by_severity={"high": 1},
+            top_violations=["require_signature"],
+            plugins=[
+                PluginResult(name="good", status="compliant", violations=[]),
+                PluginResult(
+                    name="bad",
+                    status="non_compliant",
+                    violations=[
+                        Violation(
+                            rule="require_signature",
+                            severity="high",
+                            message="Not signed",
+                            remediation="Sign it",
+                        )
+                    ],
+                ),
+            ],
+        )
+
+    def test_json_format(self) -> None:
+        """JSON output is valid and contains expected fields."""
+        output = format_report(self._sample_result(), "json")
+        parsed = json.loads(output)
+
+        assert parsed["total"] == 2
+        assert parsed["compliant"] == 1
+        assert len(parsed["plugins"]) == 2
+
+    def test_markdown_format(self) -> None:
+        """Markdown output contains headers, tables, and status icons."""
+        output = format_report(self._sample_result(), "markdown")
+
+        assert "# Batch Policy Evaluation Report" in output
+        assert "\u2713 good" in output
+        assert "\u2717 bad" in output
+        assert "`require_signature`" in output
+
+    def test_text_format(self) -> None:
+        """Text output contains summary and per-plugin details."""
+        output = format_report(self._sample_result(), "text")
+
+        assert "Batch Policy Evaluation Report" in output
+        assert "\u2713 good" in output
+        assert "\u2717 bad" in output
+        assert "require_signature" in output
+
+    def test_unknown_format_raises(self) -> None:
+        """Unknown format raises an error."""
+        with pytest.raises(Exception):
+            format_report(self._sample_result(), "xml")
+
+
+# ---------------------------------------------------------------------------
+# CLI command tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLICommand:
+    """Tests for the evaluate-batch CLI command."""
+
+    def test_exit_code_success(self, tmp_path: Path) -> None:
+        """Exit code 0 when all plugins are compliant."""
+        _write_manifest(tmp_path, "ok-plugin", signature="sig")
+        _write_policy(tmp_path, {"require_signature": True})
+
+        runner = CliRunner()
+        result = runner.invoke(
+            evaluate_batch_command,
+            [str(tmp_path), "--policy", str(tmp_path / "policy.yaml")],
+        )
+
+        assert result.exit_code == 0
+
+    def test_exit_code_failure(self, tmp_path: Path) -> None:
+        """Exit code 1 when violations exist."""
+        _write_manifest(tmp_path, "unsigned-plugin")
+        _write_policy(tmp_path, {"require_signature": True})
+
+        runner = CliRunner()
+        result = runner.invoke(
+            evaluate_batch_command,
+            [str(tmp_path), "--policy", str(tmp_path / "policy.yaml")],
+        )
+
+        assert result.exit_code == 1
+
+    def test_json_output(self, tmp_path: Path) -> None:
+        """--format json produces valid JSON."""
+        _write_manifest(tmp_path, "test-plugin")
+        _write_policy(tmp_path, {})
+
+        runner = CliRunner()
+        result = runner.invoke(
+            evaluate_batch_command,
+            [
+                str(tmp_path),
+                "--policy",
+                str(tmp_path / "policy.yaml"),
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["total"] == 1
+
+    def test_markdown_output(self, tmp_path: Path) -> None:
+        """--format markdown produces a markdown report."""
+        _write_manifest(tmp_path, "test-plugin")
+        _write_policy(tmp_path, {})
+
+        runner = CliRunner()
+        result = runner.invoke(
+            evaluate_batch_command,
+            [
+                str(tmp_path),
+                "--policy",
+                str(tmp_path / "policy.yaml"),
+                "--format",
+                "markdown",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "# Batch Policy Evaluation Report" in result.output
+
+    def test_output_file(self, tmp_path: Path) -> None:
+        """--output writes the report to a file."""
+        _write_manifest(tmp_path, "test-plugin")
+        _write_policy(tmp_path, {})
+        out_file = tmp_path / "report.json"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            evaluate_batch_command,
+            [
+                str(tmp_path),
+                "--policy",
+                str(tmp_path / "policy.yaml"),
+                "--format",
+                "json",
+                "--output",
+                str(out_file),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert out_file.exists()
+        parsed = json.loads(out_file.read_text())
+        assert parsed["total"] == 1

--- a/packages/agent-marketplace/tests/test_schema_adapters.py
+++ b/packages/agent-marketplace/tests/test_schema_adapters.py
@@ -1,0 +1,336 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for Copilot / Claude plugin manifest schema adapters."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_marketplace.exceptions import MarketplaceError
+from agent_marketplace.manifest import PluginManifest, PluginType
+from agent_marketplace.schema_adapters import (
+    AgentDef,
+    ClaudePluginManifest,
+    CopilotPluginManifest,
+    MCPServerDef,
+    SkillDef,
+    adapt_to_canonical,
+    detect_manifest_format,
+    extract_capabilities,
+    extract_mcp_servers,
+)
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def copilot_data() -> dict:
+    """Minimal valid Copilot plugin manifest dict."""
+    return {
+        "name": "my-copilot-plugin",
+        "description": "A Copilot plugin",
+        "version": "1.0.0",
+        "author": "alice@example.com",
+        "skills": [{"name": "code-review", "description": "Review code"}],
+        "agents": [{"name": "reviewer", "model": "gpt-4", "instructions": "Be helpful"}],
+        "mcps": [
+            {
+                "name": "repo-server",
+                "url": "https://mcp.example.com",
+                "tools": ["read_file", "search"],
+            }
+        ],
+    }
+
+
+@pytest.fixture()
+def claude_data() -> dict:
+    """Minimal valid Claude plugin manifest dict."""
+    return {
+        "name": "my-claude-plugin",
+        "description": "A Claude plugin",
+        "version": "2.0.0",
+        "author": "bob@example.com",
+        "permissions": ["file_read", "network"],
+        "allowed_tools": ["bash", "editor"],
+        "skills": [{"name": "summarise", "description": "Summarise text"}],
+        "agents": [],
+        "mcps": [
+            {
+                "name": "local-mcp",
+                "command": "npx mcp-server",
+                "tools": ["run_test"],
+            }
+        ],
+    }
+
+
+@pytest.fixture()
+def generic_data() -> dict:
+    """A plain canonical plugin manifest dict."""
+    return {
+        "name": "plain-plugin",
+        "version": "0.1.0",
+        "description": "Nothing special",
+        "author": "eve@example.com",
+        "plugin_type": "integration",
+    }
+
+
+# ── detect_manifest_format ──────────────────────────────────────────────────
+
+
+class TestDetectManifestFormat:
+    def test_copilot_detected_by_skills(self, copilot_data: dict):
+        assert detect_manifest_format(copilot_data) == "copilot"
+
+    def test_copilot_detected_by_mcps_only(self):
+        data = {"name": "x", "mcps": []}
+        assert detect_manifest_format(data) == "copilot"
+
+    def test_claude_detected_by_permissions(self, claude_data: dict):
+        assert detect_manifest_format(claude_data) == "claude"
+
+    def test_claude_wins_with_allowed_tools(self):
+        data = {"name": "x", "allowed_tools": ["bash"]}
+        assert detect_manifest_format(data) == "claude"
+
+    def test_generic_fallback(self, generic_data: dict):
+        assert detect_manifest_format(generic_data) == "generic"
+
+    def test_claude_takes_precedence_over_copilot(self):
+        """When both Claude and Copilot signals exist, Claude wins."""
+        data = {"name": "x", "skills": [], "permissions": ["net"]}
+        assert detect_manifest_format(data) == "claude"
+
+
+# ── Pydantic models ─────────────────────────────────────────────────────────
+
+
+class TestCopilotPluginManifest:
+    def test_valid_manifest(self, copilot_data: dict):
+        m = CopilotPluginManifest(**copilot_data)
+        assert m.name == "my-copilot-plugin"
+        assert len(m.skills) == 1
+        assert len(m.agents) == 1
+        assert len(m.mcps) == 1
+
+    def test_missing_name_raises(self):
+        with pytest.raises(Exception):
+            CopilotPluginManifest(description="no name")
+
+    def test_defaults(self):
+        m = CopilotPluginManifest(name="minimal")
+        assert m.version == "1.0.0"
+        assert m.skills == []
+        assert m.agents == []
+        assert m.mcps == []
+
+
+class TestClaudePluginManifest:
+    def test_valid_manifest(self, claude_data: dict):
+        m = ClaudePluginManifest(**claude_data)
+        assert m.name == "my-claude-plugin"
+        assert m.permissions == ["file_read", "network"]
+        assert m.allowed_tools == ["bash", "editor"]
+
+    def test_defaults(self):
+        m = ClaudePluginManifest(name="minimal")
+        assert m.permissions == []
+        assert m.allowed_tools == []
+
+
+class TestMCPServerDef:
+    def test_url_server(self):
+        s = MCPServerDef(name="s1", url="https://example.com")
+        assert s.url == "https://example.com"
+
+    def test_command_server(self):
+        s = MCPServerDef(name="s1", command="npx serve")
+        assert s.command == "npx serve"
+
+    def test_neither_url_nor_command_raises(self):
+        with pytest.raises(MarketplaceError, match="must declare either"):
+            MCPServerDef(name="bad")
+
+
+# ── adapt_to_canonical ──────────────────────────────────────────────────────
+
+
+class TestAdaptToCanonical:
+    def test_copilot_to_canonical(self, copilot_data: dict):
+        manifest = adapt_to_canonical(copilot_data, "copilot")
+        assert isinstance(manifest, PluginManifest)
+        assert manifest.name == "my-copilot-plugin"
+        assert manifest.plugin_type == PluginType.AGENT
+        assert manifest.author == "alice@example.com"
+        assert "code-review" in manifest.capabilities
+
+    def test_claude_to_canonical(self, claude_data: dict):
+        manifest = adapt_to_canonical(claude_data, "claude")
+        assert isinstance(manifest, PluginManifest)
+        assert manifest.name == "my-claude-plugin"
+        assert "bash" in manifest.capabilities
+        assert "editor" in manifest.capabilities
+
+    def test_generic_passthrough(self, generic_data: dict):
+        manifest = adapt_to_canonical(generic_data, "generic")
+        assert manifest.name == "plain-plugin"
+        assert manifest.plugin_type == PluginType.INTEGRATION
+
+    def test_unknown_format_raises(self, copilot_data: dict):
+        with pytest.raises(MarketplaceError, match="Unknown manifest format"):
+            adapt_to_canonical(copilot_data, "unknown-fmt")
+
+    def test_invalid_copilot_raises(self):
+        with pytest.raises(MarketplaceError, match="Invalid copilot manifest"):
+            adapt_to_canonical({}, "copilot")
+
+    def test_author_defaults_to_unknown(self):
+        data = {"name": "no-author", "skills": []}
+        manifest = adapt_to_canonical(data, "copilot")
+        assert manifest.author == "unknown"
+
+
+# ── extract_capabilities ────────────────────────────────────────────────────
+
+
+class TestExtractCapabilities:
+    def test_copilot_skills_and_mcp_tools(self, copilot_data: dict):
+        caps = extract_capabilities(copilot_data, "copilot")
+        assert "code-review" in caps
+        assert "read_file" in caps
+        assert "search" in caps
+
+    def test_claude_includes_allowed_tools(self, claude_data: dict):
+        caps = extract_capabilities(claude_data, "claude")
+        assert "bash" in caps
+        assert "editor" in caps
+        assert "summarise" in caps
+
+    def test_generic_returns_capabilities_field(self, generic_data: dict):
+        generic_data["capabilities"] = ["cap-a", "cap-b"]
+        caps = extract_capabilities(generic_data, "generic")
+        assert caps == ["cap-a", "cap-b"]
+
+    def test_deduplication(self):
+        data = {
+            "skills": [{"name": "dup"}, {"name": "dup"}],
+            "mcps": [{"name": "s", "url": "http://x", "tools": ["dup"]}],
+        }
+        caps = extract_capabilities(data, "copilot")
+        assert caps.count("dup") == 1
+
+    def test_sorted_output(self):
+        data = {"skills": [{"name": "z"}, {"name": "a"}], "mcps": []}
+        caps = extract_capabilities(data, "copilot")
+        assert caps == sorted(caps)
+
+
+# ── extract_mcp_servers ─────────────────────────────────────────────────────
+
+
+class TestExtractMCPServers:
+    def test_extracts_server_names(self, copilot_data: dict):
+        assert extract_mcp_servers(copilot_data) == ["repo-server"]
+
+    def test_empty_when_no_mcps(self, generic_data: dict):
+        assert extract_mcp_servers(generic_data) == []
+
+    def test_multiple_servers(self):
+        data = {
+            "mcps": [
+                {"name": "s1", "url": "http://a"},
+                {"name": "s2", "command": "run"},
+            ]
+        }
+        assert extract_mcp_servers(data) == ["s1", "s2"]
+
+
+# ── Top-level import smoke test ─────────────────────────────────────────────
+
+
+def test_schema_adapter_imports():
+    """New public symbols are importable from the top-level package."""
+    from agent_marketplace import (
+        ClaudePluginManifest,
+        CopilotPluginManifest,
+        adapt_to_canonical,
+        detect_manifest_format,
+        extract_capabilities,
+        extract_mcp_servers,
+    )
+
+    assert callable(detect_manifest_format)
+    assert callable(adapt_to_canonical)
+    assert callable(extract_capabilities)
+    assert callable(extract_mcp_servers)
+    assert CopilotPluginManifest is not None
+    assert ClaudePluginManifest is not None
+
+
+# ── CLI verify integration (file-based) ─────────────────────────────────────
+
+
+class TestVerifyCLIIntegration:
+    """Verify the CLI can handle Copilot/Claude plugin.json files."""
+
+    def test_verify_copilot_plugin_json(self, tmp_path: Path, copilot_data: dict):
+        manifest_file = tmp_path / "plugin.json"
+        manifest_file.write_text(json.dumps(copilot_data))
+
+        from click.testing import CliRunner
+
+        from agent_marketplace.cli_commands import plugin
+
+        runner = CliRunner()
+        result = runner.invoke(plugin, ["verify", str(manifest_file)])
+        assert result.exit_code == 0
+        assert "copilot" in result.output
+        assert "my-copilot-plugin" in result.output
+
+    def test_verify_claude_plugin_json(self, tmp_path: Path, claude_data: dict):
+        manifest_file = tmp_path / "plugin.json"
+        manifest_file.write_text(json.dumps(claude_data))
+
+        from click.testing import CliRunner
+
+        from agent_marketplace.cli_commands import plugin
+
+        runner = CliRunner()
+        result = runner.invoke(plugin, ["verify", str(manifest_file)])
+        assert result.exit_code == 0
+        assert "claude" in result.output
+        assert "my-claude-plugin" in result.output
+
+    def test_verify_with_explicit_format(self, tmp_path: Path, copilot_data: dict):
+        manifest_file = tmp_path / "plugin.json"
+        manifest_file.write_text(json.dumps(copilot_data))
+
+        from click.testing import CliRunner
+
+        from agent_marketplace.cli_commands import plugin
+
+        runner = CliRunner()
+        result = runner.invoke(
+            plugin, ["verify", "--format", "copilot-plugin", str(manifest_file)]
+        )
+        assert result.exit_code == 0
+        assert "my-copilot-plugin" in result.output
+
+    def test_verify_dir_with_plugin_json(self, tmp_path: Path, copilot_data: dict):
+        manifest_file = tmp_path / "plugin.json"
+        manifest_file.write_text(json.dumps(copilot_data))
+
+        from click.testing import CliRunner
+
+        from agent_marketplace.cli_commands import plugin
+
+        runner = CliRunner()
+        result = runner.invoke(plugin, ["verify", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "my-copilot-plugin" in result.output


### PR DESCRIPTION
## Description

Two related marketplace features in one PR:

### Schema Adapters (#424)
Adds native support for Copilot and Claude plugin manifest formats.

- \CopilotPluginManifest\ / \ClaudePluginManifest\ Pydantic models (skills, agents, mcps fields)
- \detect_manifest_format()\ — auto-detect copilot/claude/generic
- \dapt_to_canonical()\ — convert any format to canonical \PluginManifest\
- \xtract_mcp_servers()\ — extract MCP server names for security analysis
- \--format\ option on \erify\ CLI command
- **33 tests**

### Batch Evaluation (#429)
Adds bulk scanning of plugin directories against governance policies.

- \valuate_batch(directory, policy_path)\ — scan all plugins, evaluate against policy
- \BatchResult\ / \PluginResult\ / \Violation\ models for structured results
- \ormat_report()\ — JSON, markdown, or text output
- \valuate-batch\ CLI command with \--policy\, \--output\, \--format\ flags
- Exit code 0/1 for CI integration
- **18 tests**

### Total: 55 tests passing

Closes #424, Closes #429