### PR TITLE
fix: restore istanbul-reports@3.2.0 in lockfile

### DIFF
--- a/packages/agent-mesh/sdks/typescript/package-lock.json
+++ b/packages/agent-mesh/sdks/typescript/package-lock.json
@@ -3380,8 +3380,8 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.1.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",


### PR DESCRIPTION
The bulk 3.2.0→3.2.1 version bump accidentally changed istanbul-reports version in package-lock.json. istanbul-reports@3.2.1 does not exist on npm, causing npm install to fail in CI.