### PR TITLE
feat: multi-stage policy pipeline (pre_input, pre_tool, post_tool, pre_output)

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -38,10 +38,17 @@ class PolicyRule(BaseModel):
     Rules define conditions and actions:
     - condition: Expression that evaluates to true/false
     - action: What to do when condition matches (allow, deny, warn, require_approval)
+    - stage: When in the agent lifecycle this rule is evaluated
     """
 
     name: str = Field(..., description="Rule name")
     description: Optional[str] = Field(None)
+
+    # Lifecycle stage
+    stage: Literal["pre_input", "pre_tool", "post_tool", "pre_output"] = Field(
+        default="pre_tool",
+        description="Agent lifecycle stage: pre_input, pre_tool, post_tool, pre_output",
+    )
 
     # Condition
     condition: str = Field(..., description="Condition expression")
@@ -739,11 +746,13 @@ class PolicyEngine:
         self,
         agent_did: str,
         context: dict,
+        stage: str = "pre_tool",
     ) -> PolicyDecision:
         """Evaluate all applicable policies for an agent action.
 
-        Collects ALL matching rules across all applicable policies,
-        then resolves conflicts using the configured strategy:
+        Collects ALL matching rules across all applicable policies
+        for the given lifecycle stage, then resolves conflicts using
+        the configured strategy:
 
         - ``priority_first_match``: Highest-priority matching rule wins
           (v1.0 behavior).
@@ -755,6 +764,9 @@ class PolicyEngine:
         Args:
             agent_did: Decentralized identifier of the acting agent.
             context: Runtime context dict describing the action.
+            stage: Lifecycle stage to evaluate. One of ``"pre_input"``,
+                ``"pre_tool"`` (default), ``"post_tool"``, ``"pre_output"``.
+                Only rules matching this stage are evaluated.
 
         Returns:
             A ``PolicyDecision`` indicating whether the action is allowed
@@ -780,6 +792,8 @@ class PolicyEngine:
                     scope = PolicyScope.GLOBAL
 
                 for rule in policy.rules:
+                    if rule.stage != stage:
+                        continue  # skip rules for other stages
                     if rule.enabled and rule.evaluate(context):
                         candidates.append(CandidateDecision(
                             action=rule.action,

--- a/packages/agent-mesh/tests/test_multi_stage_pipeline.py
+++ b/packages/agent-mesh/tests/test_multi_stage_pipeline.py
@@ -1,0 +1,241 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for multi-stage policy pipeline."""
+
+import pytest
+from agentmesh.governance.policy import Policy, PolicyEngine, PolicyRule
+
+
+MULTI_STAGE_POLICY = """
+apiVersion: governance.toolkit/v1
+name: multi-stage
+agents: ["*"]
+default_action: allow
+rules:
+  - name: block-injection-input
+    stage: pre_input
+    condition: "input.contains_injection"
+    action: deny
+    description: "Prompt injection detected in input"
+    priority: 100
+
+  - name: block-export
+    stage: pre_tool
+    condition: "action.type == 'export'"
+    action: deny
+    description: "Export not allowed"
+    priority: 50
+
+  - name: block-pii-in-output
+    stage: post_tool
+    condition: "tool.output.contains_pii"
+    action: deny
+    description: "PII detected in tool output"
+    priority: 80
+
+  - name: sanitize-response
+    stage: pre_output
+    condition: "response.contains_secrets"
+    action: deny
+    description: "Secrets in agent response"
+    priority: 90
+
+  - name: allow-read
+    stage: pre_tool
+    condition: "action.type == 'read'"
+    action: allow
+    priority: 10
+
+  - name: log-all-tools
+    stage: pre_tool
+    condition: "true"
+    action: log
+    priority: 0
+"""
+
+
+class TestMultiStagePipeline:
+    """Tests for stage-aware policy evaluation."""
+
+    def test_rule_default_stage_is_pre_tool(self):
+        """Rules without explicit stage default to pre_tool."""
+        policy = Policy.from_yaml("""
+apiVersion: governance.toolkit/v1
+name: default-stage
+default_action: allow
+rules:
+  - name: some-rule
+    condition: "true"
+    action: allow
+""")
+        assert policy.rules[0].stage == "pre_tool"
+
+    def test_rule_explicit_stage(self):
+        """Rules with explicit stage are parsed correctly."""
+        policy = Policy.from_yaml(MULTI_STAGE_POLICY)
+        stages = {r.name: r.stage for r in policy.rules}
+        assert stages["block-injection-input"] == "pre_input"
+        assert stages["block-export"] == "pre_tool"
+        assert stages["block-pii-in-output"] == "post_tool"
+        assert stages["sanitize-response"] == "pre_output"
+        assert stages["allow-read"] == "pre_tool"
+        assert stages["log-all-tools"] == "pre_tool"
+
+    def test_evaluate_pre_input_stage(self):
+        """Only pre_input rules fire at pre_input stage."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        # Injection detected — should be denied at pre_input
+        result = engine.evaluate("*", {
+            "input": {"contains_injection": True},
+        }, stage="pre_input")
+        assert not result.allowed
+        assert result.matched_rule == "block-injection-input"
+
+    def test_evaluate_pre_input_no_match(self):
+        """Clean input passes pre_input stage."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        result = engine.evaluate("*", {
+            "input": {"contains_injection": False},
+        }, stage="pre_input")
+        assert result.allowed
+
+    def test_evaluate_pre_tool_stage(self):
+        """Only pre_tool rules fire at pre_tool stage."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        # Export should be denied
+        result = engine.evaluate("*", {
+            "action": {"type": "export"},
+        }, stage="pre_tool")
+        assert not result.allowed
+        assert result.matched_rule == "block-export"
+
+    def test_evaluate_pre_tool_allows_read(self):
+        """Read action is allowed at pre_tool."""
+        engine = PolicyEngine(conflict_strategy="priority_first_match")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        result = engine.evaluate("*", {
+            "action": {"type": "read"},
+        }, stage="pre_tool")
+        assert result.allowed
+
+    def test_evaluate_post_tool_stage(self):
+        """Only post_tool rules fire at post_tool stage."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        # PII in tool output — denied
+        result = engine.evaluate("*", {
+            "tool": {"output": {"contains_pii": True}},
+        }, stage="post_tool")
+        assert not result.allowed
+        assert result.matched_rule == "block-pii-in-output"
+
+    def test_evaluate_post_tool_clean(self):
+        """Clean tool output passes post_tool."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        result = engine.evaluate("*", {
+            "tool": {"output": {"contains_pii": False}},
+        }, stage="post_tool")
+        assert result.allowed
+
+    def test_evaluate_pre_output_stage(self):
+        """Only pre_output rules fire at pre_output stage."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        result = engine.evaluate("*", {
+            "response": {"contains_secrets": True},
+        }, stage="pre_output")
+        assert not result.allowed
+        assert result.matched_rule == "sanitize-response"
+
+    def test_stages_are_isolated(self):
+        """Rules from one stage don't fire at another stage."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        # block-export is pre_tool — should NOT fire at post_tool
+        result = engine.evaluate("*", {
+            "action": {"type": "export"},
+        }, stage="post_tool")
+        assert result.allowed  # no post_tool rules match this context
+
+    def test_default_stage_is_pre_tool(self):
+        """evaluate() without stage arg defaults to pre_tool."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml(MULTI_STAGE_POLICY)
+
+        # This should only evaluate pre_tool rules
+        result = engine.evaluate("*", {
+            "action": {"type": "export"},
+        })
+        assert not result.allowed
+        assert result.matched_rule == "block-export"
+
+    def test_backward_compat_no_stage_in_yaml(self):
+        """Policies without stage field work as before (all rules = pre_tool)."""
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml("""
+apiVersion: governance.toolkit/v1
+name: legacy-no-stage
+agents: ["*"]
+default_action: allow
+rules:
+  - name: block-delete
+    condition: "action.type == 'delete'"
+    action: deny
+""")
+        result = engine.evaluate("*", {"action": {"type": "delete"}})
+        assert not result.allowed
+
+    def test_multiple_stages_single_policy(self):
+        """A single policy can have rules across all 4 stages."""
+        policy = Policy.from_yaml(MULTI_STAGE_POLICY)
+        stages = set(r.stage for r in policy.rules)
+        assert stages == {"pre_input", "pre_tool", "post_tool", "pre_output"}
+
+    def test_stage_with_composition(self, tmp_path):
+        """Stage-aware rules work with policy extends."""
+        (tmp_path / "parent.yaml").write_text("""
+apiVersion: governance.toolkit/v1
+name: parent
+default_action: allow
+rules:
+  - name: parent-pre-input
+    stage: pre_input
+    condition: "input.blocked"
+    action: deny
+""")
+        (tmp_path / "child.yaml").write_text("""
+apiVersion: governance.toolkit/v1
+name: child
+extends: parent.yaml
+agents: ["*"]
+default_action: allow
+rules:
+  - name: child-post-tool
+    stage: post_tool
+    condition: "tool.output.sensitive"
+    action: deny
+""")
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        policy = engine.load_yaml_file(str(tmp_path / "child.yaml"))
+
+        # Parent pre_input rule
+        result = engine.evaluate("*", {"input": {"blocked": True}}, stage="pre_input")
+        assert not result.allowed
+        assert result.matched_rule == "parent-pre-input"
+
+        # Child post_tool rule
+        result = engine.evaluate("*", {"tool": {"output": {"sensitive": True}}}, stage="post_tool")
+        assert not result.allowed
+        assert result.matched_rule == "child-post-tool"


### PR DESCRIPTION
## Summary
Adds lifecycle stage awareness to policy rules. Rules can now target 4 stages:

- `pre_input` — prompt injection detection before agent processes input
- `pre_tool` — tool call gating (default, backward compatible)
- `post_tool` — DLP/PII check on tool output before agent uses it
- `pre_output` — sanitize agent response before it reaches the user

```yaml
rules:
  - name: block-pii-in-tool-output
    stage: post_tool
    condition: "tool.output.contains_pii"
    action: deny
```

Rules without `stage` default to `pre_tool`. Fully backward compatible.
Works with `extends` composition.

14 tests. All pass.

Closes #1373
