### PR TITLE
feat: add fork burst, feature overlap, and thin credibility detection

### DIFF
--- a/scripts/contributor_check.py
+++ b/scripts/contributor_check.py
@@ -265,6 +265,248 @@ def check_repo_themes(username: str) -> list[Signal]:
             value=len(recent_repos),
         ))
 
+    # Fork burst detection: many forks created in a short window
+    fork_signals = _check_fork_burst(repos)
+    signals.extend(fork_signals)
+
+    return signals
+
+
+def _check_fork_burst(repos: list[dict]) -> list[Signal]:
+    """Detect credibility-farming fork bursts (e.g., forking awesome lists)."""
+    signals: list[Signal] = []
+    now = datetime.now(timezone.utc)
+
+    forks = []
+    awesome_forks = []
+    for repo in repos:
+        if not repo.get("fork"):
+            continue
+        created = datetime.fromisoformat(repo["created_at"].replace("Z", "+00:00"))
+        if (now - created).days > 90:
+            continue
+        forks.append({"name": repo["name"], "created": created})
+        name_lower = repo.get("name", "").lower()
+        if "awesome" in name_lower or "curated" in (repo.get("description") or "").lower():
+            awesome_forks.append({"name": repo["name"], "created": created})
+
+    if not forks:
+        return signals
+
+    forks.sort(key=lambda f: f["created"])
+    max_window = 0
+    for f in forks:
+        window_count = sum(
+            1 for f2 in forks
+            if abs((f2["created"] - f["created"]).total_seconds()) <= 72 * 3600
+        )
+        max_window = max(max_window, window_count)
+
+    awesome_window = 0
+    if awesome_forks:
+        awesome_forks.sort(key=lambda f: f["created"])
+        for f in awesome_forks:
+            count = sum(
+                1 for f2 in awesome_forks
+                if abs((f2["created"] - f["created"]).total_seconds()) <= 72 * 3600
+            )
+            awesome_window = max(awesome_window, count)
+
+    if awesome_window >= 3:
+        signals.append(Signal(
+            name="awesome_fork_burst",
+            severity="HIGH",
+            detail=f"{awesome_window} awesome-list forks within 72 hours (credibility farming)",
+            value=awesome_window,
+        ))
+    elif max_window >= 5:
+        signals.append(Signal(
+            name="fork_burst",
+            severity="MEDIUM",
+            detail=f"{max_window} forks within 72 hours",
+            value=max_window,
+        ))
+
+    return signals
+
+
+# Feature buckets for detecting concept clones of AGT
+_AGT_FEATURE_BUCKETS: dict[str, list[str]] = {
+    "mcp_security": [
+        "mcp scanner", "mcp security", "tool poisoning", "mcp gateway",
+        "rug pull", "typosquat", "mcp tool scan",
+    ],
+    "policy_engine": [
+        "policy engine", "policy evaluator", "policy enforcement",
+        "cedar polic", "yaml polic", "deny-by-default",
+    ],
+    "identity_crypto": [
+        "ed25519", "agent identity", "zero-trust identity",
+        "cryptographic identity", "agent keypair", "agent did",
+    ],
+    "runtime_controls": [
+        "execution sandbox", "kill switch", "circuit breaker",
+        "permission level", "sandboxing", "emergency shutdown",
+    ],
+    "audit_trust": [
+        "audit trail", "trust scor", "hash-chain", "tamper-proof log",
+        "governance decision", "trust tier",
+    ],
+    "compliance": [
+        "owasp agentic", "owasp agent", "compliance attestation",
+        "eu ai act", "nist ai rmf",
+    ],
+}
+
+
+def check_feature_overlap(username: str, target_repo: str | None = None) -> list[Signal]:
+    """Detect repos that clone AGT's feature set using bucketed analysis."""
+    signals: list[Signal] = []
+    if not target_repo:
+        return signals
+
+    repos = _api(f"/users/{username}/repos", {"per_page": "100", "sort": "updated"})
+    if not repos:
+        return signals
+
+    now = datetime.now(timezone.utc)
+
+    for repo in repos:
+        if repo.get("fork"):
+            continue
+
+        name = repo.get("name", "")
+        desc = (repo.get("description") or "").lower()
+        topics = " ".join(repo.get("topics", []))
+        searchable = f"{name} {desc} {topics}".lower()
+
+        # Quick scan: does this repo match at least 2 buckets?
+        matched_buckets = set()
+        for bucket, keywords in _AGT_FEATURE_BUCKETS.items():
+            for kw in keywords:
+                if kw in searchable:
+                    matched_buckets.add(bucket)
+                    break
+
+        if len(matched_buckets) < 2:
+            continue
+
+        # Deep scan: fetch README for candidates
+        readme_text = ""
+        readme = _api(f"/repos/{username}/{name}/readme")
+        if readme and readme.get("content"):
+            try:
+                import base64
+                readme_text = base64.b64decode(readme["content"]).decode("utf-8", errors="replace").lower()
+            except Exception:
+                pass
+
+        full_text = f"{searchable} {readme_text}"
+        final_buckets = set()
+        for bucket, keywords in _AGT_FEATURE_BUCKETS.items():
+            for kw in keywords:
+                if kw in full_text:
+                    final_buckets.add(bucket)
+                    break
+
+        created = datetime.fromisoformat(repo["created_at"].replace("Z", "+00:00"))
+        age_days = (now - created).days
+        stars = repo.get("stargazers_count", 0)
+
+        if len(final_buckets) >= 4:
+            signals.append(Signal(
+                name="feature_overlap",
+                severity="HIGH",
+                detail=(
+                    f"Repo '{name}' matches {len(final_buckets)}/6 AGT feature buckets "
+                    f"({', '.join(sorted(final_buckets))}), "
+                    f"age={age_days}d, stars={stars}"
+                ),
+                value=len(final_buckets),
+            ))
+        elif len(final_buckets) >= 3:
+            signals.append(Signal(
+                name="feature_overlap",
+                severity="MEDIUM",
+                detail=(
+                    f"Repo '{name}' matches {len(final_buckets)}/6 AGT feature buckets "
+                    f"({', '.join(sorted(final_buckets))})"
+                ),
+                value=len(final_buckets),
+            ))
+
+    return signals
+
+
+def check_thin_credibility(username: str, target_repo: str | None = None) -> list[Signal]:
+    """Detect young, low-star projects promoted across multiple orgs."""
+    signals: list[Signal] = []
+
+    repos = _api(f"/users/{username}/repos", {"per_page": "100", "sort": "created"})
+    if not repos:
+        return signals
+
+    now = datetime.now(timezone.utc)
+
+    thin_repos: list[dict] = []
+    for repo in repos:
+        if repo.get("fork"):
+            continue
+        created = datetime.fromisoformat(repo["created_at"].replace("Z", "+00:00"))
+        age_days = (now - created).days
+        stars = repo.get("stargazers_count", 0)
+
+        if age_days <= 60 and stars < 5:
+            thin_repos.append({
+                "name": repo["name"],
+                "full_name": repo.get("full_name", f"{username}/{repo['name']}"),
+                "age_days": age_days,
+                "stars": stars,
+            })
+
+    if not thin_repos:
+        return signals
+
+    issues = _search_issues(f"author:{username} is:issue", per_page=50)
+    if not issues:
+        return signals
+
+    for thin in thin_repos:
+        repo_name = thin["name"].lower()
+        full_name = thin["full_name"].lower()
+        promoting_orgs = set()
+
+        for issue in issues:
+            body = (issue.get("body") or "").lower()
+            title = (issue.get("title") or "").lower()
+            repo_url = issue.get("repository_url", "")
+            issue_org = repo_url.replace("https://api.github.com/repos/", "").split("/")[0].lower()
+
+            if repo_name in body or repo_name in title or full_name in body:
+                if issue_org != username.lower():
+                    promoting_orgs.add(issue_org)
+
+        if len(promoting_orgs) >= 2:
+            signals.append(Signal(
+                name="thin_credibility",
+                severity="HIGH",
+                detail=(
+                    f"Repo '{thin['name']}' ({thin['age_days']}d old, {thin['stars']} stars) "
+                    f"promoted across {len(promoting_orgs)} orgs ({', '.join(sorted(promoting_orgs)[:5])})"
+                ),
+                value=len(promoting_orgs),
+            ))
+        elif len(promoting_orgs) >= 1:
+            signals.append(Signal(
+                name="thin_credibility",
+                severity="MEDIUM",
+                detail=(
+                    f"Repo '{thin['name']}' ({thin['age_days']}d old, {thin['stars']} stars) "
+                    f"promoted in {list(promoting_orgs)[0]}"
+                ),
+                value=len(promoting_orgs),
+            ))
+
     return signals
 
 
@@ -420,6 +662,10 @@ def check_contributor(username: str, target_repo: str | None = None) -> Reputati
 
     if target_repo:
         for signal in check_credential_spray(username, target_repo):
+            report.add(signal)
+        for signal in check_feature_overlap(username, target_repo):
+            report.add(signal)
+        for signal in check_thin_credibility(username, target_repo):
             report.add(signal)
 
     report.compute_risk()

--- a/scripts/tests/test_contributor_check.py
+++ b/scripts/tests/test_contributor_check.py
@@ -20,7 +20,10 @@ from contributor_check import (
     ReputationReport,
     check_account_shape,
     check_contributor,
+    check_feature_overlap,
+    check_thin_credibility,
     format_report,
+    _check_fork_burst,
 )
 
 
@@ -217,3 +220,159 @@ class TestCheckContributor:
         assert report.risk in ("MEDIUM", "HIGH")
         signal_names = [s.name for s in report.signals]
         assert "new_account_burst" in signal_names or "repo_velocity" in signal_names
+
+
+# ---------------------------------------------------------------------------
+# Fork burst tests
+# ---------------------------------------------------------------------------
+
+class TestForkBurst:
+    def test_no_forks_no_signal(self):
+        repos = [
+            {"name": "my-project", "fork": False, "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")},
+        ]
+        signals = _check_fork_burst(repos)
+        assert len(signals) == 0
+
+    def test_awesome_fork_burst_detected(self):
+        now = datetime.now(timezone.utc)
+        repos = [
+            {"name": f"awesome-list-{i}", "fork": True, "description": "curated list", "created_at": (now - timedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")}
+            for i in range(5)
+        ]
+        signals = _check_fork_burst(repos)
+        names = [s.name for s in signals]
+        assert "awesome_fork_burst" in names
+        burst = [s for s in signals if s.name == "awesome_fork_burst"]
+        assert burst[0].severity == "HIGH"
+
+    def test_general_fork_burst_medium(self):
+        now = datetime.now(timezone.utc)
+        repos = [
+            {"name": f"project-{i}", "fork": True, "created_at": (now - timedelta(hours=i * 2)).strftime("%Y-%m-%dT%H:%M:%SZ")}
+            for i in range(6)
+        ]
+        signals = _check_fork_burst(repos)
+        names = [s.name for s in signals]
+        assert "fork_burst" in names
+
+    def test_old_forks_ignored(self):
+        old = datetime.now(timezone.utc) - timedelta(days=120)
+        repos = [
+            {"name": f"awesome-old-{i}", "fork": True, "description": "awesome list", "created_at": (old + timedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")}
+            for i in range(5)
+        ]
+        signals = _check_fork_burst(repos)
+        assert len(signals) == 0
+
+
+# ---------------------------------------------------------------------------
+# Feature overlap tests
+# ---------------------------------------------------------------------------
+
+class TestFeatureOverlap:
+    @patch("contributor_check._api")
+    def test_clone_repo_detected(self, mock_api):
+        def api_side_effect(path, params=None):
+            if "/repos" in path and "readme" not in path:
+                return [{
+                    "name": "my-agent-guard",
+                    "fork": False,
+                    "description": "policy engine with mcp scanner, ed25519 agent identity, execution sandbox, audit trail, circuit breaker, owasp agentic compliance",
+                    "topics": ["kill-switch", "trust-scoring"],
+                    "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "stargazers_count": 1,
+                    "full_name": "clone-user/my-agent-guard",
+                }]
+            if "readme" in path:
+                return None
+            return []
+
+        mock_api.side_effect = api_side_effect
+        signals = check_feature_overlap("clone-user", "microsoft/agent-governance-toolkit")
+        assert any(s.name == "feature_overlap" and s.severity == "HIGH" for s in signals)
+
+    @patch("contributor_check._api")
+    def test_unrelated_repo_no_signal(self, mock_api):
+        def api_side_effect(path, params=None):
+            if "/repos" in path:
+                return [{
+                    "name": "my-website",
+                    "fork": False,
+                    "description": "personal blog built with Next.js",
+                    "topics": ["react", "nextjs"],
+                    "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "stargazers_count": 5,
+                }]
+            return []
+
+        mock_api.side_effect = api_side_effect
+        signals = check_feature_overlap("normal-user", "microsoft/agent-governance-toolkit")
+        assert len(signals) == 0
+
+    def test_no_target_repo_skips(self):
+        signals = check_feature_overlap("anyone", None)
+        assert len(signals) == 0
+
+
+# ---------------------------------------------------------------------------
+# Thin credibility tests
+# ---------------------------------------------------------------------------
+
+class TestThinCredibility:
+    @patch("contributor_check._search_issues")
+    @patch("contributor_check._api")
+    def test_thin_repo_promoted_across_orgs(self, mock_api, mock_search):
+        now = datetime.now(timezone.utc)
+
+        def api_side_effect(path, params=None):
+            if "/repos" in path:
+                return [{
+                    "name": "my-framework",
+                    "fork": False,
+                    "full_name": "promo-user/my-framework",
+                    "description": "my governance framework",
+                    "created_at": (now - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "stargazers_count": 0,
+                }]
+            return []
+
+        mock_api.side_effect = api_side_effect
+        mock_search.return_value = [
+            {
+                "title": "Add my-framework support",
+                "body": "my-framework provides governance...",
+                "repository_url": "https://api.github.com/repos/aaif/project-proposals",
+                "created_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+            {
+                "title": "Integrate my-framework",
+                "body": "my-framework would be great for...",
+                "repository_url": "https://api.github.com/repos/openssf/some-project",
+                "created_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+        ]
+        signals = check_thin_credibility("promo-user", "microsoft/agent-governance-toolkit")
+        assert any(s.name == "thin_credibility" and s.severity == "HIGH" for s in signals)
+
+    @patch("contributor_check._search_issues")
+    @patch("contributor_check._api")
+    def test_established_repo_no_signal(self, mock_api, mock_search):
+        now = datetime.now(timezone.utc)
+
+        def api_side_effect(path, params=None):
+            if "/repos" in path:
+                return [{
+                    "name": "mature-project",
+                    "fork": False,
+                    "full_name": "good-user/mature-project",
+                    "description": "well established project",
+                    "created_at": (now - timedelta(days=365)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "stargazers_count": 500,
+                }]
+            return []
+
+        mock_api.side_effect = api_side_effect
+        mock_search.return_value = []
+        signals = check_thin_credibility("good-user", "microsoft/agent-governance-toolkit")
+        assert len(signals) == 0


### PR DESCRIPTION
## Summary

Adds three new signal checkers to contributor_check.py to detect quiet clone contributors who were previously missed:

### New Signals

1. **Fork Burst** (\_check_fork_burst\): Detects credibility-farming via rapid forking of awesome-lists (3+ in 72h = HIGH) or general repos (5+ in 72h = MEDIUM)

2. **Feature Overlap** (\check_feature_overlap\): Uses 6 bucketed AGT feature categories to detect concept clones. Scans repo name/desc/topics, then fetches README for deeper analysis. 4+ bucket matches = HIGH, 3 = MEDIUM.

3. **Thin Credibility** (\check_thin_credibility\): Finds young (<60 day), low-star (<5) repos being promoted across multiple orgs via issues. 2+ orgs = HIGH, 1 = MEDIUM.

### Testing

- 9 new unit tests (26 total, all passing)
- Validated against known clone account (Aveerayy/agent-guard): now correctly flagged as HIGH

### Motivation

These signals close detection gaps identified during AAIF project-proposals scanning where quiet clone contributors (no spray pattern, just feature duplication) were missed by existing checks.