### PR TITLE
docs: complete i18n coverage — add Chinese quickstart + serve all translations via Pages

### DIFF
--- a/QUICKSTART.zh-CN.md
+++ b/QUICKSTART.zh-CN.md
@@ -1,0 +1,154 @@
+# 🚀 10分钟快速入门指南
+
+从零开始，在10分钟内构建受治理的AI智能体。
+
+> **前提条件：** Python 3.10+ / Node.js 18+ / .NET 8.0+（任选其一或多个）
+
+## 架构概述
+
+治理层在执行前拦截每个智能体操作：
+
+```mermaid
+graph LR
+    A[AI Agent] -->|Tool Call| B{Governance Layer}
+    B -->|Policy Check| C{PolicyEngine}
+    C -->|Allowed| D[Execute Tool]
+    C -->|Blocked| E[Security Block]
+    D --> F[Audit Log]
+    E --> F
+    F --> G[OTEL / Structured Logs]
+```
+
+## 1. 安装
+
+安装治理工具包：
+
+```bash
+pip install agent-governance-toolkit[full]
+```
+
+或安装单独的包：
+
+```bash
+pip install agent-os-kernel        # 策略执行 + 框架集成
+pip install agentmesh-platform     # 零信任身份 + 信任卡
+pip install agent-governance-toolkit    # OWASP ASI 验证 + 完整性 CLI
+pip install agent-sre              # SLO、错误预算、混沌测试
+pip install agentmesh-runtime       # 执行监督 + 权限环
+pip install agentmesh-marketplace      # 插件生命周期管理
+pip install agentmesh-lightning        # 强化学习训练治理
+```
+
+### TypeScript / Node.js
+
+```bash
+npm install @microsoft/agentmesh-sdk
+```
+
+### .NET
+
+```bash
+dotnet add package Microsoft.AgentGovernance
+```
+
+## 2. 验证安装
+
+运行内置的验证脚本：
+
+```bash
+python scripts/check_gov.py
+```
+
+或直接使用治理 CLI：
+
+```bash
+agent-governance verify
+agent-governance verify --badge
+```
+
+## 3. 你的第一个受治理智能体
+
+创建一个名为 `governed_agent.py` 的文件：
+
+```python
+from agent_os.policies import PolicyEvaluator, PolicyDecision
+from agent_os.policies.schema import (
+    PolicyDocument, PolicyRule, PolicyCondition,
+    PolicyAction, PolicyOperator, PolicyDefaults,
+)
+
+# 内联定义治理规则（或从 YAML 加载 — 见下文）
+policy = PolicyDocument(
+    name="agent-safety",
+    version="1.0",
+    description="示例安全策略",
+    defaults=PolicyDefaults(action=PolicyAction.ALLOW),
+    rules=[
+        PolicyRule(
+            name="block-dangerous-tools",
+            condition=PolicyCondition(
+                field="tool_name",
+                operator=PolicyOperator.IN,
+                value=["execute_code", "delete_file", "shell_exec"],
+            ),
+            action=PolicyAction.DENY,
+            message="工具被策略阻止",
+            priority=100,
+        ),
+    ],
+)
+
+evaluator = PolicyEvaluator(policies=[policy])
+
+# 允许
+result = evaluator.evaluate({"tool_name": "web_search", "input_text": "latest AI news"})
+print(f"操作允许: {result.allowed}")   # True
+
+# 阻止 — 确定性
+result = evaluator.evaluate({"tool_name": "delete_file", "input_text": "/etc/passwd"})
+print(f"操作允许: {result.allowed}")   # False
+print(f"原因: {result.reason}")       # "工具被策略阻止"
+```
+
+运行：
+
+```bash
+python governed_agent.py
+```
+
+## 4. 包装现有框架
+
+工具包与所有主要智能体框架集成：
+
+```bash
+pip install langchain-agentmesh      # LangChain 适配器
+pip install llamaindex-agentmesh     # LlamaIndex 适配器
+pip install crewai-agentmesh         # CrewAI 适配器
+```
+
+支持的框架：**LangChain**、**OpenAI Agents SDK**、**AutoGen**、**CrewAI**、
+**Google ADK**、**Semantic Kernel**、**LlamaIndex**、**Anthropic**、**Mistral**、**Gemini** 等。
+
+## 5. 检查 OWASP ASI 2026 覆盖率
+
+验证你的部署是否覆盖了 OWASP 智能体安全威胁：
+
+```bash
+agent-governance verify
+agent-governance verify --json
+agent-governance verify --badge
+```
+
+## 后续步骤
+
+| 内容 | 位置 |
+|------|------|
+| 完整 API 参考（Python） | [packages/agent-os/README.md](../../packages/agent-os/README.md) |
+| TypeScript SDK 文档 | [packages/agent-mesh/sdks/typescript/](../../packages/agent-mesh/sdks/typescript/README.md) |
+| .NET SDK 文档 | [packages/agent-governance-dotnet/](../../packages/agent-governance-dotnet/README.md) |
+| OWASP 覆盖图 | [docs/OWASP-COMPLIANCE.md](../OWASP-COMPLIANCE.md) |
+| 贡献指南 | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
+
+---
+
+*基于 [@davidequarracino](https://github.com/davidequarracino) 的初始快速入门贡献。*

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ result := client.ExecuteWithGovernance("data.read", nil)
 </details>
 
 > **Full walkthrough:** [QUICKSTART.md](QUICKSTART.md) — zero to governed agents in 10 minutes with YAML policies, OPA/Rego, and Cedar support.
+> 🌍 Also available in: [日本語](QUICKSTART.ja.md) | [简体中文](QUICKSTART.zh-CN.md)
 
 ---
 

--- a/docs/i18n/QUICKSTART.ja.md
+++ b/docs/i18n/QUICKSTART.ja.md
@@ -1,0 +1,223 @@
+# 🚀 10分で始めるクイックスタートガイド
+
+ゼロからガバナンスされたAIエージェントを10分以内に構築できます。
+
+> **前提条件:** Python 3.10以上 / Node.js 18以上 / .NET 8.0以上 (いずれか1つ以上)
+
+## アーキテクチャ概要
+
+ガバナンスレイヤーは、エージェントのすべてのアクションを実行前にチェックします。
+
+```mermaid
+graph LR
+    A[AI Agent] -->|Tool Call| B{Governance Layer}
+    B -->|Policy Check| C{PolicyEngine}
+    C -->|Allowed| D[Execute Tool]
+    C -->|Blocked| E[Security Block]
+    D --> F[Audit Log]
+    E --> F
+    F --> G[OTEL / Structured Logs]
+```
+
+## 1. インストール
+
+ガバナンスツールキットをインストールします。
+
+```bash
+pip install agent-governance-toolkit[full]
+```
+
+または、個別のパッケージをインストールします。
+
+```bash
+pip install agent-os-kernel        # Policy enforcement + framework integrations
+pip install agentmesh-platform     # Zero-trust identity + trust cards
+pip install agent-governance-toolkit    # OWASP ASI verification + integrity CLI
+pip install agent-sre              # SLOs, error budgets, chaos testing
+pip install agentmesh-runtime       # Execution supervisor + privilege rings
+pip install agentmesh-marketplace      # Plugin lifecycle management
+pip install agentmesh-lightning        # RL training governance
+```
+
+### TypeScript / Node.js
+
+```bash
+npm install @microsoft/agentmesh-sdk
+```
+
+### .NET
+
+```bash
+dotnet add package Microsoft.AgentGovernance
+```
+
+## 2. インストールの確認
+
+付属の検証スクリプトを実行します。
+
+```bash
+python scripts/check_gov.py
+```
+
+または、ガバナンスCLIを直接使用します。
+
+```bash
+agent-governance verify
+agent-governance verify --badge
+```
+
+## 3. 最初のガバナンスされたエージェント
+
+`governed_agent.py` というファイルを作成します。
+
+```python
+from agent_os.policy import PolicyEngine, CapabilityModel, PolicyScope
+
+# Define what your agent is allowed to do
+capabilities = CapabilityModel(
+    allowed_tools=["web_search", "read_file", "send_email"],
+    blocked_tools=["execute_code", "delete_file"],
+    blocked_patterns=[r"\b\d{3}-\d{2}-\d{4}\b"],  # Block SSN patterns
+    require_human_approval=True,
+    max_tool_calls=10,
+)
+
+# Create a policy engine
+engine = PolicyEngine(capabilities=capabilities)
+
+# Every agent action goes through the policy engine
+result = engine.evaluate(action="web_search", input_text="latest AI news")
+print(f"Action allowed: {result.allowed}")
+print(f"Reason: {result.reason}")
+
+# This will be blocked
+result = engine.evaluate(action="delete_file", input_text="/etc/passwd")
+print(f"Action allowed: {result.allowed}")  # False
+print(f"Reason: {result.reason}")           # "Tool 'delete_file' is blocked"
+```
+
+実行します。
+
+```bash
+python governed_agent.py
+```
+
+### 最初のガバナンスされたエージェント — TypeScript
+
+`governed_agent.ts` というファイルを作成します。
+
+```typescript
+import { PolicyEngine, AgentIdentity, AuditLogger } from "@microsoft/agentmesh-sdk";
+
+const identity = AgentIdentity.generate("my-agent", ["web_search", "read_file"]);
+
+const engine = new PolicyEngine([
+  { action: "web_search", effect: "allow" },
+  { action: "delete_file", effect: "deny" },
+]);
+
+console.log(engine.evaluate("web_search"));  // "allow"
+console.log(engine.evaluate("delete_file")); // "deny"
+```
+
+### 最初のガバナンスされたエージェント — .NET
+
+`GovernedAgent.cs` というファイルを作成します。
+
+```csharp
+using AgentGovernance;
+using AgentGovernance.Policy;
+
+var kernel = new GovernanceKernel(new GovernanceOptions
+{
+    PolicyPaths = new() { "policies/default.yaml" },
+    EnablePromptInjectionDetection = true,
+});
+
+var result = kernel.EvaluateToolCall("did:mesh:agent-1", "web_search", new() { ["query"] = "AI news" });
+Console.WriteLine($"Allowed: {result.Allowed}");  // True (if policy permits)
+
+result = kernel.EvaluateToolCall("did:mesh:agent-1", "delete_file", new() { ["path"] = "/etc/passwd" });
+Console.WriteLine($"Allowed: {result.Allowed}");  // False
+```
+
+## 4. 既存のフレームワークに組み込む
+
+このツールキットは、主要なエージェントフレームワークすべてと統合できます。以下に LangChain の例を示します。
+
+```python
+from agent_os import KernelSpace
+from agent_os.policy import CapabilityModel
+
+# Initialize with governance
+kernel = KernelSpace(
+    capabilities=CapabilityModel(
+        allowed_tools=["web_search", "calculator"],
+        max_tool_calls=5,
+    )
+)
+
+# Wrap your LangChain agent — every tool call is now governed
+governed_agent = kernel.wrap(your_langchain_agent)
+```
+
+サポートされているフレームワーク: **LangChain**, **OpenAI Agents SDK**, **AutoGen**, **CrewAI**,
+**Google ADK**, **Semantic Kernel**, **LlamaIndex**, **Anthropic**, **Mistral**, **Gemini** など。
+
+## 5. OWASP ASI 2026 のカバレッジを確認する
+
+導入した環境が OWASP Agentic Security Threats をカバーしているかを確認します。
+
+```bash
+# Text summary
+agent-governance verify
+
+# JSON for CI/CD pipelines
+agent-governance verify --json
+
+# Badge for your README
+agent-governance verify --badge
+```
+
+### セキュアなエラーハンドリング
+
+このツールキットに含まれるすべての CLI ツールは、内部情報の漏洩を防ぐために強化されています。JSON モードでコマンドが失敗した場合、サニタイズされたスキーマが返されます。
+
+```json
+{
+  "status": "error",
+  "message": "An internal error occurred during verification",
+  "type": "InternalError"
+}
+```
+
+既知のエラー（例: "File not found"）では具体的なエラーメッセージが表示されます。一方、予期しないシステムエラーは、セキュリティの完全性を確保するためにマスクされます。
+
+## 6. モジュールの整合性を確認する
+
+ガバナンスモジュールが改ざんされていないことを確認します。
+
+```bash
+# Generate a baseline integrity manifest
+agent-governance integrity --generate integrity.json
+
+# Verify against the manifest later
+agent-governance integrity --manifest integrity.json
+```
+
+## 次のステップ
+
+| 内容 | リンク |
+|------|--------|
+| 完全なAPIリファレンス (Python) | [packages/agent-os/README.md](packages/agent-os/README.md) |
+| TypeScript SDK ドキュメント | [packages/agent-mesh/sdks/typescript/README.md](packages/agent-mesh/sdks/typescript/README.md) |
+| .NET SDK ドキュメント | [packages/agent-governance-dotnet/README.md](packages/agent-governance-dotnet/README.md) |
+| OWASP カバレッジマップ | [docs/OWASP-COMPLIANCE.md](docs/OWASP-COMPLIANCE.md) |
+| フレームワーク統合 | [packages/agent-os/src/agent_os/integrations/](packages/agent-os/src/agent_os/integrations/) |
+| サンプルアプリケーション | [packages/agent-os/examples/](packages/agent-os/examples/) |
+| コントリビュートガイド | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| 変更履歴 | [CHANGELOG.md](CHANGELOG.md) |
+
+---
+
+*本クイックスタートは、 [@davidequarracino](https://github.com/davidequarracino) による初期の貢献 ([#106](https://github.com/microsoft/agent-governance-toolkit/pull/106), [#108](https://github.com/microsoft/agent-governance-toolkit/pull/108)) に基づいています。*

--- a/docs/i18n/QUICKSTART.zh-CN.md
+++ b/docs/i18n/QUICKSTART.zh-CN.md
@@ -1,0 +1,154 @@
+# 🚀 10分钟快速入门指南
+
+从零开始，在10分钟内构建受治理的AI智能体。
+
+> **前提条件：** Python 3.10+ / Node.js 18+ / .NET 8.0+（任选其一或多个）
+
+## 架构概述
+
+治理层在执行前拦截每个智能体操作：
+
+```mermaid
+graph LR
+    A[AI Agent] -->|Tool Call| B{Governance Layer}
+    B -->|Policy Check| C{PolicyEngine}
+    C -->|Allowed| D[Execute Tool]
+    C -->|Blocked| E[Security Block]
+    D --> F[Audit Log]
+    E --> F
+    F --> G[OTEL / Structured Logs]
+```
+
+## 1. 安装
+
+安装治理工具包：
+
+```bash
+pip install agent-governance-toolkit[full]
+```
+
+或安装单独的包：
+
+```bash
+pip install agent-os-kernel        # 策略执行 + 框架集成
+pip install agentmesh-platform     # 零信任身份 + 信任卡
+pip install agent-governance-toolkit    # OWASP ASI 验证 + 完整性 CLI
+pip install agent-sre              # SLO、错误预算、混沌测试
+pip install agentmesh-runtime       # 执行监督 + 权限环
+pip install agentmesh-marketplace      # 插件生命周期管理
+pip install agentmesh-lightning        # 强化学习训练治理
+```
+
+### TypeScript / Node.js
+
+```bash
+npm install @microsoft/agentmesh-sdk
+```
+
+### .NET
+
+```bash
+dotnet add package Microsoft.AgentGovernance
+```
+
+## 2. 验证安装
+
+运行内置的验证脚本：
+
+```bash
+python scripts/check_gov.py
+```
+
+或直接使用治理 CLI：
+
+```bash
+agent-governance verify
+agent-governance verify --badge
+```
+
+## 3. 你的第一个受治理智能体
+
+创建一个名为 `governed_agent.py` 的文件：
+
+```python
+from agent_os.policies import PolicyEvaluator, PolicyDecision
+from agent_os.policies.schema import (
+    PolicyDocument, PolicyRule, PolicyCondition,
+    PolicyAction, PolicyOperator, PolicyDefaults,
+)
+
+# 内联定义治理规则（或从 YAML 加载 — 见下文）
+policy = PolicyDocument(
+    name="agent-safety",
+    version="1.0",
+    description="示例安全策略",
+    defaults=PolicyDefaults(action=PolicyAction.ALLOW),
+    rules=[
+        PolicyRule(
+            name="block-dangerous-tools",
+            condition=PolicyCondition(
+                field="tool_name",
+                operator=PolicyOperator.IN,
+                value=["execute_code", "delete_file", "shell_exec"],
+            ),
+            action=PolicyAction.DENY,
+            message="工具被策略阻止",
+            priority=100,
+        ),
+    ],
+)
+
+evaluator = PolicyEvaluator(policies=[policy])
+
+# 允许
+result = evaluator.evaluate({"tool_name": "web_search", "input_text": "latest AI news"})
+print(f"操作允许: {result.allowed}")   # True
+
+# 阻止 — 确定性
+result = evaluator.evaluate({"tool_name": "delete_file", "input_text": "/etc/passwd"})
+print(f"操作允许: {result.allowed}")   # False
+print(f"原因: {result.reason}")       # "工具被策略阻止"
+```
+
+运行：
+
+```bash
+python governed_agent.py
+```
+
+## 4. 包装现有框架
+
+工具包与所有主要智能体框架集成：
+
+```bash
+pip install langchain-agentmesh      # LangChain 适配器
+pip install llamaindex-agentmesh     # LlamaIndex 适配器
+pip install crewai-agentmesh         # CrewAI 适配器
+```
+
+支持的框架：**LangChain**、**OpenAI Agents SDK**、**AutoGen**、**CrewAI**、
+**Google ADK**、**Semantic Kernel**、**LlamaIndex**、**Anthropic**、**Mistral**、**Gemini** 等。
+
+## 5. 检查 OWASP ASI 2026 覆盖率
+
+验证你的部署是否覆盖了 OWASP 智能体安全威胁：
+
+```bash
+agent-governance verify
+agent-governance verify --json
+agent-governance verify --badge
+```
+
+## 后续步骤
+
+| 内容 | 位置 |
+|------|------|
+| 完整 API 参考（Python） | [packages/agent-os/README.md](../../packages/agent-os/README.md) |
+| TypeScript SDK 文档 | [packages/agent-mesh/sdks/typescript/](../../packages/agent-mesh/sdks/typescript/README.md) |
+| .NET SDK 文档 | [packages/agent-governance-dotnet/](../../packages/agent-governance-dotnet/README.md) |
+| OWASP 覆盖图 | [docs/OWASP-COMPLIANCE.md](../OWASP-COMPLIANCE.md) |
+| 贡献指南 | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
+
+---
+
+*基于 [@davidequarracino](https://github.com/davidequarracino) 的初始快速入门贡献。*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,3 +149,8 @@ nav:
     - NIST RFI Mapping: reference/nist-rfi-mapping.md
     - Changelog: reference/changelog.md
     - Contributing: reference/contributing.md
+  - 🌍 Languages:
+    - 日本語 README: i18n/README.ja.md
+    - 日本語 クイックスタート: i18n/QUICKSTART.ja.md
+    - 简体中文 README: i18n/README.zh-CN.md
+    - 简体中文 快速入门: i18n/QUICKSTART.zh-CN.md


### PR DESCRIPTION
Adds missing Chinese quickstart, copies i18n docs into Pages nav. All 3 languages (EN/JA/ZH) now have both README and QUICKSTART.