### PR TITLE
fix(lint): fix unused import and ordering in integrity.py

### DIFF
--- a/packages/agent-compliance/src/agent_compliance/integrity.py
+++ b/packages/agent-compliance/src/agent_compliance/integrity.py
@@ -32,10 +32,9 @@ from datetime import datetime, timezone
 from types import ModuleType
 from typing import Any, Optional
 
-logger = logging.getLogger(__name__)
+from agent_compliance.verify import _validate_module_name
 
-# Import the shared allowlist validation from verify.py
-from agent_compliance.verify import ALLOWED_MODULE_PREFIXES, _validate_module_name
+logger = logging.getLogger(__name__)
 
 # Governance modules whose integrity we verify
 GOVERNANCE_MODULES = [


### PR DESCRIPTION
Branch: `fix/lint-compliance` (1 commits ahead of main)

### Commits

b522cb33 fix(lint): fix unused import and ordering in integrity.py