### PR TITLE
docs(agentmesh-avp): document did:key-only limitation

### DIFF
--- a/packages/agentmesh-integrations/agentmesh-avp/README.md
+++ b/packages/agentmesh-integrations/agentmesh-avp/README.md
@@ -55,6 +55,11 @@ score = await engine.get_trust_score("did:key:z6MkAgent...")
 | `timeout` | `10.0` | HTTP timeout in seconds |
 | `min_score_threshold` | `0.3` | Minimum score for score-based verification |
 
+## Limitations
+
+- **DID method**: Only `did:key` identifiers are supported. Other DID methods (`did:web`, `did:ion`, etc.) will be rejected by the DID format validator.
+- **Fallback behavior**: When the AVP verification endpoint is unreachable, `verify_identity` falls back to score-based verification using `min_score_threshold`. This is logged as a warning.
+
 ## About Agent Veil Protocol
 
 AVP is an open reputation layer for AI agents. 110+ agents in production, daily IPFS anchors, MIT-licensed SDK.


### PR DESCRIPTION
## Summary

Follow-up to merged #1010. Documents two known behaviors of the `agentmesh-avp` provider that aren't immediately obvious from the API surface:

- **DID method scope**: only `did:key` identifiers are accepted. Other methods (`did:web`, `did:ion`, etc.) are rejected by the format validator in `provider.py` (`_DID_PATTERN = r"^did:key:z6Mk[1-9A-HJ-NP-Za-km-z]{43,}$"`).
- **Fallback behavior**: `verify_identity` falls back to score-based verification using `min_score_threshold` when the AVP endpoint is unreachable, and logs a warning.

No code changes — adds a `## Limitations` section to `packages/agentmesh-integrations/agentmesh-avp/README.md` (5 lines).

## Context

- Independent of the wire protocol v1.0 discussion (#1276) and DID method standardization (LIMITATIONS.md §12) — this is AVP-side `did:key` validation, not agent-mesh internal DID format.
- Supersedes the `docs/avp-did-key-limitation` local branch referenced in review comments on #1010.

## Test plan

- [x] Verified `_DID_PATTERN` on current `main` still constrains to `did:key:z6Mk…`
- [x] Verified fallback behavior matches current `provider.py` logic
- [ ] No runtime/test surface to exercise — docs-only