### PR TITLE
fix(ci): switch NuGet push from DotNetCoreCLI@2 to NuGetCommand@2

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -356,7 +356,7 @@ stages:
               ls -la $(Pipeline.Workspace)/nuget-publish/
             displayName: 'List packages'
 
-          - task: DotNetCoreCLI@2
+          - task: NuGetCommand@2
             displayName: 'Push to NuGet.org'
             inputs:
               command: 'push'


### PR DESCRIPTION
Branch: `fix/nuget-push-task` (1 commits ahead of main)

### Commits

6c8e766b fix(ci): switch NuGet push from DotNetCoreCLI@2 to NuGetCommand@2