### PR TITLE
feat(dotnet): add kill switch and lifecycle management to .NET SDK

### DIFF
--- a/packages/agent-governance-dotnet/README.md
+++ b/packages/agent-governance-dotnet/README.md
@@ -134,6 +134,63 @@ var limits = enforcer.GetLimits(ring);
 
 When enabled via `GovernanceOptions.EnableRings`, ring checks are automatically enforced in the middleware pipeline.
 
+### Kill Switch
+
+Terminate rogue agents immediately with an arm/disarm safety mechanism, event history, and subscriber notifications:
+
+```csharp
+using AgentGovernance.Hypervisor;
+
+var ks = new KillSwitch();
+ks.Arm();
+
+// Subscribe to kill events
+ks.OnKill += (_, evt) =>
+    Console.WriteLine($"Killed {evt.AgentId}: {evt.Reason} — {evt.Detail}");
+
+// Terminate an agent
+var killEvent = ks.Kill("did:mesh:rogue-agent", KillReason.PolicyViolation, "exceeded scope");
+
+// Review history
+foreach (var e in ks.History)
+    Console.WriteLine($"{e.Timestamp}: {e.AgentId} — {e.Reason}");
+
+ks.Disarm(); // Prevents further kills until re-armed
+```
+
+| Reason | Description |
+|--------|-------------|
+| `PolicyViolation` | Agent violated a governance policy |
+| `TrustThreshold` | Trust score dropped below threshold |
+| `ManualOverride` | Human operator triggered the kill |
+| `AnomalyDetected` | Anomalous behaviour detected |
+| `ResourceExhaustion` | Resource consumption limits exceeded |
+
+### Lifecycle Management
+
+Eight-state lifecycle machine with validated transitions, event logging, and convenience methods:
+
+```csharp
+using AgentGovernance.Lifecycle;
+
+var mgr = new LifecycleManager("did:mesh:agent-007");
+
+mgr.Activate();                          // Provisioning → Active
+mgr.Suspend("scheduled maintenance");    // Active → Suspended
+mgr.Transition(LifecycleState.Active, "maintenance done", "ops");
+mgr.Quarantine("trust breach detected"); // Active → Quarantined
+mgr.Decommission("end of life");         // Quarantined → Decommissioning
+
+// Check transition validity
+bool canActivate = mgr.CanTransition(LifecycleState.Active); // false
+
+// Review full event log
+foreach (var evt in mgr.Events)
+    Console.WriteLine($"{evt.Timestamp}: {evt.FromState} → {evt.ToState} ({evt.Reason})");
+```
+
+**Lifecycle states:** Provisioning → Active ↔ Suspended / Rotating / Degraded / Quarantined → Decommissioning → Decommissioned
+
 ### Saga Orchestrator
 
 Multi-step transaction governance with automatic compensation on failure:

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Hypervisor/KillSwitch.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Hypervisor/KillSwitch.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AgentGovernance.Hypervisor;
+
+/// <summary>
+/// Reason an agent was terminated via the kill switch.
+/// </summary>
+public enum KillReason
+{
+    /// <summary>Agent violated a governance policy.</summary>
+    PolicyViolation,
+
+    /// <summary>Agent's trust score dropped below the acceptable threshold.</summary>
+    TrustThreshold,
+
+    /// <summary>A human operator manually triggered the kill.</summary>
+    ManualOverride,
+
+    /// <summary>Anomalous behaviour was detected by the monitoring system.</summary>
+    AnomalyDetected,
+
+    /// <summary>Agent exceeded resource consumption limits.</summary>
+    ResourceExhaustion
+}
+
+/// <summary>
+/// Immutable record of a single kill switch activation.
+/// </summary>
+/// <param name="AgentId">DID of the terminated agent.</param>
+/// <param name="Reason">Why the agent was killed.</param>
+/// <param name="Detail">Human-readable detail message.</param>
+/// <param name="Timestamp">UTC time the kill occurred.</param>
+public record KillEvent(string AgentId, KillReason Reason, string Detail, DateTimeOffset Timestamp);
+
+/// <summary>
+/// Agent kill switch that can be armed/disarmed.
+/// When armed, calling <see cref="Kill"/> terminates the target agent,
+/// records the event, and notifies subscribers.
+/// </summary>
+public class KillSwitch
+{
+    private readonly List<KillEvent> _history = new();
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Whether the kill switch is currently armed. Only armed switches can kill agents.
+    /// </summary>
+    public bool IsArmed { get; private set; }
+
+    /// <summary>
+    /// Immutable snapshot of all recorded kill events.
+    /// </summary>
+    public IReadOnlyList<KillEvent> History
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _history.ToList().AsReadOnly();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Raised immediately after an agent is killed.
+    /// </summary>
+    public event EventHandler<KillEvent>? OnKill;
+
+    /// <summary>
+    /// Arms the kill switch, enabling <see cref="Kill"/> to terminate agents.
+    /// </summary>
+    public void Arm()
+    {
+        IsArmed = true;
+    }
+
+    /// <summary>
+    /// Disarms the kill switch. Subsequent calls to <see cref="Kill"/> will throw.
+    /// </summary>
+    public void Disarm()
+    {
+        IsArmed = false;
+    }
+
+    /// <summary>
+    /// Terminates the specified agent, records the event, and raises <see cref="OnKill"/>.
+    /// </summary>
+    /// <param name="agentId">DID of the agent to terminate.</param>
+    /// <param name="reason">Reason for the kill.</param>
+    /// <param name="detail">Human-readable detail message.</param>
+    /// <returns>The recorded <see cref="KillEvent"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the switch is not armed.</exception>
+    public KillEvent Kill(string agentId, KillReason reason, string detail)
+    {
+        if (!IsArmed)
+        {
+            throw new InvalidOperationException("Kill switch is not armed.");
+        }
+
+        var killEvent = new KillEvent(agentId, reason, detail, DateTimeOffset.UtcNow);
+
+        lock (_lock)
+        {
+            _history.Add(killEvent);
+        }
+
+        OnKill?.Invoke(this, killEvent);
+        return killEvent;
+    }
+}

--- a/packages/agent-governance-dotnet/src/AgentGovernance/Lifecycle/LifecycleManager.cs
+++ b/packages/agent-governance-dotnet/src/AgentGovernance/Lifecycle/LifecycleManager.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AgentGovernance.Lifecycle;
+
+/// <summary>
+/// Eight-state lifecycle model for governed agents.
+/// </summary>
+public enum LifecycleState
+{
+    /// <summary>Agent is being provisioned and is not yet ready.</summary>
+    Provisioning,
+
+    /// <summary>Agent is running and accepting work.</summary>
+    Active,
+
+    /// <summary>Agent is temporarily paused (e.g., policy hold).</summary>
+    Suspended,
+
+    /// <summary>Agent credentials or keys are being rotated.</summary>
+    Rotating,
+
+    /// <summary>Agent is running in a degraded capacity.</summary>
+    Degraded,
+
+    /// <summary>Agent is isolated due to a security or trust concern.</summary>
+    Quarantined,
+
+    /// <summary>Agent shutdown is in progress.</summary>
+    Decommissioning,
+
+    /// <summary>Agent has been fully decommissioned.</summary>
+    Decommissioned
+}
+
+/// <summary>
+/// Immutable record of a lifecycle state transition.
+/// </summary>
+/// <param name="AgentId">DID of the agent.</param>
+/// <param name="FromState">Previous lifecycle state.</param>
+/// <param name="ToState">New lifecycle state.</param>
+/// <param name="Reason">Human-readable reason for the transition.</param>
+/// <param name="Timestamp">UTC time of the transition.</param>
+/// <param name="InitiatedBy">Identifier of the actor that initiated the transition.</param>
+public record LifecycleEvent(
+    string AgentId,
+    LifecycleState FromState,
+    LifecycleState ToState,
+    string Reason,
+    DateTimeOffset Timestamp,
+    string InitiatedBy);
+
+/// <summary>
+/// Manages the lifecycle of a single governed agent using an eight-state
+/// machine with validated transitions.
+/// </summary>
+public class LifecycleManager
+{
+    private static readonly Dictionary<LifecycleState, HashSet<LifecycleState>> ValidTransitions = new()
+    {
+        [LifecycleState.Provisioning] = new()
+        {
+            LifecycleState.Active,
+            LifecycleState.Decommissioning
+        },
+        [LifecycleState.Active] = new()
+        {
+            LifecycleState.Suspended,
+            LifecycleState.Rotating,
+            LifecycleState.Degraded,
+            LifecycleState.Quarantined,
+            LifecycleState.Decommissioning
+        },
+        [LifecycleState.Suspended] = new()
+        {
+            LifecycleState.Active,
+            LifecycleState.Quarantined,
+            LifecycleState.Decommissioning
+        },
+        [LifecycleState.Rotating] = new()
+        {
+            LifecycleState.Active,
+            LifecycleState.Degraded,
+            LifecycleState.Decommissioning
+        },
+        [LifecycleState.Degraded] = new()
+        {
+            LifecycleState.Active,
+            LifecycleState.Quarantined,
+            LifecycleState.Decommissioning
+        },
+        [LifecycleState.Quarantined] = new()
+        {
+            LifecycleState.Active,
+            LifecycleState.Decommissioning
+        },
+        [LifecycleState.Decommissioning] = new()
+        {
+            LifecycleState.Decommissioned
+        },
+        [LifecycleState.Decommissioned] = new()
+    };
+
+    private readonly string _agentId;
+    private readonly List<LifecycleEvent> _events = new();
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Creates a new <see cref="LifecycleManager"/> for the given agent.
+    /// The agent starts in <see cref="LifecycleState.Provisioning"/>.
+    /// </summary>
+    /// <param name="agentId">DID of the agent to manage.</param>
+    public LifecycleManager(string agentId)
+    {
+        _agentId = agentId;
+        State = LifecycleState.Provisioning;
+    }
+
+    /// <summary>
+    /// Current lifecycle state of the agent.
+    /// </summary>
+    public LifecycleState State { get; private set; }
+
+    /// <summary>
+    /// Immutable snapshot of all recorded lifecycle events.
+    /// </summary>
+    public IReadOnlyList<LifecycleEvent> Events
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _events.ToList().AsReadOnly();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns whether a transition from the current state to <paramref name="toState"/> is valid.
+    /// </summary>
+    public bool CanTransition(LifecycleState toState)
+    {
+        return ValidTransitions.TryGetValue(State, out var targets) && targets.Contains(toState);
+    }
+
+    /// <summary>
+    /// Transitions the agent to a new state if the transition is valid.
+    /// </summary>
+    /// <param name="toState">The target state.</param>
+    /// <param name="reason">Human-readable reason for the transition.</param>
+    /// <param name="initiatedBy">Identifier of the actor initiating the transition.</param>
+    /// <returns>The recorded <see cref="LifecycleEvent"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the transition is not allowed.</exception>
+    public LifecycleEvent Transition(LifecycleState toState, string reason, string initiatedBy)
+    {
+        if (!CanTransition(toState))
+        {
+            throw new InvalidOperationException(
+                $"Cannot transition from {State} to {toState}.");
+        }
+
+        var fromState = State;
+        State = toState;
+
+        var evt = new LifecycleEvent(_agentId, fromState, toState, reason, DateTimeOffset.UtcNow, initiatedBy);
+
+        lock (_lock)
+        {
+            _events.Add(evt);
+        }
+
+        return evt;
+    }
+
+    // ── Convenience methods ──────────────────────────────────────
+
+    /// <summary>
+    /// Transitions the agent to <see cref="LifecycleState.Active"/>.
+    /// </summary>
+    public LifecycleEvent Activate(string reason = "Ready")
+        => Transition(LifecycleState.Active, reason, "system");
+
+    /// <summary>
+    /// Transitions the agent to <see cref="LifecycleState.Suspended"/>.
+    /// </summary>
+    public LifecycleEvent Suspend(string reason)
+        => Transition(LifecycleState.Suspended, reason, "system");
+
+    /// <summary>
+    /// Transitions the agent to <see cref="LifecycleState.Quarantined"/>.
+    /// </summary>
+    public LifecycleEvent Quarantine(string reason)
+        => Transition(LifecycleState.Quarantined, reason, "system");
+
+    /// <summary>
+    /// Transitions the agent to <see cref="LifecycleState.Decommissioning"/>.
+    /// </summary>
+    public LifecycleEvent Decommission(string reason)
+        => Transition(LifecycleState.Decommissioning, reason, "system");
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/KillSwitchTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/KillSwitchTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AgentGovernance.Hypervisor;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class KillSwitchTests
+{
+    [Fact]
+    public void NewKillSwitch_IsNotArmed()
+    {
+        var ks = new KillSwitch();
+
+        Assert.False(ks.IsArmed);
+    }
+
+    [Fact]
+    public void Arm_SetsIsArmedTrue()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+
+        Assert.True(ks.IsArmed);
+    }
+
+    [Fact]
+    public void Disarm_SetsIsArmedFalse()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+        ks.Disarm();
+
+        Assert.False(ks.IsArmed);
+    }
+
+    [Fact]
+    public void Kill_WhenDisarmed_Throws()
+    {
+        var ks = new KillSwitch();
+
+        Assert.Throws<InvalidOperationException>(
+            () => ks.Kill("agent-1", KillReason.ManualOverride, "test"));
+    }
+
+    [Fact]
+    public void Kill_WhenArmed_ReturnsEvent()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+
+        var evt = ks.Kill("agent-1", KillReason.PolicyViolation, "exceeded scope");
+
+        Assert.Equal("agent-1", evt.AgentId);
+        Assert.Equal(KillReason.PolicyViolation, evt.Reason);
+        Assert.Equal("exceeded scope", evt.Detail);
+        Assert.True(evt.Timestamp <= DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void Kill_FiresOnKillEvent()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+
+        KillEvent? received = null;
+        ks.OnKill += (_, e) => received = e;
+
+        ks.Kill("agent-1", KillReason.AnomalyDetected, "drift");
+
+        Assert.NotNull(received);
+        Assert.Equal("agent-1", received!.AgentId);
+        Assert.Equal(KillReason.AnomalyDetected, received.Reason);
+    }
+
+    [Fact]
+    public void History_TracksAllKills()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+
+        ks.Kill("agent-1", KillReason.PolicyViolation, "v1");
+        ks.Kill("agent-2", KillReason.TrustThreshold, "v2");
+        ks.Kill("agent-3", KillReason.ResourceExhaustion, "v3");
+
+        Assert.Equal(3, ks.History.Count);
+        Assert.Equal("agent-1", ks.History[0].AgentId);
+        Assert.Equal("agent-2", ks.History[1].AgentId);
+        Assert.Equal("agent-3", ks.History[2].AgentId);
+    }
+
+    [Fact]
+    public void History_IsEmpty_WhenNoKills()
+    {
+        var ks = new KillSwitch();
+
+        Assert.Empty(ks.History);
+    }
+
+    [Fact]
+    public void ArmDisarmArm_AllowsKillAfterRearm()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+        ks.Disarm();
+        ks.Arm();
+
+        var evt = ks.Kill("agent-1", KillReason.ManualOverride, "re-armed");
+
+        Assert.Equal("agent-1", evt.AgentId);
+    }
+
+    [Fact]
+    public void Kill_AllReasons_Accepted()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+
+        foreach (var reason in Enum.GetValues<KillReason>())
+        {
+            var evt = ks.Kill($"agent-{reason}", reason, reason.ToString());
+            Assert.Equal(reason, evt.Reason);
+        }
+
+        Assert.Equal(Enum.GetValues<KillReason>().Length, ks.History.Count);
+    }
+}

--- a/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/LifecycleManagerTests.cs
+++ b/packages/agent-governance-dotnet/tests/AgentGovernance.Tests/LifecycleManagerTests.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AgentGovernance.Lifecycle;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class LifecycleManagerTests
+{
+    private const string AgentId = "did:mesh:lifecycle-test";
+
+    [Fact]
+    public void NewManager_StartsInProvisioning()
+    {
+        var mgr = new LifecycleManager(AgentId);
+
+        Assert.Equal(LifecycleState.Provisioning, mgr.State);
+        Assert.Empty(mgr.Events);
+    }
+
+    [Fact]
+    public void Activate_FromProvisioning_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+
+        var evt = mgr.Activate();
+
+        Assert.Equal(LifecycleState.Active, mgr.State);
+        Assert.Equal(LifecycleState.Provisioning, evt.FromState);
+        Assert.Equal(LifecycleState.Active, evt.ToState);
+        Assert.Equal("Ready", evt.Reason);
+        Assert.Equal(AgentId, evt.AgentId);
+    }
+
+    [Fact]
+    public void Suspend_FromActive_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+
+        var evt = mgr.Suspend("policy hold");
+
+        Assert.Equal(LifecycleState.Suspended, mgr.State);
+        Assert.Equal("policy hold", evt.Reason);
+    }
+
+    [Fact]
+    public void Quarantine_FromActive_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+
+        var evt = mgr.Quarantine("trust breach");
+
+        Assert.Equal(LifecycleState.Quarantined, mgr.State);
+        Assert.Equal("trust breach", evt.Reason);
+    }
+
+    [Fact]
+    public void Decommission_FromActive_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+
+        var evt = mgr.Decommission("end of life");
+
+        Assert.Equal(LifecycleState.Decommissioning, mgr.State);
+        Assert.Equal("end of life", evt.Reason);
+    }
+
+    [Fact]
+    public void FullLifecycle_ProvisionToDecommissioned()
+    {
+        var mgr = new LifecycleManager(AgentId);
+
+        mgr.Activate();
+        mgr.Suspend("maintenance");
+        mgr.Transition(LifecycleState.Active, "maintenance complete", "ops");
+        mgr.Decommission("retiring");
+        mgr.Transition(LifecycleState.Decommissioned, "done", "ops");
+
+        Assert.Equal(LifecycleState.Decommissioned, mgr.State);
+        Assert.Equal(5, mgr.Events.Count);
+    }
+
+    [Fact]
+    public void InvalidTransition_Throws()
+    {
+        var mgr = new LifecycleManager(AgentId);
+
+        // Provisioning → Quarantined is not allowed
+        Assert.Throws<InvalidOperationException>(
+            () => mgr.Quarantine("should fail"));
+    }
+
+    [Fact]
+    public void Decommissioned_CannotTransition()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+        mgr.Decommission("retiring");
+        mgr.Transition(LifecycleState.Decommissioned, "done", "ops");
+
+        Assert.Throws<InvalidOperationException>(
+            () => mgr.Activate("should fail"));
+    }
+
+    [Fact]
+    public void CanTransition_ReturnsCorrectly()
+    {
+        var mgr = new LifecycleManager(AgentId);
+
+        Assert.True(mgr.CanTransition(LifecycleState.Active));
+        Assert.True(mgr.CanTransition(LifecycleState.Decommissioning));
+        Assert.False(mgr.CanTransition(LifecycleState.Suspended));
+        Assert.False(mgr.CanTransition(LifecycleState.Quarantined));
+    }
+
+    [Fact]
+    public void Transition_RecordsInitiatedBy()
+    {
+        var mgr = new LifecycleManager(AgentId);
+
+        var evt = mgr.Transition(LifecycleState.Active, "init", "admin-user");
+
+        Assert.Equal("admin-user", evt.InitiatedBy);
+    }
+
+    [Fact]
+    public void ConvenienceMethods_UseSystemAsInitiator()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        var evt = mgr.Activate();
+
+        Assert.Equal("system", evt.InitiatedBy);
+    }
+
+    [Fact]
+    public void Events_AreImmutableSnapshot()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+
+        var snapshot = mgr.Events;
+        mgr.Suspend("pause");
+
+        // Snapshot should not reflect the new event
+        Assert.Single(snapshot);
+        Assert.Equal(2, mgr.Events.Count);
+    }
+
+    [Fact]
+    public void Rotating_FromActive_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+
+        var evt = mgr.Transition(LifecycleState.Rotating, "key rotation", "security");
+
+        Assert.Equal(LifecycleState.Rotating, mgr.State);
+        Assert.Equal("key rotation", evt.Reason);
+    }
+
+    [Fact]
+    public void Degraded_FromActive_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+
+        var evt = mgr.Transition(LifecycleState.Degraded, "partial failure", "monitor");
+
+        Assert.Equal(LifecycleState.Degraded, mgr.State);
+    }
+
+    [Fact]
+    public void Quarantine_FromDegraded_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+        mgr.Transition(LifecycleState.Degraded, "failing", "monitor");
+
+        mgr.Quarantine("escalation");
+
+        Assert.Equal(LifecycleState.Quarantined, mgr.State);
+    }
+
+    [Fact]
+    public void Active_FromQuarantined_Succeeds()
+    {
+        var mgr = new LifecycleManager(AgentId);
+        mgr.Activate();
+        mgr.Quarantine("incident");
+
+        mgr.Transition(LifecycleState.Active, "cleared", "ops");
+
+        Assert.Equal(LifecycleState.Active, mgr.State);
+    }
+}


### PR DESCRIPTION
Branch: `feat/sdk-parity-dotnet` (1 commits ahead of main)

### Commits

29819526 feat(dotnet): add kill switch and lifecycle management to .NET SDK