### PR TITLE
fix(ci): fix hypervisor e2e test + add daily scheduled CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
 
 permissions:
   contents: read
@@ -61,7 +63,7 @@ jobs:
   # ── Python lint + test (only when Python files change) ────────────────
   lint:
     needs: changes
-    if: needs.changes.outputs.python == 'true'
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -79,7 +81,7 @@ jobs:
   # ── Python test (only when Python files change) ───────────────────────
   test:
     needs: changes
-    if: needs.changes.outputs.python == 'true'
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -114,7 +116,7 @@ jobs:
   # ── PyPI package build (only when Python files change) ────────────────
   build-pypi:
     needs: changes
-    if: needs.changes.outputs.python == 'true'
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -137,7 +139,7 @@ jobs:
   # ── Python dependency safety (only when Python files change) ──────────
   security:
     needs: changes
-    if: needs.changes.outputs.python == 'true'
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -162,7 +164,7 @@ jobs:
   # ── .NET build + test (only when C# files change) ────────────────────
   test-dotnet:
     needs: changes
-    if: needs.changes.outputs.dotnet == 'true'
+    if: needs.changes.outputs.dotnet == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -185,7 +187,7 @@ jobs:
   # ── Integration tests (only when integration packages change) ────────
   test-integrations:
     needs: changes
-    if: needs.changes.outputs.integrations == 'true' || needs.changes.outputs.python == 'true'
+    if: needs.changes.outputs.integrations == 'true' || needs.changes.outputs.python == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -311,7 +313,7 @@ jobs:
   # ── Workflow security audit (only when workflows change) ─────────────
   workflow-security:
     needs: changes
-    if: needs.changes.outputs.workflows == 'true'
+    if: needs.changes.outputs.workflows == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -336,7 +338,7 @@ jobs:
   # ── TypeScript integration tests (only when TS files change) ─────────
   test-integrations-ts:
     needs: changes
-    if: needs.changes.outputs.typescript == 'true'
+    if: needs.changes.outputs.typescript == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -365,7 +367,7 @@ jobs:
   # ── npm package build + test (only when TS files change) ──────────────
   build-npm:
     needs: changes
-    if: needs.changes.outputs.typescript == 'true'
+    if: needs.changes.outputs.typescript == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -399,7 +401,7 @@ jobs:
   # ── Rust build + test (only when Rust files change) ──────────────────
   build-rust:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -414,7 +416,7 @@ jobs:
   # ── Go build + test (only when Go files change) ─────────────────────
   build-go:
     needs: changes
-    if: needs.changes.outputs.go == 'true'
+    if: needs.changes.outputs.go == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/packages/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
+++ b/packages/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
@@ -424,11 +424,13 @@ class TestAuditTrailIntegration:
                 [VFSChange(path=f"/doc{i}", operation="add", content_hash=f"h{i}")],
             )
 
-        assert session.delta_engine.verify_chain() is True
+        valid, error = session.delta_engine.verify_chain()
+        assert valid is True
 
-        # Tamper with a delta — Public Preview doesn't detect tampering
+        # Tamper with a delta — chain verification now detects tampering
         session.delta_engine._deltas[5].agent_did = "did:mesh:tampered"
-        assert session.delta_engine.verify_chain() is True
+        valid, error = session.delta_engine.verify_chain()
+        assert valid is False
 
     async def test_hash_chain_root_deterministic(self):
         """Same session with same deltas produces consistent audit log roots."""


### PR DESCRIPTION
1. Fix verify_chain() assertion in test_hypervisor_e2e.py for new tuple return + tamper detection
2. Add daily cron schedule (06:00 UTC) to CI workflow
3. All path-filtered jobs run unconditionally on schedule