### PR TITLE
fix(ci): add mkdocs-minify-plugin to dep scan allowlist

### DIFF
--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -75,7 +75,7 @@ REGISTERED_PACKAGES = {
     "langfuse", "arize", "arize-phoenix", "llamaindex", "braintrust", "helicone",
     "datadog", "langsmith", "wandb", "mlflow", "agentops",
     "typer", "jsonschema", "anyio", "pre-commit", "import-linter",
-    "mkdocs", "mkdocs-material", "mkdocstrings", "datasets", "sqlglot",
+    "mkdocs", "mkdocs-material", "mkdocs-minify-plugin", "mkdocstrings", "datasets", "sqlglot",
     "aio-pika", "aiokafka",
     # Cedar/OPA policy backends
     "cedarpy", "llama-index-core", "ddtrace",


### PR DESCRIPTION
Fixes CI failure on main — mkdocs-minify-plugin from the GitHub Pages PR was not in the allowlist.