### PR TITLE
fix(lint): remove unused imports and fix redefinition in agent-os

### DIFF
--- a/packages/agent-os/src/agent_os/__init__.py
+++ b/packages/agent-os/src/agent_os/__init__.py
@@ -361,7 +361,7 @@ from agent_os.content_governance import (
 from agent_os.execution_context_policy import (
     ContextualPolicyEngine,
     EnforcementLevel,
-    ExecutionContext,
+    ExecutionContext as ContextualExecutionContext,
 )
 
 from agent_os.github_enterprise import (

--- a/packages/agent-os/src/agent_os/cli/cmd_audit.py
+++ b/packages/agent-os/src/agent_os/cli/cmd_audit.py
@@ -8,7 +8,6 @@ import argparse
 import csv
 import json
 from pathlib import Path
-from typing import Any
 
 from .output import (
     Colors,

--- a/packages/agent-os/src/agent_os/cli/cmd_init.py
+++ b/packages/agent-os/src/agent_os/cli/cmd_init.py
@@ -9,8 +9,6 @@ import json
 from pathlib import Path
 
 from .output import (
-    AVAILABLE_POLICIES,
-    Colors,
     format_error,
     get_output_format,
 )

--- a/packages/agent-os/src/agent_os/cli/cmd_validate.py
+++ b/packages/agent-os/src/agent_os/cli/cmd_validate.py
@@ -13,7 +13,7 @@ import json
 import re
 from pathlib import Path
 
-from .output import Colors, get_output_format
+from .output import Colors
 
 
 # ============================================================================

--- a/packages/agent-os/src/agent_os/cli/output.py
+++ b/packages/agent-os/src/agent_os/cli/output.py
@@ -12,9 +12,9 @@ import argparse
 import json
 import logging
 import os
+import pathlib
 import sys
 import traceback
-from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ def get_output_format(args: argparse.Namespace) -> str:
     return getattr(args, "format", "text")
 
 
-def get_config_path(args_path: str | None = None) -> "Path":
+def get_config_path(args_path: str | None = None) -> "pathlib.Path":
     """Resolve the config path from args or AGENTOS_CONFIG env var."""
     from pathlib import Path as _Path
 


### PR DESCRIPTION
Branch: `fix/lint-f401` (1 commits ahead of main)

### Commits

7b848af9 fix(lint): remove unused imports and fix redefinition in agent-os