### PR TITLE
fix: TypeScript 6.0 build compatibility for agentmesh-sdk

### DIFF
--- a/packages/agent-mesh/sdks/typescript/jest.config.js
+++ b/packages/agent-mesh/sdks/typescript/jest.config.js
@@ -8,4 +8,16 @@ module.exports = {
   testMatch: ['**/*.test.ts'],
   collectCoverageFrom: ['src/**/*.ts'],
   coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^@noble/curves/(.+?)(\\.js)?$': '<rootDir>/node_modules/@noble/curves/$1.js',
+    '^@noble/hashes/(.+?)(\\.js)?$': '<rootDir>/node_modules/@noble/hashes/$1.js',
+    '^@noble/ciphers/(.+?)(\\.js)?$': '<rootDir>/node_modules/@noble/ciphers/$1.js',
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(@noble)/)',
+  ],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+    '.*@noble.+\\.js$': ['ts-jest', { tsconfig: { allowJs: true } }],
+  },
 };

--- a/packages/agent-mesh/sdks/typescript/src/encryption/ratchet.ts
+++ b/packages/agent-mesh/sdks/typescript/src/encryption/ratchet.ts
@@ -11,7 +11,7 @@
 import { x25519 } from "@noble/curves/ed25519";
 import { chacha20poly1305 } from "@noble/ciphers/chacha";
 import { hkdf } from "@noble/hashes/hkdf";
-import { sha256 } from "@noble/hashes/sha256";
+import { sha256 } from "@noble/hashes/sha2";
 import { hmac } from "@noble/hashes/hmac";
 import { randomBytes } from "@noble/ciphers/webcrypto";
 

--- a/packages/agent-mesh/sdks/typescript/src/encryption/x3dh.ts
+++ b/packages/agent-mesh/sdks/typescript/src/encryption/x3dh.ts
@@ -11,11 +11,9 @@
  * Reference: https://signal.org/docs/specifications/x3dh/ (CC0)
  */
 
-import { x25519 } from "@noble/curves/ed25519";
-import { edwardsToMontgomeryPriv, edwardsToMontgomeryPub } from "@noble/curves/ed25519";
+import { x25519, ed25519 } from "@noble/curves/ed25519";
 import { hkdf } from "@noble/hashes/hkdf";
-import { sha256 } from "@noble/hashes/sha256";
-import { ed25519 } from "@noble/curves/ed25519";
+import { sha256, sha512 } from "@noble/hashes/sha2";
 import { randomBytes } from "@noble/ciphers/webcrypto";
 
 const X3DH_INFO = new TextEncoder().encode("AgentMesh_X3DH_v1");
@@ -60,8 +58,13 @@ export function ed25519ToX25519(
     throw new Error("ed25519Private must be 32 or 64 bytes");
   }
   const priv32 = ed25519Private.length === 64 ? ed25519Private.slice(0, 32) : ed25519Private;
-  const privateKey = edwardsToMontgomeryPriv(priv32);
-  const publicKey = edwardsToMontgomeryPub(ed25519Public);
+  // Ed25519 seed → SHA-512 → first 32 bytes → clamp per RFC 7748 §5
+  const h = sha512(priv32);
+  const privateKey = h.slice(0, 32);
+  privateKey[0] &= 248;
+  privateKey[31] &= 127;
+  privateKey[31] |= 64;
+  const publicKey = x25519.getPublicKey(privateKey);
   return { privateKey, publicKey };
 }
 

--- a/packages/agent-mesh/sdks/typescript/tests/encryption.test.ts
+++ b/packages/agent-mesh/sdks/typescript/tests/encryption.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../src/encryption";
 
 function makeManager(): X3DHKeyManager {
-  const priv = ed25519.utils.randomPrivateKey();
+  const priv = ed25519.utils.randomSecretKey();
   const pub = ed25519.getPublicKey(priv);
   return new X3DHKeyManager(priv, pub);
 }
@@ -68,7 +68,7 @@ describe("X25519KeyPair", () => {
   });
 
   test("ed25519 to x25519 conversion", () => {
-    const priv = ed25519.utils.randomPrivateKey();
+    const priv = ed25519.utils.randomSecretKey();
     const pub = ed25519.getPublicKey(priv);
     const kp = ed25519ToX25519(priv, pub);
     expect(kp.privateKey.length).toBe(32);

--- a/packages/agent-mesh/sdks/typescript/tsconfig.json
+++ b/packages/agent-mesh/sdks/typescript/tsconfig.json
@@ -13,7 +13,9 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Problem
CI build fails with:
\\\
tsconfig.json(16,25): error TS5107: Option 'moduleResolution=node10' is deprecated
\\\
TypeScript was bumped to 6.0.3 which deprecates \
ode10\ module resolution and renamed several \@noble/*\ APIs.

## Changes
- **tsconfig.json**: Add \ignoreDeprecations: '6.0'\, add \	ypes: ['node', 'jest']\
- **x3dh.ts**: Fix \@noble/hashes/sha256\ → \@noble/hashes/sha2\ (module renamed); replace removed \dwardsToMontgomeryPriv/Pub\ with manual SHA-512 + RFC 7748 §5 clamping
- **ratchet.ts**: Same sha2 import fix
- **encryption.test.ts**: Fix \andomPrivateKey()\ → \andomSecretKey()\ (API renamed)
- **jest.config.js**: Add \moduleNameMapper\ + \	ransformIgnorePatterns\ for ESM \@noble\ packages

## Verification
All 20 encryption tests pass locally. \	sc\ compiles cleanly.