### PR TITLE
feat: add ESRP NuGet publish pipeline for Microsoft.AgentGovernance

### DIFF
--- a/pipelines/nuget-publish.yml
+++ b/pipelines/nuget-publish.yml
@@ -1,0 +1,310 @@
+# ---------------------------------------------------------
+# Azure DevOps Pipeline: Publish NuGet Package to NuGet.org
+# via ESRP Release (Microsoft's approved OSS publishing path)
+#
+# GitHub Actions cannot sign NuGet packages with Microsoft
+# certificates. NuGet.org requires packages under the
+# Microsoft.* prefix to be signed with a registered cert.
+# This ADO pipeline handles: build → ESRP sign → publish.
+#
+# Prerequisites:
+#   1. Complete ESRP Release onboarding (https://aka.ms/esrp-onboarding)
+#   2. Configure Azure Identity (Managed Identity recommended)
+#   3. Set up ESRP signing certificate in Azure Key Vault
+#      - KeyCode CP-401405 for NuGet signing
+#      - KeyCode CP-230012 for Authenticode (DLL) signing
+#   4. Install ESRP Release ADO Task extension
+#   5. Register Microsoft.AgentGovernance on NuGet.org
+#
+# See: docs/internal/nuget-publishing.md for full setup guide.
+# ---------------------------------------------------------
+
+trigger: none  # Manual or release-gated trigger only
+
+pr: none
+
+parameters:
+  - name: dotnetVersion
+    type: string
+    displayName: '.NET SDK version'
+    default: '8.0.x'
+
+  - name: configuration
+    type: string
+    displayName: 'Build configuration'
+    default: 'Release'
+    values:
+      - Debug
+      - Release
+
+  - name: dryRun
+    type: boolean
+    displayName: 'Dry run (build + sign only, skip NuGet publish)'
+    default: false
+
+# -------------------------------------------------------
+# ESRP Configuration
+# Service connection name is hardcoded (required at compile time by ADO).
+# All other values sourced from ADO pipeline variables (mark as secret):
+#   ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER,
+#   ESRP_CLIENT_ID, ESRP_DOMAIN_TENANT_ID, ESRP_OWNERS, ESRP_APPROVERS,
+#   NUGET_API_KEY
+# -------------------------------------------------------
+variables:
+  esrpServiceConnection: 'Agent Governance Toolkit'
+  esrpKeyVaultName: $(ESRP_KEYVAULT_NAME)
+  esrpSignCertName: $(ESRP_CERT_IDENTIFIER)
+  esrpClientId: $(ESRP_CLIENT_ID)
+  esrpDomainTenantId: $(ESRP_DOMAIN_TENANT_ID)
+  esrpOwners: $(ESRP_OWNERS)
+  esrpApprovers: $(ESRP_APPROVERS)
+  packagePath: 'packages/agent-governance-dotnet'
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  # -------------------------------------------------------
+  # Stage 1: Build + Test + Pack
+  # -------------------------------------------------------
+  - stage: Build
+    displayName: 'Build and Test .NET SDK'
+    jobs:
+      - job: BuildAndPack
+        displayName: 'Build, Test, Pack'
+        steps:
+          - checkout: self
+
+          - task: UseDotNet@2
+            inputs:
+              packageType: 'sdk'
+              version: '${{ parameters.dotnetVersion }}'
+            displayName: 'Use .NET SDK ${{ parameters.dotnetVersion }}'
+
+          - script: |
+              dotnet build --configuration ${{ parameters.configuration }}
+            workingDirectory: '$(packagePath)'
+            displayName: 'Build .NET SDK'
+
+          - script: |
+              dotnet test --configuration ${{ parameters.configuration }} --no-build --logger "trx;LogFileName=test-results.trx"
+            workingDirectory: '$(packagePath)'
+            displayName: 'Run .NET tests'
+
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'VSTest'
+              testResultsFiles: '$(packagePath)/**/test-results.trx'
+            displayName: 'Publish test results'
+            condition: always()
+
+          - script: |
+              dotnet pack src/AgentGovernance/AgentGovernance.csproj \
+                --configuration ${{ parameters.configuration }} \
+                --no-build \
+                --output ./nupkg
+              echo "=== Packed NuGet artifacts ==="
+              ls -la ./nupkg/
+            workingDirectory: '$(packagePath)'
+            displayName: 'Pack NuGet package'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: '$(packagePath)/nupkg'
+              artifact: 'nuget-unsigned'
+              publishLocation: 'pipeline'
+            displayName: 'Publish unsigned NuGet artifacts'
+
+  # -------------------------------------------------------
+  # Stage 2: ESRP Sign (Authenticode DLLs + NuGet package)
+  # -------------------------------------------------------
+  - stage: Sign
+    displayName: 'ESRP Sign'
+    dependsOn: Build
+    condition: succeeded()
+    jobs:
+      - job: ESRPSign
+        displayName: 'Authenticode + NuGet Sign via ESRP'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'nuget-unsigned'
+              targetPath: '$(Pipeline.Workspace)/nuget-unsigned'
+            displayName: 'Download unsigned NuGet artifacts'
+
+          - script: |
+              echo "=== Unsigned artifacts ==="
+              ls -la $(Pipeline.Workspace)/nuget-unsigned/
+            displayName: 'List unsigned artifacts'
+
+          # ---------------------------------------------------------
+          # ESRP Authenticode Sign — sign DLLs inside the .nupkg
+          #
+          # KeyCode: CP-230012 (Microsoft 3rd Party Authenticode)
+          # OperationCode: SigntoolSign + SigntoolVerify
+          # ---------------------------------------------------------
+          - task: EsrpCodeSigning@5
+            displayName: 'ESRP Authenticode Sign DLLs'
+            inputs:
+              connectedservicename: '$(esrpServiceConnection)'
+              usemanagedidentity: true
+              keyvaultname: '$(esrpKeyVaultName)'
+              signcertname: '$(esrpSignCertName)'
+              folderlocation: '$(Pipeline.Workspace)/nuget-unsigned'
+              pattern: '**/*.dll'
+              signConfigType: inlineSignParams
+              inlinesignparams: |
+                [
+                  {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                      {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft.AgentGovernance"
+                      },
+                      {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "https://github.com/microsoft/agent-governance-toolkit"
+                      },
+                      {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                      },
+                      {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      },
+                      {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                      }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                  },
+                  {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                  }
+                ]
+
+          # ---------------------------------------------------------
+          # ESRP NuGet Sign — sign the .nupkg itself
+          #
+          # KeyCode: CP-401405 (Microsoft NuGet signing)
+          # OperationCode: NuGetSign + NuGetVerify
+          # ---------------------------------------------------------
+          - task: EsrpCodeSigning@5
+            displayName: 'ESRP NuGet Sign Package'
+            inputs:
+              connectedservicename: '$(esrpServiceConnection)'
+              usemanagedidentity: true
+              keyvaultname: '$(esrpKeyVaultName)'
+              signcertname: '$(esrpSignCertName)'
+              folderlocation: '$(Pipeline.Workspace)/nuget-unsigned'
+              pattern: '**/*.nupkg'
+              signConfigType: inlineSignParams
+              inlinesignparams: |
+                [
+                  {
+                    "keyCode": "CP-401405",
+                    "operationSetCode": "NuGetSign",
+                    "parameters": [],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                  },
+                  {
+                    "keyCode": "CP-401405",
+                    "operationSetCode": "NuGetVerify",
+                    "parameters": [],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                  }
+                ]
+
+          - script: |
+              echo "=== Signed artifacts ==="
+              ls -la $(Pipeline.Workspace)/nuget-unsigned/
+            displayName: 'List signed artifacts'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: '$(Pipeline.Workspace)/nuget-unsigned'
+              artifact: 'nuget-signed'
+              publishLocation: 'pipeline'
+            displayName: 'Publish signed NuGet artifacts'
+
+  # -------------------------------------------------------
+  # Stage 3: Publish to NuGet.org via ESRP Release
+  # -------------------------------------------------------
+  - stage: Publish
+    displayName: 'Publish to NuGet.org via ESRP'
+    dependsOn: Sign
+    condition: and(succeeded(), eq('${{ parameters.dryRun }}', false))
+    jobs:
+      - job: PublishNuGet
+        displayName: 'ESRP Release to NuGet.org'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'nuget-signed'
+              targetPath: '$(Pipeline.Workspace)/nuget-signed'
+            displayName: 'Download signed NuGet artifacts'
+
+          - script: |
+              echo "=== Signed artifacts to publish ==="
+              ls -la $(Pipeline.Workspace)/nuget-signed/
+            displayName: 'List signed artifacts'
+
+          # ---------------------------------------------------------
+          # ESRP Release Task — Publishes signed package to NuGet.org
+          # ---------------------------------------------------------
+          - task: EsrpRelease@11
+            displayName: 'ESRP Publish to NuGet.org'
+            inputs:
+              connectedservicename: '$(esrpServiceConnection)'
+              usemanagedidentity: true
+              keyvaultname: '$(esrpKeyVaultName)'
+              signcertname: '$(esrpSignCertName)'
+              clientid: '$(esrpClientId)'
+              intent: 'PackageDistribution'
+              contenttype: 'NuGet'
+              contentsource: 'Folder'
+              folderlocation: '$(Pipeline.Workspace)/nuget-signed'
+              waitforreleasecompletion: true
+              owners: '$(esrpOwners)'
+              approvers: '$(esrpApprovers)'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: 'ESRPRELPACMAN'
+              domaintenantid: '$(esrpDomainTenantId)'
+
+  # -------------------------------------------------------
+  # Stage 4: Verify published package
+  # -------------------------------------------------------
+  - stage: Verify
+    displayName: 'Verify Published Package'
+    dependsOn: Publish
+    condition: succeeded()
+    jobs:
+      - job: VerifyPackage
+        displayName: 'Verify package on NuGet.org'
+        steps:
+          - task: UseDotNet@2
+            inputs:
+              packageType: 'sdk'
+              version: '${{ parameters.dotnetVersion }}'
+            displayName: 'Use .NET SDK'
+
+          - script: |
+              echo "=== Verifying package on NuGet.org ==="
+              sleep 60  # Allow NuGet index to update
+              dotnet nuget list source
+              # Try to resolve the package
+              dotnet new console -o /tmp/verify-nuget --force
+              cd /tmp/verify-nuget
+              dotnet add package Microsoft.AgentGovernance --prerelease 2>&1 | head -10 || echo "⚠️ Package not yet indexed (may take a few minutes)"
+            displayName: 'Verify Microsoft.AgentGovernance on NuGet.org'


### PR DESCRIPTION
Adds an ADO pipeline for publishing the .NET NuGet package via ESRP, matching the existing PyPI pipeline pattern.

### Why
NuGet.org requires \Microsoft.*\ packages to be signed with a Microsoft-registered certificate. The GitHub Actions workflow can build and test, but cannot sign. This ADO pipeline handles the full sign-and-publish flow.

### Pipeline stages
1. **Build** — \dotnet build\ + \dotnet test\ + \dotnet pack\
2. **Sign** — ESRP Authenticode (CP-230012) for DLLs + ESRP NuGet (CP-401405) for .nupkg
3. **Publish** — ESRP Release to NuGet.org (\contenttype: NuGet\)
4. **Verify** — Confirm package is available on NuGet.org

### Configuration
Uses the same ESRP service connection and pipeline variables as \pypi-publish.yml\. Supports \dryRun\ parameter for testing without publishing.

### Related
- Fixes the build failure from run [#23654696141](https://github.com/microsoft/agent-governance-toolkit/actions/runs/23654696141)
- Complements PR #469 (which gates the GH Actions NuGet push on ESRP)