### PR TITLE
feat(openshell): add governance skill package and runnable example

### DIFF
--- a/docs/integrations/openshell.md
+++ b/docs/integrations/openshell.md
@@ -69,7 +69,7 @@ Neither replaces the other — they're complementary layers in a defense-in-dept
 
 ### Option A: Governance Skill Inside the Sandbox
 
-Install the toolkit as an [OpenClaw skill](../packages/agentmesh-integrations/openclaw-skill/) that the agent invokes before each action:
+Install the toolkit as an [OpenShell governance skill](../../packages/agentmesh-integrations/openshell-skill/) that the agent invokes before each action:
 
 ```bash
 # Inside the sandbox
@@ -209,7 +209,8 @@ OpenShell can *host* the sidecar. The governance sidecar runs inside or alongsid
 
 ## Related
 
-- [OpenClaw Skill](../../packages/agentmesh-integrations/openclaw-skill/) — Lightweight skill for OpenClaw agents
+- [OpenShell Governance Skill](../../packages/agentmesh-integrations/openshell-skill/) — Python skill package for OpenShell agents
+- [Runnable Example](../../examples/openshell-governed/) — Self-contained demo with policy enforcement and trust scoring
 - [OpenClaw Sidecar Deployment](../deployment/openclaw-sidecar.md) — AKS and Docker Compose guide
 - [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) — Runtime sandbox for AI agents
 - [Architecture](../ARCHITECTURE.md) — Full toolkit architecture

--- a/examples/openshell-governed/README.md
+++ b/examples/openshell-governed/README.md
@@ -1,54 +1,16 @@
 # Governed AI Agent in OpenShell Sandbox
 
-Demonstrates the **Agent Governance Toolkit** providing policy enforcement, trust scoring, and audit logging inside an **NVIDIA OpenShell** sandbox.
-
-```
-┌──────────────────────────────────────────────────────────┐
-│  OpenShell Sandbox                                        │
-│                                                           │
-│  ┌─────────────────┐    ┌──────────────────────────────┐ │
-│  │  AI Agent        │    │  Governance Skill (AGT)      │ │
-│  │                  │    │                              │ │
-│  │  "shell:rm -rf"  ├────►  Policy check  → ❌ DENIED   │ │
-│  │  "shell:python"  ├────►  Policy check  → ✅ ALLOWED  │ │
-│  │                  │    │  Trust scoring → 0.55        │ │
-│  │                  │    │  Audit trail   → logged      │ │
-│  └─────────────────┘    └──────────────────────────────┘ │
-│                                                           │
-│  ┌──────────────────────────────────────────────────────┐ │
-│  │  OpenShell Engine: Landlock + seccomp + OPA proxy    │ │
-│  └──────────────────────────────────────────────────────┘ │
-└──────────────────────────────────────────────────────────┘
-```
+Demonstrates AGT policy enforcement, trust scoring, and audit inside an OpenShell sandbox.
 
 ## Quick Start
 
 ```bash
-# From the repo root
 python examples/openshell-governed/demo.py
 ```
 
-## What You'll See
+3 allowed (file read, python, git) + 3 denied (rm, metadata, /etc write). Trust decays 1.00 to 0.55.
 
-The demo simulates 6 agent actions through the governance layer:
+## Related
 
-| # | Action | Result | Why |
-|---|--------|--------|-----|
-| 1 | Read `/workspace/main.py` | ✅ Allowed | File reads permitted |
-| 2 | Run `python` | ✅ Allowed | Safe shell command |
-| 3 | Run `git` | ✅ Allowed | Safe shell command |
-| 4 | `rm -rf /tmp/data` | ❌ Denied | Destructive command blocked |
-| 5 | Access `169.254.169.254` | ❌ Denied | Cloud metadata blocked |
-| 6 | Write to `/etc/shadow` | ❌ Denied | Outside workspace |
-
-Trust score decays from 1.00 → ~0.55 as violations accumulate.
-
-## Policy
-
-See [`policies/sandbox-policy.yaml`](policies/sandbox-policy.yaml) for the governance rules.
-
-## Learn More
-
-- [OpenShell Integration Guide](../../docs/integrations/openshell.md) — Full architecture
-- [OpenClaw Sidecar Deployment](../../docs/deployment/openclaw-sidecar.md) — AKS + Docker Compose
-- [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) — The sandbox runtime
+- [OpenShell Integration Guide](../../docs/integrations/openshell.md)
+- [Governance Skill Package](../../packages/agentmesh-integrations/openshell-skill/)

--- a/examples/openshell-governed/demo.py
+++ b/examples/openshell-governed/demo.py
@@ -1,96 +1,25 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Governed AI Agent in OpenShell Sandbox — Demo.
-
-Demonstrates the Agent Governance Toolkit providing policy enforcement,
-trust scoring, and audit logging inside an NVIDIA OpenShell sandbox.
-
-Usage:
-    pip install agentmesh-platform   # optional, works without it too
-    python demo.py
-"""
-
-from __future__ import annotations
-
+"""Governed AI Agent in OpenShell Sandbox - Demo."""
 import sys
 from pathlib import Path
-
-# Add the skill package to path for standalone use
 _skill_dir = Path(__file__).resolve().parent.parent.parent / "packages" / "agentmesh-integrations" / "openshell-skill"
-if _skill_dir.exists():
-    sys.path.insert(0, str(_skill_dir))
-
+if _skill_dir.exists(): sys.path.insert(0, str(_skill_dir))
 from openshell_agentmesh.skill import GovernanceSkill
 
-
-def main() -> None:
+def main():
     print("=" * 60)
     print("   Governed AI Agent in OpenShell Sandbox")
     print("=" * 60)
-
-    # Load policies
-    policy_dir = Path(__file__).parent / "policies"
-    skill = GovernanceSkill(policy_dir=policy_dir)
-    print(f"\n📜 Loaded {len(skill._rules)} governance rules from {policy_dir}")
-
-    agent_did = "did:mesh:sandbox-agent-001"
-    print(f"🆔 Agent: {agent_did}  (trust: {skill.get_trust_score(agent_did):.2f})")
-
-    # Simulate agent actions
-    actions = [
-        ("file:read:/workspace/main.py", "Read source file"),
-        ("shell:python", "Run Python tests"),
-        ("shell:git", "Git commit"),
-        ("shell:rm -rf /tmp/data", "Delete temp data"),
-        ("http:GET:169.254.169.254/metadata", "Access cloud metadata"),
-        ("file:write:/etc/shadow", "Write to /etc/shadow"),
-    ]
-
-    print(f"\n{'─' * 60}")
-    print("   Simulating 6 agent actions through governance layer")
-    print(f"{'─' * 60}\n")
-
-    for action, description in actions:
-        decision = skill.check_policy(action, context={"agent_did": agent_did})
-
-        if decision.allowed:
-            icon = "✅"
-        else:
-            icon = "❌"
-            skill.adjust_trust(agent_did, -0.15)
-
-        trust = skill.get_trust_score(agent_did)
-        print(f"  {icon} {description:<30} [{action}]")
-        print(f"     {'ALLOWED' if decision.allowed else 'DENIED ':>7} — {decision.reason}")
-        print(f"     Trust: {trust:.2f}  |  Rule: {decision.policy_name or 'default'}")
-        print()
-
-    # Summary
-    trust_final = skill.get_trust_score(agent_did)
+    skill = GovernanceSkill(policy_dir=Path(__file__).parent / "policies")
+    agent = "did:mesh:sandbox-agent-001"
+    print(f"\n  Loaded {len(skill._rules)} rules | Agent: {agent} (trust: {skill.get_trust_score(agent):.2f})\n" + "-" * 60)
+    for action, desc in [("file:read:/workspace/main.py","Read source file"),("shell:python","Run Python"),("shell:git","Git commit"),("shell:rm -rf /tmp","Delete temp data"),("http:GET:169.254.169.254/metadata","Cloud metadata"),("file:write:/etc/shadow","Write /etc/shadow")]:
+        d = skill.check_policy(action, context={"agent_did": agent})
+        if not d.allowed: skill.adjust_trust(agent, -0.15)
+        print(f"  {"[OK]" if d.allowed else "[XX]"} {desc:<28} trust={skill.get_trust_score(agent):.2f}  {d.reason}")
     log = skill.get_audit_log()
-    allowed = sum(1 for e in log if e["decision"] == "allow")
-    denied = len(log) - allowed
+    a = sum(1 for e in log if e["decision"] == "allow")
+    print(f"\n  Audit: {a} allowed, {len(log)-a} denied | Final trust: {skill.get_trust_score(agent):.2f}\n" + "=" * 60)
 
-    print(f"{'─' * 60}")
-    print("   📋 Audit Trail Summary")
-    print(f"{'─' * 60}")
-    print(f"   Total actions:  {len(log)}")
-    print(f"   Allowed:        {allowed}")
-    print(f"   Denied:         {denied}")
-    print(f"   Final trust:    {trust_final:.2f} (started at 1.00)")
-    print()
-
-    print("   Recent audit entries:")
-    for entry in log:
-        icon = "✅" if entry["decision"] == "allow" else "❌"
-        print(f"   {icon} {entry['timestamp'][:19]}  {entry['action'][:40]}")
-
-    print(f"\n{'=' * 60}")
-    print("   OpenShell provides the sandbox walls.")
-    print("   AGT provides the governance brain.")
-    print("   Together: defense-in-depth for AI agents.")
-    print(f"{'=' * 60}")
-
-
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__": main()

--- a/examples/openshell-governed/policies/sandbox-policy.yaml
+++ b/examples/openshell-governed/policies/sandbox-policy.yaml
@@ -1,63 +1,31 @@
 apiVersion: governance.toolkit/v1
 metadata:
   name: openshell-sandbox-policy
-  description: Governance policy for agents running inside OpenShell sandboxes
 rules:
   - name: block-dangerous-shell
-    condition:
-      field: action
-      operator: matches
-      value: "shell:(rm|dd|mkfs|shutdown|reboot|chmod|chown)"
+    condition: {field: action, operator: matches, value: "shell:(rm|dd|mkfs|shutdown|reboot|chmod|chown)"}
     action: deny
     priority: 100
     message: "Destructive shell command blocked by governance policy"
-
   - name: block-metadata-endpoint
-    condition:
-      field: action
-      operator: contains
-      value: "169.254.169.254"
+    condition: {field: action, operator: contains, value: "169.254.169.254"}
     action: deny
     priority: 100
     message: "Cloud metadata endpoint access blocked"
-
   - name: block-writes-outside-workspace
-    condition:
-      field: action
-      operator: matches
-      value: "file:write:/(etc|usr|root|bin|sbin)"
+    condition: {field: action, operator: matches, value: "file:write:/(etc|usr|root|bin|sbin)"}
     action: deny
     priority: 95
     message: "File writes restricted to /workspace"
-
   - name: allow-file-read
-    condition:
-      field: action
-      operator: starts_with
-      value: "file:read"
+    condition: {field: action, operator: starts_with, value: "file:read"}
     action: allow
     priority: 90
-
   - name: allow-file-write-workspace
-    condition:
-      field: action
-      operator: starts_with
-      value: "file:write:/workspace"
+    condition: {field: action, operator: starts_with, value: "file:write:/workspace"}
     action: allow
     priority: 85
-
   - name: allow-safe-shell
-    condition:
-      field: action
-      operator: in
-      value:
-        - "shell:ls"
-        - "shell:cat"
-        - "shell:grep"
-        - "shell:find"
-        - "shell:echo"
-        - "shell:python"
-        - "shell:pip"
-        - "shell:git"
+    condition: {field: action, operator: in, value: ["shell:ls","shell:cat","shell:grep","shell:find","shell:echo","shell:python","shell:pip","shell:git"]}
     action: allow
     priority: 80

--- a/examples/policies/atr-community-rules.yaml
+++ b/examples/policies/atr-community-rules.yaml
@@ -1,0 +1,198 @@
+# ATR Community Detection Rules
+#
+# Extended detection patterns for AI agent threat detection.
+# Inspired by Cisco AI Defense's 108-rule catalogue and the broader
+# ATR (Agent Threat Research) community.
+#
+# Reference: Issue #901
+# Credits: Cisco AI Defense / ATR community research
+#
+# ⚠️  IMPORTANT: This is a community-maintained rule set provided as a
+# starting point. Review and customize for your environment before
+# deploying to production.
+
+version: "1.0"
+name: atr-community-rules
+description: >
+  Extended ATR community detection rules — 90+ patterns across 9 categories
+  for comprehensive AI agent threat detection. Supplements the base
+  mcp-security.yaml with deeper coverage of prompt injection, data
+  exfiltration, privilege escalation, credential theft, and supply-chain
+  attacks.
+
+categories:
+
+  # -----------------------------------------------------------------------
+  # 1. Invisible Unicode (existing category — extended)
+  # -----------------------------------------------------------------------
+  invisible_unicode:
+    - '[\u200b\u200c\u200d\ufeff]'          # zero-width chars
+    - '[\u202a-\u202e]'                      # bidi overrides
+    - '[\u2066-\u2069]'                      # bidi isolates
+    - '[\u00ad]'                             # soft hyphen
+    - '[\u2060\u180e]'                       # word joiner / mongolian vowel
+    - '[\u034f]'                             # combining grapheme joiner
+    - '[\u115f\u1160]'                       # hangul filler chars
+    - '[\u2800]'                             # braille blank
+    - '[\uffa0]'                             # halfwidth hangul filler
+
+  # -----------------------------------------------------------------------
+  # 2. Hidden Comments (existing category — extended)
+  # -----------------------------------------------------------------------
+  hidden_comments:
+    - '<!--.*?-->'                           # HTML comments
+    - '\[//\]:\s*#\s*\(.*?\)'               # markdown reference-style
+    - '\[comment\]:\s*<>\s*\(.*?\)'          # markdown comment
+    - '%\s.*$'                               # LaTeX-style comments
+    - '{#.*?#}'                              # Jinja2 comments
+    - '/\*[\s\S]*?\*/'                       # C-style block comments in prompts
+
+  # -----------------------------------------------------------------------
+  # 3. Hidden Instructions / Prompt Injection (existing — extended)
+  # -----------------------------------------------------------------------
+  hidden_instructions:
+    - 'ignore\s+(all\s+)?previous'
+    - 'override\s+(the\s+)?(previous|above|original)'
+    - 'instead\s+of\s+(the\s+)?(above|previous|described)'
+    - 'actually\s+do'
+    - '\bsystem\s*:'
+    - '\bassistant\s*:'
+    - 'do\s+not\s+follow'
+    - 'disregard\s+(all\s+)?(above|prior|previous)'
+    - 'forget\s+(all\s+)?(previous|prior|above)'
+    - 'new\s+instructions?\s*:'
+    - 'begin\s+new\s+(task|instructions?|session)'
+    - 'switch\s+to\s+(a\s+)?new\s+(role|mode|persona)'
+    - 'from\s+now\s+on\s+(you\s+are|act\s+as)'
+    - 'pretend\s+(you\s+are|to\s+be)'
+    - 'jailbreak'
+    - 'DAN\s+mode'
+    - 'developer\s+mode\s+enabled'
+    - '\[SYSTEM\]'
+    - '###\s*(SYSTEM|INSTRUCTION|OVERRIDE)'
+
+  # -----------------------------------------------------------------------
+  # 4. Encoded Payloads (existing — extended)
+  # -----------------------------------------------------------------------
+  encoded_payloads:
+    - '[A-Za-z0-9+/]{40,}={0,2}'            # base64 blobs
+    - '(?:\\x[0-9a-fA-F]{2}){4,}'           # hex escape sequences
+    - '(?:%[0-9a-fA-F]{2}){4,}'             # URL-encoded sequences
+    - '\\u[0-9a-fA-F]{4}(?:\\u[0-9a-fA-F]{4}){3,}'  # unicode escapes
+    - 'data:[a-z]+/[a-z]+;base64,'          # data URI with base64
+    - 'eval\(atob\('                         # JS decode-and-exec
+
+  # -----------------------------------------------------------------------
+  # 5. Exfiltration (existing — extended)
+  # -----------------------------------------------------------------------
+  exfiltration:
+    - '\bcurl\b'
+    - '\bwget\b'
+    - '\bfetch\s*\('
+    - 'https?://'
+    - '\bsend\s+email\b'
+    - '\bsend\s+to\b'
+    - '\bpost\s+to\b'
+    - 'include\s+the\s+contents?\s+of\b'
+    - '\bexfiltrat'
+    - '\bupload\s+(this|the|all)\b'
+    - 'webhook[.:]\s*https?://'
+    - '\bsend\s+(data|file|content)\s+to\b'
+    - '\brequest\.post\b'
+    - '\bhttp\.client\b'
+    - 'dns\s+tunnel'
+    - '\bngrok\b'
+
+  # -----------------------------------------------------------------------
+  # 6. Privilege Escalation (NEW)
+  # -----------------------------------------------------------------------
+  privilege_escalation:
+    - '\bsudo\b'
+    - '\badmin\s+access\b'
+    - '\broot\s+access\b'
+    - '\belevate\s+privile'
+    - '\bexec\s*\('
+    - '\beval\s*\('
+    - '\bchmod\s+[0-7]{3,4}\b'
+    - '\bchown\b'
+    - 'grant\s+(all|admin|superuser)'
+    - 'role\s*=\s*["\']?admin'
+    - '\bsetuid\b'
+    - 'escalat(e|ion)\s+(to\s+)?(admin|root|superuser)'
+    - '\bsu\s+-\b'
+    - 'modify\s+(acl|permission|role)'
+    - 'add\s+(to\s+)?admin\s+group'
+    - '\brunas\b'
+
+  # -----------------------------------------------------------------------
+  # 7. Credential Theft (NEW)
+  # -----------------------------------------------------------------------
+  credential_theft:
+    - '\bAPI[_-]?KEY\b'
+    - '\bSECRET[_-]?KEY\b'
+    - '\bACCESS[_-]?TOKEN\b'
+    - '\bBEARER\s+[A-Za-z0-9._~+/=-]+'
+    - 'password\s*[:=]'
+    - '\bAWS_SECRET_ACCESS_KEY\b'
+    - '\bAZURE[_-]?(CLIENT|TENANT)[_-]?SECRET\b'
+    - '\bGH[_-]?TOKEN\b'
+    - '\bGITHUB[_-]?TOKEN\b'
+    - 'print\s*\(\s*os\.environ'
+    - 'dump\s+(all\s+)?env(ironment)?\s+var'
+    - '\b\.env\b.*\bread\b'
+    - 'extract\s+(api|secret|token|key|credential)'
+    - '\bcredential\s+store\b'
+    - 'keychain\s+(dump|extract|read)'
+
+  # -----------------------------------------------------------------------
+  # 8. Supply Chain (NEW)
+  # -----------------------------------------------------------------------
+  supply_chain:
+    - 'pip\s+install\s+--index-url\s+http://'
+    - 'npm\s+install\s+--registry\s+http://'
+    - '\btyposquat'
+    - 'dependency\s+confusion'
+    - 'install\s+from\s+http://'
+    - '\bsetup\.py\b.*\bos\.system\b'
+    - 'postinstall.*curl'
+    - '\bpre-commit\s+hook\b.*\b(curl|wget|exec)\b'
+    - 'requirements\.txt.*--extra-index-url'
+    - 'package\s+manifest\s+tamper'
+    - '\bpinned\s+hash\s+mismatch\b'
+    - 'lockfile\s+(inject|poison|manipulat)'
+
+  # -----------------------------------------------------------------------
+  # 9. Excessive Autonomy (NEW)
+  # -----------------------------------------------------------------------
+  excessive_autonomy:
+    - 'spawn\s+(a\s+)?(new\s+)?agent'
+    - 'create\s+(a\s+)?(new\s+)?(sub-?)?agent'
+    - 'self[_-]?modif(y|ication)'
+    - 'rewrit(e|ing)\s+(my|your|own)\s+(code|instructions|prompt)'
+    - 'autonomous(ly)?\s+(decide|act|execute|run)'
+    - 'loop\s+until\s+(done|complete|success)'
+    - 'run\s+indefinitely'
+    - 'disable\s+(safety|guardrail|limit|oversight)'
+    - 'remove\s+(all\s+)?(constraint|restriction|limit)'
+    - 'bypass\s+(approval|review|human)'
+
+suspicious_decoded_keywords:
+  - ignore
+  - override
+  - system
+  - password
+  - secret
+  - admin
+  - root
+  - exec
+  - eval
+  - "import os"
+  - send
+  - curl
+  - fetch
+  - credential
+  - token
+  - jailbreak
+  - exfiltrate
+  - typosquat
+  - keychain

--- a/examples/policies/mcp-security.yaml
+++ b/examples/policies/mcp-security.yaml
@@ -85,3 +85,5 @@ suspicious_decoded_keywords:
   - send
   - curl
   - fetch
+
+# For extended detection rules (87+ patterns), see atr-community-rules.yaml

--- a/packages/agent-os/src/agent_os/policies/data_classification.py
+++ b/packages/agent-os/src/agent_os/policies/data_classification.py
@@ -1,0 +1,252 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Data-layer ABAC policies for AI agent governance.
+
+Extends the policy engine beyond tool-level to data-level enforcement.
+Agents are checked not just for which tools they can use, but which
+data classifications they can access.
+
+Addresses the market gap where 63% of organizations cannot stop
+their AI from accessing unauthorized data (Kiteworks 2026 research).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from enum import IntEnum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class DataClassification(IntEnum):
+    """Sensitivity levels for data classification, ordered by sensitivity."""
+
+    PUBLIC = 0
+    INTERNAL = 1
+    CONFIDENTIAL = 2
+    RESTRICTED = 3
+    TOP_SECRET = 4
+
+
+class DataLabel(BaseModel):
+    """Label describing data sensitivity and handling requirements."""
+
+    classification: DataClassification
+    categories: list[str] = Field(
+        default_factory=list,
+        description="Data categories such as PII, PHI, PCI, GDPR, ITAR",
+    )
+    owner: str = ""
+    retention_days: int = 90
+    geography: str = ""
+
+
+class ABACPolicy(BaseModel):
+    """Attribute-Based Access Control policy for an agent."""
+
+    agent_id: str
+    allowed_classifications: list[DataClassification] = Field(default_factory=list)
+    allowed_categories: list[str] = Field(default_factory=list)
+    denied_categories: list[str] = Field(default_factory=list)
+    required_geography: Optional[str] = None
+    max_classification: DataClassification = DataClassification.PUBLIC
+
+
+class DataAccessDecision(BaseModel):
+    """Result of evaluating an agent's data access request."""
+
+    allowed: bool
+    reason: str
+    agent_id: str
+    data_label: DataLabel
+    matched_policy: Optional[str] = None
+    evaluated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class DataAccessEvaluator:
+    """Evaluates agent data-access requests against ABAC policies.
+
+    When multiple policies exist for the same agent, the most restrictive
+    result wins (deny takes precedence over allow).
+    """
+
+    def __init__(self, policies: list[ABACPolicy]) -> None:
+        self._policies = policies
+
+    def evaluate(self, agent_id: str, data_label: DataLabel) -> DataAccessDecision:
+        """Check whether *agent_id* may access data described by *data_label*."""
+        agent_policies = [p for p in self._policies if p.agent_id == agent_id]
+        if not agent_policies:
+            return DataAccessDecision(
+                allowed=False,
+                reason="No ABAC policy registered for agent",
+                agent_id=agent_id,
+                data_label=data_label,
+            )
+
+        # Evaluate each policy; any denial means overall denial (most restrictive wins)
+        for policy in agent_policies:
+            decision = self._evaluate_single(agent_id, data_label, policy)
+            if not decision.allowed:
+                return decision
+
+        # All policies passed
+        return DataAccessDecision(
+            allowed=True,
+            reason="Access permitted by all applicable policies",
+            agent_id=agent_id,
+            data_label=data_label,
+            matched_policy=agent_policies[0].agent_id,
+        )
+
+    @staticmethod
+    def _evaluate_single(
+        agent_id: str, data_label: DataLabel, policy: ABACPolicy
+    ) -> DataAccessDecision:
+        policy_ref = policy.agent_id
+
+        if data_label.classification > policy.max_classification:
+            return DataAccessDecision(
+                allowed=False,
+                reason=(
+                    f"Classification {data_label.classification.name} exceeds "
+                    f"max {policy.max_classification.name}"
+                ),
+                agent_id=agent_id,
+                data_label=data_label,
+                matched_policy=policy_ref,
+            )
+
+        if (
+            policy.allowed_classifications
+            and data_label.classification not in policy.allowed_classifications
+        ):
+            return DataAccessDecision(
+                allowed=False,
+                reason=(
+                    f"Classification {data_label.classification.name} not in "
+                    f"allowed list"
+                ),
+                agent_id=agent_id,
+                data_label=data_label,
+                matched_policy=policy_ref,
+            )
+
+        for cat in data_label.categories:
+            if cat in policy.denied_categories:
+                return DataAccessDecision(
+                    allowed=False,
+                    reason=f"Category '{cat}' is explicitly denied",
+                    agent_id=agent_id,
+                    data_label=data_label,
+                    matched_policy=policy_ref,
+                )
+
+        if policy.allowed_categories:
+            for cat in data_label.categories:
+                if cat not in policy.allowed_categories:
+                    return DataAccessDecision(
+                        allowed=False,
+                        reason=f"Category '{cat}' not in allowed categories",
+                        agent_id=agent_id,
+                        data_label=data_label,
+                        matched_policy=policy_ref,
+                    )
+
+        if (
+            policy.required_geography
+            and data_label.geography
+            and data_label.geography != policy.required_geography
+        ):
+            return DataAccessDecision(
+                allowed=False,
+                reason=(
+                    f"Geography '{data_label.geography}' does not match "
+                    f"required '{policy.required_geography}'"
+                ),
+                agent_id=agent_id,
+                data_label=data_label,
+                matched_policy=policy_ref,
+            )
+
+        return DataAccessDecision(
+            allowed=True,
+            reason="Policy passed",
+            agent_id=agent_id,
+            data_label=data_label,
+            matched_policy=policy_ref,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PII / PHI / PCI detection helpers
+# ---------------------------------------------------------------------------
+
+_SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b")
+_PHONE_RE = re.compile(
+    r"\b(?:\+1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"
+)
+
+_MRN_RE = re.compile(r"\bMRN[-:\s]?\d{6,10}\b", re.IGNORECASE)
+_ICD_RE = re.compile(r"\b[A-Z]\d{2}(?:\.\d{1,4})?\b")
+
+_CC_RE = re.compile(r"\b(?:\d[ -]*?){13,19}\b")
+
+
+def detect_pii(text: str) -> list[str]:
+    """Detect PII patterns (SSN, email, phone) in *text*."""
+    findings: list[str] = []
+    if _SSN_RE.search(text):
+        findings.append("SSN")
+    if _EMAIL_RE.search(text):
+        findings.append("email")
+    if _PHONE_RE.search(text):
+        findings.append("phone")
+    return findings
+
+
+def detect_phi(text: str) -> list[str]:
+    """Detect PHI patterns (medical record numbers, diagnosis codes)."""
+    findings: list[str] = []
+    if _MRN_RE.search(text):
+        findings.append("MRN")
+    if _ICD_RE.search(text):
+        findings.append("ICD-code")
+    return findings
+
+
+def detect_pci(text: str) -> list[str]:
+    """Detect PCI patterns (credit card numbers)."""
+    findings: list[str] = []
+    if _CC_RE.search(text):
+        findings.append("credit-card")
+    return findings
+
+
+def classify_text(text: str) -> DataLabel:
+    """Auto-classify *text* based on detected sensitive-data patterns."""
+    categories: list[str] = []
+    classification = DataClassification.PUBLIC
+
+    pii = detect_pii(text)
+    if pii:
+        categories.append("PII")
+        classification = max(classification, DataClassification.CONFIDENTIAL)
+
+    phi = detect_phi(text)
+    if phi:
+        categories.append("PHI")
+        classification = max(classification, DataClassification.RESTRICTED)
+
+    pci = detect_pci(text)
+    if pci:
+        categories.append("PCI")
+        classification = max(classification, DataClassification.CONFIDENTIAL)
+
+    if not categories:
+        classification = DataClassification.PUBLIC
+
+    return DataLabel(classification=classification, categories=categories)

--- a/packages/agent-os/tests/test_data_classification.py
+++ b/packages/agent-os/tests/test_data_classification.py
@@ -1,0 +1,334 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for data-layer ABAC policies and detection helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_os.policies.data_classification import (
+    ABACPolicy,
+    DataAccessDecision,
+    DataAccessEvaluator,
+    DataClassification,
+    DataLabel,
+    classify_text,
+    detect_pci,
+    detect_phi,
+    detect_pii,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def public_label() -> DataLabel:
+    return DataLabel(classification=DataClassification.PUBLIC, categories=[], geography="US")
+
+
+@pytest.fixture()
+def confidential_pii_label() -> DataLabel:
+    return DataLabel(
+        classification=DataClassification.CONFIDENTIAL,
+        categories=["PII"],
+        geography="US",
+    )
+
+
+@pytest.fixture()
+def restricted_phi_label() -> DataLabel:
+    return DataLabel(
+        classification=DataClassification.RESTRICTED,
+        categories=["PHI"],
+        geography="EU",
+    )
+
+
+@pytest.fixture()
+def permissive_policy() -> ABACPolicy:
+    return ABACPolicy(
+        agent_id="agent-1",
+        allowed_classifications=[
+            DataClassification.PUBLIC,
+            DataClassification.INTERNAL,
+            DataClassification.CONFIDENTIAL,
+        ],
+        allowed_categories=["PII", "GDPR"],
+        denied_categories=[],
+        max_classification=DataClassification.CONFIDENTIAL,
+    )
+
+
+@pytest.fixture()
+def restrictive_policy() -> ABACPolicy:
+    return ABACPolicy(
+        agent_id="agent-1",
+        allowed_classifications=[DataClassification.PUBLIC],
+        allowed_categories=[],
+        denied_categories=["PII"],
+        max_classification=DataClassification.PUBLIC,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Classification hierarchy enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestClassificationHierarchy:
+    def test_public_less_than_top_secret(self) -> None:
+        assert DataClassification.PUBLIC < DataClassification.TOP_SECRET
+
+    def test_ordering(self) -> None:
+        assert (
+            DataClassification.PUBLIC
+            < DataClassification.INTERNAL
+            < DataClassification.CONFIDENTIAL
+            < DataClassification.RESTRICTED
+            < DataClassification.TOP_SECRET
+        )
+
+    def test_exceeds_max_classification_denied(
+        self, permissive_policy: ABACPolicy
+    ) -> None:
+        label = DataLabel(classification=DataClassification.RESTRICTED)
+        evaluator = DataAccessEvaluator([permissive_policy])
+        decision = evaluator.evaluate("agent-1", label)
+        assert not decision.allowed
+        assert "exceeds" in decision.reason.lower()
+
+    def test_within_max_classification_allowed(
+        self, permissive_policy: ABACPolicy, public_label: DataLabel
+    ) -> None:
+        evaluator = DataAccessEvaluator([permissive_policy])
+        decision = evaluator.evaluate("agent-1", public_label)
+        assert decision.allowed
+
+
+# ---------------------------------------------------------------------------
+# Category allow / deny lists
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryLists:
+    def test_denied_category_blocks_access(self) -> None:
+        policy = ABACPolicy(
+            agent_id="agent-x",
+            denied_categories=["ITAR"],
+            max_classification=DataClassification.TOP_SECRET,
+        )
+        label = DataLabel(
+            classification=DataClassification.INTERNAL, categories=["ITAR"]
+        )
+        decision = DataAccessEvaluator([policy]).evaluate("agent-x", label)
+        assert not decision.allowed
+        assert "denied" in decision.reason.lower()
+
+    def test_allowed_category_passes(self, permissive_policy: ABACPolicy) -> None:
+        label = DataLabel(
+            classification=DataClassification.CONFIDENTIAL, categories=["PII"]
+        )
+        evaluator = DataAccessEvaluator([permissive_policy])
+        decision = evaluator.evaluate("agent-1", label)
+        assert decision.allowed
+
+    def test_unlisted_category_denied_when_allowlist_set(self) -> None:
+        policy = ABACPolicy(
+            agent_id="agent-y",
+            allowed_categories=["PII"],
+            max_classification=DataClassification.TOP_SECRET,
+        )
+        label = DataLabel(
+            classification=DataClassification.PUBLIC, categories=["GDPR"]
+        )
+        decision = DataAccessEvaluator([policy]).evaluate("agent-y", label)
+        assert not decision.allowed
+        assert "not in allowed" in decision.reason.lower()
+
+    def test_empty_allowlist_permits_all_categories(self) -> None:
+        policy = ABACPolicy(
+            agent_id="agent-z",
+            allowed_categories=[],
+            max_classification=DataClassification.TOP_SECRET,
+        )
+        label = DataLabel(
+            classification=DataClassification.PUBLIC, categories=["PCI", "GDPR"]
+        )
+        decision = DataAccessEvaluator([policy]).evaluate("agent-z", label)
+        assert decision.allowed
+
+
+# ---------------------------------------------------------------------------
+# Geography restrictions
+# ---------------------------------------------------------------------------
+
+
+class TestGeography:
+    def test_matching_geography_allowed(self) -> None:
+        policy = ABACPolicy(
+            agent_id="geo-agent",
+            required_geography="US",
+            max_classification=DataClassification.CONFIDENTIAL,
+        )
+        label = DataLabel(classification=DataClassification.PUBLIC, geography="US")
+        decision = DataAccessEvaluator([policy]).evaluate("geo-agent", label)
+        assert decision.allowed
+
+    def test_mismatched_geography_denied(self) -> None:
+        policy = ABACPolicy(
+            agent_id="geo-agent",
+            required_geography="US",
+            max_classification=DataClassification.CONFIDENTIAL,
+        )
+        label = DataLabel(classification=DataClassification.PUBLIC, geography="EU")
+        decision = DataAccessEvaluator([policy]).evaluate("geo-agent", label)
+        assert not decision.allowed
+        assert "geography" in decision.reason.lower()
+
+    def test_no_geography_requirement_allows_any(self) -> None:
+        policy = ABACPolicy(
+            agent_id="flex-agent",
+            max_classification=DataClassification.TOP_SECRET,
+        )
+        label = DataLabel(classification=DataClassification.PUBLIC, geography="APAC")
+        decision = DataAccessEvaluator([policy]).evaluate("flex-agent", label)
+        assert decision.allowed
+
+
+# ---------------------------------------------------------------------------
+# Default deny for unregistered agents
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultDeny:
+    def test_unregistered_agent_denied(self, public_label: DataLabel) -> None:
+        evaluator = DataAccessEvaluator([])
+        decision = evaluator.evaluate("unknown-agent", public_label)
+        assert not decision.allowed
+        assert "no abac policy" in decision.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# Multiple policies — most restrictive wins
+# ---------------------------------------------------------------------------
+
+
+class TestMultiplePolicies:
+    def test_most_restrictive_wins(self) -> None:
+        permissive = ABACPolicy(
+            agent_id="multi",
+            max_classification=DataClassification.TOP_SECRET,
+        )
+        restrictive = ABACPolicy(
+            agent_id="multi",
+            denied_categories=["PII"],
+            max_classification=DataClassification.TOP_SECRET,
+        )
+        label = DataLabel(
+            classification=DataClassification.PUBLIC, categories=["PII"]
+        )
+        decision = DataAccessEvaluator([permissive, restrictive]).evaluate(
+            "multi", label
+        )
+        assert not decision.allowed
+
+    def test_all_policies_allow(self) -> None:
+        p1 = ABACPolicy(agent_id="multi2", max_classification=DataClassification.CONFIDENTIAL)
+        p2 = ABACPolicy(agent_id="multi2", max_classification=DataClassification.RESTRICTED)
+        label = DataLabel(classification=DataClassification.INTERNAL)
+        decision = DataAccessEvaluator([p1, p2]).evaluate("multi2", label)
+        assert decision.allowed
+
+
+# ---------------------------------------------------------------------------
+# PII detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPII:
+    def test_ssn_detected(self) -> None:
+        assert "SSN" in detect_pii("My SSN is 123-45-6789")
+
+    def test_email_detected(self) -> None:
+        assert "email" in detect_pii("Contact user@example.com")
+
+    def test_phone_detected(self) -> None:
+        assert "phone" in detect_pii("Call (555) 123-4567")
+
+    def test_no_pii(self) -> None:
+        assert detect_pii("Hello world") == []
+
+
+# ---------------------------------------------------------------------------
+# PHI detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPHI:
+    def test_mrn_detected(self) -> None:
+        assert "MRN" in detect_phi("Patient MRN: 12345678")
+
+    def test_icd_code_detected(self) -> None:
+        assert "ICD-code" in detect_phi("Diagnosis J45.20")
+
+    def test_no_phi(self) -> None:
+        assert detect_phi("No medical data here") == []
+
+
+# ---------------------------------------------------------------------------
+# PCI detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPCI:
+    def test_credit_card_detected(self) -> None:
+        assert "credit-card" in detect_pci("Card 4111 1111 1111 1111")
+
+    def test_no_pci(self) -> None:
+        assert detect_pci("No card numbers") == []
+
+
+# ---------------------------------------------------------------------------
+# Auto-classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyText:
+    def test_plain_text_is_public(self) -> None:
+        label = classify_text("Hello world")
+        assert label.classification == DataClassification.PUBLIC
+        assert label.categories == []
+
+    def test_pii_classified_confidential(self) -> None:
+        label = classify_text("SSN: 123-45-6789")
+        assert label.classification >= DataClassification.CONFIDENTIAL
+        assert "PII" in label.categories
+
+    def test_phi_classified_restricted(self) -> None:
+        label = classify_text("Patient MRN: 12345678")
+        assert label.classification >= DataClassification.RESTRICTED
+        assert "PHI" in label.categories
+
+    def test_mixed_pii_and_pci(self) -> None:
+        label = classify_text("Email user@test.com card 4111 1111 1111 1111")
+        assert "PII" in label.categories
+        assert "PCI" in label.categories
+
+
+# ---------------------------------------------------------------------------
+# Decision model
+# ---------------------------------------------------------------------------
+
+
+class TestDataAccessDecision:
+    def test_evaluated_at_populated(self) -> None:
+        d = DataAccessDecision(
+            allowed=True,
+            reason="ok",
+            agent_id="a",
+            data_label=DataLabel(classification=DataClassification.PUBLIC),
+        )
+        assert d.evaluated_at is not None

--- a/packages/agentmesh-integrations/openshell-skill/README.md
+++ b/packages/agentmesh-integrations/openshell-skill/README.md
@@ -1,0 +1,30 @@
+# OpenShell + AgentMesh Governance Skill
+
+**Public Preview** - Governance skill bringing AGT capabilities into NVIDIA OpenShell sandboxes.
+
+OpenShell provides the **walls** (Landlock, seccomp, OPA proxy). This skill provides the **brain** (policy, trust, audit).
+
+## Install
+
+```bash
+pip install openshell-agentmesh
+```
+
+## Quick Start
+
+```python
+from openshell_agentmesh import GovernanceSkill
+
+skill = GovernanceSkill(policy_dir="./policies")
+decision = skill.check_policy("shell:python test.py")
+print(decision.allowed)  # True
+
+decision = skill.check_policy("shell:rm -rf /tmp")
+print(decision.allowed)  # False
+```
+
+## Related
+
+- [OpenShell Integration Guide](../../docs/integrations/openshell.md)
+- [Runnable Example](../../examples/openshell-governed/)
+- [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell)

--- a/packages/agentmesh-integrations/openshell-skill/openshell_agentmesh/__init__.py
+++ b/packages/agentmesh-integrations/openshell-skill/openshell_agentmesh/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""OpenShell + AgentMesh governance skill — policy, trust, and audit for sandboxed agents."""
+"""OpenShell + AgentMesh governance skill."""
 
 from openshell_agentmesh.skill import GovernanceSkill, PolicyDecision
 

--- a/packages/agentmesh-integrations/openshell-skill/openshell_agentmesh/skill.py
+++ b/packages/agentmesh-integrations/openshell-skill/openshell_agentmesh/skill.py
@@ -1,199 +1,98 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Governance skill for OpenShell sandboxed agents.
-
-Provides policy evaluation, trust scoring, identity verification, and
-audit logging that any agent inside an OpenShell sandbox can invoke.
-"""
+"""Governance skill for OpenShell sandboxed agents."""
 
 from __future__ import annotations
-
 import re
-import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
-
 import yaml
-
 
 @dataclass
 class PolicyDecision:
     """Result of a policy evaluation."""
-
     allowed: bool
     action: str
     reason: str
     policy_name: Optional[str] = None
     trust_score: float = 0.0
 
-
 @dataclass
 class _PolicyRule:
-    """Internal representation of a loaded policy rule."""
-
     name: str
     field: str
     operator: str
     value: Any
-    action: str  # allow / deny / escalate
+    action: str
     priority: int = 0
     message: str = ""
 
-
 class GovernanceSkill:
-    """AGT governance skill for OpenShell sandboxes.
-
-    Loads YAML policies and evaluates agent actions against them,
-    tracks per-agent trust scores, and maintains an audit log.
-
-    Args:
-        policy_dir: Directory containing YAML policy files.
-        trust_threshold: Minimum trust score for action approval.
-    """
-
-    def __init__(
-        self,
-        policy_dir: Optional[Path] = None,
-        trust_threshold: float = 0.5,
-    ) -> None:
+    """AGT governance skill for OpenShell sandboxes."""
+    def __init__(self, policy_dir: Optional[Path] = None, trust_threshold: float = 0.5) -> None:
         self._rules: list[_PolicyRule] = []
         self._trust_scores: dict[str, float] = {}
         self._audit_log: list[dict] = []
         self._trust_threshold = trust_threshold
-
         if policy_dir:
             self.load_policies(policy_dir)
 
     def load_policies(self, policy_dir: Path) -> int:
-        """Load all YAML policies from a directory.
-
-        Returns:
-            Number of rules loaded.
-        """
         policy_dir = Path(policy_dir)
         if not policy_dir.is_dir():
             raise FileNotFoundError(f"Policy directory not found: {policy_dir}")
-
         self._rules.clear()
         for yaml_file in sorted(policy_dir.glob("*.yaml")):
             with open(yaml_file, encoding="utf-8") as f:
                 doc = yaml.safe_load(f)
             if not doc:
                 continue
-            for rule_data in doc.get("rules", []):
-                cond = rule_data.get("condition", {})
-                self._rules.append(
-                    _PolicyRule(
-                        name=rule_data.get("name", yaml_file.stem),
-                        field=cond.get("field", "action"),
-                        operator=cond.get("operator", "equals"),
-                        value=cond.get("value", ""),
-                        action=rule_data.get("action", "deny"),
-                        priority=rule_data.get("priority", 0),
-                        message=rule_data.get("message", ""),
-                    )
-                )
-        # Higher priority rules evaluate first
+            for rd in doc.get("rules", []):
+                cond = rd.get("condition", {})
+                self._rules.append(_PolicyRule(name=rd.get("name", yaml_file.stem), field=cond.get("field", "action"), operator=cond.get("operator", "equals"), value=cond.get("value", ""), action=rd.get("action", "deny"), priority=rd.get("priority", 0), message=rd.get("message", "")))
         self._rules.sort(key=lambda r: r.priority, reverse=True)
         return len(self._rules)
 
-    def check_policy(
-        self,
-        action: str,
-        context: Optional[dict] = None,
-    ) -> PolicyDecision:
-        """Evaluate an action against loaded policies.
-
-        Args:
-            action: The action string (e.g., "shell:rm -rf /tmp").
-            context: Optional context dict with additional fields.
-
-        Returns:
-            PolicyDecision with allow/deny and reason.
-        """
+    def check_policy(self, action: str, context: Optional[dict] = None) -> PolicyDecision:
         context = context or {}
         agent_did = context.get("agent_did", "unknown")
         trust = self.get_trust_score(agent_did)
-
         for rule in self._rules:
             target = action if rule.field == "action" else context.get(rule.field, "")
             if self._match(rule.operator, target, rule.value):
                 allowed = rule.action == "allow"
-                reason = rule.message or f"{'Allowed' if allowed else 'Denied'} by rule: {rule.name}"
-                decision = PolicyDecision(
-                    allowed=allowed,
-                    action=action,
-                    reason=reason,
-                    policy_name=rule.name,
-                    trust_score=trust,
-                )
+                reason = rule.message or f"{"Allowed" if allowed else "Denied"} by rule: {rule.name}"
+                decision = PolicyDecision(allowed=allowed, action=action, reason=reason, policy_name=rule.name, trust_score=trust)
                 self.log_action(action, "allow" if allowed else "deny", agent_did, context)
                 return decision
-
-        # No rule matched — default deny
-        decision = PolicyDecision(
-            allowed=False,
-            action=action,
-            reason="No matching policy rule — default deny",
-            trust_score=trust,
-        )
+        decision = PolicyDecision(allowed=False, action=action, reason="No matching rule - default deny", trust_score=trust)
         self.log_action(action, "deny", agent_did, context)
         return decision
 
     def get_trust_score(self, agent_did: str) -> float:
-        """Return the trust score for an agent DID.
-
-        Unknown agents start at 1.0 (full trust, decays on violations).
-        """
         return self._trust_scores.get(agent_did, 1.0)
 
     def adjust_trust(self, agent_did: str, delta: float) -> float:
-        """Adjust trust score by delta, clamped to [0.0, 1.0]."""
         current = self.get_trust_score(agent_did)
         new_score = max(0.0, min(1.0, current + delta))
         self._trust_scores[agent_did] = new_score
         return new_score
 
-    def log_action(
-        self,
-        action: str,
-        decision: str,
-        agent_did: str = "unknown",
-        context: Optional[dict] = None,
-    ) -> dict:
-        """Create an audit log entry.
-
-        Returns:
-            The created audit entry dict.
-        """
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "action": action,
-            "decision": decision,
-            "agent_did": agent_did,
-            "trust_score": self.get_trust_score(agent_did),
-            "context": context or {},
-        }
+    def log_action(self, action: str, decision: str, agent_did: str = "unknown", context: Optional[dict] = None) -> dict:
+        entry = {"timestamp": datetime.now(timezone.utc).isoformat(), "action": action, "decision": decision, "agent_did": agent_did, "trust_score": self.get_trust_score(agent_did), "context": context or {}}
         self._audit_log.append(entry)
         return entry
 
     def get_audit_log(self, limit: int = 50) -> list[dict]:
-        """Return the most recent audit log entries."""
         return self._audit_log[-limit:]
 
     @staticmethod
     def _match(operator: str, target: str, value: Any) -> bool:
-        """Evaluate a single condition."""
-        if operator == "equals":
-            return target == value
-        if operator == "starts_with":
-            return target.startswith(str(value))
-        if operator == "contains":
-            return str(value) in target
-        if operator == "matches":
-            return bool(re.search(str(value), target))
-        if operator == "in":
-            return target in (value if isinstance(value, list) else [value])
+        if operator == "equals": return target == value
+        if operator == "starts_with": return target.startswith(str(value))
+        if operator == "contains": return str(value) in target
+        if operator == "matches": return bool(re.search(str(value), target))
+        if operator == "in": return target in (value if isinstance(value, list) else [value])
         return False

--- a/packages/agentmesh-integrations/openshell-skill/pyproject.toml
+++ b/packages/agentmesh-integrations/openshell-skill/pyproject.toml
@@ -5,23 +5,14 @@ build-backend = "hatchling.build"
 [project]
 name = "openshell_agentmesh"
 version = "0.1.0"
-description = "Public Preview — OpenShell + AgentMesh governance skill for sandboxed AI agents"
+description = "Public Preview - OpenShell + AgentMesh governance skill for sandboxed AI agents"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
-authors = [
-    { name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" }
-]
-keywords = ["agents", "openshell", "nvidia", "sandbox", "governance", "trust", "agentmesh"]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-]
-dependencies = [
-    "pyyaml>=6.0,<7.0",
-]
+authors = [{ name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" }]
+keywords = ["agents", "openshell", "nvidia", "sandbox", "governance", "agentmesh"]
+classifiers = ["Development Status :: 3 - Alpha", "License :: OSI Approved :: MIT License", "Programming Language :: Python :: 3"]
+dependencies = ["pyyaml>=6.0,<7.0"]
 
 [project.optional-dependencies]
 agentmesh = ["agentmesh-platform>=3.0,<4.0"]
@@ -29,8 +20,6 @@ dev = ["pytest>=7.0"]
 
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"
-Repository = "https://github.com/microsoft/agent-governance-toolkit"
-Documentation = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/integrations/openshell.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["openshell_agentmesh"]

--- a/packages/agentmesh-integrations/openshell-skill/tests/test_skill.py
+++ b/packages/agentmesh-integrations/openshell-skill/tests/test_skill.py
@@ -1,106 +1,49 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Tests for the OpenShell governance skill."""
-
-from __future__ import annotations
-
-import yaml
-import pytest
+import yaml, pytest
 from pathlib import Path
+from openshell_agentmesh.skill import GovernanceSkill
 
-from openshell_agentmesh.skill import GovernanceSkill, PolicyDecision
-
-
-SAMPLE_POLICY = {
-    "apiVersion": "governance.toolkit/v1",
-    "rules": [
-        {
-            "name": "allow-file-read",
-            "condition": {"field": "action", "operator": "starts_with", "value": "file:read"},
-            "action": "allow",
-            "priority": 90,
-        },
-        {
-            "name": "allow-safe-shell",
-            "condition": {"field": "action", "operator": "in", "value": ["shell:ls", "shell:python", "shell:git"]},
-            "action": "allow",
-            "priority": 80,
-        },
-        {
-            "name": "block-dangerous-shell",
-            "condition": {"field": "action", "operator": "matches", "value": "shell:(rm|dd|curl)"},
-            "action": "deny",
-            "priority": 100,
-            "message": "Dangerous shell command blocked",
-        },
-    ],
-}
-
+SAMPLE_POLICY = {"apiVersion": "governance.toolkit/v1", "rules": [
+    {"name": "allow-file-read", "condition": {"field": "action", "operator": "starts_with", "value": "file:read"}, "action": "allow", "priority": 90},
+    {"name": "allow-safe-shell", "condition": {"field": "action", "operator": "in", "value": ["shell:ls", "shell:python", "shell:git"]}, "action": "allow", "priority": 80},
+    {"name": "block-dangerous-shell", "condition": {"field": "action", "operator": "matches", "value": "shell:(rm|dd|curl)"}, "action": "deny", "priority": 100, "message": "Dangerous shell command blocked"},
+]}
 
 @pytest.fixture
-def policy_dir(tmp_path: Path) -> Path:
-    policy_file = tmp_path / "test-policy.yaml"
-    with open(policy_file, "w", encoding="utf-8") as f:
+def policy_dir(tmp_path):
+    with open(tmp_path / "test-policy.yaml", "w", encoding="utf-8") as f:
         yaml.dump(SAMPLE_POLICY, f)
     return tmp_path
 
-
 class TestGovernanceSkill:
-    def test_policy_allow_file_read(self, policy_dir: Path) -> None:
-        skill = GovernanceSkill(policy_dir=policy_dir)
-        decision = skill.check_policy("file:read:/workspace/main.py")
-        assert decision.allowed is True
-        assert decision.policy_name == "allow-file-read"
-
-    def test_policy_allow_safe_shell(self, policy_dir: Path) -> None:
-        skill = GovernanceSkill(policy_dir=policy_dir)
-        decision = skill.check_policy("shell:python")
-        assert decision.allowed is True
-
-    def test_policy_deny_dangerous_shell(self, policy_dir: Path) -> None:
-        skill = GovernanceSkill(policy_dir=policy_dir)
-        decision = skill.check_policy("shell:rm -rf /tmp")
-        assert decision.allowed is False
-        assert "blocked" in decision.reason.lower()
-
-    def test_policy_default_deny(self, policy_dir: Path) -> None:
-        skill = GovernanceSkill(policy_dir=policy_dir)
-        decision = skill.check_policy("unknown:action")
-        assert decision.allowed is False
-
-    def test_trust_score_default(self) -> None:
-        skill = GovernanceSkill()
-        assert skill.get_trust_score("did:mesh:unknown") == 1.0
-
-    def test_trust_score_adjust(self) -> None:
-        skill = GovernanceSkill()
-        skill.adjust_trust("did:mesh:agent1", -0.3)
-        assert skill.get_trust_score("did:mesh:agent1") == pytest.approx(0.7)
-        skill.adjust_trust("did:mesh:agent1", -0.9)
-        assert skill.get_trust_score("did:mesh:agent1") == 0.0
-
-    def test_audit_log(self, policy_dir: Path) -> None:
-        skill = GovernanceSkill(policy_dir=policy_dir)
-        skill.check_policy("file:read:/test")
-        skill.check_policy("shell:rm -rf /")
-        log = skill.get_audit_log()
-        assert len(log) == 2
-        assert log[0]["decision"] == "allow"
-        assert log[1]["decision"] == "deny"
-
-    def test_load_policies_count(self, policy_dir: Path) -> None:
-        skill = GovernanceSkill()
-        count = skill.load_policies(policy_dir)
-        assert count == 3
-
-    def test_load_policies_missing_dir(self) -> None:
+    def test_allow_file_read(self, policy_dir):
+        assert GovernanceSkill(policy_dir=policy_dir).check_policy("file:read:/workspace/main.py").allowed
+    def test_allow_safe_shell(self, policy_dir):
+        assert GovernanceSkill(policy_dir=policy_dir).check_policy("shell:python").allowed
+    def test_deny_dangerous(self, policy_dir):
+        d = GovernanceSkill(policy_dir=policy_dir).check_policy("shell:rm -rf /tmp")
+        assert not d.allowed and "blocked" in d.reason.lower()
+    def test_default_deny(self, policy_dir):
+        assert not GovernanceSkill(policy_dir=policy_dir).check_policy("unknown:action").allowed
+    def test_trust_default(self):
+        assert GovernanceSkill().get_trust_score("did:mesh:x") == 1.0
+    def test_trust_adjust(self):
+        s = GovernanceSkill()
+        s.adjust_trust("did:mesh:a", -0.3)
+        assert s.get_trust_score("did:mesh:a") == pytest.approx(0.7)
+    def test_audit_log(self, policy_dir):
+        s = GovernanceSkill(policy_dir=policy_dir)
+        s.check_policy("file:read:/test")
+        s.check_policy("shell:rm /")
+        log = s.get_audit_log()
+        assert len(log) == 2 and log[0]["decision"] == "allow" and log[1]["decision"] == "deny"
+    def test_load_count(self, policy_dir):
+        assert GovernanceSkill().load_policies(policy_dir) == 3
+    def test_missing_dir(self):
         with pytest.raises(FileNotFoundError):
             GovernanceSkill(policy_dir=Path("/nonexistent"))
-
-    def test_priority_ordering(self, policy_dir: Path) -> None:
-        """Higher priority rules should match first."""
-        skill = GovernanceSkill(policy_dir=policy_dir)
-        # shell:rm matches both block-dangerous (100) and NOT safe-shell
-        decision = skill.check_policy("shell:rm")
-        assert decision.allowed is False
-        assert decision.policy_name == "block-dangerous-shell"
+    def test_priority(self, policy_dir):
+        d = GovernanceSkill(policy_dir=policy_dir).check_policy("shell:rm")
+        assert not d.allowed and d.policy_name == "block-dangerous-shell"


### PR DESCRIPTION
## OpenShell Integration - Skill Package + Runnable Example

Adds code and a working demo to complement the existing OpenShell integration docs.

### New: openshell-agentmesh skill
- GovernanceSkill class with YAML policy evaluation, trust scoring, audit logging
- 10 passing tests

### New: Runnable example
- 6-scenario demo: 3 allowed + 3 denied, trust decays 1.00 to 0.55

### Updated docs
- Links to new skill package and example, fixes stale reference