### PR TITLE
fix(docs): replace example Sentry DSN that triggered secret scanning

### DIFF
--- a/agent-governance-python/agent-sre/docs/integration-guide.md
+++ b/agent-governance-python/agent-sre/docs/integration-guide.md
@@ -92,7 +92,7 @@ from agent_sre.integrations.sentry import SentryExporter
 
 # Initialize with your Sentry DSN
 exporter = SentryExporter(
-    dsn="https://examplePublicKey@o0.ingest.sentry.io/0",
+    dsn="https://your-public-key@o0.ingest.sentry.io/0",  # replace with your DSN
     environment="production",
     release="agent-v1.2.0",
 )


### PR DESCRIPTION
Replaces the example Sentry DSN placeholder that triggered Copilot Secret Scanning alert. The string `examplePublicKey@o0.ingest.sentry.io` was flagged as a password. Replaced with `your-public-key@o0.ingest.sentry.io` which is clearly a placeholder.
