### PR TITLE
docs: add ADOPTERS.md and make deployment guides multi-cloud

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,56 @@
+# Adopters
+
+Organizations using the Agent Governance Toolkit in production or evaluation.
+
+_If your organization uses AGT, please add it here! It helps the project gain
+momentum and credibility. Submit a PR editing this file — see
+[CONTRIBUTING.md](CONTRIBUTING.md) for guidelines._
+
+## Production
+
+| Organization | Industry | Use Case | Contact |
+|---|---|---|---|
+| | | | |
+
+## Evaluation / Pilot
+
+| Organization | Industry | Use Case | Contact |
+|---|---|---|---|
+| | | | |
+
+## Academic / Research
+
+| Organization | Focus Area | Contact |
+|---|---|---|
+| | | |
+
+---
+
+## How to Add Your Organization
+
+1. Fork the repository
+2. Edit this file — add a row to the appropriate table
+3. Submit a pull request
+
+**What to include:**
+- **Organization:** Your company/institution name (link to website)
+- **Industry:** e.g., Financial Services, Healthcare, Technology, Government
+- **Use Case:** Brief description (1-2 sentences) of how you use AGT
+- **Contact:** GitHub handle of a representative (optional but helpful)
+
+**Example:**
+
+```markdown
+| [Contoso](https://contoso.com) | Financial Services | Policy enforcement for trading agents — deterministic action governance on multi-agent workflows processing market data | [@jsmith](https://github.com/jsmith) |
+```
+
+We welcome all adopters — from "just evaluating" to "running in production
+at scale." Every entry helps others discover the project and understand
+its real-world applicability.
+
+## Why Add Your Name?
+
+- 🏢 **Visibility** — show your organization's AI governance maturity
+- 🤝 **Community** — connect with other AGT users facing similar challenges
+- 📈 **Project health** — help maintainers prioritize features based on real usage
+- 🛡️ **Signal** — demonstrate industry adoption for regulatory conversations

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ See **[SDK Feature Matrix](docs/SDK-FEATURE-MATRIX.md)** for detailed per-langua
 **Compliance & Deployment**
 - [Known Limitations](docs/LIMITATIONS.md) — Honest design boundaries and recommended layered defense
 - [OWASP Compliance](docs/OWASP-COMPLIANCE.md) — Full ASI-01 through ASI-10 mapping
-- [Azure Deployment](docs/deployment/README.md) — AKS, AI Foundry, Container Apps
+- [Deployment Guides](docs/deployment/README.md) — Azure (AKS, Foundry, Container Apps), AWS (ECS/Fargate), GCP (GKE), Docker Compose
 - [NIST AI RMF Alignment](docs/compliance/nist-ai-rmf-alignment.md) · [EU AI Act](docs/compliance/) · [SOC 2 Mapping](docs/compliance/soc2-mapping.md)
 
 **Extensions**
@@ -288,6 +288,8 @@ This toolkit provides **application-level governance** (Python middleware), not 
 ## Contributing
 
 - [Contributing Guide](CONTRIBUTING.md) · [Community](COMMUNITY.md) · [Security Policy](SECURITY.md) · [Changelog](CHANGELOG.md)
+
+**Using AGT?** Add your organization to [ADOPTERS.md](ADOPTERS.md) — it helps the project gain momentum and helps others discover real-world use cases.
 
 ## Important Notes
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,87 +1,91 @@
-# Azure Deployment Guides
+# Deployment Guides
 
-Deploy the Agent Governance Toolkit on Azure for production-grade runtime security governance of AI agents.
+Deploy the Agent Governance Toolkit on any cloud or on-premises infrastructure.
 
+> **No vendor lock-in** — AGT is pure Python/TypeScript/.NET/Rust/Go with zero cloud-vendor
+> dependencies. It runs anywhere containers run.
+>
 > **Quick start:** `pip install agent-governance-toolkit[full]` — see the [main README](../../README.md) for local development.
 
 ---
 
-## Deployment Options
+## Choose Your Platform
+
+### Azure
 
 | Scenario | Guide | Best For |
 |----------|-------|----------|
-| **Azure Kubernetes Service (AKS)** | [AKS Sidecar Deployment](../../packages/agent-mesh/docs/deployment/azure.md) | Production workloads needing full control over infrastructure, multi-agent systems, enterprise-grade HA |
-| **Azure AI Foundry Agent Service** | [Foundry Integration](azure-foundry-agent-service.md) | Teams building agents with Azure AI Foundry who want governance as middleware |
-| **Azure Container Apps** | [Container Apps Deployment](azure-container-apps.md) | Serverless container workloads, rapid prototyping, scale-to-zero scenarios |
-| **OpenClaw on AKS** | [OpenClaw Sidecar](openclaw-sidecar.md) | Securing OpenClaw autonomous agents with governance guardrails |
+| **Azure Kubernetes Service (AKS)** | [AKS Sidecar Deployment](../../packages/agent-mesh/docs/deployment/azure.md) | Production multi-agent systems, enterprise HA |
+| **Azure AI Foundry Agent Service** | [Foundry Integration](azure-foundry-agent-service.md) | Agents built with Azure AI Foundry |
+| **Azure Container Apps** | [Container Apps](azure-container-apps.md) | Serverless, scale-to-zero scenarios |
+| **OpenClaw on AKS** | [OpenClaw Sidecar](openclaw-sidecar.md) | Governing OpenClaw autonomous agents |
+
+### AWS
+
+| Scenario | Guide | Best For |
+|----------|-------|----------|
+| **AWS ECS / Fargate** | [ECS Deployment](aws-ecs.md) | Serverless containers, simple agent deployments |
+| **AWS EKS** | [ECS Guide](aws-ecs.md) (Kubernetes section) | Production multi-agent on Kubernetes |
+
+### Google Cloud
+
+| Scenario | Guide | Best For |
+|----------|-------|----------|
+| **Google Kubernetes Engine (GKE)** | [GKE Deployment](gcp-gke.md) | Production multi-agent on GKE |
+| **Cloud Run** | [GKE Guide](gcp-gke.md) (Cloud Run section) | Serverless container workloads |
+
+### Self-Hosted / On-Premises
+
+| Scenario | Guide | Best For |
+|----------|-------|----------|
+| **Docker Compose** | [OpenClaw Sidecar](openclaw-sidecar.md#quick-start-with-docker-compose) | Local development, testing |
+| **Private Endpoints** | [Private Endpoints](private-endpoints.md) | Air-gapped / regulated environments |
 
 ---
 
 ## Architecture Overview
 
-The toolkit supports three primary deployment patterns on Azure:
+The toolkit supports three primary deployment patterns on any cloud:
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  Azure                                                          │
-│                                                                 │
-│  ┌─────────────────┐  ┌──────────────────┐  ┌───────────────┐  │
-│  │ AKS             │  │ Container Apps   │  │ Foundry Agent │  │
-│  │                 │  │                  │  │ Service       │  │
-│  │ ┌─────┐┌─────┐ │  │ ┌─────┐┌──────┐ │  │               │  │
-│  │ │Agent││Gov  │ │  │ │Agent││Gov   │ │  │  ┌─────────┐  │  │
-│  │ │     ││Side-│ │  │ │     ││Init/ │ │  │  │Governance│  │  │
-│  │ │     ││car  │ │  │ │     ││Side  │ │  │  │Middleware│  │  │
-│  │ └─────┘└─────┘ │  │ └─────┘└──────┘ │  │  └─────────┘  │  │
-│  │  Pod            │  │  Container Group │  │   In-Process  │  │
-│  └─────────────────┘  └──────────────────┘  └───────────────┘  │
-│                                                                 │
-│  ┌──────────────────────────────────────────────────────────┐   │
-│  │ Shared: Azure Key Vault │ Azure Monitor │ Managed ID    │   │
-│  └──────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────────┐
+│  Any Cloud (Azure / AWS / GCP / On-Prem)                              │
+│                                                                        │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌─────────────────────┐  │
+│  │ Kubernetes (AKS/ │  │ Serverless (ACA/ │  │ Agent Framework     │  │
+│  │ EKS/GKE)         │  │ Fargate/CloudRun)│  │ (Foundry/Bedrock/   │  │
+│  │                  │  │                  │  │  Vertex)            │  │
+│  │ ┌─────┐┌─────┐  │  │ ┌─────┐┌──────┐ │  │                     │  │
+│  │ │Agent││Gov  │  │  │ │Agent││Gov   │ │  │  ┌─────────────┐   │  │
+│  │ │     ││Side-│  │  │ │     ││Init/ │ │  │  │ Governance  │   │  │
+│  │ │     ││car  │  │  │ │     ││Side  │ │  │  │ Middleware   │   │  │
+│  │ └─────┘└─────┘  │  │ └─────┘└──────┘ │  │  └─────────────┘   │  │
+│  │  Pod / Task      │  │  Container Group │  │   In-Process       │  │
+│  └──────────────────┘  └──────────────────┘  └─────────────────────┘  │
+│                                                                        │
+│  ┌─────────────────────────────────────────────────────────────────┐   │
+│  │ Shared: Secret Store │ Monitoring │ Identity Provider           │   │
+│  │ (Key Vault / Secrets │ (CloudWatch│ (Managed ID / IAM Role /   │   │
+│  │  Manager / Secret Mgr│  / Monitor)│  Workload Identity)        │   │
+│  └─────────────────────────────────────────────────────────────────┘   │
+└────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
 ## Which Option Should I Choose?
 
-**Choose AKS if:**
+**Choose Kubernetes (AKS/EKS/GKE) if:**
 - You need full control over networking, scaling, and pod configuration
 - You're running multi-agent systems with sidecar-per-agent governance
-- You require enterprise features: managed identity, Key Vault, zone-redundant HA
-- You're deploying OpenClaw or other containerized autonomous agents
+- You require enterprise features: managed identity, secret stores, zone-redundant HA
 
-**Choose Azure AI Foundry Agent Service if:**
-- You're already building agents with Azure AI Foundry
-- You want governance as in-process middleware (no sidecar overhead)
-- You prefer a managed service over managing Kubernetes infrastructure
+**Choose Serverless (Container Apps/Fargate/Cloud Run) if:**
+- You want scale-to-zero and simpler operational overhead
+- You're running single-agent or small-scale scenarios
+- You're prototyping before moving to Kubernetes for production
 
-**Choose Azure Container Apps if:**
-- You want serverless scaling (including scale-to-zero)
-- You're running single-agent or small-scale multi-agent scenarios
-- You want a simpler operational model than Kubernetes
-- You're prototyping before moving to AKS for production
-
----
-
-## Other Cloud Platforms
-
-| Cloud | Guide |
-|-------|-------|
-| AWS (EKS/ECS) | [AWS Deployment](../../packages/agent-mesh/docs/deployment/aws.md) |
-| GCP (GKE) | [GCP Deployment](../../packages/agent-mesh/docs/deployment/gcp.md) |
-| Generic Kubernetes | [Kubernetes Guide](../../packages/agent-mesh/docs/deployment/kubernetes.md) |
-
----
-
-## Common Azure Resources
-
-All deployment options benefit from these Azure services:
-
-- **Azure Key Vault** — Store agent private keys, DID secrets, and policy signing keys
-- **Azure Monitor / Container Insights** — Collect governance metrics via OpenTelemetry
-- **Managed Identity** — Authenticate to Azure services without credentials in code
-- **Azure Event Grid** — React to governance events (policy violations, trust score changes)
-
-See the [AKS guide](../../packages/agent-mesh/docs/deployment/azure.md) for detailed setup of each.
+**Choose In-Process Middleware if:**
+- You're using a managed agent framework (Azure AI Foundry, Bedrock, Vertex)
+- You want zero sidecar overhead
+- Your agents run as functions, not long-lived containers


### PR DESCRIPTION
Branch: `feat/adopters-and-cloud-guides` (1 commits ahead of main)

### Commits

caaee590 docs: add ADOPTERS.md and make deployment guides multi-cloud