### PR TITLE
docs: normalize all tutorials to consistent format

### DIFF
--- a/docs/tutorials/01-policy-engine.md
+++ b/docs/tutorials/01-policy-engine.md
@@ -1,4 +1,17 @@
-# Tutorial: Policy Engine
+# Tutorial 01 — Policy Engine
+
+> **Package:** `agent-os-kernel` · **Time:** 30 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- YAML rules for declarative governance policies
+- Operators for matching agent context and tool calls
+- Conflict resolution strategies for competing rules
+- Middleware integration with AI frameworks
+
+---
 
 The policy engine is the governance backbone of the Agent Governance Toolkit. It
 evaluates declarative YAML rules against runtime context and returns
@@ -798,3 +811,11 @@ if decision:
 | Conflict resolution | `packages/agent-mesh/src/agentmesh/governance/conflict_resolution.py` |
 | Policy examples | `packages/agent-os/examples/policies/` |
 | Research demo | `demo/policies/research_policy.yaml` |
+
+---
+
+## Next Steps
+
+- **Trust & Identity:** [Tutorial 02 — Trust and Identity](02-trust-and-identity.md)
+- **Framework Integrations:** [Tutorial 03 — Framework Integrations](03-framework-integrations.md)
+- **Audit & Compliance:** [Tutorial 04 — Audit Logging & Compliance](04-audit-and-compliance.md)

--- a/docs/tutorials/02-trust-and-identity.md
+++ b/docs/tutorials/02-trust-and-identity.md
@@ -1,5 +1,18 @@
 # Tutorial 02 — Trust and Identity
 
+> **Package:** `agentmesh-platform` · **Time:** 30 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- Ed25519 credentials and cryptographic agent identity
+- Decentralized Identifiers (DIDs) for agent verification
+- SPIFFE/SVID integration for workload identity
+- Trust scoring on a continuous 0–1000 scale
+
+---
+
 ## Building Verifiable Agent Identity and Dynamic Trust
 
 **Prerequisites:** `pip install agentmesh-platform`
@@ -682,4 +695,10 @@ entries = log.get_entries(
 | Policies | `TrustPolicy` | YAML-based declarative trust rules |
 | Audit | `AuditLog` | Tamper-evident Merkle-chained event log |
 
-**Next:** [Tutorial 03 — Policy Engine and Compliance](03-policy-engine.md)
+---
+
+## Next Steps
+
+- **Policy Engine:** [Tutorial 01 — Policy Engine](01-policy-engine.md)
+- **Framework Integrations:** [Tutorial 03 — Framework Integrations](03-framework-integrations.md)
+- **Advanced Trust:** [Tutorial 17 — Advanced Trust & Behavior Monitoring](17-advanced-trust-and-behavior.md)

--- a/docs/tutorials/03-framework-integrations.md
+++ b/docs/tutorials/03-framework-integrations.md
@@ -1,7 +1,20 @@
 # Tutorial 03 — Wrapping AI Frameworks with Governance
 
+> **Package:** `agent-os-kernel` · **Time:** 25 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- Govern LangChain agents with policy-aware wrappers
+- Govern CrewAI multi-agent workflows
+- Govern AutoGen conversational agents
+- Govern OpenAI Agents and Google ADK pipelines
+
+---
+
 Every adapter in Agent OS follows the same pattern: **create a policy, create a
-kernel, wrap the framework object, use the governed object as normal**.  The
+kernel, wrap the framework object, use the governed object as normal**.The
 kernel sits between your code and the LLM framework—intercepting calls,
 enforcing limits, blocking disallowed tools, and logging everything.
 

--- a/docs/tutorials/04-audit-and-compliance.md
+++ b/docs/tutorials/04-audit-and-compliance.md
@@ -1,7 +1,19 @@
-# Tutorial 4 — Audit Logging & Compliance
+# Tutorial 04 — Audit Logging & Compliance
+
+> **Package:** `agent-governance-toolkit` · **Time:** 25 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- Append-only audit logs with cryptographic integrity
+- Hash chains for tamper-evident event recording
+- OWASP ASI 2026 compliance mapping and verification
+
+---
 
 Every action an AI agent takes — tool calls, policy decisions, trust
-handshakes — must be recorded in a **tamper-proof** log. Without it,
+handshakes — must be recorded in a **tamper-proof** log.Without it,
 you cannot answer the question every auditor will ask: *"What exactly did
 this agent do, and who authorised it?"*
 

--- a/docs/tutorials/05-agent-reliability.md
+++ b/docs/tutorials/05-agent-reliability.md
@@ -1,4 +1,17 @@
-# Agent Reliability Engineering
+# Tutorial 05 — Agent Reliability Engineering
+
+> **Package:** `agent-sre` · **Time:** 30 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- SLOs and error budgets for autonomous agents
+- Circuit breakers and automatic recovery
+- Chaos testing for agent resilience
+- Cost controls and rogue agent detection
+
+---
 
 Site Reliability Engineering (SRE) practices adapted for autonomous AI agents —
 rogue detection, circuit breakers, SLOs, chaos testing, and cost controls.

--- a/docs/tutorials/06-execution-sandboxing.md
+++ b/docs/tutorials/06-execution-sandboxing.md
@@ -1,4 +1,16 @@
-# 🛡️ Tutorial 06 — Execution Sandboxing
+# Tutorial 06 — Execution Sandboxing
+
+> **Package:** `agentmesh-runtime` · **Time:** 30 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- 4-tier privilege ring model for agent isolation
+- Resource limits and capability guards
+- Termination control and kill switch integration
+
+---
 
 **Isolate AI agents at runtime using privilege rings, saga transactions, and kill switches.**
 

--- a/docs/tutorials/07-mcp-security-gateway.md
+++ b/docs/tutorials/07-mcp-security-gateway.md
@@ -1,7 +1,19 @@
 # Tutorial 07 — MCP Security Gateway
 
+> **Package:** `agent-os-kernel` · **Time:** 30 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- Tool poisoning detection and definition drift monitoring
+- Parameter sanitization and schema enforcement
+- Human-in-the-loop approval workflows for sensitive tools
+
+---
+
 The MCP Security Gateway is a governance layer that sits between MCP clients and
-servers, enforcing policy-based controls on every tool call.  It defends against
+servers, enforcing policy-based controls on every tool call.It defends against
 tool misuse ([OWASP ASI02](https://genai.owasp.org/)) and MCP-layer attacks such
 as tool poisoning, rug pulls, and cross-server impersonation—before an agent can
 act on a compromised tool definition.

--- a/docs/tutorials/08-opa-rego-cedar-policies.md
+++ b/docs/tutorials/08-opa-rego-cedar-policies.md
@@ -1,7 +1,19 @@
 # Tutorial 08 — OPA/Rego & Cedar Policy Backends
 
+> **Package:** `agent-os-kernel` · **Time:** 35 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- External policy backends for OPA/Rego and Cedar
+- 3 evaluation modes: standalone, hybrid, and multi-backend
+- Enterprise policy integration with existing infrastructure
+
+---
+
 The Agent Governance Toolkit ships with a declarative YAML policy engine that
-covers most use cases out of the box. But enterprises rarely start from
+covers most use cases out of the box.But enterprises rarely start from
 scratch—they already have policy investments in [Open Policy Agent
 (OPA)](https://www.openpolicyagent.org/) with Rego, or
 [Cedar](https://www.cedarpolicy.com/) from AWS. Rather than force a rewrite,
@@ -1278,3 +1290,11 @@ print(f"Reason: {decision.reason}")
 | `PolicyEngine` | `packages/agent-mesh/src/agentmesh/governance/policy.py` |
 | OPA tests | `packages/agent-mesh/tests/test_opa.py` |
 | Cedar tests | `packages/agent-mesh/tests/test_cedar.py` |
+
+---
+
+## Next Steps
+
+- **Policy Engine:** [Tutorial 01 — Policy Engine](01-policy-engine.md)
+- **Prompt Injection:** [Tutorial 09 — Prompt Injection Detection](09-prompt-injection-detection.md)
+- **Compliance Verification:** [Tutorial 18 — Compliance Verification](18-compliance-verification.md)

--- a/docs/tutorials/09-prompt-injection-detection.md
+++ b/docs/tutorials/09-prompt-injection-detection.md
@@ -1,6 +1,19 @@
 # Tutorial 09 — Prompt Injection Detection & Input Security
 
-Prompt injection is the #1 threat to AI agent systems. An attacker crafts
+> **Package:** `agent-os-kernel` · **Time:** 30 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- 7 attack types and detection strategies
+- MemoryGuard for protecting stored context
+- ConversationGuardian for multi-agent dialogue safety
+- Red-teaming with AdversarialEvaluator
+
+---
+
+Prompt injection is the #1 threat to AI agent systems.An attacker crafts
 input that overrides the agent's instructions—exfiltrating data, calling
 forbidden tools, or breaking safety guardrails entirely. Unlike traditional
 web attacks that target _code_, prompt injections target _intent_.
@@ -1066,3 +1079,11 @@ assert report.risk_score == 0.0, f"Gaps found: {report.failed} attacks succeeded
 | Adversarial tests | `packages/agent-os/tests/test_adversarial.py` |
 | Conversation guardian tests | `packages/agent-os/tests/test_conversation_guardian.py` |
 | Escalation tests | `packages/agent-os/tests/test_escalation.py` |
+
+---
+
+## Next Steps
+
+- **MCP Security:** [Tutorial 07 — MCP Security Gateway](07-mcp-security-gateway.md)
+- **Plugin Marketplace:** [Tutorial 10 — Plugin Marketplace](10-plugin-marketplace.md)
+- **Agent Reliability:** [Tutorial 05 — Agent Reliability Engineering](05-agent-reliability.md)

--- a/docs/tutorials/10-plugin-marketplace.md
+++ b/docs/tutorials/10-plugin-marketplace.md
@@ -1,5 +1,17 @@
 # Tutorial 10 — Plugin Marketplace
 
+> **Package:** `agentmesh-marketplace` · **Time:** 25 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- Plugin signing and Ed25519 verification
+- CLI commands for plugin lifecycle management
+- Supply-chain security and sandboxed execution
+
+---
+
 The Plugin Marketplace is the supply-chain layer of the Agent Governance Toolkit.
 It manages the full lifecycle of plugins — discovery, installation, verification,
 sandboxed execution, and removal — so your agent mesh can safely extend its

--- a/docs/tutorials/11-saga-orchestration.md
+++ b/docs/tutorials/11-saga-orchestration.md
@@ -1,4 +1,17 @@
-# 🔄 Tutorial 11 — Saga Orchestration
+# Tutorial 11 — Saga Orchestration
+
+> **Package:** `agentmesh-runtime` · **Time:** 30 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- Multi-step transactions with compensating actions
+- Saga DSL for declarative pipeline definitions
+- Fan-out for parallel step execution
+- Compensating actions and rollback strategies
+
+---
 
 **Multi-step agent transactions with compensating actions, parallel fan-out, and semantic checkpoints.**
 
@@ -992,3 +1005,11 @@ Governance Toolkit. Here's where to go next:
    achieved when restarting a saga.
 6. **Plan for ESCALATED state** — wire up alerting for sagas that can't
    be compensated automatically.
+
+---
+
+## Next Steps
+
+- **Liability & Attribution:** [Tutorial 12 — Liability & Attribution](12-liability-and-attribution.md)
+- **Observability:** [Tutorial 13 — Observability & Distributed Tracing](13-observability-and-tracing.md)
+- **Execution Sandboxing:** [Tutorial 06 — Execution Sandboxing](06-execution-sandboxing.md)

--- a/docs/tutorials/12-liability-and-attribution.md
+++ b/docs/tutorials/12-liability-and-attribution.md
@@ -1,4 +1,17 @@
-# ⚖️ Tutorial 12 — Liability & Attribution
+# Tutorial 12 — Liability & Attribution
+
+> **Package:** `agentmesh-runtime` · **Time:** 25 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- Vouching and sponsorship protocols for agent accountability
+- Slashing penalties for governance violations
+- Causal attribution across multi-agent workflows
+- Quarantine and isolation for misbehaving agents
+
+---
 
 **Track accountability across multi-agent workflows: who vouched for whom, who caused what, and what penalties apply when things go wrong.**
 

--- a/docs/tutorials/13-observability-and-tracing.md
+++ b/docs/tutorials/13-observability-and-tracing.md
@@ -1,4 +1,17 @@
-# 📡 Tutorial 13 — Observability & Distributed Tracing
+# Tutorial 13 — Observability & Distributed Tracing
+
+> **Package:** `agentmesh-runtime` · **Time:** 30 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- Causal trace IDs for hierarchical event tracking
+- Event bus for structured, immutable event streaming
+- Prometheus metrics and ring-level collectors
+- OpenTelemetry-compatible span export
+
+---
 
 **Instrument autonomous agents with structured events, causal trace IDs, Prometheus metrics, and OpenTelemetry-compatible span export.**
 
@@ -859,4 +872,8 @@ Here's where to go next:
 
 ---
 
-*Part of the [Agent Governance Toolkit](../../README.md) tutorial series.*
+## Next Steps
+
+- **Kill Switch:** [Tutorial 14 — Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md)
+- **Agent Reliability:** [Tutorial 05 — Agent Reliability Engineering](05-agent-reliability.md)
+- **Saga Orchestration:** [Tutorial 11 — Saga Orchestration](11-saga-orchestration.md)

--- a/docs/tutorials/14-kill-switch-and-rate-limiting.md
+++ b/docs/tutorials/14-kill-switch-and-rate-limiting.md
@@ -1,4 +1,16 @@
-# 🛑 Tutorial 14 — Kill Switch & Rate Limiting
+# Tutorial 14 — Kill Switch & Rate Limiting
+
+> **Package:** `agentmesh-runtime` · **Time:** 20 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- Emergency termination with KillSwitch and audit trails
+- Rate limiting with per-agent token bucket enforcement
+- Ring elevation and breach detection
+
+---
 
 **Emergency controls for autonomous agents — the "big red button", rate governors, and ring-breach detection.**
 
@@ -1436,3 +1448,11 @@ print(f"HTTP: {http_status['agent_tokens']:.0f}/{http_status['agent_capacity']} 
 | **Ring Enforcement** | `RingElevationManager` | Temporary privilege escalation with TTL |
 | **Ring Enforcement** | `RingBreachDetector` | Behavioral anomaly detection with circuit breaker |
 | **Ring Enforcement** | `BreachSeverity` | 5-level severity classification (NONE→CRITICAL) |
+
+---
+
+## Next Steps
+
+- **Execution Sandboxing:** [Tutorial 06 — Execution Sandboxing](06-execution-sandboxing.md)
+- **Observability:** [Tutorial 13 — Observability & Distributed Tracing](13-observability-and-tracing.md)
+- **Agent Reliability:** [Tutorial 05 — Agent Reliability Engineering](05-agent-reliability.md)

--- a/docs/tutorials/15-rl-training-governance.md
+++ b/docs/tutorials/15-rl-training-governance.md
@@ -1,8 +1,20 @@
 # Tutorial 15 — RL Training Governance
 
+> **Package:** `agentmesh-lightning` · **Time:** 25 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- GovernedRunner for policy-enforced training loops
+- PolicyReward for converting violations into reward signals
+- Gym-compatible environments with governance constraints
+
+---
+
 Reinforcement-learning agents learn by trial and error — but in production
 systems those "errors" can be SQL injections, budget overruns, or
-unauthorised data access. The **agent-lightning** package lets you enforce
+unauthorised data access.The **agent-lightning** package lets you enforce
 governance constraints *during* RL training so the agent learns to be safe
 and effective from the very first episode.
 

--- a/docs/tutorials/16-protocol-bridges.md
+++ b/docs/tutorials/16-protocol-bridges.md
@@ -1,5 +1,18 @@
 # Tutorial 16 — Protocol Bridges (A2A, MCP, IATP)
 
+> **Package:** `agentmesh-platform` · **Time:** 30 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- A2A task envelopes and trust-gated communication
+- MCP proxy with policy enforcement and trust thresholds
+- IATP attestation and cross-protocol message translation
+- Trust-gated communication between heterogeneous agents
+
+---
+
 ## Connecting Agents Across Protocols with Trust-Gated Communication
 
 **Prerequisites:** `pip install agentmesh-platform a2a-agentmesh mcp-trust-proxy`

--- a/docs/tutorials/17-advanced-trust-and-behavior.md
+++ b/docs/tutorials/17-advanced-trust-and-behavior.md
@@ -1,5 +1,9 @@
 # Tutorial 17 — Advanced Trust & Behavior Monitoring
 
+> **Package:** `agentmesh-platform` · **Time:** 35 minutes · **Prerequisites:** Python 3.11+
+
+---
+
 ## Dynamic Trust Management Through Observed Behavior
 
 **Prerequisites:** `pip install agentmesh-platform`

--- a/docs/tutorials/18-compliance-verification.md
+++ b/docs/tutorials/18-compliance-verification.md
@@ -1,5 +1,17 @@
 # Tutorial 18 — Compliance Verification & Attestation
 
+> **Package:** `agent-governance-toolkit` · **Time:** 30 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- Governance grading with automated compliance checks
+- Regulatory framework mapping (OWASP ASI 2026)
+- Cryptographic attestation records for audit trails
+
+---
+
 ## Proving governance compliance — from internal verification to regulatory audits
 
 Every governed agent system must answer a deceptively simple question: _"Can you prove you're compliant?"_  Not "do you think you are," but **prove** — with cryptographic attestations, coverage grades, and audit-ready reports that satisfy both your engineering team and your compliance officer.

--- a/docs/tutorials/19-dotnet-sdk.md
+++ b/docs/tutorials/19-dotnet-sdk.md
@@ -1,5 +1,9 @@
 # Tutorial 19 — .NET SDK (Microsoft.AgentGovernance)
 
+> **Package:** `Microsoft.AgentGovernance` · **Time:** 30 minutes · **Prerequisites:** .NET 8.0+
+
+---
+
 Full agent governance in C# / .NET 8 — the same policy engine, execution rings,
 circuit breakers, prompt injection detection, SLO tracking, saga orchestration,
 rate limiting, zero-trust identity, and OpenTelemetry metrics you get from the

--- a/docs/tutorials/20-typescript-sdk.md
+++ b/docs/tutorials/20-typescript-sdk.md
@@ -1,5 +1,18 @@
 # Tutorial 20 — TypeScript SDK (@agentmesh/sdk)
 
+> **Package:** `@agentmesh/sdk` · **Time:** 30 minutes · **Prerequisites:** Node.js 18+
+
+---
+
+## What You'll Learn
+
+- Identity and Ed25519 DIDs in TypeScript/Node.js
+- Trust scoring and peer verification
+- Declarative policy evaluation
+- Hash-chain audit logging
+
+---
+
 Build governance-aware AI agents in TypeScript and Node.js.
 The `@microsoft/agentmesh-sdk` package provides cryptographic identity (Ed25519 DIDs),
 trust scoring, declarative policy evaluation, and hash-chain audit logging — all in

--- a/docs/tutorials/21-rust-sdk.md
+++ b/docs/tutorials/21-rust-sdk.md
@@ -2,6 +2,8 @@
 
 # Tutorial 21 — Rust SDK (`agentmesh` crate)
 
+> **Package:** `agentmesh` crate · **Time:** 30 minutes · **Prerequisites:** Rust 1.75+
+
 Full agent governance in Rust — policy evaluation, trust scoring, hash-chain
 audit logging, and Ed25519 agent identity. The `agentmesh` crate provides the
 same governance primitives as the Python, TypeScript, and .NET SDKs with Rust's

--- a/docs/tutorials/build-custom-integration.md
+++ b/docs/tutorials/build-custom-integration.md
@@ -1,5 +1,17 @@
 # Tutorial 28 — Building Custom Governance Integrations
 
+> **Package:** `agent-os-kernel` / standalone · **Time:** 30 minutes · **Prerequisites:** Python 3.10+
+
+---
+
+## What You'll Learn
+
+- Trust integrations — standalone packages for identity, gating, and trust tracking
+- Kernel adapters — `BaseIntegration` subclasses with pre/post hooks and tool interception
+- Publishing governance packages — package structure, PR requirements, and versioning
+
+---
+
 Every governed agent system follows the same pattern: verify identity, gate
 actions, intercept tool calls, log everything. The toolkit provides 15 kernel
 adapters and 17 trust integrations that implement this pattern. This tutorial
@@ -852,3 +864,11 @@ to match the toolkit version on acceptance.
 | Framework integrations tutorial | `docs/tutorials/03-framework-integrations.md` |
 | Template integration (copy this) | `packages/agentmesh-integrations/template-agentmesh/` |
 | GovernancePolicy patterns | Tutorial 03, Section 7 |
+
+---
+
+## Next Steps
+
+- [Tutorial 03 — Framework Integrations](03-framework-integrations.md)
+- [Tutorial 02 — Trust & Identity](02-trust-and-identity.md)
+- [Tutorial 04 — Audit & Compliance](04-audit-and-compliance.md)

--- a/docs/tutorials/progressive-governance.md
+++ b/docs/tutorials/progressive-governance.md
@@ -1,4 +1,15 @@
-# Progressive Governance: Start Simple, Add Layers
+# Guide: Progressive Governance — Start Simple, Add Layers
+
+> **Applies to:** All AGT packages · **Time:** 15 minutes · **Prerequisites:** None
+
+---
+
+## What You'll Learn
+
+- The 5-level progressive complexity model for agent governance
+- When to add each governance layer based on your team's risk profile
+
+---
 
 > **You don't need the full stack to start.** Most teams run Level 1–2 in
 > production and never need Level 5. Pick the level that matches your risk.

--- a/docs/tutorials/retrofit-governance.md
+++ b/docs/tutorials/retrofit-governance.md
@@ -1,4 +1,15 @@
-# Retrofit Governance onto an Existing Agent
+# Guide: Retrofit Governance onto an Existing Agent
+
+> **Package:** `agent-os-kernel` · **Time:** 10 minutes · **Prerequisites:** Python 3.10+, existing agent
+
+---
+
+## What You'll Learn
+
+- Add policy enforcement to any existing agent in 3 steps — install, wrap, and configure
+- Blocked-pattern detection and audit trail without rewriting existing logic
+
+---
 
 Got an AI agent already running in production? This tutorial shows you how to
 add policy enforcement, blocked-pattern detection, and an audit trail in **three


### PR DESCRIPTION
Standardize 20 tutorials (01-20) to match the gold-standard template (22-27, 29-30). Fixed titles (removed emojis, added numbers), added metadata blocks (Package/Time/Prerequisites), added What You'll Learn and Next Steps sections. Body content unchanged.