### PR TITLE
docs: add OWASP MCP Top 10 compliance mapping

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,7 +28,13 @@
     "CD",
     "PR",
     "MCP",
-    "A2A"
+    "A2A",
+    "HMAC",
+    "Merkle",
+    "backdoors",
+    "metacharacters",
+    "metacharacter",
+    "Blocklist"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/docs/MCP-OWASP-COMPLIANCE.md
+++ b/docs/MCP-OWASP-COMPLIANCE.md
@@ -376,7 +376,7 @@ Three MCP risks have partial coverage today with planned enhancements targeting 
 |-----------|--------|
 | [OWASP MCP Top 10 (2025 Beta)](https://owasp.org/www-project-mcp-top-10/) | 7/10 covered, 3 partial (roadmap) |
 | [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | 10/10 covered — see [OWASP-COMPLIANCE.md](OWASP-COMPLIANCE.md) |
-| [OWASP MCP Security Cheat Sheet (§1–§12)](https://cheatsheetseries.owasp.org/cheatsheets/Model_Context_Protocol_Security_Cheat_Sheet.html) | 11/12 covered — §11 (Consent UI) out of scope for server-side SDKs |
+| OWASP MCP Security Cheat Sheet (§1–§12) | 11/12 covered — §11 (Consent UI) out of scope for server-side SDKs |
 | [NIST AI Agent Standards Initiative](https://www.nist.gov/news-events/news/2026/02/announcing-ai-agent-standards-initiative-interoperable-and-secure) | Agent identity (IATP), authentication, audit trails |
 | [EU AI Act (Aug 2026)](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) | Risk classification, audit trails, human oversight |
 


### PR DESCRIPTION
## Summary

Adds `docs/MCP-OWASP-COMPLIANCE.md` - a compliance mapping for the [OWASP Top 10 for Model Context Protocol (2025 Beta)](https://owasp.org/www-project-mcp-top-10/), mirroring the structure of the existing `docs/OWASP-COMPLIANCE.md` (which covers the OWASP Agentic Top 10).

## What's Covered

Maps all 10 MCP risks (MCP01-MCP10) to AGT components:

- **7 fully covered**: MCP02 (Privilege Escalation), MCP03 (Tool Poisoning), MCP04 (Supply Chain), MCP05 (Command Injection), MCP07 (Insufficient Auth), MCP08 (Lack of Audit), MCP10 (Context Over-Sharing)
- **3 partial with roadmap**: MCP01 (Token Mismanagement), MCP06 (Intent Flow Subversion), MCP09 (Shadow Servers)

Includes:
- Detailed mapping with code examples for each risk
- Multi-language SDK coverage table (Python, .NET, TypeScript, Rust, Go)
- Roadmap section for the 3 gaps (target: June 2026 protocol alignment)
- Cross-reference to OWASP Agentic Top 10, MCP Security Cheat Sheet, NIST, EU AI Act

> The OWASP MCP Top 10 is in Phase 3 Beta. Doc is marked accordingly.

## Changes
- `docs/MCP-OWASP-COMPLIANCE.md` - new file (391 lines)

## Testing
Documentation only - no code changes