### PR TITLE
feat(policy): add CLI vs IDE governance surface parity detection

### DIFF
--- a/agent-governance-typescript/src/index.ts
+++ b/agent-governance-typescript/src/index.ts
@@ -25,6 +25,7 @@ export { OPABackend } from './policy-backends/opa';
 export { PromptDefenseEvaluator } from './prompt-defense';
 export { RingEnforcer, RingBreachError } from './rings';
 export { GovernanceVerifier } from './verify';
+export { SurfaceParityChecker } from './surface-parity';
 
 // E2E Encryption (AgentMesh Wire Protocol v1.0)
 export {
@@ -72,6 +73,10 @@ export type {
   AgentMeshConfig,
   GovernanceResult,
   RingViolation,
+  GovernanceSurface,
+  SurfaceRuleMapping,
+  SurfaceGap,
+  SurfaceParityReport,
 } from './types';
 export type { PromptDefenseConfig, PromptDefenseFinding, PromptDefenseReport } from './prompt-defense';
 export type {

--- a/agent-governance-typescript/src/policy.ts
+++ b/agent-governance-typescript/src/policy.ts
@@ -764,6 +764,7 @@ function dataToPolicy(data: Record<string, unknown>): Policy {
         approvers: r.approvers as string[] | undefined,
         priority: r.priority as number | undefined,
         enabled: r.enabled as boolean | undefined,
+        surfaces: r.surfaces as import('./types').GovernanceSurface[] | undefined,
       });
     }
   }

--- a/agent-governance-typescript/src/surface-parity.ts
+++ b/agent-governance-typescript/src/surface-parity.ts
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import type {
+  GovernanceSurface,
+  Policy,
+  PolicyAction,
+  PolicyRule,
+  SurfaceGap,
+  SurfaceParityReport,
+  SurfaceRuleMapping,
+} from './types';
+
+const KNOWN_SURFACES: GovernanceSurface[] = ['cli', 'ide', 'api'];
+
+const SURFACE_CONDITION_PATTERNS: Array<{ pattern: RegExp; surface: GovernanceSurface }> = [
+  { pattern: /\bsurface\s*==\s*['"]cli['"]/i, surface: 'cli' },
+  { pattern: /\bsurface\s*==\s*['"]ide['"]/i, surface: 'ide' },
+  { pattern: /\bsurface\s*==\s*['"]api['"]/i, surface: 'api' },
+  { pattern: /\bcontext\.surface\s*==\s*['"]cli['"]/i, surface: 'cli' },
+  { pattern: /\bcontext\.surface\s*==\s*['"]ide['"]/i, surface: 'ide' },
+  { pattern: /\bcontext\.surface\s*==\s*['"]api['"]/i, surface: 'api' },
+  { pattern: /\bsurface\s+in\s+\[.*?['"]cli['"].*?\]/i, surface: 'cli' },
+  { pattern: /\bsurface\s+in\s+\[.*?['"]ide['"].*?\]/i, surface: 'ide' },
+  { pattern: /\bsurface\s+in\s+\[.*?['"]api['"].*?\]/i, surface: 'api' },
+];
+
+/**
+ * Detects governance parity gaps between enforcement surfaces (CLI, IDE, API).
+ *
+ * When organizations deploy governance policies, rules may be enforced
+ * differently depending on the surface. This checker identifies rules
+ * that only apply to some surfaces, highlighting enforcement gaps.
+ */
+export class SurfaceParityChecker {
+  /**
+   * Analyze a set of policies for surface parity gaps.
+   */
+  analyzePolicies(policies: Policy[]): SurfaceParityReport {
+    const mappings: SurfaceRuleMapping[] = [];
+
+    for (const policy of policies) {
+      for (const rule of policy.rules) {
+        if (rule.enabled === false) continue;
+
+        const detected = this.detectSurfaces(rule);
+        mappings.push({
+          rule,
+          policyName: policy.name,
+          detectedSurfaces: detected,
+          isUniversal: detected.length === 0,
+        });
+      }
+    }
+
+    const gaps = this.findGaps(mappings);
+    const universalRules = mappings.filter((m) => m.isUniversal).length;
+    const surfaceSpecificRules = mappings.length - universalRules;
+
+    const surfaceCoverage = this.computeCoverage(mappings);
+    const parityScore = this.computeParityScore(mappings, gaps);
+
+    return {
+      analyzedAt: new Date(),
+      totalRules: mappings.length,
+      universalRules,
+      surfaceSpecificRules,
+      gaps,
+      mappings,
+      surfaceCoverage,
+      parityScore,
+    };
+  }
+
+  /**
+   * Detect which surfaces a rule targets.
+   * Returns empty array for universal rules (no surface restriction).
+   */
+  detectSurfaces(rule: PolicyRule): GovernanceSurface[] {
+    const surfaces = new Set<GovernanceSurface>();
+
+    // Explicit surfaces field takes precedence
+    if (rule.surfaces && rule.surfaces.length > 0) {
+      return [...rule.surfaces];
+    }
+
+    // Parse condition string for surface references
+    if (typeof rule.condition === 'string') {
+      for (const { pattern, surface } of SURFACE_CONDITION_PATTERNS) {
+        if (pattern.test(rule.condition)) {
+          surfaces.add(surface);
+        }
+      }
+    }
+
+    // Check object-form conditions for surface keys
+    if (rule.condition && typeof rule.condition === 'object') {
+      const condObj = rule.condition as Record<string, unknown>;
+      if (condObj.surface && typeof condObj.surface === 'string') {
+        const val = condObj.surface.toLowerCase();
+        if (KNOWN_SURFACES.includes(val as GovernanceSurface)) {
+          surfaces.add(val as GovernanceSurface);
+        }
+      }
+      if (condObj['context.surface'] && typeof condObj['context.surface'] === 'string') {
+        const val = condObj['context.surface'].toLowerCase();
+        if (KNOWN_SURFACES.includes(val as GovernanceSurface)) {
+          surfaces.add(val as GovernanceSurface);
+        }
+      }
+    }
+
+    return [...surfaces];
+  }
+
+  /**
+   * Find gaps by grouping surface-specific rules by their normalized semantics
+   * and checking which surfaces are missing counterparts.
+   */
+  private findGaps(mappings: SurfaceRuleMapping[]): SurfaceGap[] {
+    const gaps: SurfaceGap[] = [];
+    const surfaceSpecific = mappings.filter((m) => !m.isUniversal);
+
+    // Group by normalized key (action + non-surface conditions)
+    const groups = new Map<string, SurfaceRuleMapping[]>();
+    for (const mapping of surfaceSpecific) {
+      const key = this.normalizeRuleKey(mapping.rule);
+      const group = groups.get(key) ?? [];
+      group.push(mapping);
+      groups.set(key, group);
+    }
+
+    for (const [, group] of groups) {
+      const coveredSurfaces = new Set<GovernanceSurface>();
+      for (const m of group) {
+        for (const s of m.detectedSurfaces) {
+          coveredSurfaces.add(s);
+        }
+      }
+
+      // Only flag gaps if rule exists for some surfaces but not all
+      if (coveredSurfaces.size > 0 && coveredSurfaces.size < KNOWN_SURFACES.length) {
+        const presentOn = [...coveredSurfaces];
+        const missingFrom = KNOWN_SURFACES.filter((s) => !coveredSurfaces.has(s));
+        const representative = group[0];
+        const ruleAction = representative.rule.ruleAction;
+        const severity = this.classifySeverity(ruleAction);
+
+        gaps.push({
+          ruleName: representative.rule.name ?? 'unnamed-rule',
+          policyName: representative.policyName,
+          presentOn,
+          missingFrom,
+          ruleAction,
+          severity,
+          recommendation: this.generateRecommendation(
+            representative.rule.name ?? 'unnamed-rule',
+            presentOn,
+            missingFrom,
+            ruleAction,
+          ),
+        });
+      }
+    }
+
+    return gaps;
+  }
+
+  /**
+   * Generate a normalized key for a rule based on its semantics
+   * (action + non-surface conditions), so we can group rules that
+   * do the same thing on different surfaces.
+   */
+  private normalizeRuleKey(rule: PolicyRule): string {
+    const action = rule.ruleAction ?? rule.effect ?? 'unknown';
+    const condStr = this.stripSurfaceFromCondition(rule);
+    return `${action}::${condStr}`;
+  }
+
+  /**
+   * Remove surface-related parts from a condition to get the
+   * "semantic core" of a rule for comparison purposes.
+   */
+  private stripSurfaceFromCondition(rule: PolicyRule): string {
+    if (typeof rule.condition === 'string') {
+      let stripped = rule.condition;
+      // Remove surface == 'x' clauses and surrounding connectives
+      stripped = stripped.replace(/\bsurface\s*==\s*['"][^'"]*['"]/gi, '');
+      stripped = stripped.replace(/\bcontext\.surface\s*==\s*['"][^'"]*['"]/gi, '');
+      stripped = stripped.replace(/\bsurface\s+in\s+\[[^\]]*\]/gi, '');
+      // Clean up dangling 'and'/'or'
+      stripped = stripped.replace(/^\s*(and|or)\s+/i, '');
+      stripped = stripped.replace(/\s+(and|or)\s*$/i, '');
+      stripped = stripped.replace(/\s+(and|or)\s+(and|or)\s+/gi, ' and ');
+      return stripped.trim() || (rule.name ?? '');
+    }
+
+    if (rule.condition && typeof rule.condition === 'object') {
+      const condObj = { ...(rule.condition as Record<string, unknown>) };
+      delete condObj.surface;
+      delete condObj['context.surface'];
+      return JSON.stringify(condObj);
+    }
+
+    return rule.name ?? rule.action ?? '';
+  }
+
+  private classifySeverity(action: PolicyAction | undefined): 'high' | 'medium' | 'low' {
+    if (action === 'deny' || action === 'require_approval') return 'high';
+    if (action === 'warn' || action === 'log') return 'medium';
+    return 'low';
+  }
+
+  private generateRecommendation(
+    ruleName: string,
+    presentOn: GovernanceSurface[],
+    missingFrom: GovernanceSurface[],
+    action: PolicyAction | undefined,
+  ): string {
+    const present = presentOn.join(', ');
+    const missing = missingFrom.join(', ');
+
+    if (action === 'deny' || action === 'require_approval') {
+      return (
+        `Rule "${ruleName}" enforces ${action} on ${present} but not ${missing}. ` +
+        `This creates a bypass path: users can avoid governance by switching surfaces.`
+      );
+    }
+
+    return (
+      `Rule "${ruleName}" applies on ${present} but not ${missing}. ` +
+      `Consider extending coverage for consistent governance.`
+    );
+  }
+
+  private computeCoverage(
+    mappings: SurfaceRuleMapping[],
+  ): Record<GovernanceSurface, number> {
+    const coverage: Record<GovernanceSurface, number> = { cli: 0, ide: 0, api: 0, unknown: 0 };
+    const universalCount = mappings.filter((m) => m.isUniversal).length;
+
+    for (const surface of KNOWN_SURFACES) {
+      const surfaceCount = mappings.filter(
+        (m) => !m.isUniversal && m.detectedSurfaces.includes(surface),
+      ).length;
+      coverage[surface] = surfaceCount + universalCount;
+    }
+
+    return coverage;
+  }
+
+  /**
+   * Compute a 0-100 parity score.
+   * 100 = perfect parity (all rules are universal or all surfaces equally covered).
+   * Deductions for each gap, weighted by severity.
+   */
+  private computeParityScore(
+    mappings: SurfaceRuleMapping[],
+    gaps: SurfaceGap[],
+  ): number {
+    if (mappings.length === 0) return 100;
+
+    const severityWeights = { high: 15, medium: 8, low: 3 };
+    let deductions = 0;
+    for (const gap of gaps) {
+      deductions += severityWeights[gap.severity] * gap.missingFrom.length;
+    }
+
+    return Math.max(0, Math.round(100 - deductions));
+  }
+}

--- a/agent-governance-typescript/src/types.ts
+++ b/agent-governance-typescript/src/types.ts
@@ -109,6 +109,43 @@ export interface PolicyRule {
 
   /** Whether this rule is enabled (default true). */
   enabled?: boolean;
+
+  /** Governance surfaces this rule applies to (omit for universal rules). */
+  surfaces?: GovernanceSurface[];
+}
+
+/** Governance surface where policy enforcement occurs. */
+export type GovernanceSurface = 'cli' | 'ide' | 'api' | 'unknown';
+
+/** Maps a rule to the surfaces it covers. */
+export interface SurfaceRuleMapping {
+  rule: PolicyRule;
+  policyName: string;
+  detectedSurfaces: GovernanceSurface[];
+  isUniversal: boolean;
+}
+
+/** A gap where a rule exists for one surface but not another. */
+export interface SurfaceGap {
+  ruleName: string;
+  policyName: string;
+  presentOn: GovernanceSurface[];
+  missingFrom: GovernanceSurface[];
+  ruleAction: PolicyAction | undefined;
+  severity: 'high' | 'medium' | 'low';
+  recommendation: string;
+}
+
+/** Report of governance parity analysis across surfaces. */
+export interface SurfaceParityReport {
+  analyzedAt: Date;
+  totalRules: number;
+  universalRules: number;
+  surfaceSpecificRules: number;
+  gaps: SurfaceGap[];
+  mappings: SurfaceRuleMapping[];
+  surfaceCoverage: Record<GovernanceSurface, number>;
+  parityScore: number;
 }
 
 /** A complete policy document (matches Python Policy model). */

--- a/agent-governance-typescript/tests/surface-parity.test.ts
+++ b/agent-governance-typescript/tests/surface-parity.test.ts
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { SurfaceParityChecker } from '../src/surface-parity';
+import type { Policy, PolicyRule } from '../src/types';
+
+function makePolicy(name: string, rules: PolicyRule[]): Policy {
+  return { name, rules, default_action: 'deny' };
+}
+
+describe('SurfaceParityChecker', () => {
+  let checker: SurfaceParityChecker;
+
+  beforeEach(() => {
+    checker = new SurfaceParityChecker();
+  });
+
+  describe('detectSurfaces()', () => {
+    it('returns empty array for universal rules (no surface restriction)', () => {
+      const rule: PolicyRule = {
+        name: 'block-external',
+        condition: "agent.type == 'external'",
+        ruleAction: 'deny',
+      };
+      expect(checker.detectSurfaces(rule)).toEqual([]);
+    });
+
+    it('detects surface from explicit surfaces field', () => {
+      const rule: PolicyRule = {
+        name: 'cli-only',
+        condition: "agent.type == 'external'",
+        ruleAction: 'deny',
+        surfaces: ['cli'],
+      };
+      expect(checker.detectSurfaces(rule)).toEqual(['cli']);
+    });
+
+    it('detects surface from condition string (surface == "cli")', () => {
+      const rule: PolicyRule = {
+        name: 'cli-check',
+        condition: "surface == 'cli' and agent.risk > 5",
+        ruleAction: 'deny',
+      };
+      expect(checker.detectSurfaces(rule)).toEqual(['cli']);
+    });
+
+    it('detects surface from context.surface in condition', () => {
+      const rule: PolicyRule = {
+        name: 'ide-check',
+        condition: "context.surface == 'ide'",
+        ruleAction: 'warn',
+      };
+      expect(checker.detectSurfaces(rule)).toEqual(['ide']);
+    });
+
+    it('detects multiple surfaces from in-expression', () => {
+      const rule: PolicyRule = {
+        name: 'multi-surface',
+        condition: "surface in ['cli', 'api']",
+        ruleAction: 'log',
+      };
+      const surfaces = checker.detectSurfaces(rule);
+      expect(surfaces).toContain('cli');
+      expect(surfaces).toContain('api');
+    });
+
+    it('detects surface from object-form condition', () => {
+      const rule: PolicyRule = {
+        name: 'obj-cond',
+        condition: { surface: 'api', 'agent.type': 'external' },
+        ruleAction: 'deny',
+      };
+      expect(checker.detectSurfaces(rule)).toEqual(['api']);
+    });
+
+    it('prefers explicit surfaces over condition parsing', () => {
+      const rule: PolicyRule = {
+        name: 'explicit-wins',
+        condition: "surface == 'cli'",
+        ruleAction: 'deny',
+        surfaces: ['ide', 'api'],
+      };
+      expect(checker.detectSurfaces(rule)).toEqual(['ide', 'api']);
+    });
+  });
+
+  describe('analyzePolicies()', () => {
+    it('reports no gaps for all-universal rules', () => {
+      const policy = makePolicy('universal-policy', [
+        { name: 'rule-a', condition: "agent.type == 'external'", ruleAction: 'deny' },
+        { name: 'rule-b', condition: 'agent.risk >= 8', ruleAction: 'require_approval' },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.totalRules).toBe(2);
+      expect(report.universalRules).toBe(2);
+      expect(report.surfaceSpecificRules).toBe(0);
+      expect(report.gaps).toHaveLength(0);
+      expect(report.parityScore).toBe(100);
+    });
+
+    it('detects CLI-only deny rule as high severity gap', () => {
+      const policy = makePolicy('cli-only-policy', [
+        { name: 'block-external', condition: "surface == 'cli' and agent.type == 'external'", ruleAction: 'deny' },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.gaps).toHaveLength(1);
+      expect(report.gaps[0].severity).toBe('high');
+      expect(report.gaps[0].presentOn).toEqual(['cli']);
+      expect(report.gaps[0].missingFrom).toContain('ide');
+      expect(report.gaps[0].missingFrom).toContain('api');
+    });
+
+    it('no gap when all surfaces covered explicitly', () => {
+      const policy = makePolicy('full-coverage', [
+        { name: 'rule-cli', surfaces: ['cli'], condition: "agent.type == 'external'", ruleAction: 'deny' },
+        { name: 'rule-ide', surfaces: ['ide'], condition: "agent.type == 'external'", ruleAction: 'deny' },
+        { name: 'rule-api', surfaces: ['api'], condition: "agent.type == 'external'", ruleAction: 'deny' },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.gaps).toHaveLength(0);
+    });
+
+    it('skips disabled rules', () => {
+      const policy = makePolicy('disabled-policy', [
+        { name: 'disabled-rule', surfaces: ['cli'], condition: "agent.type == 'external'", ruleAction: 'deny', enabled: false },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.totalRules).toBe(0);
+      expect(report.gaps).toHaveLength(0);
+    });
+
+    it('classifies warn/log gaps as medium severity', () => {
+      const policy = makePolicy('warn-policy', [
+        { name: 'warn-rule', surfaces: ['ide'], condition: 'agent.risk >= 3', ruleAction: 'warn' },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.gaps).toHaveLength(1);
+      expect(report.gaps[0].severity).toBe('medium');
+    });
+
+    it('classifies allow gaps as low severity', () => {
+      const policy = makePolicy('allow-policy', [
+        { name: 'allow-rule', surfaces: ['api'], condition: 'agent.trusted', ruleAction: 'allow' },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.gaps).toHaveLength(1);
+      expect(report.gaps[0].severity).toBe('low');
+    });
+
+    it('handles empty policies', () => {
+      const report = checker.analyzePolicies([]);
+      expect(report.totalRules).toBe(0);
+      expect(report.gaps).toHaveLength(0);
+      expect(report.parityScore).toBe(100);
+    });
+
+    it('handles policies with no rules', () => {
+      const report = checker.analyzePolicies([makePolicy('empty', [])]);
+      expect(report.totalRules).toBe(0);
+      expect(report.parityScore).toBe(100);
+    });
+
+    it('computes surface coverage including universal rules', () => {
+      const policy = makePolicy('mixed', [
+        { name: 'universal', condition: 'agent.risk >= 9', ruleAction: 'deny' },
+        { name: 'cli-only', surfaces: ['cli'], condition: 'agent.risk >= 5', ruleAction: 'warn' },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.surfaceCoverage.cli).toBe(2);
+      expect(report.surfaceCoverage.ide).toBe(1);
+      expect(report.surfaceCoverage.api).toBe(1);
+    });
+
+    it('analyzes across multiple policies', () => {
+      const policies = [
+        makePolicy('policy-a', [
+          { name: 'deny-external', surfaces: ['cli'], condition: "agent.type == 'external'", ruleAction: 'deny' },
+        ]),
+        makePolicy('policy-b', [
+          { name: 'deny-external', surfaces: ['ide'], condition: "agent.type == 'external'", ruleAction: 'deny' },
+        ]),
+      ];
+      const report = checker.analyzePolicies(policies);
+      // cli + ide covered, only api missing
+      expect(report.gaps).toHaveLength(1);
+      expect(report.gaps[0].missingFrom).toEqual(['api']);
+    });
+
+    it('generates recommendation with bypass warning for deny gaps', () => {
+      const policy = makePolicy('test', [
+        { name: 'block-untrusted', surfaces: ['cli'], condition: "trust == 'none'", ruleAction: 'deny' },
+      ]);
+      const report = checker.analyzePolicies([policy]);
+      expect(report.gaps[0].recommendation).toContain('bypass');
+    });
+
+    it('parity score decreases with high-severity gaps', () => {
+      const noGaps = checker.analyzePolicies([
+        makePolicy('all-universal', [
+          { name: 'r1', condition: 'agent.risk >= 9', ruleAction: 'deny' },
+        ]),
+      ]);
+      const withGaps = checker.analyzePolicies([
+        makePolicy('cli-only', [
+          { name: 'r1', surfaces: ['cli'], condition: 'agent.risk >= 9', ruleAction: 'deny' },
+        ]),
+      ]);
+      expect(noGaps.parityScore).toBeGreaterThan(withGaps.parityScore);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds SurfaceParityChecker to detect governance enforcement gaps across surfaces (CLI, IDE, API).

## Problem

Organizations deploy governance policies that may be enforced differently depending on the surface (CLI tools, IDE extensions, API calls). A deny rule that only applies to CLI usage creates a bypass path where users can avoid governance by switching to IDE or API.

## Solution

- **New types**: \GovernanceSurface\, \SurfaceRuleMapping\, \SurfaceGap\, \SurfaceParityReport\
- **Optional \surfaces\ field** on \PolicyRule\ for explicit surface targeting
- **\SurfaceParityChecker\** class that:
  - Detects surfaces from explicit metadata or condition expression parsing
  - Groups rules by normalized semantics (action + non-surface conditions) to find gaps
  - Classifies gap severity (high for deny/require_approval, medium for warn/log, low for allow)
  - Computes a 0-100 parity score
  - Generates actionable recommendations
- **\dataToPolicy()\** updated to parse \surfaces\ from policy documents
- **19 tests** covering surface detection, gap analysis, severity classification, and edge cases

## Test Results

All 283 tests pass (22 suites), including 19 new surface parity tests.

Closes #1369