### PR TITLE
fix(ci): resolve lint errors, test import guard, and docs build failure

### DIFF
--- a/packages/agent-mesh/src/agentmesh/server/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/server/__init__.py
@@ -17,7 +17,6 @@ import time
 from typing import Any
 
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
 
 COMPONENT = os.getenv("AGENTMESH_COMPONENT", "unknown")
 VERSION = "0.3.0"

--- a/packages/agent-mesh/src/agentmesh/server/__main__.py
+++ b/packages/agent-mesh/src/agentmesh/server/__main__.py
@@ -33,9 +33,9 @@ def main() -> None:
         component = os.getenv("AGENTMESH_COMPONENT")
 
     if component not in COMPONENTS or not component:
-        print(f"Usage: python -m agentmesh.server <component>")
-        print(f"   or: AGENTMESH_COMPONENT=<component> python -m agentmesh.server")
-        print(f"Components: {', '.join(COMPONENTS)}")
+        print("Usage: python -m agentmesh.server <component>")
+        print("   or: AGENTMESH_COMPONENT=<component> python -m agentmesh.server")
+        print("Components:", ", ".join(COMPONENTS))
         sys.exit(1)
 
     module_path, func_name = COMPONENTS[component]

--- a/packages/agent-mesh/src/agentmesh/server/api_gateway.py
+++ b/packages/agent-mesh/src/agentmesh/server/api_gateway.py
@@ -11,14 +11,13 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any
 
 import httpx
 from fastapi import HTTPException, Request, Response
 from pydantic import BaseModel, Field
 
-from agentmesh.services.rate_limiter import RateLimiter
 from agentmesh.server import create_base_app, run_server
+from agentmesh.services.rate_limiter import RateLimiter
 
 logger = logging.getLogger(__name__)
 

--- a/packages/agent-mesh/src/agentmesh/server/audit_collector.py
+++ b/packages/agent-mesh/src/agentmesh/server/audit_collector.py
@@ -12,14 +12,13 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field
 
-from agentmesh.governance.audit import AuditEntry
-from agentmesh.services.audit import AuditService
 from agentmesh.governance.audit_backends import FileAuditSink
 from agentmesh.server import create_base_app, run_server
+from agentmesh.services.audit import AuditService
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ RETENTION_DAYS = int(os.getenv("AGENTMESH_AUDIT_RETENTION_DAYS", "90"))
 
 # Service instance
 _audit_service = AuditService()
-_file_sink: Optional[FileAuditSink] = None
+_file_sink: FileAuditSink | None = None
 
 
 @app.on_event("startup")
@@ -43,7 +42,10 @@ async def startup() -> None:
     if data_path.exists() or data_path.parent.exists():
         data_path.mkdir(parents=True, exist_ok=True)
         _file_sink = FileAuditSink(audit_dir=data_path)
-        logger.info("Audit persistence enabled at %s (retention: %d days)", data_path, RETENTION_DAYS)
+        logger.info(
+            "Audit persistence enabled at %s (retention: %d days)",
+            data_path, RETENTION_DAYS,
+        )
     else:
         logger.warning("Audit data dir %s not available — running in-memory only", AUDIT_DATA_DIR)
 
@@ -55,12 +57,12 @@ class LogEntryRequest(BaseModel):
     event_type: str = Field(..., description="Type of event (agent_action, policy_decision, etc.)")
     agent_did: str = Field(..., description="DID of the acting agent")
     action: str = Field(..., description="Action performed")
-    resource: Optional[str] = None
-    target_did: Optional[str] = None
+    resource: str | None = None
+    target_did: str | None = None
     data: dict[str, Any] = Field(default_factory=dict)
     outcome: str = Field(default="success")
-    policy_decision: Optional[str] = None
-    trace_id: Optional[str] = None
+    policy_decision: str | None = None
+    trace_id: str | None = None
 
 
 class LogEntryResponse(BaseModel):
@@ -74,8 +76,8 @@ class BatchLogRequest(BaseModel):
 
 
 class QueryParams(BaseModel):
-    agent_did: Optional[str] = None
-    event_type: Optional[str] = None
+    agent_did: str | None = None
+    event_type: str | None = None
     limit: int = Field(default=100, ge=1, le=1000)
 
 

--- a/packages/agent-mesh/src/agentmesh/server/policy_server.py
+++ b/packages/agent-mesh/src/agentmesh/server/policy_server.py
@@ -13,12 +13,12 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
-from agentmesh.governance.policy import Policy, PolicyEngine, PolicyDecision
+from agentmesh.governance.policy import PolicyDecision, PolicyEngine
 from agentmesh.governance.policy_evaluator import PolicyEvaluator
 from agentmesh.governance.trust_policy import TrustPolicy
 from agentmesh.server import create_base_app, run_server
@@ -35,7 +35,7 @@ POLICY_DIR = os.getenv("AGENTMESH_POLICY_DIR", "/etc/agentmesh/policies")
 # Loaded policy state
 _engine: PolicyEngine = PolicyEngine()
 _trust_policies: list[TrustPolicy] = []
-_trust_evaluator: Optional[PolicyEvaluator] = None
+_trust_evaluator: PolicyEvaluator | None = None
 _loaded_count: int = 0
 
 
@@ -94,15 +94,15 @@ async def startup() -> None:
 class EvaluateRequest(BaseModel):
     agent_did: str = Field(..., description="DID of the acting agent")
     action: str = Field(..., description="Action being performed")
-    resource: Optional[str] = Field(None, description="Target resource")
+    resource: str | None = Field(None, description="Target resource")
     context: dict[str, Any] = Field(default_factory=dict, description="Additional context")
 
 
 class EvaluateResponse(BaseModel):
     decision: str = Field(..., description="allow, deny, warn, or require_approval")
-    matched_rule: Optional[str] = None
+    matched_rule: str | None = None
     reason: str = ""
-    policy_name: Optional[str] = None
+    policy_name: str | None = None
 
 
 class TrustEvaluateRequest(BaseModel):
@@ -112,7 +112,7 @@ class TrustEvaluateRequest(BaseModel):
 class TrustEvaluateResponse(BaseModel):
     allowed: bool
     action: str
-    rule_name: Optional[str] = None
+    rule_name: str | None = None
     reason: str = ""
 
 

--- a/packages/agent-mesh/src/agentmesh/server/trust_engine.py
+++ b/packages/agent-mesh/src/agentmesh/server/trust_engine.py
@@ -10,15 +10,15 @@ Wraps agentmesh.trust (TrustHandshake, TrustBridge, CapabilityRegistry).
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
-from agentmesh.identity.agent_id import AgentIdentity, AgentDID, IdentityRegistry
-from agentmesh.trust.handshake import TrustHandshake, HandshakeChallenge, HandshakeResponse
-from agentmesh.trust.capability import CapabilityRegistry, CapabilityGrant
+from agentmesh.identity.agent_id import AgentDID, AgentIdentity, IdentityRegistry
 from agentmesh.server import create_base_app, run_server
+from agentmesh.trust.capability import CapabilityRegistry
+from agentmesh.trust.handshake import HandshakeChallenge, HandshakeResponse, TrustHandshake
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,9 @@ _pending_challenges: dict[str, tuple[TrustHandshake, HandshakeChallenge]] = {}
 
 
 class ChallengeRequest(BaseModel):
-    agent_did: str = Field(..., description="DID of the agent requesting a challenge (did:mesh:...)")
+    agent_did: str = Field(
+        ..., description="DID of the agent requesting a challenge (did:mesh:...)"
+    )
 
 
 class ChallengeResponse(BaseModel):
@@ -62,15 +64,17 @@ class VerifyResponse(BaseModel):
     trust_score: int = 0
     trust_level: str = ""
     peer_did: str = ""
-    rejection_reason: Optional[str] = None
+    rejection_reason: str | None = None
 
 
 class RegisterAgentRequest(BaseModel):
     name: str = Field(..., description="Human-readable agent name")
     public_key: str = Field(..., description="Base64-encoded Ed25519 public key")
     sponsor_email: str = Field(..., description="Human sponsor email")
-    description: Optional[str] = None
-    did_unique_id: Optional[str] = Field(None, description="Custom unique ID; auto-generated if omitted")
+    description: str | None = None
+    did_unique_id: str | None = Field(
+        None, description="Custom unique ID; auto-generated if omitted"
+    )
 
 
 class GrantCapabilityRequest(BaseModel):

--- a/packages/agent-mesh/tests/test_server.py
+++ b/packages/agent-mesh/tests/test_server.py
@@ -7,7 +7,9 @@ Uses FastAPI TestClient for synchronous HTTP testing of all four servers.
 """
 
 import pytest
-from fastapi.testclient import TestClient
+
+fastapi = pytest.importorskip("fastapi", reason="fastapi not installed (optional [server] extra)")
+from fastapi.testclient import TestClient  # noqa: E402
 
 
 # ── Trust Engine Tests ───────────────────────────────────────────────

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -35,7 +35,8 @@ cp docs/adr/*.md "$SITE_DOCS/adr/"
 # Reference
 cp BENCHMARKS.md "$SITE_DOCS/reference/benchmarks.md"
 cp docs/COMPARISON.md "$SITE_DOCS/reference/comparison.md"
-cp docs/nist-rfi-mapping.md "$SITE_DOCS/reference/nist-rfi-mapping.md"
+[ -f docs/nist-rfi-mapping.md ] && cp docs/nist-rfi-mapping.md "$SITE_DOCS/reference/nist-rfi-mapping.md"
+[ -f docs/compliance/nist-rfi-2026-00206.md ] && cp docs/compliance/nist-rfi-2026-00206.md "$SITE_DOCS/reference/nist-rfi-mapping.md"
 cp CHANGELOG.md "$SITE_DOCS/reference/changelog.md"
 cp CONTRIBUTING.md "$SITE_DOCS/reference/contributing.md"
 


### PR DESCRIPTION
Fixes CI pipeline failures on main:

1. **Lint (agent-mesh)**: Removed unused imports (F401), fixed f-strings (F541), line lengths (E501), import sorting (I001), and Optional to X|None (UP045) in server modules
2. **Tests (agent-mesh 3.11/3.12/3.13)**: test_server.py now uses pytest.importorskip so tests skip gracefully when the optional [server] extra is not installed in CI
3. **Docs deploy**: scripts/build-docs.sh referenced docs/nist-rfi-mapping.md which does not exist — now uses conditional copy from docs/compliance/nist-rfi-2026-00206.md