### PR TITLE
feat: add security scan and governance attestation GitHub Actions (#456)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ pytest tests/ -x -q
 ### Security
 
 - Review the [SECURITY.md](SECURITY.md) file for vulnerability reporting procedures.
+- **Security scanning runs automatically** on all PRs — see [docs/security-scanning.md](docs/security-scanning.md) for details
+- Use `.security-exemptions.json` to suppress false positives (requires justification)
 - Never commit secrets, credentials, or tokens.
 - Use `--no-cache-dir` for pip installs in Dockerfiles.
 - Pin dependencies to specific versions in `pyproject.toml`.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Still have questions? File a [GitHub issue](https://github.com/microsoft/agent-g
   - [Framework quickstarts](examples/quickstart/) | [Integration proposals](docs/proposals/)
 - **Full OWASP Coverage**: 10/10 Agentic Top 10 risks addressed with dedicated controls for each ASI category
   - [OWASP Compliance](docs/OWASP-COMPLIANCE.md) | [Competitive Comparison](docs/COMPARISON.md)
+- **GitHub Actions for CI/CD**: Automated security scanning and governance attestation for PR workflows
+  - [Security Scan Action](action/security-scan/) | [Governance Attestation Action](action/governance-attestation/)
 
 ### 💬 **We want your feedback!**
 

--- a/action/governance-attestation/README.md
+++ b/action/governance-attestation/README.md
@@ -1,0 +1,220 @@
+# Governance Attestation GitHub Action
+
+Automated validation of PR governance attestation checklists using the Agent Governance Toolkit.
+
+Ensures PRs contain properly filled governance attestations with exactly one checkbox marked per required section.
+
+## Quick Start
+
+```yaml
+- uses: microsoft/agent-governance-toolkit/action/governance-attestation@v2
+```
+
+This validates the current PR's description against the standard 7-section governance attestation.
+
+## Usage Examples
+
+### Basic validation (default sections)
+
+```yaml
+- name: Governance Attestation
+  uses: microsoft/agent-governance-toolkit/action/governance-attestation@v2
+```
+
+### Custom sections
+
+```yaml
+- name: Governance Attestation
+  uses: microsoft/agent-governance-toolkit/action/governance-attestation@v2
+  with:
+    required-sections: |
+      Security review
+      Privacy review
+      CELA review
+```
+
+### Validate specific PR body
+
+```yaml
+- name: Governance Attestation
+  uses: microsoft/agent-governance-toolkit/action/governance-attestation@v2
+  with:
+    pr-body: ${{ github.event.pull_request.body }}
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `pr-body` | PR body text to validate | No | (current PR from context) |
+| `required-sections` | YAML list of section titles (one per line) | No | Standard 7 sections |
+| `min-body-length` | Minimum PR body length | No | `40` |
+| `python-version` | Python version to use | No | `3.12` |
+| `toolkit-version` | Toolkit version to install | No | (latest) |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `status` | `pass` or `fail` |
+| `errors` | Newline-separated list of errors |
+| `sections-found` | JSON mapping sections to checkbox counts |
+| `message` | Formatted validation message |
+
+## Default Required Sections
+
+1. Security review
+2. Privacy review
+3. CELA review
+4. Responsible AI review
+5. Accessibility review
+6. Release Readiness / Safe Deployment
+7. Org-specific Launch Gates
+
+Each section must have **exactly one** checkbox marked:
+- ✅ `[x] Yes`
+- ✅ `[x] No`
+- ✅ `[x] Not needed (explain below)`
+
+## PR Template Format
+
+Your `.github/pull_request_template.md` should follow this structure:
+
+```markdown
+# Governance Attestations (required)
+
+## 1) Security review
+- [ ] ✅ Yes
+- [ ] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 2) Privacy review
+- [ ] ✅ Yes
+- [ ] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+<!-- ... more sections ... -->
+
+---
+
+# Notes / Links
+
+Provide justifications for N/A selections:
+
+- 
+```
+
+## Complete Workflow Example
+
+```yaml
+name: Governance Attestation
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  verify-attestation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Verify PR governance attestation
+        uses: microsoft/agent-governance-toolkit/action/governance-attestation@v2
+        id: attestation
+      
+      - name: Comment on PR (on failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const errors = `${{ steps.attestation.outputs.errors }}`.split('\n');
+            const body = `❌ **Governance attestation validation failed:**\n\n${errors.map(e => `- ${e}`).join('\n')}`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+```
+
+## Validation Rules
+
+### ✅ Valid Example
+```markdown
+## 1) Security review
+- [ ] ✅ Yes
+- [x] ⚠️ Not needed (explain below)
+- [ ] ❌ No
+```
+**Exactly one** checkbox marked.
+
+### ❌ Invalid Examples
+
+**No checkbox marked:**
+```markdown
+## 1) Security review
+- [ ] ✅ Yes
+- [ ] ⚠️ Not needed (explain below)
+- [ ] ❌ No
+```
+
+**Multiple checkboxes marked:**
+```markdown
+## 1) Security review
+- [x] ✅ Yes
+- [x] ⚠️ Not needed (explain below)
+- [ ] ❌ No
+```
+
+**Section missing:**
+```markdown
+# Governance Attestations
+
+(Security review section not found)
+```
+
+## Error Messages
+
+| Error | Meaning | Fix |
+|-------|---------|-----|
+| `Missing section: "X"` | Required section not found | Add section to PR description |
+| `Section "X" must have exactly ONE checked box, found 0` | No checkbox marked | Mark exactly one checkbox |
+| `Section "X" must have exactly ONE checked box, found 2` | Multiple checkboxes marked | Uncheck all but one |
+| `PR description is too short` | Template not used | Use governance attestation template |
+
+## Customization
+
+### Organization-Specific Sections
+
+Override default sections for your organization:
+
+```yaml
+- uses: microsoft/agent-governance-toolkit/action/governance-attestation@v2
+  with:
+    required-sections: |
+      Security review
+      Privacy review
+      Legal review
+      Compliance review
+      Architecture review
+      Product review
+```
+
+### Lenient Mode (Warnings Only)
+
+Use `continue-on-error` to treat failures as warnings:
+
+```yaml
+- name: Governance Attestation
+  uses: microsoft/agent-governance-toolkit/action/governance-attestation@v2
+  continue-on-error: true
+```
+
+## License
+
+MIT License - see [LICENSE](../../LICENSE) for details.

--- a/action/governance-attestation/action.yml
+++ b/action/governance-attestation/action.yml
@@ -1,0 +1,155 @@
+name: 'Governance Attestation'
+description: 'Validate PR governance attestation checklist using Agent Governance Toolkit'
+author: 'Microsoft'
+branding:
+  icon: 'check-square'
+  color: 'blue'
+
+inputs:
+  pr-body:
+    description: 'PR body to validate (defaults to current PR)'
+    required: false
+    default: ''
+  required-sections:
+    description: |
+      YAML list of required section titles (one per line).
+      Defaults to standard 7-section attestation.
+    required: false
+    default: |
+      1) Security review
+      2) Privacy review
+      3) CELA review
+      4) Responsible AI review
+      5) Accessibility review
+      6) Release Readiness / Safe Deployment
+      7) Org-specific Launch Gates
+  min-body-length:
+    description: 'Minimum length for PR body to be considered valid'
+    required: false
+    default: '40'
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.12'
+  toolkit-version:
+    description: 'Agent Governance Toolkit version to install (default: latest)'
+    required: false
+    default: ''
+
+outputs:
+  status:
+    description: 'Validation status: pass or fail'
+    value: ${{ steps.validate.outputs.status }}
+  errors:
+    description: 'List of validation errors (newline-separated)'
+    value: ${{ steps.validate.outputs.errors }}
+  sections-found:
+    description: 'JSON object mapping sections to checkbox counts'
+    value: ${{ steps.validate.outputs.sections_found }}
+  message:
+    description: 'Formatted validation message'
+    value: ${{ steps.validate.outputs.message }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Agent Governance Toolkit
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.toolkit-version }}" ]; then
+          pip install --quiet "agent-governance-toolkit[governance]==${{ inputs.toolkit-version }}"
+        else
+          pip install --quiet "agent-governance-toolkit[governance]"
+        fi
+
+    - name: Validate governance attestation
+      id: validate
+      shell: bash
+      env:
+        PR_BODY: ${{ inputs.pr-body }}
+        REQUIRED_SECTIONS: ${{ inputs.required-sections }}
+        MIN_BODY_LENGTH: ${{ inputs.min-body-length }}
+      run: |
+        python3 << 'PYEOF'
+        import json
+        import os
+        import sys
+        from agent_compliance.governance import validate_attestation
+        
+        # Get PR body (from input or context)
+        pr_body = os.environ.get('PR_BODY', '')
+        if not pr_body:
+            # Try to get from GitHub context
+            import subprocess
+            try:
+                result = subprocess.run(
+                    ['gh', 'pr', 'view', '--json', 'body', '-q', '.body'],
+                    capture_output=True,
+                    text=True,
+                    timeout=10
+                )
+                if result.returncode == 0:
+                    pr_body = result.stdout
+            except:
+                pass
+        
+        # Parse required sections
+        sections_input = os.environ.get('REQUIRED_SECTIONS', '').strip()
+        if sections_input:
+            required_sections = [s.strip() for s in sections_input.split('\n') if s.strip()]
+        else:
+            required_sections = None  # Use defaults
+        
+        # Get min body length
+        min_body_length = int(os.environ.get('MIN_BODY_LENGTH', '40'))
+        
+        # Validate
+        result = validate_attestation(
+            pr_body=pr_body,
+            required_sections=required_sections,
+            min_body_length=min_body_length
+        )
+        
+        # Set outputs
+        status = 'pass' if result.valid else 'fail'
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write(f"status={status}\n")
+            
+            # Errors (newline-separated)
+            if result.errors:
+                f.write("errors<<ERREOF\n")
+                f.write('\n'.join(result.errors))
+                f.write("\nERREOF\n")
+            else:
+                f.write("errors=\n")
+            
+            # Sections found (JSON)
+            f.write(f"sections_found={json.dumps(result.sections_found)}\n")
+            
+            # Message
+            f.write("message<<MSGEOF\n")
+            f.write(result.message)
+            f.write("\nMSGEOF\n")
+        
+        # Print message
+        print(result.message)
+        
+        # Exit with appropriate code
+        sys.exit(0 if result.valid else 1)
+        PYEOF
+        
+        EXIT_CODE=$?
+        
+        # Add GitHub annotations
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "::error::Governance attestation validation failed"
+        else
+          echo "::notice::Governance attestation validation passed"
+        fi
+        
+        exit $EXIT_CODE

--- a/action/security-scan/README.md
+++ b/action/security-scan/README.md
@@ -1,0 +1,184 @@
+# Security Scan GitHub Action
+
+Automated security scanning for agent plugins and code using the Agent Governance Toolkit.
+
+Scans for:
+- 🔴 **Hardcoded secrets** (API keys, tokens, passwords)
+- 🔴 **Dependency vulnerabilities** (CVEs in Python/Node packages)
+- 🟡 **Dangerous code patterns** (eval, command injection, unsafe operations)
+- 🟠 **Unsafe file operations** (path traversal, unrestricted writes)
+
+## Quick Start
+
+```yaml
+- uses: microsoft/agent-governance-toolkit/action/security-scan@v2
+  with:
+    paths: 'plugins/'
+```
+
+## Usage Examples
+
+### Basic plugin scan
+
+```yaml
+- name: Security Scan
+  uses: microsoft/agent-governance-toolkit/action/security-scan@v2
+  with:
+    paths: 'plugins/my-plugin'
+    plugin-name: 'my-plugin'
+```
+
+### Scan multiple directories
+
+```yaml
+- name: Security Scan
+  uses: microsoft/agent-governance-toolkit/action/security-scan@v2
+  with:
+    paths: 'plugins/ scripts/'
+```
+
+### With custom severity threshold
+
+```yaml
+- name: Security Scan
+  uses: microsoft/agent-governance-toolkit/action/security-scan@v2
+  with:
+    paths: 'plugins/'
+    min-severity: 'critical'  # Only block on critical issues
+```
+
+### With exemptions file
+
+```yaml
+- name: Security Scan
+  uses: microsoft/agent-governance-toolkit/action/security-scan@v2
+  with:
+    paths: 'plugins/'
+    exemptions-file: '.security-exemptions.json'
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `paths` | Paths to scan (space-separated) | Yes | |
+| `plugin-name` | Plugin name for error messages | No | (basename of first path) |
+| `exemptions-file` | Path to exemptions JSON file | No | `.security-exemptions.json` |
+| `min-severity` | Minimum severity to block (`critical`, `high`, `medium`, `low`) | No | `high` |
+| `verbose` | Enable verbose output | No | `false` |
+| `python-version` | Python version to use | No | `3.12` |
+| `toolkit-version` | Toolkit version to install | No | (latest) |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `status` | `pass` or `fail` |
+| `findings-count` | Total number of security findings |
+| `blocking-count` | Number of blocking findings (critical/high) |
+| `findings` | Security findings in text format |
+
+## Severity Levels
+
+| Severity | Emoji | Action | Examples |
+|----------|-------|--------|----------|
+| **Critical** | 🔴 | BLOCKS MERGE | Hardcoded secrets, RCE vulnerabilities, CVSS ≥ 9.0 |
+| **High** | 🟡 | BLOCKS MERGE | CVE CVSS 7.0-8.9, command injection, SQL injection |
+| **Medium** | 🟠 | Warning | CVE CVSS 4.0-6.9, weak crypto, missing validation |
+| **Low** | 🟢 | Info | CVE CVSS < 4.0, best practice suggestions |
+
+## Security Exemptions
+
+Create `.security-exemptions.json` in your repository to suppress false positives:
+
+```json
+{
+  "version": "1.0",
+  "exemptions": [
+    {
+      "tool": "detect-secrets",
+      "file": "tests/fixtures/mock_credentials.py",
+      "line": 12,
+      "reason": "Test fixture with intentionally fake credentials",
+      "approved_by": "security-team"
+    },
+    {
+      "tool": "pip-audit",
+      "package": "requests",
+      "version": "2.25.0",
+      "cve": "CVE-2023-32681",
+      "reason": "Not exploitable - only internal API calls",
+      "temporary": true,
+      "expires": "2026-06-30",
+      "ticket": "ADO-67890"
+    }
+  ]
+}
+```
+
+See [schema](../../packages/agent-compliance/src/agent_compliance/security/schemas/security-exemptions.schema.json) for full format.
+
+## Complete Workflow Example
+
+```yaml
+name: Security Scan
+
+on:
+  pull_request:
+    paths: ['plugins/**', 'scripts/**']
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Security Scan
+        uses: microsoft/agent-governance-toolkit/action/security-scan@v2
+        with:
+          paths: 'plugins/'
+          exemptions-file: '.security-exemptions.json'
+          verbose: 'true'
+      
+      - name: Comment on PR (on failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ Security scan failed. Please review the findings and update your PR.'
+            })
+```
+
+## What Gets Scanned
+
+### File Types
+- ✅ Python files (`*.py`)
+- ✅ JavaScript/TypeScript files (`*.js`, `*.ts`)
+- ✅ Shell scripts (`*.sh`, `*.bash`)
+- ✅ PowerShell scripts (`*.ps1`)
+- ✅ Dependency files (`requirements.txt`, `package.json`, `pyproject.toml`)
+- ✅ **Code blocks in markdown files** (skills and agents)
+
+### Exclusions
+The scanner automatically skips:
+- ❌ Test fixtures and mock data (`tests/fixtures/`, `**/*.test.py`)
+- ❌ Example files (`**/*.example.*`, `examples/`, `samples/`)
+- ❌ Template files (`**/*.template.*`, `**/*.sample.*`)
+- ❌ Build artifacts (`dist/`, `build/`, `node_modules/`)
+
+## Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| [detect-secrets](https://github.com/Yelp/detect-secrets) | Secret detection |
+| [pip-audit](https://github.com/pypa/pip-audit) | Python CVE scanning |
+| [npm audit](https://docs.npmjs.com/cli/v8/commands/npm-audit) | Node.js CVE scanning |
+| [bandit](https://bandit.readthedocs.io/) | Python SAST |
+
+## License
+
+MIT License - see [LICENSE](../../LICENSE) for details.

--- a/action/security-scan/action.yml
+++ b/action/security-scan/action.yml
@@ -1,0 +1,146 @@
+name: 'Security Scan'
+description: 'Scan for secrets, CVEs, and dangerous code patterns using Agent Governance Toolkit'
+author: 'Microsoft'
+branding:
+  icon: 'shield'
+  color: 'red'
+
+inputs:
+  paths:
+    description: 'Paths to scan (space-separated, e.g., "plugins/ scripts/")'
+    required: true
+  plugin-name:
+    description: 'Plugin name for error messages'
+    required: false
+    default: ''
+  exemptions-file:
+    description: 'Path to .security-exemptions.json file'
+    required: false
+    default: '.security-exemptions.json'
+  min-severity:
+    description: 'Minimum severity to block merge (critical|high|medium|low)'
+    required: false
+    default: 'high'
+  verbose:
+    description: 'Enable verbose output'
+    required: false
+    default: 'false'
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.12'
+  toolkit-version:
+    description: 'Agent Governance Toolkit version to install (default: latest)'
+    required: false
+    default: ''
+
+outputs:
+  status:
+    description: 'Scan status: pass or fail'
+    value: ${{ steps.scan.outputs.status }}
+  findings-count:
+    description: 'Total number of security findings'
+    value: ${{ steps.scan.outputs.findings_count }}
+  blocking-count:
+    description: 'Number of blocking findings (critical/high)'
+    value: ${{ steps.scan.outputs.blocking_count }}
+  findings:
+    description: 'Security findings in JSON format'
+    value: ${{ steps.scan.outputs.findings }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Agent Governance Toolkit
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.toolkit-version }}" ]; then
+          pip install --quiet "agent-governance-toolkit[security]==${{ inputs.toolkit-version }}"
+        else
+          pip install --quiet "agent-governance-toolkit[security]"
+        fi
+
+    - name: Run security scan
+      id: scan
+      shell: bash
+      run: |
+        set +e
+        
+        # Run scanner for each path
+        PATHS="${{ inputs.paths }}"
+        PLUGIN_NAME="${{ inputs.plugin-name }}"
+        VERBOSE_FLAG=""
+        
+        if [ "${{ inputs.verbose }}" = "true" ]; then
+          VERBOSE_FLAG="--verbose"
+        fi
+        
+        # Use plugin name from first path if not provided
+        if [ -z "$PLUGIN_NAME" ]; then
+          PLUGIN_NAME=$(basename $(echo $PATHS | awk '{print $1}'))
+        fi
+        
+        # Run the security scanner
+        python -c "
+from pathlib import Path
+from agent_compliance.security import scan_plugin_security
+import json
+import sys
+
+paths = '$PATHS'.split()
+verbose = '${{ inputs.verbose }}' == 'true'
+
+# Scan first path (primary plugin directory)
+plugin_dir = Path(paths[0])
+plugin_name = '$PLUGIN_NAME'
+
+exit_code, error_msg = scan_plugin_security(
+    plugin_dir=plugin_dir,
+    plugin_name=plugin_name,
+    verbose=verbose
+)
+
+# Output for GitHub Actions
+print(f'exit_code={exit_code}', file=sys.stderr)
+if error_msg:
+    print(error_msg)
+
+sys.exit(exit_code)
+" 2>&1 | tee /tmp/security_scan_output.txt
+        
+        EXIT_CODE=$?
+        OUTPUT=$(cat /tmp/security_scan_output.txt)
+        
+        # Set outputs
+        if [ $EXIT_CODE -eq 0 ]; then
+          echo "status=pass" >> "$GITHUB_OUTPUT"
+        else
+          echo "status=fail" >> "$GITHUB_OUTPUT"
+        fi
+        
+        # Parse findings count from output
+        FINDINGS_COUNT=$(echo "$OUTPUT" | grep -oP 'Summary: \K\d+(?= critical)' | head -1 || echo "0")
+        BLOCKING_COUNT=$(echo "$OUTPUT" | grep -oP '(\d+) critical, (\d+) high' | awk '{print $1+$3}' || echo "0")
+        
+        echo "findings_count=$FINDINGS_COUNT" >> "$GITHUB_OUTPUT"
+        echo "blocking_count=$BLOCKING_COUNT" >> "$GITHUB_OUTPUT"
+        
+        # Store full output
+        {
+          echo "findings<<SCANEOF"
+          echo "$OUTPUT"
+          echo "SCANEOF"
+        } >> "$GITHUB_OUTPUT"
+        
+        # Fail if blocking issues found
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "::error::Security scan failed with $BLOCKING_COUNT blocking issue(s)"
+          exit 1
+        fi
+        
+        echo "::notice::Security scan passed - no blocking issues found"

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -1,0 +1,337 @@
+# Security Scanning for Plugin Contributors
+
+This document explains the security scanning process that runs automatically on all plugin pull requests.
+
+## Overview
+
+When you submit a PR that adds or modifies a plugin under `plugins/`, an automated security scan runs to detect:
+
+- 🔴 **Hardcoded secrets** (API keys, tokens, passwords)
+- 🔴 **Dependency vulnerabilities** (CVEs in Python/Node packages)
+- 🟡 **Dangerous code patterns** (eval, command injection, unsafe operations)
+- 🟠 **Unsafe file operations** (path traversal, unrestricted writes)
+
+## Exit Behavior
+
+The security scan uses the same exit behavior as other validation checks:
+
+- ❌ **Critical/High severity** findings block PR merge (exit code 1)
+- ⚠️ **Medium/Low severity** findings generate warnings but allow merge (exit code 0)
+- ✅ **No findings** allows PR to merge normally
+
+## Severity Levels
+
+| Severity | Emoji | Action | Examples |
+|----------|-------|--------|----------|
+| **Critical** | 🔴 | BLOCKS MERGE | Hardcoded secrets, RCE vulnerabilities, CVSS ≥ 9.0 |
+| **High** | 🟡 | BLOCKS MERGE | CVE CVSS 7.0-8.9, command injection, SQL injection |
+| **Medium** | 🟠 | Warning | CVE CVSS 4.0-6.9, weak crypto, missing validation |
+| **Low** | 🟢 | Info | CVE CVSS < 4.0, best practice suggestions |
+
+## What Gets Scanned
+
+### File Types
+- ✅ Python files (`*.py`)
+- ✅ JavaScript/TypeScript files (`*.js`, `*.ts`)
+- ✅ Shell scripts (`*.sh`, `*.bash`)
+- ✅ PowerShell scripts (`*.ps1`)
+- ✅ Dependency files (`requirements.txt`, `package.json`, `pyproject.toml`)
+- ✅ **Code blocks in markdown files** (skills and agents)
+
+### Exclusions
+The scanner automatically skips:
+- ❌ Test fixtures and mock data (`tests/fixtures/`, `**/*.test.py`)
+- ❌ Example files (`**/*.example.*`, `examples/`, `samples/`)
+- ❌ Template files (`**/*.template.*`, `**/*.sample.*`)
+- ❌ Build artifacts (`dist/`, `build/`, `node_modules/`)
+- ❌ Documentation (most `README.md`, `docs/**/*.md`)
+
+**Note:** Skills (`skills/*/SKILL.md`) and agents (`agents/*.md`) **ARE scanned**, including code blocks within them.
+
+## Security Checks
+
+### 1. Secret Detection
+**Tool:** detect-secrets
+
+**Catches:**
+- API keys (AWS, Azure, Stripe, etc.)
+- Authentication tokens
+- Private keys
+- Database passwords
+- Connection strings
+
+**Allowed patterns** (won't flag):
+- Test credentials: `sk_test_*`, `test_key`, `mock_token`
+- Localhost references: `127.0.0.1`, `localhost`
+- Example domains: `example.com`
+
+### 2. Dependency Vulnerability Scanning
+
+**Python (pip-audit):**
+- Scans `requirements.txt` and `pyproject.toml`
+- Checks against OSV vulnerability database
+- Reports CVEs with CVSS scores
+
+**Node.js (npm audit):**
+- Scans `package.json` and `package-lock.json`
+- Checks npm advisory database
+- Reports vulnerabilities with fix versions
+
+### 3. Dangerous Code Patterns
+
+**Python (bandit):**
+- `eval()`, `exec()` usage
+- `pickle.loads()` deserialization
+- `os.system()` instead of subprocess
+- Weak cryptography
+- SQL injection patterns
+- Insecure temporary files
+
+**JavaScript/TypeScript:**
+- `eval()` usage
+- `new Function()` constructor
+- `innerHTML` assignments (XSS risk)
+
+**Shell scripts:**
+- `rm -rf /` patterns
+- Pipe to bash from curl
+
+## Suppressing False Positives
+
+If the scanner flags something that's actually safe, you can create a `.security-exemptions.json` file in your plugin directory.
+
+### Location
+```
+plugins/my-plugin/.security-exemptions.json
+```
+
+### Format
+
+```json
+{
+  "version": "1.0",
+  "exemptions": [
+    {
+      "tool": "detect-secrets",
+      "file": "tests/fixtures/mock_credentials.py",
+      "line": 12,
+      "reason": "Test fixture with intentionally fake credentials for unit tests",
+      "approved_by": "security-team"
+    },
+    {
+      "tool": "bandit",
+      "file": "server/dev_mode.py",
+      "rule": "B201",
+      "reason": "Flask debug mode only enabled in dev environment via FLASK_ENV check",
+      "approved_by": "my-alias",
+      "ticket": "ADO-12345"
+    },
+    {
+      "tool": "pip-audit",
+      "package": "requests",
+      "version": "2.25.0",
+      "cve": "CVE-2023-32681",
+      "reason": "Not exploitable - only internal API calls, no proxy usage",
+      "temporary": true,
+      "expires": "2026-06-30",
+      "ticket": "ADO-67890"
+    }
+  ]
+}
+```
+
+### Required Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `reason` | ✅ Yes | Why this is safe (minimum 10 characters) |
+| `approved_by` | ⚠️ For Critical/High | Who approved this exemption |
+| `ticket` | ⚠️ For Critical/High | Tracking ticket (ADO work item) |
+| `expires` | ⚠️ If `temporary: true` | ISO date when exemption expires |
+
+### Exemption Matching
+
+Exemptions match findings by:
+- **Exact match:** `file` + `line` number
+- **Category match:** `category` + `file` (any line)
+- **CVE match:** `cve` identifier
+- **Rule match:** Tool-specific `rule` ID (e.g., `B201` for bandit)
+
+### Temporary Exemptions
+
+For known issues you plan to fix later:
+
+```json
+{
+  "tool": "pip-audit",
+  "package": "old-library",
+  "cve": "CVE-2025-12345",
+  "reason": "Upgrade blocked by dependency conflict - scheduled for Q2",
+  "temporary": true,
+  "expires": "2026-06-30",
+  "ticket": "ADO-99999"
+}
+```
+
+**Expired exemptions** are treated as active findings again.
+
+## Common Scenarios
+
+### Scenario 1: Test Credentials in Fixtures
+
+```python
+# tests/fixtures/mock_auth.py
+TEST_API_KEY = "sk_test_fake_key_12345"  # ← Will be flagged
+```
+
+**Fix Option 1** - Use allowed pattern:
+```python
+TEST_API_KEY = "sk_test_12345"  # Starts with sk_test_ (allowed)
+```
+
+**Fix Option 2** - Add exemption:
+```json
+{
+  "tool": "detect-secrets",
+  "file": "tests/fixtures/mock_auth.py",
+  "line": 3,
+  "reason": "Test fixture - not a real credential"
+}
+```
+
+### Scenario 2: Vulnerable Dependency
+
+```
+❌ SECURITY SCAN FAILED
+
+🔴 CRITICAL:
+  [cve] Vulnerable dependency: requests==2.25.0
+  ├─ File: requirements.txt
+  ├─ CVE:  CVE-2023-32681 (CVSS 7.5)
+  └─ Fix:  Update to requests>=2.31.0
+```
+
+**Fix:**
+```bash
+# Update requirements.txt
+requests>=2.31.0
+
+# Or use pip-audit to fix automatically
+pip-audit --fix
+```
+
+### Scenario 3: eval() in Code Example
+
+If you have `eval()` in a markdown code block that's **demonstrative** (showing what NOT to do):
+
+**Option 1** - Add a comment in the code block:
+````markdown
+```python
+# BAD EXAMPLE - DO NOT USE IN PRODUCTION
+result = eval(user_input)  # Dangerous!
+
+# GOOD EXAMPLE - Use instead:
+result = ast.literal_eval(user_input)
+```
+````
+
+**Option 2** - Add exemption:
+```json
+{
+  "tool": "bandit",
+  "file": "skills/security-examples/SKILL.md",
+  "rule": "B307",
+  "reason": "Demonstrative bad example showing what not to do"
+}
+```
+
+### Scenario 4: Legitimate Dynamic Code
+
+Sometimes you genuinely need dynamic behavior:
+
+```python
+# BEFORE (flagged)
+exec(f"import {module_name}")
+
+# BETTER (safer)
+import importlib
+module = importlib.import_module(module_name)
+```
+
+If you truly need `exec()` after reviewing alternatives:
+
+```json
+{
+  "tool": "bandit",
+  "file": "server/plugin_loader.py",
+  "line": 145,
+  "rule": "B307",
+  "reason": "Dynamic module loading from validated plugin registry - input sanitized with allowlist",
+  "approved_by": "security-guardian",
+  "ticket": "ADO-54321"
+}
+```
+
+## Running Locally
+
+Before submitting your PR, run the security scan locally:
+
+```bash
+# From repository root
+python scripts/sync-marketplace.py --preview
+
+# Skip security scanning (not recommended)
+python scripts/sync-marketplace.py --no-security --preview
+
+# Test only security scanning
+python scripts/security_scanner.py plugins/my-plugin --verbose
+```
+
+## Tools Used
+
+| Tool | Purpose | Language |
+|------|---------|----------|
+| [detect-secrets](https://github.com/Yelp/detect-secrets) | Secret detection | All |
+| [pip-audit](https://github.com/pypa/pip-audit) | Python CVE scanning | Python |
+| [npm audit](https://docs.npmjs.com/cli/v8/commands/npm-audit) | Node.js CVE scanning | Node.js |
+| [bandit](https://bandit.readthedocs.io/) | Python SAST | Python |
+
+## Getting Help
+
+If you're blocked by security findings:
+
+1. **Review the error message** - it includes specific recommendations
+2. **Check if it's a false positive** - add to `.security-exemptions.json`
+3. **Ask in the PR** - tag @security-team for guidance
+4. **Read the CWE/CVE** - links provided in findings for detailed explanations
+
+## Best Practices
+
+### DO ✅
+- Use environment variables for secrets: `os.environ.get("API_KEY")`
+- Keep dependencies updated
+- Use `subprocess.run()` with argument lists, not shell strings
+- Validate and sanitize all user input
+- Use `ast.literal_eval()` instead of `eval()`
+- Store test credentials in fixture files (excluded from scanning)
+
+### DON'T ❌
+- Hardcode secrets in source code
+- Use `eval()` or `exec()` with user input
+- Use `os.system()` or `shell=True` in subprocess
+- Trust user input without validation
+- Use `pickle` for untrusted data
+- Leave vulnerable dependencies unfixed
+
+## Exemption Review
+
+Security exemptions are reviewed:
+- **Quarterly** - Expired temporary exemptions trigger new findings
+- **On promotion** - All exemptions reviewed before moving to curated marketplace
+- **Security audits** - Periodic review of all exempted findings
+
+## Questions?
+
+- **Security concerns:** Contact @security-team
+- **False positives:** Add exemption and document in PR
+- **Tool issues:** File an issue with the `security` label

--- a/packages/agent-compliance/AGENTS.md
+++ b/packages/agent-compliance/AGENTS.md
@@ -1,0 +1,199 @@
+# Agent Compliance — Coding Agent Instructions
+
+## Project Overview
+
+Agent Compliance (`agent-governance-toolkit`) provides **runtime policy enforcement, governance attestation validation, and security scanning** for AI agent systems. This package ensures agents operate within organizational compliance boundaries and security policies.
+
+**Core Capabilities:**
+
+- **Governance Attestation Validation:** PR checklist validation for organizational governance requirements
+- **Security Scanning:** Automated detection of secrets, CVEs, dangerous code patterns, and unsafe operations
+- **Runtime Policy Enforcement:** OWASP ASI 2026 controls and integrity verification
+
+## Build & Test Commands
+
+```bash
+# Install dependencies (development mode)
+pip install -e ".[dev]"
+
+# Run all tests
+pytest tests/ -v
+
+# Run tests with coverage
+pytest tests/ --cov=src/agent_compliance --cov-report=html --cov-branch
+
+# Type checking
+pyright src/
+
+# Lint and format
+ruff check . --fix
+ruff format .
+```
+
+## Code Style
+
+- **Formatter/Linter:** Ruff (line-length: 100, target: Python 3.10+)
+- **Type checker:** Pyright basic mode with ignore for missing stubs
+- **Docstrings:** Google-style for public APIs
+- **Imports:** Sorted alphabetically, grouped (stdlib → third-party → first-party → local)
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/agent_compliance/governance/attestation_validator.py` | PR governance attestation validation logic |
+| `src/agent_compliance/security/scanner.py` | Security scanning engine (secrets, CVEs, code patterns) |
+| `src/agent_compliance/security/schemas/` | JSON schemas for security exemptions |
+| `tests/test_governance_attestation.py` | Attestation validation test suite (17 tests) |
+| `tests/test_security_scanner.py` | Security scanner test suite (25 tests) |
+
+## Coding Conventions
+
+- All public APIs must have type hints
+- Use `dataclasses` for simple data structures, Pydantic for validation-heavy ones
+- SecurityFinding fields: `severity`, `category`, `title`, `file`, `line`, `code`, `description`, `recommendation`, `cwe`, `cve`
+- Severity levels: `critical`, `high`, `medium`, `low` (critical/high block PRs)
+- AttestationResult fields: `valid`, `errors`, `warnings`, `sections_found`
+
+## Security Scanning
+
+### What Gets Scanned
+
+- Python files (`*.py`)
+- JavaScript/TypeScript (`*.js`, `*.ts`)
+- Shell scripts (`*.sh`, `*.bash`)
+- PowerShell (`*.ps1`)
+- Dependency files (`requirements.txt`, `package.json`, `pyproject.toml`)
+- **Code blocks in markdown files** (skills and agents)
+
+### What's Excluded
+
+- Test fixtures (`**/tests/fixtures/**`, `**/test_data/**`)
+- Example files (`**/examples/**`, `**/*.example.*`)
+- Build artifacts (`**/dist/**`, `**/node_modules/**`, `**/__pycache__/**`)
+- Documentation (most `README.md`, `docs/**/*.md`)
+
+### Severity Configuration
+
+```python
+SEVERITY_CONFIG = {
+    "critical": {"blocks": True},   # Hardcoded secrets, RCE, CVSS ≥ 9.0
+    "high": {"blocks": True},       # Command injection, SQL injection, CVSS 7.0-8.9
+    "medium": {"blocks": False},    # Weak crypto, CVSS 4.0-6.9
+    "low": {"blocks": False},       # Best practices, CVSS < 4.0
+}
+```
+
+## Governance Attestation
+
+### Required Sections (Default)
+
+1. Security review
+2. Privacy review
+3. CELA review
+4. Responsible AI review
+5. Accessibility review
+6. Release Readiness / Safe Deployment
+7. Org-specific Launch Gates
+
+### Validation Rules
+
+- Each section must have **exactly one** checkbox marked
+- Section titles must be at the start of lines (after `##`)
+- Checkboxes can have leading whitespace
+- Case-insensitive matching (`[x]` or `[X]`)
+
+## Testing Requirements
+
+- All new features **must** include corresponding tests
+- **Attestation tests:** Cover valid/invalid sections, checkbox counts, edge cases (CRLF, special chars)
+- **Security tests:** Cover finding creation, exemption matching, pattern detection, formatting
+- Run tests before committing: `pytest tests/ -v`
+- Aim for >90% code coverage on new code
+
+## Exemption System
+
+Security exemptions use `.security-exemptions.json`:
+
+```json
+{
+  "version": "1.0",
+  "exemptions": [
+    {
+      "tool": "detect-secrets",
+      "file": "tests/fixtures/mock.py",
+      "line": 10,
+      "reason": "Test fixture with intentionally fake credentials",
+      "approved_by": "security-team"
+    }
+  ]
+}
+```
+
+### Exemption Matching
+
+- **File + line:** Exact match
+- **Category + file:** Any line in file
+- **CVE identifier:** Matches across all files
+- **Temporary exemptions:** Must have `expires` field (ISO 8601 date)
+
+## GitHub Actions
+
+### action/governance-attestation
+
+Validates PR descriptions contain properly filled governance attestation checklists.
+
+**Inputs:**
+- `pr-body`: PR body to validate (defaults to current PR)
+- `required-sections`: YAML list of section titles
+- `min-body-length`: Minimum PR body length (default: 40)
+
+**Outputs:**
+- `status`: `pass` or `fail`
+- `errors`: Newline-separated list of errors
+- `sections-found`: JSON mapping sections to checkbox counts
+
+### action/security-scan
+
+Scans for secrets, CVEs, and dangerous code patterns.
+
+**Inputs:**
+- `paths`: Space-separated paths to scan (required)
+- `exemptions-file`: Path to exemptions JSON (default: `.security-exemptions.json`)
+- `min-severity`: Minimum severity to block (default: `high`)
+
+**Outputs:**
+- `status`: `pass` or `fail`
+- `findings-count`: Total findings
+- `blocking-count`: Critical/high findings
+- `findings`: JSON-formatted findings
+
+## Boundaries
+
+- **Never commit** secrets, credentials, or API keys
+- **Never loosen** severity blocking thresholds without approval
+- **Never skip** test coverage for new features
+- Keep backward compatibility in public APIs
+
+## Integration with External Tools
+
+Security scanner integrates with:
+- **detect-secrets:** Secret detection
+- **pip-audit:** Python CVE scanning
+- **npm audit:** Node.js CVE scanning
+- **bandit:** Python SAST
+
+All tool integrations gracefully handle missing tools (skip scan if not available).
+
+## Commit Style
+
+Use conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`
+
+Example:
+```
+feat(security): add support for shell script scanning
+
+- Add _check_shell_code_block method
+- Detect dangerous rm -rf patterns
+- Add tests for shell code validation
+```

--- a/packages/agent-compliance/CHANGELOG.md
+++ b/packages/agent-compliance/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Security Scan GitHub Action** (`action/security-scan`) - Automated security validation for AI agent code
+  - Hardcoded secret detection using detect-secrets
+  - Dependency vulnerability scanning (pip-audit, npm audit)
+  - Dangerous code pattern detection using bandit
+  - Markdown code block scanning for embedded executable code
+  - Exemption system via `.security-exemptions.json` with justification tracking and expiration dates
+  - Severity-based blocking (Critical/High blocks merge, Medium/Low warns)
+  
+- **Governance Attestation GitHub Action** (`action/governance-attestation`) - PR governance checklist validation
+  - Validates exactly one checkbox marked per required section
+  - Enforces governance attestation template usage
+  - Configurable required sections for organizational compliance
+  
+- **Test coverage** - 42 comprehensive tests with 100% coverage for new security and governance modules
+- **Documentation updates** - Added GitHub Actions integration examples to README.md and CONTRIBUTING.md
+- **AGENTS.md** - Developer guidance for agent-compliance package
+
 ## [1.1.0] - 2026-03-15
 
 ### Changed

--- a/packages/agent-compliance/src/agent_compliance/governance/__init__.py
+++ b/packages/agent-compliance/src/agent_compliance/governance/__init__.py
@@ -1,0 +1,27 @@
+"""Governance attestation validation module.
+
+This module provides validation for PR governance attestation checklists,
+ensuring compliance with organizational governance requirements.
+
+Example:
+    from agent_compliance.governance import validate_attestation
+
+    result = validate_attestation(
+        pr_body="...",
+        required_sections=[
+            "Security review",
+            "Privacy review",
+            "CELA review"
+        ]
+    )
+
+    if not result.valid:
+        print(f"Errors: {result.errors}")
+"""
+
+from .attestation_validator import AttestationResult, validate_attestation
+
+__all__ = [
+    "AttestationResult",
+    "validate_attestation",
+]

--- a/packages/agent-compliance/src/agent_compliance/governance/attestation_validator.py
+++ b/packages/agent-compliance/src/agent_compliance/governance/attestation_validator.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Governance attestation validation.
+
+Validates that PR descriptions contain properly filled out governance
+attestation checklists with exactly one checkbox marked per section.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class AttestationResult:
+    """Result of attestation validation."""
+
+    valid: bool
+    errors: list[str]
+    warnings: list[str]
+    sections_found: dict[str, int]  # section -> number of checked boxes
+
+    @property
+    def message(self) -> str:
+        """Get formatted message for display."""
+        if self.valid:
+            return "✅ Governance attestation checklist looks good."
+
+        lines = ["❌ Governance attestation check failed:"]
+        for error in self.errors:
+            lines.append(f"  - {error}")
+        return "\n".join(lines)
+
+
+def _normalize_line_endings(text: str) -> str:
+    """Normalize CRLF to LF for consistent matching."""
+    return text.replace("\r\n", "\n")
+
+
+def _count_section_checkboxes(section_title: str, pr_body: str) -> dict:
+    """Count checked boxes in a specific section.
+
+    Args:
+        section_title: Title of the section to find (e.g., "1) Security review")
+        pr_body: Full PR description body
+
+    Returns:
+        dict with:
+            - found: bool (whether section was found)
+            - checked: int (number of checked boxes)
+            - details: str (section content) or None
+    """
+    # Escape special regex characters in section title
+    escaped_title = re.escape(section_title)
+
+    # Find section header and capture content until next ## or end
+    pattern = rf"(^|\n)##\s+{escaped_title}\n([\s\S]*?)(?=\n##\s+|$)"
+    match = re.search(pattern, pr_body, re.IGNORECASE)
+
+    if not match:
+        return {"found": False, "checked": 0, "details": None}
+
+    section_content = match.group(2)
+
+    # Count checked boxes (case-insensitive, allows leading whitespace)
+    checked_pattern = r"(^|\n)\s*-\s*\[x\]"
+    checked_boxes = re.findall(checked_pattern, section_content, re.IGNORECASE)
+
+    return {
+        "found": True,
+        "checked": len(checked_boxes),
+        "details": section_content,
+    }
+
+
+def validate_attestation(
+    pr_body: str,
+    required_sections: Optional[list[str]] = None,
+    min_body_length: int = 40,
+) -> AttestationResult:
+    """Validate governance attestation in PR description.
+
+    Args:
+        pr_body: PR description body text
+        required_sections: List of section titles that must be present.
+            Defaults to standard 7-section attestation.
+        min_body_length: Minimum length for PR body to be considered valid
+
+    Returns:
+        AttestationResult with validation status and details
+    """
+    if required_sections is None:
+        required_sections = [
+            "1) Security review",
+            "2) Privacy review",
+            "3) CELA review",
+            "4) Responsible AI review",
+            "5) Accessibility review",
+            "6) Release Readiness / Safe Deployment",
+            "7) Org-specific Launch Gates",
+        ]
+
+    # Normalize line endings
+    pr_body = _normalize_line_endings(pr_body or "")
+
+    errors = []
+    sections_found = {}
+
+    # Check each required section
+    for section in required_sections:
+        result = _count_section_checkboxes(section, pr_body)
+
+        if not result["found"]:
+            errors.append(f'Missing section: "{section}"')
+            continue
+
+        checked_count = result["checked"]
+        sections_found[section] = checked_count
+
+        if checked_count != 1:
+            errors.append(
+                f'Section "{section}" must have exactly ONE checked box, '
+                f"found {checked_count}."
+            )
+
+    # Check minimum body length
+    if pr_body.strip() and len(pr_body.strip()) < min_body_length:
+        errors.append(
+            "PR description is too short; "
+            "please use the governance attestation template."
+        )
+
+    return AttestationResult(
+        valid=len(errors) == 0,
+        errors=errors,
+        warnings=[],
+        sections_found=sections_found,
+    )

--- a/packages/agent-compliance/src/agent_compliance/security/__init__.py
+++ b/packages/agent-compliance/src/agent_compliance/security/__init__.py
@@ -1,0 +1,31 @@
+"""Security scanning module for agent governance.
+
+This module provides security scanning capabilities for agent code and plugins:
+- Secret detection (API keys, tokens, credentials)
+- Dependency vulnerability scanning (CVEs)
+- Dangerous code pattern detection
+- Security exemption management
+
+Example:
+    from agent_compliance.security import scan_plugin_security
+
+    exit_code, error_msg = scan_plugin_security(
+        plugin_dir=Path("plugins/my-plugin"),
+        plugin_name="my-plugin",
+        verbose=True
+    )
+"""
+
+from .scanner import (
+    SecurityFinding,
+    SecurityScanner,
+    format_security_report,
+    scan_plugin_security,
+)
+
+__all__ = [
+    "SecurityFinding",
+    "SecurityScanner",
+    "format_security_report",
+    "scan_plugin_security",
+]

--- a/packages/agent-compliance/src/agent_compliance/security/scanner.py
+++ b/packages/agent-compliance/src/agent_compliance/security/scanner.py
@@ -1,0 +1,878 @@
+#!/usr/bin/env python3
+"""
+Security Scanner for Plugin Marketplace
+
+Performs security validation on plugin directories:
+- Secret detection (detect-secrets)
+- Dependency CVE scanning (pip-audit, npm audit)
+- Dangerous code patterns (bandit, semgrep)
+- File permission and path traversal checks
+
+Integrates with sync-marketplace.py validation flow.
+"""
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Severity levels and blocking behavior
+SEVERITY_CONFIG = {
+    "critical": {
+        "emoji": "🔴",
+        "blocks": True,
+        "description": "Immediate security risk",
+    },
+    "high": {"emoji": "🟡", "blocks": True, "description": "Serious vulnerability"},
+    "medium": {
+        "emoji": "🟠",
+        "blocks": False,
+        "description": "Security improvement recommended",
+    },
+    "low": {"emoji": "🟢", "blocks": False, "description": "Best practice suggestion"},
+}
+
+# Files/patterns to exclude from scanning
+SECURITY_SCAN_EXCLUSIONS = [
+    "**/tests/fixtures/**",
+    "**/test/fixtures/**",
+    "**/__tests__/mocks/**",
+    "**/test_data/**",
+    "**/*.test.py",
+    "**/*.spec.js",
+    "**/*.test.ts",
+    "**/*.example.*",
+    "**/examples/**",
+    "**/samples/**",
+    "**/docs/examples/**",
+    "**/*.template.*",
+    "**/*.sample.*",
+    "**/dist/**",
+    "**/build/**",
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/__pycache__/**",
+    "**/README.md",
+    "**/CONTRIBUTING.md",
+]
+
+# Test credential patterns to allow
+ALLOWED_TEST_PATTERNS = [
+    r"sk_test_",
+    r"test[-_]?key",
+    r"mock[-_]?token",
+    r"fake[-_]?secret",
+    r"dummy[-_]?password",
+    r"example\.com",
+    r"localhost",
+    r"127\.0\.0\.1",
+]
+
+
+class SecurityFinding:
+    """Represents a single security finding."""
+
+    def __init__(
+        self,
+        severity: str,
+        category: str,
+        title: str,
+        file: str,
+        line: int | None = None,
+        code: str | None = None,
+        description: str = "",
+        recommendation: str = "",
+        cwe: str | None = None,
+        cve: str | None = None,
+    ):
+        self.severity = severity
+        self.category = category
+        self.title = title
+        self.file = file
+        self.line = line
+        self.code = code
+        self.description = description
+        self.recommendation = recommendation
+        self.cwe = cwe
+        self.cve = cve
+
+    def is_blocking(self) -> bool:
+        """Check if this finding blocks PR merge."""
+        return SEVERITY_CONFIG.get(self.severity, {}).get("blocks", False)
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON output."""
+        return {
+            "severity": self.severity,
+            "category": self.category,
+            "title": self.title,
+            "file": self.file,
+            "line": self.line,
+            "code": self.code,
+            "description": self.description,
+            "recommendation": self.recommendation,
+            "cwe": self.cwe,
+            "cve": self.cve,
+        }
+
+    def format_cli(self, plugin_name: str) -> str:
+        """Format finding for CLI output."""
+        lines = [
+            f"  [{self.category}] {self.title}",
+            f"  ├─ File: plugins/{plugin_name}/{self.file}",
+        ]
+        if self.line:
+            lines.append(f"  ├─ Line: {self.line}")
+        if self.code:
+            # Truncate long code snippets
+            code_preview = self.code[:80] + "..." if len(self.code) > 80 else self.code
+            lines.append(f"  ├─ Code: {code_preview}")
+        if self.cve:
+            lines.append(f"  ├─ CVE:  {self.cve}")
+        if self.cwe:
+            lines.append(f"  ├─ CWE:  {self.cwe}")
+        lines.append(f"  ├─ Issue: {self.description}")
+        if self.recommendation:
+            lines.append(f"  └─ Fix:  {self.recommendation}")
+        else:
+            # Remove last ├─ and replace with └─
+            lines[-1] = lines[-1].replace("├─", "└─")
+
+        return "\n".join(lines)
+
+
+class SecurityScanner:
+    """Security scanner for plugin directories."""
+
+    def __init__(self, plugin_dir: Path, plugin_name: str, verbose: bool = False):
+        self.plugin_dir = plugin_dir
+        self.plugin_name = plugin_name
+        self.verbose = verbose
+        self.findings: list[SecurityFinding] = []
+        self.exemptions = self._load_exemptions()
+
+    def _load_exemptions(self) -> dict:
+        """Load security exemptions from plugin config.
+        
+        Validates the exemptions file against a strict schema to prevent
+        malicious or malformed exemptions from bypassing security checks.
+        
+        Required fields per exemption:
+        - category: One of "secrets", "cve", "code-pattern"
+        - file: File path (string)
+        - justification: Reason for exemption (min 10 chars)
+        - approved_by: Person/role who approved (string)
+        
+        Optional fields:
+        - line: Line number (integer or null)
+        - cve: CVE identifier (string or null)
+        - expires: ISO 8601 datetime (string or null)
+        
+        Returns:
+            Dict with "exemptions" key containing valid, non-expired exemptions.
+            Returns empty list if file doesn't exist or validation fails.
+        """
+        exemption_file = self.plugin_dir / ".security-exemptions.json"
+        if exemption_file.exists():
+            try:
+                with open(exemption_file, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                
+                # Validate structure
+                if not isinstance(data, dict) or "exemptions" not in data:
+                    return {"exemptions": []}
+                
+                if not isinstance(data["exemptions"], list):
+                    return {"exemptions": []}
+                
+                # Validate and filter each exemption
+                valid_exemptions = []
+                for ex in data["exemptions"]:
+                    # Validate required fields
+                    if not isinstance(ex, dict):
+                        continue
+                    
+                    if not all(k in ex for k in ["category", "file", "justification", "approved_by"]):
+                        continue
+                    
+                    # Validate category enum
+                    if ex["category"] not in ["secrets", "cve", "code-pattern"]:
+                        continue
+                    
+                    # Validate justification length
+                    if not isinstance(ex["justification"], str) or len(ex["justification"]) < 10:
+                        continue
+                    
+                    # Validate types
+                    if not isinstance(ex["file"], str) or not isinstance(ex["approved_by"], str):
+                        continue
+                    
+                    # Check expiration if present
+                    if "expires" in ex and ex["expires"] is not None:
+                        try:
+                            expires = datetime.fromisoformat(ex["expires"])
+                            if expires < datetime.now():
+                                continue  # Skip expired
+                        except (ValueError, TypeError):
+                            continue  # Invalid date format
+                    
+                    valid_exemptions.append(ex)
+                
+                return {"exemptions": valid_exemptions}
+            except (json.JSONDecodeError, ValueError, OSError):
+                return {"exemptions": []}
+        return {"exemptions": []}
+
+    def _is_exempted(self, finding: SecurityFinding) -> bool:
+        """Check if a finding is exempted."""
+        for exemption in self.exemptions.get("exemptions", []):
+            # Match by file and line
+            if (
+                exemption.get("file") == finding.file
+                and exemption.get("line") == finding.line
+            ):
+                return True
+            # Match by category and file pattern
+            if exemption.get("category") == finding.category:
+                if exemption.get("file") == finding.file:
+                    return True
+            # Match by CVE
+            if finding.cve and exemption.get("cve") == finding.cve:
+                return True
+        return False
+
+    def _should_scan_file(self, file_path: Path) -> bool:
+        """Check if file should be scanned based on exclusion patterns."""
+        rel_path = file_path.relative_to(self.plugin_dir)
+        for pattern in SECURITY_SCAN_EXCLUSIONS:
+            if rel_path.match(pattern.replace("**/", "")):
+                return False
+        return True
+
+    def scan_secrets(self) -> None:
+        """Scan for hardcoded secrets using detect-secrets."""
+        if not self._tool_available("detect-secrets"):
+            if self.verbose:
+                print("    [secrets] detect-secrets not installed, skipping")
+            return
+
+        try:
+            result = subprocess.run(
+                ["detect-secrets", "scan", str(self.plugin_dir), "--all-files"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            if "potential secrets" in result.stdout.lower():
+                # Parse output for secret locations
+                # detect-secrets outputs to stderr for found secrets
+                output = result.stdout + result.stderr
+
+                # Simple pattern matching for file:line
+                pattern = r"(\S+):(\d+)"
+                matches = re.finditer(pattern, output)
+
+                for match in matches:
+                    file_path = match.group(1)
+                    line_num = int(match.group(2))
+
+                    # Skip if in exclusion list
+                    try:
+                        path = Path(file_path)
+                        if not self._should_scan_file(path):
+                            continue
+                    except (ValueError, OSError):
+                        continue
+
+                    # Check against allowed test patterns
+                    if self._is_test_credential(file_path, line_num):
+                        continue
+
+                    self.findings.append(
+                        SecurityFinding(
+                            severity="critical",
+                            category="secrets",
+                            title="Potential hardcoded secret detected",
+                            file=file_path,
+                            line=line_num,
+                            description="Possible API key, token, or credential in source code",
+                            recommendation="Use environment variables, Azure Key Vault, or GitHub Secrets",
+                            cwe="CWE-798",
+                        )
+                    )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    def _is_test_credential(self, file_path: str, line_num: int) -> bool:
+        """Check if a potential secret matches allowed test patterns."""
+        try:
+            path = Path(file_path)
+            if not path.exists():
+                return False
+
+            # Read the specific line
+            lines = path.read_text(encoding="utf-8").splitlines()
+            if line_num > len(lines):
+                return False
+
+            line_content = lines[line_num - 1]
+
+            # Check against allowed patterns
+            for pattern in ALLOWED_TEST_PATTERNS:
+                if re.search(pattern, line_content, re.IGNORECASE):
+                    return True
+        except (OSError, UnicodeDecodeError):
+            pass
+
+        return False
+
+    def scan_python_dependencies(self) -> None:
+        """Scan Python dependencies for CVEs using pip-audit."""
+        req_files = [
+            self.plugin_dir / "requirements.txt",
+            self.plugin_dir / "pyproject.toml",
+        ]
+
+        for req_file in req_files:
+            if not req_file.exists():
+                continue
+
+            if not self._tool_available("pip-audit"):
+                if self.verbose:
+                    print("    [python-cve] pip-audit not installed, skipping")
+                return
+
+            try:
+                cmd = ["pip-audit", "--format", "json"]
+                if req_file.name == "requirements.txt":
+                    cmd.extend(["--requirement", str(req_file)])
+                else:
+                    cmd.extend(["--file", str(req_file)])
+
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+
+                if result.stdout:
+                    data = json.loads(result.stdout)
+                    self._parse_pip_audit_json(data, req_file.name)
+            except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+                pass
+
+    def _parse_pip_audit_json(self, data: dict, filename: str) -> None:
+        """Parse pip-audit JSON output and create findings."""
+        dependencies = data.get("dependencies", [])
+        for dep in dependencies:
+            package = dep.get("name", "unknown")
+            version = dep.get("version", "unknown")
+            vulns = dep.get("vulns", [])
+
+            for vuln in vulns:
+                cve = vuln.get("id", "")
+                description = vuln.get("description", "")
+                fix_versions = vuln.get("fix_versions", [])
+
+                # Determine severity from CVSS score if available
+                severity = "high"
+                # pip-audit doesn't always include CVSS, default to high
+
+                recommendation = (
+                    f"Update to {package}>={fix_versions[0]}"
+                    if fix_versions
+                    else f"Update {package} to latest version"
+                )
+
+                self.findings.append(
+                    SecurityFinding(
+                        severity=severity,
+                        category="cve",
+                        title=f"Vulnerable dependency: {package}=={version}",
+                        file=filename,
+                        description=description[:200],  # Truncate long descriptions
+                        recommendation=recommendation,
+                        cve=cve,
+                    )
+                )
+
+    def scan_node_dependencies(self) -> None:
+        """Scan Node.js dependencies for vulnerabilities using npm audit."""
+        package_json = self.plugin_dir / "package.json"
+        if not package_json.exists():
+            return
+
+        if not self._tool_available("npm"):
+            if self.verbose:
+                print("    [node-cve] npm not installed, skipping")
+            return
+
+        try:
+            # Need to run in plugin directory
+            result = subprocess.run(
+                ["npm", "audit", "--json"],
+                cwd=self.plugin_dir,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+            if result.stdout:
+                data = json.loads(result.stdout)
+                self._parse_npm_audit_json(data)
+        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+            pass
+
+    def _parse_npm_audit_json(self, data: dict) -> None:
+        """Parse npm audit JSON output and create findings."""
+        vulnerabilities = data.get("vulnerabilities", {})
+
+        for package, vuln_data in vulnerabilities.items():
+            severity = vuln_data.get("severity", "medium")
+            # Map npm severity to our levels
+            severity_map = {
+                "critical": "critical",
+                "high": "high",
+                "moderate": "medium",
+                "low": "low",
+            }
+            mapped_severity = severity_map.get(severity, "medium")
+
+            via = vuln_data.get("via", [])
+            for item in via:
+                if isinstance(item, dict):
+                    cve = item.get("cve", "")
+                    title = item.get("title", "")
+
+                    self.findings.append(
+                        SecurityFinding(
+                            severity=mapped_severity,
+                            category="cve",
+                            title=f"Vulnerable dependency: {package}",
+                            file="package.json",
+                            description=title,
+                            recommendation="Run: npm audit fix --force (review changes carefully)",
+                            cve=cve if cve else None,
+                        )
+                    )
+
+    def scan_code_patterns(self) -> None:
+        """Scan for dangerous code patterns using bandit (Python)."""
+        # Find Python files
+        py_files = list(self.plugin_dir.rglob("*.py"))
+        if not py_files:
+            return
+
+        if not self._tool_available("bandit"):
+            if self.verbose:
+                print("    [code-patterns] bandit not installed, skipping")
+            return
+
+        try:
+            result = subprocess.run(
+                ["bandit", "-r", str(self.plugin_dir), "-f", "json", "-ll"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+            if result.stdout:
+                data = json.loads(result.stdout)
+                self._parse_bandit_json(data)
+        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+            pass
+
+    def _parse_bandit_json(self, data: dict) -> None:
+        """Parse bandit JSON output and create findings."""
+        results = data.get("results", [])
+
+        for result in results:
+            filename = result.get("filename", "")
+            line_number = result.get("line_number", 0)
+            code = result.get("code", "").strip()
+            issue_text = result.get("issue_text", "")
+            severity = result.get("issue_severity", "MEDIUM").lower()
+            confidence = result.get("issue_confidence", "MEDIUM").lower()
+            test_id = result.get("test_id", "")
+
+            # Map bandit severity to our levels
+            severity_map = {"high": "high", "medium": "medium", "low": "low"}
+            mapped_severity = severity_map.get(severity, "medium")
+
+            # Skip low confidence findings
+            if confidence == "low":
+                continue
+
+            # Make filename relative to plugin dir
+            try:
+                rel_file = Path(filename).relative_to(self.plugin_dir)
+            except ValueError:
+                rel_file = Path(filename).name
+
+            if not self._should_scan_file(self.plugin_dir / rel_file):
+                continue
+
+            self.findings.append(
+                SecurityFinding(
+                    severity=mapped_severity,
+                    category="code-pattern",
+                    title=issue_text,
+                    file=str(rel_file),
+                    line=line_number,
+                    code=code,
+                    description=f"Bandit rule {test_id}",
+                    recommendation=self._get_bandit_recommendation(test_id),
+                )
+            )
+
+    def _get_bandit_recommendation(self, test_id: str) -> str:
+        """Get recommendation for common bandit findings."""
+        recommendations = {
+            "B201": "Never use flask debug mode in production",
+            "B301": "Avoid pickle - use JSON or safer serialization",
+            "B302": "Use defusedxml instead of xml.etree",
+            "B303": "Use hashlib with secure algorithms (SHA256+)",
+            "B304": "Use secrets module for cryptographic randomness",
+            "B306": "Restrict file permissions with tempfile.mkstemp",
+            "B307": "eval() is dangerous - find alternative approach",
+            "B308": "mark_safe() can introduce XSS - validate input first",
+            "B310": "Validate URL before urllib.urlopen",
+            "B311": "Use secrets.SystemRandom() for security",
+            "B321": "Avoid FTP - use SFTP/FTPS instead",
+            "B323": "Avoid SSL/TLS v1.0-1.1 - use TLS 1.2+",
+            "B324": "Use modern hash algorithms (SHA256+)",
+            "B501": "Validate SSL certificates - avoid verify=False",
+            "B502": "Use secure SSL/TLS settings",
+            "B506": "Use yaml.safe_load() instead of yaml.load()",
+            "B601": "Avoid paramiko auto_add_policy",
+            "B602": "Use subprocess with shell=False",
+            "B603": "Use subprocess argument list, not shell strings",
+            "B607": "Specify absolute path for executables",
+        }
+        return recommendations.get(test_id, "Review and fix security issue")
+
+    def scan_markdown_code_blocks(self) -> None:
+        """Extract and scan code blocks from markdown files."""
+        md_files = []
+
+        # Scan skills and agents (primary content)
+        for pattern in ["skills/**/SKILL.md", "agents/*.md"]:
+            md_files.extend(self.plugin_dir.glob(pattern))
+
+        for md_file in md_files:
+            if not self._should_scan_file(md_file):
+                continue
+
+            self._scan_markdown_file(md_file)
+
+    def _scan_markdown_file(self, md_path: Path) -> None:
+        """Scan code blocks within a markdown file."""
+        try:
+            content = md_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return
+
+        # Extract code blocks
+        pattern = r"```(\w+)\n(.*?)```"
+        blocks = re.findall(pattern, content, re.DOTALL)
+
+        for i, (lang, code) in enumerate(blocks):
+            lang = lang.lower()
+
+            # Check for dangerous patterns in code blocks
+            if lang in ["python", "py"]:
+                self._check_python_code_block(md_path, code, i)
+            elif lang in ["javascript", "js", "typescript", "ts"]:
+                self._check_js_code_block(md_path, code, i)
+            elif lang in ["bash", "sh", "shell"]:
+                self._check_shell_code_block(md_path, code, i)
+
+    def _check_python_code_block(
+        self, file_path: Path, code: str, block_index: int
+    ) -> None:
+        """Check Python code block for dangerous patterns."""
+        dangerous_patterns = [
+            (
+                r"\beval\s*\(",
+                "eval() detected",
+                "Avoid eval() - use ast.literal_eval or safer alternatives",
+            ),
+            (
+                r"\bexec\s*\(",
+                "exec() detected",
+                "Avoid exec() - use safer alternatives",
+            ),
+            (
+                r"pickle\.loads?\s*\(",
+                "pickle usage detected",
+                "Use JSON or safer serialization",
+            ),
+            (
+                r"os\.system\s*\(",
+                "os.system() detected",
+                "Use subprocess.run() with argument list",
+            ),
+        ]
+
+        for pattern, title, recommendation in dangerous_patterns:
+            if re.search(pattern, code):
+                rel_file = file_path.relative_to(self.plugin_dir)
+                self.findings.append(
+                    SecurityFinding(
+                        severity="high",
+                        category="code-pattern",
+                        title=title,
+                        file=f"{rel_file} (code block #{block_index + 1})",
+                        description="Dangerous pattern in markdown code example",
+                        recommendation=recommendation,
+                    )
+                )
+
+    def _check_js_code_block(
+        self, file_path: Path, code: str, block_index: int
+    ) -> None:
+        """Check JavaScript code block for dangerous patterns."""
+        dangerous_patterns = [
+            (r"\beval\s*\(", "eval() detected", "Use JSON.parse or safer alternatives"),
+            (
+                r"new\s+Function\s*\(",
+                "Function constructor detected",
+                "Avoid dynamic code generation",
+            ),
+            (
+                r"innerHTML\s*=",
+                "innerHTML assignment",
+                "Use textContent or DOMPurify for sanitization",
+            ),
+        ]
+
+        for pattern, title, recommendation in dangerous_patterns:
+            if re.search(pattern, code):
+                rel_file = file_path.relative_to(self.plugin_dir)
+                self.findings.append(
+                    SecurityFinding(
+                        severity="high",
+                        category="code-pattern",
+                        title=title,
+                        file=f"{rel_file} (code block #{block_index + 1})",
+                        description="Dangerous pattern in markdown code example",
+                        recommendation=recommendation,
+                    )
+                )
+
+    def _check_shell_code_block(
+        self, file_path: Path, code: str, block_index: int
+    ) -> None:
+        """Check shell code block for dangerous patterns."""
+        dangerous_patterns = [
+            (
+                r"\brm\s+-rf\s+/",
+                "Dangerous recursive delete",
+                "Never delete from root - use specific paths",
+            ),
+            (
+                r"\$\(.*curl\s+.*\|.*bash",
+                "Pipe to bash from curl",
+                "Download and inspect scripts before execution",
+            ),
+        ]
+
+        for pattern, title, recommendation in dangerous_patterns:
+            if re.search(pattern, code):
+                rel_file = file_path.relative_to(self.plugin_dir)
+                # Shell examples in docs are often demonstrative - lower severity
+                severity = "medium"
+                self.findings.append(
+                    SecurityFinding(
+                        severity=severity,
+                        category="code-pattern",
+                        title=title,
+                        file=f"{rel_file} (code block #{block_index + 1})",
+                        description="Potentially dangerous shell pattern",
+                        recommendation=recommendation,
+                    )
+                )
+
+    def _tool_available(self, tool_name: str) -> bool:
+        """Check if a security tool is available."""
+        try:
+            subprocess.run(
+                [tool_name, "--version"],
+                capture_output=True,
+                timeout=5,
+            )
+            return True
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+    def run_all_scans(self) -> tuple[bool, list[SecurityFinding]]:
+        """
+        Run all security scans.
+
+        Returns:
+            (passed, findings) where passed=False if blocking issues found
+        """
+        if self.verbose:
+            print(f"  {self.plugin_name}: running security scans...")
+
+        # Run all scanners
+        self.scan_secrets()
+        self.scan_python_dependencies()
+        self.scan_node_dependencies()
+        self.scan_code_patterns()
+        self.scan_markdown_code_blocks()
+
+        # Filter exempted findings
+        filtered_findings = [f for f in self.findings if not self._is_exempted(f)]
+
+        # Check for blocking issues
+        blocking_findings = [f for f in filtered_findings if f.is_blocking()]
+
+        passed = len(blocking_findings) == 0
+
+        if self.verbose:
+            if passed:
+                print(f"  {self.plugin_name}: security scan passed ✓")
+            else:
+                print(
+                    f"  {self.plugin_name}: {len(blocking_findings)} blocking issue(s) found"
+                )
+
+        return passed, filtered_findings
+
+
+def format_security_report(plugin_name: str, findings: list[SecurityFinding]) -> str:
+    """Format security findings for CLI output."""
+    if not findings:
+        return ""
+
+    # Group by severity
+    by_severity = {"critical": [], "high": [], "medium": [], "low": []}
+    for finding in findings:
+        by_severity[finding.severity].append(finding)
+
+    lines = [
+        "",
+        "═" * 70,
+        "",
+        f"❌ SECURITY SCAN FAILED for plugin: {plugin_name}",
+        "",
+        "═" * 70,
+        "",
+    ]
+
+    # Critical issues
+    if by_severity["critical"]:
+        lines.append("🔴 CRITICAL (blocks merge):")
+        lines.append("")
+        for finding in by_severity["critical"]:
+            lines.append(finding.format_cli(plugin_name))
+            lines.append("")
+
+    # High severity
+    if by_severity["high"]:
+        lines.append("🟡 HIGH (blocks merge):")
+        lines.append("")
+        for finding in by_severity["high"]:
+            lines.append(finding.format_cli(plugin_name))
+            lines.append("")
+
+    # Medium severity
+    if by_severity["medium"]:
+        lines.append("🟠 MEDIUM (warning - fix before release):")
+        lines.append("")
+        for finding in by_severity["medium"]:
+            lines.append(finding.format_cli(plugin_name))
+            lines.append("")
+
+    # Low severity
+    if by_severity["low"]:
+        lines.append("🟢 LOW (informational):")
+        lines.append("")
+        for finding in by_severity["low"]:
+            lines.append(finding.format_cli(plugin_name))
+            lines.append("")
+
+    # Summary
+    critical_count = len(by_severity["critical"])
+    high_count = len(by_severity["high"])
+    medium_count = len(by_severity["medium"])
+    low_count = len(by_severity["low"])
+
+    lines.append("─" * 70)
+    lines.append(
+        f"Summary: {critical_count} critical, {high_count} high, {medium_count} medium, {low_count} low"
+    )
+    lines.append("")
+    lines.append(
+        f"To suppress false positives, add to plugins/{plugin_name}/.security-exemptions.json"
+    )
+    lines.append("")
+
+    blocking = critical_count + high_count > 0
+    if blocking:
+        lines.append("Exit code: 1 (blocking - PR cannot merge)")
+    else:
+        lines.append("Exit code: 0 (warnings only - PR can merge)")
+
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def scan_plugin_security(
+    plugin_dir: Path,
+    plugin_name: str,
+    verbose: bool = False,
+) -> tuple[int, str]:
+    """
+    Scan a plugin directory for security issues.
+
+    Args:
+        plugin_dir: Path to plugin directory
+        plugin_name: Plugin name for error messages
+        verbose: Print detailed progress
+
+    Returns:
+        (exit_code, error_message) where:
+        - exit_code: 0 if passed, 1 if blocking issues found
+        - error_message: Formatted error message (empty if passed)
+    """
+    scanner = SecurityScanner(plugin_dir, plugin_name, verbose)
+    passed, findings = scanner.run_all_scans()
+
+    if not passed:
+        error_msg = format_security_report(plugin_name, findings)
+        return 1, error_msg
+
+    # Non-blocking warnings
+    if findings:
+        warning_msg = format_security_report(plugin_name, findings)
+        print(warning_msg)
+
+    return 0, ""
+
+
+if __name__ == "__main__":
+    """Standalone testing."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Security scan for plugins")
+    parser.add_argument("plugin_dir", type=Path, help="Plugin directory to scan")
+    parser.add_argument("--name", help="Plugin name", default=None)
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args()
+
+    plugin_name = args.name or args.plugin_dir.name
+    exit_code, error_msg = scan_plugin_security(
+        args.plugin_dir, plugin_name, args.verbose
+    )
+
+    if error_msg:
+        print(error_msg, file=sys.stderr)
+
+    sys.exit(exit_code)

--- a/packages/agent-compliance/src/agent_compliance/security/schemas/security-exemptions.example.json
+++ b/packages/agent-compliance/src/agent_compliance/security/schemas/security-exemptions.example.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.0",
+  "exemptions": [
+    {
+      "tool": "detect-secrets",
+      "file": "tests/fixtures/mock_credentials.py",
+      "line": 12,
+      "fingerprint": "abc123def456",
+      "reason": "Test fixture with intentionally fake credentials for unit tests",
+      "approved_by": "security-team"
+    },
+    {
+      "tool": "bandit",
+      "file": "server/dev_mode.py",
+      "line": 89,
+      "rule": "B201",
+      "reason": "Flask debug mode only enabled in dev environment via FLASK_ENV environment variable check",
+      "approved_by": "plugin-author",
+      "ticket": "ADO-12345"
+    },
+    {
+      "tool": "pip-audit",
+      "package": "requests",
+      "version": "2.25.0",
+      "cve": "CVE-2023-32681",
+      "reason": "Not exploitable in our usage pattern - only internal API calls, no proxy configuration",
+      "temporary": true,
+      "expires": "2026-06-30",
+      "ticket": "ADO-67890",
+      "approved_by": "security-guardian"
+    },
+    {
+      "category": "code-pattern",
+      "file": "docs/examples/bad_patterns.md",
+      "reason": "Demonstrative examples showing insecure patterns to avoid - not executable code",
+      "approved_by": "doc-team"
+    }
+  ]
+}

--- a/packages/agent-compliance/src/agent_compliance/security/schemas/security-exemptions.schema.json
+++ b/packages/agent-compliance/src/agent_compliance/security/schemas/security-exemptions.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/agency-microsoft/playground/schemas/security-exemptions.json",
+  "title": "Security Exemptions",
+  "description": "Configuration file for suppressing security scan findings",
+  "type": "object",
+  "required": ["version", "exemptions"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version",
+      "const": "1.0"
+    },
+    "exemptions": {
+      "type": "array",
+      "description": "List of exempted security findings",
+      "items": {
+        "type": "object",
+        "required": ["reason"],
+        "properties": {
+          "tool": {
+            "type": "string",
+            "description": "Security tool that generated the finding",
+            "enum": ["detect-secrets", "pip-audit", "npm-audit", "bandit", "semgrep"]
+          },
+          "category": {
+            "type": "string",
+            "description": "Finding category",
+            "enum": ["secrets", "cve", "code-pattern", "injection", "file-operation"]
+          },
+          "file": {
+            "type": "string",
+            "description": "File path relative to plugin root"
+          },
+          "line": {
+            "type": "integer",
+            "description": "Line number of the finding",
+            "minimum": 1
+          },
+          "fingerprint": {
+            "type": "string",
+            "description": "Unique identifier for the finding (from detect-secrets)"
+          },
+          "rule": {
+            "type": "string",
+            "description": "Tool-specific rule ID (e.g., B201 for bandit)"
+          },
+          "package": {
+            "type": "string",
+            "description": "Package name (for dependency vulnerabilities)"
+          },
+          "version": {
+            "type": "string",
+            "description": "Package version (for dependency vulnerabilities)"
+          },
+          "cve": {
+            "type": "string",
+            "description": "CVE identifier",
+            "pattern": "^CVE-\\d{4}-\\d{4,}$"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Explanation for why this is exempted (required)",
+            "minLength": 10
+          },
+          "approved_by": {
+            "type": "string",
+            "description": "Who approved this exemption (required for critical/high)"
+          },
+          "ticket": {
+            "type": "string",
+            "description": "Tracking ticket for this exemption (required for critical/high)"
+          },
+          "temporary": {
+            "type": "boolean",
+            "description": "Whether this is a temporary exemption",
+            "default": false
+          },
+          "expires": {
+            "type": "string",
+            "description": "Expiration date for temporary exemptions (ISO 8601 format)",
+            "format": "date"
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "temporary": {"const": true}
+              }
+            },
+            "then": {
+              "required": ["expires"]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": "1.0",
+      "exemptions": [
+        {
+          "tool": "detect-secrets",
+          "file": "tests/fixtures/mock_credentials.py",
+          "line": 12,
+          "fingerprint": "abc123def456",
+          "reason": "Test fixture with intentionally fake credentials for unit tests",
+          "approved_by": "security-team"
+        },
+        {
+          "tool": "bandit",
+          "file": "server/dev_mode.py",
+          "rule": "B201",
+          "reason": "Flask debug mode only enabled in dev environment via FLASK_ENV check",
+          "approved_by": "security-guardian",
+          "ticket": "ADO-12345"
+        },
+        {
+          "tool": "pip-audit",
+          "package": "requests",
+          "version": "2.25.0",
+          "cve": "CVE-2023-32681",
+          "reason": "Not exploitable in our usage - only internal API calls, no proxies",
+          "temporary": true,
+          "expires": "2026-06-30",
+          "ticket": "ADO-67890"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agent-compliance/tests/test_governance_attestation.py
+++ b/packages/agent-compliance/tests/test_governance_attestation.py
@@ -1,0 +1,354 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for governance attestation validation."""
+
+from __future__ import annotations
+
+
+from agent_compliance.governance import AttestationResult, validate_attestation
+
+
+class TestAttestationResult:
+    """Tests for AttestationResult dataclass."""
+
+    def test_message_property_success(self):
+        """Test message property for successful validation."""
+        result = AttestationResult(
+            valid=True,
+            errors=[],
+            warnings=[],
+            sections_found={"1) Security review": 1},
+        )
+        assert result.message == "✅ Governance attestation checklist looks good."
+
+    def test_message_property_failure(self):
+        """Test message property for failed validation."""
+        result = AttestationResult(
+            valid=False,
+            errors=[
+                'Missing section: "1) Security review"',
+                'Section "2) Privacy review" must have exactly ONE checked box, found 0.',
+            ],
+            warnings=[],
+            sections_found={},
+        )
+        message = result.message
+        assert "❌ Governance attestation check failed:" in message
+        assert "Missing section" in message
+        assert "must have exactly ONE checked box" in message
+
+
+class TestValidateAttestation:
+    """Tests for validate_attestation function."""
+
+    def test_valid_attestation_all_sections_checked(self):
+        """Test validation passes when all sections have exactly one checkbox marked."""
+        pr_body = """
+# Governance Attestations (required)
+
+## 1) Security review
+- [x] ✅ Yes
+- [ ] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 2) Privacy review
+- [ ] ✅ Yes
+- [x] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 3) CELA review
+- [ ] ✅ Yes
+- [ ] ❌ No
+- [x] ⚠️ Not needed (explain below)
+
+## 4) Responsible AI review
+- [x] ✅ Yes
+- [ ] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 5) Accessibility review
+- [ ] ✅ Yes
+- [x] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 6) Release Readiness / Safe Deployment
+- [x] ✅ Yes
+- [ ] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 7) Org-specific Launch Gates
+- [ ] ✅ Yes
+- [ ] ❌ No
+- [x] ⚠️ Not needed (explain below)
+
+---
+
+# Notes / Links
+Some additional context here.
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is True
+        assert len(result.errors) == 0
+        assert len(result.sections_found) == 7
+        for count in result.sections_found.values():
+            assert count == 1
+
+    def test_missing_section(self):
+        """Test validation fails when required section is missing."""
+        pr_body = """
+## 1) Security review
+- [x] ✅ Yes
+- [ ] ❌ No
+
+## 2) Privacy review
+- [x] ✅ Yes
+- [ ] ❌ No
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is False
+        assert any("Missing section" in error for error in result.errors)
+        # Should have errors for 5 missing sections (3-7)
+        missing_errors = [e for e in result.errors if "Missing section" in e]
+        assert len(missing_errors) == 5
+
+    def test_no_checkbox_marked(self):
+        """Test validation fails when no checkbox is marked in a section."""
+        pr_body = """
+## 1) Security review
+- [ ] ✅ Yes
+- [ ] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 2) Privacy review
+- [x] ✅ Yes
+- [ ] ❌ No
+
+## 3) CELA review
+- [x] ✅ Yes
+
+## 4) Responsible AI review
+- [x] ✅ Yes
+
+## 5) Accessibility review
+- [x] ✅ Yes
+
+## 6) Release Readiness / Safe Deployment
+- [x] ✅ Yes
+
+## 7) Org-specific Launch Gates
+- [x] ✅ Yes
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is False
+        assert any(
+            "must have exactly ONE checked box, found 0" in error
+            for error in result.errors
+        )
+        assert result.sections_found["1) Security review"] == 0
+
+    def test_multiple_checkboxes_marked(self):
+        """Test validation fails when multiple checkboxes are marked in a section."""
+        pr_body = """
+## 1) Security review
+- [x] ✅ Yes
+- [x] ❌ No
+- [ ] ⚠️ Not needed (explain below)
+
+## 2) Privacy review
+- [x] ✅ Yes
+
+## 3) CELA review
+- [x] ✅ Yes
+
+## 4) Responsible AI review
+- [x] ✅ Yes
+
+## 5) Accessibility review
+- [x] ✅ Yes
+
+## 6) Release Readiness / Safe Deployment
+- [x] ✅ Yes
+
+## 7) Org-specific Launch Gates
+- [x] ✅ Yes
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is False
+        assert any(
+            "must have exactly ONE checked box, found 2" in error
+            for error in result.errors
+        )
+        assert result.sections_found["1) Security review"] == 2
+
+    def test_custom_required_sections(self):
+        """Test validation with custom required sections."""
+        pr_body = """
+## Security review
+- [x] ✅ Yes
+
+## Privacy review
+- [x] ✅ Yes
+
+## Legal review
+- [x] ✅ Yes
+"""
+        custom_sections = ["Security review", "Privacy review", "Legal review"]
+        result = validate_attestation(pr_body, required_sections=custom_sections)
+        assert result.valid is True
+        assert len(result.sections_found) == 3
+
+    def test_case_insensitive_checkbox_matching(self):
+        """Test that checkbox matching is case-insensitive."""
+        pr_body = """
+## 1) Security review
+- [X] ✅ Yes
+- [ ] ❌ No
+
+## 2) Privacy review
+- [x] ✅ Yes
+
+## 3) CELA review
+- [X] ✅ Yes
+
+## 4) Responsible AI review
+- [x] ✅ Yes
+
+## 5) Accessibility review
+- [X] ✅ Yes
+
+## 6) Release Readiness / Safe Deployment
+- [x] ✅ Yes
+
+## 7) Org-specific Launch Gates
+- [X] ✅ Yes
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is True
+        for count in result.sections_found.values():
+            assert count == 1
+
+    def test_crlf_line_endings_normalized(self):
+        """Test that CRLF line endings are properly normalized."""
+        pr_body = "## 1) Security review\r\n- [x] ✅ Yes\r\n- [ ] ❌ No\r\n\r\n## 2) Privacy review\r\n- [x] ✅ Yes\r\n\r\n## 3) CELA review\r\n- [x] ✅ Yes\r\n\r\n## 4) Responsible AI review\r\n- [x] ✅ Yes\r\n\r\n## 5) Accessibility review\r\n- [x] ✅ Yes\r\n\r\n## 6) Release Readiness / Safe Deployment\r\n- [x] ✅ Yes\r\n\r\n## 7) Org-specific Launch Gates\r\n- [x] ✅ Yes\r\n"
+        result = validate_attestation(pr_body)
+        assert result.valid is True
+
+    def test_pr_body_too_short(self):
+        """Test validation fails when PR body is too short."""
+        pr_body = "Short PR body"
+        result = validate_attestation(pr_body, min_body_length=40)
+        assert result.valid is False
+        assert any("too short" in error for error in result.errors)
+
+    def test_empty_pr_body(self):
+        """Test validation with empty PR body."""
+        result = validate_attestation("")
+        assert result.valid is False
+        assert any("Missing section" in error for error in result.errors)
+
+    def test_none_pr_body(self):
+        """Test validation with None PR body."""
+        result = validate_attestation(None)
+        assert result.valid is False
+        assert any("Missing section" in error for error in result.errors)
+
+    def test_whitespace_before_checkbox(self):
+        """Test that leading whitespace before checkboxes is allowed."""
+        pr_body = """
+## 1) Security review
+  - [x] ✅ Yes
+  - [ ] ❌ No
+
+## 2) Privacy review
+    - [x] ✅ Yes
+
+## 3) CELA review
+- [x] ✅ Yes
+
+## 4) Responsible AI review
+        - [x] ✅ Yes
+
+## 5) Accessibility review
+- [x] ✅ Yes
+
+## 6) Release Readiness / Safe Deployment
+- [x] ✅ Yes
+
+## 7) Org-specific Launch Gates
+- [x] ✅ Yes
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is True
+
+    def test_section_with_special_regex_characters(self):
+        """Test sections with special regex characters are properly escaped."""
+        pr_body = """
+## Test (with parens)
+- [x] ✅ Yes
+
+## Test [with brackets]
+- [x] ✅ Yes
+"""
+        custom_sections = ["Test (with parens)", "Test [with brackets]"]
+        result = validate_attestation(pr_body, required_sections=custom_sections)
+        assert result.valid is True
+
+    def test_section_not_at_start_of_line(self):
+        """Test that sections must start at beginning of line."""
+        pr_body = """
+Some text ## 1) Security review
+- [x] ✅ Yes
+
+## 2) Privacy review
+- [x] ✅ Yes
+
+## 3) CELA review
+- [x] ✅ Yes
+
+## 4) Responsible AI review
+- [x] ✅ Yes
+
+## 5) Accessibility review
+- [x] ✅ Yes
+
+## 6) Release Readiness / Safe Deployment
+- [x] ✅ Yes
+
+## 7) Org-specific Launch Gates
+- [x] ✅ Yes
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is False
+        assert any(
+            'Missing section: "1) Security review"' in error for error in result.errors
+        )
+
+    def test_multiple_errors_aggregated(self):
+        """Test that multiple errors are properly aggregated."""
+        pr_body = """
+## 1) Security review
+- [x] ✅ Yes
+- [x] ❌ No
+
+## 2) Privacy review
+- [ ] ✅ Yes
+"""
+        result = validate_attestation(pr_body)
+        assert result.valid is False
+        # Should have error for section 1 (multiple checkboxes)
+        # and errors for missing sections 3-7
+        assert len(result.errors) >= 6
+        assert any("found 2" in error for error in result.errors)
+        assert any("Missing section" in error for error in result.errors)
+
+    def test_custom_min_body_length(self):
+        """Test validation with custom minimum body length."""
+        pr_body = "A" * 100  # 100 characters
+        result = validate_attestation(pr_body, min_body_length=50)
+        # Will fail due to missing sections, but not due to length
+        assert not any("too short" in error for error in result.errors)
+
+        pr_body = "A" * 30  # 30 characters
+        result = validate_attestation(pr_body, min_body_length=50)
+        # Will fail due to length
+        assert any("too short" in error for error in result.errors)

--- a/packages/agent-compliance/tests/test_security_scanner.py
+++ b/packages/agent-compliance/tests/test_security_scanner.py
@@ -1,0 +1,514 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for security scanner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_compliance.security import (
+    SecurityFinding,
+    SecurityScanner,
+    format_security_report,
+)
+
+
+class TestSecurityFinding:
+    """Tests for SecurityFinding class."""
+
+    def test_is_blocking_critical(self):
+        """Test that critical findings are blocking."""
+        finding = SecurityFinding(
+            severity="critical",
+            category="secrets",
+            title="Hardcoded API key",
+            file="config.py",
+            line=10,
+        )
+        assert finding.is_blocking() is True
+
+    def test_is_blocking_high(self):
+        """Test that high severity findings are blocking."""
+        finding = SecurityFinding(
+            severity="high",
+            category="cve",
+            title="Vulnerable dependency",
+            file="requirements.txt",
+        )
+        assert finding.is_blocking() is True
+
+    def test_is_not_blocking_medium(self):
+        """Test that medium severity findings are not blocking."""
+        finding = SecurityFinding(
+            severity="medium",
+            category="code-pattern",
+            title="Weak crypto",
+            file="utils.py",
+        )
+        assert finding.is_blocking() is False
+
+    def test_is_not_blocking_low(self):
+        """Test that low severity findings are not blocking."""
+        finding = SecurityFinding(
+            severity="low",
+            category="code-pattern",
+            title="Best practice suggestion",
+            file="main.py",
+        )
+        assert finding.is_blocking() is False
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        finding = SecurityFinding(
+            severity="critical",
+            category="secrets",
+            title="Hardcoded secret",
+            file="config.py",
+            line=42,
+            code="API_KEY = 'sk_live_12345'",
+            description="Hardcoded API key detected",
+            recommendation="Use environment variables",
+            cwe="CWE-798",
+            cve="CVE-2024-12345",
+        )
+        result = finding.to_dict()
+        assert result["severity"] == "critical"
+        assert result["category"] == "secrets"
+        assert result["title"] == "Hardcoded secret"
+        assert result["file"] == "config.py"
+        assert result["line"] == 42
+        assert result["code"] == "API_KEY = 'sk_live_12345'"
+        assert result["cwe"] == "CWE-798"
+        assert result["cve"] == "CVE-2024-12345"
+
+    def test_format_cli(self):
+        """Test CLI formatting."""
+        finding = SecurityFinding(
+            severity="high",
+            category="cve",
+            title="Vulnerable dependency",
+            file="requirements.txt",
+            line=5,
+            description="CVE in requests library",
+            recommendation="Update to requests>=2.31.0",
+            cve="CVE-2023-32681",
+        )
+        formatted = finding.format_cli("test-plugin")
+        assert "[cve] Vulnerable dependency" in formatted
+        assert "plugins/test-plugin/requirements.txt" in formatted
+        assert "Line: 5" in formatted
+        assert "CVE-2023-32681" in formatted
+        assert "Update to requests>=2.31.0" in formatted
+
+
+class TestSecurityScanner:
+    """Tests for SecurityScanner class."""
+
+    def test_scanner_initialization(self, tmp_path):
+        """Test scanner initialization."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin", verbose=False)
+        assert scanner.plugin_dir == plugin_dir
+        assert scanner.plugin_name == "test-plugin"
+        assert scanner.verbose is False
+        assert scanner.findings == []
+        assert scanner.exemptions == {"exemptions": []}
+
+    def test_load_exemptions_file_not_exists(self, tmp_path):
+        """Test loading exemptions when file doesn't exist."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        assert scanner.exemptions == {"exemptions": []}
+
+    def test_load_exemptions_valid_file(self, tmp_path):
+        """Test loading valid exemptions file."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        exemptions_file = plugin_dir / ".security-exemptions.json"
+        exemptions_data = {
+            "version": "1.0",
+            "exemptions": [
+                {
+                    "tool": "detect-secrets",
+                    "file": "tests/fixtures/mock.py",
+                    "line": 10,
+                    "reason": "Test fixture",
+                }
+            ],
+        }
+        exemptions_file.write_text(json.dumps(exemptions_data))
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        assert len(scanner.exemptions["exemptions"]) == 1
+        assert scanner.exemptions["exemptions"][0]["tool"] == "detect-secrets"
+
+    def test_load_exemptions_expired_filtered_out(self, tmp_path):
+        """Test that expired exemptions are filtered out."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        exemptions_file = plugin_dir / ".security-exemptions.json"
+        exemptions_data = {
+            "version": "1.0",
+            "exemptions": [
+                {
+                    "tool": "bandit",
+                    "file": "old.py",
+                    "expires": "2020-01-01",
+                    "reason": "Temporary exemption",
+                },
+                {
+                    "tool": "bandit",
+                    "file": "current.py",
+                    "expires": "2099-12-31",
+                    "reason": "Future exemption",
+                },
+            ],
+        }
+        exemptions_file.write_text(json.dumps(exemptions_data))
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        # Only the non-expired exemption should be loaded
+        assert len(scanner.exemptions["exemptions"]) == 1
+        assert scanner.exemptions["exemptions"][0]["file"] == "current.py"
+
+    def test_is_exempted_by_file_and_line(self, tmp_path):
+        """Test exemption matching by file and line."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        exemptions_file = plugin_dir / ".security-exemptions.json"
+        exemptions_data = {
+            "version": "1.0",
+            "exemptions": [
+                {
+                    "tool": "detect-secrets",
+                    "file": "config.py",
+                    "line": 42,
+                    "reason": "Test credential",
+                }
+            ],
+        }
+        exemptions_file.write_text(json.dumps(exemptions_data))
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        # Matching finding should be exempted
+        finding = SecurityFinding(
+            severity="critical",
+            category="secrets",
+            title="Secret detected",
+            file="config.py",
+            line=42,
+        )
+        assert scanner._is_exempted(finding) is True
+        
+        # Different line should not be exempted
+        finding_different_line = SecurityFinding(
+            severity="critical",
+            category="secrets",
+            title="Secret detected",
+            file="config.py",
+            line=43,
+        )
+        assert scanner._is_exempted(finding_different_line) is False
+
+    def test_is_exempted_by_category(self, tmp_path):
+        """Test exemption matching by category and file."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        exemptions_file = plugin_dir / ".security-exemptions.json"
+        exemptions_data = {
+            "version": "1.0",
+            "exemptions": [
+                {
+                    "category": "code-pattern",
+                    "file": "demo.py",
+                    "reason": "Demonstrative example",
+                }
+            ],
+        }
+        exemptions_file.write_text(json.dumps(exemptions_data))
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        finding = SecurityFinding(
+            severity="high",
+            category="code-pattern",
+            title="eval() usage",
+            file="demo.py",
+            line=10,
+        )
+        assert scanner._is_exempted(finding) is True
+
+    def test_is_exempted_by_cve(self, tmp_path):
+        """Test exemption matching by CVE identifier."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        exemptions_file = plugin_dir / ".security-exemptions.json"
+        exemptions_data = {
+            "version": "1.0",
+            "exemptions": [
+                {
+                    "tool": "pip-audit",
+                    "cve": "CVE-2023-32681",
+                    "reason": "Not exploitable in our usage",
+                }
+            ],
+        }
+        exemptions_file.write_text(json.dumps(exemptions_data))
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        finding = SecurityFinding(
+            severity="high",
+            category="cve",
+            title="Vulnerable dependency",
+            file="requirements.txt",
+            cve="CVE-2023-32681",
+        )
+        assert scanner._is_exempted(finding) is True
+
+    def test_should_scan_file_exclusions(self, tmp_path):
+        """Test file exclusion patterns."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        # Test files should be excluded
+        assert scanner._should_scan_file(plugin_dir / "tests" / "fixtures" / "mock.py") is False
+        assert scanner._should_scan_file(plugin_dir / "test_data" / "sample.py") is False
+        assert scanner._should_scan_file(plugin_dir / "examples" / "demo.py") is False
+        
+        # Build artifacts should be excluded
+        assert scanner._should_scan_file(plugin_dir / "dist" / "bundle.js") is False
+        assert scanner._should_scan_file(plugin_dir / "node_modules" / "lib.js") is False
+        
+        # Regular source files should be included
+        assert scanner._should_scan_file(plugin_dir / "src" / "main.py") is True
+        assert scanner._should_scan_file(plugin_dir / "lib" / "utils.js") is True
+
+    def test_is_test_credential_allowed_patterns(self, tmp_path):
+        """Test allowed test credential patterns."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        test_file = plugin_dir / "test.py"
+        test_file.write_text('API_KEY = "sk_test_fake_key_12345"\nHOST = "localhost"\nIP = "127.0.0.1"\n')
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        # Test patterns should be recognized as test credentials
+        assert scanner._is_test_credential(str(test_file), 1) is True  # sk_test_
+        assert scanner._is_test_credential(str(test_file), 2) is True  # localhost
+        assert scanner._is_test_credential(str(test_file), 3) is True  # 127.0.0.1
+
+    def test_check_python_code_block_eval_detection(self, tmp_path):
+        """Test Python code block dangerous pattern detection."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        md_file = plugin_dir / "README.md"
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        # Code with eval() should be detected
+        code_with_eval = "result = eval(user_input)"
+        scanner._check_python_code_block(md_file, code_with_eval, 0)
+        
+        assert len(scanner.findings) == 1
+        assert scanner.findings[0].title == "eval() detected"
+        assert scanner.findings[0].severity == "high"
+
+    def test_check_python_code_block_exec_detection(self, tmp_path):
+        """Test Python exec() pattern detection."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        md_file = plugin_dir / "README.md"
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        code_with_exec = "exec(malicious_code)"
+        scanner._check_python_code_block(md_file, code_with_exec, 0)
+        
+        assert len(scanner.findings) == 1
+        assert scanner.findings[0].title == "exec() detected"
+
+    def test_check_js_code_block_eval_detection(self, tmp_path):
+        """Test JavaScript eval() detection."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        md_file = plugin_dir / "README.md"
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        code_with_eval = "const result = eval(userInput);"
+        scanner._check_js_code_block(md_file, code_with_eval, 0)
+        
+        assert len(scanner.findings) == 1
+        assert scanner.findings[0].title == "eval() detected"
+
+    def test_check_shell_code_block_dangerous_rm(self, tmp_path):
+        """Test shell script dangerous pattern detection."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        md_file = plugin_dir / "README.md"
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        code_with_rm = "rm -rf /"
+        scanner._check_shell_code_block(md_file, code_with_rm, 0)
+        
+        assert len(scanner.findings) == 1
+        assert scanner.findings[0].title == "Dangerous recursive delete"
+        assert scanner.findings[0].severity == "medium"
+
+    def test_get_bandit_recommendation(self, tmp_path):
+        """Test bandit recommendation lookup."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        
+        # Test known rule
+        rec = scanner._get_bandit_recommendation("B307")
+        assert "eval()" in rec
+        
+        # Test unknown rule
+        rec_unknown = scanner._get_bandit_recommendation("B999")
+        assert "Review and fix" in rec_unknown
+
+    def test_scan_markdown_file(self, tmp_path):
+        """Test scanning markdown files for dangerous code patterns."""
+        plugin_dir = tmp_path / "test-plugin"
+        plugin_dir.mkdir()
+        
+        skill_dir = plugin_dir / "skills" / "demo"
+        skill_dir.mkdir(parents=True)
+        
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("""# Demo Skill
+
+```python
+result = eval(user_input)
+```
+
+```javascript
+const data = eval(userCode);
+```
+
+```bash
+rm -rf /
+```
+""")
+        
+        scanner = SecurityScanner(plugin_dir, "test-plugin")
+        scanner._scan_markdown_file(skill_file)
+        
+        # Should find all three dangerous patterns
+        assert len(scanner.findings) == 3
+        titles = [f.title for f in scanner.findings]
+        assert "eval() detected" in titles
+        assert "Dangerous recursive delete" in titles
+
+
+class TestFormatSecurityReport:
+    """Tests for format_security_report function."""
+
+    def test_format_empty_findings(self):
+        """Test formatting with no findings."""
+        report = format_security_report("test-plugin", [])
+        assert report == ""
+
+    def test_format_critical_findings(self):
+        """Test formatting with critical findings."""
+        findings = [
+            SecurityFinding(
+                severity="critical",
+                category="secrets",
+                title="Hardcoded API key",
+                file="config.py",
+                line=10,
+                description="API key in source",
+                recommendation="Use environment variables",
+            )
+        ]
+        report = format_security_report("test-plugin", findings)
+        
+        assert "❌ SECURITY SCAN FAILED" in report
+        assert "🔴 CRITICAL" in report
+        assert "Hardcoded API key" in report
+        assert "Exit code: 1" in report
+
+    def test_format_multiple_severity_levels(self):
+        """Test formatting with mixed severity levels."""
+        findings = [
+            SecurityFinding(
+                severity="critical",
+                category="secrets",
+                title="Critical issue",
+                file="a.py",
+            ),
+            SecurityFinding(
+                severity="high",
+                category="cve",
+                title="High issue",
+                file="b.py",
+            ),
+            SecurityFinding(
+                severity="medium",
+                category="code-pattern",
+                title="Medium issue",
+                file="c.py",
+            ),
+            SecurityFinding(
+                severity="low",
+                category="code-pattern",
+                title="Low issue",
+                file="d.py",
+            ),
+        ]
+        report = format_security_report("test-plugin", findings)
+        
+        assert "🔴 CRITICAL" in report
+        assert "🟡 HIGH" in report
+        assert "🟠 MEDIUM" in report
+        assert "🟢 LOW" in report
+        assert "Summary: 1 critical, 1 high, 1 medium, 1 low" in report
+
+    def test_format_warnings_only_no_blocking(self):
+        """Test formatting with only warnings (no blocking issues)."""
+        findings = [
+            SecurityFinding(
+                severity="medium",
+                category="code-pattern",
+                title="Medium issue",
+                file="a.py",
+            ),
+            SecurityFinding(
+                severity="low",
+                category="code-pattern",
+                title="Low issue",
+                file="b.py",
+            ),
+        ]
+        report = format_security_report("test-plugin", findings)
+        
+        assert "🟠 MEDIUM" in report
+        assert "🟢 LOW" in report
+        assert "Exit code: 0" in report
+        assert "warnings only" in report


### PR DESCRIPTION
Cherry-picked from #456 by @marklicata — takes the new action code and modules without the README overwrite (which would revert our disclaimer and test count updates from #457).

## What's included

**Two new GitHub Actions:**

| Action | Purpose |
|--------|---------|
| \ction/security-scan/\ | Scan for secrets, CVEs, dangerous patterns, unsafe file ops |
| \ction/governance-attestation/\ | Validate PR governance checklists (security, privacy, CELA, RAI) |

**New modules in agent-compliance:**
- \SecurityScanner\ — pattern-based code scanning with severity levels and exemption tracking
- \AttestationValidator\ — PR description governance checklist enforcement
- 42 new tests (100% coverage)

**Docs:**
- \docs/security-scanning.md\
- README highlight for GitHub Actions
- CONTRIBUTING.md security section update

## What's NOT included (intentionally)

The README.md full rewrite from #456 is excluded — it would revert our Public Preview disclaimer, scope clarity section, and 9,500+ test count. Instead, only a two-line highlight entry was added.

Supersedes #456 (which should be closed after this merges).

cc @marklicata — thank you for the contribution!