### PR TITLE
fix(lint): remove unused imports in encryption modules

### DIFF
--- a/packages/agent-mesh/src/agentmesh/encryption/bridge.py
+++ b/packages/agent-mesh/src/agentmesh/encryption/bridge.py
@@ -20,8 +20,7 @@ Usage:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import dataclass
 
 from agentmesh.encryption.channel import ChannelEstablishment, SecureChannel
 from agentmesh.encryption.x3dh import InMemoryPreKeyStore, PreKeyBundle, PreKeyStore, X3DHKeyManager

--- a/packages/agent-mesh/src/agentmesh/encryption/channel.py
+++ b/packages/agent-mesh/src/agentmesh/encryption/channel.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass
 
 from agentmesh.encryption.ratchet import DoubleRatchet, EncryptedMessage
-from agentmesh.encryption.x3dh import PreKeyBundle, X3DHKeyManager, X3DHResult
+from agentmesh.encryption.x3dh import PreKeyBundle, X3DHKeyManager
 
 logger = logging.getLogger(__name__)
 

--- a/packages/agent-mesh/src/agentmesh/encryption/x3dh.py
+++ b/packages/agent-mesh/src/agentmesh/encryption/x3dh.py
@@ -12,7 +12,6 @@ Reference: https://signal.org/docs/specifications/x3dh/
 from __future__ import annotations
 
 import logging
-import os
 import secrets
 from dataclasses import dataclass, field
 from typing import Protocol
@@ -324,8 +323,6 @@ class X3DHKeyManager:
     @staticmethod
     def _verify_signed_pre_key(bundle: PreKeyBundle) -> None:
         """Verify the signed pre-key signature against the identity key."""
-        from nacl.signing import VerifyKey
-
         # Convert X25519 identity key back to Ed25519 is not directly possible,
         # so we verify using the signature which was created with Ed25519.
         # The bundle must carry enough info to verify. For now, we verify


### PR DESCRIPTION
Fixes F401 lint errors in x3dh.py, channel.py, bridge.py. All 61 encryption tests still passing.