### PR TITLE
feat: add optional advisory policy checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **AgentMesh**: Optional advisory policy checks after deterministic `PolicyEngine`
+  allow decisions, with callable and endpoint adapters for defense-in-depth
+  classification.
+
+### Compatibility
+- **AgentMesh**: `PolicyEngine.evaluate()` remains deterministic-only unless
+  `set_advisory_check()` is configured. When enabled, advisory checks can only
+  tighten deterministic allow results and may add advisory metadata to
+  `PolicyDecision.metadata`.
+- **AgentMesh**: Internal deprecated `datetime.utcnow()` usage was replaced with
+  `_utcnow()` for Python 3.13 compatibility while preserving naive UTC
+  timestamps in public models.
 
 ## [3.2.1] - 2026-04-22
 

--- a/packages/agent-mesh/CHANGELOG.md
+++ b/packages/agent-mesh/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to AgentMesh will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Optional advisory policy checks that run after deterministic
+  `PolicyEngine.evaluate()` allow decisions.
+- `AdvisoryCheck`, `FunctionAdvisoryCheck`, and `EndpointAdvisoryCheck` adapters
+  for custom functions, local models, and classifier endpoints.
+
+### Security
+- `EndpointAdvisoryCheck` now requires HTTPS, uses explicit exact-host
+  allowlisting, rejects wildcard host patterns, and enforces bounded timeout and
+  retry settings with a total advisory timeout budget.
+- Advisory metadata is sanitized before being attached to decisions or audit
+  records.
+
+### Compatibility
+- `PolicyEngine.evaluate()` is unchanged unless `set_advisory_check()` is
+  configured. When enabled, advisory checks run only after deterministic allow
+  results and can tighten those results to `warn` or `deny`.
+- `PolicyDecision.metadata["advisory"]` is only present when the advisory stage
+  runs.
+- Internal deprecated `datetime.utcnow()` calls were replaced with `_utcnow()`
+  for Python 3.13 compatibility while preserving naive UTC timestamps in public
+  models.
+
 ## [1.0.0-alpha.1] - 2026-02-01
 
 ### Added

--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -476,6 +476,32 @@ rules:
     approvers: ["security-team"]
 ```
 
+Optional advisory checks run only after deterministic policy evaluation allows an
+action. They are non-deterministic defense-in-depth and can only tighten the
+result by flagging for review or blocking:
+
+```python
+from agentmesh.governance import AuditLog, PolicyEngine
+from agentmesh.governance.advisory import AdvisoryResult
+
+audit_log = AuditLog()
+engine = PolicyEngine()
+
+def reviewer(agent_did, context, deterministic_decision):
+    return AdvisoryResult(
+        action="flag_for_review",
+        reason="possible context poisoning",
+        classifier="custom-reviewer",
+    )
+
+engine.set_advisory_check(
+    reviewer,
+    classifier="custom-reviewer",
+    actions=["flag_for_review", "block"],
+    audit_log=audit_log,
+)
+```
+
 ## Protocol Support
 
 | Protocol | Status | Description |

--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -478,7 +478,8 @@ rules:
 
 Optional advisory checks run only after deterministic policy evaluation allows an
 action. They are non-deterministic defense-in-depth and can only tighten the
-result by flagging for review or blocking:
+result by flagging for review or blocking. Advisory checks are disabled by
+default unless `set_advisory_check()` is called:
 
 ```python
 from agentmesh.governance import AuditLog, PolicyEngine
@@ -500,6 +501,8 @@ engine.set_advisory_check(
     actions=["flag_for_review", "block"],
     audit_log=audit_log,
 )
+
+engine.clear_advisory_check()  # disable the advisory stage
 ```
 
 ## Protocol Support

--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -507,7 +507,18 @@ engine.clear_advisory_check()  # disable the advisory stage
 
 For classifier endpoints, use HTTPS, configure `allowed_hosts`, and keep timeout
 and retry settings bounded so advisory checks cannot delay deterministic policy
-evaluation indefinitely.
+evaluation indefinitely. `allowed_hosts` uses exact host matches only; wildcard
+patterns such as `*.example.com` are rejected.
+
+Compatibility notes:
+- `PolicyEngine.evaluate()` behaves exactly as before unless `set_advisory_check()`
+  is called. Once enabled, advisory checks run only after a deterministic allow
+  result and may tighten that result to `warn` or `deny`.
+- `PolicyDecision.metadata["advisory"]` is only populated when the advisory
+  stage runs.
+- Internal `datetime.utcnow()` calls were replaced with `_utcnow()` for Python
+  3.13 compatibility, but public timestamps still remain naive UTC `datetime`
+  values for backward compatibility.
 
 ## Protocol Support
 

--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -505,6 +505,10 @@ engine.set_advisory_check(
 engine.clear_advisory_check()  # disable the advisory stage
 ```
 
+For classifier endpoints, use HTTPS, configure `allowed_hosts`, and keep timeout
+and retry settings bounded so advisory checks cannot delay deterministic policy
+evaluation indefinitely.
+
 ## Protocol Support
 
 | Protocol | Status | Description |

--- a/packages/agent-mesh/README.md
+++ b/packages/agent-mesh/README.md
@@ -502,13 +502,15 @@ engine.set_advisory_check(
     audit_log=audit_log,
 )
 
+current_advisory = engine.advisory_config
 engine.clear_advisory_check()  # disable the advisory stage
 ```
 
 For classifier endpoints, use HTTPS, configure `allowed_hosts`, and keep timeout
 and retry settings bounded so advisory checks cannot delay deterministic policy
 evaluation indefinitely. `allowed_hosts` uses exact host matches only; wildcard
-patterns such as `*.example.com` are rejected.
+patterns such as `*.example.com` are rejected. `advisory_config` returns a copy
+of the current advisory configuration so callers can inspect it safely.
 
 Compatibility notes:
 - `PolicyEngine.evaluate()` behaves exactly as before unless `set_advisory_check()`

--- a/packages/agent-mesh/src/agentmesh/governance/advisory.py
+++ b/packages/agent-mesh/src/agentmesh/governance/advisory.py
@@ -26,8 +26,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MAX_ENDPOINT_TIMEOUT_SECONDS = 10.0
-MAX_ENDPOINT_RETRIES = 5
+MAX_ENDPOINT_TIMEOUT_SECONDS = 5.0
+MAX_ENDPOINT_RETRIES = 2
+MAX_ENDPOINT_TOTAL_SECONDS = 6.0
 MAX_METADATA_DEPTH = 4
 MAX_METADATA_ITEMS = 50
 MAX_METADATA_KEY_LENGTH = 128
@@ -131,6 +132,8 @@ class EndpointAdvisoryCheck:
 
         endpoint_host = parsed.hostname.lower()
         trusted_hosts = {host.lower() for host in allowed_hosts or ()}
+        if any("*" in host for host in trusted_hosts):
+            raise ValueError("Wildcard advisory endpoint hosts are not supported.")
         if trusted_hosts and endpoint_host not in trusted_hosts:
             raise ValueError(f"Advisory endpoint host '{parsed.hostname}' is not allowed.")
         if timeout <= 0:
@@ -174,14 +177,20 @@ class EndpointAdvisoryCheck:
             "deterministic_decision": decision_payload,
         }
 
+        deadline = time.monotonic() + MAX_ENDPOINT_TOTAL_SECONDS
         attempt = 0
         while True:
             try:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise httpx.TimeoutException(
+                        "Advisory check exceeded the total timeout budget."
+                    )
                 response = httpx.post(
                     self.url,
                     json=payload,
                     headers=self.headers,
-                    timeout=self.timeout,
+                    timeout=min(self.timeout, remaining),
                 )
                 response.raise_for_status()
                 return normalize_advisory_result(
@@ -191,8 +200,11 @@ class EndpointAdvisoryCheck:
             except httpx.HTTPError:
                 if attempt >= self.max_retries:
                     raise
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise
                 if self.retry_backoff:
-                    time.sleep(min(self.retry_backoff * (2**attempt), 1.0))
+                    time.sleep(min(self.retry_backoff * (2**attempt), 1.0, remaining))
                 attempt += 1
 
 

--- a/packages/agent-mesh/src/agentmesh/governance/advisory.py
+++ b/packages/agent-mesh/src/agentmesh/governance/advisory.py
@@ -1,0 +1,184 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Optional advisory checks for defense-in-depth.
+
+Advisory checks are intentionally separated from deterministic policy
+enforcement. They run only after deterministic policy evaluation allows an
+action, and they can only add a flag or block.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Literal, Protocol, runtime_checkable
+
+import httpx
+from pydantic import BaseModel, Field
+
+AdvisoryAction = Literal["allow", "flag_for_review", "block"]
+AdvisoryEffect = Literal["flag_for_review", "block"]
+AdvisoryOnError = Literal["allow"]
+AdvisoryFunction = Callable[
+    [str, dict[str, Any], Any],
+    "AdvisoryResult | Mapping[str, Any] | str | bool | None",
+]
+
+
+class AdvisoryConfig(BaseModel):
+    """Configuration for optional, non-deterministic advisory checks."""
+
+    enabled: bool = False
+    classifier: str | None = None
+    actions: set[AdvisoryEffect] = Field(
+        default_factory=lambda: {"flag_for_review", "block"}
+    )
+    on_error: AdvisoryOnError = "allow"
+
+
+class AdvisoryResult(BaseModel):
+    """Decision returned by an advisory classifier or reviewer."""
+
+    action: AdvisoryAction = "allow"
+    reason: str | None = None
+    classifier: str | None = None
+    confidence: float | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+@runtime_checkable
+class AdvisoryCheck(Protocol):
+    """Interface implemented by classifier endpoints, local models, or callables."""
+
+    name: str
+
+    def evaluate(
+        self,
+        agent_did: str,
+        context: dict[str, Any],
+        deterministic_decision: Any,
+    ) -> AdvisoryResult | Mapping[str, Any] | str | bool | None:
+        """Evaluate an action that has already passed deterministic policy."""
+
+
+class FunctionAdvisoryCheck:
+    """Wrap a custom function or local model behind the advisory interface."""
+
+    def __init__(self, func: AdvisoryFunction, name: str = "custom") -> None:
+        self.func = func
+        self.name = name
+
+    def evaluate(
+        self,
+        agent_did: str,
+        context: dict[str, Any],
+        deterministic_decision: Any,
+    ) -> AdvisoryResult | Mapping[str, Any] | str | bool | None:
+        """Run the configured advisory function."""
+        return self.func(agent_did, context, deterministic_decision)
+
+
+class EndpointAdvisoryCheck:
+    """Call a classifier endpoint that returns an advisory decision."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        name: str = "classifier-endpoint",
+        headers: Mapping[str, str] | None = None,
+        timeout: float = 2.0,
+    ) -> None:
+        self.url = url
+        self.name = name
+        self.headers = dict(headers or {})
+        self.timeout = timeout
+
+    def evaluate(
+        self,
+        agent_did: str,
+        context: dict[str, Any],
+        deterministic_decision: Any,
+    ) -> AdvisoryResult:
+        """POST the advisory payload to the endpoint and normalize the response."""
+        if hasattr(deterministic_decision, "model_dump"):
+            decision_payload = deterministic_decision.model_dump(mode="json")
+        else:
+            decision_payload = deterministic_decision
+
+        response = httpx.post(
+            self.url,
+            json={
+                "agent_did": agent_did,
+                "context": context,
+                "deterministic_decision": decision_payload,
+            },
+            headers=self.headers,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return normalize_advisory_result(response.json(), default_classifier=self.name)
+
+
+def normalize_advisory_result(
+    result: AdvisoryResult | Mapping[str, Any] | str | bool | None,
+    *,
+    default_classifier: str | None = None,
+) -> AdvisoryResult:
+    """Normalize endpoint, model, and function outputs into ``AdvisoryResult``."""
+    if isinstance(result, AdvisoryResult):
+        if result.classifier is None and default_classifier is not None:
+            return result.model_copy(update={"classifier": default_classifier})
+        return result
+
+    if result is None:
+        return AdvisoryResult(action="allow", classifier=default_classifier)
+
+    if isinstance(result, bool):
+        return AdvisoryResult(
+            action="allow" if result else "block",
+            classifier=default_classifier,
+        )
+
+    if isinstance(result, str):
+        return AdvisoryResult(
+            action=_normalize_action(result),
+            classifier=default_classifier,
+        )
+
+    data = dict(result)
+    raw_action = data.get("action") or data.get("decision") or data.get("verdict")
+    metadata = dict(data.get("metadata") or {})
+    known = {
+        "action",
+        "decision",
+        "verdict",
+        "reason",
+        "classifier",
+        "confidence",
+        "metadata",
+    }
+    metadata.update({key: value for key, value in data.items() if key not in known})
+
+    return AdvisoryResult(
+        action=_normalize_action(raw_action),
+        reason=data.get("reason"),
+        classifier=data.get("classifier") or default_classifier,
+        confidence=data.get("confidence"),
+        metadata=metadata,
+    )
+
+
+def _normalize_action(action: Any) -> AdvisoryAction:
+    if action is None:
+        return "allow"
+
+    value = str(action).strip().lower().replace("-", "_")
+    if value in {"allow", "allowed", "pass", "passed", "safe", "ok", "none"}:
+        return "allow"
+    if value in {"flag", "flagged", "flag_for_review", "warn", "warning", "review"}:
+        return "flag_for_review"
+    if value in {"block", "blocked", "deny", "denied", "unsafe"}:
+        return "block"
+
+    raise ValueError(f"Unsupported advisory action: {action!r}")

--- a/packages/agent-mesh/src/agentmesh/governance/advisory.py
+++ b/packages/agent-mesh/src/agentmesh/governance/advisory.py
@@ -11,6 +11,8 @@ action, and they can only add a flag or block.
 from __future__ import annotations
 
 import logging
+import math
+import re
 import time
 from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
@@ -23,6 +25,15 @@ if TYPE_CHECKING:
     from .policy import PolicyDecision
 
 logger = logging.getLogger(__name__)
+
+MAX_ENDPOINT_TIMEOUT_SECONDS = 10.0
+MAX_ENDPOINT_RETRIES = 5
+MAX_METADATA_DEPTH = 4
+MAX_METADATA_ITEMS = 50
+MAX_METADATA_KEY_LENGTH = 128
+MAX_METADATA_STRING_LENGTH = 4096
+_METADATA_SKIP = object()
+_METADATA_KEY_PATTERN = re.compile(r"[^A-Za-z0-9_.-]")
 
 AdvisoryAction = Literal["allow", "flag_for_review", "block"]
 AdvisoryEffect = Literal["flag_for_review", "block"]
@@ -118,13 +129,22 @@ class EndpointAdvisoryCheck:
         if not parsed.hostname:
             raise ValueError("Advisory endpoint URL must include a hostname.")
 
-        trusted_hosts = set(allowed_hosts or ())
-        if trusted_hosts and parsed.hostname not in trusted_hosts:
+        endpoint_host = parsed.hostname.lower()
+        trusted_hosts = {host.lower() for host in allowed_hosts or ()}
+        if trusted_hosts and endpoint_host not in trusted_hosts:
             raise ValueError(f"Advisory endpoint host '{parsed.hostname}' is not allowed.")
         if timeout <= 0:
             raise ValueError("Advisory endpoint timeout must be greater than zero.")
+        if timeout > MAX_ENDPOINT_TIMEOUT_SECONDS:
+            raise ValueError(
+                f"Advisory endpoint timeout must be <= {MAX_ENDPOINT_TIMEOUT_SECONDS:g} seconds."
+            )
         if max_retries < 0:
             raise ValueError("Advisory endpoint max_retries must be zero or greater.")
+        if max_retries > MAX_ENDPOINT_RETRIES:
+            raise ValueError(
+                f"Advisory endpoint max_retries must be <= {MAX_ENDPOINT_RETRIES}."
+            )
         if retry_backoff < 0:
             raise ValueError("Advisory endpoint retry_backoff must be zero or greater.")
 
@@ -183,9 +203,10 @@ def normalize_advisory_result(
 ) -> AdvisoryResult:
     """Normalize endpoint, model, and function outputs into ``AdvisoryResult``."""
     if isinstance(result, AdvisoryResult):
+        updates: dict[str, Any] = {"metadata": _sanitize_metadata(result.metadata)}
         if result.classifier is None and default_classifier is not None:
-            return result.model_copy(update={"classifier": default_classifier})
-        return result
+            updates["classifier"] = default_classifier
+        return result.model_copy(update=updates)
 
     if result is None:
         return AdvisoryResult(action="allow", classifier=default_classifier)
@@ -205,7 +226,7 @@ def normalize_advisory_result(
     try:
         data = dict(result)
     except (TypeError, ValueError):
-        logger.warning("Malformed advisory result %r; defaulting to allow", result)
+        logger.error("Malformed advisory result %r; defaulting to allow", result)
         return AdvisoryResult(
             action="allow",
             reason="Malformed advisory result; deterministic allow preserved",
@@ -214,7 +235,7 @@ def normalize_advisory_result(
         )
 
     raw_action = data.get("action") or data.get("decision") or data.get("verdict")
-    metadata = dict(data.get("metadata") or {})
+    metadata = _sanitize_metadata(data.get("metadata"))
     known = {
         "action",
         "decision",
@@ -224,7 +245,9 @@ def normalize_advisory_result(
         "confidence",
         "metadata",
     }
-    metadata.update({key: value for key, value in data.items() if key not in known})
+    metadata.update(
+        _sanitize_metadata({key: value for key, value in data.items() if key not in known})
+    )
 
     try:
         return AdvisoryResult(
@@ -235,7 +258,7 @@ def normalize_advisory_result(
             metadata=metadata,
         )
     except Exception as exc:
-        logger.warning("Invalid advisory result %r; defaulting to allow", result)
+        logger.error("Invalid advisory result %r; defaulting to allow", result)
         return AdvisoryResult(
             action="allow",
             reason="Invalid advisory result; deterministic allow preserved",
@@ -260,5 +283,60 @@ def _normalize_action(action: Any) -> AdvisoryAction:
     if value in {"block", "blocked", "deny", "denied", "unsafe"}:
         return "block"
 
-    logger.warning("Unsupported advisory action %r; defaulting to allow", action)
+    logger.error("Unsupported advisory action %r; defaulting to allow", action)
     return "allow"
+
+
+def _sanitize_metadata(raw_metadata: Any, *, depth: int = 0) -> dict[str, Any]:
+    """Return JSON-safe advisory metadata with sanitized keys and bounded values."""
+    if raw_metadata is None:
+        return {}
+    if not isinstance(raw_metadata, Mapping):
+        logger.error("Malformed advisory metadata %r; dropping metadata", raw_metadata)
+        return {"malformed_metadata": True}
+
+    sanitized: dict[str, Any] = {}
+    for key, value in raw_metadata.items():
+        clean_key = _sanitize_metadata_key(key)
+        if clean_key is None:
+            continue
+        clean_value = _sanitize_metadata_value(value, depth=depth)
+        if clean_value is not _METADATA_SKIP:
+            sanitized[clean_key] = clean_value
+    return sanitized
+
+
+def _sanitize_metadata_key(key: Any) -> str | None:
+    key_text = _METADATA_KEY_PATTERN.sub("_", str(key))[:MAX_METADATA_KEY_LENGTH]
+    key_text = key_text.strip(".-")
+    if not key_text:
+        return None
+    if key_text.startswith("__"):
+        key_text = f"metadata{key_text}"
+    key_text = key_text.strip("_")
+    if not key_text:
+        return None
+    return key_text
+
+
+def _sanitize_metadata_value(value: Any, *, depth: int) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else _METADATA_SKIP
+    if isinstance(value, str):
+        return value[:MAX_METADATA_STRING_LENGTH]
+    if depth >= MAX_METADATA_DEPTH:
+        return _METADATA_SKIP
+    if isinstance(value, Mapping):
+        return _sanitize_metadata(value, depth=depth + 1)
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        sanitized_items = []
+        for item in value[:MAX_METADATA_ITEMS]:
+            clean_item = _sanitize_metadata_value(item, depth=depth + 1)
+            if clean_item is not _METADATA_SKIP:
+                sanitized_items.append(clean_item)
+        return sanitized_items
+    return _METADATA_SKIP

--- a/packages/agent-mesh/src/agentmesh/governance/advisory.py
+++ b/packages/agent-mesh/src/agentmesh/governance/advisory.py
@@ -10,17 +10,25 @@ action, and they can only add a flag or block.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
-from typing import Any, Literal, Protocol, runtime_checkable
+import logging
+import time
+from collections.abc import Callable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from .policy import PolicyDecision
+
+logger = logging.getLogger(__name__)
 
 AdvisoryAction = Literal["allow", "flag_for_review", "block"]
 AdvisoryEffect = Literal["flag_for_review", "block"]
 AdvisoryOnError = Literal["allow"]
 AdvisoryFunction = Callable[
-    [str, dict[str, Any], Any],
+    [str, dict[str, Any], "PolicyDecision"],
     "AdvisoryResult | Mapping[str, Any] | str | bool | None",
 ]
 
@@ -56,7 +64,7 @@ class AdvisoryCheck(Protocol):
         self,
         agent_did: str,
         context: dict[str, Any],
-        deterministic_decision: Any,
+        deterministic_decision: PolicyDecision,
     ) -> AdvisoryResult | Mapping[str, Any] | str | bool | None:
         """Evaluate an action that has already passed deterministic policy."""
 
@@ -65,6 +73,7 @@ class FunctionAdvisoryCheck:
     """Wrap a custom function or local model behind the advisory interface."""
 
     def __init__(self, func: AdvisoryFunction, name: str = "custom") -> None:
+        """Create an advisory check from a Python callable."""
         self.func = func
         self.name = name
 
@@ -72,7 +81,7 @@ class FunctionAdvisoryCheck:
         self,
         agent_did: str,
         context: dict[str, Any],
-        deterministic_decision: Any,
+        deterministic_decision: PolicyDecision,
     ) -> AdvisoryResult | Mapping[str, Any] | str | bool | None:
         """Run the configured advisory function."""
         return self.func(agent_did, context, deterministic_decision)
@@ -88,17 +97,50 @@ class EndpointAdvisoryCheck:
         name: str = "classifier-endpoint",
         headers: Mapping[str, str] | None = None,
         timeout: float = 2.0,
+        allowed_hosts: Sequence[str] | None = None,
+        max_retries: int = 0,
+        retry_backoff: float = 0.1,
     ) -> None:
+        """Create an HTTPS classifier endpoint advisory check.
+
+        Args:
+            url: HTTPS endpoint that returns an advisory decision.
+            name: Classifier label used in metadata.
+            headers: Optional request headers, such as authorization.
+            timeout: Per-request timeout in seconds.
+            allowed_hosts: Optional exact host allowlist for endpoint URLs.
+            max_retries: Number of retries for transient HTTP failures.
+            retry_backoff: Initial exponential backoff delay in seconds.
+        """
+        parsed = urlparse(url)
+        if parsed.scheme != "https":
+            raise ValueError("Advisory endpoint must use HTTPS for secure communication.")
+        if not parsed.hostname:
+            raise ValueError("Advisory endpoint URL must include a hostname.")
+
+        trusted_hosts = set(allowed_hosts or ())
+        if trusted_hosts and parsed.hostname not in trusted_hosts:
+            raise ValueError(f"Advisory endpoint host '{parsed.hostname}' is not allowed.")
+        if timeout <= 0:
+            raise ValueError("Advisory endpoint timeout must be greater than zero.")
+        if max_retries < 0:
+            raise ValueError("Advisory endpoint max_retries must be zero or greater.")
+        if retry_backoff < 0:
+            raise ValueError("Advisory endpoint retry_backoff must be zero or greater.")
+
         self.url = url
         self.name = name
         self.headers = dict(headers or {})
         self.timeout = timeout
+        self.allowed_hosts = trusted_hosts
+        self.max_retries = max_retries
+        self.retry_backoff = retry_backoff
 
     def evaluate(
         self,
         agent_did: str,
         context: dict[str, Any],
-        deterministic_decision: Any,
+        deterministic_decision: PolicyDecision,
     ) -> AdvisoryResult:
         """POST the advisory payload to the endpoint and normalize the response."""
         if hasattr(deterministic_decision, "model_dump"):
@@ -106,18 +148,32 @@ class EndpointAdvisoryCheck:
         else:
             decision_payload = deterministic_decision
 
-        response = httpx.post(
-            self.url,
-            json={
-                "agent_did": agent_did,
-                "context": context,
-                "deterministic_decision": decision_payload,
-            },
-            headers=self.headers,
-            timeout=self.timeout,
-        )
-        response.raise_for_status()
-        return normalize_advisory_result(response.json(), default_classifier=self.name)
+        payload = {
+            "agent_did": agent_did,
+            "context": context,
+            "deterministic_decision": decision_payload,
+        }
+
+        attempt = 0
+        while True:
+            try:
+                response = httpx.post(
+                    self.url,
+                    json=payload,
+                    headers=self.headers,
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                return normalize_advisory_result(
+                    response.json(),
+                    default_classifier=self.name,
+                )
+            except httpx.HTTPError:
+                if attempt >= self.max_retries:
+                    raise
+                if self.retry_backoff:
+                    time.sleep(min(self.retry_backoff * (2**attempt), 1.0))
+                attempt += 1
 
 
 def normalize_advisory_result(
@@ -146,7 +202,17 @@ def normalize_advisory_result(
             classifier=default_classifier,
         )
 
-    data = dict(result)
+    try:
+        data = dict(result)
+    except (TypeError, ValueError):
+        logger.warning("Malformed advisory result %r; defaulting to allow", result)
+        return AdvisoryResult(
+            action="allow",
+            reason="Malformed advisory result; deterministic allow preserved",
+            classifier=default_classifier,
+            metadata={"malformed_result": True},
+        )
+
     raw_action = data.get("action") or data.get("decision") or data.get("verdict")
     metadata = dict(data.get("metadata") or {})
     known = {
@@ -160,16 +226,29 @@ def normalize_advisory_result(
     }
     metadata.update({key: value for key, value in data.items() if key not in known})
 
-    return AdvisoryResult(
-        action=_normalize_action(raw_action),
-        reason=data.get("reason"),
-        classifier=data.get("classifier") or default_classifier,
-        confidence=data.get("confidence"),
-        metadata=metadata,
-    )
+    try:
+        return AdvisoryResult(
+            action=_normalize_action(raw_action),
+            reason=data.get("reason"),
+            classifier=data.get("classifier") or default_classifier,
+            confidence=data.get("confidence"),
+            metadata=metadata,
+        )
+    except Exception as exc:
+        logger.warning("Invalid advisory result %r; defaulting to allow", result)
+        return AdvisoryResult(
+            action="allow",
+            reason="Invalid advisory result; deterministic allow preserved",
+            classifier=default_classifier,
+            metadata={
+                "malformed_result": True,
+                "error_type": type(exc).__name__,
+            },
+        )
 
 
 def _normalize_action(action: Any) -> AdvisoryAction:
+    """Normalize classifier action labels, defaulting unknown labels to allow."""
     if action is None:
         return "allow"
 
@@ -181,4 +260,5 @@ def _normalize_action(action: Any) -> AdvisoryAction:
     if value in {"block", "blocked", "deny", "denied", "unsafe"}:
         return "block"
 
-    raise ValueError(f"Unsupported advisory action: {action!r}")
+    logger.warning("Unsupported advisory action %r; defaulting to allow", action)
+    return "allow"

--- a/packages/agent-mesh/src/agentmesh/governance/advisory.py
+++ b/packages/agent-mesh/src/agentmesh/governance/advisory.py
@@ -109,6 +109,7 @@ class EndpointAdvisoryCheck:
         name: str = "classifier-endpoint",
         headers: Mapping[str, str] | None = None,
         timeout: float = 2.0,
+        total_timeout: float = MAX_ENDPOINT_TOTAL_SECONDS,
         allowed_hosts: Sequence[str] | None = None,
         max_retries: int = 0,
         retry_backoff: float = 0.1,
@@ -120,6 +121,7 @@ class EndpointAdvisoryCheck:
             name: Classifier label used in metadata.
             headers: Optional request headers, such as authorization.
             timeout: Per-request timeout in seconds.
+            total_timeout: Total timeout budget for the advisory check.
             allowed_hosts: Optional exact host allowlist for endpoint URLs.
             max_retries: Number of retries for transient HTTP failures.
             retry_backoff: Initial exponential backoff delay in seconds.
@@ -142,6 +144,13 @@ class EndpointAdvisoryCheck:
             raise ValueError(
                 f"Advisory endpoint timeout must be <= {MAX_ENDPOINT_TIMEOUT_SECONDS:g} seconds."
             )
+        if total_timeout <= 0:
+            raise ValueError("Advisory endpoint total_timeout must be greater than zero.")
+        if total_timeout > MAX_ENDPOINT_TOTAL_SECONDS:
+            raise ValueError(
+                "Advisory endpoint total_timeout must be <= "
+                f"{MAX_ENDPOINT_TOTAL_SECONDS:g} seconds."
+            )
         if max_retries < 0:
             raise ValueError("Advisory endpoint max_retries must be zero or greater.")
         if max_retries > MAX_ENDPOINT_RETRIES:
@@ -155,6 +164,7 @@ class EndpointAdvisoryCheck:
         self.name = name
         self.headers = dict(headers or {})
         self.timeout = timeout
+        self.total_timeout = total_timeout
         self.allowed_hosts = trusted_hosts
         self.max_retries = max_retries
         self.retry_backoff = retry_backoff
@@ -177,7 +187,7 @@ class EndpointAdvisoryCheck:
             "deterministic_decision": decision_payload,
         }
 
-        deadline = time.monotonic() + MAX_ENDPOINT_TOTAL_SECONDS
+        deadline = time.monotonic() + self.total_timeout
         attempt = 0
         while True:
             try:
@@ -319,6 +329,7 @@ def _sanitize_metadata(raw_metadata: Any, *, depth: int = 0) -> dict[str, Any]:
 
 
 def _sanitize_metadata_key(key: Any) -> str | None:
+    """Normalize advisory metadata keys into bounded, safe identifier strings."""
     key_text = _METADATA_KEY_PATTERN.sub("_", str(key))[:MAX_METADATA_KEY_LENGTH]
     key_text = key_text.strip(".-")
     if not key_text:
@@ -332,6 +343,7 @@ def _sanitize_metadata_key(key: Any) -> str | None:
 
 
 def _sanitize_metadata_value(value: Any, *, depth: int) -> Any:
+    """Normalize advisory metadata values into bounded JSON-safe structures."""
     if value is None or isinstance(value, bool):
         return value
     if isinstance(value, int):

--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -854,7 +854,7 @@ class PolicyEngine:
                 default_classifier=self._advisory_config.classifier,
             )
         except Exception as exc:
-            logger.warning(
+            logger.error(
                 "Advisory check failed; preserving deterministic allow",
                 exc_info=True,
             )

--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -44,6 +44,7 @@ SUPPORTED_API_VERSIONS = {
 
 
 def _utcnow() -> datetime:
+    """Return a naive UTC timestamp for compatibility with existing models."""
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 

--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -11,15 +11,27 @@ Supports schema versioning via ``apiVersion`` (e.g.,
 warnings; unknown versions raise ``ValueError``.
 """
 
-from datetime import datetime
-from typing import Optional, Literal, Any
-from pydantic import BaseModel, Field
+import json
 import logging
 import os
-import warnings
-import yaml
-import json
 import re
+import warnings
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+from .advisory import (
+    AdvisoryCheck,
+    AdvisoryConfig,
+    AdvisoryEffect,
+    AdvisoryFunction,
+    AdvisoryResult,
+    FunctionAdvisoryCheck,
+    normalize_advisory_result,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +41,10 @@ SUPPORTED_API_VERSIONS = {
     "governance.toolkit/v1": {"status": "current"},
     "1.0": {"status": "deprecated", "migrate_to": "governance.toolkit/v1"},
 }
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 class PolicyRule(BaseModel):
@@ -202,8 +218,8 @@ class Policy(BaseModel):
     default_action: Literal["allow", "deny"] = Field(default="deny")
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
 
     @classmethod
     def from_yaml(cls, yaml_content: str, base_dir: str = "") -> "Policy":
@@ -420,11 +436,14 @@ class PolicyDecision(BaseModel):
     rate_limit_reset: Optional[datetime] = None
 
     # Timing
-    evaluated_at: datetime = Field(default_factory=datetime.utcnow)
+    evaluated_at: datetime = Field(default_factory=_utcnow)
     evaluation_ms: Optional[float] = None
 
     # Extension metadata (e.g., authority resolver details)
-    metadata: Optional[dict] = Field(default=None, description="Additional decision context from resolvers")
+    metadata: Optional[dict] = Field(
+        default=None,
+        description="Additional decision context from resolvers and advisory checks",
+    )
 
 
 class PolicyEngine:
@@ -464,6 +483,9 @@ class PolicyEngine:
         self._authority_resolver: Any = None  # AuthorityResolver protocol
         self._conflict_strategy = ConflictResolutionStrategy(conflict_strategy)
         self._resolver = PolicyConflictResolver(self._conflict_strategy)
+        self._advisory_config = AdvisoryConfig()
+        self._advisory_check: AdvisoryCheck | None = None
+        self._advisory_audit_log: Any = None
 
     def load_policy(self, policy: Policy) -> None:
         """Load a policy into the engine.
@@ -531,7 +553,67 @@ class PolicyEngine:
         """
         self._authority_resolver = resolver
 
-    def _apply_rule(self, rule: PolicyRule, policy: Policy, context: Optional[dict] = None) -> PolicyDecision:
+    def set_advisory_check(
+        self,
+        check: AdvisoryCheck | AdvisoryFunction,
+        *,
+        enabled: bool = True,
+        classifier: str | None = None,
+        actions: Sequence[AdvisoryEffect] | None = None,
+        on_error: Literal["allow"] = "allow",
+        audit_log: Any = None,
+    ) -> None:
+        """Register an optional, non-deterministic advisory check.
+
+        Advisory checks run only after deterministic policy evaluation
+        returns an allowed decision. They can flag the action for review
+        or block it, but they never override a deterministic deny.
+
+        Args:
+            check: ``AdvisoryCheck`` instance or function with signature
+                ``(agent_did, context, deterministic_decision)``.
+            enabled: Whether the advisory stage should run.
+            classifier: Label used in metadata and audit records.
+            actions: Advisory effects allowed to tighten a decision.
+            on_error: Failure behavior. ``"allow"`` preserves the
+                deterministic allow decision.
+            audit_log: Optional ``AuditLog`` used for advisory audit events.
+        """
+        if callable(check) and not isinstance(check, AdvisoryCheck):
+            advisory_check = FunctionAdvisoryCheck(
+                check,
+                name=classifier or getattr(check, "__name__", "custom"),
+            )
+        else:
+            advisory_check = check
+
+        configured_actions = set(actions or ("flag_for_review", "block"))
+        self._advisory_config = AdvisoryConfig(
+            enabled=enabled,
+            classifier=classifier or getattr(advisory_check, "name", None),
+            actions=configured_actions,
+            on_error=on_error,
+        )
+        self._advisory_check = advisory_check
+        self._advisory_audit_log = audit_log
+
+    def clear_advisory_check(self) -> None:
+        """Disable and remove the advisory check stage."""
+        self._advisory_config = AdvisoryConfig()
+        self._advisory_check = None
+        self._advisory_audit_log = None
+
+    @property
+    def advisory_config(self) -> AdvisoryConfig:
+        """Return the current advisory configuration."""
+        return self._advisory_config.model_copy(deep=True)
+
+    def _apply_rule(
+        self,
+        rule: PolicyRule,
+        policy: Policy,
+        context: Optional[dict] = None,
+    ) -> PolicyDecision:
         """Apply a matched rule and generate actionable error messages."""
         # Check rate limit if applicable
         if rule.limit:
@@ -541,7 +623,10 @@ class PolicyEngine:
                     action="deny",
                     matched_rule=rule.name,
                     policy_name=policy.name,
-                    reason=f"Rate limit exceeded for rule '{rule.name}': {rule.limit}. Wait for rate limit to reset.",
+                    reason=(
+                        f"Rate limit exceeded for rule '{rule.name}': {rule.limit}. "
+                        "Wait for rate limit to reset."
+                    ),
                     rate_limited=True,
                 )
             self._increment_rate_limit(rule)
@@ -612,7 +697,7 @@ class PolicyEngine:
             return False
 
         # Check if reset time passed
-        if datetime.utcnow() > limit_data["reset_at"]:
+        if _utcnow() > limit_data["reset_at"]:
             self._rate_limits[limit_key] = None
             return False
 
@@ -633,7 +718,7 @@ class PolicyEngine:
             from datetime import timedelta
             self._rate_limits[limit_key] = {
                 "count": 0,
-                "reset_at": datetime.utcnow() + timedelta(seconds=period),
+                "reset_at": _utcnow() + timedelta(seconds=period),
             }
 
         self._rate_limits[limit_key]["count"] += 1
@@ -688,7 +773,12 @@ class PolicyEngine:
 
     # ── OPA/Rego integration ──────────────────────────────────
 
-    def load_rego(self, rego_path: Optional[str] = None, rego_content: Optional[str] = None, package: str = "agentmesh") -> "OPAEvaluator":  # noqa: F821
+    def load_rego(
+        self,
+        rego_path: Optional[str] = None,
+        rego_content: Optional[str] = None,
+        package: str = "agentmesh",
+    ) -> "OPAEvaluator":  # noqa: F821
         """
         Load a .rego file alongside YAML/JSON policies.
 
@@ -742,6 +832,192 @@ class PolicyEngine:
         self._cedar_evaluators.append(evaluator)
         return evaluator
 
+    def _finalize_decision(
+        self,
+        agent_did: str,
+        context: dict,
+        decision: PolicyDecision,
+        start: datetime,
+    ) -> PolicyDecision:
+        """Apply optional advisory tightening after deterministic allow."""
+        if not decision.allowed:
+            return decision
+
+        if not self._advisory_config.enabled or self._advisory_check is None:
+            return decision
+
+        try:
+            raw_result = self._advisory_check.evaluate(agent_did, context, decision)
+            advisory_result = normalize_advisory_result(
+                raw_result,
+                default_classifier=self._advisory_config.classifier,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Advisory check failed; preserving deterministic allow",
+                exc_info=True,
+            )
+            advisory_result = AdvisoryResult(
+                action=self._advisory_config.on_error,
+                reason="Advisory check failed; deterministic allow preserved",
+                classifier=self._advisory_config.classifier,
+                metadata={
+                    "error": True,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            return self._apply_advisory_result(
+                agent_did,
+                context,
+                decision,
+                advisory_result,
+                start,
+            )
+
+        if (
+            advisory_result.action != "allow"
+            and advisory_result.action not in self._advisory_config.actions
+        ):
+            metadata = dict(advisory_result.metadata)
+            metadata["requested_action"] = advisory_result.action
+            metadata["action_enabled"] = False
+            advisory_result = advisory_result.model_copy(
+                update={
+                    "action": "allow",
+                    "reason": "Advisory action not enabled; deterministic allow preserved",
+                    "metadata": metadata,
+                }
+            )
+
+        return self._apply_advisory_result(
+            agent_did,
+            context,
+            decision,
+            advisory_result,
+            start,
+        )
+
+    def _apply_advisory_result(
+        self,
+        agent_did: str,
+        context: dict,
+        deterministic_decision: PolicyDecision,
+        advisory_result: AdvisoryResult,
+        start: datetime,
+    ) -> PolicyDecision:
+        """Merge an advisory result into the deterministic decision."""
+        advisory_record = {
+            "deterministic": False,
+            "classifier": advisory_result.classifier or self._advisory_config.classifier,
+            "action": advisory_result.action,
+            "reason": advisory_result.reason,
+            "confidence": advisory_result.confidence,
+            "metadata": advisory_result.metadata,
+        }
+        self._log_advisory_decision(
+            agent_did,
+            context,
+            deterministic_decision,
+            advisory_record,
+        )
+
+        metadata = dict(deterministic_decision.metadata or {})
+        metadata["advisory"] = advisory_record
+        elapsed = (_utcnow() - start).total_seconds() * 1000
+
+        if advisory_result.action == "block":
+            return deterministic_decision.model_copy(
+                update={
+                    "allowed": False,
+                    "action": "deny",
+                    "reason": self._advisory_reason("blocked", advisory_result),
+                    "metadata": metadata,
+                    "evaluation_ms": elapsed,
+                }
+            )
+
+        if advisory_result.action == "flag_for_review":
+            return deterministic_decision.model_copy(
+                update={
+                    "allowed": True,
+                    "action": "warn",
+                    "reason": self._advisory_reason("flagged for review", advisory_result),
+                    "metadata": metadata,
+                    "evaluation_ms": elapsed,
+                }
+            )
+
+        return deterministic_decision.model_copy(
+            update={
+                "metadata": metadata,
+                "evaluation_ms": elapsed,
+            }
+        )
+
+    def _log_advisory_decision(
+        self,
+        agent_did: str,
+        context: dict,
+        deterministic_decision: PolicyDecision,
+        advisory_record: dict[str, Any],
+    ) -> None:
+        """Write an advisory audit record when an audit log is configured."""
+        if self._advisory_audit_log is None:
+            return
+
+        action_name = self._context_action_name(context)
+        resource = context.get("resource")
+        if not isinstance(resource, str):
+            resource = None
+
+        outcome_by_action = {
+            "allow": "allowed",
+            "flag_for_review": "flagged",
+            "block": "denied",
+        }
+        try:
+            self._advisory_audit_log.log(
+                event_type="advisory_policy_evaluation",
+                agent_did=agent_did,
+                action=action_name,
+                resource=resource,
+                data={
+                    "deterministic": False,
+                    "advisory": advisory_record,
+                    "deterministic_decision": {
+                        "allowed": deterministic_decision.allowed,
+                        "action": deterministic_decision.action,
+                        "policy_name": deterministic_decision.policy_name,
+                        "matched_rule": deterministic_decision.matched_rule,
+                    },
+                    "context_snapshot": context,
+                },
+                outcome=outcome_by_action.get(advisory_record["action"], "allowed"),
+                policy_decision=advisory_record["action"],
+            )
+        except Exception:
+            logger.warning("Failed to write advisory audit event", exc_info=True)
+
+    def _context_action_name(self, context: dict) -> str:
+        action = context.get("action")
+        if isinstance(action, dict):
+            action_type = action.get("type")
+            if isinstance(action_type, str):
+                return action_type
+        if isinstance(action, str):
+            return action
+        tool_name = context.get("tool_name")
+        if isinstance(tool_name, str):
+            return tool_name
+        return "unknown"
+
+    def _advisory_reason(self, outcome: str, advisory_result: AdvisoryResult) -> str:
+        reason = advisory_result.reason or "advisory classifier matched"
+        classifier = advisory_result.classifier or self._advisory_config.classifier
+        if classifier:
+            return f"Advisory check {outcome} by {classifier}: {reason}"
+        return f"Advisory check {outcome}: {reason}"
+
     def evaluate(
         self,
         agent_did: str,
@@ -777,7 +1053,7 @@ class PolicyEngine:
             PolicyScope,
         )
 
-        start = datetime.utcnow()
+        start = _utcnow()
 
         # 1. Check YAML/JSON policies first
         applicable = [p for p in self._policies.values() if p.applies_to(agent_did)]
@@ -808,7 +1084,7 @@ class PolicyEngine:
             if candidates:
                 result = self._resolver.resolve(candidates)
                 winner = result.winning_decision
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+                elapsed = (_utcnow() - start).total_seconds() * 1000
 
                 # Apply rate limiting for the winning rule
                 matched_rule = None
@@ -822,25 +1098,35 @@ class PolicyEngine:
 
                 if matched_rule and matched_rule.limit:
                     if self._is_rate_limited(matched_rule):
-                        return PolicyDecision(
-                            allowed=False,
-                            action="deny",
-                            matched_rule=matched_rule.name,
-                            policy_name=winner.policy_name,
-                            reason=f"Rate limited: {matched_rule.limit}",
-                            evaluated_at=start,
-                            evaluation_ms=elapsed,
+                        return self._finalize_decision(
+                            agent_did,
+                            context,
+                            PolicyDecision(
+                                allowed=False,
+                                action="deny",
+                                matched_rule=matched_rule.name,
+                                policy_name=winner.policy_name,
+                                reason=f"Rate limited: {matched_rule.limit}",
+                                evaluated_at=start,
+                                evaluation_ms=elapsed,
+                            ),
+                            start,
                         )
 
-                return PolicyDecision(
-                    allowed=(winner.action == "allow"),
-                    action=winner.action,
-                    matched_rule=winner.rule_name,
-                    policy_name=winner.policy_name,
-                    reason=winner.reason,
-                    approvers=winner.approvers,
-                    evaluated_at=start,
-                    evaluation_ms=elapsed,
+                return self._finalize_decision(
+                    agent_did,
+                    context,
+                    PolicyDecision(
+                        allowed=(winner.action == "allow"),
+                        action=winner.action,
+                        matched_rule=winner.rule_name,
+                        policy_name=winner.policy_name,
+                        reason=winner.reason,
+                        approvers=winner.approvers,
+                        evaluated_at=start,
+                        evaluation_ms=elapsed,
+                    ),
+                    start,
                 )
 
         # 2. Authority resolution (trust-based narrowing)
@@ -875,27 +1161,43 @@ class PolicyEngine:
             )
             authority_decision = self._authority_resolver.resolve(authority_req)
             if authority_decision.decision == "deny":
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
-                return PolicyDecision(
-                    allowed=False,
-                    action="deny",
-                    reason=f"Authority resolver denied: {authority_decision.narrowing_reason or 'trust check failed'}",
-                    evaluated_at=start,
-                    evaluation_ms=elapsed,
+                elapsed = (_utcnow() - start).total_seconds() * 1000
+                return self._finalize_decision(
+                    agent_did,
+                    context,
+                    PolicyDecision(
+                        allowed=False,
+                        action="deny",
+                        reason=(
+                            "Authority resolver denied: "
+                            f"{authority_decision.narrowing_reason or 'trust check failed'}"
+                        ),
+                        evaluated_at=start,
+                        evaluation_ms=elapsed,
+                    ),
+                    start,
                 )
             if authority_decision.decision == "allow_narrowed":
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
-                return PolicyDecision(
-                    allowed=True,
-                    action="allow",
-                    reason=f"Authority resolver narrowed: {authority_decision.narrowing_reason}",
-                    evaluated_at=start,
-                    evaluation_ms=elapsed,
-                    metadata={
-                        "effective_scope": authority_decision.effective_scope,
-                        "effective_spend_limit": authority_decision.effective_spend_limit,
-                        "trust_tier": authority_decision.trust_tier,
-                    },
+                elapsed = (_utcnow() - start).total_seconds() * 1000
+                return self._finalize_decision(
+                    agent_did,
+                    context,
+                    PolicyDecision(
+                        allowed=True,
+                        action="allow",
+                        reason=(
+                            "Authority resolver narrowed: "
+                            f"{authority_decision.narrowing_reason}"
+                        ),
+                        evaluated_at=start,
+                        evaluation_ms=elapsed,
+                        metadata={
+                            "effective_scope": authority_decision.effective_scope,
+                            "effective_spend_limit": authority_decision.effective_spend_limit,
+                            "trust_tier": authority_decision.trust_tier,
+                        },
+                    ),
+                    start,
                 )
 
         # 3. Check Rego policies
@@ -903,13 +1205,21 @@ class PolicyEngine:
             query = f"data.{package}.allow"
             opa_result = evaluator.evaluate(query, context)
             if opa_result.error is None:
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
-                return PolicyDecision(
-                    allowed=opa_result.allowed,
-                    action="allow" if opa_result.allowed else "deny",
-                    reason=f"OPA/Rego policy ({package}): {'allowed' if opa_result.allowed else 'denied'}",
-                    evaluated_at=start,
-                    evaluation_ms=elapsed,
+                elapsed = (_utcnow() - start).total_seconds() * 1000
+                return self._finalize_decision(
+                    agent_did,
+                    context,
+                    PolicyDecision(
+                        allowed=opa_result.allowed,
+                        action="allow" if opa_result.allowed else "deny",
+                        reason=(
+                            f"OPA/Rego policy ({package}): "
+                            f"{'allowed' if opa_result.allowed else 'denied'}"
+                        ),
+                        evaluated_at=start,
+                        evaluation_ms=elapsed,
+                    ),
+                    start,
                 )
 
         # 4. Check Cedar policies
@@ -919,13 +1229,18 @@ class PolicyEngine:
             cedar_action = f'Action::"{action_name}"' if "::" not in action_name else action_name
             cedar_result = cedar_eval.evaluate(cedar_action, context)
             if cedar_result.error is None:
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
-                return PolicyDecision(
-                    allowed=cedar_result.allowed,
-                    action="allow" if cedar_result.allowed else "deny",
-                    reason=f"Cedar policy: {'allowed' if cedar_result.allowed else 'denied'}",
-                    evaluated_at=start,
-                    evaluation_ms=elapsed,
+                elapsed = (_utcnow() - start).total_seconds() * 1000
+                return self._finalize_decision(
+                    agent_did,
+                    context,
+                    PolicyDecision(
+                        allowed=cedar_result.allowed,
+                        action="allow" if cedar_result.allowed else "deny",
+                        reason=f"Cedar policy: {'allowed' if cedar_result.allowed else 'denied'}",
+                        evaluated_at=start,
+                        evaluation_ms=elapsed,
+                    ),
+                    start,
                 )
 
         # 5. No rules matched - use default
@@ -936,13 +1251,22 @@ class PolicyEngine:
             # Operators must explicitly load an allow policy.
             default = "deny"
 
-        elapsed = (datetime.utcnow() - start).total_seconds() * 1000
-        return PolicyDecision(
-            allowed=(default == "allow"),
-            action=default,
-            reason="No matching rules, using default" if applicable else "No policies loaded (deny by default)",
-            evaluated_at=start,
-            evaluation_ms=elapsed,
+        elapsed = (_utcnow() - start).total_seconds() * 1000
+        return self._finalize_decision(
+            agent_did,
+            context,
+            PolicyDecision(
+                allowed=(default == "allow"),
+                action=default,
+                reason=(
+                    "No matching rules, using default"
+                    if applicable
+                    else "No policies loaded (deny by default)"
+                ),
+                evaluated_at=start,
+                evaluation_ms=elapsed,
+            ),
+            start,
         )
 
 

--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import threading
 import warnings
 from collections.abc import Sequence
 from datetime import datetime, timezone
@@ -487,6 +488,7 @@ class PolicyEngine:
         self._advisory_config = AdvisoryConfig()
         self._advisory_check: AdvisoryCheck | None = None
         self._advisory_audit_log: Any = None
+        self._advisory_lock = threading.RLock()
 
     def load_policy(self, policy: Policy) -> None:
         """Load a policy into the engine.
@@ -589,25 +591,37 @@ class PolicyEngine:
             advisory_check = check
 
         configured_actions = set(actions or ("flag_for_review", "block"))
-        self._advisory_config = AdvisoryConfig(
-            enabled=enabled,
-            classifier=classifier or getattr(advisory_check, "name", None),
-            actions=configured_actions,
-            on_error=on_error,
-        )
-        self._advisory_check = advisory_check
-        self._advisory_audit_log = audit_log
+        with self._advisory_lock:
+            self._advisory_config = AdvisoryConfig(
+                enabled=enabled,
+                classifier=classifier or getattr(advisory_check, "name", None),
+                actions=configured_actions,
+                on_error=on_error,
+            )
+            self._advisory_check = advisory_check
+            self._advisory_audit_log = audit_log
 
     def clear_advisory_check(self) -> None:
         """Disable and remove the advisory check stage."""
-        self._advisory_config = AdvisoryConfig()
-        self._advisory_check = None
-        self._advisory_audit_log = None
+        with self._advisory_lock:
+            self._advisory_config = AdvisoryConfig()
+            self._advisory_check = None
+            self._advisory_audit_log = None
 
     @property
     def advisory_config(self) -> AdvisoryConfig:
         """Return the current advisory configuration."""
-        return self._advisory_config.model_copy(deep=True)
+        with self._advisory_lock:
+            return self._advisory_config.model_copy(deep=True)
+
+    def _advisory_state(self) -> tuple[AdvisoryConfig, AdvisoryCheck | None, Any]:
+        """Return a consistent snapshot of advisory configuration and hooks."""
+        with self._advisory_lock:
+            return (
+                self._advisory_config.model_copy(deep=True),
+                self._advisory_check,
+                self._advisory_audit_log,
+            )
 
     def _apply_rule(
         self,
@@ -844,14 +858,16 @@ class PolicyEngine:
         if not decision.allowed:
             return decision
 
-        if not self._advisory_config.enabled or self._advisory_check is None:
+        advisory_config, advisory_check, advisory_audit_log = self._advisory_state()
+
+        if not advisory_config.enabled or advisory_check is None:
             return decision
 
         try:
-            raw_result = self._advisory_check.evaluate(agent_did, context, decision)
+            raw_result = advisory_check.evaluate(agent_did, context, decision)
             advisory_result = normalize_advisory_result(
                 raw_result,
-                default_classifier=self._advisory_config.classifier,
+                default_classifier=advisory_config.classifier,
             )
         except Exception as exc:
             logger.error(
@@ -859,9 +875,9 @@ class PolicyEngine:
                 exc_info=True,
             )
             advisory_result = AdvisoryResult(
-                action=self._advisory_config.on_error,
+                action=advisory_config.on_error,
                 reason="Advisory check failed; deterministic allow preserved",
-                classifier=self._advisory_config.classifier,
+                classifier=advisory_config.classifier,
                 metadata={
                     "error": True,
                     "error_type": type(exc).__name__,
@@ -872,12 +888,14 @@ class PolicyEngine:
                 context,
                 decision,
                 advisory_result,
+                advisory_config,
+                advisory_audit_log,
                 start,
             )
 
         if (
             advisory_result.action != "allow"
-            and advisory_result.action not in self._advisory_config.actions
+            and advisory_result.action not in advisory_config.actions
         ):
             metadata = dict(advisory_result.metadata)
             metadata["requested_action"] = advisory_result.action
@@ -895,6 +913,8 @@ class PolicyEngine:
             context,
             decision,
             advisory_result,
+            advisory_config,
+            advisory_audit_log,
             start,
         )
 
@@ -904,12 +924,14 @@ class PolicyEngine:
         context: dict,
         deterministic_decision: PolicyDecision,
         advisory_result: AdvisoryResult,
+        advisory_config: AdvisoryConfig,
+        advisory_audit_log: Any,
         start: datetime,
     ) -> PolicyDecision:
         """Merge an advisory result into the deterministic decision."""
         advisory_record = {
             "deterministic": False,
-            "classifier": advisory_result.classifier or self._advisory_config.classifier,
+            "classifier": advisory_result.classifier or advisory_config.classifier,
             "action": advisory_result.action,
             "reason": advisory_result.reason,
             "confidence": advisory_result.confidence,
@@ -919,6 +941,7 @@ class PolicyEngine:
             agent_did,
             context,
             deterministic_decision,
+            advisory_audit_log,
             advisory_record,
         )
 
@@ -931,7 +954,11 @@ class PolicyEngine:
                 update={
                     "allowed": False,
                     "action": "deny",
-                    "reason": self._advisory_reason("blocked", advisory_result),
+                    "reason": self._advisory_reason(
+                        "blocked",
+                        advisory_result,
+                        advisory_config,
+                    ),
                     "metadata": metadata,
                     "evaluation_ms": elapsed,
                 }
@@ -942,7 +969,11 @@ class PolicyEngine:
                 update={
                     "allowed": True,
                     "action": "warn",
-                    "reason": self._advisory_reason("flagged for review", advisory_result),
+                    "reason": self._advisory_reason(
+                        "flagged for review",
+                        advisory_result,
+                        advisory_config,
+                    ),
                     "metadata": metadata,
                     "evaluation_ms": elapsed,
                 }
@@ -960,10 +991,11 @@ class PolicyEngine:
         agent_did: str,
         context: dict,
         deterministic_decision: PolicyDecision,
+        advisory_audit_log: Any,
         advisory_record: dict[str, Any],
     ) -> None:
         """Write an advisory audit record when an audit log is configured."""
-        if self._advisory_audit_log is None:
+        if advisory_audit_log is None:
             return
 
         action_name = self._context_action_name(context)
@@ -977,7 +1009,7 @@ class PolicyEngine:
             "block": "denied",
         }
         try:
-            self._advisory_audit_log.log(
+            advisory_audit_log.log(
                 event_type="advisory_policy_evaluation",
                 agent_did=agent_did,
                 action=action_name,
@@ -1012,9 +1044,14 @@ class PolicyEngine:
             return tool_name
         return "unknown"
 
-    def _advisory_reason(self, outcome: str, advisory_result: AdvisoryResult) -> str:
+    def _advisory_reason(
+        self,
+        outcome: str,
+        advisory_result: AdvisoryResult,
+        advisory_config: AdvisoryConfig,
+    ) -> str:
         reason = advisory_result.reason or "advisory classifier matched"
-        classifier = advisory_result.classifier or self._advisory_config.classifier
+        classifier = advisory_result.classifier or advisory_config.classifier
         if classifier:
             return f"Advisory check {outcome} by {classifier}: {reason}"
         return f"Advisory check {outcome}: {reason}"

--- a/packages/agent-mesh/tests/test_advisory.py
+++ b/packages/agent-mesh/tests/test_advisory.py
@@ -188,12 +188,20 @@ def test_endpoint_advisory_check_allows_hosts_case_insensitively() -> None:
     assert check.allowed_hosts == {"classifier.example"}
 
 
+def test_endpoint_advisory_check_rejects_wildcard_hosts() -> None:
+    with pytest.raises(ValueError, match="Wildcard"):
+        EndpointAdvisoryCheck(
+            "https://classifier.example/check",
+            allowed_hosts=["*.example.com"],
+        )
+
+
 def test_endpoint_advisory_check_bounds_timeout_and_retries() -> None:
     with pytest.raises(ValueError, match="timeout"):
-        EndpointAdvisoryCheck("https://classifier.example/check", timeout=10.1)
+        EndpointAdvisoryCheck("https://classifier.example/check", timeout=5.1)
 
     with pytest.raises(ValueError, match="max_retries"):
-        EndpointAdvisoryCheck("https://classifier.example/check", max_retries=6)
+        EndpointAdvisoryCheck("https://classifier.example/check", max_retries=3)
 
 
 def test_endpoint_timeout_falls_through_to_deterministic_allow(monkeypatch) -> None:

--- a/packages/agent-mesh/tests/test_advisory.py
+++ b/packages/agent-mesh/tests/test_advisory.py
@@ -1,0 +1,144 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for optional advisory policy checks."""
+
+from __future__ import annotations
+
+from agentmesh.governance import AuditLog, Policy, PolicyEngine, PolicyRule
+from agentmesh.governance.advisory import AdvisoryResult
+
+AGENT_DID = "did:agentmesh:test"
+
+
+def _allowing_engine() -> PolicyEngine:
+    engine = PolicyEngine()
+    engine.load_policy(
+        Policy(
+            name="allow-safe-actions",
+            agents=["*"],
+            rules=[
+                PolicyRule(
+                    name="allow-tool",
+                    condition="action.type == 'tool_call'",
+                    action="allow",
+                )
+            ],
+            default_action="deny",
+        )
+    )
+    return engine
+
+
+def test_advisory_block_tightens_deterministic_allow() -> None:
+    audit_log = AuditLog()
+    engine = _allowing_engine()
+
+    def classifier(agent_did: str, context: dict, deterministic_decision):
+        assert agent_did == AGENT_DID
+        assert context["action"]["type"] == "tool_call"
+        assert deterministic_decision.allowed is True
+        return AdvisoryResult(
+            action="block",
+            reason="possible prompt injection",
+            classifier="custom-reviewer",
+            confidence=0.91,
+        )
+
+    engine.set_advisory_check(classifier, audit_log=audit_log)
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is False
+    assert decision.action == "deny"
+    assert decision.matched_rule == "allow-tool"
+    assert decision.metadata["advisory"]["deterministic"] is False
+    assert decision.metadata["advisory"]["action"] == "block"
+
+    entries = audit_log.get_entries_by_type("advisory_policy_evaluation")
+    assert len(entries) == 1
+    assert entries[0].data["deterministic"] is False
+    assert entries[0].policy_decision == "block"
+
+
+def test_advisory_flag_keeps_action_allowed_and_marks_for_review() -> None:
+    audit_log = AuditLog()
+    engine = _allowing_engine()
+    engine.set_advisory_check(
+        lambda *_: {
+            "action": "flag_for_review",
+            "reason": "possible social engineering",
+            "classifier": "azure-content-safety",
+        },
+        audit_log=audit_log,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is True
+    assert decision.action == "warn"
+    assert decision.metadata["advisory"]["deterministic"] is False
+    assert decision.metadata["advisory"]["action"] == "flag_for_review"
+
+    entries = audit_log.get_entries_by_type("advisory_policy_evaluation")
+    assert len(entries) == 1
+    assert entries[0].data["deterministic"] is False
+    assert entries[0].policy_decision == "flag_for_review"
+
+
+def test_advisory_failure_falls_through_to_deterministic_allow() -> None:
+    audit_log = AuditLog()
+    engine = _allowing_engine()
+
+    def failing_classifier(*_):
+        raise RuntimeError("classifier unavailable")
+
+    engine.set_advisory_check(
+        failing_classifier,
+        classifier="custom-endpoint",
+        audit_log=audit_log,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is True
+    assert decision.action == "allow"
+    assert decision.matched_rule == "allow-tool"
+    assert decision.metadata["advisory"]["deterministic"] is False
+    assert decision.metadata["advisory"]["action"] == "allow"
+    assert decision.metadata["advisory"]["metadata"]["error"] is True
+
+    entries = audit_log.get_entries_by_type("advisory_policy_evaluation")
+    assert len(entries) == 1
+    assert entries[0].data["deterministic"] is False
+    assert entries[0].policy_decision == "allow"
+
+
+def test_advisory_never_overrides_deterministic_deny() -> None:
+    audit_log = AuditLog()
+    calls: list[str] = []
+    engine = PolicyEngine()
+    engine.load_policy(
+        Policy(
+            name="deny-export",
+            agents=["*"],
+            rules=[
+                PolicyRule(
+                    name="deny-export",
+                    condition="action.type == 'export'",
+                    action="deny",
+                )
+            ],
+            default_action="allow",
+        )
+    )
+    engine.set_advisory_check(
+        lambda *_: calls.append("called") or {"action": "allow"},
+        audit_log=audit_log,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "export"}})
+
+    assert decision.allowed is False
+    assert decision.action == "deny"
+    assert calls == []
+    assert audit_log.get_entries_by_type("advisory_policy_evaluation") == []

--- a/packages/agent-mesh/tests/test_advisory.py
+++ b/packages/agent-mesh/tests/test_advisory.py
@@ -119,6 +119,37 @@ def test_advisory_failure_falls_through_to_deterministic_allow() -> None:
     assert entries[0].policy_decision == "allow"
 
 
+def test_advisory_disabled_skips_check() -> None:
+    calls: list[str] = []
+    engine = _allowing_engine()
+    engine.set_advisory_check(
+        lambda *_: calls.append("called") or {"action": "block"},
+        enabled=False,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is True
+    assert decision.action == "allow"
+    assert calls == []
+
+
+def test_advisory_config_returns_copy() -> None:
+    engine = _allowing_engine()
+    engine.set_advisory_check(
+        lambda *_: {"action": "flag_for_review"},
+        classifier="custom-reviewer",
+    )
+
+    config = engine.advisory_config
+    config.enabled = False
+    config.actions.clear()
+
+    fresh_config = engine.advisory_config
+    assert fresh_config.enabled is True
+    assert fresh_config.actions == {"flag_for_review", "block"}
+
+
 def test_advisory_invalid_action_falls_through_to_deterministic_allow() -> None:
     audit_log = AuditLog()
     engine = _allowing_engine()
@@ -199,6 +230,9 @@ def test_endpoint_advisory_check_rejects_wildcard_hosts() -> None:
 def test_endpoint_advisory_check_bounds_timeout_and_retries() -> None:
     with pytest.raises(ValueError, match="timeout"):
         EndpointAdvisoryCheck("https://classifier.example/check", timeout=5.1)
+
+    with pytest.raises(ValueError, match="total_timeout"):
+        EndpointAdvisoryCheck("https://classifier.example/check", total_timeout=6.1)
 
     with pytest.raises(ValueError, match="max_retries"):
         EndpointAdvisoryCheck("https://classifier.example/check", max_retries=3)

--- a/packages/agent-mesh/tests/test_advisory.py
+++ b/packages/agent-mesh/tests/test_advisory.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 import httpx
 import pytest
 from agentmesh.governance import AuditLog, Policy, PolicyEngine, PolicyRule
-from agentmesh.governance.advisory import AdvisoryResult, EndpointAdvisoryCheck
+from agentmesh.governance.advisory import (
+    AdvisoryResult,
+    EndpointAdvisoryCheck,
+    normalize_advisory_result,
+)
 
 AGENT_DID = "did:agentmesh:test"
 
@@ -175,6 +179,23 @@ def test_endpoint_advisory_check_enforces_allowed_hosts() -> None:
         )
 
 
+def test_endpoint_advisory_check_allows_hosts_case_insensitively() -> None:
+    check = EndpointAdvisoryCheck(
+        "https://Classifier.Example/check",
+        allowed_hosts=["CLASSIFIER.EXAMPLE"],
+    )
+
+    assert check.allowed_hosts == {"classifier.example"}
+
+
+def test_endpoint_advisory_check_bounds_timeout_and_retries() -> None:
+    with pytest.raises(ValueError, match="timeout"):
+        EndpointAdvisoryCheck("https://classifier.example/check", timeout=10.1)
+
+    with pytest.raises(ValueError, match="max_retries"):
+        EndpointAdvisoryCheck("https://classifier.example/check", max_retries=6)
+
+
 def test_endpoint_timeout_falls_through_to_deterministic_allow(monkeypatch) -> None:
     audit_log = AuditLog()
     engine = _allowing_engine()
@@ -238,6 +259,57 @@ def test_endpoint_advisory_check_retries_transient_http_errors(monkeypatch) -> N
     assert calls == 2
     assert result.action == "block"
     assert result.classifier == "classifier-endpoint"
+
+
+def test_endpoint_malformed_json_falls_through_to_deterministic_allow(monkeypatch) -> None:
+    audit_log = AuditLog()
+    engine = _allowing_engine()
+
+    def malformed_json_post(*args, **kwargs):
+        request = httpx.Request("POST", "https://classifier.example/check")
+        return httpx.Response(200, content=b"not-json", request=request)
+
+    monkeypatch.setattr("agentmesh.governance.advisory.httpx.post", malformed_json_post)
+    engine.set_advisory_check(
+        EndpointAdvisoryCheck(
+            "https://classifier.example/check",
+            allowed_hosts=["classifier.example"],
+        ),
+        audit_log=audit_log,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is True
+    assert decision.action == "allow"
+    assert decision.metadata["advisory"]["deterministic"] is False
+    assert decision.metadata["advisory"]["action"] == "allow"
+    assert decision.metadata["advisory"]["metadata"]["error"] is True
+
+    entries = audit_log.get_entries_by_type("advisory_policy_evaluation")
+    assert len(entries) == 1
+    assert entries[0].data["deterministic"] is False
+    assert entries[0].policy_decision == "allow"
+
+
+def test_advisory_result_metadata_is_sanitized() -> None:
+    result = normalize_advisory_result(
+        {
+            "action": "flag",
+            "metadata": {
+                "bad key\n": "value",
+                "__proto__": "pollute",
+                "nested": {"safe": "ok", "object": object()},
+                "object": object(),
+            },
+        }
+    )
+
+    assert result.action == "flag_for_review"
+    assert result.metadata["bad_key"] == "value"
+    assert result.metadata["metadata__proto"] == "pollute"
+    assert result.metadata["nested"] == {"safe": "ok"}
+    assert "object" not in result.metadata
 
 
 def test_advisory_never_overrides_deterministic_deny() -> None:

--- a/packages/agent-mesh/tests/test_advisory.py
+++ b/packages/agent-mesh/tests/test_advisory.py
@@ -4,8 +4,10 @@
 
 from __future__ import annotations
 
+import httpx
+import pytest
 from agentmesh.governance import AuditLog, Policy, PolicyEngine, PolicyRule
-from agentmesh.governance.advisory import AdvisoryResult
+from agentmesh.governance.advisory import AdvisoryResult, EndpointAdvisoryCheck
 
 AGENT_DID = "did:agentmesh:test"
 
@@ -111,6 +113,131 @@ def test_advisory_failure_falls_through_to_deterministic_allow() -> None:
     assert len(entries) == 1
     assert entries[0].data["deterministic"] is False
     assert entries[0].policy_decision == "allow"
+
+
+def test_advisory_invalid_action_falls_through_to_deterministic_allow() -> None:
+    audit_log = AuditLog()
+    engine = _allowing_engine()
+    engine.set_advisory_check(
+        lambda *_: {
+            "action": "unexpected",
+            "reason": "malformed classifier response",
+            "classifier": "custom-endpoint",
+        },
+        audit_log=audit_log,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is True
+    assert decision.action == "allow"
+    assert decision.metadata["advisory"]["deterministic"] is False
+    assert decision.metadata["advisory"]["action"] == "allow"
+
+    entries = audit_log.get_entries_by_type("advisory_policy_evaluation")
+    assert len(entries) == 1
+    assert entries[0].data["deterministic"] is False
+    assert entries[0].policy_decision == "allow"
+
+
+def test_malformed_advisory_result_falls_through_to_deterministic_allow() -> None:
+    audit_log = AuditLog()
+    engine = _allowing_engine()
+    engine.set_advisory_check(
+        lambda *_: ["not", "a", "result"],
+        audit_log=audit_log,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is True
+    assert decision.action == "allow"
+    assert decision.metadata["advisory"]["deterministic"] is False
+    assert decision.metadata["advisory"]["action"] == "allow"
+    assert decision.metadata["advisory"]["metadata"]["malformed_result"] is True
+
+    entries = audit_log.get_entries_by_type("advisory_policy_evaluation")
+    assert len(entries) == 1
+    assert entries[0].data["deterministic"] is False
+    assert entries[0].policy_decision == "allow"
+
+
+def test_endpoint_advisory_check_requires_https() -> None:
+    with pytest.raises(ValueError, match="HTTPS"):
+        EndpointAdvisoryCheck("http://classifier.example/check")
+
+
+def test_endpoint_advisory_check_enforces_allowed_hosts() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        EndpointAdvisoryCheck(
+            "https://untrusted.example/check",
+            allowed_hosts=["classifier.example"],
+        )
+
+
+def test_endpoint_timeout_falls_through_to_deterministic_allow(monkeypatch) -> None:
+    audit_log = AuditLog()
+    engine = _allowing_engine()
+
+    def timeout_post(*args, **kwargs):
+        raise httpx.TimeoutException("classifier timed out")
+
+    monkeypatch.setattr("agentmesh.governance.advisory.httpx.post", timeout_post)
+    engine.set_advisory_check(
+        EndpointAdvisoryCheck(
+            "https://classifier.example/check",
+            allowed_hosts=["classifier.example"],
+            timeout=0.1,
+        ),
+        audit_log=audit_log,
+    )
+
+    decision = engine.evaluate(AGENT_DID, {"action": {"type": "tool_call"}})
+
+    assert decision.allowed is True
+    assert decision.action == "allow"
+    assert decision.metadata["advisory"]["deterministic"] is False
+    assert decision.metadata["advisory"]["action"] == "allow"
+    assert decision.metadata["advisory"]["metadata"]["error"] is True
+
+    entries = audit_log.get_entries_by_type("advisory_policy_evaluation")
+    assert len(entries) == 1
+    assert entries[0].data["deterministic"] is False
+    assert entries[0].policy_decision == "allow"
+
+
+def test_endpoint_advisory_check_retries_transient_http_errors(monkeypatch) -> None:
+    calls = 0
+
+    def flaky_post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.ConnectError("temporary network failure")
+        request = httpx.Request("POST", "https://classifier.example/check")
+        return httpx.Response(
+            200,
+            json={"action": "block", "reason": "unsafe"},
+            request=request,
+        )
+
+    monkeypatch.setattr("agentmesh.governance.advisory.httpx.post", flaky_post)
+    check = EndpointAdvisoryCheck(
+        "https://classifier.example/check",
+        allowed_hosts=["classifier.example"],
+        max_retries=1,
+        retry_backoff=0,
+    )
+
+    result = check.evaluate(
+        AGENT_DID,
+        {"action": {"type": "tool_call"}},
+        _allowing_engine().evaluate(AGENT_DID, {"action": {"type": "tool_call"}}),
+    )
+
+    assert calls == 2
+    assert result.action == "block"
+    assert result.classifier == "classifier-endpoint"
 
 
 def test_advisory_never_overrides_deterministic_deny() -> None:


### PR DESCRIPTION
Fixes #1377

## Summary
Adds an optional advisory check stage to `PolicyEngine` that runs only after deterministic policy evaluation returns `allow`. The advisory stage is non-deterministic by design and can only tighten the deterministic result by flagging for review or blocking.

## Scope
- Added an `AdvisoryCheck` interface with function and HTTPS endpoint adapters.
- Runs advisory evaluation only after deterministic `allow`.
- Advisory can only tighten outcomes; deterministic `deny` remains canonical.
- Advisory failures fall through to the deterministic result.
- Advisory audit entries are marked with `deterministic: false`.
- Added focused tests for advisory block, advisory flag, failure fallthrough, malformed responses, endpoint validation, and config handling.
- Added documentation for advisory configuration and compatibility notes.

## Why
This addresses threats that static rules do not capture well, including social engineering, context poisoning, and subtle prompt injection, without changing AGT's deterministic trust boundary.

## Validation
- `PYTHONPATH=packages/agent-mesh/src python3 -m pytest packages/agent-mesh/tests/test_advisory.py -q`
- `PYTHONPATH=packages/agent-mesh/src python3 -m pytest packages/agent-mesh/tests/test_advisory.py packages/agent-mesh/tests/test_governance.py::TestPolicyEngine packages/agent-mesh/tests/test_conflict_resolution.py -q`
- `python3 -m ruff check --isolated --line-length 100 --target-version py311 --select E,F,I,N,W,UP packages/agent-mesh/src/agentmesh/governance/advisory.py packages/agent-mesh/tests/test_advisory.py`
- `python3 -m ruff check --isolated --line-length 100 --target-version py311 --select F,I,E501 packages/agent-mesh/src/agentmesh/governance/policy.py`

## Status
All automated checks are passing. The only remaining required gate is maintainer approval.