### PR TITLE
Promote EU AI Act risk classifier from examples to library

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/governance/__init__.py
@@ -46,6 +46,12 @@ from .trust_policy import (
 from .async_policy_evaluator import AsyncTrustPolicyEvaluator
 from .async_policy_evaluator import ConcurrencyStats as TrustConcurrencyStats
 from .policy_evaluator import PolicyEvaluator, TrustPolicyDecision
+from .eu_ai_act import (
+    RiskLevel,
+    AgentRiskProfile,
+    ClassificationResult,
+    EUAIActRiskClassifier,
+)
 from .federation import (
     PolicyCategory,
     OrgPolicyRule,
@@ -119,5 +125,10 @@ __all__ = [
     "InMemoryFederationStore",
     "FileFederationStore",
     "FederationEngine",
+    # EU AI Act risk classifier (issue #756)
+    "RiskLevel",
+    "AgentRiskProfile",
+    "ClassificationResult",
+    "EUAIActRiskClassifier",
 ]
 

--- a/packages/agent-mesh/src/agentmesh/governance/eu_ai_act.py
+++ b/packages/agent-mesh/src/agentmesh/governance/eu_ai_act.py
@@ -1,0 +1,234 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+EU AI Act Risk Classifier (Regulation 2024/1689)
+
+Structured risk classification per Article 6 and Annex III with:
+- Art. 5 prohibited practices detection
+- Art. 6(1) Annex I safety-component path
+- Art. 6(3) exemptions for narrow procedural tasks
+- Profiling override per GDPR Art. 4(4)
+- Configurable risk categories via external YAML/JSON
+
+Promoted from examples/06-eu-ai-act-compliance per issue #756.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Risk levels
+# ---------------------------------------------------------------------------
+
+class RiskLevel(Enum):
+    """EU AI Act risk tiers (Article 6)."""
+    UNACCEPTABLE = "unacceptable"
+    HIGH = "high"
+    LIMITED = "limited"
+    MINIMAL = "minimal"
+
+
+# ---------------------------------------------------------------------------
+# Agent profile
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AgentRiskProfile:
+    """Describes an AI system for risk classification.
+
+    Attributes:
+        name: Human-readable system name.
+        description: Free-text description of the system's purpose.
+        domain: Primary domain / use-case identifier.
+        capabilities: List of capability identifiers.
+        is_safety_component: Whether the system is a safety component
+            under EU harmonisation legislation (Annex I).
+        harmonisation_legislation: Specific Annex I legislation if applicable.
+        involves_profiling: Whether the system profiles natural persons
+            per GDPR Art. 4(4).
+        exemption_tags: Art. 6(3) exemption identifiers, if any.
+    """
+    name: str
+    description: str = ""
+    domain: str = ""
+    capabilities: List[str] = field(default_factory=list)
+    is_safety_component: bool = False
+    harmonisation_legislation: Optional[str] = None
+    involves_profiling: bool = False
+    exemption_tags: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Classification result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ClassificationResult:
+    """Result of a risk classification."""
+    risk_level: RiskLevel
+    triggers: List[str]
+    exemptions_applied: List[str]
+    profiling_override: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Configuration loader
+# ---------------------------------------------------------------------------
+
+def _normalize(value: str) -> str:
+    """Lowercase and replace spaces/hyphens with underscores."""
+    return value.lower().replace(" ", "_").replace("-", "_")
+
+
+def _load_config(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load risk classification config from YAML or JSON.
+
+    Falls back to the bundled ``eu_ai_act_defaults.yaml``.
+    """
+    if path is None:
+        path = Path(__file__).parent / "eu_ai_act_defaults.yaml"
+
+    with open(path) as f:
+        if path.suffix in (".yaml", ".yml"):
+            return yaml.safe_load(f)
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Risk Classifier
+# ---------------------------------------------------------------------------
+
+class EUAIActRiskClassifier:
+    """Classify an AI system's risk level per Article 6 and Annex III.
+
+    Supports external configuration so classification rules can be updated
+    when the regulation is amended (e.g. Annex III changes).
+
+    Parameters:
+        config_path: Optional path to a YAML or JSON config file.
+            When ``None``, uses the bundled defaults.
+    """
+
+    def __init__(self, config_path: Optional[Path] = None) -> None:
+        cfg = _load_config(config_path)
+        self._unacceptable: Set[str] = set(cfg.get("unacceptable_domains", []))
+        self._high_risk_domains: Set[str] = set(cfg.get("high_risk_domains", []))
+        self._high_risk_caps: Set[str] = set(cfg.get("high_risk_capabilities", []))
+        self._annex_i: Set[str] = set(cfg.get("annex_i_legislation", []))
+        self._limited: Set[str] = set(cfg.get("limited_risk_indicators", []))
+        self._exemptions: Set[str] = set(cfg.get("article_6_3_exemptions", []))
+
+    # ---- public API ----
+
+    def classify(self, profile: AgentRiskProfile) -> ClassificationResult:
+        """Classify the risk level for an agent profile."""
+        domain = _normalize(profile.domain)
+        caps = {_normalize(c) for c in profile.capabilities}
+        exemption_tags = {_normalize(t) for t in profile.exemption_tags}
+
+        triggers: List[str] = []
+        exemptions_applied: List[str] = []
+        profiling_override = False
+
+        # 1. Article 5 -- Prohibited practices (always checked first)
+        if domain in self._unacceptable:
+            triggers.append(
+                f"Domain '{profile.domain}' is prohibited under Article 5"
+            )
+            return ClassificationResult(
+                risk_level=RiskLevel.UNACCEPTABLE,
+                triggers=triggers,
+                exemptions_applied=[],
+            )
+
+        # 2. Article 6(1) -- Safety component under Annex I legislation
+        if profile.is_safety_component:
+            legislation = _normalize(profile.harmonisation_legislation or "")
+            if legislation in self._annex_i:
+                triggers.append(
+                    f"Safety component under Annex I legislation: "
+                    f"{profile.harmonisation_legislation}"
+                )
+                return ClassificationResult(
+                    risk_level=RiskLevel.HIGH,
+                    triggers=triggers,
+                    exemptions_applied=[],
+                )
+
+        # 3. Article 6(2) -- Annex III domain check
+        is_annex_iii = domain in self._high_risk_domains
+
+        if is_annex_iii:
+            # 3a. Check Art. 6(3) exemptions
+            valid_exemptions = exemption_tags & self._exemptions
+            if valid_exemptions:
+                # 3b. Profiling override: exemptions do NOT apply when profiling
+                if profile.involves_profiling:
+                    profiling_override = True
+                    triggers.append(
+                        f"Domain '{profile.domain}' listed in Annex III"
+                    )
+                    triggers.append(
+                        "Art. 6(3) exemptions overridden: system involves "
+                        "profiling of natural persons (GDPR Art. 4(4))"
+                    )
+                    return ClassificationResult(
+                        risk_level=RiskLevel.HIGH,
+                        triggers=triggers,
+                        exemptions_applied=[],
+                        profiling_override=True,
+                    )
+                else:
+                    # Exemptions apply -- downgrade from HIGH
+                    exemptions_applied = sorted(valid_exemptions)
+                    triggers.append(
+                        f"Domain '{profile.domain}' listed in Annex III "
+                        f"but exempted under Art. 6(3)"
+                    )
+            else:
+                triggers.append(
+                    f"Domain '{profile.domain}' listed in Annex III (high-risk)"
+                )
+                return ClassificationResult(
+                    risk_level=RiskLevel.HIGH,
+                    triggers=triggers,
+                    exemptions_applied=[],
+                )
+
+        # 4. Capability-based escalation
+        matched_caps = caps & self._high_risk_caps
+        if matched_caps and not exemptions_applied:
+            triggers.append(
+                f"High-risk capabilities: {', '.join(sorted(matched_caps))}"
+            )
+            return ClassificationResult(
+                risk_level=RiskLevel.HIGH,
+                triggers=triggers,
+                exemptions_applied=[],
+            )
+
+        # 5. Article 50 -- LIMITED transparency obligations
+        if domain in self._limited or caps & self._limited:
+            triggers.append(
+                f"Transparency obligations under Article 50"
+            )
+            return ClassificationResult(
+                risk_level=RiskLevel.LIMITED,
+                triggers=triggers,
+                exemptions_applied=exemptions_applied,
+            )
+
+        # 6. MINIMAL
+        return ClassificationResult(
+            risk_level=RiskLevel.MINIMAL,
+            triggers=triggers or ["No elevated-risk triggers detected"],
+            exemptions_applied=exemptions_applied,
+        )

--- a/packages/agent-mesh/src/agentmesh/governance/eu_ai_act_defaults.yaml
+++ b/packages/agent-mesh/src/agentmesh/governance/eu_ai_act_defaults.yaml
@@ -1,0 +1,75 @@
+# EU AI Act Risk Classification Defaults
+# Regulation (EU) 2024/1689
+#
+# This file is designed to be updated as the regulation evolves
+# (e.g., Annex III amendments by the European Commission).
+
+# Article 5 - Prohibited AI practices
+unacceptable_domains:
+  - social_scoring
+  - real_time_biometric_identification
+  - subliminal_manipulation
+  - exploitation_of_vulnerabilities
+  - predictive_policing_individual
+  - emotion_recognition_workplace
+  - emotion_recognition_education
+  - untargeted_facial_scraping
+
+# Annex III - High-risk AI systems
+high_risk_domains:
+  - biometric_identification
+  - critical_infrastructure
+  - education_training
+  - employment_recruitment
+  - essential_services
+  - law_enforcement
+  - migration_border
+  - justice_democracy
+  - medical_diagnosis
+  - credit_scoring
+  - insurance_pricing
+  - safety_components
+
+# Capabilities that escalate to HIGH risk
+high_risk_capabilities:
+  - autonomous_decision_making
+  - personal_data_processing
+  - safety_critical_control
+  - law_enforcement_support
+  - biometric_processing
+  - financial_decisioning
+
+# Article 6(1) - Safety components under EU harmonisation legislation (Annex I)
+annex_i_legislation:
+  - machinery_regulation
+  - toy_safety
+  - recreational_craft
+  - lifts
+  - pressure_equipment
+  - radio_equipment
+  - cableway_installations
+  - personal_protective_equipment
+  - medical_devices
+  - in_vitro_diagnostics
+  - civil_aviation
+  - motor_vehicles
+  - rail_systems
+  - marine_equipment
+
+# Article 50 - Transparency obligations (LIMITED risk)
+limited_risk_indicators:
+  - chatbot
+  - content_generation
+  - deepfake_generation
+  - emotion_detection
+  - text_generation
+  - image_generation
+
+# Article 6(3) - Exemptions for high-risk classification
+# These narrow procedural tasks do NOT qualify as high-risk even if
+# the domain is listed in Annex III, UNLESS profiling is involved.
+article_6_3_exemptions:
+  - narrow_procedural_task        # (a) performs a narrow procedural task
+  - improve_prior_human_activity  # (b) improves result of prior human activity
+  - pattern_detection_no_action   # (c) detects patterns without replacing human assessment
+  - preparatory_task              # (d) preparatory task for Annex III assessment

--- a/packages/agent-mesh/tests/governance/test_eu_ai_act.py
+++ b/packages/agent-mesh/tests/governance/test_eu_ai_act.py
@@ -1,0 +1,234 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the EU AI Act risk classifier (issue #756)."""
+
+import pytest
+
+from agentmesh.governance.eu_ai_act import (
+    AgentRiskProfile,
+    EUAIActRiskClassifier,
+    RiskLevel,
+)
+
+
+@pytest.fixture
+def classifier():
+    return EUAIActRiskClassifier()
+
+
+# -----------------------------------------------------------------------
+# Article 5 -- Prohibited practices
+# -----------------------------------------------------------------------
+
+class TestUnacceptableRisk:
+    def test_social_scoring(self, classifier):
+        profile = AgentRiskProfile(name="scorer", domain="social_scoring")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.UNACCEPTABLE
+
+    def test_real_time_biometric(self, classifier):
+        profile = AgentRiskProfile(
+            name="biowatch",
+            domain="real_time_biometric_identification",
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.UNACCEPTABLE
+
+    def test_subliminal_manipulation(self, classifier):
+        profile = AgentRiskProfile(name="manip", domain="subliminal_manipulation")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.UNACCEPTABLE
+
+
+# -----------------------------------------------------------------------
+# Article 6(1) -- Annex I safety components
+# -----------------------------------------------------------------------
+
+class TestAnnexISafetyComponent:
+    def test_safety_component_medical_device(self, classifier):
+        profile = AgentRiskProfile(
+            name="med-safety",
+            domain="general_monitoring",
+            is_safety_component=True,
+            harmonisation_legislation="medical_devices",
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+        assert any("Annex I" in t for t in result.triggers)
+
+    def test_safety_component_unknown_legislation(self, classifier):
+        """Safety component under non-Annex-I legislation is not auto-HIGH."""
+        profile = AgentRiskProfile(
+            name="widget",
+            domain="general",
+            is_safety_component=True,
+            harmonisation_legislation="unknown_directive",
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.MINIMAL
+
+
+# -----------------------------------------------------------------------
+# Article 6(2) -- Annex III high-risk domains
+# -----------------------------------------------------------------------
+
+class TestAnnexIIIHighRisk:
+    @pytest.mark.parametrize("domain", [
+        "credit_scoring",
+        "medical_diagnosis",
+        "employment_recruitment",
+        "law_enforcement",
+        "critical_infrastructure",
+    ])
+    def test_annex_iii_domains(self, classifier, domain):
+        profile = AgentRiskProfile(name="system", domain=domain)
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+
+
+# -----------------------------------------------------------------------
+# Capability-based escalation
+# -----------------------------------------------------------------------
+
+class TestCapabilityEscalation:
+    def test_autonomous_decision_making(self, classifier):
+        profile = AgentRiskProfile(
+            name="auto-decider",
+            domain="general",
+            capabilities=["autonomous_decision_making"],
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+
+    def test_multiple_capabilities(self, classifier):
+        profile = AgentRiskProfile(
+            name="multi",
+            domain="general",
+            capabilities=["biometric_processing", "financial_decisioning"],
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+
+
+# -----------------------------------------------------------------------
+# Article 6(3) -- Exemptions
+# -----------------------------------------------------------------------
+
+class TestArticle63Exemptions:
+    def test_narrow_procedural_task_exemption(self, classifier):
+        """Annex III domain with valid exemption should NOT be HIGH."""
+        profile = AgentRiskProfile(
+            name="helper",
+            domain="credit_scoring",
+            exemption_tags=["narrow_procedural_task"],
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level != RiskLevel.HIGH
+        assert "narrow_procedural_task" in result.exemptions_applied
+
+    def test_pattern_detection_exemption(self, classifier):
+        profile = AgentRiskProfile(
+            name="detector",
+            domain="law_enforcement",
+            exemption_tags=["pattern_detection_no_action"],
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level != RiskLevel.HIGH
+
+    def test_invalid_exemption_ignored(self, classifier):
+        """Unrecognized exemption tag should not grant an exemption."""
+        profile = AgentRiskProfile(
+            name="faker",
+            domain="credit_scoring",
+            exemption_tags=["made_up_exemption"],
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+
+
+# -----------------------------------------------------------------------
+# Profiling override (GDPR Art. 4(4))
+# -----------------------------------------------------------------------
+
+class TestProfilingOverride:
+    def test_profiling_overrides_exemption(self, classifier):
+        """When profiling is involved, Art. 6(3) exemptions do NOT apply."""
+        profile = AgentRiskProfile(
+            name="profiler",
+            domain="credit_scoring",
+            exemption_tags=["narrow_procedural_task"],
+            involves_profiling=True,
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+        assert result.profiling_override is True
+        assert len(result.exemptions_applied) == 0
+
+    def test_profiling_without_exemption(self, classifier):
+        """Profiling in Annex III domain is HIGH regardless."""
+        profile = AgentRiskProfile(
+            name="profiler2",
+            domain="employment_recruitment",
+            involves_profiling=True,
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+
+
+# -----------------------------------------------------------------------
+# Limited and minimal risk
+# -----------------------------------------------------------------------
+
+class TestLimitedAndMinimalRisk:
+    def test_chatbot_is_limited(self, classifier):
+        profile = AgentRiskProfile(name="bot", domain="chatbot")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.LIMITED
+
+    def test_content_generation_is_limited(self, classifier):
+        profile = AgentRiskProfile(name="gen", domain="content_generation")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.LIMITED
+
+    def test_generic_system_is_minimal(self, classifier):
+        profile = AgentRiskProfile(name="basic", domain="general_utility")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.MINIMAL
+
+    def test_empty_profile_is_minimal(self, classifier):
+        profile = AgentRiskProfile(name="empty")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.MINIMAL
+
+
+# -----------------------------------------------------------------------
+# Issue #756 regression: keyword-only matching misses descriptions
+# -----------------------------------------------------------------------
+
+class TestRegressions:
+    def test_behavioral_scoring_not_missed(self, classifier):
+        """The old assess_risk_category() missed this because no keywords
+        matched. The new classifier correctly maps the domain."""
+        profile = AgentRiskProfile(
+            name="citizen-rater",
+            domain="social_scoring",
+            description="Rate citizens based on behavior for government rewards",
+        )
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.UNACCEPTABLE
+
+
+# -----------------------------------------------------------------------
+# Domain normalization
+# -----------------------------------------------------------------------
+
+class TestNormalization:
+    def test_spaces_and_hyphens_normalized(self, classifier):
+        profile = AgentRiskProfile(name="test", domain="Credit Scoring")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH
+
+    def test_mixed_case(self, classifier):
+        profile = AgentRiskProfile(name="test", domain="LAW-ENFORCEMENT")
+        result = classifier.classify(profile)
+        assert result.risk_level == RiskLevel.HIGH


### PR DESCRIPTION
## Summary

Closes #756. Moves the EU AI Act risk classifier from `examples/06-eu-ai-act-compliance/` into the `agentmesh.governance` library as `EUAIActRiskClassifier`.

### What changed

**New files:**
- `governance/eu_ai_act.py` -- `EUAIActRiskClassifier` with structured risk assessment
- `governance/eu_ai_act_defaults.yaml` -- configurable risk categories (Annex I, III, Art. 5, Art. 6(3))
- `tests/governance/test_eu_ai_act.py` -- 24 tests covering all classification paths

**Modified:**
- `governance/__init__.py` -- exports `RiskLevel`, `AgentRiskProfile`, `ClassificationResult`, `EUAIActRiskClassifier`

### Features added per issue requirements

1. Art. 5 prohibited practices detection
2. Art. 6(1) Annex I safety-component path (harmonisation legislation)
3. Art. 6(2) Annex III domain-based classification
4. Art. 6(3) exemptions (narrow procedural task, pattern detection, preparatory task, improve prior human activity)
5. Profiling override per GDPR Art. 4(4) -- exemptions do NOT apply when profiling
6. External YAML config so Annex III amendments can be tracked without code changes

### Regression fix

The old `assess_risk_category()` in agent-os used keyword substring matching against `str(system_description)`. A system described as "Rate citizens based on behavior for government rewards" classified as MINIMAL_RISK because no keywords matched. The new classifier uses structured domain mapping and correctly identifies this as UNACCEPTABLE (social scoring).

## Test plan

- 24 tests all passing: `pytest packages/agent-mesh/tests/governance/test_eu_ai_act.py -v`
- Covers: unacceptable risk, Annex I safety components, Annex III domains, capability escalation, Art. 6(3) exemptions, profiling override, limited/minimal risk, domain normalization, regression case