### PR TITLE
community: add Policy-as-Code vs Prompt Engineering blog post to COMMUNITY.md

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -13,6 +13,7 @@ Community-written content about agent governance, security, and the toolkit.
 | Title | Author | Platform |
 |-------|--------|----------|
 | [Why AI Agent Governance Matters in 2026](https://dev.to/kanishtyagii/why-ai-agent-governance-matters-in-2026-4mnk) | [@kanish5](https://github.com/kanish5) | Dev.to |
+| [Policy-as-Code vs Prompt Engineering — When Guardrails Need Governance](https://dev.to/kanishtyagii/policy-as-code-vs-prompt-engineering-when-guardrails-need-governance-23pi) | [@kanish5](https://github.com/kanish5) | Dev.to |
 
 ---
 


### PR DESCRIPTION
Closes #716

## Summary
Published a blog post on Dev.to contrasting prompt-level guardrails 
with policy-as-code governance.

## Blog post
**Title:** Policy-as-Code vs Prompt Engineering — When Guardrails Need Governance
**URL:** https://dev.to/kanishtyagii/policy-as-code-vs-prompt-engineering-when-guardrails-need-governance-23pi
**Platform:** Dev.to

## Topics covered
- Why prompt engineering guardrails are fragile (jailbreaks, context limits, model dependency)
- How policy-as-code enforces rules at the infrastructure layer
- Real example: PII in memory writes caught by code, not prompts
- The layered model: policies for hard constraints, prompts for guidance
- Getting started with agent-governance-toolkit

## Change
Added second entry to the "Blog Posts & Articles" section in COMMUNITY.md