### PR TITLE
fix(ci): update Rust build path after crate rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,10 +457,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Build
-        working-directory: packages/agent-mesh/sdks/rust/agentmesh
+        working-directory: packages/agent-mesh/sdks/rust
         run: cargo build --release
       - name: Test
-        working-directory: packages/agent-mesh/sdks/rust/agentmesh
+        working-directory: packages/agent-mesh/sdks/rust
         run: cargo test --release
 
   # ── Go build + test (only when Go files change) ─────────────────────
@@ -517,4 +517,5 @@ jobs:
             exit 1
           fi
           echo "All jobs passed or were correctly skipped"
+
 


### PR DESCRIPTION
CI was using old path. Now builds from workspace root.