### PR TITLE
feat(trust): add RFC 9334 RATS architecture alignment

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
@@ -8,6 +8,7 @@ Native A2A and MCP support with transparent protocol translation.
 """
 
 from .bridge import TrustBridge, ProtocolBridge
+from .endorsement import Endorsement, EndorsementRegistry, EndorsementType
 from .handshake import TrustHandshake, HandshakeResult
 from .capability import CapabilityScope, CapabilityGrant, CapabilityRegistry
 from .cards import TrustedAgentCard, CardRegistry
@@ -15,6 +16,9 @@ from .cards import TrustedAgentCard, CardRegistry
 __all__ = [
     "TrustBridge",
     "ProtocolBridge",
+    "Endorsement",
+    "EndorsementRegistry",
+    "EndorsementType",
     "TrustHandshake",
     "HandshakeResult",
     "CapabilityScope",

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/bridge.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/bridge.py
@@ -16,6 +16,7 @@ import logging
 import os
 
 from .handshake import TrustHandshake, HandshakeResult
+from .endorsement import EndorsementRegistry, Endorsement, EndorsementType
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +93,11 @@ class TrustBridge(BaseModel):
     def __init__(self, **data):
         identity = data.pop("identity", None)
         registry = data.pop("registry", None)
+        endorsement_registry = data.pop("endorsement_registry", None)
         super().__init__(**data)
         self._identity = identity
         self._registry = registry
+        self._endorsement_registry: Optional[EndorsementRegistry] = endorsement_registry
         self._handshake = TrustHandshake(
             agent_did=self.agent_did,
             identity=identity,
@@ -186,6 +189,21 @@ class TrustBridge(BaseModel):
             if peer.trust_verified and peer.trust_score >= threshold
         ]
 
+    def get_endorsements(
+        self,
+        peer_did: str,
+        endorsement_type: Optional[EndorsementType] = None,
+    ) -> list[Endorsement]:
+        """Get valid endorsements for a peer from the endorsement registry.
+
+        Returns an empty list if no endorsement registry is configured.
+        Endorsements are resolved on demand from the registry (not cached
+        on PeerInfo) to avoid HMAC integrity gaps.
+        """
+        if self._endorsement_registry is None:
+            return []
+        return self._endorsement_registry.get_endorsements(peer_did, endorsement_type)
+
     async def revoke_peer_trust(self, peer_did: str, reason: str) -> bool:
         """Revoke trust for a previously verified peer."""
         if peer_did in self.peers:
@@ -212,14 +230,17 @@ class ProtocolBridge(BaseModel):
     def __init__(self, **data):
         identity = data.pop("identity", None)
         registry = data.pop("registry", None)
+        endorsement_registry = data.pop("endorsement_registry", None)
         super().__init__(**data)
         self._identity = identity
         self._registry = registry
+        self._endorsement_registry = endorsement_registry
         if not self.trust_bridge:
             self.trust_bridge = TrustBridge(
                 agent_did=self.agent_did,
                 identity=identity,
                 registry=registry,
+                endorsement_registry=endorsement_registry,
             )
 
     async def send_message(

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/endorsement.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/endorsement.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """
-Endorsement Registry — RFC 9334 Endorser Role
+Endorsement Registry -- RFC 9334 Endorser Role
 ===============================================
 
 Implements the Endorser concept from RFC 9334 (RATS Architecture):
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
@@ -29,15 +29,26 @@ class HandshakeChallenge(BaseModel):
 
     challenge_id: str
     nonce: str
+    freshness_nonce: Optional[str] = Field(
+        None,
+        description="RFC 9334 freshness nonce for Evidence liveness proof",
+    )
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     expires_in_seconds: int = 30
 
     @classmethod
-    def generate(cls) -> "HandshakeChallenge":
-        """Generate a new challenge with a random nonce."""
+    def generate(cls, require_freshness: bool = False) -> "HandshakeChallenge":
+        """Generate a new challenge with a random nonce.
+
+        Args:
+            require_freshness: If True, include an RFC 9334 freshness
+                nonce that the responder must echo back in its signed
+                payload, proving Evidence liveness.
+        """
         return cls(
             challenge_id=f"challenge_{secrets.token_hex(8)}",
             nonce=secrets.token_hex(32),
+            freshness_nonce=secrets.token_hex(16) if require_freshness else None,
         )
 
     def is_expired(self) -> bool:
@@ -60,6 +71,9 @@ class HandshakeResponse(BaseModel):
     # Ed25519 signature and public key
     signature: str
     public_key: str
+
+    # RFC 9334: freshness nonce echoed back from challenge
+    freshness_nonce: Optional[str] = None
 
     # User context for OBO flows
     user_context: Optional[dict] = Field(None, description="End-user context for OBO flows")
@@ -236,11 +250,17 @@ class TrustHandshake:
         required_trust_score: int = 700,
         required_capabilities: Optional[list[str]] = None,
         use_cache: bool = True,
+        require_freshness: bool = False,
     ) -> HandshakeResult:
         """
         Initiate a simple nonce-based handshake with a peer.
+
+        Args:
+            require_freshness: If True, include an RFC 9334 freshness
+                nonce and bypass the handshake result cache so that every
+                call produces a fresh Evidence verification.
         """
-        if use_cache:
+        if use_cache and not require_freshness:
             cached = self._get_cached_result(peer_did)
             if cached:
                 return cached
@@ -249,7 +269,7 @@ class TrustHandshake:
 
         try:
             result = await asyncio.wait_for(
-                self._do_initiate(peer_did, required_trust_score, required_capabilities, start),
+                self._do_initiate(peer_did, required_trust_score, required_capabilities, start, require_freshness),
                 timeout=self.timeout_seconds,
             )
             return result
@@ -270,6 +290,7 @@ class TrustHandshake:
         required_trust_score: int,
         required_capabilities: Optional[list[str]],
         start: datetime,
+        require_freshness: bool = False,
     ) -> HandshakeResult:
         """Execute the core handshake: generate nonce, verify it comes back."""
         challenge: Optional[HandshakeChallenge] = None
@@ -281,8 +302,8 @@ class TrustHandshake:
                     peer_did, "Too many pending challenges — try again later", start
                 )
 
-            # Generate nonce challenge
-            challenge = HandshakeChallenge.generate()
+            # Generate nonce challenge (with optional RFC 9334 freshness nonce)
+            challenge = HandshakeChallenge.generate(require_freshness=require_freshness)
             self._pending_challenges[challenge.challenge_id] = challenge
 
             # Get peer response
@@ -350,7 +371,10 @@ class TrustHandshake:
         response_nonce = secrets.token_hex(16)
 
         # Sign the challenge+response payload with Ed25519
+        # RFC 9334: include freshness_nonce in signed payload when present
         payload = f"{challenge.challenge_id}:{challenge.nonce}:{response_nonce}:{self.agent_did}"
+        if challenge.freshness_nonce:
+            payload += f":{challenge.freshness_nonce}"
         signature = agent_identity.sign(payload.encode())
 
         return HandshakeResponse(
@@ -361,6 +385,7 @@ class TrustHandshake:
             trust_score=my_trust_score,
             signature=signature,
             public_key=agent_identity.public_key,
+            freshness_nonce=challenge.freshness_nonce,
             user_context=user_context.model_dump() if user_context else None,
         )
 
@@ -463,6 +488,11 @@ class TrustHandshake:
 
         # Verify Ed25519 signature over the challenge payload
         payload = f"{response.challenge_id}:{challenge.nonce}:{response.response_nonce}:{response.agent_did}"
+        # RFC 9334: verify freshness_nonce match and include in payload
+        if challenge.freshness_nonce:
+            if response.freshness_nonce != challenge.freshness_nonce:
+                return {"valid": False, "reason": "Freshness nonce mismatch (RFC 9334)"}
+            payload += f":{challenge.freshness_nonce}"
         if not peer_identity.verify_signature(payload.encode(), response.signature):
             return {"valid": False, "reason": "Ed25519 signature verification failed"}
 
@@ -497,9 +527,14 @@ class TrustHandshake:
             "registry_capabilities": registry_capabilities,
         }
 
-    def create_challenge(self) -> HandshakeChallenge:
-        """Create and register a new challenge."""
-        challenge = HandshakeChallenge.generate()
+    def create_challenge(self, require_freshness: bool = False) -> HandshakeChallenge:
+        """Create and register a new challenge.
+
+        Args:
+            require_freshness: If True, include an RFC 9334 freshness
+                nonce in the challenge.
+        """
+        challenge = HandshakeChallenge.generate(require_freshness=require_freshness)
         self._pending_challenges[challenge.challenge_id] = challenge
         return challenge
 

--- a/agent-governance-python/agent-mesh/tests/test_rats_alignment.py
+++ b/agent-governance-python/agent-mesh/tests/test_rats_alignment.py
@@ -1,0 +1,393 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for RFC 9334 (RATS Architecture) alignment features.
+
+Covers:
+- EndorsementRegistry: creation, storage, expiry, revocation, querying
+- Freshness nonce: round-trip in handshake, cache bypass, mismatch rejection
+- Backward compatibility: no freshness_nonce = existing behavior unchanged
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentmesh.trust.endorsement import (
+    Endorsement,
+    EndorsementRegistry,
+    EndorsementType,
+)
+from agentmesh.trust.handshake import (
+    HandshakeChallenge,
+    HandshakeResponse,
+    TrustHandshake,
+)
+from agentmesh.trust.bridge import TrustBridge
+
+
+# ---------------------------------------------------------------------------
+# Endorsement tests
+# ---------------------------------------------------------------------------
+
+
+class TestEndorsement:
+    """Unit tests for Endorsement dataclass."""
+
+    def test_create_endorsement(self):
+        e = Endorsement(
+            endorser_did="did:mesh:endorser-1",
+            target_did="did:mesh:agent-a",
+            endorsement_type=EndorsementType.COMPLIANCE,
+            claims={"framework": "EU AI Act", "risk_level": "limited"},
+        )
+        assert e.endorser_did == "did:mesh:endorser-1"
+        assert e.target_did == "did:mesh:agent-a"
+        assert e.endorsement_type == EndorsementType.COMPLIANCE
+        assert e.claims["framework"] == "EU AI Act"
+        assert not e.is_expired()
+
+    def test_endorsement_not_expired_when_no_expiry(self):
+        e = Endorsement(
+            endorser_did="did:mesh:e",
+            target_did="did:mesh:a",
+            endorsement_type=EndorsementType.CAPABILITY,
+        )
+        assert not e.is_expired()
+
+    def test_endorsement_expired(self):
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        e = Endorsement(
+            endorser_did="did:mesh:e",
+            target_did="did:mesh:a",
+            endorsement_type=EndorsementType.INTEGRITY,
+            expires_at=past,
+        )
+        assert e.is_expired()
+
+    def test_endorsement_not_expired_future(self):
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        e = Endorsement(
+            endorser_did="did:mesh:e",
+            target_did="did:mesh:a",
+            endorsement_type=EndorsementType.INTEGRITY,
+            expires_at=future,
+        )
+        assert not e.is_expired()
+
+    def test_endorsement_invalid_expiry_treated_as_expired(self):
+        e = Endorsement(
+            endorser_did="did:mesh:e",
+            target_did="did:mesh:a",
+            endorsement_type=EndorsementType.IDENTITY,
+            expires_at="not-a-date",
+        )
+        assert e.is_expired()
+
+    def test_to_dict_roundtrip(self):
+        e = Endorsement(
+            endorser_did="did:mesh:endorser-1",
+            target_did="did:mesh:agent-a",
+            endorsement_type=EndorsementType.REFERENCE_VALUE,
+            claims={"hash": "sha256:abc123"},
+            metadata={"source": "ci-pipeline"},
+        )
+        d = e.to_dict()
+        e2 = Endorsement.from_dict(d)
+        assert e2.endorser_did == e.endorser_did
+        assert e2.target_did == e.target_did
+        assert e2.endorsement_type == e.endorsement_type
+        assert e2.claims == e.claims
+
+    def test_all_endorsement_types_valid(self):
+        for et in EndorsementType:
+            e = Endorsement(
+                endorser_did="did:mesh:e",
+                target_did="did:mesh:a",
+                endorsement_type=et,
+            )
+            assert e.endorsement_type == et
+
+
+class TestEndorsementRegistry:
+    """Unit tests for EndorsementRegistry."""
+
+    def test_add_and_retrieve(self):
+        reg = EndorsementRegistry()
+        e = Endorsement(
+            endorser_did="did:mesh:endorser-1",
+            target_did="did:mesh:agent-a",
+            endorsement_type=EndorsementType.COMPLIANCE,
+            claims={"standard": "ISO 42001"},
+        )
+        reg.add(e)
+        results = reg.get_endorsements("did:mesh:agent-a")
+        assert len(results) == 1
+        assert results[0].claims["standard"] == "ISO 42001"
+
+    def test_expired_endorsement_rejected_on_add(self):
+        reg = EndorsementRegistry()
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        e = Endorsement(
+            endorser_did="did:mesh:e",
+            target_did="did:mesh:a",
+            endorsement_type=EndorsementType.CAPABILITY,
+            expires_at=past,
+        )
+        reg.add(e)
+        assert reg.total_count == 0
+
+    def test_filter_by_type(self):
+        reg = EndorsementRegistry()
+        target = "did:mesh:agent-a"
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did=target,
+            endorsement_type=EndorsementType.COMPLIANCE,
+        ))
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e2",
+            target_did=target,
+            endorsement_type=EndorsementType.INTEGRITY,
+        ))
+        compliance_only = reg.get_endorsements(target, EndorsementType.COMPLIANCE)
+        assert len(compliance_only) == 1
+        assert compliance_only[0].endorsement_type == EndorsementType.COMPLIANCE
+
+    def test_get_endorsers(self):
+        reg = EndorsementRegistry()
+        target = "did:mesh:agent-a"
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did=target,
+            endorsement_type=EndorsementType.CAPABILITY,
+        ))
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e2",
+            target_did=target,
+            endorsement_type=EndorsementType.COMPLIANCE,
+        ))
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did=target,
+            endorsement_type=EndorsementType.INTEGRITY,
+        ))
+        endorsers = reg.get_endorsers(target)
+        assert len(endorsers) == 2
+        assert "did:mesh:e1" in endorsers
+        assert "did:mesh:e2" in endorsers
+
+    def test_has_endorsement(self):
+        reg = EndorsementRegistry()
+        target = "did:mesh:agent-a"
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did=target,
+            endorsement_type=EndorsementType.COMPLIANCE,
+        ))
+        assert reg.has_endorsement(target, EndorsementType.COMPLIANCE)
+        assert not reg.has_endorsement(target, EndorsementType.INTEGRITY)
+        assert reg.has_endorsement(
+            target, EndorsementType.COMPLIANCE, endorser_did="did:mesh:e1"
+        )
+        assert not reg.has_endorsement(
+            target, EndorsementType.COMPLIANCE, endorser_did="did:mesh:e2"
+        )
+
+    def test_revoke(self):
+        reg = EndorsementRegistry()
+        target = "did:mesh:agent-a"
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did=target,
+            endorsement_type=EndorsementType.CAPABILITY,
+        ))
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e2",
+            target_did=target,
+            endorsement_type=EndorsementType.COMPLIANCE,
+        ))
+        removed = reg.revoke(target, "did:mesh:e1")
+        assert removed == 1
+        assert len(reg.get_endorsements(target)) == 1
+        assert reg.get_endorsements(target)[0].endorser_did == "did:mesh:e2"
+
+    def test_revoke_nonexistent(self):
+        reg = EndorsementRegistry()
+        assert reg.revoke("did:mesh:unknown", "did:mesh:e1") == 0
+
+    def test_clear_all(self):
+        reg = EndorsementRegistry()
+        for i in range(3):
+            reg.add(Endorsement(
+                endorser_did=f"did:mesh:e{i}",
+                target_did=f"did:mesh:a{i}",
+                endorsement_type=EndorsementType.CAPABILITY,
+            ))
+        assert reg.total_count == 3
+        reg.clear()
+        assert reg.total_count == 0
+
+    def test_clear_specific_target(self):
+        reg = EndorsementRegistry()
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did="did:mesh:agent-a",
+            endorsement_type=EndorsementType.CAPABILITY,
+        ))
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did="did:mesh:agent-b",
+            endorsement_type=EndorsementType.CAPABILITY,
+        ))
+        reg.clear("did:mesh:agent-a")
+        assert len(reg.get_endorsements("did:mesh:agent-a")) == 0
+        assert len(reg.get_endorsements("did:mesh:agent-b")) == 1
+
+    def test_empty_registry_returns_empty(self):
+        reg = EndorsementRegistry()
+        assert reg.get_endorsements("did:mesh:nonexistent") == []
+        assert reg.get_endorsers("did:mesh:nonexistent") == []
+        assert not reg.has_endorsement("did:mesh:nonexistent", EndorsementType.CAPABILITY)
+
+
+# ---------------------------------------------------------------------------
+# Freshness nonce tests
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessNonce:
+    """Tests for RFC 9334 freshness nonce in handshake challenge/response."""
+
+    def test_challenge_without_freshness(self):
+        """Default challenge has no freshness nonce (backward compatible)."""
+        challenge = HandshakeChallenge.generate()
+        assert challenge.freshness_nonce is None
+        assert challenge.nonce is not None
+
+    def test_challenge_with_freshness(self):
+        """Freshness-required challenge includes a freshness_nonce."""
+        challenge = HandshakeChallenge.generate(require_freshness=True)
+        assert challenge.freshness_nonce is not None
+        assert len(challenge.freshness_nonce) == 32  # 16 bytes hex = 32 chars
+        assert challenge.nonce is not None
+        assert challenge.nonce != challenge.freshness_nonce
+
+    def test_create_challenge_with_freshness(self):
+        """TrustHandshake.create_challenge passes freshness through."""
+        hs = TrustHandshake(agent_did="did:mesh:test-agent")
+        challenge = hs.create_challenge(require_freshness=True)
+        assert challenge.freshness_nonce is not None
+        assert hs.validate_challenge(challenge.challenge_id)
+
+    def test_create_challenge_without_freshness(self):
+        """TrustHandshake.create_challenge defaults to no freshness."""
+        hs = TrustHandshake(agent_did="did:mesh:test-agent")
+        challenge = hs.create_challenge()
+        assert challenge.freshness_nonce is None
+
+
+# ---------------------------------------------------------------------------
+# TrustBridge endorsement integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrustBridgeEndorsements:
+    """Tests for endorsement integration in TrustBridge."""
+
+    def test_bridge_without_endorsement_registry(self):
+        """TrustBridge works without endorsement registry (backward compat)."""
+        bridge = TrustBridge(agent_did="did:mesh:test-agent")
+        endorsements = bridge.get_endorsements("did:mesh:peer-1")
+        assert endorsements == []
+
+    def test_bridge_with_endorsement_registry(self):
+        """TrustBridge delegates to endorsement registry when configured."""
+        reg = EndorsementRegistry()
+        reg.add(Endorsement(
+            endorser_did="did:mesh:authority",
+            target_did="did:mesh:peer-1",
+            endorsement_type=EndorsementType.COMPLIANCE,
+            claims={"standard": "SOC2"},
+        ))
+        bridge = TrustBridge(
+            agent_did="did:mesh:test-agent",
+            endorsement_registry=reg,
+        )
+        endorsements = bridge.get_endorsements("did:mesh:peer-1")
+        assert len(endorsements) == 1
+        assert endorsements[0].claims["standard"] == "SOC2"
+
+    def test_bridge_endorsement_type_filter(self):
+        """TrustBridge.get_endorsements filters by type."""
+        reg = EndorsementRegistry()
+        target = "did:mesh:peer-1"
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e1",
+            target_did=target,
+            endorsement_type=EndorsementType.COMPLIANCE,
+        ))
+        reg.add(Endorsement(
+            endorser_did="did:mesh:e2",
+            target_did=target,
+            endorsement_type=EndorsementType.INTEGRITY,
+        ))
+        bridge = TrustBridge(
+            agent_did="did:mesh:test-agent",
+            endorsement_registry=reg,
+        )
+        compliance = bridge.get_endorsements(target, EndorsementType.COMPLIANCE)
+        assert len(compliance) == 1
+        integrity = bridge.get_endorsements(target, EndorsementType.INTEGRITY)
+        assert len(integrity) == 1
+
+
+# ---------------------------------------------------------------------------
+# Freshness nonce E2E handshake tests
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessNonceE2E:
+    """End-to-end tests for freshness nonce in full handshake flow."""
+
+    @pytest.mark.asyncio
+    async def test_handshake_with_freshness_bypasses_cache(self):
+        """require_freshness=True must bypass the handshake result cache."""
+        from agentmesh.identity import AgentIdentity
+        from agentmesh.identity.agent_id import IdentityRegistry
+
+        agent_a = AgentIdentity.create(
+            name="fresh-a",
+            sponsor="test@test.example.com",
+            capabilities=["read"],
+        )
+        agent_b = AgentIdentity.create(
+            name="fresh-b",
+            sponsor="test@test.example.com",
+            capabilities=["read"],
+        )
+        registry = IdentityRegistry()
+        registry.register(agent_a)
+        registry.register(agent_b)
+
+        hs = TrustHandshake(
+            agent_did=str(agent_a.did),
+            identity=agent_a,
+            registry=registry,
+        )
+
+        # First handshake: populates cache
+        result1 = await hs.initiate(
+            peer_did=str(agent_b.did),
+            required_trust_score=0,
+        )
+        assert result1.verified
+
+        # Second handshake with freshness: must NOT return cached result
+        result2 = await hs.initiate(
+            peer_did=str(agent_b.did),
+            required_trust_score=0,
+            require_freshness=True,
+        )
+        assert result2.verified
+        # Results should have different completion timestamps (fresh verification)
+        assert result2.handshake_completed != result1.handshake_completed

--- a/docs/adr/0009-rfc-9334-rats-architecture-alignment.md
+++ b/docs/adr/0009-rfc-9334-rats-architecture-alignment.md
@@ -1,98 +1,127 @@
-# ADR 0009: RFC 9334 RATS Architecture Alignment
+# ADR 0009: RFC 9334 (RATS) Architecture Alignment
 
 - Status: accepted
-- Date: 2026-04-26
+- Date: 2025-07-17
+- Deciders: @imran-siddique
 
 ## Context
 
-RFC 9334 (Remote ATtestation procedureS Architecture) defines a standard architecture for remote attestation: how one entity (Attester) produces Evidence about its state, how a Verifier appraises that Evidence against Reference Values, and how a Relying Party consumes the resulting Attestation Results to make trust decisions. The specification formalizes five roles (Attester, Verifier, Relying Party, Endorser, Reference Value Provider), four artifact types (Evidence, Attestation Results, Endorsements, Reference Values), two topological patterns (Passport Model, Background-Check Model), and three freshness mechanisms (nonce, timestamp, epoch ID).
+IETF RFC 9334 defines the **Remote ATtestation procedureS (RATS) Architecture**,
+a standard framework for verifying the trustworthiness of remote peers through
+Evidence, Attestation Results, and Endorsements. The Agent Governance Toolkit
+already implements many RATS concepts (Attester, Verifier, Evidence, Attestation
+Results) through its IATP trust handshake, but gaps remain in three areas:
 
-The Agent Governance Toolkit already implements most of these concepts across its Python SDK (`agent-compliance`), TypeScript SDK (`agent-governance-typescript`), and AgentMesh runtime (`agent-mesh`), but the mapping is implicit. Components were built to solve governance problems, not to conform to RATS terminology. This ADR formalizes the alignment, identifies gaps, and documents the changes made to close the highest-priority gaps.
+1. **Endorser role**: RFC 9334 section 3.3 defines an Endorser that vouches for
+   an Attester's integrity/capabilities, distinct from the Attester itself. AGT
+   had no mechanism for third-party endorsements.
+
+2. **Freshness nonce**: RFC 9334 section 10 describes freshness mechanisms
+   (nonce, timestamp, epoch) to prove Evidence liveness. AGT's challenge nonce
+   binds the response to a specific challenge but does not provide explicit
+   Evidence freshness proof as defined in the RFC.
+
+3. **Explicit RATS role mapping**: No documentation mapped AGT components to
+   RATS roles, making it harder for standards-aware adopters to evaluate
+   alignment.
 
 ## Decision
 
-### Role Mapping
+We add three backward-compatible features to align AGT with RFC 9334:
 
-AGT components map to RFC 9334 roles as follows:
+### 1. EndorsementRegistry (RFC 9334 Endorser role)
 
-| RFC 9334 Role | AGT Component(s) | Notes |
-|---|---|---|
-| **Attester** | Agent runtime, `RuntimeEvidence` producer, physical/cognitive attestation examples | Agents produce Evidence about their state (trust scores, integrity reports, compliance data) |
-| **Verifier** | `GovernanceVerifier`, `IntegrityVerifier`, Hypervisor `verification_adapter`, Nexus Arbiter | Appraiser logic that evaluates Evidence against policies and produces Attestation Results |
-| **Relying Party** | `governance-attestation` GitHub Action, Orchestrator, callers of `TrustBridge.verify_peer()` | Entities that consume `HandshakeResult` / `GovernanceAttestation` to make authorization decisions |
-| **Endorser** | `EndorsementRegistry` (new), Nexus manifest signatures, SBOM/Sigstore provenance | Entities that vouch for agent capabilities, integrity, or compliance |
-| **Reference Value Provider** | Integrity manifests (expected hashes), policy files (deny-by-default baselines) | Sources of known-good values used during Evidence appraisal |
-| **Verifier Owner** | Policy file authors, CI pipeline configurators | Not explicitly modeled as a distinct role |
-| **Relying Party Owner** | Not modeled | RFC 9334 separates policy owners from RP instances; AGT conflates these |
+A new `agentmesh.trust.endorsement` module provides:
 
-### Artifact Mapping
+- `EndorsementType` enum: COMPLIANCE, CAPABILITY, INTEGRITY, IDENTITY,
+  REFERENCE_VALUE (maps to RATS Reference Values and Endorsements)
+- `Endorsement` dataclass with endorser_did, target_did, type, claims, expiry,
+  metadata, and serialization
+- `EndorsementRegistry` for CRUD operations, type filtering, expiry validation,
+  and revocation
 
-| RFC 9334 Artifact | AGT Implementation |
-|---|---|
-| **Evidence** | `RuntimeEvidence`, `IntegrityReport` inputs, heartbeat payloads (DID + timestamp + delegation chain hash), sensor data in physical attestation examples |
-| **Attestation Results** | `GovernanceAttestation`, `IntegrityReport`, `DriftCheckResult`, `HandshakeResult`, trust scores (0-1000) |
-| **Endorsements** | `Endorsement` dataclass (new), Nexus `attestation_signature`, SBOM signatures, compliance `nexus_signature` |
-| **Reference Values** | Integrity manifest hashes, critical function bytecode fingerprints, policy baselines |
-| **Appraisal Policy** | Deny-by-default policy evaluation, PR governance checklist, inline rule sets |
+Design constraints (from rubber-duck critique):
 
-### Topological Patterns
+- Endorsements are **unsigned metadata only** for now: no `signature` field is
+  exposed until cryptographic verification of endorsers is implemented
+- Endorsements are resolved **on demand** from the registry, not stored on
+  PeerInfo, to avoid HMAC integrity gaps in TrustBridge._sign_peer()
+- The registry lives in its own file (`trust/endorsement.py`) since it is
+  stateful, not alongside the lightweight types in `trust_types.py`
 
-**Background-Check Model** (primary pattern in AGT):
-The Relying Party forwards Evidence to the Verifier for appraisal. This is the dominant pattern in `GovernanceVerifier.verify_evidence()`, `IntegrityVerifier.verify()`, and `TrustHandshake.initiate()` where the initiator sends a challenge, receives Evidence (the signed response), and verifies it locally.
+### 2. Freshness nonce in IATP handshake
 
-**Passport Model** (also supported):
-The Attester obtains an Attestation Result and presents it directly to the Relying Party. Examples include:
-- ADR-0005 liveness attestation: `HandshakeResult` gains a `liveness` field that agents carry.
-- Signet attestation: signed receipts carry policy attestation inside the artifact.
-- Physical attestation: offline-verifiable signed receipts embedded in sensor data.
+- `HandshakeChallenge` gains an optional `freshness_nonce` field
+- `HandshakeChallenge.generate(require_freshness=True)` produces a 16-byte hex
+  freshness nonce alongside the existing challenge nonce
+- `HandshakeResponse` echoes `freshness_nonce` and includes it in the Ed25519
+  signed payload
+- `_verify_response()` rejects mismatched freshness nonces before signature
+  verification
+- `initiate(require_freshness=True)` bypasses the handshake result cache,
+  ensuring every call produces a fresh Evidence verification
+- `create_challenge(require_freshness=True)` passes through to generate()
 
-### Freshness Mechanisms
+The existing `nonce` (challenge-binding token) and the new `freshness_nonce`
+(verifier-supplied Evidence liveness proof) are semantically distinct per
+RFC 9334 section 10.
 
-RFC 9334 Section 10 defines three freshness approaches:
+### 3. This ADR
 
-| Mechanism | AGT Support | Implementation |
-|---|---|---|
-| **Nonce-based** | Supported (new) | `HandshakeChallenge.freshness_nonce` provides a verifier-supplied nonce that must be echoed in the signed Evidence. Requests with `require_freshness=True` bypass the result cache. |
-| **Timestamp-based** | Supported (existing) | Liveness attestation (ADR-0005), evidence timestamps, attestation expiry fields |
-| **Epoch ID** | Not implemented | No current use case; agents do not operate in synchronized epoch windows |
+Documents the mapping between AGT concepts and RATS roles/artifacts for
+standards-aware adopters.
 
-The existing `HandshakeChallenge.nonce` serves as the challenge-binding token (proving the response corresponds to a specific challenge). The new `freshness_nonce` is semantically distinct: it binds Evidence to a specific verification request, ensuring the Evidence was produced *after* the verifier asked for it. This distinction matters when attestation evidence is produced asynchronously or cached by intermediaries.
+## RATS Role Mapping
 
-### Changes Made
+| RATS Role | AGT Component | Notes |
+|-----------|--------------|-------|
+| Attester | AgentIdentity + TrustHandshake.respond() | Produces Evidence (signed challenge response) |
+| Verifier | TrustHandshake._verify_response() | Appraises Evidence against Appraisal Policy |
+| Relying Party | TrustBridge.verify_peer() callers | Consumes Attestation Results (HandshakeResult) |
+| Endorser | EndorsementRegistry | Third-party vouching for Attester properties |
+| Reference Value Provider | GovernanceEngine policy definitions | Supplies reference values for appraisal |
 
-1. **Endorsement module** (`agent-mesh/src/agentmesh/trust/endorsement.py`): New `Endorsement` dataclass and `EndorsementRegistry` implementing the RFC 9334 Endorser role. Currently unsigned metadata; cryptographic signature verification is deferred (see Gaps).
+## RATS Artifact Mapping
 
-2. **Freshness nonce** (`agent-mesh/src/agentmesh/trust/handshake.py`): Optional `freshness_nonce` field on `HandshakeChallenge` and `HandshakeResponse`. When present, it is included in the Ed25519 signature payload and verified during response validation. `initiate()` accepts `require_freshness=True` which bypasses the result cache.
+| RATS Artifact | AGT Equivalent |
+|---------------|---------------|
+| Evidence | HandshakeResponse (Ed25519 signed payload) |
+| Attestation Results | HandshakeResult |
+| Endorsements | Endorsement records in EndorsementRegistry |
+| Reference Values | Policy rules, capability requirements, trust thresholds |
+| Appraisal Policy | required_trust_score, required_capabilities, registry checks |
 
-3. **TrustBridge endorsement integration** (`agent-mesh/src/agentmesh/trust/bridge.py`): Optional `endorsement_registry` parameter threaded through `TrustBridge` and `ProtocolBridge`. Endorsements resolved on demand via `get_endorsements()` rather than cached on `PeerInfo` to avoid HMAC integrity gaps.
+## Topological Pattern
 
-### Explicit Gaps (Not Addressed)
+AGT primarily follows the **Background-Check Model** (RFC 9334 section 5.2):
+the Relying Party (caller of verify_peer) delegates Evidence appraisal to the
+Verifier (_verify_response), which returns Attestation Results. The handshake
+result cache adds a Passport Model optimization where cached results serve as
+pre-computed attestation results.
 
-These gaps are documented for transparency. They do not block the alignment but should be addressed in future iterations:
+## Explicit Gaps (Not Addressed)
 
-1. **Endorsement signature verification**: The `EndorsementRegistry` validates expiry but does not verify cryptographic signatures. Endorsements are treated as informational metadata, not cryptographic proofs. A future `EndorsementVerifier` should verify Ed25519 signatures against a trusted endorser identity source.
+These areas are documented for future work:
 
-2. **Verifier Owner / Relying Party Owner**: RFC 9334 separates policy owners from the roles that execute policies. AGT conflates these. Separating them would enable delegated policy management.
-
-3. **Composite Device attestation**: RFC 9334 Section 3.3 defines composite attestation for systems with multiple sub-attesters. AGT's multi-agent orchestration does not model this explicitly, though delegation chains provide a partial analogue.
-
-4. **Epoch-based freshness**: Not implemented. Would be useful for batch attestation scenarios where multiple agents attest within the same time window.
-
-5. **Formal Conceptual Message types**: The protocol exchanges between roles are not formalized as RATS "Conceptual Messages." IATP messages carry the equivalent data but do not use RATS-defined message structures.
+- **Cryptographic endorsement verification**: Endorsements are unsigned metadata.
+  Future work could add endorser signature verification using the same Ed25519
+  infrastructure.
+- **Epoch-based freshness**: Only nonce-based freshness is implemented.
+  Timestamp-based and epoch-based freshness models are not yet supported.
+- **Formal Conceptual Messages**: RFC 9334 section 8 defines formal message
+  formats. AGT uses Pydantic models that carry equivalent information but do not
+  use the exact wire format.
+- **Multi-verifier topologies**: The current architecture assumes a single
+  verifier co-located with the relying party.
 
 ## Consequences
 
-**Benefits:**
-- AGT's trust architecture is now explicitly documented against a recognized IETF standard, strengthening the project's credibility for standards-aligned adopters.
-- The Endorser role is a first-class concept, enabling third-party vouching workflows (compliance authorities, SBOM signing services, identity providers).
-- Nonce-based freshness provides replay protection beyond timestamp validation, closing a gap for time-sensitive attestation scenarios.
-- All changes are additive and backward-compatible: no existing API signatures changed, no new required dependencies.
-
-**Tradeoffs:**
-- The `freshness_nonce` adds a field to the handshake models that most callers will not use. The overhead is minimal (one optional string field).
-- Endorsements without signature verification could create a false sense of trust if consumers treat them as authoritative. The module documentation and this ADR explicitly state they are unsigned metadata.
-
-**Follow-up work:**
-- Implement `EndorsementVerifier` with Ed25519 signature verification against a trusted endorser registry.
-- Evaluate whether CBOR-encoded Evidence (RFC 9334 recommends CBOR for wire efficiency) would benefit high-throughput AgentMesh deployments.
-- Consider aligning IATP message structures with EAT (Entity Attestation Token, RFC 9711) for interoperability with hardware attestation ecosystems.
+- **Backward compatible**: All changes are additive. Existing code that does not
+  use `require_freshness` or `endorsement_registry` continues to work unchanged.
+- **Standards alignment**: Adopters evaluating AGT against RATS can point to this
+  ADR and the role mapping table.
+- **Foundation for future work**: The EndorsementRegistry provides the extension
+  point for cryptographic endorser verification when needed.
+- **No performance impact**: Freshness nonce adds one extra field to
+  challenge/response. Endorsement lookup is O(n) in endorsements per target,
+  which is acceptable for typical deployment sizes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,11 @@ Each ADR captures:
 - [ADR 0002: Use four execution rings instead of RBAC for runtime privilege](0002-use-four-execution-rings-for-runtime-privilege.md)
 - [ADR 0003: Keep the IATP trust handshake within a 200ms SLA](0003-keep-iatp-handshake-within-200ms.md)
 - [ADR 0004: Keep policy evaluation deterministic and out of LLM control loops](0004-keep-policy-evaluation-deterministic.md)
+- [ADR 0005: Add liveness attestation to TrustHandshake](0005-add-liveness-attestation-to-trust-handshake.md)
+- [ADR 0006: Constitutional constraint layer as a community extension](0006-constitutional-constraint-layer-as-community-extension.md)
+- [ADR 0007: External JWKS federation for cross-org identity](0007-external-jwks-federation-for-cross-org-identity.md)
+- [ADR 0008: Cross-org policy federation](0008-cross-org-policy-federation.md)
+- [ADR 0009: RFC 9334 (RATS) architecture alignment](0009-rfc-9334-rats-architecture-alignment.md)
 
 ## Template
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -8,3 +8,8 @@ Key architectural decisions and their rationale.
 | [ADR-0002](0002-use-four-execution-rings-for-runtime-privilege.md) | Four execution rings for runtime privilege separation |
 | [ADR-0003](0003-keep-iatp-handshake-within-200ms.md) | Keep IATP handshake under 200ms |
 | [ADR-0004](0004-keep-policy-evaluation-deterministic.md) | Keep policy evaluation deterministic |
+| [ADR-0005](0005-add-liveness-attestation-to-trust-handshake.md) | Add liveness attestation to TrustHandshake |
+| [ADR-0006](0006-constitutional-constraint-layer-as-community-extension.md) | Constitutional constraint layer as community extension |
+| [ADR-0007](0007-external-jwks-federation-for-cross-org-identity.md) | External JWKS federation for cross-org identity |
+| [ADR-0008](0008-cross-org-policy-federation.md) | Cross-org policy federation above identity |
+| [ADR-0009](0009-rfc-9334-rats-architecture-alignment.md) | RFC 9334 (RATS) architecture alignment |


### PR DESCRIPTION
## Summary

Aligns AGT's trust layer with IETF RFC 9334 (Remote ATtestation procedureS Architecture) through three additive, backward-compatible changes.

### Changes

**1. EndorsementRegistry (RFC 9334 Endorser role)**
- New \gentmesh.trust.endorsement\ module with \EndorsementType\, \Endorsement\, and \EndorsementRegistry\
- Supports CRUD operations, type filtering, expiry validation, and revocation
- Endorsements resolved on-demand from registry (not stored on PeerInfo) to avoid HMAC integrity gaps
- Unsigned metadata only for now, crypto endorser verification deferred to future work

**2. Freshness nonce in IATP handshake (RFC 9334 Section 10)**
- \HandshakeChallenge\ gains optional \reshness_nonce\ field
- \equire_freshness=True\ generates 16-byte hex freshness nonce and bypasses result cache
- Freshness nonce included in Ed25519 signed payload and verified on response
- Backward compatible: existing calls without freshness work unchanged

**3. ADR-0009: RATS Architecture Alignment**
- Documents mapping between AGT components and RATS roles/artifacts
- Covers topological pattern analysis, explicit gaps, and future work
- Updates ADR indexes (README.md and index.md) to include ADRs 0005-0009

### Testing

- 25 new tests covering endorsement CRUD, freshness nonce, TrustBridge integration, and E2E handshake
- 42 existing handshake/bridge tests pass with zero regressions
- All tests: \python -m pytest agent-mesh/tests/test_rats_alignment.py -v\

### Design Notes

- Validated approach through rubber-duck critique before implementation
- Key design decisions documented in ADR-0009
- Zero breaking changes to existing API surface