### PR TITLE
fix(ci): EsrpCodeSigning@5 AuthCertName not AuthSignCertName

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -373,7 +373,7 @@ stages:
               AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
-              AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
+              AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)/nuget-unsigned'
               Pattern: '*.nupkg'
               signConfigType: 'inlineSignParams'


### PR DESCRIPTION
One-field fix: \AuthSignCertName\ → \AuthCertName\. EsrpCodeSigning@5 uses \AuthCertName\ for the signing cert, not \AuthSignCertName\ (which is silently ignored, causing 'AuthCertName should be set').