### PR TITLE
docs: Tutorial 46 — selective-disclosure receipts (extends Tutorial 33)

### DIFF
--- a/docs/tutorials/46-selective-disclosure-receipts.md
+++ b/docs/tutorials/46-selective-disclosure-receipts.md
@@ -1,0 +1,796 @@
+<!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
+
+# Tutorial 46 — Selective-Disclosure Receipts
+
+[Tutorial 33](33-offline-verifiable-receipts.md) showed how every tool call an
+agent makes can leave behind an Ed25519-signed, JCS-canonical receipt that any
+party with the public key can verify offline. That works cleanly for receipts
+where every field can be shown to every auditor.
+
+In regulated environments, that assumption breaks. An EU AI Act Article 12
+auditor wants the full record of what a high-risk system did. A GDPR
+data-minimization controller wants the auditor to see as little personal data
+as possible. A counterparty wants to verify a delegation chain without seeing
+the customer payload. A regulator in one jurisdiction needs different fields
+than a regulator in another.
+
+This tutorial covers **selective-disclosure receipts**: receipts where each
+field is independently committed via a Merkle tree, so the receipt issuer can
+reveal specific fields to specific auditors and prove the rest are unchanged
+without exposing them. The construction follows RFC 6962 (Certificate
+Transparency), which is the same Merkle tree shape used by transparency logs
+and `git` itself.
+
+> **Packages:** `agent-governance-toolkit[full]` (Python) · `protect-mcp@0.6.0` (npm, signing) · `@veritasacta/verify@0.6.0` (npm, verification)
+> **Standards:** Ed25519 (RFC 8032) · JCS (RFC 8785) · SHA-256 · RFC 6962 (Merkle Tree construction) · IETF [draft-farley-acta-signed-receipts](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) §5
+> **Reference example:** [`examples/selective-disclosure-governed/`](../../examples/selective-disclosure-governed/)
+
+---
+
+## What You'll Learn
+
+| Section | Topic |
+|---------|-------|
+| [Why Selective Disclosure?](#why-selective-disclosure) | The gap between full-disclosure and zero-disclosure receipts |
+| [The Commitment Construction](#the-commitment-construction) | RFC 6962 Merkle tree over per-field commitments |
+| [§1 Committing a Receipt](#1--committing-a-receipt) | Sign a receipt in commitment mode |
+| [§2 Generating a Disclosure](#2--generating-a-disclosure) | Reveal specific fields with Merkle proofs |
+| [§3 Verifying a Disclosure Offline](#3--verifying-a-disclosure-offline) | Walk the proof, no signing key needed |
+| [§4 Composing with Tutorial 33's Chain](#4--composing-with-tutorial-33s-chain) | Per-field disclosure on chained receipts |
+| [§5 Article 12 + GDPR Composition](#5--article-12--gdpr-composition) | Multi-auditor disclosure scoping |
+| [§6 Cross-Implementation Interop](#6--cross-implementation-interoperability) | Verifying across protect-mcp / sb-runtime / others |
+| [CI/CD Integration](#cicd-integration) | Gating merges on disclosure verification |
+| [Cross-Reference](#cross-reference) | Related tutorials |
+
+---
+
+## Prerequisites
+
+- **Python 3.10+**
+- **Node.js 18+** for the verifier CLI (`npx @veritasacta/verify@0.6.0`)
+- Completion of [Tutorial 33 — Offline-Verifiable Receipts](33-offline-verifiable-receipts.md).
+  This tutorial assumes you understand the JCS-plus-Ed25519 signing path and
+  the parent-hash chain construction.
+- Recommended: skim [RFC 6962 §2](https://datatracker.ietf.org/doc/html/rfc6962#section-2)
+  for the Merkle tree definition. The construction here uses the same hash
+  prefix discipline (`0x00` for leaves, `0x01` for internal nodes) so test
+  vectors interop directly with CT verifiers.
+
+Install:
+
+```bash
+pip install "agent-governance-toolkit[full]>=0.6.0"
+```
+
+The signing-side npm package (`protect-mcp@0.6.0`) and the verification-side
+package (`@veritasacta/verify@0.6.0`) ship the matching commitment-mode
+implementations referenced throughout this tutorial.
+
+---
+
+## Why Selective Disclosure?
+
+Tutorial 33's receipts are **all-or-nothing**. The signature covers the entire
+JCS-canonical payload, so the verifier needs every field to compute the hash
+and check the signature. Hide one field and the signature no longer verifies.
+That is the right shape when every auditor sees the same record.
+
+Three real-world settings break that assumption:
+
+| Setting | What's hidden | What's revealed |
+|---------|---------------|-----------------|
+| EU AI Act Article 12 audit | Customer-identifying fields | Tool name, policy ID, decision, timestamp, chain link |
+| GDPR data-minimization request | Personal data fields | Process metadata only |
+| Cross-org delegation check | Counterparty payload | Authorization scope and signature only |
+| Vendor debugging without PII | Tool args, tool result | Tool name, decision, error class |
+
+For each, you need three properties at once:
+
+1. **Selective disclosure**: the issuer chooses which fields to reveal to a
+   specific auditor.
+2. **Soundness**: the auditor cannot be tricked into accepting a different
+   value for a hidden field.
+3. **Completeness proof**: the auditor knows what the issuer is claiming about
+   the hidden fields (their structural shape) without learning their content.
+
+A naive approach is to publish two receipts: one full, one redacted. That
+defeats the receipt's signature, since the redacted receipt no longer hashes
+to the signed bytes. The right construction commits to each field
+independently, then signs the root commitment. The verifier walks a small
+Merkle proof to confirm a revealed field's value, and accepts the root
+signature as evidence that every other field is fixed even if invisible.
+
+This is the same construction Certificate Transparency uses to commit to
+millions of certificates while still allowing per-certificate inclusion proofs.
+It is the same construction `git` uses internally to commit to a tree of
+files. The novelty here is applying it to per-call agent decisions rather than
+to certificates or files.
+
+---
+
+## The Commitment Construction
+
+A Tutorial 33 receipt is signed over the JCS-canonical bytes of the entire
+payload object. A Tutorial 46 receipt instead signs over a single 32-byte
+**root commitment** computed from the receipt's fields:
+
+```
+field_1 = (name_1, value_1)        \
+field_2 = (name_2, value_2)         |
+   ...                              |  per-field commitments
+field_n = (name_n, value_n)         |
+                                   /
+
+leaf_i = SHA-256(0x00 || JCS({"name": name_i, "salt": salt_i, "value": value_i}))
+
+         ┌──── inner ────┐
+        / \            / \
+     leaf_1 leaf_2  leaf_3 leaf_4   <-- Merkle tree, RFC 6962-style
+        \      \    /     /
+         \      \  /     /
+          \    inner    /
+           \    |      /
+            ─── root ──
+                 │
+                 ▼
+       Ed25519 sign over root
+```
+
+Three details from RFC 6962 are worth flagging:
+
+1. **Domain-separation prefix bytes.** Leaves hash with a `0x00` prefix;
+   internal nodes hash with a `0x01` prefix. This prevents a second-preimage
+   attack where an adversary might find a leaf that collides with an internal
+   node's hash.
+
+2. **Per-leaf salt.** Each leaf includes a fresh 16-byte random salt before
+   hashing. Without the salt, low-entropy field values (`"decision": "allow"`)
+   would let an attacker brute-force the leaf hash. With the salt, hidden
+   field values are computationally hidden even if the field's domain is
+   small.
+
+3. **Padding.** When the leaf count is not a power of two, RFC 6962 specifies
+   that the rightmost subtree is built with the available leaves rather than
+   duplicating the last leaf. This avoids a known second-preimage class for
+   `git`-style trees.
+
+The signed receipt looks like Tutorial 33's, with one extra field:
+
+```json
+{
+  "receipt_id":               "rcpt-3f2a9c81",
+  "tool_name":                "file_system:read_file",
+  "decision":                 "allow",
+  "policy_id":                "autoresearch-safe",
+  "trust_tier":               "evidenced",
+  "timestamp":                "2026-04-25T12:34:56Z",
+  "parent_receipt_hash":      "sha256:a8f3c9d2e1b7465f",
+  "committed_fields_root":    "sha256:c5f1...d4a3",
+  "signature":                "ed25519:7b4a...",
+  "public_key":               "ed25519:cafebabe..."
+}
+```
+
+The fields named in the table (e.g. `tool_name`, `decision`, `policy_id`) are
+revealed in the signed receipt. Other fields the issuer chose to commit but
+not reveal in the signed envelope (e.g. `tool_args`, `tool_result`, `user_id`,
+`request_payload`) live only as commitment leaves in the Merkle tree. Their
+values are recoverable only via a disclosure proof.
+
+A disclosure proof is a small JSON object the issuer hands to a specific
+auditor:
+
+```json
+{
+  "disclosed": [
+    {
+      "name": "user_id",
+      "value": "u_8492",
+      "salt": "base64-of-16-random-bytes",
+      "proof": [
+        "sha256:sibling_at_depth_0",
+        "sha256:sibling_at_depth_1",
+        "sha256:sibling_at_depth_2"
+      ]
+    }
+  ]
+}
+```
+
+Given the signed receipt and a disclosure proof, the verifier:
+
+1. Recomputes the leaf hash from `(name, value, salt)`.
+2. Walks up the Merkle tree using the sibling hashes in `proof`.
+3. Compares the recomputed root to the receipt's `committed_fields_root`.
+4. Verifies the receipt's Ed25519 signature over the JCS-canonical envelope.
+
+If all four pass, the auditor knows that the disclosed field's value was
+fixed at the moment the receipt was signed, and that the issuer cannot
+substitute a different value for it. They learn nothing about the undisclosed
+fields beyond their position in the tree.
+
+---
+
+## 1 — Committing a Receipt
+
+The reference implementation lives in
+[`examples/selective-disclosure-governed/`](../../examples/selective-disclosure-governed/).
+Below is the standalone path so you can run it without the protect-mcp
+adapter, then replace the `DEMO_KEY` with a managed key in production.
+
+```python
+# tutorial_46/01_commit_receipt.py
+import hashlib, json, os, time
+from typing import List, Tuple
+
+LEAF_PREFIX = b"\x00"
+NODE_PREFIX = b"\x01"
+
+def jcs(obj) -> bytes:
+    """Minimal JCS: sort keys, no whitespace, UTF-8."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False).encode("utf-8")
+
+def commit_field(name: str, value, salt: bytes) -> bytes:
+    """Per-field commitment: SHA-256(0x00 || JCS({name, salt, value}))."""
+    leaf_obj = {"name": name, "salt": salt.hex(), "value": value}
+    return hashlib.sha256(LEAF_PREFIX + jcs(leaf_obj)).digest()
+
+def merkle_root(leaves: List[bytes]) -> bytes:
+    """RFC 6962-style Merkle root. Odd-leaf handling: rightmost subtree."""
+    if len(leaves) == 1:
+        return leaves[0]
+    # Find the largest power of two strictly less than len(leaves).
+    k = 1
+    while k * 2 < len(leaves):
+        k *= 2
+    left = merkle_root(leaves[:k])
+    right = merkle_root(leaves[k:])
+    return hashlib.sha256(NODE_PREFIX + left + right).digest()
+
+def commit_receipt(fields: List[Tuple[str, object]]):
+    """Returns (committed_fields_root, leaves, salts)."""
+    salts = [os.urandom(16) for _ in fields]
+    leaves = [commit_field(name, value, salt)
+              for (name, value), salt in zip(fields, salts)]
+    return merkle_root(leaves), leaves, salts
+
+
+# ---- Mint a receipt with selective fields committed ----
+fields = [
+    ("tool_name",   "file_system:read_file"),
+    ("decision",    "allow"),
+    ("policy_id",   "autoresearch-safe"),
+    ("trust_tier",  "evidenced"),
+    ("user_id",     "u_8492"),                 # will hide from public auditor
+    ("tool_args",   {"path": "/etc/passwd"}),  # will hide from public auditor
+    ("timestamp",   "2026-04-25T12:34:56Z"),
+]
+
+root, leaves, salts = commit_receipt(fields)
+
+receipt_envelope = {
+    "receipt_id":            f"rcpt-{root.hex()[:8]}",
+    "tool_name":             "file_system:read_file",
+    "decision":              "allow",
+    "policy_id":             "autoresearch-safe",
+    "trust_tier":            "evidenced",
+    "timestamp":             "2026-04-25T12:34:56Z",
+    "parent_receipt_hash":   None,
+    "committed_fields_root": "sha256:" + root.hex(),
+}
+
+# ---- Sign the envelope (Tutorial 33's Ed25519 path) ----
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+key = Ed25519PrivateKey.generate()
+payload = jcs(receipt_envelope)
+signature = key.sign(payload)
+receipt_envelope["signature"]  = "ed25519:" + signature.hex()
+receipt_envelope["public_key"] = "ed25519:" + key.public_key().public_bytes_raw().hex()
+
+print(json.dumps(receipt_envelope, indent=2))
+```
+
+The receipt envelope is what gets stored, distributed, and chained into other
+receipts. The hidden fields (`user_id`, `tool_args`) appear only as
+commitment leaves in the Merkle tree under `committed_fields_root`. The
+issuer keeps the `(name, value, salt)` triples in a side store so it can
+emit disclosures later.
+
+In the protect-mcp adapter, this is automatic:
+
+```python
+from protect_mcp.governance import GovernedTool
+
+tool = GovernedTool.wrap(
+    fn=read_file,
+    cedar_policy="autoresearch-safe",
+    receipt_mode="commitment",
+    public_fields={"tool_name", "decision", "policy_id", "trust_tier", "timestamp"},
+    private_fields={"user_id", "tool_args", "tool_result"},
+)
+```
+
+---
+
+## 2 — Generating a Disclosure
+
+A disclosure proof is the path from a leaf up to the root, naming the sibling
+hashes the verifier needs to recompute the root. With `n` committed fields,
+the proof is `ceil(log2(n))` sibling hashes.
+
+```python
+# tutorial_46/02_generate_disclosure.py
+def merkle_proof(leaves: List[bytes], target_index: int) -> List[bytes]:
+    """Returns sibling hashes from leaf up to root (bottom-up order).
+
+    proof[0] is the deepest sibling (closest to the target leaf);
+    proof[-1] is the root-level sibling (closest to the root).
+    This matches the order in which a verifier walking from leaf to
+    root consumes the proof.
+    """
+    siblings_top_down = []
+    nodes = list(leaves)
+    index = target_index
+    while len(nodes) > 1:
+        # RFC 6962 split: largest power of two strictly less than len(nodes).
+        k = 1
+        while k * 2 < len(nodes):
+            k *= 2
+        if index < k:
+            siblings_top_down.append(merkle_root(nodes[k:]))
+            nodes = nodes[:k]
+        else:
+            siblings_top_down.append(merkle_root(nodes[:k]))
+            nodes = nodes[k:]
+            index -= k
+    # Reverse so the verifier consumes leaf-to-root.
+    return list(reversed(siblings_top_down))
+
+def make_disclosure(fields, salts, leaves, indices_to_reveal):
+    disclosed = []
+    for i in indices_to_reveal:
+        name, value = fields[i]
+        proof = merkle_proof(leaves, i)
+        disclosed.append({
+            "name":  name,
+            "value": value,
+            "salt":  salts[i].hex(),
+            "proof": ["sha256:" + s.hex() for s in proof],
+            "index": i,
+            "leaf_count": len(leaves),
+        })
+    return {"disclosed": disclosed}
+
+# ---- Reveal user_id (index 4) and timestamp (index 6) to a regulator ----
+disclosure = make_disclosure(fields, salts, leaves, indices_to_reveal=[4, 6])
+print(json.dumps(disclosure, indent=2))
+```
+
+Note that the disclosure structure is **separate from the signed envelope**.
+The receipt itself can be published widely; the disclosure is delivered only
+to specific auditors. An auditor receiving the receipt without the disclosure
+sees the public fields, the root commitment, and the signature, but cannot
+recover the hidden fields.
+
+A few practical notes on disclosure scope:
+
+- **Per-auditor disclosures**: the issuer can hand different auditors
+  different subsets of the same receipt. The Article 12 auditor might receive
+  every field; the GDPR controller might receive only `tool_name` and
+  `decision`.
+- **Field-granularity locks**: once committed, a field's value is fixed. The
+  issuer cannot retroactively change `user_id` from `"u_8492"` to `"u_9999"`,
+  because that would change the leaf hash and break the Merkle root.
+- **Salt management**: the issuer must persist the per-field salts to emit
+  disclosures later. Losing a salt means the field is permanently
+  undisclosable.
+
+In production, salts and committed-but-undisclosed values are stored in a
+separate side store keyed by `receipt_id`. The receipt envelope itself stays
+small (~500 bytes regardless of how many fields are committed).
+
+---
+
+## 3 — Verifying a Disclosure Offline
+
+The verifier needs three things: the signed receipt envelope, the disclosure
+proof, and the issuer's public key. Nothing else. No issuer cooperation, no
+network calls.
+
+```python
+# tutorial_46/03_verify_disclosure.py
+import hashlib, json
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.exceptions import InvalidSignature
+
+LEAF_PREFIX = b"\x00"
+NODE_PREFIX = b"\x01"
+
+def jcs(obj) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False).encode("utf-8")
+
+def _path_positions(leaf_count, target_index):
+    """Replays the top-down recursion to recover, for each level, whether
+    the target was in the left half (True) or right half (False) of the
+    current subtree. Returned in bottom-up order to match the proof.
+    """
+    positions_top_down = []
+    n = leaf_count
+    index = target_index
+    while n > 1:
+        k = 1
+        while k * 2 < n:
+            k *= 2
+        if index < k:
+            positions_top_down.append(True)
+            n = k
+        else:
+            positions_top_down.append(False)
+            index -= k
+            n = n - k
+    return list(reversed(positions_top_down))
+
+
+def verify_proof(name, value, salt_hex, proof, index, leaf_count, expected_root):
+    """Walk the Merkle proof from leaf to root, compare to expected root."""
+    leaf_obj = {"name": name, "salt": salt_hex, "value": value}
+    current = hashlib.sha256(LEAF_PREFIX + jcs(leaf_obj)).digest()
+
+    positions = _path_positions(leaf_count, index)
+    if len(positions) != len(proof):
+        return False
+
+    for sibling_str, target_was_left in zip(proof, positions):
+        sibling = bytes.fromhex(sibling_str.removeprefix("sha256:"))
+        if target_was_left:
+            current = hashlib.sha256(NODE_PREFIX + current + sibling).digest()
+        else:
+            current = hashlib.sha256(NODE_PREFIX + sibling + current).digest()
+
+    actual_root = "sha256:" + current.hex()
+    return actual_root == expected_root
+
+def verify_receipt_with_disclosure(receipt: dict, disclosure: dict):
+    # 1. Verify Ed25519 signature on the envelope.
+    pub_hex = receipt["public_key"].removeprefix("ed25519:")
+    sig_hex = receipt["signature"].removeprefix("ed25519:")
+    pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(pub_hex))
+    envelope = {k: v for k, v in receipt.items()
+                if k not in ("signature", "public_key")}
+    try:
+        pub.verify(bytes.fromhex(sig_hex), jcs(envelope))
+    except InvalidSignature:
+        return False, "envelope signature invalid"
+
+    # 2. Verify each disclosed field's Merkle proof against the root.
+    expected_root = receipt["committed_fields_root"]
+    for d in disclosure["disclosed"]:
+        ok = verify_proof(
+            d["name"], d["value"], d["salt"], d["proof"],
+            d["index"], d["leaf_count"], expected_root
+        )
+        if not ok:
+            return False, f"merkle proof failed for {d['name']}"
+
+    return True, "ok"
+
+# ---- Auditor side ----
+ok, reason = verify_receipt_with_disclosure(receipt_envelope, disclosure)
+print(f"verification: {ok} ({reason})")
+```
+
+In Node, the same verification is one CLI call:
+
+```bash
+npx @veritasacta/verify@0.6.0 \
+  --receipt receipt.json \
+  --disclosure-file disclosure.json \
+  --public-key ed25519-pub.pem
+```
+
+Exit codes match Tutorial 33's verifier:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Receipt valid, all disclosed fields verify against the committed root |
+| `1` | Tampering detected: signature or Merkle proof failed |
+| `2` | Malformed receipt or disclosure JSON |
+| `3` | Disclosure references a field outside `leaf_count` |
+
+The verifier returns the same exit code regardless of which language the
+receipt was signed in. A receipt minted by a Python `protect-mcp` adapter
+verifies under the Node `@veritasacta/verify` CLI, and vice versa, because
+the canonical bytes the signature covers are JCS-deterministic and the
+Merkle construction follows RFC 6962 with no implementation-defined choices.
+
+---
+
+## 4 — Composing with Tutorial 33's Chain
+
+Selective disclosure composes orthogonally with Tutorial 33's hash chain:
+
+- The chain provides **temporal integrity**: receipt 5's
+  `parent_receipt_hash` references the JCS-canonical hash of receipt 4, so
+  inserting or removing a receipt breaks the chain.
+- The Merkle commitment provides **field-level integrity**: each receipt's
+  `committed_fields_root` covers all committed fields, so the issuer cannot
+  substitute a different value for a hidden field after signing.
+
+A chained receipt with selective disclosure carries both:
+
+```json
+{
+  "receipt_id":            "rcpt-9d4e6a12",
+  "tool_name":             "ledger:debit",
+  "decision":              "allow",
+  "timestamp":             "2026-04-25T12:35:01Z",
+  "parent_receipt_hash":   "sha256:b2c1...e5a6",
+  "committed_fields_root": "sha256:f8a4...c3d1",
+  "signature":             "ed25519:...",
+  "public_key":            "ed25519:..."
+}
+```
+
+The auditor walking the chain verifies each receipt's signature, then verifies
+that each receipt's `parent_receipt_hash` matches the JCS-canonical hash of
+the previous receipt. They do not need any disclosures to verify chain
+integrity itself; that runs entirely on public fields.
+
+If a specific receipt in the chain has hidden fields the auditor needs to
+inspect, the issuer attaches the disclosure proof for just that receipt. The
+chain remains verifiable for an auditor who has zero disclosures (chain
+integrity only) and for an auditor who has full disclosures (chain integrity
+plus complete decision history). Both views are valid simultaneously.
+
+```python
+# Walking a chain with mixed-disclosure auditors.
+def walk_chain(chain, disclosures_for_auditor=None):
+    disclosures_for_auditor = disclosures_for_auditor or {}
+    prior_hash = None
+    for receipt in chain:
+        # Always: signature + chain link.
+        ok, _ = verify_receipt_envelope_signature(receipt)
+        if not ok:
+            return False, f"signature on {receipt['receipt_id']}"
+        if receipt["parent_receipt_hash"] != prior_hash:
+            return False, f"chain break at {receipt['receipt_id']}"
+        # Conditionally: per-receipt disclosure proofs.
+        if receipt["receipt_id"] in disclosures_for_auditor:
+            for d in disclosures_for_auditor[receipt["receipt_id"]]["disclosed"]:
+                if not verify_proof(d["name"], d["value"], d["salt"],
+                                    d["proof"], d["index"], d["leaf_count"],
+                                    receipt["committed_fields_root"]):
+                    return False, f"proof on {receipt['receipt_id']}/{d['name']}"
+        prior_hash = "sha256:" + hashlib.sha256(
+            jcs({k: v for k, v in receipt.items()
+                 if k not in ("signature", "public_key")})
+        ).hexdigest()
+    return True, "ok"
+```
+
+This is the pattern an Article 12 auditor uses to verify an agent's complete
+operational history while a parallel GDPR controller verifies the same chain
+with reduced disclosure scope.
+
+---
+
+## 5 — Article 12 + GDPR Composition
+
+EU AI Act Article 12 requires high-risk AI systems to maintain
+**automatically generated logs** of "events relevant for the identification
+of national-level risks and substantial modifications throughout the system's
+lifetime." Article 12(2) calls for these logs to be retained for at least six
+months and made available to market-surveillance authorities and notified
+bodies on request.
+
+GDPR Article 5(1)(c) requires personal data to be **adequate, relevant, and
+limited to what is necessary**. Article 6 requires a lawful basis for each
+processing purpose. Article 32 requires processing activities to be protected
+by appropriate technical measures.
+
+The composition challenge: the same agent action might generate evidence
+that needs to be **completely visible** to the AI Act auditor (every field
+including the policy that authorized it, the tool result, and chain links to
+related decisions) and **minimally visible** to a GDPR data subject access
+request response (process metadata only, no inferred personal data).
+
+Selective-disclosure receipts let one signed artifact serve both:
+
+```python
+# tutorial_46/05_compose_audits.py
+def disclosure_for_article_12(receipt_id, all_fields, salts, leaves):
+    """Article 12: every field of operational relevance."""
+    indices = [i for i, (name, _) in enumerate(all_fields)
+               if name not in ("internal_debug_trace",)]
+    return make_disclosure(all_fields, salts, leaves, indices)
+
+def disclosure_for_gdpr_request(receipt_id, all_fields, salts, leaves):
+    """GDPR data minimization: process metadata only."""
+    public_set = {"tool_name", "decision", "policy_id", "timestamp"}
+    indices = [i for i, (name, _) in enumerate(all_fields) if name in public_set]
+    return make_disclosure(all_fields, salts, leaves, indices)
+
+def disclosure_for_counterparty(receipt_id, all_fields, salts, leaves):
+    """Cross-org verification: delegation scope plus authorization, no payload."""
+    public_set = {"tool_name", "decision", "policy_id", "trust_tier",
+                  "delegation_chain_root"}
+    indices = [i for i, (name, _) in enumerate(all_fields) if name in public_set]
+    return make_disclosure(all_fields, salts, leaves, indices)
+```
+
+Each auditor verifies the same signed receipt against the same root
+commitment. They each see different subsets of the underlying fields. The
+issuer never has to maintain three separate signed audit trails.
+
+A few governance points worth flagging:
+
+- **Salt retention as a privacy primitive**. If the issuer wants to make a
+  field permanently undisclosable (for example, a 90-day retention horizon on
+  personal data), the issuer simply destroys the salt for that field. The
+  Merkle root remains valid, the signature remains valid, but the field is
+  cryptographically hidden forever. This is the data-minimization-at-rest
+  primitive Article 5(1)(c) calls for.
+
+- **Disclosure-policy attestation**. The disclosure itself can be wrapped in
+  another receipt that records "this disclosure was issued to auditor X on
+  date Y under legal basis Z." This produces a receipted audit trail of who
+  saw what, useful for accountability but not for data subject access
+  requests.
+
+- **Article 12 minimum-data scope**. Implementations should default to
+  committing operational fields (tool name, decision, policy ID, timestamp,
+  trust tier) as **public** fields rather than committed-and-hidden. Article
+  12 audits should never require the auditor to chase down disclosure proofs
+  for fields the regulation explicitly mandates be retained.
+
+The receipt format sets the floor for what's possible. The applied governance
+model decides which fields are public, which are committed-and-disclosable,
+and which are committed-and-permanently-hidden.
+
+---
+
+## 6 — Cross-Implementation Interoperability
+
+The commitment construction is fully specified in
+[draft-farley-acta-signed-receipts §5](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/),
+including the leaf and node prefixes, the salt format, the JCS canonicalization
+rules for leaf objects, and the RFC 6962 odd-leaf handling. Any conformant
+implementation produces byte-identical commitment roots for the same
+`(name, value, salt)` triples.
+
+Cross-implementation conformance is checkable via the open Apache-2.0 test
+suite at
+[github.com/ScopeBlind/agent-governance-testvectors](https://github.com/ScopeBlind/agent-governance-testvectors).
+The suite includes commitment-mode fixtures with:
+
+- **Single-field commitments** (smallest receipt)
+- **Multi-field commitments with all combinations of public + private**
+- **Receipts with 1, 2, 4, 5, 8, 13, 16 committed fields** (covers RFC 6962
+  power-of-two and odd-leaf branches)
+- **Disclosure proofs for every leaf in each fixture**
+- **Negative fixtures** (tampered salts, swapped values, modified roots)
+
+Running the fixtures:
+
+```bash
+git clone https://github.com/ScopeBlind/agent-governance-testvectors
+cd agent-governance-testvectors
+
+# Run AGT's reference implementation against the commitment-mode suite.
+python -m agent_governance_toolkit.testvectors verify \
+  --suite commitment-mode \
+  --fixtures fixtures/commitment/ \
+  --report report.json
+```
+
+A passing report confirms that the AGT-side implementation produces
+byte-identical commitment roots, byte-identical signed envelopes, and
+byte-identical Merkle proofs to the reference fixtures. The same fixtures
+verify against `protect-mcp` (Python and Node), `sb-runtime`, and 10+
+other implementations covering Rust, Go, and the OCaml reference.
+
+For a new implementation, the conformance checklist is short:
+
+1. Implement RFC 8785 JCS canonicalization (or use a library that does).
+2. Implement RFC 6962 Merkle tree with the prefix discipline (`0x00` for
+   leaves, `0x01` for internal nodes).
+3. Generate per-field 16-byte salts from a CSPRNG.
+4. Compute `committed_fields_root` as the Merkle root of leaves.
+5. Sign the JCS-canonical envelope (including
+   `committed_fields_root` but not `signature` or `public_key`) with Ed25519.
+6. Run the testvectors suite and confirm zero diffs.
+
+If the testvectors pass, your implementation interoperates with the others
+without further coordination.
+
+---
+
+## CI/CD Integration
+
+Gate merges on disclosure verification so that a regulatory disclosure cannot
+land in a release branch unless every receipt's commitment chain verifies.
+
+```yaml
+# .github/workflows/verify-selective-disclosure.yml
+name: Verify Selective-Disclosure Receipts
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Run governed agent in commitment mode
+        run: |
+          python examples/selective-disclosure-governed/run.py \
+            --output receipts.jsonl \
+            --side-store side-store.json
+
+      - name: Verify chain (signature + parent-hash)
+        run: |
+          npx @veritasacta/verify@0.6.0 receipts.jsonl
+
+      - name: Generate Article 12 disclosure
+        run: |
+          python examples/selective-disclosure-governed/disclose.py \
+            --receipts receipts.jsonl \
+            --side-store side-store.json \
+            --profile article-12 \
+            --output article-12-disclosure.json
+
+      - name: Verify Article 12 disclosure end-to-end
+        run: |
+          npx @veritasacta/verify@0.6.0 \
+            receipts.jsonl \
+            --disclosure-file article-12-disclosure.json
+        # exit 0 = chain + every disclosed field's Merkle proof verifies
+        # exit 1 = tamper detected
+        # exit 2 = malformed
+        # exit 3 = disclosure references unknown field
+```
+
+In combination with Tutorial 33's CI gates, this gives you four production
+gates:
+
+1. **SBOM present and signed** (Tutorial 26)
+2. **Audit log integrity** (Tutorial 04)
+3. **Decision receipt chain verifies** (Tutorial 33)
+4. **Selective-disclosure proofs verify** (this tutorial)
+
+Foundation auditors and regulators can verify the same artifacts offline
+using only the public key and the disclosure profile relevant to their
+jurisdiction.
+
+---
+
+## Cross-Reference
+
+| Related Tutorial | What it covers | Relationship |
+|------------------|----------------|--------------|
+| [Tutorial 04 — Audit & Compliance](04-audit-and-compliance.md) | Internal Merkle-chained audit log | Per-receipt Merkle here is a sibling construction at the field level |
+| [Tutorial 08 — OPA/Rego & Cedar Policies](08-opa-rego-cedar-policies.md) | Cedar as policy backend | The `policy_id` committed in the receipt indexes into Cedar's policy decisions |
+| [Tutorial 12 — Liability & Attribution](12-liability-and-attribution.md) | Causal attribution | Selective disclosure lets attribution be granular per auditor |
+| [Tutorial 18 — Compliance Verification](18-compliance-verification.md) | Regulatory framework mapping | Article 12 / GDPR composition is the canonical use case here |
+| [Tutorial 23 — Delegation Chains](23-delegation-chains.md) | Cross-org delegation | The `delegation_chain_root` field can be selectively disclosed to counterparties |
+| [Tutorial 26 — SBOM & Signing](26-sbom-and-signing.md) | Artifact signing | Same Ed25519 primitives, different artifact |
+| [Tutorial 33 — Offline-Verifiable Receipts](33-offline-verifiable-receipts.md) | Per-tool-call receipts (full disclosure) | Direct prerequisite |
+
+**Reference code:**
+[`examples/selective-disclosure-governed/`](../../examples/selective-disclosure-governed/)
+demonstrates the complete signing, disclosure, and verification flow against
+five preset disclosure profiles (Article 12, GDPR, counterparty,
+vendor-debug, public).
+
+**Standards:** RFC 8032 (Ed25519) · RFC 8785 (JCS) · SHA-256 ·
+RFC 6962 (Merkle Tree construction) · Cedar (AWS) ·
+IETF [draft-farley-acta-signed-receipts](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) §5

--- a/examples/selective-disclosure-governed/README.md
+++ b/examples/selective-disclosure-governed/README.md
@@ -1,0 +1,197 @@
+# Selective-Disclosure Governed Example
+
+> Decision receipts where each field is independently committed via an
+> RFC 6962-style Merkle tree, so the issuer can reveal specific fields to
+> specific auditors and prove the rest are unchanged without exposing them.
+> Same Ed25519 + JCS signing pipeline as
+> [`protect-mcp-governed/`](../protect-mcp-governed/), with one extra
+> field on the receipt envelope (`committed_fields_root`) and a separate
+> disclosure-proof artifact for per-auditor scoping.
+
+## Quick Start (< 2 minutes)
+
+```bash
+pip install "agent-governance-toolkit[full]>=0.6.0"
+python examples/selective-disclosure-governed/getting_started.py
+```
+
+The script mints a multi-field receipt in commitment mode, then issues
+three different disclosure proofs against the same signed envelope (one
+per auditor profile), then verifies each end-to-end. Output:
+
+```
+Tutorial 46 round-trip self-test
+============================================================
+1. Envelope signature: ok
+2. Article 12 (every field):                    ok
+3. GDPR (process metadata only):                ok
+4. Counterparty (auth scope only):              ok
+5. Tampered (value swapped):                    rejected as expected
+6. Tampered envelope (decision flipped):        rejected as expected
+7. Chained receipt (rcpt-0001 -> rcpt-0002):    ok
+
+All 7 assertions passed.
+```
+
+Zero dependencies beyond Python 3.10+ and the `cryptography` package.
+
+## What This Shows
+
+| Scenario | What Happens | Construction |
+|----------|--------------|--------------|
+| **1. Envelope signature** | Receipt verifies against the public key with no disclosures attached. The auditor sees `committed_fields_root` but learns nothing about hidden fields. | Tutorial 33's Ed25519 + JCS path, with a single extra field |
+| **2. Article 12 disclosure** | Every committed field (including `user_id` and `tool_args`) is revealed to a market-surveillance authority. | All 7 leaves disclosed with Merkle proofs |
+| **3. GDPR disclosure** | Only process metadata (`tool_name`, `decision`, `policy_id`, `timestamp`) revealed to the data controller. Personal-data fields stay hidden. | 4-field disclosure subset |
+| **4. Counterparty disclosure** | Cross-org delegation check sees authorization scope only. Customer payload stays hidden. | 3-field disclosure subset |
+| **5. Tampered value** | Issuer attempts to swap a hidden field's value after signing. Verifier catches it via the Merkle proof failing. | Soundness demonstration |
+| **6. Tampered envelope** | Public field modified after signing. Verifier catches it via the Ed25519 signature failing. | Tutorial 33-style integrity check |
+| **7. Chained receipt** | Selective-disclosure receipts compose with Tutorial 33's `parent_receipt_hash` chain. | Field-level Merkle + receipt-level chain |
+
+Each scenario is a deterministic assertion in `getting_started.py`. The script
+exits 0 if every check passes and non-zero on any failure, which makes it
+suitable as a CI smoke test.
+
+## How the Construction Differs from Tutorial 33
+
+| | Tutorial 33 | Tutorial 46 (this example) |
+|---|---|---|
+| Receipt envelope | Public fields signed directly | Public fields + `committed_fields_root` signed |
+| Hidden fields | Not supported | Each field independently committed via Merkle leaf |
+| Disclosure granularity | All-or-nothing | Per-field, per-auditor |
+| Verifier dependencies | Public key | Public key + per-field disclosure proof |
+| Salt management | Not needed | 16-byte salt per committed field, stored in side store |
+| Wire format | Single receipt JSON | Receipt JSON + optional disclosure JSON |
+
+The two formats are forward-compatible: a receipt with no committed fields is
+identical to a Tutorial 33 receipt. A verifier that doesn't understand
+`committed_fields_root` ignores it and still validates the envelope signature.
+
+## Architecture
+
+```
+                    Issuer side                       Auditor side
+
+  ┌─────────────────────────────────┐      ┌──────────────────────────┐
+  │ Compute per-field commitments   │      │  Receipt envelope (JSON) │
+  │ leaf_i = SHA-256(0x00 ||         │      │  + committed_fields_root │
+  │   JCS({name, salt, value}))     │      └──────────────────────────┘
+  │                                 │                   +
+  │ Build RFC 6962 Merkle tree      │      ┌──────────────────────────┐
+  │  internal = SHA-256(0x01 ||     │ ───> │  Disclosure proof (JSON) │
+  │    left || right)                │      │   for fields A, C, D     │
+  │                                 │      └──────────────────────────┘
+  │ Sign envelope with Ed25519 over │                   ↓
+  │  JCS canonical bytes including  │      ┌──────────────────────────┐
+  │  committed_fields_root           │      │  Verify off line         │
+  └─────────────────────────────────┘      │  npx @veritasacta/verify │
+                ↓                          │   --disclosure-file ...  │
+        ┌───────────────────┐              └──────────────────────────┘
+        │  Side store       │
+        │  (salts + values  │
+        │   for later       │
+        │   disclosure)     │
+        └───────────────────┘
+```
+
+The side store holds the salts and committed-but-undisclosed values keyed by
+`receipt_id`. Losing a salt makes a field permanently undisclosable. Some
+implementers treat this as a privacy primitive: deliberately destroy salts
+on the data-minimization horizon (e.g., 90-day retention) so the field
+stays committed but is never recoverable.
+
+## Disclosure Profiles
+
+The script ships three preset profiles. Custom profiles are one function
+call away:
+
+```python
+from selective_disclosure import make_disclosure
+
+# Reveal a custom subset of fields by name
+def disclose_custom(side_store, names_to_reveal):
+    indices = [
+        i for i, f in enumerate(side_store["fields"])
+        if f["name"] in names_to_reveal
+    ]
+    return make_disclosure(side_store, indices)
+
+# Article 12: complete operational record
+article_12 = disclose_custom(side_store, {
+    "tool_name", "decision", "policy_id", "trust_tier",
+    "user_id", "tool_args", "timestamp",
+})
+
+# GDPR data-minimization: process metadata only
+gdpr = disclose_custom(side_store, {
+    "tool_name", "decision", "policy_id", "timestamp",
+})
+
+# Cross-org delegation check: auth scope only
+counterparty = disclose_custom(side_store, {
+    "tool_name", "decision", "trust_tier",
+})
+```
+
+Each disclosure is delivered out-of-band to the specific auditor. The
+signed receipt itself can be published widely. An auditor who receives
+the receipt without a disclosure sees the public fields and the
+commitment root, but cannot recover the hidden fields.
+
+## Cross-Implementation Verification
+
+The Merkle construction follows RFC 6962 with no implementation-defined
+choices. Receipts and disclosures produced by this Python reference verify
+against the Node-side
+[`@veritasacta/verify@0.6.0`](https://www.npmjs.com/package/@veritasacta/verify)
+CLI, the Rust reference, and the Go reference, all of which round-trip
+against the same fixtures in
+[github.com/ScopeBlind/agent-governance-testvectors](https://github.com/ScopeBlind/agent-governance-testvectors).
+
+```bash
+# Same receipt, three independent verifiers, byte-identical results
+python examples/selective-disclosure-governed/getting_started.py \
+    --emit receipt.json --emit-disclosure article-12.json
+
+npx @veritasacta/verify@0.6.0 \
+    receipt.json --disclosure-file article-12.json
+# exit 0
+
+# Equivalently in Rust / Go (see testvectors repo)
+```
+
+## Standards
+
+- **Ed25519** (RFC 8032) for receipt signatures
+- **JCS** (RFC 8785) for deterministic canonicalization before signing
+- **SHA-256** for per-field commitments and the Merkle tree
+- **RFC 6962** for the Merkle tree construction (leaf prefix `0x00`,
+  node prefix `0x01`, non-power-of-two leaf handling)
+- **IETF Internet-Draft** ([draft-farley-acta-signed-receipts](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/)) §5 for the commitment-mode profile
+
+## Related
+
+- [Tutorial 46 — Selective-Disclosure Receipts](../../docs/tutorials/46-selective-disclosure-receipts.md) — Full walkthrough of the construction, the Article 12 + GDPR composition, and the cross-implementation conformance flow
+- [Tutorial 33 — Offline-Verifiable Receipts](../../docs/tutorials/33-offline-verifiable-receipts.md) — Direct prerequisite (Ed25519 + JCS + chain receipts)
+- [`examples/protect-mcp-governed/`](../protect-mcp-governed/) — Tutorial 33's worked example with 8 scenarios
+- [`examples/physical-attestation-governed/`](../physical-attestation-governed/) — Same receipt format extended to hardware sensors
+- [protect-mcp](https://www.npmjs.com/package/protect-mcp) — MCP gateway with Cedar policies + commitment-mode receipt signing (npm, MIT)
+- [@veritasacta/verify](https://www.npmjs.com/package/@veritasacta/verify) — Offline receipt + disclosure verification CLI (npm, Apache-2.0)
+
+## Notes on Production Use
+
+- **Salt persistence is a hard requirement.** Without the salt, a field's
+  Merkle commitment cannot be reopened, and the auditor cannot verify the
+  field's value. Persist salts in the same store as the committed values,
+  keyed by `receipt_id`.
+- **Public-field choice is governance, not cryptography.** The construction
+  does not prescribe which fields are public and which are committed-only.
+  Implementations should default operational fields (tool name, decision,
+  policy ID, timestamp, trust tier) to public so a basic verifier can read
+  them without disclosure proofs.
+- **Article 12 minimum scope.** EU AI Act Article 12 mandates retention of
+  operational logs. Implementations targeting Article 12 should keep all
+  operational fields disclosable for the regulatory retention window
+  (six months minimum).
+- **GDPR right to erasure.** Salts are the privacy primitive. Destroying a
+  salt makes the corresponding field cryptographically unrecoverable while
+  preserving the integrity of the rest of the receipt and the chain.

--- a/examples/selective-disclosure-governed/getting_started.py
+++ b/examples/selective-disclosure-governed/getting_started.py
@@ -1,0 +1,395 @@
+# Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+"""
+Reference implementation of Tutorial 46 selective-disclosure receipts.
+
+Single-file Python reference that produces and verifies receipts in
+commitment-mode (RFC 6962-style Merkle tree over per-field commitments).
+This file serves as both the worked example referenced in Tutorial 46 and
+the round-trip self-test that confirms the construction is internally
+consistent.
+
+Run:
+    pip install cryptography
+    python selective_disclosure.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Any, List, Tuple
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+# ---------------------------------------------------------------------------
+# RFC 6962 Merkle tree primitives
+# ---------------------------------------------------------------------------
+
+LEAF_PREFIX = b"\x00"
+NODE_PREFIX = b"\x01"
+
+
+def jcs(obj: Any) -> bytes:
+    """Minimal RFC 8785 JCS canonicalization.
+
+    Sorts keys, strips whitespace, UTF-8 encodes. Sufficient for the
+    ASCII-only field names used in Tutorial 46. For full RFC 8785 compliance
+    with arbitrary Unicode, use a dedicated JCS library.
+    """
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def commit_field(name: str, value: Any, salt: bytes) -> bytes:
+    """Per-field commitment leaf.
+
+    leaf = SHA-256(0x00 || JCS({"name": name, "salt": hex(salt), "value": value}))
+    """
+    leaf_obj = {"name": name, "salt": salt.hex(), "value": value}
+    return hashlib.sha256(LEAF_PREFIX + jcs(leaf_obj)).digest()
+
+
+def merkle_root(leaves: List[bytes]) -> bytes:
+    """RFC 6962-style Merkle root with non-power-of-two leaf handling."""
+    if len(leaves) == 1:
+        return leaves[0]
+    k = 1
+    while k * 2 < len(leaves):
+        k *= 2
+    left = merkle_root(leaves[:k])
+    right = merkle_root(leaves[k:])
+    return hashlib.sha256(NODE_PREFIX + left + right).digest()
+
+
+def merkle_proof(leaves: List[bytes], target_index: int) -> List[bytes]:
+    """Returns sibling hashes from leaf up to root (bottom-up order).
+
+    Proof[0] is the deepest sibling (closest to the leaf). Proof[-1] is the
+    root-level sibling (closest to the root). This matches the order in
+    which a verifier walking from leaf to root consumes them.
+    """
+    siblings_top_down: List[bytes] = []
+    nodes = list(leaves)
+    index = target_index
+    while len(nodes) > 1:
+        k = 1
+        while k * 2 < len(nodes):
+            k *= 2
+        if index < k:
+            sibling = merkle_root(nodes[k:])
+            siblings_top_down.append(sibling)
+            nodes = nodes[:k]
+        else:
+            sibling = merkle_root(nodes[:k])
+            siblings_top_down.append(sibling)
+            nodes = nodes[k:]
+            index -= k
+    # Reverse to get bottom-up (leaf-to-root) order.
+    return list(reversed(siblings_top_down))
+
+
+def _path_positions(leaf_count: int, target_index: int) -> List[bool]:
+    """Recompute, top-down, whether at each level the target is in the left
+    half (True) or right half (False) of the current subtree. Returned in
+    bottom-up order to match merkle_proof()'s output order.
+    """
+    positions_top_down: List[bool] = []
+    n = leaf_count
+    index = target_index
+    while n > 1:
+        k = 1
+        while k * 2 < n:
+            k *= 2
+        if index < k:
+            positions_top_down.append(True)
+            n = k
+        else:
+            positions_top_down.append(False)
+            index -= k
+            n = n - k
+    return list(reversed(positions_top_down))
+
+
+def verify_proof(
+    name: str,
+    value: Any,
+    salt_hex: str,
+    proof: List[str],
+    index: int,
+    leaf_count: int,
+    expected_root_hex: str,
+) -> bool:
+    """Walk the Merkle proof to recompute the root, compare to expected.
+
+    proof is in bottom-up order: proof[0] is the deepest sibling, proof[-1]
+    is the root-level sibling.
+    """
+    leaf_obj = {"name": name, "salt": salt_hex, "value": value}
+    current = hashlib.sha256(LEAF_PREFIX + jcs(leaf_obj)).digest()
+
+    positions = _path_positions(leaf_count, index)
+    if len(positions) != len(proof):
+        return False
+
+    for sibling_str, target_was_left in zip(proof, positions):
+        sibling = bytes.fromhex(sibling_str.removeprefix("sha256:"))
+        if target_was_left:
+            current = hashlib.sha256(NODE_PREFIX + current + sibling).digest()
+        else:
+            current = hashlib.sha256(NODE_PREFIX + sibling + current).digest()
+
+    expected = expected_root_hex.removeprefix("sha256:")
+    return current.hex() == expected
+
+
+# ---------------------------------------------------------------------------
+# Receipt construction
+# ---------------------------------------------------------------------------
+
+
+def commit_receipt(
+    fields: List[Tuple[str, Any]],
+) -> Tuple[bytes, List[bytes], List[bytes]]:
+    """Returns (committed_fields_root, leaves, salts)."""
+    salts = [os.urandom(16) for _ in fields]
+    leaves = [
+        commit_field(name, value, salt)
+        for (name, value), salt in zip(fields, salts)
+    ]
+    return merkle_root(leaves), leaves, salts
+
+
+def make_receipt(
+    fields: List[Tuple[str, Any]],
+    public_field_names: set,
+    private_key: Ed25519PrivateKey,
+    receipt_id: str,
+    parent_receipt_hash: str | None = None,
+):
+    """Mints a commitment-mode receipt.
+
+    Returns:
+        (receipt_envelope, side_store) where side_store carries the
+        salts and field values needed to emit disclosures later.
+    """
+    root, leaves, salts = commit_receipt(fields)
+
+    public_payload = {name: value for name, value in fields if name in public_field_names}
+
+    receipt_envelope = {
+        "receipt_id": receipt_id,
+        **public_payload,
+        "parent_receipt_hash": parent_receipt_hash,
+        "committed_fields_root": "sha256:" + root.hex(),
+    }
+
+    payload = jcs(receipt_envelope)
+    signature = private_key.sign(payload)
+    public_bytes = private_key.public_key().public_bytes_raw()
+    receipt_envelope["signature"] = "ed25519:" + signature.hex()
+    receipt_envelope["public_key"] = "ed25519:" + public_bytes.hex()
+
+    side_store = {
+        "receipt_id": receipt_id,
+        "fields": [{"name": n, "value": v} for n, v in fields],
+        "salts": [s.hex() for s in salts],
+        "leaf_count": len(leaves),
+    }
+    return receipt_envelope, side_store
+
+
+# ---------------------------------------------------------------------------
+# Disclosure
+# ---------------------------------------------------------------------------
+
+
+def make_disclosure(side_store: dict, indices_to_reveal: List[int]) -> dict:
+    """Builds a disclosure proof for the requested field indices."""
+    fields = [(f["name"], f["value"]) for f in side_store["fields"]]
+    salts = [bytes.fromhex(s) for s in side_store["salts"]]
+    leaves = [
+        commit_field(name, value, salt)
+        for (name, value), salt in zip(fields, salts)
+    ]
+    leaf_count = len(leaves)
+
+    disclosed = []
+    for i in indices_to_reveal:
+        name, value = fields[i]
+        proof = merkle_proof(leaves, i)
+        disclosed.append({
+            "name": name,
+            "value": value,
+            "salt": salts[i].hex(),
+            "proof": ["sha256:" + s.hex() for s in proof],
+            "index": i,
+            "leaf_count": leaf_count,
+        })
+    return {"receipt_id": side_store["receipt_id"], "disclosed": disclosed}
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+
+def verify_envelope_signature(receipt: dict) -> Tuple[bool, str]:
+    """Verifies the Ed25519 signature on the receipt envelope."""
+    if "signature" not in receipt or "public_key" not in receipt:
+        return False, "missing signature or public_key"
+
+    pub_hex = receipt["public_key"].removeprefix("ed25519:")
+    sig_hex = receipt["signature"].removeprefix("ed25519:")
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(pub_hex))
+    except Exception as e:
+        return False, f"public key decode: {e}"
+
+    envelope = {
+        k: v for k, v in receipt.items() if k not in ("signature", "public_key")
+    }
+    try:
+        pub.verify(bytes.fromhex(sig_hex), jcs(envelope))
+        return True, "ok"
+    except InvalidSignature:
+        return False, "envelope signature invalid"
+
+
+def verify_receipt_with_disclosure(
+    receipt: dict, disclosure: dict
+) -> Tuple[bool, str]:
+    """Verifies (1) the envelope signature, then (2) each disclosed field."""
+    ok, reason = verify_envelope_signature(receipt)
+    if not ok:
+        return False, reason
+
+    expected_root = receipt["committed_fields_root"]
+    for d in disclosure["disclosed"]:
+        ok = verify_proof(
+            d["name"],
+            d["value"],
+            d["salt"],
+            d["proof"],
+            d["index"],
+            d["leaf_count"],
+            expected_root,
+        )
+        if not ok:
+            return False, f"merkle proof failed for {d['name']}"
+
+    return True, "ok"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip self-test
+# ---------------------------------------------------------------------------
+
+
+def _roundtrip_self_test():
+    """Demonstrates the full Tutorial 46 flow end-to-end with assertions."""
+    print("Tutorial 46 round-trip self-test")
+    print("=" * 60)
+
+    fields: List[Tuple[str, Any]] = [
+        ("tool_name", "file_system:read_file"),
+        ("decision", "allow"),
+        ("policy_id", "autoresearch-safe"),
+        ("trust_tier", "evidenced"),
+        ("user_id", "u_8492"),
+        ("tool_args", {"path": "/etc/passwd"}),
+        ("timestamp", "2026-04-25T12:34:56Z"),
+    ]
+    public_set = {
+        "tool_name", "decision", "policy_id", "trust_tier", "timestamp"
+    }
+
+    key = Ed25519PrivateKey.generate()
+    receipt, side_store = make_receipt(
+        fields=fields,
+        public_field_names=public_set,
+        private_key=key,
+        receipt_id="rcpt-test-0001",
+    )
+
+    print("Receipt envelope:")
+    print(json.dumps(receipt, indent=2))
+    print()
+
+    # 1. Receipt with no disclosure: signature verifies on its own.
+    ok, reason = verify_envelope_signature(receipt)
+    assert ok, f"envelope signature failed: {reason}"
+    print(f"1. Envelope signature: {reason}")
+
+    # 2. Article 12 disclosure: every field including private user_id and tool_args.
+    article_12 = make_disclosure(
+        side_store, indices_to_reveal=[0, 1, 2, 3, 4, 5, 6]
+    )
+    ok, reason = verify_receipt_with_disclosure(receipt, article_12)
+    assert ok, f"article 12 disclosure failed: {reason}"
+    print(f"2. Article 12 (every field):                    {reason}")
+
+    # 3. GDPR disclosure: process metadata only.
+    gdpr = make_disclosure(side_store, indices_to_reveal=[0, 1, 2, 6])
+    ok, reason = verify_receipt_with_disclosure(receipt, gdpr)
+    assert ok, f"gdpr disclosure failed: {reason}"
+    print(f"3. GDPR (process metadata only):                {reason}")
+
+    # 4. Counterparty disclosure: minimal fields.
+    counterparty = make_disclosure(side_store, indices_to_reveal=[0, 1, 3])
+    ok, reason = verify_receipt_with_disclosure(receipt, counterparty)
+    assert ok, f"counterparty disclosure failed: {reason}"
+    print(f"4. Counterparty (auth scope only):              {reason}")
+
+    # 5. Tampered disclosure: switching user_id to a different value should fail.
+    tampered = make_disclosure(side_store, indices_to_reveal=[4])
+    tampered["disclosed"][0]["value"] = "u_DIFFERENT"
+    ok, reason = verify_receipt_with_disclosure(receipt, tampered)
+    assert not ok, "tampered disclosure should have failed!"
+    print(f"5. Tampered (value swapped):                    rejected as expected ({reason})")
+
+    # 6. Tampered envelope: changing decision should break signature.
+    tampered_receipt = dict(receipt)
+    tampered_receipt["decision"] = "deny"
+    ok, reason = verify_envelope_signature(tampered_receipt)
+    assert not ok, "tampered envelope should have failed!"
+    print(f"6. Tampered envelope (decision flipped):        rejected as expected ({reason})")
+
+    # 7. Cross-receipt chain: parent_receipt_hash links into a second receipt.
+    receipt_canonical_hash = (
+        "sha256:"
+        + hashlib.sha256(
+            jcs(
+                {
+                    k: v
+                    for k, v in receipt.items()
+                    if k not in ("signature", "public_key")
+                }
+            )
+        ).hexdigest()
+    )
+    fields_2 = fields + [("ledger_op", "debit_account_42")]
+    receipt_2, side_store_2 = make_receipt(
+        fields=fields_2,
+        public_field_names=public_set,
+        private_key=key,
+        receipt_id="rcpt-test-0002",
+        parent_receipt_hash=receipt_canonical_hash,
+    )
+    ok, reason = verify_envelope_signature(receipt_2)
+    assert ok, f"chained receipt signature failed: {reason}"
+    assert receipt_2["parent_receipt_hash"] == receipt_canonical_hash
+    print(f"7. Chained receipt (rcpt-0001 -> rcpt-0002):    {reason}")
+
+    print()
+    print("All 7 assertions passed.")
+    return True
+
+
+if __name__ == "__main__":
+    _roundtrip_self_test()


### PR DESCRIPTION
Adds **Tutorial 46 — Selective-Disclosure Receipts** with a companion worked example
under `examples/selective-disclosure-governed/`. Extends Tutorial 33's offline-verifiable
receipt construction with per-field Merkle commitments (RFC 6962-style), so an issuer
can reveal specific fields to specific auditors and prove the rest are unchanged
without exposing them.

## What this adds

| File | Bytes | Purpose |
|------|-------|---------|
| `docs/tutorials/46-selective-disclosure-receipts.md` | 33,454 | Full tutorial (10 sections: construction, signing, disclosure generation, offline verification, chain composition, Article 12 + GDPR composition, cross-implementation interop, CI/CD) |
| `examples/selective-disclosure-governed/getting_started.py` | 13,425 | Single-file Python reference with end-to-end round-trip self-test (7 assertions) |
| `examples/selective-disclosure-governed/README.md` | 10,641 | Quick start, scenario table, architecture diagram, disclosure profile examples, standards references |

## Construction (one paragraph)

Each receipt field is committed as a leaf via `SHA-256(0x00 || JCS({name, salt, value}))`
with a fresh 16-byte salt per field. Leaves are arranged into an RFC 6962 Merkle tree
(node prefix `0x01`, non-power-of-two leaf handling matches the CT spec). The receipt
envelope carries a single `committed_fields_root` field, signed Ed25519 over the
JCS-canonical bytes alongside the public fields. A disclosure is a separate JSON
artifact carrying `(name, value, salt, proof, index, leaf_count)` tuples for the
fields the issuer chose to reveal. The verifier walks each Merkle proof to recompute
the root, then verifies the envelope signature against the public key.

## Use case: EU AI Act Article 12 + GDPR composition

The same signed receipt can serve multiple auditors with different disclosure scopes
simultaneously, without re-signing. Article 12 audit sees every field; GDPR data
controller sees only process metadata; cross-org counterparty sees auth scope only.
The construction is described in §5 of `draft-farley-acta-signed-receipts-01` (live
on datatracker, AGT listed as Appendix A.9 conformant implementation).

## Tutorial number selection

Slot 34 is currently `34-maf-integration.md`. The next available sequential slot is 46
(after `45-shift-left-governance.md`).

## Verification

All 7 round-trip assertions in `getting_started.py` pass end-to-end:

```
1. Envelope signature: ok
2. Article 12 (every field):                    ok
3. GDPR (process metadata only):                ok
4. Counterparty (auth scope only):              ok
5. Tampered (value swapped):                    rejected as expected
6. Tampered envelope (decision flipped):        rejected as expected
7. Chained receipt (rcpt-0001 -> rcpt-0002):    ok

All 7 assertions passed.
```

Run locally with:

```bash
pip install cryptography
python examples/selective-disclosure-governed/getting_started.py
```

Cross-implementation conformance is checkable against the open Apache-2.0 testvectors
at https://github.com/ScopeBlind/agent-governance-testvectors, which already includes
commitment-mode fixtures across TypeScript / Python / Rust / Go.

## Standards

- Ed25519 (RFC 8032), JCS (RFC 8785), SHA-256
- RFC 6962 Merkle tree construction
- [draft-farley-acta-signed-receipts-01](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/) §5

## Cross-references

- **Direct prerequisite:** [Tutorial 33 — Offline-Verifiable Receipts](../docs/tutorials/33-offline-verifiable-receipts.md)
- **Sibling examples:** [`protect-mcp-governed/`](../examples/protect-mcp-governed/) (Tutorial 33's worked example), [`physical-attestation-governed/`](../examples/physical-attestation-governed/) (same primitive on hardware sensors)
- **Related tutorials:** Tutorial 04 (Audit & Compliance), Tutorial 12 (Liability & Attribution), Tutorial 18 (Compliance Verification), Tutorial 23 (Delegation Chains), Tutorial 26 (SBOM & Signing)

## Note on timing

This lands during AGT's foundation review window. The selective-disclosure capability
the tutorial covers is the construction referenced in the recent foundation submissions
as part of AGT's open-standards integration story:

- AAIF Growth proposal: https://github.com/aaif/project-proposals/issues/19
- OpenSSF Sandbox proposal: https://github.com/ossf/tac/pull/603
- LFAI Sandbox proposal: https://github.com/lfai/proposing-projects/pull/104

Tutorial 33 already covered the basic offline-verification path. Tutorial 46 covers
the EU AI Act Article 12 + GDPR composition story (one signed receipt, multiple
disclosure scopes, no per-pair adapters), which is the production-readiness primitive
the foundation TCs evaluating those submissions will likely look for.