### PR TITLE
feat: Graph API group membership sync for Entra Agent ID bridge (closes #1173, addresses #1174)

### DIFF
--- a/docs/tutorials/31-entra-agent-id-bridge.md
+++ b/docs/tutorials/31-entra-agent-id-bridge.md
@@ -242,9 +242,9 @@ registry.suspend_agent(
 )
 
 # When AGT kill switch fires → disable in Entra
-# (This requires Graph API — not yet built into AGT)
-# POST https://graph.microsoft.com/v1.0/applications/{entra_object_id}
-# { "disabledByMicrosoftStatus": "DisabledDueToViolationOfServicesAgreement" }
+# Use Graph API: PATCH /servicePrincipals/{entra_object_id}
+# with { "accountEnabled": false }
+# (Requires Directory.ReadWrite.All or Application.ReadWrite.All permission)
 
 # When sponsor re-approves → reactivate
 registry.reactivate_agent(agent_did="did:agentmesh:a7f3b2c1...")
@@ -299,13 +299,58 @@ def verify_tool_call(agent_did: str, tool_name: str, params: dict) -> bool:
     return True
 ```
 
+## Step 6 — Group Membership Sync via Graph API
+
+Automatically map Entra group memberships to AGT capabilities:
+
+```python
+from agentmesh.identity.entra_graph import EntraGraphClient, build_group_scope_map
+
+# 1. Get a Graph API token (via managed identity, workload identity, etc.)
+token = entra_agent.get_agent_token(scope="https://graph.microsoft.com/.default")
+
+# 2. Create the Graph client
+graph_client = EntraGraphClient(access_token=token)
+
+# 3. Define group-to-capability mapping (keyed by Entra group object ID)
+group_scope_map = build_group_scope_map({
+    "aaaaaaaa-1111-2222-3333-444444444444": ["read:customer-data", "read:reports"],
+    "bbbbbbbb-1111-2222-3333-444444444444": ["write:reports", "export:csv"],
+})
+
+# 4. Sync — fetches groups from Graph, maps to capabilities, preserves manual caps
+capabilities = registry.sync_group_memberships(
+    agent_did=identity.did,
+    graph_client=graph_client,
+    group_scope_map=group_scope_map,
+)
+print(f"Updated capabilities: {capabilities}")
+# ['export:csv', 'manual:cap', 'read:customer-data', 'read:reports', 'write:reports']
+```
+
+> **Note:** The Graph API call requires `GroupMember.Read.All` or `Directory.Read.All` permission on the Entra application. Group sync only updates AGT **capabilities** — Entra API **scopes** remain unchanged.
+
+## Step 7 — Validate Bridge Configuration
+
+Before going to production, validate the bridge mapping is complete:
+
+```python
+valid, issues = registry.validate_bridge_configuration(agent_did=identity.did)
+if not valid:
+    print(f"Bridge configuration issues: {issues}")
+    # e.g., ['Missing entra_app_id — Agent365 may not resolve the agent']
+else:
+    print("Bridge configuration OK — ready for enterprise deployment")
+```
+
 ## Known Gaps and Limitations
 
 | Gap | Status | Workaround |
 |-----|--------|------------|
-| **Graph API provisioning** | Not in AGT | Create Entra Agent ID via Azure Portal or Graph API, then register mapping in AGT |
-| **Agent365 native integration** | Not yet tested | Agent365 sees Entra Agent ID — AGT bridge maps the DID; should work but needs validation |
+| **Graph API group membership sync** | ✅ Built | `EntraGraphClient.get_group_memberships()` + `EntraAgentRegistry.sync_group_memberships()` — maps Entra groups to AGT capabilities |
+| **Agent365 native integration** | Configuration validated | `EntraAgentRegistry.validate_bridge_configuration()` checks bridge mapping completeness; end-to-end Agent365 testing pending |
 | **Bidirectional lifecycle sync** | One-way (manual) | Use Azure Event Grid or Logic Apps to sync Entra state changes → AGT kill switch |
+| **Graph API service principal disable** | Not in AGT | Use Graph API directly: `PATCH /servicePrincipals/{id}` with `accountEnabled: false` |
 | **Entra bridge in non-Python SDKs** | Python-only | TS, .NET, Rust, Go SDKs need `EntraAgentRegistry` and `EntraAgentID` ported |
 | **DID format inconsistency** | `did:agentmesh:*` (Python, .NET) vs `did:agentmesh:*` (TS, Rust, Go) | Both formats work; standardization planned for v4.0 |
 | **Cryptographic token verification** | Claim-level only | Add `azure-identity` for JWKS-based signature verification |

--- a/packages/agent-mesh/src/agentmesh/identity/entra.py
+++ b/packages/agent-mesh/src/agentmesh/identity/entra.py
@@ -12,11 +12,17 @@ Requires: azure-identity (optional dependency)
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from agentmesh.identity.entra_graph import EntraGraphClient
+
+logger = logging.getLogger(__name__)
 
 
 class EntraAgentStatus(str, Enum):
@@ -279,6 +285,95 @@ class EntraAgentRegistry:
     def get_audit_log(self) -> list[dict[str, Any]]:
         """Return the full audit log."""
         return list(self._audit_log)
+
+    # -- Graph API integration (Issue #1173) -----------------------------------
+
+    def sync_group_memberships(
+        self,
+        agent_did: str,
+        graph_client: "EntraGraphClient",
+        group_scope_map: dict[str, list[str]],
+    ) -> list[str]:
+        """
+        Sync Entra group memberships to AGT capabilities for an agent.
+
+        Fetches the agent's group memberships from Microsoft Graph API,
+        maps them to AGT capabilities using ``group_scope_map``, and
+        updates the agent's capabilities (preserving manually assigned ones).
+
+        Args:
+            agent_did: The agent's AgentMesh DID.
+            graph_client: An authenticated ``EntraGraphClient`` instance.
+            group_scope_map: Mapping of Entra group object IDs to lists
+                of AGT capability strings.
+
+        Returns:
+            The updated list of capabilities.
+
+        Raises:
+            KeyError: If the agent is not registered.
+            GraphAPIError: If the Graph API call fails.
+        """
+        from agentmesh.identity.entra_graph import sync_memberships_to_capabilities
+
+        identity = self._agents.get(agent_did)
+        if not identity:
+            raise KeyError(f"Agent {agent_did!r} not found in registry")
+
+        groups = graph_client.get_group_memberships(identity.entra_object_id)
+
+        new_caps = sync_memberships_to_capabilities(
+            groups=groups,
+            group_scope_map=group_scope_map,
+            preserve_existing=identity.capabilities,
+        )
+
+        identity.capabilities = new_caps
+        self._log_event("sync_group_memberships", identity, {
+            "groups_found": len(groups),
+            "capabilities_after": new_caps,
+        })
+        return new_caps
+
+    # -- Bridge validation (Issue #1174) ---------------------------------------
+
+    def validate_bridge_configuration(
+        self, agent_did: str
+    ) -> tuple[bool, list[str]]:
+        """
+        Validate that an agent's Entra bridge configuration is complete.
+
+        Checks that all required fields for enterprise identity bridging
+        are populated. This validates the **configuration** (not live
+        connectivity to Entra or Agent365).
+
+        Returns:
+            Tuple of (valid, issues) where issues is a list of problems found.
+        """
+        identity = self._agents.get(agent_did)
+        if not identity:
+            return False, [f"Agent {agent_did!r} not found in registry"]
+
+        issues: list[str] = []
+
+        if not identity.entra_object_id:
+            issues.append("Missing entra_object_id")
+        if not identity.tenant_id:
+            issues.append("Missing tenant_id")
+        if not identity.sponsor_email:
+            issues.append("Missing sponsor_email (required for Agent365)")
+        if not identity.agent_did:
+            issues.append("Missing agent_did")
+        if identity.status != EntraAgentStatus.ACTIVE:
+            issues.append(
+                f"Agent status is {identity.status.value}, expected active"
+            )
+        if not identity.entra_app_id:
+            issues.append(
+                "Missing entra_app_id — Agent365 may not resolve the agent"
+            )
+
+        return (len(issues) == 0, issues)
 
     def _log_event(
         self,

--- a/packages/agent-mesh/src/agentmesh/identity/entra_graph.py
+++ b/packages/agent-mesh/src/agentmesh/identity/entra_graph.py
@@ -1,0 +1,212 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Microsoft Graph API client for Entra Agent ID integration.
+
+Provides group membership queries and capability scope synchronization
+using only the Python standard library (urllib).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+
+
+class GraphAPIError(Exception):
+    """Raised when a Graph API call fails."""
+
+    def __init__(self, message: str, status_code: int = 0) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class EntraGraphClient:
+    """
+    Lightweight Microsoft Graph API client for agent identity operations.
+
+    Accepts an injected access token so callers can use any auth flow
+    (managed identity, client credentials, workload identity federation).
+
+    Usage::
+
+        token = entra_agent_id.get_agent_token(
+            scope="https://graph.microsoft.com/.default"
+        )
+        client = EntraGraphClient(access_token=token)
+        groups = client.get_group_memberships("service-principal-object-id")
+    """
+
+    def __init__(self, access_token: str, *, timeout: int = 10) -> None:
+        if not access_token:
+            raise ValueError("access_token must not be empty")
+        self._token = access_token
+        self._timeout = timeout
+
+    # -- public API ------------------------------------------------------------
+
+    def get_group_memberships(self, object_id: str) -> list[dict[str, Any]]:
+        """
+        Fetch Entra group memberships for a service principal.
+
+        Calls ``GET /servicePrincipals/{id}/memberOf/microsoft.graph.group``
+        and follows ``@odata.nextLink`` pagination automatically.
+
+        Returns a list of group dicts with at least ``id`` and ``displayName``.
+        """
+        if not object_id:
+            raise ValueError("object_id must not be empty")
+
+        url = (
+            f"{GRAPH_BASE}/servicePrincipals/{object_id}"
+            f"/memberOf/microsoft.graph.group"
+            f"?$select=id,displayName,description"
+        )
+        groups: list[dict[str, Any]] = []
+
+        while url:
+            data = self._get(url)
+            for item in data.get("value", []):
+                groups.append({
+                    "id": item["id"],
+                    "displayName": item.get("displayName", ""),
+                    "description": item.get("description", ""),
+                })
+            url = data.get("@odata.nextLink")
+
+        return groups
+
+    def get_app_role_assignments(self, object_id: str) -> list[dict[str, Any]]:
+        """
+        Fetch app role assignments for a service principal.
+
+        Returns a list of role assignment dicts.
+        """
+        if not object_id:
+            raise ValueError("object_id must not be empty")
+
+        url = (
+            f"{GRAPH_BASE}/servicePrincipals/{object_id}/appRoleAssignments"
+            f"?$select=id,appRoleId,resourceDisplayName"
+        )
+        roles: list[dict[str, Any]] = []
+
+        while url:
+            data = self._get(url)
+            for item in data.get("value", []):
+                roles.append({
+                    "id": item["id"],
+                    "appRoleId": item.get("appRoleId", ""),
+                    "resourceDisplayName": item.get("resourceDisplayName", ""),
+                })
+            url = data.get("@odata.nextLink")
+
+        return roles
+
+    # -- internals -------------------------------------------------------------
+
+    def _get(self, url: str) -> dict[str, Any]:
+        """Execute a GET request against Graph API."""
+        req = Request(url, headers={
+            "Authorization": f"Bearer {self._token}",
+            "Accept": "application/json",
+            "ConsistencyLevel": "eventual",
+        })
+        try:
+            with urlopen(req, timeout=self._timeout) as resp:
+                return json.loads(resp.read().decode())
+        except HTTPError as exc:
+            body = ""
+            try:
+                body = exc.read().decode()[:500]
+            except Exception:
+                pass
+            raise GraphAPIError(
+                f"Graph API returned {exc.code}: {body}",
+                status_code=exc.code,
+            ) from exc
+        except URLError as exc:
+            raise GraphAPIError(
+                f"Failed to reach Graph API: {exc.reason}"
+            ) from exc
+
+
+def build_group_scope_map(
+    mappings: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """
+    Validate and normalize a group-to-capability mapping.
+
+    Keys are Entra group **object IDs** (UUIDs). Values are lists of
+    AGT capability strings to grant when the agent is a member.
+
+    Example::
+
+        map = build_group_scope_map({
+            "aaa-bbb-ccc": ["read:customer-data", "read:reports"],
+            "ddd-eee-fff": ["write:reports"],
+        })
+    """
+    if not mappings:
+        raise ValueError("group_scope_map must not be empty")
+
+    normalized: dict[str, list[str]] = {}
+    for group_id, caps in mappings.items():
+        if not group_id:
+            raise ValueError("Group ID must not be empty")
+        if not caps:
+            raise ValueError(f"Capabilities list for group {group_id!r} must not be empty")
+        normalized[group_id] = list(caps)
+
+    return normalized
+
+
+def sync_memberships_to_capabilities(
+    groups: list[dict[str, Any]],
+    group_scope_map: dict[str, list[str]],
+    *,
+    preserve_existing: Optional[list[str]] = None,
+) -> list[str]:
+    """
+    Map Entra group memberships to AGT capabilities.
+
+    Only groups present in ``group_scope_map`` contribute capabilities.
+    Unknown groups are logged and skipped. Manually assigned capabilities
+    in ``preserve_existing`` are preserved (union merge).
+
+    Returns a deduplicated, sorted list of capabilities.
+    """
+    derived: set[str] = set()
+
+    matched = 0
+    for group in groups:
+        group_id = group.get("id", "")
+        caps = group_scope_map.get(group_id)
+        if caps:
+            derived.update(caps)
+            matched += 1
+        else:
+            logger.debug(
+                "Skipping unmapped group %r (%s)",
+                group.get("displayName", ""),
+                group_id,
+            )
+
+    if matched == 0:
+        logger.warning(
+            "No Entra groups matched the scope map (%d groups checked)",
+            len(groups),
+        )
+
+    # Preserve manually assigned capabilities
+    if preserve_existing:
+        derived.update(preserve_existing)
+
+    return sorted(derived)

--- a/packages/agent-mesh/tests/test_entra_graph.py
+++ b/packages/agent-mesh/tests/test_entra_graph.py
@@ -1,0 +1,364 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for Entra Graph API client and group membership sync."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from agentmesh.identity.entra import (
+    EntraAgentRegistry,
+    EntraAgentStatus,
+)
+from agentmesh.identity.entra_graph import (
+    EntraGraphClient,
+    GraphAPIError,
+    build_group_scope_map,
+    sync_memberships_to_capabilities,
+)
+
+TENANT_ID = "contoso-tenant-001"
+SPONSOR = "alice@contoso.com"
+
+# -- Helper to mock urlopen ---------------------------------------------------
+
+
+def _mock_response(data: dict, status: int = 200) -> MagicMock:
+    """Create a mock that works as a context manager returning JSON data."""
+    mock = MagicMock()
+    mock.read.return_value = json.dumps(data).encode()
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    return mock
+
+
+# =============================================================================
+# EntraGraphClient tests
+# =============================================================================
+
+
+class TestEntraGraphClientInit:
+    def test_valid(self):
+        client = EntraGraphClient("token-abc")
+        assert client._token == "token-abc"
+
+    def test_empty_token_rejected(self):
+        with pytest.raises(ValueError, match="access_token"):
+            EntraGraphClient("")
+
+
+class TestGetGroupMemberships:
+    def test_single_page(self):
+        response = {
+            "value": [
+                {"id": "grp-1", "displayName": "Analysts", "description": "Data analysts"},
+                {"id": "grp-2", "displayName": "Reporters", "description": ""},
+            ]
+        }
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            return_value=_mock_response(response),
+        ):
+            client = EntraGraphClient("token")
+            groups = client.get_group_memberships("sp-obj-001")
+
+        assert len(groups) == 2
+        assert groups[0]["id"] == "grp-1"
+        assert groups[0]["displayName"] == "Analysts"
+        assert groups[1]["id"] == "grp-2"
+
+    def test_pagination(self):
+        page1 = {
+            "value": [{"id": "grp-1", "displayName": "G1", "description": ""}],
+            "@odata.nextLink": "https://graph.microsoft.com/v1.0/next-page",
+        }
+        page2 = {
+            "value": [{"id": "grp-2", "displayName": "G2", "description": ""}],
+        }
+        pages = iter([_mock_response(page1), _mock_response(page2)])
+
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            side_effect=lambda *a, **kw: next(pages),
+        ):
+            client = EntraGraphClient("token")
+            groups = client.get_group_memberships("sp-obj-002")
+
+        assert len(groups) == 2
+        assert groups[0]["id"] == "grp-1"
+        assert groups[1]["id"] == "grp-2"
+
+    def test_empty_response(self):
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            return_value=_mock_response({"value": []}),
+        ):
+            client = EntraGraphClient("token")
+            groups = client.get_group_memberships("sp-obj-003")
+
+        assert groups == []
+
+    def test_empty_object_id_rejected(self):
+        client = EntraGraphClient("token")
+        with pytest.raises(ValueError, match="object_id"):
+            client.get_group_memberships("")
+
+    def test_http_error(self):
+        from urllib.error import HTTPError
+
+        err = HTTPError(
+            url="https://graph.microsoft.com/v1.0/...",
+            code=403,
+            msg="Forbidden",
+            hdrs={},
+            fp=MagicMock(read=MagicMock(return_value=b"Insufficient privileges")),
+        )
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            side_effect=err,
+        ):
+            client = EntraGraphClient("token")
+            with pytest.raises(GraphAPIError, match="403") as exc_info:
+                client.get_group_memberships("sp-obj-004")
+            assert exc_info.value.status_code == 403
+
+    def test_url_error(self):
+        from urllib.error import URLError
+
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            side_effect=URLError("timeout"),
+        ):
+            client = EntraGraphClient("token")
+            with pytest.raises(GraphAPIError, match="Failed to reach"):
+                client.get_group_memberships("sp-obj-005")
+
+
+class TestGetAppRoleAssignments:
+    def test_single_page(self):
+        response = {
+            "value": [
+                {"id": "role-1", "appRoleId": "ar-1", "resourceDisplayName": "Graph"},
+            ]
+        }
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            return_value=_mock_response(response),
+        ):
+            client = EntraGraphClient("token")
+            roles = client.get_app_role_assignments("sp-obj-010")
+
+        assert len(roles) == 1
+        assert roles[0]["appRoleId"] == "ar-1"
+
+
+# =============================================================================
+# build_group_scope_map tests
+# =============================================================================
+
+
+class TestBuildGroupScopeMap:
+    def test_valid(self):
+        result = build_group_scope_map({
+            "grp-1": ["read:data", "read:reports"],
+            "grp-2": ["write:reports"],
+        })
+        assert result == {
+            "grp-1": ["read:data", "read:reports"],
+            "grp-2": ["write:reports"],
+        }
+
+    def test_empty_map_rejected(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            build_group_scope_map({})
+
+    def test_empty_group_id_rejected(self):
+        with pytest.raises(ValueError, match="Group ID"):
+            build_group_scope_map({"": ["read:data"]})
+
+    def test_empty_capabilities_rejected(self):
+        with pytest.raises(ValueError, match="Capabilities list"):
+            build_group_scope_map({"grp-1": []})
+
+
+# =============================================================================
+# sync_memberships_to_capabilities tests
+# =============================================================================
+
+
+class TestSyncMembershipsToCapabilities:
+    def test_basic_mapping(self):
+        groups = [
+            {"id": "grp-1", "displayName": "Analysts"},
+            {"id": "grp-2", "displayName": "Writers"},
+        ]
+        scope_map = {
+            "grp-1": ["read:data"],
+            "grp-2": ["write:reports"],
+        }
+        result = sync_memberships_to_capabilities(groups, scope_map)
+        assert result == ["read:data", "write:reports"]
+
+    def test_unmapped_groups_skipped(self):
+        groups = [
+            {"id": "grp-1", "displayName": "Analysts"},
+            {"id": "grp-unknown", "displayName": "Random"},
+        ]
+        scope_map = {"grp-1": ["read:data"]}
+        result = sync_memberships_to_capabilities(groups, scope_map)
+        assert result == ["read:data"]
+
+    def test_no_matches_returns_empty(self):
+        groups = [{"id": "grp-unknown", "displayName": "Random"}]
+        scope_map = {"grp-1": ["read:data"]}
+        result = sync_memberships_to_capabilities(groups, scope_map)
+        assert result == []
+
+    def test_preserve_existing(self):
+        groups = [{"id": "grp-1", "displayName": "Analysts"}]
+        scope_map = {"grp-1": ["read:data"]}
+        result = sync_memberships_to_capabilities(
+            groups, scope_map, preserve_existing=["manual:cap"]
+        )
+        assert result == ["manual:cap", "read:data"]
+
+    def test_deduplication(self):
+        groups = [
+            {"id": "grp-1", "displayName": "G1"},
+            {"id": "grp-2", "displayName": "G2"},
+        ]
+        scope_map = {
+            "grp-1": ["read:data", "shared:cap"],
+            "grp-2": ["write:data", "shared:cap"],
+        }
+        result = sync_memberships_to_capabilities(groups, scope_map)
+        assert result == ["read:data", "shared:cap", "write:data"]
+
+    def test_empty_groups(self):
+        result = sync_memberships_to_capabilities([], {"grp-1": ["read:data"]})
+        assert result == []
+
+
+# =============================================================================
+# EntraAgentRegistry.sync_group_memberships tests
+# =============================================================================
+
+
+class TestRegistrySyncGroupMemberships:
+    def _make_registry_with_agent(self):
+        reg = EntraAgentRegistry(tenant_id=TENANT_ID)
+        reg.register(
+            agent_did="did:mesh:sync-agent",
+            agent_name="Sync Agent",
+            entra_object_id="sp-obj-100",
+            sponsor_email=SPONSOR,
+            capabilities=["manual:cap"],
+            scopes=["Files.Read"],
+        )
+        return reg
+
+    def test_sync_updates_capabilities(self):
+        reg = self._make_registry_with_agent()
+
+        graph_response = {
+            "value": [
+                {"id": "grp-1", "displayName": "Analysts", "description": ""},
+            ]
+        }
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            return_value=_mock_response(graph_response),
+        ):
+            client = EntraGraphClient("token")
+            caps = reg.sync_group_memberships(
+                "did:mesh:sync-agent",
+                client,
+                {"grp-1": ["read:data"]},
+            )
+
+        assert "read:data" in caps
+        assert "manual:cap" in caps  # preserved
+
+        agent = reg.get_by_did("did:mesh:sync-agent")
+        assert agent.capabilities == caps
+        # scopes should be untouched
+        assert agent.scopes == ["Files.Read"]
+
+    def test_sync_audit_log(self):
+        reg = self._make_registry_with_agent()
+
+        with patch(
+            "agentmesh.identity.entra_graph.urlopen",
+            return_value=_mock_response({"value": []}),
+        ):
+            client = EntraGraphClient("token")
+            reg.sync_group_memberships(
+                "did:mesh:sync-agent", client, {"grp-1": ["read:data"]}
+            )
+
+        log = reg.get_audit_log()
+        sync_events = [e for e in log if e["event_type"] == "sync_group_memberships"]
+        assert len(sync_events) == 1
+        assert "groups_found" in sync_events[0]
+
+    def test_sync_unknown_agent_raises(self):
+        reg = EntraAgentRegistry(tenant_id=TENANT_ID)
+        client = EntraGraphClient("token")
+        with pytest.raises(KeyError, match="not found"):
+            reg.sync_group_memberships(
+                "did:mesh:nonexistent", client, {"grp-1": ["read:data"]}
+            )
+
+
+# =============================================================================
+# EntraAgentRegistry.validate_bridge_configuration tests
+# =============================================================================
+
+
+class TestValidateBridgeConfiguration:
+    def test_valid_configuration(self):
+        reg = EntraAgentRegistry(tenant_id=TENANT_ID)
+        reg.register(
+            agent_did="did:mesh:valid-agent",
+            agent_name="Valid",
+            entra_object_id="obj-001",
+            sponsor_email=SPONSOR,
+        )
+        # Set entra_app_id for full validation
+        agent = reg.get_by_did("did:mesh:valid-agent")
+        agent.entra_app_id = "app-001"
+
+        valid, issues = reg.validate_bridge_configuration("did:mesh:valid-agent")
+        assert valid
+        assert issues == []
+
+    def test_missing_entra_app_id_warns(self):
+        reg = EntraAgentRegistry(tenant_id=TENANT_ID)
+        reg.register(
+            agent_did="did:mesh:no-app-id",
+            agent_name="NoAppId",
+            entra_object_id="obj-002",
+            sponsor_email=SPONSOR,
+        )
+        valid, issues = reg.validate_bridge_configuration("did:mesh:no-app-id")
+        assert not valid
+        assert any("entra_app_id" in i for i in issues)
+
+    def test_suspended_agent(self):
+        reg = EntraAgentRegistry(tenant_id=TENANT_ID)
+        reg.register(
+            agent_did="did:mesh:suspended",
+            agent_name="Suspended",
+            entra_object_id="obj-003",
+            sponsor_email=SPONSOR,
+        )
+        reg.suspend_agent("did:mesh:suspended")
+        valid, issues = reg.validate_bridge_configuration("did:mesh:suspended")
+        assert not valid
+        assert any("suspended" in i for i in issues)
+
+    def test_unregistered_agent(self):
+        reg = EntraAgentRegistry(tenant_id=TENANT_ID)
+        valid, issues = reg.validate_bridge_configuration("did:mesh:unknown")
+        assert not valid
+        assert any("not found" in i for i in issues)


### PR DESCRIPTION
## Summary

Adds Microsoft Graph API integration to the Entra Agent ID bridge, enabling automatic synchronization of Entra group memberships to AGT capability scopes.

## Changes

### New: \ntra_graph.py\ — Graph API client
- \EntraGraphClient\ — stdlib-only Graph API client with injected access token
- \get_group_memberships()\ — fetches groups via \/servicePrincipals/{id}/memberOf/microsoft.graph.group\ with automatic pagination
- \get_app_role_assignments()\ — fetches app role assignments
- \GraphAPIError\ — typed exception with HTTP status code
- \uild_group_scope_map()\ — validates group-to-capability config (keyed by group object ID)
- \sync_memberships_to_capabilities()\ — pure function mapping groups to capabilities with dedup and manual-cap preservation

### Updated: \ntra.py\ — Registry integration
- \EntraAgentRegistry.sync_group_memberships()\ — end-to-end sync: fetch groups → map to capabilities → update agent → audit log
- \EntraAgentRegistry.validate_bridge_configuration()\ — validates bridge mapping completeness for Agent365 compatibility

### Updated: Tutorial 31
- Added Steps 6 (Group Membership Sync) and 7 (Bridge Validation)
- Refreshed Known Gaps table: Graph API group sync marked ✅ Built
- Fixed kill-switch Entra endpoint (was wrong \pplications/{id}\, now correct \servicePrincipals/{id}\)
- Agent365 status updated to 'Configuration validated'

### Tests: 26 new tests
- Graph client: pagination, empty responses, HTTP errors, URL errors
- Scope map: validation, edge cases
- Sync logic: mapping, dedup, preserve existing, unmapped groups
- Registry integration: end-to-end sync, audit log, bridge validation

## Design Decisions
- **Group mapping by object ID** (not display name) — display names aren't unique
- **Capabilities separate from scopes** — group sync only updates \capabilities\, not Entra API \scopes\
- **Injected token** — \EntraGraphClient(access_token=...)\ keeps auth decoupled from Graph operations
- **Preserve manual capabilities** — sync does union merge, never wipes manually assigned caps

Closes #1173
Addresses #1174