### PR TITLE
fix(ci): pass --legacy-peer-deps directly in npm install command

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -213,7 +213,7 @@ stages:
               inputs:
                 version: '${{ parameters.nodeVersion }}'
 
-            - script: npm ci --ignore-scripts 2>/dev/null || npm install
+            - script: npm ci --ignore-scripts --legacy-peer-deps 2>/dev/null || npm install --legacy-peer-deps
               workingDirectory: '${{ pkg.path }}'
               displayName: 'Install dependencies'
 


### PR DESCRIPTION
Branch: `fix/npm-legacy-peer-deps` (1 commits ahead of main)

### Commits

aee24a06 fix(ci): pass --legacy-peer-deps directly in npm install command