### PR TITLE
feat: 2-line governance wrapper (govern() function)

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/governance/__init__.py
@@ -7,6 +7,7 @@ Declarative policy engine with automated compliance mapping.
 Append-only audit logs with optional external sinks.
 """
 
+from .govern import govern, GovernedCallable, GovernanceConfig, GovernanceDenied
 from .policy import PolicyEngine, Policy, PolicyRule, PolicyDecision
 from .conflict_resolution import (
     ConflictResolutionStrategy,
@@ -75,6 +76,11 @@ from .federation import (
 )
 
 __all__ = [
+    # High-level wrapper (issue #1372)
+    "govern",
+    "GovernedCallable",
+    "GovernanceConfig",
+    "GovernanceDenied",
     "AsyncTrustPolicyEvaluator",
     "TrustConcurrencyStats",
     "PolicyEngine",

--- a/packages/agent-mesh/src/agentmesh/governance/govern.py
+++ b/packages/agent-mesh/src/agentmesh/governance/govern.py
@@ -1,0 +1,210 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+High-level governance wrapper — 2-line integration for any agent framework.
+
+Usage:
+    from agentmesh.governance.govern import govern, GovernanceConfig
+
+    governed_fn = govern(my_tool_function, policy="my-policy.yaml")
+    result = governed_fn(action="read", resource="users")
+
+Or wrap an entire callable (agent, tool, function):
+    from agentmesh.governance import govern
+    safe_agent = govern(agent.run, policy="org-policy.yaml")
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional, Union
+
+from .policy import Policy, PolicyDecision, PolicyEngine
+from .audit import AuditLog
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GovernanceConfig:
+    """Configuration for the govern() wrapper.
+
+    Attributes:
+        policy: Policy file path, YAML string, or Policy object.
+        agent_id: Agent identifier for policy evaluation. Defaults to "*".
+        audit: Whether to enable audit logging. Defaults to True.
+        audit_file: Path for file-based audit log. None = in-memory only.
+        on_deny: Callback when a policy denies an action. Default: raise.
+        conflict_strategy: Policy conflict resolution strategy.
+    """
+
+    policy: Union[str, Policy]
+    agent_id: str = "*"
+    audit: bool = True
+    audit_file: Optional[str] = None
+    on_deny: Optional[Callable[[PolicyDecision], Any]] = None
+    conflict_strategy: str = "deny_overrides"
+
+
+class GovernanceDenied(Exception):
+    """Raised when a governed action is denied by policy."""
+
+    def __init__(self, decision: PolicyDecision):
+        self.decision = decision
+        super().__init__(
+            f"Action denied by policy rule '{decision.matched_rule}': "
+            f"{decision.reason}"
+        )
+
+
+class GovernedCallable:
+    """Wraps any callable with policy enforcement and audit logging.
+
+    This is the core primitive — framework-specific wrappers build on it.
+    """
+
+    def __init__(self, fn: Callable, config: GovernanceConfig):
+        self._fn = fn
+        self._config = config
+        self._engine = PolicyEngine(conflict_strategy=config.conflict_strategy)
+        self._audit = AuditLog() if config.audit else None
+
+        # Load policy
+        policy = config.policy
+        if isinstance(policy, str):
+            if os.path.isfile(policy):
+                loaded = self._engine.load_yaml_file(policy)
+            else:
+                loaded = self._engine.load_yaml(policy)
+        elif isinstance(policy, Policy):
+            loaded = policy
+            self._engine.load_policy(loaded)
+        else:
+            raise TypeError(
+                f"policy must be a file path, YAML string, or Policy object, "
+                f"got {type(policy).__name__}"
+            )
+
+        # Ensure the policy applies to our agent_id. If no agents are
+        # specified, default to wildcard so govern() works out of the box.
+        if not loaded.agent and not loaded.agents:
+            loaded.agents = ["*"]
+
+        functools.update_wrapper(self, fn)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the wrapped function with governance enforcement."""
+        # Build evaluation context from kwargs
+        context = self._build_context(args, kwargs)
+
+        # Evaluate policy
+        start = time.monotonic()
+        decision = self._engine.evaluate(self._config.agent_id, context)
+        eval_ms = (time.monotonic() - start) * 1000
+
+        # Audit
+        if self._audit:
+            self._audit.log(
+                event_type="policy_evaluation",
+                agent_did=self._config.agent_id,
+                action=context.get("action", {}).get("type", "unknown"),
+                outcome=decision.action,
+                policy_decision=decision.action,
+                data={
+                    "rule": decision.matched_rule or "",
+                    "reason": decision.reason or "",
+                    "evaluation_ms": round(eval_ms, 3),
+                },
+            )
+
+        # Handle decision
+        if not decision.allowed:
+            if self._config.on_deny:
+                return self._config.on_deny(decision)
+            raise GovernanceDenied(decision)
+
+        # Allowed — execute the wrapped function
+        return self._fn(*args, **kwargs)
+
+    def _build_context(self, args: tuple, kwargs: dict) -> dict:
+        """Build policy evaluation context from function arguments."""
+        context: dict[str, Any] = {}
+
+        # If kwargs contains 'action', use it directly
+        if "action" in kwargs:
+            action_val = kwargs["action"]
+            if isinstance(action_val, dict):
+                context["action"] = action_val
+            else:
+                context["action"] = {"type": str(action_val)}
+        elif args:
+            context["action"] = {"type": str(args[0])}
+
+        # Pass through other kwargs as context
+        for key, val in kwargs.items():
+            if key != "action":
+                if isinstance(val, dict):
+                    context[key] = val
+                else:
+                    context[key] = {"value": val}
+
+        return context
+
+    @property
+    def engine(self) -> PolicyEngine:
+        """Access the underlying policy engine for advanced use."""
+        return self._engine
+
+    @property
+    def audit_log(self) -> Optional[AuditLog]:
+        """Access the audit log for inspection."""
+        return self._audit
+
+
+def govern(
+    fn: Callable,
+    *,
+    policy: Union[str, Policy],
+    agent_id: str = "*",
+    audit: bool = True,
+    on_deny: Optional[Callable[[PolicyDecision], Any]] = None,
+    conflict_strategy: str = "deny_overrides",
+) -> GovernedCallable:
+    """Wrap any callable with AGT governance — 2-line integration.
+
+    Args:
+        fn: The function, tool, or agent callable to govern.
+        policy: Policy file path (supports ``extends``), inline YAML
+            string, or a ``Policy`` object.
+        agent_id: Agent identifier for policy evaluation. Default ``"*"``.
+        audit: Enable audit logging. Default ``True``.
+        on_deny: Optional callback on denial. Default: raise
+            ``GovernanceDenied``.
+        conflict_strategy: Conflict resolution strategy. Default
+            ``"deny_overrides"`` (any deny wins).
+
+    Returns:
+        A ``GovernedCallable`` that enforces policy before execution.
+
+    Example::
+
+        from agentmesh.governance import govern
+
+        def send_email(to, body):
+            ...
+
+        safe_send = govern(send_email, policy="email-policy.yaml")
+        safe_send(to="user@example.com", body="Hello")  # policy-checked
+    """
+    config = GovernanceConfig(
+        policy=policy,
+        agent_id=agent_id,
+        audit=audit,
+        on_deny=on_deny,
+        conflict_strategy=conflict_strategy,
+    )
+    return GovernedCallable(fn, config)

--- a/packages/agent-mesh/tests/test_govern.py
+++ b/packages/agent-mesh/tests/test_govern.py
@@ -1,0 +1,218 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the govern() high-level wrapper."""
+
+import os
+import pytest
+from agentmesh.governance.govern import (
+    govern,
+    GovernedCallable,
+    GovernanceConfig,
+    GovernanceDenied,
+)
+from agentmesh.governance.policy import Policy
+
+
+# ── Test fixtures ──────────────────────────────────────────────────
+
+ALLOW_ALL_POLICY = """
+apiVersion: governance.toolkit/v1
+name: allow-all
+default_action: allow
+rules: []
+"""
+
+DENY_EXPORT_POLICY = """
+apiVersion: governance.toolkit/v1
+name: deny-export
+default_action: allow
+rules:
+  - name: block-export
+    condition: "action.type == 'export'"
+    action: deny
+    description: "Exporting data is not allowed"
+"""
+
+MIXED_POLICY = """
+apiVersion: governance.toolkit/v1
+name: mixed-rules
+default_action: deny
+rules:
+  - name: allow-read
+    condition: "action.type == 'read'"
+    action: allow
+    priority: 10
+  - name: block-pii
+    condition: "data.contains_pii"
+    action: deny
+    priority: 100
+    description: "PII data cannot be processed"
+  - name: warn-large
+    condition: "data.size_mb > 100"
+    action: warn
+    priority: 50
+"""
+
+
+def dummy_tool(action: str = "read", **kwargs):
+    """A simple tool function for testing."""
+    return {"action": action, "status": "executed", **kwargs}
+
+
+def add(a: int, b: int) -> int:
+    """Simple function to test wrapping."""
+    return a + b
+
+
+# ── Core govern() tests ───────────────────────────────────────────
+
+class TestGovern:
+    """Tests for the govern() wrapper function."""
+
+    def test_govern_allows_action(self):
+        """Governed function executes when policy allows."""
+        safe = govern(dummy_tool, policy=ALLOW_ALL_POLICY)
+        result = safe(action="read")
+        assert result["status"] == "executed"
+        assert result["action"] == "read"
+
+    def test_govern_denies_action(self):
+        """Governed function raises GovernanceDenied when policy denies."""
+        safe = govern(dummy_tool, policy=DENY_EXPORT_POLICY)
+        with pytest.raises(GovernanceDenied) as exc_info:
+            safe(action="export")
+        assert "block-export" in str(exc_info.value)
+        assert exc_info.value.decision.action == "deny"
+
+    def test_govern_allows_non_matching_action(self):
+        """Non-matching actions pass through when default is allow."""
+        safe = govern(dummy_tool, policy=DENY_EXPORT_POLICY)
+        result = safe(action="read")
+        assert result["status"] == "executed"
+
+    def test_govern_with_on_deny_callback(self):
+        """Custom on_deny callback is called instead of raising."""
+        denied_actions = []
+
+        def on_deny(decision):
+            denied_actions.append(decision)
+            return {"status": "denied", "rule": decision.matched_rule}
+
+        safe = govern(
+            dummy_tool,
+            policy=DENY_EXPORT_POLICY,
+            on_deny=on_deny,
+        )
+        result = safe(action="export")
+        assert result["status"] == "denied"
+        assert result["rule"] == "block-export"
+        assert len(denied_actions) == 1
+
+    def test_govern_audit_logging(self):
+        """Audit log captures allow and deny decisions."""
+        safe = govern(dummy_tool, policy=DENY_EXPORT_POLICY, on_deny=lambda d: None)
+
+        # Allowed action
+        safe(action="read")
+        # Denied action (with on_deny callback so no exception)
+        safe(action="export")
+
+        log = safe.audit_log
+        assert log is not None
+        entries = log.query()
+        assert len(entries) >= 2
+
+    def test_govern_no_audit(self):
+        """Audit can be disabled."""
+        safe = govern(dummy_tool, policy=ALLOW_ALL_POLICY, audit=False)
+        safe(action="read")
+        assert safe.audit_log is None
+
+    def test_govern_with_policy_file(self, tmp_path):
+        """govern() accepts a file path for policy."""
+        policy_file = tmp_path / "test-policy.yaml"
+        policy_file.write_text(DENY_EXPORT_POLICY)
+
+        safe = govern(dummy_tool, policy=str(policy_file))
+        result = safe(action="read")
+        assert result["status"] == "executed"
+
+        with pytest.raises(GovernanceDenied):
+            safe(action="export")
+
+    def test_govern_with_policy_file_extends(self, tmp_path):
+        """govern() resolves extends when loading from file."""
+        (tmp_path / "base.yaml").write_text("""
+apiVersion: governance.toolkit/v1
+name: base
+default_action: allow
+rules:
+  - name: base-deny-delete
+    condition: "action.type == 'delete'"
+    action: deny
+""")
+        (tmp_path / "child.yaml").write_text("""
+apiVersion: governance.toolkit/v1
+name: child
+extends: base.yaml
+default_action: allow
+rules:
+  - name: child-allow-read
+    condition: "action.type == 'read'"
+    action: allow
+""")
+        safe = govern(dummy_tool, policy=str(tmp_path / "child.yaml"))
+        # Inherited deny
+        with pytest.raises(GovernanceDenied):
+            safe(action="delete")
+        # Own allow
+        result = safe(action="read")
+        assert result["status"] == "executed"
+
+    def test_govern_with_policy_object(self):
+        """govern() accepts a pre-built Policy object."""
+        policy = Policy.from_yaml(DENY_EXPORT_POLICY)
+        safe = govern(dummy_tool, policy=policy)
+        with pytest.raises(GovernanceDenied):
+            safe(action="export")
+
+    def test_govern_preserves_function_name(self):
+        """Wrapped function preserves __name__ and __doc__."""
+        safe = govern(dummy_tool, policy=ALLOW_ALL_POLICY)
+        assert safe.__wrapped__.__name__ == "dummy_tool"
+
+    def test_govern_passes_through_kwargs(self):
+        """Extra kwargs are passed to the wrapped function."""
+        safe = govern(dummy_tool, policy=ALLOW_ALL_POLICY)
+        result = safe(action="read", resource="users", limit=10)
+        assert result["resource"] == "users"
+        assert result["limit"] == 10
+
+    def test_govern_wraps_non_tool_function(self):
+        """govern() works with any callable, not just 'tool' functions."""
+        safe_add = govern(add, policy=ALLOW_ALL_POLICY)
+        assert safe_add(a=3, b=4) == 7
+
+    def test_govern_engine_accessible(self):
+        """The underlying PolicyEngine is accessible for advanced use."""
+        safe = govern(dummy_tool, policy=DENY_EXPORT_POLICY)
+        assert safe.engine is not None
+        assert len(safe.engine._policies) == 1
+
+    def test_govern_invalid_policy_type(self):
+        """Passing an invalid policy type raises TypeError."""
+        with pytest.raises(TypeError, match="policy must be"):
+            govern(dummy_tool, policy=12345)
+
+    def test_govern_context_from_dict_action(self):
+        """Action as dict is passed through to context."""
+        safe = govern(dummy_tool, policy=DENY_EXPORT_POLICY)
+        with pytest.raises(GovernanceDenied):
+            safe(action={"type": "export", "target": "s3"})
+
+    def test_govern_multiple_calls(self):
+        """Governed function can be called multiple times."""
+        safe = govern(dummy_tool, policy=ALLOW_ALL_POLICY)
+        for i in range(10):
+            result = safe(action="read", iteration=i)
+            assert result["iteration"] == i


### PR DESCRIPTION
## Summary
Adds a high-level `govern()` wrapper that reduces AGT integration to 2 lines.

### Before (5+ imports, 10+ lines)
```python
from agentmesh.governance import PolicyEngine, Policy, AuditLog
engine = PolicyEngine()
engine.load_yaml(policy_yaml)
audit = AuditLog()
# manually evaluate, log, handle denials...
```

### After (1 import, 1 line)
```python
from agentmesh.governance import govern
safe_fn = govern(my_tool, policy="policy.yaml")
```

### Features
- Accepts policy file path (with `extends`), inline YAML, or Policy object
- Automatic audit logging
- Custom `on_deny` callback or raise `GovernanceDenied`
- Engine and audit_log accessible for advanced use

### Tests
16 tests. All pass.

Closes #1372
