### PR TITLE
feat: add contributor reputation checker (contributor_check.py)

### DIFF
--- a/scripts/contributor_check.py
+++ b/scripts/contributor_check.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Contributor reputation checker for OSS maintainers.
+
+Evaluates a GitHub contributor's profile for signals of coordinated
+inauthentic behavior (claw patterns): account-shape anomalies,
+cross-repo spray, credential laundering, and network coordination.
+
+Usage:
+    python scripts/contributor_check.py --username <handle>
+    python scripts/contributor_check.py --username <handle> --repo microsoft/agent-governance-toolkit
+    python scripts/contributor_check.py --username <handle> --json
+
+Requires: GITHUB_TOKEN environment variable (or gh CLI auth).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+_TOKEN: str | None = None
+
+
+def _get_token() -> str:
+    """Resolve a GitHub token from env or gh CLI."""
+    global _TOKEN
+    if _TOKEN:
+        return _TOKEN
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                token = result.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+
+    if not token:
+        print("Error: set GITHUB_TOKEN or authenticate with `gh auth login`", file=sys.stderr)
+        sys.exit(1)
+
+    _TOKEN = token
+    return token
+
+
+def _api(path: str, params: dict[str, str] | None = None) -> Any:
+    """Call the GitHub REST API and return parsed JSON."""
+    url = f"https://api.github.com{path}"
+    if params:
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        url = f"{url}?{qs}"
+
+    req = Request(url)
+    req.add_header("Authorization", f"Bearer {_get_token()}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+
+    try:
+        with urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+    except HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def _search_issues(query: str, per_page: int = 30) -> list[dict]:
+    """Search GitHub issues/PRs."""
+    data = _api("/search/issues", {"q": query, "per_page": str(per_page)})
+    return data.get("items", []) if data else []
+
+
+# ---------------------------------------------------------------------------
+# Signal checkers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Signal:
+    """A single reputation signal."""
+    name: str
+    severity: str  # LOW, MEDIUM, HIGH
+    detail: str
+    value: Any = None
+
+
+@dataclass
+class ReputationReport:
+    """Full reputation report for a contributor."""
+    username: str
+    risk: str = "LOW"
+    signals: list[Signal] = field(default_factory=list)
+    profile: dict = field(default_factory=dict)
+    stats: dict = field(default_factory=dict)
+
+    def add(self, signal: Signal) -> None:
+        self.signals.append(signal)
+
+    @property
+    def high_count(self) -> int:
+        return sum(1 for s in self.signals if s.severity == "HIGH")
+
+    @property
+    def medium_count(self) -> int:
+        return sum(1 for s in self.signals if s.severity == "MEDIUM")
+
+    def compute_risk(self) -> str:
+        if self.high_count >= 2:
+            self.risk = "HIGH"
+        elif self.high_count >= 1 or self.medium_count >= 3:
+            self.risk = "MEDIUM"
+        else:
+            self.risk = "LOW"
+        return self.risk
+
+
+def check_account_shape(user: dict) -> list[Signal]:
+    """Check account age, repo velocity, follower ratios."""
+    signals: list[Signal] = []
+
+    created = datetime.fromisoformat(user["created_at"].replace("Z", "+00:00"))
+    age_days = (datetime.now(timezone.utc) - created).days
+
+    public_repos = user.get("public_repos", 0)
+    followers = user.get("followers", 0)
+    following = user.get("following", 0)
+
+    # Repo velocity
+    if age_days > 0:
+        repos_per_day = public_repos / age_days
+        if repos_per_day > 0.5 and public_repos > 15:
+            signals.append(Signal(
+                name="repo_velocity",
+                severity="HIGH",
+                detail=f"{public_repos} repos in {age_days} days ({repos_per_day:.2f}/day)",
+                value=repos_per_day,
+            ))
+        elif repos_per_day > 0.2 and public_repos > 10:
+            signals.append(Signal(
+                name="repo_velocity",
+                severity="MEDIUM",
+                detail=f"{public_repos} repos in {age_days} days ({repos_per_day:.2f}/day)",
+                value=repos_per_day,
+            ))
+
+    # Following farming
+    if following > 100 and followers > 0:
+        ratio = following / followers
+        if ratio > 20:
+            signals.append(Signal(
+                name="following_farming",
+                severity="HIGH",
+                detail=f"{followers} followers / {following} following (ratio 1:{ratio:.0f})",
+                value=ratio,
+            ))
+        elif ratio > 5:
+            signals.append(Signal(
+                name="following_farming",
+                severity="MEDIUM",
+                detail=f"{followers} followers / {following} following (ratio 1:{ratio:.0f})",
+                value=ratio,
+            ))
+
+    # Very new account with high activity
+    if age_days < 90 and public_repos > 20:
+        signals.append(Signal(
+            name="new_account_burst",
+            severity="HIGH",
+            detail=f"Account is {age_days} days old with {public_repos} repos",
+        ))
+    elif age_days < 180 and public_repos > 30:
+        signals.append(Signal(
+            name="new_account_burst",
+            severity="MEDIUM",
+            detail=f"Account is {age_days} days old with {public_repos} repos",
+        ))
+
+    # Zero followers with many repos
+    if followers == 0 and public_repos > 5:
+        signals.append(Signal(
+            name="zero_followers",
+            severity="MEDIUM",
+            detail=f"0 followers despite {public_repos} public repos",
+        ))
+
+    return signals
+
+
+def check_repo_themes(username: str) -> list[Signal]:
+    """Check if repos are overwhelmingly governance/security themed."""
+    signals: list[Signal] = []
+    repos = _api(f"/users/{username}/repos", {"per_page": "100", "sort": "created"})
+    if not repos:
+        return signals
+
+    governance_keywords = {
+        "governance", "policy", "trust", "attestation", "identity",
+        "passport", "delegation", "audit", "compliance", "zero-trust",
+        "agent-governance", "mcp-secure", "agent-guard", "veil",
+    }
+
+    governance_count = 0
+    recent_repos = []
+    now = datetime.now(timezone.utc)
+
+    for repo in repos:
+        name_lower = repo.get("name", "").lower()
+        desc_lower = (repo.get("description") or "").lower()
+        topics = repo.get("topics", [])
+
+        is_gov = False
+        for kw in governance_keywords:
+            if kw in name_lower or kw in desc_lower or kw in topics:
+                is_gov = True
+                break
+        if is_gov:
+            governance_count += 1
+
+        created = datetime.fromisoformat(repo["created_at"].replace("Z", "+00:00"))
+        if (now - created).days < 90:
+            recent_repos.append(repo["name"])
+
+    total = len(repos)
+    if total > 5 and governance_count / total > 0.5:
+        signals.append(Signal(
+            name="governance_theme_concentration",
+            severity="MEDIUM",
+            detail=f"{governance_count}/{total} repos are governance/security themed",
+            value=governance_count,
+        ))
+
+    if len(recent_repos) > 15:
+        signals.append(Signal(
+            name="recent_repo_burst",
+            severity="HIGH",
+            detail=f"{len(recent_repos)} repos created in last 90 days",
+            value=len(recent_repos),
+        ))
+
+    return signals
+
+
+def check_spray_pattern(username: str) -> list[Signal]:
+    """Check if user filed similar issues across many repos."""
+    signals: list[Signal] = []
+
+    issues = _search_issues(f"author:{username} is:issue", per_page=100)
+    if not issues:
+        return signals
+
+    # Group by repo
+    repos_hit: dict[str, list[dict]] = {}
+    for issue in issues:
+        repo_url = issue.get("repository_url", "")
+        repo_name = repo_url.replace("https://api.github.com/repos/", "")
+        repos_hit.setdefault(repo_name, []).append(issue)
+
+    # Check for spray: many repos with similar issue titles
+    unique_repos = len(repos_hit)
+    if unique_repos >= 5:
+        # Check if issues were filed in a short window
+        dates = []
+        for issue in issues:
+            created = datetime.fromisoformat(issue["created_at"].replace("Z", "+00:00"))
+            dates.append(created)
+
+        if dates:
+            dates.sort()
+            # Check if 5+ repos were hit within 7 days
+            window_repos = set()
+            for i, d in enumerate(dates):
+                window_repos_local = {
+                    issues[j].get("repository_url", "").replace("https://api.github.com/repos/", "")
+                    for j, d2 in enumerate(dates)
+                    if abs((d2 - d).days) <= 7
+                }
+                window_repos = max(window_repos, window_repos_local, key=len)
+
+            if len(window_repos) >= 5:
+                signals.append(Signal(
+                    name="cross_repo_spray",
+                    severity="HIGH",
+                    detail=f"Issues filed in {len(window_repos)} repos within 7 days",
+                    value=len(window_repos),
+                ))
+            elif unique_repos >= 8:
+                signals.append(Signal(
+                    name="cross_repo_spread",
+                    severity="MEDIUM",
+                    detail=f"Issues filed across {unique_repos} different repos",
+                    value=unique_repos,
+                ))
+
+    return signals
+
+
+def check_credential_spray(username: str, target_repo: str | None = None) -> list[Signal]:
+    """Check if user cites merges from one repo in issues across other repos."""
+    signals: list[Signal] = []
+
+    issues = _search_issues(f"author:{username} is:issue", per_page=50)
+    if not issues:
+        return signals
+
+    # Look for PR/merge references in issue bodies
+    credential_citations = 0
+    repos_with_citations = set()
+
+    for issue in issues:
+        body = (issue.get("body") or "").lower()
+        repo_url = issue.get("repository_url", "")
+        repo_name = repo_url.replace("https://api.github.com/repos/", "")
+
+        # Skip issues in the target repo itself
+        if target_repo and repo_name == target_repo:
+            continue
+
+        # Look for credential patterns
+        credential_patterns = [
+            "pr #", "pull/", "merged", "contributor",
+            "already in production", "integration with",
+        ]
+        has_credential = any(pat in body for pat in credential_patterns)
+
+        if has_credential and target_repo and target_repo.lower() in body:
+            credential_citations += 1
+            repos_with_citations.add(repo_name)
+
+    if credential_citations >= 3:
+        signals.append(Signal(
+            name="credential_laundering",
+            severity="HIGH",
+            detail=f"Cites {target_repo} merges in issues across {len(repos_with_citations)} repos",
+            value=credential_citations,
+        ))
+    elif credential_citations >= 1:
+        signals.append(Signal(
+            name="credential_citation",
+            severity="MEDIUM",
+            detail=f"Cites {target_repo} in issues across {len(repos_with_citations)} other repos",
+            value=credential_citations,
+        ))
+
+    return signals
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+def check_contributor(username: str, target_repo: str | None = None) -> ReputationReport:
+    """Run all checks and produce a reputation report."""
+    report = ReputationReport(username=username)
+
+    # Fetch user profile
+    user = _api(f"/users/{username}")
+    if not user:
+        report.risk = "UNKNOWN"
+        report.signals.append(Signal(
+            name="user_not_found",
+            severity="HIGH",
+            detail=f"GitHub user '{username}' does not exist",
+        ))
+        return report
+
+    report.profile = {
+        "name": user.get("name"),
+        "bio": user.get("bio"),
+        "company": user.get("company"),
+        "created_at": user.get("created_at"),
+        "public_repos": user.get("public_repos"),
+        "followers": user.get("followers"),
+        "following": user.get("following"),
+    }
+
+    created = datetime.fromisoformat(user["created_at"].replace("Z", "+00:00"))
+    age_days = (datetime.now(timezone.utc) - created).days
+    report.stats = {
+        "account_age_days": age_days,
+        "repos_per_day": round(user.get("public_repos", 0) / max(age_days, 1), 3),
+    }
+
+    # Run checks
+    for signal in check_account_shape(user):
+        report.add(signal)
+
+    for signal in check_repo_themes(username):
+        report.add(signal)
+
+    for signal in check_spray_pattern(username):
+        report.add(signal)
+
+    if target_repo:
+        for signal in check_credential_spray(username, target_repo):
+            report.add(signal)
+
+    report.compute_risk()
+    return report
+
+
+def format_report(report: ReputationReport, as_json: bool = False) -> str:
+    """Format a reputation report for display."""
+    if as_json:
+        return json.dumps({
+            "username": report.username,
+            "risk": report.risk,
+            "profile": report.profile,
+            "stats": report.stats,
+            "signals": [
+                {"name": s.name, "severity": s.severity, "detail": s.detail}
+                for s in report.signals
+            ],
+        }, indent=2)
+
+    risk_icon = {"LOW": "🟢", "MEDIUM": "🟡", "HIGH": "🔴", "UNKNOWN": "⚪"}.get(report.risk, "⚪")
+    lines = [
+        f"Contributor Check: {report.username}",
+        f"{'=' * 50}",
+        f"Risk: {risk_icon} {report.risk}",
+        "",
+    ]
+
+    if report.profile:
+        p = report.profile
+        lines.append("Profile:")
+        if p.get("name"):
+            lines.append(f"  Name:         {p['name']}")
+        if p.get("bio"):
+            lines.append(f"  Bio:          {p['bio'][:80]}")
+        if p.get("company"):
+            lines.append(f"  Company:      {p['company']}")
+        lines.append(f"  Created:      {p.get('created_at', 'unknown')}")
+        lines.append(f"  Public repos: {p.get('public_repos', 0)}")
+        lines.append(f"  Followers:    {p.get('followers', 0)}")
+        lines.append(f"  Following:    {p.get('following', 0)}")
+        lines.append("")
+
+    if report.stats:
+        lines.append("Stats:")
+        lines.append(f"  Account age:    {report.stats.get('account_age_days', 0)} days")
+        lines.append(f"  Repos/day:      {report.stats.get('repos_per_day', 0)}")
+        lines.append("")
+
+    if report.signals:
+        lines.append("Signals:")
+        for s in report.signals:
+            icon = {"LOW": "  ", "MEDIUM": "⚠️", "HIGH": "🚩"}.get(s.severity, "  ")
+            lines.append(f"  {icon} [{s.severity}] {s.name}: {s.detail}")
+        lines.append("")
+    else:
+        lines.append("No signals detected.")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check a GitHub contributor's reputation for claw indicators.",
+    )
+    parser.add_argument("--username", "-u", required=True, help="GitHub username to check")
+    parser.add_argument("--repo", "-r", default=None, help="Target repo (owner/repo) for credential audit")
+    parser.add_argument("--json", dest="as_json", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    report = check_contributor(args.username, args.repo)
+    print(format_report(report, as_json=args.as_json))
+
+    # Exit code reflects risk
+    if report.risk == "HIGH":
+        return 2
+    elif report.risk == "MEDIUM":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_contributor_check.py
+++ b/scripts/tests/test_contributor_check.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for contributor_check.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from contributor_check import (
+    Signal,
+    ReputationReport,
+    check_account_shape,
+    check_contributor,
+    format_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_user(
+    created_days_ago: int = 365,
+    public_repos: int = 10,
+    followers: int = 50,
+    following: int = 20,
+    **kwargs,
+) -> dict:
+    """Create a mock GitHub user profile."""
+    created = datetime.now(timezone.utc) - timedelta(days=created_days_ago)
+    return {
+        "login": kwargs.get("login", "test-user"),
+        "name": kwargs.get("name", "Test User"),
+        "bio": kwargs.get("bio", "A developer"),
+        "company": kwargs.get("company"),
+        "created_at": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "public_repos": public_repos,
+        "followers": followers,
+        "following": following,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Account shape tests
+# ---------------------------------------------------------------------------
+
+class TestAccountShape:
+    def test_normal_account_no_signals(self):
+        user = _make_user(created_days_ago=730, public_repos=15, followers=50, following=30)
+        signals = check_account_shape(user)
+        assert len(signals) == 0
+
+    def test_high_repo_velocity(self):
+        user = _make_user(created_days_ago=30, public_repos=20)
+        signals = check_account_shape(user)
+        names = [s.name for s in signals]
+        assert "repo_velocity" in names or "new_account_burst" in names
+
+    def test_following_farming_high(self):
+        user = _make_user(followers=10, following=500)
+        signals = check_account_shape(user)
+        names = [s.name for s in signals]
+        assert "following_farming" in names
+
+    def test_following_farming_extreme(self):
+        user = _make_user(followers=94, following=2092)
+        signals = check_account_shape(user)
+        farm_signals = [s for s in signals if s.name == "following_farming"]
+        assert len(farm_signals) == 1
+        assert farm_signals[0].severity == "HIGH"
+
+    def test_new_account_burst(self):
+        user = _make_user(created_days_ago=60, public_repos=54)
+        signals = check_account_shape(user)
+        burst = [s for s in signals if s.name == "new_account_burst"]
+        assert len(burst) == 1
+        assert burst[0].severity == "HIGH"
+
+    def test_zero_followers_with_repos(self):
+        user = _make_user(followers=0, following=0, public_repos=20)
+        signals = check_account_shape(user)
+        names = [s.name for s in signals]
+        assert "zero_followers" in names
+
+    def test_established_account_no_flags(self):
+        user = _make_user(created_days_ago=1000, public_repos=30, followers=200, following=50)
+        signals = check_account_shape(user)
+        assert all(s.severity != "HIGH" for s in signals)
+
+
+# ---------------------------------------------------------------------------
+# Report tests
+# ---------------------------------------------------------------------------
+
+class TestReputationReport:
+    def test_low_risk_no_signals(self):
+        report = ReputationReport(username="clean-user")
+        assert report.compute_risk() == "LOW"
+
+    def test_medium_risk_one_high(self):
+        report = ReputationReport(username="sus-user")
+        report.add(Signal("test", "HIGH", "test detail"))
+        assert report.compute_risk() == "MEDIUM"
+
+    def test_high_risk_two_high(self):
+        report = ReputationReport(username="claw-user")
+        report.add(Signal("test1", "HIGH", "detail 1"))
+        report.add(Signal("test2", "HIGH", "detail 2"))
+        assert report.compute_risk() == "HIGH"
+
+    def test_medium_risk_three_medium(self):
+        report = ReputationReport(username="borderline-user")
+        report.add(Signal("t1", "MEDIUM", "d1"))
+        report.add(Signal("t2", "MEDIUM", "d2"))
+        report.add(Signal("t3", "MEDIUM", "d3"))
+        assert report.compute_risk() == "MEDIUM"
+
+
+# ---------------------------------------------------------------------------
+# Format tests
+# ---------------------------------------------------------------------------
+
+class TestFormat:
+    def test_text_output_contains_username(self):
+        report = ReputationReport(username="example-user")
+        report.risk = "LOW"
+        output = format_report(report)
+        assert "example-user" in output
+        assert "LOW" in output
+
+    def test_json_output_valid(self):
+        report = ReputationReport(username="json-user")
+        report.risk = "HIGH"
+        report.add(Signal("test_sig", "HIGH", "some detail"))
+        output = format_report(report, as_json=True)
+        data = json.loads(output)
+        assert data["username"] == "json-user"
+        assert data["risk"] == "HIGH"
+        assert len(data["signals"]) == 1
+        assert data["signals"][0]["name"] == "test_sig"
+
+    def test_text_output_signals_displayed(self):
+        report = ReputationReport(username="sig-user")
+        report.add(Signal("spray", "HIGH", "5 repos in 7 days"))
+        output = format_report(report)
+        assert "spray" in output
+        assert "5 repos in 7 days" in output
+
+
+# ---------------------------------------------------------------------------
+# Integration test (mocked API)
+# ---------------------------------------------------------------------------
+
+class TestCheckContributor:
+    @patch("contributor_check._api")
+    def test_user_not_found(self, mock_api):
+        mock_api.return_value = None
+        report = check_contributor("ghost-user")
+        assert report.risk == "UNKNOWN"
+        assert any(s.name == "user_not_found" for s in report.signals)
+
+    @patch("contributor_check._search_issues")
+    @patch("contributor_check._api")
+    def test_clean_user(self, mock_api, mock_search):
+        def api_side_effect(path, params=None):
+            if "/users/" in path and "/repos" not in path:
+                return _make_user(created_days_ago=500, public_repos=8, followers=100, following=30)
+            if "/repos" in path:
+                return []
+            return []
+
+        mock_api.side_effect = api_side_effect
+        mock_search.return_value = []
+        report = check_contributor("clean-dev")
+        assert report.risk == "LOW"
+        assert len(report.signals) == 0
+
+    @patch("contributor_check._search_issues")
+    @patch("contributor_check._api")
+    def test_suspicious_user(self, mock_api, mock_search):
+        now_str = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        def api_side_effect(path, params=None):
+            if "/users/" in path and "/repos" not in path:
+                return _make_user(
+                    login="claw-bot",
+                    created_days_ago=57,
+                    public_repos=54,
+                    followers=2,
+                    following=0,
+                )
+            if "/repos" in path:
+                return [
+                    {
+                        "name": f"agent-governance-{i}",
+                        "description": "governance toolkit",
+                        "topics": ["agent-governance"],
+                        "created_at": now_str,
+                    }
+                    for i in range(20)
+                ]
+            return []
+
+        mock_api.side_effect = api_side_effect
+        mock_search.return_value = []
+
+        report = check_contributor("claw-bot")
+        assert report.risk in ("MEDIUM", "HIGH")
+        signal_names = [s.name for s in report.signals]
+        assert "new_account_burst" in signal_names or "repo_velocity" in signal_names


### PR DESCRIPTION
## Summary

Adds `scripts/contributor_check.py`, a standalone Python tool that evaluates GitHub contributors for signals of coordinated inauthentic behavior (claw patterns).

## What it checks

1. **Account shape**: repo velocity, following farming ratio, new account burst, zero followers
2. **Repository themes**: concentration of governance/security-themed repos
3. **Cross-repo spray**: similar issues filed across many repos in a short window
4. **Credential laundering**: citing merges from one repo as credentials in issues across other repos

## Usage

`ash
python scripts/contributor_check.py --username piiiico
python scripts/contributor_check.py --username aeoess --repo microsoft/agent-governance-toolkit
python scripts/contributor_check.py --username clean-dev --json
`

## Output

Risk level (LOW/MEDIUM/HIGH) with signal breakdown. Exit code reflects risk (0=LOW, 1=MEDIUM, 2=HIGH) for CI integration.

## Tests

17 unit tests covering:
- Account shape signal detection (7 tests)
- Report risk computation (4 tests)
- Output formatting, text and JSON (3 tests)
- Integration with mocked API (3 tests)

All passing:
`
17 passed in 1.00s
`

## Notes

- Uses only stdlib + GitHub REST API (no additional dependencies)
- Resolves GitHub token from GITHUB_TOKEN env var or `gh auth token`
- Designed as a speed bump for human reviewers, not a gate

Closes #1473
