### PR TITLE
fix(security): upgrade axios to 1.15.0 ΓÇö CVE-2026-40175, CVE-2025-62718

### DIFF
--- a/packages/agent-os-vscode/package.json
+++ b/packages/agent-os-vscode/package.json
@@ -533,7 +533,7 @@
     "typescript": "5.3.0"
   },
   "dependencies": {
-    "axios": "1.13.6",
+    "axios": "1.15.0",
     "ws": "8.20.0"
   }
 }

--- a/packages/agent-os/extensions/copilot/package.json
+++ b/packages/agent-os/extensions/copilot/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@octokit/webhooks": "14.2.0",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "dotenv": "17.4.1",
     "express": "5.2.1",
     "path-to-regexp": "8.4.2",

--- a/packages/agent-os/extensions/cursor/package.json
+++ b/packages/agent-os/extensions/cursor/package.json
@@ -265,6 +265,6 @@
     "@vscode/vsce": "2.22.0"
   },
   "dependencies": {
-    "axios": "1.13.5"
+    "axios": "1.15.0"
   }
 }


### PR DESCRIPTION
Branch: `fix/cve-2026-40175-axios` (1 commits ahead of main)

### Commits

2387a85c fix(security): upgrade axios to 1.15.0 ΓÇö CVE-2026-40175, CVE-2025-62718