### PR TITLE
fix: add license header to benchmark tests __init__.py

### DIFF
--- a/benchmarks/tests/__init__.py
+++ b/benchmarks/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.


### PR DESCRIPTION
Branch: `fix/benchmark-license-header` (1 commits ahead of main)

### Commits

479ece08 fix: add license header to benchmark tests __init__.py