### PR TITLE
fix(docs): correct npm package name and stale version refs across 21 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,7 +196,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **TypeScript SDK full parity** (— PolicyEngine + AgentIdentity) — rich policy evaluation with 4 conflict resolution strategies, expression evaluator, rate limiting, YAML/JSON policy documents, Ed25519 identity with lifecycle/delegation/JWK/JWKS/DID export, IdentityRegistry with cascade revocation. 136 tests passing. (#269)
-- **@agentmesh/sdk 1.0.0** — TypeScript package now publish-ready with `exports` field, `prepublishOnly` build hook, correct `repository.directory`, MIT license.
+- **@microsoft/agentmesh-sdk 1.0.0** — TypeScript package now publish-ready with `exports` field, `prepublishOnly` build hook, correct `repository.directory`, MIT license.
 - **Multi-language README** — root README now surfaces Python (PyPI), TypeScript (npm), and .NET (NuGet) install sections, badges, quickstart code, and a multi-SDK packages table.
 - **Multi-language QUICKSTART** — getting started guide now covers all three SDKs with code examples.
 - **Semantic Kernel + Azure AI Foundry** added to framework integration table.
@@ -254,7 +254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 pip install agent-governance-toolkit[full]
 
 # TypeScript
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
 
 # .NET
 dotnet add package Microsoft.AgentGovernance

--- a/INDEPENDENCE.md
+++ b/INDEPENDENCE.md
@@ -24,7 +24,7 @@ Core paths (`agent_os/`, `agentmesh/`, `agent_hypervisor/`, `agent_sre/`) must f
 | **agentmesh** (Rust) | None — pure crypto + serde | ✅ Independent |
 | **agentmesh-mcp** (Rust) | None — pure crypto + serde | ✅ Independent |
 | **agentmesh** (Go) | None — yaml.v3 only | ✅ Independent |
-| **@agentmesh/sdk** (TypeScript) | None — zero runtime deps | ✅ Independent |
+| **@microsoft/agentmesh-sdk** (TypeScript) | None — zero runtime deps | ✅ Independent |
 | **Microsoft.AgentGovernance** (.NET) | None — YamlDotNet only | ✅ Independent |
 
 ## Adapter Pattern

--- a/QUICKSTART.ja.md
+++ b/QUICKSTART.ja.md
@@ -42,7 +42,7 @@ pip install agentmesh-lightning        # RL training governance
 ### TypeScript / Node.js
 
 ```bash
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
 ```
 
 ### .NET
@@ -107,7 +107,7 @@ python governed_agent.py
 `governed_agent.ts` というファイルを作成します。
 
 ```typescript
-import { PolicyEngine, AgentIdentity, AuditLogger } from "@agentmesh/sdk";
+import { PolicyEngine, AgentIdentity, AuditLogger } from "@microsoft/agentmesh-sdk";
 
 const identity = AgentIdentity.generate("my-agent", ["web_search", "read_file"]);
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -42,7 +42,7 @@ pip install agentmesh-lightning        # RL training governance
 ### TypeScript / Node.js
 
 ```bash
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
 ```
 
 ### .NET
@@ -145,7 +145,7 @@ python governed_agent.py
 Create a file called `governed_agent.ts`:
 
 ```typescript
-import { PolicyEngine, AgentIdentity, AuditLogger } from "@agentmesh/sdk";
+import { PolicyEngine, AgentIdentity, AuditLogger } from "@microsoft/agentmesh-sdk";
 
 const identity = AgentIdentity.generate("my-agent", ["web_search", "read_file"]);
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ result = evaluator.evaluate({"tool_name": "delete_file"})   # ❌ Blocked determ
 <summary><b>TypeScript</b></summary>
 
 ```typescript
-import { PolicyEngine } from "@agentmesh/sdk";
+import { PolicyEngine } from "@microsoft/agentmesh-sdk";
 
 const engine = new PolicyEngine([
   { action: "web_search", effect: "allow" },
@@ -216,7 +216,7 @@ Full methodology: [BENCHMARKS.md](BENCHMARKS.md)
 | Language | Package | Command |
 |----------|---------|---------|
 | **Python** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@agentmesh/sdk`](packages/agent-mesh/sdks/typescript/) | `npm install @agentmesh/sdk` |
+| **TypeScript** | [`@microsoft/agentmesh-sdk`](packages/agent-mesh/sdks/typescript/) | `npm install @microsoft/agentmesh-sdk` |
 | **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
 | **Rust** | [`agentmesh`](https://crates.io/crates/agentmesh) | `cargo add agentmesh` |
 | **Go** | [`agentmesh`](packages/agent-mesh/sdks/go/) | `go get github.com/microsoft/agent-governance-toolkit/sdks/go` |

--- a/RELEASE_NOTES_v2.1.0.md
+++ b/RELEASE_NOTES_v2.1.0.md
@@ -18,7 +18,7 @@ The toolkit is now a **polyglot governance layer**. All three SDKs have first-cl
 | Language | Package | Install |
 |----------|---------|---------|
 | **Python** | [`agent-governance-toolkit[full]`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@agentmesh/sdk`](https://www.npmjs.com/package/@agentmesh/sdk) | `npm install @agentmesh/sdk` |
+| **TypeScript** | [`@microsoft/agentmesh-sdk`](https://www.npmjs.com/package/@microsoft/agentmesh-sdk) | `npm install @microsoft/agentmesh-sdk` |
 | **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
 
 ### TypeScript SDK Full Parity (1.0.0)
@@ -99,7 +99,7 @@ Full methodology: [BENCHMARKS.md](BENCHMARKS.md)
 pip install agent-governance-toolkit[full]
 
 # TypeScript
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
 
 # .NET
 dotnet add package Microsoft.AgentGovernance

--- a/docs/SDK-FEATURE-MATRIX.md
+++ b/docs/SDK-FEATURE-MATRIX.md
@@ -69,7 +69,7 @@ governance stack for enterprise deployments:
 
 ### TypeScript SDK
 
-**Package:** [`@agentmesh/sdk`](https://www.npmjs.com/package/@agentmesh/sdk) ·
+**Package:** [`@microsoft/agentmesh-sdk`](https://www.npmjs.com/package/@microsoft/agentmesh-sdk) ·
 **Source:** [`packages/agent-mesh/sdks/typescript/`](../packages/agent-mesh/sdks/typescript/)
 
 | Module | Features |
@@ -161,7 +161,7 @@ full governance stack.
 | Language | Command |
 |----------|---------|
 | Python | `pip install agent-governance-toolkit[full]` |
-| TypeScript | `npm install @agentmesh/sdk` |
+| TypeScript | `npm install @microsoft/agentmesh-sdk` |
 | .NET | `dotnet add package Microsoft.AgentGovernance` |
 | Rust | `cargo add agentmesh` |
 | Rust (MCP only) | `cargo add agentmesh-mcp` |

--- a/docs/case-studies/TEMPLATE.md
+++ b/docs/case-studies/TEMPLATE.md
@@ -491,7 +491,7 @@ For each challenge, include:
 ## Template Metadata
 
 **Version**: 1.0
-**AGT Version**: 3.0.2
+**AGT Version**: 3.1.0
 **Maintained By**: Agent Governance Toolkit Community
 **Repository**: https://github.com/microsoft/agent-governance-toolkit
 
@@ -537,7 +537,7 @@ For each challenge, include:
   - **Minor updates** (typo fixes, clarifications): Don't update version tag
   - **Compatibility updates** (component names, APIs): Update to new AGT version and add changelog note:
     Changelog:
-  - v3.0.2 → v3.5.0 (March 2026): Updated AgentMesh references to AgentTrust
+  - v3.1.0 → v3.5.0 (March 2026): Updated AgentMesh references to AgentTrust
   - v3.5.0 → v4.0.0 (June 2026): Updated trust scoring from 0-1000 to 0-100 scale
 
   **Handling Outdated Case Studies:**
@@ -562,7 +562,7 @@ For each challenge, include:
   **Documentation Freeze for Stable References:**
 
   Some organizations may reference case studies in compliance documentation or vendor contracts. To support this:
-  - Version-specific case studies remain available via Git tags (e.g., `git checkout v3.0.2`)
+  - Version-specific case studies remain available via Git tags (e.g., `git checkout v3.1.0`)
   - Breaking changes to case studies should be communicated in release notes
   - Consider maintaining at least 2 major versions of case study documentation
 

--- a/docs/case-studies/sample-ecommerce-customer-service.md
+++ b/docs/case-studies/sample-ecommerce-customer-service.md
@@ -1,6 +1,6 @@
 # GDPR-Compliant Customer Service Agents at VelvetCart Commerce
-_Disclaimer: This document presents a hypothetical use case intended to guide architecture and compliance planning. No real-world company data or metrics are included. This case study references AGT version 3.0.2. Component names and capabilities may differ in newer versions. Refer to the current documentation for the latest features. AGT is a tool to assist with compliance but does not guarantee compliance. Compliance depends on proper implementation and operational practices._
-**AGT Version**: 3.0.2
+_Disclaimer: This document presents a hypothetical use case intended to guide architecture and compliance planning. No real-world company data or metrics are included. This case study references AGT version 3.1.0. Component names and capabilities may differ in newer versions. Refer to the current documentation for the latest features. AGT is a tool to assist with compliance but does not guarantee compliance. Compliance depends on proper implementation and operational practices._
+**AGT Version**: 3.1.0
 
 ## Case Study Metadata
 

--- a/docs/case-studies/sample-financial-trading-compliance.md
+++ b/docs/case-studies/sample-financial-trading-compliance.md
@@ -1,5 +1,5 @@
 # SEC-Compliant Algorithmic Trading Agents at Merchantlife Trading Group
-_Disclaimer: This document presents a hypothetical use case intended to guide architecture and compliance planning. No real-world company data or metrics are included. This case study references AGT version 3.0.2. Component names and capabilities may differ in newer versions. Refer to the current documentation for the latest features. AGT is a tool to assist with compliance but does not guarantee compliance. Compliance depends on proper implementation and operational practices._
+_Disclaimer: This document presents a hypothetical use case intended to guide architecture and compliance planning. No real-world company data or metrics are included. This case study references AGT version 3.1.0. Component names and capabilities may differ in newer versions. Refer to the current documentation for the latest features. AGT is a tool to assist with compliance but does not guarantee compliance. Compliance depends on proper implementation and operational practices._
 
 ## Case Study Metadata
 

--- a/docs/case-studies/sample-healthcare-prior-authorization.md
+++ b/docs/case-studies/sample-healthcare-prior-authorization.md
@@ -1,5 +1,5 @@
 # HIPAA-Compliant Prior Authorization Agents at Cascade Health Partners
-_Disclaimer: This document presents a hypothetical use case intended to guide architecture and compliance planning. No real-world company data or metrics are included. This case study references AGT version 3.0.2. Component names and capabilities may differ in newer versions. Refer to the current documentation for the latest features. AGT is a tool to assist with compliance but does not guarantee compliance. Compliance depends on proper implementation and operational practices._
+_Disclaimer: This document presents a hypothetical use case intended to guide architecture and compliance planning. No real-world company data or metrics are included. This case study references AGT version 3.1.0. Component names and capabilities may differ in newer versions. Refer to the current documentation for the latest features. AGT is a tool to assist with compliance but does not guarantee compliance. Compliance depends on proper implementation and operational practices._
 
 ## Case Study Metadata
 

--- a/docs/compliance/atf-conformance-assessment.md
+++ b/docs/compliance/atf-conformance-assessment.md
@@ -10,7 +10,7 @@
 **ATF Version:** 0.9.0
 **Target Maturity Level:** Senior
 **Assessment Date:** April 2026
-**Toolkit Version:** 3.0.2
+**Toolkit Version:** 3.1.0
 **Repository:** https://github.com/microsoft/agent-governance-toolkit
 
 ---

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -49,7 +49,7 @@ pip install agent-governance-toolkit[full]
 
 **TypeScript / Node.js** (npm)
 ```bash
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
 ```
 
 **.NET** (NuGet)
@@ -153,7 +153,7 @@ if decision.allowed:
 ### ポリシーの適用 — TypeScript
 
 ```typescript
-import { PolicyEngine } from "@agentmesh/sdk";
+import { PolicyEngine } from "@microsoft/agentmesh-sdk";
 
 const engine = new PolicyEngine([
   { action: "web_search", effect: "allow" },
@@ -285,7 +285,7 @@ decision = engine.evaluate("did:mesh:agent-1", {"tool_name": "analyze"})
 | 言語 | パッケージ | インストール |
 |----------|---------|---------|
 | **Python** | [`agent-governance-toolkit[full]`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@agentmesh/sdk`](../../packages/agent-mesh/sdks/typescript/) | `npm install @agentmesh/sdk` |
+| **TypeScript** | [`@microsoft/agentmesh-sdk`](../../packages/agent-mesh/sdks/typescript/) | `npm install @microsoft/agentmesh-sdk` |
 | **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
 | **Rust** | [`agentmesh`](https://crates.io/crates/agentmesh) | `cargo add agentmesh` |
 | **Rust MCP** | [`agentmesh-mcp`](https://crates.io/crates/agentmesh-mcp) | `cargo add agentmesh-mcp` |

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -42,7 +42,7 @@ pip install agent-governance-toolkit[full]
 
 **TypeScript / Node.js** (npm)
 ```bash
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
 ```
 
 **.NET** (NuGet)
@@ -135,7 +135,7 @@ if decision.allowed:
 ### 执行策略 — TypeScript
 
 ```typescript
-import { PolicyEngine } from "@agentmesh/sdk";
+import { PolicyEngine } from "@microsoft/agentmesh-sdk";
 
 const engine = new PolicyEngine([
   { action: "web_search", effect: "allow" },
@@ -267,7 +267,7 @@ decision = engine.evaluate("did:mesh:agent-1", {"tool_name": "analyze"})
 | 语言 | Package | Install |
 |----------|---------|---------|
 | **Python** | [`agent-governance-toolkit[full]`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@agentmesh/sdk`](../../packages/agent-mesh/sdks/typescript/) | `npm install @agentmesh/sdk` |
+| **TypeScript** | [`@microsoft/agentmesh-sdk`](../../packages/agent-mesh/sdks/typescript/) | `npm install @microsoft/agentmesh-sdk` |
 | **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
 | **Rust** | [`agentmesh`](https://crates.io/crates/agentmesh) | `cargo add agentmesh` |
 | **Go** | [`agentmesh`](../../packages/agent-mesh/sdks/go/) | `go get github.com/microsoft/agent-governance-toolkit/sdks/go` |

--- a/docs/modern-agent-architecture-overview.md
+++ b/docs/modern-agent-architecture-overview.md
@@ -216,7 +216,7 @@ Catches: tool poisoning, typosquatting, hidden instructions, rug-pull attacks.
 pip install agent-governance-toolkit[full]
 ```
 
-Also available for: **TypeScript** (`npm install @agentmesh/sdk`), **.NET** (`dotnet add package Microsoft.AgentGovernance`), **Rust** (`cargo add agentmesh`), **Go**
+Also available for: **TypeScript** (`npm install @microsoft/agentmesh-sdk`), **.NET** (`dotnet add package Microsoft.AgentGovernance`), **Rust** (`cargo add agentmesh`), **Go**
 
 ### Step 2: Your First Governed Agent
 

--- a/docs/tutorials/20-typescript-sdk.md
+++ b/docs/tutorials/20-typescript-sdk.md
@@ -1,6 +1,6 @@
-# Tutorial 20 — TypeScript SDK (@agentmesh/sdk)
+# Tutorial 20 — TypeScript SDK (@microsoft/agentmesh-sdk)
 
-> **Package:** `@agentmesh/sdk` · **Time:** 30 minutes · **Prerequisites:** Node.js 18+
+> **Package:** `@microsoft/agentmesh-sdk` · **Time:** 30 minutes · **Prerequisites:** Node.js 18+
 
 ---
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -65,7 +65,7 @@ guides.
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
 | 19 | [.NET SDK](19-dotnet-sdk.md) | GovernanceKernel, policy, rings, saga, SLO, OpenTelemetry in C# | `Microsoft.AgentGovernance` |
-| 20 | [TypeScript SDK](20-typescript-sdk.md) | Identity, trust, policy, audit in TypeScript/Node.js | `@agentmesh/sdk` |
+| 20 | [TypeScript SDK](20-typescript-sdk.md) | Identity, trust, policy, audit in TypeScript/Node.js | `@microsoft/agentmesh-sdk` |
 | 21 | [Rust SDK](21-rust-sdk.md) | Policy, trust, audit, identity with `agentmesh` crate | `agentmesh` |
 | 22 | [Go SDK](22-go-sdk.md) | Policy, trust, audit, identity with Go module | `agentmesh` |
 
@@ -73,7 +73,7 @@ guides.
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 23 | [Delegation Chains](23-delegation-chains.md) | Monotonic scope narrowing, multi-agent delegation, cascade revocation | `@agentmesh/sdk` |
+| 23 | [Delegation Chains](23-delegation-chains.md) | Monotonic scope narrowing, multi-agent delegation, cascade revocation | `@microsoft/agentmesh-sdk` |
 | 24 | [Cost & Token Budgets](24-cost-and-token-budgets.md) | Per-session token limits, context scheduling, budget signals | `agent-os-kernel` |
 
 ## Supply Chain Security
@@ -159,7 +159,7 @@ Install the full toolkit:
 ```bash
 pip install agent-governance-toolkit[full]    # Python
 dotnet add package Microsoft.AgentGovernance  # .NET
-npm install @agentmesh/sdk                    # TypeScript
+npm install @microsoft/agentmesh-sdk                    # TypeScript
 cargo add agentmesh                           # Rust
 go get github.com/microsoft/agent-governance-toolkit/sdks/go  # Go
 ```

--- a/packages/agent-mesh/docs/trust-model-guide.md
+++ b/packages/agent-mesh/docs/trust-model-guide.md
@@ -532,7 +532,7 @@ print(f"At risk: {report['at_risk_agents']}")
 ### Example 6: Using the TypeScript SDK
 
 ```typescript
-import { TrustManager } from '@agentmesh/sdk';
+import { TrustManager } from '@microsoft/agentmesh-sdk';
 
 const manager = new TrustManager({
   initialScore: 0.5,

--- a/packages/agent-mesh/docs/trust-scoring-api.md
+++ b/packages/agent-mesh/docs/trust-scoring-api.md
@@ -584,7 +584,7 @@ metrics = score.to_dict()
 The TypeScript SDK provides a simpler trust model suitable for client-side use.
 
 ```typescript
-import { TrustManager } from '@agentmesh/sdk';
+import { TrustManager } from '@microsoft/agentmesh-sdk';
 
 const manager = new TrustManager({
   initialScore: 0.5,

--- a/packages/agent-mesh/sdks/typescript/README.md
+++ b/packages/agent-mesh/sdks/typescript/README.md
@@ -1,4 +1,4 @@
-# @agentmesh/sdk
+# @microsoft/agentmesh-sdk
 
 > [!IMPORTANT]
 > **Public Preview** — This npm package is a Microsoft-signed public preview release.
@@ -11,13 +11,13 @@ Provides agent identity (Ed25519 DIDs), trust scoring, policy evaluation, hash-c
 ## Installation
 
 ```bash
-npm install @agentmesh/sdk
+npm install @microsoft/agentmesh-sdk
 ```
 
 ## Quick Start
 
 ```typescript
-import { AgentMeshClient } from '@agentmesh/sdk';
+import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
 
 const client = AgentMeshClient.create('my-agent', {
   capabilities: ['data.read', 'data.write'],
@@ -44,7 +44,7 @@ console.log(client.audit.verify()); // true
 Manage agent identities built on Ed25519 key pairs.
 
 ```typescript
-import { AgentIdentity } from '@agentmesh/sdk';
+import { AgentIdentity } from '@microsoft/agentmesh-sdk';
 
 const identity = AgentIdentity.generate('agent-1', ['read']);
 const signature = identity.sign(new TextEncoder().encode('hello'));
@@ -60,7 +60,7 @@ const restored = AgentIdentity.fromJSON(json);
 Track and score trust for peer agents.
 
 ```typescript
-import { TrustManager } from '@agentmesh/sdk';
+import { TrustManager } from '@microsoft/agentmesh-sdk';
 
 const tm = new TrustManager({ initialScore: 0.5, decayFactor: 0.95 });
 
@@ -76,7 +76,7 @@ const score = tm.getTrustScore('peer-1');
 Rule-based policy evaluation with conditions and YAML support.
 
 ```typescript
-import { PolicyEngine } from '@agentmesh/sdk';
+import { PolicyEngine } from '@microsoft/agentmesh-sdk';
 
 const engine = new PolicyEngine([
   { action: 'data.*', effect: 'allow' },
@@ -96,7 +96,7 @@ await engine.loadFromYAML('./policy.yaml');
 Append-only audit log with hash-chain integrity verification.
 
 ```typescript
-import { AuditLogger } from '@agentmesh/sdk';
+import { AuditLogger } from '@microsoft/agentmesh-sdk';
 
 const logger = new AuditLogger();
 
@@ -113,7 +113,7 @@ logger.exportJSON(); // full log as JSON string
 Unified client tying identity, trust, policy, and audit together.
 
 ```typescript
-import { AgentMeshClient } from '@agentmesh/sdk';
+import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
 
 const client = AgentMeshClient.create('my-agent', {
   policyRules: [{ action: 'data.*', effect: 'allow' }],
@@ -128,7 +128,7 @@ const result = await client.executeWithGovernance('data.read', { user: 'alice' }
 Scan MCP tool definitions for security threats — tool poisoning, typosquatting, hidden instructions, and rug-pull payloads.
 
 ```typescript
-import { McpSecurityScanner } from '@agentmesh/sdk';
+import { McpSecurityScanner } from '@microsoft/agentmesh-sdk';
 
 const scanner = new McpSecurityScanner();
 
@@ -158,7 +158,7 @@ const risky = results.filter((r) => !r.safe);
 Govern agent state transitions with an enforced state machine and event log.
 
 ```typescript
-import { LifecycleManager, LifecycleState } from '@agentmesh/sdk';
+import { LifecycleManager, LifecycleState } from '@microsoft/agentmesh-sdk';
 
 const lm = new LifecycleManager('agent-1');
 

--- a/packages/agent-os/README.md
+++ b/packages/agent-os/README.md
@@ -175,7 +175,7 @@ That's it! Your agent now has deterministic policy enforcement. [Learn more →]
 
 **🎬 See all features in action:**
 ```bash
-git clone https://github.com/microsoft/agent-governance-toolkit && python agent-os/demo.py
+git clone https://github.com/microsoft/agent-governance-toolkit && cd agent-governance-toolkit && pip install -e packages/agent-os && python demo/maf_governance_demo.py
 ```
 
 <details>
@@ -501,10 +501,10 @@ summary_hash = await rt.terminate_session(session.sso.session_id)
 |-----------|-------------|--------|
 | [`mcp-server`](extensions/mcp-server/) | ⭐ **MCP Server** — Works with Claude, Copilot, Cursor (`npx agentos-mcp-server`) | ✅ Published (v1.0.1) |
 | [`vscode`](../../agent-os-vscode/) | VS Code extension with real-time policy checks, enterprise features | ✅ Published (v1.0.1) |
-| [`copilot`](extensions/copilot/) | GitHub Copilot extension (Vercel/Docker deployment) | ✅ Published (v1.0.0) |
-| [`jetbrains`](extensions/jetbrains/) | IntelliJ, PyCharm, WebStorm plugin (Kotlin) | ✅ Built (v1.0.0) |
+| [`copilot`](extensions/copilot/) | GitHub Copilot extension (Vercel/Docker deployment) | ✅ Published |
+| [`jetbrains`](extensions/jetbrains/) | IntelliJ, PyCharm, WebStorm plugin (Kotlin) | ✅ Built |
 | [`cursor`](extensions/cursor/) | Cursor IDE extension (Composer integration) | ✅ Built (v0.1.0) |
-| [`chrome`](extensions/chrome/) | Chrome extension for GitHub, Jira, AWS, GitLab | ✅ Built (v1.0.0) |
+| [`chrome`](extensions/chrome/) | Chrome extension for GitHub, Jira, AWS, GitLab | ✅ Built |
 | [`github-cli`](extensions/github-cli/) | `gh agent-os` CLI extension | ⚠️ Basic |
 
 ---


### PR DESCRIPTION
## Summary

Fixes incorrect npm package name and stale version references found across documentation.

### npm package name: @agentmesh/sdk → @microsoft/agentmesh-sdk
The TypeScript SDK was renamed to `@microsoft/agentmesh-sdk` but 13 markdown files still referenced the old `@agentmesh/sdk` name. This would cause `npm install` failures for anyone following the docs.

**Files fixed:** README.md, QUICKSTART.md, QUICKSTART.ja.md, CHANGELOG.md, INDEPENDENCE.md, SDK-FEATURE-MATRIX.md, i18n READMEs, tutorial 20, tutorials README, trust docs, TS SDK README.

### Other fixes
- agent-os README: broken demo path (`agent-os/demo.py` → `demo/maf_governance_demo.py`)
- agent-os README: removed stale `v1.0.0` labels from extension status table
- Case study templates + ATF conformance: AGT Version 3.0.2 → 3.1.0

**21 files changed, 0 remaining issues.**