### PR TITLE
fix: gate NuGet publish on ESRP signing configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,9 +245,15 @@ jobs:
         working-directory: packages/agent-governance-dotnet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          ESRP_AAD_ID: ${{ secrets.ESRP_AAD_ID }}
         run: |
           if [ -z "$NUGET_API_KEY" ]; then
             echo "::warning::NUGET_API_KEY not set, skipping NuGet publish"
+            exit 0
+          fi
+          if [ -z "$ESRP_AAD_ID" ]; then
+            echo "::warning::ESRP signing not configured — NuGet.org requires Microsoft-signed packages for the Microsoft.* prefix. Skipping publish until ESRP certificates are provisioned."
+            echo "::warning::Build artifacts are available as workflow artifacts for manual signing and upload."
             exit 0
           fi
           # Push both .nupkg and .snupkg (symbol package)


### PR DESCRIPTION
Fixes the publish workflow failure: NuGet.org rejects unsigned packages under the \Microsoft.*\ prefix.

**Error:** \This package must be signed with a registered certificate.\

**Root cause:** The publish step ran even when ESRP signing wasn't performed (secrets not configured yet).

**Fix:** Add \ESRP_AAD_ID\ check before \dotnet nuget push\ — skip with a warning when ESRP certificates are not provisioned. Build artifacts are still uploaded for manual signing.