### PR TITLE
feat(cascade): add cascading failure containment for multi-agent systems (OWASP ASI-08)

### DIFF
--- a/agent-governance-typescript/src/cascade-containment.ts
+++ b/agent-governance-typescript/src/cascade-containment.ts
@@ -1,0 +1,480 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { randomUUID } from 'crypto';
+import { CircuitBreaker, type CircuitBreakerState } from './metrics';
+import type {
+  AgentHealthStatus,
+  AgentNode,
+  BlastRadiusPolicy,
+  CascadeAction,
+  CascadeAnalysis,
+  CascadeContainmentConfig,
+  CascadeEvent,
+  TrustTier,
+} from './types';
+
+const DEFAULT_BLAST_RADIUS_POLICY: BlastRadiusPolicy = {
+  maxDependencyDepth: 5,
+  maxFanout: 10,
+  circuitBreakerThreshold: 5,
+  circuitBreakerResetMs: 30_000,
+  autoQuarantine: true,
+  autoRollback: false,
+};
+
+const TIER_DEFAULTS: Record<TrustTier, Partial<BlastRadiusPolicy>> = {
+  Untrusted: {
+    maxDependencyDepth: 2,
+    maxFanout: 3,
+    circuitBreakerThreshold: 3,
+    autoQuarantine: true,
+    autoRollback: true,
+  },
+  Provisional: {
+    maxDependencyDepth: 3,
+    maxFanout: 5,
+    circuitBreakerThreshold: 4,
+    autoQuarantine: true,
+    autoRollback: false,
+  },
+  Trusted: {
+    maxDependencyDepth: 5,
+    maxFanout: 10,
+    circuitBreakerThreshold: 5,
+    autoQuarantine: false,
+    autoRollback: false,
+  },
+  Verified: {
+    maxDependencyDepth: 8,
+    maxFanout: 20,
+    circuitBreakerThreshold: 8,
+    autoQuarantine: false,
+    autoRollback: false,
+  },
+};
+
+/**
+ * Manages cascading failure containment for multi-agent systems (OWASP ASI-08).
+ *
+ * Tracks agent dependency graphs, maintains per-link circuit breakers,
+ * and applies blast radius policies based on trust tier to contain
+ * failures before they propagate through the system.
+ */
+export class CascadeContainmentManager {
+  private readonly nodes = new Map<string, AgentNode>();
+  private readonly breakers = new Map<string, CircuitBreaker>();
+  private readonly events: CascadeEvent[] = [];
+  private readonly config: CascadeContainmentConfig;
+
+  constructor(config?: Partial<CascadeContainmentConfig>) {
+    this.config = {
+      defaultPolicy: { ...DEFAULT_BLAST_RADIUS_POLICY, ...config?.defaultPolicy },
+      tierPolicies: config?.tierPolicies,
+      cascadeThreshold: config?.cascadeThreshold ?? 3,
+    };
+  }
+
+  /**
+   * Register an agent in the dependency graph.
+   */
+  registerAgent(agentId: string, trustTier: TrustTier = 'Provisional'): AgentNode {
+    if (this.nodes.has(agentId)) {
+      return this.nodes.get(agentId)!;
+    }
+
+    const node: AgentNode = {
+      agentId,
+      trustTier,
+      healthStatus: 'healthy',
+      dependencies: [],
+      dependents: [],
+      lastHealthCheck: new Date().toISOString(),
+    };
+
+    this.nodes.set(agentId, node);
+    return node;
+  }
+
+  /**
+   * Declare a dependency: `fromAgent` depends on `toAgent`.
+   * Creates a circuit breaker for this link.
+   */
+  addDependency(fromAgent: string, toAgent: string): void {
+    this.ensureAgent(fromAgent);
+    this.ensureAgent(toAgent);
+
+    const from = this.nodes.get(fromAgent)!;
+    const to = this.nodes.get(toAgent)!;
+
+    if (!from.dependencies.includes(toAgent)) {
+      const policy = this.getPolicyForAgent(fromAgent);
+
+      if (from.dependencies.length >= policy.maxFanout) {
+        throw new Error(
+          `Agent "${fromAgent}" exceeds max fanout (${policy.maxFanout}) for tier ${from.trustTier}`,
+        );
+      }
+
+      const depth = this.getDepthTo(toAgent) + 1;
+      if (depth > policy.maxDependencyDepth) {
+        throw new Error(
+          `Dependency depth ${depth} exceeds max (${policy.maxDependencyDepth}) for tier ${from.trustTier}`,
+        );
+      }
+
+      from.dependencies.push(toAgent);
+      to.dependents.push(fromAgent);
+
+      const linkKey = this.linkKey(fromAgent, toAgent);
+      if (!this.breakers.has(linkKey)) {
+        this.breakers.set(
+          linkKey,
+          new CircuitBreaker(policy.circuitBreakerThreshold, policy.circuitBreakerResetMs),
+        );
+      }
+    }
+  }
+
+  /**
+   * Check if an agent can call its dependency (circuit breaker is not open).
+   */
+  canCall(fromAgent: string, toAgent: string): boolean {
+    const breaker = this.breakers.get(this.linkKey(fromAgent, toAgent));
+    if (!breaker) return true;
+    return breaker.canExecute();
+  }
+
+  /**
+   * Record a successful call between agents.
+   */
+  recordSuccess(fromAgent: string, toAgent: string): void {
+    const breaker = this.breakers.get(this.linkKey(fromAgent, toAgent));
+    if (breaker) {
+      breaker.onSuccess();
+    }
+
+    const target = this.nodes.get(toAgent);
+    if (target && target.healthStatus !== 'healthy') {
+      target.healthStatus = 'healthy';
+      target.lastHealthCheck = new Date().toISOString();
+    }
+  }
+
+  /**
+   * Record a failed call between agents. May trigger containment actions.
+   */
+  recordFailure(fromAgent: string, toAgent: string, reason: string = 'call failed'): CascadeEvent[] {
+    const triggered: CascadeEvent[] = [];
+    const breaker = this.breakers.get(this.linkKey(fromAgent, toAgent));
+
+    if (breaker) {
+      breaker.onFailure();
+
+      if (breaker.state === 'open') {
+        const evt = this.emitEvent(toAgent, [fromAgent], 'circuit_opened', reason);
+        triggered.push(evt);
+      }
+    }
+
+    // Update health status of target agent
+    const target = this.nodes.get(toAgent);
+    if (target) {
+      const openBreakersToTarget = this.countOpenBreakersTo(toAgent);
+      if (openBreakersToTarget >= (this.config.cascadeThreshold ?? 3)) {
+        target.healthStatus = 'failing';
+      } else if (openBreakersToTarget > 0) {
+        target.healthStatus = 'degraded';
+      }
+      target.lastHealthCheck = new Date().toISOString();
+    }
+
+    // Apply containment based on policy
+    const containmentEvents = this.applyContainment(toAgent, reason);
+    triggered.push(...containmentEvents);
+
+    return triggered;
+  }
+
+  /**
+   * Propagate health status through dependency graph.
+   * When a node fails, its dependents are notified and may degrade.
+   */
+  propagateHealth(agentId: string): CascadeEvent[] {
+    const triggered: CascadeEvent[] = [];
+    const node = this.nodes.get(agentId);
+    if (!node) return triggered;
+
+    if (node.healthStatus !== 'failing' && node.healthStatus !== 'unreachable') {
+      return triggered;
+    }
+
+    const affected: string[] = [];
+    for (const dependentId of node.dependents) {
+      const dependent = this.nodes.get(dependentId);
+      if (dependent && dependent.healthStatus === 'healthy') {
+        dependent.healthStatus = 'degraded';
+        dependent.lastHealthCheck = new Date().toISOString();
+        affected.push(dependentId);
+      }
+    }
+
+    if (affected.length > 0) {
+      const evt = this.emitEvent(
+        agentId,
+        affected,
+        'health_propagated',
+        `Health degradation propagated from ${agentId}`,
+      );
+      triggered.push(evt);
+
+      // Recursive propagation for transitive dependents
+      for (const affectedId of affected) {
+        const deeper = this.propagateHealth(affectedId);
+        triggered.push(...deeper);
+      }
+    }
+
+    return triggered;
+  }
+
+  /**
+   * Compute the blast radius for a given agent: how many agents would
+   * be affected if this agent fails completely.
+   */
+  computeBlastRadius(agentId: string): number {
+    const visited = new Set<string>();
+    this.collectDependents(agentId, visited);
+    visited.delete(agentId);
+    return visited.size;
+  }
+
+  /**
+   * Analyze the current state of the agent graph for cascade risk.
+   */
+  analyze(): CascadeAnalysis {
+    let healthyAgents = 0;
+    let degradedAgents = 0;
+    let failingAgents = 0;
+
+    for (const node of this.nodes.values()) {
+      switch (node.healthStatus) {
+        case 'healthy':
+          healthyAgents++;
+          break;
+        case 'degraded':
+          degradedAgents++;
+          break;
+        case 'failing':
+        case 'unreachable':
+          failingAgents++;
+          break;
+      }
+    }
+
+    let openCircuitBreakers = 0;
+    for (const breaker of this.breakers.values()) {
+      if (breaker.state === 'open') {
+        openCircuitBreakers++;
+      }
+    }
+
+    const blastRadiusMap: Record<string, number> = {};
+    for (const agentId of this.nodes.keys()) {
+      blastRadiusMap[agentId] = this.computeBlastRadius(agentId);
+    }
+
+    const totalAgents = this.nodes.size;
+    const cascadeRisk = this.assessCascadeRisk(
+      failingAgents,
+      degradedAgents,
+      totalAgents,
+      openCircuitBreakers,
+    );
+
+    return {
+      totalAgents,
+      healthyAgents,
+      degradedAgents,
+      failingAgents,
+      openCircuitBreakers,
+      cascadeRisk,
+      blastRadiusMap,
+      events: [...this.events],
+    };
+  }
+
+  /**
+   * Get the dependency graph as a list of agent nodes.
+   */
+  getGraph(): AgentNode[] {
+    return [...this.nodes.values()].map((n) => ({ ...n }));
+  }
+
+  /**
+   * Get the circuit breaker state for a specific link.
+   */
+  getBreakerState(fromAgent: string, toAgent: string): CircuitBreakerState | undefined {
+    return this.breakers.get(this.linkKey(fromAgent, toAgent))?.state;
+  }
+
+  /**
+   * Get all containment events.
+   */
+  getEvents(): CascadeEvent[] {
+    return [...this.events];
+  }
+
+  /**
+   * Get the effective blast radius policy for an agent.
+   */
+  getPolicyForAgent(agentId: string): BlastRadiusPolicy {
+    const node = this.nodes.get(agentId);
+    const tier = node?.trustTier ?? 'Provisional';
+    return this.getPolicyForTier(tier);
+  }
+
+  /**
+   * Get the effective blast radius policy for a trust tier.
+   */
+  getPolicyForTier(tier: TrustTier): BlastRadiusPolicy {
+    const tierOverrides = this.config.tierPolicies?.[tier] ?? TIER_DEFAULTS[tier];
+    return { ...this.config.defaultPolicy, ...tierOverrides };
+  }
+
+  /**
+   * Reset a specific agent back to healthy status.
+   */
+  resetAgent(agentId: string): void {
+    const node = this.nodes.get(agentId);
+    if (node) {
+      node.healthStatus = 'healthy';
+      node.lastHealthCheck = new Date().toISOString();
+    }
+  }
+
+  // ── Internal helpers ──
+
+  private ensureAgent(agentId: string): void {
+    if (!this.nodes.has(agentId)) {
+      this.registerAgent(agentId);
+    }
+  }
+
+  private linkKey(from: string, to: string): string {
+    return `${from}->${to}`;
+  }
+
+  private countOpenBreakersTo(agentId: string): number {
+    const node = this.nodes.get(agentId);
+    if (!node) return 0;
+
+    let count = 0;
+    for (const depId of node.dependents) {
+      const breaker = this.breakers.get(this.linkKey(depId, agentId));
+      if (breaker && breaker.state === 'open') {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private getDepthTo(agentId: string, visited = new Set<string>()): number {
+    if (visited.has(agentId)) return 0;
+    visited.add(agentId);
+
+    const node = this.nodes.get(agentId);
+    if (!node || node.dependencies.length === 0) return 0;
+
+    let maxDepth = 0;
+    for (const dep of node.dependencies) {
+      maxDepth = Math.max(maxDepth, 1 + this.getDepthTo(dep, visited));
+    }
+    return maxDepth;
+  }
+
+  private collectDependents(agentId: string, visited: Set<string>): void {
+    if (visited.has(agentId)) return;
+    visited.add(agentId);
+
+    const node = this.nodes.get(agentId);
+    if (!node) return;
+
+    for (const depId of node.dependents) {
+      this.collectDependents(depId, visited);
+    }
+  }
+
+  private applyContainment(agentId: string, reason: string): CascadeEvent[] {
+    const triggered: CascadeEvent[] = [];
+    const node = this.nodes.get(agentId);
+    if (!node) return triggered;
+
+    const policy = this.getPolicyForAgent(agentId);
+
+    if (node.healthStatus === 'failing' && policy.autoQuarantine) {
+      node.healthStatus = 'unreachable';
+      const evt = this.emitEvent(
+        agentId,
+        [agentId],
+        'agent_quarantined',
+        `Auto-quarantined: ${reason}`,
+      );
+      triggered.push(evt);
+
+      // Propagate health to dependents
+      const propagated = this.propagateHealth(agentId);
+      triggered.push(...propagated);
+    }
+
+    if (node.healthStatus === 'unreachable' && policy.autoRollback) {
+      const evt = this.emitEvent(
+        agentId,
+        [agentId],
+        'rollback_triggered',
+        `Auto-rollback triggered: ${reason}`,
+      );
+      triggered.push(evt);
+    }
+
+    return triggered;
+  }
+
+  private assessCascadeRisk(
+    failing: number,
+    degraded: number,
+    total: number,
+    openBreakers: number,
+  ): 'low' | 'medium' | 'high' | 'critical' {
+    if (total === 0) return 'low';
+
+    const failRatio = failing / total;
+    const degradeRatio = degraded / total;
+
+    if (failRatio >= 0.3 || openBreakers >= 5) return 'critical';
+    if (failRatio >= 0.15 || degradeRatio >= 0.3) return 'high';
+    if (failRatio > 0 || degradeRatio >= 0.15) return 'medium';
+    return 'low';
+  }
+
+  private emitEvent(
+    sourceAgentId: string,
+    affectedAgentIds: string[],
+    action: CascadeAction,
+    reason: string,
+  ): CascadeEvent {
+    const blastRadius = this.computeBlastRadius(sourceAgentId);
+    const event: CascadeEvent = {
+      eventId: randomUUID(),
+      timestamp: new Date().toISOString(),
+      sourceAgentId,
+      affectedAgentIds,
+      action,
+      reason,
+      blastRadius,
+      containedAt: this.events.length,
+    };
+    this.events.push(event);
+    return event;
+  }
+}

--- a/agent-governance-typescript/src/index.ts
+++ b/agent-governance-typescript/src/index.ts
@@ -26,6 +26,7 @@ export { PromptDefenseEvaluator } from './prompt-defense';
 export { RingEnforcer, RingBreachError } from './rings';
 export { GovernanceVerifier } from './verify';
 export { SurfaceParityChecker } from './surface-parity';
+export { CascadeContainmentManager } from './cascade-containment';
 
 // E2E Encryption (AgentMesh Wire Protocol v1.0)
 export {
@@ -77,6 +78,13 @@ export type {
   SurfaceRuleMapping,
   SurfaceGap,
   SurfaceParityReport,
+  AgentHealthStatus,
+  AgentNode,
+  BlastRadiusPolicy,
+  CascadeAction,
+  CascadeAnalysis,
+  CascadeContainmentConfig,
+  CascadeEvent,
 } from './types';
 export type { PromptDefenseConfig, PromptDefenseFinding, PromptDefenseReport } from './prompt-defense';
 export type {

--- a/agent-governance-typescript/src/types.ts
+++ b/agent-governance-typescript/src/types.ts
@@ -265,6 +265,69 @@ export interface KillSwitchResult {
   handoffAgentId?: string;
 }
 
+// ΓöÇΓöÇ Cascade Containment ΓöÇΓöÇ
+
+/** Configuration for blast radius containment, keyed by trust tier. */
+export interface BlastRadiusPolicy {
+  maxDependencyDepth: number;
+  maxFanout: number;
+  circuitBreakerThreshold: number;
+  circuitBreakerResetMs: number;
+  autoQuarantine: boolean;
+  autoRollback: boolean;
+}
+
+/** Agent node in the dependency graph. */
+export interface AgentNode {
+  agentId: string;
+  trustTier: TrustTier;
+  healthStatus: AgentHealthStatus;
+  dependencies: string[];
+  dependents: string[];
+  lastHealthCheck?: string;
+}
+
+export type AgentHealthStatus = 'healthy' | 'degraded' | 'failing' | 'unreachable';
+
+/** Event emitted when a cascade containment action is taken. */
+export interface CascadeEvent {
+  eventId: string;
+  timestamp: string;
+  sourceAgentId: string;
+  affectedAgentIds: string[];
+  action: CascadeAction;
+  reason: string;
+  blastRadius: number;
+  containedAt: number;
+}
+
+export type CascadeAction =
+  | 'circuit_opened'
+  | 'agent_degraded'
+  | 'agent_quarantined'
+  | 'agent_killed'
+  | 'rollback_triggered'
+  | 'health_propagated';
+
+/** Configuration for cascade containment. */
+export interface CascadeContainmentConfig {
+  defaultPolicy: BlastRadiusPolicy;
+  tierPolicies?: Partial<Record<TrustTier, Partial<BlastRadiusPolicy>>>;
+  cascadeThreshold?: number;
+}
+
+/** Summary of cascade containment analysis. */
+export interface CascadeAnalysis {
+  totalAgents: number;
+  healthyAgents: number;
+  degradedAgents: number;
+  failingAgents: number;
+  openCircuitBreakers: number;
+  cascadeRisk: 'low' | 'medium' | 'high' | 'critical';
+  blastRadiusMap: Record<string, number>;
+  events: CascadeEvent[];
+}
+
 // ΓöÇΓöÇ Audit ΓöÇΓöÇ
 
 export interface AuditConfig {

--- a/agent-governance-typescript/tests/cascade-containment.test.ts
+++ b/agent-governance-typescript/tests/cascade-containment.test.ts
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { CascadeContainmentManager } from '../src/cascade-containment';
+
+describe('CascadeContainmentManager', () => {
+  let manager: CascadeContainmentManager;
+
+  beforeEach(() => {
+    manager = new CascadeContainmentManager();
+  });
+
+  describe('registerAgent()', () => {
+    it('registers an agent with default trust tier', () => {
+      const node = manager.registerAgent('agent-a');
+      expect(node.agentId).toBe('agent-a');
+      expect(node.trustTier).toBe('Provisional');
+      expect(node.healthStatus).toBe('healthy');
+    });
+
+    it('registers an agent with specified trust tier', () => {
+      const node = manager.registerAgent('agent-a', 'Verified');
+      expect(node.trustTier).toBe('Verified');
+    });
+
+    it('returns existing node on duplicate registration', () => {
+      const first = manager.registerAgent('agent-a', 'Trusted');
+      const second = manager.registerAgent('agent-a', 'Untrusted');
+      expect(second.trustTier).toBe('Trusted');
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('addDependency()', () => {
+    it('creates a dependency link between two agents', () => {
+      manager.registerAgent('a');
+      manager.registerAgent('b');
+      manager.addDependency('a', 'b');
+
+      const graph = manager.getGraph();
+      const nodeA = graph.find((n) => n.agentId === 'a')!;
+      const nodeB = graph.find((n) => n.agentId === 'b')!;
+
+      expect(nodeA.dependencies).toContain('b');
+      expect(nodeB.dependents).toContain('a');
+    });
+
+    it('auto-registers agents if not yet registered', () => {
+      manager.addDependency('x', 'y');
+      expect(manager.getGraph()).toHaveLength(2);
+    });
+
+    it('does not duplicate dependencies', () => {
+      manager.addDependency('a', 'b');
+      manager.addDependency('a', 'b');
+      const nodeA = manager.getGraph().find((n) => n.agentId === 'a')!;
+      expect(nodeA.dependencies.filter((d) => d === 'b')).toHaveLength(1);
+    });
+
+    it('enforces max fanout per trust tier', () => {
+      manager.registerAgent('hub', 'Untrusted');
+      // Untrusted default maxFanout is 3
+      manager.addDependency('hub', 'dep-1');
+      manager.addDependency('hub', 'dep-2');
+      manager.addDependency('hub', 'dep-3');
+      expect(() => manager.addDependency('hub', 'dep-4')).toThrow(/max fanout/);
+    });
+
+    it('enforces max dependency depth per trust tier', () => {
+      // Untrusted maxDependencyDepth is 2
+      manager.registerAgent('a', 'Untrusted');
+      manager.registerAgent('b');
+      manager.registerAgent('c');
+      manager.registerAgent('d');
+      manager.addDependency('b', 'c');
+      manager.addDependency('c', 'd');
+      // a -> b (depth via b is 2+1=3 > 2)
+      expect(() => manager.addDependency('a', 'b')).toThrow(/depth/);
+    });
+  });
+
+  describe('canCall() / recordSuccess() / recordFailure()', () => {
+    beforeEach(() => {
+      manager.registerAgent('caller');
+      manager.registerAgent('callee');
+      manager.addDependency('caller', 'callee');
+    });
+
+    it('allows calls when circuit breaker is closed', () => {
+      expect(manager.canCall('caller', 'callee')).toBe(true);
+    });
+
+    it('opens circuit breaker after threshold failures', () => {
+      // Default Provisional threshold is 4
+      for (let i = 0; i < 4; i++) {
+        manager.recordFailure('caller', 'callee', 'timeout');
+      }
+      expect(manager.canCall('caller', 'callee')).toBe(false);
+      expect(manager.getBreakerState('caller', 'callee')).toBe('open');
+    });
+
+    it('emits circuit_opened event when breaker trips', () => {
+      for (let i = 0; i < 4; i++) {
+        manager.recordFailure('caller', 'callee', 'timeout');
+      }
+      const events = manager.getEvents();
+      expect(events.some((e) => e.action === 'circuit_opened')).toBe(true);
+    });
+
+    it('resets circuit breaker on success', () => {
+      for (let i = 0; i < 3; i++) {
+        manager.recordFailure('caller', 'callee');
+      }
+      manager.recordSuccess('caller', 'callee');
+      expect(manager.getBreakerState('caller', 'callee')).toBe('closed');
+    });
+
+    it('returns true for unregistered links', () => {
+      expect(manager.canCall('unknown-a', 'unknown-b')).toBe(true);
+    });
+  });
+
+  describe('health propagation', () => {
+    it('propagates health degradation to dependents', () => {
+      // Use Trusted agents (no auto-quarantine) with low cascade threshold
+      const mgr = new CascadeContainmentManager({ cascadeThreshold: 1 });
+      mgr.registerAgent('a', 'Trusted');
+      mgr.registerAgent('b', 'Trusted');
+      mgr.registerAgent('c', 'Trusted');
+      mgr.addDependency('a', 'b');
+      mgr.addDependency('b', 'c');
+
+      // Trip breaker b->c (Trusted threshold is 5)
+      for (let i = 0; i < 6; i++) {
+        mgr.recordFailure('b', 'c', 'fail');
+      }
+
+      // c is now 'failing' (Trusted doesn't auto-quarantine)
+      expect(mgr.getGraph().find((n) => n.agentId === 'c')!.healthStatus).toBe('failing');
+
+      // Propagate to b (which depends on c as a dependency, but c's dependent is b)
+      const events = mgr.propagateHealth('c');
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0].action).toBe('health_propagated');
+      expect(mgr.getGraph().find((n) => n.agentId === 'b')!.healthStatus).toBe('degraded');
+    });
+
+    it('does not propagate from healthy agents', () => {
+      manager.registerAgent('a');
+      manager.registerAgent('b');
+      manager.registerAgent('c');
+      manager.addDependency('a', 'b');
+      manager.addDependency('b', 'c');
+      const events = manager.propagateHealth('c');
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe('blast radius', () => {
+    it('computes zero blast radius for leaf nodes', () => {
+      manager.registerAgent('leaf');
+      expect(manager.computeBlastRadius('leaf')).toBe(0);
+    });
+
+    it('computes blast radius for node with dependents', () => {
+      // a, b, c all depend on service-x
+      manager.registerAgent('service-x');
+      manager.addDependency('a', 'service-x');
+      manager.addDependency('b', 'service-x');
+      manager.addDependency('c', 'service-x');
+      expect(manager.computeBlastRadius('service-x')).toBe(3);
+    });
+
+    it('computes transitive blast radius', () => {
+      // gateway -> service -> database
+      // gateway depends on service, client depends on gateway
+      manager.addDependency('client', 'gateway');
+      manager.addDependency('gateway', 'service');
+      manager.addDependency('service', 'database');
+      // database failing affects service, gateway, client
+      expect(manager.computeBlastRadius('database')).toBe(3);
+    });
+  });
+
+  describe('containment policies', () => {
+    it('applies stricter policy for untrusted agents', () => {
+      const untrustedPolicy = manager.getPolicyForTier('Untrusted');
+      const verifiedPolicy = manager.getPolicyForTier('Verified');
+      expect(untrustedPolicy.maxFanout).toBeLessThan(verifiedPolicy.maxFanout);
+      expect(untrustedPolicy.circuitBreakerThreshold).toBeLessThan(verifiedPolicy.circuitBreakerThreshold);
+      expect(untrustedPolicy.autoQuarantine).toBe(true);
+    });
+
+    it('auto-quarantines untrusted failing agent', () => {
+      manager.registerAgent('bad-agent', 'Untrusted');
+      manager.registerAgent('victim');
+      manager.registerAgent('victim-2');
+      manager.registerAgent('victim-3');
+      manager.addDependency('victim', 'bad-agent');
+      manager.addDependency('victim-2', 'bad-agent');
+      manager.addDependency('victim-3', 'bad-agent');
+
+      // Provisional callers have threshold 4, need 4+ failures to trip each breaker
+      for (let i = 0; i < 5; i++) {
+        manager.recordFailure('victim', 'bad-agent', 'error');
+      }
+      for (let i = 0; i < 5; i++) {
+        manager.recordFailure('victim-2', 'bad-agent', 'error');
+      }
+      for (let i = 0; i < 5; i++) {
+        manager.recordFailure('victim-3', 'bad-agent', 'error');
+      }
+
+      const events = manager.getEvents();
+      expect(events.some((e) => e.action === 'agent_quarantined')).toBe(true);
+    });
+
+    it('does not auto-quarantine verified agents by default', () => {
+      manager.registerAgent('trusted-svc', 'Verified');
+      manager.registerAgent('caller-1');
+      manager.addDependency('caller-1', 'trusted-svc');
+
+      for (let i = 0; i < 10; i++) {
+        manager.recordFailure('caller-1', 'trusted-svc', 'error');
+      }
+
+      const events = manager.getEvents();
+      expect(events.some((e) => e.action === 'agent_quarantined')).toBe(false);
+    });
+
+    it('allows custom policy overrides', () => {
+      const custom = new CascadeContainmentManager({
+        defaultPolicy: {
+          maxDependencyDepth: 2,
+          maxFanout: 2,
+          circuitBreakerThreshold: 2,
+          circuitBreakerResetMs: 1000,
+          autoQuarantine: true,
+          autoRollback: true,
+        },
+      });
+      const policy = custom.getPolicyForTier('Verified');
+      expect(policy.maxFanout).toBe(20); // Tier defaults override
+    });
+  });
+
+  describe('analyze()', () => {
+    it('returns correct analysis for healthy graph', () => {
+      manager.registerAgent('a');
+      manager.registerAgent('b');
+      manager.addDependency('a', 'b');
+
+      const analysis = manager.analyze();
+      expect(analysis.totalAgents).toBe(2);
+      expect(analysis.healthyAgents).toBe(2);
+      expect(analysis.cascadeRisk).toBe('low');
+    });
+
+    it('returns correct analysis for degraded graph', () => {
+      manager.registerAgent('a');
+      manager.registerAgent('b');
+      manager.addDependency('a', 'b');
+
+      // Trip breaker to degrade
+      for (let i = 0; i < 5; i++) {
+        manager.recordFailure('a', 'b', 'fail');
+      }
+
+      const analysis = manager.analyze();
+      expect(analysis.openCircuitBreakers).toBeGreaterThan(0);
+      expect(analysis.cascadeRisk).not.toBe('low');
+    });
+
+    it('includes blast radius map', () => {
+      manager.addDependency('a', 'b');
+      manager.addDependency('c', 'b');
+
+      const analysis = manager.analyze();
+      expect(analysis.blastRadiusMap['b']).toBe(2);
+    });
+
+    it('returns empty analysis for empty graph', () => {
+      const analysis = manager.analyze();
+      expect(analysis.totalAgents).toBe(0);
+      expect(analysis.cascadeRisk).toBe('low');
+    });
+  });
+
+  describe('resetAgent()', () => {
+    it('resets a failing agent to healthy', () => {
+      manager.registerAgent('svc', 'Untrusted');
+      manager.addDependency('caller', 'svc');
+      for (let i = 0; i < 10; i++) {
+        manager.recordFailure('caller', 'svc');
+      }
+
+      manager.resetAgent('svc');
+      const node = manager.getGraph().find((n) => n.agentId === 'svc')!;
+      expect(node.healthStatus).toBe('healthy');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements \CascadeContainmentManager\ for OWASP ASI-08 cascading failure containment in multi-agent systems.

## Problem

When agents form dependency chains, a single failing agent can cascade failures through the entire system. Without containment, blast radius is unbounded.

## Solution

**\CascadeContainmentManager\** class that:
- Tracks agent dependency graphs with fanout and depth enforcement
- Maintains per-link circuit breakers (configurable per trust tier)
- Computes blast radius (how many agents are affected if one fails)
- Propagates health status through dependency chains
- Auto-quarantines failing agents based on trust tier policy
- Triggers rollback for Untrusted agents
- Provides cascade risk analysis (low/medium/high/critical)

**Trust-tier-aware blast radius policies:**
| Tier | Max Depth | Max Fanout | Breaker Threshold | Auto-Quarantine | Auto-Rollback |
|------|-----------|------------|-------------------|-----------------|---------------|
| Untrusted | 2 | 3 | 3 | Yes | Yes |
| Provisional | 3 | 5 | 4 | Yes | No |
| Trusted | 5 | 10 | 5 | No | No |
| Verified | 8 | 20 | 8 | No | No |

**New types:** \BlastRadiusPolicy\, \AgentNode\, \AgentHealthStatus\, \CascadeEvent\, \CascadeAction\, \CascadeContainmentConfig\, \CascadeAnalysis\

## Test Results

All 310 tests pass (23 suites), including 27 new cascade containment tests.

Closes #1368