### PR TITLE
fix(ci): update working directories for reorganized package paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,10 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install ruff
-        run: pip install --require-hashes --no-cache-dir -r requirements/ci-lint.txt
+        run: pip install --require-hashes --no-cache-dir -r agent-governance-python/requirements/ci-lint.txt
       - name: Lint ${{ matrix.package }}
-        run: ruff check ${{ matrix.package }}/src/ --select E,F,W --ignore E501
+        working-directory: agent-governance-python/${{ matrix.package }}
+        run: ruff check src/ --select E,F,W --ignore E501
 
   # ── Python test (only when Python files change) ───────────────────────
   test:
@@ -127,12 +128,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install ${{ matrix.package }}
-        working-directory: ${{ matrix.package }}
+        working-directory: agent-governance-python/${{ matrix.package }}
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
           pip install --no-cache-dir pytest==8.4.1 pytest-asyncio==0.26.0 2>/dev/null || true
       - name: Test ${{ matrix.package }}
-        working-directory: ${{ matrix.package }}
+        working-directory: agent-governance-python/${{ matrix.package }}
         run: pytest tests/ -q --tb=short
 
   # ── PyPI package build (only when Python files change) ────────────────
@@ -161,10 +162,10 @@ jobs:
       - name: Install build tools
         run: pip install --no-cache-dir build==1.2.2 setuptools==75.8.0
       - name: Build ${{ matrix.package }}
-        working-directory: ${{ matrix.package }}
+        working-directory: agent-governance-python/${{ matrix.package }}
         run: python -m build
       - name: Verify wheel
-        working-directory: ${{ matrix.package }}
+        working-directory: agent-governance-python/${{ matrix.package }}
         run: ls -la dist/*.whl
 
   # ── Python dependency safety (only when Python files change) ──────────
@@ -186,9 +187,9 @@ jobs:
         run: |
           for pkg in agent-os agent-mesh agent-hypervisor agent-sre agent-compliance agent-runtime agent-lightning; do
             echo "=== $pkg ==="
-            cd $pkg
+            cd agent-governance-python/$pkg
             pip install --no-cache-dir -e . 2>/dev/null || true  # Install local package (Scorecard: pinned via pyproject.toml)
-            cd ..
+            cd ../..
           done
           safety check 2>/dev/null || echo "Safety check completed with warnings"
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ See **[Language Package Feature Matrix](docs/SDK-FEATURE-MATRIX.md)** for detail
 | Agent OS | [`agent-os-kernel`](https://pypi.org/project/agent-os-kernel/) | Policy engine, capability model, audit logging, MCP gateway |
 | AgentMesh | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | Zero-trust identity, trust scoring, A2A/MCP/IATP bridges |
 | Agent Runtime | [`agentmesh-runtime`](agent-governance-python/agent-runtime/) | Privilege rings, saga orchestration, termination control |
-| Agent SRE | [`agent-sre`](https://pypi.org/project/agent-governance-python/agent-sre/) | SLOs, error budgets, chaos engineering, circuit breakers |
+| Agent SRE | [`agent-sre`](https://pypi.org/project/agent-sre/) | SLOs, error budgets, chaos engineering, circuit breakers |
 | Agent Compliance | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | OWASP verification, integrity checks, policy linting |
 | Agent Discovery | [`agent-discovery`](agent-governance-python/agent-discovery/) | Shadow AI discovery, inventory, risk scoring |
 | Agent Hypervisor | [`agent-hypervisor`](agent-governance-python/agent-hypervisor/) | Reversibility verification, execution plan validation |


### PR DESCRIPTION
## Problem

After refactor #1471 moved Python packages under agent-governance-python/, the CI workflow's lint, test, build-pypi, and security jobs still used the old flat paths. This caused all Python CI jobs to fail with 'No such file or directory'.

This blocks all 4 pending Dependabot PRs (#1472, #1474, #1477, #1478) and any future Python changes from passing CI.

## Fix

Updated working-directory in ci.yml to use agent-governance-python/ prefix for:
- lint job (ruff check + requirements path)
- test job (pip install + pytest)
- build-pypi job (python -m build + wheel verify)
- security job (safety check loop)

Also fixes a malformed PyPI link for Agent SRE in README.md.
