### PR TITLE
fix: resolve mutually exclusive cryptography version in dev extras

### DIFF
--- a/packages/agent-os/pyproject.toml
+++ b/packages/agent-os/pyproject.toml
@@ -116,7 +116,7 @@ dev = [
     "aiohttp>=3.13.3,<4.0",
     "structlog>=24.1.0,<25.0",
     "redis>=4.0.0,<5.0",
-    "cryptography>=45.0.3,<46.0",
+    "cryptography>=46.0.5,<47.0",
     "eval_type_backport>=0.2.0; python_version < '3.10'",
 ]
 


### PR DESCRIPTION
The `dev` extras group declared `cryptography>=45.0.3,<46.0` while the `iatp` extras (which `dev` includes transitively via `full`) declared `cryptography>=46.0.5,<47.0`. These constraints are mutually exclusive — no version of cryptography satisfies both simultaneously.

When pip attempts to install `.[dev]` it cannot resolve the dependency tree, causing the install to fall back to a minimal install without `redis` and the other optional dependencies. This produces 3 test failures in test_stateless.py:

  - TestRedisConfig::test_get_client_creates_pool_with_config
  - TestRedisConfig::test_get_client_without_config_uses_from_url
  - TestRedisErrorHandling::test_unavailable_redis_via_get_client

All three fail with ModuleNotFoundError: No module named 'redis' because redis was never actually installed due to the dependency resolution failure.

Fix: align the cryptography pin in dev extras to match the iatp constraint (>=46.0.5,<47.0). The latest release is 46.0.6 which satisfies this range. All 2,861 tests pass after this change.

## Description
<!-- Briefly describe the changes in this PR -->

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
