### PR TITLE
feat(agentmesh-avp): add AVPProvider for EigenTrust reputation scoring

### DIFF
--- a/packages/agentmesh-integrations/agentmesh-avp/README.md
+++ b/packages/agentmesh-integrations/agentmesh-avp/README.md
@@ -1,0 +1,68 @@
+# Agent Veil Protocol Integration for AgentMesh
+
+Trust scoring for AgentMesh agents using [Agent Veil Protocol](https://agentveil.dev) — EigenTrust reputation, sybil resistance, and DID-based identity.
+
+## Features
+
+- **EigenTrust Scores** — Map AVP reputation scores to AgentMesh trust engine
+- **Identity Verification** — Verify agents via AVP's DID registry
+- **Full Reputation Profile** — Access confidence, risk factors, attestation history
+- **Graceful Fallback** — Returns safe defaults when AVP API is unreachable
+
+## Installation
+
+```bash
+pip install agentmesh-avp
+```
+
+## Usage
+
+```python
+from agentmesh.trust import TrustEngine
+from agentmesh_avp import AVPProvider
+
+# Create provider pointing to AVP API
+provider = AVPProvider(
+    base_url="https://agentveil.dev",
+    # Optional: map agent IDs to AVP DIDs
+    did_resolver=my_resolver,
+)
+
+# Register with AgentMesh trust engine
+engine = TrustEngine(external_providers=[provider])
+
+# Get composite trust score (AgentMesh + AVP EigenTrust)
+score = await engine.get_trust_score("did:key:z6MkAgent...")
+```
+
+## API Reference
+
+### `AVPProvider`
+
+| Method | Description |
+|---|---|
+| `get_trust_score(agent_id)` | Returns EigenTrust score (0.0-1.0) |
+| `get_reputation(agent_id)` | Returns full profile (score, confidence, tier, risk) |
+| `verify_identity(agent_id, credentials)` | Verifies agent via AVP DID registry |
+
+### Constructor Arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `base_url` | `https://agentveil.dev` | AVP server URL |
+| `did_resolver` | `None` | Maps agent_id to AVP DID string |
+| `name_resolver` | `None` | Maps agent_id to AVP agent name |
+| `timeout` | `10.0` | HTTP timeout in seconds |
+| `min_score_threshold` | `0.3` | Minimum score for score-based verification |
+
+## About Agent Veil Protocol
+
+AVP is an open reputation layer for AI agents. 110+ agents in production, daily IPFS anchors, MIT-licensed SDK.
+
+- [agentveil.dev](https://agentveil.dev)
+- [SDK on PyPI](https://pypi.org/project/agentveil/) — `pip install agentveil`
+- [GitHub](https://github.com/creatorrmode-lead/avp-sdk)
+
+## Contributing
+
+See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.

--- a/packages/agentmesh-integrations/agentmesh-avp/agentmesh_avp/__init__.py
+++ b/packages/agentmesh-integrations/agentmesh-avp/agentmesh_avp/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""AgentMesh Agent Veil Protocol Integration."""
+
+from agentmesh_avp.provider import AVPProvider
+
+__all__ = ["AVPProvider"]
+__version__ = "0.1.0"

--- a/packages/agentmesh-integrations/agentmesh-avp/agentmesh_avp/provider.py
+++ b/packages/agentmesh-integrations/agentmesh-avp/agentmesh_avp/provider.py
@@ -1,0 +1,179 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Agent Veil Protocol provider for AgentMesh trust engine.
+
+Implements the TrustProvider interface using AVP's EigenTrust
+reputation API for trust scoring and DID-based identity verification.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Callable, Optional
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+# DID format: did:key:z6Mk followed by 43+ base58btc characters
+_DID_PATTERN = re.compile(r"^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]{43,}$")
+
+
+def _is_valid_did(value: str) -> bool:
+    """Validate that a string matches the expected did:key format."""
+    return bool(_DID_PATTERN.match(value))
+
+
+class AVPProvider:
+    """Trust provider backed by Agent Veil Protocol.
+
+    Queries the AVP reputation API to retrieve EigenTrust scores
+    and verify agent identity via DID (did:key).
+
+    Args:
+        base_url: AVP server URL.
+        did_resolver: Optional callable that maps agent_id -> AVP DID.
+            If not provided, agent_id is assumed to be a DID string.
+        name_resolver: Optional callable that maps agent_id -> AVP agent name.
+            Used by verify_identity when agent_id is not a registered name.
+        timeout: HTTP request timeout in seconds.
+        min_score_threshold: Minimum score to consider an agent verified.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://agentveil.dev",
+        did_resolver: Optional[Callable[[str], Optional[str]]] = None,
+        name_resolver: Optional[Callable[[str], Optional[str]]] = None,
+        timeout: float = 10.0,
+        min_score_threshold: float = 0.3,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.did_resolver = did_resolver
+        self.name_resolver = name_resolver
+        self.min_score_threshold = min_score_threshold
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    def _resolve_did(self, agent_id: str) -> Optional[str]:
+        """Resolve agent_id to a validated AVP DID string."""
+        if self.did_resolver:
+            resolved = self.did_resolver(agent_id)
+            if resolved and _is_valid_did(resolved):
+                return resolved
+            return None
+        if _is_valid_did(agent_id):
+            return agent_id
+        return None
+
+    def _resolve_name(self, agent_id: str) -> Optional[str]:
+        """Resolve agent_id to an AVP agent name."""
+        if self.name_resolver:
+            return self.name_resolver(agent_id)
+        return agent_id
+
+    @staticmethod
+    def _extract_score(data: Any) -> Optional[float]:
+        """Extract and validate score from API response.
+
+        Returns None if the response is not a dict or score is
+        not a valid number.
+        """
+        if not isinstance(data, dict):
+            return None
+        raw = data.get("score")
+        if raw is None:
+            return None
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return None
+
+    async def get_trust_score(self, agent_id: str) -> float:
+        """Return a normalised trust score (0.0-1.0) from AVP EigenTrust.
+
+        Calls GET /v1/reputation/{did} and returns the ``score`` field.
+        Returns 0.0 if the DID is unknown or the API is unreachable.
+        """
+        did = self._resolve_did(agent_id)
+        if not did:
+            return 0.0
+
+        try:
+            resp = await self._client.get(
+                f"{self.base_url}/v1/reputation/{did}"
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            score = self._extract_score(data)
+            if score is None:
+                log.warning("AVP returned invalid score for %s: %r", did, data)
+                return 0.0
+            return max(0.0, min(1.0, score))
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("AVP reputation request failed for %s: %s", did, exc)
+            return 0.0
+
+    async def get_reputation(self, agent_id: str) -> dict[str, Any]:
+        """Return the full AVP reputation profile for an agent.
+
+        Includes score, confidence, tier, risk factors, attestation
+        count, and EigenTrust algorithm metadata.
+        Returns an empty dict if the agent is unknown or the API fails.
+        """
+        did = self._resolve_did(agent_id)
+        if not did:
+            return {}
+
+        try:
+            resp = await self._client.get(
+                f"{self.base_url}/v1/reputation/{did}"
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if not isinstance(data, dict):
+                log.warning("AVP returned non-dict response for %s", did)
+                return {}
+            return data
+        except (httpx.HTTPError, ValueError) as exc:
+            log.warning("AVP reputation request failed for %s: %s", did, exc)
+            return {}
+
+    async def verify_identity(
+        self, agent_id: str, credentials: dict[str, Any]
+    ) -> bool:
+        """Verify agent identity via AVP verification endpoint.
+
+        Calls GET /v1/agents/verify/{name} and checks the ``verified``
+        field. Falls back to score-based verification if the name
+        endpoint is unavailable.
+
+        The ``credentials`` argument is accepted for interface
+        compatibility but not inspected or logged.
+        """
+        name = self._resolve_name(agent_id)
+        if not name:
+            return False
+
+        try:
+            resp = await self._client.get(
+                f"{self.base_url}/v1/agents/verify/{name}"
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if not isinstance(data, dict):
+                return False
+            return bool(data.get("verified", False))
+        except httpx.HTTPError:
+            log.warning(
+                "AVP verify endpoint failed for %s, falling back to "
+                "score-based verification",
+                name,
+            )
+            score = await self.get_trust_score(agent_id)
+            return score >= self.min_score_threshold
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/packages/agentmesh-integrations/agentmesh-avp/agentmesh_avp/provider.py
+++ b/packages/agentmesh-integrations/agentmesh-avp/agentmesh_avp/provider.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import re
 from typing import Any, Callable, Optional
+from urllib.parse import quote
 
 import httpx
 
@@ -68,10 +69,15 @@ class AVPProvider:
         return None
 
     def _resolve_name(self, agent_id: str) -> Optional[str]:
-        """Resolve agent_id to an AVP agent name."""
-        if self.name_resolver:
-            return self.name_resolver(agent_id)
-        return agent_id
+        """Resolve agent_id to a sanitized AVP agent name.
+
+        Output is URL-encoded to prevent path injection when
+        interpolated into API URLs.
+        """
+        raw = self.name_resolver(agent_id) if self.name_resolver else agent_id
+        if not raw:
+            return None
+        return quote(raw, safe="")
 
     @staticmethod
     def _extract_score(data: Any) -> Optional[float]:

--- a/packages/agentmesh-integrations/agentmesh-avp/pyproject.toml
+++ b/packages/agentmesh-integrations/agentmesh-avp/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=68.0,<69.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agentmesh_avp"
+version = "0.1.0"
+description = "Agent Veil Protocol integration for AgentMesh trust engine"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.9"
+dependencies = [
+    "agentmesh>=0.1.0,<1.0",
+    "httpx>=0.27.0,<1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0,<8.0",
+    "pytest-asyncio>=0.21,<1.0",
+    "respx>=0.20,<1.0",
+]
+
+[project.urls]
+Homepage = "https://agentveil.dev"
+SDK = "https://github.com/creatorrmode-lead/avp-sdk"

--- a/packages/agentmesh-integrations/agentmesh-avp/tests/test_provider.py
+++ b/packages/agentmesh-integrations/agentmesh-avp/tests/test_provider.py
@@ -208,6 +208,37 @@ class TestVerifyIdentity:
         assert result is False  # 0.1 < 0.3 threshold
 
 
+class TestPathInjection:
+    """Tests for URL path injection prevention."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_name_with_path_traversal(self, provider):
+        """Name containing ../ must be URL-encoded, not passed raw."""
+        malicious = "../../admin"
+        # quote("../../admin", safe="") → "..%2F..%2Fadmin"
+        from urllib.parse import quote
+        encoded = quote(malicious, safe="")
+        respx.get(f"{BASE}/v1/agents/verify/{encoded}").mock(
+            return_value=httpx.Response(200, json={"verified": False})
+        )
+        result = await provider.verify_identity(malicious, {})
+        assert result is False
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_name_with_slashes(self, provider):
+        """Slashes in name must not create new URL path segments."""
+        from urllib.parse import quote
+        name = "agent/../../secret"
+        encoded = quote(name, safe="")
+        respx.get(f"{BASE}/v1/agents/verify/{encoded}").mock(
+            return_value=httpx.Response(200, json={"verified": False})
+        )
+        result = await provider.verify_identity(name, {})
+        assert result is False
+
+
 class TestMalformedResponses:
     """Tests for malformed or malicious API responses."""
 

--- a/packages/agentmesh-integrations/agentmesh-avp/tests/test_provider.py
+++ b/packages/agentmesh-integrations/agentmesh-avp/tests/test_provider.py
@@ -1,0 +1,273 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for AVPProvider."""
+
+import pytest
+import httpx
+import respx
+
+from agentmesh_avp.provider import AVPProvider, _is_valid_did
+
+BASE = "https://agentveil.dev"
+# Valid did:key format: z6Mk + 43 base58btc chars
+TEST_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"
+TEST_NAME = "test_agent"
+
+
+@pytest.fixture
+def provider():
+    return AVPProvider(base_url=BASE, min_score_threshold=0.3)
+
+
+@pytest.fixture
+def provider_with_resolvers():
+    return AVPProvider(
+        base_url=BASE,
+        did_resolver=lambda aid: TEST_DID if aid == "lookup_me" else None,
+        name_resolver=lambda aid: aid.split(":")[-1] if ":" in aid else aid,
+    )
+
+
+class TestDIDValidation:
+    def test_valid_did(self):
+        assert _is_valid_did(TEST_DID) is True
+
+    def test_rejects_short_did(self):
+        assert _is_valid_did("did:key:z6MkTooShort") is False
+
+    def test_rejects_wrong_prefix(self):
+        assert _is_valid_did("did:web:example.com") is False
+
+    def test_rejects_empty(self):
+        assert _is_valid_did("") is False
+
+    def test_rejects_plain_string(self):
+        assert _is_valid_did("not-a-did") is False
+
+
+class TestGetTrustScore:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_score(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={
+                "did": TEST_DID,
+                "score": 0.75,
+                "confidence": 0.5,
+            })
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.75
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_clamps_to_1(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={"score": 1.5})
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 1.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_clamps_to_0(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={"score": -0.5})
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_0_on_404(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(404)
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_0_on_timeout(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            side_effect=httpx.ReadTimeout("timeout")
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_returns_0_for_invalid_did(self, provider):
+        score = await provider.get_trust_score("not-a-did")
+        assert score == 0.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_did_resolver(self, provider_with_resolvers):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={"score": 0.6})
+        )
+        score = await provider_with_resolvers.get_trust_score("lookup_me")
+        assert score == 0.6
+
+    @pytest.mark.asyncio
+    async def test_resolver_returns_invalid_did(self, provider_with_resolvers):
+        """Resolver returns None for unknown agent, score should be 0."""
+        score = await provider_with_resolvers.get_trust_score("unknown_agent")
+        assert score == 0.0
+
+
+class TestGetReputation:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_full_profile(self, provider):
+        profile = {
+            "did": TEST_DID,
+            "score": 0.85,
+            "confidence": 0.7,
+            "flow_score": 1.0,
+            "risk_score": 0.0,
+            "risk_factors": [],
+            "algorithm_ver": "eigentrust_v1",
+            "attestation_count": 12,
+            "unique_attesters": 8,
+        }
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json=profile)
+        )
+        result = await provider.get_reputation(TEST_DID)
+        assert result["score"] == 0.85
+        assert result["attestation_count"] == 12
+        assert result["algorithm_ver"] == "eigentrust_v1"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_error(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(500)
+        )
+        result = await provider.get_reputation(TEST_DID)
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_invalid_did(self, provider):
+        result = await provider.get_reputation("not-a-did")
+        assert result == {}
+
+
+class TestVerifyIdentity:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_verified_agent(self, provider):
+        respx.get(f"{BASE}/v1/agents/verify/{TEST_NAME}").mock(
+            return_value=httpx.Response(200, json={
+                "verified": True,
+                "agent_name": TEST_NAME,
+                "did": TEST_DID,
+                "score": 0.8,
+                "tier": "trusted",
+            })
+        )
+        result = await provider.verify_identity(TEST_NAME, {})
+        assert result is True
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_unverified_agent(self, provider):
+        respx.get(f"{BASE}/v1/agents/verify/{TEST_NAME}").mock(
+            return_value=httpx.Response(200, json={
+                "verified": False,
+                "agent_name": TEST_NAME,
+            })
+        )
+        result = await provider.verify_identity(TEST_NAME, {})
+        assert result is False
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fallback_to_score_on_http_error(self, provider):
+        """When verify endpoint fails, falls back to score-based check."""
+        respx.get(f"{BASE}/v1/agents/verify/{TEST_DID}").mock(
+            return_value=httpx.Response(500)
+        )
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={"score": 0.5})
+        )
+        result = await provider.verify_identity(TEST_DID, {})
+        assert result is True  # 0.5 >= 0.3 threshold
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_fallback_fails_below_threshold(self, provider):
+        respx.get(f"{BASE}/v1/agents/verify/{TEST_DID}").mock(
+            return_value=httpx.Response(500)
+        )
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={"score": 0.1})
+        )
+        result = await provider.verify_identity(TEST_DID, {})
+        assert result is False  # 0.1 < 0.3 threshold
+
+
+class TestMalformedResponses:
+    """Tests for malformed or malicious API responses."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_score_missing_from_response(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={"did": TEST_DID})
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_score_is_string(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json={"score": "not_a_number"})
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_response_is_list_not_dict(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json=[1, 2, 3])
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_response_is_null(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json=None)
+        )
+        score = await provider.get_trust_score(TEST_DID)
+        assert score == 0.0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_reputation_returns_empty_on_list_response(self, provider):
+        respx.get(f"{BASE}/v1/reputation/{TEST_DID}").mock(
+            return_value=httpx.Response(200, json=[{"score": 0.5}])
+        )
+        result = await provider.get_reputation(TEST_DID)
+        assert result == {}
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_verify_returns_false_on_list_response(self, provider):
+        respx.get(f"{BASE}/v1/agents/verify/{TEST_NAME}").mock(
+            return_value=httpx.Response(200, json=[{"verified": True}])
+        )
+        result = await provider.verify_identity(TEST_NAME, {})
+        assert result is False
+
+
+class TestClose:
+    @pytest.mark.asyncio
+    async def test_close(self, provider):
+        await provider.close()
+        assert provider._client.is_closed


### PR DESCRIPTION
AVPProvider implements the TrustProvider interface to bring external reputation scoring into AgentMesh. It queries the [Agent Veil Protocol](https://agentveil.dev) API for EigenTrust-based trust scores computed from real agent-to-agent interactions — covering a gap that static policies can't: is this agent actually trustworthy based on its track record? The provider includes DID validation (regex), response schema validation, DID-based identity verification with score-based fallback, graceful degradation with logging on all error paths, and 27 tests using respx mocks. A working end-to-end example of trust-gated delegation using this pattern with AWS Bedrock is here: [aws_bedrock.py](https://github.com/creatorrmode-lead/avp-sdk/blob/main/examples/aws_bedrock.py).

Happy to adjust if this pattern doesn't fit the current roadmap.

**Test results**: 27/27 passed

```
tests/test_provider.py::TestDIDValidation::test_valid_did PASSED
tests/test_provider.py::TestDIDValidation::test_rejects_short_did PASSED
tests/test_provider.py::TestDIDValidation::test_rejects_wrong_prefix PASSED
tests/test_provider.py::TestDIDValidation::test_rejects_empty PASSED
tests/test_provider.py::TestDIDValidation::test_rejects_plain_string PASSED
tests/test_provider.py::TestGetTrustScore::test_returns_score PASSED
tests/test_provider.py::TestGetTrustScore::test_clamps_to_1 PASSED
tests/test_provider.py::TestGetTrustScore::test_clamps_to_0 PASSED
tests/test_provider.py::TestGetTrustScore::test_returns_0_on_404 PASSED
tests/test_provider.py::TestGetTrustScore::test_returns_0_on_timeout PASSED
tests/test_provider.py::TestGetTrustScore::test_returns_0_for_invalid_did PASSED
tests/test_provider.py::TestGetTrustScore::test_did_resolver PASSED
tests/test_provider.py::TestGetTrustScore::test_resolver_returns_invalid_did PASSED
tests/test_provider.py::TestGetReputation::test_returns_full_profile PASSED
tests/test_provider.py::TestGetReputation::test_returns_empty_on_error PASSED
tests/test_provider.py::TestGetReputation::test_returns_empty_for_invalid_did PASSED
tests/test_provider.py::TestVerifyIdentity::test_verified_agent PASSED
tests/test_provider.py::TestVerifyIdentity::test_unverified_agent PASSED
tests/test_provider.py::TestVerifyIdentity::test_fallback_to_score_on_http_error PASSED
tests/test_provider.py::TestVerifyIdentity::test_fallback_fails_below_threshold PASSED
tests/test_provider.py::TestMalformedResponses::test_score_missing_from_response PASSED
tests/test_provider.py::TestMalformedResponses::test_score_is_string PASSED
tests/test_provider.py::TestMalformedResponses::test_response_is_list_not_dict PASSED
tests/test_provider.py::TestMalformedResponses::test_response_is_null PASSED
tests/test_provider.py::TestMalformedResponses::test_reputation_returns_empty_on_list_response PASSED
tests/test_provider.py::TestMalformedResponses::test_verify_returns_false_on_list_response PASSED
tests/test_provider.py::TestClose::test_close PASSED

============================== 27 passed in 0.50s ==============================
```

**Security feedback addressed:**
- DID format validation via regex (rejects malformed/injected DIDs)
- Response schema validation (`isinstance` checks, `_extract_score()`)
- Fallback event logging (`log.warning` on all error paths)
- `credentials` dict not inspected or logged (documented in docstring)
- Added 12 new tests: 5 DID validation + 6 malformed response + 1 resolver edge case