### PR TITLE
docs: add reference integration example for plugin marketplace governance (#427)

### DIFF
--- a/examples/marketplace-governance/.github/workflows/plugin-governance.yml
+++ b/examples/marketplace-governance/.github/workflows/plugin-governance.yml
@@ -1,0 +1,124 @@
+# Plugin Governance CI — validates plugins contributed via pull requests
+#
+# This workflow runs on PRs that modify files under plugins/ and enforces
+# marketplace policies before a plugin can be merged.
+#
+# Three jobs run in sequence:
+#   1. validate-manifest  — schema-checks each changed plugin.json
+#   2. evaluate-policy    — batch-evaluates all plugins against policy
+#   3. governance-verify  — full governance attestation (OWASP controls)
+
+name: Plugin Governance
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/**'
+      - 'policies/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # ------------------------------------------------------------------
+  # Job 1: Validate that each changed plugin has a well-formed manifest
+  # ------------------------------------------------------------------
+  validate-manifest:
+    name: Validate Plugin Manifests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect changed plugins
+        id: changes
+        run: |
+          PLUGINS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+            | grep '^plugins/' \
+            | cut -d'/' -f1-2 \
+            | sort -u)
+          echo "plugins<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$PLUGINS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "Found changed plugin directories:"
+          echo "$PLUGINS"
+
+      - name: Validate each manifest
+        uses: microsoft/agent-governance-toolkit/action@v2
+        with:
+          command: marketplace-verify
+          manifest-path: plugins/
+          output-format: text
+
+  # ------------------------------------------------------------------
+  # Job 2: Evaluate all plugins against marketplace and safety policies
+  # ------------------------------------------------------------------
+  evaluate-policy:
+    name: Evaluate Marketplace Policy
+    runs-on: ubuntu-latest
+    needs: validate-manifest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Option A: Use the GitHub Action (recommended)
+      - name: Run governance action
+        uses: microsoft/agent-governance-toolkit/action@v2
+        with:
+          command: policy-evaluate
+          policy-path: policies/marketplace-policy.yaml
+          output-format: json
+
+      # Option B: Direct CLI usage (alternative)
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install toolkit
+        run: pip install --quiet agent-governance-toolkit[full]
+
+      - name: Batch evaluate plugins
+        run: |
+          python -m agent_marketplace.batch evaluate-batch plugins/ \
+            --policy policies/plugin-safety.yaml \
+            --format markdown \
+            --output governance-report.md
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: governance-report
+          path: governance-report.md
+
+  # ------------------------------------------------------------------
+  # Job 3: Full governance verification (OWASP controls attestation)
+  # ------------------------------------------------------------------
+  governance-verify:
+    name: Governance Verification
+    runs-on: ubuntu-latest
+    needs: evaluate-policy
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run governance verification
+        id: verify
+        uses: microsoft/agent-governance-toolkit/action@v2
+        with:
+          command: governance-verify
+          output-format: json
+          fail-on-warning: 'true'
+
+      - name: Report status
+        if: always()
+        run: |
+          echo "## Governance Status" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Status:** ${{ steps.verify.outputs.status }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Controls passed:** ${{ steps.verify.outputs.controls-passed }} / ${{ steps.verify.outputs.controls-total }}" >> "$GITHUB_STEP_SUMMARY"

--- a/examples/marketplace-governance/README.md
+++ b/examples/marketplace-governance/README.md
@@ -1,0 +1,173 @@
+# Governance for GitHub-Based Plugin Marketplaces
+
+⚠️ **IMPORTANT:** This is a SAMPLE integration example provided as a starting point.
+You MUST review, customize, and extend these configurations for your specific
+use case before deploying to production.
+
+## Overview
+
+This example demonstrates how to integrate the Agent Governance Toolkit into a
+GitHub-based plugin marketplace. Plugins are contributed via pull requests,
+validated automatically in CI, and promoted through environments (dev → staging →
+production) only after passing governance checks.
+
+The pattern enforces:
+
+- **MCP server allowlists** — only approved servers may be referenced by plugins
+- **Plugin type restrictions** — control which plugin categories are accepted
+- **Signature requirements** — require Ed25519 signatures in production
+- **Tool safety rules** — block dangerous tools and enforce token budgets
+- **Batch evaluation** — scan all plugins on every PR for policy drift
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                  Plugin Marketplace (GitHub)                  │
+│                                                              │
+│  contributor ──► Pull Request ──► CI Governance Pipeline      │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │                   PR Workflow                          │  │
+│  │                                                        │  │
+│  │  ┌──────────────┐   ┌───────────────┐   ┌──────────┐  │  │
+│  │  │   Validate   │──►│   Evaluate    │──►│  Verify  │  │  │
+│  │  │   Manifest   │   │    Policy     │   │ Governance│  │  │
+│  │  └──────────────┘   └───────────────┘   └──────────┘  │  │
+│  │        │                    │                  │        │  │
+│  │        ▼                    ▼                  ▼        │  │
+│  │  plugin.json         marketplace-       governance     │  │
+│  │  schema check        policy.yaml        attestation    │  │
+│  │                      plugin-safety.yaml                │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                              │                               │
+│                    ┌─────────┴─────────┐                     │
+│                    ▼                   ▼                      │
+│              ✅ Compliant        ❌ Non-compliant             │
+│              Merge + promote     Block PR                     │
+│              to environment      with annotations             │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Directory Structure
+
+```
+examples/marketplace-governance/
+├── README.md                              # This file
+├── .github/
+│   └── workflows/
+│       └── plugin-governance.yml          # CI workflow for PR validation
+├── policies/
+│   ├── marketplace-policy.yaml            # MCP allowlist and plugin controls
+│   └── plugin-safety.yaml                 # Tool restrictions and token budgets
+└── plugins/
+    ├── example-compliant/
+    │   └── plugin.json                    # Passes all governance checks
+    └── example-non-compliant/
+        └── plugin.json                    # Uses a blocked MCP server
+```
+
+## Step-by-Step Integration Guide
+
+### 1. Add Governance Policies to Your Repo
+
+Copy the policy files from `policies/` into your marketplace repository:
+
+```bash
+cp -r policies/ your-marketplace/policies/
+```
+
+The two policy files serve different purposes:
+
+| File | Purpose |
+|------|---------|
+| `marketplace-policy.yaml` | Controls which MCP servers, plugin types, and signing requirements are enforced |
+| `plugin-safety.yaml` | Agent-level safety rules — tool restrictions, file access auditing, token budgets |
+
+See the inline comments in each file for customization guidance.
+
+### 2. Add the GitHub Action to Your PR Workflow
+
+Copy `.github/workflows/plugin-governance.yml` into your repository. The workflow
+triggers on pull requests that modify files under `plugins/` and runs three jobs:
+
+1. **validate-manifest** — Checks that each changed plugin has a valid `plugin.json`
+2. **evaluate-policy** — Evaluates all plugins against `marketplace-policy.yaml`
+3. **governance-verify** — Runs the full governance attestation suite
+
+```yaml
+- uses: microsoft/agent-governance-toolkit/action@v2
+  with:
+    command: marketplace-verify
+    manifest-path: plugins/my-plugin/plugin.json
+```
+
+### 3. Configure Marketplace Policy
+
+Edit `policies/marketplace-policy.yaml` to match your marketplace:
+
+- **MCP server allowlist** — Add the MCP servers your marketplace trusts
+  (e.g., `code-search`, `ms-learn`, `playwright`). Any plugin referencing an
+  unlisted server will be rejected.
+- **Plugin types** — Restrict to the types you accept (`integration`, `agent`,
+  `policy_template`, `validator`).
+- **Signature requirements** — Set `require_signature: true` for production to
+  enforce Ed25519 plugin signing.
+
+### 4. Configure Plugin Safety Policy
+
+Edit `policies/plugin-safety.yaml` to define agent-level safety rules:
+
+- **Tool restrictions** — Block dangerous tools like `shell_exec`, `eval`, and
+  `file_delete` to prevent destructive actions.
+- **Audit rules** — Log sensitive operations (e.g., file access) without
+  blocking them.
+- **Token budgets** — Cap the maximum tokens per tool call to prevent runaway
+  costs.
+
+### 5. Add Pre-Commit Hooks for Local Feedback
+
+Give plugin contributors fast local feedback before they push:
+
+```bash
+# Install the toolkit
+pip install agent-governance-toolkit[full]
+
+# Validate a single manifest
+python -m agent_marketplace.cli_commands verify plugins/my-plugin/plugin.json
+
+# Batch-evaluate all plugins against policy
+python -m agent_marketplace.batch evaluate-batch plugins/ \
+  --policy policies/marketplace-policy.yaml \
+  --format text
+```
+
+You can wire this into a Git pre-commit hook or use [pre-commit](https://pre-commit.com/).
+
+## Customization Points
+
+| What | Where | Notes |
+|------|-------|-------|
+| Allowed MCP servers | `policies/marketplace-policy.yaml` → `mcp_servers.allowed` | Add/remove servers as your trust boundary changes |
+| Blocked MCP servers | `policies/marketplace-policy.yaml` → `mcp_servers.blocked` | Use blocklist mode for open marketplaces |
+| Plugin type restrictions | `policies/marketplace-policy.yaml` → `allowed_plugin_types` | Remove to allow all types |
+| Signature enforcement | `policies/marketplace-policy.yaml` → `require_signature` | `false` for dev, `true` for production |
+| Dangerous tool rules | `policies/plugin-safety.yaml` → `rules[]` | Add rules matching your security posture |
+| Token budgets | `policies/plugin-safety.yaml` → `rules[]` | Adjust `max_tokens` per your cost tolerance |
+| CI trigger paths | `.github/workflows/plugin-governance.yml` → `paths` | Narrow or widen the trigger scope |
+| Toolkit version | Action input `toolkit-version` | Pin to a specific version for reproducibility |
+| Output format | Action input `output-format` | `json` for machine-readable, `text` for human-readable |
+
+## Related Tutorials
+
+- [Tutorial 07 — MCP Security Gateway](../../docs/tutorials/07-mcp-security-gateway.md):
+  Deep dive into MCP server allowlisting and tool-poisoning detection
+- [Tutorial 10 — Plugin Marketplace](../../docs/tutorials/10-plugin-marketplace.md):
+  End-to-end plugin lifecycle — discovery, installation, verification, and signing
+- [Tutorial 18 — Compliance Verification](../../docs/tutorials/18-compliance-verification.md):
+  Governance attestation and compliance evidence generation
+
+## Related
+
+- [Policies](../policies/) — Additional sample governance policies
+- [Quickstart](../quickstart/) — One-file governed agents for popular frameworks

--- a/examples/marketplace-governance/plugins/example-compliant/plugin.json
+++ b/examples/marketplace-governance/plugins/example-compliant/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "code-review-assistant",
+  "description": "An agent plugin that performs automated code reviews using approved MCP servers for code search and documentation lookup.",
+  "version": "1.0.0",
+  "author": "marketplace-contrib",
+  "skills": [
+    {
+      "name": "review-pull-request",
+      "description": "Analyzes pull request diffs for common issues"
+    },
+    {
+      "name": "suggest-improvements",
+      "description": "Suggests code quality improvements based on best practices"
+    }
+  ],
+  "agents": [
+    {
+      "name": "reviewer",
+      "model": "gpt-4o",
+      "instructions": "You are a code review assistant. Analyze diffs and suggest improvements."
+    }
+  ],
+  "mcps": [
+    {
+      "name": "code-search",
+      "url": "https://mcp.github.dev/code-search",
+      "tools": ["search_code", "get_file_contents"]
+    },
+    {
+      "name": "ms-learn",
+      "url": "https://mcp.microsoft.com/ms-learn",
+      "tools": ["search_docs", "get_article"]
+    }
+  ]
+}

--- a/examples/marketplace-governance/plugins/example-non-compliant/plugin.json
+++ b/examples/marketplace-governance/plugins/example-non-compliant/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "risky-automation-tool",
+  "description": "An agent plugin that automates tasks using unrestricted shell access and filesystem writes.",
+  "version": "0.9.0",
+  "author": "unknown-contributor",
+  "skills": [
+    {
+      "name": "run-script",
+      "description": "Executes arbitrary shell scripts on the host"
+    }
+  ],
+  "agents": [
+    {
+      "name": "automator",
+      "model": "gpt-4o",
+      "instructions": "You are an automation agent. Execute scripts as requested."
+    }
+  ],
+  "mcps": [
+    {
+      "name": "shell-exec",
+      "command": "/bin/bash",
+      "tools": ["shell_exec", "os_system", "subprocess_run"]
+    },
+    {
+      "name": "filesystem-write",
+      "command": "fs-server --mode=write",
+      "tools": ["file_write_root", "file_delete", "rmtree"]
+    }
+  ]
+}

--- a/examples/marketplace-governance/policies/marketplace-policy.yaml
+++ b/examples/marketplace-governance/policies/marketplace-policy.yaml
@@ -1,0 +1,59 @@
+# Marketplace Policy — Sample Configuration
+#
+# ⚠️  IMPORTANT: This is a SAMPLE configuration provided as a starting point.
+# You MUST review, customize, and extend these rules for your specific
+# use case before deploying to production. Microsoft does not guarantee
+# that these rules are comprehensive or sufficient for your security
+# requirements.
+#
+# Schema: MarketplacePolicy (agent_marketplace.marketplace_policy)
+# Docs:   docs/tutorials/10-plugin-marketplace.md
+
+# ---------------------------------------------------------------------------
+# MCP Server Controls
+# ---------------------------------------------------------------------------
+# Defines which MCP servers plugins are allowed to reference.
+# Plugins declaring an MCP server not on this list will be rejected.
+
+mcp_servers:
+  mode: allowlist
+
+  allowed:
+    # Safe defaults — read-only or sandboxed servers
+    - code-search          # GitHub code search (read-only)
+    - ms-learn             # Microsoft Learn documentation (read-only)
+    - playwright           # Browser automation (sandboxed)
+    - web-fetch            # HTTP GET requests (read-only)
+    - azure-devops-search  # Azure DevOps work item search (read-only)
+
+  blocked:
+    # Dangerous servers — always blocked regardless of mode
+    - shell-exec           # Arbitrary shell command execution
+    - filesystem-write     # Unrestricted filesystem write access
+    - raw-network          # Unrestricted outbound network access
+    - eval-server          # Dynamic code evaluation
+
+  # Plugins must explicitly declare every MCP server they use.
+  # Un-declared servers will cause a policy violation.
+  require_declaration: true
+
+# ---------------------------------------------------------------------------
+# Plugin Type Restrictions
+# ---------------------------------------------------------------------------
+# Only accept these plugin types in the marketplace.
+# Valid types: policy_template, integration, agent, validator
+
+allowed_plugin_types:
+  - integration
+  - agent
+  - policy_template
+
+# ---------------------------------------------------------------------------
+# Signature Requirements
+# ---------------------------------------------------------------------------
+# For development/testing, signatures are not required.
+# Set to true in production to enforce Ed25519 plugin signing.
+#
+# require_signature: true    # ← enable for production
+
+require_signature: false

--- a/examples/marketplace-governance/policies/plugin-safety.yaml
+++ b/examples/marketplace-governance/policies/plugin-safety.yaml
@@ -1,0 +1,77 @@
+# Plugin Safety — Sample Configuration
+#
+# ⚠️  IMPORTANT: This is a SAMPLE configuration provided as a starting point.
+# You MUST review, customize, and extend these rules for your specific
+# use case before deploying to production. Microsoft does not guarantee
+# that these rules are comprehensive or sufficient for your security
+# requirements.
+#
+# Agent-OS policy format for tool-level safety enforcement.
+# Used by: agent_marketplace.batch.evaluate_batch
+# Docs:    docs/tutorials/07-mcp-security-gateway.md
+
+version: "1.0"
+name: plugin-safety
+description: >
+  Sample plugin safety policy — defines tool restrictions, audit rules,
+  and token budgets for marketplace plugins. Evaluated during batch
+  policy checks in CI and at plugin installation time.
+
+disclaimer: >
+  This is a sample configuration. It is NOT exhaustive and should be
+  customized for your specific security requirements.
+
+rules:
+  # -------------------------------------------------------------------
+  # Block dangerous tools
+  # -------------------------------------------------------------------
+  # These tools are unconditionally denied for all marketplace plugins.
+
+  - name: block-shell-execution
+    pattern: '\b(shell_exec|os_system|subprocess_run|exec|eval)\b'
+    message: "Dangerous tool blocked — shell execution or eval is not permitted"
+    severity: critical
+    suggestion: "Use a sandboxed MCP server instead of direct shell access"
+
+  - name: block-file-destructive
+    pattern: '\b(file_delete|file_write_root|rmtree|rm_rf)\b'
+    message: "Destructive file operation blocked"
+    severity: critical
+    suggestion: "Use scoped file access through an approved MCP server"
+
+  - name: block-network-unrestricted
+    pattern: '\b(raw_socket|tcp_connect|udp_send)\b'
+    message: "Unrestricted network access blocked"
+    severity: high
+    suggestion: "Use the web-fetch MCP server for outbound HTTP requests"
+
+  # -------------------------------------------------------------------
+  # Audit sensitive operations
+  # -------------------------------------------------------------------
+  # These actions are allowed but logged for compliance review.
+
+  - name: audit-file-read
+    pattern: '\b(file_read|read_file|get_file_contents)\b'
+    message: "File read operation — logged for audit"
+    severity: low
+    suggestion: "Ensure file paths are scoped to the plugin workspace"
+
+  - name: audit-external-api
+    pattern: '\b(http_post|api_call|webhook_send)\b'
+    message: "External API call — logged for audit"
+    severity: medium
+    suggestion: "Verify the endpoint is on the approved external services list"
+
+  # -------------------------------------------------------------------
+  # Token budget enforcement
+  # -------------------------------------------------------------------
+  # Caps the maximum tokens per tool invocation to prevent runaway costs.
+
+  require_capabilities: true
+  min_description_length: 10
+  max_dependencies: 10
+
+  # Additional runtime constraints (enforced by Agent OS policy engine)
+  # max_tokens_per_call: 4096
+  # max_calls_per_minute: 60
+  # require_human_approval_above: 8192


### PR DESCRIPTION
## Description

Complete reference example showing how to integrate governance into a GitHub-based plugin marketplace.

### Contents

\\\
examples/marketplace-governance/
├── README.md                              # Integration guide with architecture diagram
├── .github/workflows/plugin-governance.yml # 3-job CI workflow
├── policies/
│   ├── marketplace-policy.yaml            # MCP server allowlist/blocklist
│   └── plugin-safety.yaml                 # Tool restrictions & token limits
└── plugins/
    ├── example-compliant/plugin.json      # Passes all checks
    └── example-non-compliant/plugin.json  # Uses blocked MCP servers
\\\

### Highlights
- Uses \microsoft/agent-governance-toolkit/action@v2\ (from #423)
- References marketplace policies from #425
- Shows pre-commit hooks from #428
- Links to tutorials 07, 10, 18

Closes #427