### PR TITLE
fix: use published typescript 5.7.3 for agentmesh-sdk

### DIFF
--- a/packages/agent-mesh/sdks/typescript/package.json
+++ b/packages/agent-mesh/sdks/typescript/package.json
@@ -31,7 +31,7 @@
     "directory": "packages/agent-mesh/sdks/typescript"
   },
   "devDependencies": {
-    "typescript": "5.7.0",
+    "typescript": "5.7.3",
     "@types/node": "25.5.0",
     "jest": "29.7.0",
     "ts-jest": "29.2.5",


### PR DESCRIPTION
typescript@5.7.0 was never published as a stable release. Only dev prereleases exist. Updated to 5.7.3 (latest stable 5.7.x).