### PR TITLE
fix: add .js extensions to @noble/* imports for Node.js runtime

### DIFF
--- a/packages/agent-mesh/sdks/typescript/src/encryption/ratchet.ts
+++ b/packages/agent-mesh/sdks/typescript/src/encryption/ratchet.ts
@@ -8,12 +8,12 @@
  * Reference: https://signal.org/docs/specifications/doubleratchet/ (CC0)
  */
 
-import { x25519 } from "@noble/curves/ed25519";
-import { chacha20poly1305 } from "@noble/ciphers/chacha";
-import { hkdf } from "@noble/hashes/hkdf";
-import { sha256 } from "@noble/hashes/sha2";
-import { hmac } from "@noble/hashes/hmac";
-import { randomBytes } from "@noble/ciphers/utils";
+import { x25519 } from "@noble/curves/ed25519.js";
+import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
+import { hkdf } from "@noble/hashes/hkdf.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { hmac } from "@noble/hashes/hmac.js";
+import { randomBytes } from "@noble/ciphers/utils.js";
 
 const KDF_INFO_RATCHET = new TextEncoder().encode("AgentMesh_Ratchet_v1");
 const NONCE_LEN = 12;

--- a/packages/agent-mesh/sdks/typescript/src/encryption/x3dh.ts
+++ b/packages/agent-mesh/sdks/typescript/src/encryption/x3dh.ts
@@ -11,10 +11,10 @@
  * Reference: https://signal.org/docs/specifications/x3dh/ (CC0)
  */
 
-import { x25519, ed25519 } from "@noble/curves/ed25519";
-import { hkdf } from "@noble/hashes/hkdf";
-import { sha256, sha512 } from "@noble/hashes/sha2";
-import { randomBytes } from "@noble/ciphers/utils";
+import { x25519, ed25519 } from "@noble/curves/ed25519.js";
+import { hkdf } from "@noble/hashes/hkdf.js";
+import { sha256, sha512 } from "@noble/hashes/sha2.js";
+import { randomBytes } from "@noble/ciphers/utils.js";
 
 const X3DH_INFO = new TextEncoder().encode("AgentMesh_X3DH_v1");
 const KEY_LEN = 32;

--- a/packages/agent-mesh/sdks/typescript/tests/encryption.test.ts
+++ b/packages/agent-mesh/sdks/typescript/tests/encryption.test.ts
@@ -7,8 +7,8 @@
  * Implements against: docs/specs/AGENTMESH-WIRE-1.0.md
  */
 
-import { ed25519 } from "@noble/curves/ed25519";
-import { randomBytes } from "@noble/ciphers/utils";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { randomBytes } from "@noble/ciphers/utils.js";
 import {
   X3DHKeyManager,
   generateX25519KeyPair,


### PR DESCRIPTION
Published SDK fails with ERR_PACKAGE_PATH_NOT_EXPORTED because @noble packages require .js extensions in their exports map. Adds .js to all subpath imports in x3dh.ts, ratchet.ts, encryption.test.ts. 20 tests pass.