### PR TITLE
examples: add cognitive-attestation-governed (signed reasoning-substrate attestation layered on AGT policy)

### DIFF
--- a/examples/cognitive-attestation-governed/README.md
+++ b/examples/cognitive-attestation-governed/README.md
@@ -27,6 +27,7 @@ The envelope is small (~1-3 KB), JCS-canonical, and verifiable offline with a si
 4. The envelope is Ed25519-signed and JCS-canonicalized with timestamp bound into the signature
 5. A second party verifies the envelope offline using only the public key and the canonical schema
 6. A tampered envelope is rejected by the verifier with the reason surfaced
+7. A stale envelope (older than `max_age_seconds`) is rejected by the freshness check, demonstrating replay defence
 
 ## Install
 
@@ -42,7 +43,7 @@ The Cognitive Attestation primitive used here is a small self-contained implemen
 python getting_started.py
 ```
 
-Expected output: an AGT-style policy decision, then a signed Cognitive Attestation envelope, then a passing offline verification, then a tamper rejection that explicitly reports detection.
+Expected output: an AGT-style policy decision, signed envelope, passing offline verification, tamper rejection with reason, and a replay rejection when the envelope is verified 10 minutes after signing against a 300-second freshness window.
 
 ## How it composes
 

--- a/examples/cognitive-attestation-governed/README.md
+++ b/examples/cognitive-attestation-governed/README.md
@@ -1,0 +1,75 @@
+# Cognitive Attestation + AGT
+
+**Status:** experimental, community-driven.
+
+Demonstrates layering [Cognitive Attestation](https://doi.org/10.5281/zenodo.19646276) on top of AGT policy enforcement. AGT decides whether an action is allowed based on policy. Cognitive Attestation signs an interpretable decomposition of the model state that drove that decision, so downstream auditors can inspect what the reasoning substrate looked like when the action fired, not just whether the policy rule matched.
+
+**AGT enforces policy. Cognitive Attestation explains the reasoning.**
+
+## What this adds
+
+Policy enforcement answers whether an action is permitted. It does not explain the internal model state that produced the action. Cognitive Attestation captures that layer with a small signed envelope:
+
+- `action_ref`: content-addressed hash of the action being attested
+- `feature_activations`: sparse-autoencoder features with activation statistics, canonically sorted
+- `dictionary_ref`: which SAE dictionary produced the features (reproducibility pointer)
+- `canonical_hash`: RFC 8785 JCS canonicalization over the envelope
+- Ed25519 signature over the canonical form
+
+The envelope is small (~1-3 KB), JCS-canonical, and verifiable offline with a single Ed25519 public key.
+
+## What this example shows
+
+1. AGT evaluates a policy (allow/deny) before execution
+2. If allowed, the agent produces an action
+3. A Cognitive Attestation envelope is built over that action, carrying SAE feature activations that represent the decomposed model state
+4. The envelope is Ed25519-signed and JCS-canonicalized
+5. A second party verifies the envelope offline using only the public key and the canonical schema
+6. A tampered envelope is rejected by the verifier
+
+## Install
+
+```bash
+pip install agent-governance-toolkit cryptography
+```
+
+The Cognitive Attestation primitive used here is a small self-contained implementation of the published spec. Reference implementation and normative schema live at [github.com/aeoess/agent-passport-system](https://github.com/aeoess/agent-passport-system) (see `src/v2/cognitive-attestation/`) under Apache 2.0.
+
+## Run
+
+```bash
+python getting_started.py
+```
+
+Expected output: an AGT-style policy decision, then a signed Cognitive Attestation envelope, then a passing offline verification, then a passing tamper rejection.
+
+## How it composes
+
+```
+Agent action
+    |
+    +-> AGT policy engine      (allow / deny)
+    |
+    +-> Cognitive Attestation  (signed feature decomposition
+                                of the reasoning substrate)
+            |
+            v
+     Offline verifier
+     (public key + JCS + schema)
+```
+
+Policy and attestation are separate layers. A decision can be permitted by policy yet produce a revealing attestation (for audit), or denied by policy and produce nothing. The two are complementary.
+
+## Prior art and attribution
+
+- Paper: *Cognitive Attestation: Signing Interpretable Decompositions of Latent Model State in AI Agent Governance*, Zenodo DOI [10.5281/zenodo.19646276](https://doi.org/10.5281/zenodo.19646276), April 2026.
+- Reference implementation: [aeoess/agent-passport-system](https://github.com/aeoess/agent-passport-system) (Apache 2.0, v2.1.0 on npm and PyPI).
+- Schema: `papers/paper-4/poc/schema/cognitive_attestation.schema.json` in the reference repo.
+- Canonicalization: RFC 8785 (JCS).
+- Signature: Ed25519 via standard libraries.
+
+## Limitations
+
+- Interpretability depends on the underlying SAE dictionary. Choosing a dictionary is a governance decision; this example uses a fixed placeholder dictionary ref for reproducibility.
+- Feature labels are dictionary-author-assigned and not independently verified by the attestation itself. A v1.1 validation pass is on the reference-implementation roadmap.
+- This example is community-contributed, not part of AGT's core runtime. Treat outputs as experimental.

--- a/examples/cognitive-attestation-governed/README.md
+++ b/examples/cognitive-attestation-governed/README.md
@@ -13,7 +13,8 @@ Policy enforcement answers whether an action is permitted. It does not explain t
 - `action_ref`: content-addressed hash of the action being attested
 - `feature_activations`: sparse-autoencoder features with activation statistics, canonically sorted
 - `dictionary_ref`: which SAE dictionary produced the features (reproducibility pointer)
-- `canonical_hash`: RFC 8785 JCS canonicalization over the envelope
+- `timestamp`: ISO 8601 UTC timestamp, bound into the signature for replay defence
+- `canonical_hash`: [RFC 8785](https://datatracker.ietf.org/doc/html/rfc8785) JCS canonicalization over the envelope
 - Ed25519 signature over the canonical form
 
 The envelope is small (~1-3 KB), JCS-canonical, and verifiable offline with a single Ed25519 public key.
@@ -23,9 +24,9 @@ The envelope is small (~1-3 KB), JCS-canonical, and verifiable offline with a si
 1. AGT evaluates a policy (allow/deny) before execution
 2. If allowed, the agent produces an action
 3. A Cognitive Attestation envelope is built over that action, carrying SAE feature activations that represent the decomposed model state
-4. The envelope is Ed25519-signed and JCS-canonicalized
+4. The envelope is Ed25519-signed and JCS-canonicalized with timestamp bound into the signature
 5. A second party verifies the envelope offline using only the public key and the canonical schema
-6. A tampered envelope is rejected by the verifier
+6. A tampered envelope is rejected by the verifier with the reason surfaced
 
 ## Install
 
@@ -41,7 +42,7 @@ The Cognitive Attestation primitive used here is a small self-contained implemen
 python getting_started.py
 ```
 
-Expected output: an AGT-style policy decision, then a signed Cognitive Attestation envelope, then a passing offline verification, then a passing tamper rejection.
+Expected output: an AGT-style policy decision, then a signed Cognitive Attestation envelope, then a passing offline verification, then a tamper rejection that explicitly reports detection.
 
 ## How it composes
 
@@ -60,16 +61,25 @@ Agent action
 
 Policy and attestation are separate layers. A decision can be permitted by policy yet produce a revealing attestation (for audit), or denied by policy and produce nothing. The two are complementary.
 
+## Security notes
+
+The Ed25519 private key in `getting_started.py` is generated on the fly for demonstration. Production deployments MUST store signing keys securely. Options that are appropriate in order of increasing assurance: OS keychain (Keychain on macOS, DPAPI on Windows, libsecret on Linux); HashiCorp Vault or cloud KMS; an HSM or TPM-backed key store such as Azure Key Vault Managed HSM, AWS CloudHSM, or YubiHSM. The example does not prescribe one, but a signing key that ends up in a container image, a git repo, or an unencrypted disk defeats the purpose of the attestation chain.
+
+The minimal JCS implementation in `getting_started.py` covers the field types used by this envelope but is NOT a full RFC 8785 implementation. Production code should use a spec-conformant library (the [`jcs`](https://pypi.org/project/jcs/) PyPI package, or the APS SDK's implementation which is tested against cross-language conformance vectors).
+
+The policy evaluator in the example is a minimal placeholder to keep the example self-contained. It is NOT a substitute for AGT's real policy engine.
+
 ## Prior art and attribution
 
 - Paper: *Cognitive Attestation: Signing Interpretable Decompositions of Latent Model State in AI Agent Governance*, Zenodo DOI [10.5281/zenodo.19646276](https://doi.org/10.5281/zenodo.19646276), April 2026.
-- Reference implementation: [aeoess/agent-passport-system](https://github.com/aeoess/agent-passport-system) (Apache 2.0, v2.1.0 on npm and PyPI).
+- Reference implementation: [aeoess/agent-passport-system](https://github.com/aeoess/agent-passport-system) (Apache 2.0, v2.2.0 on npm and PyPI). Full primitive lives in `src/v2/cognitive-attestation/` with 29 tests including cross-language conformance vectors.
 - Schema: `papers/paper-4/poc/schema/cognitive_attestation.schema.json` in the reference repo.
-- Canonicalization: RFC 8785 (JCS).
+- Canonicalization: [RFC 8785](https://datatracker.ietf.org/doc/html/rfc8785) (JCS).
 - Signature: Ed25519 via standard libraries.
 
 ## Limitations
 
 - Interpretability depends on the underlying SAE dictionary. Choosing a dictionary is a governance decision; this example uses a fixed placeholder dictionary ref for reproducibility.
 - Feature labels are dictionary-author-assigned and not independently verified by the attestation itself. A v1.1 validation pass is on the reference-implementation roadmap.
+- The minimal JCS here does not handle Unicode normalization edge cases or all IEEE 754 special values. See the "Security notes" above.
 - This example is community-contributed, not part of AGT's core runtime. Treat outputs as experimental.

--- a/examples/cognitive-attestation-governed/getting_started.py
+++ b/examples/cognitive-attestation-governed/getting_started.py
@@ -161,19 +161,65 @@ def sign_envelope(unsigned: dict[str, Any], sk: Ed25519PrivateKey) -> dict[str, 
     return signed
 
 
-def verify_envelope(signed: dict[str, Any]) -> bool:
+def verify_envelope(
+    signed: dict[str, Any],
+    max_age_seconds: int | None = 300,
+    now: datetime | None = None,
+) -> tuple[bool, str]:
+    """Verify signature AND (optionally) freshness.
+
+    Returns (ok, reason). On success, reason is "ok". On failure, reason is
+    one of: "signature_invalid", "envelope_expired", "envelope_not_yet_valid",
+    "timestamp_malformed", "missing_signature", "missing_pubkey".
+
+    Set max_age_seconds=None to disable freshness checking (signature-only
+    verification, not recommended for live traffic).
+    """
     import base64
     from cryptography.exceptions import InvalidSignature
 
+    # Signature check
+    if "signature_b64" not in signed:
+        return False, "missing_signature"
+    if "signer_pubkey_hex" not in signed:
+        return False, "missing_pubkey"
     to_verify = {k: v for k, v in signed.items() if k not in {"signature_b64"}}
     canonical = canonicalize_jcs(to_verify)
-    sig = base64.b64decode(signed["signature_b64"])
-    pk = Ed25519PublicKey.from_public_bytes(bytes.fromhex(signed["signer_pubkey_hex"]))
     try:
+        sig = base64.b64decode(signed["signature_b64"])
+        pk = Ed25519PublicKey.from_public_bytes(
+            bytes.fromhex(signed["signer_pubkey_hex"])
+        )
         pk.verify(sig, canonical)
-        return True
     except InvalidSignature:
-        return False
+        return False, "signature_invalid"
+    except Exception:
+        return False, "signature_invalid"
+
+    # Freshness check (replay defence). An envelope older than max_age_seconds
+    # is rejected even with a valid signature, because the signed timestamp
+    # lets the verifier distinguish a new legitimate envelope from a replay
+    # of an old one.
+    if max_age_seconds is not None:
+        ts_str = signed.get("timestamp")
+        if not ts_str:
+            return False, "timestamp_malformed"
+        try:
+            # Accept "...Z" and "...+00:00" forms
+            ts_str_norm = ts_str.replace("Z", "+00:00")
+            ts = datetime.fromisoformat(ts_str_norm)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            return False, "timestamp_malformed"
+        current = now or datetime.now(timezone.utc)
+        age = (current - ts).total_seconds()
+        if age > max_age_seconds:
+            return False, "envelope_expired"
+        if age < -max_age_seconds:
+            return False, "envelope_not_yet_valid"
+
+    return True, "ok"
 
 
 # ---------------------------------------------------------------------------
@@ -281,15 +327,30 @@ def main() -> None:
     print(f"Signature (b64):         {signed['signature_b64'][:40]}...")
     print(f"Features attested:       {len(signed['feature_activations'])}")
 
-    # Step 7: offline verification
-    ok = verify_envelope(signed)
-    print(f"\nOffline verification: {'PASS' if ok else 'FAIL'}")
+    # Step 7: offline verification (signature + freshness)
+    ok, reason = verify_envelope(signed)
+    print(f"\nOffline verification: {'PASS' if ok else f'FAIL ({reason})'}")
 
     # Step 8: tamper check
     tampered = json.loads(json.dumps(signed))
     tampered["feature_activations"][0]["activation_statistic"] = 0.99
-    ok2 = verify_envelope(tampered)
-    print(f"Tamper detection:     {'PASS (tampering detected, envelope rejected)' if not ok2 else 'FAIL (tampering not detected, envelope accepted)'}")
+    ok2, reason2 = verify_envelope(tampered)
+    if not ok2:
+        print(f"Tamper detection:     PASS (tampering detected, envelope rejected, reason={reason2})")
+    else:
+        print("Tamper detection:     FAIL (tampering not detected, envelope accepted)")
+
+    # Step 9: freshness / replay defence
+    import copy
+    from datetime import timedelta
+    stale = copy.deepcopy(signed)
+    # Simulate verifying the same valid envelope 10 minutes later (>300s default)
+    later = datetime.now(timezone.utc) + timedelta(minutes=10)
+    ok3, reason3 = verify_envelope(stale, max_age_seconds=300, now=later)
+    if not ok3 and reason3 == "envelope_expired":
+        print(f"Replay defence:       PASS (stale envelope rejected, reason={reason3})")
+    else:
+        print(f"Replay defence:       FAIL (ok={ok3}, reason={reason3})")
 
 
 if __name__ == "__main__":

--- a/examples/cognitive-attestation-governed/getting_started.py
+++ b/examples/cognitive-attestation-governed/getting_started.py
@@ -1,0 +1,263 @@
+"""AGT + Cognitive Attestation: policy enforcement plus signed interpretability.
+
+AGT decides whether an action is allowed. Cognitive Attestation signs the
+interpretable decomposition of model state behind the decision, so an auditor
+can verify what the reasoning substrate looked like when the action fired,
+not just whether the policy rule matched.
+
+Paper: Cognitive Attestation (Zenodo DOI 10.5281/zenodo.19646276)
+Reference implementation: github.com/aeoess/agent-passport-system
+Community-contributed, experimental, Apache 2.0.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+# ---------------------------------------------------------------------------
+# RFC 8785 JCS canonicalization (minimal subset sufficient for this envelope)
+# ---------------------------------------------------------------------------
+
+def canonicalize_jcs(value: Any) -> bytes:
+    """RFC 8785 JSON Canonicalization Scheme (minimal)."""
+    return _encode(value).encode("utf-8")
+
+
+def _encode(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and value == int(value):
+            return str(int(value))
+        return json.dumps(value)
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, list):
+        return "[" + ",".join(_encode(v) for v in value) + "]"
+    if isinstance(value, dict):
+        keys = sorted(value.keys())
+        return "{" + ",".join(
+            f"{json.dumps(k, ensure_ascii=False)}:{_encode(value[k])}" for k in keys
+        ) + "}"
+    raise TypeError(f"Not JSON-serializable: {type(value).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Envelope types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FeatureActivation:
+    feature_id: str
+    activation_statistic: float
+    label: str = ""
+
+
+@dataclass
+class CognitiveAttestation:
+    spec_version: str = "1.0"
+    action_ref: str = ""
+    dictionary_ref: str = ""
+    feature_activations: list[FeatureActivation] = field(default_factory=list)
+    canonical_hash: str = ""
+    signer_role: str = "agent"
+    signer_pubkey_hex: str = ""
+    signature_b64: str = ""
+
+
+def build_envelope(
+    action: dict[str, Any],
+    features: list[FeatureActivation],
+    dictionary_ref: str,
+    signer_role: str = "agent",
+) -> dict[str, Any]:
+    """Build the unsigned envelope (canonical form, ready to sign)."""
+    action_bytes = canonicalize_jcs(action)
+    action_ref = "sha256:" + hashlib.sha256(action_bytes).hexdigest()
+
+    # Canonical sort: (feature_id, activation_statistic) as spec requires
+    sorted_features = sorted(
+        features,
+        key=lambda f: (f.feature_id, f.activation_statistic),
+    )
+
+    envelope = {
+        "spec_version": "1.0",
+        "action_ref": action_ref,
+        "dictionary_ref": dictionary_ref,
+        "feature_activations": [
+            {
+                "feature_id": f.feature_id,
+                "activation_statistic": f.activation_statistic,
+                "label": f.label,
+            }
+            for f in sorted_features
+        ],
+        "signer_role": signer_role,
+    }
+    canonical = canonicalize_jcs(envelope)
+    envelope["canonical_hash"] = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    return envelope
+
+
+def sign_envelope(unsigned: dict[str, Any], sk: Ed25519PrivateKey) -> dict[str, Any]:
+    """Attach signer pubkey, then sign the canonical form (excluding signature)."""
+    import base64
+    pk = sk.public_key()
+    pk_hex = pk.public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
+
+    # Build the exact dict that the verifier will canonicalize
+    to_sign = dict(unsigned)
+    to_sign["signer_pubkey_hex"] = pk_hex
+    # canonicalize over everything except the signature itself
+    canonical = canonicalize_jcs(to_sign)
+    sig = sk.sign(canonical)
+
+    signed = dict(to_sign)
+    signed["signature_b64"] = base64.b64encode(sig).decode("ascii")
+    return signed
+
+
+def verify_envelope(signed: dict[str, Any]) -> bool:
+    import base64
+    from cryptography.exceptions import InvalidSignature
+
+    to_verify = {k: v for k, v in signed.items() if k not in {"signature_b64"}}
+    canonical = canonicalize_jcs(to_verify)
+    sig = base64.b64decode(signed["signature_b64"])
+    pk = Ed25519PublicKey.from_public_bytes(bytes.fromhex(signed["signer_pubkey_hex"]))
+    try:
+        pk.verify(sig, canonical)
+        return True
+    except InvalidSignature:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Minimal AGT-style policy evaluator (stand-in so the example runs standalone)
+# ---------------------------------------------------------------------------
+
+def evaluate_policy(action: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
+    """Minimal policy check. In production, use agent-governance-toolkit."""
+    tool = action.get("tool", "")
+    for rule in policy.get("rules", []):
+        match = rule.get("match", {}).get("tool", {})
+        one_of = match.get("one_of", [])
+        if tool in one_of:
+            return {
+                "decision": rule["action"],
+                "rule_id": rule["id"],
+                "reason": rule.get("reason", ""),
+            }
+    return {
+        "decision": policy.get("default_action", "deny"),
+        "rule_id": "default",
+        "reason": "No matching rule.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Demo
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    # Step 1: agent has an Ed25519 key
+    sk = Ed25519PrivateKey.generate()
+    pk_hex = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
+    print(f"Agent pubkey: {pk_hex[:20]}...")
+
+    # Step 2: policy (AGT-compatible shape)
+    policy = {
+        "version": 1,
+        "name": "cogattest-demo-policy",
+        "default_action": "deny",
+        "rules": [
+            {
+                "id": "allow-read",
+                "match": {"tool": {"one_of": ["web_search", "file_read"]}},
+                "action": "allow",
+            },
+            {
+                "id": "deny-destructive",
+                "match": {"tool": {"one_of": ["file_delete", "drop_database"]}},
+                "action": "deny",
+                "reason": "Destructive operations blocked.",
+            },
+        ],
+    }
+
+    # Step 3: proposed action
+    action = {
+        "tool": "web_search",
+        "params": {"query": "ed25519 signature properties"},
+        "target": "mcp://search",
+    }
+
+    # Step 4: AGT-style policy decision
+    decision = evaluate_policy(action, policy)
+    print(f"\nAGT policy decision: {decision['decision']} "
+          f"(rule={decision['rule_id']})")
+
+    if decision["decision"] != "allow":
+        print("Action blocked. No attestation produced.")
+        return
+
+    # Step 5: agent's reasoning substrate, decomposed into SAE features.
+    # In production this comes from running a sparse autoencoder over
+    # the model's residual stream. Here we use a fixed demo dictionary
+    # and static features so the output is reproducible.
+    features = [
+        FeatureActivation("f_0412", 0.87, "search-intent"),
+        FeatureActivation("f_1055", 0.54, "cryptography-topic"),
+        FeatureActivation("f_0233", 0.33, "query-formulation"),
+    ]
+    dictionary_ref = (
+        "sae://neuronpedia/gpt2-small/"
+        "res-jb/12288/v1"
+    )
+
+    # Step 6: build + sign Cognitive Attestation envelope
+    unsigned = build_envelope(
+        action=action,
+        features=features,
+        dictionary_ref=dictionary_ref,
+        signer_role="agent",
+    )
+    signed = sign_envelope(unsigned, sk)
+    print(f"\nEnvelope action_ref:    {signed['action_ref']}")
+    print(f"Envelope canonical_hash: {signed['canonical_hash']}")
+    print(f"Signer pubkey:           {signed['signer_pubkey_hex'][:20]}...")
+    print(f"Signature (b64):         {signed['signature_b64'][:40]}...")
+    print(f"Features attested:       {len(signed['feature_activations'])}")
+
+    # Step 7: offline verification
+    ok = verify_envelope(signed)
+    print(f"\nOffline verification: {'PASS' if ok else 'FAIL'}")
+
+    # Step 8: tamper check
+    tampered = json.loads(json.dumps(signed))
+    tampered["feature_activations"][0]["activation_statistic"] = 0.99
+    ok2 = verify_envelope(tampered)
+    print(f"Tamper detection:     {'PASS (rejected)' if not ok2 else 'FAIL (accepted)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cognitive-attestation-governed/getting_started.py
+++ b/examples/cognitive-attestation-governed/getting_started.py
@@ -17,6 +17,8 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
+from datetime import datetime, timezone
+
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PrivateKey,
     Ed25519PublicKey,
@@ -30,6 +32,14 @@ from cryptography.hazmat.primitives.serialization import (
 
 # ---------------------------------------------------------------------------
 # RFC 8785 JCS canonicalization (minimal subset sufficient for this envelope)
+# ---------------------------------------------------------------------------
+# NOTE: This is a MINIMAL JCS implementation that covers the field types used
+# in this example envelope. It does not implement the full RFC 8785 edge
+# cases (Unicode normalization, certain IEEE 754 special values, etc.).
+# Production code should use a fully-tested JCS library such as `jcs` on PyPI
+# or the reference implementation at github.com/cyberphone/json-canonicalization.
+# The APS SDK at github.com/aeoess/agent-passport-system ships a spec-conformant
+# implementation used for all real signatures.
 # ---------------------------------------------------------------------------
 
 def canonicalize_jcs(value: Any) -> bytes:
@@ -88,16 +98,30 @@ def build_envelope(
     features: list[FeatureActivation],
     dictionary_ref: str,
     signer_role: str = "agent",
+    timestamp: str | None = None,
 ) -> dict[str, Any]:
-    """Build the unsigned envelope (canonical form, ready to sign)."""
+    """Build the unsigned envelope (canonical form, ready to sign).
+
+    The `timestamp` field is included in the canonical form and therefore
+    in the signature. This prevents replay of a valid envelope into a
+    different point in time: any attempt to reuse a previously-signed
+    envelope will still carry the original timestamp, which a verifier
+    can reject against freshness policy.
+    """
     action_bytes = canonicalize_jcs(action)
     action_ref = "sha256:" + hashlib.sha256(action_bytes).hexdigest()
 
-    # Canonical sort: (feature_id, activation_statistic) as spec requires
+    # Canonical sort: (feature_id, activation_statistic). This order is
+    # required by the Cognitive Attestation spec (Zenodo 10.5281/zenodo.19646276,
+    # Section 3.2) so that two independently-produced envelopes over the
+    # same feature set produce identical canonical bytes.
     sorted_features = sorted(
         features,
         key=lambda f: (f.feature_id, f.activation_statistic),
     )
+
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     envelope = {
         "spec_version": "1.0",
@@ -112,6 +136,7 @@ def build_envelope(
             for f in sorted_features
         ],
         "signer_role": signer_role,
+        "timestamp": timestamp,
     }
     canonical = canonicalize_jcs(envelope)
     envelope["canonical_hash"] = "sha256:" + hashlib.sha256(canonical).hexdigest()
@@ -156,7 +181,15 @@ def verify_envelope(signed: dict[str, Any]) -> bool:
 # ---------------------------------------------------------------------------
 
 def evaluate_policy(action: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
-    """Minimal policy check. In production, use agent-governance-toolkit."""
+    """Minimal policy check for demonstration purposes ONLY.
+
+    This is NOT a substitute for the AGT policy engine. It intentionally
+    implements only exact-match tool name rules so this example is fully
+    self-contained and does not pull AGT as a heavy dependency. Real
+    deployments MUST replace this with `agent-governance-toolkit`'s
+    policy engine, which supports regex matches, nested conditions,
+    temporal rules, obligations, and the full AGT rule schema.
+    """
     tool = action.get("tool", "")
     for rule in policy.get("rules", []):
         match = rule.get("match", {}).get("tool", {})
@@ -256,7 +289,7 @@ def main() -> None:
     tampered = json.loads(json.dumps(signed))
     tampered["feature_activations"][0]["activation_statistic"] = 0.99
     ok2 = verify_envelope(tampered)
-    print(f"Tamper detection:     {'PASS (rejected)' if not ok2 else 'FAIL (accepted)'}")
+    print(f"Tamper detection:     {'PASS (tampering detected, envelope rejected)' if not ok2 else 'FAIL (tampering not detected, envelope accepted)'}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds `examples/cognitive-attestation-governed/`: a self-contained community example showing how to layer a signed interpretability envelope on top of AGT's policy decision.

AGT decides whether an action is permitted. The Cognitive Attestation envelope signs a sparse-autoencoder decomposition of the model state that drove the decision, so downstream auditors can inspect what the reasoning substrate looked like when the action fired, not just whether the policy rule matched.

## What's in the PR

- `README.md`: what the example shows, install/run, composition diagram, prior-art attribution, limitations. 75 lines.
- `getting_started.py`: runnable end-to-end demo. Minimal AGT-style policy evaluator (standalone for this example), envelope construction, Ed25519 sign/verify, tamper rejection, RFC 8785 JCS canonicalization. 263 lines. No dependency on the APS SDK; uses only `cryptography` from stdlib-adjacent install.

## Expected output

```
AGT policy decision: allow (rule=allow-read)

Envelope action_ref:    sha256:929da5560f87f5a32fc4706c9260a3188e9402a8891c534587eae8dc28240a2c
Envelope canonical_hash: sha256:501f58bc9ffcef404f4076a572bd1c7ba9e2d416651ce3b967d5706ac3a04b12
Signer pubkey:           <pubkey>...
Signature (b64):         <sig>...
Features attested:       3

Offline verification: PASS
Tamper detection:     PASS (rejected)
```

## Positioning

Follows the pattern set by `examples/signet-attestation/` (Signet, @willamhou): a third-party primitive demonstrated alongside AGT's policy engine, self-contained, README with prior-art attribution, labeled experimental per `examples/AGENTS.md`.

## Prior art

- Paper: *Cognitive Attestation: Signing Interpretable Decompositions of Latent Model State in AI Agent Governance*, Zenodo DOI [10.5281/zenodo.19646276](https://doi.org/10.5281/zenodo.19646276), April 2026.
- Reference implementation: [aeoess/agent-passport-system](https://github.com/aeoess/agent-passport-system) (Apache 2.0, v2.1.0 on npm and PyPI). Full primitive lives in `src/v2/cognitive-attestation/`.
- Follow-on from earlier merged contributions in this repo (#274, #598).

## Checklist

- [x] Example is runnable and self-contained
- [x] README follows `examples/AGENTS.md` conventions (setup, run, expected output, prior art, experimental labeling)
- [x] Minimal dependencies; each one explained
- [x] Placeholder dictionary ref only; no real secrets or credentials
- [x] Does not modify core packages
- [x] Python syntax check passes; `python3 getting_started.py` runs end-to-end with both verification and tamper rejection reporting PASS

Happy to iterate on placement, naming, or scope if the example fits better under a different directory or prefix.
