### PR TITLE
docs: update tutorial count to 40+

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ See **[Language Package Feature Matrix](docs/SDK-FEATURE-MATRIX.md)** for detail
 
 **Getting Started**
 - [Quick Start](QUICKSTART.md) — Zero to governed agents in 10 minutes
-- [Tutorials](docs/tutorials/) — 31 numbered tutorials + 7-chapter Policy-as-Code deep dive
+- [Tutorials](docs/tutorials/) — 40+ numbered tutorials + 7-chapter Policy-as-Code deep dive
 - [FAQ](docs/FAQ.md) — Technical Q&A for customers, partners, and evaluators
 
 **Architecture & Reference**

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ The Agent Governance Toolkit (AGT) provides a comprehensive set of packages for 
 |---|---|
 | :material-rocket-launch: [**Quick Start**](quickstart.md) | Get running in 5 minutes |
 | :material-cube-outline: [**Packages**](packages/index.md) | 11 packages for every governance layer |
-| :material-school: [**Tutorials**](tutorials/index.md) | 27 step-by-step guides |
+| :material-school: [**Tutorials**](tutorials/index.md) | 40+ step-by-step guides |
 | :material-cloud-upload: [**Deployment**](deployment/index.md) | Azure Container Apps, Foundry, OpenClaw |
 | :material-shield-check: [**Security**](security/threat-model.md) | Threat model, OWASP compliance, scanning |
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,6 @@
 # Tutorials
 
-27 step-by-step guides covering every aspect of AI agent governance.
+40+ step-by-step guides covering every aspect of AI agent governance.
 
 ## Foundations
 


### PR DESCRIPTION
Updates tutorial count from 27 to 40+ in docs/index.md, docs/tutorials/index.md, and README.md.