### PR TITLE
fix(ci): harden contributor check with maintainer skip list and security improvements

### DIFF
--- a/.github/actions/contributor-check/action.yml
+++ b/.github/actions/contributor-check/action.yml
@@ -43,6 +43,15 @@ runs:
       with:
         python-version: "3.12"
 
+    - name: Validate inputs
+      shell: bash
+      run: |
+        threshold="${{ inputs.risk-threshold }}"
+        if [ -n "$threshold" ] && [ "$threshold" != "LOW" ] && [ "$threshold" != "MEDIUM" ] && [ "$threshold" != "HIGH" ]; then
+          echo "::error::Invalid risk-threshold '$threshold'. Must be LOW, MEDIUM, or HIGH."
+          exit 1
+        fi
+
     - name: Resolve inputs
       id: inputs
       shell: bash
@@ -435,3 +444,12 @@ runs:
             echo ""
           fi
         } >> "$GITHUB_STEP_SUMMARY"
+
+    # ── Cleanup temp files ──
+    - name: Cleanup temporary files
+      if: always()
+      shell: bash
+      run: |
+        rm -f /tmp/agt-profile.json /tmp/agt-profile.log
+        rm -f /tmp/agt-cred.json /tmp/agt-cred.log
+        rm -f /tmp/agt-cluster.json /tmp/agt-cluster.log

--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -19,6 +19,10 @@ on:
           - "false"
           - "true"
 
+concurrency:
+  group: contributor-check-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   issues: write
@@ -31,7 +35,9 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.actor != 'dependabot[bot]' &&
        github.actor != 'github-actions[bot]' &&
-       github.actor != 'copilot-swe-agent[bot]')
+       github.actor != 'copilot-swe-agent[bot]' &&
+       github.actor != 'imran-siddique' &&
+       github.actor != 'eltoncarr-ms')
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

Addresses false positives and security scanner feedback from PR #1497.

## Changes

- **Maintainer skip list**: Added imran-siddique and eltoncarr-ms to the contributor-check workflow skip list, preventing false-positive HIGH risk flags on maintainer PRs
- **Concurrency group**: Prevents duplicate comments when multiple workflows trigger on the same PR/issue
- **Risk-threshold validation**: Validates that risk-threshold input is LOW, MEDIUM, or HIGH (prevents bypass via invalid values)
- **Temp file cleanup**: Securely removes /tmp/agt-*.json and /tmp/agt-*.log after each run

## Testing

No functional changes to detection logic. Workflow improvements only.