### PR TITLE
feat(agentmesh-integrations): add AuditEntry accountability export example

### DIFF
--- a/packages/agentmesh-integrations/audit-accountability-export/README.md
+++ b/packages/agentmesh-integrations/audit-accountability-export/README.md
@@ -88,11 +88,20 @@ statement = accountability_export_to_eeoap_statement(export)
 }
 ```
 
+## Sensitivity note
+
+Exported data may include values derived from `AuditEntry.data`. Review and
+redact sensitive fields before sharing externally. This example is intended to
+demonstrate a smallest-stable external accountability export shape, not to
+define a blanket-safe export for all audit records.
+
 ## Running locally
 
 From the repository root:
 
 ```bash
+pip install .[dev]
+
 PYTHONPATH=packages/agent-mesh/src:packages/agentmesh-integrations/audit-accountability-export \
   python -m pytest packages/agentmesh-integrations/audit-accountability-export/tests -q
 

--- a/packages/agentmesh-integrations/audit-accountability-export/README.md
+++ b/packages/agentmesh-integrations/audit-accountability-export/README.md
@@ -1,0 +1,104 @@
+# Audit Accountability Export
+
+This integration is a small example adapter for mapping real AgentMesh
+`AuditEntry` / `AuditService` output into a smallest-stable external
+accountability export shape.
+
+It follows the interoperability discussion in
+[issue #1314](https://github.com/microsoft/agent-governance-toolkit/issues/1314)
+and the docs-only note merged in
+[PR #1319](https://github.com/microsoft/agent-governance-toolkit/pull/1319).
+
+## Purpose
+
+The adapter treats AGT audit output as upstream runtime-governance evidence and
+emits a compact downstream accountability shape with:
+
+- actor reference
+- subject reference
+- operation
+- policy digest
+- decision
+- occurrence timestamp
+- input and output references
+- evidence references
+
+The EEOAP mapping function is an external mapping example. It does not import an
+external validator and does not imply official AGT runtime support for EEOAP.
+
+## Non-goals
+
+- no AGT runtime changes
+- no `AuditEntry` / `AuditService` contract changes
+- no replacement of `agt verify --evidence`
+- no new AGT-native evidence format
+- no required dependency on EEOAP or external validators
+- no production compliance claim
+
+## Pipeline
+
+```text
+AuditService output
+-> AuditEntry
+-> external accountability export shape
+-> EEOAP mapping example
+```
+
+## Example
+
+```python
+from agentmesh.services.audit import AuditService
+from audit_accountability_export import (
+    accountability_export_to_eeoap_statement,
+    audit_entry_to_accountability_export,
+)
+
+audit = AuditService()
+entry = audit.log_policy_decision(
+    "did:mesh:research-agent",
+    "metadata.enrich",
+    decision="allow",
+    policy_name="approved-metadata-policy",
+    data={
+        "subject_ref": "urn:demo:client-note-001",
+        "input_refs": ["urn:demo:client-note-001"],
+        "output_refs": ["urn:demo:client-note-001-derived"],
+    },
+)
+
+export = audit_entry_to_accountability_export(entry)
+statement = accountability_export_to_eeoap_statement(export)
+```
+
+## Export shape
+
+```json
+{
+  "export_type": "agt.audit_entry.external_accountability_export",
+  "export_version": "0.1",
+  "actor_ref": "...",
+  "subject_ref": "...",
+  "operation": "...",
+  "policy_digest": "...",
+  "decision": "...",
+  "occurred_at": "...",
+  "input_refs": [],
+  "output_refs": [],
+  "evidence_refs": []
+}
+```
+
+## Running locally
+
+From the repository root:
+
+```bash
+PYTHONPATH=packages/agent-mesh/src:packages/agentmesh-integrations/audit-accountability-export \
+  python -m pytest packages/agentmesh-integrations/audit-accountability-export/tests -q
+
+PYTHONPATH=packages/agent-mesh/src:packages/agentmesh-integrations/audit-accountability-export \
+  python packages/agentmesh-integrations/audit-accountability-export/examples/basic_auditservice_export.py
+```
+
+The tests create real `AuditService` entries and use the returned `AuditEntry`
+objects as the source. They do not rely on static synthetic fixtures.

--- a/packages/agentmesh-integrations/audit-accountability-export/audit_accountability_export/__init__.py
+++ b/packages/agentmesh-integrations/audit-accountability-export/audit_accountability_export/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""External accountability export helpers for AgentMesh audit entries."""
+
+from .export import (
+    accountability_export_to_eeoap_statement,
+    audit_entry_to_accountability_export,
+    canonical_sha256,
+)
+
+__all__ = [
+    "accountability_export_to_eeoap_statement",
+    "audit_entry_to_accountability_export",
+    "canonical_sha256",
+]

--- a/packages/agentmesh-integrations/audit-accountability-export/audit_accountability_export/export.py
+++ b/packages/agentmesh-integrations/audit-accountability-export/audit_accountability_export/export.py
@@ -113,6 +113,11 @@ def accountability_export_to_eeoap_statement(export: dict[str, Any]) -> dict[str
 
 
 def _policy_context(entry: AuditEntry) -> dict[str, Any] | None:
+    """Return the minimal policy context included in the external digest.
+
+    This helper intentionally limits the digest input to a smallest-stable
+    interoperability shape rather than defining a new AGT-native policy format.
+    """
     data = entry.data or {}
     context = {
         key: value
@@ -127,6 +132,11 @@ def _policy_context(entry: AuditEntry) -> dict[str, Any] | None:
 
 
 def _subject_ref(entry: AuditEntry) -> str | None:
+    """Resolve a subject reference using the narrowest stable fallback chain.
+
+    Prefer the direct audit resource first, then `target_did`, then an explicit
+    `subject_ref` in `AuditEntry.data` when present.
+    """
     data = entry.data or {}
     return entry.resource or entry.target_did or data.get("subject_ref")
 

--- a/packages/agentmesh-integrations/audit-accountability-export/audit_accountability_export/export.py
+++ b/packages/agentmesh-integrations/audit-accountability-export/audit_accountability_export/export.py
@@ -1,0 +1,153 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Map AgentMesh audit entries to external accountability examples.
+
+This module intentionally stays outside AGT runtime governance. It reads a real
+``AuditEntry`` object and emits a small external export shape that downstream
+accountability tooling can map further.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agentmesh.governance.audit import AuditEntry
+
+
+EXPORT_TYPE = "agt.audit_entry.external_accountability_export"
+EXPORT_VERSION = "0.1"
+EEOAP_MAPPING_PROFILE = "external.operation_accountability.mapping.example"
+EEOAP_MAPPING_VERSION = "0.1"
+
+
+def canonical_sha256(value: Any) -> str:
+    """Return a stable SHA-256 digest for JSON-like values."""
+    canonical = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    )
+    return f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+
+
+def audit_entry_to_accountability_export(entry: AuditEntry) -> dict[str, Any]:
+    """Build the smallest external accountability export from an ``AuditEntry``.
+
+    The export is an interoperability shape, not a new AGT runtime evidence
+    format. It keeps the source AGT audit entry as an evidence reference.
+    """
+    data = entry.data or {}
+    policy_context = _policy_context(entry)
+
+    return {
+        "export_type": EXPORT_TYPE,
+        "export_version": EXPORT_VERSION,
+        "actor_ref": entry.agent_did,
+        "subject_ref": _subject_ref(entry),
+        "operation": entry.action,
+        "policy_digest": canonical_sha256(policy_context) if policy_context else None,
+        "decision": entry.policy_decision or entry.outcome,
+        "occurred_at": _timestamp(entry.timestamp),
+        "input_refs": _list_field(data.get("input_refs", [])),
+        "output_refs": _list_field(data.get("output_refs", [])),
+        "evidence_refs": [
+            {
+                "type": "agt.audit_entry",
+                "entry_id": entry.entry_id,
+                "event_type": entry.event_type,
+                "entry_hash": entry.entry_hash,
+                "digest": canonical_sha256(entry.model_dump(mode="json")),
+            }
+        ],
+    }
+
+
+def accountability_export_to_eeoap_statement(export: dict[str, Any]) -> dict[str, Any]:
+    """Map an accountability export into an EEOAP-like example statement.
+
+    This mapping does not import or invoke external validators and does not imply
+    official AGT runtime support for any external profile.
+    """
+    return {
+        "profile": EEOAP_MAPPING_PROFILE,
+        "profile_version": EEOAP_MAPPING_VERSION,
+        "actor": {
+            "id": export.get("actor_ref"),
+        },
+        "subject": {
+            "id": export.get("subject_ref"),
+        },
+        "operation": {
+            "name": export.get("operation"),
+            "occurred_at": export.get("occurred_at"),
+        },
+        "policy": {
+            "digest": export.get("policy_digest"),
+            "decision": export.get("decision"),
+        },
+        "provenance": {
+            "source_export_type": export.get("export_type"),
+            "source_export_version": export.get("export_version"),
+        },
+        "evidence": {
+            "references": [
+                {"role": "input", "ref": ref}
+                for ref in export.get("input_refs", [])
+            ]
+            + [
+                {"role": "output", "ref": ref}
+                for ref in export.get("output_refs", [])
+            ],
+            "artifacts": export.get("evidence_refs", []),
+        },
+        "validation": {
+            "status": "not_validated",
+            "external_validator_required": False,
+        },
+    }
+
+
+def _policy_context(entry: AuditEntry) -> dict[str, Any] | None:
+    data = entry.data or {}
+    context = {
+        key: value
+        for key, value in {
+            "policy_decision": entry.policy_decision,
+            "matched_rule": entry.matched_rule,
+            "policy_name": data.get("policy_name"),
+        }.items()
+        if value not in (None, "")
+    }
+    return context or None
+
+
+def _subject_ref(entry: AuditEntry) -> str | None:
+    data = entry.data or {}
+    return entry.resource or entry.target_did or data.get("subject_ref")
+
+
+def _timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _list_field(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)

--- a/packages/agentmesh-integrations/audit-accountability-export/examples/basic_auditservice_export.py
+++ b/packages/agentmesh-integrations/audit-accountability-export/examples/basic_auditservice_export.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Basic AuditService to external accountability export example."""
+
+from __future__ import annotations
+
+import json
+
+from agentmesh.services.audit import AuditService
+
+from audit_accountability_export import (
+    accountability_export_to_eeoap_statement,
+    audit_entry_to_accountability_export,
+)
+
+
+def main() -> None:
+    audit = AuditService()
+
+    audit.log_action(
+        "did:mesh:research-agent",
+        "metadata.enrich",
+        resource="urn:demo:client-note-001",
+        data={
+            "input_refs": ["urn:demo:client-note-001"],
+            "output_refs": ["urn:demo:client-note-001-derived"],
+        },
+    )
+    entry = audit.log_policy_decision(
+        "did:mesh:research-agent",
+        "metadata.enrich",
+        decision="allow",
+        policy_name="approved-metadata-policy",
+        data={
+            "subject_ref": "urn:demo:client-note-001",
+            "input_refs": ["urn:demo:client-note-001"],
+            "output_refs": ["urn:demo:client-note-001-derived"],
+        },
+    )
+
+    export = audit_entry_to_accountability_export(entry)
+    statement = accountability_export_to_eeoap_statement(export)
+
+    print(json.dumps({"export": export, "eeoap_mapping_example": statement}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agentmesh-integrations/audit-accountability-export/pyproject.toml
+++ b/packages/agentmesh-integrations/audit-accountability-export/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "audit_accountability_export"
+version = "0.1.0"
+description = "Example adapter from AgentMesh AuditEntry output to an external accountability export shape"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [
+    { name = "Microsoft Corporation" }
+]
+keywords = ["agents", "audit", "accountability", "agentmesh", "governance", "interoperability"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-governance-toolkit"
+Repository = "https://github.com/microsoft/agent-governance-toolkit"
+Documentation = "https://github.com/microsoft/agent-governance-toolkit/issues/1314"
+
+[tool.hatch.build.targets.wheel]
+packages = ["audit_accountability_export"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/agentmesh-integrations/audit-accountability-export/tests/test_audit_entry_export.py
+++ b/packages/agentmesh-integrations/audit-accountability-export/tests/test_audit_entry_export.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for AuditEntry external accountability export."""
+
+from agentmesh.services.audit import AuditService
+
+from audit_accountability_export import (
+    accountability_export_to_eeoap_statement,
+    audit_entry_to_accountability_export,
+)
+
+
+def test_log_action_export_uses_real_auditservice_output():
+    service = AuditService()
+
+    entry = service.log_action(
+        "did:mesh:alice",
+        "read_file",
+        resource="urn:demo:file-001",
+        data={
+            "input_refs": ["urn:demo:file-001"],
+            "output_refs": ["urn:demo:file-001#view"],
+        },
+        trace_id="trace-001",
+    )
+    export = audit_entry_to_accountability_export(entry)
+
+    assert service.entry_count == 1
+    assert entry.entry_hash
+    assert export["actor_ref"] == "did:mesh:alice"
+    assert export["subject_ref"] == "urn:demo:file-001"
+    assert export["operation"] == "read_file"
+    assert export["policy_digest"] is None
+    assert export["decision"] == "success"
+    assert export["occurred_at"]
+    assert export["input_refs"] == ["urn:demo:file-001"]
+    assert export["output_refs"] == ["urn:demo:file-001#view"]
+    assert export["evidence_refs"][0]["entry_id"] == entry.entry_id
+    assert export["evidence_refs"][0]["entry_hash"] == entry.entry_hash
+    assert export["evidence_refs"][0]["digest"].startswith("sha256:")
+
+
+def test_log_policy_decision_export_and_eeoap_mapping():
+    service = AuditService()
+
+    entry = service.log_policy_decision(
+        "did:mesh:policy-agent",
+        "metadata.enrich",
+        decision="allow",
+        policy_name="approved-metadata-policy",
+        data={
+            "subject_ref": "urn:demo:client-note-001",
+            "input_refs": ["urn:demo:client-note-001"],
+            "output_refs": ["urn:demo:client-note-001-derived"],
+        },
+    )
+    export = audit_entry_to_accountability_export(entry)
+    statement = accountability_export_to_eeoap_statement(export)
+
+    assert entry.event_type == "policy_decision"
+    assert entry.entry_hash
+    assert export["export_type"] == "agt.audit_entry.external_accountability_export"
+    assert export["export_version"] == "0.1"
+    assert export["actor_ref"] == "did:mesh:policy-agent"
+    assert export["subject_ref"] == "urn:demo:client-note-001"
+    assert export["operation"] == "metadata.enrich"
+    assert export["policy_digest"].startswith("sha256:")
+    assert export["decision"] == "allow"
+    assert export["occurred_at"]
+    assert export["input_refs"] == ["urn:demo:client-note-001"]
+    assert export["output_refs"] == ["urn:demo:client-note-001-derived"]
+    assert export["evidence_refs"][0]["entry_id"] == entry.entry_id
+
+    assert statement["profile"] == "external.operation_accountability.mapping.example"
+    assert statement["actor"]["id"] == export["actor_ref"]
+    assert statement["subject"]["id"] == export["subject_ref"]
+    assert statement["operation"]["name"] == export["operation"]
+    assert statement["policy"]["digest"] == export["policy_digest"]
+    assert statement["policy"]["decision"] == "allow"
+    assert statement["evidence"]["artifacts"] == export["evidence_refs"]
+    assert statement["validation"]["external_validator_required"] is False
+
+
+def test_subject_ref_fallback_prefers_resource_then_subject_ref():
+    service = AuditService()
+
+    resource_entry = service.log_action(
+        "did:mesh:alice",
+        "inspect",
+        resource="urn:demo:resource",
+        data={"subject_ref": "urn:demo:subject"},
+    )
+    subject_entry = service.log_action(
+        "did:mesh:alice",
+        "inspect",
+        data={"subject_ref": "urn:demo:subject"},
+    )
+
+    assert audit_entry_to_accountability_export(resource_entry)["subject_ref"] == "urn:demo:resource"
+    assert audit_entry_to_accountability_export(subject_entry)["subject_ref"] == "urn:demo:subject"


### PR DESCRIPTION
## Summary

Adds a small AgentMesh integration example that maps real AGT `AuditService` / `AuditEntry` output into a smallest-stable external accountability export shape, then demonstrates an EEOAP mapping from that shape.

This follows the discussion in #1314 and the merged documentation note in #1319.

## Scope

This PR is intentionally narrow.

It does not change:

* AGT runtime behavior
* `AuditEntry` or `AuditService` contracts
* policy enforcement
* identity mechanisms
* sandboxing
* `agt verify --evidence`
* AGT evidence verification behavior
* AGT official evidence schemas

It does not introduce:

* a required dependency on `agent-evidence`
* a new AGT-native evidence format
* a production compliance claim

## Why

The goal is to freeze a smallest-stable export shape that makes external operation-accountability validation easier without depending on AGT internals or replacing AGT evidence verification.

## Validation

Commands run:

* `git diff --check` -> passed
* `PYTHONPATH=packages/agentmesh-integrations/audit-accountability-export /tmp/agt-audit-export-venv/bin/python -m pytest packages/agentmesh-integrations/audit-accountability-export/tests -q` -> `3 passed`
* `PYTHONPATH=packages/agentmesh-integrations/audit-accountability-export /tmp/agt-audit-export-venv/bin/python packages/agentmesh-integrations/audit-accountability-export/examples/basic_auditservice_export.py` -> passed and emitted the export / EEOAP mapping example
* `/tmp/agt-audit-export-venv/bin/ruff check packages/agentmesh-integrations/audit-accountability-export` -> `All checks passed!`

The local validation environment installed the editable `packages/agent-mesh` package into a temporary virtualenv under `/tmp` so the tests use real `AuditService` output.

## Notes

The EEOAP mapping is an external mapping example. It is not an official AGT runtime integration and does not imply official adoption of the EEOAP schema.
