### PR TITLE
fix(pipeline): run NuGet ESRP signing on Windows agent

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -114,7 +114,9 @@ parameters:
 #
 # Note: ESRP_DOMAIN_TENANT_ID was removed from pipeline variables due to
 # cyclical reference. The Microsoft corporate tenant ID is a well-known
-# public value used as the ESRP default.
+# public value used as the ESRP default. If ESRP_DOMAIN_TENANT_ID still
+# exists in ADO pipeline variables, DELETE IT — it causes a cyclical
+# variable expansion warning that confuses log triage.
 # -------------------------------------------------------
 
 variables:
@@ -353,16 +355,18 @@ stages:
     jobs:
       - job: PublishNuGet
         displayName: 'ESRP Sign + NuGet Push'
+        pool:
+          vmImage: windows-latest  # ESRP Code Signing requires Windows agent
         steps:
           - task: DownloadPipelineArtifact@2
             inputs:
               artifact: 'nuget-unsigned'
-              targetPath: '$(Pipeline.Workspace)/nuget-unsigned'
+              targetPath: '$(Pipeline.Workspace)\nuget-unsigned'
             displayName: 'Download unsigned NuGet artifacts'
 
-          - script: |
-              echo "=== Unsigned packages ==="
-              ls -la $(Pipeline.Workspace)/nuget-unsigned/
+          - powershell: |
+              Write-Host "=== Unsigned packages ==="
+              Get-ChildItem "$(Pipeline.Workspace)\nuget-unsigned" -Recurse
             displayName: 'List unsigned packages'
 
           # Step 1: Sign the .nupkg with ESRP Code Signing
@@ -374,7 +378,7 @@ stages:
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
               AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
-              FolderPath: '$(Pipeline.Workspace)/nuget-unsigned'
+              FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.nupkg'
               signConfigType: 'inlineSignParams'
               inlineOperation: |
@@ -395,16 +399,16 @@ stages:
                   }
                 ]
 
-          - script: |
-              echo "=== Signed packages ==="
-              ls -la $(Pipeline.Workspace)/nuget-unsigned/
+          - powershell: |
+              Write-Host "=== Signed packages ==="
+              Get-ChildItem "$(Pipeline.Workspace)\nuget-unsigned" -Recurse
             displayName: 'List signed packages'
 
           # Step 2: Push signed package to NuGet.org
-          - script: |
-              dotnet nuget push "$(Pipeline.Workspace)/nuget-unsigned/**/*.nupkg" \
-                --source https://api.nuget.org/v3/index.json \
-                --api-key "$NUGET_API_KEY" \
+          - powershell: |
+              dotnet nuget push "$(Pipeline.Workspace)\nuget-unsigned\*.nupkg" `
+                --source https://api.nuget.org/v3/index.json `
+                --api-key "$env:NUGET_API_KEY" `
                 --skip-duplicate
             env:
               NUGET_API_KEY: $(NUGET_API_KEY)


### PR DESCRIPTION
ESRP Code Signing task produces garbled mixed paths on Linux. Moves NuGet signing to windows-latest with PowerShell commands.