### PR TITLE
feat(cli): add 'agentos sign' command for plugin signing (closes #1430)

### DIFF
--- a/packages/agent-os/src/agent_os/cli/__init__.py
+++ b/packages/agent-os/src/agent_os/cli/__init__.py
@@ -613,6 +613,10 @@ def main() -> int:
     metrics_parser = subparsers.add_parser("metrics", help="Output Prometheus metrics")
     metrics_parser.add_argument("--json", action="store_true", help="Output in JSON format")
 
+    # sign — plugin signing & verification
+    from agent_os.cli.cmd_sign import register_sign_subcommands
+    register_sign_subcommands(subparsers)
+
     args = parser.parse_args()
 
     # Handle CI mode
@@ -639,9 +643,13 @@ def main() -> int:
         "policy": cmd_policy,
         "metrics": cmd_metrics,
         "health": cmd_health,
+        "sign": None,  # handled by sub-subcommands
     }
 
     handler = commands.get(args.command)
+    if handler is None and args.command == "sign":
+        from agent_os.cli.cmd_sign import cmd_sign
+        handler = cmd_sign
     if handler is None:
         parser.print_help()
         return 0

--- a/packages/agent-os/src/agent_os/cli/cmd_sign.py
+++ b/packages/agent-os/src/agent_os/cli/cmd_sign.py
@@ -1,0 +1,221 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+``agentos sign`` — Sign and verify plugin manifests.
+
+Wraps :class:`agentmesh.marketplace.signing.PluginSigner` for CLI use.
+
+Usage::
+
+    # Generate a signing keypair
+    agentos sign keygen --out keys/
+
+    # Sign a plugin manifest
+    agentos sign plugin ./my-plugin/ --key keys/signing.key
+
+    # Verify a signed manifest
+    agentos sign verify ./my-plugin/ --pubkey keys/signing.pub
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from agentmesh.marketplace.manifest import MANIFEST_FILENAME, PluginManifest
+from agentmesh.marketplace.signing import PluginSigner, verify_signature
+
+logger = logging.getLogger(__name__)
+
+
+def _load_private_key(path: Path) -> ed25519.Ed25519PrivateKey:
+    """Load an Ed25519 private key from a PEM file."""
+    data = path.read_bytes()
+    key = serialization.load_pem_private_key(data, password=None)
+    if not isinstance(key, ed25519.Ed25519PrivateKey):
+        raise SystemExit(f"Key at {path} is not Ed25519")
+    return key
+
+
+def _load_public_key(path: Path) -> ed25519.Ed25519PublicKey:
+    """Load an Ed25519 public key from a PEM file."""
+    data = path.read_bytes()
+    key = serialization.load_pem_public_key(data)
+    if not isinstance(key, ed25519.Ed25519PublicKey):
+        raise SystemExit(f"Key at {path} is not Ed25519")
+    return key
+
+
+def _load_manifest(plugin_dir: Path) -> PluginManifest:
+    """Load agent-plugin.yaml from a plugin directory."""
+    manifest_path = plugin_dir / MANIFEST_FILENAME
+    if not manifest_path.exists():
+        raise SystemExit(
+            f"No {MANIFEST_FILENAME} found in {plugin_dir}. "
+            "Run 'agentos sign init' in your plugin directory first."
+        )
+    import yaml
+
+    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    return PluginManifest(**raw)
+
+
+def _save_manifest(manifest: PluginManifest, plugin_dir: Path) -> None:
+    """Write the signed manifest back to disk."""
+    import yaml
+
+    manifest_path = plugin_dir / MANIFEST_FILENAME
+    data = json.loads(manifest.model_dump_json(exclude_none=True))
+    manifest_path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def cmd_sign_keygen(args: argparse.Namespace) -> int:
+    """Generate an Ed25519 signing keypair."""
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    priv_path = out_dir / "signing.key"
+    pub_path = out_dir / "signing.pub"
+
+    priv_path.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    priv_path.chmod(0o600)
+
+    pub_path.write_bytes(
+        public_key.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+
+    # Also output the public key fingerprint for easy identification
+    raw_pub = public_key.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    fingerprint = base64.b64encode(raw_pub).decode()[:16]
+
+    print(f"✅ Keypair generated:")
+    print(f"   Private key: {priv_path}")
+    print(f"   Public key:  {pub_path}")
+    print(f"   Fingerprint: {fingerprint}...")
+    print()
+    print(f"⚠️  Keep {priv_path} secret. Share {pub_path} with verifiers.")
+    return 0
+
+
+def cmd_sign_plugin(args: argparse.Namespace) -> int:
+    """Sign a plugin's agent-plugin.yaml manifest."""
+    plugin_dir = Path(args.plugin_dir)
+    key_path = Path(args.key)
+
+    if not key_path.exists():
+        raise SystemExit(f"Private key not found: {key_path}")
+
+    private_key = _load_private_key(key_path)
+    manifest = _load_manifest(plugin_dir)
+    signer = PluginSigner(private_key)
+    signed = signer.sign(manifest)
+    _save_manifest(signed, plugin_dir)
+
+    print(f"✅ Signed {manifest.name}@{manifest.version}")
+    print(f"   Manifest: {plugin_dir / MANIFEST_FILENAME}")
+    print(f"   Signature: {signed.signature[:32]}...")
+    return 0
+
+
+def cmd_sign_verify(args: argparse.Namespace) -> int:
+    """Verify a signed plugin manifest."""
+    plugin_dir = Path(args.plugin_dir)
+    pub_path = Path(args.pubkey)
+
+    if not pub_path.exists():
+        raise SystemExit(f"Public key not found: {pub_path}")
+
+    public_key = _load_public_key(pub_path)
+    manifest = _load_manifest(plugin_dir)
+
+    try:
+        verify_signature(manifest, public_key)
+        print(f"✅ Signature valid: {manifest.name}@{manifest.version}")
+
+        if args.json:
+            result = {
+                "valid": True,
+                "plugin": manifest.name,
+                "version": manifest.version,
+                "author": manifest.author,
+            }
+            print(json.dumps(result, indent=2))
+        return 0
+    except Exception as exc:
+        print(f"❌ Signature invalid: {exc}", file=sys.stderr)
+        if args.json:
+            result = {"valid": False, "error": str(exc)}
+            print(json.dumps(result, indent=2))
+        return 1
+
+
+def register_sign_subcommands(subparsers: argparse._SubParsersAction) -> None:
+    """Register 'sign' subcommand and its sub-subcommands on the main parser."""
+    sign_parser = subparsers.add_parser(
+        "sign",
+        help="Sign and verify plugin manifests",
+    )
+    sign_sub = sign_parser.add_subparsers(dest="sign_command")
+
+    # keygen
+    keygen_p = sign_sub.add_parser("keygen", help="Generate Ed25519 signing keypair")
+    keygen_p.add_argument(
+        "--out", default=".", help="Output directory for keypair (default: current dir)"
+    )
+
+    # plugin (sign a manifest)
+    plugin_p = sign_sub.add_parser("plugin", help="Sign a plugin manifest")
+    plugin_p.add_argument("plugin_dir", help="Path to plugin directory")
+    plugin_p.add_argument("--key", required=True, help="Path to Ed25519 private key (.key)")
+
+    # verify
+    verify_p = sign_sub.add_parser("verify", help="Verify a signed plugin manifest")
+    verify_p.add_argument("plugin_dir", help="Path to plugin directory")
+    verify_p.add_argument("--pubkey", required=True, help="Path to Ed25519 public key (.pub)")
+    verify_p.add_argument("--json", action="store_true", help="Output in JSON format")
+
+
+def cmd_sign(args: argparse.Namespace) -> int:
+    """Route sign subcommands."""
+    handlers = {
+        "keygen": cmd_sign_keygen,
+        "plugin": cmd_sign_plugin,
+        "verify": cmd_sign_verify,
+    }
+
+    handler = handlers.get(args.sign_command)
+    if handler is None:
+        print("Usage: agentos sign {keygen|plugin|verify}")
+        print()
+        print("Commands:")
+        print("  keygen   Generate Ed25519 signing keypair")
+        print("  plugin   Sign a plugin manifest")
+        print("  verify   Verify a signed plugin manifest")
+        return 0
+
+    return handler(args)

--- a/packages/agent-os/tests/test_cmd_sign.py
+++ b/packages/agent-os/tests/test_cmd_sign.py
@@ -1,0 +1,224 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the ``agentos sign`` CLI command."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from agent_os.cli.cmd_sign import (
+    cmd_sign_keygen,
+    cmd_sign_plugin,
+    cmd_sign_verify,
+    _load_manifest,
+    _load_private_key,
+    _load_public_key,
+    _save_manifest,
+)
+from agentmesh.marketplace.manifest import PluginManifest, PluginType
+
+
+@pytest.fixture()
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture()
+def sample_manifest(tmp_dir: Path) -> Path:
+    """Create a sample plugin directory with agent-plugin.yaml."""
+    plugin_dir = tmp_dir / "my-plugin"
+    plugin_dir.mkdir()
+    manifest = {
+        "name": "my-plugin",
+        "version": "1.0.0",
+        "description": "Test plugin",
+        "author": "test@example.com",
+        "plugin_type": "integration",
+        "capabilities": ["search"],
+    }
+    (plugin_dir / "agent-plugin.yaml").write_text(
+        yaml.dump(manifest), encoding="utf-8"
+    )
+    return plugin_dir
+
+
+@pytest.fixture()
+def keypair(tmp_dir: Path) -> tuple[Path, Path]:
+    """Generate a keypair and return (private_key_path, public_key_path)."""
+    from cryptography.hazmat.primitives import serialization
+
+    key = ed25519.Ed25519PrivateKey.generate()
+    priv_path = tmp_dir / "signing.key"
+    pub_path = tmp_dir / "signing.pub"
+
+    priv_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    pub_path.write_bytes(
+        key.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    return priv_path, pub_path
+
+
+class TestKeygen:
+    def test_generates_keypair(self, tmp_dir: Path):
+        class Args:
+            out = str(tmp_dir / "keys")
+
+        result = cmd_sign_keygen(Args())
+        assert result == 0
+        assert (tmp_dir / "keys" / "signing.key").exists()
+        assert (tmp_dir / "keys" / "signing.pub").exists()
+
+    def test_keys_are_valid_ed25519(self, tmp_dir: Path):
+        class Args:
+            out = str(tmp_dir / "keys")
+
+        cmd_sign_keygen(Args())
+        priv = _load_private_key(tmp_dir / "keys" / "signing.key")
+        pub = _load_public_key(tmp_dir / "keys" / "signing.pub")
+        assert isinstance(priv, ed25519.Ed25519PrivateKey)
+        assert isinstance(pub, ed25519.Ed25519PublicKey)
+
+
+class TestSignPlugin:
+    def test_signs_manifest(self, sample_manifest: Path, keypair: tuple[Path, Path]):
+        priv_path, _ = keypair
+
+        class Args:
+            plugin_dir = str(sample_manifest)
+            key = str(priv_path)
+
+        result = cmd_sign_plugin(Args())
+        assert result == 0
+
+        manifest = _load_manifest(sample_manifest)
+        assert manifest.signature is not None
+        assert len(manifest.signature) > 0
+
+    def test_missing_key_fails(self, sample_manifest: Path, tmp_dir: Path):
+        class Args:
+            plugin_dir = str(sample_manifest)
+            key = str(tmp_dir / "nonexistent.key")
+
+        with pytest.raises(SystemExit):
+            cmd_sign_plugin(Args())
+
+    def test_missing_manifest_fails(self, tmp_dir: Path, keypair: tuple[Path, Path]):
+        priv_path, _ = keypair
+        empty_dir = tmp_dir / "empty"
+        empty_dir.mkdir()
+
+        class Args:
+            plugin_dir = str(empty_dir)
+            key = str(priv_path)
+
+        with pytest.raises(SystemExit):
+            cmd_sign_plugin(Args())
+
+
+class TestVerify:
+    def test_valid_signature_passes(self, sample_manifest: Path, keypair: tuple[Path, Path]):
+        priv_path, pub_path = keypair
+
+        # Sign first
+        class SignArgs:
+            plugin_dir = str(sample_manifest)
+            key = str(priv_path)
+
+        cmd_sign_plugin(SignArgs())
+
+        # Verify
+        class VerifyArgs:
+            plugin_dir = str(sample_manifest)
+            pubkey = str(pub_path)
+            json = False
+
+        result = cmd_sign_verify(VerifyArgs())
+        assert result == 0
+
+    def test_wrong_key_fails(self, sample_manifest: Path, keypair: tuple[Path, Path], tmp_dir: Path):
+        priv_path, _ = keypair
+
+        # Sign with original key
+        class SignArgs:
+            plugin_dir = str(sample_manifest)
+            key = str(priv_path)
+
+        cmd_sign_plugin(SignArgs())
+
+        # Generate a different key and try to verify
+        from cryptography.hazmat.primitives import serialization
+
+        other_key = ed25519.Ed25519PrivateKey.generate()
+        other_pub_path = tmp_dir / "other.pub"
+        other_pub_path.write_bytes(
+            other_key.public_key().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        )
+
+        class VerifyArgs:
+            plugin_dir = str(sample_manifest)
+            pubkey = str(other_pub_path)
+            json = False
+
+        result = cmd_sign_verify(VerifyArgs())
+        assert result == 1
+
+    def test_unsigned_manifest_fails(self, sample_manifest: Path, keypair: tuple[Path, Path]):
+        _, pub_path = keypair
+
+        class VerifyArgs:
+            plugin_dir = str(sample_manifest)
+            pubkey = str(pub_path)
+            json = False
+
+        result = cmd_sign_verify(VerifyArgs())
+        assert result == 1
+
+    def test_json_output(self, sample_manifest: Path, keypair: tuple[Path, Path], capsys):
+        priv_path, pub_path = keypair
+
+        class SignArgs:
+            plugin_dir = str(sample_manifest)
+            key = str(priv_path)
+
+        cmd_sign_plugin(SignArgs())
+
+        class VerifyArgs:
+            plugin_dir = str(sample_manifest)
+            pubkey = str(pub_path)
+            json = True
+
+        result = cmd_sign_verify(VerifyArgs())
+        assert result == 0
+        captured = capsys.readouterr()
+        assert '"valid": true' in captured.out
+
+
+class TestLoadSaveManifest:
+    def test_round_trip(self, sample_manifest: Path):
+        manifest = _load_manifest(sample_manifest)
+        assert manifest.name == "my-plugin"
+        assert manifest.version == "1.0.0"
+
+        manifest_copy = manifest.model_copy(update={"signature": "test-sig"})
+        _save_manifest(manifest_copy, sample_manifest)
+
+        reloaded = _load_manifest(sample_manifest)
+        assert reloaded.signature == "test-sig"


### PR DESCRIPTION
Adds agentos sign CLI command with keygen/plugin/verify subcommands for Ed25519 plugin manifest signing. 10 tests. Wraps existing PluginSigner from agentmesh.marketplace. Closes #1430