### PR TITLE
docs: reland empty-merge changes from PRs #1017 and #1020

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -119,6 +119,8 @@ format or cloud-locked state.
 | Framework-agnostic library | A managed cloud service |
 | Audit trail of actions | Audit trail of outcomes |
 | Permission layer (L3/L4) | Application logic security (L7) |
+| Action governance | Knowledge / data provenance governance |
+| Enforcement infrastructure | Turnkey compliance solution |
 
 ## Recommended Architecture
 
@@ -141,6 +143,106 @@ For production deployments, we recommend a **layered defense**:
 ```
 
 AGT is one layer in a defense-in-depth strategy, not the entire strategy.
+
+---
+
+## 7. Knowledge Governance Gap
+
+AGT governs **agent actions** (tool calls, resource access, inter-agent messages).
+It does **not** govern the **knowledge agents consume** — the documents, databases,
+embeddings, and context retrieved during reasoning.
+
+**What this means in practice:**
+
+- ✅ AGT blocks an agent from calling `send_email` if policy forbids it
+- ❌ AGT does **not** verify the provenance, freshness, or authorization of
+  documents retrieved via RAG
+- ❌ AGT does **not** track which knowledge sources influenced an agent's decision
+- ❌ AGT does **not** enforce data classification labels on retrieved context
+
+**Example gap:** An agent retrieves a confidential HR document via a search tool
+(which AGT permits via policy), then summarizes it in a Slack message (also
+permitted). Both actions are individually governed, but the *knowledge flow* —
+confidential data reaching an unauthorized channel — is invisible to AGT.
+
+**Mitigations available today:**
+- Use **egress policies** to restrict which domains agents can send data to
+- Use **blocked_patterns** to catch PII/confidential patterns in tool arguments
+- Combine AGT with a **data classification** layer that labels context before
+  it reaches the agent
+
+**What we're building:**
+- Integration points for external knowledge governance systems
+- Context provenance tracking in audit logs
+
+> *This gap was identified in external analysis by [Mojar AI](https://www.mojar.ai/blog/industry-news/microsoft-agent-governance-toolkit-missing-knowledge-layer).*
+
+## 8. Credential Persistence Gap
+
+AGT governs **what agents do** with tools. It does **not** manage or observe the
+**credentials agents hold** across tasks within a session.
+
+**What this means in practice:**
+
+- ✅ AGT blocks an agent from calling a tool it's not authorized to use
+- ❌ AGT does **not** track which API keys, OAuth tokens, or secrets an agent
+  is currently holding
+- ❌ AGT does **not** revoke credentials at task boundaries within a session
+- ❌ AGT does **not** detect credential accumulation beyond what's needed for
+  the current task
+
+**Example gap:** An agent receives an email API token for Task A, then moves to
+Task B (which doesn't require email access). The token persists. If the agent is
+compromised during Task B, the attacker gains email access that should no longer
+be active.
+
+**Mitigations available today:**
+- Use **scoped capabilities** in Agent OS policies to limit which tools are
+  available per task context
+- Use **short-lived credentials** with external secret managers (e.g., Azure
+  Key Vault, HashiCorp Vault) and TTL-based rotation
+- Use **trust decay** in AgentMesh to reduce trust scores over time
+
+**What we're building:**
+- Task-scoped credential lifecycle hooks
+- Automatic credential revocation at context switches
+
+> *This gap was identified in external analysis by [Moltbook](https://www.moltbook.com/post/c3fdafe4-f58e-4854-9fd6-eec2052b7638).*
+
+## 9. Initialization and Configuration Bypass Risk
+
+AGT's governance enforcement requires **correct initialization**. If the
+governance middleware is imported but not properly configured, agents may run
+without effective policy enforcement.
+
+**What this means in practice:**
+
+- ✅ When properly initialized with policies loaded, AGT enforces all rules
+  before execution
+- ⚠️ If the policy evaluator has **no policies loaded**, the default action is
+  `allow` — all actions pass through ungoverned
+- ⚠️ If `permissive` mode is used without realizing it allows all actions, agents
+  run effectively ungoverned
+- ✅ On **runtime errors** during policy evaluation, AGT fails closed (denies
+  access) — this is correct behavior
+
+**Example gap:** A developer imports `agent_os` and adds it to their agent
+framework integration, but forgets to load policy files. The governance
+dashboard shows "governed" status, but no rules are enforced.
+
+**Mitigations available today:**
+- Use `strict` mode (deny-by-default) in production — this requires explicit
+  allow rules for every permitted action
+- Use `agt audit` CLI command to verify loaded policies and detect permissive
+  defaults
+- Use the **MCP Security Scanner** to validate tool configurations
+- Run `agt doctor` to check that all components are properly initialized
+
+**What we're building:**
+- Startup validation that warns when no policies are loaded
+- Dashboard indicators for effective enforcement state (not just import state)
+
+> *This risk was identified in external red-team analysis by [Periculo](https://www.periculo.co.uk/cyber-security-blog/red-teaming-the-microsoft-agent-governance-toolkit-15-bypass-vectors).*
 
 ---
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -4,7 +4,7 @@ This document summarizes the security threat model for the Agent Governance
 Toolkit (AGT) using a STRIDE-oriented view of the main trust boundaries in the
 system.
 
-For the current 10/10 OWASP Agentic Top 10 coverage mapping, see
+For the OWASP Agentic Top 10 coverage mapping, see
 [`packages/agent-compliance/docs/OWASP-COMPLIANCE.md`](../packages/agent-compliance/docs/OWASP-COMPLIANCE.md).
 
 ## Scope
@@ -175,6 +175,27 @@ AGT reduces risk but does not eliminate it. The main residual risks are:
 - External tools or plugins that behave unsafely inside their allowed scope
 - Gaps between documented controls and the exact deployment posture of a given
   organization
+- **Knowledge flow risks**: AGT governs tool calls but not the knowledge
+  (documents, embeddings, context) that agents consume and propagate — see
+  [Limitations §7](LIMITATIONS.md#7-knowledge-governance-gap)
+- **Credential persistence**: AGT does not observe or revoke credentials agents
+  hold across tasks within a session — accumulated permissions may exceed
+  what the current task requires — see
+  [Limitations §8](LIMITATIONS.md#8-credential-persistence-gap)
+
+## Configuration Bypass Vectors
+
+Governance enforcement depends on correct initialization. These configuration
+states can result in agents running without effective governance:
+
+| Bypass Vector | Risk | Mitigation |
+|---------------|------|------------|
+| **No policies loaded** | Default action is `allow` — all actions pass ungoverned | Always load policy files; use `strict` mode in production |
+| **Permissive mode in production** | `permissive` mode allows all actions by default | Reserve `permissive` mode for dev/test; enforce `strict` in deployment |
+| **Tool aliasing** | Registering a tool under an unexpected name bypasses name-based policy rules | Use `strict` mode (deny-by-default) so unrecognized tools are blocked; use regex patterns in policy rules rather than exact tool names |
+| **Import-only governance** | Importing the governance module without configuring policies creates false "governed" status | Use `agt doctor` and `agt audit` to verify effective enforcement state |
+
+> *These vectors were identified in external red-team analysis by [Periculo](https://www.periculo.co.uk/cyber-security-blog/red-teaming-the-microsoft-agent-governance-toolkit-15-bypass-vectors).*
 
 ## Recommended Operational Practices
 

--- a/docs/compliance/soc2-mapping.md
+++ b/docs/compliance/soc2-mapping.md
@@ -27,9 +27,9 @@ The Agent Governance Toolkit provides runtime governance infrastructure that add
 
 | Criteria | Coverage | Key Controls Addressed | Primary Gaps |
 |----------|----------|----------------------|--------------|
-| **Security** (CC1–CC9) | ⚠️ Partial | Policy engine, RBAC, DID identity, execution rings, audit logging, MCP security scanning | Kill switch placeholder, detection modules unwired from enforcement |
+| **Security** (CC1–CC9) | ⚠️ Partial | Policy engine, RBAC, DID identity, execution rings, audit logging, MCP security scanning, kill switch | Detection modules unwired from enforcement |
 | **Availability** (A1) | ⚠️ Partial | Circuit breakers, SLO/error budgets, chaos testing framework, sub-millisecond enforcement | Chaos engine framework-only, no health check endpoints, rate limiter unwired |
-| **Processing Integrity** (PI1) | ⚠️ Partial | Merkle audit chain, policy validation, input sanitization, drift detection | 3 of 4 audit chain implementations have integrity defects, `post_execute()` never blocks |
+| **Processing Integrity** (PI1) | ⚠️ Partial | Merkle audit chain, Delta audit chain (SHA-256 verified), policy validation, input sanitization, drift detection | 2 of 4 audit chain implementations have integrity defects, `post_execute()` never blocks |
 | **Confidentiality** (C1) | ⚠️ Partial | Ed25519 identity, HMAC-SHA256 signing, egress policy, PII/secret detection, credential redaction in audit logs | Symmetric HMAC keys, no at-rest encryption, non-credential PII not redacted in audit entries |
 | **Privacy** (P1–P8) | ❌ Gap | 2 PII regex patterns, blocked patterns, retention_days schema field | No consent management, no DSAR, no data minimization, retention not enforced |
 
@@ -130,7 +130,7 @@ audit.log_decision(
 
 ### Security Gaps
 
-- [ ] **Kill switch is placeholder** (CC7.4): `KillSwitch.kill()` at `kill_switch.py:86` returns structured `KillResult` objects but does not terminate agent processes. `handoff_success_count` is hardcoded to 0. All in-flight saga steps are auto-marked COMPENSATED without actual compensation.
+- [x] ~~**Kill switch is placeholder**~~ (CC7.4): **Resolved.** `KillSwitch` now registers agents and substitutes, creates `StepHandoff` records, and increments `handoff_success_count` during saga orchestration. See `kill_switch.py:69-178`.
 - [ ] **Detection modules not wired to enforcement** (CC6.8): `PromptInjectionDetector`, `RateLimiter`, `BoundedSemaphore`, `ScopeGuard`, `SupplyChainGuard`, and `MCPSecurityScanner` exist as standalone utilities but are not auto-wired into the `BaseIntegration` enforcement lifecycle. 6 of 10 OWASP risks share this structural gap.
 - [ ] **MCP scanner acknowledges incompleteness** (CC7.3): Line 287 of `mcp_security.py` warns it "uses built-in sample rules that may not cover all MCP tool poisoning techniques."
 - [ ] **Regex-only prompt injection detection** (CC6.8): No semantic or multilingual detection. English-only regex patterns can be bypassed via paraphrasing.
@@ -260,7 +260,7 @@ assert entry.previous_hash != "" or log.entries.index(entry) == 0
 
 ### Processing Integrity Gaps
 
-- [ ] **DeltaEngine chain verification is a stub** (PI1.5): `verify_chain()` at `packages/agent-hypervisor/src/hypervisor/audit/delta.py:99` always returns `True` with comment "Public Preview: no chain verification." The hypervisor's entire audit trail has zero tamper evidence.
+- [x] ~~**DeltaEngine chain verification is a stub**~~ (PI1.5): **Resolved.** `verify_chain()` now computes SHA-256 hashes and verifies parent linkage across entries. See `delta.py:67-127`.
 - [ ] **FlightRecorder hash covers INSERT-time state** (PI1.5): Hash is computed at insert time with `policy_verdict='pending'`, but the verdict is later updated to `'allowed'`/`'blocked'`. Tampering of the verdict field is undetectable by integrity verification.
 - [ ] **Anomaly detections outside tamper-evident chain** (PI1.5): `RogueAgentDetector` stores assessments in an in-memory list, not in the integrity-protected audit chain.
 - [ ] **`post_execute()` never blocks** (PI1.3): `base.py:977-1038` computes drift scores and emits `DRIFT_DETECTED` events but always returns `(True, None)` — advisory only, no enforcement on output integrity.
@@ -269,7 +269,7 @@ assert entry.previous_hash != "" or log.entries.index(entry) == 0
 
 ### Recommended Controls
 
-1. **Fix DeltaEngine `verify_chain()` stub** — replace with real SHA-256 chain verification (same algorithm as `MerkleAuditChain`).
+1. ~~**Fix DeltaEngine `verify_chain()` stub**~~ — **Done.** Now performs real SHA-256 chain verification.
 2. **Fix FlightRecorder hash** — compute hash over final state including resolved verdict, not INSERT-time state.
 3. Wire anomaly detections into the tamper-evident audit chain.
 4. Add `GovernancePolicy.block_on_drift` flag to enable enforcement in `post_execute()`.
@@ -409,8 +409,8 @@ All file paths referenced in this document, organized by package:
 | File | Evidence For |
 |------|-------------|
 | `src/hypervisor/models.py:46-69` | CC6.7 — Execution rings (Ring 0–3) |
-| `src/hypervisor/security/kill_switch.py:64-136` | CC7.4 — Kill switch (placeholder handoff) |
-| `src/hypervisor/audit/delta.py:59-110` | PI1.5 — Delta audit engine (`verify_chain()` stub) |
+| `src/hypervisor/security/kill_switch.py:64-178` | CC7.4 — Kill switch with saga handoff |
+| `src/hypervisor/audit/delta.py:59-127` | PI1.5 — Delta audit engine with SHA-256 chain verification |
 | `src/hypervisor/rings/breach_detector.py:1-60` | CC9.1 — Ring breach detection |
 
 ### Agent SRE (`packages/agent-sre/`)
@@ -446,15 +446,21 @@ All gaps consolidated and rated by severity for remediation prioritization.
 | Gap | Criteria | Impact | Location |
 |-----|----------|--------|----------|
 | **Non-credential PII not redacted in audit logs** | C1.1, P6 | Credential-like secrets are redacted via `CredentialRedactor`, but non-credential PII (email, phone, addresses) in tool parameters is still stored verbatim | `MCPGateway.intercept_tool_call()` |
-| **DeltaEngine `verify_chain()` is a stub** | PI1.5 | Returns `True` always — hypervisor audit trail has zero tamper evidence | `delta.py:99` |
 | **No consent management** | P2 | Fundamental Privacy criteria requirement not addressed | — |
 | **No data subject access request support** | P5 | Required for Privacy criteria compliance | — |
+
+### Resolved (formerly Critical/High)
+
+| Gap | Criteria | Resolution |
+|-----|----------|------------|
+| ~~DeltaEngine `verify_chain()` stub~~ | PI1.5 | Now performs SHA-256 chain verification (`delta.py:67-127`) |
+| ~~Kill switch placeholder~~ | CC7.4 | Now implements saga handoff with `handoff_success_count` tracking (`kill_switch.py:69-178`) |
+| ~~Audit logs store unredacted parameters~~ | C1.1 | Credential-like secrets now redacted via `CredentialRedactor` before audit persistence |
 
 ### High
 
 | Gap | Criteria | Impact | Location |
 |-----|----------|--------|----------|
-| **Kill switch placeholder** | CC7.4 | Does not terminate agent processes; `handoff_success_count` hardcoded to 0 | `kill_switch.py:86` |
 | **Detection modules unwired** | CC6.8 | 6 detection modules exist but none are integrated into enforcement lifecycle | `base.py` (multiple) |
 | **FlightRecorder hash gap** | PI1.5 | Hash covers INSERT-time state, not final verdict — tampering undetectable | `flight_recorder.py` |
 | **HMAC symmetric key risk** | C1.2 | Insider with the key can forge the entire audit chain | `audit_backends.py:61-87` |


### PR DESCRIPTION
## Summary

Re-lands documentation changes from PRs #1017 and #1020 which were squash-merged as empty commits (0 file changes).

### What happened
PRs #1017 and #1020 were merged but resulted in empty commits on main. The documentation changes never actually landed.

### Changes re-applied

**LIMITATIONS.md** (+100 lines):
- Section 7: Knowledge governance gap (Mojar AI)
- Section 8: Credential persistence gap (Moltbook)
- Section 9: Initialization and configuration bypass risk (Periculo)
- Two new rows in What AGT Is Not table

**THREAT_MODEL.md** (+22 lines):
- Knowledge flow and credential persistence added to residual risks
- Configuration bypass vectors table (no policies, permissive mode, tool aliasing, import-only)
- Removed stale 10/10 qualifier from OWASP reference

**docs/compliance/soc2-mapping.md** (+15/-9 lines):
- Kill switch marked as resolved (saga handoff in kill_switch.py:69-178)
- DeltaEngine verify_chain() marked as resolved (SHA-256 in delta.py:67-127)
- New Resolved section in gaps summary
- Processing Integrity updated to 2 of 4 defects (was 3 of 4)
