### PR TITLE
docs: add architecture video series links

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,14 @@
 
 The Agent Governance Toolkit provides **deterministic application-layer interception** — every agent action is evaluated against policy **before execution**, at sub-millisecond latency. For high-security environments, composes with container/VM isolation for defense-in-depth.
 
+## Video Walkthrough Series
+
+Community video series covering the toolkit architecture:
+
+1. [Agent OS & Policy Engine](https://www.youtube.com/watch?v=jq-3FWk5KlI)
+2. [Agent Mesh & Trust Layer](https://www.youtube.com/watch?v=pCJWqCWpXRI)
+3. [Agent SRE & Observability](https://youtu.be/5Rey8lzgVvs)
+
 ## System Architecture
 
 ```


### PR DESCRIPTION
## Description
Adds the 3-part Agent Governance Toolkit architecture video series to `docs/ARCHITECTURE.md` so contributors can discover the walkthroughs directly from the architecture documentation.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Related Issues
Closes #701
