### PR TITLE
feat(python): add standalone agent-mcp-governance package

### DIFF
--- a/packages/agent-mcp-governance/README.md
+++ b/packages/agent-mcp-governance/README.md
@@ -1,0 +1,75 @@
+<!--
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT License.
+-->
+
+# agent-mcp-governance
+
+`agent-mcp-governance` is a standalone **Public Preview** package that exposes
+the MCP governance primitives used in this repository:
+
+- `MCPGateway` for policy enforcement and audit logging
+- `MCPSlidingRateLimiter` for per-agent call budgets
+- `MCPSessionAuthenticator` for short-lived MCP sessions
+- `MCPMessageSigner`, `MCPSecurityScanner`, and `MCPResponseScanner` for
+  message integrity and security scanning
+
+This package is intentionally thin. It exists as a focused MCP governance
+surface for enterprise packaging and reuse scenarios without pulling in the
+full Agent Governance Toolkit as an install-time dependency.
+
+## Installation
+
+```bash
+pip install agent-mcp-governance
+```
+
+## Quick usage
+
+```python
+from agent_mcp_governance import (
+    MCPGateway,
+    MCPSessionAuthenticator,
+    MCPSlidingRateLimiter,
+)
+
+
+class DemoPolicy:
+    name = "demo"
+    allowed_tools = ["read_file", "web_search"]
+    max_tool_calls = 10
+    log_all_calls = True
+    require_human_approval = False
+
+    def matches_pattern(self, _text: str) -> list[str]:
+        return []
+
+
+policy = DemoPolicy()
+gateway = MCPGateway(policy)
+rate_limiter = MCPSlidingRateLimiter(max_calls_per_window=5, window_size=60.0)
+session_auth = MCPSessionAuthenticator()
+
+token = session_auth.create_session("agent-123", user_id="alice@example.com")
+session = session_auth.validate_session("agent-123", token)
+
+if session and rate_limiter.try_acquire(session.rate_limit_key):
+    allowed, reason = gateway.intercept_tool_call(
+        session.agent_id,
+        "read_file",
+        {"path": "docs/architecture.md"},
+    )
+    print(allowed, reason)
+```
+
+## Zero AGT dependency note
+
+The package metadata declares **zero Agent Governance Toolkit dependencies**
+(`dependencies = []` in `pyproject.toml`). That makes this package suitable for
+monorepo, vendored, and enterprise repackaging workflows where MCP governance
+components are distributed independently from the broader toolkit.
+
+## Security guidance
+
+For deployment guidance and hardening recommendations, see the
+[OWASP MCP Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/MCP_Security_Cheat_Sheet.html).

--- a/packages/agent-mcp-governance/pyproject.toml
+++ b/packages/agent-mcp-governance/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent_mcp_governance"
+version = "0.1.0"
+description = "Public Preview MCP governance APIs for sessions, signing, scanning, and gateway enforcement."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [
+  { name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+  "agent-os-kernel>=3.0.0,<4.0.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_mcp_governance"]

--- a/packages/agent-mcp-governance/src/agent_mcp_governance/__init__.py
+++ b/packages/agent-mcp-governance/src/agent_mcp_governance/__init__.py
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Thin MCP governance re-exports for standalone packaging."""
+
+from __future__ import annotations
+
+from agent_os.credential_redactor import (
+    CredentialMatch,
+    CredentialPattern,
+    CredentialRedactor,
+)
+from agent_os.mcp_gateway import ApprovalStatus, AuditEntry, GatewayConfig, MCPGateway
+from agent_os.mcp_message_signer import (
+    MCPMessageSigner,
+    MCPSignedEnvelope,
+    MCPVerificationResult,
+)
+from agent_os.mcp_protocols import (
+    InMemoryAuditSink,
+    InMemoryNonceStore,
+    InMemoryRateLimitStore,
+    InMemorySessionStore,
+    MCPAuditSink,
+    MCPNonceStore,
+    MCPRateLimitStore,
+    MCPSessionStore,
+)
+from agent_os.mcp_response_scanner import (
+    MCPResponseScanner,
+    MCPResponseScanResult,
+    MCPResponseThreat,
+)
+from agent_os.mcp_security import (
+    MCPSeverity,
+    MCPSecurityScanner,
+    MCPThreat,
+    MCPThreatType,
+    ScanResult,
+    ToolFingerprint,
+)
+from agent_os.mcp_session_auth import MCPSession, MCPSessionAuthenticator
+from agent_os.mcp_sliding_rate_limiter import MCPSlidingRateLimiter
+
+__all__ = [
+    "ApprovalStatus",
+    "AuditEntry",
+    "CredentialMatch",
+    "CredentialPattern",
+    "CredentialRedactor",
+    "GatewayConfig",
+    "InMemoryAuditSink",
+    "InMemoryNonceStore",
+    "InMemoryRateLimitStore",
+    "InMemorySessionStore",
+    "MCPAuditSink",
+    "MCPGateway",
+    "MCPMessageSigner",
+    "MCPNonceStore",
+    "MCPRateLimitStore",
+    "MCPResponseScanResult",
+    "MCPResponseScanner",
+    "MCPResponseThreat",
+    "MCPSecurityScanner",
+    "MCPSeverity",
+    "MCPSession",
+    "MCPSessionAuthenticator",
+    "MCPSessionStore",
+    "MCPSignedEnvelope",
+    "MCPSlidingRateLimiter",
+    "MCPThreat",
+    "MCPThreatType",
+    "MCPVerificationResult",
+    "ScanResult",
+    "ToolFingerprint",
+]


### PR DESCRIPTION
## Description

Introduces the standalone `agent-mcp-governance` Python package with zero AGT dependency. This allows MCP server operators to adopt MCP governance primitives without pulling in the full Agent Governance Toolkit.

**Package:** `agent-mcp-governance` (PyPI name: `agent_mcp_governance`)
- `dependencies = []` — no AGT dependency
- Re-exports MCP primitives from agent-os-kernel
- README with installation, quick-start examples, and OWASP MCP Cheat Sheet mapping

> **Part 2 of 3** — Merge after #774. See also:
> - Part 1: #774 Core MCP security primitives ← **merge first**
> - Part 3: Documentation and examples ← merge last

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Package(s) Affected
- [x] agent-os-kernel

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest — 2938 passed, 86 skipped)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues
Part 2 of 3 (split from original PR for easier review). Merge after #774.