### PR TITLE
feat: attribute ratchets (monotonic session state)

### DIFF
--- a/packages/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/packages/agent-mesh/src/agentmesh/governance/__init__.py
@@ -18,6 +18,7 @@ from .approval import (
     WebhookApproval,
 )
 from .policy import PolicyEngine, Policy, PolicyRule, PolicyDecision
+from .session_state import SessionState, SessionAttribute
 from .conflict_resolution import (
     ConflictResolutionStrategy,
     PolicyScope,
@@ -98,6 +99,9 @@ __all__ = [
     "CallbackApproval",
     "ConsoleApproval",
     "WebhookApproval",
+    # Session state / attribute ratchets (issue #1375)
+    "SessionState",
+    "SessionAttribute",
     "AsyncTrustPolicyEvaluator",
     "TrustConcurrencyStats",
     "PolicyEngine",

--- a/packages/agent-mesh/src/agentmesh/governance/policy.py
+++ b/packages/agent-mesh/src/agentmesh/governance/policy.py
@@ -138,6 +138,38 @@ class PolicyRule(BaseModel):
             actual = self._get_nested(context, path)
             return actual == value
 
+        # Inequality: action.type != 'export'
+        neq_match = re.match(r"(\w+(?:\.\w+)*)\s*!=\s*['\"]([^'\"]+)['\"]", expr)
+        if neq_match:
+            path, value = neq_match.groups()
+            actual = self._get_nested(context, path)
+            return actual != value
+
+        # Membership: field in ['a', 'b', 'c']
+        in_match = re.match(
+            r"(\w+(?:\.\w+)*)\s+in\s+\[([^\]]*)\]", expr
+        )
+        if in_match:
+            path, items_str = in_match.groups()
+            actual = self._get_nested(context, path)
+            items = [s.strip().strip("'\"") for s in items_str.split(",") if s.strip()]
+            return actual in items
+
+        # Comparison: field > number
+        cmp_match = re.match(r"(\w+(?:\.\w+)*)\s*(>=|<=|>|<)\s*(\d+(?:\.\d+)?)", expr)
+        if cmp_match:
+            path, op, num_str = cmp_match.groups()
+            actual = self._get_nested(context, path)
+            try:
+                actual_num = float(actual) if actual is not None else 0
+                target = float(num_str)
+                if op == ">": return actual_num > target
+                if op == "<": return actual_num < target
+                if op == ">=": return actual_num >= target
+                if op == "<=": return actual_num <= target
+            except (TypeError, ValueError):
+                return False
+
         # Boolean attribute: data.contains_pii
         bool_match = re.match(r"^(\w+(?:\.\w+)*)$", expr)
         if bool_match:

--- a/packages/agent-mesh/src/agentmesh/governance/session_state.py
+++ b/packages/agent-mesh/src/agentmesh/governance/session_state.py
@@ -1,0 +1,182 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Session state with monotonic (ratchet) attributes.
+
+Tracks runtime attributes across tool calls within a session.
+Attributes declared as ``monotonic`` can only move forward in their
+ordering — once an agent touches confidential data, sensitivity
+cannot be reset to public.
+
+Usage::
+
+    from agentmesh.governance.session_state import SessionState, SessionAttribute
+
+    state = SessionState([
+        SessionAttribute(
+            name="data_sensitivity",
+            ordering=["public", "internal", "confidential", "restricted"],
+            monotonic=True,
+        ),
+    ])
+
+    state.set("data_sensitivity", "confidential")  # OK
+    state.set("data_sensitivity", "public")         # ignored (monotonic)
+    assert state.get("data_sensitivity") == "confidential"
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionAttribute:
+    """Definition of a session-scoped attribute.
+
+    Attributes:
+        name: Attribute name (used in policy conditions as ``session.<name>``).
+        ordering: Ordered list of allowed values (low → high).
+        monotonic: If True, value can only move forward in ordering.
+        initial: Starting value. Defaults to first item in ordering.
+    """
+
+    name: str
+    ordering: list[str] = field(default_factory=list)
+    monotonic: bool = False
+    initial: Optional[str] = None
+
+    def __post_init__(self):
+        if self.initial is None and self.ordering:
+            self.initial = self.ordering[0]
+
+
+class SessionState:
+    """Tracks runtime session attributes with optional monotonic enforcement.
+
+    Integrates with PolicyEngine by injecting ``session.*`` keys into
+    the evaluation context.
+    """
+
+    def __init__(self, attributes: list[SessionAttribute] | None = None):
+        self._definitions: dict[str, SessionAttribute] = {}
+        self._values: dict[str, str] = {}
+
+        for attr in (attributes or []):
+            self._definitions[attr.name] = attr
+            if attr.initial is not None:
+                self._values[attr.name] = attr.initial
+
+    def define(self, attr: SessionAttribute) -> None:
+        """Register a new session attribute."""
+        self._definitions[attr.name] = attr
+        if attr.name not in self._values and attr.initial is not None:
+            self._values[attr.name] = attr.initial
+
+    def set(self, name: str, value: str) -> bool:
+        """Set a session attribute value.
+
+        For monotonic attributes, the value can only move forward in
+        the ordering. Attempts to move backward are silently ignored
+        and return False.
+
+        Args:
+            name: Attribute name.
+            value: New value.
+
+        Returns:
+            True if the value was updated, False if rejected (monotonic).
+        """
+        defn = self._definitions.get(name)
+
+        if defn and defn.monotonic and defn.ordering:
+            current = self._values.get(name, defn.initial or "")
+            try:
+                current_idx = defn.ordering.index(current) if current else -1
+            except ValueError:
+                current_idx = -1
+            try:
+                new_idx = defn.ordering.index(value)
+            except ValueError:
+                logger.warning(
+                    "Session attribute '%s' value '%s' not in ordering — rejected",
+                    name, value,
+                )
+                return False
+
+            if new_idx <= current_idx:
+                logger.debug(
+                    "Monotonic ratchet: '%s' cannot move from '%s' (%d) to '%s' (%d)",
+                    name, current, current_idx, value, new_idx,
+                )
+                return False
+
+        self._values[name] = value
+        return True
+
+    def get(self, name: str) -> Optional[str]:
+        """Get current value of a session attribute."""
+        return self._values.get(name)
+
+    def get_all(self) -> dict[str, str]:
+        """Get all current attribute values."""
+        return dict(self._values)
+
+    def inject_context(self, context: dict) -> dict:
+        """Inject session state into a policy evaluation context.
+
+        Adds ``session.*`` keys so policy conditions can reference them:
+        ``session.data_sensitivity == 'confidential'``
+
+        Args:
+            context: Existing policy context dict.
+
+        Returns:
+            The context dict with ``session`` key added (mutated in place).
+        """
+        context["session"] = dict(self._values)
+        return context
+
+    def reset(self) -> None:
+        """Reset all attributes to their initial values."""
+        for name, defn in self._definitions.items():
+            if defn.initial is not None:
+                self._values[name] = defn.initial
+            else:
+                self._values.pop(name, None)
+
+    @classmethod
+    def from_policy_yaml(cls, yaml_content: str) -> "SessionState":
+        """Parse session_attributes from a policy YAML string.
+
+        Example YAML::
+
+            session_attributes:
+              - name: data_sensitivity
+                ordering: [public, internal, confidential, restricted]
+                monotonic: true
+                initial: public
+
+        Args:
+            yaml_content: Raw YAML string.
+
+        Returns:
+            A configured SessionState instance.
+        """
+        import yaml
+
+        data = yaml.safe_load(yaml_content) or {}
+        attrs_data = data.get("session_attributes", [])
+        attributes = []
+        for ad in attrs_data:
+            attributes.append(SessionAttribute(
+                name=ad["name"],
+                ordering=ad.get("ordering", []),
+                monotonic=ad.get("monotonic", False),
+                initial=ad.get("initial"),
+            ))
+        return cls(attributes)

--- a/packages/agent-mesh/tests/test_session_state.py
+++ b/packages/agent-mesh/tests/test_session_state.py
@@ -1,0 +1,274 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for session state with monotonic attribute ratchets."""
+
+import pytest
+from agentmesh.governance.session_state import SessionState, SessionAttribute
+
+
+class TestSessionAttribute:
+    def test_default_initial_is_first_ordering(self):
+        attr = SessionAttribute(name="sens", ordering=["low", "med", "high"])
+        assert attr.initial == "low"
+
+    def test_explicit_initial(self):
+        attr = SessionAttribute(name="sens", ordering=["low", "med", "high"], initial="med")
+        assert attr.initial == "med"
+
+    def test_no_ordering_no_initial(self):
+        attr = SessionAttribute(name="tag")
+        assert attr.initial is None
+
+
+class TestSessionState:
+    def test_set_and_get(self):
+        state = SessionState([
+            SessionAttribute(name="level", ordering=["a", "b", "c"]),
+        ])
+        assert state.get("level") == "a"
+        state.set("level", "b")
+        assert state.get("level") == "b"
+
+    def test_monotonic_ratchet_up(self):
+        state = SessionState([
+            SessionAttribute(
+                name="data_sensitivity",
+                ordering=["public", "internal", "confidential", "restricted"],
+                monotonic=True,
+            ),
+        ])
+        assert state.get("data_sensitivity") == "public"
+
+        assert state.set("data_sensitivity", "confidential") is True
+        assert state.get("data_sensitivity") == "confidential"
+
+    def test_monotonic_rejects_ratchet_down(self):
+        state = SessionState([
+            SessionAttribute(
+                name="data_sensitivity",
+                ordering=["public", "internal", "confidential", "restricted"],
+                monotonic=True,
+            ),
+        ])
+        state.set("data_sensitivity", "confidential")
+
+        # Try to go back — should be rejected
+        assert state.set("data_sensitivity", "public") is False
+        assert state.get("data_sensitivity") == "confidential"
+
+    def test_monotonic_rejects_same_value(self):
+        state = SessionState([
+            SessionAttribute(
+                name="level",
+                ordering=["low", "med", "high"],
+                monotonic=True,
+            ),
+        ])
+        state.set("level", "med")
+        # Same value = not moving forward
+        assert state.set("level", "med") is False
+        assert state.get("level") == "med"
+
+    def test_monotonic_rejects_unknown_value(self):
+        state = SessionState([
+            SessionAttribute(
+                name="level",
+                ordering=["low", "med", "high"],
+                monotonic=True,
+            ),
+        ])
+        assert state.set("level", "unknown") is False
+        assert state.get("level") == "low"
+
+    def test_non_monotonic_allows_any_direction(self):
+        state = SessionState([
+            SessionAttribute(
+                name="mode",
+                ordering=["read", "write", "admin"],
+                monotonic=False,
+            ),
+        ])
+        state.set("mode", "admin")
+        assert state.get("mode") == "admin"
+
+        # Can go back when not monotonic
+        assert state.set("mode", "read") is True
+        assert state.get("mode") == "read"
+
+    def test_multiple_attributes(self):
+        state = SessionState([
+            SessionAttribute(
+                name="data_sensitivity",
+                ordering=["public", "internal", "confidential"],
+                monotonic=True,
+            ),
+            SessionAttribute(
+                name="access_level",
+                ordering=["viewer", "editor", "admin"],
+                monotonic=False,
+            ),
+        ])
+        state.set("data_sensitivity", "confidential")
+        state.set("access_level", "admin")
+
+        assert state.get("data_sensitivity") == "confidential"
+        assert state.get("access_level") == "admin"
+
+        # Sensitivity can't go down, access can
+        assert state.set("data_sensitivity", "public") is False
+        assert state.set("access_level", "viewer") is True
+
+    def test_get_all(self):
+        state = SessionState([
+            SessionAttribute(name="a", ordering=["x", "y"], initial="x"),
+            SessionAttribute(name="b", ordering=["1", "2"], initial="1"),
+        ])
+        assert state.get_all() == {"a": "x", "b": "1"}
+
+    def test_get_unknown_returns_none(self):
+        state = SessionState()
+        assert state.get("nonexistent") is None
+
+    def test_inject_context(self):
+        state = SessionState([
+            SessionAttribute(
+                name="data_sensitivity",
+                ordering=["public", "confidential"],
+                initial="public",
+            ),
+        ])
+        state.set("data_sensitivity", "confidential")
+
+        context = {"action": {"type": "export"}}
+        state.inject_context(context)
+
+        assert context["session"]["data_sensitivity"] == "confidential"
+
+    def test_reset(self):
+        state = SessionState([
+            SessionAttribute(
+                name="level",
+                ordering=["low", "high"],
+                monotonic=True,
+                initial="low",
+            ),
+        ])
+        state.set("level", "high")
+        assert state.get("level") == "high"
+
+        state.reset()
+        assert state.get("level") == "low"
+
+    def test_define_after_init(self):
+        state = SessionState()
+        state.define(SessionAttribute(
+            name="risk",
+            ordering=["low", "med", "high"],
+            monotonic=True,
+        ))
+        assert state.get("risk") == "low"
+        state.set("risk", "high")
+        assert state.set("risk", "low") is False
+
+    def test_ratchet_full_ordering(self):
+        """Walk through the full ordering sequence."""
+        state = SessionState([
+            SessionAttribute(
+                name="s",
+                ordering=["public", "internal", "confidential", "restricted"],
+                monotonic=True,
+            ),
+        ])
+        assert state.set("s", "internal") is True
+        assert state.set("s", "confidential") is True
+        assert state.set("s", "restricted") is True
+        # Can't go back at any point
+        assert state.set("s", "confidential") is False
+        assert state.set("s", "public") is False
+        assert state.get("s") == "restricted"
+
+
+class TestFromPolicyYaml:
+    def test_parse_session_attributes(self):
+        state = SessionState.from_policy_yaml("""
+session_attributes:
+  - name: data_sensitivity
+    ordering: [public, internal, confidential, restricted]
+    monotonic: true
+    initial: public
+  - name: region
+    ordering: [us, eu, apac]
+    monotonic: false
+""")
+        assert state.get("data_sensitivity") == "public"
+        state.set("data_sensitivity", "restricted")
+        assert state.set("data_sensitivity", "public") is False
+
+        state.set("region", "eu")
+        assert state.set("region", "us") is True  # non-monotonic
+
+    def test_empty_yaml(self):
+        state = SessionState.from_policy_yaml("")
+        assert state.get_all() == {}
+
+    def test_no_session_attributes_key(self):
+        state = SessionState.from_policy_yaml("""
+apiVersion: governance.toolkit/v1
+name: no-session
+rules: []
+""")
+        assert state.get_all() == {}
+
+
+class TestIntegrationWithPolicyContext:
+    def test_ratchet_blocks_export_after_sensitive_read(self):
+        """End-to-end: read confidential doc → export blocked by policy."""
+        from agentmesh.governance.policy import PolicyEngine
+
+        engine = PolicyEngine(conflict_strategy="deny_overrides")
+        engine.load_yaml("""
+apiVersion: governance.toolkit/v1
+name: dlp-policy
+agents: ["*"]
+default_action: allow
+rules:
+  - name: block-export-sensitive
+    stage: pre_tool
+    condition: "session.data_sensitivity in ['confidential', 'restricted']"
+    action: deny
+    description: "Cannot export after touching sensitive data"
+    priority: 100
+    """)
+
+        state = SessionState([
+            SessionAttribute(
+                name="data_sensitivity",
+                ordering=["public", "internal", "confidential", "restricted"],
+                monotonic=True,
+            ),
+        ])
+
+        # Before reading sensitive data — export is allowed
+        ctx1 = {"action": {"type": "export"}}
+        state.inject_context(ctx1)
+        result1 = engine.evaluate("*", ctx1)
+        assert result1.allowed
+
+        # Simulate reading a confidential document
+        state.set("data_sensitivity", "confidential")
+
+        # After reading sensitive data — export is blocked
+        ctx2 = {"action": {"type": "export"}}
+        state.inject_context(ctx2)
+        result2 = engine.evaluate("*", ctx2)
+        assert not result2.allowed
+        assert result2.matched_rule == "block-export-sensitive"
+
+        # Try to reset sensitivity (monotonic — rejected)
+        assert state.set("data_sensitivity", "public") is False
+
+        # Export still blocked
+        ctx3 = {"action": {"type": "export"}}
+        state.inject_context(ctx3)
+        result3 = engine.evaluate("*", ctx3)
+        assert not result3.allowed


### PR DESCRIPTION
## Summary
Adds monotonic session state for DLP use cases. Once an agent touches sensitive data, sensitivity can only ratchet up — never reset.

```python
from agentmesh.governance import SessionState, SessionAttribute

state = SessionState([
    SessionAttribute(name="data_sensitivity",
                     ordering=["public", "internal", "confidential", "restricted"],
                     monotonic=True)
])
state.set("data_sensitivity", "confidential")  # OK
state.set("data_sensitivity", "public")         # rejected (monotonic)
```

Integrates with PolicyEngine via `state.inject_context(ctx)` which adds `session.*` keys.

Also adds `in`, `!=`, `>`, `<`, `>=`, `<=` operators to the expression evaluator.

### End-to-end DLP test
Read confidential doc -> export blocked by policy -> try to reset sensitivity -> still blocked.

20 tests. All pass.

Closes #1375
