### PR TITLE
fix(encryption): align X3DH test assertions with updated error messages

### DIFF
--- a/agent-governance-typescript/tests/encryption.test.ts
+++ b/agent-governance-typescript/tests/encryption.test.ts
@@ -169,7 +169,7 @@ describe("X3DHKeyManager", () => {
     const bundle = bob.getPublicBundle();
     const tampered = { ...bundle, signedPreKey: new Uint8Array(bundle.signedPreKey) };
     tampered.signedPreKey[0] ^= 0xff;
-    expect(() => alice.initiate(tampered)).toThrow("signature verification failed");
+    expect(() => alice.initiate(tampered)).toThrow("Signed pre-key signature verification FAILED");
   });
 
   test("forged identity key rejected", () => {
@@ -180,7 +180,7 @@ describe("X3DHKeyManager", () => {
     const attackerPriv = ed25519.utils.randomSecretKey();
     const attackerPub = ed25519.getPublicKey(attackerPriv);
     const forged = { ...bundle, identityKeyEd: attackerPub };
-    expect(() => alice.initiate(forged)).toThrow("signature verification failed");
+    expect(() => alice.initiate(forged)).toThrow("Signed pre-key signature verification FAILED");
   });
 
   test("missing identityKeyEd throws (fail-closed)", () => {
@@ -189,7 +189,7 @@ describe("X3DHKeyManager", () => {
     bob.generateSignedPreKey();
     const bundle = bob.getPublicBundle();
     delete (bundle as any).identityKeyEd;
-    expect(() => alice.initiate(bundle)).toThrow("identityKeyEd is required");
+    expect(() => alice.initiate(bundle)).toThrow("Missing or invalid Ed25519 identity key (identityKeyEd)");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes 3 broken tests on `main` in `encryption.test.ts` caused by error message text drift.

## Problem

The `verifyBundle()` function in `x3dh.ts` was updated with more descriptive error messages, but the corresponding test assertions in `encryption.test.ts` still checked for the old short substrings — causing 3 tests to fail on every CI run:

| Test | Old assertion | Actual error |
|------|---------------|--------------|
| `tampered signed pre-key rejected` | `"signature verification failed"` | `"Signed pre-key signature verification FAILED..."` |
| `forged identity key rejected` | `"signature verification failed"` | `"Signed pre-key signature verification FAILED..."` |
| `missing identityKeyEd throws (fail-closed)` | `"identityKeyEd is required"` | `"Missing or invalid Ed25519 identity key (identityKeyEd)..."` |

## Fix

Updated 3 `toThrow()` assertions to match the current error text in `x3dh.ts:verifyBundle()`.

## Testing

```
Before: 22 passed, 3 failed, 25 total
After:  25 passed, 25 total ✅

Full suite: 20 suites, 255 tests — all green ✅
```