### PR TITLE
fix(ts): fix TS SDK build + export encryption module (v3.3.0) — closes #1404

### DIFF
--- a/packages/agent-mesh/sdks/typescript/package.json
+++ b/packages/agent-mesh/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-governance-sdk",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Public Preview — TypeScript SDK for the Agent Governance Toolkit: agent identity, trust scoring, policy evaluation, and audit logging",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/agent-mesh/sdks/typescript/src/encryption/ratchet.ts
+++ b/packages/agent-mesh/sdks/typescript/src/encryption/ratchet.ts
@@ -13,7 +13,13 @@ import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
 import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { hmac } from "@noble/hashes/hmac.js";
-import { randomBytes } from "@noble/ciphers/utils.js";
+import { webcrypto } from "node:crypto";
+
+const randomBytes = (n: number): Uint8Array => {
+  const buf = new Uint8Array(n);
+  webcrypto.getRandomValues(buf);
+  return buf;
+};
 
 const KDF_INFO_RATCHET = new TextEncoder().encode("AgentMesh_Ratchet_v1");
 const NONCE_LEN = 12;

--- a/packages/agent-mesh/sdks/typescript/src/encryption/x3dh.ts
+++ b/packages/agent-mesh/sdks/typescript/src/encryption/x3dh.ts
@@ -14,7 +14,13 @@
 import { x25519, ed25519 } from "@noble/curves/ed25519.js";
 import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256, sha512 } from "@noble/hashes/sha2.js";
-import { randomBytes } from "@noble/ciphers/utils.js";
+import { webcrypto } from "node:crypto";
+
+const randomBytes = (n: number): Uint8Array => {
+  const buf = new Uint8Array(n);
+  webcrypto.getRandomValues(buf);
+  return buf;
+};
 
 const X3DH_INFO = new TextEncoder().encode("AgentMesh_X3DH_v1");
 const KEY_LEN = 32;

--- a/packages/agent-mesh/sdks/typescript/tsconfig.json
+++ b/packages/agent-mesh/sdks/typescript/tsconfig.json
@@ -14,7 +14,6 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node10",
-    "ignoreDeprecations": "6.0",
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
Fixes TS build for TypeScript 6, replaces dropped noble randomBytes, bumps to v3.3.0 with encryption exports. Unblocks Azure/azureclaw#29.