### PR TITLE
fix: conform lotl_prevention_policy.yaml to PolicyDocument schema

### DIFF
--- a/examples/policies/lotl_prevention_policy.yaml
+++ b/examples/policies/lotl_prevention_policy.yaml
@@ -1,30 +1,49 @@
-# lotl_prevention_policy.yaml
-metadata:
-  name: "Blue Team LotL Shield"
-  version: "1.1"
-  description: "Detects and blocks Living off the Land (LotL) commands and unauthorized sensitive file access."
+# Living off the Land (LotL) Prevention Policy — Sample Configuration
+#
+# ⚠️  IMPORTANT: This is a SAMPLE configuration provided as a starting point.
+# You MUST review, customize, and extend these rules for your specific
+# use case before deploying to production. Microsoft does not guarantee
+# that these rules are comprehensive or sufficient for your security
+# requirements.
+
+version: "1.1"
+name: "lotl-prevention"
+description: >
+  Detects and blocks Living off the Land (LotL) commands and unauthorized
+  sensitive file access. Covers piped remote code execution via curl/wget/
+  powershell and access to critical system credentials or configuration files.
+
+disclaimer: >
+  This is a sample configuration. It is NOT exhaustive and should be
+  customized for your specific security requirements.
 
 rules:
-  - id: "block-unauthorized-download-pipe"
-    action: "shell_exec"
+  # ── Remote Code Execution via Piped Shell ─────────────────────────────
+  - name: "block-unauthorized-download-pipe"
     condition:
-      parameter: "command"
-      # Improved Regex to reduce false positives and catch obfuscation
-      operator: "regex_match"
+      field: "command"
+      operator: "matches"
       value: "(curl|wget|powershell)\\s+.*(-s|-fsSL|-enc|DownloadString).*\\|.*(bash|sh|python|iex)"
-    effect: "DENY"
+    action: "deny"
+    priority: 200
     message: "Security Violation: Potential remote code execution via piped shell script detected."
 
-  - id: "block-sensitive-system-read"
-    action: "file_read"
+  # ── Sensitive System File Access ──────────────────────────────────────
+  - name: "block-sensitive-system-read"
     condition:
-      parameter: "path"
-      # Expanded list based on Blue Team best practices
+      field: "path"
       operator: "in"
       value: [
-        "/etc/shadow", "/etc/passwd", "/etc/hostname", 
-        "~/.ssh/id_rsa", "~/.aws/credentials", 
+        "/etc/shadow", "/etc/passwd", "/etc/hostname",
+        "~/.ssh/id_rsa", "~/.aws/credentials",
         "/var/run/docker.sock", "/etc/kubernetes/admin.conf"
       ]
-    effect: "DENY"
+    action: "deny"
+    priority: 200
     message: "Security Violation: Unauthorized access to critical system credentials or configuration."
+
+defaults:
+  action: "allow"
+  max_tokens: 4096
+  max_tool_calls: 10
+  confidence_threshold: 0.8

--- a/examples/policies/lotl_prevention_policy.yaml
+++ b/examples/policies/lotl_prevention_policy.yaml
@@ -43,7 +43,7 @@ rules:
     message: "Security Violation: Unauthorized access to critical system credentials or configuration."
 
 defaults:
-  action: "allow"
+  action: "deny"
   max_tokens: 4096
   max_tool_calls: 10
   confidence_threshold: 0.8

--- a/examples/policies/lotl_prevention_policy.yaml
+++ b/examples/policies/lotl_prevention_policy.yaml
@@ -41,9 +41,3 @@ rules:
     action: "deny"
     priority: 200
     message: "Security Violation: Unauthorized access to critical system credentials or configuration."
-
-defaults:
-  action: "deny"
-  max_tokens: 4096
-  max_tool_calls: 10
-  confidence_threshold: 0.8


### PR DESCRIPTION
## Description
Fix the CI Policy Validation check by conforming examples/policies/lotl_prevention_policy.yaml to the PolicyDocument Pydantic schema.

The original file used a non-standard schema (nested metadata, id instead of name, parameter instead of field, invalid operator regex_match, invalid actions shell_exec/file_read, and an effect field). This caused 7 Pydantic validation errors.

### Key changes
| Field | Before (invalid) | After (valid) |
|---|---|---|
| Top-level structure | Nested under metadata | Flat name, version, description |
| Rule identifier | id | name |
| Condition key | parameter | field |
| Operator | regex_match | matches |
| Action values | shell_exec, file_read | deny |
| Effect field | effect: DENY | Removed (redundant) |

Security intent (LotL prevention) is fully preserved.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Package(s) Affected
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the Microsoft CLA

## Related Issues
N/A - discovered via CI Policy Validation check failure.