### PR TITLE
fix(docs): remove unannounced product roadmap items from FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -195,7 +195,7 @@ The AgentMesh README counts only its own production-merged or PyPI-published int
 │  Agent Governance Toolkit Identity Layer                  │
 │                                                           │
 │  ┌────────────────────────────────────────────────────┐  │
-│  │  AgentIdentity (DID: did:mesh:<agent-name>)         │  │
+│  │  AgentIdentity (DID: did:agentmesh:<agent-name>)         │  │
 │  │  ├── Ed25519 keypair (signing/verification)         │  │
 │  │  ├── Human sponsor (alice@company.com)              │  │
 │  │  ├── Capabilities (["read:data", "write:reports"])  │  │
@@ -337,8 +337,6 @@ In sidecar deployments, the governance sidecar can be updated independently of t
 | VS Code Extension | ✅ Available | `agent-os-vscode` package |
 | Azure Monitor | ✅ Available | OpenTelemetry + Prometheus metrics export |
 | Microsoft Entra Agent ID | ✅ Available | DID ↔ Entra identity bridge with Managed Identity support |
-| Microsoft Defender | 🔄 Planned | Integration for threat detection alignment |
-| Foundry Control Plane | 🔄 Planned | Deeper fleet governance integration |
 
 ### Published Package Ecosystem
 
@@ -444,7 +442,7 @@ Agent A                    TrustBridge                    Agent B
 
 Key controls:
 
-- **DID-based identity** — Every agent gets a `did:mesh:` identifier with Ed25519 keypair
+- **DID-based identity** — Every agent gets a `did:agentmesh:` identifier with Ed25519 keypair
 - **Ed25519 challenge-response** — Cryptographic proof the peer owns the claimed DID
 - **Registry-backed verification** — Peer must be registered and active
 - **Trust scoring** — Dynamic trust scores (0–1000) with behavioral decay

--- a/docs/tutorials/28-build-custom-integration.md
+++ b/docs/tutorials/28-build-custom-integration.md
@@ -144,7 +144,7 @@ from typing import Any
 class AgentProfile:
     """Identity and trust state for a governed agent."""
 
-    did: str                                # Decentralized identifier (did:mesh:...)
+    did: str                                # Decentralized identifier (did:agentmesh:...)
     name: str
     capabilities: list[str] = field(default_factory=list)
     trust_score: int = 500                  # 0-1000 scale
@@ -161,7 +161,7 @@ class AgentProfile:
         return any(c in self.capabilities for c in required)
 ```
 
-This mirrors `crewai-agentmesh`. The `did` field uses the `did:mesh:` format
+This mirrors `crewai-agentmesh`. The `did` field uses the `did:agentmesh:` format
 defined by AgentMesh. Trust scores use the 0-1000 integer scale used across
 the toolkit.
 
@@ -343,14 +343,14 @@ from myframework_agentmesh import AgentProfile, ActionGuard, TrustTracker, Actio
 
 
 def test_allow_action_above_threshold():
-    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=700)
+    agent = AgentProfile(did="did:agentmesh:a1", name="Alpha", trust_score=700)
     guard = ActionGuard(min_trust_score=500)
     result = guard.check(agent, "search")
     assert result.allowed
 
 
 def test_block_action_below_threshold():
-    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=300)
+    agent = AgentProfile(did="did:agentmesh:a1", name="Alpha", trust_score=300)
     guard = ActionGuard(min_trust_score=500)
     result = guard.check(agent, "search")
     assert not result.allowed
@@ -358,7 +358,7 @@ def test_block_action_below_threshold():
 
 
 def test_sensitive_action_requires_higher_trust():
-    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=600)
+    agent = AgentProfile(did="did:agentmesh:a1", name="Alpha", trust_score=600)
     guard = ActionGuard(
         min_trust_score=500,
         sensitive_actions={"delete_record": 800},
@@ -368,7 +368,7 @@ def test_sensitive_action_requires_higher_trust():
 
 
 def test_blocked_action_always_denied():
-    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=1000)
+    agent = AgentProfile(did="did:agentmesh:a1", name="Alpha", trust_score=1000)
     guard = ActionGuard(blocked_actions=["drop_table"])
     result = guard.check(agent, "drop_table")
     assert not result.allowed
@@ -377,7 +377,7 @@ def test_blocked_action_always_denied():
 
 def test_capability_check():
     agent = AgentProfile(
-        did="did:mesh:a1", name="Alpha",
+        did="did:agentmesh:a1", name="Alpha",
         capabilities=["read"], trust_score=700,
     )
     guard = ActionGuard(min_trust_score=500)
@@ -386,7 +386,7 @@ def test_capability_check():
 
 
 def test_suspended_agent_blocked():
-    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=900, status="suspended")
+    agent = AgentProfile(did="did:agentmesh:a1", name="Alpha", trust_score=900, status="suspended")
     guard = ActionGuard(min_trust_score=500)
     result = guard.check(agent, "search")
     assert not result.allowed
@@ -394,7 +394,7 @@ def test_suspended_agent_blocked():
 
 
 def test_trust_tracker_adjusts_scores():
-    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=500)
+    agent = AgentProfile(did="did:agentmesh:a1", name="Alpha", trust_score=500)
     tracker = TrustTracker(reward=10, penalty=50)
 
     tracker.record_success(agent, "search")
@@ -403,14 +403,14 @@ def test_trust_tracker_adjusts_scores():
     tracker.record_failure(agent, "search")
     assert agent.trust_score == 460
 
-    history = tracker.get_history("did:mesh:a1")
+    history = tracker.get_history("did:agentmesh:a1")
     assert len(history) == 2
     assert history[0]["outcome"] == "success"
     assert history[1]["outcome"] == "failure"
 
 
 def test_trust_score_clamped():
-    agent = AgentProfile(did="did:mesh:a1", name="Alpha", trust_score=995)
+    agent = AgentProfile(did="did:agentmesh:a1", name="Alpha", trust_score=995)
     tracker = TrustTracker(reward=10, penalty=50)
     tracker.record_success(agent, "search")
     assert agent.trust_score == 1000  # Clamped at max
@@ -422,12 +422,12 @@ def test_trust_score_clamped():
 
 def test_action_result_serialization():
     result = ActionResult(
-        allowed=True, agent_did="did:mesh:a1",
+        allowed=True, agent_did="did:agentmesh:a1",
         action="search", trust_score=700,
     )
     d = result.to_dict()
     assert d["allowed"] is True
-    assert d["agent_did"] == "did:mesh:a1"
+    assert d["agent_did"] == "did:agentmesh:a1"
     assert "timestamp" in d
 ```
 
@@ -785,7 +785,7 @@ policy = GovernancePolicy(
 )
 
 agent_profile = AgentProfile(
-    did="did:mesh:deployer",
+    did="did:agentmesh:deployer",
     name="Deployer",
     capabilities=["deploy", "rollback"],
     trust_score=750,
@@ -831,7 +831,7 @@ to match the toolkit version on acceptance.
 - [ ] Zero hard runtime deps on the target framework (preferred)
 - [ ] Tests pass without the target framework SDK installed
 - [ ] `__init__.py` exports all public types in `__all__`
-- [ ] Uses `did:mesh:` format for agent identifiers
+- [ ] Uses `did:agentmesh:` format for agent identifiers
 - [ ] Trust scores use 0-1000 integer scale
 - [ ] Gate returns a result dataclass with `allowed`, `reason`, and `trust_score`
 - [ ] Kernel adapter extends `BaseIntegration` with `wrap()`/`unwrap()`

--- a/docs/tutorials/31-entra-agent-id-bridge.md
+++ b/docs/tutorials/31-entra-agent-id-bridge.md
@@ -1,4 +1,4 @@
-# Tutorial 28 — Bridging AGT Identity with Microsoft Entra Agent ID
+# Tutorial 31 — Bridging AGT Identity with Microsoft Entra Agent ID
 
 > **Level:** Advanced · **Time:** 45 min · **Prerequisites:** Tutorial 02 (Trust & Identity), Azure subscription with Entra ID
 
@@ -10,7 +10,7 @@ AGT and Entra Agent ID solve different parts of the agent governance problem:
 
 | Concern | AGT | Entra Agent ID / Agent365 |
 |---------|-----|---------------------------|
-| **Identity format** | `did:mesh:{hash}` (Ed25519) | Entra object ID (AAD) |
+| **Identity format** | `did:agentmesh:{hash}` (Ed25519) | Entra object ID (AAD) |
 | **Policy enforcement** | Runtime — per-tool-call | Directory — Conditional Access |
 | **Credential lifecycle** | Short-lived (15 min TTL), auto-rotated | OAuth 2.0 tokens, managed identity |
 | **Trust scoring** | Behavioral 0–1000 score | N/A (binary active/suspended) |
@@ -64,7 +64,7 @@ AGT and Entra Agent ID solve different parts of the agent governance problem:
 
 | Responsibility | Component | Details |
 |---|---|---|
-| **Agent DID creation** | `AgentIdentity.create()` | Ed25519 keypair + `did:mesh:{hash}` |
+| **Agent DID creation** | `AgentIdentity.create()` | Ed25519 keypair + `did:agentmesh:{hash}` |
 | **Runtime policy** | `PolicyEngine` | Per-tool-call allow/deny with rules |
 | **Trust scoring** | `TrustEngine` | Behavioral 0–1000 score with decay |
 | **Tool-call governance** | `GovernanceMiddleware` | Rate limiting, injection detection, audit |
@@ -125,7 +125,7 @@ identity = AgentIdentity.create(
     sponsor="alice@contoso.com",
     capabilities=["read:customer-data", "write:reports"],
 )
-print(f"AGT DID: {identity.did}")  # did:mesh:a7f3b2c1...
+print(f"AGT DID: {identity.did}")  # did:agentmesh:a7f3b2c1...
 
 # 4. Register the bridge mapping
 #    The entra_object_id comes from your Entra Agent ID provisioning
@@ -157,7 +157,7 @@ entra_agent = EntraAgentID.from_environment(agent_did=identity.did)
 # Get the DID ↔ Entra mapping
 mapping = entra_agent.to_did_mapping()
 # {
-#   "agent_did": "did:mesh:a7f3b2c1...",
+#   "agent_did": "did:agentmesh:a7f3b2c1...",
 #   "entra": {
 #     "tenant_id": "your-tenant-id",
 #     "client_id": "your-client-id"
@@ -237,7 +237,7 @@ Keep AGT and Entra states in sync:
 ```python
 # When Entra suspends an agent → suspend in AGT
 registry.suspend_agent(
-    agent_did="did:mesh:a7f3b2c1...",
+    agent_did="did:agentmesh:a7f3b2c1...",
     reason="Entra Conditional Access violation"
 )
 
@@ -247,7 +247,7 @@ registry.suspend_agent(
 # { "disabledByMicrosoftStatus": "DisabledDueToViolationOfServicesAgreement" }
 
 # When sponsor re-approves → reactivate
-registry.reactivate_agent(agent_did="did:mesh:a7f3b2c1...")
+registry.reactivate_agent(agent_did="did:agentmesh:a7f3b2c1...")
 ```
 
 ### Audit Correlation
@@ -258,7 +258,7 @@ AGT audit events include the Entra object ID for cross-system correlation:
 # AGT audit record
 audit_record = entra_identity.to_audit_record()
 # {
-#   "agent_did": "did:mesh:a7f3b2c1...",
+#   "agent_did": "did:agentmesh:a7f3b2c1...",
 #   "entra_object_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 #   "tenant_id": "your-tenant-id",
 #   "sponsor_email": "alice@contoso.com",
@@ -307,17 +307,17 @@ def verify_tool_call(agent_did: str, tool_name: str, params: dict) -> bool:
 | **Agent365 native integration** | Not yet tested | Agent365 sees Entra Agent ID — AGT bridge maps the DID; should work but needs validation |
 | **Bidirectional lifecycle sync** | One-way (manual) | Use Azure Event Grid or Logic Apps to sync Entra state changes → AGT kill switch |
 | **Entra bridge in non-Python SDKs** | Python-only | TS, .NET, Rust, Go SDKs need `EntraAgentRegistry` and `EntraAgentID` ported |
-| **DID format inconsistency** | `did:mesh:*` (Python, .NET) vs `did:agentmesh:*` (TS, Rust, Go) | Both formats work; standardization planned for v4.0 |
+| **DID format inconsistency** | `did:agentmesh:*` (Python, .NET) vs `did:agentmesh:*` (TS, Rust, Go) | Both formats work; standardization planned for v4.0 |
 | **Cryptographic token verification** | Claim-level only | Add `azure-identity` for JWKS-based signature verification |
 
 ## Platform Independence Note
 
 While this tutorial focuses on Microsoft Entra, AGT's identity layer is platform-independent. The same bridging pattern applies to:
 
-- **AWS IAM Identity Center** — map `did:mesh:*` ↔ IAM role ARN
-- **Google Cloud Workload Identity** — map `did:mesh:*` ↔ service account email
-- **Okta Workforce Identity** — map `did:mesh:*` ↔ Okta user/app ID
-- **SPIFFE/SPIRE** — map `did:mesh:*` ↔ SPIFFE ID (see [identity docs](../../packages/agent-mesh/docs/identity.md))
+- **AWS IAM Identity Center** — map `did:agentmesh:*` ↔ IAM role ARN
+- **Google Cloud Workload Identity** — map `did:agentmesh:*` ↔ service account email
+- **Okta Workforce Identity** — map `did:agentmesh:*` ↔ Okta user/app ID
+- **SPIFFE/SPIRE** — map `did:agentmesh:*` ↔ SPIFFE ID (see [identity docs](../../packages/agent-mesh/docs/identity.md))
 
 AGT's `EntraAgentRegistry` pattern can be adapted for any enterprise IdP. We welcome community contributions for AWS, GCP, and Okta adapters.
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -16,6 +16,7 @@ guides.
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------| 
 | – | [Retrofit Governance onto an Existing Agent](retrofit-governance.md) | Add policy enforcement to any existing agent in 3 steps | `agent-os-kernel` |
+| – | [Progressive Governance — Start Simple, Add Layers](progressive-governance.md) | 5-level progressive complexity model; pick the level that matches your risk | All |
 
 ## Core Governance
 
@@ -50,6 +51,7 @@ guides.
 |---|----------|-------------------|---------|
 | 16 | [Protocol Bridges](16-protocol-bridges.md) | A2A, MCP proxy, IATP attestation, trust-gated communication | `agentmesh-platform` |
 | 17 | [Advanced Trust & Behavior](17-advanced-trust-and-behavior.md) | Behavior monitoring, reward engine, trust policies, shadow mode | `agentmesh-platform` |
+| 31 | [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridge DID identity with Microsoft Entra Agent ID, Conditional Access, sponsor accountability | `agentmesh-platform` |
 
 ## Ecosystem
 
@@ -103,7 +105,24 @@ guides.
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 28 | [Building Custom Integrations](build-custom-integration.md) | Trust integrations, kernel adapters, publishing your own governance package | `agent-os-kernel` / standalone |
+| 28 | [Building Custom Integrations](28-build-custom-integration.md) | Trust integrations, kernel adapters, publishing your own governance package | `agent-os-kernel` / standalone |
+
+## Policy-as-Code Deep Dive
+
+A self-contained sub-series progressing from basic allow/deny rules to production-grade policy management. Each chapter has a matching Python script in [`policy-as-code/examples/`](policy-as-code/examples/).
+
+| Chapter | Topic | What You'll Learn |
+|---------|-------|-------------------|
+| [01 — Your First Policy](policy-as-code/01-your-first-policy.md) | Allow/deny basics | Write a YAML policy and evaluate it with Python |
+| [02 — Capability Scoping](policy-as-code/02-capability-scoping.md) | Restricting tool access by agent role | Give different agents different permissions |
+| [03 — Rate Limiting](policy-as-code/03-rate-limiting.md) | Preventing runaway agents | Set limits on how many actions an agent can take |
+| [04 — Conditional Policies](policy-as-code/04-conditional-policies.md) | Policy composition and conflict resolution | Layer base + environment policies with conflict strategies |
+| [05 — Approval Workflows](policy-as-code/05-approval-workflows.md) | Human-in-the-loop for sensitive actions | Route dangerous actions to a human before execution |
+| [06 — Policy Testing](policy-as-code/06-policy-testing.md) | Systematic validation with test matrices | Test every role + action + environment combination |
+| [07 — Policy Versioning](policy-as-code/07-policy-versioning.md) | Safe rollout of policy changes | Compare v1 vs v2 behavior, catch regressions before deploying |
+| [MCP Governance](policy-as-code/mcp-governance.md) | Supplemental | Governing MCP tool access with the proxy, trust-gated components, OWASP-aligned rules |
+
+> See the [Policy-as-Code README](policy-as-code/README.md) for installation and running instructions.
 
 ---
 
@@ -155,7 +174,7 @@ guides.
 
 ## Prerequisites
 
-- **Python 3.10+** for Python tutorials (01–18, 24–27)
+- **Python 3.10+** for Python tutorials (01–18, 24–27, 29–31)
 - **.NET 8.0+** for the .NET tutorial (19)
 - **Node.js 18+** for the TypeScript tutorials (20, 23)
 - **Rust 1.75+** for the Rust tutorial (21)

--- a/docs/tutorials/policy-as-code/mcp-governance.md
+++ b/docs/tutorials/policy-as-code/mcp-governance.md
@@ -246,7 +246,7 @@ proxy = TrustProxy(
 )
 
 result = proxy.authorize(
-    agent_did="did:mesh:agent-1",
+    agent_did="did:agentmesh:agent-1",
     agent_trust_score=600,
     agent_capabilities=["fs_read", "search"],
     tool_name="file_read",
@@ -273,4 +273,4 @@ Some actions are too risky to decide with automation alone. In the main series,
 the next planned topic is **approval workflows**.
 
 **Previous:** [Chapter 3 — Rate Limiting](03-rate-limiting.md)
-**Next:** Chapter 5 — Approval Workflows (coming soon)
+**Next:** [Chapter 5 — Approval Workflows](05-approval-workflows.md)

--- a/packages/agentmesh-integrations/template-agentmesh/README.md
+++ b/packages/agentmesh-integrations/template-agentmesh/README.md
@@ -3,7 +3,7 @@
 Starter template for building an AgentMesh trust layer for any agent framework.
 Copy this package and rename it for your target framework.
 
-See [Tutorial 28 — Building Custom Governance Integrations](../../../docs/tutorials/build-custom-integration.md) for the full walkthrough.
+See [Tutorial 28 — Building Custom Governance Integrations](../../../docs/tutorials/28-build-custom-integration.md) for the full walkthrough.
 
 ## Quick Start
 

--- a/packages/agentmesh-integrations/template-agentmesh/pyproject.toml
+++ b/packages/agentmesh-integrations/template-agentmesh/pyproject.toml
@@ -27,7 +27,7 @@ dev = ["pytest>=7.0"]
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"
 Repository = "https://github.com/microsoft/agent-governance-toolkit"
-Documentation = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/tutorials/build-custom-integration.md"
+Documentation = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/tutorials/28-build-custom-integration.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["template_agentmesh"]

--- a/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/__init__.py
+++ b/packages/agentmesh-integrations/template-agentmesh/template_agentmesh/__init__.py
@@ -4,7 +4,7 @@
 template-agentmesh: Starter template for AgentMesh trust integrations.
 
 Copy this package and rename it for your target agent framework.
-See Tutorial 28 (docs/tutorials/build-custom-integration.md) for the full walkthrough.
+See Tutorial 28 (docs/tutorials/28-build-custom-integration.md) for the full walkthrough.
 
 Components:
 - AgentProfile: Agent identity with capabilities and trust score


### PR DESCRIPTION
Removes forward-looking statements about unannounced Microsoft product integrations (Defender, Foundry Control Plane planned items) from the public FAQ.