### PR TITLE
fix: upgrade ts-jest 29.1.0 to 29.2.5 for peer resolution bug

### DIFF
--- a/packages/agent-mesh/sdks/typescript/package.json
+++ b/packages/agent-mesh/sdks/typescript/package.json
@@ -34,7 +34,7 @@
     "typescript": "5.7.0",
     "@types/node": "25.5.0",
     "jest": "29.7.0",
-    "ts-jest": "29.1.0",
+    "ts-jest": "29.2.5",
     "@types/jest": "29.5.14",
     "eslint": "9.0.0",
     "@typescript-eslint/parser": "8.58.0",


### PR DESCRIPTION
ts-jest 29.1.0 has a peer dep resolution bug causing typescript to show as undefined during npm install. Upgrading to 29.2.5 fixes the ERESOLVE error in agentmesh-sdk.