### PR TITLE
fix(ci): add --allow-dirty to cargo package for CI builds

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -394,7 +394,7 @@ stages:
 
           - script: |
               cargo package --list
-              cargo package
+              cargo package --allow-dirty
               echo "=== Packaged crate ==="
               ls -la target/package/*.crate
               # ESRP requires a zip containing the .crate file(s)


### PR DESCRIPTION
Branch: `fix/cargo-allow-dirty` (1 commits ahead of main)

### Commits

3ba8f76a fix(ci): add --allow-dirty to cargo package for CI builds