### PR TITLE
feat: package contributor reputation check as reusable GitHub Action

### DIFF
--- a/.github/actions/contributor-check/action.yml
+++ b/.github/actions/contributor-check/action.yml
@@ -1,0 +1,437 @@
+name: "Contributor Reputation Check"
+description: >
+  Reusable composite action that screens GitHub contributors for coordinated
+  inauthentic behavior: account-shape anomalies, cross-repo spray, credential
+  laundering, and network coordination. Part of AGT's shift-left governance.
+
+inputs:
+  github-token:
+    description: "GitHub token with issues:write and pull-requests:write"
+    required: true
+  checks:
+    description: "Comma-separated list of checks to run: profile, credential, cluster"
+    required: false
+    default: "profile,credential"
+  target-repo:
+    description: "Repository for credential audit (owner/repo). Defaults to the current repo."
+    required: false
+    default: ""
+  risk-threshold:
+    description: "Minimum risk to comment/label: MEDIUM or HIGH"
+    required: false
+    default: "MEDIUM"
+
+outputs:
+  risk:
+    description: "Overall risk level: LOW, MEDIUM, HIGH, or UNKNOWN"
+    value: ${{ steps.aggregate.outputs.risk }}
+  profile-risk:
+    description: "Profile analysis risk level"
+    value: ${{ steps.profile.outputs.risk }}
+  credential-risk:
+    description: "Credential audit risk level"
+    value: ${{ steps.credential.outputs.risk }}
+  cluster-risk:
+    description: "Cluster detection risk level (empty if not run)"
+    value: ${{ steps.cluster.outputs.risk }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: "3.12"
+
+    - name: Resolve inputs
+      id: inputs
+      shell: bash
+      run: |
+        username=""
+        number="0"
+        type="manual"
+
+        event_name="${{ github.event_name }}"
+
+        if [ "$event_name" = "pull_request_target" ] || [ "$event_name" = "pull_request" ]; then
+          username="${{ github.event.pull_request.user.login }}"
+          number="${{ github.event.pull_request.number }}"
+          type="pr"
+        elif [ "$event_name" = "issues" ]; then
+          username="${{ github.event.issue.user.login }}"
+          number="${{ github.event.issue.number }}"
+          type="issue"
+        elif [ "$event_name" = "workflow_dispatch" ]; then
+          username="${{ github.event.inputs.username || '' }}"
+          type="manual"
+        fi
+
+        echo "username=$username" >> "$GITHUB_OUTPUT"
+        echo "number=$number" >> "$GITHUB_OUTPUT"
+        echo "type=$type" >> "$GITHUB_OUTPUT"
+
+        target="${{ inputs.target-repo }}"
+        if [ -z "$target" ]; then
+          target="${{ github.repository }}"
+        fi
+        echo "target_repo=$target" >> "$GITHUB_OUTPUT"
+
+        scripts="${{ github.action_path }}/../../../scripts"
+        echo "scripts_dir=$scripts" >> "$GITHUB_OUTPUT"
+
+    # ── Profile check ──
+    - name: Run profile check
+      id: profile
+      if: contains(inputs.checks, 'profile')
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        scripts="${{ steps.inputs.outputs.scripts_dir }}"
+        username="${{ steps.inputs.outputs.username }}"
+        target="${{ steps.inputs.outputs.target_repo }}"
+
+        if [ -z "$username" ]; then
+          echo "risk=UNKNOWN" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        set +e
+        python "$scripts/contributor_check.py" \
+          --username "$username" \
+          --repo "$target" \
+          --json > /tmp/agt-profile.json 2>/tmp/agt-profile.log
+        set -e
+
+        risk=$(python -c "import json; print(json.load(open('/tmp/agt-profile.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
+        echo "risk=$risk" >> "$GITHUB_OUTPUT"
+
+        signals=$(python -c "
+        import json
+        r = json.load(open('/tmp/agt-profile.json'))
+        for s in r.get('signals', []):
+            print(f\"- **[{s['severity']}]** {s['name']}: {s['detail']}\")
+        " 2>/dev/null || echo "")
+        {
+          echo "signals<<PROFILE_SIGNALS_EOF"
+          echo "$signals"
+          echo "PROFILE_SIGNALS_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    # ── Credential audit ──
+    - name: Run credential audit
+      id: credential
+      if: contains(inputs.checks, 'credential')
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        scripts="${{ steps.inputs.outputs.scripts_dir }}"
+        username="${{ steps.inputs.outputs.username }}"
+        target="${{ steps.inputs.outputs.target_repo }}"
+
+        if [ -z "$username" ]; then
+          echo "risk=UNKNOWN" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        set +e
+        python "$scripts/credential_audit.py" \
+          --username "$username" \
+          --repo "$target" \
+          --json > /tmp/agt-cred.json 2>/tmp/agt-cred.log
+        set -e
+
+        risk=$(python -c "import json; print(json.load(open('/tmp/agt-cred.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
+        echo "risk=$risk" >> "$GITHUB_OUTPUT"
+
+        merges=$(python -c "import json; print(len(json.load(open('/tmp/agt-cred.json')).get('merges', [])))" 2>/dev/null || echo "0")
+        citations=$(python -c "import json; print(len(json.load(open('/tmp/agt-cred.json')).get('citations', [])))" 2>/dev/null || echo "0")
+        spray_repos=$(python -c "import json; print(json.load(open('/tmp/agt-cred.json')).get('spray_repos_count', 0))" 2>/dev/null || echo "0")
+        echo "merges=$merges" >> "$GITHUB_OUTPUT"
+        echo "citations=$citations" >> "$GITHUB_OUTPUT"
+        echo "spray_repos=$spray_repos" >> "$GITHUB_OUTPUT"
+
+    # ── Cluster detection (opt-in) ──
+    - name: Run cluster detection
+      id: cluster
+      if: contains(inputs.checks, 'cluster')
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        scripts="${{ steps.inputs.outputs.scripts_dir }}"
+        username="${{ steps.inputs.outputs.username }}"
+
+        if [ -z "$username" ]; then
+          echo "risk=UNKNOWN" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        set +e
+        python "$scripts/cluster_detect.py" \
+          --seed "$username" \
+          --json > /tmp/agt-cluster.json 2>/tmp/agt-cluster.log
+        set -e
+
+        risk=$(python -c "import json; print(json.load(open('/tmp/agt-cluster.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
+        echo "risk=$risk" >> "$GITHUB_OUTPUT"
+
+        accounts=$(python -c "import json; print(json.load(open('/tmp/agt-cluster.json')).get('account_count', 0))" 2>/dev/null || echo "0")
+        edges=$(python -c "import json; print(json.load(open('/tmp/agt-cluster.json')).get('edge_count', 0))" 2>/dev/null || echo "0")
+        echo "accounts=$accounts" >> "$GITHUB_OUTPUT"
+        echo "edges=$edges" >> "$GITHUB_OUTPUT"
+
+    # ── Aggregate risk ──
+    - name: Compute overall risk
+      id: aggregate
+      shell: bash
+      run: |
+        risk_to_num() {
+          case "$1" in
+            HIGH) echo 3 ;; MEDIUM) echo 2 ;; LOW) echo 1 ;; *) echo 0 ;;
+          esac
+        }
+
+        p=$(risk_to_num "${{ steps.profile.outputs.risk }}")
+        c=$(risk_to_num "${{ steps.credential.outputs.risk }}")
+        k=$(risk_to_num "${{ steps.cluster.outputs.risk }}")
+
+        max=$p
+        [ "$c" -gt "$max" ] && max=$c
+        [ "$k" -gt "$max" ] && max=$k
+
+        case "$max" in
+          3) overall="HIGH" ;; 2) overall="MEDIUM" ;; 1) overall="LOW" ;; *) overall="LOW" ;;
+        esac
+        echo "risk=$overall" >> "$GITHUB_OUTPUT"
+
+    # ── Post comment (idempotent via marker) ──
+    - name: Post review comment
+      if: >-
+        steps.inputs.outputs.type != 'manual' &&
+        (steps.aggregate.outputs.risk == 'HIGH' ||
+         (inputs.risk-threshold == 'MEDIUM' && steps.aggregate.outputs.risk == 'MEDIUM'))
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        username="${{ steps.inputs.outputs.username }}"
+        number="${{ steps.inputs.outputs.number }}"
+        type="${{ steps.inputs.outputs.type }}"
+        overall="${{ steps.aggregate.outputs.risk }}"
+        profile_risk="${{ steps.profile.outputs.risk }}"
+        cred_risk="${{ steps.credential.outputs.risk }}"
+        owner="${{ github.repository_owner }}"
+        repo="${{ github.event.repository.name }}"
+
+        if [ "$overall" = "HIGH" ]; then icon="🔴"; else icon="🟡"; fi
+
+        body="<!-- agt-contributor-check -->
+        $icon **Contributor Reputation Check: $overall risk**
+
+        | Check | Risk |
+        |-------|------|
+        | Profile analysis | $profile_risk |
+        | Credential audit | $cred_risk |
+        "
+
+        profile_signals="${{ steps.profile.outputs.signals }}"
+        if [ -n "$profile_signals" ]; then
+          body="$body
+        <details>
+        <summary>Profile signals</summary>
+
+        $profile_signals
+
+        </details>
+        "
+        fi
+
+        citations="${{ steps.credential.outputs.citations }}"
+        if [ "$citations" != "0" ] && [ -n "$citations" ]; then
+          spray_repos="${{ steps.credential.outputs.spray_repos }}"
+          merges="${{ steps.credential.outputs.merges }}"
+          body="$body
+        <details>
+        <summary>Credential audit: $merges merged PRs, $citations citations across $spray_repos repos</summary>
+
+        The contributor cites merged PRs from this repo in issues filed across other repositories.
+        This pattern may indicate credential laundering.
+
+        </details>
+        "
+        fi
+
+        body="$body
+        ---
+        *Automated check by [AGT Contributor Reputation](https://github.com/microsoft/agent-governance-toolkit/tree/main/scripts#contributor-reputation-tools). Not a judgment.*"
+
+        # Idempotent comment: find and update existing, or create new
+        python3 << 'PYEOF'
+        import json, os, sys
+        from urllib.request import Request, urlopen
+        from urllib.error import HTTPError
+
+        token = os.environ["GITHUB_TOKEN"]
+        owner = os.environ.get("owner", "")
+        repo_name = os.environ.get("repo", "")
+        number = os.environ.get("number", "0")
+        body = os.environ.get("body", "")
+        item_type = os.environ.get("type", "issue")
+        marker = "<!-- agt-contributor-check -->"
+
+        base = "https://api.github.com"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+        def api(method, path, data=None):
+            url = f"{base}{path}"
+            req = Request(url, method=method, headers=headers)
+            if data:
+                req.add_header("Content-Type", "application/json")
+                req.data = json.dumps(data).encode()
+            with urlopen(req, timeout=15) as resp:
+                return json.loads(resp.read())
+
+        # Search for existing comment with our marker
+        existing_id = None
+        page = 1
+        while True:
+            comments = api("GET", f"/repos/{owner}/{repo_name}/issues/{number}/comments?per_page=100&page={page}")
+            for c in comments:
+                if marker in (c.get("body") or ""):
+                    existing_id = c["id"]
+                    break
+            if existing_id or len(comments) < 100:
+                break
+            page += 1
+
+        if existing_id:
+            api("PATCH", f"/repos/{owner}/{repo_name}/issues/comments/{existing_id}", {"body": body})
+            print(f"Updated existing comment {existing_id}")
+        else:
+            api("POST", f"/repos/{owner}/{repo_name}/issues/{number}/comments", {"body": body})
+            print("Created new comment")
+        PYEOF
+
+    # ── Label (idempotent) ──
+    - name: Add risk label
+      if: >-
+        steps.inputs.outputs.type != 'manual' &&
+        (steps.aggregate.outputs.risk == 'HIGH' ||
+         (inputs.risk-threshold == 'MEDIUM' && steps.aggregate.outputs.risk == 'MEDIUM'))
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        number="${{ steps.inputs.outputs.number }}"
+        type="${{ steps.inputs.outputs.type }}"
+        risk="${{ steps.aggregate.outputs.risk }}"
+        owner="${{ github.repository_owner }}"
+        repo="${{ github.event.repository.name }}"
+
+        # Use Python for portability (no gh CLI dependency)
+        python3 << PYEOF
+        import json, os, sys
+        from urllib.request import Request, urlopen
+        from urllib.error import HTTPError
+
+        token = os.environ["GITHUB_TOKEN"]
+        owner = "$owner"
+        repo = "$repo"
+        number = "$number"
+        risk = "$risk"
+
+        base = "https://api.github.com"
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+        def api(method, path, data=None):
+            url = f"{base}{path}"
+            req = Request(url, method=method, headers=headers)
+            if data:
+                req.add_header("Content-Type", "application/json")
+                req.data = json.dumps(data).encode()
+            try:
+                with urlopen(req, timeout=15) as resp:
+                    return json.loads(resp.read())
+            except HTTPError as e:
+                if e.code == 422:
+                    return None  # label already exists or already applied
+                raise
+
+        color = "D93F0B" if risk == "HIGH" else "FFA500"
+
+        # Create label if missing
+        try:
+            api("POST", f"/repos/{owner}/{repo}/labels", {
+                "name": f"needs-review:{risk}",
+                "description": f"Contributor reputation check flagged {risk} risk",
+                "color": color,
+            })
+        except HTTPError:
+            pass
+
+        # Remove stale risk labels
+        for level in ["LOW", "MEDIUM", "HIGH"]:
+            if level != risk:
+                try:
+                    req = Request(
+                        f"{base}/repos/{owner}/{repo}/issues/{number}/labels/needs-review:{level}",
+                        method="DELETE", headers=headers,
+                    )
+                    urlopen(req, timeout=15)
+                except Exception:
+                    pass
+
+        # Apply current label
+        api("POST", f"/repos/{owner}/{repo}/issues/{number}/labels", {
+            "labels": [f"needs-review:{risk}"],
+        })
+        print(f"Applied label needs-review:{risk}")
+        PYEOF
+
+    # ── Job summary ──
+    - name: Write job summary
+      if: always()
+      shell: bash
+      run: |
+        username="${{ steps.inputs.outputs.username }}"
+        overall="${{ steps.aggregate.outputs.risk }}"
+        profile_risk="${{ steps.profile.outputs.risk }}"
+        cred_risk="${{ steps.credential.outputs.risk }}"
+        cluster_risk="${{ steps.cluster.outputs.risk }}"
+
+        {
+          echo "## Contributor Reputation Check: \`$username\`"
+          echo ""
+          echo "| Check | Risk |"
+          echo "|-------|------|"
+          echo "| **Overall** | **$overall** |"
+          if [ -n "$profile_risk" ]; then echo "| Profile analysis | $profile_risk |"; fi
+          if [ -n "$cred_risk" ]; then echo "| Credential audit | $cred_risk |"; fi
+          if [ -n "$cluster_risk" ]; then echo "| Cluster detection | $cluster_risk |"; fi
+          echo ""
+
+          profile_signals="${{ steps.profile.outputs.signals }}"
+          if [ -n "$profile_signals" ]; then
+            echo "### Profile signals"
+            echo "$profile_signals"
+            echo ""
+          fi
+
+          citations="${{ steps.credential.outputs.citations }}"
+          if [ "$citations" != "0" ] && [ -n "$citations" ]; then
+            echo "### Credential audit"
+            echo "- Merged PRs: ${{ steps.credential.outputs.merges }}"
+            echo "- Spray citations: $citations across ${{ steps.credential.outputs.spray_repos }} repos"
+            echo ""
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -11,7 +11,7 @@ on:
         description: "GitHub username to check"
         required: true
       run_cluster:
-        description: "Run cluster detection (API-heavy)"
+        description: "Run cluster detection (API-heavy, opt-in)"
         required: false
         default: "false"
         type: choice
@@ -27,7 +27,6 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
-    # Skip bot accounts on auto triggers
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.actor != 'dependabot[bot]' &&
@@ -37,301 +36,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          sparse-checkout: scripts
+          sparse-checkout: |
+            scripts
+            .github/actions/contributor-check
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - name: Run contributor reputation check
+        id: reputation
+        uses: ./.github/actions/contributor-check
         with:
-          python-version: "3.12"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          checks: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_cluster == 'true' && 'profile,credential,cluster' || 'profile,credential' }}
 
-      - name: Determine author
-        id: author
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "username=${{ github.event.inputs.username }}" >> "$GITHUB_OUTPUT"
-            echo "number=0" >> "$GITHUB_OUTPUT"
-            echo "type=manual" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
-            echo "username=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "type=pr" >> "$GITHUB_OUTPUT"
-          else
-            echo "username=${{ github.event.issue.user.login }}" >> "$GITHUB_OUTPUT"
-            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-            echo "type=issue" >> "$GITHUB_OUTPUT"
-          fi
-
-      # ── Step 1: Contributor profile check ──
-      - name: Run contributor check
-        id: profile
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set +e
-          python scripts/contributor_check.py \
-            --username "${{ steps.author.outputs.username }}" \
-            --repo "${{ github.repository }}" \
-            --json > /tmp/profile.json 2>/tmp/profile.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-          set -e
-
-          risk=$(python -c "import json; print(json.load(open('/tmp/profile.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
-          echo "risk=$risk" >> "$GITHUB_OUTPUT"
-
-          signals=$(python -c "
-          import json
-          r = json.load(open('/tmp/profile.json'))
-          for s in r.get('signals', []):
-              print(f\"- **[{s['severity']}]** {s['name']}: {s['detail']}\")
-          " 2>/dev/null || echo "")
-          {
-            echo "signals<<PROFILE_EOF"
-            echo "$signals"
-            echo "PROFILE_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "::group::Profile check output"
-          cat /tmp/profile.json
-          echo ""
-          cat /tmp/profile.log
-          echo "::endgroup::"
-
-      # ── Step 2: Credential audit ──
-      - name: Run credential audit
-        id: cred
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set +e
-          python scripts/credential_audit.py \
-            --username "${{ steps.author.outputs.username }}" \
-            --repo "${{ github.repository }}" \
-            --json > /tmp/cred.json 2>/tmp/cred.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-          set -e
-
-          risk=$(python -c "import json; print(json.load(open('/tmp/cred.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
-          echo "risk=$risk" >> "$GITHUB_OUTPUT"
-
-          merges=$(python -c "import json; print(len(json.load(open('/tmp/cred.json')).get('merges', [])))" 2>/dev/null || echo "0")
-          citations=$(python -c "import json; print(len(json.load(open('/tmp/cred.json')).get('citations', [])))" 2>/dev/null || echo "0")
-          spray_repos=$(python -c "import json; print(json.load(open('/tmp/cred.json')).get('spray_repos_count', 0))" 2>/dev/null || echo "0")
-          echo "merges=$merges" >> "$GITHUB_OUTPUT"
-          echo "citations=$citations" >> "$GITHUB_OUTPUT"
-          echo "spray_repos=$spray_repos" >> "$GITHUB_OUTPUT"
-
-          echo "::group::Credential audit output"
-          cat /tmp/cred.json
-          echo ""
-          cat /tmp/cred.log
-          echo "::endgroup::"
-
-      # ── Step 3: Cluster detection (manual dispatch only) ──
-      - name: Run cluster detection
-        id: cluster
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.run_cluster == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set +e
-          python scripts/cluster_detect.py \
-            --seed "${{ steps.author.outputs.username }}" \
-            --json > /tmp/cluster.json 2>/tmp/cluster.log
-          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
-          set -e
-
-          risk=$(python -c "import json; print(json.load(open('/tmp/cluster.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
-          echo "risk=$risk" >> "$GITHUB_OUTPUT"
-
-          accounts=$(python -c "import json; print(json.load(open('/tmp/cluster.json')).get('account_count', 0))" 2>/dev/null || echo "0")
-          edges=$(python -c "import json; print(json.load(open('/tmp/cluster.json')).get('edge_count', 0))" 2>/dev/null || echo "0")
-          echo "accounts=$accounts" >> "$GITHUB_OUTPUT"
-          echo "edges=$edges" >> "$GITHUB_OUTPUT"
-
-          echo "::group::Cluster detection output"
-          cat /tmp/cluster.json
-          echo ""
-          cat /tmp/cluster.log
-          echo "::endgroup::"
-
-      # ── Step 4: Compute overall risk ──
-      - name: Compute overall risk
-        id: overall
-        run: |
-          profile_risk="${{ steps.profile.outputs.risk }}"
-          cred_risk="${{ steps.cred.outputs.risk }}"
-          cluster_risk="${{ steps.cluster.outputs.risk }}"
-
-          # Map risk levels to numbers
-          risk_to_num() {
-            case "$1" in
-              HIGH) echo 3 ;;
-              MEDIUM) echo 2 ;;
-              LOW) echo 1 ;;
-              *) echo 0 ;;
-            esac
-          }
-
-          p=$(risk_to_num "$profile_risk")
-          c=$(risk_to_num "$cred_risk")
-          k=$(risk_to_num "$cluster_risk")
-
-          max=$p
-          [ "$c" -gt "$max" ] && max=$c
-          [ "$k" -gt "$max" ] && max=$k
-
-          case "$max" in
-            3) overall="HIGH" ;;
-            2) overall="MEDIUM" ;;
-            1) overall="LOW" ;;
-            *) overall="LOW" ;;
-          esac
-
-          echo "risk=$overall" >> "$GITHUB_OUTPUT"
-          echo "Overall risk: $overall (profile=$profile_risk, credential=$cred_risk, cluster=$cluster_risk)"
-
-      # ── Step 5: Post comment on MEDIUM or HIGH risk ──
-      - name: Post review comment
-        if: >-
-          steps.author.outputs.type != 'manual' &&
-          (steps.overall.outputs.risk == 'HIGH' || steps.overall.outputs.risk == 'MEDIUM')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          username="${{ steps.author.outputs.username }}"
-          number="${{ steps.author.outputs.number }}"
-          type="${{ steps.author.outputs.type }}"
-          overall="${{ steps.overall.outputs.risk }}"
-          profile_risk="${{ steps.profile.outputs.risk }}"
-          cred_risk="${{ steps.cred.outputs.risk }}"
-
-          if [ "$overall" = "HIGH" ]; then
-            icon="🔴"
-          else
-            icon="🟡"
-          fi
-
-          # Build the comment body
-          body="<!-- contributor-reputation-check -->
-          $icon **Contributor Reputation Check: $overall risk**
-
-          | Check | Risk |
-          |-------|------|
-          | Profile analysis | $profile_risk |
-          | Credential audit | $cred_risk |
-          "
-
-          # Add profile signals if any
-          profile_signals="${{ steps.profile.outputs.signals }}"
-          if [ -n "$profile_signals" ]; then
-            body="$body
-          <details>
-          <summary>Profile signals</summary>
-
-          $profile_signals
-
-          </details>
-          "
-          fi
-
-          # Add credential summary if citations found
-          citations="${{ steps.cred.outputs.citations }}"
-          if [ "$citations" != "0" ] && [ -n "$citations" ]; then
-            spray_repos="${{ steps.cred.outputs.spray_repos }}"
-            merges="${{ steps.cred.outputs.merges }}"
-            body="$body
-          <details>
-          <summary>Credential audit: $merges merged PRs, $citations citations across $spray_repos repos</summary>
-
-          The contributor cites merged PRs from this repo in issues filed across other repositories.
-          This pattern may indicate credential laundering.
-
-          </details>
-          "
-          fi
-
-          body="$body
-          ---
-          *Maintainers: please review the contributor's profile and contribution history before merging.*
-          *This is an automated check, not a judgment. See [contributor reputation tools](https://github.com/${{ github.repository }}/tree/main/scripts#contributor-reputation-tools) for details.*"
-
-          if [ "$type" = "pr" ]; then
-            gh pr comment "$number" --body "$body"
-          else
-            gh issue comment "$number" --body "$body"
-          fi
-
-      # ── Step 6: Add labels ──
-      - name: Add risk label
-        if: >-
-          steps.author.outputs.type != 'manual' &&
-          (steps.overall.outputs.risk == 'MEDIUM' || steps.overall.outputs.risk == 'HIGH')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          number="${{ steps.author.outputs.number }}"
-          type="${{ steps.author.outputs.type }}"
-          risk="${{ steps.overall.outputs.risk }}"
-
-          if [ "$risk" = "HIGH" ]; then
-            color="D93F0B"
-          else
-            color="FFA500"
-          fi
-
-          gh label create "needs-review:$risk" \
-            --description "Contributor reputation check flagged $risk risk" \
-            --color "$color" \
-            --force 2>/dev/null || true
-
-          if [ "$type" = "pr" ]; then
-            gh pr edit "$number" --add-label "needs-review:$risk"
-          else
-            gh issue edit "$number" --add-label "needs-review:$risk"
-          fi
-
-      # ── Step 7: Summary (always, for workflow run visibility) ──
-      - name: Write job summary
+      - name: Log results
         if: always()
         run: |
-          username="${{ steps.author.outputs.username }}"
-          overall="${{ steps.overall.outputs.risk }}"
-          profile_risk="${{ steps.profile.outputs.risk }}"
-          cred_risk="${{ steps.cred.outputs.risk }}"
-          cluster_risk="${{ steps.cluster.outputs.risk }}"
-
-          {
-            echo "## Contributor Reputation Check: \`$username\`"
-            echo ""
-            echo "| Check | Risk |"
-            echo "|-------|------|"
-            echo "| **Overall** | **$overall** |"
-            echo "| Profile analysis | $profile_risk |"
-            echo "| Credential audit | $cred_risk |"
-            if [ -n "$cluster_risk" ]; then
-              echo "| Cluster detection | $cluster_risk |"
-            fi
-            echo ""
-
-            profile_signals="${{ steps.profile.outputs.signals }}"
-            if [ -n "$profile_signals" ]; then
-              echo "### Profile signals"
-              echo "$profile_signals"
-              echo ""
-            fi
-
-            citations="${{ steps.cred.outputs.citations }}"
-            if [ "$citations" != "0" ] && [ -n "$citations" ]; then
-              echo "### Credential audit"
-              echo "- Merged PRs: ${{ steps.cred.outputs.merges }}"
-              echo "- Spray citations: $citations across ${{ steps.cred.outputs.spray_repos }} repos"
-              echo ""
-            fi
-
-            if [ -n "$cluster_risk" ]; then
-              echo "### Cluster detection"
-              echo "- Accounts: ${{ steps.cluster.outputs.accounts }}"
-              echo "- Edges: ${{ steps.cluster.outputs.edges }}"
-              echo ""
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Overall risk: ${{ steps.reputation.outputs.risk }}"
+          echo "Profile risk: ${{ steps.reputation.outputs.profile-risk }}"
+          echo "Credential risk: ${{ steps.reputation.outputs.credential-risk }}"
+          echo "Cluster risk: ${{ steps.reputation.outputs.cluster-risk }}"

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ result := client.ExecuteWithGovernance("data.read", nil)
 | Capability | What It Does | Links |
 |---|---|---|
 | **Policy Engine** | Every action evaluated before execution — sub-millisecond, deterministic. Supports YAML, OPA/Rego, and Cedar policies | [Agent OS](agent-governance-python/agent-os/) · [Benchmarks](docs/BENCHMARKS.md) |
+| **Contributor Reputation** | Screens PR/issue authors for social engineering: credential laundering, spray patterns, network coordination. Reusable GitHub Action for any repo | [Action](.github/actions/contributor-check/) · [Scripts](scripts/) |
 | **Zero-Trust Identity** | Ed25519 + quantum-safe ML-DSA-65 credentials, trust scoring (0–1000), SPIFFE/SVID | [AgentMesh](agent-governance-python/agent-mesh/) |
 | **Execution Sandboxing** | 4-tier privilege rings, saga orchestration, kill switch | [Runtime](agent-governance-python/agent-runtime/) · [Hypervisor](agent-governance-python/agent-hypervisor/) |
 | **Agent SRE** | SLOs, error budgets, replay debugging, chaos engineering, circuit breakers | [Agent SRE](agent-governance-python/agent-sre/) |

--- a/docs/tutorials/45-shift-left-governance.md
+++ b/docs/tutorials/45-shift-left-governance.md
@@ -22,6 +22,7 @@ binary analysis, and supply chain verification on every build.
 |---------|-------|
 | [Why Shift-Left?](#why-shift-left) | The case for catching violations before runtime |
 | [Commit-Time](#commit-time-pre-commit-hooks) | Pre-commit hooks for policy and plugin validation |
+| [PR-Time: Contributor Reputation](#pr-time-contributor-reputation) | Automated screening for coordinated inauthentic behavior |
 | [PR-Time](#pr-time-gates) | Governance attestation, dependency review, secret scanning |
 | [CI/Build-Time](#cibuild-time-checks) | Governance verify, policy validation, security scans, binary analysis |
 | [Language-Specific Build Checks](#language-specific-build-time-enforcement) | .NET, TypeScript, Python build-time enforcement |
@@ -43,17 +44,22 @@ Shift-left governance moves checks earlier in the development lifecycle:
   Commit        PR           CI/Build        Release        Runtime
     │            │              │               │              │
     ▼            ▼              ▼               ▼              ▼
- ┌──────┐  ┌─────────┐  ┌────────────┐  ┌───────────┐  ┌──────────┐
- │ pre- │  │ attest  │  │ governance │  │ SBOM +    │  │ policy   │
- │commit│  │ + dep   │  │ verify +   │  │ signing + │  │ engine + │
- │hooks │  │ review  │  │ CodeQL +   │  │ provenance│  │ trust +  │
- │      │  │ + scans │  │ BinSkim    │  │           │  │ audit    │
- └──────┘  └─────────┘  └────────────┘  └───────────┘  └──────────┘
-   Fastest feedback                              Most comprehensive
+```
+  Contributor   Commit        PR           CI/Build        Release        Runtime
+     │            │            │              │               │              │
+     ▼            ▼            ▼              ▼               ▼              ▼
+  ┌──────┐  ┌──────┐  ┌─────────┐  ┌────────────┐  ┌───────────┐  ┌──────────┐
+  │reputa│  │ pre- │  │ attest  │  │ governance │  │ SBOM +    │  │ policy   │
+  │tion  │  │commit│  │ + dep   │  │ verify +   │  │ signing + │  │ engine + │
+  │check │  │hooks │  │ review  │  │ CodeQL +   │  │ provenance│  │ trust +  │
+  │      │  │      │  │ + scans │  │ BinSkim    │  │           │  │ audit    │
+  └──────┘  └──────┘  └─────────┘  └────────────┘  └───────────┘  └──────────┘
+    Earliest feedback                                        Most comprehensive
 ```
 
 **Why it matters:**
 
+- A social engineering contributor caught at PR open never gets code reviewed
 - A malformed policy file caught at commit time costs zero CI minutes
 - A secret caught in PR review never reaches the default branch
 - A dependency confusion attack blocked in CI never reaches production
@@ -122,6 +128,83 @@ For teams adopting AGT incrementally:
 3. **Week 3**: Enable all hooks as blocking
 4. **Week 4**: Graduate to full blocking per the
    [graduation checklist](../operations/advisory-to-blocking-graduation.md)
+
+---
+
+## PR-Time: Contributor Reputation
+
+The **leftmost** check in AGT's shift-left pipeline. Before reviewing code,
+before running CI, the contributor reputation action screens the author's
+GitHub profile for signals of coordinated inauthentic behavior.
+
+### What It Detects
+
+| Signal | Severity | Description |
+|--------|----------|-------------|
+| Following farming | MEDIUM/HIGH | Extreme following:follower ratios (e.g., 2000 following, 50 followers) |
+| Repo velocity | MEDIUM/HIGH | Unnatural repo creation rate (e.g., 60 repos in 90 days) |
+| Cross-repo spray | HIGH | Same issue template filed across dozens of repos in days |
+| Credential laundering | HIGH | Citing merged PRs as credentials in spray issues across other repos |
+| Governance theme concentration | MEDIUM | Repos overwhelmingly themed around governance/security topics |
+| Network coordination | MEDIUM/HIGH | Shared forks, synchronized filing, co-comment patterns (opt-in) |
+
+### Add It to Your Repo
+
+AGT ships a reusable composite action. Add this workflow to any repository:
+
+```yaml
+# .github/workflows/contributor-check.yml
+name: Contributor Reputation Check
+
+on:
+  pull_request_target:        # Use pull_request_target, not pull_request
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout AGT action
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/agent-governance-toolkit
+          sparse-checkout: |
+            scripts
+            .github/actions/contributor-check
+          path: agt
+
+      - name: Run contributor check
+        uses: ./agt/.github/actions/contributor-check
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          checks: profile,credential    # Add 'cluster' for deep analysis
+          risk-threshold: MEDIUM        # MEDIUM or HIGH
+```
+
+### How It Works
+
+1. **On every PR or issue open**, the action runs two checks (profile + credential audit) using only the GitHub REST API and Python stdlib. No dependencies to install.
+
+2. **Risk is computed** as the max across all checks:
+   - **LOW**: No action taken (silent pass)
+   - **MEDIUM**: Posts a collapsible comment, adds `needs-review:MEDIUM` label
+   - **HIGH**: Posts a detailed comment, adds `needs-review:HIGH` label
+
+3. **Comments are idempotent**: re-runs update the same comment instead of creating duplicates. Old risk labels are removed before applying the current one.
+
+4. **Cluster detection** (opt-in) maps coordination networks from a seed account via shared forks, co-comments, and synchronized filing. It is API-heavy and recommended only for manual dispatch investigations.
+
+> **Important:** Use `pull_request_target` (not `pull_request`) so the action
+> has write permissions to comment and label on fork PRs. Do not run untrusted
+> PR code before this action in the same workflow.
 
 ---
 


### PR DESCRIPTION
## Summary

Packages AGT's contributor reputation tools as a reusable composite GitHub Action that any OSS repo can adopt as part of their shift-left governance strategy.

### What it does

- Profile analysis: Following farming, repo velocity, new account bursts, governance theme concentration
- Credential audit: Merged PRs cited as credentials in spray issues across other repos
- Cluster detection: Shared forks, co-comments, synchronized filing (opt-in, API-heavy)

### Design decisions

- Zero dependencies: Uses only Python stdlib (urllib, json, argparse)
- No gh CLI dependency: All GitHub API calls via Python urllib for portability
- Idempotent: Marker-based comment upsert, stale risk labels removed before new ones
- Outputs: risk, profile-risk, credential-risk, cluster-risk for downstream workflow decisions

### Docs updated

- Tutorial 45 (Shift-Left Governance): Contributor Reputation as leftmost check
- README What You Get table: Added Contributor Reputation row

All 38 tests pass.