### PR TITLE
fix: export new modules from package __init__.py files

### DIFF
--- a/packages/agent-marketplace/src/agent_marketplace/__init__.py
+++ b/packages/agent-marketplace/src/agent_marketplace/__init__.py
@@ -51,6 +51,24 @@ from agent_marketplace.trust_tiers import (
     get_tier_config,
     get_trust_tier,
 )
+from agent_marketplace.quality_assessment import (
+    AssessmentDimension,
+    AssessmentGrade,
+    DimensionResult,
+    QualityAssessmentReport,
+    QualityAssessor,
+)
+from agent_marketplace.usage_trust import (
+    UsageSignals,
+    UsageTrustAdjustment,
+    UsageTrustScorer,
+)
+from agent_marketplace.workflow_bundle import (
+    BundleComponent,
+    BundleRegistry,
+    ComponentType,
+    WorkflowBundle,
+)
 
 __all__ = [
     "ClaudePluginManifest",
@@ -88,4 +106,19 @@ __all__ = [
     "load_marketplace_policy",
     "save_manifest",
     "verify_signature",
+    # Quality Assessment (v3.0.2+)
+    "AssessmentDimension",
+    "AssessmentGrade",
+    "DimensionResult",
+    "QualityAssessmentReport",
+    "QualityAssessor",
+    # Usage Trust (v3.0.2+)
+    "UsageSignals",
+    "UsageTrustAdjustment",
+    "UsageTrustScorer",
+    # Workflow Bundles (v3.0.2+)
+    "BundleComponent",
+    "BundleRegistry",
+    "ComponentType",
+    "WorkflowBundle",
 ]

--- a/packages/agent-os/src/agent_os/__init__.py
+++ b/packages/agent-os/src/agent_os/__init__.py
@@ -326,4 +326,50 @@ __all__ = [
     "ContextWindow",
     "ContextPriority",
     "BudgetExceeded",
+
+    # Content Governance
+    "ContentQualityEvaluator",
+    "ContentDimension",
+    "QualityGate",
+    "ContentQualityReport",
+
+    # Execution Context Policy
+    "ContextualPolicyEngine",
+    "ExecutionContext",
+    "EnforcementLevel",
+
+    # GitHub Enterprise Integration
+    "EnterpriseGovernanceManager",
+    "GovernanceTier",
+
+    # Shift-Left Metrics
+    "ShiftLeftTracker",
+    "ViolationStage",
 ]
+
+# ============================================================================
+# Content Governance (v3.0.2+)
+# ============================================================================
+
+from agent_os.content_governance import (
+    ContentDimension,
+    ContentQualityEvaluator,
+    ContentQualityReport,
+    QualityGate,
+)
+
+from agent_os.execution_context_policy import (
+    ContextualPolicyEngine,
+    EnforcementLevel,
+    ExecutionContext,
+)
+
+from agent_os.github_enterprise import (
+    EnterpriseGovernanceManager,
+    GovernanceTier,
+)
+
+from agent_os.shift_left_metrics import (
+    ShiftLeftTracker,
+    ViolationStage,
+)


### PR DESCRIPTION
Exports 6 new modules added in v3.0.2 from their package __init__.py files so they're importable via the public API. Also deleted 4 stale copilot/* branches.