### PR TITLE
community: add blog post on AI agent governance to COMMUNITY.md

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -6,6 +6,16 @@
 - **[GitHub Discussions](https://github.com/microsoft/agent-governance-toolkit/discussions)** — Questions, ideas, and general conversation
 - **[Stack Overflow](https://stackoverflow.com/questions/tagged/agent-governance-toolkit)** — Technical Q&A (tag: `agent-governance-toolkit`)
 
+## Blog Posts & Articles
+
+Community-written content about agent governance, security, and the toolkit.
+
+| Title | Author | Platform |
+|-------|--------|----------|
+| [Why AI Agent Governance Matters in 2026](https://dev.to/kanishtyagii/why-ai-agent-governance-matters-in-2026-4mnk) | [@kanish5](https://github.com/kanish5) | Dev.to |
+
+---
+
 ## Stay Updated
 
 - ⭐ **Star** the repository to get notified of new releases


### PR DESCRIPTION
Closes #694

## Summary
Published a blog post on Dev.to covering why AI agent governance matters 
in 2026, written from the perspective of a hands-on contributor to this toolkit.

## Blog post
**Title:** Why AI Agent Governance Matters in 2026  
**URL:** https://dev.to/kanishtyagii/why-ai-agent-governance-matters-in-2026-4mnk  
**Platform:** Dev.to  

## Topics covered
- MCP tool poisoning attacks
- Runaway tool call loops
- PII in agent memory writes  
- Prompt injection across delegation chains
- How the toolkit addresses these with policy enforcement, audit logging, and circuit breakers

## Change
Added a new "Blog Posts & Articles" section to COMMUNITY.md with the post linked.