### PR TITLE
feat(oci): add OCI manifest adapter for AI Card spec alignment

### DIFF
--- a/agent-governance-typescript/src/index.ts
+++ b/agent-governance-typescript/src/index.ts
@@ -28,6 +28,7 @@ export { GovernanceVerifier } from './verify';
 export { SurfaceParityChecker } from './surface-parity';
 export { CascadeContainmentManager } from './cascade-containment';
 export { ContextPoisoningDetector } from './context-poisoning';
+export { OciManifestAdapter } from './oci-manifest';
 
 // E2E Encryption (AgentMesh Wire Protocol v1.0)
 export {
@@ -92,6 +93,13 @@ export type {
   PoisoningFinding,
   ContextPoisoningScanResult,
   ContextIsolationViolation,
+  OciManifest,
+  OciDescriptor,
+  AICard,
+  AICardSkill,
+  AICardCapabilities,
+  AICardInvocation,
+  OciPackageResult,
 } from './types';
 export type { PromptDefenseConfig, PromptDefenseFinding, PromptDefenseReport } from './prompt-defense';
 export type {

--- a/agent-governance-typescript/src/oci-manifest.ts
+++ b/agent-governance-typescript/src/oci-manifest.ts
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { createHash } from 'crypto';
+import type {
+  AgentIdentityJSON,
+  AICard,
+  AICardCapabilities,
+  AICardSkill,
+  OciDescriptor,
+  OciManifest,
+  OciPackageResult,
+  PolicyRule,
+} from './types';
+
+const AI_CARD_MEDIA_TYPE = 'application/vnd.ai-card.agent.v1+json';
+const POLICY_MEDIA_TYPE = 'application/vnd.agt.policy.v1+json';
+const OCI_MANIFEST_MEDIA_TYPE = 'application/vnd.oci.image.manifest.v2+json';
+const OCI_CONFIG_MEDIA_TYPE = 'application/vnd.oci.image.config.v1+json';
+
+/**
+ * Converts AGT agent manifests to/from OCI manifest format with AI Card
+ * compatibility. Enables registry-based discovery and verification of
+ * agent metadata.
+ */
+export class OciManifestAdapter {
+  /**
+   * Convert an AGT agent identity to an AI Card.
+   */
+  identityToAICard(identity: AgentIdentityJSON, extra?: Partial<AICard>): AICard {
+    const card: AICard = {
+      name: identity.name ?? identity.did,
+      version: '1.0.0',
+      description: identity.description,
+      author: identity.organization ?? identity.sponsor,
+      capabilities: this.capabilitiesToAICard(identity.capabilities),
+      metadata: {
+        did: identity.did,
+        status: identity.status ?? 'active',
+        createdAt: identity.createdAt,
+        expiresAt: identity.expiresAt,
+        parentDid: identity.parentDid,
+        delegationDepth: identity.delegationDepth,
+      },
+      ...extra,
+    };
+
+    return card;
+  }
+
+  /**
+   * Convert an AI Card back to an AGT agent identity.
+   */
+  aiCardToIdentity(card: AICard, publicKey: string): AgentIdentityJSON {
+    const metadata = (card.metadata ?? {}) as Record<string, unknown>;
+    return {
+      did: (metadata.did as string) ?? `did:agent:${card.name}`,
+      publicKey,
+      capabilities: this.aiCardToCapabilities(card.capabilities),
+      name: card.name,
+      description: card.description,
+      organization: card.author,
+      status: (metadata.status as AgentIdentityJSON['status']) ?? 'active',
+      createdAt: metadata.createdAt as string | undefined,
+      expiresAt: metadata.expiresAt as string | undefined,
+      parentDid: metadata.parentDid as string | undefined,
+      delegationDepth: metadata.delegationDepth as number | undefined,
+    };
+  }
+
+  /**
+   * Package an agent identity and optional policy rules into an OCI manifest.
+   */
+  package(
+    identity: AgentIdentityJSON,
+    policyRules?: PolicyRule[],
+    extra?: Partial<AICard>,
+  ): OciPackageResult {
+    const aiCard = this.identityToAICard(identity, extra);
+    const aiCardJson = JSON.stringify(aiCard, null, 2);
+    const aiCardDescriptor = this.createDescriptor(aiCardJson, AI_CARD_MEDIA_TYPE, {
+      'org.opencontainers.image.title': 'ai-card.json',
+    });
+
+    const layers: Array<{ descriptor: OciDescriptor; content: string }> = [
+      { descriptor: aiCardDescriptor, content: aiCardJson },
+    ];
+
+    if (policyRules && policyRules.length > 0) {
+      const policyJson = JSON.stringify({ rules: policyRules }, null, 2);
+      const policyDescriptor = this.createDescriptor(policyJson, POLICY_MEDIA_TYPE, {
+        'org.opencontainers.image.title': 'policy.json',
+      });
+      layers.push({ descriptor: policyDescriptor, content: policyJson });
+    }
+
+    const configContent = JSON.stringify({
+      created: new Date().toISOString(),
+      author: identity.organization ?? identity.sponsor ?? 'unknown',
+      agent: { did: identity.did, name: identity.name },
+    });
+    const configDescriptor = this.createDescriptor(configContent, OCI_CONFIG_MEDIA_TYPE);
+
+    const manifest: OciManifest = {
+      schemaVersion: 2,
+      mediaType: OCI_MANIFEST_MEDIA_TYPE,
+      config: configDescriptor,
+      layers: layers.map((l) => l.descriptor),
+      annotations: {
+        'org.opencontainers.image.title': identity.name ?? identity.did,
+        'org.opencontainers.image.description': identity.description ?? '',
+        'org.opencontainers.image.vendor': identity.organization ?? '',
+        'dev.ai-card.version': aiCard.version,
+        'dev.agt.did': identity.did,
+      },
+    };
+
+    return { manifest, aiCard, configBlob: configContent, layers };
+  }
+
+  /**
+   * Extract an AI Card from an OCI manifest's layers.
+   */
+  unpackAICard(layers: Array<{ descriptor: OciDescriptor; content: string }>): AICard | null {
+    const aiCardLayer = layers.find((l) => l.descriptor.mediaType === AI_CARD_MEDIA_TYPE);
+    if (!aiCardLayer) return null;
+
+    try {
+      return JSON.parse(aiCardLayer.content) as AICard;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Extract policy rules from an OCI manifest's layers.
+   */
+  unpackPolicies(layers: Array<{ descriptor: OciDescriptor; content: string }>): PolicyRule[] {
+    const policyLayer = layers.find((l) => l.descriptor.mediaType === POLICY_MEDIA_TYPE);
+    if (!policyLayer) return [];
+
+    try {
+      const parsed = JSON.parse(policyLayer.content) as { rules: PolicyRule[] };
+      return parsed.rules ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Verify the integrity of an OCI manifest by checking layer digests.
+   */
+  verifyManifest(
+    manifest: OciManifest,
+    layers: Array<{ descriptor: OciDescriptor; content: string }>,
+    configContent?: string,
+  ): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+
+    if (manifest.schemaVersion !== 2) {
+      errors.push(`Unsupported schema version: ${manifest.schemaVersion}`);
+    }
+
+    // Verify config digest
+    if (configContent) {
+      const expectedDigest = this.sha256Digest(configContent);
+      if (manifest.config.digest !== expectedDigest) {
+        errors.push(`Config digest mismatch: expected ${expectedDigest}, got ${manifest.config.digest}`);
+      }
+    }
+
+    // Verify layer digests
+    for (const layer of layers) {
+      const expectedDigest = this.sha256Digest(layer.content);
+      if (layer.descriptor.digest !== expectedDigest) {
+        errors.push(
+          `Layer digest mismatch for ${layer.descriptor.annotations?.['org.opencontainers.image.title'] ?? 'unknown'}: expected ${expectedDigest}, got ${layer.descriptor.digest}`,
+        );
+      }
+
+      const expectedSize = Buffer.byteLength(layer.content, 'utf-8');
+      if (layer.descriptor.size !== expectedSize) {
+        errors.push(
+          `Layer size mismatch: expected ${expectedSize}, got ${layer.descriptor.size}`,
+        );
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  // ── Internal helpers ──
+
+  private createDescriptor(
+    content: string,
+    mediaType: string,
+    annotations?: Record<string, string>,
+  ): OciDescriptor {
+    return {
+      mediaType,
+      digest: this.sha256Digest(content),
+      size: Buffer.byteLength(content, 'utf-8'),
+      annotations,
+    };
+  }
+
+  private sha256Digest(content: string): string {
+    const hash = createHash('sha256').update(content, 'utf-8').digest('hex');
+    return `sha256:${hash}`;
+  }
+
+  private capabilitiesToAICard(capabilities: string[]): AICardCapabilities {
+    return {
+      domains: capabilities,
+      input_modes: ['text'],
+      output_modes: ['text', 'json'],
+    };
+  }
+
+  private aiCardToCapabilities(capabilities?: AICardCapabilities): string[] {
+    if (!capabilities) return [];
+    return capabilities.domains ?? [];
+  }
+}

--- a/agent-governance-typescript/src/types.ts
+++ b/agent-governance-typescript/src/types.ts
@@ -394,6 +394,72 @@ export interface ContextIsolationViolation {
   description: string;
 }
 
+// ΓöÇΓöÇ OCI Manifest Adapter ΓöÇΓöÇ
+
+/** OCI manifest format (v2 schema). */
+export interface OciManifest {
+  schemaVersion: 2;
+  mediaType: string;
+  config: OciDescriptor;
+  layers: OciDescriptor[];
+  annotations?: Record<string, string>;
+}
+
+/** OCI content descriptor. */
+export interface OciDescriptor {
+  mediaType: string;
+  digest: string;
+  size: number;
+  annotations?: Record<string, string>;
+}
+
+/** AI Card agent metadata (framework-neutral). */
+export interface AICard {
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  license?: string;
+  homepage?: string;
+  repository?: string;
+  skills?: AICardSkill[];
+  capabilities?: AICardCapabilities;
+  invocation?: AICardInvocation;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AICardSkill {
+  name: string;
+  description?: string;
+  parameters?: Record<string, string>;
+  returns?: string;
+}
+
+export interface AICardCapabilities {
+  languages?: string[];
+  domains?: string[];
+  input_modes?: string[];
+  output_modes?: string[];
+  streaming?: boolean;
+  async?: boolean;
+}
+
+export interface AICardInvocation {
+  protocol?: string;
+  endpoint?: string;
+  authentication?: { type: string; required: boolean };
+  method?: string;
+  format?: string;
+}
+
+/** Result of converting AGT identity to OCI manifest. */
+export interface OciPackageResult {
+  manifest: OciManifest;
+  aiCard: AICard;
+  configBlob: string;
+  layers: Array<{ descriptor: OciDescriptor; content: string }>;
+}
+
 // ΓöÇΓöÇ Audit ΓöÇΓöÇ
 
 export interface AuditConfig {

--- a/agent-governance-typescript/tests/oci-manifest.test.ts
+++ b/agent-governance-typescript/tests/oci-manifest.test.ts
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { OciManifestAdapter } from '../src/oci-manifest';
+import type { AgentIdentityJSON, PolicyRule } from '../src/types';
+
+const SAMPLE_IDENTITY: AgentIdentityJSON = {
+  did: 'did:agent:weather-bot',
+  publicKey: 'dGVzdC1rZXk=',
+  capabilities: ['weather', 'forecasting'],
+  name: 'weather-bot',
+  description: 'Provides weather updates',
+  organization: 'Contoso',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00Z',
+  expiresAt: '2027-01-01T00:00:00Z',
+};
+
+const SAMPLE_RULES: PolicyRule[] = [
+  { name: 'block-external', condition: "agent.type == 'external'", ruleAction: 'deny' },
+  { name: 'rate-limit', condition: 'true', ruleAction: 'allow', limit: '100/hour' },
+];
+
+describe('OciManifestAdapter', () => {
+  let adapter: OciManifestAdapter;
+
+  beforeEach(() => {
+    adapter = new OciManifestAdapter();
+  });
+
+  describe('identityToAICard()', () => {
+    it('converts AGT identity to AI Card', () => {
+      const card = adapter.identityToAICard(SAMPLE_IDENTITY);
+      expect(card.name).toBe('weather-bot');
+      expect(card.description).toBe('Provides weather updates');
+      expect(card.author).toBe('Contoso');
+      expect(card.capabilities?.domains).toEqual(['weather', 'forecasting']);
+    });
+
+    it('uses DID as name fallback', () => {
+      const identity = { ...SAMPLE_IDENTITY, name: undefined };
+      const card = adapter.identityToAICard(identity);
+      expect(card.name).toBe('did:agent:weather-bot');
+    });
+
+    it('preserves DID in metadata', () => {
+      const card = adapter.identityToAICard(SAMPLE_IDENTITY);
+      expect((card.metadata as Record<string, unknown>).did).toBe('did:agent:weather-bot');
+    });
+
+    it('includes delegation info in metadata', () => {
+      const identity = { ...SAMPLE_IDENTITY, parentDid: 'did:agent:parent', delegationDepth: 2 };
+      const card = adapter.identityToAICard(identity);
+      expect((card.metadata as Record<string, unknown>).parentDid).toBe('did:agent:parent');
+      expect((card.metadata as Record<string, unknown>).delegationDepth).toBe(2);
+    });
+
+    it('merges extra fields', () => {
+      const card = adapter.identityToAICard(SAMPLE_IDENTITY, {
+        version: '2.0.0',
+        license: 'MIT',
+        homepage: 'https://contoso.com',
+      });
+      expect(card.version).toBe('2.0.0');
+      expect(card.license).toBe('MIT');
+      expect(card.homepage).toBe('https://contoso.com');
+    });
+  });
+
+  describe('aiCardToIdentity()', () => {
+    it('converts AI Card back to AGT identity', () => {
+      const card = adapter.identityToAICard(SAMPLE_IDENTITY);
+      const identity = adapter.aiCardToIdentity(card, 'dGVzdC1rZXk=');
+      expect(identity.did).toBe('did:agent:weather-bot');
+      expect(identity.name).toBe('weather-bot');
+      expect(identity.publicKey).toBe('dGVzdC1rZXk=');
+      expect(identity.capabilities).toEqual(['weather', 'forecasting']);
+      expect(identity.organization).toBe('Contoso');
+    });
+
+    it('generates DID from name if not in metadata', () => {
+      const card = { name: 'my-agent', version: '1.0.0' };
+      const identity = adapter.aiCardToIdentity(card, 'key');
+      expect(identity.did).toBe('did:agent:my-agent');
+    });
+  });
+
+  describe('package()', () => {
+    it('creates valid OCI manifest with AI Card layer', () => {
+      const result = adapter.package(SAMPLE_IDENTITY);
+      expect(result.manifest.schemaVersion).toBe(2);
+      expect(result.manifest.layers).toHaveLength(1);
+      expect(result.manifest.layers[0].mediaType).toBe('application/vnd.ai-card.agent.v1+json');
+    });
+
+    it('includes policy layer when rules provided', () => {
+      const result = adapter.package(SAMPLE_IDENTITY, SAMPLE_RULES);
+      expect(result.manifest.layers).toHaveLength(2);
+      expect(result.manifest.layers[1].mediaType).toBe('application/vnd.agt.policy.v1+json');
+    });
+
+    it('populates OCI annotations', () => {
+      const result = adapter.package(SAMPLE_IDENTITY);
+      const annotations = result.manifest.annotations!;
+      expect(annotations['org.opencontainers.image.title']).toBe('weather-bot');
+      expect(annotations['dev.agt.did']).toBe('did:agent:weather-bot');
+      expect(annotations['org.opencontainers.image.vendor']).toBe('Contoso');
+    });
+
+    it('produces valid digests for all layers', () => {
+      const result = adapter.package(SAMPLE_IDENTITY, SAMPLE_RULES);
+      for (const layer of result.layers) {
+        expect(layer.descriptor.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+        expect(layer.descriptor.size).toBeGreaterThan(0);
+      }
+    });
+
+    it('round-trips identity through package/unpack', () => {
+      const result = adapter.package(SAMPLE_IDENTITY);
+      const unpacked = adapter.unpackAICard(result.layers);
+      expect(unpacked).not.toBeNull();
+      expect(unpacked!.name).toBe('weather-bot');
+      expect(unpacked!.description).toBe('Provides weather updates');
+    });
+
+    it('round-trips policy rules through package/unpack', () => {
+      const result = adapter.package(SAMPLE_IDENTITY, SAMPLE_RULES);
+      const rules = adapter.unpackPolicies(result.layers);
+      expect(rules).toHaveLength(2);
+      expect(rules[0].name).toBe('block-external');
+      expect(rules[1].limit).toBe('100/hour');
+    });
+  });
+
+  describe('unpackAICard()', () => {
+    it('returns null for empty layers', () => {
+      expect(adapter.unpackAICard([])).toBeNull();
+    });
+
+    it('returns null for invalid JSON', () => {
+      const layers = [{
+        descriptor: { mediaType: 'application/vnd.ai-card.agent.v1+json', digest: 'sha256:abc', size: 3 },
+        content: '{{{invalid',
+      }];
+      expect(adapter.unpackAICard(layers)).toBeNull();
+    });
+  });
+
+  describe('unpackPolicies()', () => {
+    it('returns empty array for layers without policy', () => {
+      expect(adapter.unpackPolicies([])).toEqual([]);
+    });
+  });
+
+  describe('verifyManifest()', () => {
+    it('validates a correctly packaged manifest', () => {
+      const result = adapter.package(SAMPLE_IDENTITY, SAMPLE_RULES);
+      const verification = adapter.verifyManifest(result.manifest, result.layers, result.configBlob);
+      expect(verification.valid).toBe(true);
+      expect(verification.errors).toHaveLength(0);
+    });
+
+    it('detects tampered layer content', () => {
+      const result = adapter.package(SAMPLE_IDENTITY);
+      result.layers[0].content = '{"name": "tampered"}';
+      const verification = adapter.verifyManifest(result.manifest, result.layers, result.configBlob);
+      expect(verification.valid).toBe(false);
+      expect(verification.errors.length).toBeGreaterThan(0);
+    });
+
+    it('detects tampered config', () => {
+      const result = adapter.package(SAMPLE_IDENTITY);
+      const verification = adapter.verifyManifest(result.manifest, result.layers, 'tampered config');
+      expect(verification.valid).toBe(false);
+      expect(verification.errors.some((e) => e.includes('Config digest'))).toBe(true);
+    });
+
+    it('detects size mismatch', () => {
+      const result = adapter.package(SAMPLE_IDENTITY);
+      result.layers[0].descriptor.size = 999999;
+      const verification = adapter.verifyManifest(result.manifest, result.layers, result.configBlob);
+      expect(verification.valid).toBe(false);
+      expect(verification.errors.some((e) => e.includes('size mismatch'))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements \OciManifestAdapter\ for converting AGT agent manifests to/from OCI manifest format with AI Card compatibility.

## Problem

AGT agent manifests use a proprietary format. The emerging AI Card specification uses OCI-style packaging for agent metadata, enabling registry-based discovery and verification. Without an adapter, AGT agents cannot participate in the broader AI Card ecosystem.

## Solution

**\OciManifestAdapter\** class with:
- **Identity conversion**: AGT \AgentIdentityJSON\ to/from \AICard\ format (bidirectional)
- **OCI packaging**: Typed layers with SHA-256 digest verification
  - \pplication/vnd.ai-card.agent.v1+json\: Agent metadata layer
  - \pplication/vnd.agt.policy.v1+json\: Governance policy layer
- **Standard OCI annotations**: title, vendor, description, DID
- **Integrity verification**: Digest and size validation for all layers
- **Round-trip fidelity**: Identity and policy rules survive package/unpack cycles

**New types:** \OciManifest\, \OciDescriptor\, \AICard\, \AICardSkill\, \AICardCapabilities\, \AICardInvocation\, \OciPackageResult\

## Test Results

All 356 tests pass (25 suites), including 20 new OCI manifest tests.

Closes #1366