### PR TITLE
fix(security): upgrade axios to 1.15.0 — CVE-2026-40175, CVE-2025-62718

### DIFF
--- a/packages/agent-os-vscode/package.json
+++ b/packages/agent-os-vscode/package.json
@@ -533,7 +533,7 @@
     "typescript": "5.3.0"
   },
   "dependencies": {
-    "axios": "1.13.6",
+    "axios": "1.15.0",
     "ws": "8.20.0"
   }
 }

--- a/packages/agent-os/extensions/copilot/package.json
+++ b/packages/agent-os/extensions/copilot/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@octokit/webhooks": "14.2.0",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "dotenv": "17.4.1",
     "express": "5.2.1",
     "path-to-regexp": "8.4.2",

--- a/packages/agent-os/extensions/cursor/package.json
+++ b/packages/agent-os/extensions/cursor/package.json
@@ -265,6 +265,6 @@
     "@vscode/vsce": "2.22.0"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   }
 }


### PR DESCRIPTION
## S360 Action Items — SFI-ES5.2 Critical

### CVE-2026-40175 (CVSS 9.9) — Header Injection / Cloud Metadata Exfiltration
Prototype pollution gadget enables CRLF injection in HTTP headers, bypassing AWS IMDSv2 and stealing IAM credentials. Fix: axios 1.15.0 adds header value sanitization.

### CVE-2025-62718 — NO_PROXY Bypass via Hostname Normalization
Trailing dots (`localhost.`) and IPv6 literals (`[::1]`) skip NO_PROXY matching, enabling SSRF through attacker-controlled proxy. Fix: axios 1.15.0 normalizes hostnames before matching.

### Changes
| Package | Old | New |
|---------|-----|-----|
| extensions/copilot | 1.14.0 | 1.15.0 |
| extensions/cursor | 1.13.5 | 1.15.0 |
| agent-os-vscode | 1.13.6 | 1.15.0 |

Action Item IDs:
- `e961ceb4-c020-4151-8a61-55cb702deff2_a4b679e003133ebb187bdd8ff96e398bf3da4033036437f7a604afafa4c23a0c`
- `e961ceb4-c020-4151-8a61-55cb702deff2_bd507accf7f077e662f8d6ef26041adb337520e91025c4557872ff4bbc5336ef`