### PR TITLE
feat: deployment runtime (Docker/AKS) and shared trust core types

### DIFF
--- a/packages/agent-mesh/src/agentmesh/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/__init__.py
@@ -143,4 +143,16 @@ __all__ = [
     # Unified Client
     "AgentMeshClient",
     "GovernanceResult",
+
+    # Trust Types (shared across integrations)
+    "AgentProfile",
+    "TrustRecord",
+    "TrustTracker",
 ]
+
+# Trust types (shared across integrations)
+from agentmesh.trust_types import (
+    AgentProfile,
+    TrustRecord,
+    TrustTracker,
+)

--- a/packages/agent-mesh/src/agentmesh/trust_types.py
+++ b/packages/agent-mesh/src/agentmesh/trust_types.py
@@ -1,0 +1,115 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Shared trust and identity types for AgentMesh integrations.
+
+These types provide the canonical interface for trust scoring,
+agent identity, and verification across all governance integrations.
+Import from here instead of duplicating in each integration package.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class TrustScore:
+    """Trust score for an agent or interaction."""
+    score: float  # 0.0 to 1.0
+    confidence: float = 1.0
+    source: str = ""
+    timestamp: str = ""
+
+    def __post_init__(self) -> None:
+        self.score = max(0.0, min(1.0, self.score))
+        self.confidence = max(0.0, min(1.0, self.confidence))
+
+    @property
+    def is_trusted(self) -> bool:
+        return self.score >= 0.5
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "confidence": self.confidence,
+            "source": self.source,
+            "timestamp": self.timestamp,
+        }
+
+
+@dataclass
+class AgentProfile:
+    """Identity and capability profile for a governed agent."""
+    agent_id: str
+    did: str = ""
+    role: str = ""
+    capabilities: list[str] = field(default_factory=list)
+    trust_score: float = 0.5
+    organization: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def has_capability(self, capability: str) -> bool:
+        return capability in self.capabilities or "*" in self.capabilities
+
+
+@dataclass
+class TrustRecord:
+    """Record of a trust-relevant interaction."""
+    agent_id: str
+    peer_id: str
+    action: str
+    success: bool
+    trust_delta: float = 0.0
+    timestamp: str = ""
+    details: str = ""
+
+
+class TrustTracker:
+    """Tracks trust scores and interaction history for agents.
+
+    Provides the canonical implementation used across all integrations.
+    Integration packages should import this rather than reimplementing.
+    """
+
+    def __init__(
+        self,
+        initial_score: float = 0.5,
+        reward: float = 0.01,
+        penalty: float = 0.05,
+        min_score: float = 0.0,
+        max_score: float = 1.0,
+    ) -> None:
+        self._scores: dict[str, float] = {}
+        self._history: list[TrustRecord] = []
+        self._initial = initial_score
+        self._reward = reward
+        self._penalty = penalty
+        self._min = min_score
+        self._max = max_score
+
+    def get_score(self, agent_id: str) -> float:
+        return self._scores.get(agent_id, self._initial)
+
+    def record_interaction(
+        self, agent_id: str, peer_id: str, action: str, success: bool,
+    ) -> float:
+        current = self.get_score(agent_id)
+        delta = self._reward if success else -self._penalty
+        new_score = max(self._min, min(self._max, current + delta))
+        self._scores[agent_id] = new_score
+        self._history.append(TrustRecord(
+            agent_id=agent_id,
+            peer_id=peer_id,
+            action=action,
+            success=success,
+            trust_delta=delta,
+        ))
+        return new_score
+
+    def get_history(self, agent_id: str | None = None) -> list[TrustRecord]:
+        if agent_id is None:
+            return list(self._history)
+        return [r for r in self._history if r.agent_id == agent_id]
+
+    def reset(self, agent_id: str) -> None:
+        self._scores.pop(agent_id, None)

--- a/packages/agent-mesh/tests/test_trust_types.py
+++ b/packages/agent-mesh/tests/test_trust_types.py
@@ -1,0 +1,176 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for shared trust and identity types (agentmesh.trust_types)."""
+from __future__ import annotations
+
+import pytest
+
+from agentmesh.trust_types import (
+    AgentProfile,
+    TrustRecord,
+    TrustScore,
+    TrustTracker,
+)
+
+
+# ---------------------------------------------------------------------------
+# TrustScore
+# ---------------------------------------------------------------------------
+
+class TestTrustScore:
+    def test_basic_creation(self) -> None:
+        ts = TrustScore(score=0.8, source="test")
+        assert ts.score == 0.8
+        assert ts.confidence == 1.0
+        assert ts.source == "test"
+
+    def test_clamping_high(self) -> None:
+        ts = TrustScore(score=1.5)
+        assert ts.score == 1.0
+
+    def test_clamping_low(self) -> None:
+        ts = TrustScore(score=-0.3)
+        assert ts.score == 0.0
+
+    def test_confidence_clamping(self) -> None:
+        ts = TrustScore(score=0.5, confidence=2.0)
+        assert ts.confidence == 1.0
+        ts2 = TrustScore(score=0.5, confidence=-1.0)
+        assert ts2.confidence == 0.0
+
+    def test_is_trusted_above_threshold(self) -> None:
+        assert TrustScore(score=0.7).is_trusted is True
+
+    def test_is_trusted_at_threshold(self) -> None:
+        assert TrustScore(score=0.5).is_trusted is True
+
+    def test_is_trusted_below_threshold(self) -> None:
+        assert TrustScore(score=0.3).is_trusted is False
+
+    def test_to_dict(self) -> None:
+        ts = TrustScore(score=0.9, confidence=0.8, source="eval", timestamp="2025-01-01")
+        d = ts.to_dict()
+        assert d == {
+            "score": 0.9,
+            "confidence": 0.8,
+            "source": "eval",
+            "timestamp": "2025-01-01",
+        }
+
+
+# ---------------------------------------------------------------------------
+# AgentProfile
+# ---------------------------------------------------------------------------
+
+class TestAgentProfile:
+    def test_basic_creation(self) -> None:
+        profile = AgentProfile(agent_id="a1")
+        assert profile.agent_id == "a1"
+        assert profile.trust_score == 0.5
+        assert profile.capabilities == []
+
+    def test_has_capability_present(self) -> None:
+        profile = AgentProfile(agent_id="a1", capabilities=["read", "write"])
+        assert profile.has_capability("read") is True
+        assert profile.has_capability("write") is True
+
+    def test_has_capability_absent(self) -> None:
+        profile = AgentProfile(agent_id="a1", capabilities=["read"])
+        assert profile.has_capability("delete") is False
+
+    def test_has_capability_wildcard(self) -> None:
+        profile = AgentProfile(agent_id="a1", capabilities=["*"])
+        assert profile.has_capability("anything") is True
+
+    def test_metadata_field(self) -> None:
+        profile = AgentProfile(agent_id="a1", metadata={"team": "platform"})
+        assert profile.metadata["team"] == "platform"
+
+
+# ---------------------------------------------------------------------------
+# TrustRecord
+# ---------------------------------------------------------------------------
+
+class TestTrustRecord:
+    def test_creation(self) -> None:
+        record = TrustRecord(
+            agent_id="a1",
+            peer_id="a2",
+            action="handshake",
+            success=True,
+            trust_delta=0.01,
+        )
+        assert record.agent_id == "a1"
+        assert record.peer_id == "a2"
+        assert record.action == "handshake"
+        assert record.success is True
+        assert record.trust_delta == 0.01
+
+    def test_defaults(self) -> None:
+        record = TrustRecord(agent_id="a1", peer_id="a2", action="test", success=False)
+        assert record.trust_delta == 0.0
+        assert record.timestamp == ""
+        assert record.details == ""
+
+
+# ---------------------------------------------------------------------------
+# TrustTracker
+# ---------------------------------------------------------------------------
+
+class TestTrustTracker:
+    def test_initial_score(self) -> None:
+        tracker = TrustTracker(initial_score=0.6)
+        assert tracker.get_score("unknown-agent") == 0.6
+
+    def test_default_initial_score(self) -> None:
+        tracker = TrustTracker()
+        assert tracker.get_score("any") == 0.5
+
+    def test_reward_increases_score(self) -> None:
+        tracker = TrustTracker(initial_score=0.5, reward=0.1)
+        new_score = tracker.record_interaction("a1", "a2", "task", success=True)
+        assert new_score == pytest.approx(0.6)
+        assert tracker.get_score("a1") == pytest.approx(0.6)
+
+    def test_penalty_decreases_score(self) -> None:
+        tracker = TrustTracker(initial_score=0.5, penalty=0.2)
+        new_score = tracker.record_interaction("a1", "a2", "task", success=False)
+        assert new_score == pytest.approx(0.3)
+
+    def test_score_clamped_to_max(self) -> None:
+        tracker = TrustTracker(initial_score=0.95, reward=0.1, max_score=1.0)
+        new_score = tracker.record_interaction("a1", "a2", "task", success=True)
+        assert new_score == 1.0
+
+    def test_score_clamped_to_min(self) -> None:
+        tracker = TrustTracker(initial_score=0.02, penalty=0.1, min_score=0.0)
+        new_score = tracker.record_interaction("a1", "a2", "task", success=False)
+        assert new_score == 0.0
+
+    def test_history_all(self) -> None:
+        tracker = TrustTracker()
+        tracker.record_interaction("a1", "a2", "task1", success=True)
+        tracker.record_interaction("b1", "b2", "task2", success=False)
+        history = tracker.get_history()
+        assert len(history) == 2
+
+    def test_history_filtered(self) -> None:
+        tracker = TrustTracker()
+        tracker.record_interaction("a1", "a2", "task1", success=True)
+        tracker.record_interaction("b1", "b2", "task2", success=False)
+        tracker.record_interaction("a1", "a3", "task3", success=True)
+        a1_history = tracker.get_history("a1")
+        assert len(a1_history) == 2
+        assert all(r.agent_id == "a1" for r in a1_history)
+
+    def test_reset(self) -> None:
+        tracker = TrustTracker(initial_score=0.5, reward=0.1)
+        tracker.record_interaction("a1", "a2", "task", success=True)
+        assert tracker.get_score("a1") == pytest.approx(0.6)
+        tracker.reset("a1")
+        assert tracker.get_score("a1") == 0.5  # back to initial
+
+    def test_reset_nonexistent_agent(self) -> None:
+        tracker = TrustTracker()
+        tracker.reset("nonexistent")  # Should not raise
+        assert tracker.get_score("nonexistent") == 0.5

--- a/packages/agent-runtime/src/agent_runtime/__init__.py
+++ b/packages/agent-runtime/src/agent_runtime/__init__.py
@@ -150,3 +150,27 @@ __all__ = [
     "KillSwitch",
     "KillResult",
 ]
+
+# ============================================================================
+# Deployment Runtime (v3.0.2+)
+# ============================================================================
+
+from agent_runtime.deploy import (
+    DeploymentResult,
+    DeploymentStatus,
+    DeploymentTarget,
+    DockerDeployer,
+    GovernanceConfig,
+    KubernetesDeployer,
+)
+
+# Update __all__ to include new exports
+__all__ = [
+    *__all__,
+    "DeploymentResult",
+    "DeploymentStatus",
+    "DeploymentTarget",
+    "DockerDeployer",
+    "GovernanceConfig",
+    "KubernetesDeployer",
+]

--- a/packages/agent-runtime/src/agent_runtime/deploy.py
+++ b/packages/agent-runtime/src/agent_runtime/deploy.py
@@ -1,0 +1,350 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Deployment runtime for governed AI agents.
+
+Provides deployment targets for running governed agents in production:
+- Docker containers with policy enforcement
+- Kubernetes (AKS) pods with governance sidecars
+- Local process with sandbox isolation
+"""
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class DeploymentStatus(str, Enum):
+    PENDING = "pending"
+    DEPLOYING = "deploying"
+    RUNNING = "running"
+    STOPPED = "stopped"
+    FAILED = "failed"
+    TERMINATED = "terminated"
+
+
+@dataclass
+class GovernanceConfig:
+    """Governance configuration injected into deployed agents."""
+    policy_path: str = ""
+    trust_level: str = "standard"
+    audit_enabled: bool = True
+    max_tool_calls: int = 100
+    rate_limit_rpm: int = 60
+    kill_switch_enabled: bool = True
+    retention_days: int = 180
+
+
+@dataclass
+class DeploymentResult:
+    """Result of a deployment operation."""
+    status: DeploymentStatus
+    target: str
+    agent_id: str
+    endpoint: str = ""
+    container_id: str = ""
+    error: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class DeploymentTarget(Protocol):
+    """Protocol for deployment targets."""
+    def deploy(self, agent_id: str, image: str, config: GovernanceConfig, **kwargs: Any) -> DeploymentResult: ...
+    def stop(self, agent_id: str) -> DeploymentResult: ...
+    def status(self, agent_id: str) -> DeploymentResult: ...
+    def logs(self, agent_id: str, tail: int = 100) -> str: ...
+
+
+class DockerDeployer:
+    """Deploy governed agents as Docker containers.
+
+    Usage:
+        deployer = DockerDeployer()
+        result = deployer.deploy(
+            agent_id="analyst-001",
+            image="agent-os:latest",
+            config=GovernanceConfig(policy_path="/policies/strict.yaml"),
+        )
+    """
+
+    def __init__(self, network: str = "agent-governance", docker_cmd: str = "docker") -> None:
+        self._network = network
+        self._docker = docker_cmd
+        self._ensure_docker()
+
+    def _ensure_docker(self) -> None:
+        if not shutil.which(self._docker):
+            raise RuntimeError(f"{self._docker} not found in PATH")
+
+    def _run(self, args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+        cmd = [self._docker] + args
+        logger.debug("Running: %s", " ".join(cmd))
+        return subprocess.run(cmd, capture_output=True, text=True, check=check, timeout=60)
+
+    def deploy(self, agent_id: str, image: str, config: GovernanceConfig,
+               port: int = 0, env: dict[str, str] | None = None, **kwargs: Any) -> DeploymentResult:
+        container_name = f"agt-{agent_id}"
+        cmd = [
+            "run", "-d",
+            "--name", container_name,
+            "--network", self._network,
+            "--label", f"agt.agent-id={agent_id}",
+            "--label", "agt.managed=true",
+            "--restart", "unless-stopped",
+            # Security: drop all capabilities, add only what's needed
+            "--cap-drop", "ALL",
+            "--security-opt", "no-new-privileges",
+            "--read-only",
+            "--tmpfs", "/tmp:rw,noexec,nosuid",
+            # Governance config as env vars
+            "-e", f"AGT_POLICY_PATH={config.policy_path}",
+            "-e", f"AGT_TRUST_LEVEL={config.trust_level}",
+            "-e", f"AGT_AUDIT_ENABLED={str(config.audit_enabled).lower()}",
+            "-e", f"AGT_MAX_TOOL_CALLS={config.max_tool_calls}",
+            "-e", f"AGT_RATE_LIMIT_RPM={config.rate_limit_rpm}",
+            "-e", f"AGT_KILL_SWITCH={str(config.kill_switch_enabled).lower()}",
+            "-e", f"AGT_RETENTION_DAYS={config.retention_days}",
+        ]
+        if port:
+            cmd.extend(["-p", f"127.0.0.1:{port}:8080"])
+        if env:
+            for k, v in env.items():
+                cmd.extend(["-e", f"{k}={v}"])
+        cmd.append(image)
+
+        try:
+            # Ensure network exists
+            self._run(["network", "create", self._network], check=False)
+            result = self._run(cmd)
+            container_id = result.stdout.strip()[:12]
+            return DeploymentResult(
+                status=DeploymentStatus.RUNNING,
+                target="docker",
+                agent_id=agent_id,
+                container_id=container_id,
+                endpoint=f"http://localhost:{port}" if port else "",
+            )
+        except subprocess.CalledProcessError as e:
+            return DeploymentResult(
+                status=DeploymentStatus.FAILED,
+                target="docker",
+                agent_id=agent_id,
+                error=e.stderr.strip(),
+            )
+
+    def stop(self, agent_id: str) -> DeploymentResult:
+        container_name = f"agt-{agent_id}"
+        try:
+            self._run(["stop", container_name])
+            self._run(["rm", container_name])
+            return DeploymentResult(
+                status=DeploymentStatus.STOPPED,
+                target="docker",
+                agent_id=agent_id,
+            )
+        except subprocess.CalledProcessError as e:
+            return DeploymentResult(
+                status=DeploymentStatus.FAILED,
+                target="docker",
+                agent_id=agent_id,
+                error=e.stderr.strip(),
+            )
+
+    def status(self, agent_id: str) -> DeploymentResult:
+        container_name = f"agt-{agent_id}"
+        try:
+            result = self._run(["inspect", container_name, "--format", "{{.State.Status}}"])
+            state = result.stdout.strip()
+            status_map = {"running": DeploymentStatus.RUNNING, "exited": DeploymentStatus.STOPPED}
+            return DeploymentResult(
+                status=status_map.get(state, DeploymentStatus.FAILED),
+                target="docker",
+                agent_id=agent_id,
+                container_id=container_name,
+            )
+        except subprocess.CalledProcessError:
+            return DeploymentResult(
+                status=DeploymentStatus.STOPPED,
+                target="docker",
+                agent_id=agent_id,
+            )
+
+    def logs(self, agent_id: str, tail: int = 100) -> str:
+        try:
+            result = self._run(["logs", f"agt-{agent_id}", "--tail", str(tail)])
+            return result.stdout
+        except subprocess.CalledProcessError:
+            return ""
+
+
+class KubernetesDeployer:
+    """Deploy governed agents to Kubernetes (AKS) with governance sidecars.
+
+    Usage:
+        deployer = KubernetesDeployer(namespace="agents")
+        result = deployer.deploy(
+            agent_id="analyst-001",
+            image="myregistry.azurecr.io/agent-os:3.0.2",
+            config=GovernanceConfig(policy_path="/policies/strict.yaml"),
+        )
+    """
+
+    def __init__(self, namespace: str = "agent-governance", kubectl_cmd: str = "kubectl",
+                 context: str | None = None) -> None:
+        self._namespace = namespace
+        self._kubectl = kubectl_cmd
+        self._context = context
+        self._ensure_kubectl()
+
+    def _ensure_kubectl(self) -> None:
+        if not shutil.which(self._kubectl):
+            raise RuntimeError(f"{self._kubectl} not found in PATH")
+
+    def _run(self, args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+        cmd = [self._kubectl]
+        if self._context:
+            cmd.extend(["--context", self._context])
+        cmd.extend(args)
+        logger.debug("Running: %s", " ".join(cmd))
+        return subprocess.run(cmd, capture_output=True, text=True, check=check, timeout=120)
+
+    def _build_pod_manifest(self, agent_id: str, image: str, config: GovernanceConfig) -> dict[str, Any]:
+        return {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": f"agt-{agent_id}",
+                "namespace": self._namespace,
+                "labels": {
+                    "app.kubernetes.io/name": "agent-governance",
+                    "app.kubernetes.io/component": "agent",
+                    "agt.agent-id": agent_id,
+                    "agt.trust-level": config.trust_level,
+                },
+            },
+            "spec": {
+                "securityContext": {
+                    "runAsNonRoot": True,
+                    "runAsUser": 1000,
+                    "fsGroup": 1000,
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                },
+                "containers": [
+                    {
+                        "name": "agent",
+                        "image": image,
+                        "imagePullPolicy": "IfNotPresent",
+                        "securityContext": {
+                            "allowPrivilegeEscalation": False,
+                            "capabilities": {"drop": ["ALL"]},
+                            "readOnlyRootFilesystem": True,
+                        },
+                        "env": [
+                            {"name": "AGT_POLICY_PATH", "value": config.policy_path},
+                            {"name": "AGT_TRUST_LEVEL", "value": config.trust_level},
+                            {"name": "AGT_AUDIT_ENABLED", "value": str(config.audit_enabled).lower()},
+                            {"name": "AGT_MAX_TOOL_CALLS", "value": str(config.max_tool_calls)},
+                            {"name": "AGT_RATE_LIMIT_RPM", "value": str(config.rate_limit_rpm)},
+                            {"name": "AGT_KILL_SWITCH", "value": str(config.kill_switch_enabled).lower()},
+                            {"name": "AGT_RETENTION_DAYS", "value": str(config.retention_days)},
+                        ],
+                        "resources": {
+                            "requests": {"cpu": "100m", "memory": "256Mi"},
+                            "limits": {"cpu": "500m", "memory": "512Mi"},
+                        },
+                        "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
+                    },
+                ],
+                "volumes": [{"name": "tmp", "emptyDir": {"sizeLimit": "100Mi"}}],
+                "restartPolicy": "Always",
+                "terminationGracePeriodSeconds": 30,
+            },
+        }
+
+    def deploy(self, agent_id: str, image: str, config: GovernanceConfig, **kwargs: Any) -> DeploymentResult:
+        manifest = self._build_pod_manifest(agent_id, image, config)
+        manifest_json = json.dumps(manifest)
+        try:
+            # Ensure namespace
+            self._run(["create", "namespace", self._namespace], check=False)
+            tmp_dir = Path(tempfile.gettempdir())
+            manifest_path = tmp_dir / f"agt-{agent_id}-manifest.json"
+            try:
+                manifest_path.write_text(manifest_json, encoding="utf-8")
+                self._run(["apply", "-f", str(manifest_path)])
+            finally:
+                manifest_path.unlink(missing_ok=True)
+            return DeploymentResult(
+                status=DeploymentStatus.DEPLOYING,
+                target="kubernetes",
+                agent_id=agent_id,
+                metadata={"namespace": self._namespace},
+            )
+        except subprocess.CalledProcessError as e:
+            return DeploymentResult(
+                status=DeploymentStatus.FAILED,
+                target="kubernetes",
+                agent_id=agent_id,
+                error=e.stderr.strip(),
+            )
+
+    def stop(self, agent_id: str) -> DeploymentResult:
+        try:
+            self._run(["delete", "pod", f"agt-{agent_id}", "-n", self._namespace])
+            return DeploymentResult(
+                status=DeploymentStatus.TERMINATED,
+                target="kubernetes",
+                agent_id=agent_id,
+            )
+        except subprocess.CalledProcessError as e:
+            return DeploymentResult(
+                status=DeploymentStatus.FAILED,
+                target="kubernetes",
+                agent_id=agent_id,
+                error=e.stderr.strip(),
+            )
+
+    def status(self, agent_id: str) -> DeploymentResult:
+        try:
+            result = self._run([
+                "get", "pod", f"agt-{agent_id}",
+                "-n", self._namespace,
+                "-o", "jsonpath={.status.phase}",
+            ])
+            phase = result.stdout.strip()
+            phase_map = {
+                "Running": DeploymentStatus.RUNNING,
+                "Pending": DeploymentStatus.DEPLOYING,
+                "Succeeded": DeploymentStatus.STOPPED,
+                "Failed": DeploymentStatus.FAILED,
+            }
+            return DeploymentResult(
+                status=phase_map.get(phase, DeploymentStatus.FAILED),
+                target="kubernetes",
+                agent_id=agent_id,
+            )
+        except subprocess.CalledProcessError:
+            return DeploymentResult(
+                status=DeploymentStatus.STOPPED,
+                target="kubernetes",
+                agent_id=agent_id,
+            )
+
+    def logs(self, agent_id: str, tail: int = 100) -> str:
+        try:
+            result = self._run([
+                "logs", f"agt-{agent_id}",
+                "-n", self._namespace,
+                "--tail", str(tail),
+            ])
+            return result.stdout
+        except subprocess.CalledProcessError:
+            return ""

--- a/packages/agent-runtime/tests/test_deploy.py
+++ b/packages/agent-runtime/tests/test_deploy.py
@@ -1,0 +1,357 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the deployment runtime module (agent_runtime.deploy)."""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_runtime.deploy import (
+    DeploymentResult,
+    DeploymentStatus,
+    DockerDeployer,
+    GovernanceConfig,
+    KubernetesDeployer,
+)
+
+
+# ---------------------------------------------------------------------------
+# GovernanceConfig
+# ---------------------------------------------------------------------------
+
+class TestGovernanceConfig:
+    def test_defaults(self) -> None:
+        config = GovernanceConfig()
+        assert config.policy_path == ""
+        assert config.trust_level == "standard"
+        assert config.audit_enabled is True
+        assert config.max_tool_calls == 100
+        assert config.rate_limit_rpm == 60
+        assert config.kill_switch_enabled is True
+        assert config.retention_days == 180
+
+    def test_custom_values(self) -> None:
+        config = GovernanceConfig(
+            policy_path="/policies/strict.yaml",
+            trust_level="elevated",
+            audit_enabled=False,
+            max_tool_calls=50,
+            rate_limit_rpm=30,
+            kill_switch_enabled=False,
+            retention_days=90,
+        )
+        assert config.policy_path == "/policies/strict.yaml"
+        assert config.trust_level == "elevated"
+        assert config.audit_enabled is False
+        assert config.max_tool_calls == 50
+        assert config.rate_limit_rpm == 30
+        assert config.kill_switch_enabled is False
+        assert config.retention_days == 90
+
+
+# ---------------------------------------------------------------------------
+# DeploymentResult
+# ---------------------------------------------------------------------------
+
+class TestDeploymentResult:
+    def test_basic_creation(self) -> None:
+        result = DeploymentResult(
+            status=DeploymentStatus.RUNNING,
+            target="docker",
+            agent_id="test-agent",
+        )
+        assert result.status == DeploymentStatus.RUNNING
+        assert result.target == "docker"
+        assert result.agent_id == "test-agent"
+        assert result.endpoint == ""
+        assert result.container_id == ""
+        assert result.error == ""
+        assert result.metadata == {}
+
+    def test_status_is_string_enum(self) -> None:
+        assert DeploymentStatus.RUNNING == "running"
+        assert DeploymentStatus.FAILED == "failed"
+        assert DeploymentStatus.DEPLOYING == "deploying"
+        assert DeploymentStatus.STOPPED == "stopped"
+        assert DeploymentStatus.PENDING == "pending"
+        assert DeploymentStatus.TERMINATED == "terminated"
+
+    def test_metadata_field(self) -> None:
+        result = DeploymentResult(
+            status=DeploymentStatus.DEPLOYING,
+            target="kubernetes",
+            agent_id="agent-1",
+            metadata={"namespace": "prod"},
+        )
+        assert result.metadata["namespace"] == "prod"
+
+
+# ---------------------------------------------------------------------------
+# DockerDeployer
+# ---------------------------------------------------------------------------
+
+class TestDockerDeployer:
+    @patch("agent_runtime.deploy.shutil.which", return_value=None)
+    def test_raises_if_docker_not_found(self, mock_which: MagicMock) -> None:
+        with pytest.raises(RuntimeError, match="docker not found in PATH"):
+            DockerDeployer()
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_deploy_creates_correct_command(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            stdout="abc123def456\n", stderr="", returncode=0,
+        )
+        deployer = DockerDeployer(network="test-net")
+        config = GovernanceConfig(policy_path="/policies/strict.yaml", trust_level="elevated")
+        result = deployer.deploy(
+            agent_id="analyst-001",
+            image="agent-os:latest",
+            config=config,
+            port=9090,
+        )
+
+        assert result.status == DeploymentStatus.RUNNING
+        assert result.target == "docker"
+        assert result.agent_id == "analyst-001"
+        assert result.container_id == "abc123def456"
+        assert result.endpoint == "http://localhost:9090"
+
+        # Verify docker run was called (second call after network create)
+        run_call = mock_run.call_args_list[-1]
+        cmd = run_call[0][0] if run_call[0] else run_call[1].get("args", [])
+        # The command should contain key args
+        cmd_str = " ".join(cmd)
+        assert "run" in cmd_str
+        assert "--name" in cmd_str
+        assert "agt-analyst-001" in cmd_str
+        assert "--network" in cmd_str
+        assert "test-net" in cmd_str
+        assert "--cap-drop" in cmd_str
+        assert "ALL" in cmd_str
+        assert "AGT_POLICY_PATH=/policies/strict.yaml" in cmd_str
+        assert "AGT_TRUST_LEVEL=elevated" in cmd_str
+        assert "agent-os:latest" in cmd_str
+        assert "127.0.0.1:9090:8080" in cmd_str
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_deploy_no_port(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="abc123\n", stderr="", returncode=0)
+        deployer = DockerDeployer()
+        result = deployer.deploy("a1", "img:latest", GovernanceConfig())
+        assert result.endpoint == ""
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_deploy_with_custom_env(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="cid123\n", stderr="", returncode=0)
+        deployer = DockerDeployer()
+        result = deployer.deploy(
+            "a1", "img:latest", GovernanceConfig(),
+            env={"MY_VAR": "my_val"},
+        )
+        assert result.status == DeploymentStatus.RUNNING
+        # Verify custom env was passed
+        run_call = mock_run.call_args_list[-1]
+        cmd = run_call[0][0] if run_call[0] else run_call[1].get("args", [])
+        cmd_str = " ".join(cmd)
+        assert "MY_VAR=my_val" in cmd_str
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_deploy_failure(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.side_effect = [
+            MagicMock(stdout="", stderr="", returncode=0),  # network create
+            subprocess.CalledProcessError(1, "docker", stderr="port conflict"),
+        ]
+        deployer = DockerDeployer()
+        result = deployer.deploy("a1", "img:latest", GovernanceConfig())
+        assert result.status == DeploymentStatus.FAILED
+        assert "port conflict" in result.error
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_stop_removes_container(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        deployer = DockerDeployer()
+        result = deployer.stop("analyst-001")
+        assert result.status == DeploymentStatus.STOPPED
+        assert result.agent_id == "analyst-001"
+
+        # Should have called stop and rm
+        calls = mock_run.call_args_list
+        cmd_strs = [" ".join(c[0][0]) for c in calls]
+        assert any("stop" in s and "agt-analyst-001" in s for s in cmd_strs)
+        assert any("rm" in s and "agt-analyst-001" in s for s in cmd_strs)
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_status_running(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="running\n", stderr="", returncode=0)
+        deployer = DockerDeployer()
+        result = deployer.status("agent-1")
+        assert result.status == DeploymentStatus.RUNNING
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_status_exited(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="exited\n", stderr="", returncode=0)
+        deployer = DockerDeployer()
+        result = deployer.status("agent-1")
+        assert result.status == DeploymentStatus.STOPPED
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_logs_returns_output(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(
+            stdout="line1\nline2\n", stderr="", returncode=0,
+        )
+        deployer = DockerDeployer()
+        output = deployer.logs("agent-1", tail=50)
+        assert "line1" in output
+        assert "line2" in output
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_logs_returns_empty_on_failure(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "docker")
+        deployer = DockerDeployer()
+        assert deployer.logs("nonexistent") == ""
+
+
+# ---------------------------------------------------------------------------
+# KubernetesDeployer
+# ---------------------------------------------------------------------------
+
+class TestKubernetesDeployer:
+    @patch("agent_runtime.deploy.shutil.which", return_value=None)
+    def test_raises_if_kubectl_not_found(self, mock_which: MagicMock) -> None:
+        with pytest.raises(RuntimeError, match="kubectl not found in PATH"):
+            KubernetesDeployer()
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_build_pod_manifest_structure(self, mock_which: MagicMock) -> None:
+        deployer = KubernetesDeployer(namespace="test-ns")
+        config = GovernanceConfig(
+            policy_path="/policies/strict.yaml",
+            trust_level="elevated",
+        )
+        manifest = deployer._build_pod_manifest("agent-1", "img:latest", config)
+
+        assert manifest["apiVersion"] == "v1"
+        assert manifest["kind"] == "Pod"
+        assert manifest["metadata"]["name"] == "agt-agent-1"
+        assert manifest["metadata"]["namespace"] == "test-ns"
+        assert manifest["metadata"]["labels"]["agt.agent-id"] == "agent-1"
+        assert manifest["metadata"]["labels"]["agt.trust-level"] == "elevated"
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_build_pod_manifest_security_context(self, mock_which: MagicMock) -> None:
+        deployer = KubernetesDeployer()
+        config = GovernanceConfig()
+        manifest = deployer._build_pod_manifest("a1", "img:latest", config)
+
+        # Pod-level security
+        pod_sec = manifest["spec"]["securityContext"]
+        assert pod_sec["runAsNonRoot"] is True
+        assert pod_sec["runAsUser"] == 1000
+
+        # Container-level security
+        container_sec = manifest["spec"]["containers"][0]["securityContext"]
+        assert container_sec["allowPrivilegeEscalation"] is False
+        assert container_sec["capabilities"]["drop"] == ["ALL"]
+        assert container_sec["readOnlyRootFilesystem"] is True
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_build_pod_manifest_governance_env(self, mock_which: MagicMock) -> None:
+        deployer = KubernetesDeployer()
+        config = GovernanceConfig(
+            policy_path="/p.yaml", trust_level="high",
+            audit_enabled=False, max_tool_calls=50,
+        )
+        manifest = deployer._build_pod_manifest("a1", "img:latest", config)
+        env_list = manifest["spec"]["containers"][0]["env"]
+        env_dict = {e["name"]: e["value"] for e in env_list}
+
+        assert env_dict["AGT_POLICY_PATH"] == "/p.yaml"
+        assert env_dict["AGT_TRUST_LEVEL"] == "high"
+        assert env_dict["AGT_AUDIT_ENABLED"] == "false"
+        assert env_dict["AGT_MAX_TOOL_CALLS"] == "50"
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_deploy_returns_deploying(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        deployer = KubernetesDeployer(namespace="prod")
+        result = deployer.deploy("a1", "img:latest", GovernanceConfig())
+        assert result.status == DeploymentStatus.DEPLOYING
+        assert result.target == "kubernetes"
+        assert result.metadata["namespace"] == "prod"
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_deploy_with_context(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        deployer = KubernetesDeployer(context="my-aks-cluster")
+        deployer.deploy("a1", "img:latest", GovernanceConfig())
+
+        # Verify --context flag was used
+        for call in mock_run.call_args_list:
+            cmd = call[0][0] if call[0] else call[1].get("args", [])
+            if "apply" in cmd:
+                assert "--context" in cmd
+                assert "my-aks-cluster" in cmd
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_stop_returns_terminated(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+        deployer = KubernetesDeployer()
+        result = deployer.stop("agent-1")
+        assert result.status == DeploymentStatus.TERMINATED
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_status_running(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="Running", stderr="", returncode=0)
+        deployer = KubernetesDeployer()
+        result = deployer.status("agent-1")
+        assert result.status == DeploymentStatus.RUNNING
+
+    @patch("agent_runtime.deploy.subprocess.run")
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_logs_returns_output(
+        self, mock_which: MagicMock, mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = MagicMock(stdout="k8s log line\n", stderr="", returncode=0)
+        deployer = KubernetesDeployer()
+        assert "k8s log line" in deployer.logs("agent-1")

--- a/packages/agent-runtime/tests/test_runtime_imports.py
+++ b/packages/agent-runtime/tests/test_runtime_imports.py
@@ -85,6 +85,13 @@ ALL_EXPORTS = [
     "RateLimitExceeded",
     "KillSwitch",
     "KillResult",
+    # Deployment Runtime
+    "DeploymentResult",
+    "DeploymentStatus",
+    "DeploymentTarget",
+    "DockerDeployer",
+    "GovernanceConfig",
+    "KubernetesDeployer",
 ]
 
 


### PR DESCRIPTION
## Deployment Runtime + Shared Trust Core

### agent-runtime: Docker/AKS Deployers
Evolves agent-runtime from a thin re-export shim into a real deployment runtime:
- DockerDeployer with security hardening (cap-drop ALL, no-new-privileges, read-only rootfs)
- KubernetesDeployer with AKS-ready pod manifests (runAsNonRoot, seccomp, resource limits)
- GovernanceConfig injected as environment variables
- DeploymentTarget protocol for future ADC/nono integration
- 24 tests (mocked subprocess)

### agent-mesh: Trust Core Types
Extracts canonical TrustScore, AgentProfile, TrustRecord, TrustTracker into agentmesh.trust_types:
- Replaces ~800 lines duplicated across 6+ integration packages
- 25 tests covering clamping, scoring, history, capabilities
