### PR TITLE
docs: MCP + Trust Verification integration guide

### DIFF
--- a/docs/integrations/mcp-trust-guide.md
+++ b/docs/integrations/mcp-trust-guide.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
+
 # Adding Governance and Trust to MCP Servers
 
 This guide shows how to add identity verification, trust scoring, tool
@@ -25,7 +27,10 @@ an LLM silently follows (OWASP ASI01 -- Prompt Injection via tools).  Third,
 a tool definition can change silently between sessions -- a "rug pull" -- to
 alter agent behavior without anyone noticing.
 
-The toolkit addresses all three with a four-layer architecture:
+The toolkit addresses all three with four composable governance layers.
+Each layer covers a distinct concern (authorization, identity, integrity,
+enforcement) and can be adopted independently or combined for
+defense-in-depth:
 
 ```
 ┌───────────────────────────────────────────────────────────────────┐
@@ -699,12 +704,13 @@ gateway = MCPGateway(policy, denied_tools=["shell"])
 
 # --- Per-request pipeline ---
 
-def governed_tool_call(agent_did, trust_score, tool_name, tool_desc, params):
+def governed_tool_call(agent_did, trust_score, capabilities, tool_name, tool_desc, params):
     # Step 1: Authorization
     auth = proxy.authorize(
         agent_did=agent_did,
         agent_trust_score=trust_score,
         tool_name=tool_name,
+        agent_capabilities=capabilities,
     )
     if not auth.allowed:
         return {"error": auth.reason}

--- a/examples/mcp-trust-verified-server/README.md
+++ b/examples/mcp-trust-verified-server/README.md
@@ -1,4 +1,11 @@
+<!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
+
 # MCP Trust-Verified Server
+
+> **DEMO ONLY.** This example accepts `agent_did` and `trust_score` as
+> client-supplied tool arguments. In production, agent identity and trust
+> scores must come from a verified source (identity registry, trust server)
+> — never from the calling agent itself.
 
 A standalone MCP server where every tool call is gated by AgentMesh trust verification. Demonstrates how to use `TrustProxy` and `MCPSecurityScanner` to enforce per-tool trust thresholds, capability requirements, and rate limits.
 

--- a/examples/mcp-trust-verified-server/server.py
+++ b/examples/mcp-trust-verified-server/server.py
@@ -3,6 +3,11 @@
 """
 MCP Trust-Verified Server — demonstrates trust-gated tool access.
 
+DEMO ONLY: This example accepts agent_did and trust_score as client-supplied
+tool arguments. In production, agent identity and trust scores must come from
+a verified source (identity registry, trust server) — never from the calling
+agent itself.
+
 Three tools with escalating trust requirements:
   - read_file:       low trust (300), no special capabilities
   - write_file:      medium trust (600), requires "fs_write" capability


### PR DESCRIPTION
## Summary

Integration guide and working example server showing how to add governance and trust verification to any MCP server.

**Guide** (`docs/integrations/mcp-trust-guide.md`) — 4-layer progression:
- **Layer 1: Trust Proxy** — per-tool authorization, capability gating, rate limiting
- **Layer 2: Trust Server** — 5-dimension trust scoring, Ed25519 identity, cryptographic handshakes, delegation verification
- **Layer 3: Security Scanner** — tool poisoning detection, rug-pull fingerprinting, schema abuse, cross-server attacks
- **Layer 4: MCP Gateway** — 5-stage runtime interception pipeline with fail-closed semantics

Plus TrustGatedMCPServer (AgentMesh embedded alternative), end-to-end flow composition, and MCP client integration.

**Example server** (`examples/mcp-trust-verified-server/`) — runnable FastMCP server with 3 tools at escalating trust thresholds (300/600/800), security scanner fingerprinting, fail-closed authorization, and audit logging.

All APIs verified against source across two independent review passes. Corrections applied: blocked_patterns tuple form, private import warnings, orphaned error message, fail-closed trust_score preservation, CONFUSED_DEPUTY threat type qualifier, wrap_mcp_server limitation note, vendor-neutral client language.

Closes #707

## Test plan

- [ ] All code blocks parse as valid Python 3.10+
- [ ] All import paths resolve to real symbols (verified against source)
- [ ] Cross-references resolve: guide ↔ example ↔ Tutorial 07 ↔ Tutorial 27
- [ ] Example server runs: `python examples/mcp-trust-verified-server/server.py`
- [ ] No vendor-specific language — MCP client references are framework-agnostic
- [ ] No new dependencies in toolkit packages