### PR TITLE
fix(security): add importlib.import_module allowlist validation

### DIFF
--- a/packages/agent-compliance/src/agent_compliance/integrity.py
+++ b/packages/agent-compliance/src/agent_compliance/integrity.py
@@ -34,6 +34,9 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
+# Import the shared allowlist validation from verify.py
+from agent_compliance.verify import ALLOWED_MODULE_PREFIXES, _validate_module_name
+
 # Governance modules whose integrity we verify
 GOVERNANCE_MODULES = [
     "agent_os.integrations.base",
@@ -244,6 +247,7 @@ class IntegrityVerifier:
         # Phase 1: File hash verification
         for mod_name in self.modules:
             try:
+                _validate_module_name(mod_name)
                 mod = importlib.import_module(mod_name)
                 source_file = inspect.getfile(mod)
                 actual_hash = _hash_file(source_file)
@@ -267,7 +271,7 @@ class IntegrityVerifier:
                         error="hash mismatch" if not passed else None,
                     )
                 )
-            except ImportError:
+            except (ImportError, ValueError):
                 report.modules_missing.append(mod_name)
             except Exception as e:
                 report.file_results.append(
@@ -285,6 +289,7 @@ class IntegrityVerifier:
         # Phase 2: Critical function bytecode verification
         for mod_name, func_path in self.critical_functions:
             try:
+                _validate_module_name(mod_name)
                 mod = importlib.import_module(mod_name)
                 func = _resolve_function(mod, func_path)
                 if func is None:
@@ -359,23 +364,25 @@ class IntegrityVerifier:
 
         for mod_name in self.modules:
             try:
+                _validate_module_name(mod_name)
                 mod = importlib.import_module(mod_name)
                 source_file = inspect.getfile(mod)
                 manifest["files"][mod_name] = {
                     "sha256": _hash_file(source_file),
                     "path": source_file,
                 }
-            except (ImportError, OSError, TypeError) as e:
+            except (ImportError, OSError, TypeError, ValueError) as e:
                 logger.warning("Could not hash module %s: %s", mod_name, e)
 
         for mod_name, func_path in self.critical_functions:
             try:
+                _validate_module_name(mod_name)
                 mod = importlib.import_module(mod_name)
                 func = _resolve_function(mod, func_path)
                 if func:
                     key = f"{mod_name}:{func_path}"
                     manifest["functions"][key] = _hash_function_bytecode(func)
-            except (ImportError, OSError, TypeError, AttributeError) as e:
+            except (ImportError, OSError, TypeError, AttributeError, ValueError) as e:
                 logger.warning(
                     "Could not hash function %s.%s: %s", mod_name, func_path, e
                 )

--- a/packages/agent-compliance/src/agent_compliance/verify.py
+++ b/packages/agent-compliance/src/agent_compliance/verify.py
@@ -31,6 +31,31 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Allowlist of module prefixes that may be imported via importlib.
+# Defense-in-depth: even though defaults are hardcoded, custom controls
+# passed via the constructor are validated against this allowlist.
+# MSRC Case 112362 — prevents RCE via unvalidated importlib.import_module.
+ALLOWED_MODULE_PREFIXES = frozenset({
+    "agent_os.",
+    "agentmesh.",
+    "agent_compliance.",
+    "agent_sre.",
+    "agent_hypervisor.",
+    "hypervisor.",
+    "agent_runtime.",
+    "agent_lightning_gov.",
+    "agent_marketplace.",
+})
+
+
+def _validate_module_name(mod_name: str) -> None:
+    """Raise ValueError if mod_name is not in the governance module allowlist."""
+    if not any(mod_name.startswith(prefix) for prefix in ALLOWED_MODULE_PREFIXES):
+        raise ValueError(
+            f"Module '{mod_name}' is not in the allowed governance module list. "
+            f"Only modules with prefixes {sorted(ALLOWED_MODULE_PREFIXES)} are permitted."
+        )
+
 
 # OWASP Agentic Security Initiative 2026 controls
 OWASP_ASI_CONTROLS = {
@@ -299,6 +324,7 @@ class GovernanceVerifier:
             )
 
         try:
+            _validate_module_name(mod_name)
             mod = importlib.import_module(mod_name)
             component = getattr(mod, component_name, None)
             if component is None:
@@ -317,7 +343,7 @@ class GovernanceVerifier:
                 module=mod_name,
                 component=component_name,
             )
-        except ImportError as e:
+        except (ImportError, ValueError) as e:
             return ControlResult(
                 control_id=control_id,
                 name=control_name,


### PR DESCRIPTION
Defense-in-depth fix for MSRC Case 112362. Adds ALLOWED_MODULE_PREFIXES validation before all importlib.import_module() calls in verify.py and integrity.py. Prevents arbitrary code execution if control specs are overridden with malicious module names. All 28 compliance tests pass.