### PR TITLE
fix: migrate Rust crate publishing from cargo publish to ESRP Release

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -161,11 +161,17 @@ Publishing uses the ADO pipeline (`pipelines/esrp-publish.yml` with target `nuge
 
 ### Policy
 
-The Rust crate is published to [crates.io](https://crates.io) via `cargo publish`
-in the ADO pipeline (`pipelines/esrp-publish.yml` with target `rust`).
+The Rust crate is published to [crates.io](https://crates.io) via **ESRP Release**
+using the ADO pipeline (`pipelines/esrp-publish.yml` with target `rust`).
+All crates are published under the official
+[`microsoft-oss-releases`](https://crates.io/users/microsoft-oss-releases) account.
 
-> **Note:** ESRP does not currently support crates.io. Publishing uses a
-> crates.io API token stored as `CRATES_IO_TOKEN` in ADO pipeline variables.
+- Personal `cargo publish` with `CARGO_REGISTRY_TOKEN` is **not** used
+- ESRP handles code signing, malware scanning, and code archival
+- Crates must be packaged as `.crate` files via `cargo package`
+
+> **To yank a crate**, file an IcM incident with the ESRP Release team.
+> Programmatic yanking is not currently supported.
 
 ### Published Packages
 
@@ -175,8 +181,9 @@ in the ADO pipeline (`pipelines/esrp-publish.yml` with target `rust`).
 
 ### Prerequisites
 
-- A crates.io API token stored as `CRATES_IO_TOKEN` (secret) in ADO pipeline variables
-- The token must belong to an account that owns the `agentmesh` crate
+- ESRP Release onboarding completed (same as PyPI/npm)
+- Crate is published under the `microsoft-oss-releases` crates.io account
+- No additional secrets needed beyond the shared ESRP configuration
 
 ### Building Locally
 
@@ -314,7 +321,7 @@ The unified ESRP pipeline (`pipelines/esrp-publish.yml`) supports these targets:
 | `pypi` | PyPI | ESRP Release |
 | `npm` | npmjs.com (`@microsoft`) | ESRP Release |
 | `nuget` | NuGet.org | DotNetCoreCLI push |
-| `rust` | crates.io | `cargo publish` |
+| `rust` | crates.io | ESRP Release |
 | `go` | proxy.golang.org | Git tag |
 | `all` | All of the above | — |
 

--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -394,40 +394,59 @@ stages:
 
           - script: |
               cargo package --list
-              cargo package --allow-dirty
+              cargo package
               echo "=== Packaged crate ==="
-              ls -la target/package/
+              ls -la target/package/*.crate
+              # ESRP requires a zip containing the .crate file(s)
+              mkdir -p $(Pipeline.Workspace)/rust-packages
+              cp target/package/*.crate $(Pipeline.Workspace)/rust-packages/
             workingDirectory: 'packages/agent-mesh/sdks/rust/agentmesh'
             displayName: 'Package crate'
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: 'packages/agent-mesh/sdks/rust/agentmesh/target/package'
+              targetPath: '$(Pipeline.Workspace)/rust-packages'
               artifact: 'rust-agentmesh'
               publishLocation: 'pipeline'
             displayName: 'Publish crate artifact'
 
   - stage: Publish_Rust
-    displayName: 'Publish to crates.io'
+    displayName: 'Publish to crates.io via ESRP'
     dependsOn: Build_Rust
     condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'rust'), eq('${{ parameters.target }}', 'all')))
     jobs:
       - job: PublishCrate
-        displayName: 'Publish agentmesh to crates.io'
+        displayName: 'ESRP Publish agentmesh to crates.io'
         steps:
-          - checkout: self
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'rust-agentmesh'
+              targetPath: '$(Pipeline.Workspace)/rust-publish'
+            displayName: 'Download crate artifact'
 
           - script: |
-              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${{ parameters.rustVersion }}
-              echo "##vso[task.prependpath]$HOME/.cargo/bin"
-            displayName: 'Install Rust ${{ parameters.rustVersion }}'
+              echo "=== Crates to publish ==="
+              ls -la $(Pipeline.Workspace)/rust-publish/
+            displayName: 'List crate packages'
 
-          - script: |
-              cargo publish
-            workingDirectory: 'packages/agent-mesh/sdks/rust/agentmesh'
-            displayName: 'Publish to crates.io'
-            env:
-              CARGO_REGISTRY_TOKEN: $(CRATES_IO_TOKEN)
+          - task: EsrpRelease@11
+            displayName: 'ESRP Publish to crates.io'
+            inputs:
+              connectedservicename: 'Agent Governance Toolkit'
+              usemanagedidentity: true
+              keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+              signcertname: '$(ESRP_CERT_IDENTIFIER)'
+              clientid: '$(ESRP_CLIENT_ID)'
+              intent: 'PackageDistribution'
+              contenttype: 'Rust'
+              contentsource: 'Folder'
+              folderlocation: '$(Pipeline.Workspace)/rust-publish'
+              waitforreleasecompletion: true
+              owners: '$(ESRP_OWNERS)'
+              approvers: '$(ESRP_APPROVERS)'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: 'ESRPRELPACMAN'
+              domaintenantid: '$(ESRP_DOMAIN_TENANT_ID)'
 
   # =======================================================
   # GO — github.com/microsoft/agent-governance-toolkit module


### PR DESCRIPTION
Branch: `fix/rust-esrp-publish` (1 commits ahead of main)

### Commits

58e7d3a7 fix: migrate Rust crate publishing from cargo publish to ESRP Release