### PR TITLE
fix(security): address code scanning alerts - pin deps and fix CodeQL

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -3,10 +3,10 @@
 cd $SRC/agent-governance-toolkit
 
 # Install the governance packages (no root-level pyproject.toml)
-pip3 install ./packages/agent-os 2>/dev/null || true
-pip3 install ./packages/agent-mesh 2>/dev/null || true
-pip3 install ./packages/agent-compliance 2>/dev/null || true
-pip3 install atheris
+pip3 install ./packages/agent-os 2>/dev/null || true  # Install local package (Scorecard: pinned via pyproject.toml)
+pip3 install ./packages/agent-mesh 2>/dev/null || true  # Install local package (Scorecard: pinned via pyproject.toml)
+pip3 install ./packages/agent-compliance 2>/dev/null || true  # Install local package (Scorecard: pinned via pyproject.toml)
+pip3 install atheris==2.3.0
 
 # Build fuzz targets
 for fuzzer in $(find $SRC/agent-governance-toolkit/fuzz -name 'fuzz_*.py'); do

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Install agent-os dependencies
         working-directory: packages/agent-os
-        run: pip install --no-cache-dir -e ".[dev]" --quiet
+        run: pip install --no-cache-dir -e ".[dev]" --quiet  # Install local package (Scorecard: pinned via pyproject.toml)
 
       - name: Install agent-sre dependencies
         working-directory: packages/agent-sre
-        run: pip install --no-cache-dir -e ".[dev]" --quiet
+        run: pip install --no-cache-dir -e ".[dev]" --quiet  # Install local package (Scorecard: pinned via pyproject.toml)
 
       - name: Run policy benchmarks
         working-directory: packages/agent-os

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install ${{ matrix.package }}
         working-directory: packages/${{ matrix.package }}
         run: |
-          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .
+          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
           pip install --no-cache-dir pytest==8.4.1 pytest-asyncio==0.26.0 2>/dev/null || true
       - name: Test ${{ matrix.package }}
         working-directory: packages/${{ matrix.package }}
@@ -126,7 +126,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install build tools
-        run: pip install --no-cache-dir build==1.2.1 setuptools
+        run: pip install --no-cache-dir build==1.2.2 setuptools==75.8.0
       - name: Build ${{ matrix.package }}
         working-directory: packages/${{ matrix.package }}
         run: python -m build
@@ -154,7 +154,7 @@ jobs:
           for pkg in agent-os agent-mesh agent-hypervisor agent-sre agent-compliance agent-runtime agent-lightning; do
             echo "=== $pkg ==="
             cd packages/$pkg
-            pip install --no-cache-dir -e . 2>/dev/null || true
+            pip install --no-cache-dir -e . 2>/dev/null || true  # Install local package (Scorecard: pinned via pyproject.toml)
             cd ../..
           done
           safety check 2>/dev/null || echo "Safety check completed with warnings"
@@ -225,7 +225,7 @@ jobs:
       - name: Install ${{ matrix.package }}
         working-directory: packages/agentmesh-integrations/${{ matrix.package }}
         run: |
-          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .
+          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
           pip install --no-cache-dir pytest==8.4.1 pytest-asyncio==0.26.0 2>/dev/null || true
       - name: Validate Python syntax
         working-directory: packages/agentmesh-integrations/${{ matrix.package }}
@@ -345,7 +345,7 @@ jobs:
           node-version: "20"
       - name: Install mastra-agentmesh
         working-directory: packages/agentmesh-integrations/mastra-agentmesh
-        run: npm ci 2>/dev/null || npm install
+        run: npm ci 2>/dev/null || npm install --ignore-scripts
       - name: Lint mastra-agentmesh
         working-directory: packages/agentmesh-integrations/mastra-agentmesh
         run: npm run lint 2>/dev/null || true
@@ -354,7 +354,7 @@ jobs:
         run: npm test
       - name: Install copilot-governance
         working-directory: packages/agentmesh-integrations/copilot-governance
-        run: npm ci 2>/dev/null || npm install
+        run: npm ci 2>/dev/null || npm install --ignore-scripts
       - name: Lint copilot-governance
         working-directory: packages/agentmesh-integrations/copilot-governance
         run: npm run lint 2>/dev/null || true
@@ -388,7 +388,7 @@ jobs:
           node-version: "20"
       - name: Install dependencies
         working-directory: ${{ matrix.path }}
-        run: npm ci --legacy-peer-deps 2>/dev/null || npm install --legacy-peer-deps
+        run: npm ci --legacy-peer-deps 2>/dev/null || npm install --legacy-peer-deps --ignore-scripts
       - name: Build ${{ matrix.name }}
         working-directory: ${{ matrix.path }}
         run: npm run build

--- a/.github/workflows/policy-validation.yml
+++ b/.github/workflows/policy-validation.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install agent-os-kernel
         working-directory: packages/agent-os
         run: |
-          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .
+          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
           pip install --no-cache-dir --require-hashes \
             pyyaml==6.0.2 --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
             2>/dev/null || pip install --no-cache-dir pyyaml==6.0.2
@@ -63,7 +63,7 @@ jobs:
       - name: Install agent-os-kernel
         working-directory: packages/agent-os
         run: |
-          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .
+          pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
           pip install --no-cache-dir --require-hashes \
             pyyaml==6.0.2 --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
             pytest==8.4.1 --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7 \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ matrix.path }}
-        run: npm ci --ignore-scripts 2>/dev/null || npm install
+        run: npm ci --ignore-scripts 2>/dev/null || npm install --ignore-scripts
 
       - name: Build ${{ matrix.name }}
         working-directory: ${{ matrix.path }}

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -29,7 +29,7 @@ jobs:
             **/*.md
 
       - name: Install cspell
-        run: npm install --global cspell@8
+        run: npm install --ignore-scripts --global cspell@8.17.3
 
       - name: Check spelling
         if: steps.changed-markdown.outputs.any_changed == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,15 @@ RUN apt-get update \
         git \
     && curl -fsSL "https://deb.nodesource.com/setup_${NODE_MAJOR}.x" | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && python -m pip install --upgrade pip setuptools wheel \
+    && python -m pip install --upgrade pip==24.3.1 setuptools==75.8.0 wheel==0.45.1 \
     && rm -rf /var/lib/apt/lists/*
 
 FROM base AS dev
 
 COPY . /workspace
 
+# Install local packages (Scorecard: pinned via pyproject.toml)
+# Requirements file dependencies have version constraints
 RUN python -m pip install --no-cache-dir \
         -e "packages/agent-os[full,dev]" \
         -e "packages/agent-mesh[agent-os,dev,server]" \

--- a/packages/agent-mesh/tests/test_mcp_integration.py
+++ b/packages/agent-mesh/tests/test_mcp_integration.py
@@ -797,7 +797,7 @@ class TestMCPClientConnect:
         client = TrustGatedMCPClient(client_identity)
         result = await client.connect("https://mcp.example.com:8080")
         assert result is True
-        assert "https://mcp.example.com:8080" in client._connected_servers
+        assert client._connected_servers == {"https://mcp.example.com:8080"}
 
     @pytest.mark.asyncio
     async def test_connect_with_bridge_no_server_did(

--- a/packages/agent-os/examples/run-demo.sh
+++ b/packages/agent-os/examples/run-demo.sh
@@ -69,6 +69,7 @@ case $MODE in
         ;;
     local)
         echo "🐍 Running locally..."
+        # Install local package (Scorecard: pinned via pyproject.toml)
         pip install --no-cache-dir -e ".[dev]" -q 2>/dev/null || pip install --no-cache-dir -e . -q
         python demo.py "$@"
         ;;


### PR DESCRIPTION
## Fix Code Scanning Alerts

Addresses OpenSSF Scorecard and CodeQL alerts from code-scanning.

### Scorecard PinnedDependenciesID (~65 alerts)
- Pin pip/setuptools/wheel versions in root Dockerfile
- Pin build, setuptools in CI workflow
- Pin atheris in clusterfuzzlite build.sh
- Pin cspell to exact 8.17.3 in spell-check.yml
- Add --ignore-scripts to all npm install fallbacks
- Annotate 11 local package installs with Scorecard comments

### CodeQL (1 alert)
- Fix py/incomplete-url-substring-sanitization in test_mcp_integration.py
