### PR TITLE
fix(security): post-merge audit — CLI crashes, XSS, blocklist validation

### DIFF
--- a/packages/agent-os-vscode/src/extension.ts
+++ b/packages/agent-os-vscode/src/extension.ts
@@ -1040,7 +1040,7 @@ async function exportAuditLog(): Promise<void> {
 }
 
 /** Escape HTML entities for safe rendering. */
-function escHtml(s: string): string { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+function escHtml(s: string): string { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
 
 /** Apply inline Markdown formatting (bold, code). */
 function inlineMdFormat(s: string): string {

--- a/packages/agent-os/src/agent_os/cli/__init__.py
+++ b/packages/agent-os/src/agent_os/cli/__init__.py
@@ -34,7 +34,6 @@ import subprocess
 import sys
 import time
 import warnings
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 
@@ -1378,6 +1377,7 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--json", action="store_true", help="Output in JSON format")
+    parser.add_argument("--version", action="store_true", help="Show version")
 
     subparsers = parser.add_subparsers(dest="command", help="Command to execute")
 
@@ -1470,7 +1470,7 @@ def main() -> int:
         "--port", type=int, default=8080, help="Port to listen on (default: 8080)"
     )
     serve_parser.add_argument(
-        "--host", default="0.0.0.0", help="Host to bind to (default: 0.0.0.0)"
+        "--host", default="127.0.0.1", help="Host to bind to (default: 127.0.0.1)"
     )
 
     # health
@@ -1516,29 +1516,7 @@ def main() -> int:
 
     # Command routing
     try:
-        if args.command == "init":
-            return cmd_init(args)
-        elif args.command == "secure":
-            return cmd_secure(args)
-        elif args.command == "audit":
-            return cmd_audit(args)
-        elif args.command == "status":
-            return cmd_status(args)
-        elif args.command == "check":
-            return cmd_check(args)
-        elif args.command == "review":
-            return cmd_review(args)
-        elif args.command == "install-hooks":
-            return cmd_install_hooks(args)
-        elif args.command == "validate":
-            return cmd_validate(args)
-        elif args.command == "metrics":
-            return cmd_metrics(args)
-        elif args.command == "health":
-            return cmd_health(args)
-        else:
-            print(f"Unknown command: {args.command}")
-            return 1
+        return handler(args)
     except KeyboardInterrupt:
         return 130
     except Exception as e:

--- a/packages/agent-os/src/agent_os/prompt_injection.py
+++ b/packages/agent-os/src/agent_os/prompt_injection.py
@@ -136,7 +136,7 @@ class DetectionConfig:
     allowlist: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        """Validate allowlist entries to prevent overly broad suppression."""
+        """Validate allowlist and blocklist entries to prevent overly broad suppression."""
         for entry in self.allowlist:
             stripped = entry.strip()
             if not stripped:
@@ -149,6 +149,21 @@ class DetectionConfig:
                     f"(minimum {_MIN_ALLOWLIST_ENTRY_LENGTH} characters). "
                     "Short entries risk disabling detection for broad input ranges."
                 )
+        for entry in self.blocklist:
+            stripped = entry.strip()
+            if not stripped:
+                raise ValueError(
+                    "Blocklist entries must not be empty or whitespace-only"
+                )
+            if len(stripped) < _MIN_ALLOWLIST_ENTRY_LENGTH:
+                raise ValueError(
+                    f"Blocklist entry '{entry}' is too short "
+                    f"(minimum {_MIN_ALLOWLIST_ENTRY_LENGTH} characters). "
+                    f"Short entries cause excessive false positives with substring matching."
+                )
+        # After validation, freeze the lists to prevent post-construction mutation
+        self.allowlist = tuple(self.allowlist)
+        self.blocklist = tuple(self.blocklist)
 
 
 @dataclass

--- a/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/__init__.py
+++ b/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 template-agentmesh: Starter template for AgentMesh trust integrations.
 

--- a/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/trust.py
+++ b/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """
 Trust layer for agent governance.
 

--- a/packages/agentmesh-integrations/template-agentmesh/tests/test_trust.py
+++ b/packages/agentmesh-integrations/template-agentmesh/tests/test_trust.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 """Tests for the template AgentMesh trust integration.
 
 These tests run without any target framework SDK installed. They validate


### PR DESCRIPTION
## Post-Merge Security Audit Fixes

Addresses 12 findings from a post-merge audit of recently merged external contributor PRs.

### Critical (2)
- **serve --host 0.0.0.0** -> 127.0.0.1 (prevents unintended network exposure)
- **args.version AttributeError** -> add --version to root parser (CLI was crashing)

### Medium (5)
- **escHtml XSS** -> add quote escaping in VS Code extension
- **Blocklist validation** -> apply same min-length validation + freeze both lists to tuples
- **Redundant dispatch** -> replace 12-branch if/elif with dict lookup
- **Unused import** -> remove dead http.server import
- **License headers** -> add to 3 template-agentmesh files
