### PR TITLE
docs: add contributor routing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# Agent Governance Toolkit - Repository Instructions
+
+## Project Overview
+
+Agent Governance Toolkit is a multi-package OSS monorepo for runtime governance of AI agents:
+policy enforcement, zero-trust identity, execution sandboxing, SRE, compliance, examples,
+docs, demos, SDKs, and publishing pipelines.
+
+Use this file for repository-wide routing. When you enter a subdirectory that has its own
+`AGENTS.md`, that narrower file takes precedence.
+
+## Repository Layout Status
+
+This routing reflects the repo **as it exists today**. Some language implementations may move from
+shared subdirectories into **standalone top-level directories** over time (for example,
+`agent-governance-golang/`).
+
+Treat current paths as a **point-in-time representation**, not a permanent architecture promise.
+When a standalone top-level implementation exists, changes for that language should go there rather
+than into `packages/` or an older shared SDK path.
+
+## Where Changes Belong
+
+| Area | Path | Use it for |
+|------|------|------------|
+| Core Python packages | `packages/*/` | Runtime code, policy engines, trust, SRE, compliance |
+| Current shared SDK paths | `packages/agent-mesh/sdks/`, `packages/agent-governance-dotnet/` | Public SDK APIs, parity work, language-specific packaging in the current layout |
+| Standalone language implementations | `agent-governance-*/` | Top-level language-specific implementations as they are introduced |
+| Docs site | `docs/` | Reference docs, tutorials, architecture, package pages |
+| Runnable examples | `examples/` | Self-contained integrations and worked examples |
+| Interactive demos | `demo/` | Live demos, dashboards, real-service walkthroughs |
+| Release pipelines | `pipelines/` | Azure DevOps ESRP publishing and release automation |
+| GitHub automation | `.github/` | CI, PR automation, issue templates, CODEOWNERS |
+
+## Routing Rules
+
+1. Prefer the smallest correct scope for a change.
+2. Put third-party integrations in `examples/` or `packages/agentmesh-integrations/` before
+   expanding core packages.
+3. Put marketing or ecosystem references in docs only after the integration is real, attributable,
+   and useful to users.
+4. Keep `.github/` changes separate from feature work; they require extra security review.
+5. If both a legacy shared path and a new standalone top-level path exist, prefer the standalone
+   top-level path for new work unless maintainers say otherwise.
+
+## OSS Contribution Expectations
+
+- Read the nearest `AGENTS.md` before changing code in that area.
+- Keep PRs scoped to the path described in the PR.
+- Add or update tests for behavior changes, bug fixes, security fixes, and new public API surface.
+- Attribute prior art in PR descriptions and docs when a design borrows from another project.
+- Prefer examples and docs for low-risk ecosystem additions; prefer core package changes only when
+  the project has clear adoption and the integration belongs in AGT long-term.
+- Do not add obscure dependencies to core paths just to support a single external project.
+
+## Decision Escalation
+
+Ask a maintainer before proceeding with:
+
+- new top-level packages or modules
+- cross-cutting changes across 3+ packages
+- security model changes
+- public breaking API changes
+- new framework integrations that materially expand the core surface
+- CI/CD architecture changes
+
+## Boundaries
+
+- Never commit secrets, credentials, or real tokens.
+- Never weaken security defaults, trust thresholds, or review requirements.
+- Do not mix unrelated changes into docs-only or example-only PRs.
+- Preserve honesty in docs: document shipped behavior, not aspirational behavior.
+
+## Validation
+
+- Run the narrowest existing tests for the paths you touched.
+- For bug fixes, prefer a regression test that would fail without the change.
+- For docs-only changes, make sure links, commands, and file paths are still correct.
+- For SDK changes, verify language-specific build and test commands in the scoped instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,43 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 ### Pull Requests
 
 1. Fork the repository and create a feature branch from `main`
-2. Make your changes in the appropriate package directory under `packages/`
-3. Add or update tests as needed
-4. Ensure all tests pass: `pytest`
-5. Update documentation if your change affects public APIs
-6. Submit a pull request with a clear description of the changes
+2. Read the nearest `AGENTS.md` before changing code in that area
+3. Make your changes in the appropriate package or top-level directory
+4. Add or update tests as needed
+5. Ensure all tests pass: `pytest`
+6. Update documentation if your change affects public APIs
+7. Submit a pull request with a clear description of the changes
+
+### Repository Routing
+
+This repo is a monorepo. Choosing the right path up front makes review much faster.
+The layout is also evolving: some language implementations may move from shared directories into
+standalone top-level directories over time. Treat the paths below as the current layout, not a
+permanent architecture promise.
+
+| If your change is about... | Start here |
+|----------------------------|------------|
+| Core governance/runtime behavior | `packages/` |
+| Current shared SDK implementations | `packages/agent-mesh/sdks/` or `packages/agent-governance-dotnet/` |
+| Standalone language implementations | `agent-governance-*/` when present |
+| Tutorials, architecture, package docs | `docs/` |
+| Runnable framework integrations | `examples/` |
+| Interactive or live demos | `demo/` |
+| Azure DevOps publishing/release automation | `pipelines/` |
+| GitHub Actions, PR automation, templates | `.github/` |
+
+If a directory contains an `AGENTS.md` file, read it before you start. It captures local
+commands, boundaries, and review expectations for that area.
+If a standalone top-level language directory exists for the implementation you are changing, prefer
+that directory over an older shared path unless maintainers tell you to keep work in the legacy
+location.
+
+### Choose the Smallest Correct Surface
+
+- Prefer a docs update when the request is informational.
+- Prefer an `examples/` contribution when proving a new external integration.
+- Prefer `packages/agentmesh-integrations/` when the integration is reusable and maintained.
+- Propose a core package change only when the functionality clearly belongs in AGT long-term.
 
 ### Attribution & Prior Art
 
@@ -47,6 +79,38 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 - In your PR description: list related projects under "Prior art / related projects"
 - In code: add a comment like `# Approach adapted from <project> (<license>)`
 - In documentation: include a "Prior art" or "Acknowledgments" section
+
+### External Integrations and Related Projects
+
+We welcome integrations, but we review them as product decisions, not just code submissions.
+
+- If you are proposing support for your own project, explain why AGT users benefit from it.
+- Start with the smallest useful contribution shape: docs mention, example, integration package,
+  then core-package change.
+- Include adoption context when requesting a large integration surface. Small or brand-new projects
+  are usually better introduced through examples than through core dependencies.
+- New dependencies must be justified, pinned correctly, and appropriate for the part of the repo
+  they are entering.
+- "Related project" PRs may be closed if they read primarily as promotion rather than user value.
+
+When in doubt, open an issue or discussion first and describe:
+
+1. the user problem
+2. the external project involved
+3. why the change belongs in AGT
+4. whether the first version can live in docs or examples
+
+### AI-Assisted Contributions
+
+AI-assisted contributions are welcome, but they are held to the same standards as any other PR.
+
+- Review, understand, and stand behind every line you submit.
+- Verify that generated code and docs match the current repository state.
+- Disclose meaningful AI assistance in the PR description when it materially shaped the change.
+- Do not use AI to launder unattributed derivative work from other projects.
+- Generated code still needs tests, docs updates, and security review where appropriate.
+- Maintainers may ask contributors to narrow scope, split commits, or rewrite generated changes
+  that are too broad or insufficiently understood.
 
 ### Development Setup
 
@@ -251,6 +315,8 @@ Before submitting your integration PR:
 - [ ] Code follows PEP 8 and uses type hints
 - [ ] No secrets or credentials committed
 - [ ] Dependencies are pinned to specific versions
+- [ ] Prior art and related projects are credited in the PR description
+- [ ] The contribution shape is appropriate (example vs integration package vs core package)
 
 ### Questions?
 

--- a/demo/AGENTS.md
+++ b/demo/AGENTS.md
@@ -1,0 +1,34 @@
+# Demo - Coding Agent Instructions
+
+## Project Overview
+
+The `demo/` directory contains live demonstrations of AGT capabilities, including real-service
+walkthroughs and visual dashboards. Demos should help users see the system working end-to-end
+without changing the core product contract.
+
+## What Belongs Here
+
+- interactive dashboards
+- live governance walkthroughs
+- scenario-driven demo scripts
+- demo policies and supporting assets
+
+## Demo Conventions
+
+- Demos must clearly distinguish production behavior from illustrative scaffolding.
+- Real credentials belong in environment variables or local secrets only, never in code or docs.
+- Document prerequisites, expected cost, and runtime side effects.
+- Prefer localhost-safe defaults and explicit opt-in for external services.
+- Reuse existing packages instead of duplicating governance logic in demo scripts.
+
+## Boundaries
+
+- Do not add hidden dependencies or services that are not documented in the demo README.
+- Do not hardcode API keys, endpoints with secrets, or tenant-specific values.
+- Do not present demo-only behavior as a supported product API.
+- Keep demos scoped; broad product features belong in packages, not in demo-only code.
+
+## Validation
+
+- Keep the documented run command accurate.
+- If you add a new demo directory, add or update its README.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,46 @@
+# Documentation - Coding Agent Instructions
+
+## Project Overview
+
+The `docs/` tree powers the published documentation site for Agent Governance Toolkit:
+reference material, tutorials, architecture docs, threat modeling, compliance content,
+package pages, and integration guides.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `docs/index.md` | Docs homepage and top-level navigation |
+| `docs/packages/` | Package landing pages and package-specific docs |
+| `docs/tutorials/` | Step-by-step guides |
+| `docs/integrations/` | External integration guides |
+| `docs/security/` | Threat model, OWASP, security guidance |
+| `mkdocs.yml` | Site navigation and build configuration |
+
+## Documentation Conventions
+
+- Be precise and honest; do not claim a feature is shipped unless the repo actually contains it.
+- Prefer updating an existing page over creating a near-duplicate page.
+- Use repo-relative links that work from the current document location.
+- Match existing tone: technical, direct, and evidence-based.
+- Keep package names, CLI commands, and install snippets aligned with the actual repo.
+- When documenting third-party integrations, explain whether they are examples, adapters,
+  or maintained first-party surfaces.
+
+## Content Boundaries
+
+- Do not introduce new ecosystem claims, benchmarks, or adoption numbers without a source.
+- Do not add translated docs unless explicitly requested; keep the source English page correct first.
+- Do not hide limitations. If behavior is partial or experimental, say so clearly.
+- Avoid copying large blocks of vendor docs; summarize and attribute instead.
+
+## When Code Changes Need Docs
+
+- Public API changes should update the nearest package page or tutorial.
+- New examples should usually update docs discoverability at least once.
+- Security-sensitive changes should review `docs/security/` and `docs/THREAT_MODEL.md`.
+
+## Validation
+
+- Check that links, file paths, and fenced code blocks are valid.
+- Keep headings and page titles stable unless a rename is intentional.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,38 @@
+# Examples - Coding Agent Instructions
+
+## Project Overview
+
+The `examples/` directory is the preferred place for runnable, self-contained integrations and
+worked examples. For OSS contributors, examples are often the best starting point for proposing
+support for a new framework or ecosystem tool.
+
+## Preferred Contribution Shape
+
+Use `examples/` when you want to:
+
+- demonstrate AGT with a third-party framework
+- prove an integration pattern before proposing a core package change
+- publish a minimal end-to-end scenario with policies and expected output
+
+Prefer an example over a core package change when the external project is new, niche, or still
+proving community demand.
+
+## Example Conventions
+
+- Keep examples runnable and self-contained.
+- Include a README with setup, run steps, expected output, and cleanup notes.
+- Attribute external projects and prior art in the README when the example is integration-driven.
+- Keep dependencies minimal and explain why each one is needed.
+- Use fake or placeholder secrets only; direct users to environment variables for real credentials.
+
+## Boundaries
+
+- Do not add obscure dependencies to the repo root just for a single example.
+- Do not let example code silently become a de facto supported public API.
+- Do not overstate maturity; label experimental or community-driven examples clearly.
+- If an example exists mainly to promote another project, keep it out of core paths.
+
+## Validation
+
+- Verify the README commands still match the file layout.
+- Keep example policies and sample outputs consistent with the documented scenario.

--- a/packages/agent-governance-dotnet/AGENTS.md
+++ b/packages/agent-governance-dotnet/AGENTS.md
@@ -1,0 +1,41 @@
+# Microsoft.AgentGovernance - Coding Agent Instructions
+
+## Project Overview
+
+`packages/agent-governance-dotnet/` contains the .NET SDK for Agent Governance Toolkit:
+policy enforcement, execution rings, trust, SRE controls, MCP security, lifecycle management,
+and auditability for .NET applications.
+
+## Build and Test Commands
+
+```bash
+dotnet build AgentGovernance.sln
+dotnet test AgentGovernance.sln
+```
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `src/` | .NET implementation |
+| `tests/` | xUnit coverage |
+| `README.md` | Package overview and examples |
+| `AgentGovernance.sln` | Solution entry point |
+
+## Coding Conventions
+
+- Keep public APIs clear and stable.
+- Prefer explicit types and validation over convenience shortcuts.
+- Match existing naming and namespace conventions.
+- If a feature brings the .NET SDK closer to parity with other SDKs, update relevant docs.
+
+## Boundaries
+
+- Do not loosen governance checks or trust enforcement.
+- Do not add hidden runtime dependencies.
+- Keep secrets and tenant-specific values out of code and samples.
+
+## Validation
+
+- Run `dotnet test AgentGovernance.sln` after changes.
+- Check README snippets if public APIs move or rename.

--- a/packages/agent-mesh/sdks/AGENTS.md
+++ b/packages/agent-mesh/sdks/AGENTS.md
@@ -1,0 +1,40 @@
+# AgentMesh SDKs - Coding Agent Instructions
+
+## Project Overview
+
+This directory contains cross-language AgentMesh SDKs:
+
+- `typescript/`
+- `rust/`
+- `go/`
+
+These SDKs should stay conceptually aligned with the trust, identity, governance, and MCP
+security surfaces provided elsewhere in the repo.
+
+## Transition Note
+
+This directory reflects the repo layout **at this point in time**. Some language implementations
+may eventually move into standalone top-level directories such as `agent-governance-golang/`,
+`agent-governance-rust/`, or `agent-governance-python/`.
+
+If that happens, treat the standalone top-level directory as the primary home for new work. This
+directory should then be treated as legacy/shared-layout guidance for the code that still lives
+here.
+
+## SDK Conventions
+
+- Preserve API parity where practical; call out intentional gaps instead of creating silent drift.
+- Keep package metadata, examples, and docs aligned with the shipped API surface.
+- Favor small, language-idiomatic wrappers over clever abstractions that hide security behavior.
+- Update shared docs such as `docs/SDK-FEATURE-MATRIX.md` when parity materially changes.
+
+## Boundaries
+
+- Do not introduce breaking API changes casually.
+- Do not weaken validation, trust checks, or security defaults to match another language.
+- Avoid language-specific one-offs unless there is a strong ecosystem reason.
+
+## Validation
+
+- Run the language-specific tests for the SDK you changed.
+- Confirm package names, versions, and build outputs still match publishing expectations.

--- a/pipelines/AGENTS.md
+++ b/pipelines/AGENTS.md
@@ -1,0 +1,33 @@
+# Pipelines - Coding Agent Instructions
+
+## Project Overview
+
+The `pipelines/` directory contains Azure DevOps release automation, especially ESRP-backed
+publishing flows for Python, npm, NuGet, Rust, and Go artifacts.
+
+## Critical Rules
+
+- Treat every pipeline edit as security-sensitive.
+- Keep secrets, client IDs, key vault names, and certificate identifiers in pipeline secrets or
+  variables, not inline in YAML.
+- Pin package-install commands to explicit versions where applicable.
+- Preserve least privilege and existing release gates.
+- Prefer comments that explain non-obvious ESRP or platform constraints.
+
+## What To Watch For
+
+- Azure DevOps compile-time vs runtime variable behavior
+- Windows-vs-Unix path differences in publishing tasks
+- artifact naming consistency across build and publish stages
+- package path correctness for monorepo publishing
+
+## Boundaries
+
+- Do not weaken release approvals or bypass ESRP requirements.
+- Do not introduce plaintext credentials into YAML.
+- Do not mix unrelated publishing changes into the same PR as product code.
+
+## Validation
+
+- Re-check all referenced package paths after edits.
+- Verify each changed stage still matches the package name, artifact name, and target registry.


### PR DESCRIPTION
## Description
Add a root `AGENTS.md`, path-scoped `AGENTS.md` files for high-value areas, and update `CONTRIBUTING.md` so contributors and coding tools have clearer routing, testing expectations, and guidance for external integrations.

This also documents the repo's transition model: current paths are treated as point-in-time layout, and future standalone top-level language implementations (for example `agent-governance-golang/`) are explicitly allowed as the preferred home once they exist.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
<!-- REQUIRED for new features, integrations, or architectural patterns -->
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
Contributor workflow structure was informed by common OSS patterns used in projects like Kubernetes, Rust, and VS Code, but this PR does not copy text or code from those repositories.

## Related Issues
None.