### PR TITLE
fix: docs audit — CLI name, package names, broken links, YAML, prereqs

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,7 +2,7 @@
 
 Get from zero to governed AI agents in under 10 minutes.
 
-> **Prerequisites:** Python 3.10+ / Node.js 18+ / .NET 8.0+ (any one or more).
+> **Prerequisites:** Python 3.11+ / Node.js 18+ / .NET 8.0+ (any one or more).
 
 ## Architecture Overview
 
@@ -62,8 +62,8 @@ python scripts/check_gov.py
 Or use the governance CLI directly:
 
 ```bash
-agent-governance verify
-agent-governance verify --badge
+agt verify
+agt verify --badge
 ```
 
 ## 3. Your First Governed Agent
@@ -290,13 +290,13 @@ Verify your deployment covers the OWASP Agentic Security Threats:
 
 ```bash
 # Text summary
-agent-governance verify
+agt verify
 
 # JSON for CI/CD pipelines
-agent-governance verify --json
+agt verify --json
 
 # Badge for your README
-agent-governance verify --badge
+agt verify --badge
 ```
 
 ### Secure Error Handling
@@ -319,10 +319,10 @@ Ensure no governance modules have been tampered with:
 
 ```bash
 # Generate a baseline integrity manifest
-agent-governance integrity --generate integrity.json
+agt integrity --generate integrity.json
 
 # Verify against the manifest later
-agent-governance integrity --manifest integrity.json
+agt integrity --manifest integrity.json
 ```
 
 ## Next Steps

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > [Open a GitHub issue](https://github.com/microsoft/agent-governance-toolkit/issues) for feedback.
 
 > [!TIP]
-> **v3.2.1 is out!** Patch: encryption exports fix for npm package. E2E encrypted agent messaging (Signal protocol), Wire Protocol spec, registry + relay services. [Changelog →](CHANGELOG.md)
+> **v3.2.2 is out!** Patch: OpenClaw sidecar docker fix, encryption exports for npm. E2E encrypted agent messaging (Signal protocol), Wire Protocol spec, registry + relay services. [Changelog →](CHANGELOG.md)
 
 **Runtime governance for AI agents** — deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous agents. Covers all **10 OWASP Agentic risks** with **9,500+ tests**.
 

--- a/docs/modern-agent-architecture-overview.md
+++ b/docs/modern-agent-architecture-overview.md
@@ -270,9 +270,9 @@ pip install crewai-agentmesh         # CrewAI
 ### Step 4: Verify OWASP Coverage
 
 ```bash
-agent-governance verify         # Text summary
-agent-governance verify --json  # JSON for CI/CD
-agent-governance verify --badge # Badge for your README
+agt verify         # Text summary
+agt verify --json  # JSON for CI/CD
+agt verify --badge # Badge for your README
 ```
 
 ---

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -26,13 +26,13 @@ AGT provides 12 packages covering every layer of agent governance.
 
 | Package | Description | Install |
 |---------|------------|---------|
-| [Agent OS](agent-os.md) | Policy engine, agent lifecycle, governance gate | `pip install agent-os` |
-| [Agent Mesh](agent-mesh.md) | Agent discovery, routing, trust mesh | `pip install agent-mesh` |
-| [Agent Runtime](agent-runtime.md) | Execution sandboxing, four privilege rings | `pip install agent-runtime` |
+| [Agent OS](agent-os.md) | Policy engine, agent lifecycle, governance gate | `pip install agent-os-kernel` |
+| [Agent Mesh](agent-mesh.md) | Agent discovery, routing, trust mesh | `pip install agentmesh-platform` |
+| [Agent Runtime](agent-runtime.md) | Execution sandboxing, four privilege rings | `pip install agentmesh-runtime` |
 | [Agent SRE](agent-sre.md) | Kill switch, SLO monitoring, chaos testing | `pip install agent-sre` |
-| [Agent Compliance](agent-compliance.md) | Audit logging, compliance frameworks | `pip install agent-compliance` |
-| [Agent Marketplace](agent-marketplace.md) | Plugin governance, marketplace trust | `pip install agent-marketplace` |
-| [Agent Lightning](agent-lightning.md) | High-performance orchestration | `pip install agent-lightning` |
+| [Agent Compliance](agent-compliance.md) | Audit logging, compliance frameworks | `pip install agent-governance-toolkit` |
+| [Agent Marketplace](agent-marketplace.md) | Plugin governance, marketplace trust | `pip install agentmesh-marketplace` |
+| [Agent Lightning](agent-lightning.md) | High-performance orchestration | `pip install agentmesh-lightning` |
 | [Agent Hypervisor](agent-hypervisor.md) | Hardware-level workload isolation | `pip install agent-hypervisor` |
 
 ## Language Packages & Tooling

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 Get from zero to governed AI agents in under 10 minutes.
 
-> **Prerequisites:** Python 3.10+ / Node.js 18+ / .NET 8.0+ (any one or more).
+> **Prerequisites:** Python 3.11+ / Node.js 18+ / .NET 8.0+ (any one or more).
 
 ## Architecture Overview
 
@@ -62,8 +62,8 @@ python scripts/check_gov.py
 Or use the governance CLI directly:
 
 ```bash
-agent-governance verify
-agent-governance verify --badge
+agt verify
+agt verify --badge
 ```
 
 ## 3. Your First Governed Agent
@@ -290,13 +290,13 @@ Verify your deployment covers the OWASP Agentic Security Threats:
 
 ```bash
 # Text summary
-agent-governance verify
+agt verify
 
 # JSON for CI/CD pipelines
-agent-governance verify --json
+agt verify --json
 
 # Badge for your README
-agent-governance verify --badge
+agt verify --badge
 ```
 
 ### Secure Error Handling
@@ -319,10 +319,10 @@ Ensure no governance modules have been tampered with:
 
 ```bash
 # Generate a baseline integrity manifest
-agent-governance integrity --generate integrity.json
+agt integrity --generate integrity.json
 
 # Verify against the manifest later
-agent-governance integrity --manifest integrity.json
+agt integrity --manifest integrity.json
 ```
 
 ## Next Steps

--- a/docs/tutorials/04-audit-and-compliance.md
+++ b/docs/tutorials/04-audit-and-compliance.md
@@ -455,7 +455,7 @@ pip install agent-governance-toolkit
 
 ```bash
 # Human-readable summary
-agent-governance verify
+agt verify
 ```
 
 Output:
@@ -479,12 +479,12 @@ Coverage: 10/10 (100%)
 
 ```bash
 # Machine-readable JSON
-agent-governance verify --json
+agt verify --json
 ```
 
 ```bash
 # Shields.io badge for your README
-agent-governance verify --badge
+agt verify --badge
 ```
 
 ### Secure Audit Handling
@@ -529,15 +529,15 @@ been tampered with:
 
 ```bash
 # Generate a baseline manifest
-agent-governance integrity --generate integrity.json
+agt integrity --generate integrity.json
 
 # Later, verify against it
-agent-governance integrity --manifest integrity.json
+agt integrity --manifest integrity.json
 ```
 
 ```bash
 # JSON output for automation
-agent-governance integrity --manifest integrity.json --json
+agt integrity --manifest integrity.json --json
 ```
 
 The integrity checker verifies:
@@ -696,13 +696,13 @@ jobs:
           pip install agentmesh-platform agent-governance
 
       - name: Generate integrity manifest
-        run: agent-governance integrity --generate integrity.json
+        run: agt integrity --generate integrity.json
 
       - name: Verify OWASP ASI 2026 coverage
-        run: agent-governance verify --json > asi_report.json
+        run: agt verify --json > asi_report.json
 
       - name: Verify supply-chain integrity
-        run: agent-governance integrity --manifest integrity.json --json > integrity_report.json
+        run: agt integrity --manifest integrity.json --json > integrity_report.json
 
       - name: Upload compliance artifacts
         if: always()
@@ -715,7 +715,7 @@ jobs:
             integrity.json
 ```
 
-> **Tip:** `agent-governance verify` exits with code **1** if any
+> **Tip:** `agt verify` exits with code **1** if any
 > control is missing, so the pipeline step will fail automatically.
 
 ---

--- a/docs/tutorials/18-compliance-verification.md
+++ b/docs/tutorials/18-compliance-verification.md
@@ -32,7 +32,7 @@ The `agent-compliance` package turns governance from a claim into evidence. In b
 | Verify source file integrity | `agent_compliance.integrity.IntegrityVerifier` |
 | Gate agent promotions by maturity | `agent_compliance.promotion.PromotionChecker` |
 | Generate compliance badges | `GovernanceAttestation.badge_markdown()` |
-| Use the CLI for CI/CD pipelines | `agent-governance verify`, `integrity` |
+| Use the CLI for CI/CD pipelines | `agt verify`, `integrity` |
 | Map to OWASP Agentic Top 10 | `OWASP_ASI_CONTROLS` mapping |
 
 ---
@@ -56,7 +56,7 @@ pip install agent-governance-toolkit[sre]
 Three CLI entry points are registered — all equivalent:
 
 ```bash
-agent-governance verify
+agt verify
 agent-governance-toolkit verify
 agent-compliance verify
 ```
@@ -798,25 +798,25 @@ print(f"README updated with compliance badge: {attestation.compliance_grade()}")
 
 ## 10. CLI Reference
 
-### 10.1 `agent-governance verify`
+### 10.1 `agt verify`
 
 Verify governance controls and output compliance status:
 
 ```bash
 # Human-readable summary (default)
-agent-governance verify
+agt verify
 
 # JSON attestation for CI/CD pipelines
-agent-governance verify --json
+agt verify --json
 
 # Markdown badge only
-agent-governance verify --badge
+agt verify --badge
 
 # Runtime evidence manifest
-agent-governance verify --evidence ./agt-evidence.json
+agt verify --evidence ./agt-evidence.json
 
 # Strict evidence mode
-agent-governance verify --evidence ./agt-evidence.json --strict
+agt verify --evidence ./agt-evidence.json --strict
 ```
 
 **Exit codes:**
@@ -833,7 +833,7 @@ agent-governance verify --evidence ./agt-evidence.json --strict
 - name: Verify governance compliance
   run: |
     pip install agent-governance-toolkit[full]
-    agent-governance verify --json > compliance-attestation.json
+    agt verify --json > compliance-attestation.json
 
 - name: Upload attestation artifact
   uses: actions/upload-artifact@v4
@@ -842,22 +842,22 @@ agent-governance verify --evidence ./agt-evidence.json --strict
     path: compliance-attestation.json
 
 - name: Update README badge
-  run: agent-governance verify --badge >> $GITHUB_STEP_SUMMARY
+  run: agt verify --badge >> $GITHUB_STEP_SUMMARY
 ```
 
-### 10.2 `agent-governance integrity`
+### 10.2 `agt integrity`
 
 Verify or generate integrity manifests:
 
 ```bash
 # Generate a manifest from current module state
-agent-governance integrity --generate integrity.json
+agt integrity --generate integrity.json
 
 # Verify against an existing manifest
-agent-governance integrity --manifest integrity.json
+agt integrity --manifest integrity.json
 
 # JSON output for automation
-agent-governance integrity --manifest integrity.json --json
+agt integrity --manifest integrity.json --json
 ```
 
 **Exit codes:**
@@ -873,11 +873,11 @@ agent-governance integrity --manifest integrity.json --json
 
 ```bash
 # Non-existent manifest — clean error, no traceback
-$ agent-governance integrity --manifest nonexistent.json
+$ agt integrity --manifest nonexistent.json
 Error: Manifest file not found: nonexistent.json
 
 # Read-only output directory — clean error
-$ agent-governance integrity --generate /readonly/integrity.json
+$ agt integrity --generate /readonly/integrity.json
 Error: Cannot write to output directory: /readonly/
 ```
 
@@ -890,10 +890,10 @@ Combine verify and integrity checks in a single pipeline step:
 set -e
 
 echo "=== Governance Verification ==="
-agent-governance verify --json > attestation.json
+agt verify --json > attestation.json
 
 echo "=== Integrity Verification ==="
-agent-governance integrity --manifest integrity.json --json > integrity-report.json
+agt integrity --manifest integrity.json --json > integrity-report.json
 
 echo "=== Results ==="
 python -c "
@@ -1083,8 +1083,8 @@ Badge: ![Governance](https://img.shields.io/badge/governance-100%25-brightgreen)
 | Promotion gates | `PromotionGate` | Named check function with severity (blocker/warning) |
 | Promotion checker | `PromotionChecker` | Evaluates 9 built-in gates for level transitions |
 | Promotion report | `PromotionReport` | Aggregate pass/fail with blocker list |
-| CLI verify | `agent-governance verify` | `--json`, `--badge`, `--evidence`, `--strict` flags; exit code 0/1 |
-| CLI integrity | `agent-governance integrity` | `--generate`, `--manifest`, `--json` flags |
+| CLI verify | `agt verify` | `--json`, `--badge`, `--evidence`, `--strict` flags; exit code 0/1 |
+| CLI integrity | `agt integrity` | `--generate`, `--manifest`, `--json` flags |
 
 ---
 
@@ -1100,7 +1100,7 @@ Badge: ![Governance](https://img.shields.io/badge/governance-100%25-brightgreen)
 
 You now know how to **prove** governance compliance — from quick five-line checks to full CI/CD pipelines with attestation storage and promotion gating.
 
-- **Automate it:** Add `agent-governance verify --json` to your CI pipeline and gate deployments on compliance grade
+- **Automate it:** Add `agt verify --json` to your CI pipeline and gate deployments on compliance grade
 - **Lock it down:** Generate an `integrity.json` manifest and verify on every deploy to catch tampering
 - **Promote safely:** Use `PromotionChecker` to enforce quality gates before moving agents to production
 - **Audit trail:** Store JSON attestations as build artifacts for regulatory audits

--- a/examples/maf-integration/02-customer-service/dotnet/README.md
+++ b/examples/maf-integration/02-customer-service/dotnet/README.md
@@ -121,5 +121,5 @@ The demo runs in **4 acts**:
 ## Related
 
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)
-- [01-loan-processing demo](../01-loan-processing/)
+- [01-loan-processing demo](../../01-loan-processing/)
 - [Python version of this demo](../python/)

--- a/examples/maf-integration/02-customer-service/python/README.md
+++ b/examples/maf-integration/02-customer-service/python/README.md
@@ -136,5 +136,5 @@ The demo runs in **4 acts**:
 ## Related
 
 - [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit)
-- [01-loan-processing demo](../01-loan-processing/)
+- [01-loan-processing demo](../../01-loan-processing/)
 - [.NET version of this demo](../dotnet/)

--- a/examples/marketplace-governance/policies/plugin-safety.yaml
+++ b/examples/marketplace-governance/policies/plugin-safety.yaml
@@ -62,11 +62,12 @@ rules:
     severity: medium
     suggestion: "Verify the endpoint is on the approved external services list"
 
-  # -------------------------------------------------------------------
-  # Token budget enforcement
-  # -------------------------------------------------------------------
-  # Caps the maximum tokens per tool invocation to prevent runaway costs.
+# -------------------------------------------------------------------
+# Plugin requirements
+# -------------------------------------------------------------------
+# Constraints enforced during batch policy evaluation.
 
+plugin_requirements:
   require_capabilities: true
   min_description_length: 10
   max_dependencies: 10

--- a/packages/agent-os/Dockerfile
+++ b/packages/agent-os/Dockerfile
@@ -3,7 +3,7 @@
 # Run:   docker run -it agent-os
 # MCP:   docker run -i agent-os --stdio
 
-FROM python:3.14-slim@sha256:bc389f7dfcb21413e72a28f491985326994795e34d2b86c8ae2f417b4e7818aa
+FROM python:3.12-slim@sha256:3d5ed973e45820f5ba5e46bd065bd88b3a504ff0724d85980dcd05eab361fcf4
 
 LABEL maintainer="Microsoft Corporation"
 LABEL description="Agent OS - A kernel architecture for governing autonomous AI agents"

--- a/scripts/check_gov.py
+++ b/scripts/check_gov.py
@@ -59,10 +59,10 @@ def verify_installation() -> int:
     print("Governance CLI:")
     try:
         from agent_compliance.cli.main import cmd_verify  # noqa: F401
-        print("  ✅  agent-governance verify............ available")
+        print("  ✅  agt verify............ available")
         results.append(True)
     except ImportError:
-        print("  ❌  agent-governance verify............ not available")
+        print("  ❌  agt verify............ not available")
         results.append(False)
     print()
 


### PR DESCRIPTION
Customer-perspective audit of all README, tutorials, demos, examples. Fixes old CLI name (agent-governance -> agt), wrong pip install names in docs/packages/index.md, stale version, Python prereq 3.10->3.11, broken YAML, broken links, and Dockerfile base image. 12 files, 7 categories of fixes.