### PR TITLE
fix: increase retention_days default to 180 for EU AI Act compliance

### DIFF
--- a/packages/agent-hypervisor/src/hypervisor/audit/gc.py
+++ b/packages/agent-hypervisor/src/hypervisor/audit/gc.py
@@ -43,7 +43,7 @@ class GCResult:
 class RetentionPolicy:
     """Configuration for what to retain after GC."""
 
-    delta_retention_days: int = 90
+    delta_retention_days: int = 180
     hash_retention: str = "permanent"
     liability_snapshot: bool = True
 

--- a/packages/agent-os/src/agent_os/policies/policy_schema.json
+++ b/packages/agent-os/src/agent_os/policies/policy_schema.json
@@ -214,9 +214,9 @@
             },
             "retention_days": {
               "type": "integer",
-              "description": "Days to retain conversation audit logs.",
-              "default": 90,
-              "minimum": 1
+              "description": "Days to retain conversation audit logs. EU AI Act Art. 26(6) requires minimum 180 days for high-risk systems.",
+              "default": 180,
+              "minimum": 30
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Branch: `fix/retention-days-eu-ai-act` (1 commits ahead of main)

### Commits

c89496c2 fix: increase retention_days default to 180 for EU AI Act compliance