### PR TITLE
feat: human-in-the-loop approval workflows

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/governance/__init__.py
@@ -8,6 +8,15 @@ Append-only audit logs with optional external sinks.
 """
 
 from .govern import govern, GovernedCallable, GovernanceConfig, GovernanceDenied
+from .approval import (
+    ApprovalHandler,
+    ApprovalRequest,
+    ApprovalDecision,
+    AutoRejectApproval,
+    CallbackApproval,
+    ConsoleApproval,
+    WebhookApproval,
+)
 from .policy import PolicyEngine, Policy, PolicyRule, PolicyDecision
 from .conflict_resolution import (
     ConflictResolutionStrategy,
@@ -81,6 +90,14 @@ __all__ = [
     "GovernedCallable",
     "GovernanceConfig",
     "GovernanceDenied",
+    # Approval workflows (issue #1374)
+    "ApprovalHandler",
+    "ApprovalRequest",
+    "ApprovalDecision",
+    "AutoRejectApproval",
+    "CallbackApproval",
+    "ConsoleApproval",
+    "WebhookApproval",
     "AsyncTrustPolicyEvaluator",
     "TrustConcurrencyStats",
     "PolicyEngine",

--- a/packages/agent-mesh/src/agentmesh/governance/approval.py
+++ b/packages/agent-mesh/src/agentmesh/governance/approval.py
@@ -1,0 +1,256 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Human-in-the-loop approval workflows for policy-gated agent actions.
+
+When a policy rule returns ``require_approval``, the approval handler
+pauses execution, requests human approval, and resumes or denies
+based on the response.
+
+Usage::
+
+    from agentmesh.governance.approval import (
+        CallbackApproval, AutoRejectApproval,
+    )
+    from agentmesh.governance import govern
+
+    handler = CallbackApproval(lambda req: ApprovalDecision(approved=True, approver="admin"))
+    safe = govern(my_tool, policy="policy.yaml", approval_handler=handler)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ApprovalRequest:
+    """Details of an action awaiting approval.
+
+    Attributes:
+        action: Description of the action (from policy context).
+        rule_name: Name of the policy rule that triggered approval.
+        policy_name: Name of the policy containing the rule.
+        agent_id: Identifier of the acting agent.
+        context: Full evaluation context.
+        approvers: List of required approvers from the policy rule.
+        requested_at: When the approval was requested.
+    """
+
+    action: str
+    rule_name: str
+    policy_name: str
+    agent_id: str
+    context: dict = field(default_factory=dict)
+    approvers: list[str] = field(default_factory=list)
+    requested_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+@dataclass
+class ApprovalDecision:
+    """Result of an approval request.
+
+    Attributes:
+        approved: Whether the action was approved.
+        approver: Identity of the person who approved/denied.
+        reason: Optional explanation.
+        decided_at: When the decision was made.
+    """
+
+    approved: bool
+    approver: str = ""
+    reason: str = ""
+    decided_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+class ApprovalHandler(ABC):
+    """Abstract base class for approval handlers."""
+
+    @abstractmethod
+    def request_approval(self, request: ApprovalRequest) -> ApprovalDecision:
+        """Request approval for a policy-gated action.
+
+        Implementations may block (waiting for human input), call an
+        external service, or auto-decide.
+
+        Args:
+            request: Details of the action awaiting approval.
+
+        Returns:
+            An ``ApprovalDecision`` indicating whether the action is approved.
+        """
+        ...
+
+
+class AutoRejectApproval(ApprovalHandler):
+    """Automatically rejects all approval requests (fail-safe default).
+
+    Use in production to ensure ``require_approval`` actions are denied
+    when no human reviewer is configured.
+
+    Args:
+        reason: Rejection reason included in the decision.
+    """
+
+    def __init__(self, reason: str = "No approval handler configured — auto-rejected"):
+        self._reason = reason
+
+    def request_approval(self, request: ApprovalRequest) -> ApprovalDecision:
+        logger.warning(
+            "Auto-rejecting approval for rule '%s' — no handler configured",
+            request.rule_name,
+        )
+        return ApprovalDecision(
+            approved=False,
+            approver="system:auto-reject",
+            reason=self._reason,
+        )
+
+
+class CallbackApproval(ApprovalHandler):
+    """Delegates approval to a custom callback function.
+
+    Args:
+        callback: Function that receives an ``ApprovalRequest`` and
+            returns an ``ApprovalDecision``.
+        timeout_seconds: Max time to wait for callback. Default 300 (5 min).
+        on_timeout: Action when timeout expires. Default: deny.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[ApprovalRequest], ApprovalDecision],
+        timeout_seconds: float = 300,
+        on_timeout: str = "deny",
+    ):
+        self._callback = callback
+        self._timeout = timeout_seconds
+        self._on_timeout = on_timeout
+
+    def request_approval(self, request: ApprovalRequest) -> ApprovalDecision:
+        start = time.monotonic()
+        try:
+            decision = self._callback(request)
+            elapsed = time.monotonic() - start
+            if elapsed > self._timeout:
+                logger.warning(
+                    "Approval callback took %.1fs (timeout=%.0fs) — enforcing timeout",
+                    elapsed, self._timeout,
+                )
+                return ApprovalDecision(
+                    approved=False,
+                    approver="system:timeout",
+                    reason=f"Approval timed out after {self._timeout}s",
+                )
+            return decision
+        except Exception as e:
+            logger.error("Approval callback error: %s", e, exc_info=True)
+            return ApprovalDecision(
+                approved=False,
+                approver="system:error",
+                reason=f"Approval callback error: {e}",
+            )
+
+
+class ConsoleApproval(ApprovalHandler):
+    """Interactive console-based approval for development/testing.
+
+    Prompts the user via stdin. NOT for production use.
+    """
+
+    def request_approval(self, request: ApprovalRequest) -> ApprovalDecision:
+        print(f"\n{'='*60}")
+        print(f"APPROVAL REQUIRED")
+        print(f"{'='*60}")
+        print(f"  Rule:    {request.rule_name}")
+        print(f"  Policy:  {request.policy_name}")
+        print(f"  Agent:   {request.agent_id}")
+        print(f"  Action:  {request.action}")
+        if request.approvers:
+            print(f"  Approvers: {', '.join(request.approvers)}")
+        print(f"{'='*60}")
+
+        try:
+            response = input("Approve? [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            response = "n"
+
+        approved = response in ("y", "yes")
+        return ApprovalDecision(
+            approved=approved,
+            approver="console:interactive",
+            reason="Approved by console" if approved else "Rejected by console",
+        )
+
+
+class WebhookApproval(ApprovalHandler):
+    """HTTP webhook-based approval (Slack, Teams, PagerDuty, etc.).
+
+    Posts an approval request to a URL and polls or waits for a
+    callback response.
+
+    Args:
+        url: Webhook endpoint URL.
+        timeout_seconds: Max time to wait. Default 300 (5 min).
+        headers: Optional HTTP headers (e.g., auth tokens).
+    """
+
+    def __init__(
+        self,
+        url: str,
+        timeout_seconds: float = 300,
+        headers: Optional[dict[str, str]] = None,
+    ):
+        self._url = url
+        self._timeout = timeout_seconds
+        self._headers = headers or {}
+
+    def request_approval(self, request: ApprovalRequest) -> ApprovalDecision:
+        import urllib.request
+        import json
+
+        payload = json.dumps({
+            "type": "approval_request",
+            "rule_name": request.rule_name,
+            "policy_name": request.policy_name,
+            "agent_id": request.agent_id,
+            "action": request.action,
+            "approvers": request.approvers,
+            "requested_at": request.requested_at.isoformat(),
+        }).encode("utf-8")
+
+        headers = {
+            "Content-Type": "application/json",
+            **self._headers,
+        }
+
+        try:
+            req = urllib.request.Request(
+                self._url, data=payload, headers=headers, method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+                return ApprovalDecision(
+                    approved=body.get("approved", False),
+                    approver=body.get("approver", "webhook"),
+                    reason=body.get("reason", ""),
+                )
+        except Exception as e:
+            logger.error("Webhook approval error: %s", e)
+            return ApprovalDecision(
+                approved=False,
+                approver="system:webhook-error",
+                reason=f"Webhook error: {e}",
+            )

--- a/packages/agent-mesh/src/agentmesh/governance/approval.py
+++ b/packages/agent-mesh/src/agentmesh/governance/approval.py
@@ -20,13 +20,12 @@ Usage::
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +90,6 @@ class ApprovalHandler(ABC):
         Returns:
             An ``ApprovalDecision`` indicating whether the action is approved.
         """
-        ...
 
 
 class AutoRejectApproval(ApprovalHandler):

--- a/packages/agent-mesh/src/agentmesh/governance/govern.py
+++ b/packages/agent-mesh/src/agentmesh/governance/govern.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Optional, Union
 
 from .policy import Policy, PolicyDecision, PolicyEngine
 from .audit import AuditLog
-from .approval import ApprovalHandler, ApprovalRequest, ApprovalDecision, AutoRejectApproval
+from .approval import ApprovalHandler, ApprovalRequest, AutoRejectApproval
 
 logger = logging.getLogger(__name__)
 

--- a/packages/agent-mesh/src/agentmesh/governance/govern.py
+++ b/packages/agent-mesh/src/agentmesh/governance/govern.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Optional, Union
 
 from .policy import Policy, PolicyDecision, PolicyEngine
 from .audit import AuditLog
+from .approval import ApprovalHandler, ApprovalRequest, ApprovalDecision, AutoRejectApproval
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class GovernanceConfig:
     audit: bool = True
     audit_file: Optional[str] = None
     on_deny: Optional[Callable[[PolicyDecision], Any]] = None
+    approval_handler: Optional[ApprovalHandler] = None
     conflict_strategy: str = "deny_overrides"
 
 
@@ -106,6 +108,10 @@ class GovernedCallable:
         decision = self._engine.evaluate(self._config.agent_id, context)
         eval_ms = (time.monotonic() - start) * 1000
 
+        # Handle require_approval
+        if decision.action == "require_approval":
+            decision = self._handle_approval(decision, context)
+
         # Audit
         if self._audit:
             self._audit.log(
@@ -129,6 +135,52 @@ class GovernedCallable:
 
         # Allowed — execute the wrapped function
         return self._fn(*args, **kwargs)
+
+    def _handle_approval(self, decision: PolicyDecision, context: dict) -> PolicyDecision:
+        """Route require_approval decisions through the approval handler."""
+        handler = self._config.approval_handler or AutoRejectApproval()
+
+        request = ApprovalRequest(
+            action=context.get("action", {}).get("type", "unknown"),
+            rule_name=decision.matched_rule or "",
+            policy_name=decision.policy_name or "",
+            agent_id=self._config.agent_id,
+            context=context,
+            approvers=decision.approvers,
+        )
+
+        approval = handler.request_approval(request)
+
+        # Audit the approval decision
+        if self._audit:
+            self._audit.log(
+                event_type="approval_decision",
+                agent_did=self._config.agent_id,
+                action=context.get("action", {}).get("type", "unknown"),
+                outcome="approved" if approval.approved else "rejected",
+                data={
+                    "rule": decision.matched_rule or "",
+                    "approver": approval.approver,
+                    "reason": approval.reason,
+                },
+            )
+
+        if approval.approved:
+            return PolicyDecision(
+                allowed=True,
+                action="allow",
+                matched_rule=decision.matched_rule,
+                policy_name=decision.policy_name,
+                reason=f"Approved by {approval.approver}: {approval.reason}",
+            )
+        else:
+            return PolicyDecision(
+                allowed=False,
+                action="deny",
+                matched_rule=decision.matched_rule,
+                policy_name=decision.policy_name,
+                reason=f"Approval rejected by {approval.approver}: {approval.reason}",
+            )
 
     def _build_context(self, args: tuple, kwargs: dict) -> dict:
         """Build policy evaluation context from function arguments."""
@@ -172,6 +224,7 @@ def govern(
     agent_id: str = "*",
     audit: bool = True,
     on_deny: Optional[Callable[[PolicyDecision], Any]] = None,
+    approval_handler: Optional[ApprovalHandler] = None,
     conflict_strategy: str = "deny_overrides",
 ) -> GovernedCallable:
     """Wrap any callable with AGT governance — 2-line integration.
@@ -205,6 +258,7 @@ def govern(
         agent_id=agent_id,
         audit=audit,
         on_deny=on_deny,
+        approval_handler=approval_handler,
         conflict_strategy=conflict_strategy,
     )
     return GovernedCallable(fn, config)

--- a/packages/agent-mesh/tests/test_approval.py
+++ b/packages/agent-mesh/tests/test_approval.py
@@ -1,0 +1,227 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for human-in-the-loop approval workflows."""
+
+import pytest
+from agentmesh.governance.approval import (
+    ApprovalHandler,
+    ApprovalRequest,
+    ApprovalDecision,
+    AutoRejectApproval,
+    CallbackApproval,
+    ConsoleApproval,
+    WebhookApproval,
+)
+from agentmesh.governance.govern import govern, GovernanceDenied
+
+
+REQUIRE_APPROVAL_POLICY = """
+apiVersion: governance.toolkit/v1
+name: approval-test
+agents: ["*"]
+default_action: allow
+rules:
+  - name: approve-transfer
+    condition: "action.type == 'transfer'"
+    action: require_approval
+    approvers: ["manager", "compliance"]
+    description: "Transfers require human approval"
+    priority: 100
+  - name: block-delete
+    condition: "action.type == 'delete'"
+    action: deny
+    priority: 100
+"""
+
+
+def dummy_tool(action="read", **kwargs):
+    return {"action": action, "status": "executed", **kwargs}
+
+
+class TestAutoRejectApproval:
+    def test_auto_rejects_all(self):
+        handler = AutoRejectApproval()
+        request = ApprovalRequest(
+            action="transfer",
+            rule_name="approve-transfer",
+            policy_name="test",
+            agent_id="agent-1",
+        )
+        decision = handler.request_approval(request)
+        assert not decision.approved
+        assert "auto-reject" in decision.approver
+
+    def test_custom_reason(self):
+        handler = AutoRejectApproval(reason="Production safety")
+        request = ApprovalRequest(
+            action="transfer", rule_name="r", policy_name="p", agent_id="a",
+        )
+        decision = handler.request_approval(request)
+        assert decision.reason == "Production safety"
+
+
+class TestCallbackApproval:
+    def test_callback_approves(self):
+        handler = CallbackApproval(
+            lambda req: ApprovalDecision(approved=True, approver="admin")
+        )
+        request = ApprovalRequest(
+            action="transfer", rule_name="r", policy_name="p", agent_id="a",
+        )
+        decision = handler.request_approval(request)
+        assert decision.approved
+        assert decision.approver == "admin"
+
+    def test_callback_rejects(self):
+        handler = CallbackApproval(
+            lambda req: ApprovalDecision(approved=False, approver="admin", reason="Too risky")
+        )
+        request = ApprovalRequest(
+            action="transfer", rule_name="r", policy_name="p", agent_id="a",
+        )
+        decision = handler.request_approval(request)
+        assert not decision.approved
+        assert decision.reason == "Too risky"
+
+    def test_callback_error_rejects(self):
+        def failing_callback(req):
+            raise RuntimeError("Service unavailable")
+
+        handler = CallbackApproval(failing_callback)
+        request = ApprovalRequest(
+            action="transfer", rule_name="r", policy_name="p", agent_id="a",
+        )
+        decision = handler.request_approval(request)
+        assert not decision.approved
+        assert "error" in decision.approver
+
+    def test_callback_receives_request_details(self):
+        received = {}
+        def capture_callback(req):
+            received["action"] = req.action
+            received["rule"] = req.rule_name
+            received["approvers"] = req.approvers
+            return ApprovalDecision(approved=True, approver="test")
+
+        handler = CallbackApproval(capture_callback)
+        request = ApprovalRequest(
+            action="transfer", rule_name="approve-transfer",
+            policy_name="p", agent_id="a", approvers=["mgr"],
+        )
+        handler.request_approval(request)
+        assert received["action"] == "transfer"
+        assert received["rule"] == "approve-transfer"
+        assert received["approvers"] == ["mgr"]
+
+
+class TestApprovalWithGovern:
+    def test_require_approval_auto_rejects_by_default(self):
+        """Without an approval handler, require_approval is auto-rejected."""
+        safe = govern(dummy_tool, policy=REQUIRE_APPROVAL_POLICY)
+        with pytest.raises(GovernanceDenied) as exc:
+            safe(action="transfer")
+        assert "auto-reject" in str(exc.value).lower() or "rejected" in str(exc.value).lower()
+
+    def test_require_approval_with_callback_approve(self):
+        """CallbackApproval that approves allows execution."""
+        handler = CallbackApproval(
+            lambda req: ApprovalDecision(approved=True, approver="admin@corp")
+        )
+        safe = govern(
+            dummy_tool,
+            policy=REQUIRE_APPROVAL_POLICY,
+            approval_handler=handler,
+        )
+        result = safe(action="transfer", amount=5000)
+        assert result["status"] == "executed"
+        assert result["amount"] == 5000
+
+    def test_require_approval_with_callback_reject(self):
+        """CallbackApproval that rejects denies execution."""
+        handler = CallbackApproval(
+            lambda req: ApprovalDecision(approved=False, approver="admin", reason="Amount too high")
+        )
+        safe = govern(
+            dummy_tool,
+            policy=REQUIRE_APPROVAL_POLICY,
+            approval_handler=handler,
+        )
+        with pytest.raises(GovernanceDenied) as exc:
+            safe(action="transfer", amount=1000000)
+        assert "Amount too high" in str(exc.value)
+
+    def test_deny_bypasses_approval(self):
+        """Deny rules are enforced without going through approval."""
+        handler = CallbackApproval(
+            lambda req: ApprovalDecision(approved=True, approver="admin")
+        )
+        safe = govern(
+            dummy_tool,
+            policy=REQUIRE_APPROVAL_POLICY,
+            approval_handler=handler,
+        )
+        # delete is deny, not require_approval — should not hit handler
+        with pytest.raises(GovernanceDenied):
+            safe(action="delete")
+
+    def test_allow_bypasses_approval(self):
+        """Allowed actions don't trigger approval."""
+        call_count = {"n": 0}
+        def counting_callback(req):
+            call_count["n"] += 1
+            return ApprovalDecision(approved=True, approver="admin")
+
+        handler = CallbackApproval(counting_callback)
+        safe = govern(
+            dummy_tool,
+            policy=REQUIRE_APPROVAL_POLICY,
+            approval_handler=handler,
+        )
+        safe(action="read")
+        assert call_count["n"] == 0  # no approval needed for read
+
+    def test_approval_audit_trail(self):
+        """Approval decisions are logged in the audit trail."""
+        handler = CallbackApproval(
+            lambda req: ApprovalDecision(approved=True, approver="admin@corp")
+        )
+        safe = govern(
+            dummy_tool,
+            policy=REQUIRE_APPROVAL_POLICY,
+            approval_handler=handler,
+        )
+        safe(action="transfer")
+
+        entries = safe.audit_log.query(event_type="approval_decision")
+        assert len(entries) >= 1
+        assert entries[0].data.get("approver") == "admin@corp"
+
+    def test_approval_with_on_deny_callback(self):
+        """on_deny callback fires when approval is rejected."""
+        handler = CallbackApproval(
+            lambda req: ApprovalDecision(approved=False, approver="admin")
+        )
+        denied = []
+        safe = govern(
+            dummy_tool,
+            policy=REQUIRE_APPROVAL_POLICY,
+            approval_handler=handler,
+            on_deny=lambda d: denied.append(d),
+        )
+        safe(action="transfer")
+        assert len(denied) == 1
+
+
+class TestApprovalRequest:
+    def test_request_has_timestamp(self):
+        req = ApprovalRequest(
+            action="test", rule_name="r", policy_name="p", agent_id="a",
+        )
+        assert req.requested_at is not None
+
+    def test_request_preserves_approvers(self):
+        req = ApprovalRequest(
+            action="test", rule_name="r", policy_name="p",
+            agent_id="a", approvers=["alice", "bob"],
+        )
+        assert req.approvers == ["alice", "bob"]

--- a/packages/agent-mesh/tests/test_approval.py
+++ b/packages/agent-mesh/tests/test_approval.py
@@ -4,13 +4,10 @@
 
 import pytest
 from agentmesh.governance.approval import (
-    ApprovalHandler,
     ApprovalRequest,
     ApprovalDecision,
     AutoRejectApproval,
     CallbackApproval,
-    ConsoleApproval,
-    WebhookApproval,
 )
 from agentmesh.governance.govern import govern, GovernanceDenied
 


### PR DESCRIPTION
## Summary
Adds human-in-the-loop approval infrastructure for `require_approval` policy actions.

### Handlers
- `AutoRejectApproval` — fail-safe default (production)
- `CallbackApproval` — custom function with timeout + error handling
- `ConsoleApproval` — interactive stdin (dev)
- `WebhookApproval` — HTTP POST (Slack/Teams/PagerDuty)

### Usage
```python
from agentmesh.governance import govern, CallbackApproval, ApprovalDecision

handler = CallbackApproval(lambda req: ApprovalDecision(approved=True, approver="admin"))
safe = govern(my_tool, policy="policy.yaml", approval_handler=handler)
```

### Key semantics
- Deny rules bypass approval entirely (deterministic > approval)
- Timeout defaults to deny (fail-safe)
- Callback errors default to deny
- Approval decisions logged in audit trail with approver identity

15 tests. All pass.

Closes #1374
