### PR TITLE
fix: update all references to use new PyPI package names

### DIFF
--- a/.github/workflows/ai-contributor-guide.yml
+++ b/.github/workflows/ai-contributor-guide.yml
@@ -63,8 +63,8 @@ jobs:
                - agent-sre: Reliability, chaos testing, SLOs
                - agent-compliance: Compliance frameworks, audit logging
                - agentmesh-marketplace: Agent registry
-               - agent-lightning: High-performance inference
-               - agent-runtime: Runtime execution environment
+               - agentmesh-lightning: High-performance inference
+               - agentmesh-runtime: Runtime execution environment
             3. **Point to relevant code** — suggest specific directories to look at
             4. **Link to resources**:
                - [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)

--- a/.github/workflows/ai-release-notes.yml
+++ b/.github/workflows/ai-release-notes.yml
@@ -78,7 +78,7 @@ jobs:
           custom-instructions: |
             You are generating release notes for microsoft/agent-governance-toolkit.
             This is a monorepo with packages: agent-os, agent-mesh, agent-hypervisor,
-            agent-sre, agent-compliance, agentmesh-marketplace, agent-lightning, agent-runtime.
+            agent-sre, agent-compliance, agentmesh-marketplace, agentmesh-lightning, agentmesh-runtime.
 
             Categorize changes by:
             1. Package affected (based on file paths in the PR)

--- a/.github/workflows/ai-spec-drafter.yml
+++ b/.github/workflows/ai-spec-drafter.yml
@@ -49,8 +49,8 @@ jobs:
             - agent-sre: Reliability engineering, chaos testing, SLO monitoring
             - agent-compliance: Compliance frameworks and audit logging
             - agentmesh-marketplace: Agent registry and marketplace
-            - agent-lightning: High-performance inference pipeline
-            - agent-runtime: Runtime execution environment
+            - agentmesh-lightning: High-performance inference pipeline
+            - agentmesh-runtime: Runtime execution environment
 
             Generate a professional engineering specification that includes:
             1. **Title and Overview** — what this spec covers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ This is a mono-repo with seven packages:
 | `agent-sre` | `packages/agent-sre/` | Observability, alerting, and reliability |
 | `agent-governance` | `packages/agent-compliance/` | Unified installer and runtime policy enforcement |
 | `agentmesh-marketplace` | `packages/agent-marketplace/` | Plugin lifecycle management for governed agent ecosystems |
-| `agent-lightning` | `packages/agent-lightning/` | RL training governance with governed runners and policy rewards |
+| `agentmesh-lightning` | `packages/agent-lightning/` | RL training governance with governed runners and policy rewards |
 
 ### Coding Guidelines
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -34,13 +34,9 @@ pip install agent-os-kernel        # Policy enforcement + framework integrations
 pip install agentmesh-platform     # Zero-trust identity + trust cards
 pip install agent-governance-toolkit    # OWASP ASI verification + integrity CLI
 pip install agent-sre              # SLOs, error budgets, chaos testing
-pip install agentmesh-runtime          # Execution supervisor + privilege rings
-pip install agentmesh-marketplace    # Plugin lifecycle management
-=======
 pip install agentmesh-runtime       # Execution supervisor + privilege rings
 pip install agentmesh-marketplace      # Plugin lifecycle management
->>>>>>> bfb3bcb (fix: rename PyPI package agentmesh-runtime to agentmesh-runtime to resolve name collision)
-pip install agent-lightning        # RL training governance
+pip install agentmesh-lightning        # RL training governance
 ```
 
 ### TypeScript / Node.js

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pip install agentmesh-runtime       # Runtime supervisor
 pip install agent-sre              # SRE toolkit
 pip install agent-governance-toolkit    # Compliance & attestation
 pip install agentmesh-marketplace      # Plugin marketplace
-pip install agent-lightning        # RL training governance
+pip install agentmesh-lightning        # RL training governance
 ```
 </details>
 

--- a/RELEASE_NOTES_v1.0.0.md
+++ b/RELEASE_NOTES_v1.0.0.md
@@ -21,11 +21,11 @@
 |---------|-------------|---------|
 | **Agent OS** | Stateless governance kernel with policy engine, VFS, and MCP proxy | `pip install agent-os-kernel` |
 | **AgentMesh** | Zero-trust identity mesh with DID, trust scoring, delegation chains | `pip install agentmesh-platform` |
-| **Agent Runtime** | Execution rings, resource limits, kill switch, saga orchestration | `pip install agent-runtime` |
+| **Agent Runtime** | Execution rings, resource limits, kill switch, saga orchestration | `pip install agentmesh-runtime` |
 | **Agent SRE** | SLOs, error budgets, circuit breakers, chaos engineering | `pip install agent-sre` |
 | **Agent Compliance** | Unified installer and runtime policy enforcement | `pip install agent-governance` |
 | **Agent Marketplace** | Plugin lifecycle management for governed agent ecosystems | `pip install agentmesh-marketplace` |
-| **Agent Lightning** | RL training governance with governed runners and policy rewards | `pip install agent-lightning` |
+| **Agent Lightning** | RL training governance with governed runners and policy rewards | `pip install agentmesh-lightning` |
 
 ## Security & Compliance
 

--- a/docs/tutorials/15-rl-training-governance.md
+++ b/docs/tutorials/15-rl-training-governance.md
@@ -32,7 +32,7 @@ See also: [Tutorial 01 — Policy Engine](01-policy-engine.md) | [Tutorial 04 �
 
 ```bash
 # Core package — governed runner, policy rewards, environment, emitter
-pip install agent-lightning
+pip install agentmesh-lightning
 
 # You also need the Agent OS kernel for policy enforcement
 pip install agent-os-kernel

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -51,10 +51,6 @@ guides.
 |---|----------|-------------------|---------|
 | 10 | [Plugin Marketplace](10-plugin-marketplace.md) | Plugin signing, verification, CLI, supply-chain security | `agentmesh-marketplace` |
 | 13 | [Observability & Tracing](13-observability-and-tracing.md) | Causal traces, event bus, Prometheus, OpenTelemetry | `agentmesh-runtime` |
-=======
-| 10 | [Plugin Marketplace](10-plugin-marketplace.md) | Plugin signing, verification, CLI, supply-chain security | `agentmesh-marketplace` |
-| 13 | [Observability & Tracing](13-observability-and-tracing.md) | Causal traces, event bus, Prometheus, OpenTelemetry | `agentmesh-runtime` |
->>>>>>> bfb3bcb (fix: rename PyPI package agentmesh-runtime to agentmesh-runtime to resolve name collision)
 | 15 | [RL Training Governance](15-rl-training-governance.md) | GovernedRunner, PolicyReward, Gym-compatible environments | `agentmesh-lightning` |
 | 18 | [Compliance Verification](18-compliance-verification.md) | Governance grading, regulatory frameworks, attestation | `agent-governance-toolkit` |
 

--- a/packages/agent-lightning/README.md
+++ b/packages/agent-lightning/README.md
@@ -12,7 +12,7 @@ Train AI agents with RL while maintaining **0% policy violations**.
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9+-blue.svg)](https://python.org)
-[![PyPI](https://img.shields.io/pypi/v/agent-lightning)](https://pypi.org/project/agent-lightning/)
+[![PyPI](https://img.shields.io/pypi/v/agentmesh-lightning)](https://pypi.org/project/agentmesh-lightning/)
 
 ## 🎯 Overview
 
@@ -29,7 +29,7 @@ This package provides governed RL training integration:
 ## 🚀 Quick Start
 
 ```bash
-pip install agent-lightning
+pip install agentmesh-lightning
 # Optional: pip install agent-os-kernel  # for kernel integration
 ```
 

--- a/packages/agent-lightning/pyproject.toml
+++ b/packages/agent-lightning/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 keywords = [
     "ai-agents", "governance", "reinforcement-learning",
-    "agent-lightning", "agent-os", "enterprise-ai"
+    "agentmesh-lightning", "agent-os", "enterprise-ai"
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -28,7 +28,7 @@ REGISTERED_PACKAGES = {
     "agentmesh-runtime",
     "agent-sre",
     "agent-governance-toolkit",
-    "agent-lightning",
+    "agentmesh-lightning",
     "agentmesh-marketplace",
     # Common dependencies
     "pydantic", "pyyaml", "cryptography", "pynacl", "httpx", "aiohttp",


### PR DESCRIPTION
Comprehensive sweep to replace all remaining old PyPI package names with their new names:
- \gent-lightning\ → \gentmesh-lightning\ (12 files)
- \gent-runtime\ → \gentmesh-runtime\ (workflows)

Also fixes merge conflict markers in QUICKSTART.md and docs/tutorials/README.md.

**Files changed:** README, QUICKSTART, CONTRIBUTING, RELEASE_NOTES_v1.0.0, tutorials, 3 GitHub workflows, scripts/check_dependency_confusion.py, packages/agent-lightning/{README,pyproject.toml}

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>