### PR TITLE
fix: restore ignoreDeprecations for TS 6.0

### DIFF
--- a/packages/agent-mesh/sdks/typescript/tsconfig.json
+++ b/packages/agent-mesh/sdks/typescript/tsconfig.json
@@ -14,6 +14,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node10",
+    "ignoreDeprecations": "6.0",
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts"],


### PR DESCRIPTION
The ignoreDeprecations setting from PR #1305 was lost during a subsequent tsconfig update. Restores it to fix CI build.