### PR TITLE
fix(esrp): switch EsrpCodeSigning@5 to managed identity auth

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -384,10 +384,10 @@ stages:
             displayName: 'ESRP Authenticode sign DLLs'
             inputs:
               ConnectedServiceName: 'Agent Governance Toolkit'
+              UseMSIAuth: true
               AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
-              AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
               AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.dll'
@@ -436,10 +436,10 @@ stages:
             displayName: 'ESRP Code Sign NuGet package'
             inputs:
               ConnectedServiceName: 'Agent Governance Toolkit'
+              UseMSIAuth: true
               AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
-              AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
               AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.nupkg'

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,0 +1,4 @@
+# Pinned dependencies for MkDocs documentation site build.
+# Update versions periodically and re-run `pip install -r site/requirements.txt`.
+mkdocs-material==9.7.6
+mkdocs-minify-plugin==0.8.0


### PR DESCRIPTION
Fixes MSAL 401 Unauthorized on NuGet ESRP signing. The working EsrpRelease@11 tasks use managed identity; the EsrpCodeSigning@5 tasks were using cert-based auth which failed. Now uses UseMSIAuth: true to match.