### PR TITLE
feat: add trust report CLI command (#406)

### DIFF
--- a/packages/agent-mesh/src/agentmesh/cli/trust_cli.py
+++ b/packages/agent-mesh/src/agentmesh/cli/trust_cli.py
@@ -137,6 +137,13 @@ def _get_demo_history(agent_id: str) -> list[dict]:
     return history
 
 
+def _categorize_tasks(history: list[dict]) -> tuple[list[str], list[str]]:
+    """Split history into successful (positive delta) and failed (negative delta) task lists."""
+    successful = [h["event"] for h in history if h["delta"] > 0]
+    failed = [h["event"] for h in history if h["delta"] < 0]
+    return successful, failed
+
+
 def _output_json(data: object) -> None:
     """Print data as JSON to stdout."""
     click.echo(json.dumps(data, indent=2, default=str))
@@ -569,3 +576,62 @@ def attest(agent_id: str, note: str, score_boost: int, fmt: str, json_flag: bool
     console.print(f"  New Level:      [{style}]{level}[/{style}]")
     console.print(f"  Attested At:    {attestation_info['attested_at']}")
     console.print()
+
+
+@trust.command("report")
+@click.option(
+    "--format", "fmt",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format (table or json).",
+)
+@click.option("--json", "json_flag", is_flag=True, help="Output as JSON (shorthand for --format json).")
+def report_agents(fmt: str, json_flag: bool):
+    """Report trust score summary for all registered agents."""
+    if json_flag:
+        fmt = "json"
+
+    peers = _get_demo_peers()
+    agents: list[PeerInfo] = list(peers.values())
+
+    if fmt == "json":
+        data = []
+        for p in agents:
+            history = _get_demo_history(p.peer_did)
+            successful, failed = _categorize_tasks(history)
+            data.append({
+                "agent_id": p.peer_did,
+                "trust_score": p.trust_score,
+                "trust_level": _trust_level_label(p.trust_score),
+                "successful_tasks": len(successful),
+                "failed_tasks": len(failed),
+                "last_activity": history[-1]["timestamp"] if history else "N/A",
+            })
+        _output_json(data)
+        return
+
+    console.print("\n[bold blue]🛡️  Trust Network — Agent Report[/bold blue]\n")
+    table = Table(box=box.ROUNDED)
+    table.add_column("Agent ID", style="cyan", no_wrap=True)
+    table.add_column("Score", justify="right")
+    table.add_column("Level")
+    table.add_column("Successes", justify="right")
+    table.add_column("Failures", justify="right")
+    table.add_column("Last Activity", style="dim")
+
+    for p in agents:
+        history = _get_demo_history(p.peer_did)
+        successful, failed = _categorize_tasks(history)
+        level = _trust_level_label(p.trust_score)
+        style = _trust_level_style(level)
+        table.add_row(
+            p.peer_did,
+            str(p.trust_score),
+            f"[{style}]{level}[/{style}]",
+            str(len(successful)),
+            str(len(failed)),
+            history[-1]["timestamp"] if history else "N/A",
+        )
+
+    console.print(table)
+    console.print(f"\n  Total agents: {len(peers)}\n")

--- a/packages/agent-mesh/tests/test_trust_cli.py
+++ b/packages/agent-mesh/tests/test_trust_cli.py
@@ -341,6 +341,54 @@ class TestTrustHelp:
         assert "trust" in result.output.lower()
 
     def test_subcommand_help(self, runner):
-        for cmd in ("list", "inspect", "history", "graph", "revoke", "attest"):
+        for cmd in ("list", "inspect", "history", "graph", "revoke", "attest", "report"):
             result = runner.invoke(app, ["trust", cmd, "--help"])
             assert result.exit_code == 0, f"Help for 'trust {cmd}' failed"
+
+
+# ---------------------------------------------------------------------------
+# trust report
+# ---------------------------------------------------------------------------
+
+class TestTrustReport:
+    def test_report_table(self, runner):
+        result = runner.invoke(app, ["trust", "report"])
+        assert result.exit_code == 0
+        assert "Trust Network" in result.output or "Agent" in result.output
+        assert "Total agents" in result.output
+
+    def test_report_json(self, runner):
+        result = runner.invoke(app, ["trust", "report", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) >= 3
+        for agent in data:
+            assert "agent_id" in agent
+            assert "trust_score" in agent
+            assert "trust_level" in agent
+            assert "successful_tasks" in agent
+            assert "failed_tasks" in agent
+            assert "last_activity" in agent
+            assert isinstance(agent["successful_tasks"], int)
+            assert isinstance(agent["failed_tasks"], int)
+
+    def test_report_json_flag(self, runner):
+        result = runner.invoke(app, ["trust", "report", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+
+    def test_report_scores_in_range(self, runner):
+        result = runner.invoke(app, ["trust", "report", "--json"])
+        data = json.loads(result.output)
+        for agent in data:
+            assert 0 <= agent["trust_score"] <= 1000
+
+    def test_report_levels_valid(self, runner):
+        result = runner.invoke(app, ["trust", "report", "--json"])
+        data = json.loads(result.output)
+        valid_levels = {"Verified Partner", "Trusted", "Standard", "Probationary", "Untrusted",
+                        "verified_partner", "trusted", "standard", "probationary", "untrusted"}
+        for agent in data:
+            assert agent["trust_level"] in valid_levels


### PR DESCRIPTION
Adds \gentmesh trust report\ — a trust score summary for all registered agents.

| Format | Command |
|--------|---------|
| Table | \gentmesh trust report\ |
| JSON | \gentmesh trust report --json\ |

Shows agent ID, score (0-1000), trust level, successful/failed task counts, and last activity.

Includes 5 new tests. Closes #406.