### PR TITLE
fix(lint): fix noqa placement for F401 in __init__.py

### DIFF
--- a/packages/agent-compliance/src/agent_compliance/__init__.py
+++ b/packages/agent-compliance/src/agent_compliance/__init__.py
@@ -31,11 +31,11 @@ try:
 except ImportError:
     pass
 
-from agent_compliance.supply_chain import (
+from agent_compliance.supply_chain import (  # noqa: F401
     SupplyChainGuard,
     SupplyChainFinding,
     SupplyChainConfig,
-)  # noqa: F401
+)
 from agent_compliance.prompt_defense import (  # noqa: F401
     PromptDefenseEvaluator,
     PromptDefenseConfig,


### PR DESCRIPTION
Move noqa: F401 to the import statement line (ruff requires it there, not on closing paren).