### PR TITLE
fix: add Windows UTF-8 console reconfiguration to policy-as-code examples

### DIFF
--- a/docs/tutorials/policy-as-code/examples/01_first_policy.py
+++ b/docs/tutorials/policy-as-code/examples/01_first_policy.py
@@ -15,6 +15,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+
+# ── Windows UTF-8 console fix ──────────────────────────────────────────
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # Allow running from the repo root without installing the packages.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))

--- a/docs/tutorials/policy-as-code/examples/02_capability_scoping.py
+++ b/docs/tutorials/policy-as-code/examples/02_capability_scoping.py
@@ -16,6 +16,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+
+# ── Windows UTF-8 console fix ──────────────────────────────────────────
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # Allow running from the repo root without installing the packages.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))

--- a/docs/tutorials/policy-as-code/examples/03_rate_limiting.py
+++ b/docs/tutorials/policy-as-code/examples/03_rate_limiting.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+
+# ── Windows UTF-8 console fix ──────────────────────────────────────────
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # Allow running from the repo root without installing the packages.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))

--- a/docs/tutorials/policy-as-code/examples/04_conditional_policies.py
+++ b/docs/tutorials/policy-as-code/examples/04_conditional_policies.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+
+# ── Windows UTF-8 console fix ──────────────────────────────────────────
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # Allow running from the repo root without installing the packages.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))

--- a/docs/tutorials/policy-as-code/examples/05_approval_workflows.py
+++ b/docs/tutorials/policy-as-code/examples/05_approval_workflows.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+
+# ── Windows UTF-8 console fix ──────────────────────────────────────────
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # Allow running from the repo root without installing the packages.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))

--- a/docs/tutorials/policy-as-code/examples/06_policy_testing.py
+++ b/docs/tutorials/policy-as-code/examples/06_policy_testing.py
@@ -19,6 +19,12 @@ from pathlib import Path
 
 import yaml
 
+
+# ── Windows UTF-8 console fix ──────────────────────────────────────────
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # Allow running from the repo root without installing the packages.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))

--- a/docs/tutorials/policy-as-code/examples/07_policy_versioning.py
+++ b/docs/tutorials/policy-as-code/examples/07_policy_versioning.py
@@ -16,6 +16,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+
+# ── Windows UTF-8 console fix ──────────────────────────────────────────
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # Allow running from the repo root without installing the packages.
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))


### PR DESCRIPTION
## Fix for #1172

All 7 `docs/tutorials/policy-as-code/examples/*.py` scripts fail on Windows with `UnicodeEncodeError` when printing emoji characters (✅ 🚫 → ⏳) because the default console encoding is `cp1252`.

### Changes

Added a platform-specific stdout/stderr reconfiguration after imports in each affected script:

```python
if sys.platform == "win32":
    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
```

### Why this approach

- **Platform-specific**: Only runs on Windows (`sys.platform == "win32"`)
- **Minimal**: No behavior change on Linux/macOS
- **Graceful degradation**: `errors="replace"` prevents crashes even if a character cannot be encoded
- **Standard pattern**: `sys.stdout.reconfigure()` is the recommended Python 3.7+ approach

### Affected files

- `01_first_policy.py`
- `02_capability_scoping.py`
- `03_rate_limiting.py`
- `04_conditional_policies.py`
- `05_approval_workflows.py`
- `06_policy_testing.py`
- `07_policy_versioning.py`

### Testing

Verified that the fix:
- Does not change any output on Linux/macOS
- Correctly reconfigures stdout/stderr on Windows
- Preserves all emoji rendering on UTF-8 capable terminals

Closes #1172