### PR TITLE
docs: Tutorial 28 — Building Custom Governance Integrations

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -80,6 +80,14 @@ guides.
 
 ---
 
+## Extending the Toolkit
+
+| # | Tutorial | What You'll Learn | Package |
+|---|----------|-------------------|---------|
+| 28 | [Building Custom Integrations](build-custom-integration.md) | Trust integrations, kernel adapters, publishing your own governance package | `agent-os-kernel` / standalone |
+
+---
+
 ## Learning Paths
 
 ### 🚀 "I want to govern my agent in 10 minutes"

--- a/docs/tutorials/build-custom-integration.md
+++ b/docs/tutorials/build-custom-integration.md
@@ -1,0 +1,854 @@
+# Tutorial 28 — Building Custom Governance Integrations
+
+Every governed agent system follows the same pattern: verify identity, gate
+actions, intercept tool calls, log everything. The toolkit provides 15 kernel
+adapters and 17 trust integrations that implement this pattern. This tutorial
+shows how to build your own for any framework not yet covered.
+
+| Section | What you'll learn |
+|---------|-------------------|
+| 1. Two Integration Styles | When to build a trust integration vs a kernel adapter |
+| 2. Trust Integration | Standalone package: identity, gating, trust tracking, tests |
+| 3. Kernel Adapter | `BaseIntegration` subclass: pre/post hooks, tool interception |
+| 4. Wiring Trust into the Kernel | Trust verification inside the governance proxy |
+| 5. Publishing | Package structure, PR requirements, versioning |
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- Familiarity with the agent framework you want to govern
+- `pip install agent-os-kernel` (for kernel-style adapters only)
+
+---
+
+## 1. Two Integration Styles
+
+The toolkit supports two approaches. Pick the one that matches your goal, or
+use both together (Section 4).
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    Your Application                      │
+├────────────────────────┬─────────────────────────────────┤
+│   Trust Integration    │       Kernel Adapter            │
+│   (who can act?)       │       (what can they do?)       │
+│                        │                                 │
+│   AgentProfile         │       GovernancePolicy          │
+│   ActionGuard          │       BaseIntegration           │
+│   TrustTracker         │       ToolCallInterceptor       │
+│                        │       pre_execute / post_execute│
+├────────────────────────┴─────────────────────────────────┤
+│                   Agent Framework                        │
+│              (OpenAI, LangChain, CrewAI, …)              │
+└──────────────────────────────────────────────────────────┘
+```
+
+| Style | When to use | Base layer | Examples |
+|-------|-------------|------------|----------|
+| **Trust integration** | Identity verification, capability gating, trust scoring between agents | Standalone dataclasses, no base class required | `crewai-agentmesh`, `langchain-agentmesh`, `openai-agents-agentmesh` |
+| **Kernel adapter** | Wrapping a framework client to enforce token limits, tool allow/deny, drift detection | `BaseIntegration` from `agent_os.integrations.base` | OpenAI, LangChain, CrewAI, Anthropic, Gemini, AutoGen kernels |
+
+Trust integrations are simpler — no dependency on `agent-os-kernel`. Kernel
+adapters are deeper — they provide the full governance lifecycle. Both styles
+coexist in production.
+
+---
+
+## 2. Trust Integration (Standalone Package)
+
+> **Starter template available.** Copy
+> `packages/agentmesh-integrations/template-agentmesh/` and rename it for your
+> framework. It includes a working `trust.py`, `__init__.py`, `pyproject.toml`,
+> and 29 tests. The walkthrough below explains each component.
+
+Trust integrations live under `packages/agentmesh-integrations/` and follow a
+consistent structure. Most have zero runtime dependencies on the target
+framework SDK (CrewAI and OpenAI Agents use duck typing). The LangChain
+integration is an exception — it requires `langchain-core` and `cryptography`
+for Ed25519 signature verification. Prefer the zero-dependency approach unless
+cryptographic verification demands otherwise.
+
+### 2.1 Scaffold the package
+
+```
+myframework-agentmesh/
+  myframework_agentmesh/
+    __init__.py       # Public API
+    trust.py          # Core implementation
+  tests/
+    test_trust.py     # Test suite
+  pyproject.toml
+  README.md
+```
+
+#### pyproject.toml
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "myframework_agentmesh"
+version = "0.1.0"
+description = "AgentMesh trust layer for MyFramework"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+dependencies = []              # No hard deps — framework needed at call time, not import time
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["myframework_agentmesh"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+Conventions from existing integrations:
+- `dependencies = []` — zero runtime deps where possible.
+- Build with `hatchling` (matches all toolkit packages).
+- Python 3.10+ (matches tutorial prerequisites in `docs/tutorials/README.md`).
+
+### 2.2 Define your data model
+
+Every trust integration needs three things: agent identity, a gate, and a
+result type.
+
+```python
+# myframework_agentmesh/trust.py
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class AgentProfile:
+    """Identity and trust state for a governed agent."""
+
+    did: str                                # Decentralized identifier (did:mesh:...)
+    name: str
+    capabilities: list[str] = field(default_factory=list)
+    trust_score: int = 500                  # 0-1000 scale
+    status: str = "active"                  # active | suspended | revoked
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def has_capability(self, capability: str) -> bool:
+        return capability in self.capabilities
+
+    def has_all_capabilities(self, required: list[str]) -> bool:
+        return all(c in self.capabilities for c in required)
+
+    def has_any_capability(self, required: list[str]) -> bool:
+        return any(c in self.capabilities for c in required)
+```
+
+This mirrors `crewai-agentmesh`. The `did` field uses the `did:mesh:` format
+defined by AgentMesh. Trust scores use the 0-1000 integer scale used across
+the toolkit.
+
+### 2.3 Build the gate
+
+The gate decides whether an agent can perform an action.
+
+```python
+@dataclass
+class ActionResult:
+    """Outcome of a trust-gated action check."""
+
+    allowed: bool
+    agent_did: str
+    action: str
+    reason: str = ""
+    trust_score: int = 0
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "agent_did": self.agent_did,
+            "action": self.action,
+            "reason": self.reason,
+            "trust_score": self.trust_score,
+            "timestamp": self.timestamp,
+        }
+
+
+class ActionGuard:
+    """Trust-gated action enforcement.
+
+    Checks agent trust score and capabilities before allowing an action.
+    Supports per-action minimum trust thresholds for sensitive operations.
+    """
+
+    def __init__(
+        self,
+        min_trust_score: int = 500,
+        sensitive_actions: dict[str, int] | None = None,
+        blocked_actions: list[str] | None = None,
+    ) -> None:
+        self.min_trust_score = min_trust_score
+        self.sensitive_actions: dict[str, int] = sensitive_actions or {}
+        self.blocked_actions: list[str] = blocked_actions or []
+
+    def check(
+        self,
+        agent: AgentProfile,
+        action: str,
+        required_capabilities: list[str] | None = None,
+    ) -> ActionResult:
+        """Evaluate whether an agent may perform an action."""
+        # Hard block
+        if action in self.blocked_actions:
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Action '{action}' is blocked by policy",
+                trust_score=agent.trust_score,
+            )
+
+        # Status check
+        if agent.status != "active":
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Agent status is '{agent.status}'",
+                trust_score=agent.trust_score,
+            )
+
+        # Trust threshold (per-action or global)
+        threshold = self.sensitive_actions.get(action, self.min_trust_score)
+        if agent.trust_score < threshold:
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Trust score {agent.trust_score} below threshold {threshold}",
+                trust_score=agent.trust_score,
+            )
+
+        # Capability check
+        if required_capabilities and not agent.has_all_capabilities(required_capabilities):
+            missing = [c for c in required_capabilities if not agent.has_capability(c)]
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Missing capabilities: {missing}",
+                trust_score=agent.trust_score,
+            )
+
+        return ActionResult(
+            allowed=True,
+            agent_did=agent.did,
+            action=action,
+            trust_score=agent.trust_score,
+        )
+```
+
+This follows `openai-agents-agentmesh`, where `TrustedFunctionGuard.check_call()`
+returns a `FunctionCallResult` with `allowed`, `reason`, and `trust_score`.
+
+### 2.4 Add trust tracking
+
+Trust scores change over time. A tracker records outcomes and adjusts scores.
+
+```python
+class TrustTracker:
+    """Records agent outcomes and adjusts trust scores."""
+
+    def __init__(self, reward: int = 10, penalty: int = 50) -> None:
+        self.reward = reward
+        self.penalty = penalty
+        self._history: list[dict[str, Any]] = []
+
+    def record_success(self, agent: AgentProfile, action: str) -> int:
+        """Reward an agent for a successful action. Returns new score."""
+        agent.trust_score = min(1000, agent.trust_score + self.reward)
+        self._history.append({
+            "did": agent.did, "action": action,
+            "outcome": "success", "new_score": agent.trust_score,
+            "timestamp": time.time(),
+        })
+        return agent.trust_score
+
+    def record_failure(self, agent: AgentProfile, action: str) -> int:
+        """Penalize an agent for a failed action. Returns new score."""
+        agent.trust_score = max(0, agent.trust_score - self.penalty)
+        self._history.append({
+            "did": agent.did, "action": action,
+            "outcome": "failure", "new_score": agent.trust_score,
+            "timestamp": time.time(),
+        })
+        return agent.trust_score
+
+    def get_history(self, did: str | None = None) -> list[dict[str, Any]]:
+        if did:
+            return [h for h in self._history if h["did"] == did]
+        return list(self._history)
+```
+
+This matches `crewai-agentmesh`'s `TrustTracker` with asymmetric reward/penalty
+(small reward for success, large penalty for failure).
+
+### 2.5 Export your public API
+
+```python
+# myframework_agentmesh/__init__.py
+"""AgentMesh trust layer for MyFramework."""
+
+from myframework_agentmesh.trust import (
+    ActionGuard,
+    ActionResult,
+    AgentProfile,
+    TrustTracker,
+)
+
+__all__ = [
+    "ActionGuard",
+    "ActionResult",
+    "AgentProfile",
+    "TrustTracker",
+]
+```
+
+### 2.6 Write tests
+
+Tests run without the target framework installed. Every existing integration
+achieves this by testing governance logic in isolation.
+
+```python
+# tests/test_trust.py
+from myframework_agentmesh import AgentProfile, ActionGuard, TrustTracker, ActionResult
+
+
+def test_allow_action_above_threshold():
+    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=700)
+    guard = ActionGuard(min_trust_score=500)
+    result = guard.check(agent, "search")
+    assert result.allowed
+
+
+def test_block_action_below_threshold():
+    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=300)
+    guard = ActionGuard(min_trust_score=500)
+    result = guard.check(agent, "search")
+    assert not result.allowed
+    assert "below threshold" in result.reason
+
+
+def test_sensitive_action_requires_higher_trust():
+    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=600)
+    guard = ActionGuard(
+        min_trust_score=500,
+        sensitive_actions={"delete_record": 800},
+    )
+    assert guard.check(agent, "search").allowed
+    assert not guard.check(agent, "delete_record").allowed
+
+
+def test_blocked_action_always_denied():
+    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=1000)
+    guard = ActionGuard(blocked_actions=["drop_table"])
+    result = guard.check(agent, "drop_table")
+    assert not result.allowed
+    assert "blocked by policy" in result.reason
+
+
+def test_capability_check():
+    agent = AgentProfile(
+        did="did:mesh:a1", name="Alpha",
+        capabilities=["read"], trust_score=700,
+    )
+    guard = ActionGuard(min_trust_score=500)
+    assert guard.check(agent, "query", required_capabilities=["read"]).allowed
+    assert not guard.check(agent, "query", required_capabilities=["write"]).allowed
+
+
+def test_suspended_agent_blocked():
+    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=900, status="suspended")
+    guard = ActionGuard(min_trust_score=500)
+    result = guard.check(agent, "search")
+    assert not result.allowed
+    assert "suspended" in result.reason
+
+
+def test_trust_tracker_adjusts_scores():
+    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=500)
+    tracker = TrustTracker(reward=10, penalty=50)
+
+    tracker.record_success(agent, "search")
+    assert agent.trust_score == 510
+
+    tracker.record_failure(agent, "search")
+    assert agent.trust_score == 460
+
+    history = tracker.get_history("did:mesh:a1")
+    assert len(history) == 2
+    assert history[0]["outcome"] == "success"
+    assert history[1]["outcome"] == "failure"
+
+
+def test_trust_score_clamped():
+    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=995)
+    tracker = TrustTracker(reward=10, penalty=50)
+    tracker.record_success(agent, "search")
+    assert agent.trust_score == 1000  # Clamped at max
+
+    agent.trust_score = 20
+    tracker.record_failure(agent, "search")
+    assert agent.trust_score == 0    # Clamped at min
+
+
+def test_action_result_serialization():
+    result = ActionResult(
+        allowed=True, agent_did="did:mesh:a1",
+        action="search", trust_score=700,
+    )
+    d = result.to_dict()
+    assert d["allowed"] is True
+    assert d["agent_did"] == "did:mesh:a1"
+    assert "timestamp" in d
+```
+
+Run the tests:
+
+```bash
+cd myframework-agentmesh
+pip install -e ".[dev]"
+pytest tests/ -x -q --tb=short
+```
+
+---
+
+## 3. Kernel Adapter (Agent OS Integration)
+
+Kernel adapters provide the full governance lifecycle: token budgets, tool
+interception, drift detection, and a unified audit trail. They extend
+`BaseIntegration` from `agent-os-kernel`.
+
+> **Already read Tutorial 03, Section 8?** That section covers the minimal
+> adapter pattern. This section goes further: it adds trust verification inside
+> the proxy, shows how `post_execute` drift detection works (event-based, not
+> blocking), and demonstrates `CompositeInterceptor` with custom interceptors.
+
+### 3.1 The BaseIntegration contract
+
+`BaseIntegration` (defined in `agent_os/integrations/base.py`) requires two
+abstract methods:
+
+| Method | Purpose |
+|--------|---------|
+| `wrap(agent)` | Accept a framework object, return a governed proxy |
+| `unwrap(governed)` | Return the original unwrapped object |
+
+The base class provides these hooks:
+
+```
+┌──────────────┐
+│  wrap(agent) │
+└──────┬───────┘
+       │  creates ExecutionContext (deep-copies policy)
+       ▼
+┌──────────────────────────────────────────────────────┐
+│                  Governed Proxy                       │
+│                                                      │
+│  run(prompt) ─────────────────────────────────────── │
+│     │                                                │
+│     ├─► pre_execute(ctx, input)                      │
+│     │     enforces: tokens, timeout, blocked         │
+│     │     patterns, human approval                   │
+│     │     returns: (allowed: bool, reason: str|None) │
+│     │                                                │
+│     ├─► framework.run(prompt)                        │
+│     │     the real LLM / agent call                  │
+│     │                                                │
+│     ├─► post_execute(ctx, output)                    │
+│     │     runs: drift detection, checkpoints         │
+│     │     emits: DRIFT_DETECTED event if threshold   │
+│     │     exceeded (event-based, not blocking)       │
+│     │     returns: (True, None) always               │
+│     │                                                │
+│     └─► emit(event_type, data)                       │
+│           fires registered listeners                 │
+│                                                      │
+│  call_tool(name, args) ──────────────────────────── │
+│     │                                                │
+│     └─► PolicyInterceptor.intercept(request)         │
+│           validates: allowed_tools, blocked_patterns │
+│           validates: call count (if context passed)  │
+│           returns: ToolCallResult(allowed, reason)   │
+└──────────────────────────────────────────────────────┘
+```
+
+**Important:** `post_execute()` always returns `(True, None)`. Drift detection
+is event-based — the base class emits a `DRIFT_DETECTED` event when the score
+exceeds the threshold, but it does not block execution. To make drift blocking,
+register an event listener that raises (shown in Section 3.4).
+
+### 3.2 Write the kernel and proxy
+
+```python
+# myframework_kernel.py
+from __future__ import annotations
+
+from agent_os.integrations.base import (
+    BaseIntegration,
+    CompositeInterceptor,
+    ExecutionContext,
+    GovernanceEventType,
+    GovernancePolicy,
+    PolicyInterceptor,
+    ToolCallRequest,
+    ToolCallResult,
+)
+from agent_os.exceptions import PolicyViolationError
+
+
+class MyFrameworkKernel(BaseIntegration):
+    """Governance kernel for MyFramework."""
+
+    def __init__(self, policy: GovernancePolicy | None = None) -> None:
+        super().__init__(policy)
+
+    def wrap(self, agent):
+        """Wrap a MyFramework agent with governance. Returns a governed proxy."""
+        agent_id = getattr(agent, "name", "unknown")
+        ctx = self.create_context(agent_id=agent_id)
+
+        self.emit(GovernanceEventType.POLICY_CHECK, {
+            "agent_id": agent_id,
+            "policy": self.policy.name,
+            "action": "wrap",
+        })
+
+        return _GovernedAgent(agent, self, ctx)
+
+    def unwrap(self, governed_agent):
+        """Remove governance, return original agent."""
+        return governed_agent._original
+
+
+class _GovernedAgent:
+    """Transparent governance proxy for a MyFramework agent."""
+
+    def __init__(self, original, kernel: MyFrameworkKernel, ctx: ExecutionContext):
+        self._original = original
+        self._kernel = kernel
+        self._ctx = ctx
+
+    def run(self, prompt: str, **kwargs):
+        """Execute with governance checks."""
+        # Pre-execution: token limits, timeout, blocked patterns
+        allowed, reason = self._kernel.pre_execute(self._ctx, prompt)
+        if not allowed:
+            self._kernel.emit(GovernanceEventType.POLICY_VIOLATION, {
+                "agent_id": self._ctx.agent_id,
+                "reason": reason,
+                "phase": "pre_execute",
+            })
+            raise PolicyViolationError(reason)
+
+        # Delegate to the real framework
+        result = self._original.run(prompt, **kwargs)
+
+        # Post-execution: drift detection (event-based, not blocking)
+        self._kernel.post_execute(self._ctx, result)
+
+        return result
+
+    def call_tool(self, tool_name: str, arguments: dict):
+        """Execute a tool call through the interception chain."""
+        request = ToolCallRequest(
+            tool_name=tool_name,
+            arguments=arguments,
+            agent_id=self._ctx.agent_id,
+        )
+
+        # Pass context so PolicyInterceptor can enforce max_tool_calls
+        interceptor = PolicyInterceptor(self._kernel.policy, self._ctx)
+        result: ToolCallResult = interceptor.intercept(request)
+
+        if not result.allowed:
+            self._kernel.emit(GovernanceEventType.TOOL_CALL_BLOCKED, {
+                "agent_id": self._ctx.agent_id,
+                "tool_name": tool_name,
+                "reason": result.reason,
+            })
+            raise PolicyViolationError(f"Tool '{tool_name}' blocked: {result.reason}")
+
+        final_args = result.modified_arguments or arguments
+        return self._original.call_tool(tool_name, final_args)
+
+    def get_context(self) -> ExecutionContext:
+        return self._ctx
+```
+
+Key differences from the minimal adapter in Tutorial 03, Section 8:
+
+- `post_execute()` result is not checked — it always returns `(True, None)`.
+  Tutorial 03 Section 8 checks the return and raises on failure, but that
+  branch can never execute. Drift is handled via events (Section 3.4).
+- `PolicyInterceptor` receives `self._ctx` so that `max_tool_calls` enforcement
+  works. Without context, call-count limits are silently skipped.
+- `PolicyViolationError` is imported from `agent_os.exceptions` (also available
+  via `agent_os.integrations.base`).
+
+### 3.3 Compose interceptors
+
+Chain multiple interceptors with `CompositeInterceptor`. All must allow the
+call for it to proceed.
+
+```python
+class RateLimitInterceptor:
+    """Block tool calls when an agent exceeds its per-minute quota."""
+
+    def __init__(self, max_per_minute: int = 30) -> None:
+        self._max = max_per_minute
+        self._counts: dict[str, list[float]] = {}
+
+    def intercept(self, request: ToolCallRequest) -> ToolCallResult:
+        import time
+        now = time.time()
+        calls = self._counts.setdefault(request.agent_id, [])
+        calls[:] = [t for t in calls if now - t < 60]
+        if len(calls) >= self._max:
+            return ToolCallResult(allowed=False, reason="Rate limit exceeded")
+        calls.append(now)
+        return ToolCallResult(allowed=True)
+
+
+# Wire into the governed proxy's call_tool method:
+policy = GovernancePolicy(allowed_tools=["search", "summarize"], max_tool_calls=10)
+composite = CompositeInterceptor([
+    PolicyInterceptor(policy),  # pass ExecutionContext as 2nd arg to enforce max_tool_calls
+    RateLimitInterceptor(max_per_minute=20),
+])
+result = composite.intercept(tool_request)  # all must allow
+```
+
+### 3.4 Register event listeners
+
+Event listeners connect your kernel to alerting, logging, or dashboards. This
+is also how to make drift detection blocking:
+
+```python
+policy = GovernancePolicy(
+    name="production",
+    allowed_tools=["search", "summarize"],
+    drift_threshold=0.15,
+    log_all_calls=True,
+)
+kernel = MyFrameworkKernel(policy=policy)
+
+# Alert on policy violations
+kernel.on(GovernanceEventType.POLICY_VIOLATION, lambda data: (
+    print(f"VIOLATION: {data['agent_id']} — {data['reason']}")
+))
+
+# Log blocked tool calls
+kernel.on(GovernanceEventType.TOOL_CALL_BLOCKED, lambda data: (
+    print(f"BLOCKED: {data['tool_name']} — {data['reason']}")
+))
+
+# Make drift detection blocking (optional)
+def on_drift(data):
+    raise PolicyViolationError(
+        f"Drift {data['drift_score']:.2f} exceeds threshold"
+    )
+
+kernel.on(GovernanceEventType.DRIFT_DETECTED, on_drift)
+
+governed = kernel.wrap(my_agent)
+```
+
+---
+
+## 4. Wiring Trust into the Kernel
+
+A production integration uses both layers: the trust integration gates *which
+agents* can act, the kernel gates *what they do*. The cleanest approach wires
+trust verification directly into the governed proxy.
+
+```
+┌───────────────┐     ┌──────────────────┐     ┌──────────────┐
+│ ActionGuard   │ ──► │ MyFrameworkKernel │ ──► │  Framework   │
+│ (trust gate)  │     │ (policy gate)    │     │  (LLM call)  │
+│               │     │                  │     │              │
+│ who can act?  │     │ pre_execute      │     │              │
+│ capabilities? │     │ tool intercept   │     │              │
+│ trust score?  │     │ drift detection  │     │              │
+└───────────────┘     └──────────────────┘     └──────────────┘
+```
+
+```python
+from __future__ import annotations
+
+from myframework_agentmesh import AgentProfile, ActionGuard
+from agent_os.integrations.base import (
+    BaseIntegration,
+    ExecutionContext,
+    GovernanceEventType,
+    GovernancePolicy,
+    PolicyInterceptor,
+    ToolCallRequest,
+    ToolCallResult,
+)
+from agent_os.exceptions import PolicyViolationError
+
+
+class TrustAwareKernel(BaseIntegration):
+    """Kernel that checks trust before enforcing policy."""
+
+    def __init__(
+        self,
+        policy: GovernancePolicy | None = None,
+        guard: ActionGuard | None = None,
+    ) -> None:
+        super().__init__(policy)
+        self.guard = guard or ActionGuard()
+
+    def wrap(self, agent, profile: AgentProfile):
+        """Wrap an agent with both trust verification and policy enforcement."""
+        # agent_id must match ^[a-zA-Z0-9_-]+$ — DIDs contain colons,
+        # so extract the final segment as the identifier.
+        agent_id = profile.did.rsplit(":", 1)[-1]
+        ctx = self.create_context(agent_id=agent_id)
+        return _TrustGovernedAgent(agent, self, ctx, profile)
+
+    def unwrap(self, governed_agent):
+        return governed_agent._original
+
+
+class _TrustGovernedAgent:
+    def __init__(self, original, kernel: TrustAwareKernel,
+                 ctx: ExecutionContext, profile: AgentProfile):
+        self._original = original
+        self._kernel = kernel
+        self._ctx = ctx
+        self._profile = profile
+
+    def run(self, prompt: str, action: str = "execute", **kwargs):
+        # Trust gate: is this agent allowed to perform this action?
+        trust_result = self._kernel.guard.check(self._profile, action)
+        if not trust_result.allowed:
+            raise PolicyViolationError(
+                f"Trust check failed for {self._profile.did}: {trust_result.reason}"
+            )
+
+        # Policy gate: does the input comply with governance rules?
+        allowed, reason = self._kernel.pre_execute(self._ctx, prompt)
+        if not allowed:
+            raise PolicyViolationError(reason)
+
+        result = self._original.run(prompt, **kwargs)
+        self._kernel.post_execute(self._ctx, result)
+        return result
+```
+
+Usage:
+
+```python
+guard = ActionGuard(
+    min_trust_score=600,
+    sensitive_actions={"deploy": 900, "delete": 800},
+    blocked_actions=["drop_database"],
+)
+
+policy = GovernancePolicy(
+    name="deploy-restricted",
+    max_tool_calls=5,
+    allowed_tools=["kubectl_apply", "helm_upgrade"],
+    blocked_patterns=["--force", "delete namespace"],
+    timeout_seconds=120,
+    log_all_calls=True,
+)
+
+agent_profile = AgentProfile(
+    did="did:mesh:deployer",
+    name="Deployer",
+    capabilities=["deploy", "rollback"],
+    trust_score=750,
+)
+
+kernel = TrustAwareKernel(policy=policy, guard=guard)
+governed = kernel.wrap(deploy_agent, profile=agent_profile)
+governed.run("Deploy v2.1.0 to staging", action="deploy")
+```
+
+---
+
+## 5. Publishing Your Integration
+
+### 5.1 Package placement
+
+Trust integrations belong in `packages/agentmesh-integrations/yourframework-agentmesh/`.
+Kernel adapters belong in `packages/agent-os/src/agent_os/integrations/yourframework_adapter.py`.
+
+### 5.2 PR requirements
+
+The `CONTRIBUTING.md` checklist applies. Key items:
+
+- Feature branch — never commit directly to `main`
+- Conventional commit messages — `feat: add MyFramework governance integration`
+- Tests — `pytest tests/ -x -q --tb=short` must pass
+- Lint — `ruff check src/ --select E,F,W --ignore E501`
+- Type hints and docstrings on all public APIs
+- Microsoft CLA signed
+- PR template (`.github/pull_request_template.md`) completed
+
+### 5.3 Versioning
+
+Follow the existing packages: start at `0.1.0`, use semantic versioning.
+Trust integrations in `agentmesh-integrations/` ship at the current toolkit
+release version (check `pyproject.toml` in any existing integration for the
+current number). New community integrations start at `0.1.0` and are bumped
+to match the toolkit version on acceptance.
+
+### 5.4 Publishing checklist
+
+- [ ] Package builds with `hatchling` and installs with `pip install -e ".[dev]"`
+- [ ] Zero hard runtime deps on the target framework (preferred)
+- [ ] Tests pass without the target framework SDK installed
+- [ ] `__init__.py` exports all public types in `__all__`
+- [ ] Uses `did:mesh:` format for agent identifiers
+- [ ] Trust scores use 0-1000 integer scale
+- [ ] Gate returns a result dataclass with `allowed`, `reason`, and `trust_score`
+- [ ] Kernel adapter extends `BaseIntegration` with `wrap()`/`unwrap()`
+- [ ] README has a Quick Start code block
+- [ ] All public functions and classes have docstrings and type hints
+- [ ] `CONTRIBUTING.md` checklist completed
+
+---
+
+## Next Steps
+
+- [Tutorial 01 — Policy Engine](01-policy-engine.md) — Policy rules, operators,
+  conflict resolution
+- [Tutorial 02 — Trust & Identity](02-trust-and-identity.md) — Ed25519
+  credentials, DIDs, trust scoring
+- [Tutorial 03 — Framework Integrations](03-framework-integrations.md) — Built-in
+  adapters for OpenAI, LangChain, CrewAI, and more
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — Contribution requirements
+
+---
+
+## Reference
+
+| Resource | Path |
+|----------|------|
+| `BaseIntegration` interface | `packages/agent-os/src/agent_os/integrations/base.py` |
+| CrewAI trust integration | `packages/agentmesh-integrations/crewai-agentmesh/` |
+| LangChain trust integration | `packages/agentmesh-integrations/langchain-agentmesh/` |
+| OpenAI Agents trust integration | `packages/agentmesh-integrations/openai-agents-agentmesh/` |
+| Framework integrations tutorial | `docs/tutorials/03-framework-integrations.md` |
+| Template integration (copy this) | `packages/agentmesh-integrations/template-agentmesh/` |
+| GovernancePolicy patterns | Tutorial 03, Section 7 |

--- a/packages/agentmesh-integrations/template-agentmesh/LICENSE
+++ b/packages/agentmesh-integrations/template-agentmesh/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agentmesh-integrations/template-agentmesh/README.md
+++ b/packages/agentmesh-integrations/template-agentmesh/README.md
@@ -1,0 +1,62 @@
+# Template AgentMesh Integration
+
+Starter template for building an AgentMesh trust layer for any agent framework.
+Copy this package and rename it for your target framework.
+
+See [Tutorial 28 — Building Custom Governance Integrations](../../../docs/tutorials/build-custom-integration.md) for the full walkthrough.
+
+## Quick Start
+
+```python
+from template_agentmesh import AgentProfile, ActionGuard, TrustTracker
+
+# Define agents with trust scores and capabilities
+agent = AgentProfile(
+    did="did:mesh:researcher",
+    name="Researcher",
+    capabilities=["search", "analyze"],
+    trust_score=700,
+)
+
+# Gate actions by trust score and capabilities
+guard = ActionGuard(
+    min_trust_score=500,
+    sensitive_actions={"delete": 800},
+    blocked_actions=["drop_database"],
+)
+
+result = guard.check(agent, "search", required_capabilities=["search"])
+assert result.allowed
+
+# Track outcomes to adjust trust over time
+tracker = TrustTracker(reward=10, penalty=50)
+tracker.record_success(agent, "search")
+assert agent.trust_score == 710
+```
+
+## How to Use This Template
+
+1. Copy `template-agentmesh/` to `yourframework-agentmesh/`
+2. Rename `template_agentmesh/` to `yourframework_agentmesh/`
+3. Update `pyproject.toml`: package name, description, keywords
+4. Extend `AgentProfile` with framework-specific fields
+5. Customize `ActionGuard` with framework-specific action types
+6. Add framework-specific validation logic to `ActionGuard.check()`
+7. Run `pytest tests/ -x -q --tb=short`
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| `AgentProfile` | Agent identity with DID, capabilities, and trust score |
+| `ActionResult` | Outcome of a trust-gated action check |
+| `ActionGuard` | Trust score and capability verification before actions |
+| `TrustTracker` | Records outcomes and adjusts trust scores over time |
+
+## Design Decisions
+
+- **Zero dependencies** — no hard dep on the target framework or AgentMesh
+- **Duck typing** — tests run without the framework SDK installed
+- **did:mesh: format** — compatible with AgentMesh identity system
+- **0-1000 trust scale** — matches the toolkit convention
+- **Asymmetric reward/penalty** — small reward (+10), large penalty (-50)

--- a/packages/agentmesh-integrations/template-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/template-agentmesh/SECURITY.md
@@ -1,0 +1,10 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md

--- a/packages/agentmesh-integrations/template-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/template-agentmesh/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "template_agentmesh"
+version = "0.1.0"
+description = "AgentMesh trust layer template — copy and rename for your framework"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+authors = [
+    { name = "Microsoft Corporation" }
+]
+keywords = ["agents", "trust", "multi-agent", "agentmesh", "governance", "template"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-governance-toolkit"
+Repository = "https://github.com/microsoft/agent-governance-toolkit"
+Documentation = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/tutorials/build-custom-integration.md"
+
+[tool.hatch.build.targets.wheel]
+packages = ["template_agentmesh"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/__init__.py
+++ b/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/__init__.py
@@ -1,0 +1,26 @@
+"""
+template-agentmesh: Starter template for AgentMesh trust integrations.
+
+Copy this package and rename it for your target agent framework.
+See Tutorial 28 (docs/tutorials/build-custom-integration.md) for the full walkthrough.
+
+Components:
+- AgentProfile: Agent identity with capabilities and trust score
+- ActionResult: Outcome of a trust-gated action check
+- ActionGuard: Trust score and capability verification
+- TrustTracker: Trust score tracking with asymmetric reward/penalty
+"""
+
+from template_agentmesh.trust import (
+    ActionGuard,
+    ActionResult,
+    AgentProfile,
+    TrustTracker,
+)
+
+__all__ = [
+    "ActionGuard",
+    "ActionResult",
+    "AgentProfile",
+    "TrustTracker",
+]

--- a/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/trust.py
+++ b/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/trust.py
@@ -1,0 +1,255 @@
+"""
+Trust layer for agent governance.
+
+This module provides the core trust primitives: agent identity, action gating,
+and trust score tracking. It has zero external dependencies and can be tested
+without the target framework SDK installed.
+
+Rename this module and customize it for your framework. The three extension
+points are:
+
+1. AgentProfile — add framework-specific fields (e.g., model name, tool list)
+2. ActionGuard.check() — add framework-specific validation logic
+3. TrustTracker — adjust reward/penalty or add persistence
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class AgentProfile:
+    """Identity and trust state for a governed agent.
+
+    Attributes:
+        did: Decentralized identifier in ``did:mesh:`` format.
+        name: Human-readable agent name.
+        capabilities: Verified capabilities this agent possesses.
+        trust_score: Trust level on a 0-1000 scale. Default 500 (neutral).
+        status: Lifecycle state — ``active``, ``suspended``, or ``revoked``.
+        metadata: Arbitrary key-value pairs for framework-specific data.
+    """
+
+    did: str
+    name: str
+    capabilities: list[str] = field(default_factory=list)
+    trust_score: int = 500
+    status: str = "active"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def has_capability(self, capability: str) -> bool:
+        """Check whether this agent has a single capability."""
+        return capability in self.capabilities
+
+    def has_all_capabilities(self, required: list[str]) -> bool:
+        """Check whether this agent has every capability in the list."""
+        return all(c in self.capabilities for c in required)
+
+    def has_any_capability(self, required: list[str]) -> bool:
+        """Check whether this agent has at least one capability in the list."""
+        return any(c in self.capabilities for c in required)
+
+
+@dataclass
+class ActionResult:
+    """Outcome of a trust-gated action check.
+
+    Attributes:
+        allowed: Whether the action is permitted.
+        agent_did: DID of the agent that was checked.
+        action: Name of the action that was evaluated.
+        reason: Human-readable explanation (populated on denial).
+        trust_score: Agent's trust score at evaluation time.
+        timestamp: Unix timestamp of the evaluation.
+    """
+
+    allowed: bool
+    agent_did: str
+    action: str
+    reason: str = ""
+    trust_score: int = 0
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dictionary for logging or JSON export."""
+        return {
+            "allowed": self.allowed,
+            "agent_did": self.agent_did,
+            "action": self.action,
+            "reason": self.reason,
+            "trust_score": self.trust_score,
+            "timestamp": self.timestamp,
+        }
+
+
+class ActionGuard:
+    """Trust-gated action enforcement.
+
+    Checks agent trust score, status, and capabilities before allowing an
+    action. Supports per-action minimum trust thresholds for sensitive
+    operations and a hard-block list for forbidden actions.
+
+    Args:
+        min_trust_score: Global minimum trust score required (0-1000).
+        sensitive_actions: Mapping of action names to their elevated
+            trust thresholds. Overrides ``min_trust_score`` per action.
+        blocked_actions: Actions that are always denied regardless of
+            trust score.
+    """
+
+    def __init__(
+        self,
+        min_trust_score: int = 500,
+        sensitive_actions: dict[str, int] | None = None,
+        blocked_actions: list[str] | None = None,
+    ) -> None:
+        self.min_trust_score = min_trust_score
+        self.sensitive_actions: dict[str, int] = sensitive_actions or {}
+        self.blocked_actions: list[str] = blocked_actions or []
+
+    def check(
+        self,
+        agent: AgentProfile,
+        action: str,
+        required_capabilities: list[str] | None = None,
+    ) -> ActionResult:
+        """Evaluate whether an agent may perform an action.
+
+        Checks are applied in order: blocked list, agent status, trust
+        threshold, then capabilities. The first failing check produces
+        the denial reason.
+
+        Args:
+            agent: The agent requesting the action.
+            action: Name of the action to evaluate.
+            required_capabilities: Capabilities the agent must possess.
+                If ``None``, no capability check is performed.
+
+        Returns:
+            An ``ActionResult`` indicating whether the action is allowed.
+        """
+        # Hard block
+        if action in self.blocked_actions:
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Action '{action}' is blocked by policy",
+                trust_score=agent.trust_score,
+            )
+
+        # Status check
+        if agent.status != "active":
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Agent status is '{agent.status}'",
+                trust_score=agent.trust_score,
+            )
+
+        # Trust threshold (per-action or global)
+        threshold = self.sensitive_actions.get(action, self.min_trust_score)
+        if agent.trust_score < threshold:
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Trust score {agent.trust_score} below threshold {threshold}",
+                trust_score=agent.trust_score,
+            )
+
+        # Capability check
+        if required_capabilities and not agent.has_all_capabilities(required_capabilities):
+            missing = [c for c in required_capabilities if not agent.has_capability(c)]
+            return ActionResult(
+                allowed=False,
+                agent_did=agent.did,
+                action=action,
+                reason=f"Missing capabilities: {missing}",
+                trust_score=agent.trust_score,
+            )
+
+        return ActionResult(
+            allowed=True,
+            agent_did=agent.did,
+            action=action,
+            trust_score=agent.trust_score,
+        )
+
+
+class TrustTracker:
+    """Records agent outcomes and adjusts trust scores.
+
+    Uses asymmetric reward/penalty: small reward for success, large penalty
+    for failure. This matches the pattern in ``crewai-agentmesh``.
+
+    Scores are clamped to [0, 1000].
+
+    Args:
+        reward: Points added on success. Default 10.
+        penalty: Points subtracted on failure. Default 50.
+    """
+
+    def __init__(self, reward: int = 10, penalty: int = 50) -> None:
+        self.reward = reward
+        self.penalty = penalty
+        self._history: list[dict[str, Any]] = []
+
+    def record_success(self, agent: AgentProfile, action: str) -> int:
+        """Reward an agent for a successful action.
+
+        Args:
+            agent: The agent to reward. Its ``trust_score`` is modified
+                in place.
+            action: Name of the action that succeeded.
+
+        Returns:
+            The agent's new trust score.
+        """
+        agent.trust_score = min(1000, agent.trust_score + self.reward)
+        self._history.append({
+            "did": agent.did,
+            "action": action,
+            "outcome": "success",
+            "new_score": agent.trust_score,
+            "timestamp": time.time(),
+        })
+        return agent.trust_score
+
+    def record_failure(self, agent: AgentProfile, action: str) -> int:
+        """Penalize an agent for a failed action.
+
+        Args:
+            agent: The agent to penalize. Its ``trust_score`` is modified
+                in place.
+            action: Name of the action that failed.
+
+        Returns:
+            The agent's new trust score.
+        """
+        agent.trust_score = max(0, agent.trust_score - self.penalty)
+        self._history.append({
+            "did": agent.did,
+            "action": action,
+            "outcome": "failure",
+            "new_score": agent.trust_score,
+            "timestamp": time.time(),
+        })
+        return agent.trust_score
+
+    def get_history(self, did: str | None = None) -> list[dict[str, Any]]:
+        """Return trust history, optionally filtered by agent DID.
+
+        Args:
+            did: If provided, return only entries for this agent.
+
+        Returns:
+            List of history records (copies, not references).
+        """
+        if did:
+            return [h for h in self._history if h["did"] == did]
+        return list(self._history)

--- a/packages/agentmesh-integrations/template-agentmesh/tests/test_trust.py
+++ b/packages/agentmesh-integrations/template-agentmesh/tests/test_trust.py
@@ -1,0 +1,294 @@
+"""Tests for the template AgentMesh trust integration.
+
+These tests run without any target framework SDK installed. They validate
+the governance logic in isolation — the same pattern used by crewai-agentmesh,
+openai-agents-agentmesh, and langchain-agentmesh.
+"""
+
+from template_agentmesh import AgentProfile, ActionGuard, ActionResult, TrustTracker
+
+
+# ── AgentProfile ──
+
+
+class TestAgentProfile:
+    def test_has_capability(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", capabilities=["read", "write"])
+        assert agent.has_capability("read")
+        assert not agent.has_capability("delete")
+
+    def test_has_all_capabilities(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", capabilities=["read", "write"])
+        assert agent.has_all_capabilities(["read", "write"])
+        assert not agent.has_all_capabilities(["read", "delete"])
+
+    def test_has_any_capability(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", capabilities=["read"])
+        assert agent.has_any_capability(["read", "write"])
+        assert not agent.has_any_capability(["delete", "admin"])
+
+    def test_default_values(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A")
+        assert agent.trust_score == 500
+        assert agent.status == "active"
+        assert agent.capabilities == []
+        assert agent.metadata == {}
+
+
+# ── ActionGuard ──
+
+
+class TestActionGuard:
+    def test_allow_above_threshold(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=700)
+        guard = ActionGuard(min_trust_score=500)
+        result = guard.check(agent, "search")
+        assert result.allowed
+        assert result.agent_did == "did:mesh:a1"
+        assert result.action == "search"
+        assert result.trust_score == 700
+
+    def test_block_below_threshold(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=300)
+        guard = ActionGuard(min_trust_score=500)
+        result = guard.check(agent, "search")
+        assert not result.allowed
+        assert "below threshold" in result.reason
+
+    def test_sensitive_action_elevated_threshold(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=600)
+        guard = ActionGuard(
+            min_trust_score=500,
+            sensitive_actions={"delete_record": 800},
+        )
+        assert guard.check(agent, "search").allowed
+        assert not guard.check(agent, "delete_record").allowed
+
+    def test_blocked_action_always_denied(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=1000)
+        guard = ActionGuard(blocked_actions=["drop_table"])
+        result = guard.check(agent, "drop_table")
+        assert not result.allowed
+        assert "blocked by policy" in result.reason
+
+    def test_suspended_agent_denied(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=900, status="suspended")
+        guard = ActionGuard(min_trust_score=500)
+        result = guard.check(agent, "search")
+        assert not result.allowed
+        assert "suspended" in result.reason
+
+    def test_revoked_agent_denied(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=900, status="revoked")
+        guard = ActionGuard(min_trust_score=500)
+        result = guard.check(agent, "search")
+        assert not result.allowed
+        assert "revoked" in result.reason
+
+    def test_capability_required_and_present(self):
+        agent = AgentProfile(
+            did="did:mesh:a1", name="A",
+            capabilities=["read", "write"], trust_score=700,
+        )
+        guard = ActionGuard(min_trust_score=500)
+        assert guard.check(agent, "query", required_capabilities=["read"]).allowed
+
+    def test_capability_required_but_missing(self):
+        agent = AgentProfile(
+            did="did:mesh:a1", name="A",
+            capabilities=["read"], trust_score=700,
+        )
+        guard = ActionGuard(min_trust_score=500)
+        result = guard.check(agent, "query", required_capabilities=["write"])
+        assert not result.allowed
+        assert "Missing capabilities" in result.reason
+        assert "write" in result.reason
+
+    def test_no_capabilities_required(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=700)
+        guard = ActionGuard(min_trust_score=500)
+        assert guard.check(agent, "search").allowed
+
+    def test_exact_threshold_allowed(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=500)
+        guard = ActionGuard(min_trust_score=500)
+        assert guard.check(agent, "search").allowed
+
+    def test_one_below_threshold_denied(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=499)
+        guard = ActionGuard(min_trust_score=500)
+        assert not guard.check(agent, "search").allowed
+
+    def test_check_order_blocked_before_status(self):
+        """Blocked actions are checked before status."""
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=900, status="suspended")
+        guard = ActionGuard(min_trust_score=500, blocked_actions=["danger"])
+        result = guard.check(agent, "danger")
+        assert "blocked by policy" in result.reason  # not "suspended"
+
+    def test_default_guard_values(self):
+        guard = ActionGuard()
+        assert guard.min_trust_score == 500
+        assert guard.sensitive_actions == {}
+        assert guard.blocked_actions == []
+
+
+# ── TrustTracker ──
+
+
+class TestTrustTracker:
+    def test_record_success_increases_score(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=500)
+        tracker = TrustTracker(reward=10, penalty=50)
+        new_score = tracker.record_success(agent, "search")
+        assert new_score == 510
+        assert agent.trust_score == 510
+
+    def test_record_failure_decreases_score(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=500)
+        tracker = TrustTracker(reward=10, penalty=50)
+        new_score = tracker.record_failure(agent, "search")
+        assert new_score == 450
+        assert agent.trust_score == 450
+
+    def test_score_clamped_at_max(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=995)
+        tracker = TrustTracker(reward=10)
+        tracker.record_success(agent, "search")
+        assert agent.trust_score == 1000
+
+    def test_score_clamped_at_min(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=20)
+        tracker = TrustTracker(penalty=50)
+        tracker.record_failure(agent, "search")
+        assert agent.trust_score == 0
+
+    def test_history_records_all_events(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=500)
+        tracker = TrustTracker(reward=10, penalty=50)
+        tracker.record_success(agent, "search")
+        tracker.record_failure(agent, "deploy")
+
+        history = tracker.get_history()
+        assert len(history) == 2
+        assert history[0]["outcome"] == "success"
+        assert history[0]["action"] == "search"
+        assert history[1]["outcome"] == "failure"
+        assert history[1]["action"] == "deploy"
+
+    def test_history_filtered_by_did(self):
+        a1 = AgentProfile(did="did:mesh:a1", name="A", trust_score=500)
+        a2 = AgentProfile(did="did:mesh:a2", name="B", trust_score=500)
+        tracker = TrustTracker()
+        tracker.record_success(a1, "search")
+        tracker.record_success(a2, "search")
+        tracker.record_failure(a1, "deploy")
+
+        a1_history = tracker.get_history("did:mesh:a1")
+        assert len(a1_history) == 2
+
+        a2_history = tracker.get_history("did:mesh:a2")
+        assert len(a2_history) == 1
+
+    def test_history_records_timestamps(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=500)
+        tracker = TrustTracker()
+        tracker.record_success(agent, "search")
+        history = tracker.get_history()
+        assert "timestamp" in history[0]
+        assert isinstance(history[0]["timestamp"], float)
+
+    def test_history_records_new_score(self):
+        agent = AgentProfile(did="did:mesh:a1", name="A", trust_score=500)
+        tracker = TrustTracker(reward=10)
+        tracker.record_success(agent, "search")
+        assert tracker.get_history()[0]["new_score"] == 510
+
+
+# ── ActionResult ──
+
+
+class TestActionResult:
+    def test_to_dict(self):
+        result = ActionResult(
+            allowed=True,
+            agent_did="did:mesh:a1",
+            action="search",
+            trust_score=700,
+        )
+        d = result.to_dict()
+        assert d["allowed"] is True
+        assert d["agent_did"] == "did:mesh:a1"
+        assert d["action"] == "search"
+        assert d["trust_score"] == 700
+        assert "timestamp" in d
+
+    def test_denied_result_includes_reason(self):
+        result = ActionResult(
+            allowed=False,
+            agent_did="did:mesh:a1",
+            action="delete",
+            reason="Trust too low",
+            trust_score=300,
+        )
+        d = result.to_dict()
+        assert d["allowed"] is False
+        assert d["reason"] == "Trust too low"
+
+    def test_default_values(self):
+        result = ActionResult(allowed=True, agent_did="did:mesh:a1", action="x")
+        assert result.reason == ""
+        assert result.trust_score == 0
+        assert isinstance(result.timestamp, float)
+
+
+# ── Integration: Full Lifecycle ──
+
+
+class TestFullLifecycle:
+    """End-to-end test: create agents, gate actions, track outcomes."""
+
+    def test_complete_workflow(self):
+        # Set up agents
+        researcher = AgentProfile(
+            did="did:mesh:researcher",
+            name="Researcher",
+            capabilities=["search", "analyze"],
+            trust_score=700,
+        )
+        writer = AgentProfile(
+            did="did:mesh:writer",
+            name="Writer",
+            capabilities=["write", "edit"],
+            trust_score=600,
+        )
+
+        # Set up guard
+        guard = ActionGuard(
+            min_trust_score=500,
+            sensitive_actions={"publish": 800},
+            blocked_actions=["delete_all"],
+        )
+
+        # Researcher can search
+        assert guard.check(researcher, "search", ["search"]).allowed
+
+        # Writer cannot publish (trust 600 < 800)
+        result = guard.check(writer, "publish")
+        assert not result.allowed
+
+        # Track outcomes
+        tracker = TrustTracker(reward=10, penalty=50)
+        tracker.record_success(researcher, "search")
+        tracker.record_success(writer, "write")
+        tracker.record_success(writer, "write")
+
+        # Writer's trust increased: 600 + 10 + 10 = 620
+        assert writer.trust_score == 620
+
+        # Still cannot publish (620 < 800)
+        assert not guard.check(writer, "publish").allowed
+
+        # Blocked action denied even with max trust
+        researcher.trust_score = 1000
+        assert not guard.check(researcher, "delete_all").allowed


### PR DESCRIPTION
## Summary

Addresses #710 — Tutorial and starter template for building governance integrations for any agent framework.

**Deliverable 1: Tutorial** (`docs/tutorials/build-custom-integration.md`)
- **Section 1** — Two integration styles: trust integration vs kernel adapter (with architecture diagram)
- **Section 2** — Trust integration walkthrough: `AgentProfile`, `ActionGuard`, `TrustTracker`, full test suite
- **Section 3** — Kernel adapter walkthrough: `BaseIntegration` subclass, `pre_execute`/`post_execute`, tool interception via `PolicyInterceptor` + `CompositeInterceptor`, event listeners (with data flow diagram)
- **Section 4** — Wiring trust into the kernel: `TrustAwareKernel` combining both layers
- **Section 5** — Publishing: package placement, PR requirements, versioning guidance

**Deliverable 2: Skeleton package** (`packages/agentmesh-integrations/template-agentmesh/`)
- Copy-and-rename starter with `AgentProfile`, `ActionResult`, `ActionGuard`, `TrustTracker`
- 29 passing tests across 6 test classes + integration lifecycle test
- Zero dependencies, hatchling build, full docstrings and type hints
- README with Quick Start and "How to Use This Template" steps
- LICENSE and SECURITY.md matching existing integrations

**Verification:**
- All imports and type signatures verified against `base.py` source at exact line numbers
- `post_execute()` correctly documented as event-based (not blocking) — differs from Tutorial 03 Section 8
- `PolicyInterceptor` context parameter documented for `max_tool_calls` enforcement
- `ExecutionContext.agent_id` regex constraint (`^[a-zA-Z0-9_-]+$`) handled in DID→agent_id conversion
- Drift event payload key verified as `drift_score` (not `drift_result`)
- `pytest tests/ -x -q --tb=short` — 29/29 passing
- `ruff check --select E,F,W --ignore E501` — clean

## Test plan

- [ ] `cd packages/agentmesh-integrations/template-agentmesh && pip install -e ".[dev]" && pytest tests/ -x -q --tb=short` — 29 tests pass
- [ ] `ruff check packages/agentmesh-integrations/template-agentmesh/ --select E,F,W --ignore E501` — clean
- [ ] All code blocks in the tutorial parse as valid Python 3.10+
- [ ] Cross-references between tutorial and skeleton resolve correctly
- [ ] Tutorial registered in `docs/tutorials/README.md` under "Extending the Toolkit"

🤖 Generated with [Claude Code](https://claude.com/claude-code)