### PR TITLE
docs: align governance wording and audit redaction docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 Agent Action ──► Policy Check ──► Allow / Deny ──► Audit Log    (< 0.1 ms)
 ```
 
-**Why it matters:** Prompt-based safety ("please follow the rules") has a [26.67% policy violation rate](BENCHMARKS.md) in red-team testing. AGT's policy-layer enforcement: **0.00%**.
+**Why it matters:** Prompt-based safety ("please follow the rules") has a [26.67% policy violation rate](BENCHMARKS.md) in red-team testing. AGT's deterministic application-layer enforcement: **0.00%**.
 
 ---
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -31,7 +31,7 @@ When evaluating agent security tooling, developers often encounter [NeMo Guardra
 | **Least-privilege capability model** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Deterministic pre-execution enforcement** | ✅ < 0.1 ms | ❌ | ❌ | ❌ | ❌ |
 | **Chaos / replay testing** | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **OWASP Agentic Top 10 coverage** | **10 / 10** ² | ~2 / 10 ¹ | ~1 / 10 ¹ | ~0 / 10 ¹ | ~1 / 10 ¹ |
+| **OWASP Agentic Top 10 mapping** | **10 / 10 categories mapped** | ~2 / 10 ¹ | ~1 / 10 ¹ | ~0 / 10 ¹ | ~1 / 10 ¹ |
 | **Framework integrations** | **12+** | 3 (LangChain, NeMo-based, custom) | 2 (LangChain, custom) | N/A (gateway) | N/A (gateway) |
 | **LLM provider routing / caching** | ❌ | ❌ | ❌ | ✅ | ✅ |
 | **Works alongside existing tools** | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -134,7 +134,7 @@ Agent Action Layer (Agent Governance Toolkit)
 
 These two layers are **complementary, not competing**. A fully governed agentic system typically needs both:
 
-1. **Agent Governance Toolkit** — enforces *what agents do* before every tool call, spawn, or API invocation, with cryptographic identity, privilege rings, SRE reliability, and full OWASP Agentic Top 10 coverage.
+1. **Agent Governance Toolkit** — enforces *what agents do* before every tool call, spawn, or API invocation, with cryptographic identity, privilege rings, SRE reliability, and mappings across all 10 OWASP Agentic Top 10 categories.
 2. **An output validator** (Guardrails AI, NeMo) — ensures the LLM's *words* conform to the format and safety rules you need.
 3. **An LLM gateway** (LiteLLM, Portkey) — routes, caches, and observes the underlying model calls.
 

--- a/docs/OWASP-COMPLIANCE.md
+++ b/docs/OWASP-COMPLIANCE.md
@@ -23,7 +23,7 @@
 | ASI-09 | Human-Agent Trust Exploitation | ✅ Covered | Agent OS — Approval Workflows |
 | ASI-10 | Rogue Agents | ✅ Covered | Agent Runtime — Kill Switch + Ring Isolation |
 
-**10 of 10 risks covered.** Full coverage achieved with AI-BOM v2.0 closing the supply chain gap.
+**Mappings in place for all 10 risk categories.** Coverage is provided through the combined governance stack; deployers should pair these controls with the layered defenses described in `docs/LIMITATIONS.md` for production use.
 
 ---
 
@@ -36,7 +36,7 @@
 **Mitigation:** Agent OS enforces **policy-based action interception** at the application layer. Every agent action passes through the policy engine before execution. Unauthorized goal changes are blocked before they reach the agent's tools.
 
 - **Policy Engine** — declarative rules controlling what agents can and cannot do
-- **Action Interception** — application-layer action interception intercepts all agent actions
+- **Action Interception** — governance middleware intercepts agent actions before execution
 - **Policy Modes** — `strict` (deny by default), `permissive` (allow by default), `audit` (log only)
 - **MCP Governance Proxy** — policy enforcement for MCP tool calls
 
@@ -292,7 +292,7 @@ child = identity.delegate(
 
 | Framework | Status |
 |-----------|--------|
-| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | 10/10 covered |
+| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | Mappings in place across all 10 categories |
 | [NIST AI RMF](https://www.nist.gov/artificial-intelligence/ai-risk-management-framework) | Govern, Map, Measure, Manage functions addressed |
 | [NIST AI Agent Standards Initiative](https://www.nist.gov/news-events/news/2026/02/announcing-ai-agent-standards-initiative-interoperable-and-secure) | Agent identity (IATP), authentication, audit trails |
 | [Singapore MGF for Agentic AI](https://www.imda.gov.sg/-/media/imda/files/about/emerging-tech-and-research/artificial-intelligence/mgf-for-agentic-ai.pdf) | Zero-trust, accountability, oversight layers |

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -4,7 +4,7 @@ This document summarizes the security threat model for the Agent Governance
 Toolkit (AGT) using a STRIDE-oriented view of the main trust boundaries in the
 system.
 
-For the OWASP Agentic Top 10 coverage mapping, see
+For the current OWASP Agentic Top 10 mapping across all 10 categories, see
 [`packages/agent-compliance/docs/OWASP-COMPLIANCE.md`](../packages/agent-compliance/docs/OWASP-COMPLIANCE.md).
 
 ## Scope

--- a/docs/compliance/mcp-owasp-top10-mapping.md
+++ b/docs/compliance/mcp-owasp-top10-mapping.md
@@ -69,7 +69,7 @@ safe_output = redactor.redact(tool_response)
 - **Tool Allow-List** — declarative list of permitted tool names; deny-by-default
 - **Capability Sandbox** — agents receive scoped capability grants (read, write, execute, network)
 - **MCP Sliding Rate Limiter** — per-agent, per-tool rate limits prevent abuse of granted capabilities
-- **Policy Engine** — kernel-level interception of all tool calls with `strict`, `permissive`, and `audit` modes
+- **Policy Engine** — application-layer interception of all tool calls with `strict`, `permissive`, and `audit` modes
 - **Delegation Narrowing** — child agent capabilities must be a subset of parent
 
 ```python
@@ -378,7 +378,7 @@ Three MCP risks have partial coverage today with planned enhancements targeting 
 | Framework | Status |
 |-----------|--------|
 | [OWASP MCP Top 10 (2025 Beta)](https://owasp.org/www-project-mcp-top-10/) | 7/10 covered, 3 partial (roadmap) |
-| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | 10/10 covered — see [OWASP-COMPLIANCE.md](../OWASP-COMPLIANCE.md) |
+| [OWASP Agentic Top 10 (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) | Mappings in place across all 10 categories — see [OWASP-COMPLIANCE.md](../OWASP-COMPLIANCE.md) |
 | OWASP MCP Security Cheat Sheet (§1–§12) | 11/12 covered — §11 (Consent UI) out of scope for server-side SDKs |
 | [NIST AI Agent Standards Initiative](https://www.nist.gov/news-events/news/2026/02/announcing-ai-agent-standards-initiative-interoperable-and-secure) | Agent identity (IATP), authentication, audit trails |
 | [EU AI Act (Aug 2026)](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) | Risk classification, audit trails, human oversight |

--- a/docs/compliance/owasp-llm-top10-mapping.md
+++ b/docs/compliance/owasp-llm-top10-mapping.md
@@ -40,7 +40,7 @@ The widest gaps are in output sanitization and sensitive data protection.
 | LLM03 | Training Data Poisoning | Partial | MemoryGuard for runtime memory stores | Training pipeline out of scope; MemoryGuard not wired into adapters |
 | LLM04 | Model Denial of Service | Partial | Token/call/timeout limits + concurrency semaphore + circuit breakers | TokenBudgetTracker advisory-only; RateLimiter not wired; no payload size limits |
 | LLM05 | Supply Chain Vulnerabilities | Partial | SBOM + Ed25519 signing + MCP fingerprinting + ContentHashInterceptor | SupplyChainGuard reporting-only; signing opt-in |
-| LLM06 | Sensitive Information Disclosure | Partial | PII patterns in MCP gateway + secret detection in codegen + egress policy + credential redaction in audit logs | Only 2 PII patterns for tool-call blocking; no output text filtering; non-credential PII not yet redacted in audit entries |
+| LLM06 | Sensitive Information Disclosure | Partial | PII patterns in MCP gateway + secret detection in codegen + egress policy | Only 2 PII patterns; no output text filtering; audit-log PII minimization remains incomplete |
 | LLM07 | Insecure Plugin Design | Partial | MCPGateway 5-stage pipeline + rug-pull detection + schema abuse scanning | JSON Schema composition ($ref/oneOf) unexamined; gateway and scanner disconnected |
 | LLM08 | Excessive Agency | Partial | Execution rings + kill switch + rogue detection + scope guard | Kill switch manual-only; detection modules advisory, not auto-wired to enforcement |
 | LLM09 | Overreliance | Partial | Drift detection + confidence threshold + adversarial evaluator | No fact-checking; confidence attribute never provided by frameworks |

--- a/docs/compliance/soc2-mapping.md
+++ b/docs/compliance/soc2-mapping.md
@@ -17,7 +17,7 @@
 
 The Agent Governance Toolkit provides runtime governance infrastructure that addresses SOC 2 Type II controls across Security, Availability, and Processing Integrity criteria. The toolkit's strongest coverage is in **Security** (CC1–CC9), where the policy engine, RBAC, cryptographic identity, execution rings, and audit logging provide a defense-in-depth enforcement stack. **Availability** (A1) is well-supported through circuit breakers, SLO enforcement, and chaos testing primitives. **Processing Integrity** (PI1) benefits from deterministic policy evaluation, Merkle audit chains, and input validation — though several audit chain implementations have integrity defects.
 
-**Confidentiality** (C1) has partial coverage through egress controls, PII pattern detection, credential redaction in audit logs, and cryptographic identity — but lacks at-rest encryption and key rotation. Credential-like secrets (API keys, tokens, connection strings, JWTs, etc.) are redacted before audit persistence via `CredentialRedactor`, but non-credential PII (email, phone, addresses) is not yet redacted in audit entries. **Privacy** (P1–P8) is the largest gap area: the toolkit detects only 2 PII patterns (SSN, credit card) for tool-call blocking, has no consent management, no data subject access request support, and no retention enforcement. Organizations deploying this toolkit in SOC 2 scope must supplement Privacy controls with external tooling.
+**Confidentiality** (C1) has partial coverage through egress controls, PII pattern detection, cryptographic identity, and credential redaction on the MCP gateway audit path — but still lacks comprehensive audit-log PII minimization, at-rest encryption, and key rotation. **Privacy** (P1–P8) is the largest gap area: the toolkit detects only 2 built-in PII patterns (SSN, credit card) on tool inputs, has no consent management, no data subject access request support, and no retention enforcement. Organizations deploying this toolkit in SOC 2 scope must supplement Privacy controls with external tooling.
 
 > **Important**: This mapping documents what the toolkit provides as infrastructure. SOC 2 Type II requires evidence of **operating effectiveness over a review period** — policies followed, controls monitored, exceptions investigated. The toolkit provides the enforcement mechanisms; the operating procedures, organizational policies, and evidence collection are the deployer's responsibility. "Partial" coverage means the toolkit provides building blocks but does not satisfy the control independently.
 
@@ -29,8 +29,8 @@ The Agent Governance Toolkit provides runtime governance infrastructure that add
 |----------|----------|----------------------|--------------|
 | **Security** (CC1–CC9) | ⚠️ Partial | Policy engine, RBAC, DID identity, execution rings, audit logging, MCP security scanning, kill switch | Detection modules unwired from enforcement |
 | **Availability** (A1) | ⚠️ Partial | Circuit breakers, SLO/error budgets, chaos testing framework, sub-millisecond enforcement | Chaos engine framework-only, no health check endpoints, rate limiter unwired |
-| **Processing Integrity** (PI1) | ⚠️ Partial | Merkle audit chain, Delta audit chain (SHA-256 verified), policy validation, input sanitization, drift detection | 2 of 4 audit chain implementations have integrity defects, `post_execute()` never blocks |
-| **Confidentiality** (C1) | ⚠️ Partial | Ed25519 identity, HMAC-SHA256 signing, egress policy, PII/secret detection, credential redaction in audit logs | Symmetric HMAC keys, no at-rest encryption, non-credential PII not redacted in audit entries |
+| **Processing Integrity** (PI1) | ⚠️ Partial | Merkle audit chain, policy validation, input sanitization, drift detection | 3 of 4 audit chain implementations have integrity defects, `post_execute()` never blocks |
+| **Confidentiality** (C1) | ⚠️ Partial | Ed25519 identity, HMAC-SHA256 signing, egress policy, PII/secret detection, MCP audit credential redaction | Symmetric HMAC keys, no at-rest encryption, incomplete audit-log PII minimization |
 | **Privacy** (P1–P8) | ❌ Gap | 2 PII regex patterns, blocked patterns, retention_days schema field | No consent management, no DSAR, no data minimization, retention not enforced |
 
 **0 of 5 criteria fully covered. 4 partially addressed. 1 gap.**
@@ -312,15 +312,15 @@ assert policy.is_allowed("api.openai.com")              # Allowed
 - [ ] **HMAC uses symmetric keys** (C1.2): Any insider with the HMAC key can forge the entire audit chain. No external commitment (Merkle root anchoring to a timestamping service) or asymmetric signing prevents full chain rewrite.
 - [ ] **No at-rest encryption** (C1.1): Audit logs, policy documents, and configuration files are stored in plaintext. No encryption for data at rest.
 - [ ] **No key rotation mechanism** (C1.2): No mechanism for rotating Ed25519 keys, HMAC secrets, or SPIFFE certificates on a schedule.
-- [x] **~~Audit logs store unredacted parameters~~** (C1.1): **Resolved for credentials.** `MCPGateway.intercept_tool_call()` now applies `CredentialRedactor.redact_data_structure(params)` before creating `AuditEntry` records. This redacts API keys, tokens, connection strings, JWTs, PEM keys, Bearer tokens, and other credential patterns. **Remaining gap:** Non-credential PII (email addresses, phone numbers, physical addresses) in tool parameters is not redacted before audit persistence. The structured audit log no longer exposes raw parameters via `logger.info()` — only agent ID, tool name, allowed/denied, and reason are logged at INFO level.
+- [ ] **Audit redaction is partial, not comprehensive** (C1.1): `mcp_gateway.py` now redacts credential-like secrets before persisted audit storage via `CredentialRedactor`, but broad PII minimization remains incomplete. Built-in PII detection still covers only SSN and credit card patterns on tool inputs, so non-credential PII can still flow into logs on some paths.
 - [ ] **Only 2 PII patterns** (C1.1): SSN and credit card number. No email, phone, IP address, JWT token, or other sensitive data patterns.
 - [ ] **`retention_days` not enforced** (C1.3): The schema field exists but no code preserves or deletes logs based on this value. A deployer can set `retention_days: 1` without validation error.
 - [ ] **No TLS enforcement** (C1.2): Network encryption deferred entirely to deployment configuration.
 
 ### Recommended Controls
 
-1. **Add `GovernancePolicy.redact_audit_pii` flag** for pattern-based PII redaction of `AuditEntry.parameters` before persistence (credential redaction already exists via `CredentialRedactor`).
-2. Expand PII patterns to cover the OWASP-recommended set (email, phone, IP address — JWT tokens are already handled by `CredentialRedactor`).
+1. **Expand audit redaction beyond credentials** so persisted audit payloads also minimize non-credential PII before storage.
+2. Expand PII patterns to cover the OWASP-recommended set (email, phone, IP address, JWT tokens).
 3. Implement asymmetric signing for audit entries to prevent insider forgery.
 4. Add key rotation tooling for Ed25519 and HMAC credentials.
 5. Enforce `retention_days` at runtime with actual log deletion and archival.
@@ -357,13 +357,13 @@ assert policy.is_allowed("api.openai.com")              # Allowed
 - [ ] **No retention enforcement** (P4): `retention_days` field exists in the policy schema but no code preserves or deletes data based on this value. Default is 90 days with minimum 1 — there is no floor enforcement.
 - [ ] **Only 2 PII patterns** (P6): SSN (`\b\d{3}-\d{2}-\d{4}\b`) and credit card number regex in `mcp_gateway.py:34-42`. No detection for email addresses, phone numbers, IP addresses, physical addresses, dates of birth, or other PII categories.
 - [ ] **No output PII scanning** (P6): PII patterns check tool *input* arguments only. LLM response text is not scanned — an agent can freely output personal data in its responses.
-- [ ] **Audit logs record non-credential PII** (P6): Credential-like secrets are redacted via `CredentialRedactor` before audit persistence, but non-credential PII (email, phone, addresses) in tool arguments is still stored verbatim in `AuditEntry`. PII in tool arguments can become PII in audit logs.
+- [ ] **Audit-log PII minimization is incomplete** (P6): The MCP gateway redacts credential-like secrets before persisted audit storage, but broader PII classes are not comprehensively minimized across audit paths. PII in tool arguments can still propagate into logs when it does not match the built-in credential patterns.
 - [ ] **No privacy notice mechanism** (P1): No feature generates or delivers privacy notices to end users interacting with governed agents.
 - [ ] **No privacy impact assessment tooling** (P8): No DPIA/PIA workflow or template generation.
 
 ### Recommended Controls
 
-1. **Implement audit PII redaction** — extend `CredentialRedactor` or add a dedicated PII redactor for `AuditEntry.parameters` before persistence (credential redaction already exists; this covers the remaining non-credential PII gap).
+1. **Broaden audit parameter minimization** — extend current credential redaction to cover a wider PII set before persistence. This remains the highest-leverage single fix.
 2. Expand PII detection from 2 patterns to the OWASP-recommended set (email, phone, IP, JWT, passport, driver's license numbers).
 3. Apply PII scanning to LLM outputs via `post_execute()` or a dedicated output interceptor.
 4. Deploy dedicated privacy management tooling (e.g., OneTrust, BigID, Transcend) for consent, DSAR, and data mapping.
@@ -445,7 +445,8 @@ All gaps consolidated and rated by severity for remediation prioritization.
 
 | Gap | Criteria | Impact | Location |
 |-----|----------|--------|----------|
-| **Non-credential PII not redacted in audit logs** | C1.1, P6 | Credential-like secrets are redacted via `CredentialRedactor`, but non-credential PII (email, phone, addresses) in tool parameters is still stored verbatim | `MCPGateway.intercept_tool_call()` |
+| **Audit-log PII minimization is incomplete** | C1.1, P6 | Credential-like secrets are redacted on the MCP gateway path, but broader PII minimization remains incomplete across audit data | `mcp_gateway.py`, `credential_redactor.py` |
+| **DeltaEngine `verify_chain()` is a stub** | PI1.5 | Returns `True` always — hypervisor audit trail has zero tamper evidence | `delta.py:99` |
 | **No consent management** | P2 | Fundamental Privacy criteria requirement not addressed | — |
 | **No data subject access request support** | P5 | Required for Privacy criteria compliance | — |
 

--- a/docs/modern-agent-architecture-overview.md
+++ b/docs/modern-agent-architecture-overview.md
@@ -18,7 +18,7 @@ Enterprise AI is shifting from chat-based copilots to **autonomous agents** — 
 
 Current frameworks (LangChain, CrewAI, AutoGen) rely on **prompt-based safety** — asking the LLM to follow rules. That's like asking a driver to self-enforce the speed limit.
 
-**Benchmark result:** Prompt-based safety has a **26.67% policy violation rate**. AGT's policy-layer enforcement: **0.00%**.
+**Benchmark result:** Prompt-based safety has a **26.67% policy violation rate**. AGT's deterministic application-layer enforcement: **0.00%**.
 
 ---
 
@@ -61,9 +61,9 @@ AGT provides **runtime governance infrastructure** — it sits between your agen
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
 
-### How It Works: The Kernel Analogy
+### How It Works: The Operating-System Analogy
 
-Think of AGT like a **Linux kernel for AI agents**:
+Think of AGT as an **operating-system-inspired governance layer for AI agents**:
 
 | OS Concept | AGT Equivalent | What It Does |
 |-----------|----------------|--------------|
@@ -74,7 +74,9 @@ Think of AGT like a **Linux kernel for AI agents**:
 | Audit logs | **Flight Recorder** | Append-only, hash-chained audit trail |
 | Certificate Authority | **AgentMesh Identity** | Ed25519 cryptographic agent credentials |
 
-**Key insight:** Current frameworks ask LLMs to *decide* whether to follow rules. AGT inverts this: **the kernel decides, the LLM computes.**
+**Key insight:** Current frameworks ask LLMs to *decide* whether to follow rules. AGT inverts this: **the policy layer decides, the LLM computes.**
+
+> **Scope note:** This is an architectural analogy, not a claim of OS-level isolation. AGT enforces policy at the application layer and composes with container or VM isolation for stronger runtime boundaries.
 
 ---
 


### PR DESCRIPTION
## Description
Routine documentation consistency cleanup to align governance wording with the current implementation.

This PR:
- updates stale audit-redaction wording in compliance docs to reflect current MCP gateway behavior
- softens a few over-strong application-boundary claims
- rephrases OWASP language from blanket coverage claims to category mappings where appropriate
- keeps the scope intentionally small and docs-only

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)


## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
