### PR TITLE
Add TrustScoreExporter and provider-keyed trust attributes

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
@@ -12,6 +12,7 @@ from .endorsement import Endorsement, EndorsementRegistry, EndorsementType
 from .handshake import TrustHandshake, HandshakeResult
 from .capability import CapabilityScope, CapabilityGrant, CapabilityRegistry
 from .cards import TrustedAgentCard, CardRegistry
+from .exporter import TrustAttributeRecord, TrustScoreExporter
 
 __all__ = [
     "TrustBridge",
@@ -26,4 +27,6 @@ __all__ = [
     "CapabilityRegistry",
     "TrustedAgentCard",
     "CardRegistry",
+    "TrustAttributeRecord",
+    "TrustScoreExporter",
 ]

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/exporter.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/exporter.py
@@ -77,6 +77,27 @@ class TrustAttributeRecord(BaseModel):
             raise ValueError("updated_at must be a timezone-aware datetime")
         return v
 
+    @field_validator("score", mode="before")
+    @classmethod
+    def reject_bool_score(cls, v: Any) -> Any:
+        # Run before coercion: pydantic would otherwise turn True/False into
+        # 1.0/0.0 and silently produce maximum/zero trust from a malformed bool.
+        if isinstance(v, bool):
+            raise ValueError("score must not be a bool")
+        return v
+
+    @field_validator("score_dimensions", mode="before")
+    @classmethod
+    def reject_bool_dimension_values(cls, v: Any) -> Any:
+        # Same reasoning as reject_bool_score, applied to each dimension value.
+        if isinstance(v, dict):
+            for name, score in v.items():
+                if isinstance(score, bool):
+                    raise ValueError(
+                        f"score_dimensions['{name}'] must not be a bool"
+                    )
+        return v
+
     @field_validator("score_dimensions")
     @classmethod
     def validate_dimension_ranges(

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/exporter.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/exporter.py
@@ -1,0 +1,140 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Trust Score Exporter
+
+Provider-agnostic abstraction for exposing TrustProvider scores as
+first-class agent trust attributes that downstream systems can consume.
+
+Refs: microsoft/agent-governance-toolkit#1274
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+def _utc_now() -> datetime:
+    """Return current UTC time as a timezone-aware datetime."""
+    return datetime.now(timezone.utc)
+
+
+class TrustAttributeRecord(BaseModel):
+    """
+    Normalized trust attribute record produced by a ``TrustScoreExporter``.
+
+    Kept intentionally separate from ``TrustedAgentCard`` so that the trust
+    attribute surface is not coupled to the card model's lifecycle. A card
+    can reference one or more records via ``provider`` keys without owning
+    their storage or refresh cadence.
+    """
+
+    provider: str = Field(
+        ...,
+        min_length=1,
+        description="Stable identifier of the trust provider that produced this record.",
+    )
+    subject_did: str = Field(
+        ...,
+        min_length=1,
+        description="DID of the agent the record refers to.",
+    )
+    score: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional scalar trust score normalized to [0.0, 1.0].",
+    )
+    score_dimensions: Optional[Dict[str, float]] = Field(
+        default=None,
+        description=(
+            "Optional multi-dimensional scores. Each value must be normalized "
+            "to [0.0, 1.0]. Use this when a single scalar is insufficient."
+        ),
+    )
+    updated_at: datetime = Field(
+        default_factory=_utc_now,
+        description="Timestamp at which the record's scores were last computed.",
+    )
+    max_age_seconds: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Optional freshness budget in seconds. If unset, freshness is "
+            "considered unbounded by the provider."
+        ),
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific metadata that does not fit the normalized shape.",
+    )
+
+    @field_validator("score_dimensions")
+    @classmethod
+    def validate_dimension_ranges(
+        cls, v: Optional[Dict[str, float]]
+    ) -> Optional[Dict[str, float]]:
+        if v is None:
+            return v
+        for name, score in v.items():
+            if not isinstance(name, str) or not name:
+                raise ValueError("score_dimensions keys must be non-empty strings")
+            if score < 0.0 or score > 1.0:
+                raise ValueError(
+                    f"score_dimensions['{name}']={score} is outside [0.0, 1.0]"
+                )
+        return v
+
+    @model_validator(mode="after")
+    def validate_at_least_one_score(self) -> "TrustAttributeRecord":
+        if self.score is None and not self.score_dimensions:
+            raise ValueError(
+                "TrustAttributeRecord requires at least one of "
+                "'score' or 'score_dimensions'"
+            )
+        return self
+
+
+class TrustScoreExporter(ABC):
+    """
+    Base abstraction that providers implement to export trust scores as
+    normalized ``TrustAttributeRecord`` instances.
+
+    Implementations are responsible for fetching/computing their own scores;
+    this class only defines the surface and a freshness helper so consumers
+    can reason about staleness uniformly across providers.
+    """
+
+    @property
+    @abstractmethod
+    def provider_key(self) -> str:
+        """Stable identifier for the provider this exporter represents."""
+
+    @abstractmethod
+    def export(self, subject_did: str) -> TrustAttributeRecord:
+        """
+        Return a ``TrustAttributeRecord`` for the given subject DID.
+
+        Implementations should populate ``provider`` with ``self.provider_key``
+        and set ``updated_at`` to the time the underlying scores were computed.
+        """
+
+    def is_fresh(
+        self,
+        record: TrustAttributeRecord,
+        *,
+        now: Optional[datetime] = None,
+    ) -> bool:
+        """
+        Return whether ``record`` is still within its freshness budget.
+
+        If ``record.max_age_seconds`` is ``None``, the record is treated as
+        having no provider-declared expiry and is always considered fresh.
+        """
+        if record.max_age_seconds is None:
+            return True
+        reference = now if now is not None else _utc_now()
+        age = reference - record.updated_at
+        return age <= timedelta(seconds=record.max_age_seconds)

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/exporter.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/exporter.py
@@ -1,14 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """
-Trust Score Exporter
+Trust Score Exporter.
 
 Provider-agnostic abstraction for exposing TrustProvider scores as
 first-class agent trust attributes that downstream systems can consume.
-
-Refs: microsoft/agent-governance-toolkit#1274
 """
 
+import math
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
@@ -71,6 +70,13 @@ class TrustAttributeRecord(BaseModel):
         description="Provider-specific metadata that does not fit the normalized shape.",
     )
 
+    @field_validator("updated_at")
+    @classmethod
+    def validate_updated_at_is_aware(cls, v: datetime) -> datetime:
+        if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+            raise ValueError("updated_at must be a timezone-aware datetime")
+        return v
+
     @field_validator("score_dimensions")
     @classmethod
     def validate_dimension_ranges(
@@ -81,6 +87,10 @@ class TrustAttributeRecord(BaseModel):
         for name, score in v.items():
             if not isinstance(name, str) or not name:
                 raise ValueError("score_dimensions keys must be non-empty strings")
+            if not math.isfinite(score):
+                raise ValueError(
+                    f"score_dimensions['{name}']={score} is not a finite number"
+                )
             if score < 0.0 or score > 1.0:
                 raise ValueError(
                     f"score_dimensions['{name}']={score} is outside [0.0, 1.0]"
@@ -132,9 +142,18 @@ class TrustScoreExporter(ABC):
 
         If ``record.max_age_seconds`` is ``None``, the record is treated as
         having no provider-declared expiry and is always considered fresh.
+
+        Raises ``ValueError`` if ``now`` is provided as a naive datetime,
+        to prevent silent mismatches against the timezone-aware
+        ``record.updated_at``.
         """
         if record.max_age_seconds is None:
             return True
-        reference = now if now is not None else _utc_now()
+        if now is None:
+            reference = _utc_now()
+        else:
+            if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
+                raise ValueError("is_fresh() requires a timezone-aware 'now'")
+            reference = now
         age = reference - record.updated_at
         return age <= timedelta(seconds=record.max_age_seconds)

--- a/agent-governance-python/agent-mesh/tests/test_trust_exporter.py
+++ b/agent-governance-python/agent-mesh/tests/test_trust_exporter.py
@@ -1,0 +1,197 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the provider-agnostic trust score exporter.
+
+Refs: microsoft/agent-governance-toolkit#1274
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pytest
+from pydantic import ValidationError
+
+from agentmesh.trust import TrustAttributeRecord, TrustScoreExporter
+
+
+SUBJECT_DID = "did:mesh:subject"
+
+
+def _record(**overrides) -> TrustAttributeRecord:
+    """Build a minimal valid record, allowing per-test overrides."""
+    base = {
+        "provider": "test-provider",
+        "subject_did": SUBJECT_DID,
+        "score": 0.5,
+    }
+    base.update(overrides)
+    return TrustAttributeRecord(**base)
+
+
+# ---------------------------------------------------------------------------
+# TrustAttributeRecord — shape & validation
+# ---------------------------------------------------------------------------
+
+class TestTrustAttributeRecord:
+    def test_minimal_valid_record_with_scalar_score(self) -> None:
+        r = _record()
+        assert r.provider == "test-provider"
+        assert r.subject_did == SUBJECT_DID
+        assert r.score == 0.5
+        assert r.score_dimensions is None
+        assert r.max_age_seconds is None
+        assert r.metadata == {}
+        assert r.updated_at.tzinfo is not None
+
+    def test_minimal_valid_record_with_dimensions_only(self) -> None:
+        r = _record(score=None, score_dimensions={"reliability": 0.8})
+        assert r.score is None
+        assert r.score_dimensions == {"reliability": 0.8}
+
+    def test_at_least_one_score_required(self) -> None:
+        with pytest.raises(ValidationError):
+            TrustAttributeRecord(
+                provider="p",
+                subject_did=SUBJECT_DID,
+            )
+
+    def test_empty_score_dimensions_does_not_satisfy_at_least_one(self) -> None:
+        with pytest.raises(ValidationError):
+            TrustAttributeRecord(
+                provider="p",
+                subject_did=SUBJECT_DID,
+                score_dimensions={},
+            )
+
+    def test_provider_must_be_non_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(provider="")
+
+    def test_subject_did_must_be_non_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(subject_did="")
+
+    def test_score_above_one_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=1.5)
+
+    def test_score_below_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=-0.1)
+
+    def test_score_dimension_value_above_one_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=None, score_dimensions={"reliability": 1.2})
+
+    def test_score_dimension_value_below_zero_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=None, score_dimensions={"reliability": -0.01})
+
+    def test_score_dimension_empty_key_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=None, score_dimensions={"": 0.5})
+
+    def test_max_age_seconds_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(max_age_seconds=0)
+        with pytest.raises(ValidationError):
+            _record(max_age_seconds=-1)
+
+    def test_updated_at_explicit_none_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(updated_at=None)
+
+    def test_serialization_round_trip(self) -> None:
+        original = _record(
+            score=0.7,
+            score_dimensions={"latency": 0.9, "accuracy": 0.6},
+            max_age_seconds=120,
+            metadata={"region": "eu"},
+        )
+        as_dict = original.model_dump()
+        for key in (
+            "provider",
+            "subject_did",
+            "score",
+            "score_dimensions",
+            "updated_at",
+            "max_age_seconds",
+            "metadata",
+        ):
+            assert key in as_dict
+        rebuilt = TrustAttributeRecord.model_validate(as_dict)
+        assert rebuilt == original
+
+
+# ---------------------------------------------------------------------------
+# TrustScoreExporter — surface & freshness helper
+# ---------------------------------------------------------------------------
+
+class _FakeExporter(TrustScoreExporter):
+    """Minimal in-test implementation; not a reference exporter."""
+
+    def __init__(self, key: str, score: float, max_age: Optional[int] = None) -> None:
+        self._key = key
+        self._score = score
+        self._max_age = max_age
+
+    @property
+    def provider_key(self) -> str:
+        return self._key
+
+    def export(self, subject_did: str) -> TrustAttributeRecord:
+        return TrustAttributeRecord(
+            provider=self._key,
+            subject_did=subject_did,
+            score=self._score,
+            max_age_seconds=self._max_age,
+        )
+
+
+class TestTrustScoreExporter:
+    def test_cannot_instantiate_abstract_base(self) -> None:
+        with pytest.raises(TypeError):
+            TrustScoreExporter()  # type: ignore[abstract]
+
+    def test_provider_key_isolation(self) -> None:
+        a = _FakeExporter("provider-a", 0.4).export(SUBJECT_DID)
+        b = _FakeExporter("provider-b", 0.9).export(SUBJECT_DID)
+        assert a.provider == "provider-a"
+        assert b.provider == "provider-b"
+        assert a != b
+
+    def test_is_fresh_no_max_age_is_always_fresh(self) -> None:
+        exporter = _FakeExporter("p", 0.5, max_age=None)
+        record = exporter.export(SUBJECT_DID)
+        far_future = record.updated_at + timedelta(days=365)
+        assert exporter.is_fresh(record, now=far_future) is True
+
+    def test_is_fresh_within_window(self) -> None:
+        exporter = _FakeExporter("p", 0.5, max_age=60)
+        record = exporter.export(SUBJECT_DID)
+        now = record.updated_at + timedelta(seconds=30)
+        assert exporter.is_fresh(record, now=now) is True
+
+    def test_is_fresh_at_exact_boundary(self) -> None:
+        exporter = _FakeExporter("p", 0.5, max_age=60)
+        record = exporter.export(SUBJECT_DID)
+        now = record.updated_at + timedelta(seconds=60)
+        assert exporter.is_fresh(record, now=now) is True
+
+    def test_is_fresh_expired(self) -> None:
+        exporter = _FakeExporter("p", 0.5, max_age=60)
+        record = exporter.export(SUBJECT_DID)
+        now = record.updated_at + timedelta(seconds=120)
+        assert exporter.is_fresh(record, now=now) is False
+
+    def test_is_fresh_default_now_uses_utc(self) -> None:
+        exporter = _FakeExporter("p", 0.5, max_age=60)
+        stale = TrustAttributeRecord(
+            provider="p",
+            subject_did=SUBJECT_DID,
+            score=0.5,
+            updated_at=datetime.now(timezone.utc) - timedelta(seconds=120),
+            max_age_seconds=60,
+        )
+        assert exporter.is_fresh(stale) is False

--- a/agent-governance-python/agent-mesh/tests/test_trust_exporter.py
+++ b/agent-governance-python/agent-mesh/tests/test_trust_exporter.py
@@ -3,7 +3,6 @@
 """Tests for the provider-agnostic trust score exporter."""
 from __future__ import annotations
 
-import math
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -119,6 +118,24 @@ class TestTrustAttributeRecord:
     def test_score_dimension_string_nan_raises(self) -> None:
         with pytest.raises(ValidationError):
             _record(score=None, score_dimensions={"x": "nan"})  # type: ignore[dict-item]
+
+    def test_score_scalar_bool_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=True)  # type: ignore[arg-type]
+        with pytest.raises(ValidationError):
+            _record(score=False)  # type: ignore[arg-type]
+
+    def test_score_dimensions_bool_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(
+                score=None,
+                score_dimensions={"x": True},  # type: ignore[dict-item]
+            )
+        with pytest.raises(ValidationError):
+            _record(
+                score=None,
+                score_dimensions={"x": False},  # type: ignore[dict-item]
+            )
 
     def test_serialization_round_trip(self) -> None:
         original = _record(

--- a/agent-governance-python/agent-mesh/tests/test_trust_exporter.py
+++ b/agent-governance-python/agent-mesh/tests/test_trust_exporter.py
@@ -1,11 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Tests for the provider-agnostic trust score exporter.
-
-Refs: microsoft/agent-governance-toolkit#1274
-"""
+"""Tests for the provider-agnostic trust score exporter."""
 from __future__ import annotations
 
+import math
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -102,6 +100,26 @@ class TestTrustAttributeRecord:
         with pytest.raises(ValidationError):
             _record(updated_at=None)
 
+    def test_updated_at_naive_raises(self) -> None:
+        naive = datetime(2026, 4, 27, 12, 0, 0)
+        assert naive.tzinfo is None
+        with pytest.raises(ValidationError):
+            _record(updated_at=naive)
+
+    def test_score_dimension_nan_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=None, score_dimensions={"x": float("nan")})
+
+    def test_score_dimension_inf_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=None, score_dimensions={"x": float("inf")})
+        with pytest.raises(ValidationError):
+            _record(score=None, score_dimensions={"x": float("-inf")})
+
+    def test_score_dimension_string_nan_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            _record(score=None, score_dimensions={"x": "nan"})  # type: ignore[dict-item]
+
     def test_serialization_round_trip(self) -> None:
         original = _record(
             score=0.7,
@@ -195,3 +213,11 @@ class TestTrustScoreExporter:
             max_age_seconds=60,
         )
         assert exporter.is_fresh(stale) is False
+
+    def test_is_fresh_naive_now_raises(self) -> None:
+        exporter = _FakeExporter("p", 0.5, max_age=60)
+        record = exporter.export(SUBJECT_DID)
+        naive_now = datetime(2026, 4, 27, 12, 0, 0)
+        assert naive_now.tzinfo is None
+        with pytest.raises(ValueError):
+            exporter.is_fresh(record, now=naive_now)


### PR DESCRIPTION
Refs #1274.

This PR adds the narrow trust-score export surface confirmed in #1274:

- provider-keyed `TrustAttributeRecord`
- base `TrustScoreExporter` abstraction
- staleness metadata via `updated_at` and `max_age_seconds`
- validation for score ranges, finite dimension values, bool coercion, and timezone-aware timestamps
- unit tests for schema shape, provider isolation, freshness checks, and serialization

Out of scope:
- reference exporters
- provenance / attestation bundles
- provider-specific logic
- changes to `TrustedAgentCard` storage lifecycle

Tests:
- `PYTHONPATH=src .venv/bin/pytest tests/test_trust_exporter.py -v`