### PR TITLE
docs: clarify standalone language package routing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,21 +11,23 @@ Use this file for repository-wide routing. When you enter a subdirectory that ha
 
 ## Repository Layout Status
 
-This routing reflects the repo **as it exists today**. Some language implementations may move from
-shared subdirectories into **standalone top-level directories** over time (for example,
-`agent-governance-golang/`).
+This routing reflects the repo **as it exists today** while reserving room for approved language
+SDK migrations. Some language implementations may move from shared subdirectories into
+**standalone top-level directories** at the repository root. The first planned example is
+`agent-governance-dotnet/`, with `agent-governance-golang/` expected as a future sibling when that
+SDK gets a standalone home.
 
 Treat current paths as a **point-in-time representation**, not a permanent architecture promise.
-When a standalone top-level implementation exists, changes for that language should go there rather
-than into `packages/` or an older shared SDK path.
+When a standalone top-level implementation exists for a language, changes for that language should
+go there rather than into `packages/` or an older shared SDK path.
 
 ## Where Changes Belong
 
 | Area | Path | Use it for |
 |------|------|------------|
 | Core Python packages | `packages/*/` | Runtime code, policy engines, trust, SRE, compliance |
-| Current shared SDK paths | `packages/agent-mesh/sdks/`, `packages/agent-governance-dotnet/` | Public SDK APIs, parity work, language-specific packaging in the current layout |
-| Standalone language implementations | `agent-governance-*/` | Top-level language-specific implementations as they are introduced |
+| Current shared SDK paths | `packages/agent-mesh/sdks/`, `packages/agent-governance-dotnet/` | Public SDK APIs and language-specific packaging that still live in the shared layout today |
+| Standalone language implementations | Reserved root-level paths such as `agent-governance-dotnet/`, future `agent-governance-golang/`, and other `agent-governance-*` siblings when present | Top-level language-specific implementations once a language SDK has moved to a standalone repo-root home |
 | Docs site | `docs/` | Reference docs, tutorials, architecture, package pages |
 | Runnable examples | `examples/` | Self-contained integrations and worked examples |
 | Interactive demos | `demo/` | Live demos, dashboards, real-service walkthroughs |
@@ -41,7 +43,9 @@ than into `packages/` or an older shared SDK path.
    and useful to users.
 4. Keep `.github/` changes separate from feature work; they require extra security review.
 5. If both a legacy shared path and a new standalone top-level path exist, prefer the standalone
-   top-level path for new work unless maintainers say otherwise.
+   top-level path for new work unless maintainers say otherwise. For the approved .NET migration,
+   that means contributor guidance should target `agent-governance-dotnet/` once the root
+   directory exists.
 
 ## OSS Contribution Expectations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,9 @@ Use this file for repository-wide routing. When you enter a subdirectory that ha
 ## Repository Layout Status
 
 This routing reflects the repo **as it exists today** while reserving room for approved language
-SDK migrations. Some language implementations may move from shared subdirectories into
-**standalone top-level directories** at the repository root. The first planned example is
-`agent-governance-dotnet/`, with `agent-governance-golang/` expected as a future sibling when that
-SDK gets a standalone home.
+SDK migrations. Language SDKs may live in **standalone top-level directories** at the repository
+root. For contributor routing, treat `agent-governance-dotnet/` as the canonical .NET home, with
+`agent-governance-golang/` as the matching sibling pattern for Go and future standalone SDKs.
 
 Treat current paths as a **point-in-time representation**, not a permanent architecture promise.
 When a standalone top-level implementation exists for a language, changes for that language should
@@ -26,8 +25,8 @@ go there rather than into `packages/` or an older shared SDK path.
 | Area | Path | Use it for |
 |------|------|------------|
 | Core Python packages | `packages/*/` | Runtime code, policy engines, trust, SRE, compliance |
-| Current shared SDK paths | `packages/agent-mesh/sdks/`, `packages/agent-governance-dotnet/` | Public SDK APIs and language-specific packaging that still live in the shared layout today |
-| Standalone language implementations | Reserved root-level paths such as `agent-governance-dotnet/`, future `agent-governance-golang/`, and other `agent-governance-*` siblings when present | Top-level language-specific implementations once a language SDK has moved to a standalone repo-root home |
+| Current shared SDK paths | `packages/agent-mesh/sdks/` | Public SDK APIs and language-specific packaging that still live in the shared layout today |
+| Standalone language implementations | `agent-governance-dotnet/`, `agent-governance-golang/`, and other `agent-governance-*` siblings | Top-level language-specific implementations at the repository root; use these as the canonical contributor-facing paths |
 | Docs site | `docs/` | Reference docs, tutorials, architecture, package pages |
 | Runnable examples | `examples/` | Self-contained integrations and worked examples |
 | Interactive demos | `demo/` | Live demos, dashboards, real-service walkthroughs |
@@ -42,10 +41,10 @@ go there rather than into `packages/` or an older shared SDK path.
 3. Put marketing or ecosystem references in docs only after the integration is real, attributable,
    and useful to users.
 4. Keep `.github/` changes separate from feature work; they require extra security review.
-5. If both a legacy shared path and a new standalone top-level path exist, prefer the standalone
+5. If both a legacy shared path and a standalone top-level path exist, prefer the standalone
    top-level path for new work unless maintainers say otherwise. For the approved .NET migration,
-   that means contributor guidance should target `agent-governance-dotnet/` once the root
-   directory exists.
+   that means contributor guidance should target `agent-governance-dotnet/` as the canonical path,
+   not `packages/agent-governance-dotnet/`.
 
 ## OSS Contribution Expectations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,16 +33,17 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 ### Repository Routing
 
 This repo is a monorepo. Choosing the right path up front makes review much faster.
-The layout is also evolving: some language implementations may move from shared directories into
-standalone top-level directories at the repository root over time. The first approved example is
-`agent-governance-dotnet/`, with `agent-governance-golang/` anticipated as a future sibling when
-that SDK moves. Treat the paths below as the current layout, not a permanent architecture promise.
+The layout is also evolving: some language implementations now use standalone top-level directories
+at the repository root. For contributor routing, treat `agent-governance-dotnet/` as the canonical
+.NET home and `agent-governance-golang/` as the matching sibling pattern for Go. Treat the paths
+below as contributor-routing guidance rather than a promise that every legacy path remains the long-
+term home for that language.
 
 | If your change is about... | Start here |
 |----------------------------|------------|
 | Core governance/runtime behavior | `packages/` |
-| Current shared SDK implementations | `packages/agent-mesh/sdks/` or `packages/agent-governance-dotnet/` while those SDKs still live in the shared layout |
-| Standalone language implementations | Reserved root-level paths such as `agent-governance-dotnet/`, future `agent-governance-golang/`, or other `agent-governance-*` siblings when present |
+| Current shared SDK implementations | `packages/agent-mesh/sdks/` and other languages that still live in the shared layout |
+| Standalone language implementations | `agent-governance-dotnet/`, `agent-governance-golang/`, or other `agent-governance-*` siblings at the repository root |
 | Tutorials, architecture, package docs | `docs/` |
 | Runnable framework integrations | `examples/` |
 | Interactive or live demos | `demo/` |
@@ -53,8 +54,8 @@ If a directory contains an `AGENTS.md` file, read it before you start. It captur
 commands, boundaries, and review expectations for that area.
 If a standalone top-level language directory exists for the implementation you are changing, prefer
 that directory over an older shared path unless maintainers tell you to keep work in the legacy
-location. For the approved .NET standalone migration, root-level contributor guidance should point
-to `agent-governance-dotnet/` as the destination path once it is introduced.
+location. For the approved .NET standalone migration, contributor guidance should point to
+`agent-governance-dotnet/` as the canonical path, not `packages/agent-governance-dotnet/`.
 
 ### Choose the Smallest Correct Surface
 
@@ -178,12 +179,12 @@ This is a mono-repo with ten packages today:
 | `agentmesh-marketplace` | `packages/agent-marketplace/` | Plugin lifecycle management for governed agent ecosystems |
 | `agentmesh-lightning` | `packages/agent-lightning/` | RL training governance with governed runners and policy rewards |
 | `agent-hypervisor` | `packages/agent-hypervisor/` | Runtime infrastructure and capability management |
-| `agent-governance-dotnet` | `packages/agent-governance-dotnet/` | .NET framework integration for agent governance |
+| `agent-governance-dotnet` | `packages/agent-governance-dotnet/` | Legacy shared-layout .NET implementation during migration to the root-level standalone path |
 | `agentmesh-integrations` | `packages/agentmesh-integrations/` | Framework integrations and extension library |
 
-Standalone language SDKs may also live at the repository root as that migration lands. The first
-planned example is `agent-governance-dotnet/`; `agent-governance-golang/` is the anticipated next
-sibling when Go gets a standalone top-level home.
+Contributor routing for the standalone .NET SDK should use `agent-governance-dotnet/` at the
+repository root as the canonical path. Legacy shared-layout references such as
+`packages/agent-governance-dotnet/` are migration context, not the target-state path.
 
 ### Coding Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 1. Fork the repository and create a feature branch from `main`
 2. Read the nearest `AGENTS.md` before changing code in that area
-3. Make your changes in the appropriate package or top-level directory
+3. Make your changes in the appropriate package or top-level directory for that part of the repo
 4. Add or update tests as needed
 5. Ensure all tests pass: `pytest`
 6. Update documentation if your change affects public APIs
@@ -34,14 +34,15 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 This repo is a monorepo. Choosing the right path up front makes review much faster.
 The layout is also evolving: some language implementations may move from shared directories into
-standalone top-level directories over time. Treat the paths below as the current layout, not a
-permanent architecture promise.
+standalone top-level directories at the repository root over time. The first approved example is
+`agent-governance-dotnet/`, with `agent-governance-golang/` anticipated as a future sibling when
+that SDK moves. Treat the paths below as the current layout, not a permanent architecture promise.
 
 | If your change is about... | Start here |
 |----------------------------|------------|
 | Core governance/runtime behavior | `packages/` |
-| Current shared SDK implementations | `packages/agent-mesh/sdks/` or `packages/agent-governance-dotnet/` |
-| Standalone language implementations | `agent-governance-*/` when present |
+| Current shared SDK implementations | `packages/agent-mesh/sdks/` or `packages/agent-governance-dotnet/` while those SDKs still live in the shared layout |
+| Standalone language implementations | Reserved root-level paths such as `agent-governance-dotnet/`, future `agent-governance-golang/`, or other `agent-governance-*` siblings when present |
 | Tutorials, architecture, package docs | `docs/` |
 | Runnable framework integrations | `examples/` |
 | Interactive or live demos | `demo/` |
@@ -52,7 +53,8 @@ If a directory contains an `AGENTS.md` file, read it before you start. It captur
 commands, boundaries, and review expectations for that area.
 If a standalone top-level language directory exists for the implementation you are changing, prefer
 that directory over an older shared path unless maintainers tell you to keep work in the legacy
-location.
+location. For the approved .NET standalone migration, root-level contributor guidance should point
+to `agent-governance-dotnet/` as the destination path once it is introduced.
 
 ### Choose the Smallest Correct Surface
 
@@ -164,7 +166,7 @@ docker compose --profile dashboard up --build dashboard
 
 ### Package Structure
 
-This is a mono-repo with ten packages:
+This is a mono-repo with ten packages today:
 
 | Package | Directory | Description |
 |---------|-----------|-------------|
@@ -178,6 +180,10 @@ This is a mono-repo with ten packages:
 | `agent-hypervisor` | `packages/agent-hypervisor/` | Runtime infrastructure and capability management |
 | `agent-governance-dotnet` | `packages/agent-governance-dotnet/` | .NET framework integration for agent governance |
 | `agentmesh-integrations` | `packages/agentmesh-integrations/` | Framework integrations and extension library |
+
+Standalone language SDKs may also live at the repository root as that migration lands. The first
+planned example is `agent-governance-dotnet/`; `agent-governance-golang/` is the anticipated next
+sibling when Go gets a standalone top-level home.
 
 ### Coding Guidelines
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -25,9 +25,9 @@ package pages, and integration guides.
 - Match existing tone: technical, direct, and evidence-based.
 - Keep package names, CLI commands, and install snippets aligned with the actual repo.
 - When documenting repo layout, treat standalone language SDKs at the repository root as a valid
-  first-party pattern. Use `agent-governance-dotnet/` as the first migration example and
-  `agent-governance-golang/` as an anticipated sibling, but say clearly when a directory is planned
-  rather than already present.
+  first-party pattern. Use `agent-governance-dotnet/` as the canonical .NET path and
+  `agent-governance-golang/` as the matching sibling pattern, and avoid framing
+  `packages/agent-governance-dotnet/` as the target-state location.
 - When documenting third-party integrations, explain whether they are examples, adapters,
   or maintained first-party surfaces.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,6 +24,10 @@ package pages, and integration guides.
 - Use repo-relative links that work from the current document location.
 - Match existing tone: technical, direct, and evidence-based.
 - Keep package names, CLI commands, and install snippets aligned with the actual repo.
+- When documenting repo layout, treat standalone language SDKs at the repository root as a valid
+  first-party pattern. Use `agent-governance-dotnet/` as the first migration example and
+  `agent-governance-golang/` as an anticipated sibling, but say clearly when a directory is planned
+  rather than already present.
 - When documenting third-party integrations, explain whether they are examples, adapters,
   or maintained first-party surfaces.
 

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -33,16 +33,17 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 ### Repository Routing
 
 This repo is a monorepo. Choosing the right path up front makes review much faster.
-The layout is also evolving: some language implementations may move from shared directories into
-standalone top-level directories at the repository root over time. The first approved example is
-`agent-governance-dotnet/`, with `agent-governance-golang/` anticipated as a future sibling when
-that SDK moves. Treat the paths below as the current layout, not a permanent architecture promise.
+The layout is also evolving: some language implementations now use standalone top-level directories
+at the repository root. For contributor routing, treat `agent-governance-dotnet/` as the canonical
+.NET home and `agent-governance-golang/` as the matching sibling pattern for Go. Treat the paths
+below as contributor-routing guidance rather than a promise that every legacy path remains the long-
+term home for that language.
 
 | If your change is about... | Start here |
 |----------------------------|------------|
 | Core governance/runtime behavior | `packages/` |
-| Current shared SDK implementations | `packages/agent-mesh/sdks/` or `packages/agent-governance-dotnet/` while those SDKs still live in the shared layout |
-| Standalone language implementations | Reserved root-level paths such as `agent-governance-dotnet/`, future `agent-governance-golang/`, or other `agent-governance-*` siblings when present |
+| Current shared SDK implementations | `packages/agent-mesh/sdks/` and other languages that still live in the shared layout |
+| Standalone language implementations | `agent-governance-dotnet/`, `agent-governance-golang/`, or other `agent-governance-*` siblings at the repository root |
 | Tutorials, architecture, package docs | `docs/` |
 | Runnable framework integrations | `examples/` |
 | Interactive or live demos | `demo/` |
@@ -53,8 +54,8 @@ If a directory contains an `AGENTS.md` file, read it before you start. It captur
 commands, boundaries, and review expectations for that area.
 If a standalone top-level language directory exists for the implementation you are changing, prefer
 that directory over an older shared path unless maintainers tell you to keep work in the legacy
-location. For the approved .NET standalone migration, root-level contributor guidance should point
-to `agent-governance-dotnet/` as the destination path once it is introduced.
+location. For the approved .NET standalone migration, contributor guidance should point to
+`agent-governance-dotnet/` as the canonical path, not `packages/agent-governance-dotnet/`.
 
 ### Attribution & Prior Art
 
@@ -139,12 +140,12 @@ This is a mono-repo with ten packages today:
 | `agentmesh-marketplace` | `packages/agent-marketplace/` | Plugin lifecycle management for governed agent ecosystems |
 | `agentmesh-lightning` | `packages/agent-lightning/` | RL training governance with governed runners and policy rewards |
 | `agent-hypervisor` | `packages/agent-hypervisor/` | Runtime infrastructure and capability management |
-| `agent-governance-dotnet` | `packages/agent-governance-dotnet/` | .NET framework integration for agent governance |
+| `agent-governance-dotnet` | `packages/agent-governance-dotnet/` | Legacy shared-layout .NET implementation during migration to the root-level standalone path |
 | `agentmesh-integrations` | `packages/agentmesh-integrations/` | Framework integrations and extension library |
 
-Standalone language SDKs may also live at the repository root as that migration lands. The first
-planned example is `agent-governance-dotnet/`; `agent-governance-golang/` is the anticipated next
-sibling when Go gets a standalone top-level home.
+Contributor routing for the standalone .NET SDK should use `agent-governance-dotnet/` at the
+repository root as the canonical path. Legacy shared-layout references such as
+`packages/agent-governance-dotnet/` are migration context, not the target-state path.
 
 ### Coding Guidelines
 

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -23,11 +23,38 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 ### Pull Requests
 
 1. Fork the repository and create a feature branch from `main`
-2. Make your changes in the appropriate package directory under `packages/`
-3. Add or update tests as needed
-4. Ensure all tests pass: `pytest`
-5. Update documentation if your change affects public APIs
-6. Submit a pull request with a clear description of the changes
+2. Read the nearest `AGENTS.md` before changing code in that area
+3. Make your changes in the appropriate package or top-level directory for that part of the repo
+4. Add or update tests as needed
+5. Ensure all tests pass: `pytest`
+6. Update documentation if your change affects public APIs
+7. Submit a pull request with a clear description of the changes
+
+### Repository Routing
+
+This repo is a monorepo. Choosing the right path up front makes review much faster.
+The layout is also evolving: some language implementations may move from shared directories into
+standalone top-level directories at the repository root over time. The first approved example is
+`agent-governance-dotnet/`, with `agent-governance-golang/` anticipated as a future sibling when
+that SDK moves. Treat the paths below as the current layout, not a permanent architecture promise.
+
+| If your change is about... | Start here |
+|----------------------------|------------|
+| Core governance/runtime behavior | `packages/` |
+| Current shared SDK implementations | `packages/agent-mesh/sdks/` or `packages/agent-governance-dotnet/` while those SDKs still live in the shared layout |
+| Standalone language implementations | Reserved root-level paths such as `agent-governance-dotnet/`, future `agent-governance-golang/`, or other `agent-governance-*` siblings when present |
+| Tutorials, architecture, package docs | `docs/` |
+| Runnable framework integrations | `examples/` |
+| Interactive or live demos | `demo/` |
+| Azure DevOps publishing/release automation | `pipelines/` |
+| GitHub Actions, PR automation, templates | `.github/` |
+
+If a directory contains an `AGENTS.md` file, read it before you start. It captures local
+commands, boundaries, and review expectations for that area.
+If a standalone top-level language directory exists for the implementation you are changing, prefer
+that directory over an older shared path unless maintainers tell you to keep work in the legacy
+location. For the approved .NET standalone migration, root-level contributor guidance should point
+to `agent-governance-dotnet/` as the destination path once it is introduced.
 
 ### Attribution & Prior Art
 
@@ -100,7 +127,7 @@ docker compose --profile dashboard up --build dashboard
 
 ### Package Structure
 
-This is a mono-repo with ten packages:
+This is a mono-repo with ten packages today:
 
 | Package | Directory | Description |
 |---------|-----------|-------------|
@@ -114,6 +141,10 @@ This is a mono-repo with ten packages:
 | `agent-hypervisor` | `packages/agent-hypervisor/` | Runtime infrastructure and capability management |
 | `agent-governance-dotnet` | `packages/agent-governance-dotnet/` | .NET framework integration for agent governance |
 | `agentmesh-integrations` | `packages/agentmesh-integrations/` | Framework integrations and extension library |
+
+Standalone language SDKs may also live at the repository root as that migration lands. The first
+planned example is `agent-governance-dotnet/`; `agent-governance-golang/` is the anticipated next
+sibling when Go gets a standalone top-level home.
 
 ### Coding Guidelines
 


### PR DESCRIPTION
## Description
Clarifies root contributor and documentation guidance for standalone language SDK routing.

This PR makes `agent-governance-dotnet/` at the repository root the canonical contributor-facing .NET path, aligns the docs copy of the contributing guide with the root guide, and keeps `packages/agent-governance-dotnet/` framed only as legacy migration context rather than the target-state location.

It also establishes the matching standalone sibling pattern for `agent-governance-golang/` and future `agent-governance-*` SDKs at the repo root.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
None.

## Related Issues
None.