### PR TITLE
fix: add allowlist input validation to PromptInjectionDetector

### DIFF
--- a/packages/agent-os/src/agent_os/prompt_injection.py
+++ b/packages/agent-os/src/agent_os/prompt_injection.py
@@ -107,6 +107,9 @@ class DetectionResult:
     explanation: str = ""
 
 
+_MIN_ALLOWLIST_ENTRY_LENGTH = 3
+
+
 @dataclass
 class DetectionConfig:
     """Configuration for the prompt injection detector.
@@ -116,12 +119,36 @@ class DetectionConfig:
             ``"permissive"``.
         custom_patterns: Additional compiled regex patterns to check.
         blocklist: Exact strings that always trigger detection.
-        allowlist: Exact strings that suppress detection.
+        allowlist: Substrings that suppress detection.  Uses substring
+            matching (``allowed.lower() in text_lower``).  Entries must be
+            at least 3 characters after stripping whitespace.
+
+    .. note::
+
+        An exact-match mode for the allowlist was considered but not
+        implemented to avoid expanding the configuration surface.  If
+        exact matching is needed, use a custom regex pattern with
+        anchors in *custom_patterns* instead.
     """
     sensitivity: str = "balanced"
     custom_patterns: list[re.Pattern[str]] = field(default_factory=list)
     blocklist: list[str] = field(default_factory=list)
     allowlist: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate allowlist entries to prevent overly broad suppression."""
+        for entry in self.allowlist:
+            stripped = entry.strip()
+            if not stripped:
+                raise ValueError(
+                    "Allowlist entries must not be empty or whitespace-only"
+                )
+            if len(stripped) < _MIN_ALLOWLIST_ENTRY_LENGTH:
+                raise ValueError(
+                    f"Allowlist entry {entry!r} is too short "
+                    f"(minimum {_MIN_ALLOWLIST_ENTRY_LENGTH} characters). "
+                    "Short entries risk disabling detection for broad input ranges."
+                )
 
 
 @dataclass

--- a/packages/agent-os/tests/test_prompt_injection.py
+++ b/packages/agent-os/tests/test_prompt_injection.py
@@ -267,6 +267,47 @@ class TestSensitivityLevels:
 
 
 # ---------------------------------------------------------------------------
+# Allowlist validation
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistValidation:
+    """Verify DetectionConfig rejects overly broad allowlist entries."""
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="empty or whitespace-only"):
+            DetectionConfig(allowlist=[""])
+
+    def test_rejects_whitespace_only(self):
+        with pytest.raises(ValueError, match="empty or whitespace-only"):
+            DetectionConfig(allowlist=["   "])
+
+    def test_rejects_short_entry(self):
+        with pytest.raises(ValueError, match="too short"):
+            DetectionConfig(allowlist=["ab"])
+
+    def test_rejects_single_space(self):
+        with pytest.raises(ValueError, match="empty or whitespace-only"):
+            DetectionConfig(allowlist=[" "])
+
+    def test_accepts_valid_entry(self):
+        config = DetectionConfig(allowlist=["quarterly report"])
+        assert config.allowlist == ["quarterly report"]
+
+    def test_accepts_minimum_length_entry(self):
+        config = DetectionConfig(allowlist=["abc"])
+        assert config.allowlist == ["abc"]
+
+    def test_rejects_mixed_valid_and_invalid(self):
+        with pytest.raises(ValueError, match="too short"):
+            DetectionConfig(allowlist=["valid phrase", "no"])
+
+    def test_empty_allowlist_is_valid(self):
+        config = DetectionConfig(allowlist=[])
+        assert config.allowlist == []
+
+
+# ---------------------------------------------------------------------------
 # Canary token detection
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `DetectionConfig.allowlist` accepted any string with no validation. Since the allowlist uses substring matching (`allowed.lower() in text_lower`), an overly broad entry (e.g., a single space) could silently disable detection for all inputs containing that substring.
- Added `__post_init__` validation: rejects empty, whitespace-only, and entries shorter than 3 characters with `ValueError`
- Fixed docstring to accurately describe substring matching behavior (previously said "Exact strings")
- Documented design alternative (exact-match mode) and rationale for not implementing it

Fixes #744

## Changes

| File | Change |
|------|--------|
| `packages/agent-os/src/agent_os/prompt_injection.py` | `__post_init__` on `DetectionConfig` + docstring fix (29 lines) |
| `packages/agent-os/tests/test_prompt_injection.py` | 8 new tests in `TestAllowlistValidation` (41 lines) |

## Test plan

- [x] `pytest tests/test_prompt_injection.py -x -q --tb=short` — 85/85 passing (42 existing + 8 new + 35 other classes)
- [x] `ruff check src/agent_os/prompt_injection.py --select E,F,W --ignore E501` — clean
- [ ] Existing allowlist test (`test_allowlist_suppresses_detection`) still passes — valid entries unaffected
- [ ] No new dependencies