### PR TITLE
fix(docker): add missing README.md and fix COPY paths in Dockerfiles

### DIFF
--- a/packages/agent-mesh/docker/Dockerfile
+++ b/packages/agent-mesh/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy package source from repo root context
 COPY packages/agent-mesh/pyproject.toml ./
+COPY packages/agent-mesh/README.md ./
 COPY packages/agent-mesh/src/ ./src/
 
 # Install the package with server extras (fastapi + uvicorn)

--- a/packages/agent-os/Dockerfile.sidecar
+++ b/packages/agent-os/Dockerfile.sidecar
@@ -15,6 +15,7 @@ WORKDIR /app
 
 # Copy agent-os package source (context is repo root)
 COPY packages/agent-os/pyproject.toml ./
+COPY packages/agent-os/README.md ./
 COPY packages/agent-os/src/ ./src/
 COPY packages/agent-os/modules/ ./modules/
 


### PR DESCRIPTION
pip install fails with 'Readme file does not exist: README.md'. Adds COPY for README.md in both Dockerfiles and fixes sidecar paths for repo-root context.