### PR TITLE
docs(adr): add ADR 0010 TEE keystore with SEV-SNP attestation

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/advisory.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/advisory.py
@@ -28,10 +28,8 @@ Usage::
 from __future__ import annotations
 
 import logging
-import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/approval.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/approval.py
@@ -170,7 +170,7 @@ class ConsoleApproval(ApprovalHandler):
 
     def request_approval(self, request: ApprovalRequest) -> ApprovalDecision:
         print(f"\n{'='*60}")
-        print(f"APPROVAL REQUIRED")
+        print("APPROVAL REQUIRED")
         print(f"{'='*60}")
         print(f"  Rule:    {request.rule_name}")
         print(f"  Policy:  {request.policy_name}")

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/evidence_pipeline.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/evidence_pipeline.py
@@ -45,8 +45,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import yaml
-
 from .annex_iv import AnnexIVDocument, TechnicalDocumentationExporter
 from .audit import AuditEntry
 from .compliance import ComplianceFramework, ComplianceReport

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
@@ -20,7 +20,7 @@ import functools
 import logging
 import os
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
 from .policy import Policy, PolicyDecision, PolicyEngine

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
@@ -163,10 +163,14 @@ class PolicyRule(BaseModel):
             try:
                 actual_num = float(actual) if actual is not None else 0
                 target = float(num_str)
-                if op == ">": return actual_num > target
-                if op == "<": return actual_num < target
-                if op == ">=": return actual_num >= target
-                if op == "<=": return actual_num <= target
+                if op == ">":
+                    return actual_num > target
+                if op == "<":
+                    return actual_num < target
+                if op == ">=":
+                    return actual_num >= target
+                if op == "<=":
+                    return actual_num <= target
             except (TypeError, ValueError):
                 return False
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/session_state.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/session_state.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/marketplace/lifecycle.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/marketplace/lifecycle.py
@@ -28,7 +28,6 @@ Usage::
 from __future__ import annotations
 
 import logging
-import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum

--- a/agent-governance-python/agent-mesh/src/agentmesh/marketplace/sigstore_provenance.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/marketplace/sigstore_provenance.py
@@ -50,7 +50,6 @@ import hashlib
 import json
 import logging
 import subprocess
-import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path

--- a/docs/adr/0010-tee-keystore-sevsnp-attestation.md
+++ b/docs/adr/0010-tee-keystore-sevsnp-attestation.md
@@ -1,0 +1,187 @@
+# ADR 0010: Add TEE keystore with SEV-SNP attestation for agent identity
+
+- Status: proposed
+- Date: 2026-04-26
+
+## Context
+
+AgentMesh identity currently proves **who** an agent is through Ed25519 DIDs
+and proves **what** it can do through capabilities, delegation, and policy. It
+does not prove **where** the agent is running or whether the signing key used by
+the agent is protected by the execution environment.
+
+That leaves a material gap for sensitive agent workloads. If an agent's signing
+key is stored on disk, injected through an environment variable, or mounted as a
+software secret, a compromised host can yield a fully valid agent identity. The
+attacker can sign handshakes and exercise delegated authority from an
+unapproved environment, even if the cryptographic identity itself remains valid.
+
+Existing ADRs address adjacent layers:
+
+- ADR 0001 establishes Ed25519 as the agent identity primitive.
+- ADR 0003 constrains the trust handshake to a 200ms budget.
+- ADR 0005 addresses liveness attestation: whether an agent is alive now.
+- ADR 0007 and ADR 0008 address cross-organization identity and policy
+  federation.
+- ADR 0009 aligns AGT's attestation vocabulary with RFC 9334 RATS.
+
+This ADR addresses a different property: **execution-environment attestation
+and key origin**. The relying party should be able to distinguish a locally
+stored software key from a key that was released into, or generated inside, a
+hardware-attested trusted execution environment (TEE).
+
+The first implementation should focus on a TEE keystore plus AMD SEV-SNP
+attestation. The design should remain cloud-agnostic at the abstraction layer,
+while being optimized for Azure in the first provider implementation because
+Azure provides deployed SEV-SNP confidential VMs, Microsoft Azure Attestation
+(MAA), and Azure Key Vault Secure Key Release (AKV SKR).
+
+Intel TDX, TPM/measured boot, Azure Confidential ACI, AWS Nitro, GCP
+Confidential Space, and other environments are intentionally sequenced after
+the SEV-SNP foundation.
+
+## Decision
+
+Add optional TEE-bound identity support to AgentMesh through three core
+abstractions:
+
+1. `TEEKeyStore`: obtains the agent signing key from a hardware-bound source.
+2. `AttestationCollector`: collects platform evidence from the runtime
+   environment.
+3. `AttestationVerifier`: verifies evidence and returns structured attestation
+   claims for the trust and policy layers.
+
+The v1 implementation starts with AMD SEV-SNP on Azure:
+
+- `SKRKeyStore` releases the agent's Ed25519 private key through Azure Key
+  Vault Secure Key Release after MAA validates a SEV-SNP attestation report.
+- `AzureSEVSNPCollector` collects SEV-SNP evidence through Azure-supported
+  mechanisms such as IMDS or `/dev/sev-guest`.
+- `MAAVerifier` validates the attestation report, extracts structured claims,
+  and checks configured reference values.
+
+The model defines three key-origin tiers:
+
+| Key origin | Description | Trust implication |
+|---|---|---|
+| `skr` | Key is released by an attestation-aware KMS after the TEE passes policy | Preferred production path for Azure |
+| `tee_generated` | Key is generated inside the TEE and attestation binds the public key hash to the environment | Strongest residency model, requires registration flow |
+| `local` | Existing software key behavior | Backward-compatible fallback with no TEE trust elevation |
+
+Attestation evidence must bind to the specific agent, handshake, and public key
+using a canonical report-data hash:
+
+```text
+SHA-256(
+  "agentmesh-attest-v1"
+  || len(agent_did) || agent_did
+  || len(challenge_id) || challenge_id
+  || nonce
+  || public_key_hash
+)
+```
+
+> **Encoding note:** `||` denotes byte concatenation. Strings are UTF-8 encoded.
+> Length prefixes are 2-byte big-endian unsigned integers. `public_key_hash` is
+> the raw 32-byte SHA-256 digest of the agent's Ed25519 public key.
+
+This prevents replay, relay, and key-swapping attacks. A verifier should reject
+evidence that is stale, bound to a different DID, bound to a different nonce, or
+bound to a different public key.
+
+The design is additive:
+
+- Agents without TEE support continue to use existing identity behavior.
+- TEE claims are exposed as optional trust attributes, not required protocol
+  fields for every deployment.
+- Trust score changes are additive bonuses or penalties only. Existing trust
+  tiers are not rebalanced.
+- Policy can require `key_origin`, `key_bound_to_tee`, `confidential_level`, or
+  `tcb_status` for sensitive actions.
+
+The core package must not take hard dependencies on platform-specific TEE
+libraries. Azure-specific collectors, verifiers, and SKR dependencies should
+ship as optional extras with lazy imports and clear errors when unavailable.
+
+## Scope and sequencing
+
+### Phase 1: ADR and foundation
+
+Define the data model and interfaces:
+
+- `AttestationEvidence`
+- `AttestationClaims`
+- `ConfidentialLevel`
+- `TEEKeyStore`
+- `AttestationCollector`
+- `AttestationVerifier`
+- `SKRKeyStore`
+- `AzureSEVSNPCollector`
+- `MAAVerifier`
+- `LocalKeyStore` fallback
+
+This phase should be testable without confidential hardware by using mock
+collectors, mock MAA responses, and mock SKR flows. Real SEV-SNP plus AKV SKR
+tests should run separately in an Azure confidential VM environment.
+
+### Phase 2: Trust and policy integration
+
+Extend the trust layer to carry optional attestation evidence and verified
+claims:
+
+- `TrustHandshake` can request and verify attestation.
+- Cache keys include attestation requirements and evidence freshness.
+- `require_attestation` and `require_tee_bound_key` modes fail closed when
+  configured.
+- Risk scoring adds an environment bonus without changing the existing score
+  formula.
+- Trust policy gains environment-aware conditions.
+
+### Phase 3: Provider expansion
+
+After the SEV-SNP keystore and attestation path is accepted, add additional
+providers incrementally:
+
+- Intel TDX attestation collector and verifier path.
+- TPM/measured boot collector for non-TEE integrity signals.
+- Azure Confidential ACI support, including CCE workload policy measurements.
+- Non-Azure TEE providers such as AWS Nitro and GCP Confidential Space.
+- Optional EAT serialization work that builds on ADR 0009's RATS alignment.
+
+## Non-goals
+
+- Do not require all agents to run in a TEE.
+- Do not replace Ed25519 DID identity, SPIFFE/SVID, Entra, or external JWKS
+  federation.
+- Do not treat liveness attestation as execution-environment attestation. ADR
+  0005 covers liveness; this ADR covers key origin and runtime evidence.
+- Do not rebalance existing trust score components or silently change existing
+  trust tiers.
+- Do not add TDX, TPM, C-ACI, Nitro, or Confidential Space in the first
+  implementation PR.
+- Do not make Azure services mandatory for the abstraction layer. Azure is the
+  first optimized provider implementation, not the only supported model.
+
+## Consequences
+
+TEE-bound identity closes a high-value gap in AgentMesh: a relying party can
+verify not only that an agent holds a valid signing key, but that the key was
+released into, or generated inside, an attested execution environment. This is
+especially valuable for agents handling PII, financial workflows, regulated
+operations, cross-organization calls, or high-impact MCP tools.
+
+The design gives operators a policy control point. Sensitive actions can require
+hardware-bound keys and current TCB status, while lower-risk agents can continue
+using local keys. This preserves backward compatibility and avoids turning TEE
+support into a deployment prerequisite.
+
+The tradeoff is operational complexity. SEV-SNP and TDX collectors are
+platform-specific and may require Linux-only native dependencies. AKV SKR and
+MAA add startup-time dependencies and require reference values to be maintained
+as platforms update firmware, guest images, and workload policies. Production
+deployments must avoid silent downgrade from a configured TEE requirement to a
+local-key fallback.
+
+The first implementation should therefore fail closed when attestation is
+required, log explicit downgrade events, keep platform dependencies optional,
+and separate cloud-agnostic interfaces from Azure-specific provider code.

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -57,7 +57,8 @@ REGISTERED_PACKAGES = {
     "python-multipart", "python-json-logger", "langchain-openai",
     # Slack / messaging
     "slack-sdk", "slack-bolt",
-    # Telemetry
+    # Telemetry / monitoring
+    "sentry-sdk",
     "opentelemetry-instrumentation-fastapi", "opentelemetry-exporter-otlp",
     "opentelemetry-instrumentation-httpx", "opentelemetry-instrumentation-asyncio",
     # pyproject.toml optional-dependency group names (not real packages)


### PR DESCRIPTION
## Summary

Adds ADR 0010 proposing optional TEE-bound identity support for AgentMesh, starting with a TEE keystore and AMD SEV-SNP attestation on Azure.

Based on PR #1487 by @pkhandavilli, rebased onto current main and with an encoding note added to the canonical report-data hash specification (clarifying byte concatenation, UTF-8 encoding, and length prefix format).

Closes #1487 supersedes.

## Changes

- `docs/adr/0010-tee-keystore-sevsnp-attestation.md`: New ADR
- `docs/adr/README.md`: Added ADR 0010 to index
- `docs/adr/index.md`: Added ADR 0010 to table
