### PR TITLE
fix: rename PyPI package agent-runtime → agentmesh-runtime (name collision with AutoGen)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,10 @@ NEVER merge a PR without thorough code review. CI passing is NOT sufficient.
 Before approving or merging ANY PR, verify ALL of the following:
 
 1. **Read the actual diff** — don't rely on PR description alone
-2. **Dependency confusion scan** — check every `pip install`, `npm install` command in docs/code for unregistered package names. The registered names are: `agent-os-kernel`, `agentmesh-platform`, `agent-hypervisor`, `agent-runtime`, `agent-sre`, `agent-governance-toolkit`, `agent-lightning`, `agentmesh-marketplace`
+2. **Dependency confusion scan** — check every `pip install`, `npm install` command in docs/code for unregistered package names. The registered names are: `agent-os-kernel`, `agentmesh-platform`, `agent-hypervisor`, `agentmesh-runtime`, `agent-sre`, `agent-governance-toolkit`, `agent-lightning`, `agentmesh-marketplace`
+=======
+2. **Dependency confusion scan** — check every `pip install`, `npm install` command in docs/code for unregistered package names. The registered names are: `agent-os-kernel`, `agentmesh-platform`, `agent-hypervisor`, `agentmesh-runtime`, `agent-sre`, `agent-governance-toolkit`, `agent-lightning`, `agentmesh-marketplace`
+>>>>>>> bfb3bcb (fix: rename PyPI package agentmesh-runtime to agentmesh-runtime to resolve name collision)
 3. **New Python modules** — verify `__init__.py` exists in any new package directory
 4. **Dependencies declared** — any new `import` must have the package in `pyproject.toml` dependencies (not just transitive)
 5. **No hardcoded secrets** — no API keys, tokens, passwords, connection strings in code or docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ This is a mono-repo with seven packages:
 |---------|-----------|-------------|
 | `agent-os-kernel` | `packages/agent-os/` | Kernel architecture for policy enforcement |
 | `agentmesh` | `packages/agent-mesh/` | Inter-agent trust and identity mesh |
-| `agent-runtime` | `packages/agent-runtime/` | Runtime sandboxing and capability isolation |
+| `agentmesh-runtime` | `packages/agent-runtime/` | Runtime sandboxing and capability isolation |
 | `agent-sre` | `packages/agent-sre/` | Observability, alerting, and reliability |
 | `agent-governance` | `packages/agent-compliance/` | Unified installer and runtime policy enforcement |
 | `agentmesh-marketplace` | `packages/agent-marketplace/` | Plugin lifecycle management for governed agent ecosystems |

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -18,7 +18,7 @@ Agent Governance Toolkit to public registries.
 | Agent OS Kernel | `agent-os-kernel` | `packages/agent-os` |
 | AgentMesh Platform | `agentmesh-platform` | `packages/agent-mesh` |
 | Agent Hypervisor | `agent-hypervisor` | `packages/agent-hypervisor` |
-| Agent Runtime | `agent-runtime` | `packages/agent-runtime` |
+| Agent Runtime | `agentmesh-runtime` | `packages/agent-runtime` |
 | Agent SRE | `agent-sre` | `packages/agent-sre` |
 | Agent Governance Toolkit | `agent-governance-toolkit` | `packages/agent-compliance` |
 | Agent Lightning | `agent-lightning` | `packages/agent-lightning` |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -34,8 +34,12 @@ pip install agent-os-kernel        # Policy enforcement + framework integrations
 pip install agentmesh-platform     # Zero-trust identity + trust cards
 pip install agent-governance-toolkit    # OWASP ASI verification + integrity CLI
 pip install agent-sre              # SLOs, error budgets, chaos testing
-pip install agent-runtime          # Execution supervisor + privilege rings
+pip install agentmesh-runtime          # Execution supervisor + privilege rings
 pip install agentmesh-marketplace    # Plugin lifecycle management
+=======
+pip install agentmesh-runtime       # Execution supervisor + privilege rings
+pip install agentmesh-marketplace      # Plugin lifecycle management
+>>>>>>> bfb3bcb (fix: rename PyPI package agentmesh-runtime to agentmesh-runtime to resolve name collision)
 pip install agent-lightning        # RL training governance
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dotnet add package Microsoft.AgentGovernance
 ```bash
 pip install agent-os-kernel        # Policy engine
 pip install agentmesh-platform     # Trust mesh
-pip install agent-runtime          # Runtime supervisor
+pip install agentmesh-runtime       # Runtime supervisor
 pip install agent-sre              # SRE toolkit
 pip install agent-governance-toolkit    # Compliance & attestation
 pip install agentmesh-marketplace      # Plugin marketplace
@@ -232,7 +232,7 @@ Three evaluation modes per backend: **embedded engine** (cedarpy/opa CLI), **rem
 |---------|------|-------------|
 | **Agent OS** | [`agent-os-kernel`](https://pypi.org/project/agent-os-kernel/) | Policy engine — deterministic action evaluation, capability model, audit logging, action interception, MCP gateway |
 | **AgentMesh** | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | Inter-agent trust — Ed25519 identity, SPIFFE/SVID credentials, trust scoring, A2A/MCP/IATP protocol bridges |
-| **Agent Runtime** | [`agent-runtime`](packages/agent-runtime/) | Execution supervisor — 4-tier privilege rings, saga orchestration, termination control, joint liability, append-only audit log |
+| **Agent Runtime** | [`agentmesh-runtime`](packages/agent-runtime/) | Execution supervisor — 4-tier privilege rings, saga orchestration, termination control, joint liability, append-only audit log |
 | **Agent SRE** | [`agent-sre`](https://pypi.org/project/agent-sre/) | Reliability engineering — SLOs, error budgets, replay debugging, chaos engineering, progressive delivery |
 | **Agent Compliance** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | Runtime policy enforcement — OWASP ASI 2026 controls, governance attestation, integrity verification |
 | **Agent Marketplace** | [`agentmesh-marketplace`](packages/agent-marketplace/) | Plugin lifecycle — discover, install, verify, and sign plugins |

--- a/docs/OWASP-COMPLIANCE.md
+++ b/docs/OWASP-COMPLIANCE.md
@@ -250,7 +250,7 @@ This single command installs the complete governance stack:
 |-------|---------|-------------------|
 | **Kernel** | `agent-os-kernel` | ASI-01, ASI-02, ASI-06, ASI-09 |
 | **Trust Mesh** | `agentmesh-platform` | ASI-03, ASI-04, ASI-07, ASI-10 |
-| **Runtime** | `agent-runtime` | ASI-05, ASI-10 |
+| **Runtime** | `agentmesh-runtime` | ASI-05, ASI-10 |
 | **SRE** | `agent-sre` | ASI-08 |
 
 ---

--- a/docs/proposals/LFAI-PROPOSAL.md
+++ b/docs/proposals/LFAI-PROPOSAL.md
@@ -17,7 +17,7 @@ The ecosystem consists of 5 interoperating packages:
 |---------|---------|------|
 | **Agent OS** | Core governance kernel (policy engine, capability sandbox, VFS) | [agent-os](https://pypi.org/project/agent-os/) |
 | **Agent Mesh** | Inter-agent trust layer (DID identity, IATP protocol) | [agent-mesh](https://pypi.org/project/agent-mesh/) |
-| **Agent Runtime** | Execution isolation (ring model, kill switch) | [agent-runtime](https://pypi.org/project/agent-runtime/) |
+| **Agent Runtime** | Execution isolation (ring model, kill switch) | [agentmesh-runtime](https://pypi.org/project/agentmesh-runtime/) |
 | **Agent SRE** | Observability & reliability (circuit breakers, anomaly detection) | [agent-sre](https://pypi.org/project/agent-sre/) |
 | **Agent Governance** | Meta-framework & compliance mapping | [agent-governance](https://pypi.org/project/agent-governance/) |
 

--- a/docs/tutorials/06-execution-sandboxing.md
+++ b/docs/tutorials/06-execution-sandboxing.md
@@ -29,7 +29,7 @@ Without sandboxing, a misbehaving agent can:
 - **Consume resources** — spin up infinite loops that exhaust CPU and memory.
 - **Cascade failures** — a failed step in a multi-agent workflow leaves the system in a broken half-finished state.
 
-The **Agent Runtime** (`pip install agent-runtime`) solves this with four
+The **Agent Runtime** (`pip install agentmesh-runtime`) solves this with four
 layers of defense:
 
 ```
@@ -54,7 +54,7 @@ layers of defense:
 ### Prerequisites
 
 - Python ≥ 3.11
-- `pip install agent-runtime` (v2.0.2+)
+- `pip install agentmesh-runtime` (v2.0.2+)
 - For capability guards: `pip install agent-os-kernel`
 
 ---
@@ -791,7 +791,7 @@ The runtime includes a FastAPI server for HTTP-based enforcement:
 
 ```bash
 # Install with API extras
-pip install "agent-runtime[api]"
+pip install "agentmesh-runtime[api]"
 
 # Start the server
 hypervisor serve --host 0.0.0.0 --port 8000
@@ -804,7 +804,7 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN pip install "agent-runtime[full,api]"
+RUN pip install "agentmesh-runtime[full,api]"
 
 EXPOSE 8000
 

--- a/docs/tutorials/11-saga-orchestration.md
+++ b/docs/tutorials/11-saga-orchestration.md
@@ -60,7 +60,7 @@ If Step 3 fails:
 ## 2. Installation
 
 ```bash
-pip install agent-runtime
+pip install agentmesh-runtime
 ```
 
 Import from either package:
@@ -82,7 +82,7 @@ from hypervisor.saga.checkpoint import CheckpointManager, SemanticCheckpoint
 from hypervisor.saga.schema import SagaSchemaValidator, SagaSchemaError
 ```
 
-**Requirements:** Python ≥ 3.11, `agent-runtime` v2.0.2+
+**Requirements:** Python ≥ 3.11, `agentmesh-runtime` v2.0.2+
 
 ---
 

--- a/docs/tutorials/12-liability-and-attribution.md
+++ b/docs/tutorials/12-liability-and-attribution.md
@@ -64,7 +64,7 @@ Agent Governance Toolkit solves this with six composable components:
 ### Prerequisites
 
 - Python ≥ 3.11
-- `pip install agent-runtime` (v2.0.2+)
+- `pip install agentmesh-runtime` (v2.0.2+)
 
 ---
 
@@ -89,7 +89,7 @@ Install the runtime package which re-exports all liability classes from the
 hypervisor:
 
 ```bash
-pip install agent-runtime
+pip install agentmesh-runtime
 ```
 
 Verify the installation:

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -33,10 +33,10 @@ guides.
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
 | 05 | [Agent Reliability (SRE)](05-agent-reliability.md) | SLOs, error budgets, circuit breakers, chaos testing | `agent-sre` |
-| 06 | [Execution Sandboxing](06-execution-sandboxing.md) | 4-tier privilege rings, resource limits, termination control | `agent-runtime` |
-| 11 | [Saga Orchestration](11-saga-orchestration.md) | Multi-step transactions, DSL, fan-out, compensating actions | `agent-runtime` |
-| 12 | [Liability & Attribution](12-liability-and-attribution.md) | Vouching, slashing, causal attribution, quarantine | `agent-runtime` |
-| 14 | [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) | Emergency termination, rate limiting, ring elevation | `agent-runtime` |
+| 06 | [Execution Sandboxing](06-execution-sandboxing.md) | 4-tier privilege rings, resource limits, termination control | `agentmesh-runtime` |
+| 11 | [Saga Orchestration](11-saga-orchestration.md) | Multi-step transactions, DSL, fan-out, compensating actions | `agentmesh-runtime` |
+| 12 | [Liability & Attribution](12-liability-and-attribution.md) | Vouching, slashing, causal attribution, quarantine | `agentmesh-runtime` |
+| 14 | [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) | Emergency termination, rate limiting, ring elevation | `agentmesh-runtime` |
 
 ## Trust & Networking
 
@@ -50,7 +50,11 @@ guides.
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
 | 10 | [Plugin Marketplace](10-plugin-marketplace.md) | Plugin signing, verification, CLI, supply-chain security | `agentmesh-marketplace` |
-| 13 | [Observability & Tracing](13-observability-and-tracing.md) | Causal traces, event bus, Prometheus, OpenTelemetry | `agent-runtime` |
+| 13 | [Observability & Tracing](13-observability-and-tracing.md) | Causal traces, event bus, Prometheus, OpenTelemetry | `agentmesh-runtime` |
+=======
+| 10 | [Plugin Marketplace](10-plugin-marketplace.md) | Plugin signing, verification, CLI, supply-chain security | `agentmesh-marketplace` |
+| 13 | [Observability & Tracing](13-observability-and-tracing.md) | Causal traces, event bus, Prometheus, OpenTelemetry | `agentmesh-runtime` |
+>>>>>>> bfb3bcb (fix: rename PyPI package agentmesh-runtime to agentmesh-runtime to resolve name collision)
 | 15 | [RL Training Governance](15-rl-training-governance.md) | GovernedRunner, PolicyReward, Gym-compatible environments | `agent-lightning` |
 | 18 | [Compliance Verification](18-compliance-verification.md) | Governance grading, regulatory frameworks, attestation | `agent-governance-toolkit` |
 

--- a/packages/agent-compliance/README.md
+++ b/packages/agent-compliance/README.md
@@ -174,7 +174,7 @@ The meta-package ensures all components are version-compatible and properly inte
 agent-governance ─── The meta-package (you are here)
 ├── agent-os-kernel ─── Governance kernel
 ├── agentmesh-platform ─── Zero-trust mesh
-├── agent-runtime ─── Runtime supervisor (optional)
+├── agentmesh-runtime ─── Runtime supervisor (optional)
 └── agent-sre ─── Reliability engineering (optional)
 ```
 

--- a/packages/agent-compliance/docs/OWASP-COMPLIANCE.md
+++ b/packages/agent-compliance/docs/OWASP-COMPLIANCE.md
@@ -250,7 +250,7 @@ This single command installs the complete governance stack:
 |-------|---------|-------------------|
 | **Kernel** | `agent-os-kernel` | ASI-01, ASI-02, ASI-06, ASI-09 |
 | **Trust Mesh** | `agentmesh-platform` | ASI-03, ASI-04, ASI-07, ASI-10 |
-| **Runtime** | `agent-runtime` | ASI-05, ASI-10 |
+| **Runtime** | `agentmesh-runtime` | ASI-05, ASI-10 |
 | **SRE** | `agent-sre` | ASI-08 |
 
 ---

--- a/packages/agent-compliance/docs/analyst/cncf-sandbox-proposal.md
+++ b/packages/agent-compliance/docs/analyst/cncf-sandbox-proposal.md
@@ -67,7 +67,7 @@ TBD — Seeking a TOC sponsor. The project aligns with the Runtime and Observabi
 - **Test suite:** 3,000+ tests across the stack (Agent OS: 2,000+, AgentMesh: 500+, Agent SRE: 329+, Agent Runtime: 200+)
 - **Framework integrations:** 12+ (LangChain, CrewAI, AutoGen, Semantic Kernel, LlamaIndex, Haystack, OpenAI Agents SDK, Google ADK, MCP, A2A, and more)
 - **Observability integrations:** 11 platforms (Datadog, Grafana, New Relic, Splunk, Azure Monitor, AWS CloudWatch, etc.)
-- **PyPI packages:** `ai-agent-governance`, `agent-os-kernel`, `agentmesh-platform`, `agent-runtime`, `agent-sre`
+- **PyPI packages:** `ai-agent-governance`, `agent-os-kernel`, `agentmesh-platform`, `agentmesh-runtime`, `agent-sre`
 
 ## Roadmap Alignment with CNCF
 

--- a/packages/agent-compliance/docs/analyst/fact-sheet.md
+++ b/packages/agent-compliance/docs/analyst/fact-sheet.md
@@ -98,7 +98,7 @@ pip install agent-governance-toolkit[full]
 # Or install individual components
 pip install agent-os-kernel          # Governance kernel only
 pip install agentmesh-platform       # Trust mesh only
-pip install agent-runtime            # Runtime isolation only
+pip install agentmesh-runtime         # Runtime isolation only
 pip install agent-sre                # Reliability engineering only
 ```
 

--- a/packages/agent-compliance/docs/submissions/owasp-genai-implementation-guide.md
+++ b/packages/agent-compliance/docs/submissions/owasp-genai-implementation-guide.md
@@ -14,7 +14,7 @@ The stack consists of four components:
 | **Agent OS** | Governance kernel — policy, sandbox, memory, MCP security | `pip install agent-os-kernel` |
 | **AgentMesh** | Identity & trust — DIDs, SPIFFE, handshake, reputation | `pip install agentmesh-platform` |
 | **Agent SRE** | Observability — SLOs, anomaly detection, chaos, OpenTelemetry | `pip install agent-sre` |
-| **Agent Runtime** | Runtime control — kill switch, execution rings, saga rollback | `pip install agent-runtime` |
+| **Agent Runtime** | Runtime control — kill switch, execution rings, saga rollback | `pip install agentmesh-runtime` |
 
 ---
 
@@ -1044,7 +1044,7 @@ This implementation guide is a community contribution to the OWASP GenAI project
 To reproduce the examples, install the stack:
 
 ```bash
-pip install agent-os-kernel agentmesh-platform agent-sre agent-runtime
+pip install agent-os-kernel agentmesh-platform agent-sre agentmesh-runtime
 ```
 
 All source code is available under the MIT license. PRs and issues welcome at

--- a/packages/agent-compliance/pyproject.toml
+++ b/packages/agent-compliance/pyproject.toml
@@ -39,12 +39,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-runtime = ["agent-runtime>=2.0.0"]
+runtime = ["agentmesh-runtime>=2.0.0"]
 sre = ["agent-sre>=1.0.0"]
 opa = []
 cedar = ["cedarpy>=4.0.0"]
 full = [
-    "agent-runtime>=2.0.0",
+    "agentmesh-runtime>=2.0.0",
     "agent-sre>=1.0.0",
 ]
 

--- a/packages/agent-compliance/src/agent_compliance/__init__.py
+++ b/packages/agent-compliance/src/agent_compliance/__init__.py
@@ -12,7 +12,7 @@ That name is deprecated and will redirect here for 6 months.
 Components:
     - agent-os-kernel: Governance kernel with policy enforcement
     - agentmesh-platform: Zero-trust agent communication (SSL for AI Agents)
-    - agent-runtime: Runtime supervisor with execution rings
+    - agentmesh-runtime: Runtime supervisor with execution rings
     - agent-sre: Site reliability engineering for AI agents
     - agentmesh-marketplace: Plugin lifecycle management
     - agent-lightning: RL training governance

--- a/packages/agent-hypervisor/README.md
+++ b/packages/agent-hypervisor/README.md
@@ -1,18 +1,10 @@
 <div align="center">
 
-# ⚠️ This package has been renamed to Agent Runtime
-
-> **`agent-hypervisor` is now `agent-runtime`.** This package is maintained for backward compatibility.
-> New projects should use [`agent-runtime`](../agent-runtime/) instead.
-> All imports (`from hypervisor import ...`) continue to work unchanged.
-
----
-
-# Agent Hypervisor → Agent Runtime — Community Edition
+# Agent Hypervisor — Community Edition
 
 **Execution supervisor for AI agents — runtime isolation, execution rings, and governance for autonomous agents**
 
-*Just as a supervisor isolates processes, Agent Runtime isolates AI agent sessions<br/>and enforces governance boundaries with a kill switch, blast radius containment, and accountability.*
+*Just as a supervisor isolates processes, Agent Hypervisor isolates AI agent sessions<br/>and enforces governance boundaries with a kill switch, blast radius containment, and accountability.*
 
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)

--- a/packages/agent-os/README.md
+++ b/packages/agent-os/README.md
@@ -420,7 +420,7 @@ agent-os/
 | [`mute-agent`](modules/mute-agent/) | 4 | `mute-agent` | Decoupled reasoning/execution architecture | ⚠️ No tests |
 | [`nexus`](modules/nexus/) | — | *Not published* | Trust exchange network | 🔬 Prototype |
 | [`mcp-kernel-server`](modules/mcp-kernel-server/) | Int | `mcp-kernel-server` | MCP server for Claude Desktop | ⚠️ No tests |
-| [**`runtime`**](https://github.com/microsoft/agent-governance-toolkit) | **⭐** | `agent-runtime` | **Execution supervisor — Execution Rings, Joint Liability, Saga Orchestrator** ([own repo](https://github.com/microsoft/agent-governance-toolkit)) | **✅ 184 tests** |
+| [**`runtime`**](https://github.com/microsoft/agent-governance-toolkit) | **⭐** | `agentmesh-runtime` | **Execution supervisor — Execution Rings, Joint Liability, Saga Orchestrator** ([own repo](https://github.com/microsoft/agent-governance-toolkit)) | **✅ 184 tests** |
 
 ---
 
@@ -428,7 +428,7 @@ agent-os/
 
 > **Execution supervisor for multi-agent collaboration** — think "VMware for AI agents."
 > 
-> **Now its own repo: [`agent-runtime`](https://github.com/microsoft/agent-governance-toolkit)** — 184 tests, 268μs full pipeline, zero dependencies beyond pydantic.
+> **Now its own repo: [`agentmesh-runtime`](https://github.com/microsoft/agent-governance-toolkit)** — 184 tests, 268μs full pipeline, zero dependencies beyond pydantic.
 
 Just as OS runtimes isolate execution environments and enforce resource boundaries, the Agent Runtime isolates AI agent sessions and enforces **governance boundaries** at sub-millisecond latency.
 
@@ -462,7 +462,7 @@ Just as OS runtimes isolate execution environments and enforce resource boundari
 ### Quick Start
 
 ```bash
-pip install agent-runtime
+pip install agentmesh-runtime
 ```
 
 ```python

--- a/packages/agent-os/pyproject.toml
+++ b/packages/agent-os/pyproject.toml
@@ -93,7 +93,7 @@ full = [
     "agent-os-kernel[cmvk,iatp,amb,observability,mcp,nexus]",
 ]
 hypervisor = [
-    "agent-runtime>=1.0.0",
+    "agentmesh-runtime>=1.0.0",
 ]
 
 # Development (includes all optional deps for full testing)

--- a/packages/agent-os/src/agent_os/integrations/compat.py
+++ b/packages/agent-os/src/agent_os/integrations/compat.py
@@ -55,7 +55,7 @@ KNOWN_PACKAGES = [
     "agentmesh-platform",
     "agent-sre",
     "agent-governance-toolkit",
-    "agent-runtime",
+    "agentmesh-runtime",
 ]
 
 

--- a/packages/agent-runtime/README.md
+++ b/packages/agent-runtime/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Agent Runtime
+# AgentMesh Runtime
 
 **Execution supervisor for multi-agent sessions — privilege rings, saga orchestration, and governance enforcement**
 
@@ -9,19 +9,21 @@
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://python.org)
-[![PyPI](https://img.shields.io/pypi/v/agent-runtime)](https://pypi.org/project/agent-runtime/)
+[![PyPI](https://img.shields.io/pypi/v/agentmesh-runtime)](https://pypi.org/project/agentmesh-runtime/)
 
 </div>
 
 > [!IMPORTANT]
-> **Community Preview** — The `agent-runtime` package on PyPI is a community preview release
+> **Community Preview** — The `agentmesh-runtime` package on PyPI is a community preview release
 > for testing and evaluation only. It is **not** an official Microsoft-signed release.
 > Official signed packages will be available in a future release.
 
 ---
 
-> **Note:** This package was previously named `agent-hypervisor`. The `agent-hypervisor` package
-> is still available for backward compatibility but will redirect to `agent-runtime` in a future release.
+> **Note:** This package was renamed from `agent-runtime` to `agentmesh-runtime` to avoid a PyPI
+> name collision with the AutoGen team's package. The `agent-hypervisor` package remains the
+> canonical upstream implementation; `agentmesh-runtime` is a thin re-export wrapper for
+> incremental import migration.
 
 ## What is Agent Runtime?
 
@@ -39,7 +41,7 @@ session level:
 ## Quick Start
 
 ```bash
-pip install agent-runtime
+pip install agentmesh-runtime
 ```
 
 ```python
@@ -90,7 +92,7 @@ Agent Runtime is one of 7 packages in the Agent Governance Toolkit:
 |---------|------|
 | **Agent OS** | Policy engine — deterministic action evaluation |
 | **AgentMesh** | Trust infrastructure — identity, credentials, protocol bridges |
-| **Agent Runtime** | Execution supervisor — rings, sessions, sagas *(this package)* |
+| **AgentMesh Runtime** | Execution supervisor — rings, sessions, sagas *(this package)* |
 | **Agent SRE** | Reliability — SLOs, circuit breakers, chaos testing |
 | **Agent Compliance** | Regulatory compliance — GDPR, HIPAA, SOX frameworks |
 | **Agent Marketplace** | Plugin lifecycle — discover, install, verify, sign |

--- a/packages/agent-runtime/pyproject.toml
+++ b/packages/agent-runtime/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agent-runtime"
+name = "agentmesh-runtime"
 version = "2.2.0"
-description = "Community Edition — Agent Runtime: Execution supervisor for multi-agent sessions with privilege rings, saga orchestration, and audit trails"
+description = "Community Edition — AgentMesh Runtime: Execution supervisor for multi-agent sessions with privilege rings, saga orchestration, and audit trails"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/pipelines/pypi-publish.yml
+++ b/pipelines/pypi-publish.yml
@@ -35,7 +35,7 @@ parameters:
         path: packages/agent-sre
       - name: agent-compliance
         path: packages/agent-compliance
-      - name: agent-runtime
+      - name: agentmesh-runtime
         path: packages/agent-runtime
       - name: agent-lightning
         path: packages/agent-lightning

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -25,7 +25,7 @@ REGISTERED_PACKAGES = {
     "agent-os-kernel",
     "agentmesh-platform",
     "agent-hypervisor",
-    "agent-runtime",
+    "agentmesh-runtime",
     "agent-sre",
     "agent-governance-toolkit",
     "agent-lightning",


### PR DESCRIPTION
Rebased version of #440 (which had merge conflicts after #439 merged).

Renames the PyPI distribution name from agent-runtime to agentmesh-runtime, since agent-runtime on PyPI is owned by AutoGen team.

Changes across 26 files: pyproject.toml, dependency declarations, docs, tutorials, CI pipelines. Directory paths and import paths unchanged.

Closes #437