### PR TITLE
feat: add bilateral receipt signing (pre-execution + post-execution)

### DIFF
--- a/docs/proposals/verifiable-compliance-receipts.md
+++ b/docs/proposals/verifiable-compliance-receipts.md
@@ -1,0 +1,75 @@
+# Proposal: Independently Verifiable Compliance Receipts
+
+**Author:** Arian Gogani (@arian-gogani)
+**Date:** 2026-04-21
+**Status:** Draft
+**Related issues:** #1249, #787, #1196
+
+## Problem
+
+AGT's audit logger writes append-only hash chains. This gives you ordering guarantees, which is good. But the evidence lives on infrastructure the operator controls. If an auditor wants to verify compliance, they have to trust that nobody modified the chain after the fact.
+
+For EU AI Act Art. 12 (enforceable August 2, 2026) and SOC 2 audit scenarios, the question isn't "did you check?" It's "can you prove you checked, and can I verify that proof without trusting you?"
+
+The missing piece: compliance evidence that a third party can verify independently, without access to the operator's infrastructure.
+
+## Proposed solution
+
+When agent-compliance runs verification, it emits a signed receipt alongside the compliance grade. The receipt carries enough information for an external verifier to confirm what happened without needing to trust the operator.
+
+### Receipt fields
+
+A receipt contains: receiptId (SHA-256 hash), agentDid, timestamp, covenantHash (hash of policy in effect), action details with inputHash, decision (permit/deny), authorizationHash + authorizationSignature (pre-execution), resultHash + resultSignature (post-execution), previousReceiptHash (chain link), and signerKeyId.
+
+### What each field does
+
+covenantHash: Hash of the policy document in effect. An auditor checks this against the declared policy.
+
+authorizationHash + authorizationSignature: Signed before execution. Proves the policy was evaluated before anything ran. Pre-execution commitment.
+
+resultHash + resultSignature: Signed after execution. Binds the actual outcome. Post-execution proof.
+
+Both signatures use the same Ed25519 key (signerKeyId), so a verifier confirms they came from the same agent process.
+
+previousReceiptHash: Links to the previous receipt. Change any receipt and every receipt after it breaks.
+
+decision: permit or deny. If deny, the action never executed and the receipt proves the block happened.
+
+## Verification model
+
+A verifier checks three things:
+1. Signature validity. Ed25519 signatures valid against the declared signer key.
+2. Chain integrity. Each previousReceiptHash matches the hash of the receipt before it.
+3. Policy binding. Each covenantHash matches the expected policy.
+
+No access to the operator's infrastructure needed. Signatures and hashes are self-contained.
+
+## How this maps to AGT
+
+agent-compliance produces compliance grades. The receipt emits alongside the grade. The grade says compliant. The receipt proves it.
+
+agent-mesh uses Ed25519 DIDs. The receipt uses the same key material. No new crypto needed.
+
+Signet attestations (#1196) use a similar shape. Converging gives AGT one evidence format.
+
+Physical AI receipts (#787) can use the same bilateral structure.
+
+## Canonicalization
+
+SHA-256 of RFC 8785 JCS canonical form. Sorted keys, no whitespace, UTF-8.
+
+Cross-verified between Nobulex (TypeScript) and AgentLedger (Python). Three test vectors produce byte-identical digests.
+
+## Integration path
+
+When agt verify runs, it optionally emits a receipt wrapping the compliance grade in a signed envelope.
+
+Operators who don't need verifiability keep using AGT as-is. Regulated environments turn on receipts and hand them to auditors.
+
+## Cross-framework status
+
+This format is discussed in LangChain RFC #35691, AutoGen #7609, CrewAI #5541, NousResearch #487, OpenLineage PR #4480 (Linux Foundation spec), and an interop test with 4 implementations.
+
+## Next steps
+
+Happy to iterate. If the direction looks right, I can follow up with a concrete implementation PR against agent-compliance.

--- a/packages/agentmesh-integrations/sb-runtime-skill/sb_runtime_agentmesh/receipts.py
+++ b/packages/agentmesh-integrations/sb-runtime-skill/sb_runtime_agentmesh/receipts.py
@@ -187,3 +187,144 @@ def receipt_hash(envelope: Mapping[str, Any]) -> str:
     """
     digest = hashlib.sha256(_canonicalize(envelope)).digest()
     return _b64url(digest)
+
+
+
+# ------------------------------------------------------------------ #
+# Bilateral receipt extension (pre-execution + post-execution)         #
+# Reference: docs/proposals/verifiable-compliance-receipts.md          #
+# ------------------------------------------------------------------ #
+
+
+def sign_authorization(
+    payload: Mapping[str, Any],
+    signer: Signer,
+    previous_receipt_hash: Optional[str] = None,
+) -> dict:
+    """Sign a pre-execution authorization receipt.
+
+    Like sign_receipt() but marks the envelope as phase='authorization'.
+    The authorization proves the policy was evaluated BEFORE the action ran.
+    Seal with seal_result() after the tool call completes.
+    """
+    final_payload = dict(payload)
+    final_payload["phase"] = "authorization"
+    final_payload.setdefault(
+        "issued_at",
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z"),
+    )
+    if previous_receipt_hash is not None:
+        final_payload["previousReceiptHash"] = previous_receipt_hash
+
+    canonical = _canonicalize(final_payload)
+    authorization_hash = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    signature = signer.private_key.sign(canonical)
+
+    return {
+        "payload": final_payload,
+        "authorization": {
+            "hash": authorization_hash,
+            "sig": _b64url(signature),
+        },
+        "signature": {
+            "alg": "EdDSA",
+            "kid": signer.kid,
+            "sig": _b64url(signature),
+        },
+        "bilateral": True,
+        "result": None,
+    }
+
+
+def seal_result(
+    envelope: dict,
+    signer: Signer,
+    result_data: Mapping[str, Any],
+) -> dict:
+    """Seal a bilateral receipt with post-execution result data.
+
+    Binds the actual outcome to the authorization. The result_signature
+    covers both authorization_hash and result_hash, proving:
+      1. The authorization existed before execution
+      2. The result was produced after execution
+      3. Both were signed by the same key
+    """
+    if not envelope.get("bilateral"):
+        raise ValueError("Cannot seal a non-bilateral receipt")
+    if envelope.get("result") is not None:
+        raise ValueError("Receipt already sealed")
+
+    result_canonical = _canonicalize(result_data)
+    result_hash = "sha256:" + hashlib.sha256(result_canonical).hexdigest()
+    auth_hash = envelope["authorization"]["hash"]
+
+    binding = f"{auth_hash}:{result_hash}".encode("utf-8")
+    result_signature = signer.private_key.sign(binding)
+
+    sealed_at = (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+    envelope["result"] = {
+        "hash": result_hash,
+        "sig": _b64url(result_signature),
+        "sealed_at": sealed_at,
+        "data": result_data,
+    }
+    return envelope
+
+
+def verify_bilateral_receipt(
+    envelope: Mapping[str, Any],
+    public_key: Ed25519PublicKey,
+) -> dict:
+    """Verify both authorization and result signatures.
+
+    Returns {valid, authorization_valid, result_valid, bilateral}.
+    Falls back to verify_receipt() for non-bilateral envelopes.
+    """
+    if not envelope.get("bilateral"):
+        std_valid = verify_receipt(envelope, public_key)
+        return {
+            "valid": std_valid,
+            "authorization_valid": std_valid,
+            "result_valid": None,
+            "bilateral": False,
+        }
+
+    auth_valid = False
+    payload = envelope.get("payload")
+    sig_section = envelope.get("signature", {})
+
+    if payload and sig_section.get("sig"):
+        canonical = _canonicalize(payload)
+        try:
+            public_key.verify(_b64url_decode(sig_section["sig"]), canonical)
+            auth_valid = True
+        except InvalidSignature:
+            auth_valid = False
+
+    result = envelope.get("result")
+    result_valid = None
+
+    if result is not None and result.get("sig"):
+        auth_hash = envelope.get("authorization", {}).get("hash", "")
+        result_hash = result.get("hash", "")
+        binding = f"{auth_hash}:{result_hash}".encode("utf-8")
+        try:
+            public_key.verify(_b64url_decode(result["sig"]), binding)
+            result_valid = True
+        except InvalidSignature:
+            result_valid = False
+
+    overall = auth_valid and (result_valid is not False)
+    return {
+        "valid": overall,
+        "authorization_valid": auth_valid,
+        "result_valid": result_valid,
+        "bilateral": True,
+    }


### PR DESCRIPTION
Extends `receipts.py` with bilateral receipt support per the design doc in #1302.

Three new functions:
- `sign_authorization()` — signs pre-execution commitment (proves policy evaluated before action ran)
- `seal_result()` — seals post-execution outcome (binds actual result to the authorization)
- `verify_bilateral_receipt()` — verifies both signatures, falls back to `verify_receipt()` for standard envelopes

Backward compatible. Existing single-signature receipts verify unchanged. Bilateral fields are additive.

The result signature covers the binding of authorization_hash and result_hash together, proving:
1. The authorization existed before execution
2. The result was produced after execution
3. Both were signed by the same key

11 tests pass locally covering: creation, chain linkage, sealing, tamper detection (payload and result), wrong key rejection, and deny receipts.

Relates to #1249.