### PR TITLE
fix: correct license reference in AgentMesh README from Apache 2.0 to MIT

### DIFF
--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -649,7 +649,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-Apache 2.0 — See [LICENSE](LICENSE) for details.
+MIT — See [LICENSE](LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
The AgentMesh README footer said 'Apache 2.0' but the LICENSE file and pyproject.toml both specify MIT. This caused incorrect metadata on PyPI for the agentmesh-platform package.

One-line fix: \Apache 2.0\ → \MIT\ in packages/agent-mesh/README.md line 652.