### PR TITLE
[codex] Add pi-mono AgentMesh integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ result := client.ExecuteWithGovernance("data.read", nil)
 | [LangGraph](https://github.com/langchain-ai/langgraph) / [LangChain](https://github.com/langchain-ai/langchain) | Adapter |
 | [CrewAI](https://github.com/crewAIInc/crewAI) | Adapter |
 | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | Middleware |
+| [pi-mono](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | TypeScript SDK Integration |
 | [Google ADK](https://github.com/google/adk-python) | Adapter |
 | [LlamaIndex](https://github.com/run-llama/llama_index) | Middleware |
 | [Haystack](https://github.com/deepset-ai/haystack) | Pipeline |

--- a/packages/agentmesh-integrations/README.md
+++ b/packages/agentmesh-integrations/README.md
@@ -47,6 +47,7 @@ AgentMesh core is a lean, zero-external-dependency library. Platform integration
 | [Moltbook](moltbook/) | — | ✅ Stable | AgentMesh governance skill for [Moltbook](https://moltbook.com) agent registry |
 | [Nostr Web of Trust](nostr-wot/) | `agentmesh-nostr-wot` | 🚧 Scaffold | Trust scoring via [MaximumSats](https://github.com/joelklabo/maximumsats-mcp) NIP-85 WoT |
 | [OpenAI Agents](openai-agents-trust/) | [`openai-agents-trust`](https://pypi.org/project/openai-agents-trust/) | ✅ Published (PyPI) | Trust guardrails, policy enforcement, governance hooks, trust-gated handoffs for OpenAI Agents SDK |
+| [pi-mono](pi-mono-agentmesh/) | `@microsoft/agentmesh-pi-mono` | Preview | TypeScript SDK integration for governed pi-mono sessions, tool-call policy checks, and audit logging |
 | [OpenClaw Skill](openclaw-skill/) | [`agentmesh-governance`](https://clawhub.ai/microsoft/agentmesh-governance) | ✅ Published (ClawHub) | Governance skill for [OpenClaw](https://openclaw.im) agents — policy enforcement, trust scoring, Ed25519 DIDs, hash-chain audit |
 
 ## Quick Start

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/LICENSE
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/README.md
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/README.md
@@ -1,0 +1,96 @@
+# @microsoft/agentmesh-pi-mono
+
+Governance, policy enforcement, and audit hooks for [pi-mono](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) coding agents.
+
+[![npm](https://img.shields.io/npm/v/@microsoft/agentmesh-pi-mono)](https://www.npmjs.com/package/@microsoft/agentmesh-pi-mono)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+## Overview
+
+`@microsoft/agentmesh-pi-mono` adds AgentMesh governance to pi-mono's SDK path by:
+
+- evaluating every `tool_call` against AgentMesh policy rules
+- adding extra safety review and deny checks for high-risk `bash` commands
+- recording prompts, tool results, and provider requests in an append-only audit log
+- exposing a small session helper so SDK consumers can create governed pi sessions without rebuilding the extension plumbing
+
+## Install
+
+```bash
+npm install @microsoft/agentmesh-pi-mono @mariozechner/pi-coding-agent @microsoft/agentmesh-sdk
+```
+
+## Quick Start
+
+```typescript
+import { createGovernedPiSession } from "@microsoft/agentmesh-pi-mono";
+
+const session = await createGovernedPiSession({
+  cwd: process.cwd(),
+  governance: {
+    agentId: "repo-helper",
+    policyRules: [
+      { action: "read", effect: "allow" },
+      { action: "grep", effect: "allow" },
+      { action: "bash", effect: "review" },
+      { action: "*", effect: "deny" },
+    ],
+  },
+});
+
+await session.prompt("Inspect the repository and summarize the test layout.");
+
+console.log(session.auditLog);
+console.log(session.verifyAuditLog());
+```
+
+## API
+
+### `PiAgentMeshGovernance`
+
+Low-level policy and audit helper for pi-mono integrations.
+
+- `evaluateToolCall(toolName, input)` returns `allow`, `deny`, or `review`
+- `recordPrompt(prompt, hasImages)` adds prompt metadata to the audit trail
+- `recordToolResult(toolName, input, result)` logs a summarized tool outcome
+- `recordProviderRequest(payload)` logs outbound model request metadata
+- `getAuditLog()` returns the in-memory audit records
+- `verifyAuditLog()` validates the underlying audit chain
+
+### `createGovernanceExtension(governance, logger?)`
+
+Returns a pi-mono `ExtensionFactory` that:
+
+- blocks `deny` and `review` tool calls before execution
+- records every tool result after execution
+- records every provider request before the model call
+
+### `GovernedPiSession`
+
+High-level session wrapper around pi-mono's SDK session creation.
+
+- `start()` creates the governed session once and reuses it
+- `prompt(text, options?)` records the prompt before delegating to `session.prompt()`
+- `continueResponse()` delegates to `session.agent.continue()`
+- `loadHistory(history)` hydrates simple `user` / `assistant` message histories
+- `stop()` aborts an active stream and disposes the underlying session
+
+## Default Bash Safety Rules
+
+Even when policy allows `bash`, the adapter adds extra protection:
+
+- `deny`: `rm -rf /`, `mkfs`, raw disk writes, fork bombs, shutdown commands, common exfiltration patterns
+- `review`: `git push`, `npm publish`, `docker push`
+
+This keeps the adapter conservative by default while still letting callers supply custom AgentMesh policy rules.
+
+## Testing
+
+```bash
+npm test
+npm run build
+```
+
+## License
+
+MIT

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/SECURITY.md
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/package.json
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@microsoft/agentmesh-pi-mono",
+  "version": "3.1.0",
+  "description": "Public Preview - Governance, policy enforcement, and audit hooks for pi-mono coding agents",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "pi-mono",
+    "agentmesh",
+    "governance",
+    "trust",
+    "audit",
+    "coding-agent",
+    "policy",
+    "security"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/agent-governance-toolkit.git",
+    "directory": "packages/agentmesh-integrations/pi-mono-agentmesh"
+  },
+  "homepage": "https://github.com/microsoft/agent-governance-toolkit/tree/main/packages/agentmesh-integrations/pi-mono-agentmesh",
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": ">=0.65.2",
+    "@microsoft/agentmesh-sdk": ">=3.0.2"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "0.65.2",
+    "@microsoft/agentmesh-sdk": "3.0.2",
+    "@types/node": "20.0.0",
+    "tsup": "8.0.0",
+    "typescript": "5.7.3",
+    "vitest": "3.0.5"
+  }
+}

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/src/governance.ts
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/src/governance.ts
@@ -1,0 +1,338 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { readFile } from "fs/promises";
+import {
+  AgentIdentity,
+  AuditLogger,
+  PolicyEngine,
+  type AuditEntry,
+  type PolicyDecision,
+  type PolicyRule,
+} from "@microsoft/agentmesh-sdk";
+
+export type PiGovernanceVerdict = "allow" | "deny" | "review";
+
+export interface PiGovernanceDecision {
+  verdict: PiGovernanceVerdict;
+  reason: string;
+  matchedRule?: string;
+  source: "policy" | "bash-safety";
+}
+
+export interface PiGovernanceAuditRecord {
+  kind: "prompt" | "tool_call" | "tool_result" | "provider_request";
+  timestamp: string;
+  action: string;
+  decision?: PiGovernanceDecision;
+  input?: unknown;
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+  auditEntry: AuditEntry;
+}
+
+export interface PiGovernanceConfig {
+  agentId?: string;
+  capabilities?: string[];
+  policyRules?: PolicyRule[];
+  policyPath?: string;
+  maxAuditEntries?: number;
+}
+
+export interface PiGovernanceLogger {
+  warn?(scope: string, message: string, data?: Record<string, unknown>): void;
+}
+
+const DEFAULT_CAPABILITIES = [
+  "read",
+  "grep",
+  "find",
+  "ls",
+  "edit",
+  "write",
+  "bash",
+];
+
+const DEFAULT_POLICY_RULES: PolicyRule[] = [
+  { action: "read", effect: "allow" },
+  { action: "grep", effect: "allow" },
+  { action: "find", effect: "allow" },
+  { action: "ls", effect: "allow" },
+  { action: "edit", effect: "allow" },
+  { action: "write", effect: "allow" },
+  { action: "bash", effect: "allow" },
+  { action: "*", effect: "deny" },
+];
+
+const BASH_DENY_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /(^|\s)rm\s+-rf\s+\/(\s|$)/i, reason: "recursive root deletion" },
+  { pattern: /(^|\s)mkfs(\s|$)/i, reason: "filesystem format attempt" },
+  { pattern: /(^|\s)dd\s+if=/i, reason: "raw disk write attempt" },
+  { pattern: /:\(\)\s*\{/i, reason: "fork bomb pattern" },
+  { pattern: /(^|\s)(shutdown|reboot|halt)(\s|$)/i, reason: "system shutdown command" },
+  { pattern: /(^|\s)(ncat|nc)\s+-l(\s|$)/i, reason: "listener or reverse shell pattern" },
+  { pattern: /curl\b.*(\s--data|\s-d\s)/i, reason: "data exfiltration via curl POST" },
+  { pattern: /wget\b.*--post/i, reason: "data exfiltration via wget POST" },
+];
+
+const BASH_REVIEW_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /(^|\s)git\s+push(\s|$)/i, reason: "pushing to a remote repository" },
+  { pattern: /(^|\s)npm\s+publish(\s|$)/i, reason: "publishing a package" },
+  { pattern: /(^|\s)docker\s+push(\s|$)/i, reason: "pushing a container image" },
+];
+
+export class PiAgentMeshGovernance {
+  private readonly identity: AgentIdentity;
+  private readonly policyEngine: PolicyEngine;
+  private readonly auditLogger: AuditLogger;
+  private readonly auditRecords: PiGovernanceAuditRecord[] = [];
+
+  constructor(private readonly config: PiGovernanceConfig = {}) {
+    this.identity = AgentIdentity.generate(
+      config.agentId || "pi-mono-agent",
+      config.capabilities || DEFAULT_CAPABILITIES,
+      {
+        name: "Pi Mono Agent",
+        description: "pi-mono coding agent governed by AgentMesh policy checks",
+      }
+    );
+    this.policyEngine = new PolicyEngine(config.policyRules || DEFAULT_POLICY_RULES);
+    this.auditLogger = new AuditLogger({
+      maxEntries: config.maxAuditEntries || 10_000,
+    });
+  }
+
+  get agentDid(): string {
+    return this.identity.did;
+  }
+
+  async initialize(): Promise<void> {
+    if (!this.config.policyPath) {
+      return;
+    }
+
+    const policyContents = await readFile(this.config.policyPath, "utf-8");
+    if (this.config.policyPath.endsWith(".json")) {
+      this.policyEngine.loadJson(policyContents);
+      return;
+    }
+    this.policyEngine.loadYaml(policyContents);
+  }
+
+  evaluateToolCall(
+    toolName: string,
+    input?: Record<string, unknown>
+  ): PiGovernanceDecision {
+    const policyDecision = this.policyEngine.evaluate(toolName, {
+      toolName,
+      ...flattenContext(input),
+    });
+
+    let decision = this.fromPolicyDecision(policyDecision, toolName);
+
+    if (decision.verdict === "allow" && toolName === "bash") {
+      decision = this.evaluateBashSafety(input);
+    }
+
+    this.record("tool_call", toolName, {
+      decision,
+      input,
+      metadata: {
+        toolName,
+      },
+    });
+
+    return decision;
+  }
+
+  recordPrompt(prompt: string, hasImages: boolean): void {
+    this.record("prompt", "prompt", {
+      input: {
+        promptLength: prompt.length,
+        preview: prompt.slice(0, 500),
+      },
+      metadata: {
+        hasImages,
+      },
+    });
+  }
+
+  recordToolResult(
+    toolName: string,
+    input: Record<string, unknown> | undefined,
+    result: {
+      content?: unknown;
+      isError?: boolean;
+      details?: unknown;
+    }
+  ): void {
+    this.record("tool_result", toolName, {
+      input,
+      output: summarizeToolResult(result.content),
+      metadata: {
+        isError: !!result.isError,
+        hasDetails: result.details !== undefined,
+      },
+    });
+  }
+
+  recordProviderRequest(payload: unknown): void {
+    const safePayload =
+      payload && typeof payload === "object"
+        ? {
+            model: (payload as Record<string, unknown>).model,
+            messageCount: Array.isArray((payload as Record<string, unknown>).messages)
+              ? ((payload as Record<string, unknown>).messages as unknown[]).length
+              : undefined,
+          }
+        : { type: typeof payload };
+
+    this.record("provider_request", "provider_request", {
+      input: safePayload,
+    });
+  }
+
+  getAuditLog(): PiGovernanceAuditRecord[] {
+    return [...this.auditRecords];
+  }
+
+  verifyAuditLog(): boolean {
+    return this.auditLogger.verify();
+  }
+
+  createBlockedToolResult(
+    decision: PiGovernanceDecision,
+    toolName: string,
+    logger?: PiGovernanceLogger
+  ): { block: true; reason: string } {
+    logger?.warn?.("Governance", "Blocked tool call", {
+      toolName,
+      reason: decision.reason,
+      verdict: decision.verdict,
+    });
+    return {
+      block: true,
+      reason: decision.reason,
+    };
+  }
+
+  private fromPolicyDecision(
+    policyDecision: PolicyDecision,
+    toolName: string
+  ): PiGovernanceDecision {
+    switch (policyDecision) {
+      case "allow":
+        return {
+          verdict: "allow",
+          reason: `Tool "${toolName}" allowed by policy`,
+          matchedRule: toolName,
+          source: "policy",
+        };
+      case "review":
+        return {
+          verdict: "review",
+          reason: `Tool "${toolName}" requires approval by policy`,
+          matchedRule: toolName,
+          source: "policy",
+        };
+      case "deny":
+      default:
+        return {
+          verdict: "deny",
+          reason: `Tool "${toolName}" denied by policy`,
+          matchedRule: toolName,
+          source: "policy",
+        };
+    }
+  }
+
+  private evaluateBashSafety(input?: Record<string, unknown>): PiGovernanceDecision {
+    const command = typeof input?.command === "string" ? input.command : "";
+
+    for (const candidate of BASH_DENY_PATTERNS) {
+      if (candidate.pattern.test(command)) {
+        return {
+          verdict: "deny",
+          reason: `Blocked bash command: ${candidate.reason}`,
+          matchedRule: candidate.pattern.source,
+          source: "bash-safety",
+        };
+      }
+    }
+
+    for (const candidate of BASH_REVIEW_PATTERNS) {
+      if (candidate.pattern.test(command)) {
+        return {
+          verdict: "review",
+          reason: `Bash command requires approval: ${candidate.reason}`,
+          matchedRule: candidate.pattern.source,
+          source: "bash-safety",
+        };
+      }
+    }
+
+    return {
+      verdict: "allow",
+      reason: "Bash command allowed",
+      source: "bash-safety",
+    };
+  }
+
+  private record(
+    kind: PiGovernanceAuditRecord["kind"],
+    action: string,
+    data: Omit<PiGovernanceAuditRecord, "kind" | "timestamp" | "action" | "auditEntry">
+  ): void {
+    const decision = data.decision?.verdict || "allow";
+    const auditEntry = this.auditLogger.log({
+      agentId: this.identity.did,
+      action: `${kind}:${action}`,
+      decision,
+    });
+
+    this.auditRecords.push({
+      kind,
+      timestamp: new Date().toISOString(),
+      action,
+      decision: data.decision,
+      input: data.input,
+      output: data.output,
+      metadata: data.metadata,
+      auditEntry,
+    });
+  }
+}
+
+function flattenContext(input?: Record<string, unknown>): Record<string, unknown> {
+  if (!input) {
+    return {};
+  }
+
+  const flattened: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      flattened[key] = value;
+      continue;
+    }
+    flattened[key] = safeJson(value);
+  }
+  return flattened;
+}
+
+function summarizeToolResult(content: unknown): Record<string, unknown> {
+  const serialized = safeJson(content);
+  return {
+    preview: serialized.slice(0, 1_000),
+    size: serialized.length,
+  };
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/src/index.ts
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/src/index.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+export {
+  PiAgentMeshGovernance,
+  type PiGovernanceAuditRecord,
+  type PiGovernanceConfig,
+  type PiGovernanceDecision,
+  type PiGovernanceLogger,
+  type PiGovernanceVerdict,
+} from "./governance";
+export {
+  GovernedPiSession,
+  createGovernanceExtension,
+  createGovernedPiSession,
+  shouldSkipHistoryHydration,
+  type GovernedPiSessionOptions,
+  type PiConversationMessage,
+} from "./session";

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/src/session.ts
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/src/session.ts
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import {
+  DefaultResourceLoader,
+  createAgentSession,
+  type AgentSession,
+  type CreateAgentSessionOptions,
+  type ExtensionAPI,
+  type ExtensionFactory,
+  type PromptOptions,
+  type ResourceLoader,
+} from "@mariozechner/pi-coding-agent";
+import {
+  PiAgentMeshGovernance,
+  type PiGovernanceConfig,
+  type PiGovernanceLogger,
+} from "./governance";
+
+export interface PiConversationMessage {
+  role: "user" | "assistant";
+  content: unknown;
+}
+
+export interface GovernedPiSessionOptions
+  extends Omit<CreateAgentSessionOptions, "resourceLoader"> {
+  governance?: PiGovernanceConfig;
+  extensionFactories?: ExtensionFactory[];
+  logger?: PiGovernanceLogger;
+  resourceLoaderFactory?: (
+    extensionFactories: ExtensionFactory[]
+  ) => Promise<ResourceLoader> | ResourceLoader;
+}
+
+export class GovernedPiSession {
+  private session?: AgentSession;
+  private initialized = false;
+  private readonly governance: PiAgentMeshGovernance;
+  private readonly governanceExtension: ExtensionFactory;
+
+  constructor(private readonly options: GovernedPiSessionOptions = {}) {
+    this.governance = new PiAgentMeshGovernance(options.governance);
+    this.governanceExtension = createGovernanceExtension(
+      this.governance,
+      this.options.logger
+    );
+  }
+
+  get agentDid(): string {
+    return this.governance.agentDid;
+  }
+
+  get auditLog() {
+    return this.governance.getAuditLog();
+  }
+
+  get rawSession(): AgentSession | undefined {
+    return this.session;
+  }
+
+  async start(): Promise<AgentSession> {
+    if (this.session) {
+      return this.session;
+    }
+
+    const { extensionFactories = [], resourceLoaderFactory, ...sessionOptions } =
+      this.options;
+    const mergedFactories = [...extensionFactories, this.governanceExtension];
+    const resourceLoader = resourceLoaderFactory
+      ? await resourceLoaderFactory(mergedFactories)
+      : new DefaultResourceLoader({
+          cwd: sessionOptions.cwd,
+          agentDir: sessionOptions.agentDir,
+          extensionFactories: mergedFactories,
+        });
+
+    await this.governance.initialize();
+    await resourceLoader.reload();
+
+    const result = await createAgentSession({
+      ...sessionOptions,
+      resourceLoader,
+    });
+
+    this.session = result.session;
+    this.initialized = true;
+    return result.session;
+  }
+
+  async prompt(text: string, options?: PromptOptions): Promise<void> {
+    const session = await this.start();
+    this.governance.recordPrompt(text, !!options?.images?.length);
+    await session.prompt(text, options);
+  }
+
+  async continueResponse(): Promise<void> {
+    const session = await this.start();
+    await session.agent.continue();
+  }
+
+  async loadHistory(history: PiConversationMessage[]): Promise<void> {
+    const session = await this.start();
+
+    if (history.length === 0 || shouldSkipHistoryHydration(history)) {
+      return;
+    }
+
+    session.agent.state.messages = mapHistoryToAgentMessages(
+      history,
+      session.model
+    ) as typeof session.agent.state.messages;
+  }
+
+  verifyAuditLog(): boolean {
+    return this.governance.verifyAuditLog();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.session) {
+      return;
+    }
+
+    try {
+      if (this.session.isStreaming) {
+        await this.session.abort();
+      }
+    } finally {
+      this.session.dispose();
+      this.session = undefined;
+      this.initialized = false;
+    }
+  }
+
+  isStarted(): boolean {
+    return this.initialized;
+  }
+}
+
+export function createGovernanceExtension(
+  governance: PiAgentMeshGovernance,
+  logger?: PiGovernanceLogger
+): ExtensionFactory {
+  return (pi: ExtensionAPI) => {
+    pi.on("tool_call", async (event) => {
+      const decision = governance.evaluateToolCall(
+        event.toolName,
+        event.input as Record<string, unknown> | undefined
+      );
+
+      if (decision.verdict === "allow") {
+        return undefined;
+      }
+
+      return governance.createBlockedToolResult(decision, event.toolName, logger);
+    });
+
+    pi.on("tool_result", async (event) => {
+      governance.recordToolResult(
+        event.toolName,
+        event.input,
+        {
+          content: event.content,
+          isError: event.isError,
+          details: event.details,
+        }
+      );
+      return undefined;
+    });
+
+    pi.on("before_provider_request", async (event) => {
+      governance.recordProviderRequest(event.payload);
+      return undefined;
+    });
+  };
+}
+
+export async function createGovernedPiSession(
+  options: GovernedPiSessionOptions = {}
+): Promise<GovernedPiSession> {
+  const session = new GovernedPiSession(options);
+  await session.start();
+  return session;
+}
+
+export function shouldSkipHistoryHydration(
+  history: PiConversationMessage[]
+): boolean {
+  return history.length === 1 && history[0]?.role === "user";
+}
+
+function mapHistoryToAgentMessages(history: PiConversationMessage[], model: any): any[] {
+  const now = Date.now();
+
+  return history
+    .filter(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        message.role &&
+        message.content !== undefined
+    )
+    .map((message, index) => {
+      const content =
+        typeof message.content === "string"
+          ? message.content
+          : JSON.stringify(message.content);
+
+      if (message.role === "assistant") {
+        return {
+          role: "assistant",
+          api: model?.api,
+          provider: model?.provider,
+          model: model?.id,
+          stopReason: "stop",
+          timestamp: now + index,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          content: [{ type: "text", text: content }],
+        };
+      }
+
+      return {
+        role: "user",
+        content,
+      };
+    });
+}

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/tests/index.test.ts
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/tests/index.test.ts
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createAgentSessionMock, loaderInstances } = vi.hoisted(() => ({
+  createAgentSessionMock: vi.fn(),
+  loaderInstances: [] as Array<{
+    options: Record<string, unknown>;
+    reload: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  class DefaultResourceLoader {
+    public readonly options: Record<string, unknown>;
+    public readonly reload = vi.fn(async () => undefined);
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      loaderInstances.push({ options, reload: this.reload });
+    }
+  }
+
+  return {
+    DefaultResourceLoader,
+    createAgentSession: createAgentSessionMock,
+  };
+});
+
+import {
+  GovernedPiSession,
+  PiAgentMeshGovernance,
+  createGovernanceExtension,
+  shouldSkipHistoryHydration,
+} from "../src";
+
+describe("PiAgentMeshGovernance", () => {
+  it("allows built-in tools and denies unknown tools by default", () => {
+    const governance = new PiAgentMeshGovernance();
+
+    expect(governance.evaluateToolCall("read", { path: "README.md" }).verdict).toBe(
+      "allow"
+    );
+    expect(governance.evaluateToolCall("deploy", { env: "prod" }).verdict).toBe(
+      "deny"
+    );
+  });
+
+  it("reviews or denies risky bash commands", () => {
+    const governance = new PiAgentMeshGovernance();
+
+    const review = governance.evaluateToolCall("bash", {
+      command: "git push origin main",
+    });
+    const deny = governance.evaluateToolCall("bash", {
+      command: "rm -rf /",
+    });
+
+    expect(review.verdict).toBe("review");
+    expect(review.reason).toContain("requires approval");
+    expect(deny.verdict).toBe("deny");
+    expect(deny.reason).toContain("Blocked bash command");
+  });
+
+  it("records prompts, tool results, and provider requests in a verifiable audit log", () => {
+    const governance = new PiAgentMeshGovernance();
+
+    governance.recordPrompt("Summarize the repo", false);
+    governance.recordToolResult("read", { path: "README.md" }, { content: "hello" });
+    governance.recordProviderRequest({ model: "claude", messages: [{ role: "user" }] });
+
+    const auditLog = governance.getAuditLog();
+    expect(auditLog.map((entry) => entry.kind)).toEqual([
+      "prompt",
+      "tool_result",
+      "provider_request",
+    ]);
+    expect(governance.verifyAuditLog()).toBe(true);
+  });
+});
+
+describe("createGovernanceExtension", () => {
+  it("blocks reviewed or denied tool calls and records downstream events", async () => {
+    const governance = new PiAgentMeshGovernance();
+    const handlers: Record<string, Function> = {};
+    const logger = { warn: vi.fn() };
+
+    createGovernanceExtension(governance, logger)({
+      on(event: string, handler: Function) {
+        handlers[event] = handler;
+      },
+    } as any);
+
+    const blocked = await handlers.tool_call({
+      type: "tool_call",
+      toolCallId: "1",
+      toolName: "bash",
+      input: { command: "git push origin main" },
+    });
+
+    expect(blocked).toEqual({
+      block: true,
+      reason: expect.stringContaining("requires approval"),
+    });
+    expect(logger.warn).toHaveBeenCalledOnce();
+
+    await handlers.tool_result({
+      type: "tool_result",
+      toolCallId: "1",
+      toolName: "read",
+      input: { path: "README.md" },
+      content: [{ type: "text", text: "hello" }],
+      isError: false,
+      details: undefined,
+    });
+    await handlers.before_provider_request({
+      type: "before_provider_request",
+      payload: { model: "claude", messages: [{ role: "user" }] },
+    });
+
+    expect(governance.getAuditLog().map((entry) => entry.kind)).toEqual([
+      "tool_call",
+      "tool_result",
+      "provider_request",
+    ]);
+  });
+});
+
+describe("GovernedPiSession", () => {
+  const fakeSession = {
+    prompt: vi.fn(async () => undefined),
+    abort: vi.fn(async () => undefined),
+    dispose: vi.fn(() => undefined),
+    isStreaming: false,
+    agent: {
+      continue: vi.fn(async () => undefined),
+      state: { messages: [] as any[] },
+    },
+    model: {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet",
+    },
+  };
+
+  beforeEach(() => {
+    loaderInstances.length = 0;
+    createAgentSessionMock.mockReset();
+    fakeSession.prompt.mockClear();
+    fakeSession.abort.mockClear();
+    fakeSession.dispose.mockClear();
+    fakeSession.agent.continue.mockClear();
+    fakeSession.agent.state.messages = [];
+    createAgentSessionMock.mockResolvedValue({ session: fakeSession });
+  });
+
+  it("creates a default resource loader with the governance extension and records prompts", async () => {
+    const extraFactory = vi.fn();
+    const session = new GovernedPiSession({
+      cwd: "/repo",
+      agentDir: "/tmp/.pi",
+      extensionFactories: [extraFactory],
+    });
+
+    await session.start();
+    await session.prompt("Inspect the working tree");
+
+    expect(loaderInstances).toHaveLength(1);
+    expect(
+      (loaderInstances[0].options.extensionFactories as unknown[]).length
+    ).toBe(2);
+    expect(loaderInstances[0].reload).toHaveBeenCalledOnce();
+    expect(createAgentSessionMock).toHaveBeenCalledOnce();
+    expect(fakeSession.prompt).toHaveBeenCalledWith("Inspect the working tree", undefined);
+    expect(session.auditLog.at(-1)?.kind).toBe("prompt");
+  });
+
+  it("hydrates history into the underlying pi session", async () => {
+    const session = new GovernedPiSession();
+
+    await session.loadHistory([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+
+    expect(fakeSession.agent.state.messages).toHaveLength(2);
+    expect(fakeSession.agent.state.messages[0]).toEqual({
+      role: "user",
+      content: "Hello",
+    });
+    expect(fakeSession.agent.state.messages[1].role).toBe("assistant");
+    expect(fakeSession.agent.state.messages[1].content[0].text).toBe("Hi there");
+  });
+
+  it("uses a caller-supplied resource loader factory when provided", async () => {
+    const resourceLoader = {
+      reload: vi.fn(async () => undefined),
+    };
+    const resourceLoaderFactory = vi.fn(() => resourceLoader);
+    const session = new GovernedPiSession({ resourceLoaderFactory });
+
+    await session.start();
+
+    expect(resourceLoaderFactory).toHaveBeenCalledOnce();
+    expect(resourceLoader.reload).toHaveBeenCalledOnce();
+  });
+});
+
+describe("shouldSkipHistoryHydration", () => {
+  it("skips a single in-flight user prompt but not longer histories", () => {
+    expect(shouldSkipHistoryHydration([{ role: "user", content: "Hi" }])).toBe(
+      true
+    );
+    expect(
+      shouldSkipHistoryHydration([
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello" },
+      ])
+    ).toBe(false);
+  });
+});

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/tsconfig.json
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/agentmesh-integrations/pi-mono-agentmesh/tsup.config.ts
+++ b/packages/agentmesh-integrations/pi-mono-agentmesh/tsup.config.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+});


### PR DESCRIPTION
Closes #968.

## What changed
- adds a new `@microsoft/agentmesh-pi-mono` integration package under `packages/agentmesh-integrations/pi-mono-agentmesh`
- ports the reusable pi-mono governance adapter and session helper into AGT as a first-class integration
- adds TypeScript tests covering allow, deny, review, audit, extension, and session/history behavior
- updates top-level integration documentation to include pi-mono

## Why
pi-mono already exposes the TypeScript hook points needed for AgentMesh governance, but AGT did not yet provide an upstream integration. This change makes the governance workflow reusable for pi-mono users instead of forcing downstream projects to maintain custom wrappers.

## Impact
pi-mono users can apply AgentMesh policy enforcement, bash safety review and deny checks, and audit logging through a supported integration package that fits the existing AGT structure.

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
