### PR TITLE
fix: add .npmrc with legacy-peer-deps to resolve ERESOLVE errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Branch: `fix/ts-jest-peer-dep` (1 commits ahead of main)

### Commits

7c299902 fix: add .npmrc with legacy-peer-deps to resolve ERESOLVE errors