### PR TITLE
chore: bump all packages to v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
-- **Hardened CLI Error Handling** — standardized sanitized JSON error output across all 7 ecosystem tools to prevent internal information disclosure (CWE-209).
-- **Audit Log Whitelisting** — implemented strict key-whitelisting in `agentmesh audit` JSON output to prevent accidental leakage of sensitive agent internal state.
-- **CLI Input Validation** — added regex-based validation for agent identifiers (DIDs/names) in registration and verification commands to prevent injection attacks.
+
+## [3.1.0] - 2026-04-11
 
 ### Added
-- **EU AI Act Risk Classifier** (`agentmesh.governance.EUAIActRiskClassifier`) — structured risk classification per Article 6 and Annex III, with Art. 6(1) Annex I safety-component path, Art. 6(3) exemptions, GDPR Art. 4(4) profiling override, and configurable YAML categories for regulatory updates (#756).
+- **Unified `agt` CLI** with plugin discovery, doctor command, and 79 tests (#924)
+- **Governance Dashboard** — real-time agent fleet visibility (#925)
+- **Agent Lifecycle Management** — provisioning to decommission (#923)
+- **Agent Discovery Package** — shadow AI discovery & inventory (#921)
+- **Quantum-Safe Signing** — ML-DSA-65 alongside Ed25519 (#927)
+- **Vendor Independence Enforcement** across all core packages
+- **OWASP ASI 2026 Taxonomy Migration** with reference architecture
+- **PromptDefenseEvaluator** — 12-vector prompt audit (#854)
+- **EU AI Act Risk Classifier** (`agentmesh.governance.EUAIActRiskClassifier`) — structured risk classification per Article 6 and Annex III, with Art. 6(1) Annex I safety-component path, Art. 6(3) exemptions, GDPR Art. 4(4) profiling override, and configurable YAML categories for regulatory updates (#756)
+
+### Security
+- Patched dependency verification bypass and trust handshake DID forgery (#920)
+- **Hardened CLI Error Handling** — standardized sanitized JSON error output across all 7 ecosystem tools to prevent internal information disclosure (CWE-209)
+- **Audit Log Whitelisting** — implemented strict key-whitelisting in `agentmesh audit` JSON output to prevent accidental leakage of sensitive agent internal state
+- **CLI Input Validation** — added regex-based validation for agent identifiers (DIDs/names) in registration and verification commands to prevent injection attacks
+
+### Fixed
+- Repo hygiene: MIT headers, compliance disclaimers, dependency confusion, network bindings (#926)
+- CI: pyyaml added to agent-compliance direct dependencies
+- Code samples updated to v3 API
+- Various dependency bumps (cryptography, path-to-regexp, etc.)
 
 ### Documentation
-- Added `EUAIActRiskClassifier` usage example and API docs to `packages/agent-mesh/README.md`.
-- Updated `QUICKSTART.md` and `Tutorial 04 — Audit & Compliance` with secure JSON error handling examples and schema details.
-- Added "Secure Error Handling" sections to primary documentation to guide users on interpreting sanitized machine-readable outputs.
+- Modern Agent Architecture overview for enterprise sharing
+- NIST AI RMF 1.0 alignment assessment
+- MCP governance consolidated into docs/compliance/
+- Policy-as-code tutorial chapter 4
+- Added `EUAIActRiskClassifier` usage example and API docs to `packages/agent-mesh/README.md`
+- Updated `QUICKSTART.md` and `Tutorial 04 — Audit & Compliance` with secure JSON error handling examples and schema details
+- Added "Secure Error Handling" sections to primary documentation to guide users on interpreting sanitized machine-readable outputs
 
 
 ## [3.0.2] - 2026-04-02

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ pip install agent-sre              # SRE toolkit
 pip install agent-governance-toolkit    # Compliance & attestation
 pip install agentmesh-marketplace      # Plugin marketplace
 pip install agentmesh-lightning        # RL training governance
+pip install agent-discovery            # Shadow AI agent discovery
 ```
 </details>
 
@@ -103,8 +104,8 @@ Still have questions? File a [GitHub issue](https://github.com/microsoft/agent-g
 
 - **Deterministic Policy Enforcement**: Every agent action evaluated against policy *before* execution at sub-millisecond latency (<0.1 ms)
   - [Policy Engine](packages/agent-os/) | [Benchmarks](BENCHMARKS.md)
-- **Zero-Trust Agent Identity**: Ed25519 cryptographic credentials, SPIFFE/SVID support, trust scoring on a 0–1000 scale
-  - [AgentMesh](packages/agent-mesh/) | [Trust Scoring](packages/agent-mesh/)
+- **Zero-Trust Agent Identity**: Ed25519 + **quantum-safe ML-DSA-65** cryptographic credentials, SPIFFE/SVID support, trust scoring on a 0–1000 scale
+  - [AgentMesh](packages/agent-mesh/) | [Quantum-Safe Signing](packages/agent-mesh/src/agentmesh/identity/quantum_safe.py)
 - **Execution Sandboxing**: 4-tier privilege rings, saga orchestration, termination control, kill switch
   - [Agent Runtime](packages/agent-runtime/) | [Agent Hypervisor](packages/agent-hypervisor/)
 - **Agent SRE**: SLOs, error budgets, replay debugging, chaos engineering, circuit breakers, progressive delivery
@@ -117,6 +118,12 @@ Still have questions? File a [GitHub issue](https://github.com/microsoft/agent-g
   - [Security workflows](.github/workflows/)
 - **12+ Framework Integrations**: Microsoft Agent Framework, LangChain, CrewAI, AutoGen, Dify, LlamaIndex, OpenAI Agents, Google ADK, and more
   - [Framework quickstarts](examples/quickstart/) | [Integration proposals](docs/proposals/)
+- **Shadow AI Discovery**: Scan processes, filesystems, and GitHub repos to find unregistered agents. Inventory with dedup, reconciliation, and risk scoring
+  - [Agent Discovery](packages/agent-discovery/) | [Tutorial](docs/tutorials/29-agent-discovery.md)
+- **Agent Lifecycle Management**: Provisioning workflows, credential rotation, heartbeat monitoring, orphan detection, decommissioning with full audit trail
+  - [Lifecycle Manager](packages/agent-mesh/src/agentmesh/lifecycle/) | [Tutorial](docs/tutorials/30-agent-lifecycle.md)
+- **Governance Dashboard**: Real-time Streamlit dashboard with fleet overview, shadow agent alerts, lifecycle monitor, policy feed, and trust heatmap
+  - [Dashboard Demo](demo/governance-dashboard/) | [Docker Compose](demo/governance-dashboard/docker-compose.yml)
 - **Full OWASP Coverage**: 10/10 Agentic Top 10 risks addressed with dedicated controls for each ASI category
   - [OWASP Compliance](docs/OWASP-COMPLIANCE.md) | [Competitive Comparison](docs/COMPARISON.md)
 - **GitHub Actions for CI/CD**: Automated security scanning and governance attestation for PR workflows
@@ -295,12 +302,15 @@ Three evaluation modes per backend: **embedded engine** (cedarpy/opa CLI), **rem
 | Package | PyPI | Description |
 |---------|------|-------------|
 | **Agent OS** | [`agent-os-kernel`](https://pypi.org/project/agent-os-kernel/) | Policy engine — deterministic action evaluation, capability model, audit logging, action interception, MCP gateway |
-| **AgentMesh** | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | Inter-agent trust — Ed25519 identity, SPIFFE/SVID credentials, trust scoring, A2A/MCP/IATP protocol bridges |
+| **AgentMesh** | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | Inter-agent trust — Ed25519/ML-DSA-65 identity, SPIFFE/SVID credentials, trust scoring, A2A/MCP/IATP protocol bridges, lifecycle management |
 | **Agent Runtime** | [`agentmesh-runtime`](packages/agent-runtime/) | Execution supervisor — 4-tier privilege rings, saga orchestration, termination control, joint liability, append-only audit log |
 | **Agent SRE** | [`agent-sre`](https://pypi.org/project/agent-sre/) | Reliability engineering — SLOs, error budgets, replay debugging, chaos engineering, progressive delivery |
 | **Agent Compliance** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | Runtime policy enforcement — OWASP ASI 2026 controls, governance attestation, integrity verification |
 | **Agent Marketplace** | [`agentmesh-marketplace`](packages/agent-marketplace/) | Plugin lifecycle — discover, install, verify, and sign plugins |
 | **Agent Lightning** | [`agentmesh-lightning`](packages/agent-lightning/) | RL training governance — governed runners, policy rewards |
+| **Agent Discovery** | [`agent-discovery`](packages/agent-discovery/) | Shadow AI discovery — scan processes, configs, and repos; inventory with dedup; reconciliation and risk scoring |
+| **Agent Hypervisor** | [`agent-hypervisor`](packages/agent-hypervisor/) | Reversibility verification, execution plan validation, hypervisor-level governance |
+| **MCP Governance** | [`agent-mcp-governance`](packages/agent-mcp-governance/) | MCP-specific security scanning and governance enforcement |
 
 ## Framework Integrations
 
@@ -326,7 +336,7 @@ Works with **20+ agent frameworks** including:
 |------|----|--------|
 | Agent Goal Hijacking | ASI-01 | ✅ Policy engine blocks unauthorized goal changes |
 | Excessive Capabilities | ASI-02 | ✅ Capability model enforces least-privilege |
-| Identity & Privilege Abuse | ASI-03 | ✅ Zero-trust identity with Ed25519 certs |
+| Identity & Privilege Abuse | ASI-03 | ✅ Zero-trust identity with Ed25519 + quantum-safe ML-DSA-65 certs |
 | Uncontrolled Code Execution | ASI-04 | ✅ Agent Runtime execution rings + sandboxing |
 | Insecure Output Handling | ASI-05 | ✅ Content policies validate all outputs |
 | Memory Poisoning | ASI-06 | ✅ Episodic memory with integrity checks |
@@ -368,7 +378,7 @@ This toolkit provides **application-level (Python middleware) governance**, not 
 | Layer | What It Provides | What It Does NOT Provide |
 |-------|-----------------|------------------------|
 | Policy Engine | Deterministic action interception, deny-list enforcement | Hardware-level memory isolation |
-| Identity (IATP) | Ed25519 cryptographic agent credentials, trust scoring | OS-level process separation |
+| Identity (IATP) | Ed25519 + ML-DSA-65 (quantum-safe) cryptographic agent credentials, trust scoring | OS-level process separation |
 | Execution Rings | Logical privilege tiers with resource limits | CPU ring-level enforcement |
 | Bootstrap Integrity | SHA-256 tamper detection of governance modules at startup | Hardware root-of-trust (TPM/Secure Boot) |
 

--- a/RELEASE_NOTES_v3.1.0.md
+++ b/RELEASE_NOTES_v3.1.0.md
@@ -1,0 +1,96 @@
+# Agent Governance Toolkit v3.1.0
+
+> [!IMPORTANT]
+> **Public Preview** — All packages published from this repository are
+> **Microsoft-signed public preview releases**. They are production-quality but
+> may have breaking changes before GA. For feedback, open an issue or contact
+> agentgovtoolkit@microsoft.com.
+
+## What's New in v3.1.0
+
+Version 3.1.0 brings **unified CLI tooling**, **real-time governance dashboards**,
+**quantum-safe cryptography**, and **full agent lifecycle management** — giving
+enterprises end-to-end visibility and control over their AI agent fleets.
+
+### Highlights
+
+- **Unified `agt` CLI** — single entry point for all governance operations with
+  plugin discovery and built-in `doctor` diagnostics (#924)
+- **Governance Dashboard** — real-time agent fleet visibility with health, trust,
+  and compliance metrics (#925)
+- **Agent Lifecycle Management** — complete provisioning-to-decommission workflow
+  for governed agents (#923)
+- **Shadow AI Discovery** — new `agent-discovery` package finds unregistered agents
+  and builds a centralized inventory (#921)
+- **Quantum-Safe Signing** — ML-DSA-65 (FIPS 204) alongside Ed25519 for
+  post-quantum readiness (#927)
+- **OWASP ASI 2026 Taxonomy** — migrated to the latest Agentic Security taxonomy
+  with reference architecture
+- **Vendor Independence** — enforced across all core packages, ensuring no
+  single-vendor lock-in
+- **PromptDefenseEvaluator** — 12-vector prompt injection audit for agent
+  compliance checks (#854)
+
+### Security Fixes
+
+- Patched dependency verification bypass and trust handshake DID forgery (#920)
+- Hardened CLI error handling to prevent internal information disclosure (CWE-209)
+- Audit log key-whitelisting to prevent leakage of sensitive agent state
+- Regex-based validation for agent identifiers to prevent injection attacks
+
+## Breaking Changes
+
+**None.** This is a backwards-compatible minor release. All existing v3.0.x
+configurations, policies, and integrations work without modification.
+
+## Upgrading
+
+```bash
+pip install --upgrade agent-governance-toolkit==3.1.0
+```
+
+For individual packages:
+
+```bash
+pip install --upgrade agent-os-kernel==3.1.0
+pip install --upgrade agentmesh-platform==3.1.0
+pip install --upgrade agent-hypervisor==3.1.0
+pip install --upgrade agent-sre==3.1.0
+```
+
+No configuration changes are required. The `agt` CLI is available automatically
+after upgrading the `agentmesh-platform` package.
+
+## Packages
+
+**Python (PyPI) — core packages @ v3.1.0:**
+
+| Package | PyPI Name | Version | Status |
+|---------|-----------|---------|--------|
+| Agent OS Kernel | [`agent-os-kernel`](https://pypi.org/project/agent-os-kernel/) | 3.1.0 | Public Preview |
+| AgentMesh Platform | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | 3.1.0 | Public Preview |
+| Agent Hypervisor | [`agent-hypervisor`](https://pypi.org/project/agent-hypervisor/) | 3.1.0 | Public Preview |
+| Agent SRE | [`agent-sre`](https://pypi.org/project/agent-sre/) | 3.1.0 | Public Preview |
+| Agent Compliance | [`agent-compliance`](https://pypi.org/project/agent-compliance/) | 3.1.0 | Public Preview |
+| AgentMesh Runtime | [`agentmesh-runtime`](https://pypi.org/project/agentmesh-runtime/) | 3.1.0 | Public Preview |
+| AgentMesh Lightning | [`agentmesh-lightning`](https://pypi.org/project/agentmesh-lightning/) | 3.1.0 | Public Preview |
+
+**New packages (independent versioning):**
+
+| Package | Version | Status |
+|---------|---------|--------|
+| Agent Discovery | 0.1.0 | Public Preview |
+| Agent MCP Governance | 0.1.0 | Public Preview |
+| APS AgentMesh | 0.1.0 | Public Preview |
+
+**npm — packages under `@microsoft` scope**
+
+**.NET — NuGet package**
+
+**Rust — crates.io crate**
+
+**Go — Go module**
+
+## Full Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the complete list of changes since v3.0.2.

--- a/demo/README.md
+++ b/demo/README.md
@@ -66,9 +66,23 @@ python demo/maf_governance_demo.py --verbose
 |------|---------|
 | `demo/maf_governance_demo.py` | Main demo script (real LLM calls) |
 | `demo/policies/research_policy.yaml` | Declarative governance policy |
+| `demo/governance-dashboard/` | **Real-time Streamlit dashboard** — fleet overview, shadow agents, lifecycle, policy feed, trust heatmap |
 | `packages/agent-os/src/agent_os/integrations/maf_adapter.py` | Governance middleware |
 | `packages/agent-mesh/src/agentmesh/governance/audit.py` | Merkle-chained audit log |
 | `packages/agent-sre/src/agent_sre/anomaly/rogue_detector.py` | Rogue agent detector |
+
+## Governance Dashboard
+
+For a visual overview of your agent fleet:
+
+```bash
+cd demo/governance-dashboard
+pip install -r requirements.txt
+streamlit run app.py
+# or: docker-compose up
+```
+
+See the [dashboard README](governance-dashboard/README.md) for details.
 
 ## Links
 

--- a/packages/agent-compliance/pyproject.toml
+++ b/packages/agent-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_governance_toolkit"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — Unified installer and runtime policy enforcement for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-hypervisor/pyproject.toml
+++ b/packages/agent-hypervisor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_hypervisor"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — Agent Hypervisor: Runtime supervisor for multi-agent Shared Sessions with Execution Rings, Joint Liability, Saga Orchestration, and hash-chained audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-lightning/pyproject.toml
+++ b/packages/agent-lightning/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_lightning"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — Agent-Lightning RL integration for the Agent Governance Toolkit: governed training with policy enforcement"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-marketplace/pyproject.toml
+++ b/packages/agent-marketplace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_marketplace"
-version = "3.0.2"
+version = "3.1.0"
 description = "Plugin marketplace for the Agent Governance Toolkit — discover, install, verify, and manage plugins"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -103,6 +103,7 @@ The protocols exist (A2A, MCP, IATP). The agents are shipping. **The trust layer
 ├───────────┼─────────────────────────────────────────────────────────────────┤
 │  LAYER 1  │  Identity & Zero-Trust Core                                     │
 │           │  Agent CA · Ephemeral creds · SPIFFE/SVID · Human sponsors      │
+│           │  Ed25519 + ML-DSA-65 (quantum-safe) · Lifecycle management      │
 └───────────┴─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -121,9 +122,12 @@ AgentMesh provides:
 | Capability | Description |
 |------------|-------------|
 | **Agent Identity** | First-class identity with human sponsor accountability |
+| **Quantum-Safe Signing** | Ed25519 + ML-DSA-65 (FIPS 204) post-quantum signatures |
 | **Ephemeral Credentials** | 15-minute TTL by default, auto-rotation |
+| **Lifecycle Management** | Provisioning → approval → activation → rotation → decommission |
 | **Protocol Bridge** | Native A2A, MCP, IATP with unified trust model |
 | **Reward Engine** | Continuous behavioral scoring |
+| **Orphan Detection** | Find silent, unowned, and stale agents |
 | **Compliance Automation** | EU AI Act, SOC 2, HIPAA, GDPR mapping |
 
 ## How It Works
@@ -610,7 +614,7 @@ classifier = EUAIActRiskClassifier(config_path="my_updated_annex_iii.yaml")
 | Quarter | Milestone |
 |---------|-----------|
 | **Q1 2026** | ✅ Core trust layer, identity, governance engine, 6 framework integrations |
-| **Q2 2026** | TypeScript SDK, Go SDK, Dashboard UI. Marketplace is now a standalone `agentmesh-marketplace` package. |
+| **Q2 2026** | ✅ TypeScript SDK, Go SDK, lifecycle management, quantum-safe ML-DSA-65 signing, governance dashboard |
 | **Q3 2026** | AI Card spec contribution, CNCF Sandbox application |
 | **Q4 2026** | Managed cloud service (AgentMesh Cloud), SOC2 Type II |
 

--- a/packages/agent-mesh/packages/langchain-agentmesh/pyproject.toml
+++ b/packages/agent-mesh/packages/langchain-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust verification for AI agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/agent-mesh/packages/mcp-trust-server/pyproject.toml
+++ b/packages/agent-mesh/packages/mcp-trust-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp_trust_server"
-version = "3.0.2"
+version = "3.1.0"
 description = "MCP server exposing AgentMesh trust management tools for Claude, GPT, and other AI agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/agent-mesh/pyproject.toml
+++ b/packages/agent-mesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_platform"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — The Secure Nervous System for Cloud-Native Agent Ecosystems - Identity, Trust, Reward, Governance"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-mesh/src/agentmesh/cli/main.py
+++ b/packages/agent-mesh/src/agentmesh/cli/main.py
@@ -57,7 +57,7 @@ def handle_error(e: Exception, output_json: bool = False, custom_msg: str | None
 
 
 @click.group()
-@click.version_option(version="1.0.0-alpha")
+@click.version_option(version="3.1.0")
 def app():
     """
     AgentMesh - The Secure Nervous System for Cloud-Native Agent Ecosystems

--- a/packages/agent-os/examples/carbon-auditor/pyproject.toml
+++ b/packages/agent-os/examples/carbon-auditor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon_auditor_swarm"
-version = "3.0.2"
+version = "3.1.0"
 description = "Autonomous auditing system for the Voluntary Carbon Market (VCM)"
 license = {text = "MIT"}
 readme = "README.md"

--- a/packages/agent-os/examples/defi-sentinel/pyproject.toml
+++ b/packages/agent-os/examples/defi-sentinel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defi_sentinel_demo"
-version = "3.0.2"
+version = "3.1.0"
 description = "DeFi Risk Sentinel demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/packages/agent-os/examples/grid-balancing/pyproject.toml
+++ b/packages/agent-os/examples/grid-balancing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grid_balancing_demo"
-version = "3.0.2"
+version = "3.1.0"
 description = "Autonomous energy trading demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/packages/agent-os/examples/pharma-compliance/pyproject.toml
+++ b/packages/agent-os/examples/pharma-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pharma_compliance_demo"
-version = "3.0.2"
+version = "3.1.0"
 description = "Pharma Compliance demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/packages/agent-os/modules/amb/pyproject.toml
+++ b/packages/agent-os/modules/amb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amb_core"
-version = "3.0.2"
+version = "3.1.0"
 description = "A lightweight, broker-agnostic message bus designed specifically for AI Agents"
 license = {text = "MIT"}
 readme = "README.md"

--- a/packages/agent-os/modules/atr/pyproject.toml
+++ b/packages/agent-os/modules/atr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_tool_registry"
-version = "3.0.2"
+version = "3.1.0"
 description = "A decentralized marketplace for agent capabilities - The Hands of AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/agent-os/modules/caas/pyproject.toml
+++ b/packages/agent-os/modules/caas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caas_core"
-version = "3.0.2"
+version = "3.1.0"
 description = "A pure, logic-only library for routing context, handling RAG fallacies, and managing context windows. Layer 1 Primitive - no agent dependencies."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/packages/agent-os/modules/cmvk/pyproject.toml
+++ b/packages/agent-os/modules/cmvk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cmvk"
-version = "3.0.2"
+version = "3.1.0"
 description = "Mathematical drift detection library for calculating drift/hallucination scores between outputs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/agent-os/modules/control-plane/pyproject.toml
+++ b/packages/agent-os/modules/control-plane/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_control_plane"
-version = "3.0.2"
+version = "3.1.0"
 description = "Layer 3: The Framework - A deterministic kernel for zero-violation governance in agentic AI systems with POSIX-style signals, VFS, and kernel/user space separation"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/packages/agent-os/modules/emk/pyproject.toml
+++ b/packages/agent-os/modules/emk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "emk"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — Episodic Memory Kernel for AI agent experience storage"
 authors = [
     { name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" }

--- a/packages/agent-os/modules/iatp/pyproject.toml
+++ b/packages/agent-os/modules/iatp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "inter_agent_trust_protocol"
-version = "3.0.2"
+version = "3.1.0"
 description = "Inter-Agent Trust Protocol (IATP) - The Envoy for AI Agents. A sidecar architecture with typed IPC pipes for preventing cascading hallucinations in autonomous agent networks."
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-os/modules/mcp-kernel-server/pyproject.toml
+++ b/packages/agent-os/modules/mcp-kernel-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp_kernel_server"
-version = "3.0.2"
+version = "3.1.0"
 description = "MCP Server for Claude Desktop - Agent OS kernel primitives including code safety verification, CMVK multi-model review, and IATP trust"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-os/modules/nexus/pyproject.toml
+++ b/packages/agent-os/modules/nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus_trust_exchange"
-version = "3.0.2"
+version = "3.1.0"
 description = "Agent Trust Exchange - viral registry and communication board for AI agents (RESEARCH PROTOTYPE)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-os/modules/observability/pyproject.toml
+++ b/packages/agent-os/modules/observability/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_os_observability"
-version = "3.0.2"
+version = "3.1.0"
 description = "Production observability for Agent OS - OpenTelemetry traces, Prometheus metrics, Grafana dashboards"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-os/modules/primitives/pyproject.toml
+++ b/packages/agent-os/modules/primitives/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_primitives"
-version = "3.0.2"
+version = "3.1.0"
 description = "Shared primitive data models for Agent OS - failure types, severity levels, and base structures"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-os/pyproject.toml
+++ b/packages/agent-os/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_os_kernel"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — A kernel architecture for governing autonomous AI agents with Nexus Trust Exchange"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-runtime/pyproject.toml
+++ b/packages/agent-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_runtime"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — AgentMesh Runtime: Execution supervisor for multi-agent sessions with privilege rings, saga orchestration, and audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agent-sre/pyproject.toml
+++ b/packages/agent-sre/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_sre"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — Reliability Engineering for AI Agent Systems"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/a2a-protocol/pyproject.toml
+++ b/packages/agentmesh-integrations/a2a-protocol/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "a2a_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "A2A protocol bridge for AgentMesh — trust-verified agent-to-agent communication via the A2A standard"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/adk-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/adk-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adk_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "Public Preview — Agent Governance Toolkit integration for Google ADK: policy enforcement, trust verification, and audit trails for ADK agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/crewai-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/crewai-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "crewai_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "AgentMesh trust layer for CrewAI — trust-verified crew member selection and capability-gated task assignment"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/flowise-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/flowise-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowise_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "AgentMesh governance nodes for Flowise — policy enforcement, trust gating, audit logging, and rate limiting for visual AI flows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/haystack-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/haystack-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "haystack_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "AgentMesh governance components for Haystack pipelines — policy enforcement, trust scoring, and tamper-evident audit trails"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/agentmesh-integrations/langchain-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/langchain-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust-gated tool execution"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/langflow-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/langflow-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langflow_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "Governance components for Langflow — policy enforcement, trust routing, audit logging, and compliance checking for visual AI flows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/agentmesh-integrations/langgraph-trust/pyproject.toml
+++ b/packages/agentmesh-integrations/langgraph-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph_trust"
-version = "3.0.2"
+version = "3.1.0"
 description = "Trust-gated checkpoint nodes for LangGraph — cryptographic identity, policy enforcement, and trust-aware routing for multi-agent graphs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
 
 [project]
 name = "llama_index_agent_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "AgentMesh trust layer integration for LlamaIndex agents"
 authors = [{name = "AgentMesh Contributors"}]
 requires-python = ">=3.9,<4.0"

--- a/packages/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
+++ b/packages/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp_trust_proxy"
-version = "3.0.2"
+version = "3.1.0"
 description = "MCP proxy that wraps any MCP tool with AgentMesh trust verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/nostr-wot/pyproject.toml
+++ b/packages/agentmesh-integrations/nostr-wot/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_nostr_wot"
-version = "3.0.2"
+version = "3.1.0"
 description = "Nostr Web of Trust integration for AgentMesh trust engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openai_agents_agentmesh"
-version = "3.0.2"
+version = "3.1.0"
 description = "AgentMesh trust layer for OpenAI Agents SDK — trust-gated function calling and handoff verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/openai-agents-trust/pyproject.toml
+++ b/packages/agentmesh-integrations/openai-agents-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openai_agents_trust"
-version = "3.0.2"
+version = "3.1.0"
 description = "Trust & governance layer for OpenAI Agents SDK — policy enforcement, trust-gated handoffs, and hash-chained audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
+++ b/packages/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pydantic_ai_governance"
-version = "3.0.2"
+version = "3.1.0"
 description = "Governance middleware for PydanticAI — semantic policy enforcement, trust scoring, and audit trails for agent tool execution"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## Summary

Bump all packages from **3.0.2** → **3.1.0** for the next minor release.

### Changes
- **39 pyproject.toml** files bumped from 3.0.2 to 3.1.0
- **CLI version** updated from 1.0.0-alpha to 3.1.0
- **CHANGELOG.md** updated with all changes since v3.0.1
- **RELEASE_NOTES_v3.1.0.md** added
- **README.md** updated with v3.1.0 features (agent discovery, lifecycle, dashboard, quantum-safe signing)

### New features in v3.1.0
- Unified `agt` CLI with plugin discovery and doctor command (#924)
- Governance Dashboard — real-time agent fleet visibility (#925)
- Agent Lifecycle Management — provisioning to decommission (#923)
- Agent Discovery — shadow AI discovery & inventory (#921)
- Quantum-safe ML-DSA-65 signing alongside Ed25519 (#927)
- Vendor independence enforcement across all core packages
- OWASP ASI 2026 taxonomy migration
- PromptDefenseEvaluator — 12-vector prompt audit (#854)

### Packages NOT bumped (independent version train)
- agent-discovery (0.1.0)
- agent-mcp-governance (0.1.0)
- aps-agentmesh (0.1.0)
- scopeblind-protect-mcp (0.1.1)
- template-agentmesh (0.1.0)

No breaking changes. No source code logic changes.