### PR TITLE
fix: correct broken README links and lint error in integrity.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Still have questions? File a [GitHub issue](https://github.com/microsoft/agent-g
 - **Agent SRE**: SLOs, error budgets, replay debugging, chaos engineering, circuit breakers, progressive delivery
   - [Agent SRE](packages/agent-sre/) | [Observability integrations](packages/agent-hypervisor/src/hypervisor/observability/)
 - **MCP Security Scanner**: Detect tool poisoning, typosquatting, hidden instructions, and rug-pull attacks in MCP tool definitions
-  - [MCP Scanner](packages/agent-os/src/agentos/mcp_security.py) | [CLI](packages/agent-os/src/agentos/cli/mcp_scan.py)
+  - [MCP Scanner](packages/agent-os/src/agent_os/mcp_security.py) | [CLI](packages/agent-os/src/agent_os/cli/mcp_scan.py)
 - **Trust Report CLI**: `agentmesh trust report` — visualize trust scores, task success/failure, and agent activity
   - [Trust CLI](packages/agent-mesh/src/agentmesh/cli/trust_cli.py)
 - **Secret Scanning & Fuzzing**: Gitleaks workflow, 7 fuzz targets covering policy, injection, sandbox, trust, and MCP


### PR DESCRIPTION
## Description
Fixes two issues on main causing CI failures across 10+ open PRs:

1. **README.md** — Broken relative links: `agentos/` → `agent_os/` for MCP Scanner paths
2. **integrity.py** — Lint errors (E402 import not at top, F401 unused import) introduced by #846

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Maintenance (dependency updates, CI/CD, refactoring)

## Package(s) Affected
- [x] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues
Unblocks CI on PRs #775, #824, #825, #826, #827, #828, #830, #832, #833, #834