### PR TITLE
fix(pipeline): add AuthCertName for EsrpCodeSigning cert-based auth

### DIFF
--- a/pipelines/esrp-publish.yml
+++ b/pipelines/esrp-publish.yml
@@ -384,10 +384,10 @@ stages:
             displayName: 'ESRP Authenticode sign DLLs'
             inputs:
               ConnectedServiceName: 'Agent Governance Toolkit'
-              UseMSIAuth: true
               AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
+              AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
               AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.dll'
@@ -436,10 +436,10 @@ stages:
             displayName: 'ESRP Code Sign NuGet package'
             inputs:
               ConnectedServiceName: 'Agent Governance Toolkit'
-              UseMSIAuth: true
               AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
+              AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
               AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.nupkg'


### PR DESCRIPTION
EsrpCodeSigning@5 needs both AuthCertName + AuthSignCertName for cert-based auth. Removes UseMSIAuth (ignored by cert-based connections). PyPI/npm/crates unaffected.