### PR TITLE
fix: three bugs in escalation and security scanner

### DIFF
--- a/packages/agent-compliance/src/agent_compliance/security/scanner.py
+++ b/packages/agent-compliance/src/agent_compliance/security/scanner.py
@@ -19,7 +19,7 @@ import json
 import re
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Severity levels and blocking behavior
@@ -289,7 +289,9 @@ class SecurityScanner:
                     if "expires" in ex and ex["expires"] is not None:
                         try:
                             expires = datetime.fromisoformat(ex["expires"])
-                            if expires < datetime.now():
+                            if expires.tzinfo is None:
+                                expires = expires.replace(tzinfo=timezone.utc)
+                            if expires < datetime.now(timezone.utc):
                                 continue  # Skip expired
                         except (ValueError, TypeError):
                             continue  # Invalid date format
@@ -360,7 +362,10 @@ class SecurityScanner:
 
                 for match in matches:
                     file_path = match.group(1)
-                    line_num = int(match.group(2))
+                    try:
+                        line_num = int(match.group(2))
+                    except (ValueError, TypeError):
+                        continue
 
                     # Skip if in exclusion list
                     try:

--- a/packages/agent-os/src/agent_os/escalation.py
+++ b/packages/agent-os/src/agent_os/escalation.py
@@ -230,6 +230,7 @@ class EscalationManager:
                 outcome=request.outcome,
                 decided_by=request.decided_by or "unknown",
                 decided_at=request.decided_at or datetime.now(timezone.utc),
+                reason=request.reason,
             )
 
         del self._pending[request.request_id]
@@ -244,6 +245,7 @@ class EscalationManager:
         request.outcome = EscalationOutcome.APPROVED
         request.decided_by = decided_by
         request.decided_at = datetime.now(timezone.utc)
+        request.reason = reason
         return True
 
     def deny(self, request_id: str, decided_by: str = "human", reason: str = "") -> bool:
@@ -254,6 +256,7 @@ class EscalationManager:
         request.outcome = EscalationOutcome.DENIED
         request.decided_by = decided_by
         request.decided_at = datetime.now(timezone.utc)
+        request.reason = reason
         return True
 
     @property


### PR DESCRIPTION
## Summary

Fix three independent bugs across `agent-os` and `agent-compliance` packages:

### 1. Escalation `reason` parameter silently discarded (agent-os)

**File:** `packages/agent-os/src/agent_os/escalation.py`

The `approve()` and `deny()` methods accept a `reason` parameter for audit trail purposes, but never stored it — it was silently dropped. The `EscalationDecision` built after resolution also didn't include the reason. This means human approval/denial decisions have no recorded rationale in the audit trail.

**Fix:** Store `request.reason = reason` in both methods, and propagate `reason=request.reason` into the `EscalationDecision`.

### 2. Naive vs aware datetime comparison drops valid exemptions (agent-compliance)

**File:** `packages/agent-compliance/src/agent_compliance/security/scanner.py:289-295`

`datetime.fromisoformat()` returns an **aware** datetime when the input string contains timezone info (e.g. `"2026-04-24T12:00:00+00:00"`). `datetime.now()` returns a **naive** datetime. Comparing them raises `TypeError: can't compare offset-naive and offset-aware datetimes` — which the existing `except (ValueError, TypeError)` catches, causing valid non-expired exemptions to be silently skipped.

**Fix:** Normalize to UTC-aware datetimes before comparison.

### 3. Unprotected `int()` parse crashes secret scanner (agent-compliance)

**File:** `packages/agent-compliance/src/agent_compliance/security/scanner.py:363`

`int(match.group(2))` can raise `ValueError` if the regex captures non-numeric content. The outer `except (subprocess.TimeoutExpired, FileNotFoundError)` doesn't catch `ValueError`, so the entire `_scan_secrets()` method crashes.

**Fix:** Wrap the `int()` call in a `try/except (ValueError, TypeError)` with `continue`.

## Files Changed

- `packages/agent-os/src/agent_os/escalation.py` — 3 lines added
- `packages/agent-compliance/src/agent_compliance/security/scanner.py` — 8 lines added, 3 lines changed

## Verification

- Both files pass `py_compile` syntax check
- Changes follow existing code conventions in both packages
