### PR TITLE
fix(docs): correct CONTRIBUTING.md relative link in agentmesh-avp README

### DIFF
--- a/packages/agentmesh-integrations/agentmesh-avp/README.md
+++ b/packages/agentmesh-integrations/agentmesh-avp/README.md
@@ -65,4 +65,4 @@ AVP is an open reputation layer for AI agents. 110+ agents in production, daily 
 
 ## Contributing
 
-See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+See the main [CONTRIBUTING.md](../../../CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Description
Fixes the failing **Markdown Link Check** workflow ([job 72488648923](https://github.com/microsoft/agent-governance-toolkit/actions/runs/24769326539#summary-72488648923)) by correcting a broken relative link in the `agentmesh-avp` README.

The README at `packages/agentmesh-integrations/agentmesh-avp/README.md` is nested 3 directories deep, so the relative link to the repo-root `CONTRIBUTING.md` needs `../../../`, not `../../`. The previous path resolved to `packages/CONTRIBUTING.md` (which does not exist), causing lychee to fail with:

```
[ERROR] file:///.../packages/CONTRIBUTING.md | Cannot find file: File not found. Check if file exists and path is correct
```

### Change
```diff
- See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
+ See the main [CONTRIBUTING.md](../../../CONTRIBUTING.md) for guidelines.
```

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

(Specifically: `packages/agentmesh-integrations/agentmesh-avp/README.md`)

## Checklist
- [x] My code follows the project style guidelines (ruff check) — _N/A, docs-only change_
- [x] I have added tests that prove my fix/feature works — _verified by re-running the lychee link checker against the updated README_
- [x] All new and existing tests pass (pytest) — _N/A, no code changes_
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
N/A — single-character relative path correction.