### PR TITLE
fix: add agent-framework to dependency scan allowlist

### DIFF
--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -84,6 +84,9 @@ REGISTERED_PACKAGES = {
     "agent-tool-registry", "cedar", "opa", "huggingface_hub",
     # APS adapter optional deps
     "aps", "agent-passport-system",
+    # Microsoft Agent Framework (MAF) — not yet on PyPI, used in examples
+    "agent-framework", "agent_framework",
+    "agent-framework-openai", "agent_framework_openai",
     # Internal cross-package references (local-only, NOT on PyPI)
     # These are flagged as HIGH RISK if found in requirements.txt with version pins
     # instead of path references. See dependency confusion attack vector.


### PR DESCRIPTION
MAF examples use agent-framework/agent-framework-openai (not yet on PyPI). Fixes dependency-scan CI failure.