### PR TITLE
feat(ci): add quality gate scripts inspired by AzureClaw Phase 0

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -1,0 +1,45 @@
+name: Quality Gates
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  no-stubs:
+    name: No Stubs/TODOs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: chmod +x ci/no-stubs.sh && ci/no-stubs.sh origin/${{ github.base_ref }}
+
+  no-custom-crypto:
+    name: No Unauthorized Crypto
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: chmod +x ci/no-custom-crypto.sh && ci/no-custom-crypto.sh origin/${{ github.base_ref }}
+
+  security-audit-required:
+    name: Security Audit Required
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: chmod +x ci/security-audit-required.sh && ci/security-audit-required.sh origin/${{ github.base_ref }}
+
+  vendored-patch-audit:
+    name: Dependency Audit Trail
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: chmod +x ci/vendored-patch-audit.sh && ci/vendored-patch-audit.sh origin/${{ github.base_ref }}

--- a/ci/no-custom-crypto.sh
+++ b/ci/no-custom-crypto.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ci/no-custom-crypto.sh — Fail if new code introduces direct crypto usage
+#                           outside the designated security modules.
+#
+# AGT's crypto belongs in:
+#   packages/agent-mesh/  (identity, encryption, trust)
+#   agent-governance-rust/src/crypto/
+#   agent-governance-typescript/src/encryption/
+#   agent-governance-dotnet/src/Security/
+#
+# Everything else should use the SDK's public API, not raw primitives.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+# Patterns that indicate direct crypto usage
+CRYPTO_PATTERNS=(
+  'from cryptography'
+  'from Crypto\.'
+  'import hashlib'
+  'import hmac'
+  'crypto\.subtle'
+  'crypto\.createHash'
+  'crypto\.createHmac'
+  'crypto\.createSign'
+  'crypto\.createCipher'
+  'use ring::'
+  'use ed25519_dalek'
+  'use x25519_dalek'
+  'use sha2::'
+  'use hmac::'
+  'use aes_gcm::'
+  'System\.Security\.Cryptography'
+  'crypto/ed25519'
+  'crypto/aes'
+  'crypto/hmac'
+  'golang\.org/x/crypto'
+)
+
+# Paths where crypto is allowed
+ALLOWED_PATHS=(
+  'packages/agent-mesh/'
+  'agent-governance-rust/src/'
+  'agent-governance-typescript/src/encryption/'
+  'agent-governance-dotnet/src/'
+  'agent-governance-golang/'
+)
+
+PATTERN=$(IFS='|'; echo "${CRYPTO_PATTERNS[*]}")
+
+# Get added lines from non-allowed paths
+ADDED=$(git diff "$BASE_REF"...HEAD --diff-filter=ACMR -U0 -- \
+  '*.py' '*.ts' '*.rs' '*.cs' '*.go' \
+  ':!packages/agent-mesh/**' \
+  ':!agent-governance-rust/**' \
+  ':!agent-governance-typescript/src/encryption/**' \
+  ':!agent-governance-dotnet/**' \
+  ':!agent-governance-golang/**' \
+  ':!*test*' ':!*spec*' ':!ci/no-custom-crypto.sh' \
+  | grep -E '^\+[^+]' || true)
+
+if [ -z "$ADDED" ]; then
+  echo "✅ no-custom-crypto: no new lines outside crypto modules"
+  exit 0
+fi
+
+HITS=$(echo "$ADDED" | grep -E "$PATTERN" || true)
+
+if [ -n "$HITS" ]; then
+  echo "❌ no-custom-crypto: direct crypto usage found outside designated modules:"
+  echo "$HITS"
+  echo ""
+  echo "Fix: use the SDK's public crypto API, or move this code into the appropriate security module."
+  exit 1
+fi
+
+echo "✅ no-custom-crypto: no unauthorized crypto usage"

--- a/ci/no-stubs.sh
+++ b/ci/no-stubs.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# ci/no-stubs.sh — Fail if new code introduces TODO/FIXME/HACK/stub markers
+#
+# Scans only ADDED lines in the diff (so existing debt doesn't block PRs).
+# Inspired by AzureClaw's Phase 0 CI gates.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+FORBIDDEN=(
+  'TODO'
+  'FIXME'
+  'HACK'
+  'XXX'
+  'raise NotImplementedError'
+  'NotImplementedException'
+  'unimplemented!()'
+  'todo!()'
+  'throw new Error.*not implemented'
+  '// stub'
+  '# stub'
+  'pass  #'
+)
+
+# Build a combined grep pattern
+PATTERN=$(IFS='|'; echo "${FORBIDDEN[*]}")
+
+# Get only added lines from the diff, excluding test files and this script
+ADDED=$(git diff "$BASE_REF"...HEAD --diff-filter=ACMR -U0 -- \
+  '*.py' '*.ts' '*.rs' '*.cs' '*.go' '*.sh' \
+  ':!*test*' ':!*spec*' ':!ci/no-stubs.sh' \
+  | grep -E '^\+[^+]' || true)
+
+if [ -z "$ADDED" ]; then
+  echo "✅ no-stubs: no new production lines to check"
+  exit 0
+fi
+
+HITS=$(echo "$ADDED" | grep -iE "$PATTERN" || true)
+
+if [ -n "$HITS" ]; then
+  echo "❌ no-stubs: found stub/TODO markers in new code:"
+  echo "$HITS"
+  echo ""
+  echo "Fix: implement the code now, or track as a GitHub issue instead of a comment."
+  exit 1
+fi
+
+echo "✅ no-stubs: no stub markers found in new code"

--- a/ci/security-audit-required.sh
+++ b/ci/security-audit-required.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ci/security-audit-required.sh — Require a security audit doc when
+#                                   capability-introducing paths change.
+#
+# If a PR touches core security surfaces (policy engine, identity, trust,
+# encryption, execution rings, kill switch), it must include a corresponding
+# docs/security-audits/YYYY-MM-DD-*.md file.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+# Paths that trigger the security audit requirement
+CAPABILITY_PATHS=(
+  'packages/agent-os/src/agent_os/policies/'
+  'packages/agent-os/src/agent_os/mcp_gateway'
+  'packages/agent-os/src/agent_os/approvals'
+  'packages/agent-mesh/src/agentmesh/identity/'
+  'packages/agent-mesh/src/agentmesh/trust/'
+  'packages/agent-mesh/src/agentmesh/encryption/'
+  'packages/agent-runtime/src/agent_runtime/rings/'
+  'packages/agent-runtime/src/agent_runtime/kill_switch'
+  'packages/agent-runtime/src/agent_runtime/saga'
+  'agent-governance-rust/src/'
+  'agent-governance-typescript/src/encryption/'
+  'agent-governance-dotnet/src/Security/'
+)
+
+# Check if any capability paths are touched
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+CAPABILITY_TOUCHED=false
+
+for path in "${CAPABILITY_PATHS[@]}"; do
+  if echo "$CHANGED_FILES" | grep -q "^$path"; then
+    CAPABILITY_TOUCHED=true
+    echo "⚡ Capability path touched: $path"
+  fi
+done
+
+if [ "$CAPABILITY_TOUCHED" = false ]; then
+  echo "✅ security-audit-required: no capability paths changed"
+  exit 0
+fi
+
+# Check for a security audit doc in this PR
+AUDIT_DOC=$(echo "$CHANGED_FILES" | grep -E '^docs/security-audits/[0-9]{4}-[0-9]{2}-[0-9]{2}-.+\.md$' || true)
+
+if [ -z "$AUDIT_DOC" ]; then
+  echo "❌ security-audit-required: capability paths changed but no security audit doc found."
+  echo ""
+  echo "This PR touches core security surfaces. Please add a security audit document:"
+  echo "  docs/security-audits/$(date +%Y-%m-%d)-<description>.md"
+  echo ""
+  echo "The audit doc should cover:"
+  echo "  - What changed and why"
+  echo "  - Threat model impact (new attack surfaces, mitigations)"
+  echo "  - Test coverage for security-relevant behavior"
+  exit 1
+fi
+
+echo "✅ security-audit-required: audit doc found: $AUDIT_DOC"

--- a/ci/vendored-patch-audit.sh
+++ b/ci/vendored-patch-audit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ci/vendored-patch-audit.sh — Require audit trail when dependency locks change.
+#
+# When lockfiles or vendored content changes, a corresponding entry must exist
+# in docs/dependency-audits/ explaining what changed and why.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+# Lockfile patterns across all SDK ecosystems
+LOCK_PATTERNS=(
+  'requirements*.txt'
+  'poetry.lock'
+  'Pipfile.lock'
+  'Cargo.lock'
+  'package-lock.json'
+  'pnpm-lock.yaml'
+  'yarn.lock'
+  'go.sum'
+  'packages.lock.json'
+)
+
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+LOCK_TOUCHED=false
+
+for pattern in "${LOCK_PATTERNS[@]}"; do
+  if echo "$CHANGED_FILES" | grep -qE "(^|/)$pattern$"; then
+    LOCK_TOUCHED=true
+    MATCHED=$(echo "$CHANGED_FILES" | grep -E "(^|/)$pattern$")
+    echo "⚡ Lockfile changed: $MATCHED"
+  fi
+done
+
+# Also check vendored content
+if echo "$CHANGED_FILES" | grep -q "^vendor/"; then
+  LOCK_TOUCHED=true
+  echo "⚡ Vendored content changed"
+fi
+
+if [ "$LOCK_TOUCHED" = false ]; then
+  echo "✅ vendored-patch-audit: no lockfiles or vendored content changed"
+  exit 0
+fi
+
+# Check for an audit doc
+AUDIT_DOC=$(echo "$CHANGED_FILES" | grep -E '^docs/dependency-audits/[0-9]{4}-[0-9]{2}-[0-9]{2}-.+\.md$' || true)
+
+if [ -z "$AUDIT_DOC" ]; then
+  echo "❌ vendored-patch-audit: lockfiles changed but no dependency audit doc found."
+  echo ""
+  echo "Please add: docs/dependency-audits/$(date +%Y-%m-%d)-<description>.md"
+  echo ""
+  echo "The audit doc should cover:"
+  echo "  - Which dependencies changed and why"
+  echo "  - Security advisory relevance (CVE numbers if applicable)"
+  echo "  - Breaking change risk assessment"
+  exit 1
+fi
+
+echo "✅ vendored-patch-audit: audit doc found: $AUDIT_DOC"

--- a/docs/dependency-audits/README.md
+++ b/docs/dependency-audits/README.md
@@ -1,0 +1,20 @@
+# Dependency Audits
+
+This directory contains dependency audit documents required by the
+`ci/vendored-patch-audit.sh` CI gate.
+
+When a PR changes lockfiles (`requirements.txt`, `Cargo.lock`,
+`package-lock.json`, `go.sum`, `packages.lock.json`, etc.) or vendored
+content, it **must** include a dated audit document here.
+
+## File naming
+
+```
+YYYY-MM-DD-<short-description>.md
+```
+
+## Required sections
+
+1. **Which dependencies changed and why**
+2. **Security advisory relevance** (CVE numbers if applicable)
+3. **Breaking change risk assessment**

--- a/docs/security-audits/README.md
+++ b/docs/security-audits/README.md
@@ -1,0 +1,25 @@
+# Security Audits
+
+This directory contains security audit documents required by the
+`ci/security-audit-required.sh` CI gate.
+
+When a PR touches core security surfaces (policy engine, identity, trust,
+encryption, execution rings, kill switch), it **must** include a dated
+audit document here.
+
+## File naming
+
+```
+YYYY-MM-DD-<short-description>.md
+```
+
+## Required sections
+
+1. **What changed and why** — brief description of the capability change
+2. **Threat model impact** — new attack surfaces, mitigations applied
+3. **Test coverage** — what tests validate the security-relevant behavior
+
+## Inspiration
+
+This practice is adapted from [AzureClaw's Phase 0 CI gates](https://github.com/Azure/azureclaw),
+which require a security audit doc for every capability-introducing change.


### PR DESCRIPTION
## What

Four diff-scoped CI quality gates that scan only new/changed code, plus a workflow to run them on every PR.

### CI Gate Scripts

| Script | Purpose |
|--------|---------|
| \ci/no-stubs.sh\ | Blocks TODO/FIXME/HACK/NotImplementedError in new production code |
| \ci/no-custom-crypto.sh\ | Blocks raw crypto usage outside designated security modules |
| \ci/security-audit-required.sh\ | Requires \docs/security-audits/\ doc when capability paths change |
| \ci/vendored-patch-audit.sh\ | Requires \docs/dependency-audits/\ doc when lockfiles change |

### Key Design Decisions

- **Diff-scoped**: Only scans added lines, so existing technical debt doesn't block PRs
- **One gate, one concern**: Each runs as its own CI job for clear failure signals
- **Cross-ecosystem**: Patterns cover Python, TypeScript, Rust, Go, C# files
- **Audit trail enforcement**: Security and dependency changes require dated documentation

### Inspiration

Adapted from [AzureClaw PR #44](https://github.com/Azure/azureclaw/pull/44) (pallakatos) Phase 0 CI gates, which enforce LOC budgets, no-stubs, no-custom-crypto, security-audit-required, and vendored-patch-audit across the AzureClaw runtime.