### PR TITLE
fix(ci): use SPDX string for Cargo.toml license field

### DIFF
--- a/packages/agent-mesh/sdks/rust/agentmesh/Cargo.toml
+++ b/packages/agent-mesh/sdks/rust/agentmesh/Cargo.toml
@@ -3,7 +3,7 @@ name = "agentmesh"
 version = "3.0.2"
 edition = "2021"
 description = "Public Preview — Rust SDK for the AgentMesh governance framework (policy, trust, audit, identity)"
-license = {text = "MIT"}
+license = "MIT"
 repository = "https://github.com/microsoft/agent-governance-toolkit"
 documentation = "https://docs.rs/agentmesh"
 readme = "README.md"


### PR DESCRIPTION
Cargo.toml requires license = MIT (SPDX string), not license = {text = MIT} (pyproject.toml table format).