### PR TITLE
fix(ci): normalize package names to underscores for PyPI compliance

### DIFF
--- a/packages/agent-compliance/pyproject.toml
+++ b/packages/agent-compliance/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0,<69.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agent-governance-toolkit"
+name = "agent_governance_toolkit"
 version = "3.0.2"
 description = "Public Preview — Unified installer and runtime policy enforcement for the Agent Governance Toolkit"
 readme = "README.md"

--- a/packages/agent-hypervisor/pyproject.toml
+++ b/packages/agent-hypervisor/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agent-hypervisor"
+name = "agent_hypervisor"
 version = "3.0.2"
 description = "Public Preview — Agent Hypervisor: Runtime supervisor for multi-agent Shared Sessions with Execution Rings, Joint Liability, Saga Orchestration, and hash-chained audit trails"
 readme = "README.md"

--- a/packages/agent-lightning/pyproject.toml
+++ b/packages/agent-lightning/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0,<69.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agentmesh-lightning"
+name = "agentmesh_lightning"
 version = "3.0.2"
 description = "Public Preview — Agent-Lightning RL integration for the Agent Governance Toolkit: governed training with policy enforcement"
 readme = "README.md"

--- a/packages/agent-marketplace/pyproject.toml
+++ b/packages/agent-marketplace/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0,<69.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agentmesh-marketplace"
+name = "agentmesh_marketplace"
 version = "3.0.2"
 description = "Plugin marketplace for the Agent Governance Toolkit — discover, install, verify, and manage plugins"
 readme = "README.md"

--- a/packages/agent-mesh/packages/langchain-agentmesh/pyproject.toml
+++ b/packages/agent-mesh/packages/langchain-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "langchain-agentmesh"
+name = "langchain_agentmesh"
 version = "3.0.2"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust verification for AI agents"
 readme = "README.md"

--- a/packages/agent-mesh/packages/mcp-trust-server/pyproject.toml
+++ b/packages/agent-mesh/packages/mcp-trust-server/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "mcp-trust-server"
+name = "mcp_trust_server"
 version = "3.0.2"
 description = "MCP server exposing AgentMesh trust management tools for Claude, GPT, and other AI agents"
 readme = "README.md"

--- a/packages/agent-mesh/pyproject.toml
+++ b/packages/agent-mesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agentmesh-platform"
+name = "agentmesh_platform"
 version = "3.0.2"
 description = "Public Preview — The Secure Nervous System for Cloud-Native Agent Ecosystems - Identity, Trust, Reward, Governance"
 readme = "README.md"

--- a/packages/agent-os/examples/carbon-auditor/pyproject.toml
+++ b/packages/agent-os/examples/carbon-auditor/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "carbon-auditor-swarm"
+name = "carbon_auditor_swarm"
 version = "3.0.2"
 description = "Autonomous auditing system for the Voluntary Carbon Market (VCM)"
 readme = "README.md"

--- a/packages/agent-os/examples/defi-sentinel/pyproject.toml
+++ b/packages/agent-os/examples/defi-sentinel/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "defi-sentinel-demo"
+name = "defi_sentinel_demo"
 version = "3.0.2"
 description = "DeFi Risk Sentinel demo using Agent OS"
 requires-python = ">=3.10"

--- a/packages/agent-os/examples/grid-balancing/pyproject.toml
+++ b/packages/agent-os/examples/grid-balancing/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "grid-balancing-demo"
+name = "grid_balancing_demo"
 version = "3.0.2"
 description = "Autonomous energy trading demo using Agent OS"
 requires-python = ">=3.10"

--- a/packages/agent-os/examples/pharma-compliance/pyproject.toml
+++ b/packages/agent-os/examples/pharma-compliance/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pharma-compliance-demo"
+name = "pharma_compliance_demo"
 version = "3.0.2"
 description = "Pharma Compliance demo using Agent OS"
 requires-python = ">=3.10"

--- a/packages/agent-os/modules/amb/pyproject.toml
+++ b/packages/agent-os/modules/amb/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "amb-core"
+name = "amb_core"
 version = "3.0.2"
 description = "A lightweight, broker-agnostic message bus designed specifically for AI Agents"
 readme = "README.md"

--- a/packages/agent-os/modules/atr/pyproject.toml
+++ b/packages/agent-os/modules/atr/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agent-tool-registry"
+name = "agent_tool_registry"
 version = "3.0.2"
 description = "A decentralized marketplace for agent capabilities - The Hands of AI Agents"
 readme = "README.md"

--- a/packages/agent-os/modules/caas/pyproject.toml
+++ b/packages/agent-os/modules/caas/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "caas-core"
+name = "caas_core"
 version = "3.0.2"
 description = "A pure, logic-only library for routing context, handling RAG fallacies, and managing context windows. Layer 1 Primitive - no agent dependencies."
 readme = "README.md"

--- a/packages/agent-os/modules/control-plane/pyproject.toml
+++ b/packages/agent-os/modules/control-plane/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=45,<46.0", "wheel", "setuptools_scm[toml]>=6.2,<7.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agent-control-plane"
+name = "agent_control_plane"
 version = "3.0.2"
 description = "Layer 3: The Framework - A deterministic kernel for zero-violation governance in agentic AI systems with POSIX-style signals, VFS, and kernel/user space separation"
 readme = "README.md"

--- a/packages/agent-os/modules/iatp/pyproject.toml
+++ b/packages/agent-os/modules/iatp/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "inter-agent-trust-protocol"
+name = "inter_agent_trust_protocol"
 version = "3.0.2"
 description = "Inter-Agent Trust Protocol (IATP) - The Envoy for AI Agents. A sidecar architecture with typed IPC pipes for preventing cascading hallucinations in autonomous agent networks."
 readme = "README.md"

--- a/packages/agent-os/modules/mcp-kernel-server/pyproject.toml
+++ b/packages/agent-os/modules/mcp-kernel-server/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mcp-kernel-server"
+name = "mcp_kernel_server"
 version = "3.0.2"
 description = "MCP Server for Claude Desktop - Agent OS kernel primitives including code safety verification, CMVK multi-model review, and IATP trust"
 readme = "README.md"

--- a/packages/agent-os/modules/nexus/pyproject.toml
+++ b/packages/agent-os/modules/nexus/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "nexus-trust-exchange"
+name = "nexus_trust_exchange"
 version = "3.0.2"
 description = "Agent Trust Exchange - viral registry and communication board for AI agents (RESEARCH PROTOTYPE)"
 readme = "README.md"

--- a/packages/agent-os/modules/observability/pyproject.toml
+++ b/packages/agent-os/modules/observability/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agent-os-observability"
+name = "agent_os_observability"
 version = "3.0.2"
 description = "Production observability for Agent OS - OpenTelemetry traces, Prometheus metrics, Grafana dashboards"
 readme = "README.md"

--- a/packages/agent-os/modules/primitives/pyproject.toml
+++ b/packages/agent-os/modules/primitives/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0,<62.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agent-primitives"
+name = "agent_primitives"
 version = "3.0.2"
 description = "Shared primitive data models for Agent OS - failure types, severity levels, and base structures"
 readme = "README.md"

--- a/packages/agent-os/pyproject.toml
+++ b/packages/agent-os/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agent-os-kernel"
+name = "agent_os_kernel"
 version = "3.0.2"
 description = "Public Preview — A kernel architecture for governing autonomous AI agents with Nexus Trust Exchange"
 readme = "README.md"

--- a/packages/agent-runtime/pyproject.toml
+++ b/packages/agent-runtime/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agentmesh-runtime"
+name = "agentmesh_runtime"
 version = "3.0.2"
 description = "Public Preview — AgentMesh Runtime: Execution supervisor for multi-agent sessions with privilege rings, saga orchestration, and audit trails"
 readme = "README.md"

--- a/packages/agent-sre/pyproject.toml
+++ b/packages/agent-sre/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "agent-sre"
+name = "agent_sre"
 version = "3.0.2"
 description = "Public Preview — Reliability Engineering for AI Agent Systems"
 readme = "README.md"

--- a/packages/agentmesh-integrations/a2a-protocol/pyproject.toml
+++ b/packages/agentmesh-integrations/a2a-protocol/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "a2a-agentmesh"
+name = "a2a_agentmesh"
 version = "3.0.2"
 description = "A2A protocol bridge for AgentMesh — trust-verified agent-to-agent communication via the A2A standard"
 readme = "README.md"

--- a/packages/agentmesh-integrations/adk-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/adk-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0,<69.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "adk-agentmesh"
+name = "adk_agentmesh"
 version = "3.0.2"
 description = "Public Preview — Agent Governance Toolkit integration for Google ADK: policy enforcement, trust verification, and audit trails for ADK agents"
 readme = "README.md"

--- a/packages/agentmesh-integrations/crewai-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/crewai-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "crewai-agentmesh"
+name = "crewai_agentmesh"
 version = "3.0.2"
 description = "AgentMesh trust layer for CrewAI — trust-verified crew member selection and capability-gated task assignment"
 readme = "README.md"

--- a/packages/agentmesh-integrations/flowise-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/flowise-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "flowise-agentmesh"
+name = "flowise_agentmesh"
 version = "3.0.2"
 description = "AgentMesh governance nodes for Flowise — policy enforcement, trust gating, audit logging, and rate limiting for visual AI flows"
 readme = "README.md"

--- a/packages/agentmesh-integrations/haystack-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/haystack-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "haystack-agentmesh"
+name = "haystack_agentmesh"
 version = "3.0.2"
 description = "AgentMesh governance components for Haystack pipelines — policy enforcement, trust scoring, and tamper-evident audit trails"
 readme = "README.md"

--- a/packages/agentmesh-integrations/langchain-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/langchain-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "langchain-agentmesh"
+name = "langchain_agentmesh"
 version = "3.0.2"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust-gated tool execution"
 readme = "README.md"

--- a/packages/agentmesh-integrations/langflow-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/langflow-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "langflow-agentmesh"
+name = "langflow_agentmesh"
 version = "3.0.2"
 description = "Governance components for Langflow — policy enforcement, trust routing, audit logging, and compliance checking for visual AI flows"
 readme = "README.md"

--- a/packages/agentmesh-integrations/langgraph-trust/pyproject.toml
+++ b/packages/agentmesh-integrations/langgraph-trust/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "langgraph-trust"
+name = "langgraph_trust"
 version = "3.0.2"
 description = "Trust-gated checkpoint nodes for LangGraph — cryptographic identity, policy enforcement, and trust-aware routing for multi-agent graphs"
 readme = "README.md"

--- a/packages/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
@@ -10,7 +10,7 @@ dev = [
 ]
 
 [project]
-name = "llama-index-agent-agentmesh"
+name = "llama_index_agent_agentmesh"
 version = "3.0.2"
 description = "AgentMesh trust layer integration for LlamaIndex agents"
 authors = [{name = "AgentMesh Contributors"}]

--- a/packages/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
+++ b/packages/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "mcp-trust-proxy"
+name = "mcp_trust_proxy"
 version = "3.0.2"
 description = "MCP proxy that wraps any MCP tool with AgentMesh trust verification"
 readme = "README.md"

--- a/packages/agentmesh-integrations/nostr-wot/pyproject.toml
+++ b/packages/agentmesh-integrations/nostr-wot/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0,<69.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "agentmesh-nostr-wot"
+name = "agentmesh_nostr_wot"
 version = "3.0.2"
 description = "Nostr Web of Trust integration for AgentMesh trust engine"
 readme = "README.md"

--- a/packages/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "openai-agents-agentmesh"
+name = "openai_agents_agentmesh"
 version = "3.0.2"
 description = "AgentMesh trust layer for OpenAI Agents SDK — trust-gated function calling and handoff verification"
 readme = "README.md"

--- a/packages/agentmesh-integrations/openai-agents-trust/pyproject.toml
+++ b/packages/agentmesh-integrations/openai-agents-trust/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "openai-agents-trust"
+name = "openai_agents_trust"
 version = "3.0.2"
 description = "Trust & governance layer for OpenAI Agents SDK — policy enforcement, trust-gated handoffs, and hash-chained audit trails"
 readme = "README.md"

--- a/packages/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "pydantic-ai-governance"
+name = "pydantic_ai_governance"
 version = "3.0.2"
 description = "Governance middleware for PydanticAI — semantic policy enforcement, trust scoring, and audit trails for agent tool execution"
 readme = "README.md"


### PR DESCRIPTION
PyPI rejects sdist uploads with hyphenated filenames (PEP 625). Changed all 37 pyproject.toml name fields from hyphens to underscores. PyPI treats these as equivalent package names.