### PR TITLE
fix(examples): rewrite production policies to valid PolicyDocument schema

### DIFF
--- a/examples/policies/production/README.md
+++ b/examples/policies/production/README.md
@@ -1,27 +1,21 @@
 # Production Policy Library
-#
-# These are production-ready policy sets for common enterprise scenarios.
-# Unlike the sample policies in the parent directory, these are designed
-# to be deployed as-is or with minimal customization.
-#
-# Each policy file is self-contained and includes:
-# - Action rules (allow/deny/escalate)
-# - Content filters (PII/PHI/PCI patterns)
-# - Rate limits
-# - Human escalation triggers
-# - Audit requirements
-#
-# Choose the policy that matches your risk profile:
-#
-# | Policy | Risk Profile | Best For |
-# |--------|-------------|----------|
-# | minimal.yaml | Low | Startups, internal tools, experimentation |
-# | enterprise.yaml | Medium | General enterprise, SaaS products |
-# | healthcare.yaml | High | HIPAA-regulated, patient data |
-# | financial.yaml | High | SOX/PCI-regulated, trading, banking |
-# | strict.yaml | Maximum | Defense, critical infrastructure, ITAR |
-#
-# Usage:
-#   from agent_os.policies import PolicyEvaluator
-#   evaluator = PolicyEvaluator()
-#   evaluator.load_policies("examples/policies/production/enterprise.yaml")
+
+Ready-to-use governance policies for common enterprise scenarios.
+Each file uses the AGT PolicyDocument schema and works with PolicyEvaluator.
+
+| Policy | Risk | Default | Best For |
+|--------|------|---------|----------|
+| minimal.yaml | Low | allow | Startups, internal tools |
+| enterprise.yaml | Medium | deny | General enterprise, SaaS |
+| healthcare.yaml | High | deny | HIPAA-regulated |
+| financial.yaml | High | deny | SOX/PCI-regulated |
+| strict.yaml | Maximum | deny | Defense, critical infrastructure |
+
+## Usage
+
+```python
+from agentmesh.governance.policy import PolicyDocument
+
+policy = PolicyDocument.from_yaml(open("enterprise.yaml").read())
+decision = policy.evaluate({"action": "write_file"})
+```

--- a/examples/policies/production/enterprise.yaml
+++ b/examples/policies/production/enterprise.yaml
@@ -1,82 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
 # Production Policy: Enterprise
-# Risk profile: MEDIUM — general enterprise, SaaS products
-# Philosophy: Allow common operations, escalate sensitive ones, block dangerous
+# Risk profile: MEDIUM
 
 version: "1.0"
-name: enterprise
-description: >
-  Standard enterprise governance. Balanced between productivity and safety.
-  Escalates sensitive operations to humans, blocks destructive actions.
+name: enterprise-governance
+description: Standard enterprise governance with escalation.
 
 rules:
-  # Safe operations — allow
-  - action: "web_search"
-    effect: allow
-  - action: "read_file"
-    effect: allow
-  - action: "api_call"
-    effect: allow
-  - action: "database_query"
-    effect: allow
-  - action: "calculator"
-    effect: allow
-  - action: "summarize"
-    effect: allow
+  - name: block-delete-file
+    condition: {field: action, operator: eq, value: delete_file}
+    action: deny
+    priority: 100
+    message: "File deletion is not permitted"
 
-  # Sensitive operations — require human approval
-  - action: "write_file"
-    effect: escalate
-    reason: "File writes require human approval"
-  - action: "send_email"
-    effect: escalate
-    reason: "Outbound email requires human review"
-  - action: "deploy"
-    effect: escalate
-    reason: "Deployments require human sign-off"
-  - action: "create_pr"
-    effect: escalate
-    reason: "PR creation requires human review"
-  - action: "database_write"
-    effect: escalate
-    reason: "Database mutations require approval"
+  - name: block-execute-code
+    condition: {field: action, operator: eq, value: execute_code}
+    action: deny
+    priority: 100
+    message: "Code execution is blocked"
 
-  # Dangerous operations — deny
-  - action: "delete_file"
-    effect: deny
-    reason: "File deletion is not permitted"
-  - action: "execute_code"
-    effect: deny
-    reason: "Arbitrary code execution is blocked"
-  - action: "ssh_connect"
-    effect: deny
-    reason: "Direct SSH is not permitted"
-  - action: "drop_table"
-    effect: deny
-    reason: "Schema changes are not permitted"
+  - name: block-ssh
+    condition: {field: action, operator: eq, value: ssh_connect}
+    action: deny
+    priority: 100
+    message: "SSH is not permitted"
 
-  # Default: deny unknown actions
-  - action: "*"
-    effect: deny
-    reason: "Unknown action — default deny"
+  - name: block-ssn-leak
+    condition: {field: output, operator: matches, value: "\\b\\d{3}-\\d{2}-\\d{4}\\b"}
+    action: deny
+    priority: 95
+    message: "SSN pattern detected in output"
 
-content_filters:
-  blocked_patterns:
-    - '\b\d{3}-\d{2}-\d{4}\b'         # SSN
-    - '\b(?:\d[ -]*?){13,16}\b'        # Credit card numbers
-    - '(?i)password\s*[:=]\s*\S+'      # Passwords in output
+  - name: escalate-write-file
+    condition: {field: action, operator: eq, value: write_file}
+    action: escalate
+    priority: 80
+    message: "File writes require approval"
 
-escalation:
-  actions_requiring_approval:
-    - write_file
-    - send_email
-    - deploy
-    - create_pr
-    - database_write
-  timeout_seconds: 300
-  default_on_timeout: deny
+  - name: escalate-send-email
+    condition: {field: action, operator: eq, value: send_email}
+    action: escalate
+    priority: 80
+    message: "Email requires review"
 
-settings:
-  require_human_approval: true
-  max_tool_calls_per_session: 50
-  log_level: "audit"
-  audit_all_decisions: true
+  - name: escalate-deploy
+    condition: {field: action, operator: eq, value: deploy}
+    action: escalate
+    priority: 80
+    message: "Deployments require sign-off"
+
+defaults:
+  action: deny
+  max_tool_calls: 50

--- a/examples/policies/production/financial.yaml
+++ b/examples/policies/production/financial.yaml
@@ -1,102 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
 # Production Policy: Financial Services (SOX/PCI)
-# Risk profile: HIGH — trading, banking, SOX/PCI-regulated
-# Philosophy: Strict controls on financial data and transactions
+# Risk profile: HIGH
 
 version: "1.0"
-name: financial-sox-pci
-description: >
-  SOX and PCI-DSS compliant governance for financial AI agents.
-  All transaction-related actions require dual approval. PCI data
-  is never exposed in agent output.
+name: financial-governance
+description: SOX/PCI-regulated governance with PCI data filtering.
 
 rules:
-  # Market data — allow (read-only)
-  - action: "fetch_market_data"
-    effect: allow
-  - action: "web_search"
-    effect: allow
-  - action: "read_report"
-    effect: allow
-  - action: "calculate"
-    effect: allow
-  - action: "summarize"
-    effect: allow
+  - name: block-pci-credit-card
+    condition: {field: output, operator: matches, value: "\\b(?:\\d[ -]*?){13,16}\\b"}
+    action: deny
+    priority: 100
+    message: "PCI: Credit card number detected"
 
-  # Account queries — allow with audit
-  - action: "query_account"
-    effect: allow
-    conditions:
-      require_audit: true
-  - action: "query_transaction_history"
-    effect: allow
-    conditions:
-      require_audit: true
+  - name: block-pii-ssn
+    condition: {field: output, operator: matches, value: "\\b\\d{3}-\\d{2}-\\d{4}\\b"}
+    action: deny
+    priority: 100
+    message: "PII: SSN pattern detected"
 
-  # Transactions — require dual approval
-  - action: "execute_trade"
-    effect: escalate
-    reason: "SOX: trades require dual approval"
-  - action: "transfer_funds"
-    effect: escalate
-    reason: "Fund transfers require dual approval"
-  - action: "modify_account"
-    effect: escalate
-    reason: "Account modifications require compliance review"
-  - action: "generate_report"
-    effect: escalate
-    reason: "Financial reports require review before distribution"
-  - action: "send_email"
-    effect: escalate
-    reason: "External communication requires compliance review"
+  - name: block-execute-code
+    condition: {field: action, operator: eq, value: execute_code}
+    action: deny
+    priority: 95
+    message: "Code execution prohibited"
 
-  # Dangerous — deny
-  - action: "delete_record"
-    effect: deny
-    reason: "SOX: financial records cannot be deleted"
-  - action: "execute_code"
-    effect: deny
-  - action: "deploy"
-    effect: deny
-  - action: "modify_schema"
-    effect: deny
-    reason: "Database schema changes require change management"
+  - name: escalate-transaction
+    condition: {field: action, operator: matches, value: "transfer_|payment_|trade_"}
+    action: escalate
+    priority: 85
+    message: "Financial transactions require compliance approval"
 
-  # Default deny
-  - action: "*"
-    effect: deny
-    reason: "SOX/PCI: unlisted actions denied by default"
+  - name: allow-read
+    condition: {field: action, operator: matches, value: "^(read_|search_|lookup_|calculate)"}
+    action: allow
+    priority: 50
 
-content_filters:
-  blocked_patterns:
-    - '\b(?:\d[ -]*?){13,16}\b'          # Credit card numbers
-    - '\b\d{3}-\d{2}-\d{4}\b'           # SSN
-    - '(?i)account\s*number\s*[:=]\s*\d+' # Account numbers
-    - '(?i)routing\s*number\s*[:=]\s*\d+' # Routing numbers
-    - '(?i)cvv\s*[:=]\s*\d{3,4}'         # CVV codes
-    - 'AKIA[0-9A-Z]{16}'                 # AWS keys (prevent exfiltration)
-
-  data_classification:
-    max_classification: CONFIDENTIAL
-    denied_categories: ["PHI", "ITAR"]
-    allowed_categories: ["PCI", "PII"]
-
-escalation:
-  actions_requiring_approval:
-    - execute_trade
-    - transfer_funds
-    - modify_account
-    - generate_report
-    - send_email
-  timeout_seconds: 900
-  default_on_timeout: deny
-  escalation_chain:
-    - trading_desk_supervisor
-    - compliance_officer
-    - chief_risk_officer
-
-settings:
-  require_human_approval: true
-  max_tool_calls_per_session: 25
-  log_level: "audit"
-  audit_all_decisions: true
-  retention_days: 2555    # 7 years SOX requirement
+defaults:
+  action: deny
+  max_tool_calls: 30

--- a/examples/policies/production/healthcare.yaml
+++ b/examples/policies/production/healthcare.yaml
@@ -1,103 +1,43 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
 # Production Policy: Healthcare (HIPAA)
-# Risk profile: HIGH — patient data, medical records, HIPAA-regulated
-# Philosophy: Deny by default, allow only explicitly permitted operations
+# Risk profile: HIGH
 
 version: "1.0"
-name: healthcare-hipaa
-description: >
-  HIPAA-compliant governance for healthcare AI agents. All patient data
-  access is logged, PHI patterns are blocked from output, and human
-  approval is required for any data mutation.
+name: healthcare-governance
+description: HIPAA-regulated governance with PHI filtering.
 
 rules:
-  # Read operations — allow with audit
-  - action: "read_patient_record"
-    effect: allow
-    conditions:
-      require_audit: true
-      require_purpose: true
-  - action: "search_medical_database"
-    effect: allow
-    conditions:
-      require_audit: true
-  - action: "web_search"
-    effect: allow
+  - name: block-phi-ssn
+    condition: {field: output, operator: matches, value: "\\b\\d{3}-\\d{2}-\\d{4}\\b"}
+    action: deny
+    priority: 100
+    message: "PHI: SSN pattern detected"
 
-  # Clinical support — allow with audit
-  - action: "summarize_diagnosis"
-    effect: allow
-    conditions:
-      require_audit: true
-  - action: "check_drug_interaction"
-    effect: allow
-  - action: "lookup_icd_code"
-    effect: allow
+  - name: block-phi-mrn
+    condition: {field: output, operator: matches, value: "(?i)MRN[:\\s]*\\d{6,}"}
+    action: deny
+    priority: 100
+    message: "PHI: Medical Record Number detected"
 
-  # Mutations — require human approval
-  - action: "update_patient_record"
-    effect: escalate
-    reason: "Patient record updates require clinician approval"
-  - action: "send_referral"
-    effect: escalate
-    reason: "Referrals require physician sign-off"
-  - action: "prescribe_medication"
-    effect: escalate
-    reason: "Prescriptions require licensed provider approval"
-  - action: "send_email"
-    effect: escalate
-    reason: "Outbound communication requires HIPAA review"
-  - action: "export_data"
-    effect: escalate
-    reason: "Data export requires compliance review"
+  - name: block-delete
+    condition: {field: action, operator: matches, value: "^delete_"}
+    action: deny
+    priority: 95
+    message: "Deletion prohibited in healthcare"
 
-  # Dangerous operations — deny
-  - action: "delete_patient_record"
-    effect: deny
-    reason: "Patient records cannot be deleted by agents"
-  - action: "execute_code"
-    effect: deny
-  - action: "ssh_connect"
-    effect: deny
-  - action: "deploy"
-    effect: deny
-    reason: "Agents cannot deploy in clinical environments"
+  - name: escalate-clinical
+    condition: {field: action, operator: matches, value: "patient_|clinical_|medical_"}
+    action: escalate
+    priority: 80
+    message: "Clinical data requires clinician approval"
 
-  # Default deny
-  - action: "*"
-    effect: deny
-    reason: "HIPAA: unlisted actions denied by default"
+  - name: allow-read
+    condition: {field: action, operator: matches, value: "^(read_|search_|lookup_)"}
+    action: allow
+    priority: 50
 
-content_filters:
-  blocked_patterns:
-    - '\b\d{3}-\d{2}-\d{4}\b'           # SSN
-    - '\bMRN[:\s]?\d{6,10}\b'           # Medical Record Number
-    - '\b[A-Z]\d{2}(?:\.\d{1,4})?\b'    # ICD codes in output
-    - '(?i)patient\s+name\s*[:=]\s*\w+'  # Patient names
-    - '(?i)date\s+of\s+birth\s*[:=]'     # DOB
-    - '\b(?:\d[ -]*?){13,16}\b'          # Credit cards
-
-  data_classification:
-    max_classification: RESTRICTED
-    denied_categories: ["PCI", "ITAR"]
-    required_geography: "US"
-
-escalation:
-  actions_requiring_approval:
-    - update_patient_record
-    - send_referral
-    - prescribe_medication
-    - send_email
-    - export_data
-  timeout_seconds: 600
-  default_on_timeout: deny
-  escalation_chain:
-    - attending_physician
-    - department_head
-    - compliance_officer
-
-settings:
-  require_human_approval: true
-  max_tool_calls_per_session: 30
-  log_level: "audit"
-  audit_all_decisions: true
-  retention_days: 2555    # 7 years HIPAA requirement
+defaults:
+  action: deny
+  max_tool_calls: 25

--- a/examples/policies/production/minimal.yaml
+++ b/examples/policies/production/minimal.yaml
@@ -1,47 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
 # Production Policy: Minimal
-# Risk profile: LOW — for startups, internal tools, experimentation
-# Philosophy: Allow most actions, block only the clearly dangerous ones
+# Risk profile: LOW - startups, internal tools, experimentation
 
 version: "1.0"
-name: minimal
-description: >
-  Minimal governance for low-risk environments. Allows most actions,
-  blocks destructive operations, and logs everything for basic audit.
+name: minimal-governance
+description: Minimal governance for low-risk environments.
 
 rules:
-  # Allow common read and search operations
-  - action: "web_search"
-    effect: allow
-  - action: "read_file"
-    effect: allow
-  - action: "api_call"
-    effect: allow
-  - action: "database_query"
-    effect: allow
+  - name: block-delete-file
+    condition: {field: action, operator: eq, value: delete_file}
+    action: deny
+    priority: 100
+    message: "File deletion requires manual intervention"
 
-  # Block destructive operations
-  - action: "delete_file"
-    effect: deny
-    reason: "File deletion requires manual intervention"
-  - action: "drop_table"
-    effect: deny
-    reason: "Database schema changes are not permitted"
-  - action: "execute_code"
-    effect: deny
-    reason: "Arbitrary code execution is blocked"
-  - action: "ssh_connect"
-    effect: deny
-    reason: "Direct SSH access is not permitted"
+  - name: block-drop-table
+    condition: {field: action, operator: eq, value: drop_table}
+    action: deny
+    priority: 100
+    message: "Database schema changes are not permitted"
 
-  # Everything else: allow
-  - action: "*"
-    effect: allow
+  - name: block-execute-code
+    condition: {field: action, operator: eq, value: execute_code}
+    action: deny
+    priority: 100
+    message: "Arbitrary code execution is blocked"
 
-content_filters:
-  blocked_patterns: []
+  - name: block-ssh
+    condition: {field: action, operator: eq, value: ssh_connect}
+    action: deny
+    priority: 100
+    message: "Direct SSH access is not permitted"
 
-settings:
-  require_human_approval: false
-  max_tool_calls_per_session: 100
-  log_level: "info"
-  audit_all_decisions: true
+defaults:
+  action: allow
+  max_tool_calls: 100

--- a/examples/policies/production/strict.yaml
+++ b/examples/policies/production/strict.yaml
@@ -1,80 +1,41 @@
-# Production Policy: Strict / High-Security
-# Risk profile: MAXIMUM — defense, critical infrastructure, ITAR
-# Philosophy: Deny everything by default. Allowlist only.
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Production Policy: Strict (Maximum Security)
+# Risk profile: MAXIMUM - defense, critical infrastructure
 
 version: "1.0"
-name: strict-high-security
-description: >
-  Maximum-security governance for defense, critical infrastructure,
-  and ITAR-regulated environments. All actions denied by default.
-  Only explicitly allowlisted operations are permitted, and all
-  mutations require multi-level human approval.
+name: strict-governance
+description: Maximum-security allowlist-only governance.
 
 rules:
-  # Explicitly allowed read-only operations
-  - action: "read_file"
-    effect: allow
-    conditions:
-      require_audit: true
-      allowed_paths:
-        - "/approved/workspace/*"
-  - action: "web_search"
-    effect: allow
-    conditions:
-      require_audit: true
-      allowed_domains:
-        - "*.gov"
-        - "*.mil"
-        - "*.edu"
+  - name: block-secrets-in-output
+    condition: {field: output, operator: matches, value: "(?i)(api[_-]?key|password|secret|token)[:\\s=]+\\S{8,}"}
+    action: deny
+    priority: 100
+    message: "Credential pattern detected in output"
 
-  # All write operations — require multi-level approval
-  - action: "write_file"
-    effect: escalate
-    reason: "All writes require security officer approval"
-  - action: "send_email"
-    effect: escalate
-    reason: "All external communication requires security review"
-  - action: "api_call"
-    effect: escalate
-    reason: "All outbound API calls require approval"
+  - name: block-pii
+    condition: {field: output, operator: matches, value: "\\b\\d{3}-\\d{2}-\\d{4}\\b"}
+    action: deny
+    priority: 100
+    message: "PII detected in output"
 
-  # Everything else — deny
-  - action: "*"
-    effect: deny
-    reason: "Strict mode: all unlisted actions denied"
+  - name: allow-read-file
+    condition: {field: action, operator: eq, value: read_file}
+    action: allow
+    priority: 50
 
-content_filters:
-  blocked_patterns:
-    - '\b\d{3}-\d{2}-\d{4}\b'           # SSN
-    - '\b(?:\d[ -]*?){13,16}\b'          # Credit cards
-    - '(?i)(classified|secret|top.secret|confidential)\s*[:/-]' # Classification markers
-    - '(?i)itar|export.control'           # ITAR references
-    - 'AKIA[0-9A-Z]{16}'                 # AWS keys
-    - 'sk-[a-zA-Z0-9]{20,}'              # API keys
-    - 'eyJ[a-zA-Z0-9\-_]+\.eyJ'          # JWT tokens
-    - '-----BEGIN.*PRIVATE KEY-----'      # PEM keys
-    - 'https?://(?!.*\.(gov|mil|edu))'    # Non-approved domains
+  - name: allow-search
+    condition: {field: action, operator: eq, value: web_search}
+    action: allow
+    priority: 50
 
-  data_classification:
-    max_classification: CONFIDENTIAL
-    denied_categories: ["ITAR"]
+  - name: allow-summarize
+    condition: {field: action, operator: eq, value: summarize}
+    action: allow
+    priority: 50
 
-escalation:
-  actions_requiring_approval:
-    - write_file
-    - send_email
-    - api_call
-  timeout_seconds: 1800
-  default_on_timeout: deny
-  escalation_chain:
-    - security_officer
-    - facility_security_officer
-    - program_manager
-
-settings:
-  require_human_approval: true
-  max_tool_calls_per_session: 10
-  log_level: "audit"
-  audit_all_decisions: true
-  retention_days: 3650    # 10 years
-  quantum_safe_signing: true
+defaults:
+  action: deny
+  max_tool_calls: 10


### PR DESCRIPTION
All 5 production policy files used a fictional schema that doesn't work with PolicyEvaluator. Rewritten to use the correct AGT PolicyDocument format (condition/operator/value, action allow/deny/escalate, priority).