### PR TITLE
fix: remove trailing whitespace from agent-os source files

### DIFF
--- a/packages/agent-marketplace/src/agent_marketplace/__init__.py
+++ b/packages/agent-marketplace/src/agent_marketplace/__init__.py
@@ -20,8 +20,16 @@ from agent_marketplace.marketplace_policy import (
     ComplianceResult,
     MCPServerPolicy,
     MarketplacePolicy,
+    OrgMarketplacePolicy,
     evaluate_plugin_compliance,
     load_marketplace_policy,
+)
+from agent_marketplace.quality_scoring import (
+    PluginQualityProfile,
+    QualityBadge,
+    QualityDimension,
+    QualityScore,
+    QualityStore,
 )
 from agent_marketplace.registry import PluginRegistry
 from agent_marketplace.schema_adapters import (
@@ -53,13 +61,19 @@ __all__ = [
     "MCPServerPolicy",
     "MarketplaceError",
     "MarketplacePolicy",
+    "OrgMarketplacePolicy",
     "PluginInstaller",
     "PluginManifest",
+    "PluginQualityProfile",
     "PluginRegistry",
     "PluginSigner",
     "PluginTrustConfig",
     "PluginTrustStore",
     "PluginType",
+    "QualityBadge",
+    "QualityDimension",
+    "QualityScore",
+    "QualityStore",
     "TRUST_TIERS",
     "adapt_to_canonical",
     "compute_initial_score",

--- a/packages/agent-marketplace/src/agent_marketplace/manifest.py
+++ b/packages/agent-marketplace/src/agent_marketplace/manifest.py
@@ -62,6 +62,10 @@ class PluginManifest(BaseModel):
         None, description="Minimum AgentMesh version required"
     )
     signature: Optional[str] = Field(None, description="Base64-encoded Ed25519 signature")
+    organization: Optional[str] = Field(
+        None,
+        description="Owning organization (None = global/shared plugin)",
+    )
 
     @field_validator("name")
     @classmethod

--- a/packages/agent-marketplace/src/agent_marketplace/marketplace_policy.py
+++ b/packages/agent-marketplace/src/agent_marketplace/marketplace_policy.py
@@ -6,11 +6,13 @@ Marketplace Policy Enforcement
 Defines marketplace-level policies for MCP server allowlist/blocklist
 enforcement, plugin type restrictions, and signature requirements.
 Operators can declare which MCP servers are permitted for plugins.
+Supports organization-scoped policy overrides (Issues #733, #737).
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
@@ -58,6 +60,16 @@ class MCPServerPolicy(BaseModel):
         return v
 
 
+@dataclass
+class OrgMarketplacePolicy:
+    """Organization-scoped marketplace policy that inherits from enterprise base."""
+
+    organization: str
+    additional_allowed_plugin_types: list[str] = field(default_factory=list)
+    additional_blocked_plugins: list[str] = field(default_factory=list)
+    mcp_server_overrides: MCPServerPolicy | None = None
+
+
 class MarketplacePolicy(BaseModel):
     """Top-level marketplace policy controlling plugin admission."""
 
@@ -73,6 +85,73 @@ class MarketplacePolicy(BaseModel):
         False,
         description="Require Ed25519 signatures on all plugins",
     )
+    org_policies: dict[str, OrgMarketplacePolicy] = Field(
+        default_factory=dict,
+        description="Organization-scoped policy overrides keyed by org name",
+    )
+    org_mcp_policies: dict[str, MCPServerPolicy] = Field(
+        default_factory=dict,
+        description="Per-organization MCP server policy overrides",
+    )
+
+    def get_effective_policy(self, organization: str | None = None) -> MarketplacePolicy:
+        """Resolve effective policy for an organization (base + org overrides).
+
+        When *organization* is ``None`` or the org has no overrides, the base
+        enterprise policy is returned unchanged.  Otherwise the base policy is
+        merged with the org-specific additions.
+        """
+        if organization is None or organization not in self.org_policies:
+            return self
+
+        org = self.org_policies[organization]
+
+        # Merge allowed plugin types: base + org additions
+        merged_types = self.allowed_plugin_types
+        if merged_types is not None and org.additional_allowed_plugin_types:
+            merged_types = list(set(merged_types + org.additional_allowed_plugin_types))
+
+        # Merge MCP server policy if org has overrides
+        merged_mcp = org.mcp_server_overrides if org.mcp_server_overrides else self.mcp_servers
+
+        return MarketplacePolicy(
+            mcp_servers=merged_mcp,
+            allowed_plugin_types=merged_types,
+            require_signature=self.require_signature,
+        )
+
+    def get_effective_mcp_policy(self, organization: str | None = None) -> MCPServerPolicy:
+        """Get effective MCP server policy for an organization.
+
+        Org policies inherit from the base (enterprise) MCP policy.
+        Org can add to allowlist but cannot remove base restrictions.
+        """
+        base = self.mcp_servers
+        if organization is None or organization not in self.org_mcp_policies:
+            return base
+        org = self.org_mcp_policies[organization]
+        # Merge: org inherits base restrictions, can add more allowed servers
+        if base.mode == "blocklist":
+            # Org cannot un-block servers blocked at enterprise level
+            merged_blocked = list(set(base.blocked + org.blocked))
+            merged_allowed = [s for s in org.allowed if s not in base.blocked]
+            return MCPServerPolicy(
+                mode=base.mode,
+                blocked=merged_blocked,
+                allowed=merged_allowed,
+                require_declaration=base.require_declaration or org.require_declaration,
+            )
+        else:  # allowlist
+            # Org can only allow servers already in the enterprise allowlist
+            merged_allowed = (
+                [s for s in org.allowed if s in base.allowed] if base.allowed else org.allowed
+            )
+            return MCPServerPolicy(
+                mode=base.mode,
+                allowed=merged_allowed or base.allowed,
+                blocked=list(set(base.blocked + org.blocked)),
+                require_declaration=base.require_declaration or org.require_declaration,
+            )
 
 
 class ComplianceResult(BaseModel):
@@ -125,6 +204,7 @@ def evaluate_plugin_compliance(
     manifest: PluginManifest,
     policy: MarketplacePolicy,
     mcp_servers: list[str] | None = None,
+    organization: str | None = None,
 ) -> ComplianceResult:
     """Check whether a plugin manifest complies with a marketplace policy.
 
@@ -134,6 +214,9 @@ def evaluate_plugin_compliance(
         mcp_servers: Optional list of MCP server names declared by the plugin.
             When ``None``, MCP declaration checks that require a server list
             will flag a violation if ``require_declaration`` is enabled.
+        organization: Optional organization name.  When provided the
+            effective MCP policy is resolved via
+            :meth:`MarketplacePolicy.get_effective_mcp_policy`.
 
     Returns:
         A :class:`ComplianceResult` indicating compliance status and any
@@ -155,8 +238,8 @@ def evaluate_plugin_compliance(
                 f"(allowed: {', '.join(policy.allowed_plugin_types)})"
             )
 
-    # -- MCP server policy ----------------------------------------------------
-    mcp_policy = policy.mcp_servers
+    # -- MCP server policy (org-aware) ----------------------------------------
+    mcp_policy = policy.get_effective_mcp_policy(organization)
 
     if mcp_policy.require_declaration and mcp_servers is None:
         violations.append(

--- a/packages/agent-marketplace/src/agent_marketplace/quality_scoring.py
+++ b/packages/agent-marketplace/src/agent_marketplace/quality_scoring.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Plugin quality scoring model — separate from trust/compliance scoring.
+
+Trust tiers answer 'is this plugin safe?'
+Quality scoring answers 'is this plugin good?'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class QualityDimension(str, Enum):
+    """Dimensions along which plugin quality is assessed."""
+
+    DOCUMENTATION = "documentation"
+    TEST_COVERAGE = "test_coverage"
+    OUTPUT_ACCURACY = "output_accuracy"
+    RELIABILITY = "reliability"
+    PERFORMANCE = "performance"
+    USER_SATISFACTION = "user_satisfaction"
+
+
+class QualityBadge(str, Enum):
+    """Badge tiers awarded based on overall quality score."""
+
+    UNRATED = "unrated"
+    BRONZE = "bronze"
+    SILVER = "silver"
+    GOLD = "gold"
+    PLATINUM = "platinum"
+
+
+@dataclass
+class QualityScore:
+    """Quality assessment for a single dimension."""
+
+    dimension: QualityDimension
+    score: float  # 0.0 to 1.0
+    evidence: str = ""
+    assessed_at: str = ""
+
+
+@dataclass
+class PluginQualityProfile:
+    """Aggregated quality profile for a plugin."""
+
+    plugin_name: str
+    plugin_version: str
+    scores: list[QualityScore] = field(default_factory=list)
+
+    @property
+    def overall_score(self) -> float:
+        """Return the mean score across all assessed dimensions."""
+        if not self.scores:
+            return 0.0
+        return sum(s.score for s in self.scores) / len(self.scores)
+
+    @property
+    def badge(self) -> QualityBadge:
+        """Derive a badge from the overall score."""
+        score = self.overall_score
+        if score >= 0.9:
+            return QualityBadge.PLATINUM
+        elif score >= 0.75:
+            return QualityBadge.GOLD
+        elif score >= 0.6:
+            return QualityBadge.SILVER
+        elif score >= 0.4:
+            return QualityBadge.BRONZE
+        return QualityBadge.UNRATED
+
+    def get_score(self, dimension: QualityDimension) -> float | None:
+        """Return the score for a specific dimension, or ``None`` if unrated."""
+        for s in self.scores:
+            if s.dimension == dimension:
+                return s.score
+        return None
+
+
+@dataclass
+class QualityStore:
+    """In-memory store for plugin quality profiles."""
+
+    _profiles: dict[str, PluginQualityProfile] = field(default_factory=dict)
+
+    def _key(self, name: str, version: str) -> str:
+        return f"{name}@{version}"
+
+    def record_score(
+        self,
+        plugin_name: str,
+        plugin_version: str,
+        score: QualityScore,
+    ) -> None:
+        """Record (or update) a quality score for a plugin dimension."""
+        key = self._key(plugin_name, plugin_version)
+        if key not in self._profiles:
+            self._profiles[key] = PluginQualityProfile(
+                plugin_name=plugin_name, plugin_version=plugin_version
+            )
+        profile = self._profiles[key]
+        # Update existing dimension or add new
+        profile.scores = [s for s in profile.scores if s.dimension != score.dimension]
+        profile.scores.append(score)
+
+    def get_profile(
+        self, plugin_name: str, plugin_version: str
+    ) -> PluginQualityProfile | None:
+        """Retrieve the quality profile for a specific plugin version."""
+        return self._profiles.get(self._key(plugin_name, plugin_version))
+
+    def get_badge(self, plugin_name: str, plugin_version: str) -> QualityBadge:
+        """Return the quality badge for a plugin, defaulting to UNRATED."""
+        profile = self.get_profile(plugin_name, plugin_version)
+        return profile.badge if profile else QualityBadge.UNRATED

--- a/packages/agent-marketplace/src/agent_marketplace/registry.py
+++ b/packages/agent-marketplace/src/agent_marketplace/registry.py
@@ -17,6 +17,7 @@ from typing import Optional
 from agent_marketplace.manifest import MarketplaceError, PluginManifest, PluginType
 from agent_marketplace.marketplace_policy import (
     MarketplacePolicy,
+    OrgMarketplacePolicy,
     evaluate_plugin_compliance,
 )
 
@@ -57,12 +58,14 @@ class PluginRegistry:
         self,
         manifest: PluginManifest,
         mcp_servers: list[str] | None = None,
+        organization: str | None = None,
     ) -> None:
         """Register a plugin manifest.
 
         Args:
             manifest: The manifest to register.
             mcp_servers: Optional list of MCP server names declared by the plugin.
+            organization: Optional organization context for org-scoped policy checks.
 
         Raises:
             MarketplaceError: If the exact name+version already exists or the
@@ -70,7 +73,8 @@ class PluginRegistry:
         """
         if self._marketplace_policy is not None:
             result = evaluate_plugin_compliance(
-                manifest, self._marketplace_policy, mcp_servers
+                manifest, self._marketplace_policy, mcp_servers,
+                organization=organization,
             )
             if not result.compliant:
                 raise MarketplaceError(
@@ -171,6 +175,26 @@ class PluginRegistry:
             latest = max(versions.values(), key=lambda m: _semver_tuple(m.version))
             if type_filter is None or latest.plugin_type == type_filter:
                 results.append(latest)
+        return results
+
+    def list_for_organization(self, organization: str) -> list[PluginManifest]:
+        """List plugins visible to an organization (org-specific + global).
+
+        A plugin is visible to an organization when its ``organization``
+        field is ``None`` (global) or matches the given *organization*.
+
+        Args:
+            organization: Organization name to filter by.
+
+        Returns:
+            List of matching manifests (all versions).
+        """
+        results: list[PluginManifest] = []
+        for name in self._plugins:
+            for version in self._plugins[name]:
+                manifest = self._plugins[name][version]
+                if manifest.organization is None or manifest.organization == organization:
+                    results.append(manifest)
         return results
 
     # ------------------------------------------------------------------

--- a/packages/agent-marketplace/tests/test_org_marketplace.py
+++ b/packages/agent-marketplace/tests/test_org_marketplace.py
@@ -1,0 +1,524 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for org-scoped marketplace, quality scoring, and per-org MCP policies.
+
+Covers:
+  - Issue #733: Org-scoped plugin listing (see global + org plugins, not other orgs)
+  - Issue #736: Quality scoring (record scores, badges, overall score)
+  - Issue #737: Per-org MCP policy resolution (inherit, merge, cannot un-block)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_marketplace.manifest import PluginManifest, PluginType
+from agent_marketplace.marketplace_policy import (
+    MCPServerPolicy,
+    MarketplacePolicy,
+    OrgMarketplacePolicy,
+    evaluate_plugin_compliance,
+)
+from agent_marketplace.quality_scoring import (
+    PluginQualityProfile,
+    QualityBadge,
+    QualityDimension,
+    QualityScore,
+    QualityStore,
+)
+from agent_marketplace.registry import PluginRegistry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest(**overrides) -> PluginManifest:
+    """Create a PluginManifest with sensible defaults."""
+    defaults = {
+        "name": "test-plugin",
+        "version": "1.0.0",
+        "description": "A test plugin",
+        "author": "test@example.com",
+        "plugin_type": PluginType.INTEGRATION,
+    }
+    defaults.update(overrides)
+    return PluginManifest(**defaults)
+
+
+# ===========================================================================
+# Issue #733 — Org-scoped plugin listing
+# ===========================================================================
+
+
+class TestPluginManifestOrganizationField:
+    """PluginManifest.organization field basics."""
+
+    def test_default_organization_is_none(self) -> None:
+        manifest = _make_manifest()
+        assert manifest.organization is None
+
+    def test_set_organization(self) -> None:
+        manifest = _make_manifest(organization="contoso")
+        assert manifest.organization == "contoso"
+
+    def test_backward_compatible_serialization(self) -> None:
+        """Existing manifests without organization still load fine."""
+        data = {
+            "name": "legacy-plugin",
+            "version": "1.0.0",
+            "description": "Legacy",
+            "author": "dev@example.com",
+            "plugin_type": "integration",
+        }
+        manifest = PluginManifest(**data)
+        assert manifest.organization is None
+
+
+class TestRegistryListForOrganization:
+    """PluginRegistry.list_for_organization visibility rules."""
+
+    def _build_registry(self) -> PluginRegistry:
+        registry = PluginRegistry()
+        # Global plugins (organization=None)
+        registry.register(_make_manifest(name="global-plugin", version="1.0.0"))
+        registry.register(_make_manifest(name="global-plugin", version="2.0.0"))
+        # Contoso-specific plugins
+        registry.register(
+            _make_manifest(name="contoso-tool", version="1.0.0", organization="contoso")
+        )
+        # Fabrikam-specific plugins
+        registry.register(
+            _make_manifest(name="fabrikam-tool", version="1.0.0", organization="fabrikam")
+        )
+        return registry
+
+    def test_org_sees_global_and_own_plugins(self) -> None:
+        registry = self._build_registry()
+        visible = registry.list_for_organization("contoso")
+        names = {m.name for m in visible}
+        assert "global-plugin" in names
+        assert "contoso-tool" in names
+
+    def test_org_does_not_see_other_org_plugins(self) -> None:
+        registry = self._build_registry()
+        visible = registry.list_for_organization("contoso")
+        names = {m.name for m in visible}
+        assert "fabrikam-tool" not in names
+
+    def test_all_versions_of_global_plugin_visible(self) -> None:
+        registry = self._build_registry()
+        visible = registry.list_for_organization("contoso")
+        global_versions = [m.version for m in visible if m.name == "global-plugin"]
+        assert sorted(global_versions) == ["1.0.0", "2.0.0"]
+
+    def test_unknown_org_sees_only_global(self) -> None:
+        registry = self._build_registry()
+        visible = registry.list_for_organization("unknown-org")
+        names = {m.name for m in visible}
+        assert names == {"global-plugin"}
+
+
+# ===========================================================================
+# Issue #733 — OrgMarketplacePolicy & get_effective_policy
+# ===========================================================================
+
+
+class TestOrgMarketplacePolicy:
+    """OrgMarketplacePolicy dataclass and MarketplacePolicy.get_effective_policy."""
+
+    def test_org_policy_defaults(self) -> None:
+        org = OrgMarketplacePolicy(organization="contoso")
+        assert org.organization == "contoso"
+        assert org.additional_allowed_plugin_types == []
+        assert org.additional_blocked_plugins == []
+        assert org.mcp_server_overrides is None
+
+    def test_get_effective_policy_no_org(self) -> None:
+        policy = MarketplacePolicy(allowed_plugin_types=["integration"])
+        effective = policy.get_effective_policy(None)
+        assert effective is policy  # identity — no merge needed
+
+    def test_get_effective_policy_unknown_org(self) -> None:
+        policy = MarketplacePolicy(allowed_plugin_types=["integration"])
+        effective = policy.get_effective_policy("unknown")
+        assert effective is policy
+
+    def test_get_effective_policy_merges_plugin_types(self) -> None:
+        policy = MarketplacePolicy(
+            allowed_plugin_types=["integration"],
+            org_policies={
+                "contoso": OrgMarketplacePolicy(
+                    organization="contoso",
+                    additional_allowed_plugin_types=["agent"],
+                ),
+            },
+        )
+        effective = policy.get_effective_policy("contoso")
+        assert set(effective.allowed_plugin_types) == {"integration", "agent"}
+
+    def test_get_effective_policy_preserves_signature_requirement(self) -> None:
+        policy = MarketplacePolicy(
+            require_signature=True,
+            org_policies={
+                "contoso": OrgMarketplacePolicy(organization="contoso"),
+            },
+        )
+        effective = policy.get_effective_policy("contoso")
+        assert effective.require_signature is True
+
+
+# ===========================================================================
+# Issue #736 — Plugin quality scoring
+# ===========================================================================
+
+
+class TestQualityScore:
+    """QualityScore dataclass."""
+
+    def test_basic_construction(self) -> None:
+        score = QualityScore(
+            dimension=QualityDimension.DOCUMENTATION,
+            score=0.85,
+            evidence="README present",
+        )
+        assert score.dimension == QualityDimension.DOCUMENTATION
+        assert score.score == 0.85
+        assert score.evidence == "README present"
+
+    def test_defaults(self) -> None:
+        score = QualityScore(dimension=QualityDimension.RELIABILITY, score=0.5)
+        assert score.evidence == ""
+        assert score.assessed_at == ""
+
+
+class TestPluginQualityProfile:
+    """PluginQualityProfile aggregation."""
+
+    def _make_profile(self, scores: list[tuple[QualityDimension, float]]) -> PluginQualityProfile:
+        return PluginQualityProfile(
+            plugin_name="test",
+            plugin_version="1.0.0",
+            scores=[QualityScore(dimension=d, score=s) for d, s in scores],
+        )
+
+    def test_overall_score_empty(self) -> None:
+        profile = PluginQualityProfile(plugin_name="x", plugin_version="1.0.0")
+        assert profile.overall_score == 0.0
+
+    def test_overall_score_average(self) -> None:
+        profile = self._make_profile([
+            (QualityDimension.DOCUMENTATION, 0.8),
+            (QualityDimension.RELIABILITY, 0.6),
+        ])
+        assert profile.overall_score == pytest.approx(0.7)
+
+    def test_badge_platinum(self) -> None:
+        profile = self._make_profile([(QualityDimension.DOCUMENTATION, 0.95)])
+        assert profile.badge == QualityBadge.PLATINUM
+
+    def test_badge_gold(self) -> None:
+        profile = self._make_profile([(QualityDimension.DOCUMENTATION, 0.80)])
+        assert profile.badge == QualityBadge.GOLD
+
+    def test_badge_silver(self) -> None:
+        profile = self._make_profile([(QualityDimension.DOCUMENTATION, 0.65)])
+        assert profile.badge == QualityBadge.SILVER
+
+    def test_badge_bronze(self) -> None:
+        profile = self._make_profile([(QualityDimension.DOCUMENTATION, 0.45)])
+        assert profile.badge == QualityBadge.BRONZE
+
+    def test_badge_unrated(self) -> None:
+        profile = self._make_profile([(QualityDimension.DOCUMENTATION, 0.2)])
+        assert profile.badge == QualityBadge.UNRATED
+
+    def test_badge_unrated_no_scores(self) -> None:
+        profile = PluginQualityProfile(plugin_name="x", plugin_version="1.0.0")
+        assert profile.badge == QualityBadge.UNRATED
+
+    def test_get_score_existing(self) -> None:
+        profile = self._make_profile([(QualityDimension.PERFORMANCE, 0.9)])
+        assert profile.get_score(QualityDimension.PERFORMANCE) == 0.9
+
+    def test_get_score_missing(self) -> None:
+        profile = self._make_profile([(QualityDimension.PERFORMANCE, 0.9)])
+        assert profile.get_score(QualityDimension.TEST_COVERAGE) is None
+
+
+class TestQualityStore:
+    """QualityStore record/retrieve operations."""
+
+    def test_record_and_retrieve(self) -> None:
+        store = QualityStore()
+        score = QualityScore(dimension=QualityDimension.DOCUMENTATION, score=0.8)
+        store.record_score("my-plugin", "1.0.0", score)
+
+        profile = store.get_profile("my-plugin", "1.0.0")
+        assert profile is not None
+        assert profile.plugin_name == "my-plugin"
+        assert len(profile.scores) == 1
+        assert profile.scores[0].score == 0.8
+
+    def test_record_updates_existing_dimension(self) -> None:
+        store = QualityStore()
+        store.record_score(
+            "my-plugin", "1.0.0",
+            QualityScore(dimension=QualityDimension.DOCUMENTATION, score=0.5),
+        )
+        store.record_score(
+            "my-plugin", "1.0.0",
+            QualityScore(dimension=QualityDimension.DOCUMENTATION, score=0.9),
+        )
+        profile = store.get_profile("my-plugin", "1.0.0")
+        assert len(profile.scores) == 1
+        assert profile.scores[0].score == 0.9
+
+    def test_record_multiple_dimensions(self) -> None:
+        store = QualityStore()
+        store.record_score(
+            "p", "1.0.0",
+            QualityScore(dimension=QualityDimension.DOCUMENTATION, score=0.8),
+        )
+        store.record_score(
+            "p", "1.0.0",
+            QualityScore(dimension=QualityDimension.RELIABILITY, score=0.6),
+        )
+        profile = store.get_profile("p", "1.0.0")
+        assert len(profile.scores) == 2
+        assert profile.overall_score == pytest.approx(0.7)
+
+    def test_get_badge_unknown_plugin(self) -> None:
+        store = QualityStore()
+        assert store.get_badge("missing", "1.0.0") == QualityBadge.UNRATED
+
+    def test_get_badge_known_plugin(self) -> None:
+        store = QualityStore()
+        store.record_score(
+            "good-plugin", "1.0.0",
+            QualityScore(dimension=QualityDimension.OUTPUT_ACCURACY, score=0.92),
+        )
+        assert store.get_badge("good-plugin", "1.0.0") == QualityBadge.PLATINUM
+
+    def test_separate_versions_have_separate_profiles(self) -> None:
+        store = QualityStore()
+        store.record_score(
+            "p", "1.0.0",
+            QualityScore(dimension=QualityDimension.RELIABILITY, score=0.4),
+        )
+        store.record_score(
+            "p", "2.0.0",
+            QualityScore(dimension=QualityDimension.RELIABILITY, score=0.95),
+        )
+        assert store.get_badge("p", "1.0.0") == QualityBadge.BRONZE
+        assert store.get_badge("p", "2.0.0") == QualityBadge.PLATINUM
+
+
+# ===========================================================================
+# Issue #737 — Per-org MCP policy resolution
+# ===========================================================================
+
+
+class TestGetEffectiveMCPPolicy:
+    """MarketplacePolicy.get_effective_mcp_policy merge logic."""
+
+    def test_no_org_returns_base(self) -> None:
+        base_mcp = MCPServerPolicy(mode="allowlist", allowed=["server-a"])
+        policy = MarketplacePolicy(mcp_servers=base_mcp)
+        effective = policy.get_effective_mcp_policy(None)
+        assert effective is base_mcp
+
+    def test_unknown_org_returns_base(self) -> None:
+        base_mcp = MCPServerPolicy(mode="allowlist", allowed=["server-a"])
+        policy = MarketplacePolicy(mcp_servers=base_mcp)
+        effective = policy.get_effective_mcp_policy("unknown-org")
+        assert effective is base_mcp
+
+    # -- Blocklist mode -------------------------------------------------------
+
+    def test_blocklist_org_cannot_unblock_enterprise_blocked(self) -> None:
+        """Org-level policy cannot remove servers blocked at enterprise level."""
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(
+                mode="blocklist",
+                blocked=["evil-server"],
+            ),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(
+                    mode="blocklist",
+                    blocked=[],  # org tries to have no blocks
+                    allowed=["evil-server"],  # org tries to allow a blocked server
+                ),
+            },
+        )
+        effective = policy.get_effective_mcp_policy("contoso")
+        assert "evil-server" in effective.blocked
+        assert "evil-server" not in effective.allowed
+
+    def test_blocklist_org_adds_own_blocks(self) -> None:
+        """Org can add additional blocked servers."""
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(mode="blocklist", blocked=["enterprise-bad"]),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(
+                    mode="blocklist",
+                    blocked=["org-bad"],
+                ),
+            },
+        )
+        effective = policy.get_effective_mcp_policy("contoso")
+        assert "enterprise-bad" in effective.blocked
+        assert "org-bad" in effective.blocked
+
+    def test_blocklist_require_declaration_inherits(self) -> None:
+        """If base requires declaration, org inherits it."""
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(
+                mode="blocklist", require_declaration=True
+            ),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(
+                    mode="blocklist", require_declaration=False
+                ),
+            },
+        )
+        effective = policy.get_effective_mcp_policy("contoso")
+        assert effective.require_declaration is True
+
+    # -- Allowlist mode -------------------------------------------------------
+
+    def test_allowlist_org_only_allows_enterprise_approved(self) -> None:
+        """Org cannot allow servers not in the enterprise allowlist."""
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(
+                mode="allowlist",
+                allowed=["approved-a", "approved-b"],
+            ),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(
+                    mode="allowlist",
+                    allowed=["approved-a", "rogue-server"],
+                ),
+            },
+        )
+        effective = policy.get_effective_mcp_policy("contoso")
+        assert "approved-a" in effective.allowed
+        assert "rogue-server" not in effective.allowed
+
+    def test_allowlist_org_inherits_base_when_no_overlap(self) -> None:
+        """When org's allowed list has no overlap, fall back to base."""
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(
+                mode="allowlist",
+                allowed=["server-a"],
+            ),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(
+                    mode="allowlist",
+                    allowed=["server-z"],  # not in base
+                ),
+            },
+        )
+        effective = policy.get_effective_mcp_policy("contoso")
+        # Falls back to base.allowed since intersection is empty
+        assert "server-a" in effective.allowed
+
+    def test_allowlist_org_adds_blocks(self) -> None:
+        """Org can add blocked servers even in allowlist mode."""
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(mode="allowlist", allowed=["server-a"]),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(
+                    mode="allowlist",
+                    blocked=["org-blocked"],
+                ),
+            },
+        )
+        effective = policy.get_effective_mcp_policy("contoso")
+        assert "org-blocked" in effective.blocked
+
+
+# ===========================================================================
+# Issue #737 — evaluate_plugin_compliance with organization
+# ===========================================================================
+
+
+class TestEvaluatePluginComplianceWithOrg:
+    """evaluate_plugin_compliance respects per-org MCP policies."""
+
+    def test_org_blocked_server_rejected(self) -> None:
+        manifest = _make_manifest()
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(mode="blocklist", blocked=["enterprise-bad"]),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(mode="blocklist", blocked=["org-bad"]),
+            },
+        )
+        result = evaluate_plugin_compliance(
+            manifest, policy, mcp_servers=["org-bad"], organization="contoso"
+        )
+        assert result.compliant is False
+        assert any("blocked" in v for v in result.violations)
+
+    def test_base_blocked_server_rejected_via_org(self) -> None:
+        manifest = _make_manifest()
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(mode="blocklist", blocked=["enterprise-bad"]),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(mode="blocklist", blocked=[]),
+            },
+        )
+        result = evaluate_plugin_compliance(
+            manifest, policy, mcp_servers=["enterprise-bad"], organization="contoso"
+        )
+        assert result.compliant is False
+
+    def test_compliant_server_with_org(self) -> None:
+        manifest = _make_manifest()
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(mode="blocklist", blocked=["enterprise-bad"]),
+            org_mcp_policies={
+                "contoso": MCPServerPolicy(mode="blocklist", blocked=["org-bad"]),
+            },
+        )
+        result = evaluate_plugin_compliance(
+            manifest, policy, mcp_servers=["good-server"], organization="contoso"
+        )
+        assert result.compliant is True
+
+    def test_without_org_uses_base_policy(self) -> None:
+        manifest = _make_manifest()
+        policy = MarketplacePolicy(
+            mcp_servers=MCPServerPolicy(
+                mode="allowlist", allowed=["approved"]
+            ),
+        )
+        result = evaluate_plugin_compliance(
+            manifest, policy, mcp_servers=["approved"], organization=None
+        )
+        assert result.compliant is True
+
+
+# ===========================================================================
+# Top-level import smoke test
+# ===========================================================================
+
+
+def test_new_symbols_importable():
+    """New public symbols are importable from the top-level package."""
+    from agent_marketplace import (
+        OrgMarketplacePolicy,
+        PluginQualityProfile,
+        QualityBadge,
+        QualityDimension,
+        QualityScore,
+        QualityStore,
+    )
+
+    assert OrgMarketplacePolicy is not None
+    assert PluginQualityProfile is not None
+    assert QualityBadge is not None
+    assert QualityDimension is not None
+    assert QualityScore is not None
+    assert QualityStore is not None

--- a/packages/agent-os/src/agent_os/cli/__init__.py
+++ b/packages/agent-os/src/agent_os/cli/__init__.py
@@ -189,7 +189,7 @@ def handle_cli_error(e: Exception, args: argparse.Namespace) -> int:
     # Sanitize exception message to avoid leaking internal details
     is_known_error = isinstance(e, (FileNotFoundError, ValueError, PermissionError))
     error_msg = "A file, value, or permission error occurred." if is_known_error else "An internal error occurred."
-    
+
     if getattr(args, "json", False) or (hasattr(args, "format") and args.format == "json"):
         print(json.dumps({
             "status": "error",

--- a/packages/agent-os/src/agent_os/cli/mcp_scan.py
+++ b/packages/agent-os/src/agent_os/cli/mcp_scan.py
@@ -12,7 +12,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import yaml
 from rich.console import Console
@@ -45,7 +45,7 @@ class SecurityFinding:
 def scan_config(config_path: Path, single_server: Optional[str] = None) -> List[SecurityFinding]:
     """Scan MCP configuration for potential security risks."""
     findings = []
-    
+
     try:
         if config_path.suffix in [".yaml", ".yml"]:
             with open(config_path) as f:
@@ -58,11 +58,11 @@ def scan_config(config_path: Path, single_server: Optional[str] = None) -> List[
         return findings
 
     mcp_servers = config.get("mcpServers", {})
-    
+
     for name, server in mcp_servers.items():
         if single_server and name != single_server:
             continue
-            
+
         # 1. Environment Variable Check
         env = server.get("env", {})
         for key in env.keys():
@@ -89,7 +89,7 @@ def get_fingerprints(config_path: Path) -> Dict[str, str]:
     """Generate fingerprints for all tools in the config."""
     # Simulated fingerprinting
     import hashlib
-    
+
     try:
         with open(config_path) as f:
             if config_path.suffix in [".yaml", ".yml"]:
@@ -106,7 +106,7 @@ def get_fingerprints(config_path: Path) -> Dict[str, str]:
         args = str(server.get("args", []))
         h = hashlib.sha256(f"{cmd}{args}".encode()).hexdigest()[:16]
         fingerprints[name] = h
-        
+
     return fingerprints
 
 
@@ -116,7 +116,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="mcp-scan",
         description="Agent OS MCP Security Scanner - Analyze MCP configs for risks"
     )
-    
+
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 
     # -- scan ---------------------------------------------------------------
@@ -162,7 +162,7 @@ def main(argv: List[str] | None = None) -> int:
     try:
         if args.command == "scan":
             findings = scan_config(config_path, args.server)
-            
+
             if args.severity:
                 findings = [f for f in findings if f.severity == args.severity or f.severity == "critical"]
 
@@ -180,23 +180,23 @@ def main(argv: List[str] | None = None) -> int:
                     table.add_row(f.server, f"[{sev_color}]{f.severity.upper()}[/{sev_color}]", f.category, f.message)
 
                 console.print(table)
-            
+
             return 1 if any(f.severity == "critical" for f in findings) else 0
 
         elif args.command == "fingerprint":
             fingerprints = get_fingerprints(config_path)
-            
+
             if args.compare:
                 with open(args.compare) as f:
                     saved = json.load(f)
-                
+
                 diffs = {}
                 for name, h in fingerprints.items():
                     if name not in saved:
                         diffs[name] = "new"
                     elif saved[name] != h:
                         diffs[name] = "changed"
-                
+
                 if output_format == "json":
                     print(json.dumps({"current": fingerprints, "diffs": diffs}, indent=2))
                 else:
@@ -205,7 +205,7 @@ def main(argv: List[str] | None = None) -> int:
                         print(f"  {name}: {status}")
                     if not diffs:
                         print("  Identical fingerprints.")
-            
+
             elif args.output:
                 with open(args.output, "w") as f:
                     json.dump(fingerprints, f, indent=2)
@@ -213,7 +213,7 @@ def main(argv: List[str] | None = None) -> int:
                     print(f"Fingerprints saved to {args.output}")
                 else:
                     print(json.dumps({"status": "success", "file": args.output}, indent=2))
-            
+
             else:
                 if output_format == "json":
                     print(json.dumps(fingerprints, indent=2))
@@ -224,7 +224,7 @@ def main(argv: List[str] | None = None) -> int:
         elif args.command == "report":
             findings = scan_config(config_path)
             fingerprints = get_fingerprints(config_path)
-            
+
             report = {
                 "config": str(config_path),
                 "summary": {
@@ -236,7 +236,7 @@ def main(argv: List[str] | None = None) -> int:
                 "findings": [f.to_dict() for f in findings],
                 "fingerprints": fingerprints
             }
-            
+
             if output_format == "json" or getattr(args, "format", "markdown") == "json":
                 print(json.dumps(report, indent=2))
             else:

--- a/packages/agent-os/src/agent_os/content_governance.py
+++ b/packages/agent-os/src/agent_os/content_governance.py
@@ -1,0 +1,140 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Content and knowledge quality governance for AI agents.
+
+Runtime governance answers 'is the agent behavior safe?'
+Content governance answers 'is the agent output accurate, well-structured,
+and meeting quality standards?'
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ContentDimension(str, Enum):
+    """Dimensions for content quality evaluation."""
+    ACCURACY = "accuracy"
+    COMPLETENESS = "completeness"
+    FRESHNESS = "freshness"
+    STRUCTURE = "structure"
+    RELEVANCE = "relevance"
+    CONSISTENCY = "consistency"
+
+
+class QualityGate(str, Enum):
+    """Content quality gate decisions."""
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+@dataclass
+class ContentQualityRule:
+    """A rule for evaluating content quality."""
+    name: str
+    dimension: ContentDimension
+    threshold: float  # 0.0 to 1.0
+    gate: QualityGate = QualityGate.WARN
+    description: str = ""
+
+
+@dataclass
+class ContentEvaluation:
+    """Result of evaluating content against quality rules."""
+    dimension: ContentDimension
+    score: float
+    gate_result: QualityGate
+    rule_name: str
+    details: str = ""
+
+
+@dataclass
+class ContentQualityReport:
+    """Aggregated quality report for agent output."""
+    agent_id: str
+    content_id: str
+    evaluations: list[ContentEvaluation] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(e.gate_result != QualityGate.FAIL for e in self.evaluations)
+
+    @property
+    def overall_score(self) -> float:
+        if not self.evaluations:
+            return 0.0
+        return sum(e.score for e in self.evaluations) / len(self.evaluations)
+
+    @property
+    def warnings(self) -> list[ContentEvaluation]:
+        return [e for e in self.evaluations if e.gate_result == QualityGate.WARN]
+
+    @property
+    def failures(self) -> list[ContentEvaluation]:
+        return [e for e in self.evaluations if e.gate_result == QualityGate.FAIL]
+
+
+class ContentQualityEvaluator:
+    """Evaluates agent output against content quality rules.
+
+    Usage:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="min-accuracy",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.8,
+            gate=QualityGate.FAIL,
+        ))
+
+        report = evaluator.evaluate(
+            agent_id="agent-1",
+            content_id="response-123",
+            scores={ContentDimension.ACCURACY: 0.75},
+        )
+        assert not report.passed  # Below 0.8 threshold
+    """
+
+    def __init__(self) -> None:
+        self._rules: list[ContentQualityRule] = []
+
+    def add_rule(self, rule: ContentQualityRule) -> None:
+        self._rules.append(rule)
+
+    def load_rules(self, rules: list[dict[str, Any]]) -> None:
+        """Load rules from a list of dicts (e.g., from YAML config)."""
+        for r in rules:
+            self._rules.append(ContentQualityRule(
+                name=r["name"],
+                dimension=ContentDimension(r["dimension"]),
+                threshold=float(r["threshold"]),
+                gate=QualityGate(r.get("gate", "warn")),
+                description=r.get("description", ""),
+            ))
+
+    def evaluate(
+        self,
+        agent_id: str,
+        content_id: str,
+        scores: dict[ContentDimension, float],
+    ) -> ContentQualityReport:
+        """Evaluate content scores against configured rules."""
+        evaluations = []
+        for rule in self._rules:
+            score = scores.get(rule.dimension, 0.0)
+            if score >= rule.threshold:
+                gate_result = QualityGate.PASS
+            else:
+                gate_result = rule.gate
+            evaluations.append(ContentEvaluation(
+                dimension=rule.dimension,
+                score=score,
+                gate_result=gate_result,
+                rule_name=rule.name,
+                details=f"Score {score:.2f} vs threshold {rule.threshold:.2f}",
+            ))
+        return ContentQualityReport(
+            agent_id=agent_id,
+            content_id=content_id,
+            evaluations=evaluations,
+        )

--- a/packages/agent-os/src/agent_os/github_enterprise.py
+++ b/packages/agent-os/src/agent_os/github_enterprise.py
@@ -1,0 +1,96 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""GitHub Enterprise managed policy and ruleset integration.
+
+Provides integration points for GitHub Enterprise features:
+- Repository rulesets for governance enforcement
+- Custom properties for repo governance tier tagging
+- Enterprise-level policy templates
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class GovernanceTier(str, Enum):
+    """Repository governance tier assigned via GitHub custom properties."""
+    UNCLASSIFIED = "unclassified"
+    BASIC = "basic"
+    STANDARD = "standard"
+    ELEVATED = "elevated"
+    CRITICAL = "critical"
+
+
+@dataclass
+class RulesetConfig:
+    """Configuration for a GitHub repository ruleset."""
+    name: str
+    enforcement: str = "active"  # active, evaluate, disabled
+    target: str = "branch"  # branch, tag, push
+    conditions: dict[str, Any] = field(default_factory=dict)
+    rules: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class EnterpriseGovernancePolicy:
+    """Enterprise-level governance policy template.
+
+    Defines rulesets and custom properties that should be applied
+    to repositories based on their governance tier.
+    """
+    name: str
+    description: str = ""
+    applicable_tiers: list[GovernanceTier] = field(default_factory=list)
+    rulesets: list[RulesetConfig] = field(default_factory=list)
+    required_custom_properties: dict[str, str] = field(default_factory=dict)
+
+
+class EnterpriseGovernanceManager:
+    """Manages GitHub Enterprise governance policies and rulesets.
+
+    Maps governance tiers to repository rulesets and enforces
+    enterprise-level policy templates across org repos.
+    """
+
+    def __init__(self) -> None:
+        self._policies: list[EnterpriseGovernancePolicy] = []
+        self._repo_tiers: dict[str, GovernanceTier] = {}
+
+    def add_policy(self, policy: EnterpriseGovernancePolicy) -> None:
+        self._policies.append(policy)
+
+    def set_repo_tier(self, repo: str, tier: GovernanceTier) -> None:
+        self._repo_tiers[repo] = tier
+
+    def get_repo_tier(self, repo: str) -> GovernanceTier:
+        return self._repo_tiers.get(repo, GovernanceTier.UNCLASSIFIED)
+
+    def get_applicable_policies(self, repo: str) -> list[EnterpriseGovernancePolicy]:
+        """Get all policies applicable to a repo based on its tier."""
+        tier = self.get_repo_tier(repo)
+        return [p for p in self._policies if tier in p.applicable_tiers]
+
+    def get_required_rulesets(self, repo: str) -> list[RulesetConfig]:
+        """Get all rulesets that should be applied to a repo."""
+        rulesets = []
+        for policy in self.get_applicable_policies(repo):
+            rulesets.extend(policy.rulesets)
+        return rulesets
+
+    def audit_repo_compliance(self, repo: str, active_rulesets: list[str]) -> dict[str, Any]:
+        """Audit a repo's compliance with its governance tier requirements."""
+        required = self.get_required_rulesets(repo)
+        required_names = {r.name for r in required}
+        active_set = set(active_rulesets)
+        missing = required_names - active_set
+        extra = active_set - required_names
+        return {
+            "repo": repo,
+            "tier": self.get_repo_tier(repo).value,
+            "compliant": len(missing) == 0,
+            "required_rulesets": sorted(required_names),
+            "active_rulesets": sorted(active_set),
+            "missing_rulesets": sorted(missing),
+            "extra_rulesets": sorted(extra),
+        }

--- a/packages/agent-os/src/agent_os/integrations/crewai_adapter.py
+++ b/packages/agent-os/src/agent_os/integrations/crewai_adapter.py
@@ -151,18 +151,18 @@ class CrewAIKernel(BaseIntegration):
 
                 def governed_run(*args, **kwargs):
                     """Governed wrapper around a CrewAI tool's run method.
-                    
+
                     Intercepts the tool call, runs pre-execution policy checks,
                     records the invocation in the audit log, and delegates
                     to the original _run implementation.
-                    
+
                     Args:
                         *args: Positional arguments forwarded to the original tool.
                         **kwargs: Keyword arguments forwarded to the original tool.
-                    
+
                     Returns:
                         The result from the original tool's run method.
-                    
+
                     Raises:
                         PolicyViolationError: If the tool call violates the active policy.
                     """
@@ -211,18 +211,18 @@ class CrewAIKernel(BaseIntegration):
 
                     def governed_execute(task, *args, **kwargs):
                         """Governed wrapper around a CrewAI agent's task execution.
-                        
+
                         Intercepts each task execution call, applies pre-execution
                         policy checks, and delegates to the original execute method.
-                        
+
                         Args:
                             task: The CrewAI Task object to execute.
                             *args: Additional positional arguments.
                             **kwargs: Additional keyword arguments.
-                        
+
                         Returns:
                             The task execution result from the underlying agent.
-                        
+
                         Raises:
                             PolicyViolationError: If the execution violates the active policy.
                         """
@@ -286,18 +286,18 @@ class CrewAIKernel(BaseIntegration):
             @functools.wraps(original_step)
             def governed_step(*args: Any, _orig=original_step, _attr=step_attr, **kwargs: Any) -> Any:
                 """Governed wrapper around a CrewAI task step.
-                
+
                 Intercepts individual step calls within a task, validates
                 inputs against the active policy, and records each step
                 in the audit trail before delegating to the original method.
-                
+
                 Args:
                     *args: Positional arguments forwarded to the original step.
                     **kwargs: Keyword arguments forwarded to the original step.
-                
+
                 Returns:
                     The result from the original step method.
-                
+
                 Raises:
                     PolicyViolationError: If the step input violates the active policy.
                 """
@@ -355,18 +355,18 @@ class CrewAIKernel(BaseIntegration):
                 @functools.wraps(save_fn)
                 def governed_save(*args: Any, _orig=save_fn, _mname=save_method_name, **kwargs: Any) -> Any:
                     """Governed wrapper around CrewAI memory save operations.
-                    
+
                     Validates content before it is written to crew memory,
                     checking for PII patterns and policy-blocked content.
                     Records every save attempt in the memory audit log.
-                    
+
                     Args:
                         *args: Positional arguments forwarded to the original save.
                         **kwargs: Keyword arguments forwarded to the original save.
-                    
+
                     Returns:
                         The result from the original memory save method.
-                    
+
                     Raises:
                         PolicyViolationError: If the content contains PII or blocked patterns.
                     """
@@ -422,18 +422,18 @@ class CrewAIKernel(BaseIntegration):
         @functools.wraps(delegate_fn)
         def governed_delegate(*args: Any, **kwargs: Any) -> Any:
             """Governed wrapper around CrewAI agent delegation.
-            
+
             Intercepts delegation calls between agents, tracks delegation
             depth, and enforces the maximum delegation limit defined in
             the active policy.
-            
+
             Args:
                 *args: Positional arguments forwarded to the original delegate.
                 **kwargs: Keyword arguments forwarded to the original delegate.
-            
+
             Returns:
                 The result from the delegated agent.
-            
+
             Raises:
                 PolicyViolationError: If the delegation depth exceeds the policy limit.
             """

--- a/packages/agent-os/src/agent_os/integrations/google_adk_adapter.py
+++ b/packages/agent-os/src/agent_os/integrations/google_adk_adapter.py
@@ -234,10 +234,10 @@ class GoogleADKKernel(BaseIntegration):
 
     def _default_violation_handler(self, error: PolicyViolationError) -> None:
         """Default handler called when a policy violation occurs.
-        
+
         Logs the violation at ERROR level. Override by passing a custom
         on_violation callable to the kernel constructor.
-        
+
         Args:
             error: The PolicyViolationError that was raised.
         """
@@ -245,9 +245,9 @@ class GoogleADKKernel(BaseIntegration):
 
     def _record(self, event_type: str, agent_name: str, details: dict[str, Any]) -> None:
         """Append an audit event to the internal audit log.
-        
+
         Records the event only when log_all_calls is enabled.
-        
+
         Args:
             event_type: Short string label for the event.
             agent_name: Name of the ADK agent generating the event.
@@ -265,10 +265,10 @@ class GoogleADKKernel(BaseIntegration):
 
     def _check_tool_allowed(self, tool_name: str) -> tuple[bool, str]:
         """Check whether a tool is permitted by the active ADK policy.
-        
+
         Args:
             tool_name: Name of the ADK tool to check.
-        
+
         Returns:
             Tuple of (allowed: bool, reason: str).
         """
@@ -280,10 +280,10 @@ class GoogleADKKernel(BaseIntegration):
 
     def _check_content(self, content: str) -> tuple[bool, str]:
         """Scan a string for policy-blocked patterns.
-        
+
         Args:
             content: The text to scan.
-        
+
         Returns:
             Tuple of (allowed: bool, reason: str).
         """
@@ -295,7 +295,7 @@ class GoogleADKKernel(BaseIntegration):
 
     def _check_timeout(self) -> tuple[bool, str]:
         """Check whether the kernel has exceeded its configured timeout.
-        
+
         Returns:
             Tuple of (within_limit: bool, reason: str).
         """
@@ -306,10 +306,10 @@ class GoogleADKKernel(BaseIntegration):
 
     def _check_budget(self, cost: float = 1.0) -> tuple[bool, str]:
         """Check whether a tool call would exceed the configured cost budget.
-        
+
         Args:
             cost: Cost units to add for this call (default 1.0).
-        
+
         Returns:
             Tuple of (within_budget: bool, reason: str).
         """
@@ -333,13 +333,13 @@ class GoogleADKKernel(BaseIntegration):
 
     def _raise_violation(self, policy_name: str, description: str) -> PolicyViolationError:
         """Create, record, and surface a PolicyViolationError.
-        
+
         Appends the error to the violations list and calls on_violation.
-        
+
         Args:
             policy_name: Short identifier for the violated policy rule.
             description: Human-readable description of the violation.
-        
+
         Returns:
             The constructed PolicyViolationError (caller may raise it).
         """

--- a/packages/agent-os/src/agent_os/integrations/guardrails_adapter.py
+++ b/packages/agent-os/src/agent_os/integrations/guardrails_adapter.py
@@ -78,7 +78,7 @@ class ValidationOutcome:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise this outcome to a plain dictionary.
-        
+
         Returns:
             A dict with validator, passed, and optionally error
             and fixed_value keys.
@@ -108,7 +108,7 @@ class ValidationResult:
     @property
     def failed_validators(self) -> list[str]:
         """Return the names of all validators that did not pass.
-        
+
         Returns:
             List of validator name strings where passed is False.
         """
@@ -116,7 +116,7 @@ class ValidationResult:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise this aggregated result to a plain dictionary.
-        
+
         Returns:
             A dict with passed, action, outcomes, and failed_validators keys.
         """
@@ -145,7 +145,7 @@ class RegexValidator:
     @property
     def name(self) -> str:
         """Return the human-readable name of this regex validator.
-        
+
         Returns:
             The validator name string used in audit logs and outcomes.
         """
@@ -153,11 +153,11 @@ class RegexValidator:
 
     def validate(self, value: str, metadata: dict[str, Any] | None = None) -> ValidationOutcome:
         """Validate a string by checking it against blocked regex patterns.
-        
+
         Args:
             value: The text to scan.
             metadata: Optional dict of additional context (unused).
-        
+
         Returns:
             ValidationOutcome indicating pass or fail.
         """
@@ -183,7 +183,7 @@ class LengthValidator:
     @property
     def name(self) -> str:
         """Return the human-readable name of this length validator.
-        
+
         Returns:
             The validator name string used in audit logs and outcomes.
         """
@@ -191,11 +191,11 @@ class LengthValidator:
 
     def validate(self, value: str, metadata: dict[str, Any] | None = None) -> ValidationOutcome:
         """Validate that a string does not exceed the configured max length.
-        
+
         Args:
             value: The text to check.
             metadata: Optional dict of additional context (unused).
-        
+
         Returns:
             ValidationOutcome with a fixed_value truncated to max_length on fail.
         """
@@ -219,7 +219,7 @@ class KeywordValidator:
     @property
     def name(self) -> str:
         """Return the human-readable name of this keyword validator.
-        
+
         Returns:
             The validator name string used in audit logs and outcomes.
         """
@@ -227,11 +227,11 @@ class KeywordValidator:
 
     def validate(self, value: str, metadata: dict[str, Any] | None = None) -> ValidationOutcome:
         """Validate that a string contains none of the blocked keywords.
-        
+
         Args:
             value: The text to scan (case-insensitive).
             metadata: Optional dict of additional context (unused).
-        
+
         Returns:
             ValidationOutcome indicating pass or fail.
         """
@@ -272,10 +272,10 @@ class GuardrailsKernel:
 
     def _default_violation_handler(self, result: ValidationResult) -> None:
         """Default handler called when one or more validators fail.
-        
+
         Logs a warning for each failed validator name. Override by
         passing a custom on_violation callable to GuardrailsKernel.
-        
+
         Args:
             result: The aggregated ValidationResult.
         """

--- a/packages/agent-os/src/agent_os/integrations/smolagents_adapter.py
+++ b/packages/agent-os/src/agent_os/integrations/smolagents_adapter.py
@@ -254,18 +254,18 @@ class SmolagentsKernel(BaseIntegration):
 
         def governed_forward(*args: Any, **kwargs: Any) -> Any:
             """Governed wrapper around a smolagents tool's forward method.
-            
+
             Intercepts the tool invocation, validates the call against
             the active policy, updates call counters and the audit log,
             then delegates to the original forward implementation.
-            
+
             Args:
                 *args: Positional arguments forwarded to the original tool.
                 **kwargs: Keyword arguments forwarded to the original tool.
-            
+
             Returns:
                 The result from the original tool's forward method.
-            
+
             Raises:
                 PolicyViolationError: If the call violates the active policy.
             """
@@ -300,10 +300,10 @@ class SmolagentsKernel(BaseIntegration):
 
     def _default_violation_handler(self, error: PolicyViolationError) -> None:
         """Default handler called when a policy violation occurs.
-        
+
         Logs the violation as an error. Override by passing a custom
         on_violation callback to the kernel constructor.
-        
+
         Args:
             error: The PolicyViolationError that was raised.
         """
@@ -311,9 +311,9 @@ class SmolagentsKernel(BaseIntegration):
 
     def _record(self, event_type: str, agent_name: str, details: dict[str, Any]) -> None:
         """Append an audit event to the internal audit log.
-        
+
         Records the event only when log_all_calls is enabled.
-        
+
         Args:
             event_type: Short string label for the event.
             agent_name: ID or name of the agent generating the event.
@@ -331,10 +331,10 @@ class SmolagentsKernel(BaseIntegration):
 
     def _check_tool_allowed(self, tool_name: str) -> tuple[bool, str]:
         """Check whether a tool is permitted by the active policy.
-        
+
         Args:
             tool_name: Name of the tool to check.
-        
+
         Returns:
             Tuple of (allowed: bool, reason: str).
         """
@@ -346,10 +346,10 @@ class SmolagentsKernel(BaseIntegration):
 
     def _check_content(self, content: str) -> tuple[bool, str]:
         """Scan a string for policy-blocked patterns.
-        
+
         Args:
             content: The text to scan.
-        
+
         Returns:
             Tuple of (allowed: bool, reason: str).
         """
@@ -361,7 +361,7 @@ class SmolagentsKernel(BaseIntegration):
 
     def _check_timeout(self) -> tuple[bool, str]:
         """Check whether the kernel has exceeded its configured timeout.
-        
+
         Returns:
             Tuple of (within_limit: bool, reason: str).
         """
@@ -372,10 +372,10 @@ class SmolagentsKernel(BaseIntegration):
 
     def _check_budget(self, cost: float = 1.0) -> tuple[bool, str]:
         """Check whether a tool call would exceed the configured cost budget.
-        
+
         Args:
             cost: Cost units to add for this call (default 1.0).
-        
+
         Returns:
             Tuple of (within_budget: bool, reason: str).
         """
@@ -397,13 +397,13 @@ class SmolagentsKernel(BaseIntegration):
 
     def _raise_violation(self, policy_name: str, description: str) -> PolicyViolationError:
         """Create, record, and surface a PolicyViolationError.
-        
+
         Appends the error to the violations list and calls on_violation.
-        
+
         Args:
             policy_name: Short identifier for the violated policy rule.
             description: Human-readable description of the violation.
-        
+
         Returns:
             The constructed PolicyViolationError (caller may raise it).
         """

--- a/packages/agent-os/src/agent_os/policies/cli.py
+++ b/packages/agent-os/src/agent_os/policies/cli.py
@@ -15,7 +15,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import yaml
 from rich.console import Console
@@ -28,11 +28,11 @@ logger = logging.getLogger("policy-cli")
 def validate_policy(policy_path: Path) -> List[Dict[str, str]]:
     """Validate a policy YAML file."""
     errors = []
-    
+
     try:
         with open(policy_path) as f:
             data = yaml.safe_load(f)
-            
+
         if not data:
             errors.append({"severity": "critical", "message": "Policy file is empty"})
             return errors
@@ -85,7 +85,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="policies-cli",
         description="Agent OS Policy Management Tools"
     )
-    
+
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 
     # -- validate -----------------------------------------------------------
@@ -130,7 +130,7 @@ def main(argv: List[str] | None = None) -> int:
                     all_results[path_str] = [{"severity": "critical", "message": "File not found"}]
                     overall_passed = False
                     continue
-                    
+
                 errors = validate_policy(path)
                 all_results[path_str] = errors
                 if any(e["severity"] in ["critical", "error"] for e in errors):
@@ -149,7 +149,7 @@ def main(argv: List[str] | None = None) -> int:
                         print(f"❌ {path}: Found {len(errors)} issues")
                         for e in errors:
                             print(f"  [{e['severity'].upper()}] {e['message']}")
-                
+
             return 0 if overall_passed else 1
 
         elif args.command == "test":
@@ -157,7 +157,7 @@ def main(argv: List[str] | None = None) -> int:
             if not path.exists():
                 print(f"Error: Policy file not found: {args.policy}")
                 return 1
-                
+
             results = test_policies(path)
             passed_count = len([r for r in results if r["passed"]])
             total_count = len(results)
@@ -181,13 +181,13 @@ def main(argv: List[str] | None = None) -> int:
 
                 console.print(table)
                 print(f"\nSummary: {passed_count}/{total_count} tests passed")
-                
+
             return 0 if passed_count == total_count else 1
 
         elif args.command == "diff":
             base_path = Path(args.base)
             target_path = Path(args.target)
-            
+
             if not base_path.exists() or not target_path.exists():
                 print("Error: One or both files not found")
                 return 1

--- a/packages/agent-os/tests/test_content_governance.py
+++ b/packages/agent-os/tests/test_content_governance.py
@@ -1,0 +1,313 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for content and knowledge quality governance (issue #734)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_os.content_governance import (
+    ContentDimension,
+    ContentEvaluation,
+    ContentQualityEvaluator,
+    ContentQualityReport,
+    ContentQualityRule,
+    QualityGate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Issue #734: Content quality governance
+# ---------------------------------------------------------------------------
+
+
+class TestBasicEvaluation:
+    """Tests for basic pass / fail / warn evaluation logic."""
+
+    def test_score_above_threshold_passes(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="accuracy-check",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.8,
+            gate=QualityGate.FAIL,
+        ))
+        report = evaluator.evaluate(
+            agent_id="agent-1",
+            content_id="resp-1",
+            scores={ContentDimension.ACCURACY: 0.9},
+        )
+        assert report.passed
+        assert len(report.evaluations) == 1
+        assert report.evaluations[0].gate_result == QualityGate.PASS
+
+    def test_score_at_threshold_passes(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="accuracy-check",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.8,
+            gate=QualityGate.FAIL,
+        ))
+        report = evaluator.evaluate(
+            agent_id="agent-1",
+            content_id="resp-2",
+            scores={ContentDimension.ACCURACY: 0.8},
+        )
+        assert report.passed
+        assert report.evaluations[0].gate_result == QualityGate.PASS
+
+    def test_score_below_threshold_fails(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="accuracy-check",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.8,
+            gate=QualityGate.FAIL,
+        ))
+        report = evaluator.evaluate(
+            agent_id="agent-1",
+            content_id="resp-3",
+            scores={ContentDimension.ACCURACY: 0.75},
+        )
+        assert not report.passed
+        assert report.evaluations[0].gate_result == QualityGate.FAIL
+        assert len(report.failures) == 1
+
+    def test_score_below_threshold_warns(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="freshness-check",
+            dimension=ContentDimension.FRESHNESS,
+            threshold=0.6,
+            gate=QualityGate.WARN,
+        ))
+        report = evaluator.evaluate(
+            agent_id="agent-1",
+            content_id="resp-4",
+            scores={ContentDimension.FRESHNESS: 0.5},
+        )
+        # warn does not block passing
+        assert report.passed
+        assert report.evaluations[0].gate_result == QualityGate.WARN
+        assert len(report.warnings) == 1
+
+    def test_missing_score_defaults_to_zero(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="relevance-check",
+            dimension=ContentDimension.RELEVANCE,
+            threshold=0.5,
+            gate=QualityGate.FAIL,
+        ))
+        report = evaluator.evaluate(
+            agent_id="agent-1",
+            content_id="resp-5",
+            scores={},  # no scores provided
+        )
+        assert not report.passed
+        assert report.evaluations[0].score == 0.0
+
+
+class TestOverallScore:
+    """Tests for overall score calculation."""
+
+    def test_single_evaluation_score(self) -> None:
+        report = ContentQualityReport(
+            agent_id="a",
+            content_id="c",
+            evaluations=[
+                ContentEvaluation(
+                    dimension=ContentDimension.ACCURACY,
+                    score=0.85,
+                    gate_result=QualityGate.PASS,
+                    rule_name="r1",
+                ),
+            ],
+        )
+        assert report.overall_score == pytest.approx(0.85)
+
+    def test_multiple_evaluations_averaged(self) -> None:
+        report = ContentQualityReport(
+            agent_id="a",
+            content_id="c",
+            evaluations=[
+                ContentEvaluation(
+                    dimension=ContentDimension.ACCURACY,
+                    score=0.9,
+                    gate_result=QualityGate.PASS,
+                    rule_name="r1",
+                ),
+                ContentEvaluation(
+                    dimension=ContentDimension.COMPLETENESS,
+                    score=0.7,
+                    gate_result=QualityGate.WARN,
+                    rule_name="r2",
+                ),
+            ],
+        )
+        assert report.overall_score == pytest.approx(0.8)
+
+    def test_empty_evaluations_returns_zero(self) -> None:
+        report = ContentQualityReport(
+            agent_id="a",
+            content_id="c",
+            evaluations=[],
+        )
+        assert report.overall_score == 0.0
+
+
+class TestLoadRulesFromDict:
+    """Tests for loading rules from dict config."""
+
+    def test_load_minimal_rule(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.load_rules([
+            {
+                "name": "min-accuracy",
+                "dimension": "accuracy",
+                "threshold": 0.7,
+            },
+        ])
+        report = evaluator.evaluate(
+            agent_id="a",
+            content_id="c",
+            scores={ContentDimension.ACCURACY: 0.8},
+        )
+        assert report.passed
+        assert report.evaluations[0].rule_name == "min-accuracy"
+        # default gate is WARN
+        assert report.evaluations[0].gate_result == QualityGate.PASS
+
+    def test_load_full_rule(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.load_rules([
+            {
+                "name": "strict-completeness",
+                "dimension": "completeness",
+                "threshold": 0.9,
+                "gate": "fail",
+                "description": "Content must be complete",
+            },
+        ])
+        report = evaluator.evaluate(
+            agent_id="a",
+            content_id="c",
+            scores={ContentDimension.COMPLETENESS: 0.85},
+        )
+        assert not report.passed
+        assert report.evaluations[0].gate_result == QualityGate.FAIL
+
+    def test_load_multiple_rules(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.load_rules([
+            {"name": "r1", "dimension": "accuracy", "threshold": 0.5},
+            {"name": "r2", "dimension": "freshness", "threshold": 0.6},
+        ])
+        report = evaluator.evaluate(
+            agent_id="a",
+            content_id="c",
+            scores={
+                ContentDimension.ACCURACY: 0.8,
+                ContentDimension.FRESHNESS: 0.9,
+            },
+        )
+        assert len(report.evaluations) == 2
+        assert report.passed
+
+
+class TestEmptyRules:
+    """Tests for empty rules producing empty report."""
+
+    def test_no_rules_returns_empty_evaluations(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        report = evaluator.evaluate(
+            agent_id="agent-x",
+            content_id="content-y",
+            scores={ContentDimension.ACCURACY: 0.99},
+        )
+        assert report.evaluations == []
+        assert report.passed  # no failures
+        assert report.overall_score == 0.0
+
+    def test_empty_report_metadata(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        report = evaluator.evaluate(
+            agent_id="agent-x",
+            content_id="content-y",
+            scores={},
+        )
+        assert report.agent_id == "agent-x"
+        assert report.content_id == "content-y"
+        assert report.warnings == []
+        assert report.failures == []
+
+
+class TestMultipleRulesSameDimension:
+    """Tests for multiple rules targeting the same dimension."""
+
+    def test_two_rules_same_dimension_both_pass(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="accuracy-warn",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.5,
+            gate=QualityGate.WARN,
+        ))
+        evaluator.add_rule(ContentQualityRule(
+            name="accuracy-fail",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.8,
+            gate=QualityGate.FAIL,
+        ))
+        report = evaluator.evaluate(
+            agent_id="a",
+            content_id="c",
+            scores={ContentDimension.ACCURACY: 0.9},
+        )
+        assert report.passed
+        assert len(report.evaluations) == 2
+        assert all(e.gate_result == QualityGate.PASS for e in report.evaluations)
+
+    def test_two_rules_same_dimension_one_fails(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="accuracy-warn",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.5,
+            gate=QualityGate.WARN,
+        ))
+        evaluator.add_rule(ContentQualityRule(
+            name="accuracy-fail",
+            dimension=ContentDimension.ACCURACY,
+            threshold=0.8,
+            gate=QualityGate.FAIL,
+        ))
+        report = evaluator.evaluate(
+            agent_id="a",
+            content_id="c",
+            scores={ContentDimension.ACCURACY: 0.6},
+        )
+        assert not report.passed
+        assert len(report.evaluations) == 2
+        # first rule passes, second fails
+        assert report.evaluations[0].gate_result == QualityGate.PASS
+        assert report.evaluations[1].gate_result == QualityGate.FAIL
+        assert len(report.failures) == 1
+
+    def test_details_string_contains_scores(self) -> None:
+        evaluator = ContentQualityEvaluator()
+        evaluator.add_rule(ContentQualityRule(
+            name="r",
+            dimension=ContentDimension.STRUCTURE,
+            threshold=0.7,
+            gate=QualityGate.WARN,
+        ))
+        report = evaluator.evaluate(
+            agent_id="a",
+            content_id="c",
+            scores={ContentDimension.STRUCTURE: 0.65},
+        )
+        details = report.evaluations[0].details
+        assert "0.65" in details
+        assert "0.70" in details

--- a/packages/agent-os/tests/test_github_enterprise.py
+++ b/packages/agent-os/tests/test_github_enterprise.py
@@ -1,0 +1,252 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for GitHub Enterprise managed policy and ruleset integration (issue #735)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_os.github_enterprise import (
+    EnterpriseGovernanceManager,
+    EnterpriseGovernancePolicy,
+    GovernanceTier,
+    RulesetConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_policy(
+    name: str,
+    tiers: list[GovernanceTier],
+    ruleset_names: list[str] | None = None,
+) -> EnterpriseGovernancePolicy:
+    """Create a policy with optional rulesets for testing."""
+    rulesets = [RulesetConfig(name=n) for n in (ruleset_names or [])]
+    return EnterpriseGovernancePolicy(
+        name=name,
+        applicable_tiers=tiers,
+        rulesets=rulesets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #735: GitHub Enterprise governance integration
+# ---------------------------------------------------------------------------
+
+
+class TestSetGetRepoTier:
+    """Tests for setting and getting repo governance tiers."""
+
+    def test_set_and_get_tier(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.set_repo_tier("org/repo-a", GovernanceTier.CRITICAL)
+        assert mgr.get_repo_tier("org/repo-a") == GovernanceTier.CRITICAL
+
+    def test_default_tier_is_unclassified(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        assert mgr.get_repo_tier("org/unknown") == GovernanceTier.UNCLASSIFIED
+
+    def test_update_tier(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.set_repo_tier("org/repo-b", GovernanceTier.BASIC)
+        mgr.set_repo_tier("org/repo-b", GovernanceTier.ELEVATED)
+        assert mgr.get_repo_tier("org/repo-b") == GovernanceTier.ELEVATED
+
+    def test_multiple_repos_independent(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.set_repo_tier("org/alpha", GovernanceTier.STANDARD)
+        mgr.set_repo_tier("org/beta", GovernanceTier.CRITICAL)
+        assert mgr.get_repo_tier("org/alpha") == GovernanceTier.STANDARD
+        assert mgr.get_repo_tier("org/beta") == GovernanceTier.CRITICAL
+
+
+class TestApplicablePoliciesByTier:
+    """Tests for getting applicable policies based on repo tier."""
+
+    def test_policy_matches_tier(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        policy = _make_policy("p1", [GovernanceTier.CRITICAL])
+        mgr.add_policy(policy)
+        mgr.set_repo_tier("org/repo", GovernanceTier.CRITICAL)
+        assert mgr.get_applicable_policies("org/repo") == [policy]
+
+    def test_policy_does_not_match_other_tier(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        policy = _make_policy("p1", [GovernanceTier.CRITICAL])
+        mgr.add_policy(policy)
+        mgr.set_repo_tier("org/repo", GovernanceTier.BASIC)
+        assert mgr.get_applicable_policies("org/repo") == []
+
+    def test_multiple_policies_same_tier(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        p1 = _make_policy("p1", [GovernanceTier.ELEVATED])
+        p2 = _make_policy("p2", [GovernanceTier.ELEVATED])
+        mgr.add_policy(p1)
+        mgr.add_policy(p2)
+        mgr.set_repo_tier("org/repo", GovernanceTier.ELEVATED)
+        result = mgr.get_applicable_policies("org/repo")
+        assert len(result) == 2
+        assert p1 in result
+        assert p2 in result
+
+    def test_policy_applicable_to_multiple_tiers(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        policy = _make_policy(
+            "wide-policy",
+            [GovernanceTier.STANDARD, GovernanceTier.ELEVATED, GovernanceTier.CRITICAL],
+        )
+        mgr.add_policy(policy)
+        mgr.set_repo_tier("org/std", GovernanceTier.STANDARD)
+        mgr.set_repo_tier("org/elev", GovernanceTier.ELEVATED)
+        mgr.set_repo_tier("org/basic", GovernanceTier.BASIC)
+        assert mgr.get_applicable_policies("org/std") == [policy]
+        assert mgr.get_applicable_policies("org/elev") == [policy]
+        assert mgr.get_applicable_policies("org/basic") == []
+
+
+class TestRequiredRulesets:
+    """Tests for required rulesets aggregation."""
+
+    def test_rulesets_from_single_policy(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1",
+            [GovernanceTier.CRITICAL],
+            ruleset_names=["branch-protection", "code-review"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.CRITICAL)
+        rulesets = mgr.get_required_rulesets("org/repo")
+        names = [r.name for r in rulesets]
+        assert "branch-protection" in names
+        assert "code-review" in names
+
+    def test_rulesets_aggregated_across_policies(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.ELEVATED], ruleset_names=["signed-commits"],
+        ))
+        mgr.add_policy(_make_policy(
+            "p2", [GovernanceTier.ELEVATED], ruleset_names=["status-checks"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.ELEVATED)
+        rulesets = mgr.get_required_rulesets("org/repo")
+        names = [r.name for r in rulesets]
+        assert "signed-commits" in names
+        assert "status-checks" in names
+
+    def test_no_rulesets_for_non_matching_tier(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.CRITICAL], ruleset_names=["branch-protection"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.BASIC)
+        assert mgr.get_required_rulesets("org/repo") == []
+
+
+class TestAuditCompliance:
+    """Tests for audit_repo_compliance (compliant + non-compliant)."""
+
+    def test_compliant_when_all_rulesets_active(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.CRITICAL],
+            ruleset_names=["branch-protection", "code-review"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.CRITICAL)
+        result = mgr.audit_repo_compliance(
+            "org/repo",
+            active_rulesets=["branch-protection", "code-review"],
+        )
+        assert result["compliant"] is True
+        assert result["missing_rulesets"] == []
+        assert result["tier"] == "critical"
+
+    def test_non_compliant_when_ruleset_missing(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.CRITICAL],
+            ruleset_names=["branch-protection", "code-review"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.CRITICAL)
+        result = mgr.audit_repo_compliance(
+            "org/repo",
+            active_rulesets=["branch-protection"],
+        )
+        assert result["compliant"] is False
+        assert "code-review" in result["missing_rulesets"]
+
+    def test_extra_rulesets_reported(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.STANDARD], ruleset_names=["status-checks"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.STANDARD)
+        result = mgr.audit_repo_compliance(
+            "org/repo",
+            active_rulesets=["status-checks", "custom-lint"],
+        )
+        assert result["compliant"] is True
+        assert "custom-lint" in result["extra_rulesets"]
+
+    def test_compliance_with_no_active_rulesets(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.ELEVATED], ruleset_names=["signed-commits"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.ELEVATED)
+        result = mgr.audit_repo_compliance("org/repo", active_rulesets=[])
+        assert result["compliant"] is False
+        assert "signed-commits" in result["missing_rulesets"]
+
+    def test_audit_result_structure(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.BASIC], ruleset_names=["r1"],
+        ))
+        mgr.set_repo_tier("org/repo", GovernanceTier.BASIC)
+        result = mgr.audit_repo_compliance("org/repo", active_rulesets=["r1"])
+        expected_keys = {
+            "repo", "tier", "compliant",
+            "required_rulesets", "active_rulesets",
+            "missing_rulesets", "extra_rulesets",
+        }
+        assert set(result.keys()) == expected_keys
+        assert result["repo"] == "org/repo"
+        assert result["tier"] == "basic"
+
+
+class TestUnclassifiedRepos:
+    """Tests that unclassified repos get no policies."""
+
+    def test_unclassified_repo_no_policies(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy("p1", [GovernanceTier.CRITICAL]))
+        mgr.add_policy(_make_policy("p2", [GovernanceTier.STANDARD]))
+        mgr.add_policy(_make_policy("p3", [GovernanceTier.BASIC]))
+        # repo not set — defaults to UNCLASSIFIED
+        assert mgr.get_applicable_policies("org/new-repo") == []
+        assert mgr.get_required_rulesets("org/new-repo") == []
+
+    def test_unclassified_repo_is_compliant_with_no_requirements(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        mgr.add_policy(_make_policy(
+            "p1", [GovernanceTier.CRITICAL], ruleset_names=["r1"],
+        ))
+        result = mgr.audit_repo_compliance("org/new-repo", active_rulesets=[])
+        assert result["compliant"] is True
+        assert result["tier"] == "unclassified"
+        assert result["required_rulesets"] == []
+
+    def test_policy_explicitly_targeting_unclassified(self) -> None:
+        mgr = EnterpriseGovernanceManager()
+        policy = _make_policy(
+            "catch-all", [GovernanceTier.UNCLASSIFIED],
+            ruleset_names=["basic-protection"],
+        )
+        mgr.add_policy(policy)
+        result = mgr.get_applicable_policies("org/new-repo")
+        assert result == [policy]


### PR DESCRIPTION
Fixes last CI failure: lint agent-os - 96 W293 trailing whitespace errors auto-fixed with ruff.