### PR TITLE
fix: post-merge hardening — MIT headers, SHA-pin actions, innerHTML removal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Python packages
   - package-ecosystem: "pip"
     directory: "/packages/agent-os"
     schedule:
@@ -40,6 +41,7 @@ updates:
     labels:
       - "dependencies"
 
+  # npm packages
   - package-ecosystem: "npm"
     directory: "/packages/agent-os/extensions/mcp-server"
     schedule:
@@ -56,6 +58,51 @@ updates:
     labels:
       - "dependencies"
 
+  - package-ecosystem: "npm"
+    directory: "/packages/agent-mesh/sdks/typescript"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # .NET
+  - package-ecosystem: "nuget"
+    directory: "/packages/agent-governance-dotnet"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # Rust
+  - package-ecosystem: "cargo"
+    directory: "/packages/agent-mesh/sdks/rust/agentmesh"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # Go
+  - package-ecosystem: "gomod"
+    directory: "/packages/agent-mesh/sdks/go"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/packages/agent-os"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Get Changed Markdown Files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             **/*.md
 
       - name: Run Link Checker
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: lycheeverse/lychee-action@v1.9.0
+        uses: lycheeverse/lychee-action@22134d37a1fff6c2974df9c92a7c7e1e86a08f9c # v1.9.0
         with:
           # Configuration is defined here directly in YAML (no JSON file needed)
           # --exclude-loopback: ignores localhost/127.0.0.1

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Secret Scanning
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"  # Weekly Monday 6am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196e0e48de9 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+      - name: Scan for high-entropy strings
+        run: |
+          echo "=== Scanning for potential secrets ==="
+          FOUND=0
+
+          # Check for hardcoded API keys/tokens (common patterns)
+          PATTERNS=(
+            '[A-Za-z0-9_-]{32,}==$'
+            'sk-[A-Za-z0-9]{48}'
+            'ghp_[A-Za-z0-9]{36}'
+            'gho_[A-Za-z0-9]{36}'
+            'AKIA[0-9A-Z]{16}'
+            'xox[bsrp]-[A-Za-z0-9-]{10,}'
+          )
+
+          for pattern in "${PATTERNS[@]}"; do
+            MATCHES=$(grep -rn --include='*.py' --include='*.ts' --include='*.js' \
+              --include='*.yaml' --include='*.yml' --include='*.json' \
+              --include='*.env*' --include='*.cfg' --include='*.ini' \
+              -E "$pattern" . \
+              --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist \
+              --exclude-dir=__pycache__ --exclude='*.lock' --exclude='package-lock.json' \
+              2>/dev/null || true)
+            if [ -n "$MATCHES" ]; then
+              echo "::warning::Potential secrets found matching pattern: $pattern"
+              echo "$MATCHES" | head -5
+              FOUND=1
+            fi
+          done
+
+          if [ "$FOUND" -eq 1 ]; then
+            echo "::warning::Review the above matches for potential secret exposure"
+          else
+            echo "OK: No high-entropy strings matching known secret patterns"
+          fi

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get changed markdown files
         id: changed-markdown
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             **/*.md

--- a/fuzz/fuzz_mcp_security.py
+++ b/fuzz/fuzz_mcp_security.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Fuzz target for the MCP security scanner."""
+
+import sys
+import atheris
+
+
+def test_one_input(data: bytes) -> None:
+    """Fuzz the MCP security scanner with arbitrary tool definitions."""
+    try:
+        text = data.decode("utf-8", errors="replace")
+    except Exception:
+        return
+
+    try:
+        from agent_os.mcp_security import MCPSecurityScanner
+
+        scanner = MCPSecurityScanner()
+
+        # Fuzz tool description scanning
+        tool_def = {
+            "name": text[:50] if len(text) > 50 else text,
+            "description": text,
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+        scanner.scan_tool(tool_def)
+    except (ValueError, TypeError, KeyError, AttributeError):
+        pass
+    except Exception:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_prompt_injection.py
+++ b/fuzz/fuzz_prompt_injection.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Fuzz target for the prompt injection detector."""
+
+import sys
+import atheris
+
+
+def test_one_input(data: bytes) -> None:
+    """Fuzz the prompt injection detector with arbitrary input."""
+    try:
+        text = data.decode("utf-8", errors="replace")
+    except Exception:
+        return
+
+    try:
+        from agent_os.prompt_injection import PromptInjectionDetector
+
+        detector = PromptInjectionDetector()
+        detector.scan(text)
+    except (ValueError, TypeError, KeyError, AttributeError):
+        pass
+    except Exception:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_sandbox.py
+++ b/fuzz/fuzz_sandbox.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Fuzz target for the sandbox AST validator."""
+
+import sys
+import atheris
+
+
+def test_one_input(data: bytes) -> None:
+    """Fuzz the sandbox code validator with arbitrary Python code."""
+    try:
+        code = data.decode("utf-8", errors="replace")
+    except Exception:
+        return
+
+    try:
+        from agent_os.sandbox import SandboxValidator
+
+        validator = SandboxValidator()
+        validator.validate_code(code)
+    except (SyntaxError, ValueError, TypeError, AttributeError):
+        pass
+    except Exception:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_trust_scoring.py
+++ b/fuzz/fuzz_trust_scoring.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Fuzz target for the trust scoring engine."""
+
+import sys
+import atheris
+
+
+def test_one_input(data: bytes) -> None:
+    """Fuzz trust scoring with arbitrary agent IDs and interaction sequences."""
+    fdp = atheris.FuzzedDataProvider(data)
+
+    try:
+        from agent_os.trust_root import TrustManager
+
+        manager = TrustManager()
+        agent_id = fdp.ConsumeUnicodeNoSurrogates(64)
+        num_interactions = fdp.ConsumeIntInRange(0, 100)
+
+        for _ in range(num_interactions):
+            if fdp.ConsumeBool():
+                manager.record_success(agent_id)
+            else:
+                manager.record_failure(agent_id)
+
+        score = manager.get_trust_score(agent_id)
+        assert 0 <= score.score <= 1000, f"Score out of bounds: {score.score}"
+    except (ValueError, TypeError, KeyError, AttributeError):
+        pass
+    except Exception:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agent-compliance/schemas/policy_schema.py
+++ b/packages/agent-compliance/schemas/policy_schema.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 

--- a/packages/agent-compliance/src/agent_compliance/governance/attestation_validator.py
+++ b/packages/agent-compliance/src/agent_compliance/governance/attestation_validator.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Governance attestation validation.
 
 Validates that PR descriptions contain properly filled out governance

--- a/packages/agent-compliance/src/agent_compliance/security/scanner.py
+++ b/packages/agent-compliance/src/agent_compliance/security/scanner.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Security Scanner for Plugin Marketplace
 

--- a/packages/agent-marketplace/src/agent_marketplace/hooks.py
+++ b/packages/agent-marketplace/src/agent_marketplace/hooks.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Pre-commit hooks for plugin manifest validation.
 
 Entry points for ``.pre-commit-hooks.yaml``:

--- a/packages/agent-mesh/sdks/typescript/tests/metrics.test.ts
+++ b/packages/agent-mesh/sdks/typescript/tests/metrics.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { GovernanceMetrics } from '../src/metrics';
+
+describe('GovernanceMetrics', () => {
+  it('should default to disabled', () => {
+    const m = new GovernanceMetrics();
+    expect((m as any).enabled).toBe(false);
+  });
+
+  it('should accept enabled flag', () => {
+    const m = new GovernanceMetrics(true);
+    expect((m as any).enabled).toBe(true);
+  });
+
+  it('should not throw on recordPolicyDecision', () => {
+    const m = new GovernanceMetrics(true);
+    expect(() => m.recordPolicyDecision('allow', 1.5)).not.toThrow();
+  });
+
+  it('should not throw on recordTrustScore', () => {
+    const m = new GovernanceMetrics(true);
+    expect(() => m.recordTrustScore('agent-1', 750)).not.toThrow();
+  });
+
+  it('should not throw on recordAuditEntry', () => {
+    const m = new GovernanceMetrics(true);
+    expect(() => m.recordAuditEntry(42)).not.toThrow();
+  });
+});

--- a/packages/agent-mesh/src/agentmesh/exceptions.py
+++ b/packages/agent-mesh/src/agentmesh/exceptions.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """Centralized exception hierarchy for AgentMesh.

--- a/packages/agent-mesh/src/agentmesh/integrations/crewai/agent.py
+++ b/packages/agent-mesh/src/agentmesh/integrations/crewai/agent.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """CrewAI trust-aware agent wrapper.

--- a/packages/agent-mesh/src/agentmesh/integrations/crewai/crew.py
+++ b/packages/agent-mesh/src/agentmesh/integrations/crewai/crew.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """CrewAI trust-aware crew wrapper.

--- a/packages/agent-mesh/src/agentmesh/integrations/langchain/callback.py
+++ b/packages/agent-mesh/src/agentmesh/integrations/langchain/callback.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """LangChain callback handler for AgentMesh trust verification.

--- a/packages/agent-mesh/src/agentmesh/integrations/langchain/tools.py
+++ b/packages/agent-mesh/src/agentmesh/integrations/langchain/tools.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """Trust-aware LangChain tool wrappers.

--- a/packages/agent-mesh/src/agentmesh/transport/base.py
+++ b/packages/agent-mesh/src/agentmesh/transport/base.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """Abstract transport interface for AgentMesh communication.

--- a/packages/agent-mesh/src/agentmesh/transport/grpc_transport.py
+++ b/packages/agent-mesh/src/agentmesh/transport/grpc_transport.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """gRPC transport for AgentMesh communication.

--- a/packages/agent-mesh/src/agentmesh/transport/websocket.py
+++ b/packages/agent-mesh/src/agentmesh/transport/websocket.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """WebSocket transport for real-time AgentMesh communication.

--- a/packages/agent-mesh/tests/test_crewai_integration.py
+++ b/packages/agent-mesh/tests/test_crewai_integration.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """Tests for CrewAI trust-aware agent and crew wrappers."""

--- a/packages/agent-mesh/tests/test_django_middleware.py
+++ b/packages/agent-mesh/tests/test_django_middleware.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """Tests for Django trust verification middleware and decorators."""

--- a/packages/agent-mesh/tests/test_integrations.py
+++ b/packages/agent-mesh/tests/test_integrations.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """Tests for Langflow, Flowise, and Haystack integrations."""

--- a/packages/agent-mesh/tests/test_langchain_integration.py
+++ b/packages/agent-mesh/tests/test_langchain_integration.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Copyright (c) Agent-Mesh Contributors. All rights reserved.
 # Licensed under the MIT License.
 """Tests for LangChain trust callback handler and tool wrappers."""

--- a/packages/agent-mesh/tests/test_otel_sdk.py
+++ b/packages/agent-mesh/tests/test_otel_sdk.py
@@ -1,0 +1,207 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the cross-SDK OpenTelemetry instrumentation module.
+
+Covers:
+* ``GovernanceInstrumentor`` span creation and metric recording
+* Context-manager tracing for policy evaluation
+* Graceful no-op degradation when ``opentelemetry`` is absent
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentmesh.observability.otel_sdk import GovernanceInstrumentor, _HAS_OTEL
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_instrumentor():
+    """Return a ``GovernanceInstrumentor`` wired to mock OTel primitives."""
+    if not _HAS_OTEL:
+        pytest.skip("opentelemetry not installed")
+
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        SimpleSpanProcessor,
+        SpanExporter,
+        SpanExportResult,
+    )
+    from opentelemetry import trace
+
+    class _InMemoryExporter(SpanExporter):
+        def __init__(self):
+            self._spans: list = []
+
+        def export(self, spans):
+            self._spans.extend(spans)
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            pass
+
+        def get_finished_spans(self):
+            return list(self._spans)
+
+    exporter = _InMemoryExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    # Force-set global provider
+    trace._TRACER_PROVIDER = None
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+    trace.set_tracer_provider(provider)
+
+    inst = GovernanceInstrumentor(service_name="test-otel-sdk")
+    return inst, exporter
+
+
+# =========================================================================
+# GovernanceInstrumentor — with OTel available
+# =========================================================================
+
+
+class TestTracePolicyEvaluation:
+    """Tests for the trace_policy_evaluation context manager."""
+
+    def test_creates_span(self):
+        inst, exporter = _make_instrumentor()
+        with inst.trace_policy_evaluation("read_data", "agent-1"):
+            pass
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "agt.policy.evaluate"
+
+    def test_sets_action_and_agent_attributes(self):
+        inst, exporter = _make_instrumentor()
+        with inst.trace_policy_evaluation("write_data", "agent-2"):
+            pass
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["agt.action"] == "write_data"
+        assert attrs["agt.agent_id"] == "agent-2"
+
+
+class TestTraceTrustUpdate:
+    """Tests for trace_trust_update."""
+
+    def test_creates_span_with_scores(self):
+        inst, exporter = _make_instrumentor()
+        inst.trace_trust_update("agent-3", 0.5, 0.8)
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "agt.trust.update"
+        attrs = dict(spans[0].attributes)
+        assert attrs["agt.agent_id"] == "agent-3"
+        assert attrs["agt.old_score"] == 0.5
+        assert attrs["agt.new_score"] == 0.8
+
+
+class TestTraceAuditAppend:
+    """Tests for trace_audit_append."""
+
+    def test_creates_span_with_seq(self):
+        inst, exporter = _make_instrumentor()
+        inst.trace_audit_append(42)
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "agt.audit.append"
+        attrs = dict(spans[0].attributes)
+        assert attrs["agt.seq"] == 42
+
+
+class TestTraceIdentityOperation:
+    """Tests for trace_identity_operation."""
+
+    def test_creates_span_with_op_and_did(self):
+        inst, exporter = _make_instrumentor()
+        inst.trace_identity_operation("verify", "did:mesh:abc")
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "agt.identity.verify"
+        attrs = dict(spans[0].attributes)
+        assert attrs["agt.did"] == "did:mesh:abc"
+
+
+class TestMetricRecording:
+    """Tests for record_* metric helpers."""
+
+    def test_record_policy_decision_does_not_raise(self):
+        inst, _ = _make_instrumentor()
+        inst.record_policy_decision("allow", 1.5)
+
+    def test_record_trust_score_does_not_raise(self):
+        inst, _ = _make_instrumentor()
+        inst.record_trust_score("agent-1", 0.95)
+
+    def test_record_audit_chain_length_does_not_raise(self):
+        inst, _ = _make_instrumentor()
+        inst.record_audit_chain_length(100)
+
+
+# =========================================================================
+# GovernanceInstrumentor — graceful degradation (OTel absent)
+# =========================================================================
+
+
+class TestGracefulDegradation:
+    """GovernanceInstrumentor must be a safe no-op without opentelemetry."""
+
+    def test_disabled_when_otel_missing(self):
+        """Instrumentor reports disabled when OTel is absent."""
+        with patch.dict(sys.modules, {"opentelemetry": None, "opentelemetry.trace": None, "opentelemetry.metrics": None}):
+            mod = importlib.import_module("agentmesh.observability.otel_sdk")
+            importlib.reload(mod)
+            inst = mod.GovernanceInstrumentor()
+            assert not inst.enabled
+
+    def test_trace_policy_evaluation_noop(self):
+        """Context manager yields without error when OTel is absent."""
+        with patch.dict(sys.modules, {"opentelemetry": None, "opentelemetry.trace": None, "opentelemetry.metrics": None}):
+            mod = importlib.import_module("agentmesh.observability.otel_sdk")
+            importlib.reload(mod)
+            inst = mod.GovernanceInstrumentor()
+            with inst.trace_policy_evaluation("act", "a1"):
+                pass
+
+    def test_trace_methods_noop(self):
+        """All trace methods complete without error when OTel is absent."""
+        with patch.dict(sys.modules, {"opentelemetry": None, "opentelemetry.trace": None, "opentelemetry.metrics": None}):
+            mod = importlib.import_module("agentmesh.observability.otel_sdk")
+            importlib.reload(mod)
+            inst = mod.GovernanceInstrumentor()
+            inst.trace_trust_update("a1", 0.5, 0.8)
+            inst.trace_audit_append(1)
+            inst.trace_identity_operation("create", "did:mesh:x")
+
+    def test_record_methods_noop(self):
+        """All record methods complete without error when OTel is absent."""
+        with patch.dict(sys.modules, {"opentelemetry": None, "opentelemetry.trace": None, "opentelemetry.metrics": None}):
+            mod = importlib.import_module("agentmesh.observability.otel_sdk")
+            importlib.reload(mod)
+            inst = mod.GovernanceInstrumentor()
+            inst.record_policy_decision("deny", 2.0)
+            inst.record_trust_score("a1", 0.5)
+            inst.record_audit_chain_length(10)
+
+    def test_explicit_disabled_flag(self):
+        """Instrumentor respects enabled=False even when OTel is available."""
+        inst = GovernanceInstrumentor(enabled=False)
+        assert not inst.enabled
+        with inst.trace_policy_evaluation("act", "a1"):
+            pass
+        inst.trace_trust_update("a1", 0.5, 0.8)
+        inst.trace_audit_append(1)
+        inst.trace_identity_operation("create", "did:mesh:x")
+        inst.record_policy_decision("deny", 2.0)
+        inst.record_trust_score("a1", 0.5)
+        inst.record_audit_chain_length(10)

--- a/packages/agent-mesh/tests/test_policy_provider.py
+++ b/packages/agent-mesh/tests/test_policy_provider.py
@@ -1,0 +1,275 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the API gateway policy provider endpoint.
+
+Covers:
+* ``PolicyProviderHandler.handle_check`` — policy evaluation via REST
+* ``PolicyProviderHandler.handle_health`` — health-check response
+* ``PolicyProviderHandler.handle_policies`` — policy listing
+* ``to_asgi_app`` — raw ASGI protocol compliance
+* Error handling for malformed requests
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentmesh.gateway.policy_provider import PolicyProviderHandler
+
+
+# ---------------------------------------------------------------------------
+# Helpers — lightweight mock objects
+# ---------------------------------------------------------------------------
+
+
+class _StubDecision:
+    """Mimics a ``PolicyDecision`` with the attributes the handler reads."""
+
+    def __init__(
+        self,
+        allowed: bool = True,
+        action: str = "allow",
+        reason: str = "",
+    ):
+        self.allowed = allowed
+        self.action = action
+        self.reason = reason
+
+
+def _make_engine(
+    decision: _StubDecision | None = None,
+    policies: list[str] | None = None,
+) -> MagicMock:
+    """Create a mock policy engine."""
+    engine = MagicMock(spec=[])
+    engine.evaluate = MagicMock(return_value=decision or _StubDecision())
+    engine.list_policies = MagicMock(return_value=policies or [])
+    return engine
+
+
+def _make_handler(
+    decision: _StubDecision | None = None,
+    policies: list[str] | None = None,
+    trust_score: float | None = None,
+    with_audit: bool = False,
+) -> PolicyProviderHandler:
+    """Create a ``PolicyProviderHandler`` with mock dependencies."""
+    engine = _make_engine(decision, policies)
+
+    trust_mgr = None
+    if trust_score is not None:
+        trust_mgr = MagicMock()
+        trust_mgr.get_trust_score.return_value = trust_score
+
+    audit = MagicMock() if with_audit else None
+    return PolicyProviderHandler(engine, trust_manager=trust_mgr, audit_logger=audit)
+
+
+# ---------------------------------------------------------------------------
+# ASGI protocol helpers
+# ---------------------------------------------------------------------------
+
+
+async def _asgi_request(
+    app,
+    method: str,
+    path: str,
+    body: bytes = b"",
+) -> tuple[int, dict]:
+    """Send a single ASGI HTTP request and return (status, parsed JSON body)."""
+    scope: dict[str, Any] = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],
+    }
+
+    body_sent = False
+
+    async def receive():
+        nonlocal body_sent
+        if not body_sent:
+            body_sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    status_code = 0
+    response_body = b""
+
+    async def send(message: dict):
+        nonlocal status_code, response_body
+        if message["type"] == "http.response.start":
+            status_code = message["status"]
+        elif message["type"] == "http.response.body":
+            response_body += message.get("body", b"")
+
+    await app(scope, receive, send)
+    return status_code, json.loads(response_body) if response_body else {}
+
+
+# =========================================================================
+# handle_check tests
+# =========================================================================
+
+
+class TestHandleCheck:
+    """Tests for POST /check — policy evaluation."""
+
+    def test_allowed_decision(self):
+        handler = _make_handler(decision=_StubDecision(allowed=True, action="allow"))
+        result = handler.handle_check(
+            {"agent_id": "agent-1", "action": "read", "context": {}}
+        )
+        assert result["allowed"] is True
+        assert result["decision"] == "allow"
+        assert "evaluation_ms" in result
+
+    def test_denied_decision(self):
+        handler = _make_handler(
+            decision=_StubDecision(allowed=False, action="deny", reason="policy violation")
+        )
+        result = handler.handle_check(
+            {"agent_id": "agent-2", "action": "delete", "context": {}}
+        )
+        assert result["allowed"] is False
+        assert result["decision"] == "deny"
+        assert result["reason"] == "policy violation"
+
+    def test_includes_trust_score(self):
+        handler = _make_handler(trust_score=0.92)
+        result = handler.handle_check(
+            {"agent_id": "agent-3", "action": "read", "context": {}}
+        )
+        assert result["trust_score"] == 0.92
+
+    def test_trust_score_none_when_no_manager(self):
+        handler = _make_handler()
+        result = handler.handle_check(
+            {"agent_id": "agent-4", "action": "read", "context": {}}
+        )
+        assert result["trust_score"] is None
+
+    def test_passes_agent_id_to_engine(self):
+        engine = _make_engine()
+        handler = PolicyProviderHandler(engine)
+        handler.handle_check(
+            {"agent_id": "agent-5", "action": "write", "context": {"key": "val"}}
+        )
+        call_args = engine.evaluate.call_args
+        assert call_args[0][0] == "agent-5"
+
+    def test_audit_logger_called(self):
+        handler = _make_handler(with_audit=True)
+        handler.handle_check(
+            {"agent_id": "agent-6", "action": "export", "context": {}}
+        )
+        handler.audit_logger.log.assert_called_once()
+
+    def test_missing_fields_use_defaults(self):
+        handler = _make_handler()
+        result = handler.handle_check({})
+        assert result["allowed"] is True
+
+
+# =========================================================================
+# handle_health tests
+# =========================================================================
+
+
+class TestHandleHealth:
+    """Tests for GET /health."""
+
+    def test_health_response_structure(self):
+        handler = _make_handler(policies=["p1", "p2"])
+        result = handler.handle_health()
+        assert result["status"] == "healthy"
+        assert result["policies_loaded"] == 2
+
+    def test_health_with_no_policies(self):
+        handler = _make_handler()
+        result = handler.handle_health()
+        assert result["status"] == "healthy"
+        assert result["policies_loaded"] == 0
+
+
+# =========================================================================
+# handle_policies tests
+# =========================================================================
+
+
+class TestHandlePolicies:
+    """Tests for GET /policies."""
+
+    def test_lists_loaded_policies(self):
+        handler = _make_handler(policies=["deny-exports", "rate-limit"])
+        result = handler.handle_policies()
+        assert result["policies"] == ["deny-exports", "rate-limit"]
+
+    def test_empty_when_no_policies(self):
+        handler = _make_handler()
+        result = handler.handle_policies()
+        assert result["policies"] == []
+
+
+# =========================================================================
+# ASGI app tests
+# =========================================================================
+
+
+class TestAsgiApp:
+    """Tests for the raw ASGI application."""
+
+    def test_health_endpoint(self):
+        handler = _make_handler(policies=["p1"])
+        app = handler.to_asgi_app()
+        status, body = asyncio.get_event_loop().run_until_complete(
+            _asgi_request(app, "GET", "/health")
+        )
+        assert status == 200
+        assert body["status"] == "healthy"
+
+    def test_policies_endpoint(self):
+        handler = _make_handler(policies=["my-policy"])
+        app = handler.to_asgi_app()
+        status, body = asyncio.get_event_loop().run_until_complete(
+            _asgi_request(app, "GET", "/policies")
+        )
+        assert status == 200
+        assert "my-policy" in body["policies"]
+
+    def test_check_endpoint(self):
+        handler = _make_handler(
+            decision=_StubDecision(allowed=True, action="allow")
+        )
+        app = handler.to_asgi_app()
+        payload = json.dumps(
+            {"agent_id": "a1", "action": "read", "context": {}}
+        ).encode()
+        status, body = asyncio.get_event_loop().run_until_complete(
+            _asgi_request(app, "POST", "/check", payload)
+        )
+        assert status == 200
+        assert body["allowed"] is True
+
+    def test_check_invalid_json(self):
+        handler = _make_handler()
+        app = handler.to_asgi_app()
+        status, body = asyncio.get_event_loop().run_until_complete(
+            _asgi_request(app, "POST", "/check", b"not-json")
+        )
+        assert status == 400
+        assert "error" in body
+
+    def test_not_found(self):
+        handler = _make_handler()
+        app = handler.to_asgi_app()
+        status, body = asyncio.get_event_loop().run_until_complete(
+            _asgi_request(app, "GET", "/unknown")
+        )
+        assert status == 404
+        assert "error" in body

--- a/packages/agent-os/examples/run-demo.sh
+++ b/packages/agent-os/examples/run-demo.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Agent OS Demo Runner
 # Usage: ./run-demo.sh <demo-name> [options]
 

--- a/packages/agent-os/extensions/chrome/src/content/aws.ts
+++ b/packages/agent-os/extensions/chrome/src/content/aws.ts
@@ -93,27 +93,37 @@ function injectAlertBanner() {
     gap: 16px;
     max-width: 600px;
   `;
-  banner.innerHTML = `
-    <div style="display: flex; align-items: center; gap: 8px;">
-      <span style="font-size: 20px;">🛡️</span>
-      <span style="font-weight: 500;">AgentOS Monitoring Active</span>
-    </div>
-    <div style="display: flex; gap: 8px;">
-      <button class="agentos-aws-btn" data-action="cost-check">
-        💰 Cost Check
-      </button>
-      <button class="agentos-aws-btn" data-action="security-scan">
-        🔒 Security Scan
-      </button>
-    </div>
-    <button class="agentos-banner-close" style="
-      background: none;
-      border: none;
-      font-size: 18px;
-      cursor: pointer;
-      color: #6b7280;
-    ">&times;</button>
-  `;
+  const bannerLeft = document.createElement('div');
+  bannerLeft.style.cssText = 'display: flex; align-items: center; gap: 8px;';
+  const bannerIcon = document.createElement('span');
+  bannerIcon.style.fontSize = '20px';
+  bannerIcon.textContent = '🛡️';
+  bannerLeft.appendChild(bannerIcon);
+  const bannerLabel = document.createElement('span');
+  bannerLabel.style.fontWeight = '500';
+  bannerLabel.textContent = 'AgentOS Monitoring Active';
+  bannerLeft.appendChild(bannerLabel);
+  banner.appendChild(bannerLeft);
+
+  const bannerActions = document.createElement('div');
+  bannerActions.style.cssText = 'display: flex; gap: 8px;';
+  for (const { action, label } of [
+    { action: 'cost-check', label: '💰 Cost Check' },
+    { action: 'security-scan', label: '🔒 Security Scan' },
+  ]) {
+    const btn = document.createElement('button');
+    btn.className = 'agentos-aws-btn';
+    btn.dataset.action = action;
+    btn.textContent = label;
+    bannerActions.appendChild(btn);
+  }
+  banner.appendChild(bannerActions);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'agentos-banner-close';
+  closeBtn.style.cssText = 'background: none; border: none; font-size: 18px; cursor: pointer; color: #6b7280;';
+  closeBtn.textContent = '\u00d7';
+  banner.appendChild(closeBtn);
 
   const style = document.createElement('style');
   style.textContent = `
@@ -164,6 +174,7 @@ function injectEC2Integration() {
       border: 1px solid #fcd34d;
       border-radius: 8px;
     `;
+    // SECURITY: innerHTML with trusted content only — static extension UI, no user data interpolated
     section.innerHTML = `
       <div style="display: flex; align-items: flex-start; gap: 12px;">
         <span style="font-size: 24px;">⚠️</span>
@@ -231,16 +242,28 @@ function injectS3Integration() {
       align-items: center;
       gap: 12px;
     `;
-    notice.innerHTML = `
-      <span style="font-size: 20px;">🛡️</span>
-      <div style="flex: 1;">
-        <span style="font-size: 13px; color: #065f46;">
-          AgentOS is monitoring bucket permissions. 
-          <strong>All buckets compliant</strong> with security policies.
-        </span>
-      </div>
-      <button class="agentos-aws-btn" data-action="s3-audit">Run Full Audit</button>
-    `;
+    const noticeIcon = document.createElement('span');
+    noticeIcon.style.fontSize = '20px';
+    noticeIcon.textContent = '🛡️';
+    notice.appendChild(noticeIcon);
+
+    const noticeBody = document.createElement('div');
+    noticeBody.style.flex = '1';
+    const noticeText = document.createElement('span');
+    noticeText.style.cssText = 'font-size: 13px; color: #065f46;';
+    noticeText.appendChild(document.createTextNode('AgentOS is monitoring bucket permissions. '));
+    const noticeStrong = document.createElement('strong');
+    noticeStrong.textContent = 'All buckets compliant';
+    noticeText.appendChild(noticeStrong);
+    noticeText.appendChild(document.createTextNode(' with security policies.'));
+    noticeBody.appendChild(noticeText);
+    notice.appendChild(noticeBody);
+
+    const auditBtn = document.createElement('button');
+    auditBtn.className = 'agentos-aws-btn';
+    auditBtn.dataset.action = 's3-audit';
+    auditBtn.textContent = 'Run Full Audit';
+    notice.appendChild(auditBtn);
 
     list.insertBefore(notice, list.firstChild);
 
@@ -271,6 +294,7 @@ function injectBillingIntegration() {
       border-radius: 8px;
       box-shadow: 0 2px 8px rgba(0,0,0,0.05);
     `;
+    // SECURITY: innerHTML with trusted content only — static extension UI, no user data interpolated
     insights.innerHTML = `
       <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 16px;">
         <span style="font-size: 24px;">🛡️</span>
@@ -311,25 +335,28 @@ function injectFAB() {
 
   const fab = document.createElement('div');
   fab.className = 'agentos-fab';
-  fab.innerHTML = `
-    <button class="agentos-fab-button" title="AgentOS">
-      🤖
-    </button>
-    <div class="agentos-fab-menu" style="display: none;">
-      <div class="agentos-fab-menu-item" data-action="cost-analysis">
-        💰 Cost Analysis
-      </div>
-      <div class="agentos-fab-menu-item" data-action="security-audit">
-        🔒 Security Audit
-      </div>
-      <div class="agentos-fab-menu-item" data-action="resource-optimizer">
-        ⚡ Optimize Resources
-      </div>
-      <div class="agentos-fab-menu-item" data-action="compliance-check">
-        ✅ Compliance Check
-      </div>
-    </div>
-  `;
+  const fabButton = document.createElement('button');
+  fabButton.className = 'agentos-fab-button';
+  fabButton.title = 'AgentOS';
+  fabButton.textContent = '🤖';
+  fab.appendChild(fabButton);
+
+  const fabMenu = document.createElement('div');
+  fabMenu.className = 'agentos-fab-menu';
+  fabMenu.style.display = 'none';
+  for (const { action, label } of [
+    { action: 'cost-analysis', label: '💰 Cost Analysis' },
+    { action: 'security-audit', label: '🔒 Security Audit' },
+    { action: 'resource-optimizer', label: '⚡ Optimize Resources' },
+    { action: 'compliance-check', label: '✅ Compliance Check' },
+  ]) {
+    const item = document.createElement('div');
+    item.className = 'agentos-fab-menu-item';
+    item.dataset.action = action;
+    item.textContent = label;
+    fabMenu.appendChild(item);
+  }
+  fab.appendChild(fabMenu);
 
   const style = document.createElement('style');
   style.textContent = `

--- a/packages/agent-os/extensions/chrome/src/content/github.ts
+++ b/packages/agent-os/extensions/chrome/src/content/github.ts
@@ -72,11 +72,16 @@ function injectPRIntegration() {
   const agentOSTab = document.createElement('a');
   agentOSTab.className = `tabnav-tab ${AGENTOS_CLASS}`;
   agentOSTab.href = '#agentos';
-  agentOSTab.innerHTML = `
-    <span style="margin-right: 4px;">🛡️</span>
-    AgentOS
-    <span class="Counter" style="margin-left: 4px; background: #22c55e; color: white;">✓</span>
-  `;
+  const tabIcon = document.createElement('span');
+  tabIcon.style.marginRight = '4px';
+  tabIcon.textContent = '🛡️';
+  agentOSTab.appendChild(tabIcon);
+  agentOSTab.appendChild(document.createTextNode(' AgentOS '));
+  const tabCounter = document.createElement('span');
+  tabCounter.className = 'Counter';
+  tabCounter.style.cssText = 'margin-left: 4px; background: #22c55e; color: white;';
+  tabCounter.textContent = '✓';
+  agentOSTab.appendChild(tabCounter);
   agentOSTab.onclick = (e) => {
     e.preventDefault();
     showAgentOSPanel();
@@ -103,25 +108,30 @@ function injectIssueIntegration() {
     border-radius: 6px;
     background: #f6f8fa;
   `;
-  agentOSSection.innerHTML = `
-    <h3 style="font-size: 14px; font-weight: 600; margin-bottom: 12px; display: flex; align-items: center; gap: 8px;">
-      🛡️ AgentOS
-    </h3>
-    <div style="font-size: 13px; color: #57606a; margin-bottom: 12px;">
-      Available automations:
-    </div>
-    <div style="display: flex; flex-direction: column; gap: 8px;">
-      <button class="btn btn-sm" onclick="window.agentOS?.runAgent('issue-labeler')">
-        🏷️ Auto-label this issue
-      </button>
-      <button class="btn btn-sm" onclick="window.agentOS?.runAgent('issue-breakdown')">
-        📝 Break into subtasks
-      </button>
-      <button class="btn btn-sm" onclick="window.agentOS?.runAgent('estimate')">
-        ⏱️ Estimate effort
-      </button>
-    </div>
-  `;
+  const sectionHeading = document.createElement('h3');
+  sectionHeading.style.cssText = 'font-size: 14px; font-weight: 600; margin-bottom: 12px; display: flex; align-items: center; gap: 8px;';
+  sectionHeading.textContent = '🛡️ AgentOS';
+  agentOSSection.appendChild(sectionHeading);
+
+  const sectionDesc = document.createElement('div');
+  sectionDesc.style.cssText = 'font-size: 13px; color: #57606a; margin-bottom: 12px;';
+  sectionDesc.textContent = 'Available automations:';
+  agentOSSection.appendChild(sectionDesc);
+
+  const buttonContainer = document.createElement('div');
+  buttonContainer.style.cssText = 'display: flex; flex-direction: column; gap: 8px;';
+  for (const { agentId, label } of [
+    { agentId: 'issue-labeler', label: '🏷️ Auto-label this issue' },
+    { agentId: 'issue-breakdown', label: '📝 Break into subtasks' },
+    { agentId: 'estimate', label: '⏱️ Estimate effort' },
+  ]) {
+    const btn = document.createElement('button');
+    btn.className = 'btn btn-sm';
+    btn.textContent = label;
+    btn.addEventListener('click', () => (window as any).agentOS?.runAgent(agentId));
+    buttonContainer.appendChild(btn);
+  }
+  agentOSSection.appendChild(buttonContainer);
 
   sidebar.insertBefore(agentOSSection, sidebar.firstChild);
   injectFAB();
@@ -136,22 +146,27 @@ function injectFAB() {
 
   const fab = document.createElement('div');
   fab.className = 'agentos-fab';
-  fab.innerHTML = `
-    <button class="agentos-fab-button" title="AgentOS">
-      🤖
-    </button>
-    <div class="agentos-fab-menu" style="display: none;">
-      <div class="agentos-fab-menu-item" data-action="create">
-        ➕ Create Agent
-      </div>
-      <div class="agentos-fab-menu-item" data-action="view">
-        👀 View Agents
-      </div>
-      <div class="agentos-fab-menu-item" data-action="logs">
-        📋 Audit Log
-      </div>
-    </div>
-  `;
+  const fabButton = document.createElement('button');
+  fabButton.className = 'agentos-fab-button';
+  fabButton.title = 'AgentOS';
+  fabButton.textContent = '🤖';
+  fab.appendChild(fabButton);
+
+  const fabMenu = document.createElement('div');
+  fabMenu.className = 'agentos-fab-menu';
+  fabMenu.style.display = 'none';
+  for (const { action, label } of [
+    { action: 'create', label: '➕ Create Agent' },
+    { action: 'view', label: '👀 View Agents' },
+    { action: 'logs', label: '📋 Audit Log' },
+  ]) {
+    const item = document.createElement('div');
+    item.className = 'agentos-fab-menu-item';
+    item.dataset.action = action;
+    item.textContent = label;
+    fabMenu.appendChild(item);
+  }
+  fab.appendChild(fabMenu);
 
   const style = document.createElement('style');
   style.textContent = `
@@ -238,6 +253,7 @@ function showAgentOSPanel() {
 
   const panel = document.createElement('div');
   panel.className = 'agentos-panel';
+  // SECURITY: innerHTML with trusted content only — static extension UI, no user data interpolated
   panel.innerHTML = `
     <div class="agentos-panel-header">
       <h2>🛡️ AgentOS Policy Check</h2>

--- a/packages/agent-os/extensions/chrome/src/content/jira.ts
+++ b/packages/agent-os/extensions/chrome/src/content/jira.ts
@@ -77,27 +77,33 @@ function injectIssueIntegration() {
       border-radius: 8px;
       background: linear-gradient(to bottom, #f4f5f7, #ffffff);
     `;
-    agentOSSection.innerHTML = `
-      <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
-        <span style="font-size: 20px;">🛡️</span>
-        <h4 style="font-size: 14px; font-weight: 600; margin: 0;">AgentOS Automation</h4>
-      </div>
-      
-      <div style="display: flex; flex-direction: column; gap: 8px;">
-        <button class="agentos-jira-btn" data-action="breakdown">
-          📝 Break into subtasks
-        </button>
-        <button class="agentos-jira-btn" data-action="estimate">
-          ⏱️ Estimate story points
-        </button>
-        <button class="agentos-jira-btn" data-action="find-prs">
-          🔗 Find related PRs
-        </button>
-        <button class="agentos-jira-btn" data-action="test-plan">
-          🧪 Generate test plan
-        </button>
-      </div>
-    `;
+    const sectionHeader = document.createElement('div');
+    sectionHeader.style.cssText = 'display: flex; align-items: center; gap: 8px; margin-bottom: 12px;';
+    const sectionIcon = document.createElement('span');
+    sectionIcon.style.fontSize = '20px';
+    sectionIcon.textContent = '🛡️';
+    sectionHeader.appendChild(sectionIcon);
+    const sectionTitle = document.createElement('h4');
+    sectionTitle.style.cssText = 'font-size: 14px; font-weight: 600; margin: 0;';
+    sectionTitle.textContent = 'AgentOS Automation';
+    sectionHeader.appendChild(sectionTitle);
+    agentOSSection.appendChild(sectionHeader);
+
+    const buttonGroup = document.createElement('div');
+    buttonGroup.style.cssText = 'display: flex; flex-direction: column; gap: 8px;';
+    for (const { action, label } of [
+      { action: 'breakdown', label: '📝 Break into subtasks' },
+      { action: 'estimate', label: '⏱️ Estimate story points' },
+      { action: 'find-prs', label: '🔗 Find related PRs' },
+      { action: 'test-plan', label: '🧪 Generate test plan' },
+    ]) {
+      const btn = document.createElement('button');
+      btn.className = 'agentos-jira-btn';
+      btn.dataset.action = action;
+      btn.textContent = label;
+      buttonGroup.appendChild(btn);
+    }
+    agentOSSection.appendChild(buttonGroup);
 
     const style = document.createElement('style');
     style.textContent = `
@@ -160,22 +166,27 @@ function injectBoardIntegration() {
       align-items: center;
       gap: 12px;
     `;
-    banner.innerHTML = `
-      <span style="font-size: 20px;">🛡️</span>
-      <div>
-        <div style="font-size: 13px; font-weight: 500;">AgentOS Active</div>
-        <div style="font-size: 11px; color: #5e6c84;">Monitoring board activity</div>
-      </div>
-      <button class="agentos-banner-btn" style="
-        background: #6366f1;
-        color: white;
-        border: none;
-        border-radius: 4px;
-        padding: 6px 12px;
-        cursor: pointer;
-        font-size: 12px;
-      ">Optimize Sprint</button>
-    `;
+    const bannerIcon = document.createElement('span');
+    bannerIcon.style.fontSize = '20px';
+    bannerIcon.textContent = '🛡️';
+    banner.appendChild(bannerIcon);
+
+    const bannerInfo = document.createElement('div');
+    const bannerTitle = document.createElement('div');
+    bannerTitle.style.cssText = 'font-size: 13px; font-weight: 500;';
+    bannerTitle.textContent = 'AgentOS Active';
+    bannerInfo.appendChild(bannerTitle);
+    const bannerSubtitle = document.createElement('div');
+    bannerSubtitle.style.cssText = 'font-size: 11px; color: #5e6c84;';
+    bannerSubtitle.textContent = 'Monitoring board activity';
+    bannerInfo.appendChild(bannerSubtitle);
+    banner.appendChild(bannerInfo);
+
+    const optimizeBtn = document.createElement('button');
+    optimizeBtn.className = 'agentos-banner-btn';
+    optimizeBtn.style.cssText = 'background: #6366f1; color: white; border: none; border-radius: 4px; padding: 6px 12px; cursor: pointer; font-size: 12px;';
+    optimizeBtn.textContent = 'Optimize Sprint';
+    banner.appendChild(optimizeBtn);
 
     document.body.appendChild(banner);
 
@@ -204,12 +215,21 @@ function injectBacklogIntegration() {
       align-items: center;
       gap: 12px;
     `;
-    toolbar.innerHTML = `
-      <span style="font-size: 14px;">🛡️ AgentOS:</span>
-      <button class="agentos-tool-btn" data-action="auto-prioritize">Auto-prioritize</button>
-      <button class="agentos-tool-btn" data-action="estimate-all">Estimate all</button>
-      <button class="agentos-tool-btn" data-action="find-duplicates">Find duplicates</button>
-    `;
+    const toolbarLabel = document.createElement('span');
+    toolbarLabel.style.fontSize = '14px';
+    toolbarLabel.textContent = '🛡️ AgentOS:';
+    toolbar.appendChild(toolbarLabel);
+    for (const { action, label } of [
+      { action: 'auto-prioritize', label: 'Auto-prioritize' },
+      { action: 'estimate-all', label: 'Estimate all' },
+      { action: 'find-duplicates', label: 'Find duplicates' },
+    ]) {
+      const btn = document.createElement('button');
+      btn.className = 'agentos-tool-btn';
+      btn.dataset.action = action;
+      btn.textContent = label;
+      toolbar.appendChild(btn);
+    }
 
     const style = document.createElement('style');
     style.textContent = `
@@ -246,22 +266,27 @@ function injectFAB() {
 
   const fab = document.createElement('div');
   fab.className = 'agentos-fab';
-  fab.innerHTML = `
-    <button class="agentos-fab-button" title="AgentOS">
-      🤖
-    </button>
-    <div class="agentos-fab-menu" style="display: none;">
-      <div class="agentos-fab-menu-item" data-action="create">
-        ➕ Create Agent
-      </div>
-      <div class="agentos-fab-menu-item" data-action="sprint-report">
-        📊 Sprint Report
-      </div>
-      <div class="agentos-fab-menu-item" data-action="velocity">
-        📈 Velocity Analysis
-      </div>
-    </div>
-  `;
+  const fabButton = document.createElement('button');
+  fabButton.className = 'agentos-fab-button';
+  fabButton.title = 'AgentOS';
+  fabButton.textContent = '🤖';
+  fab.appendChild(fabButton);
+
+  const fabMenu = document.createElement('div');
+  fabMenu.className = 'agentos-fab-menu';
+  fabMenu.style.display = 'none';
+  for (const { action, label } of [
+    { action: 'create', label: '➕ Create Agent' },
+    { action: 'sprint-report', label: '📊 Sprint Report' },
+    { action: 'velocity', label: '📈 Velocity Analysis' },
+  ]) {
+    const item = document.createElement('div');
+    item.className = 'agentos-fab-menu-item';
+    item.dataset.action = action;
+    item.textContent = label;
+    fabMenu.appendChild(item);
+  }
+  fab.appendChild(fabMenu);
 
   const style = document.createElement('style');
   style.textContent = `

--- a/packages/agent-os/extensions/copilot/src/__tests__/cors-config.test.ts
+++ b/packages/agent-os/extensions/copilot/src/__tests__/cors-config.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 describe('CORS allowlist configuration', () => {
   const originalEnv = process.env;
 

--- a/packages/agent-os/extensions/copilot/src/__tests__/cors.test.ts
+++ b/packages/agent-os/extensions/copilot/src/__tests__/cors.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
 

--- a/packages/agent-os/modules/cmvk/tests/integration/test_anthropic_verifier.py
+++ b/packages/agent-os/modules/cmvk/tests/integration/test_anthropic_verifier.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for the Anthropic Verifier agent.
 """

--- a/packages/agent-os/modules/cmvk/tests/integration/test_integration.py
+++ b/packages/agent-os/modules/cmvk/tests/integration/test_integration.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Integration tests for the full verification kernel.
 """

--- a/packages/agent-os/modules/cmvk/tests/integration/test_lateral_thinking_integration.py
+++ b/packages/agent-os/modules/cmvk/tests/integration/test_lateral_thinking_integration.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Integration test for Feature 2: Lateral Thinking implementation.
 Tests the new ExecutionTrace, NodeState classes and generator's forbidden strategies.

--- a/packages/agent-os/modules/cmvk/tests/integration/test_lateral_thinking_witness.py
+++ b/packages/agent-os/modules/cmvk/tests/integration/test_lateral_thinking_witness.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Unit tests for Lateral Thinking and Witness features.
 """

--- a/packages/agent-os/modules/cmvk/tests/integration/test_prosecutor_mode.py
+++ b/packages/agent-os/modules/cmvk/tests/integration/test_prosecutor_mode.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Unit tests for Prosecutor Mode functionality.
 """

--- a/packages/agent-os/modules/cmvk/tests/test_constitutional.py
+++ b/packages/agent-os/modules/cmvk/tests/test_constitutional.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for Constitutional Validator."""
 
 import pytest

--- a/packages/agent-os/modules/cmvk/tests/test_enhanced_features.py
+++ b/packages/agent-os/modules/cmvk/tests/test_enhanced_features.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Unit tests for CMVK enhanced features (v0.2.0).
 

--- a/packages/agent-os/modules/cmvk/tests/test_verification.py
+++ b/packages/agent-os/modules/cmvk/tests/test_verification.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Unit tests for CMVK verification module.
 

--- a/packages/agent-os/modules/cmvk/tests/unit/test_agents.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_agents.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Unit tests for the agents module.
 """

--- a/packages/agent-os/modules/cmvk/tests/unit/test_cli.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_cli.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for the CLI module.
 """

--- a/packages/agent-os/modules/cmvk/tests/unit/test_core.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_core.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Unit tests for the Cross-Model Verification Kernel.
 """

--- a/packages/agent-os/modules/cmvk/tests/unit/test_humaneval_loader.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_humaneval_loader.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for the HumanEval Dataset Loader
 

--- a/packages/agent-os/modules/cmvk/tests/unit/test_kernel.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_kernel.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for the Cross-Model Verification Kernel
 """

--- a/packages/agent-os/modules/cmvk/tests/unit/test_reproducibility.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_reproducibility.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for reproducibility and seed functionality.
 """

--- a/packages/agent-os/modules/cmvk/tests/unit/test_trace_logger.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_trace_logger.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Test for Feature 3: Trace Logger
 

--- a/packages/agent-os/modules/cmvk/tests/unit/test_visualizer.py
+++ b/packages/agent-os/modules/cmvk/tests/unit/test_visualizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Test for the Visualizer Tool
 

--- a/packages/agent-os/scripts/quickstart.sh
+++ b/packages/agent-os/scripts/quickstart.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 # Agent OS Quickstart Script
 # Run with: curl -sSL https://get.agent-os.dev | bash
 

--- a/packages/agentmesh-integrations/a2a-protocol/a2a_agentmesh/agent_card.py
+++ b/packages/agentmesh-integrations/a2a-protocol/a2a_agentmesh/agent_card.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 A2A-compliant Agent Card — maps AgentMesh identity to A2A discovery format.
 

--- a/packages/agentmesh-integrations/a2a-protocol/a2a_agentmesh/task.py
+++ b/packages/agentmesh-integrations/a2a-protocol/a2a_agentmesh/task.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 A2A Task Envelope — trust-verified task request/response wrappers.
 

--- a/packages/agentmesh-integrations/a2a-protocol/a2a_agentmesh/trust_gate.py
+++ b/packages/agentmesh-integrations/a2a-protocol/a2a_agentmesh/trust_gate.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Trust Gate — policy enforcement for A2A task negotiations.
 

--- a/packages/agentmesh-integrations/a2a-protocol/tests/test_a2a.py
+++ b/packages/agentmesh-integrations/a2a-protocol/tests/test_a2a.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for A2A AgentMesh integration.
 

--- a/packages/agentmesh-integrations/copilot-governance/src/agent.ts
+++ b/packages/agentmesh-integrations/copilot-governance/src/agent.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * GitHub Copilot Extension — agent request handler.
  *

--- a/packages/agentmesh-integrations/copilot-governance/src/index.ts
+++ b/packages/agentmesh-integrations/copilot-governance/src/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * @agentmesh/copilot-governance — GitHub Copilot Extension for agent governance review.
  *

--- a/packages/agentmesh-integrations/copilot-governance/src/owasp.ts
+++ b/packages/agentmesh-integrations/copilot-governance/src/owasp.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * OWASP Agentic Security Initiative — Agentic Top-10 risk catalogue.
  *

--- a/packages/agentmesh-integrations/copilot-governance/src/policy-validator.ts
+++ b/packages/agentmesh-integrations/copilot-governance/src/policy-validator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Validator for agent governance policy YAML files.
  *

--- a/packages/agentmesh-integrations/copilot-governance/src/reviewer.ts
+++ b/packages/agentmesh-integrations/copilot-governance/src/reviewer.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Static code reviewer for agent governance gaps.
  *

--- a/packages/agentmesh-integrations/copilot-governance/src/server.ts
+++ b/packages/agentmesh-integrations/copilot-governance/src/server.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Lightweight HTTP server for the GitHub Copilot governance extension.
  *

--- a/packages/agentmesh-integrations/copilot-governance/src/types.ts
+++ b/packages/agentmesh-integrations/copilot-governance/src/types.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Shared types for the GitHub Copilot governance extension.
  */

--- a/packages/agentmesh-integrations/copilot-governance/tests/index.test.ts
+++ b/packages/agentmesh-integrations/copilot-governance/tests/index.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 import { describe, it, expect } from "vitest";
 import { reviewCode, formatReviewResult } from "../src/reviewer";
 import { validatePolicy, formatPolicyValidation } from "../src/policy-validator";

--- a/packages/agentmesh-integrations/copilot-governance/tsup.config.ts
+++ b/packages/agentmesh-integrations/copilot-governance/tsup.config.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/packages/agentmesh-integrations/crewai-agentmesh/crewai_agentmesh/trust.py
+++ b/packages/agentmesh-integrations/crewai-agentmesh/crewai_agentmesh/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Trust layer for CrewAI — trust-verified crew selection and task assignment.
 

--- a/packages/agentmesh-integrations/crewai-agentmesh/tests/test_crewai_trust.py
+++ b/packages/agentmesh-integrations/crewai-agentmesh/tests/test_crewai_trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for CrewAI AgentMesh trust integration.
 

--- a/packages/agentmesh-integrations/dify/identity.py
+++ b/packages/agentmesh-integrations/dify/identity.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """verification Identity for Dify agents."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/dify/middleware.py
+++ b/packages/agentmesh-integrations/dify/middleware.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust middleware for Dify API requests."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/dify/trust.py
+++ b/packages/agentmesh-integrations/dify/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust management for Dify agents and workflows."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/audit_node.py
+++ b/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/audit_node.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Audit logging node with hash chain tamper evidence for Flowise flows."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/governance_node.py
+++ b/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/governance_node.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Governance policy check node for Flowise flows."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/policy.py
+++ b/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/policy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """YAML policy loading with deny-by-default semantics and wildcard support."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/rate_limiter_node.py
+++ b/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/rate_limiter_node.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Token bucket rate limiter node for Flowise flows."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/trust_gate_node.py
+++ b/packages/agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh/trust_gate_node.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust-scored routing node for Flowise flows."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/flowise-agentmesh/tests/test_flowise_nodes.py
+++ b/packages/agentmesh-integrations/flowise-agentmesh/tests/test_flowise_nodes.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Comprehensive tests for Flowise AgentMesh governance nodes."""
 
 import json

--- a/packages/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/audit.py
+++ b/packages/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/audit.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """AuditLogger component for Haystack pipelines.
 
 Append-only audit log with SHA-256 hash chain hashing and JSONL export.

--- a/packages/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/governance.py
+++ b/packages/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/governance.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """GovernancePolicyChecker component for Haystack pipelines.
 
 Loads policies from YAML and enforces tool allowlists/blocklists,

--- a/packages/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/trust_gate.py
+++ b/packages/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/trust_gate.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """TrustGate component for Haystack pipelines.
 
 Trust scoring with decay, success/failure tracking, and routing

--- a/packages/agentmesh-integrations/haystack-agentmesh/tests/test_audit.py
+++ b/packages/agentmesh-integrations/haystack-agentmesh/tests/test_audit.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for AuditLogger component."""
 
 import json

--- a/packages/agentmesh-integrations/haystack-agentmesh/tests/test_governance.py
+++ b/packages/agentmesh-integrations/haystack-agentmesh/tests/test_governance.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for GovernancePolicyChecker component."""
 
 import os

--- a/packages/agentmesh-integrations/haystack-agentmesh/tests/test_trust_gate.py
+++ b/packages/agentmesh-integrations/haystack-agentmesh/tests/test_trust_gate.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for TrustGate component."""
 
 import time

--- a/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/callbacks.py
+++ b/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/callbacks.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust callback handlers for LangChain.
 
 This module provides callback handlers that monitor and enforce

--- a/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/identity.py
+++ b/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/identity.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Cryptographic identity management for AgentMesh.
 
 This module provides verification (Cryptographic Multi-Vector Keys) based identity

--- a/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/tools.py
+++ b/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/tools.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust-gated tools for LangChain.
 
 This module provides tools that require trust verification before execution.

--- a/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/trust.py
+++ b/packages/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust verification and handshake protocols for AgentMesh.
 
 This module provides trust verification between agents, including

--- a/packages/agentmesh-integrations/langchain-agentmesh/tests/test_agentmesh.py
+++ b/packages/agentmesh-integrations/langchain-agentmesh/tests/test_agentmesh.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for AgentMesh LangChain integration."""
 
 import json

--- a/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/audit_logger.py
+++ b/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/audit_logger.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Audit trail component with SHA-256 hash chain.
 
 Captures agent actions, governance decisions, and context in a

--- a/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/compliance_checker.py
+++ b/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/compliance_checker.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Compliance validation component for Langflow flows.
 
 Validates agent actions against compliance frameworks:

--- a/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/governance_component.py
+++ b/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/governance_component.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Langflow custom component for governance policy enforcement.
 
 Provides a visual node that checks agent actions against YAML-based

--- a/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/policy.py
+++ b/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/policy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Governance policy engine with pattern matching and YAML serialization.
 
 Shared policy engine reusable across Langflow governance components.

--- a/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/trust_router.py
+++ b/packages/agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh/trust_router.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust-based routing component for Langflow flows.
 
 Routes agent actions to one of three outputs based on trust score:

--- a/packages/agentmesh-integrations/langflow-agentmesh/tests/test_langflow_components.py
+++ b/packages/agentmesh-integrations/langflow-agentmesh/tests/test_langflow_components.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for langflow-agentmesh package.
 
 Tests governance policy, governance component, trust router,

--- a/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/edges.py
+++ b/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/edges.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust-aware edge conditions for LangGraph add_conditional_edges."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/gate.py
+++ b/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/gate.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """TrustGate: Conditional checkpoint node that gates graph transitions on trust score."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/identity.py
+++ b/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/identity.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Lightweight Ed25519 identity manager (zero external dependencies beyond cryptography)."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/policy.py
+++ b/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/policy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """PolicyCheckpoint: Governance policy enforcement node for LangGraph."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/state.py
+++ b/packages/agentmesh-integrations/langgraph-trust/langgraph_trust/state.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust state types for LangGraph graphs."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/langgraph-trust/tests/test_edges.py
+++ b/packages/agentmesh-integrations/langgraph-trust/tests/test_edges.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for langgraph_trust.edges — trust_edge and trust_router."""
 
 from langgraph_trust.edges import trust_edge, trust_router

--- a/packages/agentmesh-integrations/langgraph-trust/tests/test_gate.py
+++ b/packages/agentmesh-integrations/langgraph-trust/tests/test_gate.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for langgraph_trust.gate — TrustGate and TrustScoreTracker."""
 
 import threading

--- a/packages/agentmesh-integrations/langgraph-trust/tests/test_identity.py
+++ b/packages/agentmesh-integrations/langgraph-trust/tests/test_identity.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for langgraph_trust.identity — AgentIdentityManager and AgentID."""
 
 import threading

--- a/packages/agentmesh-integrations/langgraph-trust/tests/test_policy.py
+++ b/packages/agentmesh-integrations/langgraph-trust/tests/test_policy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for langgraph_trust.policy — PolicyCheckpoint and GovernancePolicy."""
 
 from langgraph_trust.policy import GovernancePolicy, PolicyCheckpoint

--- a/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/identity.py
+++ b/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/identity.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Cryptographic identity management for AgentMesh.
 
 Uses Ed25519 for cryptographic operations.

--- a/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/query_engine.py
+++ b/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/query_engine.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust-gated query engine for LlamaIndex."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/trust.py
+++ b/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust verification protocols for AgentMesh."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/worker.py
+++ b/packages/agentmesh-integrations/llamaindex-agentmesh/llama_index/agent/agentmesh/worker.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trusted agent worker for LlamaIndex."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/mastra-agentmesh/src/audit.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/src/audit.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Audit middleware for Mastra tool execution.
  *

--- a/packages/agentmesh-integrations/mastra-agentmesh/src/governance.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/src/governance.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Governance middleware for Mastra tool execution.
  *

--- a/packages/agentmesh-integrations/mastra-agentmesh/src/governed-tool.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/src/governed-tool.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * createGovernedTool — wraps a Mastra tool with governance, trust, and audit.
  *

--- a/packages/agentmesh-integrations/mastra-agentmesh/src/index.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/src/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * @agentmesh/mastra — Governance, trust, and audit middleware for Mastra agents.
  *

--- a/packages/agentmesh-integrations/mastra-agentmesh/src/trust.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/src/trust.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Trust gate for Mastra tool execution.
  *

--- a/packages/agentmesh-integrations/mastra-agentmesh/src/types.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/src/types.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * Shared types for @agentmesh/mastra middleware.
  */

--- a/packages/agentmesh-integrations/mastra-agentmesh/tests/index.test.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/tests/index.test.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 import { describe, it, expect, beforeEach } from "vitest";
 import { governanceMiddleware } from "../src/governance";
 import { trustGate } from "../src/trust";

--- a/packages/agentmesh-integrations/mastra-agentmesh/tsup.config.ts
+++ b/packages/agentmesh-integrations/mastra-agentmesh/tsup.config.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 import { defineConfig } from "tsup";
 
 export default defineConfig({

--- a/packages/agentmesh-integrations/mcp-trust-proxy/mcp_trust_proxy/proxy.py
+++ b/packages/agentmesh-integrations/mcp-trust-proxy/mcp_trust_proxy/proxy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 MCP Trust Proxy — trust-gated tool access for MCP servers.
 

--- a/packages/agentmesh-integrations/mcp-trust-proxy/tests/test_mcp_proxy.py
+++ b/packages/agentmesh-integrations/mcp-trust-proxy/tests/test_mcp_proxy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Tests for MCP Trust Proxy.
 """

--- a/packages/agentmesh-integrations/nostr-wot/agentmesh_nostr_wot/provider.py
+++ b/packages/agentmesh-integrations/nostr-wot/agentmesh_nostr_wot/provider.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Nostr Web of Trust provider for AgentMesh trust engine.
 

--- a/packages/agentmesh-integrations/nostr-wot/tests/test_provider.py
+++ b/packages/agentmesh-integrations/nostr-wot/tests/test_provider.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for NostrWoTProvider."""
 
 import pytest

--- a/packages/agentmesh-integrations/openai-agents-agentmesh/openai_agents_agentmesh/trust.py
+++ b/packages/agentmesh-integrations/openai-agents-agentmesh/openai_agents_agentmesh/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Trust layer for OpenAI Agents SDK — function call gating and handoff verification.
 

--- a/packages/agentmesh-integrations/openai-agents-agentmesh/tests/test_openai_trust.py
+++ b/packages/agentmesh-integrations/openai-agents-agentmesh/tests/test_openai_trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for OpenAI Agents AgentMesh trust integration."""
 
 import pytest

--- a/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/audit.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/audit.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tamper-evident audit logging with hash chain."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/guardrails.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/guardrails.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Guardrails for OpenAI Agents SDK — trust, policy, and content enforcement."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/handoffs.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/handoffs.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust-gated handoffs for OpenAI Agents SDK."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/hooks.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/hooks.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Lifecycle hooks for governance tracking in OpenAI Agents SDK."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/identity.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/identity.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Lightweight agent identity using Ed25519 signatures."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/policy.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/policy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Governance policy definitions."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/trust.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/src/openai_agents_trust/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Multi-dimensional trust scoring for agents."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/openai-agents-trust/tests/test_core.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/tests/test_core.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for core modules that don't require openai-agents SDK."""
 
 import time

--- a/packages/agentmesh-integrations/openai-agents-trust/tests/test_integration.py
+++ b/packages/agentmesh-integrations/openai-agents-trust/tests/test_integration.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for OpenAI Agents SDK integration (guardrails, hooks, handoffs).
 
 Uses the real openai-agents SDK types since it's installed as a dependency.

--- a/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/audit.py
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/audit.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Audit trail for governance decisions."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/decorator.py
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/decorator.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """govern() decorator for PydanticAI tool functions.
 
 Wraps tool functions with governance policy checks, semantic intent

--- a/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/intent.py
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/intent.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Semantic intent classification for tool calls.
 
 Basic classifier that categorizes tool call intent into threat categories.

--- a/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/policy.py
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/policy.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Governance policy definition with pattern matching and YAML serialization."""
 
 from __future__ import annotations

--- a/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/toolset.py
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/toolset.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """GovernanceToolset — apply governance to all tools in a PydanticAI agent.
 
 Wraps PydanticAI's toolset pattern to intercept every tool call

--- a/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/trust.py
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Trust scoring for PydanticAI agents.
 
 Basic trust score tracking with overall score and threshold validation.

--- a/packages/agentmesh-integrations/pydantic-ai-governance/tests/test_governance.py
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/tests/test_governance.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for pydantic-ai-governance package.
 
 Tests the governance policy, semantic intent classification,

--- a/scripts/docker/dev-entrypoint.sh
+++ b/scripts/docker/dev-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 set -euo pipefail
 
 sdk_dir="/workspace/packages/agent-mesh/sdks/typescript"

--- a/scripts/docker/run-tests.sh
+++ b/scripts/docker/run-tests.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 set -euo pipefail
 
 packages=(


### PR DESCRIPTION
Post-merge hardening after auditing 14 community PRs merged in the last 7 days.

136 files, +1241/-153 lines.

- MIT headers added to 122 files (99 py, 19 ts, 4 sh)
- SHA-pinned 4 GitHub Actions in 2 workflows
- Replaced 10 innerHTML with safe DOM APIs in Chrome extension
- Verified pickle.loads and shell=True are detection-only (safe)
