### PR TITLE
fix: add .npmrc with legacy-peer-deps for ERESOLVE errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
npm shows typescript as 'undefined' during peer dep resolution, causing ERESOLVE failures across packages. Adding legacy-peer-deps=true to .npmrc bypasses strict peer checking.