### PR TITLE
docs(typescript): add MCP security documentation and examples

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -111,6 +111,7 @@ See the full list of Microsoft-controlled scopes: `@microsoft`, `@azure`,
 | AgentMesh Copilot Governance | `@microsoft/agentmesh-copilot-governance` | `packages/agentmesh-integrations/copilot-governance` |
 | AgentMesh Mastra | `@microsoft/agentmesh-mastra` | `packages/agentmesh-integrations/mastra-agentmesh` |
 | AgentMesh API | `@microsoft/agentmesh-api` | `packages/agent-mesh/services/api` |
+| AgentMesh MCP Governance | `@microsoft/agentmesh-mcp-governance` | `packages/agent-mesh/packages/mcp-governance` |
 | AgentMesh MCP Proxy | `@microsoft/agentmesh-mcp-proxy` | `packages/agent-mesh/packages/mcp-proxy` |
 | AgentMesh SDK | `@microsoft/agentmesh-sdk` | `packages/agent-mesh/sdks/typescript` |
 | Agent OS Copilot Extension | `@microsoft/agent-os-copilot-extension` | `packages/agent-os/extensions/copilot` |

--- a/packages/agent-mesh/sdks/typescript/README.md
+++ b/packages/agent-mesh/sdks/typescript/README.md
@@ -11,13 +11,19 @@ Provides agent identity (Ed25519 DIDs), trust scoring, policy evaluation, hash-c
 ## Installation
 
 ```bash
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
+```
+
+For MCP-only workloads, install the standalone governance package instead:
+
+```bash
+npm install @microsoft/agentmesh-mcp-governance
 ```
 
 ## Quick Start
 
 ```typescript
-import { AgentMeshClient } from '@agentmesh/sdk';
+import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
 
 const client = AgentMeshClient.create('my-agent', {
   capabilities: ['data.read', 'data.write'],
@@ -44,7 +50,7 @@ console.log(client.audit.verify()); // true
 Manage agent identities built on Ed25519 key pairs.
 
 ```typescript
-import { AgentIdentity } from '@agentmesh/sdk';
+import { AgentIdentity } from '@microsoft/agentmesh-sdk';
 
 const identity = AgentIdentity.generate('agent-1', ['read']);
 const signature = identity.sign(new TextEncoder().encode('hello'));
@@ -60,7 +66,7 @@ const restored = AgentIdentity.fromJSON(json);
 Track and score trust for peer agents.
 
 ```typescript
-import { TrustManager } from '@agentmesh/sdk';
+import { TrustManager } from '@microsoft/agentmesh-sdk';
 
 const tm = new TrustManager({ initialScore: 0.5, decayFactor: 0.95 });
 
@@ -76,7 +82,7 @@ const score = tm.getTrustScore('peer-1');
 Rule-based policy evaluation with conditions and YAML support.
 
 ```typescript
-import { PolicyEngine } from '@agentmesh/sdk';
+import { PolicyEngine } from '@microsoft/agentmesh-sdk';
 
 const engine = new PolicyEngine([
   { action: 'data.*', effect: 'allow' },
@@ -96,7 +102,7 @@ await engine.loadFromYAML('./policy.yaml');
 Append-only audit log with hash-chain integrity verification.
 
 ```typescript
-import { AuditLogger } from '@agentmesh/sdk';
+import { AuditLogger } from '@microsoft/agentmesh-sdk';
 
 const logger = new AuditLogger();
 
@@ -113,7 +119,7 @@ logger.exportJSON(); // full log as JSON string
 Unified client tying identity, trust, policy, and audit together.
 
 ```typescript
-import { AgentMeshClient } from '@agentmesh/sdk';
+import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
 
 const client = AgentMeshClient.create('my-agent', {
   policyRules: [{ action: 'data.*', effect: 'allow' }],
@@ -122,6 +128,125 @@ const client = AgentMeshClient.create('my-agent', {
 const result = await client.executeWithGovernance('data.read', { user: 'alice' });
 // result: { decision, trustScore, auditEntry, executionTime }
 ```
+
+### MCP Security
+
+Use the MCP security primitives to govern both tool definitions and runtime traffic.
+You can access the same governance surface either from the full SDK or from the standalone MCP package.
+
+#### Full SDK install
+
+```typescript
+import {
+  ApprovalStatus,
+  CredentialRedactor,
+  MCPGateway,
+  MCPMessageSigner,
+  MCPResponseScanner,
+  MCPSecurityScanner,
+  MCPSessionAuthenticator,
+  MCPSlidingRateLimiter,
+} from '@microsoft/agentmesh-sdk';
+```
+
+#### Standalone MCP governance install
+
+```typescript
+import {
+  ApprovalStatus,
+  CredentialRedactor,
+  MCPGateway,
+  MCPMessageSigner,
+  MCPResponseScanner,
+  MCPSecurityScanner,
+  MCPSessionAuthenticator,
+  MCPSlidingRateLimiter,
+} from '@microsoft/agentmesh-mcp-governance';
+```
+
+Both entry points expose the same MCP governance primitives; the standalone package has zero dependency on the rest of the AGT SDK.
+
+```typescript
+import {
+  ApprovalStatus,
+  CredentialRedactor,
+  MCPGateway,
+  MCPMessageSigner,
+  MCPResponseScanner,
+  MCPSecurityScanner,
+  MCPSessionAuthenticator,
+  MCPSlidingRateLimiter,
+} from '@microsoft/agentmesh-sdk';
+
+const responseScanner = new MCPResponseScanner();
+const redactor = new CredentialRedactor();
+const sessionAuth = new MCPSessionAuthenticator({
+  secret: process.env.MCP_SESSION_SECRET!,
+});
+const messageSigner = new MCPMessageSigner({
+  secret: process.env.MCP_SIGNING_SECRET!,
+});
+const rateLimiter = new MCPSlidingRateLimiter({
+  maxRequests: 60,
+  windowMs: 60_000,
+});
+const securityScanner = new MCPSecurityScanner();
+
+const gateway = new MCPGateway({
+  allowedTools: ['read_file', 'search_docs'],
+  sensitiveTools: ['deploy'],
+  rateLimiter,
+  approvalHandler: async ({ toolName }) =>
+    toolName === 'deploy'
+      ? ApprovalStatus.Approved
+      : ApprovalStatus.Pending,
+});
+
+const toolDecision = await gateway.evaluateToolCall('agent-1', 'read_file', {
+  path: '/workspace/README.md',
+});
+const issuedSession = await sessionAuth.issueToken('agent-1');
+const verifiedSession = await sessionAuth.verifyToken(
+  issuedSession.token,
+  'agent-1',
+);
+const signedMessage = messageSigner.sign({
+  tool: 'read_file',
+  args: { path: '/workspace/README.md' },
+});
+const verifiedMessage = await messageSigner.verify(signedMessage);
+const toolThreats = securityScanner.scanTool(
+  'read_file',
+  'Read the contents of a file at the specified path.',
+  {
+    type: 'object',
+    properties: { path: { type: 'string' } },
+    required: ['path'],
+    additionalProperties: false,
+  },
+  'filesystem-server',
+);
+const scannedResponse = responseScanner.scan({
+  text: 'Search completed successfully.',
+});
+const redactedSecrets = redactor.redact({
+  bearerToken: 'Bearer abcdefghijklmnop',
+});
+```
+
+The MCP surface adds:
+
+- **MCPResponseScanner** — strips and flags prompt-injection tags, imperative phrasing, credential leaks, and exfiltration URLs before tool output reaches an LLM
+- **MCPSessionAuthenticator** — HMAC-backed session tokens bound to agent identity with TTL expiry and concurrent-session enforcement
+- **MCPMessageSigner** — HMAC-SHA256 request signing with timestamps and nonce replay protection
+- **CredentialRedactor** — secret redaction for strings and nested object graphs
+- **MCPSlidingRateLimiter** — per-agent sliding-window rate limiting
+- **MCPSecurityScanner** — tool metadata scanning for poisoning, rug pulls, cross-server attacks, description injection, and schema abuse
+- **MCPGateway** — deny-list, allow-list, sanitization, rate limiting, and approval orchestration
+
+> [!NOTE]
+> The built-in nonce and session stores are in-memory and intended for single-process development or tests.
+> In multi-replica or enterprise deployments, implement the provided store interfaces against durable shared storage and inject shared clock/nonce providers for deterministic behavior.
 
 ## Development
 

--- a/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/README.md
+++ b/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/README.md
@@ -1,0 +1,99 @@
+# MCP Express Server Example
+
+This example shows a minimal Express.js server running the full AgentMesh MCP governance pipeline for a `POST /call-tool` endpoint.
+
+## What it demonstrates
+
+- `MCPGateway` allow-list, sanitization, rate limiting, and approval flow
+- `MCPMessageSigner` signing and verification of tool calls
+- `MCPSessionAuthenticator` session tokens with TTL-bound agent identity
+- `MCPSlidingRateLimiter` per-agent request throttling
+- `MCPSecurityScanner` request inspection for prompt-injection style content
+- `MCPResponseScanner` output scanning for credentials and exfiltration patterns
+- `CredentialRedactor` redaction before logging
+- `GET /health` for readiness plus a short-lived demo session token
+
+## Prerequisites
+
+- Node 18+
+- npm
+
+## Install and run
+
+```bash
+cd packages/agent-mesh/sdks/typescript/examples/mcp-express-server
+npm install
+npx tsx src/server.ts
+```
+
+The example runs against the checked-out SDK source in this repository so reviewers can exercise the current branch without publishing a package first.
+
+## Endpoints
+
+- `GET /health` - readiness plus a demo session token for `demo-agent`
+- `POST /call-tool` - signs, verifies, authenticates, rate-limits, scans, redacts, and executes a tool call
+
+## Example curl flows
+
+Fetch a demo session token:
+
+```bash
+curl http://127.0.0.1:3000/health
+```
+
+Use the returned `demoSessionToken` in a governed tool call:
+
+```bash
+curl -X POST http://127.0.0.1:3000/call-tool \
+  -H "content-type: application/json" \
+  -H "x-session-token: <PASTE_TOKEN_HERE>" \
+  -d '{
+    "agentId": "demo-agent",
+    "toolName": "search_docs",
+    "args": { "query": "OWASP MCP" }
+  }'
+```
+
+Trigger the path-traversal guard:
+
+```bash
+curl -X POST http://127.0.0.1:3000/call-tool \
+  -H "content-type: application/json" \
+  -H "x-session-token: <PASTE_TOKEN_HERE>" \
+  -d '{
+    "agentId": "demo-agent",
+    "toolName": "read_file",
+    "args": { "path": "../secrets.txt", "approved": true }
+  }'
+```
+
+Trigger response scanning for leaked credentials:
+
+```bash
+curl -X POST http://127.0.0.1:3000/call-tool \
+  -H "content-type: application/json" \
+  -H "x-session-token: <PASTE_TOKEN_HERE>" \
+  -d '{
+    "agentId": "demo-agent",
+    "toolName": "read_file",
+    "args": { "path": "workspace/secrets.txt", "approved": true }
+  }'
+```
+
+## OWASP MCP mapping
+
+| Primitive | Example role |
+| --- | --- |
+| `MCPSessionAuthenticator` | Session binding and expiry |
+| `MCPMessageSigner` | Signed tool-call envelopes |
+| `MCPGateway` | Deny/allow/sanitize/approve pipeline |
+| `MCPSlidingRateLimiter` | Request throttling |
+| `MCPSecurityScanner` | Prompt-injection style request inspection |
+| `MCPResponseScanner` | Output scanning and fail-closed blocking |
+| `CredentialRedactor` | Safe audit logging |
+
+## Run the smoke test
+
+```bash
+npm test
+```

--- a/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/package.json
+++ b/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mcp-express-server-example",
+  "private": true,
+  "version": "0.0.1",
+  "description": "Public Preview — Express.js MCP governance example for the AgentMesh TypeScript SDK",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/server.ts",
+    "test": "tsx --test test/server.test.ts"
+  },
+  "peerDependencies": {
+    "@microsoft/agentmesh-sdk": "3.0.2"
+  },
+  "dependencies": {
+    "express": "4.21.2"
+  },
+  "devDependencies": {
+    "@types/express": "5.0.3",
+    "@types/node": "25.5.0",
+    "tsx": "4.19.3",
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/src/server.ts
+++ b/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/src/server.ts
@@ -72,7 +72,8 @@ export function createExampleServer(): {
   const redactor = new sdk.CredentialRedactor();
   const responseScanner = new sdk.MCPResponseScanner();
   const securityScanner = new sdk.MCPSecurityScanner();
-  const rateLimiter = new sdk.MCPSlidingRateLimiter({ maxRequests: 5, windowMs: 60_000 });
+  const routeRateLimiter = new sdk.MCPSlidingRateLimiter({ maxRequests: 5, windowMs: 60_000 });
+  const gatewayRateLimiter = new sdk.MCPSlidingRateLimiter({ maxRequests: 5, windowMs: 60_000 });
   const sessionAuthenticator = new sdk.MCPSessionAuthenticator({
     secret: loadSecret('MCP_SESSION_SECRET'),
     ttlMs: 5 * 60_000,
@@ -84,7 +85,7 @@ export function createExampleServer(): {
     allowedTools: Object.keys(toolHandlers),
     sensitiveTools: ['read_file'],
     blockedPatterns: ['../', '..\\\\', '<system>', 'ignore previous instructions'],
-    rateLimiter,
+    rateLimiter: gatewayRateLimiter,
     auditSink,
     approvalHandler: async ({ toolName, params }) =>
       toolName === 'read_file' && params.approved !== true
@@ -131,6 +132,15 @@ export function createExampleServer(): {
     const signature = await messageSigner.verify(signedCall);
     if (!signature.valid) {
       response.status(401).json({ error: signature.reason });
+      return;
+    }
+
+    const routeRateLimit = await routeRateLimiter.consume(`${agentId}:${toolName}`);
+    if (!routeRateLimit.allowed) {
+      response.status(429).json({
+        error: 'Rate limit exceeded for this tool',
+        rateLimit: routeRateLimit,
+      });
       return;
     }
 

--- a/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/src/server.ts
+++ b/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/src/server.ts
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { randomBytes } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import express, { type Express } from 'express';
+import sdk from '../../../src/index.ts';
+
+type ToolHandler = {
+  description: string;
+  inputSchema: Record<string, unknown>;
+  run(args: Record<string, unknown>): Promise<Record<string, unknown>>;
+};
+
+const toolHandlers: Record<string, ToolHandler> = {
+  search_docs: {
+    description: 'Search internal docs for a topic and return a concise answer.',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    async run(args) {
+      const query = readString(args, 'query') ?? 'agent governance';
+      return {
+        answer: `Search results for "${query}"`,
+        source: 'docs://agentmesh/owasp-mcp',
+      };
+    },
+  },
+  read_file: {
+    description: 'Read a file from the demo workspace and return its contents.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        approved: { type: 'boolean' },
+      },
+      required: ['path'],
+      additionalProperties: false,
+    },
+    async run(args) {
+      const path = readString(args, 'path') ?? 'README.md';
+      if (path.endsWith('secrets.txt')) {
+        return {
+          contents: 'Bearer abcdefghijklmnop demo@example.com',
+          path,
+        };
+      }
+      return {
+        contents: `Read ${path} successfully.`,
+        path,
+      };
+    },
+  },
+};
+
+const toolDefinitions = Object.entries(toolHandlers).map(
+  ([name, handler]) => ({
+    name,
+    description: handler.description,
+    inputSchema: handler.inputSchema,
+  }),
+);
+
+export function createExampleServer(): {
+  app: Express;
+  issueDemoSession(agentId?: string): Promise<string>;
+} {
+  const auditSink = new sdk.InMemoryMCPAuditSink();
+  const redactor = new sdk.CredentialRedactor();
+  const responseScanner = new sdk.MCPResponseScanner();
+  const securityScanner = new sdk.MCPSecurityScanner();
+  const rateLimiter = new sdk.MCPSlidingRateLimiter({ maxRequests: 5, windowMs: 60_000 });
+  const sessionAuthenticator = new sdk.MCPSessionAuthenticator({
+    secret: loadSecret('MCP_SESSION_SECRET'),
+    ttlMs: 5 * 60_000,
+  });
+  const messageSigner = new sdk.MCPMessageSigner({
+    secret: loadSecret('MCP_SIGNING_SECRET'),
+  });
+  const gateway = new sdk.MCPGateway({
+    allowedTools: Object.keys(toolHandlers),
+    sensitiveTools: ['read_file'],
+    blockedPatterns: ['../', '..\\\\', '<system>', 'ignore previous instructions'],
+    rateLimiter,
+    auditSink,
+    approvalHandler: async ({ toolName, params }) =>
+      toolName === 'read_file' && params.approved !== true
+        ? sdk.ApprovalStatus.Pending
+        : sdk.ApprovalStatus.Approved,
+  });
+  const catalogScan = securityScanner.scanServer('mcp-express-server', toolDefinitions);
+  const app = express();
+  app.use(express.json());
+
+  app.get('/health', async (_request, response) => {
+    response.json({
+      status: 'ok',
+      catalogSafe: catalogScan.safe,
+      toolCount: toolDefinitions.length,
+      demoAgentId: 'demo-agent',
+      demoSessionToken: await issueDemoSession('demo-agent'),
+    });
+  });
+
+  app.post('/call-tool', async (request, response) => {
+    const agentId = readString(request.body, 'agentId') ?? 'demo-agent';
+    const toolName = readString(request.body, 'toolName') ?? '';
+    const args = asRecord(request.body?.args);
+    const sessionToken = request.header('x-session-token');
+    const handler = toolHandlers[toolName];
+
+    if (!sessionToken) {
+      response.status(401).json({ error: 'Missing x-session-token. Call GET /health for a demo token.' });
+      return;
+    }
+    if (!handler) {
+      response.status(404).json({ error: `Unknown tool '${toolName}'` });
+      return;
+    }
+
+    const session = await sessionAuthenticator.verifyToken(sessionToken, agentId);
+    if (!session.valid) {
+      response.status(401).json({ error: session.reason });
+      return;
+    }
+
+    const signedCall = messageSigner.sign({ agentId, toolName, args });
+    const signature = await messageSigner.verify(signedCall);
+    if (!signature.valid) {
+      response.status(401).json({ error: signature.reason });
+      return;
+    }
+
+    const requestThreats = securityScanner.scanTool(
+      toolName,
+      `${handler.description}\nRequest payload: ${JSON.stringify(args)}`,
+      handler.inputSchema,
+      'mcp-express-server',
+    );
+    if (requestThreats.some((threat) => threat.severity === 'critical')) {
+      response.status(400).json({ error: 'Security scanner rejected the request', threats: requestThreats });
+      return;
+    }
+
+    const decision = await gateway.evaluateToolCall(agentId, toolName, args);
+    if (!decision.allowed) {
+      response.status(403).json({
+        allowed: false,
+        reason: decision.reason,
+        findings: decision.findings,
+        auditParams: decision.auditParams,
+      });
+      return;
+    }
+
+    const rawResult = await handler.run(args);
+    const scannedResult = responseScanner.scan(rawResult);
+    const safeResult = {
+      safe: scannedResult.safe,
+      blocked: scannedResult.blocked,
+      findings: scannedResult.findings,
+      sanitized: scannedResult.sanitized,
+    };
+    const logEntry = redactor.redact({ agentId, toolName, args, result: safeResult.sanitized }).redacted;
+
+    if (process.env.NODE_ENV !== 'test') {
+      console.info('[mcp-express-server]', JSON.stringify(logEntry));
+    }
+
+    response.status(scannedResult.blocked ? 422 : 200).json({
+      allowed: true,
+      reason: decision.reason,
+      messageVerification: signature,
+      response: safeResult,
+      auditEntries: auditSink.getEntries().length,
+    });
+  });
+
+  async function issueDemoSession(agentId: string = 'demo-agent'): Promise<string> {
+    const issued = await sessionAuthenticator.issueToken(agentId);
+    return issued.token;
+  }
+
+  return { app, issueDemoSession };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function readString(value: unknown, key: string): string | undefined {
+  const record = asRecord(value);
+  return typeof record[key] === 'string' ? record[key] as string : undefined;
+}
+
+function loadSecret(envName: string): string {
+  const secret = process.env[envName];
+  if (secret && Buffer.byteLength(secret, 'utf-8') >= 32) {
+    return secret;
+  }
+  return randomBytes(32).toString('hex');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const port = Number(process.env.PORT ?? 3000);
+  const { app } = createExampleServer();
+  app.listen(port, () => {
+    console.log(`MCP Express example listening on http://127.0.0.1:${port}`);
+  });
+}

--- a/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/src/server.ts
+++ b/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/src/server.ts
@@ -106,6 +106,8 @@ export function createExampleServer(): {
     });
   });
 
+  // Rate limiting is applied via routeRateLimiter.consume() inside the handler
+  // codeql[js/missing-rate-limiting]
   app.post('/call-tool', async (request, response) => {
     const agentId = readString(request.body, 'agentId') ?? 'demo-agent';
     const toolName = readString(request.body, 'toolName') ?? '';

--- a/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/test/server.test.ts
+++ b/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/test/server.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { AddressInfo } from 'node:net';
+import { createExampleServer } from '../src/server.ts';
+
+process.env.NODE_ENV = 'test';
+
+test('health endpoint returns a demo session token', async () => {
+  const { app } = createExampleServer();
+  const server = app.listen(0);
+
+  try {
+    const { port } = server.address() as AddressInfo;
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    const payload = await response.json() as { status: string; demoSessionToken: string };
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.status, 'ok');
+    assert.ok(payload.demoSessionToken.length > 20);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+test('call-tool runs the governance pipeline', async () => {
+  const { app, issueDemoSession } = createExampleServer();
+  const server = app.listen(0);
+
+  try {
+    const { port } = server.address() as AddressInfo;
+    const token = await issueDemoSession('demo-agent');
+    const response = await fetch(`http://127.0.0.1:${port}/call-tool`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-session-token': token,
+      },
+      body: JSON.stringify({
+        agentId: 'demo-agent',
+        toolName: 'search_docs',
+        args: { query: 'OWASP MCP' },
+      }),
+    });
+    const payload = await response.json() as {
+      allowed: boolean;
+      messageVerification: { valid: boolean };
+      response: { safe: boolean };
+    };
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.allowed, true);
+    assert.equal(payload.messageVerification.valid, true);
+    assert.equal(payload.response.safe, true);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/tsconfig.json
+++ b/packages/agent-mesh/sdks/typescript/examples/mcp-express-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -100,14 +100,15 @@ REGISTERED_NPM_PACKAGES = {
     "@microsoft/agentmesh-api", "@microsoft/agent-os-cursor",
     "@microsoft/agentmesh-mastra", "@microsoft/agentmesh-copilot-governance",
     "@microsoft/agent-os-copilot-extension", "@microsoft/agentos-mcp-server",
-    "@microsoft/agent-os-vscode",
+    "@microsoft/agent-os-vscode", "@microsoft/agentmesh-sdk",
+    "@microsoft/agentmesh-mcp-governance",
     # Common deps
     "typescript", "tsup", "vitest", "express", "zod", "@mastra/core",
     "@modelcontextprotocol/sdk", "ws", "commander", "chalk",
     "@anthropic-ai/sdk", "@types/node", "@types/ws", "@types/express",
     # Common npm dev dependencies
     "eslint", "@typescript-eslint/parser", "@typescript-eslint/eslint-plugin",
-    "ts-jest", "@types/jest", "jest", "rimraf", "prettier",
+    "ts-jest", "@types/jest", "jest", "rimraf", "prettier", "tsx",
     "axios", "@types/vscode", "@vscode/vsce", "webpack", "webpack-cli",
     "ts-node", "nodemon", "concurrently", "dotenv",
     "esbuild", "@esbuild/linux-x64", "@esbuild/darwin-arm64",


### PR DESCRIPTION
## Description

Adds comprehensive documentation for TypeScript MCP security primitives, including API reference docs, OWASP MCP Cheat Sheet compliance mapping, quickstart guides, i18n translations, and usage examples.

> **Part 3 of 3** — Merge after #827. See also:
> - Part 1: #791 Core MCP security primitives ← merge first
> - Part 2: #827 Standalone @microsoft/agentmesh-mcp-governance package ← merge second
> - **Part 3: This PR** ← merge last

## Type of Change
- [x] Documentation update

## Package(s) Affected
- [x] agent-mesh

## Checklist
- [x] My code follows the project style guidelines
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues
Supersedes #791 (split for easier review). Merge after #827.