### PR TITLE
fix(docker): fix Dockerfile build failures for container publish

### DIFF
--- a/packages/agent-mesh/docker/Dockerfile
+++ b/packages/agent-mesh/docker/Dockerfile
@@ -35,8 +35,7 @@ COPY packages/agent-mesh/pyproject.toml ./
 COPY packages/agent-mesh/src/ ./src/
 
 # Install the package with server extras (fastapi + uvicorn)
-RUN pip install --no-cache-dir -e ".[server]" && \
-    rm -rf /root/.cache
+RUN pip install --no-cache-dir ".[server]"
 
 # Create non-root user
 RUN useradd -m -s /bin/bash -u 1000 agentmesh

--- a/packages/agent-os/Dockerfile.sidecar
+++ b/packages/agent-os/Dockerfile.sidecar
@@ -13,13 +13,12 @@ LABEL description="Agent Governance Toolkit — governance sidecar for autonomou
 
 WORKDIR /app
 
-# Copy all source (modules/ is needed for full [full] install)
-COPY pyproject.toml ./
-COPY src/ ./src/
-COPY modules/ ./modules/
+# Copy agent-os package source (context is repo root)
+COPY packages/agent-os/pyproject.toml ./
+COPY packages/agent-os/src/ ./src/
+COPY packages/agent-os/modules/ ./modules/
 
-RUN pip install --no-cache-dir -e ".[full]" && \
-    rm -rf /root/.cache
+RUN pip install --no-cache-dir ".[full]"
 
 # Create non-root user
 RUN useradd -m -s /bin/bash sidecar


### PR DESCRIPTION
Fixes both Dockerfile errors from publish-containers workflow run. AgentMesh: remove -e editable install. Sidecar: fix COPY paths for repo-root context.