### PR TITLE
fix(ci): pass NuGet API key directly via --api-key

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -356,14 +356,10 @@ stages:
               ls -la $(Pipeline.Workspace)/nuget-publish/
             displayName: 'List packages'
 
-          - task: NuGetAuthenticate@1
-            displayName: 'Authenticate to NuGet.org'
-            inputs:
-              nuGetServiceConnections: 'NuGet.org'
-
           - script: |
               dotnet nuget push "$(Pipeline.Workspace)/nuget-publish/**/*.nupkg" \
                 --source https://api.nuget.org/v3/index.json \
+                --api-key $(NUGET_API_KEY) \
                 --skip-duplicate
             displayName: 'Push to NuGet.org'
 


### PR DESCRIPTION
NuGetAuthenticate@1 rejects ApiKey service connections. Use dotnet nuget push with --api-key and the NUGET_API_KEY pipeline secret variable directly. Ensure NUGET_API_KEY is set as a secret variable in the ADO pipeline.