### PR TITLE
Add docs for EUAIActRiskClassifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit Log Whitelisting** — implemented strict key-whitelisting in `agentmesh audit` JSON output to prevent accidental leakage of sensitive agent internal state.
 - **CLI Input Validation** — added regex-based validation for agent identifiers (DIDs/names) in registration and verification commands to prevent injection attacks.
 
+### Added
+- **EU AI Act Risk Classifier** (`agentmesh.governance.EUAIActRiskClassifier`) — structured risk classification per Article 6 and Annex III, with Art. 6(1) Annex I safety-component path, Art. 6(3) exemptions, GDPR Art. 4(4) profiling override, and configurable YAML categories for regulatory updates (#756).
+
 ### Documentation
+- Added `EUAIActRiskClassifier` usage example and API docs to `packages/agent-mesh/README.md`.
 - Updated `QUICKSTART.md` and `Tutorial 04 — Audit & Compliance` with secure JSON error handling examples and schema details.
 - Added "Secure Error Handling" sections to primary documentation to guide users on interpreting sanitized machine-readable outputs.
 

--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -504,6 +504,7 @@ agentmesh/
 ├── governance/         # Layer 3: Governance & Compliance
 │   ├── policy.py       # Declarative policy engine (YAML/JSON)
 │   ├── compliance.py   # Compliance mapping (EU AI Act, SOC2, HIPAA, GDPR)
+│   ├── eu_ai_act.py    # EU AI Act risk classifier (Art. 5/6, Annex I/III)
 │   ├── audit.py        # Audit logs
 │   └── shadow.py       # Legacy reference. Shadow mode has been moved to Agent SRE.
 │
@@ -537,7 +538,7 @@ agentmesh/
 
 AgentMesh automates compliance mapping for:
 
-- **EU AI Act** — Risk classification, transparency requirements
+- **EU AI Act** — Structured risk classification (Art. 5/6, Annex I/III, Art. 6(3) exemptions)
 - **SOC 2** — Security, availability, processing integrity
 - **HIPAA** — PHI handling, audit controls
 - **GDPR** — Data processing, consent, right to explanation
@@ -561,6 +562,37 @@ report = compliance.generate_report(
     period_start=datetime.utcnow() - timedelta(days=30),
     period_end=datetime.utcnow(),
 )
+```
+
+### EU AI Act Risk Classification
+
+```python
+from agentmesh.governance import EUAIActRiskClassifier, AgentRiskProfile
+
+classifier = EUAIActRiskClassifier()
+
+# Classify a credit-scoring system
+profile = AgentRiskProfile(
+    name="CreditBot",
+    domain="credit_scoring",
+    capabilities=["financial_decisioning"],
+)
+result = classifier.classify(profile)
+print(result.risk_level)   # RiskLevel.HIGH
+print(result.triggers)     # ["Domain 'credit_scoring' listed in Annex III (high-risk)"]
+
+# Art. 6(3) exemption for a narrow procedural task
+profile = AgentRiskProfile(
+    name="FormHelper",
+    domain="employment_recruitment",
+    exemption_tags=["narrow_procedural_task"],
+)
+result = classifier.classify(profile)
+print(result.risk_level)          # Not HIGH (exempted)
+print(result.exemptions_applied)  # ["narrow_procedural_task"]
+
+# Custom config for regulatory updates
+classifier = EUAIActRiskClassifier(config_path="my_updated_annex_iii.yaml")
 ```
 
 ## Threat Model

--- a/packages/agent-mesh/src/agentmesh/governance/eu_ai_act.py
+++ b/packages/agent-mesh/src/agentmesh/governance/eu_ai_act.py
@@ -129,7 +129,28 @@ class EUAIActRiskClassifier:
     # ---- public API ----
 
     def classify(self, profile: AgentRiskProfile) -> ClassificationResult:
-        """Classify the risk level for an agent profile."""
+        """Classify the risk level for an AI system per EU AI Act Article 6.
+
+        Evaluates the profile through the following cascade:
+
+        1. **Article 5** -- prohibited practices (returns UNACCEPTABLE)
+        2. **Article 6(1)** -- safety component under Annex I legislation (returns HIGH)
+        3. **Article 6(2)** -- Annex III domain match (returns HIGH, unless exempted)
+        4. **Article 6(3)** -- exemptions for narrow procedural tasks (may downgrade)
+           - Exemptions are voided when ``profile.involves_profiling`` is ``True``
+             (GDPR Art. 4(4) profiling override).
+        5. **Capability escalation** -- high-risk capabilities (returns HIGH)
+        6. **Article 50** -- transparency obligations (returns LIMITED)
+        7. **Default** -- returns MINIMAL
+
+        Args:
+            profile: An ``AgentRiskProfile`` describing the AI system.
+
+        Returns:
+            A ``ClassificationResult`` containing the risk level, a list of
+            triggers that explain the classification, any exemptions applied,
+            and whether a profiling override was activated.
+        """
         domain = _normalize(profile.domain)
         caps = {_normalize(c) for c in profile.capabilities}
         exemption_tags = {_normalize(t) for t in profile.exemption_tags}


### PR DESCRIPTION
Follow-up to #776 addressing the docs-sync-checker feedback.

- Added detailed docstring for `classify()` method with parameter/return docs
- Added usage examples to `packages/agent-mesh/README.md` (risk classification, exemptions, custom config)
- Added `[Unreleased]` CHANGELOG entry
- Updated file tree in README to include `eu_ai_act.py`