### PR TITLE
fix: update NuGet pipeline service connection to ESRP Release AzureRM

### DIFF
--- a/pipelines/nuget-publish.yml
+++ b/pipelines/nuget-publish.yml
@@ -51,7 +51,7 @@ parameters:
 #   NUGET_API_KEY
 # -------------------------------------------------------
 variables:
-  esrpServiceConnection: 'Agent Governance Toolkit'
+  esrpServiceConnection: 'ESRP Release AzureRM'
   esrpKeyVaultName: $(ESRP_KEYVAULT_NAME)
   esrpSignCertName: $(ESRP_CERT_IDENTIFIER)
   esrpClientId: $(ESRP_CLIENT_ID)


### PR DESCRIPTION
Updates \pipelines/nuget-publish.yml\ service connection from \Agent Governance Toolkit\ (PRSS type) to \ESRP Release AzureRM\ (ARM type) — same fix we applied to PyPI/npm pipelines.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>