### PR TITLE
fix: widen agent-sre version constraint to allow 3.x in full install

### DIFF
--- a/packages/agent-compliance/pyproject.toml
+++ b/packages/agent-compliance/pyproject.toml
@@ -42,14 +42,14 @@ dependencies = [
 kernel = ["agent-os-kernel>=2.0.0,<4.0"]
 mesh = ["agentmesh-platform>=2.0.0,<4.0"]
 runtime = ["agentmesh-runtime>=2.0.0,<3.0"]
-sre = ["agent-sre>=1.0.0,<2.0"]
+sre = ["agent-sre>=1.0.0,<4.0"]
 opa = []
 cedar = ["cedarpy>=4.0.0,<5.0"]
 full = [
     "agent-os-kernel>=2.0.0,<4.0",
     "agentmesh-platform>=2.0.0,<4.0",
     "agentmesh-runtime>=2.0.0,<3.0",
-    "agent-sre>=1.0.0,<2.0",
+    "agent-sre>=1.0.0,<4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

The `[full]` and `[sre]` optional dependency extras in `agent-governance-toolkit` constrained `agent-sre` to `>=1.0.0,<2.0`, which excludes the current v3.2.2 release. This caused `pip install agent-governance-toolkit[full]` to either install an outdated 1.x version or fail resolution entirely.

Downstream impact: any code importing from `agent_sre` (e.g. `from agent_sre.anomaly import RiskLevel`) fails with `ImportError` because the installed 1.x version lacks APIs introduced in 3.x.

Updated the constraint to `>=1.0.0,<4.0`, consistent with `agent-hypervisor` which already uses `agent-sre>=1.1.0,<4.0`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Package(s) Affected
- [x] agent-sre
- [x] agent-governance

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] All new and existing tests pass (pytest) — 342 passed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution

**Prior art / related projects**: N/A

## Related Issues
<!-- Fixes # -->