### PR TITLE
fix: bind TypeScript framework adapter identity to the client

### DIFF
--- a/agent-governance-typescript/README.md
+++ b/agent-governance-typescript/README.md
@@ -342,6 +342,10 @@ console.log(result.trace.traceId);
 
 Framework-specific integrations can also call `beginInvocation()` and `complete()` directly to plug this into callback or middleware pipelines.
 
+The adapter is now **identity-bound** to the `AgentMeshClient` you construct it with. If an invocation supplies `agentId`, it must match `client.identity.did`; mismatches are denied fail-closed before the handler runs, and audit/trace data stays anchored to the bound client identity.
+
+**Migration guidance:** if you previously reused one `GenericFrameworkAdapter` across multiple runtime identities and passed per-call `agentId` values, create a separate `AgentMeshClient`/`GenericFrameworkAdapter` pair for each real agent identity instead of relying on caller-asserted IDs.
+
 ## Development
 
 ```bash

--- a/agent-governance-typescript/src/framework-adapter.ts
+++ b/agent-governance-typescript/src/framework-adapter.ts
@@ -15,6 +15,7 @@ export interface FrameworkInvocation {
   name: string;
   kind?: TraceSpanKind;
   action?: string;
+  /** Optional diagnostic identity hint; if provided, it must match the bound client identity. */
   agentId?: string;
   input?: Record<string, unknown>;
   attributes?: Record<string, unknown>;
@@ -146,37 +147,51 @@ export class GenericFrameworkAdapter {
     invocation: FrameworkInvocation,
   ): Promise<FrameworkInvocationHandle<TOutput>> {
     const action = this.resolveAction(invocation);
+    const canonicalAgentId = this.client.identity.did;
+    const assertedAgentId = invocation.agentId;
+    const normalizedInvocation: FrameworkInvocation = {
+      ...invocation,
+      agentId: canonicalAgentId,
+    };
+    const identityMismatchReason = assertedAgentId && assertedAgentId !== canonicalAgentId
+      ? `Caller-asserted agentId "${assertedAgentId}" does not match bound client identity "${canonicalAgentId}"`
+      : undefined;
     const capture = new TraceCapture(
-      invocation.agentId ?? this.client.identity.did,
-      stringifyOutput(invocation.input ?? {}),
+      canonicalAgentId,
+      stringifyOutput(normalizedInvocation.input ?? {}),
     );
     const span = capture.startSpan(
-      invocation.name,
-      invocation.kind ?? 'internal',
-      invocation.input,
+      normalizedInvocation.name,
+      normalizedInvocation.kind ?? 'internal',
+      normalizedInvocation.input,
       undefined,
-      invocation.attributes ?? {},
+      {
+        ...(normalizedInvocation.attributes ?? {}),
+        ...(assertedAgentId ? { assertedAgentId } : {}),
+      },
     );
 
-    const governanceResult = await this.client.executeWithGovernance(action, invocation.input ?? {});
+    const governanceResult = identityMismatchReason
+      ? this.rejectIdentityMismatch(action, canonicalAgentId, identityMismatchReason)
+      : await this.client.executeWithGovernance(action, normalizedInvocation.input ?? {});
     this.metrics?.recordPolicyDecision(
       governanceResult.decision,
       governanceResult.executionTime,
       {
         action,
-        invocationKind: invocation.kind ?? 'internal',
+        invocationKind: normalizedInvocation.kind ?? 'internal',
       },
     );
     this.metrics?.recordTrustScore(
-      invocation.agentId ?? this.client.identity.did,
+      canonicalAgentId,
       governanceResult.trustScore.overall,
     );
     this.metrics?.recordAuditEntry(this.client.audit.length);
 
     const allowed = governanceResult.decision === 'allow';
-    const reason = toReason(action, governanceResult);
+    const reason = identityMismatchReason ?? toReason(action, governanceResult);
     const handle = new FrameworkInvocationHandle<TOutput>(
-      invocation,
+      normalizedInvocation,
       action,
       allowed,
       reason,
@@ -231,6 +246,26 @@ export class GenericFrameworkAdapter {
     }
 
     return `${this.actionPrefix}.${invocation.kind ?? 'internal'}.${invocation.name}`;
+  }
+
+  private rejectIdentityMismatch(
+    action: string,
+    agentId: string,
+    reason: string,
+  ): GovernanceResult {
+    const auditEntry = this.client.audit.log({
+      agentId,
+      action,
+      decision: 'deny',
+    });
+    this.client.trust.recordFailure(agentId);
+    return {
+      decision: 'deny',
+      trustScore: this.client.trust.getTrustScore(agentId),
+      auditEntry,
+      executionTime: 0,
+      lifecycleState: this.client.lifecycle.state,
+    };
   }
 }
 

--- a/agent-governance-typescript/tests/framework-adapter.test.ts
+++ b/agent-governance-typescript/tests/framework-adapter.test.ts
@@ -100,4 +100,36 @@ describe('GenericFrameworkAdapter', () => {
     expect(result.trace.traceId).toBeDefined();
     expect(result.output).toEqual({ found: true });
   });
+
+  it('fails closed when a caller asserts a different agentId', async () => {
+    const client = AgentMeshClient.create('adapter-agent', {
+      policyRules: [
+        { action: 'framework.tool_call.lookup', effect: 'allow' },
+      ],
+    });
+    const metrics = new GovernanceMetrics({ enabled: true });
+    const adapter = new GenericFrameworkAdapter(client, { metrics });
+    const handler = jest.fn(async () => ({ found: true }));
+
+    const result = await adapter.run(
+      {
+        name: 'lookup',
+        kind: 'tool_call',
+        agentId: 'did:agentmesh:spoofed:1234',
+        input: { id: '123' },
+      },
+      handler,
+    );
+
+    expect(result.allowed).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.reason).toContain('Caller-asserted agentId');
+    expect(result.invocation.agentId).toBe(client.identity.did);
+    expect(result.trace.agentId).toBe(client.identity.did);
+    expect(result.governanceResult.decision).toBe('deny');
+    expect(result.governanceResult.auditEntry.agentId).toBe(client.identity.did);
+    expect(metrics.getSnapshot().events.some((event) =>
+      event.name === 'trust.score' && event.attributes.agentId === client.identity.did
+    )).toBe(true);
+  });
 });

--- a/agent-governance-typescript/tests/framework-adapter.test.ts
+++ b/agent-governance-typescript/tests/framework-adapter.test.ts
@@ -101,6 +101,80 @@ describe('GenericFrameworkAdapter', () => {
     expect(result.output).toEqual({ found: true });
   });
 
+  it('allows an explicitly matching agentId', async () => {
+    const client = AgentMeshClient.create('adapter-agent', {
+      policyRules: [
+        { action: 'framework.tool_call.lookup', effect: 'allow' },
+      ],
+    });
+    const adapter = new GenericFrameworkAdapter(client);
+    const handler = jest.fn(async () => ({ found: true }));
+
+    const result = await adapter.run(
+      {
+        name: 'lookup',
+        kind: 'tool_call',
+        agentId: client.identity.did,
+        input: { id: '123' },
+      },
+      handler,
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.invocation.agentId).toBe(client.identity.did);
+    expect(result.trace.agentId).toBe(client.identity.did);
+  });
+
+  it('binds omitted agentId to the client identity', async () => {
+    const client = AgentMeshClient.create('adapter-agent', {
+      policyRules: [
+        { action: 'framework.tool_call.lookup', effect: 'allow' },
+      ],
+    });
+    const adapter = new GenericFrameworkAdapter(client);
+    const handler = jest.fn(async () => ({ found: true }));
+
+    const result = await adapter.run(
+      {
+        name: 'lookup',
+        kind: 'tool_call',
+        input: { id: '123' },
+      },
+      handler,
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.invocation.agentId).toBe(client.identity.did);
+    expect(result.trace.agentId).toBe(client.identity.did);
+  });
+
+  it('treats an empty-string agentId as no caller assertion', async () => {
+    const client = AgentMeshClient.create('adapter-agent', {
+      policyRules: [
+        { action: 'framework.tool_call.lookup', effect: 'allow' },
+      ],
+    });
+    const adapter = new GenericFrameworkAdapter(client);
+    const handler = jest.fn(async () => ({ found: true }));
+
+    const result = await adapter.run(
+      {
+        name: 'lookup',
+        kind: 'tool_call',
+        agentId: '',
+        input: { id: '123' },
+      },
+      handler,
+    );
+
+    expect(result.allowed).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.invocation.agentId).toBe(client.identity.did);
+    expect(result.trace.agentId).toBe(client.identity.did);
+  });
+
   it('fails closed when a caller asserts a different agentId', async () => {
     const client = AgentMeshClient.create('adapter-agent', {
       policyRules: [


### PR DESCRIPTION
## Description

Fixes a TypeScript identity-integrity issue in the framework adapter layer.

`GenericFrameworkAdapter` previously accepted a caller-supplied `invocation.agentId` and used it in traces and trust metrics even though governance executed against the bound `AgentMeshClient` identity. That allowed caller-asserted identity on this runtime surface.

This change:
- binds framework invocations to `client.identity.did`
- denies mismatched caller-asserted `agentId` values fail-closed before the handler runs
- keeps audit, trust, and trace data anchored to the bound client identity
- preserves the asserted ID in trace attributes for forensic visibility
- adds a regression test for the spoofing case
- documents the migration path for integrations that previously reused one adapter across multiple identities

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

## AI & IP Disclosure
- [ ] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):
GitHub Copilot for implementation assistance; logic and final changes were manually reviewed.

## Related Issues