### PR TITLE
feat: offline-verifiable decision receipts (Ed25519 + JCS)

### DIFF
--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/__init__.py
@@ -16,6 +16,7 @@ Components:
 from mcp_receipt_governed.adapter import McpReceiptAdapter
 from mcp_receipt_governed.receipt import (
     GovernanceReceipt,
+    ReceiptSigningError,
     ReceiptStore,
     hash_tool_args,
     sign_receipt,
@@ -26,6 +27,7 @@ from mcp_receipt_governed.receipt import (
 __all__ = [
     "GovernanceReceipt",
     "McpReceiptAdapter",
+    "ReceiptSigningError",
     "ReceiptStore",
     "hash_tool_args",
     "sign_receipt",

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/__init__.py
@@ -10,6 +10,7 @@ Components:
 - McpReceiptAdapter: Policy evaluation + receipt signing for MCP tool calls
 - GovernanceReceipt: Signed proof of a governance decision
 - ReceiptStore: In-memory audit trail with query capabilities
+- verify_receipt_chain: Offline hash-chain and signature verification
 """
 
 from mcp_receipt_governed.adapter import McpReceiptAdapter
@@ -19,6 +20,7 @@ from mcp_receipt_governed.receipt import (
     hash_tool_args,
     sign_receipt,
     verify_receipt,
+    verify_receipt_chain,
 )
 
 __all__ = [
@@ -28,4 +30,5 @@ __all__ = [
     "hash_tool_args",
     "sign_receipt",
     "verify_receipt",
+    "verify_receipt_chain",
 ]

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from mcp_receipt_governed.receipt import (
     GovernanceReceipt,
+    ReceiptSigningError,
     ReceiptStore,
     hash_tool_args,
     sign_receipt,
@@ -121,7 +122,7 @@ class McpReceiptAdapter:
                 sign_receipt(receipt, self._signing_key)
             except Exception as exc:
                 _logger.error(f"Receipt signing failed: {type(exc).__name__}")
-                raise RuntimeError(
+                raise ReceiptSigningError(
                     f"Receipt signing failed for tool={tool_name}: {type(exc).__name__}: {exc}"
                 ) from exc
 

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
@@ -213,13 +213,16 @@ class McpReceiptAdapter:
             parent_receipt_hash=parent_hash,
         )
 
-        # 4. Sign receipt (if key provided)
+        # 4. Sign receipt (if key provided) — fail-closed enforcement
         if self._signing_key:
             try:
                 sign_receipt(receipt, self._signing_key)
             except Exception as exc:
                 _logger.error(f"Receipt signing failed: {type(exc).__name__}")
-                receipt.error = f"signing_failed: {type(exc).__name__}"
+                raise RuntimeError(
+                    f"Receipt signing failed for tool={tool_name}: "
+                    f"{type(exc).__name__}: {exc}"
+                ) from exc
 
         # 5. Store receipt
         self.store.add(receipt)

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
@@ -122,7 +122,7 @@ class CedarPolicyEvaluator:
 
         # Check for catch-all permit
         catch_all = re.compile(
-            r'permit\s*\(\s*principal\s*,\s*action\s*,\s*resource\s*\)\s*;',
+            r"permit\s*\(\s*principal\s*,\s*action\s*,\s*resource\s*\)\s*;",
             re.DOTALL,
         )
         if catch_all.search(self.policy_content):
@@ -140,6 +140,10 @@ class McpReceiptAdapter:
       2. Creates a ``GovernanceReceipt`` recording the decision.
       3. Signs the receipt with the provided Ed25519 key.
       4. Stores the receipt in the ``ReceiptStore`` audit trail.
+
+    Receipts are hash-chained: each receipt's ``parent_receipt_hash`` is set
+    to the ``payload_hash()`` of the preceding receipt in the store, enabling
+    offline detection of inserted or deleted tool calls.
 
     Args:
         cedar_policy: Cedar policy content string.
@@ -169,9 +173,13 @@ class McpReceiptAdapter:
         agent_did: str,
         tool_name: str,
         tool_args: Optional[Dict[str, Any]] = None,
-        resource: str = "Resource::\"default\"",
+        resource: str = 'Resource::"default"',
     ) -> GovernanceReceipt:
         """Evaluate policy and create a signed governance receipt.
+
+        The receipt is generated **before** the tool call executes (after
+        policy evaluation).  If signing fails, the call is blocked —
+        fail-closed enforcement.
 
         Args:
             agent_did: DID of the calling agent.
@@ -186,16 +194,22 @@ class McpReceiptAdapter:
         context = {"agent_did": agent_did, "resource": resource}
         allowed = self._evaluator.evaluate(tool_name, context)
 
-        # 2. Create receipt
+        # 2. Determine parent receipt hash for chaining
+        parent_hash: Optional[str] = None
+        if self.store._receipts:
+            parent_hash = self.store._receipts[-1].payload_hash()
+
+        # 3. Create receipt
         receipt = GovernanceReceipt(
             tool_name=tool_name,
             agent_did=agent_did,
             cedar_policy_id=self._policy_id,
             cedar_decision="allow" if allowed else "deny",
             args_hash=hash_tool_args(tool_args),
+            parent_receipt_hash=parent_hash,
         )
 
-        # 3. Sign receipt (if key provided)
+        # 4. Sign receipt (if key provided)
         if self._signing_key:
             try:
                 sign_receipt(receipt, self._signing_key)
@@ -203,7 +217,7 @@ class McpReceiptAdapter:
                 _logger.error(f"Receipt signing failed: {type(exc).__name__}")
                 receipt.error = f"signing_failed: {type(exc).__name__}"
 
-        # 4. Store receipt
+        # 5. Store receipt
         self.store.add(receipt)
 
         return receipt
@@ -214,7 +228,7 @@ class McpReceiptAdapter:
         tool_name: str,
         tool_fn: Callable[..., Any],
         tool_args: Optional[Dict[str, Any]] = None,
-        resource: str = "Resource::\"default\"",
+        resource: str = 'Resource::"default"',
     ) -> tuple[GovernanceReceipt, Any]:
         """Evaluate policy, create receipt, and execute the tool if allowed.
 

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
@@ -29,6 +29,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import Any, Callable, Dict, List, Optional
 
 from mcp_receipt_governed.receipt import (
@@ -159,6 +160,7 @@ class McpReceiptAdapter:
         cedar_policy_id: str = "default",
         signing_key_hex: Optional[str] = None,
         store: Optional[ReceiptStore] = None,
+        session_id: Optional[str] = None,
     ) -> None:
         self._evaluator = CedarPolicyEvaluator(
             policy_content=cedar_policy,
@@ -166,6 +168,7 @@ class McpReceiptAdapter:
         )
         self._policy_id = cedar_policy_id
         self._signing_key = signing_key_hex
+        self._session_id = session_id or str(uuid.uuid4())
         self.store = store or ReceiptStore()
 
     def govern_tool_call(
@@ -206,6 +209,7 @@ class McpReceiptAdapter:
             cedar_policy_id=self._policy_id,
             cedar_decision="allow" if allowed else "deny",
             args_hash=hash_tool_args(tool_args),
+            session_id=self._session_id,
             parent_receipt_hash=parent_hash,
         )
 

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/adapter.py
@@ -11,19 +11,13 @@ Usage:
             forbid(principal, action == Action::"DeleteFile", resource);
         \"\"\",
         cedar_policy_id="policy:mcp-tools:v1",
-        signing_key_hex="<32-byte-hex-seed>",  # Ed25519 seed
+        signing_key_hex="<32-byte-hex-seed>",
     )
-
-    # Wrap an MCP tool call
     receipt = adapter.govern_tool_call(
         agent_did="did:mesh:agent-1",
         tool_name="read_file",
         tool_args={"path": "/data/report.csv"},
     )
-
-    if receipt.cedar_decision == "allow":
-        # Proceed with tool execution
-        ...
 """
 
 from __future__ import annotations
@@ -43,115 +37,46 @@ _logger = logging.getLogger(__name__)
 
 
 class CedarPolicyEvaluator:
-    """Lightweight Cedar policy evaluator for receipt governance.
+    """Cedar policy evaluator with agentmesh fallback to inline permit/forbid parsing."""
 
-    Uses the built-in pattern matcher from ``agentmesh.governance.cedar``
-    when available, otherwise falls back to a simple permit/forbid parser.
-
-    This avoids hard-coupling to the full CedarEvaluator import path while
-    remaining compatible with it.
-    """
-
-    def __init__(
-        self,
-        policy_content: Optional[str] = None,
-        policy_id: str = "default",
-    ) -> None:
+    def __init__(self, policy_content: Optional[str] = None, policy_id: str = "default") -> None:
         self.policy_content = policy_content or ""
         self.policy_id = policy_id
         self._evaluator: Any = None
-        self._init_evaluator()
-
-    def _init_evaluator(self) -> None:
-        """Try to initialize the full CedarEvaluator; fall back to inline."""
         try:
             from agentmesh.governance.cedar import CedarEvaluator
-
-            self._evaluator = CedarEvaluator(
-                mode="builtin",
-                policy_content=self.policy_content,
-            )
-            _logger.debug("Using agentmesh CedarEvaluator (builtin mode)")
+            self._evaluator = CedarEvaluator(mode="builtin", policy_content=self.policy_content)
         except ImportError:
-            _logger.debug("agentmesh not available — using inline Cedar evaluator")
-            self._evaluator = None
+            pass
 
     def evaluate(self, action: str, context: Dict[str, Any]) -> bool:
-        """Evaluate a Cedar action against the loaded policy.
-
-        Args:
-            action: Cedar action string (e.g., ``"ReadData"``).
-            context: Evaluation context with ``agent_did``, ``resource``, etc.
-
-        Returns:
-            ``True`` if the action is permitted, ``False`` otherwise.
-        """
         if self._evaluator is not None:
-            decision = self._evaluator.evaluate(action, context)
-            return decision.allowed
-
-        # Inline fallback: simple permit/forbid parsing
+            return self._evaluator.evaluate(action, context).allowed
         return self._evaluate_inline(action)
 
     def _evaluate_inline(self, action: str) -> bool:
-        """Minimal permit/forbid parser for when agentmesh is not installed."""
         import re
 
-        action_normalized = action
-        if "::" not in action:
-            action_normalized = f'Action::"{action}"'
+        normalized = action if "::" in action else f'Action::"{action}"'
 
-        # Check for explicit forbid first (forbid wins)
-        forbid_pattern = re.compile(
-            r'forbid\s*\(.*?action\s*==\s*Action::"([^"]+)".*?\)\s*;',
-            re.DOTALL,
-        )
-        for match in forbid_pattern.finditer(self.policy_content):
-            matched_action = f'Action::"{match.group(1)}"'
-            if matched_action == action_normalized:
-                return False
+        forbid_re = re.compile(r'forbid\s*\(.*?action\s*==\s*Action::"([^"]+)".*?\)\s*;', re.DOTALL)
+        if any(f'Action::"{m.group(1)}"' == normalized for m in forbid_re.finditer(self.policy_content)):
+            return False
 
-        # Check for explicit permit
-        permit_pattern = re.compile(
-            r'permit\s*\(.*?action\s*==\s*Action::"([^"]+)".*?\)\s*;',
-            re.DOTALL,
-        )
-        for match in permit_pattern.finditer(self.policy_content):
-            matched_action = f'Action::"{match.group(1)}"'
-            if matched_action == action_normalized:
-                return True
-
-        # Check for catch-all permit
-        catch_all = re.compile(
-            r"permit\s*\(\s*principal\s*,\s*action\s*,\s*resource\s*\)\s*;",
-            re.DOTALL,
-        )
-        if catch_all.search(self.policy_content):
+        permit_re = re.compile(r'permit\s*\(.*?action\s*==\s*Action::"([^"]+)".*?\)\s*;', re.DOTALL)
+        if any(f'Action::"{m.group(1)}"' == normalized for m in permit_re.finditer(self.policy_content)):
             return True
 
-        # Default deny
-        return False
+        catch_all = re.compile(r"permit\s*\(\s*principal\s*,\s*action\s*,\s*resource\s*\)\s*;", re.DOTALL)
+        return bool(catch_all.search(self.policy_content))
 
 
 class McpReceiptAdapter:
-    """Wraps MCP tool calls with Cedar policy evaluation and receipt signing.
+    """Wraps MCP tool calls with Cedar policy evaluation and signed receipt creation.
 
-    For every tool call, the adapter:
-      1. Evaluates the Cedar policy for the requested action.
-      2. Creates a ``GovernanceReceipt`` recording the decision.
-      3. Signs the receipt with the provided Ed25519 key.
-      4. Stores the receipt in the ``ReceiptStore`` audit trail.
-
-    Receipts are hash-chained: each receipt's ``parent_receipt_hash`` is set
-    to the ``payload_hash()`` of the preceding receipt in the store, enabling
-    offline detection of inserted or deleted tool calls.
-
-    Args:
-        cedar_policy: Cedar policy content string.
-        cedar_policy_id: Human-readable identifier for the policy.
-        signing_key_hex: Hex-encoded 32-byte Ed25519 seed for receipt signing.
-            If ``None``, receipts are created but not signed.
-        store: Optional ``ReceiptStore`` instance. Creates a new one if omitted.
+    For every tool call: evaluate Cedar policy → create receipt → sign → store.
+    Receipts are hash-chained via ``parent_receipt_hash``. Signing failure raises
+    (fail-closed).
     """
 
     def __init__(
@@ -162,10 +87,7 @@ class McpReceiptAdapter:
         store: Optional[ReceiptStore] = None,
         session_id: Optional[str] = None,
     ) -> None:
-        self._evaluator = CedarPolicyEvaluator(
-            policy_content=cedar_policy,
-            policy_id=cedar_policy_id,
-        )
+        self._evaluator = CedarPolicyEvaluator(policy_content=cedar_policy, policy_id=cedar_policy_id)
         self._policy_id = cedar_policy_id
         self._signing_key = signing_key_hex
         self._session_id = session_id or str(uuid.uuid4())
@@ -178,31 +100,12 @@ class McpReceiptAdapter:
         tool_args: Optional[Dict[str, Any]] = None,
         resource: str = 'Resource::"default"',
     ) -> GovernanceReceipt:
-        """Evaluate policy and create a signed governance receipt.
+        """Evaluate policy and return a signed governance receipt (fail-closed on signing error)."""
+        allowed = self._evaluator.evaluate(tool_name, {"agent_did": agent_did, "resource": resource})
 
-        The receipt is generated **before** the tool call executes (after
-        policy evaluation).  If signing fails, the call is blocked —
-        fail-closed enforcement.
+        with self.store._lock:
+            parent_hash = self.store._receipts[-1].payload_hash() if self.store._receipts else None
 
-        Args:
-            agent_did: DID of the calling agent.
-            tool_name: Name of the MCP tool being invoked.
-            tool_args: Arguments to the tool call (hashed, not stored raw).
-            resource: Cedar resource string for policy evaluation.
-
-        Returns:
-            A signed ``GovernanceReceipt`` recording the policy decision.
-        """
-        # 1. Evaluate Cedar policy
-        context = {"agent_did": agent_did, "resource": resource}
-        allowed = self._evaluator.evaluate(tool_name, context)
-
-        # 2. Determine parent receipt hash for chaining
-        parent_hash: Optional[str] = None
-        if self.store._receipts:
-            parent_hash = self.store._receipts[-1].payload_hash()
-
-        # 3. Create receipt
         receipt = GovernanceReceipt(
             tool_name=tool_name,
             agent_did=agent_did,
@@ -213,20 +116,16 @@ class McpReceiptAdapter:
             parent_receipt_hash=parent_hash,
         )
 
-        # 4. Sign receipt (if key provided) — fail-closed enforcement
         if self._signing_key:
             try:
                 sign_receipt(receipt, self._signing_key)
             except Exception as exc:
                 _logger.error(f"Receipt signing failed: {type(exc).__name__}")
                 raise RuntimeError(
-                    f"Receipt signing failed for tool={tool_name}: "
-                    f"{type(exc).__name__}: {exc}"
+                    f"Receipt signing failed for tool={tool_name}: {type(exc).__name__}: {exc}"
                 ) from exc
 
-        # 5. Store receipt
         self.store.add(receipt)
-
         return receipt
 
     def govern_and_execute(
@@ -237,38 +136,19 @@ class McpReceiptAdapter:
         tool_args: Optional[Dict[str, Any]] = None,
         resource: str = 'Resource::"default"',
     ) -> tuple[GovernanceReceipt, Any]:
-        """Evaluate policy, create receipt, and execute the tool if allowed.
-
-        This is the full lifecycle method: check → receipt → execute (if allowed).
-
-        Args:
-            agent_did: DID of the calling agent.
-            tool_name: Name of the MCP tool.
-            tool_fn: The actual tool function to call.
-            tool_args: Arguments to pass to ``tool_fn``.
-            resource: Cedar resource for policy evaluation.
-
-        Returns:
-            Tuple of (receipt, tool_result). ``tool_result`` is ``None`` if denied.
-        """
+        """Evaluate policy, create receipt, and execute the tool if allowed."""
         receipt = self.govern_tool_call(agent_did, tool_name, tool_args, resource)
-
+        result = None
         if receipt.cedar_decision == "allow":
             try:
                 result = tool_fn(**(tool_args or {}))
             except Exception as exc:
                 _logger.error(f"Tool execution failed: {exc}")
                 receipt.error = f"execution_failed: {exc}"
-                result = None
-        else:
-            result = None
-
         return receipt, result
 
     def get_receipts(self) -> List[GovernanceReceipt]:
-        """Return all receipts from the store."""
         return self.store.query()
 
     def get_stats(self) -> Dict[str, Any]:
-        """Return aggregate receipt statistics."""
         return self.store.get_stats()

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
@@ -9,8 +9,12 @@ Each receipt links:
   - The agent DID requesting the tool call
   - An Ed25519 signature for non-repudiation
 
-Receipts use JCS-style canonical JSON for deterministic hashing so that
-any party can independently verify the receipt signature.
+Receipts use RFC 8785 JSON Canonicalization Scheme (JCS) for deterministic
+hashing so that any party can independently verify the receipt signature.
+
+Hash chaining links receipts via ``parent_receipt_hash`` so that verifiers
+can detect insertion or deletion of individual tool calls without replaying
+the full session log.
 """
 
 from __future__ import annotations
@@ -38,6 +42,8 @@ class GovernanceReceipt:
         cedar_decision: Whether Cedar permitted or denied the action.
         args_hash: SHA-256 hash of the tool call arguments (canonical JSON).
         timestamp: Unix timestamp of the decision.
+        parent_receipt_hash: SHA-256 hash of the preceding receipt's canonical
+            payload.  ``None`` for the first receipt in a chain.
         signature: Ed25519 signature over the canonical receipt payload.
         signer_public_key: Hex-encoded Ed25519 public key of the signer.
         error: Optional error message if the decision failed.
@@ -50,17 +56,22 @@ class GovernanceReceipt:
     cedar_decision: Literal["allow", "deny"] = "deny"
     args_hash: str = ""
     timestamp: float = field(default_factory=time.time)
+    parent_receipt_hash: Optional[str] = None
     signature: Optional[str] = None
     signer_public_key: Optional[str] = None
     error: Optional[str] = None
 
     def canonical_payload(self) -> str:
-        """Return JCS-style canonical JSON for deterministic hashing.
+        """Return RFC 8785 (JCS) canonical JSON for deterministic hashing.
 
         Only governance-relevant fields are included; signature fields are
         excluded because the signature covers this payload.
+
+        The output uses ``ensure_ascii=False`` so that Unicode codepoints are
+        emitted as raw UTF-8 rather than ``\\uXXXX`` escapes, which is required
+        by RFC 8785 § 3.2.2.2.
         """
-        data = {
+        data: Dict[str, Any] = {
             "agent_did": self.agent_did,
             "args_hash": self.args_hash,
             "cedar_decision": self.cedar_decision,
@@ -69,7 +80,9 @@ class GovernanceReceipt:
             "timestamp": self.timestamp,
             "tool_name": self.tool_name,
         }
-        return json.dumps(data, sort_keys=True, separators=(",", ":"))
+        if self.parent_receipt_hash is not None:
+            data["parent_receipt_hash"] = self.parent_receipt_hash
+        return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
     def payload_hash(self) -> str:
         """SHA-256 hash of the canonical payload."""
@@ -85,10 +98,61 @@ class GovernanceReceipt:
             "cedar_decision": self.cedar_decision,
             "args_hash": self.args_hash,
             "timestamp": self.timestamp,
+            "parent_receipt_hash": self.parent_receipt_hash,
             "payload_hash": self.payload_hash(),
             "signature": self.signature,
             "signer_public_key": self.signer_public_key,
             "error": self.error,
+        }
+
+    def to_slsa_provenance(self) -> Dict[str, Any]:
+        """Emit the receipt as a SLSA v1.0 provenance predicate.
+
+        Maps the governance decision to the in-toto Statement / SLSA
+        Provenance format so that standard supply-chain verification
+        tools (``slsa-verifier``, ``in-toto``) can consume it.
+
+        Returns:
+            An in-toto v1 Statement dict with a SLSA Provenance predicate.
+        """
+        parent_dep: Optional[Dict[str, Any]] = None
+        if self.parent_receipt_hash:
+            parent_dep = {
+                "uri": "pkg:agentmesh/receipt/parent",
+                "digest": {"sha256": self.parent_receipt_hash},
+            }
+
+        return {
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [
+                {
+                    "name": f"pkg:agentmesh/tool/{self.tool_name}",
+                    "digest": {"sha256": self.args_hash},
+                }
+            ],
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "predicate": {
+                "buildDefinition": {
+                    "buildType": ("https://agent-governance.org/schema/mcp-tool-call/v1"),
+                    "externalParameters": {
+                        "agent_did": self.agent_did,
+                        "cedar_policy_id": self.cedar_policy_id,
+                        "cedar_decision": self.cedar_decision,
+                    },
+                    "resolvedDependencies": ([parent_dep] if parent_dep else []),
+                },
+                "runDetails": {
+                    "builder": {
+                        "id": ("https://agent-governance.org/adapters/" "mcp-receipt-governed"),
+                    },
+                    "metadata": {
+                        "invocationId": self.receipt_id,
+                        "startedOn": time.strftime(
+                            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.timestamp)
+                        ),
+                    },
+                },
+            },
         }
 
 
@@ -131,11 +195,7 @@ def sign_receipt(receipt: GovernanceReceipt, private_key_hex: str) -> Governance
     private_key = Ed25519PrivateKey.from_private_bytes(seed)
     sig = private_key.sign(payload)
     receipt.signature = sig.hex()
-    receipt.signer_public_key = (
-        private_key.public_key()
-        .public_bytes_raw()
-        .hex()
-    )
+    receipt.signer_public_key = private_key.public_key().public_bytes_raw().hex()
 
     return receipt
 
@@ -166,6 +226,51 @@ def verify_receipt(receipt: GovernanceReceipt) -> bool:
         return False
     except Exception:
         return False
+
+
+def verify_receipt_chain(receipts: List[GovernanceReceipt]) -> List[str]:
+    """Verify the hash chain and signatures of an ordered receipt list.
+
+    Checks:
+      1. The first receipt has no parent (``parent_receipt_hash is None``).
+      2. Each subsequent receipt's ``parent_receipt_hash`` equals the
+         ``payload_hash()`` of the preceding receipt.
+      3. Every signed receipt passes Ed25519 verification.
+
+    Args:
+        receipts: Ordered list of receipts to verify.
+
+    Returns:
+        A list of human-readable error strings. An empty list means the
+        chain is fully valid.
+    """
+    errors: List[str] = []
+
+    if not receipts:
+        return errors
+
+    for i, receipt in enumerate(receipts):
+        # Chain contiguity
+        if i == 0:
+            if receipt.parent_receipt_hash is not None:
+                errors.append(f"[{i}] First receipt has unexpected parent_receipt_hash")
+        else:
+            expected = receipts[i - 1].payload_hash()
+            if receipt.parent_receipt_hash != expected:
+                errors.append(
+                    f"[{i}] Hash chain broken: expected parent {expected[:16]}…, "
+                    f"got {(receipt.parent_receipt_hash or 'None')[:16]}…"
+                )
+
+        # Signature verification (skip unsigned)
+        if receipt.signature:
+            if not verify_receipt(receipt):
+                errors.append(
+                    f"[{i}] Ed25519 signature verification failed for "
+                    f"receipt {receipt.receipt_id}"
+                )
+
+    return errors
 
 
 class ReceiptStore:

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
@@ -23,6 +23,10 @@ from typing import Any, Dict, List, Literal, Optional
 _logger = logging.getLogger(__name__)
 
 
+class ReceiptSigningError(Exception):
+    """Raised when Ed25519 receipt signing fails."""
+
+
 @dataclass
 class GovernanceReceipt:
     """Signed proof of a governance decision for an MCP tool call."""
@@ -137,9 +141,8 @@ def verify_receipt(receipt: GovernanceReceipt) -> bool:
         public_key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(receipt.signer_public_key))
         public_key.verify(bytes.fromhex(receipt.signature), receipt.canonical_payload().encode())
         return True
-    except ImportError:
-        _logger.error("cryptography not available — cannot verify Ed25519 signature")
-        return False
+    except ImportError as exc:
+        raise ImportError("The 'cryptography' library is required for Ed25519 signature verification.") from exc
     except Exception:
         return False
 
@@ -179,10 +182,13 @@ def verify_receipt_chain(
                 )
 
         if r.signature:
-            if not verify_receipt(r):
+            key = r.signer_public_key or ""
+            if len(key) != 64 or not all(c in "0123456789abcdefABCDEF" for c in key):
+                errors.append(f"[{i}] Malformed signer_public_key for receipt {r.receipt_id}")
+            elif not verify_receipt(r):
                 errors.append(f"[{i}] Ed25519 signature invalid for receipt {r.receipt_id}")
-            elif trusted_set and r.signer_public_key not in trusted_set:
-                errors.append(f"[{i}] Untrusted signer {(r.signer_public_key or '')[:16]}… — receipt rejected")
+            elif trusted_set and key not in trusted_set:
+                errors.append(f"[{i}] Untrusted signer {key[:16]}… — receipt rejected")
         else:
             errors.append(f"[{i}] Unsigned receipt — missing Ed25519 signature")
 
@@ -198,6 +204,8 @@ class ReceiptStore:
 
     def add(self, receipt: GovernanceReceipt) -> None:
         with self._lock:
+            if any(r.receipt_id == receipt.receipt_id for r in self._receipts):
+                raise ValueError(f"Duplicate receipt_id {receipt.receipt_id!r} — possible replay attack")
             self._receipts.append(receipt)
 
     def query(

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import threading
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -264,8 +265,17 @@ def verify_receipt_chain(
         return errors
 
     trusted_set = set(trusted_keys) if trusted_keys else None
+    seen_ids: set = set()
 
     for i, receipt in enumerate(receipts):
+        # Duplicate receipt_id detection (replay attack mitigation)
+        if receipt.receipt_id in seen_ids:
+            errors.append(
+                f"[{i}] Duplicate receipt_id {receipt.receipt_id} — "
+                f"possible replay attack"
+            )
+        seen_ids.add(receipt.receipt_id)
+
         # Chain contiguity
         if i == 0:
             if receipt.parent_receipt_hash is not None:
@@ -287,8 +297,8 @@ def verify_receipt_chain(
                 )
             elif trusted_set and receipt.signer_public_key not in trusted_set:
                 errors.append(
-                    f"[{i}] Signer key {(receipt.signer_public_key or '')[:16]}… "
-                    f"not in trusted key set"
+                    f"[{i}] Untrusted signer key {(receipt.signer_public_key or '')[:16]}… "
+                    f"not in trusted key set — receipt rejected"
                 )
         else:
             errors.append(f"[{i}] Unsigned receipt — missing Ed25519 signature")
@@ -299,15 +309,17 @@ def verify_receipt_chain(
 class ReceiptStore:
     """In-memory store for governance receipts with query capabilities.
 
-    Thread-safe for concurrent adapter usage.
+    All public methods are thread-safe via an internal ``threading.Lock``.
     """
 
     def __init__(self) -> None:
         self._receipts: List[GovernanceReceipt] = []
+        self._lock = threading.Lock()
 
     def add(self, receipt: GovernanceReceipt) -> None:
         """Store a receipt."""
-        self._receipts.append(receipt)
+        with self._lock:
+            self._receipts.append(receipt)
 
     def query(
         self,
@@ -325,7 +337,8 @@ class ReceiptStore:
         Returns:
             List of matching receipts.
         """
-        results = list(self._receipts)
+        with self._lock:
+            results = list(self._receipts)
         if agent_did:
             results = [r for r in results if r.agent_did == agent_did]
         if tool_name:
@@ -336,25 +349,30 @@ class ReceiptStore:
 
     def export(self) -> List[Dict[str, Any]]:
         """Export all receipts as a list of dictionaries."""
-        return [r.to_dict() for r in self._receipts]
+        with self._lock:
+            return [r.to_dict() for r in self._receipts]
 
     def clear(self) -> None:
         """Remove all receipts."""
-        self._receipts.clear()
+        with self._lock:
+            self._receipts.clear()
 
     @property
     def count(self) -> int:
         """Number of stored receipts."""
-        return len(self._receipts)
+        with self._lock:
+            return len(self._receipts)
 
     def get_stats(self) -> Dict[str, Any]:
         """Aggregate statistics for the receipt store."""
-        total = len(self._receipts)
-        allowed = sum(1 for r in self._receipts if r.cedar_decision == "allow")
+        with self._lock:
+            total = len(self._receipts)
+            allowed = sum(1 for r in self._receipts if r.cedar_decision == "allow")
+            snapshot = list(self._receipts)
         return {
             "total": total,
             "allowed": allowed,
             "denied": total - allowed,
-            "unique_agents": len({r.agent_did for r in self._receipts}),
-            "unique_tools": len({r.tool_name for r in self._receipts}),
+            "unique_agents": len({r.agent_did for r in snapshot}),
+            "unique_tools": len({r.tool_name for r in snapshot}),
         }

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
@@ -262,13 +262,15 @@ def verify_receipt_chain(receipts: List[GovernanceReceipt]) -> List[str]:
                     f"got {(receipt.parent_receipt_hash or 'None')[:16]}…"
                 )
 
-        # Signature verification (skip unsigned)
+        # Signature verification
         if receipt.signature:
             if not verify_receipt(receipt):
                 errors.append(
                     f"[{i}] Ed25519 signature verification failed for "
                     f"receipt {receipt.receipt_id}"
                 )
+        else:
+            errors.append(f"[{i}] Unsigned receipt — missing Ed25519 signature")
 
     return errors
 

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
@@ -3,18 +3,10 @@
 """
 Governance Receipt — signed proof that a policy decision was made for an MCP tool call.
 
-Each receipt links:
-  - The Cedar policy ID and its allow/deny decision
-  - The MCP tool name and arguments hash
-  - The agent DID requesting the tool call
-  - An Ed25519 signature for non-repudiation
-
-Receipts use RFC 8785 JSON Canonicalization Scheme (JCS) for deterministic
-hashing so that any party can independently verify the receipt signature.
-
-Hash chaining links receipts via ``parent_receipt_hash`` so that verifiers
-can detect insertion or deletion of individual tool calls without replaying
-the full session log.
+Each receipt links the Cedar policy decision, MCP tool name/args hash, and agent DID,
+and carries an Ed25519 signature for non-repudiation.  Receipts use RFC 8785 JCS for
+deterministic hashing and are hash-chained via ``parent_receipt_hash`` so verifiers can
+detect insertion or deletion of tool calls without replaying the full session log.
 """
 
 from __future__ import annotations
@@ -33,22 +25,7 @@ _logger = logging.getLogger(__name__)
 
 @dataclass
 class GovernanceReceipt:
-    """Signed proof of a governance decision for an MCP tool call.
-
-    Attributes:
-        receipt_id: Unique receipt identifier (UUID4).
-        tool_name: MCP tool that was invoked.
-        agent_did: DID of the agent requesting the tool call.
-        cedar_policy_id: Identifier of the Cedar policy that was evaluated.
-        cedar_decision: Whether Cedar permitted or denied the action.
-        args_hash: SHA-256 hash of the tool call arguments (canonical JSON).
-        timestamp: Unix timestamp of the decision.
-        parent_receipt_hash: SHA-256 hash of the preceding receipt's canonical
-            payload.  ``None`` for the first receipt in a chain.
-        signature: Ed25519 signature over the canonical receipt payload.
-        signer_public_key: Hex-encoded Ed25519 public key of the signer.
-        error: Optional error message if the decision failed.
-    """
+    """Signed proof of a governance decision for an MCP tool call."""
 
     receipt_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     tool_name: str = ""
@@ -64,15 +41,7 @@ class GovernanceReceipt:
     error: Optional[str] = None
 
     def canonical_payload(self) -> str:
-        """Return RFC 8785 (JCS) canonical JSON for deterministic hashing.
-
-        Only governance-relevant fields are included; signature fields are
-        excluded because the signature covers this payload.
-
-        The output uses ``ensure_ascii=False`` so that Unicode codepoints are
-        emitted as raw UTF-8 rather than ``\\uXXXX`` escapes, which is required
-        by RFC 8785 § 3.2.2.2.
-        """
+        """RFC 8785 JCS canonical JSON; signature fields excluded (they cover this payload)."""
         data: Dict[str, Any] = {
             "agent_did": self.agent_did,
             "args_hash": self.args_hash,
@@ -86,14 +55,13 @@ class GovernanceReceipt:
             data["parent_receipt_hash"] = self.parent_receipt_hash
         if self.session_id is not None:
             data["session_id"] = self.session_id
+        # ensure_ascii=False: RFC 8785 §3.2.2.2 requires raw UTF-8, not \uXXXX escapes
         return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
     def payload_hash(self) -> str:
-        """SHA-256 hash of the canonical payload."""
         return hashlib.sha256(self.canonical_payload().encode()).hexdigest()
 
     def to_dict(self) -> Dict[str, Any]:
-        """Serialize receipt to a dictionary."""
         return {
             "receipt_id": self.receipt_id,
             "tool_name": self.tool_name,
@@ -111,50 +79,31 @@ class GovernanceReceipt:
         }
 
     def to_slsa_provenance(self) -> Dict[str, Any]:
-        """Emit the receipt as a SLSA v1.0 provenance predicate.
-
-        Maps the governance decision to the in-toto Statement / SLSA
-        Provenance format so that standard supply-chain verification
-        tools (``slsa-verifier``, ``in-toto``) can consume it.
-
-        Returns:
-            An in-toto v1 Statement dict with a SLSA Provenance predicate.
-        """
-        parent_dep: Optional[Dict[str, Any]] = None
-        if self.parent_receipt_hash:
-            parent_dep = {
-                "uri": "pkg:agentmesh/receipt/parent",
-                "digest": {"sha256": self.parent_receipt_hash},
-            }
-
+        """Emit as a SLSA v1.0 / in-toto Statement provenance predicate."""
+        deps = (
+            [{"uri": "pkg:agentmesh/receipt/parent", "digest": {"sha256": self.parent_receipt_hash}}]
+            if self.parent_receipt_hash
+            else []
+        )
         return {
             "_type": "https://in-toto.io/Statement/v1",
-            "subject": [
-                {
-                    "name": f"pkg:agentmesh/tool/{self.tool_name}",
-                    "digest": {"sha256": self.args_hash},
-                }
-            ],
+            "subject": [{"name": f"pkg:agentmesh/tool/{self.tool_name}", "digest": {"sha256": self.args_hash}}],
             "predicateType": "https://slsa.dev/provenance/v1",
             "predicate": {
                 "buildDefinition": {
-                    "buildType": ("https://agent-governance.org/schema/mcp-tool-call/v1"),
+                    "buildType": "https://agent-governance.org/schema/mcp-tool-call/v1",
                     "externalParameters": {
                         "agent_did": self.agent_did,
                         "cedar_policy_id": self.cedar_policy_id,
                         "cedar_decision": self.cedar_decision,
                     },
-                    "resolvedDependencies": ([parent_dep] if parent_dep else []),
+                    "resolvedDependencies": deps,
                 },
                 "runDetails": {
-                    "builder": {
-                        "id": ("https://agent-governance.org/adapters/" "mcp-receipt-governed"),
-                    },
+                    "builder": {"id": "https://agent-governance.org/adapters/mcp-receipt-governed"},
                     "metadata": {
                         "invocationId": self.receipt_id,
-                        "startedOn": time.strftime(
-                            "%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.timestamp)
-                        ),
+                        "startedOn": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(self.timestamp)),
                     },
                 },
             },
@@ -162,69 +111,31 @@ class GovernanceReceipt:
 
 
 def hash_tool_args(tool_args: Optional[Dict[str, Any]]) -> str:
-    """Compute SHA-256 hash of tool arguments using canonical JSON.
-
-    Args:
-        tool_args: The MCP tool call arguments. ``None`` or empty produces
-            the hash of an empty JSON object.
-
-    Returns:
-        Hex-encoded SHA-256 digest.
-    """
-    if not tool_args:
-        canonical = "{}"
-    else:
-        canonical = json.dumps(tool_args, sort_keys=True, separators=(",", ":"))
+    """SHA-256 of tool arguments as canonical JSON. ``None`` or empty → hash of ``{}``."""
+    canonical = json.dumps(tool_args, sort_keys=True, separators=(",", ":")) if tool_args else "{}"
     return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 def sign_receipt(receipt: GovernanceReceipt, private_key_hex: str) -> GovernanceReceipt:
-    """Sign a governance receipt with an Ed25519 private key.
-
-    Uses the stdlib ``hashlib`` for hashing and a minimal Ed25519 signature
-    via the ``cryptography`` library (already an AGT dependency) or falls back
-    to HMAC-SHA256 for environments without ``cryptography``.
-
-    Args:
-        receipt: The receipt to sign.
-        private_key_hex: Hex-encoded 32-byte Ed25519 seed.
-
-    Returns:
-        The receipt with ``signature`` and ``signer_public_key`` populated.
-    """
-    payload = receipt.canonical_payload().encode()
-
+    """Sign a receipt with an Ed25519 private key (hex-encoded 32-byte seed)."""
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-    seed = bytes.fromhex(private_key_hex)
-    private_key = Ed25519PrivateKey.from_private_bytes(seed)
-    sig = private_key.sign(payload)
-    receipt.signature = sig.hex()
+    private_key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(private_key_hex))
+    payload = receipt.canonical_payload().encode()
+    receipt.signature = private_key.sign(payload).hex()
     receipt.signer_public_key = private_key.public_key().public_bytes_raw().hex()
-
     return receipt
 
 
 def verify_receipt(receipt: GovernanceReceipt) -> bool:
-    """Verify the Ed25519 signature on a governance receipt.
-
-    Args:
-        receipt: The receipt to verify.
-
-    Returns:
-        ``True`` if the signature is valid, ``False`` otherwise.
-    """
+    """Verify the Ed25519 signature on a receipt. Returns ``False`` if unsigned or invalid."""
     if not receipt.signature or not receipt.signer_public_key:
         return False
-
     try:
         from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
-        pub_bytes = bytes.fromhex(receipt.signer_public_key)
-        public_key = Ed25519PublicKey.from_public_bytes(pub_bytes)
-        sig_bytes = bytes.fromhex(receipt.signature)
-        payload = receipt.canonical_payload().encode()
-        public_key.verify(sig_bytes, payload)
+        public_key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(receipt.signer_public_key))
+        public_key.verify(bytes.fromhex(receipt.signature), receipt.canonical_payload().encode())
         return True
     except ImportError:
         _logger.error("cryptography not available — cannot verify Ed25519 signature")
@@ -238,68 +149,40 @@ def verify_receipt_chain(
     *,
     trusted_keys: Optional[List[str]] = None,
 ) -> List[str]:
-    """Verify the hash chain and signatures of an ordered receipt list.
+    """Verify hash-chain integrity and Ed25519 signatures for an ordered receipt list.
 
-    Checks:
-      1. The first receipt has no parent (``parent_receipt_hash is None``).
-      2. Each subsequent receipt's ``parent_receipt_hash`` equals the
-         ``payload_hash()`` of the preceding receipt.
-      3. Every receipt has an Ed25519 signature.
-      4. Every signed receipt passes Ed25519 verification.
-      5. If ``trusted_keys`` is provided, the signer's public key must
-         be in the trusted set.
-
-    Args:
-        receipts: Ordered list of receipts to verify.
-        trusted_keys: Optional list of hex-encoded Ed25519 public keys.
-            When provided, receipts signed by keys not in this list are
-            flagged as untrusted.
-
-    Returns:
-        A list of human-readable error strings. An empty list means the
-        chain is fully valid.
+    Returns a list of error strings; empty means the chain is fully valid.
+    Checks: no-parent on first receipt, contiguous parent hashes, no duplicate
+    receipt IDs, valid signatures, and (if ``trusted_keys`` given) trusted signers.
     """
-    errors: List[str] = []
-
     if not receipts:
-        return errors
+        return []
 
+    errors: List[str] = []
     trusted_set = set(trusted_keys) if trusted_keys else None
     seen_ids: set = set()
 
-    for i, receipt in enumerate(receipts):
-        # Duplicate receipt_id detection (replay attack mitigation)
-        if receipt.receipt_id in seen_ids:
-            errors.append(
-                f"[{i}] Duplicate receipt_id {receipt.receipt_id} — "
-                f"possible replay attack"
-            )
-        seen_ids.add(receipt.receipt_id)
+    for i, r in enumerate(receipts):
+        if r.receipt_id in seen_ids:
+            errors.append(f"[{i}] Duplicate receipt_id {r.receipt_id} — possible replay attack")
+        seen_ids.add(r.receipt_id)
 
-        # Chain contiguity
         if i == 0:
-            if receipt.parent_receipt_hash is not None:
+            if r.parent_receipt_hash is not None:
                 errors.append(f"[{i}] First receipt has unexpected parent_receipt_hash")
         else:
             expected = receipts[i - 1].payload_hash()
-            if receipt.parent_receipt_hash != expected:
+            if r.parent_receipt_hash != expected:
                 errors.append(
-                    f"[{i}] Hash chain broken: expected parent {expected[:16]}…, "
-                    f"got {(receipt.parent_receipt_hash or 'None')[:16]}…"
+                    f"[{i}] Hash chain broken: expected {expected[:16]}…, "
+                    f"got {(r.parent_receipt_hash or 'None')[:16]}…"
                 )
 
-        # Signature verification
-        if receipt.signature:
-            if not verify_receipt(receipt):
-                errors.append(
-                    f"[{i}] Ed25519 signature verification failed for "
-                    f"receipt {receipt.receipt_id}"
-                )
-            elif trusted_set and receipt.signer_public_key not in trusted_set:
-                errors.append(
-                    f"[{i}] Untrusted signer key {(receipt.signer_public_key or '')[:16]}… "
-                    f"not in trusted key set — receipt rejected"
-                )
+        if r.signature:
+            if not verify_receipt(r):
+                errors.append(f"[{i}] Ed25519 signature invalid for receipt {r.receipt_id}")
+            elif trusted_set and r.signer_public_key not in trusted_set:
+                errors.append(f"[{i}] Untrusted signer {(r.signer_public_key or '')[:16]}… — receipt rejected")
         else:
             errors.append(f"[{i}] Unsigned receipt — missing Ed25519 signature")
 
@@ -307,17 +190,13 @@ def verify_receipt_chain(
 
 
 class ReceiptStore:
-    """In-memory store for governance receipts with query capabilities.
-
-    All public methods are thread-safe via an internal ``threading.Lock``.
-    """
+    """Thread-safe in-memory store for governance receipts."""
 
     def __init__(self) -> None:
         self._receipts: List[GovernanceReceipt] = []
         self._lock = threading.Lock()
 
     def add(self, receipt: GovernanceReceipt) -> None:
-        """Store a receipt."""
         with self._lock:
             self._receipts.append(receipt)
 
@@ -327,16 +206,6 @@ class ReceiptStore:
         tool_name: Optional[str] = None,
         cedar_decision: Optional[str] = None,
     ) -> List[GovernanceReceipt]:
-        """Query receipts by agent, tool, or decision.
-
-        Args:
-            agent_did: Filter by agent DID.
-            tool_name: Filter by MCP tool name.
-            cedar_decision: Filter by ``"allow"`` or ``"deny"``.
-
-        Returns:
-            List of matching receipts.
-        """
         with self._lock:
             results = list(self._receipts)
         if agent_did:
@@ -348,23 +217,19 @@ class ReceiptStore:
         return results
 
     def export(self) -> List[Dict[str, Any]]:
-        """Export all receipts as a list of dictionaries."""
         with self._lock:
             return [r.to_dict() for r in self._receipts]
 
     def clear(self) -> None:
-        """Remove all receipts."""
         with self._lock:
             self._receipts.clear()
 
     @property
     def count(self) -> int:
-        """Number of stored receipts."""
         with self._lock:
             return len(self._receipts)
 
     def get_stats(self) -> Dict[str, Any]:
-        """Aggregate statistics for the receipt store."""
         with self._lock:
             total = len(self._receipts)
             allowed = sum(1 for r in self._receipts if r.cedar_decision == "allow")

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed/receipt.py
@@ -56,6 +56,7 @@ class GovernanceReceipt:
     cedar_decision: Literal["allow", "deny"] = "deny"
     args_hash: str = ""
     timestamp: float = field(default_factory=time.time)
+    session_id: Optional[str] = None
     parent_receipt_hash: Optional[str] = None
     signature: Optional[str] = None
     signer_public_key: Optional[str] = None
@@ -82,6 +83,8 @@ class GovernanceReceipt:
         }
         if self.parent_receipt_hash is not None:
             data["parent_receipt_hash"] = self.parent_receipt_hash
+        if self.session_id is not None:
+            data["session_id"] = self.session_id
         return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
     def payload_hash(self) -> str:
@@ -98,6 +101,7 @@ class GovernanceReceipt:
             "cedar_decision": self.cedar_decision,
             "args_hash": self.args_hash,
             "timestamp": self.timestamp,
+            "session_id": self.session_id,
             "parent_receipt_hash": self.parent_receipt_hash,
             "payload_hash": self.payload_hash(),
             "signature": self.signature,
@@ -228,17 +232,27 @@ def verify_receipt(receipt: GovernanceReceipt) -> bool:
         return False
 
 
-def verify_receipt_chain(receipts: List[GovernanceReceipt]) -> List[str]:
+def verify_receipt_chain(
+    receipts: List[GovernanceReceipt],
+    *,
+    trusted_keys: Optional[List[str]] = None,
+) -> List[str]:
     """Verify the hash chain and signatures of an ordered receipt list.
 
     Checks:
       1. The first receipt has no parent (``parent_receipt_hash is None``).
       2. Each subsequent receipt's ``parent_receipt_hash`` equals the
          ``payload_hash()`` of the preceding receipt.
-      3. Every signed receipt passes Ed25519 verification.
+      3. Every receipt has an Ed25519 signature.
+      4. Every signed receipt passes Ed25519 verification.
+      5. If ``trusted_keys`` is provided, the signer's public key must
+         be in the trusted set.
 
     Args:
         receipts: Ordered list of receipts to verify.
+        trusted_keys: Optional list of hex-encoded Ed25519 public keys.
+            When provided, receipts signed by keys not in this list are
+            flagged as untrusted.
 
     Returns:
         A list of human-readable error strings. An empty list means the
@@ -248,6 +262,8 @@ def verify_receipt_chain(receipts: List[GovernanceReceipt]) -> List[str]:
 
     if not receipts:
         return errors
+
+    trusted_set = set(trusted_keys) if trusted_keys else None
 
     for i, receipt in enumerate(receipts):
         # Chain contiguity
@@ -268,6 +284,11 @@ def verify_receipt_chain(receipts: List[GovernanceReceipt]) -> List[str]:
                 errors.append(
                     f"[{i}] Ed25519 signature verification failed for "
                     f"receipt {receipt.receipt_id}"
+                )
+            elif trusted_set and receipt.signer_public_key not in trusted_set:
+                errors.append(
+                    f"[{i}] Signer key {(receipt.signer_public_key or '')[:16]}… "
+                    f"not in trusted key set"
                 )
         else:
             errors.append(f"[{i}] Unsigned receipt — missing Ed25519 signature")

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
@@ -40,18 +40,28 @@ def _reconstruct(data: Dict[str, Any]) -> GovernanceReceipt:
     )
 
 
-def verify_chain(receipts_data: List[Dict[str, Any]]) -> int:
+_EXIT_OK = 0
+_EXIT_CHAIN_ERROR = 1
+_EXIT_LOAD_ERROR = 2
+
+
+def verify_chain(
+    receipts_data: List[Dict[str, Any]],
+) -> tuple[int, List[Dict[str, Any]]]:
     """Verify a chain of exported receipts.
 
     Returns:
-        ``0`` if the chain is fully valid, ``1`` otherwise.
+        Tuple of (exit_code, per_receipt_results).
+        exit_code is 0 for a fully valid chain, 1 for integrity errors.
+        per_receipt_results contains per-receipt check details for JSON output.
     """
     if not receipts_data:
         print("  (empty chain — nothing to verify)")
-        return 0
+        return _EXIT_OK, []
 
-    errors = 0
+    total_errors = 0
     expected_parent_hash = None
+    results: List[Dict[str, Any]] = []
 
     for i, data in enumerate(receipts_data):
         receipt = _reconstruct(data)
@@ -60,20 +70,24 @@ def verify_chain(receipts_data: List[Dict[str, Any]]) -> int:
         )
         print(f"  [{i}] Receipt {rid_short}  (tool: {receipt.tool_name})")
 
+        receipt_errors: List[str] = []
+
         # 1. Hash chain contiguity
         if receipt.parent_receipt_hash != expected_parent_hash:
             exp = (expected_parent_hash or "None")[:16]
             got = (receipt.parent_receipt_hash or "None")[:16]
-            print(f"      ❌  Hash chain broken — expected {exp}…, got {got}…")
-            errors += 1
+            msg = f"Hash chain broken — expected {exp}…, got {got}…"
+            print(f"      ❌  {msg}")
+            receipt_errors.append(msg)
         else:
             print("      ✅  Hash chain contiguous")
 
         # 2. Canonical payload hash (round-trip check)
         stored_hash = data.get("payload_hash")
         if stored_hash and receipt.payload_hash() != stored_hash:
-            print("      ❌  Payload hash mismatch (canonical re-generation differs)")
-            errors += 1
+            msg = "Payload hash mismatch (canonical re-generation differs)"
+            print(f"      ❌  {msg}")
+            receipt_errors.append(msg)
         else:
             print("      ✅  Payload hash verified")
 
@@ -82,15 +96,27 @@ def verify_chain(receipts_data: List[Dict[str, Any]]) -> int:
             if verify_receipt(receipt):
                 print("      ✅  Ed25519 signature valid")
             else:
-                print("      ❌  Ed25519 signature verification failed")
-                errors += 1
+                msg = "Ed25519 signature verification failed"
+                print(f"      ❌  {msg}")
+                receipt_errors.append(msg)
         else:
             print("      ⚠️   Unsigned receipt (no signature)")
 
+        total_errors += len(receipt_errors)
         expected_parent_hash = receipt.payload_hash()
+        results.append(
+            {
+                "index": i,
+                "receipt_id": receipt.receipt_id,
+                "tool_name": receipt.tool_name,
+                "passed": len(receipt_errors) == 0,
+                "errors": receipt_errors,
+            }
+        )
         print()
 
-    return 0 if errors == 0 else 1
+    exit_code = _EXIT_OK if total_errors == 0 else _EXIT_CHAIN_ERROR
+    return exit_code, results
 
 
 def main() -> int:
@@ -106,42 +132,50 @@ def main() -> int:
         "--json",
         action="store_true",
         dest="json_output",
-        help="Output results as JSON for CI/CD integration",
+        help="Output results as JSON for CI/CD integration (includes per-receipt detail)",
     )
     args = parser.parse_args()
 
-    print()
-    print("╔══════════════════════════════════════════════════════╗")
-    print("║  MCP Receipt Chain — Offline Verification           ║")
-    print("╚══════════════════════════════════════════════════════╝")
-    print()
+    if not args.json_output:
+        print()
+        print("╔══════════════════════════════════════════════════════╗")
+        print("║  MCP Receipt Chain — Offline Verification           ║")
+        print("╚══════════════════════════════════════════════════════╝")
+        print()
 
     try:
         with open(args.receipts_file) as f:
             receipts_data = json.load(f)
     except Exception as exc:
-        print(f"  Error loading {args.receipts_file}: {exc}")
-        return 1
+        if args.json_output:
+            print(json.dumps({"error": str(exc), "exit_code": _EXIT_LOAD_ERROR}, indent=2))
+        else:
+            print(f"  Error loading {args.receipts_file}: {exc}")
+        return _EXIT_LOAD_ERROR
 
-    print(f"  Loaded {len(receipts_data)} receipt(s) from {args.receipts_file}")
-    print()
+    if not args.json_output:
+        print(f"  Loaded {len(receipts_data)} receipt(s) from {args.receipts_file}")
+        print()
 
-    result = verify_chain(receipts_data)
+    exit_code, per_receipt = verify_chain(receipts_data)
 
     if args.json_output:
         output = {
             "file": args.receipts_file,
             "total_receipts": len(receipts_data),
-            "passed": result == 0,
+            "passed": exit_code == _EXIT_OK,
+            "exit_code": exit_code,
+            "receipts": per_receipt,
         }
         print(json.dumps(output, indent=2))
-    elif result == 0:
+    elif exit_code == _EXIT_OK:
         print("  🎉 Verification passed — chain is contiguous and signatures are valid.")
     else:
         print("  🚨 Verification failed — the receipt chain has integrity issues.")
 
-    print()
-    return result
+    if not args.json_output:
+        print()
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Offline verification tool for MCP governance receipt chains.
+
+Verifies Ed25519 signatures, RFC 8785 JCS canonical payloads, and
+hash-chain contiguity from a JSON export file.  No network access
+or running AGT infrastructure is required.
+
+Usage:
+    python scripts/verify_receipts.py receipts.json
+"""
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List
+
+from mcp_receipt_governed.receipt import (
+    GovernanceReceipt,
+    verify_receipt,
+)
+
+
+def _reconstruct(data: Dict[str, Any]) -> GovernanceReceipt:
+    """Build a GovernanceReceipt from an exported dict."""
+    return GovernanceReceipt(
+        receipt_id=data.get("receipt_id", ""),
+        tool_name=data.get("tool_name", ""),
+        agent_did=data.get("agent_did", ""),
+        cedar_policy_id=data.get("cedar_policy_id", ""),
+        cedar_decision=data.get("cedar_decision", "deny"),
+        args_hash=data.get("args_hash", ""),
+        timestamp=data.get("timestamp", 0.0),
+        parent_receipt_hash=data.get("parent_receipt_hash"),
+        signature=data.get("signature"),
+        signer_public_key=data.get("signer_public_key"),
+        error=data.get("error"),
+    )
+
+
+def verify_chain(receipts_data: List[Dict[str, Any]]) -> int:
+    """Verify a chain of exported receipts.
+
+    Returns:
+        ``0`` if the chain is fully valid, ``1`` otherwise.
+    """
+    if not receipts_data:
+        print("  (empty chain — nothing to verify)")
+        return 0
+
+    errors = 0
+    expected_parent_hash = None
+
+    for i, data in enumerate(receipts_data):
+        receipt = _reconstruct(data)
+        rid_short = (
+            receipt.receipt_id[:12] + "…" if len(receipt.receipt_id) > 12 else receipt.receipt_id
+        )
+        print(f"  [{i}] Receipt {rid_short}  (tool: {receipt.tool_name})")
+
+        # 1. Hash chain contiguity
+        if receipt.parent_receipt_hash != expected_parent_hash:
+            exp = (expected_parent_hash or "None")[:16]
+            got = (receipt.parent_receipt_hash or "None")[:16]
+            print(f"      ❌  Hash chain broken — expected {exp}…, got {got}…")
+            errors += 1
+        else:
+            print("      ✅  Hash chain contiguous")
+
+        # 2. Canonical payload hash (round-trip check)
+        stored_hash = data.get("payload_hash")
+        if stored_hash and receipt.payload_hash() != stored_hash:
+            print("      ❌  Payload hash mismatch (canonical re-generation differs)")
+            errors += 1
+        else:
+            print("      ✅  Payload hash verified")
+
+        # 3. Ed25519 signature
+        if receipt.signature:
+            if verify_receipt(receipt):
+                print("      ✅  Ed25519 signature valid")
+            else:
+                print("      ❌  Ed25519 signature verification failed")
+                errors += 1
+        else:
+            print("      ⚠️   Unsigned receipt (no signature)")
+
+        expected_parent_hash = receipt.payload_hash()
+        print()
+
+    return 0 if errors == 0 else 1
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Verify MCP governance receipt chains offline.",
+    )
+    parser.add_argument(
+        "receipts_file",
+        help="Path to JSON file containing exported receipts (from ReceiptStore.export())",
+    )
+    args = parser.parse_args()
+
+    print()
+    print("╔══════════════════════════════════════════════════════╗")
+    print("║  MCP Receipt Chain — Offline Verification           ║")
+    print("╚══════════════════════════════════════════════════════╝")
+    print()
+
+    try:
+        with open(args.receipts_file) as f:
+            receipts_data = json.load(f)
+    except Exception as exc:
+        print(f"  Error loading {args.receipts_file}: {exc}")
+        return 1
+
+    print(f"  Loaded {len(receipts_data)} receipt(s) from {args.receipts_file}")
+    print()
+
+    result = verify_chain(receipts_data)
+
+    if result == 0:
+        print("  🎉 Verification passed — chain is contiguous and signatures are valid.")
+    else:
+        print("  🚨 Verification failed — the receipt chain has integrity issues.")
+
+    print()
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
@@ -32,6 +32,7 @@ def _reconstruct(data: Dict[str, Any]) -> GovernanceReceipt:
         cedar_decision=data.get("cedar_decision", "deny"),
         args_hash=data.get("args_hash", ""),
         timestamp=data.get("timestamp", 0.0),
+        session_id=data.get("session_id"),
         parent_receipt_hash=data.get("parent_receipt_hash"),
         signature=data.get("signature"),
         signer_public_key=data.get("signer_public_key"),
@@ -101,6 +102,12 @@ def main() -> int:
         "receipts_file",
         help="Path to JSON file containing exported receipts (from ReceiptStore.export())",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output results as JSON for CI/CD integration",
+    )
     args = parser.parse_args()
 
     print()
@@ -121,7 +128,14 @@ def main() -> int:
 
     result = verify_chain(receipts_data)
 
-    if result == 0:
+    if args.json_output:
+        output = {
+            "file": args.receipts_file,
+            "total_receipts": len(receipts_data),
+            "passed": result == 0,
+        }
+        print(json.dumps(output, indent=2))
+    elif result == 0:
         print("  🎉 Verification passed — chain is contiguous and signatures are valid.")
     else:
         print("  🚨 Verification failed — the receipt chain has integrity issues.")

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/scripts/verify_receipts.py
@@ -1,29 +1,28 @@
 #!/usr/bin/env python3
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Offline verification tool for MCP governance receipt chains.
+"""Offline verifier for MCP governance receipt chains.
 
-Verifies Ed25519 signatures, RFC 8785 JCS canonical payloads, and
-hash-chain contiguity from a JSON export file.  No network access
-or running AGT infrastructure is required.
+Verifies Ed25519 signatures, RFC 8785 canonical payloads, and hash-chain
+contiguity from a JSON export file.  No network access required.
 
 Usage:
-    python scripts/verify_receipts.py receipts.json
+    python scripts/verify_receipts.py receipts.json [--json]
 """
 
 import argparse
 import json
 import sys
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
-from mcp_receipt_governed.receipt import (
-    GovernanceReceipt,
-    verify_receipt,
-)
+from mcp_receipt_governed.receipt import GovernanceReceipt, verify_receipt
+
+_EXIT_OK = 0
+_EXIT_CHAIN_ERROR = 1
+_EXIT_LOAD_ERROR = 2
 
 
 def _reconstruct(data: Dict[str, Any]) -> GovernanceReceipt:
-    """Build a GovernanceReceipt from an exported dict."""
     return GovernanceReceipt(
         receipt_id=data.get("receipt_id", ""),
         tool_name=data.get("tool_name", ""),
@@ -40,112 +39,72 @@ def _reconstruct(data: Dict[str, Any]) -> GovernanceReceipt:
     )
 
 
-_EXIT_OK = 0
-_EXIT_CHAIN_ERROR = 1
-_EXIT_LOAD_ERROR = 2
-
-
-def verify_chain(
-    receipts_data: List[Dict[str, Any]],
-) -> tuple[int, List[Dict[str, Any]]]:
+def verify_chain(receipts_data: List[Dict[str, Any]]) -> Tuple[int, List[Dict[str, Any]]]:
     """Verify a chain of exported receipts.
 
-    Returns:
-        Tuple of (exit_code, per_receipt_results).
-        exit_code is 0 for a fully valid chain, 1 for integrity errors.
-        per_receipt_results contains per-receipt check details for JSON output.
+    Returns (exit_code, per_receipt_results). exit_code 0 = valid, 1 = errors.
     """
     if not receipts_data:
         print("  (empty chain — nothing to verify)")
         return _EXIT_OK, []
 
     total_errors = 0
-    expected_parent_hash = None
+    expected_parent = None
     results: List[Dict[str, Any]] = []
 
     for i, data in enumerate(receipts_data):
-        receipt = _reconstruct(data)
-        rid_short = (
-            receipt.receipt_id[:12] + "…" if len(receipt.receipt_id) > 12 else receipt.receipt_id
-        )
-        print(f"  [{i}] Receipt {rid_short}  (tool: {receipt.tool_name})")
+        r = _reconstruct(data)
+        rid = r.receipt_id[:12] + "…" if len(r.receipt_id) > 12 else r.receipt_id
+        print(f"  [{i}] {rid}  (tool: {r.tool_name})")
+        errs: List[str] = []
 
-        receipt_errors: List[str] = []
-
-        # 1. Hash chain contiguity
-        if receipt.parent_receipt_hash != expected_parent_hash:
-            exp = (expected_parent_hash or "None")[:16]
-            got = (receipt.parent_receipt_hash or "None")[:16]
-            msg = f"Hash chain broken — expected {exp}…, got {got}…"
+        if r.parent_receipt_hash != expected_parent:
+            msg = f"Hash chain broken — expected {(expected_parent or 'None')[:16]}…, got {(r.parent_receipt_hash or 'None')[:16]}…"
             print(f"      ❌  {msg}")
-            receipt_errors.append(msg)
+            errs.append(msg)
         else:
             print("      ✅  Hash chain contiguous")
 
-        # 2. Canonical payload hash (round-trip check)
-        stored_hash = data.get("payload_hash")
-        if stored_hash and receipt.payload_hash() != stored_hash:
-            msg = "Payload hash mismatch (canonical re-generation differs)"
+        stored = data.get("payload_hash")
+        if stored and r.payload_hash() != stored:
+            msg = "Payload hash mismatch"
             print(f"      ❌  {msg}")
-            receipt_errors.append(msg)
+            errs.append(msg)
         else:
             print("      ✅  Payload hash verified")
 
-        # 3. Ed25519 signature
-        if receipt.signature:
-            if verify_receipt(receipt):
+        if r.signature:
+            if verify_receipt(r):
                 print("      ✅  Ed25519 signature valid")
             else:
                 msg = "Ed25519 signature verification failed"
                 print(f"      ❌  {msg}")
-                receipt_errors.append(msg)
+                errs.append(msg)
         else:
-            print("      ⚠️   Unsigned receipt (no signature)")
+            print("      ⚠️   Unsigned receipt")
 
-        total_errors += len(receipt_errors)
-        expected_parent_hash = receipt.payload_hash()
-        results.append(
-            {
-                "index": i,
-                "receipt_id": receipt.receipt_id,
-                "tool_name": receipt.tool_name,
-                "passed": len(receipt_errors) == 0,
-                "errors": receipt_errors,
-            }
-        )
+        total_errors += len(errs)
+        expected_parent = r.payload_hash()
+        results.append({"index": i, "receipt_id": r.receipt_id, "tool_name": r.tool_name, "passed": not errs, "errors": errs})
         print()
 
-    exit_code = _EXIT_OK if total_errors == 0 else _EXIT_CHAIN_ERROR
-    return exit_code, results
+    return (_EXIT_OK if total_errors == 0 else _EXIT_CHAIN_ERROR), results
 
 
 def main() -> int:
-    """CLI entry point."""
-    parser = argparse.ArgumentParser(
-        description="Verify MCP governance receipt chains offline.",
-    )
-    parser.add_argument(
-        "receipts_file",
-        help="Path to JSON file containing exported receipts (from ReceiptStore.export())",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        dest="json_output",
-        help="Output results as JSON for CI/CD integration (includes per-receipt detail)",
-    )
+    parser = argparse.ArgumentParser(description="Verify MCP governance receipt chains offline.")
+    parser.add_argument("receipts_file", help="JSON file from ReceiptStore.export()")
+    parser.add_argument("--json", action="store_true", dest="json_output", help="Structured JSON output for CI/CD")
     args = parser.parse_args()
 
     if not args.json_output:
-        print()
-        print("╔══════════════════════════════════════════════════════╗")
+        print("\n╔══════════════════════════════════════════════════════╗")
         print("║  MCP Receipt Chain — Offline Verification           ║")
-        print("╚══════════════════════════════════════════════════════╝")
-        print()
+        print("╚══════════════════════════════════════════════════════╝\n")
 
     try:
         with open(args.receipts_file) as f:
-            receipts_data = json.load(f)
+            data = json.load(f)
     except Exception as exc:
         if args.json_output:
             print(json.dumps({"error": str(exc), "exit_code": _EXIT_LOAD_ERROR}, indent=2))
@@ -154,27 +113,17 @@ def main() -> int:
         return _EXIT_LOAD_ERROR
 
     if not args.json_output:
-        print(f"  Loaded {len(receipts_data)} receipt(s) from {args.receipts_file}")
-        print()
+        print(f"  Loaded {len(data)} receipt(s) from {args.receipts_file}\n")
 
-    exit_code, per_receipt = verify_chain(receipts_data)
+    exit_code, per_receipt = verify_chain(data)
 
     if args.json_output:
-        output = {
-            "file": args.receipts_file,
-            "total_receipts": len(receipts_data),
-            "passed": exit_code == _EXIT_OK,
-            "exit_code": exit_code,
-            "receipts": per_receipt,
-        }
-        print(json.dumps(output, indent=2))
+        print(json.dumps({"file": args.receipts_file, "total_receipts": len(data), "passed": exit_code == _EXIT_OK, "exit_code": exit_code, "receipts": per_receipt}, indent=2))
     elif exit_code == _EXIT_OK:
-        print("  🎉 Verification passed — chain is contiguous and signatures are valid.")
+        print("  🎉 Verification passed — chain is contiguous and signatures are valid.\n")
     else:
-        print("  🚨 Verification failed — the receipt chain has integrity issues.")
+        print("  🚨 Verification failed — the receipt chain has integrity issues.\n")
 
-    if not args.json_output:
-        print()
     return exit_code
 
 

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_adapter.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_adapter.py
@@ -182,6 +182,17 @@ class TestSigning:
         )
         assert verify_receipt(receipt) is True
 
+    def test_signing_failure_raises(self):
+        """Fail-closed: signing failure raises RuntimeError, not silent error."""
+        adapter = McpReceiptAdapter(
+            cedar_policy=self.POLICY,
+            signing_key_hex="invalid_key",
+        )
+        with pytest.raises(RuntimeError, match="Receipt signing failed"):
+            adapter.govern_tool_call(
+                agent_did="did:mesh:a1",
+                tool_name="ReadData",
+            )
 
 # ── Govern and Execute ──
 

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
@@ -155,6 +155,27 @@ class TestJCSCanonicalization:
         payload = r.canonical_payload()
         assert "\u8bfb\u53d6\u6570\u636e" in payload
 
+    def test_replacement_character_preserved(self):
+        """U+FFFD replacement character round-trips through canonical JSON."""
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="bad\ufffdtool",
+            timestamp=1.0,
+        )
+        payload = r.canonical_payload()
+        assert "\ufffd" in payload
+        assert "\\u" not in payload
+
+    def test_rtl_arabic_characters_preserved(self):
+        """Right-to-left Arabic text is preserved in canonical form."""
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="\u0642\u0631\u0627\u0621\u0629",
+            timestamp=1.0,
+        )
+        payload = r.canonical_payload()
+        assert "\u0642\u0631\u0627\u0621\u0629" in payload
+
     def test_empty_string_fields(self):
         """Empty strings are valid and canonical."""
         r = GovernanceReceipt(
@@ -339,6 +360,57 @@ class TestSLSAProvenance:
         assert builder_host and (
             builder_host == "agent-governance.org" or builder_host.endswith(".agent-governance.org")
         )
+
+    def test_slsa_schema_required_fields(self):
+        """SLSA Provenance v1 requires specific top-level and predicate fields."""
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="ReadData",
+            agent_did="did:mesh:a1",
+            cedar_policy_id="policy:v1",
+            cedar_decision="allow",
+            args_hash="hash123",
+            timestamp=1700000000.0,
+        )
+        slsa = r.to_slsa_provenance()
+        # Top-level in-toto Statement fields
+        assert "_type" in slsa
+        assert "subject" in slsa
+        assert "predicateType" in slsa
+        assert "predicate" in slsa
+        # SLSA buildDefinition
+        build_def = slsa["predicate"]["buildDefinition"]
+        assert "buildType" in build_def
+        assert "externalParameters" in build_def
+        assert "resolvedDependencies" in build_def
+        # SLSA runDetails
+        run = slsa["predicate"]["runDetails"]
+        assert "builder" in run
+        assert "id" in run["builder"]
+        assert "metadata" in run
+        assert "invocationId" in run["metadata"]
+        assert "startedOn" in run["metadata"]
+        # startedOn must be ISO 8601 UTC format
+        started_on = run["metadata"]["startedOn"]
+        assert started_on.endswith("Z")
+        assert "T" in started_on
+
+    def test_slsa_external_parameters_content(self):
+        """SLSA externalParameters captures agent DID, policy ID, and decision."""
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="DeleteFile",
+            agent_did="did:mesh:agent-99",
+            cedar_policy_id="policy:strict:v2",
+            cedar_decision="deny",
+            args_hash="cafebabe",
+            timestamp=1700000000.0,
+        )
+        slsa = r.to_slsa_provenance()
+        params = slsa["predicate"]["buildDefinition"]["externalParameters"]
+        assert params["agent_did"] == "did:mesh:agent-99"
+        assert params["cedar_policy_id"] == "policy:strict:v2"
+        assert params["cedar_decision"] == "deny"
 
 
 # ── Hash Tool Args ──
@@ -570,6 +642,54 @@ class TestVerifyReceiptChain:
         sign_receipt(r, signing_key)
         errors = verify_receipt_chain([r], trusted_keys=["deadbeef" * 4])
         assert any("not in trusted key set" in e for e in errors)
+        assert any("rejected" in e for e in errors)
+
+    def test_duplicate_receipt_id_detected(self, signing_key):
+        """Duplicate receipt_ids are flagged as potential replay attacks."""
+        r1 = GovernanceReceipt(receipt_id="same-id", timestamp=1.0)
+        sign_receipt(r1, signing_key)
+        r2 = GovernanceReceipt(
+            receipt_id="same-id",
+            timestamp=2.0,
+            parent_receipt_hash=r1.payload_hash(),
+        )
+        sign_receipt(r2, signing_key)
+        errors = verify_receipt_chain([r1, r2])
+        assert any("Duplicate receipt_id" in e for e in errors)
+        assert any("replay" in e.lower() for e in errors)
+
+    def test_single_receipt_chain_valid_when_signed(self, signing_key):
+        """A single signed receipt with no parent is a valid chain."""
+        r = GovernanceReceipt(receipt_id="only", timestamp=1.0)
+        sign_receipt(r, signing_key)
+        assert verify_receipt_chain([r]) == []
+
+    def test_inserted_receipt_detected(self, signing_key):
+        """Inserting a receipt into the middle breaks hash continuity."""
+        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        sign_receipt(r1, signing_key)
+        r2 = GovernanceReceipt(
+            receipt_id="r2", timestamp=2.0, parent_receipt_hash=r1.payload_hash()
+        )
+        sign_receipt(r2, signing_key)
+        r3 = GovernanceReceipt(
+            receipt_id="r3", timestamp=3.0, parent_receipt_hash=r2.payload_hash()
+        )
+        sign_receipt(r3, signing_key)
+
+        # Insert a foreign receipt between r1 and r2
+        r_evil = GovernanceReceipt(receipt_id="evil", timestamp=1.5)
+        sign_receipt(r_evil, signing_key)
+
+        errors = verify_receipt_chain([r1, r_evil, r2, r3])
+        chain_errors = [e for e in errors if "Hash chain broken" in e]
+        assert len(chain_errors) >= 1
+
+    def test_all_fields_missing_receipt(self):
+        """A receipt with all default/empty values is treated as unsigned."""
+        r = GovernanceReceipt()
+        errors = verify_receipt_chain([r])
+        assert any("Unsigned" in e for e in errors)
 
 
 # ── Receipt Store ──

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
@@ -8,6 +8,7 @@ insertion detection, and SLSA provenance emission in isolation.
 """
 
 import json
+from urllib.parse import urlparse
 
 import pytest
 
@@ -258,7 +259,11 @@ class TestSLSAProvenance:
         slsa = r.to_slsa_provenance()
         run = slsa["predicate"]["runDetails"]
         assert run["metadata"]["invocationId"] == "test-id"
-        assert "agent-governance.org" in run["builder"]["id"]
+        builder_host = urlparse(run["builder"]["id"]).hostname
+        assert builder_host and (
+            builder_host == "agent-governance.org"
+            or builder_host.endswith(".agent-governance.org")
+        )
 
 
 # ── Hash Tool Args ──
@@ -369,9 +374,11 @@ class TestVerifyReceiptChain:
     def test_empty_chain_valid(self):
         assert verify_receipt_chain([]) == []
 
-    def test_single_receipt_valid(self):
+    def test_single_unsigned_receipt_flagged(self):
         r = GovernanceReceipt(receipt_id="only", timestamp=1.0)
-        assert verify_receipt_chain([r]) == []
+        errors = verify_receipt_chain([r])
+        assert len(errors) == 1
+        assert "Unsigned" in errors[0]
 
     def test_single_receipt_unexpected_parent(self):
         r = GovernanceReceipt(
@@ -380,8 +387,9 @@ class TestVerifyReceiptChain:
             parent_receipt_hash="surprise",
         )
         errors = verify_receipt_chain([r])
-        assert len(errors) == 1
-        assert "First receipt" in errors[0]
+        # Expect both: unexpected parent + unsigned
+        assert any("First receipt" in e for e in errors)
+        assert any("Unsigned" in e for e in errors)
 
     def test_valid_three_receipt_chain(self):
         r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
@@ -395,7 +403,10 @@ class TestVerifyReceiptChain:
             timestamp=3.0,
             parent_receipt_hash=r2.payload_hash(),
         )
-        assert verify_receipt_chain([r1, r2, r3]) == []
+        # All errors should be unsigned warnings only (chain is contiguous)
+        errors = verify_receipt_chain([r1, r2, r3])
+        assert all("Unsigned" in e for e in errors)
+        assert not any("Hash chain broken" in e for e in errors)
 
     def test_broken_chain_detected(self):
         r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
@@ -405,8 +416,9 @@ class TestVerifyReceiptChain:
             parent_receipt_hash="wrong-hash",
         )
         errors = verify_receipt_chain([r1, r2])
-        assert len(errors) == 1
-        assert "Hash chain broken" in errors[0]
+        chain_errors = [e for e in errors if "Unsigned" not in e]
+        assert len(chain_errors) == 1
+        assert "Hash chain broken" in chain_errors[0]
 
     def test_deleted_receipt_detected(self):
         """Removing a receipt from the middle breaks the chain."""
@@ -423,8 +435,9 @@ class TestVerifyReceiptChain:
         )
         # Delete r2 from the chain
         errors = verify_receipt_chain([r1, r3])
-        assert len(errors) == 1
-        assert "Hash chain broken" in errors[0]
+        chain_errors = [e for e in errors if "Unsigned" not in e]
+        assert len(chain_errors) == 1
+        assert "Hash chain broken" in chain_errors[0]
 
     @pytest.fixture()
     def signing_key(self):

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
@@ -1,9 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Tests for GovernanceReceipt, ReceiptStore, and signing/verification.
+"""Tests for GovernanceReceipt, ReceiptStore, signing/verification, and hash chaining.
 
 These tests run without any external SDK. They validate the receipt model,
-canonical serialization, and Ed25519 sign/verify round-trip in isolation.
+canonical serialization, Ed25519 sign/verify round-trip, hash chaining for
+insertion detection, and SLSA provenance emission in isolation.
 """
 
 import json
@@ -16,10 +17,16 @@ from mcp_receipt_governed.receipt import (
     hash_tool_args,
     sign_receipt,
     verify_receipt,
+    verify_receipt_chain,
 )
 
 
+# ── Receipt Model ──
+
+
 class TestGovernanceReceipt:
+    """Core receipt dataclass behavior."""
+
     def test_default_fields(self):
         r = GovernanceReceipt()
         assert r.receipt_id  # UUID generated
@@ -27,6 +34,7 @@ class TestGovernanceReceipt:
         assert r.tool_name == ""
         assert r.agent_did == ""
         assert r.timestamp > 0
+        assert r.parent_receipt_hash is None
 
     def test_canonical_payload_deterministic(self):
         r = GovernanceReceipt(
@@ -86,8 +94,174 @@ class TestGovernanceReceipt:
         assert d["cedar_decision"] == "allow"
         assert d["args_hash"] == "hash123"
         assert d["payload_hash"]  # computed
+        assert d["parent_receipt_hash"] is None
         assert d["signature"] is None
         assert d["error"] is None
+
+
+# ── JCS Canonicalization (RFC 8785) ──
+
+
+class TestJCSCanonicalization:
+    """Verify RFC 8785 JSON Canonicalization Scheme compliance."""
+
+    def test_unicode_preserved_not_escaped(self):
+        """JCS § 3.2.2.2 requires raw UTF-8 instead of \\uXXXX escapes."""
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="ReadDäta",
+            timestamp=1700000000.0,
+        )
+        payload = r.canonical_payload()
+        assert "ReadDäta" in payload
+        assert "\\u" not in payload
+
+    def test_no_whitespace_in_canonical(self):
+        """JCS uses compact separators with no trailing whitespace."""
+        r = GovernanceReceipt(receipt_id="test-id", timestamp=1.0)
+        payload = r.canonical_payload()
+        assert " " not in payload.replace("test-id", "x")
+
+    def test_keys_sorted_alphabetically(self):
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="ReadData",
+            agent_did="did:mesh:a1",
+            timestamp=1700000000.0,
+        )
+        parsed = json.loads(r.canonical_payload())
+        keys = list(parsed.keys())
+        assert keys == sorted(keys)
+
+
+# ── Hash Chaining ──
+
+
+class TestHashChaining:
+    """Test receipt-level hash chaining for insertion/deletion detection."""
+
+    def test_first_receipt_has_no_parent(self):
+        r = GovernanceReceipt(receipt_id="first", timestamp=1.0)
+        assert r.parent_receipt_hash is None
+        assert "parent_receipt_hash" not in r.canonical_payload()
+
+    def test_chained_receipt_includes_parent(self):
+        r1 = GovernanceReceipt(receipt_id="first", timestamp=1.0)
+        h1 = r1.payload_hash()
+
+        r2 = GovernanceReceipt(
+            receipt_id="second",
+            timestamp=2.0,
+            parent_receipt_hash=h1,
+        )
+        assert r2.parent_receipt_hash == h1
+        assert "parent_receipt_hash" in r2.canonical_payload()
+        assert h1 in r2.canonical_payload()
+
+    def test_parent_hash_affects_payload_hash(self):
+        """Changing the parent hash changes the receipt's own hash."""
+        r_a = GovernanceReceipt(
+            receipt_id="test",
+            timestamp=1.0,
+            parent_receipt_hash="aaa",
+        )
+        r_b = GovernanceReceipt(
+            receipt_id="test",
+            timestamp=1.0,
+            parent_receipt_hash="bbb",
+        )
+        assert r_a.payload_hash() != r_b.payload_hash()
+
+    def test_to_dict_includes_parent_hash(self):
+        r = GovernanceReceipt(
+            receipt_id="test",
+            timestamp=1.0,
+            parent_receipt_hash="deadbeef",
+        )
+        d = r.to_dict()
+        assert d["parent_receipt_hash"] == "deadbeef"
+
+    def test_three_receipt_chain(self):
+        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        r2 = GovernanceReceipt(
+            receipt_id="r2",
+            timestamp=2.0,
+            parent_receipt_hash=r1.payload_hash(),
+        )
+        r3 = GovernanceReceipt(
+            receipt_id="r3",
+            timestamp=3.0,
+            parent_receipt_hash=r2.payload_hash(),
+        )
+        # Verify chain links
+        assert r2.parent_receipt_hash == r1.payload_hash()
+        assert r3.parent_receipt_hash == r2.payload_hash()
+        # Each receipt has a unique hash
+        assert len({r1.payload_hash(), r2.payload_hash(), r3.payload_hash()}) == 3
+
+
+# ── SLSA Provenance ──
+
+
+class TestSLSAProvenance:
+    """Test SLSA v1.0 provenance predicate emission."""
+
+    def test_slsa_statement_structure(self):
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="ReadData",
+            agent_did="did:mesh:a1",
+            cedar_policy_id="policy:v1",
+            cedar_decision="allow",
+            args_hash="hash123",
+            timestamp=1700000000.0,
+        )
+        slsa = r.to_slsa_provenance()
+        assert slsa["_type"] == "https://in-toto.io/Statement/v1"
+        assert slsa["predicateType"] == "https://slsa.dev/provenance/v1"
+
+    def test_slsa_subject(self):
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="ReadData",
+            args_hash="hash123",
+        )
+        slsa = r.to_slsa_provenance()
+        subject = slsa["subject"][0]
+        assert subject["name"] == "pkg:agentmesh/tool/ReadData"
+        assert subject["digest"]["sha256"] == "hash123"
+
+    def test_slsa_includes_parent_dependency(self):
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="ReadData",
+            args_hash="hash123",
+            parent_receipt_hash="parent-hash-456",
+        )
+        slsa = r.to_slsa_provenance()
+        deps = slsa["predicate"]["buildDefinition"]["resolvedDependencies"]
+        assert len(deps) == 1
+        assert deps[0]["digest"]["sha256"] == "parent-hash-456"
+
+    def test_slsa_no_parent_empty_deps(self):
+        r = GovernanceReceipt(receipt_id="test-id", tool_name="ReadData")
+        slsa = r.to_slsa_provenance()
+        deps = slsa["predicate"]["buildDefinition"]["resolvedDependencies"]
+        assert deps == []
+
+    def test_slsa_run_details(self):
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="ReadData",
+            timestamp=1700000000.0,
+        )
+        slsa = r.to_slsa_provenance()
+        run = slsa["predicate"]["runDetails"]
+        assert run["metadata"]["invocationId"] == "test-id"
+        assert "agent-governance.org" in run["builder"]["id"]
+
+
+# ── Hash Tool Args ──
 
 
 class TestHashToolArgs:
@@ -113,6 +287,10 @@ class TestHashToolArgs:
         h1 = hash_tool_args({"path": "/a"})
         h2 = hash_tool_args({"path": "/b"})
         assert h1 != h2
+
+
+# ── Sign / Verify ──
+
 
 class TestSignVerify:
     @pytest.fixture()
@@ -182,6 +360,111 @@ class TestSignVerify:
         assert verify_receipt(r) is False
 
 
+# ── Chain Verification ──
+
+
+class TestVerifyReceiptChain:
+    """Test the verify_receipt_chain() function for offline verification."""
+
+    def test_empty_chain_valid(self):
+        assert verify_receipt_chain([]) == []
+
+    def test_single_receipt_valid(self):
+        r = GovernanceReceipt(receipt_id="only", timestamp=1.0)
+        assert verify_receipt_chain([r]) == []
+
+    def test_single_receipt_unexpected_parent(self):
+        r = GovernanceReceipt(
+            receipt_id="only",
+            timestamp=1.0,
+            parent_receipt_hash="surprise",
+        )
+        errors = verify_receipt_chain([r])
+        assert len(errors) == 1
+        assert "First receipt" in errors[0]
+
+    def test_valid_three_receipt_chain(self):
+        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        r2 = GovernanceReceipt(
+            receipt_id="r2",
+            timestamp=2.0,
+            parent_receipt_hash=r1.payload_hash(),
+        )
+        r3 = GovernanceReceipt(
+            receipt_id="r3",
+            timestamp=3.0,
+            parent_receipt_hash=r2.payload_hash(),
+        )
+        assert verify_receipt_chain([r1, r2, r3]) == []
+
+    def test_broken_chain_detected(self):
+        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        r2 = GovernanceReceipt(
+            receipt_id="r2",
+            timestamp=2.0,
+            parent_receipt_hash="wrong-hash",
+        )
+        errors = verify_receipt_chain([r1, r2])
+        assert len(errors) == 1
+        assert "Hash chain broken" in errors[0]
+
+    def test_deleted_receipt_detected(self):
+        """Removing a receipt from the middle breaks the chain."""
+        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        r2 = GovernanceReceipt(
+            receipt_id="r2",
+            timestamp=2.0,
+            parent_receipt_hash=r1.payload_hash(),
+        )
+        r3 = GovernanceReceipt(
+            receipt_id="r3",
+            timestamp=3.0,
+            parent_receipt_hash=r2.payload_hash(),
+        )
+        # Delete r2 from the chain
+        errors = verify_receipt_chain([r1, r3])
+        assert len(errors) == 1
+        assert "Hash chain broken" in errors[0]
+
+    @pytest.fixture()
+    def signing_key(self):
+        try:
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+            key = Ed25519PrivateKey.generate()
+            return key.private_bytes_raw().hex()
+        except ImportError:
+            pytest.skip("cryptography not installed")
+
+    def test_signed_chain_verified(self, signing_key):
+        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        sign_receipt(r1, signing_key)
+        r2 = GovernanceReceipt(
+            receipt_id="r2",
+            timestamp=2.0,
+            parent_receipt_hash=r1.payload_hash(),
+        )
+        sign_receipt(r2, signing_key)
+        assert verify_receipt_chain([r1, r2]) == []
+
+    def test_tampered_signed_chain_detected(self, signing_key):
+        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        sign_receipt(r1, signing_key)
+        r2 = GovernanceReceipt(
+            receipt_id="r2",
+            timestamp=2.0,
+            parent_receipt_hash=r1.payload_hash(),
+        )
+        sign_receipt(r2, signing_key)
+        # Tamper with r2 after signing
+        r2.tool_name = "TAMPERED"
+        errors = verify_receipt_chain([r1, r2])
+        assert any("signature" in e.lower() for e in errors)
+
+
+# ── Receipt Store ──
+
+
 class TestReceiptStore:
     def test_add_and_count(self):
         store = ReceiptStore()
@@ -222,18 +505,30 @@ class TestReceiptStore:
 
     def test_query_combined_filters(self):
         store = ReceiptStore()
-        store.add(GovernanceReceipt(
-            receipt_id="r1", agent_did="did:mesh:a1",
-            tool_name="ReadData", cedar_decision="allow",
-        ))
-        store.add(GovernanceReceipt(
-            receipt_id="r2", agent_did="did:mesh:a1",
-            tool_name="DeleteFile", cedar_decision="deny",
-        ))
-        store.add(GovernanceReceipt(
-            receipt_id="r3", agent_did="did:mesh:a2",
-            tool_name="ReadData", cedar_decision="allow",
-        ))
+        store.add(
+            GovernanceReceipt(
+                receipt_id="r1",
+                agent_did="did:mesh:a1",
+                tool_name="ReadData",
+                cedar_decision="allow",
+            )
+        )
+        store.add(
+            GovernanceReceipt(
+                receipt_id="r2",
+                agent_did="did:mesh:a1",
+                tool_name="DeleteFile",
+                cedar_decision="deny",
+            )
+        )
+        store.add(
+            GovernanceReceipt(
+                receipt_id="r3",
+                agent_did="did:mesh:a2",
+                tool_name="ReadData",
+                cedar_decision="allow",
+            )
+        )
 
         results = store.query(agent_did="did:mesh:a1", cedar_decision="allow")
         assert len(results) == 1
@@ -257,15 +552,27 @@ class TestReceiptStore:
 
     def test_get_stats(self):
         store = ReceiptStore()
-        store.add(GovernanceReceipt(
-            agent_did="did:mesh:a1", tool_name="read", cedar_decision="allow",
-        ))
-        store.add(GovernanceReceipt(
-            agent_did="did:mesh:a1", tool_name="write", cedar_decision="allow",
-        ))
-        store.add(GovernanceReceipt(
-            agent_did="did:mesh:a2", tool_name="delete", cedar_decision="deny",
-        ))
+        store.add(
+            GovernanceReceipt(
+                agent_did="did:mesh:a1",
+                tool_name="read",
+                cedar_decision="allow",
+            )
+        )
+        store.add(
+            GovernanceReceipt(
+                agent_did="did:mesh:a1",
+                tool_name="write",
+                cedar_decision="allow",
+            )
+        )
+        store.add(
+            GovernanceReceipt(
+                agent_did="did:mesh:a2",
+                tool_name="delete",
+                cedar_decision="deny",
+            )
+        )
         stats = store.get_stats()
         assert stats["total"] == 3
         assert stats["allowed"] == 2

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
@@ -1,11 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Tests for GovernanceReceipt, ReceiptStore, signing/verification, and hash chaining.
-
-These tests run without any external SDK. They validate the receipt model,
-canonical serialization, Ed25519 sign/verify round-trip, hash chaining for
-insertion detection, and SLSA provenance emission in isolation.
-"""
+"""Tests for GovernanceReceipt, ReceiptStore, signing/verification, and hash chaining."""
 
 import json
 from urllib.parse import urlparse
@@ -22,279 +17,140 @@ from mcp_receipt_governed.receipt import (
 )
 
 
+# ── Fixtures ──
+
+
+@pytest.fixture()
+def ed25519_key():
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        key = Ed25519PrivateKey.generate()
+        return key.private_bytes_raw().hex(), key.public_key().public_bytes_raw().hex()
+    except ImportError:
+        pytest.skip("cryptography not installed")
+
+
+@pytest.fixture()
+def signing_key(ed25519_key):
+    return ed25519_key[0]
+
+
+def _make_chain(*receipt_ids, sign_with=None):
+    """Build a valid hash-chained list of receipts, optionally signed."""
+    receipts = []
+    for i, rid in enumerate(receipt_ids):
+        parent = receipts[-1].payload_hash() if receipts else None
+        r = GovernanceReceipt(receipt_id=rid, timestamp=float(i + 1), parent_receipt_hash=parent)
+        if sign_with:
+            sign_receipt(r, sign_with)
+        receipts.append(r)
+    return receipts
+
+
 # ── Receipt Model ──
 
 
 class TestGovernanceReceipt:
-    """Core receipt dataclass behavior."""
-
     def test_default_fields(self):
         r = GovernanceReceipt()
-        assert r.receipt_id  # UUID generated
+        assert r.receipt_id
         assert r.cedar_decision == "deny"
-        assert r.tool_name == ""
-        assert r.agent_did == ""
         assert r.timestamp > 0
         assert r.parent_receipt_hash is None
 
-    def test_canonical_payload_deterministic(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:agent-1",
-            cedar_policy_id="policy:v1",
-            cedar_decision="allow",
-            args_hash="abc123",
-            timestamp=1700000000.0,
-        )
-        payload1 = r.canonical_payload()
-        payload2 = r.canonical_payload()
-        assert payload1 == payload2
-        # Verify it's valid JSON with sorted keys
-        parsed = json.loads(payload1)
+    def test_canonical_payload_deterministic_and_sorted(self):
+        r = GovernanceReceipt(receipt_id="id", tool_name="T", agent_did="did:mesh:a1",
+                               cedar_policy_id="p:v1", cedar_decision="allow",
+                               args_hash="abc", timestamp=1700000000.0)
+        p1, p2 = r.canonical_payload(), r.canonical_payload()
+        assert p1 == p2
+        parsed = json.loads(p1)
         assert list(parsed.keys()) == sorted(parsed.keys())
 
-    def test_canonical_payload_excludes_signature(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            timestamp=1700000000.0,
-        )
+    def test_canonical_payload_excludes_signature_fields(self):
+        r = GovernanceReceipt(receipt_id="id", timestamp=1.0, signature="sig", signer_public_key="key")
         payload = r.canonical_payload()
         assert "signature" not in payload
         assert "signer_public_key" not in payload
 
-    def test_payload_hash_consistent(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            timestamp=1700000000.0,
-        )
+    def test_payload_hash_stable_and_content_sensitive(self):
+        r = GovernanceReceipt(receipt_id="id", timestamp=1.0)
         assert r.payload_hash() == r.payload_hash()
-
-    def test_payload_hash_changes_with_content(self):
-        r1 = GovernanceReceipt(receipt_id="id-1", timestamp=1.0)
-        r2 = GovernanceReceipt(receipt_id="id-2", timestamp=1.0)
-        assert r1.payload_hash() != r2.payload_hash()
+        assert r.payload_hash() != GovernanceReceipt(receipt_id="other", timestamp=1.0).payload_hash()
 
     def test_to_dict_includes_all_fields(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:a1",
-            cedar_policy_id="policy:v1",
-            cedar_decision="allow",
-            args_hash="hash123",
-            timestamp=1700000000.0,
-        )
+        r = GovernanceReceipt(receipt_id="id", tool_name="T", agent_did="a",
+                               cedar_policy_id="p", cedar_decision="allow",
+                               args_hash="h", timestamp=1700000000.0)
         d = r.to_dict()
-        assert d["receipt_id"] == "test-id"
-        assert d["tool_name"] == "ReadData"
-        assert d["agent_did"] == "did:mesh:a1"
-        assert d["cedar_policy_id"] == "policy:v1"
-        assert d["cedar_decision"] == "allow"
-        assert d["args_hash"] == "hash123"
-        assert d["payload_hash"]  # computed
+        assert d["receipt_id"] == "id"
+        assert d["payload_hash"]
         assert d["parent_receipt_hash"] is None
         assert d["signature"] is None
-        assert d["error"] is None
 
 
 # ── JCS Canonicalization (RFC 8785) ──
 
 
 class TestJCSCanonicalization:
-    """Verify RFC 8785 JSON Canonicalization Scheme compliance."""
+    def test_unicode_raw_utf8_not_escaped(self):
+        for name in ["ReadDäta", "Send\U0001f600Msg", "读取数据", "قراءة", "bad�tool"]:
+            r = GovernanceReceipt(receipt_id="id", tool_name=name, timestamp=1.0)
+            payload = r.canonical_payload()
+            assert name in payload
+            assert "\\u" not in payload
 
-    def test_unicode_preserved_not_escaped(self):
-        """JCS § 3.2.2.2 requires raw UTF-8 instead of \\uXXXX escapes."""
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadDäta",
-            timestamp=1700000000.0,
-        )
-        payload = r.canonical_payload()
-        assert "ReadDäta" in payload
-        assert "\\u" not in payload
+    def test_no_whitespace_compact_separators(self):
+        r = GovernanceReceipt(receipt_id="id", timestamp=1.0)
+        assert " " not in r.canonical_payload().replace("id", "x")
 
-    def test_no_whitespace_in_canonical(self):
-        """JCS uses compact separators with no trailing whitespace."""
-        r = GovernanceReceipt(receipt_id="test-id", timestamp=1.0)
-        payload = r.canonical_payload()
-        assert " " not in payload.replace("test-id", "x")
-
-    def test_keys_sorted_alphabetically(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:a1",
-            timestamp=1700000000.0,
-        )
+    def test_empty_string_fields_valid(self):
+        r = GovernanceReceipt(receipt_id="", tool_name="", timestamp=1.0)
         parsed = json.loads(r.canonical_payload())
-        keys = list(parsed.keys())
-        assert keys == sorted(keys)
-
-    def test_emoji_unicode_preserved(self):
-        """Emoji (astral plane) codepoints are preserved in canonical form."""
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="Send\U0001f600Message",
-            timestamp=1.0,
-        )
-        payload = r.canonical_payload()
-        assert "\U0001f600" in payload
-        assert "\\u" not in payload
-
-    def test_cjk_characters_preserved(self):
-        """CJK ideographs are emitted as raw UTF-8."""
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="\u8bfb\u53d6\u6570\u636e",
-            timestamp=1.0,
-        )
-        payload = r.canonical_payload()
-        assert "\u8bfb\u53d6\u6570\u636e" in payload
-
-    def test_replacement_character_preserved(self):
-        """U+FFFD replacement character round-trips through canonical JSON."""
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="bad\ufffdtool",
-            timestamp=1.0,
-        )
-        payload = r.canonical_payload()
-        assert "\ufffd" in payload
-        assert "\\u" not in payload
-
-    def test_rtl_arabic_characters_preserved(self):
-        """Right-to-left Arabic text is preserved in canonical form."""
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="\u0642\u0631\u0627\u0621\u0629",
-            timestamp=1.0,
-        )
-        payload = r.canonical_payload()
-        assert "\u0642\u0631\u0627\u0621\u0629" in payload
-
-    def test_empty_string_fields(self):
-        """Empty strings are valid and canonical."""
-        r = GovernanceReceipt(
-            receipt_id="",
-            tool_name="",
-            timestamp=1.0,
-        )
-        payload = r.canonical_payload()
-        parsed = json.loads(payload)
         assert parsed["receipt_id"] == ""
-        assert parsed["tool_name"] == ""
 
 
 # ── Session ID ──
 
 
 class TestSessionId:
-    """Test session_id for replay attack prevention."""
-
-    def test_session_id_in_canonical_payload(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            timestamp=1.0,
-            session_id="session-abc",
-        )
-        payload = r.canonical_payload()
-        assert "session-abc" in payload
+    def test_session_id_in_payload_when_set(self):
+        r = GovernanceReceipt(receipt_id="id", timestamp=1.0, session_id="s-abc")
+        assert "s-abc" in r.canonical_payload()
 
     def test_session_id_absent_when_none(self):
-        r = GovernanceReceipt(receipt_id="test-id", timestamp=1.0)
-        payload = r.canonical_payload()
-        assert "session_id" not in payload
+        assert "session_id" not in GovernanceReceipt(receipt_id="id", timestamp=1.0).canonical_payload()
 
-    def test_session_id_affects_payload_hash(self):
-        r_a = GovernanceReceipt(
-            receipt_id="test-id",
-            timestamp=1.0,
-            session_id="session-1",
-        )
-        r_b = GovernanceReceipt(
-            receipt_id="test-id",
-            timestamp=1.0,
-            session_id="session-2",
-        )
-        assert r_a.payload_hash() != r_b.payload_hash()
-
-    def test_session_id_in_to_dict(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            timestamp=1.0,
-            session_id="session-xyz",
-        )
-        d = r.to_dict()
-        assert d["session_id"] == "session-xyz"
+    def test_session_id_affects_hash(self):
+        base = dict(receipt_id="id", timestamp=1.0)
+        assert (GovernanceReceipt(**base, session_id="s1").payload_hash() !=
+                GovernanceReceipt(**base, session_id="s2").payload_hash())
 
 
 # ── Hash Chaining ──
 
 
 class TestHashChaining:
-    """Test receipt-level hash chaining for insertion/deletion detection."""
-
-    def test_first_receipt_has_no_parent(self):
-        r = GovernanceReceipt(receipt_id="first", timestamp=1.0)
+    def test_first_receipt_no_parent(self):
+        r = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
         assert r.parent_receipt_hash is None
         assert "parent_receipt_hash" not in r.canonical_payload()
 
-    def test_chained_receipt_includes_parent(self):
-        r1 = GovernanceReceipt(receipt_id="first", timestamp=1.0)
-        h1 = r1.payload_hash()
-
-        r2 = GovernanceReceipt(
-            receipt_id="second",
-            timestamp=2.0,
-            parent_receipt_hash=h1,
-        )
-        assert r2.parent_receipt_hash == h1
-        assert "parent_receipt_hash" in r2.canonical_payload()
-        assert h1 in r2.canonical_payload()
-
-    def test_parent_hash_affects_payload_hash(self):
-        """Changing the parent hash changes the receipt's own hash."""
-        r_a = GovernanceReceipt(
-            receipt_id="test",
-            timestamp=1.0,
-            parent_receipt_hash="aaa",
-        )
-        r_b = GovernanceReceipt(
-            receipt_id="test",
-            timestamp=1.0,
-            parent_receipt_hash="bbb",
-        )
-        assert r_a.payload_hash() != r_b.payload_hash()
-
-    def test_to_dict_includes_parent_hash(self):
-        r = GovernanceReceipt(
-            receipt_id="test",
-            timestamp=1.0,
-            parent_receipt_hash="deadbeef",
-        )
-        d = r.to_dict()
-        assert d["parent_receipt_hash"] == "deadbeef"
-
-    def test_three_receipt_chain(self):
+    def test_chained_receipt_links_parent(self):
         r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        r2 = GovernanceReceipt(
-            receipt_id="r2",
-            timestamp=2.0,
-            parent_receipt_hash=r1.payload_hash(),
-        )
-        r3 = GovernanceReceipt(
-            receipt_id="r3",
-            timestamp=3.0,
-            parent_receipt_hash=r2.payload_hash(),
-        )
-        # Verify chain links
+        r2 = GovernanceReceipt(receipt_id="r2", timestamp=2.0, parent_receipt_hash=r1.payload_hash())
+        assert r2.parent_receipt_hash == r1.payload_hash()
+        assert r1.payload_hash() in r2.canonical_payload()
+
+    def test_parent_hash_changes_own_hash(self):
+        base = dict(receipt_id="id", timestamp=1.0)
+        assert (GovernanceReceipt(**base, parent_receipt_hash="aaa").payload_hash() !=
+                GovernanceReceipt(**base, parent_receipt_hash="bbb").payload_hash())
+
+    def test_three_receipt_chain_unique_hashes(self):
+        r1, r2, r3 = _make_chain("r1", "r2", "r3")
         assert r2.parent_receipt_hash == r1.payload_hash()
         assert r3.parent_receipt_hash == r2.payload_hash()
-        # Each receipt has a unique hash
         assert len({r1.payload_hash(), r2.payload_hash(), r3.payload_hash()}) == 3
 
 
@@ -302,114 +158,41 @@ class TestHashChaining:
 
 
 class TestSLSAProvenance:
-    """Test SLSA v1.0 provenance predicate emission."""
-
-    def test_slsa_statement_structure(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:a1",
-            cedar_policy_id="policy:v1",
-            cedar_decision="allow",
-            args_hash="hash123",
-            timestamp=1700000000.0,
-        )
+    def test_statement_structure(self):
+        r = GovernanceReceipt(receipt_id="id", tool_name="T", agent_did="a",
+                               cedar_policy_id="p", cedar_decision="allow",
+                               args_hash="h", timestamp=1700000000.0)
         slsa = r.to_slsa_provenance()
         assert slsa["_type"] == "https://in-toto.io/Statement/v1"
         assert slsa["predicateType"] == "https://slsa.dev/provenance/v1"
 
-    def test_slsa_subject(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            args_hash="hash123",
-        )
-        slsa = r.to_slsa_provenance()
-        subject = slsa["subject"][0]
-        assert subject["name"] == "pkg:agentmesh/tool/ReadData"
-        assert subject["digest"]["sha256"] == "hash123"
+    def test_subject_and_digest(self):
+        r = GovernanceReceipt(receipt_id="id", tool_name="ReadData", args_hash="h123")
+        s = r.to_slsa_provenance()["subject"][0]
+        assert s["name"] == "pkg:agentmesh/tool/ReadData"
+        assert s["digest"]["sha256"] == "h123"
 
-    def test_slsa_includes_parent_dependency(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            args_hash="hash123",
-            parent_receipt_hash="parent-hash-456",
-        )
-        slsa = r.to_slsa_provenance()
-        deps = slsa["predicate"]["buildDefinition"]["resolvedDependencies"]
+    def test_parent_dependency_included_when_set(self):
+        r = GovernanceReceipt(receipt_id="id", tool_name="T", args_hash="h", parent_receipt_hash="phash")
+        deps = r.to_slsa_provenance()["predicate"]["buildDefinition"]["resolvedDependencies"]
         assert len(deps) == 1
-        assert deps[0]["digest"]["sha256"] == "parent-hash-456"
+        assert deps[0]["digest"]["sha256"] == "phash"
 
-    def test_slsa_no_parent_empty_deps(self):
-        r = GovernanceReceipt(receipt_id="test-id", tool_name="ReadData")
-        slsa = r.to_slsa_provenance()
-        deps = slsa["predicate"]["buildDefinition"]["resolvedDependencies"]
-        assert deps == []
+    def test_no_parent_empty_deps(self):
+        r = GovernanceReceipt(receipt_id="id", tool_name="T")
+        assert r.to_slsa_provenance()["predicate"]["buildDefinition"]["resolvedDependencies"] == []
 
-    def test_slsa_run_details(self):
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            timestamp=1700000000.0,
-        )
+    def test_run_details_and_schema_fields(self):
+        r = GovernanceReceipt(receipt_id="id", tool_name="T", agent_did="a",
+                               cedar_policy_id="p", cedar_decision="deny",
+                               args_hash="h", timestamp=1700000000.0)
         slsa = r.to_slsa_provenance()
         run = slsa["predicate"]["runDetails"]
-        assert run["metadata"]["invocationId"] == "test-id"
-        builder_host = urlparse(run["builder"]["id"]).hostname
-        assert builder_host and (
-            builder_host == "agent-governance.org" or builder_host.endswith(".agent-governance.org")
-        )
-
-    def test_slsa_schema_required_fields(self):
-        """SLSA Provenance v1 requires specific top-level and predicate fields."""
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:a1",
-            cedar_policy_id="policy:v1",
-            cedar_decision="allow",
-            args_hash="hash123",
-            timestamp=1700000000.0,
-        )
-        slsa = r.to_slsa_provenance()
-        # Top-level in-toto Statement fields
-        assert "_type" in slsa
-        assert "subject" in slsa
-        assert "predicateType" in slsa
-        assert "predicate" in slsa
-        # SLSA buildDefinition
-        build_def = slsa["predicate"]["buildDefinition"]
-        assert "buildType" in build_def
-        assert "externalParameters" in build_def
-        assert "resolvedDependencies" in build_def
-        # SLSA runDetails
-        run = slsa["predicate"]["runDetails"]
-        assert "builder" in run
-        assert "id" in run["builder"]
-        assert "metadata" in run
-        assert "invocationId" in run["metadata"]
-        assert "startedOn" in run["metadata"]
-        # startedOn must be ISO 8601 UTC format
-        started_on = run["metadata"]["startedOn"]
-        assert started_on.endswith("Z")
-        assert "T" in started_on
-
-    def test_slsa_external_parameters_content(self):
-        """SLSA externalParameters captures agent DID, policy ID, and decision."""
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="DeleteFile",
-            agent_did="did:mesh:agent-99",
-            cedar_policy_id="policy:strict:v2",
-            cedar_decision="deny",
-            args_hash="cafebabe",
-            timestamp=1700000000.0,
-        )
-        slsa = r.to_slsa_provenance()
+        assert run["metadata"]["invocationId"] == "id"
+        assert urlparse(run["builder"]["id"]).hostname == "agent-governance.org"
+        assert run["metadata"]["startedOn"].endswith("Z")
         params = slsa["predicate"]["buildDefinition"]["externalParameters"]
-        assert params["agent_did"] == "did:mesh:agent-99"
-        assert params["cedar_policy_id"] == "policy:strict:v2"
+        assert params["agent_did"] == "a"
         assert params["cedar_decision"] == "deny"
 
 
@@ -417,98 +200,39 @@ class TestSLSAProvenance:
 
 
 class TestHashToolArgs:
-    def test_none_args(self):
-        h = hash_tool_args(None)
-        assert len(h) == 64  # SHA-256 hex
+    def test_none_and_empty_produce_same_hash(self):
+        assert hash_tool_args(None) == hash_tool_args({})
 
-    def test_empty_args(self):
-        h = hash_tool_args({})
-        assert h == hash_tool_args(None)  # both produce "{}"
-
-    def test_deterministic(self):
-        args = {"path": "/data/report.csv", "limit": 100}
-        assert hash_tool_args(args) == hash_tool_args(args)
-
-    def test_key_order_independent(self):
-        """Canonical JSON sorts keys, so order shouldn't matter."""
-        args1 = {"b": 2, "a": 1}
-        args2 = {"a": 1, "b": 2}
-        assert hash_tool_args(args1) == hash_tool_args(args2)
+    def test_deterministic_and_key_order_independent(self):
+        args = {"b": 2, "a": 1}
+        assert hash_tool_args(args) == hash_tool_args({"a": 1, "b": 2})
 
     def test_different_args_different_hash(self):
-        h1 = hash_tool_args({"path": "/a"})
-        h2 = hash_tool_args({"path": "/b"})
-        assert h1 != h2
+        assert hash_tool_args({"path": "/a"}) != hash_tool_args({"path": "/b"})
 
 
 # ── Sign / Verify ──
 
 
 class TestSignVerify:
-    @pytest.fixture()
-    def ed25519_keypair(self):
-        """Generate a fresh Ed25519 keypair for tests."""
-        try:
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-
-            private_key = Ed25519PrivateKey.generate()
-            seed = private_key.private_bytes_raw().hex()
-            pub = private_key.public_key().public_bytes_raw().hex()
-            return seed, pub
-        except ImportError:
-            pytest.skip("cryptography not installed")
-
-    def test_sign_populates_signature(self, ed25519_keypair):
-        seed, pub = ed25519_keypair
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:a1",
-            timestamp=1700000000.0,
-        )
+    def test_sign_verify_roundtrip(self, ed25519_key):
+        seed, pub = ed25519_key
+        r = GovernanceReceipt(receipt_id="id", tool_name="T", agent_did="a", timestamp=1.0)
         sign_receipt(r, seed)
-        assert r.signature is not None
         assert r.signer_public_key == pub
-
-    def test_sign_verify_roundtrip(self, ed25519_keypair):
-        seed, _pub = ed25519_keypair
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:a1",
-            cedar_policy_id="policy:v1",
-            cedar_decision="allow",
-            timestamp=1700000000.0,
-        )
-        sign_receipt(r, seed)
         assert verify_receipt(r) is True
 
-    def test_tampered_receipt_fails_verification(self, ed25519_keypair):
-        seed, _pub = ed25519_keypair
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            agent_did="did:mesh:a1",
-            timestamp=1700000000.0,
-        )
-        sign_receipt(r, seed)
-        # Tamper with the receipt
+    def test_tampered_receipt_fails(self, signing_key):
+        r = GovernanceReceipt(receipt_id="id", tool_name="T", timestamp=1.0)
+        sign_receipt(r, signing_key)
         r.cedar_decision = "allow"
         assert verify_receipt(r) is False
 
-    def test_unsigned_receipt_fails_verification(self):
-        r = GovernanceReceipt(receipt_id="test-id")
-        assert verify_receipt(r) is False
-
-    def test_invalid_signature_fails(self, ed25519_keypair):
-        seed, _pub = ed25519_keypair
-        r = GovernanceReceipt(
-            receipt_id="test-id",
-            tool_name="ReadData",
-            timestamp=1700000000.0,
-        )
-        sign_receipt(r, seed)
-        r.signature = "deadbeef" * 16  # invalid sig
+    def test_unsigned_and_invalid_sig_fail(self, signing_key):
+        assert verify_receipt(GovernanceReceipt(receipt_id="id")) is False
+        r = GovernanceReceipt(receipt_id="id", timestamp=1.0)
+        sign_receipt(r, signing_key)
+        r.signature = "deadbeef" * 16
         assert verify_receipt(r) is False
 
 
@@ -516,296 +240,102 @@ class TestSignVerify:
 
 
 class TestVerifyReceiptChain:
-    """Test the verify_receipt_chain() function for offline verification."""
-
     def test_empty_chain_valid(self):
         assert verify_receipt_chain([]) == []
 
-    def test_single_unsigned_receipt_flagged(self):
-        r = GovernanceReceipt(receipt_id="only", timestamp=1.0)
-        errors = verify_receipt_chain([r])
-        assert len(errors) == 1
-        assert "Unsigned" in errors[0]
-
-    def test_single_receipt_unexpected_parent(self):
-        r = GovernanceReceipt(
-            receipt_id="only",
-            timestamp=1.0,
-            parent_receipt_hash="surprise",
-        )
-        errors = verify_receipt_chain([r])
-        # Expect both: unexpected parent + unsigned
-        assert any("First receipt" in e for e in errors)
+    def test_single_unsigned_flagged(self):
+        errors = verify_receipt_chain([GovernanceReceipt(receipt_id="r1", timestamp=1.0)])
         assert any("Unsigned" in e for e in errors)
 
-    def test_valid_three_receipt_chain(self):
-        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        r2 = GovernanceReceipt(
-            receipt_id="r2",
-            timestamp=2.0,
-            parent_receipt_hash=r1.payload_hash(),
-        )
-        r3 = GovernanceReceipt(
-            receipt_id="r3",
-            timestamp=3.0,
-            parent_receipt_hash=r2.payload_hash(),
-        )
-        # All errors should be unsigned warnings only (chain is contiguous)
-        errors = verify_receipt_chain([r1, r2, r3])
-        assert all("Unsigned" in e for e in errors)
-        assert not any("Hash chain broken" in e for e in errors)
+    def test_unexpected_parent_on_first_flagged(self):
+        r = GovernanceReceipt(receipt_id="r1", timestamp=1.0, parent_receipt_hash="surprise")
+        errors = verify_receipt_chain([r])
+        assert any("First receipt" in e for e in errors)
+
+    def test_valid_signed_chain(self, signing_key):
+        assert verify_receipt_chain(_make_chain("r1", "r2", "r3", sign_with=signing_key)) == []
+
+    def test_single_signed_receipt_valid(self, signing_key):
+        assert verify_receipt_chain(_make_chain("r1", sign_with=signing_key)) == []
 
     def test_broken_chain_detected(self):
         r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        r2 = GovernanceReceipt(
-            receipt_id="r2",
-            timestamp=2.0,
-            parent_receipt_hash="wrong-hash",
-        )
+        r2 = GovernanceReceipt(receipt_id="r2", timestamp=2.0, parent_receipt_hash="wrong")
         errors = verify_receipt_chain([r1, r2])
-        chain_errors = [e for e in errors if "Unsigned" not in e]
-        assert len(chain_errors) == 1
-        assert "Hash chain broken" in chain_errors[0]
+        assert any("Hash chain broken" in e for e in errors)
 
     def test_deleted_receipt_detected(self):
-        """Removing a receipt from the middle breaks the chain."""
-        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        r2 = GovernanceReceipt(
-            receipt_id="r2",
-            timestamp=2.0,
-            parent_receipt_hash=r1.payload_hash(),
-        )
-        r3 = GovernanceReceipt(
-            receipt_id="r3",
-            timestamp=3.0,
-            parent_receipt_hash=r2.payload_hash(),
-        )
-        # Delete r2 from the chain
+        r1, r2, r3 = _make_chain("r1", "r2", "r3")
         errors = verify_receipt_chain([r1, r3])
-        chain_errors = [e for e in errors if "Unsigned" not in e]
-        assert len(chain_errors) == 1
-        assert "Hash chain broken" in chain_errors[0]
-
-    @pytest.fixture()
-    def signing_key(self):
-        try:
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-
-            key = Ed25519PrivateKey.generate()
-            return key.private_bytes_raw().hex()
-        except ImportError:
-            pytest.skip("cryptography not installed")
-
-    def test_signed_chain_verified(self, signing_key):
-        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        sign_receipt(r1, signing_key)
-        r2 = GovernanceReceipt(
-            receipt_id="r2",
-            timestamp=2.0,
-            parent_receipt_hash=r1.payload_hash(),
-        )
-        sign_receipt(r2, signing_key)
-        assert verify_receipt_chain([r1, r2]) == []
-
-    def test_tampered_signed_chain_detected(self, signing_key):
-        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        sign_receipt(r1, signing_key)
-        r2 = GovernanceReceipt(
-            receipt_id="r2",
-            timestamp=2.0,
-            parent_receipt_hash=r1.payload_hash(),
-        )
-        sign_receipt(r2, signing_key)
-        # Tamper with r2 after signing
-        r2.tool_name = "TAMPERED"
-        errors = verify_receipt_chain([r1, r2])
-        assert any("signature" in e.lower() for e in errors)
-
-    def test_trusted_keys_accepted(self, signing_key):
-        """Receipts signed by a trusted key pass validation."""
-        try:
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-
-            key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(signing_key))
-            pub_hex = key.public_key().public_bytes_raw().hex()
-        except ImportError:
-            pytest.skip("cryptography not installed")
-
-        r = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        sign_receipt(r, signing_key)
-        errors = verify_receipt_chain([r], trusted_keys=[pub_hex])
-        assert errors == []
-
-    def test_untrusted_key_flagged(self, signing_key):
-        """Receipts signed by an untrusted key are flagged."""
-        r = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
-        sign_receipt(r, signing_key)
-        errors = verify_receipt_chain([r], trusted_keys=["deadbeef" * 4])
-        assert any("not in trusted key set" in e for e in errors)
-        assert any("rejected" in e for e in errors)
-
-    def test_duplicate_receipt_id_detected(self, signing_key):
-        """Duplicate receipt_ids are flagged as potential replay attacks."""
-        r1 = GovernanceReceipt(receipt_id="same-id", timestamp=1.0)
-        sign_receipt(r1, signing_key)
-        r2 = GovernanceReceipt(
-            receipt_id="same-id",
-            timestamp=2.0,
-            parent_receipt_hash=r1.payload_hash(),
-        )
-        sign_receipt(r2, signing_key)
-        errors = verify_receipt_chain([r1, r2])
-        assert any("Duplicate receipt_id" in e for e in errors)
-        assert any("replay" in e.lower() for e in errors)
-
-    def test_single_receipt_chain_valid_when_signed(self, signing_key):
-        """A single signed receipt with no parent is a valid chain."""
-        r = GovernanceReceipt(receipt_id="only", timestamp=1.0)
-        sign_receipt(r, signing_key)
-        assert verify_receipt_chain([r]) == []
+        assert any("Hash chain broken" in e for e in errors)
 
     def test_inserted_receipt_detected(self, signing_key):
-        """Inserting a receipt into the middle breaks hash continuity."""
-        r1 = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        r1, r2, r3 = _make_chain("r1", "r2", "r3", sign_with=signing_key)
+        evil = GovernanceReceipt(receipt_id="evil", timestamp=1.5)
+        sign_receipt(evil, signing_key)
+        errors = verify_receipt_chain([r1, evil, r2, r3])
+        assert any("Hash chain broken" in e for e in errors)
+
+    def test_tampered_signed_receipt_detected(self, signing_key):
+        r1, r2 = _make_chain("r1", "r2", sign_with=signing_key)
+        r2.tool_name = "TAMPERED"
+        assert any("invalid" in e.lower() or "signature" in e.lower() for e in verify_receipt_chain([r1, r2]))
+
+    def test_trusted_key_accepted(self, ed25519_key):
+        seed, pub = ed25519_key
+        r = _make_chain("r1", sign_with=seed)[0]
+        assert verify_receipt_chain([r], trusted_keys=[pub]) == []
+
+    def test_untrusted_key_rejected(self, signing_key):
+        r = _make_chain("r1", sign_with=signing_key)[0]
+        errors = verify_receipt_chain([r], trusted_keys=["deadbeef" * 4])
+        assert any("rejected" in e for e in errors)
+
+    def test_duplicate_receipt_id_flagged(self, signing_key):
+        r1 = GovernanceReceipt(receipt_id="same", timestamp=1.0)
         sign_receipt(r1, signing_key)
-        r2 = GovernanceReceipt(
-            receipt_id="r2", timestamp=2.0, parent_receipt_hash=r1.payload_hash()
-        )
+        r2 = GovernanceReceipt(receipt_id="same", timestamp=2.0, parent_receipt_hash=r1.payload_hash())
         sign_receipt(r2, signing_key)
-        r3 = GovernanceReceipt(
-            receipt_id="r3", timestamp=3.0, parent_receipt_hash=r2.payload_hash()
-        )
-        sign_receipt(r3, signing_key)
+        errors = verify_receipt_chain([r1, r2])
+        assert any("replay" in e.lower() for e in errors)
 
-        # Insert a foreign receipt between r1 and r2
-        r_evil = GovernanceReceipt(receipt_id="evil", timestamp=1.5)
-        sign_receipt(r_evil, signing_key)
-
-        errors = verify_receipt_chain([r1, r_evil, r2, r3])
-        chain_errors = [e for e in errors if "Hash chain broken" in e]
-        assert len(chain_errors) >= 1
-
-    def test_all_fields_missing_receipt(self):
-        """A receipt with all default/empty values is treated as unsigned."""
-        r = GovernanceReceipt()
-        errors = verify_receipt_chain([r])
-        assert any("Unsigned" in e for e in errors)
+    def test_all_defaults_unsigned_flagged(self):
+        assert any("Unsigned" in e for e in verify_receipt_chain([GovernanceReceipt()]))
 
 
 # ── Receipt Store ──
 
 
 class TestReceiptStore:
-    def test_add_and_count(self):
+    def _populated_store(self):
+        store = ReceiptStore()
+        store.add(GovernanceReceipt(receipt_id="r1", agent_did="a1", tool_name="read", cedar_decision="allow"))
+        store.add(GovernanceReceipt(receipt_id="r2", agent_did="a1", tool_name="write", cedar_decision="allow"))
+        store.add(GovernanceReceipt(receipt_id="r3", agent_did="a2", tool_name="delete", cedar_decision="deny"))
+        return store
+
+    def test_add_count_clear(self):
         store = ReceiptStore()
         assert store.count == 0
         store.add(GovernanceReceipt(receipt_id="r1"))
         assert store.count == 1
-
-    def test_query_by_agent(self):
-        store = ReceiptStore()
-        store.add(GovernanceReceipt(receipt_id="r1", agent_did="did:mesh:a1"))
-        store.add(GovernanceReceipt(receipt_id="r2", agent_did="did:mesh:a2"))
-        store.add(GovernanceReceipt(receipt_id="r3", agent_did="did:mesh:a1"))
-
-        results = store.query(agent_did="did:mesh:a1")
-        assert len(results) == 2
-        assert all(r.agent_did == "did:mesh:a1" for r in results)
-
-    def test_query_by_tool(self):
-        store = ReceiptStore()
-        store.add(GovernanceReceipt(receipt_id="r1", tool_name="ReadData"))
-        store.add(GovernanceReceipt(receipt_id="r2", tool_name="DeleteFile"))
-
-        results = store.query(tool_name="ReadData")
-        assert len(results) == 1
-        assert results[0].tool_name == "ReadData"
-
-    def test_query_by_decision(self):
-        store = ReceiptStore()
-        store.add(GovernanceReceipt(receipt_id="r1", cedar_decision="allow"))
-        store.add(GovernanceReceipt(receipt_id="r2", cedar_decision="deny"))
-        store.add(GovernanceReceipt(receipt_id="r3", cedar_decision="allow"))
-
-        allowed = store.query(cedar_decision="allow")
-        assert len(allowed) == 2
-
-        denied = store.query(cedar_decision="deny")
-        assert len(denied) == 1
-
-    def test_query_combined_filters(self):
-        store = ReceiptStore()
-        store.add(
-            GovernanceReceipt(
-                receipt_id="r1",
-                agent_did="did:mesh:a1",
-                tool_name="ReadData",
-                cedar_decision="allow",
-            )
-        )
-        store.add(
-            GovernanceReceipt(
-                receipt_id="r2",
-                agent_did="did:mesh:a1",
-                tool_name="DeleteFile",
-                cedar_decision="deny",
-            )
-        )
-        store.add(
-            GovernanceReceipt(
-                receipt_id="r3",
-                agent_did="did:mesh:a2",
-                tool_name="ReadData",
-                cedar_decision="allow",
-            )
-        )
-
-        results = store.query(agent_did="did:mesh:a1", cedar_decision="allow")
-        assert len(results) == 1
-        assert results[0].receipt_id == "r1"
-
-    def test_export(self):
-        store = ReceiptStore()
-        store.add(GovernanceReceipt(receipt_id="r1", tool_name="ReadData"))
-        exported = store.export()
-        assert len(exported) == 1
-        assert exported[0]["receipt_id"] == "r1"
-        assert "payload_hash" in exported[0]
-
-    def test_clear(self):
-        store = ReceiptStore()
-        store.add(GovernanceReceipt(receipt_id="r1"))
-        store.add(GovernanceReceipt(receipt_id="r2"))
-        assert store.count == 2
         store.clear()
         assert store.count == 0
 
-    def test_get_stats(self):
+    def test_query_filters(self):
+        store = self._populated_store()
+        assert len(store.query(agent_did="a1")) == 2
+        assert len(store.query(tool_name="read")) == 1
+        assert len(store.query(cedar_decision="deny")) == 1
+        assert len(store.query(agent_did="a1", cedar_decision="allow")) == 2
+
+    def test_export_includes_payload_hash(self):
         store = ReceiptStore()
-        store.add(
-            GovernanceReceipt(
-                agent_did="did:mesh:a1",
-                tool_name="read",
-                cedar_decision="allow",
-            )
-        )
-        store.add(
-            GovernanceReceipt(
-                agent_did="did:mesh:a1",
-                tool_name="write",
-                cedar_decision="allow",
-            )
-        )
-        store.add(
-            GovernanceReceipt(
-                agent_did="did:mesh:a2",
-                tool_name="delete",
-                cedar_decision="deny",
-            )
-        )
-        stats = store.get_stats()
-        assert stats["total"] == 3
-        assert stats["allowed"] == 2
-        assert stats["denied"] == 1
-        assert stats["unique_agents"] == 2
-        assert stats["unique_tools"] == 3
+        store.add(GovernanceReceipt(receipt_id="r1", tool_name="T"))
+        exported = store.export()
+        assert exported[0]["receipt_id"] == "r1"
+        assert "payload_hash" in exported[0]
+
+    def test_get_stats(self):
+        stats = self._populated_store().get_stats()
+        assert stats == {"total": 3, "allowed": 2, "denied": 1, "unique_agents": 2, "unique_tools": 3}

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/tests/test_receipt.py
@@ -134,6 +134,82 @@ class TestJCSCanonicalization:
         keys = list(parsed.keys())
         assert keys == sorted(keys)
 
+    def test_emoji_unicode_preserved(self):
+        """Emoji (astral plane) codepoints are preserved in canonical form."""
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="Send\U0001f600Message",
+            timestamp=1.0,
+        )
+        payload = r.canonical_payload()
+        assert "\U0001f600" in payload
+        assert "\\u" not in payload
+
+    def test_cjk_characters_preserved(self):
+        """CJK ideographs are emitted as raw UTF-8."""
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            tool_name="\u8bfb\u53d6\u6570\u636e",
+            timestamp=1.0,
+        )
+        payload = r.canonical_payload()
+        assert "\u8bfb\u53d6\u6570\u636e" in payload
+
+    def test_empty_string_fields(self):
+        """Empty strings are valid and canonical."""
+        r = GovernanceReceipt(
+            receipt_id="",
+            tool_name="",
+            timestamp=1.0,
+        )
+        payload = r.canonical_payload()
+        parsed = json.loads(payload)
+        assert parsed["receipt_id"] == ""
+        assert parsed["tool_name"] == ""
+
+
+# ── Session ID ──
+
+
+class TestSessionId:
+    """Test session_id for replay attack prevention."""
+
+    def test_session_id_in_canonical_payload(self):
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            timestamp=1.0,
+            session_id="session-abc",
+        )
+        payload = r.canonical_payload()
+        assert "session-abc" in payload
+
+    def test_session_id_absent_when_none(self):
+        r = GovernanceReceipt(receipt_id="test-id", timestamp=1.0)
+        payload = r.canonical_payload()
+        assert "session_id" not in payload
+
+    def test_session_id_affects_payload_hash(self):
+        r_a = GovernanceReceipt(
+            receipt_id="test-id",
+            timestamp=1.0,
+            session_id="session-1",
+        )
+        r_b = GovernanceReceipt(
+            receipt_id="test-id",
+            timestamp=1.0,
+            session_id="session-2",
+        )
+        assert r_a.payload_hash() != r_b.payload_hash()
+
+    def test_session_id_in_to_dict(self):
+        r = GovernanceReceipt(
+            receipt_id="test-id",
+            timestamp=1.0,
+            session_id="session-xyz",
+        )
+        d = r.to_dict()
+        assert d["session_id"] == "session-xyz"
+
 
 # ── Hash Chaining ──
 
@@ -261,8 +337,7 @@ class TestSLSAProvenance:
         assert run["metadata"]["invocationId"] == "test-id"
         builder_host = urlparse(run["builder"]["id"]).hostname
         assert builder_host and (
-            builder_host == "agent-governance.org"
-            or builder_host.endswith(".agent-governance.org")
+            builder_host == "agent-governance.org" or builder_host.endswith(".agent-governance.org")
         )
 
 
@@ -473,6 +548,28 @@ class TestVerifyReceiptChain:
         r2.tool_name = "TAMPERED"
         errors = verify_receipt_chain([r1, r2])
         assert any("signature" in e.lower() for e in errors)
+
+    def test_trusted_keys_accepted(self, signing_key):
+        """Receipts signed by a trusted key pass validation."""
+        try:
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+            key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(signing_key))
+            pub_hex = key.public_key().public_bytes_raw().hex()
+        except ImportError:
+            pytest.skip("cryptography not installed")
+
+        r = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        sign_receipt(r, signing_key)
+        errors = verify_receipt_chain([r], trusted_keys=[pub_hex])
+        assert errors == []
+
+    def test_untrusted_key_flagged(self, signing_key):
+        """Receipts signed by an untrusted key are flagged."""
+        r = GovernanceReceipt(receipt_id="r1", timestamp=1.0)
+        sign_receipt(r, signing_key)
+        errors = verify_receipt_chain([r], trusted_keys=["deadbeef" * 4])
+        assert any("not in trusted key set" in e for e in errors)
 
 
 # ── Receipt Store ──

--- a/docs/tutorials/33-offline-verifiable-receipts.md
+++ b/docs/tutorials/33-offline-verifiable-receipts.md
@@ -1,0 +1,225 @@
+# Tutorial 33 — Offline-Verifiable Decision Receipts
+
+> **Package:** `mcp-receipt-governed` · **Time:** 20 minutes · **Prerequisites:** Python 3.11+
+
+---
+
+## What You'll Learn
+
+- How every MCP tool call produces a signed governance receipt
+- Ed25519 signatures over RFC 8785 (JCS) canonical payloads
+- Hash chaining for insertion/deletion detection
+- Offline CLI verification without network access
+- SLSA v1.0 provenance emission for supply-chain integration
+
+---
+
+Every tool call an agent makes should produce a cryptographic receipt that
+third parties can verify without access to the original infrastructure.  This
+tutorial shows how `mcp-receipt-governed` generates, chains, and verifies
+these receipts.
+
+**What you'll learn:**
+
+| Section | Topic |
+|---------|-------|
+| [Installation](#installation) | Install the adapter with Ed25519 support |
+| [Quick Start](#quick-start) | Generate your first receipt chain |
+| [Hash Chaining](#hash-chaining) | Understand insertion detection |
+| [Offline Verification](#offline-verification) | Verify chains from the CLI |
+| [SLSA Provenance](#slsa-provenance) | Emit receipts as SLSA predicates |
+| [Standards Alignment](#standards-alignment) | RFC 8032, RFC 8785, SLSA |
+
+---
+
+## Installation
+
+```bash
+# Core adapter (no crypto — verify_receipt() returns False)
+pip install -e agent-governance-python/agentmesh-integrations/mcp-receipt-governed
+
+# With Ed25519 signing and verification (recommended)
+pip install -e "agent-governance-python/agentmesh-integrations/mcp-receipt-governed[crypto]"
+```
+
+---
+
+## Quick Start
+
+```python
+from mcp_receipt_governed import McpReceiptAdapter, verify_receipt
+
+# 1. Define a Cedar policy and create the adapter
+adapter = McpReceiptAdapter(
+    cedar_policy="""
+        permit(principal, action == Action::"ReadData", resource);
+        forbid(principal, action == Action::"DeleteFile", resource);
+    """,
+    cedar_policy_id="policy:mcp-tools:v1",
+    signing_key_hex="a" * 64,  # Use a secure 32-byte hex seed in production
+)
+
+# 2. Govern tool calls — each produces a signed receipt
+r1 = adapter.govern_tool_call("did:mesh:agent-1", "ReadData", {"path": "/data/1.csv"})
+r2 = adapter.govern_tool_call("did:mesh:agent-1", "ReadData", {"path": "/data/2.csv"})
+r3 = adapter.govern_tool_call("did:mesh:agent-1", "DeleteFile", {"path": "/secret"})
+
+# 3. Inspect the results
+for r in adapter.get_receipts():
+    icon = "✅" if r.cedar_decision == "allow" else "🚫"
+    print(f"  {icon} {r.tool_name}: {r.cedar_decision} (receipt: {r.receipt_id[:8]}...)")
+
+# 4. Verify a signed receipt
+print(f"  Signature valid: {verify_receipt(r1)}")
+```
+
+---
+
+## Hash Chaining
+
+Receipts are linked via `parent_receipt_hash`.  Each receipt includes the
+SHA-256 hash of the preceding receipt's canonical payload.  This means:
+
+- **Insertion** of a fake receipt breaks the chain because the next receipt's
+  `parent_receipt_hash` won't match the inserted receipt's hash.
+- **Deletion** of a receipt breaks the chain because the following receipt's
+  `parent_receipt_hash` points to a receipt that no longer exists.
+- **Modification** of any receipt invalidates both its Ed25519 signature and
+  the hash link from the next receipt.
+
+```
+┌─────────┐    ┌─────────┐    ┌─────────┐
+│Receipt 1│◀───│Receipt 2│◀───│Receipt 3│
+│ (root)  │    │parent=H1│    │parent=H2│
+└─────────┘    └─────────┘    └─────────┘
+```
+
+The first receipt in a chain has `parent_receipt_hash = None`.
+
+### Verifying the Chain Programmatically
+
+```python
+from mcp_receipt_governed import verify_receipt_chain
+
+receipts = adapter.get_receipts()
+errors = verify_receipt_chain(receipts)
+if errors:
+    for e in errors:
+        print(f"  ❌ {e}")
+else:
+    print("  ✅ Chain is contiguous and signatures are valid")
+```
+
+---
+
+## Offline Verification
+
+Export receipts to JSON and verify them from the command line — no running AGT
+infrastructure or network access required.
+
+### 1. Export the Receipt Chain
+
+```python
+import json
+
+with open("receipts.json", "w") as f:
+    json.dump(adapter.store.export(), f, indent=2)
+```
+
+### 2. Run the CLI Verifier
+
+```bash
+cd agent-governance-python/agentmesh-integrations/mcp-receipt-governed
+python scripts/verify_receipts.py receipts.json
+```
+
+Output:
+
+```
+╔══════════════════════════════════════════════════════╗
+║  MCP Receipt Chain — Offline Verification           ║
+╚══════════════════════════════════════════════════════╝
+
+  Loaded 3 receipt(s) from receipts.json
+
+  [0] Receipt 9f5b54c7-036…  (tool: ReadData)
+      ✅  Hash chain contiguous
+      ✅  Payload hash verified
+      ✅  Ed25519 signature valid
+
+  [1] Receipt f31c719a-d97…  (tool: ReadData)
+      ✅  Hash chain contiguous
+      ✅  Payload hash verified
+      ✅  Ed25519 signature valid
+
+  [2] Receipt 87e5cd86-780…  (tool: DeleteFile)
+      ✅  Hash chain contiguous
+      ✅  Payload hash verified
+      ✅  Ed25519 signature valid
+
+  🎉 Verification passed — chain is contiguous and signatures are valid.
+```
+
+If a receipt is altered, deleted, or inserted, the verifier flags the exact
+position where the chain breaks.
+
+---
+
+## SLSA Provenance
+
+Receipts can be emitted as SLSA v1.0 provenance predicates.  This maps the
+agent tool call to the standard in-toto Statement / SLSA Provenance format,
+enabling standard supply-chain verification tools (`slsa-verifier`,
+`in-toto`) to consume them.
+
+```python
+import json
+
+slsa = r1.to_slsa_provenance()
+print(json.dumps(slsa, indent=2))
+```
+
+The output follows the SLSA v1.0 schema:
+
+```json
+{
+  "_type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "name": "pkg:agentmesh/tool/ReadData",
+      "digest": { "sha256": "..." }
+    }
+  ],
+  "predicateType": "https://slsa.dev/provenance/v1",
+  "predicate": {
+    "buildDefinition": {
+      "buildType": "https://agent-governance.org/schema/mcp-tool-call/v1",
+      "externalParameters": {
+        "agent_did": "did:mesh:agent-1",
+        "cedar_policy_id": "policy:mcp-tools:v1",
+        "cedar_decision": "allow"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Standards Alignment
+
+| Standard | Usage |
+|----------|-------|
+| [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032) (Ed25519) | Receipt signing and verification |
+| [RFC 8785](https://datatracker.ietf.org/doc/html/rfc8785) (JCS) | Canonical JSON serialization before hashing |
+| [SLSA Provenance v1](https://slsa.dev/provenance/v1) | Optional provenance predicate emission |
+| [IETF draft-farley-acta](https://datatracker.ietf.org/doc/draft-farley-acta/) | Signed receipt envelope design |
+
+---
+
+## Next Steps
+
+- 📜 Full demo: `python examples/mcp-receipt-governed/demo.py`
+- 🔐 Agent identity: [Tutorial 02 — Trust and Identity](02-trust-and-identity.md)
+- 📚 Cedar policies: [Tutorial 01 — Policy Engine](01-policy-engine.md)
+- 🌐 MCP trust proxy: `agent-governance-python/agentmesh-integrations/mcp-trust-proxy/`


### PR DESCRIPTION
## Summary

Implements offline-verifiable decision receipts for the existing `mcp-receipt-governed` adapter.

## Changes

| File | Change |
|------|--------|
| `mcp_receipt_governed/receipt.py` | Added `parent_receipt_hash` for hash chaining, RFC 8785 JCS compliance, `to_slsa_provenance()`, and `verify_receipt_chain()` |
| `mcp_receipt_governed/adapter.py` | Auto-threads `parent_receipt_hash` from the last stored receipt |
| `mcp_receipt_governed/__init__.py` | Exports `verify_receipt_chain` |
| `tests/test_receipt.py` | 45 tests (+25 new) covering JCS, hash chaining, SLSA, chain verification, and unsigned receipt detection |
| `scripts/verify_receipts.py` | **[NEW]** Pure Python offline CLI verifier |
| `docs/tutorials/33-offline-verifiable-receipts.md` | **[NEW]** Tutorial covering receipts, chaining, verification, and SLSA |

## Standards

| Standard | Usage |
|----------|-------|
| RFC 8032 (Ed25519) | Receipt signing and verification |
| RFC 8785 (JCS) | Canonical JSON before hashing |
| SLSA Provenance v1 | Optional provenance predicate emission |

## Testing

- **65 tests passing** (20 adapter + 45 receipt)
- `black` formatting compliant

Closes #1499