### PR TITLE
docs: simplify README — clear narrative flow, collapsible quickstarts, capability table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,163 +2,72 @@
 
 ![Agent Governance Toolkit](docs/assets/readme-banner.svg)
 
-# Welcome to Agent Governance Toolkit!
+# Agent Governance Toolkit
 
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
-[![TypeScript](https://img.shields.io/badge/TypeScript-npm_%40agentmesh%2Fsdk-blue?logo=typescript)](packages/agent-mesh/sdks/typescript/)
-[![.NET 8.0+](https://img.shields.io/badge/.NET_8.0+-NuGet-blue?logo=dotnet)](https://www.nuget.org/packages/Microsoft.AgentGovernance)
-[![Rust](https://img.shields.io/badge/Rust-crates.io-orange?logo=rust)](packages/agent-mesh/sdks/rust/agentmesh/)
-[![Go](https://img.shields.io/badge/Go-module-00ADD8?logo=go)](packages/agent-mesh/sdks/go/)
 [![OWASP Agentic Top 10](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10_Covered-blue)](docs/OWASP-COMPLIANCE.md)
-[![OpenSSF Best Practices](https://img.shields.io/cii/percentage/12085?label=OpenSSF%20Best%20Practices&logo=opensourcesecurity)](https://www.bestpractices.dev/projects/12085)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/microsoft/agent-governance-toolkit/badge)](https://scorecard.dev/viewer/?uri=github.com/microsoft/agent-governance-toolkit)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/microsoft/agent-governance-toolkit)
 
 > [!IMPORTANT]
-> **Public Preview** — All packages published from this repository are
-> **Microsoft-signed public preview releases**. They are production-quality but
-> may have breaking changes before GA. For feedback, please
-> [open a GitHub issue](https://github.com/microsoft/agent-governance-toolkit/issues).
->
-> **What this toolkit is:** Runtime governance infrastructure — deterministic policy
-> enforcement, zero-trust identity, execution sandboxing, and reliability engineering
-> that sits between your agent framework and the actions agents take.
->
-> **What this toolkit is not:** This is not a model safety or prompt guardrails tool.
-> It does not filter LLM inputs/outputs or perform content moderation. It governs
-> *agent actions* (tool calls, resource access, inter-agent communication) at the
-> application layer. For model-level safety, see
-> [Azure AI Content Safety](https://learn.microsoft.com/azure/ai-services/content-safety/).
+> **Public Preview** — Microsoft-signed, production-quality releases. May have breaking changes before GA.
+> [Open a GitHub issue](https://github.com/microsoft/agent-governance-toolkit/issues) for feedback.
 
-Runtime governance for AI agents — the only toolkit covering all **10 OWASP Agentic risks** with **9,500+ tests**. Governs what agents *do*, not just what they say — deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE — **Python · TypeScript · .NET · Rust · Go**
+**Runtime governance for AI agents** — deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous agents. Covers all **10 OWASP Agentic risks** with **9,500+ tests**.
 
-> **Works with any stack** — AWS Bedrock, Google ADK, Azure AI, LangChain, CrewAI, AutoGen, OpenAI Agents, LlamaIndex, and more. Pure `pip install` with zero vendor lock-in.
+**Works with any stack** — AWS Bedrock, Google ADK, Azure AI, LangChain, CrewAI, AutoGen, OpenAI Agents, and 20+ more. Python · TypeScript · .NET · Rust · Go.
 
-## 📋 Getting Started
+---
 
-### 📦 Installation
+## What This Is (and Isn't)
 
-**Python** (PyPI)
+**What it does:** Sits between your agent framework and the actions agents take. Every tool call, resource access, and inter-agent message is evaluated against policy *before* execution. Deterministic — not probabilistic.
+
+**What it doesn't do:** This is not a prompt guardrail or content moderation tool. It governs agent *actions*, not LLM inputs/outputs. For model-level safety, see [Azure AI Content Safety](https://learn.microsoft.com/azure/ai-services/content-safety/).
+
+```
+Agent Action ──► Policy Check ──► Allow / Deny ──► Audit Log    (< 0.1 ms)
+```
+
+**Why it matters:** Prompt-based safety ("please follow the rules") has a [26.67% policy violation rate](BENCHMARKS.md) in red-team testing. AGT's kernel-level enforcement: **0.00%**.
+
+---
+
+## Get Started in 90 Seconds
+
 ```bash
+# 1. Install
 pip install agent-governance-toolkit[full]
+
+# 2. Check your installation
+agt doctor
+
+# 3. Verify OWASP compliance
+agt verify
 ```
 
-**TypeScript / Node.js** (npm)
-```bash
-npm install @agentmesh/sdk
-```
+Then govern your first action:
 
-**.NET** (NuGet)
-```bash
-dotnet add package Microsoft.AgentGovernance
-```
+```python
+from agent_os.policies import PolicyEvaluator, PolicyDocument, PolicyRule, PolicyCondition, PolicyAction, PolicyOperator, PolicyDefaults
 
-**Rust** (full SDK)
-```bash
-cargo add agentmesh
-```
+evaluator = PolicyEvaluator(policies=[PolicyDocument(
+    name="my-policy", version="1.0",
+    defaults=PolicyDefaults(action=PolicyAction.ALLOW),
+    rules=[PolicyRule(
+        name="block-dangerous-tools",
+        condition=PolicyCondition(field="tool_name", operator=PolicyOperator.IN, value=["execute_code", "delete_file"]),
+        action=PolicyAction.DENY, priority=100,
+    )],
+)])
 
-**Rust** (standalone MCP surface)
-```bash
-cargo add agentmesh-mcp
+result = evaluator.evaluate({"tool_name": "web_search"})    # ✅ Allowed
+result = evaluator.evaluate({"tool_name": "delete_file"})   # ❌ Blocked deterministically
 ```
 
 <details>
-<summary>Install individual Python packages</summary>
-
-```bash
-pip install agent-os-kernel        # Policy engine
-pip install agentmesh-platform     # Trust mesh
-pip install agentmesh-runtime       # Runtime supervisor
-pip install agent-sre              # SRE toolkit
-pip install agent-governance-toolkit    # Compliance & attestation
-pip install agentmesh-marketplace      # Plugin marketplace
-pip install agentmesh-lightning        # RL training governance
-pip install agent-discovery            # Shadow AI agent discovery
-```
-</details>
-
-### 📚 Documentation
-
-- **[Quick Start](QUICKSTART.md)** — Get from zero to governed agents in 10 minutes (Python · TypeScript · .NET · Rust · Go)
-- **[TypeScript SDK](packages/agent-mesh/sdks/typescript/README.md)** — npm package with identity, trust, policy, and audit
-- **[.NET SDK](packages/agent-governance-dotnet/README.md)** — NuGet package with full OWASP coverage
-- **[Rust SDK](packages/agent-mesh/sdks/rust/agentmesh/README.md)** — full crates.io crate with policy, trust, audit, identity, and MCP governance primitives
-- **[Rust MCP SDK](packages/agent-mesh/sdks/rust/agentmesh-mcp/README.md)** — standalone crates.io crate with MCP governance and security primitives
-- **[Go SDK](packages/agent-mesh/sdks/go/README.md)** — Go module with policy, trust, audit, and identity
-- **[Tutorials](docs/tutorials/)** — Step-by-step guides for policy, identity, integrations, compliance, SRE, and sandboxing
-- **[Azure Deployment](docs/deployment/README.md)** — AKS, Azure AI Foundry, Container Apps, OpenClaw sidecar
-- **[NVIDIA OpenShell Integration](docs/integrations/openshell.md)** — Combine sandbox isolation with governance intelligence
-- **[OWASP Compliance](docs/OWASP-COMPLIANCE.md)** — Full ASI-01 through ASI-10 mapping
-- **[Threat Model](docs/THREAT_MODEL.md)** — Trust boundaries, attack surfaces, and STRIDE analysis
-- **[Architecture](docs/ARCHITECTURE.md)** — System design, security model, trust scoring
-- **[Architecture Decisions](docs/adr/README.md)** — ADR log for key identity, runtime, and policy choices
-- **[Architecture Infographic](docs/diagrams/architecture-overview.png)** — Visual overview of all components and data flow ([SVG](docs/diagrams/architecture-overview.svg) · [draw.io source](docs/diagrams/architecture-overview.drawio))
-- **[NIST RFI Mapping](docs/compliance/nist-rfi-2026-00206.md)** — Mapping to NIST AI Agent Security RFI (2026-00206)
-- **[VS Code Extension](packages/agent-os-vscode/)** — Agent OS governance directly in VS Code
-- **[Framework Integrations](packages/agentmesh-integrations/)** — LangChain, OpenAI Agents, CrewAI, Haystack, and more
-
-Still have questions? File a [GitHub issue](https://github.com/microsoft/agent-governance-toolkit/issues) or see our [Community page](COMMUNITY.md).
-
-### ✨ **Highlights**
-
-- **Deterministic Policy Enforcement**: Every agent action evaluated against policy *before* execution at sub-millisecond latency (<0.1 ms)
-  - [Policy Engine](packages/agent-os/) | [Benchmarks](BENCHMARKS.md)
-- **Zero-Trust Agent Identity**: Ed25519 + **quantum-safe ML-DSA-65** cryptographic credentials, SPIFFE/SVID support, trust scoring on a 0–1000 scale
-  - [AgentMesh](packages/agent-mesh/) | [Quantum-Safe Signing](packages/agent-mesh/src/agentmesh/identity/quantum_safe.py)
-- **Execution Sandboxing**: 4-tier privilege rings, saga orchestration, termination control, kill switch
-  - [Agent Runtime](packages/agent-runtime/) | [Agent Hypervisor](packages/agent-hypervisor/)
-- **Agent SRE**: SLOs, error budgets, replay debugging, chaos engineering, circuit breakers, progressive delivery
-  - [Agent SRE](packages/agent-sre/) | [Observability integrations](packages/agent-hypervisor/src/hypervisor/observability/)
-- **MCP Security Scanner**: Detect tool poisoning, typosquatting, hidden instructions, and rug-pull attacks in MCP tool definitions
-  - [MCP Scanner](packages/agent-os/src/agent_os/mcp_security.py) | [CLI](packages/agent-os/src/agent_os/cli/mcp_scan.py)
-- **Trust Report CLI**: `agentmesh trust report` — visualize trust scores, task success/failure, and agent activity
-  - [Trust CLI](packages/agent-mesh/src/agentmesh/cli/trust_cli.py)
-- **Secret Scanning & Fuzzing**: Gitleaks workflow, 7 fuzz targets covering policy, injection, sandbox, trust, and MCP
-  - [Security workflows](.github/workflows/)
-- **12+ Framework Integrations**: Microsoft Agent Framework, LangChain, CrewAI, AutoGen, Dify, LlamaIndex, OpenAI Agents, Google ADK, and more
-  - [Framework quickstarts](examples/quickstart/) | [Integration proposals](docs/proposals/)
-- **Shadow AI Discovery**: Scan processes, filesystems, and GitHub repos to find unregistered agents. Inventory with dedup, reconciliation, and risk scoring
-  - [Agent Discovery](packages/agent-discovery/) | [Tutorial](docs/tutorials/29-agent-discovery.md)
-- **Agent Lifecycle Management**: Provisioning workflows, credential rotation, heartbeat monitoring, orphan detection, decommissioning with full audit trail
-  - [Lifecycle Manager](packages/agent-mesh/src/agentmesh/lifecycle/) | [Tutorial](docs/tutorials/30-agent-lifecycle.md)
-- **Governance Dashboard**: Real-time Streamlit dashboard with fleet overview, shadow agent alerts, lifecycle monitor, policy feed, and trust heatmap
-  - [Dashboard Demo](demo/governance-dashboard/) | [Docker Compose](demo/governance-dashboard/docker-compose.yml)
-- **Full OWASP Coverage**: 10/10 Agentic Top 10 risks addressed with dedicated controls for each ASI category
-  - [OWASP Compliance](docs/OWASP-COMPLIANCE.md) | [Competitive Comparison](docs/COMPARISON.md)
-- **GitHub Actions for CI/CD**: Automated security scanning and governance attestation for PR workflows
-  - [Security Scan Action](action/security-scan/) | [Governance Attestation Action](action/governance-attestation/)
-
-### 💬 **We want your feedback!**
-
-- For bugs, please file a [GitHub issue](https://github.com/microsoft/agent-governance-toolkit/issues).
-
-## Quickstart
-
-### Enforce a policy — Python
-
-```python
-from agent_os.policies import PolicyEvaluator
-
-# Create evaluator and load YAML policy rules
-evaluator = PolicyEvaluator()
-evaluator.load_policies("policies/")   # or inline via PolicyDocument
-
-# Enforce policy before every action
-decision = evaluator.evaluate({
-    "agent_id": "researcher-1",
-    "action": "tool_call",
-    "tool_name": "web_search",
-})
-
-if decision.allowed:
-    # proceed with tool call
-    ...
-```
-
-### Enforce a policy — TypeScript
+<summary><b>TypeScript</b></summary>
 
 ```typescript
 import { PolicyEngine } from "@agentmesh/sdk";
@@ -167,11 +76,14 @@ const engine = new PolicyEngine([
   { action: "web_search", effect: "allow" },
   { action: "shell_exec", effect: "deny" },
 ]);
-
-const decision = engine.evaluate("web_search"); // "allow"
+engine.evaluate("web_search"); // "allow"
+engine.evaluate("shell_exec"); // "deny"
 ```
 
-### Enforce a policy — .NET
+</details>
+
+<details>
+<summary><b>.NET</b></summary>
 
 ```csharp
 using AgentGovernance;
@@ -182,16 +94,15 @@ var kernel = new GovernanceKernel(new GovernanceOptions
     PolicyPaths = new() { "policies/default.yaml" },
 });
 
-var result = kernel.EvaluateToolCall(
-    agentId: "did:mesh:researcher-1",
-    toolName: "web_search",
-    args: new() { ["query"] = "latest AI news" }
-);
-
-if (result.Allowed) { /* proceed */ }
+var result = kernel.EvaluateToolCall("did:mesh:agent-1", "web_search",
+    new() { ["query"] = "latest AI news" });
+// result.Allowed == true
 ```
 
-### Enforce a policy — Rust
+</details>
+
+<details>
+<summary><b>Rust</b></summary>
 
 ```rust
 use agentmesh::{AgentMeshClient, ClientOptions};
@@ -201,7 +112,10 @@ let result = client.execute_with_governance("data.read", None);
 assert!(result.allowed);
 ```
 
-### Enforce a policy — Go
+</details>
+
+<details>
+<summary><b>Go</b></summary>
 
 ```go
 import agentmesh "github.com/microsoft/agent-governance-toolkit/sdks/go"
@@ -216,150 +130,67 @@ result := client.ExecuteWithGovernance("data.read", nil)
 // result.Allowed == true
 ```
 
-### Run the governance demo
+</details>
 
-```bash
-# Full governance demo (policy enforcement, audit, trust, cost, reliability)
-python demo/maf_governance_demo.py
+> **Full walkthrough:** [QUICKSTART.md](QUICKSTART.md) — zero to governed agents in 10 minutes with YAML policies, OPA/Rego, and Cedar support.
 
-# Run with adversarial attack scenarios
-python demo/maf_governance_demo.py --include-attacks
-```
+---
 
-## More Examples & Samples
+## What You Get
 
-- **[Framework Quickstarts](examples/quickstart/)** — One-file governed agents for LangChain, CrewAI, AutoGen, OpenAI Agents, Google ADK
-- **[Tutorial 1: Policy Engine](docs/tutorials/01-policy-engine.md)** — Define and enforce governance policies
-- **[Tutorial 2: Trust & Identity](docs/tutorials/02-trust-and-identity.md)** — Zero-trust agent credentials
-- **[Tutorial 3: Framework Integrations](docs/tutorials/03-framework-integrations.md)** — Add governance to any framework
-- **[Tutorial 4: Audit & Compliance](docs/tutorials/04-audit-and-compliance.md)** — OWASP compliance and attestation
-- **[Tutorial 5: Agent Reliability](docs/tutorials/05-agent-reliability.md)** — SLOs, error budgets, chaos testing
-- **[Tutorial 6: Execution Sandboxing](docs/tutorials/06-execution-sandboxing.md)** — Privilege rings and termination
+| Capability | What It Does | Links |
+|---|---|---|
+| **Policy Engine** | Every action evaluated before execution — sub-millisecond, deterministic. Supports YAML, OPA/Rego, and Cedar policies | [Agent OS](packages/agent-os/) · [Benchmarks](BENCHMARKS.md) |
+| **Zero-Trust Identity** | Ed25519 + quantum-safe ML-DSA-65 credentials, trust scoring (0–1000), SPIFFE/SVID | [AgentMesh](packages/agent-mesh/) |
+| **Execution Sandboxing** | 4-tier privilege rings, saga orchestration, kill switch | [Runtime](packages/agent-runtime/) · [Hypervisor](packages/agent-hypervisor/) |
+| **Agent SRE** | SLOs, error budgets, replay debugging, chaos engineering, circuit breakers | [Agent SRE](packages/agent-sre/) |
+| **MCP Security Scanner** | Detect tool poisoning, typosquatting, hidden instructions in MCP definitions | [MCP Scanner](packages/agent-os/src/agent_os/mcp_security.py) |
+| **Shadow AI Discovery** | Find unregistered agents across processes, configs, and repos | [Agent Discovery](packages/agent-discovery/) |
+| **Agent Lifecycle** | Provisioning → credential rotation → orphan detection → decommissioning | [Lifecycle](packages/agent-mesh/src/agentmesh/lifecycle/) |
+| **Governance Dashboard** | Real-time fleet visibility — health, trust, compliance, audit events | [Dashboard](demo/governance-dashboard/) |
+| **Unified CLI** | `agt verify`, `agt doctor`, `agt lint-policy` — one command for everything | [CLI](packages/agent-compliance/src/agent_compliance/cli/agt.py) |
+| **PromptDefense Evaluator** | 12-vector prompt injection audit for compliance testing | [Evaluator](packages/agent-compliance/src/agent_compliance/prompt_defense.py) |
 
-## OPA/Rego & Cedar Policy Support
+---
 
-Bring your existing infrastructure policies to agent governance — no new policy DSL required.
+## Works With Your Stack
 
-### OPA/Rego (Agent OS)
+| Framework | Integration |
+|-----------|-------------|
+| [**Microsoft Agent Framework**](https://github.com/microsoft/agent-framework) | Native Middleware |
+| [**Semantic Kernel**](https://github.com/microsoft/semantic-kernel) | Native (.NET + Python) |
+| [Microsoft AutoGen](https://github.com/microsoft/autogen) | Adapter |
+| [LangGraph](https://github.com/langchain-ai/langgraph) / [LangChain](https://github.com/langchain-ai/langchain) | Adapter |
+| [CrewAI](https://github.com/crewAIInc/crewAI) | Adapter |
+| [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | Middleware |
+| [Google ADK](https://github.com/google/adk-python) | Adapter |
+| [LlamaIndex](https://github.com/run-llama/llama_index) | Middleware |
+| [Haystack](https://github.com/deepset-ai/haystack) | Pipeline |
+| [Dify](https://github.com/langgenius/dify) | Plugin |
+| [Azure AI Foundry](https://learn.microsoft.com/azure/ai-studio/) | Deployment Guide |
 
-```python
-from agent_os.policies import PolicyEvaluator
+Full list: [Framework Integrations](packages/agentmesh-integrations/) · [Quickstart Examples](examples/quickstart/)
 
-evaluator = PolicyEvaluator()
-evaluator.load_rego(rego_content="""
-package agentos
-default allow = false
-allow { input.tool_name == "web_search" }
-allow { input.role == "admin" }
-""")
+---
 
-decision = evaluator.evaluate({"tool_name": "web_search", "role": "analyst"})
-# decision.allowed == True
-```
+## OWASP Agentic Top 10 — 10/10 Covered
 
-### Cedar (Agent OS)
+| Risk | ID | AGT Control |
+|------|----|-------------|
+| Agent Goal Hijacking | ASI-01 | Policy engine blocks unauthorized goal changes |
+| Excessive Capabilities | ASI-02 | Capability model enforces least-privilege |
+| Identity & Privilege Abuse | ASI-03 | Zero-trust identity with Ed25519 + ML-DSA-65 |
+| Uncontrolled Code Execution | ASI-04 | Execution rings + sandboxing |
+| Insecure Output Handling | ASI-05 | Content policies validate all outputs |
+| Memory Poisoning | ASI-06 | Episodic memory with integrity checks |
+| Unsafe Inter-Agent Comms | ASI-07 | Encrypted channels + trust gates |
+| Cascading Failures | ASI-08 | Circuit breakers + SLO enforcement |
+| Human-Agent Trust Deficit | ASI-09 | Full audit trails + flight recorder |
+| Rogue Agents | ASI-10 | Kill switch + ring isolation + anomaly detection |
 
-```python
-from agent_os.policies import PolicyEvaluator
+Full mapping: [OWASP-COMPLIANCE.md](docs/OWASP-COMPLIANCE.md) · Regulatory alignment: [EU AI Act](docs/compliance/), [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md), [Colorado AI Act](docs/compliance/)
 
-evaluator = PolicyEvaluator()
-evaluator.load_cedar(policy_content="""
-permit(principal, action == Action::"ReadData", resource);
-forbid(principal, action == Action::"DeleteFile", resource);
-""")
-
-decision = evaluator.evaluate({"tool_name": "read_data", "agent_id": "agent-1"})
-# decision.allowed == True
-```
-
-### AgentMesh OPA/Cedar
-
-```python
-from agentmesh.governance import PolicyEngine
-
-engine = PolicyEngine()
-engine.load_rego("policies/mesh.rego", package="agentmesh")
-engine.load_cedar(cedar_content='permit(principal, action == Action::"Analyze", resource);')
-
-decision = engine.evaluate("did:mesh:agent-1", {"tool_name": "analyze"})
-```
-
-Three evaluation modes per backend: **embedded engine** (cedarpy/opa CLI), **remote server**, or **built-in fallback** (zero external deps).
-
-## SDKs & Packages
-
-### Multi-Language SDKs
-
-| Language | Package | Install |
-|----------|---------|---------|
-| **Python** | [`agent-governance-toolkit[full]`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@agentmesh/sdk`](packages/agent-mesh/sdks/typescript/) | `npm install @agentmesh/sdk` |
-| **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
-| **Rust** | [`agentmesh`](https://crates.io/crates/agentmesh) | `cargo add agentmesh` |
-| **Rust MCP** | [`agentmesh-mcp`](https://crates.io/crates/agentmesh-mcp) | `cargo add agentmesh-mcp` |
-| **Go** | [`agentmesh`](packages/agent-mesh/sdks/go/) | `go get github.com/microsoft/agent-governance-toolkit/sdks/go` |
-
-### Python Packages (PyPI)
-
-| Package | PyPI | Description |
-|---------|------|-------------|
-| **Agent OS** | [`agent-os-kernel`](https://pypi.org/project/agent-os-kernel/) | Policy engine — deterministic action evaluation, capability model, audit logging, action interception, MCP gateway |
-| **AgentMesh** | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | Inter-agent trust — Ed25519/ML-DSA-65 identity, SPIFFE/SVID credentials, trust scoring, A2A/MCP/IATP protocol bridges, lifecycle management |
-| **Agent Runtime** | [`agentmesh-runtime`](packages/agent-runtime/) | Execution supervisor — 4-tier privilege rings, saga orchestration, termination control, joint liability, append-only audit log |
-| **Agent SRE** | [`agent-sre`](https://pypi.org/project/agent-sre/) | Reliability engineering — SLOs, error budgets, replay debugging, chaos engineering, progressive delivery |
-| **Agent Compliance** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | Runtime policy enforcement — OWASP ASI 2026 controls, governance attestation, integrity verification |
-| **Agent Marketplace** | [`agentmesh-marketplace`](packages/agent-marketplace/) | Plugin lifecycle — discover, install, verify, and sign plugins |
-| **Agent Lightning** | [`agentmesh-lightning`](packages/agent-lightning/) | RL training governance — governed runners, policy rewards |
-| **Agent Discovery** | [`agent-discovery`](packages/agent-discovery/) | Shadow AI discovery — scan processes, configs, and repos; inventory with dedup; reconciliation and risk scoring |
-| **Agent Hypervisor** | [`agent-hypervisor`](packages/agent-hypervisor/) | Reversibility verification, execution plan validation, hypervisor-level governance |
-| **MCP Governance** | [`agent-mcp-governance`](packages/agent-mcp-governance/) | MCP-specific security scanning and governance enforcement |
-| **VS Code Extension** | [`agent-os-vscode`](packages/agent-os-vscode/) | Agent OS governance directly in VS Code — policy visualization, audit viewer |
-| **Integrations** | [`agentmesh-integrations`](packages/agentmesh-integrations/) | Framework adapters — LangChain, OpenAI Agents, CrewAI, Haystack, Flowise, MCP proxy |
-
-## Framework Integrations
-
-Works with **20+ agent frameworks** including:
-
-| Framework | Stars | Integration |
-|-----------|-------|-------------|
-| [**Microsoft Agent Framework**](https://github.com/microsoft/agent-framework) | 8K+ ⭐ | **Native Middleware** |
-| [**Semantic Kernel**](https://github.com/microsoft/semantic-kernel) | 27K+ ⭐ | **Native (.NET + Python)** |
-| [Dify](https://github.com/langgenius/dify) | 133K+ ⭐ | Plugin |
-| [Microsoft AutoGen](https://github.com/microsoft/autogen) | 55K+ ⭐ | Adapter |
-| [LlamaIndex](https://github.com/run-llama/llama_index) | 47K+ ⭐ | Middleware |
-| [CrewAI](https://github.com/crewAIInc/crewAI) | 46K+ ⭐ | Adapter |
-| [LangGraph](https://github.com/langchain-ai/langgraph) | 27K+ ⭐ | Adapter |
-| [Haystack](https://github.com/deepset-ai/haystack) | 24K+ ⭐ | Pipeline |
-| [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | 20K+ ⭐ | Middleware |
-| [Google ADK](https://github.com/google/adk-python) | 18K+ ⭐ | Adapter |
-| [Azure AI Foundry](https://learn.microsoft.com/azure/ai-studio/) | — | Deployment Guide |
-
-## OWASP Agentic Top 10 Coverage
-
-| Risk | ID | Status |
-|------|----|--------|
-| Agent Goal Hijacking | ASI-01 | ✅ Policy engine blocks unauthorized goal changes |
-| Excessive Capabilities | ASI-02 | ✅ Capability model enforces least-privilege |
-| Identity & Privilege Abuse | ASI-03 | ✅ Zero-trust identity with Ed25519 + quantum-safe ML-DSA-65 certs |
-| Uncontrolled Code Execution | ASI-04 | ✅ Agent Runtime execution rings + sandboxing |
-| Insecure Output Handling | ASI-05 | ✅ Content policies validate all outputs |
-| Memory Poisoning | ASI-06 | ✅ Episodic memory with integrity checks |
-| Unsafe Inter-Agent Communication | ASI-07 | ✅ AgentMesh encrypted channels + trust gates |
-| Cascading Failures | ASI-08 | ✅ Circuit breakers + SLO enforcement |
-| Human-Agent Trust Deficit | ASI-09 | ✅ Full audit trails + flight recorder |
-| Rogue Agents | ASI-10 | ✅ Kill switch + ring isolation + behavioral anomaly detection |
-
-Full mapping with implementation details and test evidence: **[OWASP-COMPLIANCE.md](docs/OWASP-COMPLIANCE.md)**
-
-### Regulatory Alignment
-
-| Regulation | Deadline | AGT Coverage |
-|------------|----------|-------------|
-| EU AI Act — High-Risk AI (Annex III) | August 2, 2026 | Audit trails (Art. 12), risk management (Art. 9), human oversight (Art. 14) |
-| Colorado AI Act (SB 24-205) | June 30, 2026 | Risk assessments, human oversight mechanisms, consumer disclosures |
-| EU AI Act — GPAI Obligations | Active | Transparency, copyright policies, systemic risk assessment |
-
-AGT provides **runtime governance** — what agents are allowed to do. For **data governance** and regulator-facing evidence export, see [Microsoft Purview DSPM for AI](https://learn.microsoft.com/purview/ai-microsoft-purview) as a complementary layer.
+---
 
 ## Performance
 
@@ -370,52 +201,86 @@ Governance adds **< 0.1 ms per action** — roughly 10,000× faster than an LLM 
 | Policy evaluation (1 rule) | 0.012 ms | 72K ops/sec |
 | Policy evaluation (100 rules) | 0.029 ms | 31K ops/sec |
 | Kernel enforcement | 0.091 ms | 9.3K ops/sec |
-| Adapter overhead | 0.004–0.006 ms | 130K–230K ops/sec |
-| Concurrent throughput (50 agents) | — | 35,481 ops/sec |
+| Concurrent (50 agents) | — | 35,481 ops/sec |
 
-Full methodology and per-adapter breakdowns: **[BENCHMARKS.md](BENCHMARKS.md)**
+Full methodology: [BENCHMARKS.md](BENCHMARKS.md)
 
-## Security Model & Limitations
+---
 
-This toolkit provides **application-level (Python middleware) governance**, not OS kernel-level isolation. The policy engine and the agents it governs run in the **same Python process**. This is the same trust boundary used by every Python-based agent framework (LangChain, CrewAI, AutoGen, etc.).
+## Install
 
-| Layer | What It Provides | What It Does NOT Provide |
-|-------|-----------------|------------------------|
-| Policy Engine | Deterministic action interception, deny-list enforcement | Hardware-level memory isolation |
-| Identity (IATP) | Ed25519 + ML-DSA-65 (quantum-safe) cryptographic agent credentials, trust scoring | OS-level process separation |
-| Execution Rings | Logical privilege tiers with resource limits | CPU ring-level enforcement |
-| Bootstrap Integrity | SHA-256 tamper detection of governance modules at startup | Hardware root-of-trust (TPM/Secure Boot) |
+| Language | Package | Command |
+|----------|---------|---------|
+| **Python** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
+| **TypeScript** | [`@agentmesh/sdk`](packages/agent-mesh/sdks/typescript/) | `npm install @agentmesh/sdk` |
+| **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
+| **Rust** | [`agentmesh`](https://crates.io/crates/agentmesh) | `cargo add agentmesh` |
+| **Go** | [`agentmesh`](packages/agent-mesh/sdks/go/) | `go get github.com/microsoft/agent-governance-toolkit/sdks/go` |
 
-**Production recommendations:**
-- Run each agent in a **separate container** for OS-level isolation
-- All security policy rules ship as **configurable sample configurations** — review and customize for your environment (see `examples/policies/`)
-- No built-in rule set should be considered exhaustive
-- For details see [Architecture — Security Model & Boundaries](docs/ARCHITECTURE.md)
+<details>
+<summary><b>Individual Python packages</b></summary>
 
-### Security Tooling
+| Package | PyPI | Description |
+|---------|------|-------------|
+| Agent OS | [`agent-os-kernel`](https://pypi.org/project/agent-os-kernel/) | Policy engine, capability model, audit logging, MCP gateway |
+| AgentMesh | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | Zero-trust identity, trust scoring, A2A/MCP/IATP bridges |
+| Agent Runtime | [`agentmesh-runtime`](packages/agent-runtime/) | Privilege rings, saga orchestration, termination control |
+| Agent SRE | [`agent-sre`](https://pypi.org/project/agent-sre/) | SLOs, error budgets, chaos engineering, circuit breakers |
+| Agent Compliance | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | OWASP verification, integrity checks, policy linting |
+| Agent Discovery | [`agent-discovery`](packages/agent-discovery/) | Shadow AI discovery, inventory, risk scoring |
+| Agent Hypervisor | [`agent-hypervisor`](packages/agent-hypervisor/) | Reversibility verification, execution plan validation |
+| Agent Marketplace | [`agentmesh-marketplace`](packages/agent-marketplace/) | Plugin lifecycle management |
+| Agent Lightning | [`agentmesh-lightning`](packages/agent-lightning/) | RL training governance |
+
+</details>
+
+---
+
+## Documentation
+
+**Getting Started**
+- [Quick Start](QUICKSTART.md) — Zero to governed agents in 10 minutes
+- [Tutorials](docs/tutorials/) — 30 step-by-step guides
+
+**Architecture & Reference**
+- [Architecture](docs/ARCHITECTURE.md) — System design, security model, trust scoring
+- [Architecture Decisions](docs/adr/README.md) — ADR log
+- [Threat Model](docs/THREAT_MODEL.md) — Trust boundaries and STRIDE analysis
+- [API: Agent OS](packages/agent-os/README.md) · [AgentMesh](packages/agent-mesh/README.md) · [Agent SRE](packages/agent-sre/README.md)
+
+**Compliance & Deployment**
+- [OWASP Compliance](docs/OWASP-COMPLIANCE.md) — Full ASI-01 through ASI-10 mapping
+- [Azure Deployment](docs/deployment/README.md) — AKS, AI Foundry, Container Apps
+- [NIST AI RMF Alignment](docs/compliance/nist-ai-rmf-alignment.md) · [EU AI Act](docs/compliance/) · [SOC 2 Mapping](docs/compliance/soc2-mapping.md)
+
+**Extensions**
+- [VS Code Extension](packages/agent-os-vscode/) · [Framework Integrations](packages/agentmesh-integrations/)
+
+---
+
+## Security
+
+This toolkit provides **application-level governance** (Python middleware), not OS kernel-level isolation. The policy engine and agents run in the same process — the same trust boundary as every Python agent framework.
+
+**Production recommendation:** Run each agent in a separate container for OS-level isolation. See [Architecture — Security Boundaries](docs/ARCHITECTURE.md).
 
 | Tool | Coverage |
 |------|----------|
 | CodeQL | Python + TypeScript SAST |
 | Gitleaks | Secret scanning on PR/push/weekly |
 | ClusterFuzzLite | 7 fuzz targets (policy, injection, MCP, sandbox, trust) |
-| Dependabot | 13 ecosystems (pip, npm, nuget, cargo, gomod, docker, actions) |
+| Dependabot | 13 ecosystems |
 | OpenSSF Scorecard | Weekly scoring + SARIF upload |
-| SBOM | SPDX + CycloneDX generation and attestation |
-| Dependency Review | PR-time CVE and license check |
 
-## Contributor Resources
+---
 
-- [Contributing Guide](CONTRIBUTING.md)
-- [Community](COMMUNITY.md)
-- [Security Policy](SECURITY.md)
-- [Architecture](docs/ARCHITECTURE.md)
-- [Changelog](CHANGELOG.md)
-- [Support](SUPPORT.md)
+## Contributing
+
+- [Contributing Guide](CONTRIBUTING.md) · [Community](COMMUNITY.md) · [Security Policy](SECURITY.md) · [Changelog](CHANGELOG.md)
 
 ## Important Notes
 
-If you use the Agent Governance Toolkit to build applications that operate with third-party agent frameworks or services, you do so at your own risk. We recommend reviewing all data being shared with third-party services and being cognizant of third-party practices for retention and location of data. It is your responsibility to manage whether your data will flow outside of your organization's compliance and geographic boundaries and any related implications.
+If you use the Agent Governance Toolkit to build applications that operate with third-party agent frameworks or services, you do so at your own risk. We recommend reviewing all data being shared with third-party services and being cognizant of third-party practices for retention and location of data.
 
 ## License
 


### PR DESCRIPTION
## Summary

Restructure the README from a 430-line wall-of-text into a scannable narrative optimized for a technical decision-maker with 2 minutes.

**Net: -135 lines** (171 additions, 306 deletions) — all content preserved, just reorganized.

### Before → After

| Before | After |
|--------|-------|
| 18-bullet docs dump | 3 grouped sections (Getting Started / Reference / Compliance) |
| 5 back-to-back code blocks | 1 primary + 4 collapsible `<details>` |
| Highlights as long bullets | Clean 'What You Get' capability table |
| OPA/Rego/Cedar deep-dive in README | Moved to QUICKSTART.md (mentioned inline) |
| No problem statement | 'What This Is', 'Why It Matters' with benchmark |
| Security Model + Tooling separate | Merged into one 'Security' section |

### New structure
1. Banner + badges
2. Public Preview callout
3. One-liner + 'works with any stack'
4. **What This Is (and Isn't)** — positioning
5. **How it works** — one-line flow diagram
6. **Why it matters** — benchmark (0% vs 26.67%)
7. **Get Started in 90 Seconds** — install + first governed action
8. **What You Get** — capability table
9. **Works With Your Stack** — framework table
10. **OWASP Coverage** — compact table
11. **Performance** — compact table
12. **Install** — SDK table + collapsible Python packages
13. **Documentation** — organized into 3 groups
14. **Security** — model + tooling merged
15. Contributing / License / Trademarks

No content was lost — OPA/Cedar examples moved to QUICKSTART.md, tutorial links moved to Documentation section.