### PR TITLE
fix(ci): correct EsrpCodeSigning@5 input ΓÇö AuthCertName not AuthSignCertName

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -373,7 +373,7 @@ stages:
               AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
-              AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
+              AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)/nuget-unsigned'
               Pattern: '*.nupkg'
               signConfigType: 'inlineSignParams'


### PR DESCRIPTION
Branch: `fix/esrp-authcertname` (1 commits ahead of main)

### Commits

509726de fix(ci): correct EsrpCodeSigning@5 input ΓÇö AuthCertName not AuthSignCertName