### PR TITLE
fix(ci): install local agent-primitives before agent-os tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,12 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install local sibling dependencies
+        run: |
+          # agent-os depends on agent_primitives (local, not on PyPI at >=3.x)
+          if [ "${{ matrix.package }}" = "agent-os" ]; then
+            pip install --no-cache-dir -e agent-governance-python/agent-primitives
+          fi
       - name: Install ${{ matrix.package }}
         working-directory: agent-governance-python/${{ matrix.package }}
         run: |


### PR DESCRIPTION
## Summary

Fixes agent-os CI test failures caused by unresolvable \gent_primitives>=3.2.0\ dependency. PyPI only has 0.1.0/0.2.0, but the local package is at 3.2.2.

## Changes

- Added a pre-install step in the CI test job that installs \gent-primitives\ from the local path before running agent-os tests
- Only triggers for the \gent-os\ matrix entry (no impact on other packages)

## Impact

Unblocks CI for PR #1502 and any future PRs touching agent-os.