### PR TITLE
docs: add attribution & prior art policy (motivated by #748)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,8 @@ Do NOT auto-merge large feature PRs without maintainer review.
 
 When external contributors open issues or PRs proposing integration with their own project/tool/library, apply these quality checks before investing review time:
 
+- **Attribution & prior art check**: If the PR implements functionality similar to an existing open-source project, verify it credits that project explicitly. Check the "Prior art" section in the PR template. If the PR mirrors patterns from a known project (architecture, CLI conventions, config schema, API design) without attribution, **request changes immediately** and do not merge until attribution is added. Uncredited derivatives of community work will be closed.
+- **Timeline verification**: For PRs that arrive shortly after a community member proposes similar functionality in an issue, verify the PR author isn't racing to submit an uncredited copy of the proposed approach. Check issue discussion history for prior art.
 - **Minimum credibility threshold**: The referenced project should have meaningful community adoption (e.g., 50+ GitHub stars, multiple contributors, evidence of production usage). One-person repos with <10 stars and no community traction do not warrant integration effort.
 - **Self-promotion filter**: Issues or PRs that primarily serve to promote the contributor's own low-profile project — rather than adding genuine value to AGT — should be deprioritized. Politely acknowledge but do not fast-track.
 - **Verify claims**: If the PR cites benchmarks, adoption numbers, or production deployments, spot-check them. Unverifiable claims are a red flag.
@@ -42,7 +44,8 @@ NEVER merge a PR without thorough code review. CI passing is NOT sufficient.
 Before approving or merging ANY PR, verify ALL of the following:
 
 1. **Read the actual diff** — don't rely on PR description alone
-2. **Dependency confusion scan** — check every `pip install`, `npm install`, `cargo add` command in docs/code for unregistered package names. The registered names are:
+2. **Attribution & prior art** — check if the PR implements patterns similar to known open-source projects. If it does, verify proper attribution exists in the PR description and code. Check whether the PR arrived shortly after a community member proposed similar work in an issue — if so, verify the contributor isn't submitting an uncredited derivative. **PRs without proper attribution will not be merged.**
+3. **Dependency confusion scan** — check every `pip install`, `npm install`, `cargo add` command in docs/code for unregistered package names. The registered names are:
    - **PyPI:** `agent-os-kernel`, `agentmesh-platform`, `agent-hypervisor`, `agentmesh-runtime`, `agent-sre`, `agent-governance-toolkit`, `agentmesh-lightning`, `agentmesh-marketplace`
    - **PyPI (local-only, not published):** `agent-governance-dotnet`, `agentmesh-integrations`, `agent-primitives`, `emk`
    - **PyPI (common deps):** `streamlit`, `plotly`, `pandas`, `networkx`, `aioredis`, `pypdf`, `spacy`, `slack-sdk`, `docker`, `langchain-openai`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,5 +24,15 @@
 - [ ] I have updated documentation as needed
 - [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)
 
+## Attribution & Prior Art
+<!-- REQUIRED for new features, integrations, or architectural patterns -->
+- [ ] This contribution does not contain code copied or derived from other projects without attribution
+- [ ] Any external projects that inspired this design are credited in code comments or documentation
+- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below
+
+**Prior art / related projects** (if any):
+<!-- Example: "Sandboxing approach inspired by https://github.com/example/project (Apache-2.0)" -->
+<!-- Leave blank if not applicable -->
+
 ## Related Issues
 <!-- Link related issues: Fixes #123, Closes #456 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,25 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 5. Update documentation if your change affects public APIs
 6. Submit a pull request with a clear description of the changes
 
+### Attribution & Prior Art
+
+**All contributions must properly attribute prior work.** This is a hard requirement, not a suggestion.
+
+- If your contribution implements functionality similar to an existing open-source project, you **must** credit that project in your PR description and in code comments or documentation where the pattern is used.
+- Copying or closely adapting architecture, API design, CLI conventions, or documentation from another project without attribution is not acceptable, even if the code is rewritten.
+- When in doubt, cite the prior art. Over-attribution is always better than under-attribution.
+- PRs found to contain uncredited derivatives of other open-source work will be closed.
+
+**Examples of what requires attribution:**
+- Adapting a sandboxing approach from another security tool
+- Using an algorithm or protocol design described in another project's docs
+- Mirroring CLI flags, config schema, or architectural patterns from a known project
+
+**How to attribute:**
+- In your PR description: list related projects under "Prior art / related projects"
+- In code: add a comment like `# Approach adapted from <project> (<license>)`
+- In documentation: include a "Prior art" or "Acknowledgments" section
+
 ### Development Setup
 
 ```bash


### PR DESCRIPTION
Adds mandatory attribution requirements across three files to catch uncredited derivatives of community work early in the contribution process. Motivated by the nono/sb-runtime attribution discussion in #748.