### PR TITLE
fix(security): remaining findings - workflow_run, Docker tags, dep confusion script

### DIFF
--- a/.github/workflows/ai-pr-summary.yml
+++ b/.github/workflows/ai-pr-summary.yml
@@ -28,8 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     # Only run when the triggering workflow was for a PR
     if: >-
-      github.event.workflow_run.event == 'pull_request' ||
-      github.event.workflow_run.event == 'pull_request_target'
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.event == 'pull_request_target')
     steps:
       - name: Get PR number from triggering workflow
         id: pr

--- a/packages/agent-os/modules/scak/docker-compose.yml
+++ b/packages/agent-os/modules/scak/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
   # Vector DB (Qdrant) for Tier 3 Archive
   vectordb:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.14.1
     container_name: scak-vectordb
     ports:
       - "6333:6333"

--- a/packages/agent-sre/examples/docker-compose/docker-compose.yml
+++ b/packages/agent-sre/examples/docker-compose/docker-compose.yml
@@ -93,7 +93,7 @@ services:
         condition: service_healthy
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.4.0
     ports:
       - "9090:9090"
     volumes:
@@ -103,7 +103,7 @@ services:
         condition: service_healthy
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.6.0
     ports:
       - "3000:3000"
     environment:

--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -359,8 +359,10 @@ stages:
           - script: |
               dotnet nuget push "$(Pipeline.Workspace)/nuget-publish/**/*.nupkg" \
                 --source https://api.nuget.org/v3/index.json \
-                --api-key $(NUGET_API_KEY) \
+                --api-key "$NUGET_API_KEY" \
                 --skip-duplicate
+            env:
+              NUGET_API_KEY: $(NUGET_API_KEY)
             displayName: 'Push to NuGet.org'
 
   # =======================================================

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -58,9 +58,32 @@ REGISTERED_PACKAGES = {
     "slack-sdk", "slack-bolt",
     # Telemetry
     "opentelemetry-instrumentation-fastapi",
-    # Internal cross-package references (not on PyPI)
+    # Internal cross-package references (local-only, NOT on PyPI)
+    # These are flagged as HIGH RISK if found in requirements.txt with version pins
+    # instead of path references. See dependency confusion attack vector.
     "agent-primitives", "emk",
     # With extras (base name is what matters)
+}
+
+# Local-only packages that should NEVER appear with version pins in
+# requirements.txt (they must use path references like -e ../primitives)
+LOCAL_ONLY_PACKAGES = {"agent-primitives", "emk"}
+
+# Known npm packages for this project
+REGISTERED_NPM_PACKAGES = {
+    "@microsoft/agent-os-kernel", "@microsoft/agentmesh-mcp-proxy",
+    "@microsoft/agentmesh-api", "@microsoft/agent-os-cursor",
+    "@microsoft/agentmesh-mastra",
+    # Common deps
+    "typescript", "tsup", "vitest", "express", "zod", "@mastra/core",
+    "@modelcontextprotocol/sdk", "ws", "commander", "chalk",
+    "@anthropic-ai/sdk", "@types/node", "@types/ws", "@types/express",
+}
+
+# Known Cargo crate names
+REGISTERED_CARGO_PACKAGES = {
+    "serde", "serde_json", "serde_yaml", "sha2", "ed25519-dalek",
+    "rand", "thiserror", "tempfile", "agentmesh",
 }
 
 # Patterns that are always safe (not package names)
@@ -170,6 +193,100 @@ def check_notebook(filepath: str) -> list[str]:
     return findings
 
 
+def check_pyproject_toml(filepath: str) -> list[str]:
+    """Check a pyproject.toml for unregistered package dependencies."""
+    findings = []
+    try:
+        with open(filepath, encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError):
+        return findings
+
+    registered_lower = {p.lower() for p in REGISTERED_PACKAGES}
+    # Match dependency lines like: "package>=1.0" or "package[extra]>=1.0,<2.0"
+    dep_re = re.compile(r'^[\s"]*([a-zA-Z0-9_-]+)', re.MULTILINE)
+    in_deps = False
+    for line_num, line in enumerate(content.splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("[project.dependencies]") or \
+           stripped.startswith("[project.optional-dependencies"):
+            in_deps = True
+            continue
+        if stripped.startswith("[") and in_deps:
+            in_deps = False
+            continue
+        if not in_deps:
+            continue
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = dep_re.match(stripped.strip('"').strip("'").strip(","))
+        if m:
+            pkg = m.group(1)
+            if pkg.lower() not in registered_lower and pkg.lower() not in {
+                "python", "requires-python",
+            }:
+                severity = "HIGH RISK" if pkg.lower() in {
+                    p.lower() for p in LOCAL_ONLY_PACKAGES
+                } else ""
+                msg = f"  {filepath}:{line_num}: '{pkg}' may not be registered on PyPI"
+                if severity:
+                    msg += f" [{severity}: local-only package]"
+                findings.append(msg)
+    return findings
+
+
+def check_package_json(filepath: str) -> list[str]:
+    """Check a package.json for unregistered npm package dependencies."""
+    findings = []
+    try:
+        with open(filepath, encoding="utf-8", errors="ignore") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return findings
+
+    registered_lower = {p.lower() for p in REGISTERED_NPM_PACKAGES}
+    for section in ("dependencies", "devDependencies", "peerDependencies"):
+        for pkg in data.get(section, {}):
+            if pkg.lower() not in registered_lower:
+                findings.append(
+                    f"  {filepath}: npm '{pkg}' ({section}) may not be registered"
+                )
+    return findings
+
+
+def check_cargo_toml(filepath: str) -> list[str]:
+    """Check a Cargo.toml for unregistered crate dependencies."""
+    findings = []
+    try:
+        with open(filepath, encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError):
+        return findings
+
+    registered_lower = {p.lower() for p in REGISTERED_CARGO_PACKAGES}
+    in_deps = False
+    for line_num, line in enumerate(content.splitlines(), 1):
+        stripped = line.strip()
+        if stripped in ("[dependencies]", "[dev-dependencies]",
+                        "[build-dependencies]"):
+            in_deps = True
+            continue
+        if stripped.startswith("[") and in_deps:
+            in_deps = False
+            continue
+        if not in_deps or not stripped or stripped.startswith("#"):
+            continue
+        m = re.match(r'^([a-zA-Z0-9_-]+)\s*=', stripped)
+        if m:
+            crate = m.group(1)
+            if crate.lower() not in registered_lower:
+                findings.append(
+                    f"  {filepath}:{line_num}: crate '{crate}' "
+                    f"may not be registered on crates.io"
+                )
+    return findings
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Detect unregistered PyPI package names in pip install commands.",
@@ -199,7 +316,7 @@ def main() -> int:
     for f in files:
         all_findings.extend(check_file(f))
 
-    # --strict: additionally scan all notebooks and requirements files in the repo
+    # --strict: additionally scan all notebooks, requirements, and manifest files
     if args.strict:
         for nb in glob.glob("**/*.ipynb", recursive=True):
             if "node_modules" in nb or ".ipynb_checkpoints" in nb:
@@ -210,6 +327,21 @@ def main() -> int:
             if "node_modules" in req:
                 continue
             all_findings.extend(check_requirements_file(req))
+
+        for pyproj in glob.glob("**/pyproject.toml", recursive=True):
+            if "node_modules" in pyproj:
+                continue
+            all_findings.extend(check_pyproject_toml(pyproj))
+
+        for pkgjson in glob.glob("**/package.json", recursive=True):
+            if "node_modules" in pkgjson:
+                continue
+            all_findings.extend(check_package_json(pkgjson))
+
+        for cargo in glob.glob("**/Cargo.toml", recursive=True):
+            if "node_modules" in cargo:
+                continue
+            all_findings.extend(check_cargo_toml(cargo))
 
     if all_findings:
         print("⚠️  Potential dependency confusion detected:")


### PR DESCRIPTION
## Security Audit - Batch 6: Remaining Medium Findings

### Changes
- **workflow_run validation (CWE-918):** Added conclusion==success check to ai-pr-summary.yml
- **NuGet API key (CWE-532):** Moved key from inline script to env: block in ESRP pipeline
- **Docker pinning (CWE-1104):** Replaced :latest tags with specific versions (Prometheus v3.4.0, Grafana 11.6.0, Qdrant v1.14.1)
- **Dep confusion script (coverage gap):** Extended check_dependency_confusion.py to scan pyproject.toml, package.json, and Cargo.toml; flag local-only packages as HIGH RISK

### Files Changed (5)
ai-pr-summary.yml, esrp-publish.yml, 2 docker-compose.yml, check_dependency_confusion.py
