### PR TITLE
fix(ci): switch NuGet push to NuGetCommand@2 for encrypted API key support

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -356,7 +356,7 @@ stages:
               ls -la $(Pipeline.Workspace)/nuget-publish/
             displayName: 'List packages'
 
-          - task: DotNetCoreCLI@2
+          - task: NuGetCommand@2
             displayName: 'Push to NuGet.org'
             inputs:
               command: 'push'


### PR DESCRIPTION
DotNetCoreCLI@2 doesn't support encrypted API keys from service connections. NuGetCommand@2 handles them properly.