### PR TITLE
fix(docker,tests,security): fix Docker build, test failures, and path validation bypass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,13 +168,17 @@ Python packages in this monorepo, and the TypeScript SDK dependencies.
 
 ```bash
 # Build and start the development container
-docker compose up --build dev
-
-# Open a shell in the running container
-docker compose exec dev bash
+docker compose up --build dev -d
 
 # Run the full test suite
 docker compose run --rm test
+```
+
+To access the container and run commands interactively, use the following command:
+
+```bash
+# Open a shell in the running container
+docker compose exec dev bash
 ```
 
 The repository is bind-mounted into `/workspace`, so Python source changes are

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update \
         ca-certificates \
         curl \
         git \
+        gnupg \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
         | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \

--- a/agent-governance-python/agent-lightning/pyproject.toml
+++ b/agent-governance-python/agent-lightning/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = []
 
 [project.optional-dependencies]
 agent-os = ["agent-os-kernel>=2.0.0,<4.0"]
-dev = ["pytest>=7.0,<8.0", "pytest-cov"]
+dev = ["pytest>=7.0,<10.0", "pytest-cov"]
 
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"

--- a/agent-governance-python/agent-marketplace/pyproject.toml
+++ b/agent-governance-python/agent-marketplace/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 cli = ["click>=8.0,<9.0", "rich>=13.0,<14.0"]
-dev = ["pytest>=7.0,<8.0", "pytest-cov"]
+dev = ["pytest>=7.0,<10.0", "pytest-cov"]
 
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"

--- a/agent-governance-python/agent-mesh/tests/test_marketplace.py
+++ b/agent-governance-python/agent-mesh/tests/test_marketplace.py
@@ -296,20 +296,37 @@ class TestPluginSigning:
 class TestPluginInstaller:
     """Tests for plugin installation, uninstallation, and sandboxing."""
 
-    def test_install_and_list(self, tmp_path: Path, manifest: PluginManifest) -> None:
+    @pytest.fixture()
+    def _signing(self):
+        """Provide a signer, trusted-keys dict, and a helper to sign manifests."""
+        private_key = ed25519.Ed25519PrivateKey.generate()
+        public_key = private_key.public_key()
+        signer = PluginSigner(private_key)
+        trusted_keys = {"tester@example.com": public_key}
+        return signer, trusted_keys
+
+    def test_install_and_list(self, tmp_path: Path, manifest: PluginManifest, _signing) -> None:
+        signer, trusted_keys = _signing
+        signed = signer.sign(manifest)
         registry = PluginRegistry()
-        registry.register(manifest)
-        installer = PluginInstaller(plugins_dir=tmp_path / "plugins", registry=registry)
+        registry.register(signed)
+        installer = PluginInstaller(
+            plugins_dir=tmp_path / "plugins", registry=registry, trusted_keys=trusted_keys,
+        )
         dest = installer.install("test-plugin")
         assert (dest / MANIFEST_FILENAME).exists()
         installed = installer.list_installed()
         assert len(installed) == 1
         assert installed[0].name == "test-plugin"
 
-    def test_uninstall(self, tmp_path: Path, manifest: PluginManifest) -> None:
+    def test_uninstall(self, tmp_path: Path, manifest: PluginManifest, _signing) -> None:
+        signer, trusted_keys = _signing
+        signed = signer.sign(manifest)
         registry = PluginRegistry()
-        registry.register(manifest)
-        installer = PluginInstaller(plugins_dir=tmp_path / "plugins", registry=registry)
+        registry.register(signed)
+        installer = PluginInstaller(
+            plugins_dir=tmp_path / "plugins", registry=registry, trusted_keys=trusted_keys,
+        )
         installer.install("test-plugin")
         installer.uninstall("test-plugin")
         assert installer.list_installed() == []
@@ -320,25 +337,31 @@ class TestPluginInstaller:
         with pytest.raises(MarketplaceError, match="not installed"):
             installer.uninstall("ghost")
 
-    def test_install_with_dependency(self, tmp_path: Path) -> None:
-        registry = PluginRegistry()
+    def test_install_with_dependency(self, tmp_path: Path, _signing) -> None:
+        signer, trusted_keys = _signing
         dep = _make_manifest(name="dep-plugin", version="1.0.0")
         main = _make_manifest(name="main-plugin", dependencies=["dep-plugin>=1.0.0"])
-        registry.register(dep)
-        registry.register(main)
-        installer = PluginInstaller(plugins_dir=tmp_path / "plugins", registry=registry)
+        registry = PluginRegistry()
+        registry.register(signer.sign(dep))
+        registry.register(signer.sign(main))
+        installer = PluginInstaller(
+            plugins_dir=tmp_path / "plugins", registry=registry, trusted_keys=trusted_keys,
+        )
         installer.install("main-plugin")
         installed_names = [p.name for p in installer.list_installed()]
         assert "main-plugin" in installed_names
         assert "dep-plugin" in installed_names
 
-    def test_circular_dependency_detected(self, tmp_path: Path) -> None:
-        registry = PluginRegistry()
+    def test_circular_dependency_detected(self, tmp_path: Path, _signing) -> None:
+        signer, trusted_keys = _signing
         a = _make_manifest(name="plugin-a", dependencies=["plugin-b"])
         b = _make_manifest(name="plugin-b", dependencies=["plugin-a"])
-        registry.register(a)
-        registry.register(b)
-        installer = PluginInstaller(plugins_dir=tmp_path / "plugins", registry=registry)
+        registry = PluginRegistry()
+        registry.register(signer.sign(a))
+        registry.register(signer.sign(b))
+        installer = PluginInstaller(
+            plugins_dir=tmp_path / "plugins", registry=registry, trusted_keys=trusted_keys,
+        )
         with pytest.raises(MarketplaceError, match="Circular dependency"):
             installer.install("plugin-a")
 

--- a/agent-governance-python/agent-mesh/tests/test_negative_security.py
+++ b/agent-governance-python/agent-mesh/tests/test_negative_security.py
@@ -390,11 +390,15 @@ class TestPluginSignatureBypass:
     """Test that unsigned or wrongly-signed plugins are handled correctly."""
 
     def test_unsigned_plugin_accepted_when_no_trusted_keys(self, tmp_path: Path):
-        """If no trusted_keys are configured, ALL plugins are accepted
-        regardless of verify=True. This is a configuration weakness.
+        """Unsigned plugins are rejected when no trusted_keys are configured.
+
+        Originally asserted permissive acceptance (a known weakness).
+        PR #921 (f71da82) hardened the installer to fail closed.
+        https://github.com/microsoft/agent-governance-toolkit/pull/921
         """
         from agentmesh.marketplace import (
             PluginInstaller, PluginRegistry, PluginManifest, PluginType,
+            MarketplaceError,
         )
 
         registry = PluginRegistry()
@@ -411,10 +415,9 @@ class TestPluginSignatureBypass:
             registry=registry,
             # No trusted_keys!
         )
-        # This succeeds even with verify=True because there's no signature
-        # AND no trusted key for the author
-        dest = installer.install("unsigned-plugin", verify=True)
-        assert dest.exists()
+        # PR #921: installer now fails closed — no signature means rejection
+        with pytest.raises(MarketplaceError, match="has no signature"):
+            installer.install("unsigned-plugin", verify=True)
 
     def test_signed_plugin_with_wrong_key_rejected(self, tmp_path: Path):
         """Plugin signed by an unknown key should be rejected if author

--- a/agent-governance-python/agent-mesh/tests/test_otel_sdk.py
+++ b/agent-governance-python/agent-mesh/tests/test_otel_sdk.py
@@ -96,7 +96,8 @@ class TestTraceTrustUpdate:
 
     def test_creates_span_with_scores(self):
         inst, exporter = _make_instrumentor()
-        inst.trace_trust_update("agent-3", 0.5, 0.8)
+        with inst.trace_trust_update("agent-3", 0.5, 0.8):
+            pass
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         assert spans[0].name == "agt.trust.update"
@@ -111,7 +112,8 @@ class TestTraceAuditAppend:
 
     def test_creates_span_with_seq(self):
         inst, exporter = _make_instrumentor()
-        inst.trace_audit_append(42)
+        with inst.trace_audit_append(42):
+            pass
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         assert spans[0].name == "agt.audit.append"
@@ -124,7 +126,8 @@ class TestTraceIdentityOperation:
 
     def test_creates_span_with_op_and_did(self):
         inst, exporter = _make_instrumentor()
-        inst.trace_identity_operation("verify", "did:mesh:abc")
+        with inst.trace_identity_operation("verify", "did:mesh:abc"):
+            pass
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         assert spans[0].name == "agt.identity.verify"
@@ -179,9 +182,12 @@ class TestGracefulDegradation:
             mod = importlib.import_module("agentmesh.observability.otel_sdk")
             importlib.reload(mod)
             inst = mod.GovernanceInstrumentor()
-            inst.trace_trust_update("a1", 0.5, 0.8)
-            inst.trace_audit_append(1)
-            inst.trace_identity_operation("create", "did:mesh:x")
+            with inst.trace_trust_update("a1", 0.5, 0.8):
+                pass
+            with inst.trace_audit_append(1):
+                pass
+            with inst.trace_identity_operation("create", "did:mesh:x"):
+                pass
 
     def test_record_methods_noop(self):
         """All record methods complete without error when OTel is absent."""
@@ -199,9 +205,12 @@ class TestGracefulDegradation:
         assert not inst.enabled
         with inst.trace_policy_evaluation("act", "a1"):
             pass
-        inst.trace_trust_update("a1", 0.5, 0.8)
-        inst.trace_audit_append(1)
-        inst.trace_identity_operation("create", "did:mesh:x")
+        with inst.trace_trust_update("a1", 0.5, 0.8):
+            pass
+        with inst.trace_audit_append(1):
+            pass
+        with inst.trace_identity_operation("create", "did:mesh:x"):
+            pass
         inst.record_policy_decision("deny", 2.0)
         inst.record_trust_score("a1", 0.5)
         inst.record_audit_chain_length(10)

--- a/agent-governance-python/agent-os/tests/conftest.py
+++ b/agent-governance-python/agent-os/tests/conftest.py
@@ -12,7 +12,6 @@ from pathlib import Path
 # Add modules to path for testing
 REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
-sys.path.insert(0, str(REPO_ROOT / "modules" / "primitives"))
 sys.path.insert(0, str(REPO_ROOT / "modules" / "control-plane" / "src"))
 sys.path.insert(0, str(REPO_ROOT / "modules" / "iatp"))
 sys.path.insert(0, str(REPO_ROOT / "modules" / "cmvk" / "src"))

--- a/agent-governance-python/agent-primitives/pyproject.toml
+++ b/agent-governance-python/agent-primitives/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0,<62.0", "wheel"]
+requires = ["setuptools>=64.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -41,7 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.4.0,<8.0",
+    "pytest>=7.4.0,<10.0",
     "mypy>=1.8.0,<2.0",
     "ruff>=0.1.0,<1.0",
 ]

--- a/agent-governance-python/agent-sre/src/agent_sre/slo/persistence.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/slo/persistence.py
@@ -170,9 +170,17 @@ def _validate_db_path(raw: str) -> str:
     # Also allow paths that are *inside* the current working directory.
     safe_roots.append(Path.cwd().resolve())
 
-    if not any(
-        str(resolved).startswith(str(root)) for root in safe_roots
-    ):
+    # Exclude filesystem roots — they provide no confinement (e.g. Path.home()
+    # returns "/" when running as a user without an /etc/passwd entry).
+    safe_roots = [r for r in safe_roots if r.parent != r]
+
+    if not safe_roots:
+        raise ValueError(
+            f"Invalid db_path {raw!r}: all candidate safe directories resolve "
+            f"to filesystem roots. No confined directory available."
+        )
+
+    if not any(resolved == root or resolved.is_relative_to(root) for root in safe_roots):
         raise ValueError(
             f"Invalid db_path {raw!r}: resolved path {resolved} is outside "
             f"allowed directories (home, temp, cwd). Move the database file "

--- a/agent-governance-python/agent-sre/tests/unit/test_sli_persistence.py
+++ b/agent-governance-python/agent-sre/tests/unit/test_sli_persistence.py
@@ -176,11 +176,14 @@ class TestSQLiteMeasurementStore:
             _validate_db_path("file:///etc/passwd")
 
     def test_file_uri_inside_home_accepted(self, tmp_path: object) -> None:
-        """file:// URI resolving inside home dir should be accepted."""
+        """file:// URI resolving inside a safe directory should be accepted."""
         import pathlib
         home = pathlib.Path.home()
-        # Construct a path under home that looks like a file:// URI
-        target = str(home / "sli_test.db")
+        if home.parent == home:
+            # Container/CI: home resolves to "/" — use tmp_path instead.
+            target = str(tmp_path / "sli_test.db")  # type: ignore[operator]
+        else:
+            target = str(home / "sli_test.db")
         result = _validate_db_path(f"file://{target}")
         assert result == str(pathlib.Path(target).resolve())
 
@@ -193,6 +196,17 @@ class TestSQLiteMeasurementStore:
         """/var/log/syslog is outside home/tmp/cwd — should be rejected."""
         with pytest.raises(ValueError, match="Invalid db_path|outside allowed"):
             _validate_db_path("/var/log/syslog")
+
+    def test_prefix_confusion_rejected(self, tmp_path: object) -> None:
+        """Paths sharing a prefix with a safe dir must not pass.
+
+        Regression test: the old str.startswith check would accept
+        /tmp-evil/db.sqlite because it starts with /tmp.
+        """
+        import pathlib
+        evil = pathlib.Path("/tmp-evil/db.sqlite")
+        with pytest.raises(ValueError, match="Invalid db_path|outside allowed"):
+            _validate_db_path(str(evil))
 
     def test_excessively_long_path_raises(self) -> None:
         """Paths > 4096 chars should be rejected."""

--- a/docs/reference/contributing.md
+++ b/docs/reference/contributing.md
@@ -152,13 +152,17 @@ Python packages in this monorepo, and the TypeScript SDK dependencies.
 
 ```bash
 # Build and start the development container
-docker compose up --build dev
-
-# Open a shell in the running container
-docker compose exec dev bash
+docker compose up --build dev -d
 
 # Run the full test suite
 docker compose run --rm test
+```
+
+To access the container and run commands interactively, use the following command:
+
+```bash
+# Open a shell in the running container
+docker compose exec dev bash
 ```
 
 The repository is bind-mounted into `/workspace`, so Python source changes are


### PR DESCRIPTION
## Summary

Fixes the Docker dev container build failure (missing gnupg), resolves 8 test failures across 4 packages, and patches a security bug in _validate_db_path where path confinement was silently bypassed in container environments.

## Motivation & Context

docker compose run --rm test was failing with 8 errors across agent-os, agent-mesh, and agent-sre. Root causes were a mix of stale paths, tests not matching updated production APIs, and a real security bug in path validation that only manifests when Path.home() resolves to / (common in containers and CI).

## Changes Made

### Docker build fix
- **Dockerfile**: Added gnupg to apt-get install — required by the gpg --dearmor command that imports the NodeSource GPG key. Build failed with gpg: command not found.

### Stale import path removal
- **packages/agent-os/tests/conftest.py**: Removed sys.path.insert for modules/primitives, a directory that only contained __pycache__ (no .py sources). agent_primitives was moved to agent-governance-python/agent-primitives/ and is installed as an editable package. The stale path caused Python to find a broken namespace package, shadowing the real installed package and producing 4 ImportError failures.

### OTel SDK test corrections
- **packages/agent-mesh/tests/test_otel_sdk.py**: 	race_trust_update, 	race_audit_append, and 	race_identity_operation are @contextlib.contextmanager methods. Tests called them without with, so the generator was created but never entered — no span was produced. Fixed all call sites (including no-op/disabled path tests) to use with statements, matching the existing correct usage in 	race_policy_evaluation tests.

### Marketplace test alignment with fail-closed installer
- **packages/agent-mesh/tests/test_marketplace.py**: PR #921 hardened PluginInstaller to reject unsigned plugins when verify=True (fail-closed). Tests used unsigned manifests and relied on the old permissive behavior. Updated to use signed manifests with a _signing fixture (Ed25519 keypair + PluginSigner), exercising the real verification path rather than bypassing it with verify=False.
- **packages/agent-mesh/tests/test_negative_security.py**: Updated 	est_unsigned_plugin_accepted_when_no_trusted_keys to assert MarketplaceError is raised, matching the fail-closed behavior introduced in PR #921 (commit 71da82). Docstring documents the behavioral history and links to the PR.

### Path validation security fix
- **packages/agent-sre/src/agent_sre/slo/persistence.py**: Fixed two bugs in _validate_db_path:
  1. **Root-home bypass**: When Path.home() resolves to / (containers, CI with no /etc/passwd entry), every path passes the confinement check. Fix: filter out filesystem roots (
.parent != r) from safe_roots.
  2. **Prefix confusion**: str.startswith("/tmp") accepts /tmp-evil/db.sqlite. Fix: replaced with Path.is_relative_to() for proper path containment.
  3. **Fail-closed on empty safe_roots**: Raises ValueError when all candidate safe dirs collapse to filesystem roots.
- **packages/agent-sre/tests/unit/test_sli_persistence.py**: Updated 	est_file_uri_inside_home_accepted to handle root-home environments (falls back to 	mp_path). Added 	est_prefix_confusion_rejected regression test for the startswith bypass.

### Contributing docs & dependency ranges
- **docs/reference/contributing.md**: Updated Docker quickstart to use docker compose up --build dev -d (detached) and separated the exec instruction.
- **pyproject.toml (3 files)**: Widened pytest version upper bounds from <8.0 to <10.0 to support pytest 8.x installed in the Docker image.

## Testing

- Full suite via docker compose run --rm test: **7,858 passed, 0 failed**
- Targeted runs for each fix area confirmed individually
- Prefix-confusion regression test added for the startswith bypass

### How to Test Locally

`bash
git checkout fix/docker-tests-and-path-validation
docker compose up --build dev -d
docker compose run --rm test
`

## Checklist

- [x] Self-reviewed my own diff
- [x] Tests added / updated for all changed logic
- [x] No new lint errors or type errors
- [x] Documentation updated (contributing.md)
- [x] No secrets or credentials committed
- [x] Breaking changes: none

## Reviewers & Focus Areas

- **Security review**: _validate_db_path fix in persistence.py — please verify the 
.parent != r root detection and is_relative_to() containment are correct cross-platform.
- **Behavioral alignment**: 	est_unsigned_plugin_accepted_when_no_trusted_keys — confirm the fail-closed behavior from PR #921 is the intended direction.
- **Marketplace tests**: Verify the signed-manifest approach (_signing fixture) properly exercises the verification path vs. the old verify=False bypass.