### PR TITLE
fix(ci): pass --legacy-peer-deps directly in npm install

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -213,7 +213,7 @@ stages:
               inputs:
                 version: '${{ parameters.nodeVersion }}'
 
-            - script: npm ci --ignore-scripts 2>/dev/null || npm install
+            - script: npm ci --ignore-scripts --legacy-peer-deps 2>/dev/null || npm install --legacy-peer-deps
               workingDirectory: '${{ pkg.path }}'
               displayName: 'Install dependencies'
 


### PR DESCRIPTION
Root .npmrc not reliably picked up when workingDirectory is a subdirectory. Pass --legacy-peer-deps directly to npm ci/install in the pipeline to fix typescript@undefined ERESOLVE errors.