### PR TITLE
feat(go): add kill switch support

### DIFF
--- a/agent-governance-golang/README.md
+++ b/agent-governance-golang/README.md
@@ -1,6 +1,6 @@
 # AgentMesh Go module
 
-Go module for the AgentMesh governance framework — identity, trust scoring, policy evaluation, tamper-evident audit logging, MCP security scanning, execution privilege rings, agent lifecycle management, SLO tracking, shadow discovery, prompt defense, and native Go integrations.
+Go module for the AgentMesh governance framework — identity, trust scoring, policy evaluation, tamper-evident audit logging, MCP security scanning, execution privilege rings, kill switches, agent lifecycle management, SLO tracking, shadow discovery, prompt defense, and native Go integrations.
 
 ## Install
 
@@ -149,6 +149,34 @@ enforcer.Assign("agent-1", agentmesh.RingStandard)
 fmt.Println(enforcer.CheckAccess("agent-1", "data.read")) // true
 ```
 
+### Kill Switch (`kill_switch.go`)
+
+Scoped execution stop controls for global, agent, and capability-level containment.
+
+| Type / Function | Description |
+|---|---|
+| `NewKillSwitch()` | Create a single kill switch |
+| `NewKillSwitchRegistry()` | Create a scoped kill switch registry |
+| `GlobalKillSwitchScope()` | Target all execution globally |
+| `AgentKillSwitchScope(agentID)` | Target one agent |
+| `CapabilityKillSwitchScope(capability)` | Target one capability or tool |
+| `(*KillSwitchRegistry).Activate(scope, reason, message)` | Activate a scoped kill switch |
+| `(*KillSwitchRegistry).Clear(scope, reason, message)` | Clear a scoped kill switch |
+| `(*KillSwitchRegistry).DecisionFor(agentID, capability)` | Resolve whether execution is currently allowed |
+| `(*KillSwitchRegistry).History()` | Return the recorded activation/clear history |
+
+```go
+registry := agentmesh.NewKillSwitchRegistry()
+_, _ = registry.Activate(
+    agentmesh.AgentKillSwitchScope("agent-1"),
+    agentmesh.KillSwitchReasonSecurityIncident,
+    "contain suspicious behavior",
+)
+
+decision := registry.DecisionFor("agent-1", "tool.run")
+fmt.Printf("Allowed: %v\n", decision.Allowed) // false
+```
+
 ### Lifecycle (`lifecycle.go`)
 
 Eight-state lifecycle model with validated transitions.
@@ -193,7 +221,7 @@ Go-native integration helpers built around a composable governance middleware st
 | Type / Function | Description |
 |---|---|
 | `GovernedOperation` | Common operation envelope for tool calls, prompts, and request flows |
-| `CreateGovernanceMiddlewareStack(config)` | Compose policy, capability guard, prompt defense, audit, and SLO middleware |
+| `CreateGovernanceMiddlewareStack(config)` | Compose audit, kill switch, policy, capability guard, prompt defense, and SLO middleware |
 | `NewHTTPGovernanceMiddleware(config)` | Create `net/http` middleware backed by the governance stack |
 | `GovernOperation(...)` | Wrap a generic operation with the standard governance stack |
 

--- a/agent-governance-golang/packages/agentmesh/kill_switch.go
+++ b/agent-governance-golang/packages/agentmesh/kill_switch.go
@@ -1,0 +1,270 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrKillSwitchActive is returned when execution is blocked by an active kill switch.
+var ErrKillSwitchActive = errors.New("kill switch active")
+
+// KillSwitchReason captures why a kill switch was activated or cleared.
+type KillSwitchReason string
+
+const (
+	KillSwitchReasonPolicyViolation      KillSwitchReason = "policy_violation"
+	KillSwitchReasonSecurityIncident     KillSwitchReason = "security_incident"
+	KillSwitchReasonOperatorRequest      KillSwitchReason = "operator_request"
+	KillSwitchReasonErrorBudgetExhausted KillSwitchReason = "error_budget_exhausted"
+)
+
+// KillSwitchScopeKind identifies the scope affected by a kill switch.
+type KillSwitchScopeKind string
+
+const (
+	KillSwitchScopeGlobal     KillSwitchScopeKind = "global"
+	KillSwitchScopeAgent      KillSwitchScopeKind = "agent"
+	KillSwitchScopeCapability KillSwitchScopeKind = "capability"
+)
+
+// KillSwitchScope identifies the resource targeted by a kill switch.
+type KillSwitchScope struct {
+	Kind  KillSwitchScopeKind `json:"kind"`
+	Value string              `json:"value,omitempty"`
+}
+
+// GlobalKillSwitchScope returns the process-wide kill switch scope.
+func GlobalKillSwitchScope() KillSwitchScope {
+	return KillSwitchScope{Kind: KillSwitchScopeGlobal}
+}
+
+// AgentKillSwitchScope returns the kill switch scope for a specific agent.
+func AgentKillSwitchScope(agentID string) KillSwitchScope {
+	return KillSwitchScope{Kind: KillSwitchScopeAgent, Value: strings.TrimSpace(agentID)}
+}
+
+// CapabilityKillSwitchScope returns the kill switch scope for a specific capability.
+func CapabilityKillSwitchScope(capability string) KillSwitchScope {
+	return KillSwitchScope{Kind: KillSwitchScopeCapability, Value: strings.TrimSpace(capability)}
+}
+
+func normalizeKillSwitchScope(scope KillSwitchScope) KillSwitchScope {
+	switch scope.Kind {
+	case KillSwitchScopeGlobal:
+		scope.Value = ""
+	case KillSwitchScopeAgent, KillSwitchScopeCapability:
+		scope.Value = strings.TrimSpace(scope.Value)
+	}
+	return scope
+}
+
+func (s KillSwitchScope) validate() error {
+	s = normalizeKillSwitchScope(s)
+	switch s.Kind {
+	case KillSwitchScopeGlobal:
+		return nil
+	case KillSwitchScopeAgent, KillSwitchScopeCapability:
+		if strings.TrimSpace(s.Value) == "" {
+			return fmt.Errorf("kill switch scope %q requires a non-empty value", s.Kind)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown kill switch scope kind %q", s.Kind)
+	}
+}
+
+// String returns a stable string representation for logging and map keys.
+func (s KillSwitchScope) String() string {
+	s = normalizeKillSwitchScope(s)
+	if s.Value == "" {
+		return string(s.Kind)
+	}
+	return fmt.Sprintf("%s:%s", s.Kind, s.Value)
+}
+
+// KillSwitchEvent records a single activation or clear action.
+type KillSwitchEvent struct {
+	Active    bool             `json:"active"`
+	Reason    KillSwitchReason `json:"reason"`
+	Message   string           `json:"message,omitempty"`
+	Timestamp time.Time        `json:"timestamp"`
+}
+
+// KillSwitchDecision reports whether execution is permitted for a given lookup.
+type KillSwitchDecision struct {
+	Allowed bool             `json:"allowed"`
+	Scope   *KillSwitchScope `json:"scope,omitempty"`
+	Event   *KillSwitchEvent `json:"event,omitempty"`
+}
+
+// KillSwitchHistoryEntry records a scoped kill switch event.
+type KillSwitchHistoryEntry struct {
+	Scope KillSwitchScope `json:"scope"`
+	Event KillSwitchEvent `json:"event"`
+}
+
+// KillSwitch tracks active state and the latest event for a single scope.
+type KillSwitch struct {
+	mu    sync.RWMutex
+	event *KillSwitchEvent
+}
+
+// NewKillSwitch creates an inactive kill switch.
+func NewKillSwitch() *KillSwitch {
+	return &KillSwitch{}
+}
+
+// Activate marks the kill switch active and records the event.
+func (s *KillSwitch) Activate(reason KillSwitchReason, message string) KillSwitchEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	event := KillSwitchEvent{
+		Active:    true,
+		Reason:    reason,
+		Message:   strings.TrimSpace(message),
+		Timestamp: time.Now().UTC(),
+	}
+	s.event = &event
+	return event
+}
+
+// Clear marks the kill switch inactive and records the event.
+func (s *KillSwitch) Clear(reason KillSwitchReason, message string) KillSwitchEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	event := KillSwitchEvent{
+		Active:    false,
+		Reason:    reason,
+		Message:   strings.TrimSpace(message),
+		Timestamp: time.Now().UTC(),
+	}
+	s.event = &event
+	return event
+}
+
+// IsActive reports whether the kill switch is currently active.
+func (s *KillSwitch) IsActive() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.event != nil && s.event.Active
+}
+
+// Event returns the latest event recorded for the kill switch.
+func (s *KillSwitch) Event() *KillSwitchEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneKillSwitchEvent(s.event)
+}
+
+func cloneKillSwitchEvent(event *KillSwitchEvent) *KillSwitchEvent {
+	if event == nil {
+		return nil
+	}
+	clone := *event
+	return &clone
+}
+
+// KillSwitchRegistry manages scoped kill switches and their history.
+type KillSwitchRegistry struct {
+	mu       sync.RWMutex
+	switches map[string]*KillSwitch
+	history  []KillSwitchHistoryEntry
+}
+
+// NewKillSwitchRegistry creates an empty scoped kill switch registry.
+func NewKillSwitchRegistry() *KillSwitchRegistry {
+	return &KillSwitchRegistry{
+		switches: make(map[string]*KillSwitch),
+		history:  make([]KillSwitchHistoryEntry, 0),
+	}
+}
+
+func (r *KillSwitchRegistry) switchFor(scope KillSwitchScope) *KillSwitch {
+	key := scope.String()
+	if existing, ok := r.switches[key]; ok {
+		return existing
+	}
+	killSwitch := NewKillSwitch()
+	r.switches[key] = killSwitch
+	return killSwitch
+}
+
+// Activate marks the given scope blocked and records the event in registry history.
+func (r *KillSwitchRegistry) Activate(scope KillSwitchScope, reason KillSwitchReason, message string) (*KillSwitchEvent, error) {
+	scope = normalizeKillSwitchScope(scope)
+	if err := scope.validate(); err != nil {
+		return nil, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	event := r.switchFor(scope).Activate(reason, message)
+	r.history = append(r.history, KillSwitchHistoryEntry{Scope: scope, Event: event})
+	return cloneKillSwitchEvent(&event), nil
+}
+
+// Clear marks the given scope allowed again and records the event in registry history.
+func (r *KillSwitchRegistry) Clear(scope KillSwitchScope, reason KillSwitchReason, message string) (*KillSwitchEvent, error) {
+	scope = normalizeKillSwitchScope(scope)
+	if err := scope.validate(); err != nil {
+		return nil, err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	event := r.switchFor(scope).Clear(reason, message)
+	r.history = append(r.history, KillSwitchHistoryEntry{Scope: scope, Event: event})
+	return cloneKillSwitchEvent(&event), nil
+}
+
+// DecisionFor resolves whether a specific agent/capability combination is currently allowed.
+func (r *KillSwitchRegistry) DecisionFor(agentID string, capability string) KillSwitchDecision {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	scopes := []KillSwitchScope{GlobalKillSwitchScope()}
+	if trimmedAgentID := strings.TrimSpace(agentID); trimmedAgentID != "" {
+		scopes = append(scopes, AgentKillSwitchScope(trimmedAgentID))
+	}
+	if trimmedCapability := strings.TrimSpace(capability); trimmedCapability != "" {
+		scopes = append(scopes, CapabilityKillSwitchScope(trimmedCapability))
+	}
+
+	for _, scope := range scopes {
+		killSwitch, ok := r.switches[scope.String()]
+		if !ok {
+			continue
+		}
+		event := killSwitch.Event()
+		if event != nil && event.Active {
+			scopeCopy := scope
+			return KillSwitchDecision{
+				Allowed: false,
+				Scope:   &scopeCopy,
+				Event:   event,
+			}
+		}
+	}
+
+	return KillSwitchDecision{Allowed: true}
+}
+
+// History returns a copy of scoped kill switch events in chronological order.
+func (r *KillSwitchRegistry) History() []KillSwitchHistoryEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	history := make([]KillSwitchHistoryEntry, len(r.history))
+	copy(history, r.history)
+	return history
+}

--- a/agent-governance-golang/packages/agentmesh/kill_switch_test.go
+++ b/agent-governance-golang/packages/agentmesh/kill_switch_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestKillSwitchToggleState(t *testing.T) {
+	killSwitch := NewKillSwitch()
+	if killSwitch.IsActive() {
+		t.Fatal("expected new kill switch to be inactive")
+	}
+
+	activated := killSwitch.Activate(KillSwitchReasonSecurityIncident, "suspicious outbound traffic")
+	if !activated.Active {
+		t.Fatal("expected activation event to be active")
+	}
+	if !killSwitch.IsActive() {
+		t.Fatal("expected kill switch to be active")
+	}
+
+	cleared := killSwitch.Clear(KillSwitchReasonOperatorRequest, "incident resolved")
+	if cleared.Active {
+		t.Fatal("expected clear event to be inactive")
+	}
+	if killSwitch.IsActive() {
+		t.Fatal("expected kill switch to be inactive after clear")
+	}
+}
+
+func TestKillSwitchRegistryDecisionForScopedMatches(t *testing.T) {
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(AgentKillSwitchScope("agent-42"), KillSwitchReasonPolicyViolation, "repeated policy denials"); err != nil {
+		t.Fatalf("Activate agent scope: %v", err)
+	}
+
+	decision := registry.DecisionFor("agent-42", "tool.run")
+	if decision.Allowed {
+		t.Fatal("expected agent-scoped kill switch to deny execution")
+	}
+	if decision.Scope == nil || decision.Scope.Kind != KillSwitchScopeAgent || decision.Scope.Value != "agent-42" {
+		t.Fatalf("unexpected scope %#v", decision.Scope)
+	}
+	if decision.Event == nil || !decision.Event.Active {
+		t.Fatalf("expected active event, got %#v", decision.Event)
+	}
+
+	allowedDecision := registry.DecisionFor("agent-7", "tool.run")
+	if !allowedDecision.Allowed {
+		t.Fatalf("unexpected denial for unrelated agent: %#v", allowedDecision)
+	}
+}
+
+func TestKillSwitchRegistryPrefersGlobalScope(t *testing.T) {
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(GlobalKillSwitchScope(), KillSwitchReasonSecurityIncident, "platform containment"); err != nil {
+		t.Fatalf("Activate global scope: %v", err)
+	}
+	if _, err := registry.Activate(AgentKillSwitchScope("agent-7"), KillSwitchReasonPolicyViolation, "agent-specific issue"); err != nil {
+		t.Fatalf("Activate agent scope: %v", err)
+	}
+
+	decision := registry.DecisionFor("agent-7", "tool.run")
+	if decision.Allowed {
+		t.Fatal("expected global kill switch to deny execution")
+	}
+	if decision.Scope == nil || decision.Scope.Kind != KillSwitchScopeGlobal {
+		t.Fatalf("expected global scope, got %#v", decision.Scope)
+	}
+}
+
+func TestKillSwitchRegistryHistoryAndValidation(t *testing.T) {
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(CapabilityKillSwitchScope(""), KillSwitchReasonOperatorRequest, "missing capability"); err == nil {
+		t.Fatal("expected validation error for empty capability scope")
+	}
+
+	if _, err := registry.Activate(CapabilityKillSwitchScope("tool.run"), KillSwitchReasonOperatorRequest, "maintenance"); err != nil {
+		t.Fatalf("Activate capability scope: %v", err)
+	}
+	if _, err := registry.Clear(CapabilityKillSwitchScope("tool.run"), KillSwitchReasonOperatorRequest, "maintenance complete"); err != nil {
+		t.Fatalf("Clear capability scope: %v", err)
+	}
+
+	history := registry.History()
+	if len(history) != 2 {
+		t.Fatalf("history length = %d, want 2", len(history))
+	}
+	if history[0].Scope.Kind != KillSwitchScopeCapability || history[0].Scope.Value != "tool.run" {
+		t.Fatalf("unexpected first history entry scope %#v", history[0].Scope)
+	}
+	if !history[0].Event.Active || history[1].Event.Active {
+		t.Fatalf("unexpected history events %#v", history)
+	}
+
+	decision := registry.DecisionFor("agent-1", "tool.run")
+	if !decision.Allowed {
+		t.Fatalf("expected cleared capability to allow execution, got %#v", decision)
+	}
+}
+
+func TestKillSwitchRegistryNormalizesExportedScopes(t *testing.T) {
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(KillSwitchScope{
+		Kind:  KillSwitchScopeGlobal,
+		Value: "ignored",
+	}, KillSwitchReasonSecurityIncident, "global containment"); err != nil {
+		t.Fatalf("Activate malformed global scope: %v", err)
+	}
+
+	globalDecision := registry.DecisionFor("agent-1", "tool.run")
+	if globalDecision.Allowed {
+		t.Fatal("expected normalized global scope to deny execution")
+	}
+	if globalDecision.Scope == nil || globalDecision.Scope.Kind != KillSwitchScopeGlobal || globalDecision.Scope.Value != "" {
+		t.Fatalf("unexpected normalized global scope %#v", globalDecision.Scope)
+	}
+
+	if _, err := registry.Clear(GlobalKillSwitchScope(), KillSwitchReasonOperatorRequest, "global clear"); err != nil {
+		t.Fatalf("Clear normalized global scope: %v", err)
+	}
+	if _, err := registry.Activate(KillSwitchScope{
+		Kind:  KillSwitchScopeAgent,
+		Value: " agent-9 ",
+	}, KillSwitchReasonPolicyViolation, "agent containment"); err != nil {
+		t.Fatalf("Activate whitespace agent scope: %v", err)
+	}
+
+	agentDecision := registry.DecisionFor("agent-9", "tool.run")
+	if agentDecision.Allowed {
+		t.Fatal("expected normalized agent scope to deny execution")
+	}
+	if agentDecision.Scope == nil || agentDecision.Scope.Kind != KillSwitchScopeAgent || agentDecision.Scope.Value != "agent-9" {
+		t.Fatalf("unexpected normalized agent scope %#v", agentDecision.Scope)
+	}
+}
+
+func TestKillSwitchMiddlewareDeniesOperation(t *testing.T) {
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(CapabilityKillSwitchScope("calculator"), KillSwitchReasonOperatorRequest, "tool maintenance"); err != nil {
+		t.Fatalf("Activate capability scope: %v", err)
+	}
+
+	handlerCalled := false
+	err := KillSwitchMiddleware(registry)(func(*GovernedOperation) error {
+		handlerCalled = true
+		return nil
+	})(&GovernedOperation{
+		AgentID:  "agent-9",
+		Action:   "tool.run",
+		ToolName: "calculator",
+	})
+	if err == nil {
+		t.Fatal("expected kill switch denial")
+	}
+	if !errors.Is(err, ErrKillSwitchActive) {
+		t.Fatalf("expected ErrKillSwitchActive, got %v", err)
+	}
+	if handlerCalled {
+		t.Fatal("expected kill switch middleware to stop handler execution")
+	}
+}

--- a/agent-governance-golang/packages/agentmesh/middleware.go
+++ b/agent-governance-golang/packages/agentmesh/middleware.go
@@ -69,6 +69,7 @@ func (s *GovernanceMiddlewareStack) Execute(operation *GovernedOperation, final 
 type MiddlewareStackConfig struct {
 	Policy                    *PolicyEngine
 	Audit                     *AuditLogger
+	KillSwitches              *KillSwitchRegistry
 	SLO                       *SLOEngine
 	SLOObjective              string
 	AllowedTools              []string
@@ -119,6 +120,9 @@ func CreateGovernanceMiddlewareStack(config MiddlewareStackConfig) (*GovernanceM
 	if config.Audit != nil {
 		stack.Use(AuditTrailMiddleware(config.Audit))
 	}
+	if config.KillSwitches != nil {
+		stack.Use(KillSwitchMiddleware(config.KillSwitches))
+	}
 	stack.Use(PolicyEvaluationMiddleware(config.Policy))
 	if len(config.AllowedTools) > 0 || len(config.DeniedTools) > 0 {
 		stack.Use(CapabilityGuardMiddleware(config.AllowedTools, config.DeniedTools))
@@ -130,6 +134,36 @@ func CreateGovernanceMiddlewareStack(config MiddlewareStackConfig) (*GovernanceM
 		stack.Use(SLOTrackingMiddleware(config.SLO, config.SLOObjective))
 	}
 	return stack, nil
+}
+
+// KillSwitchMiddleware blocks execution when a scoped kill switch is active.
+func KillSwitchMiddleware(registry *KillSwitchRegistry) OperationMiddleware {
+	return func(next OperationHandler) OperationHandler {
+		return func(operation *GovernedOperation) error {
+			if registry == nil {
+				return next(operation)
+			}
+
+			capability := defaultString(operation.ToolName, operation.Action)
+			decision := registry.DecisionFor(operation.AgentID, capability)
+			ensureOperationMetadata(operation)
+			operation.Metadata["kill_switch_decision"] = decision
+			if err := killSwitchDecisionError(decision); err != nil {
+				return err
+			}
+			return next(operation)
+		}
+	}
+}
+
+func killSwitchDecisionError(decision KillSwitchDecision) error {
+	if decision.Allowed {
+		return nil
+	}
+	if decision.Scope != nil {
+		return fmt.Errorf("%w: %s", ErrKillSwitchActive, decision.Scope.String())
+	}
+	return ErrKillSwitchActive
 }
 
 // PolicyEvaluationMiddleware enforces policy before the next handler executes.
@@ -264,6 +298,7 @@ func SLOTrackingMiddleware(slo *SLOEngine, objective string) OperationMiddleware
 type HTTPMiddlewareConfig struct {
 	Policy                    *PolicyEngine
 	Audit                     *AuditLogger
+	KillSwitches              *KillSwitchRegistry
 	SLO                       *SLOEngine
 	SLOObjective              string
 	ActionResolver            func(*http.Request) string
@@ -283,6 +318,7 @@ func NewHTTPGovernanceMiddleware(config HTTPMiddlewareConfig) (func(http.Handler
 	stack, err := CreateGovernanceMiddlewareStack(MiddlewareStackConfig{
 		Policy:                    config.Policy,
 		Audit:                     config.Audit,
+		KillSwitches:              config.KillSwitches,
 		SLO:                       config.SLO,
 		SLOObjective:              config.SLOObjective,
 		AllowedTools:              config.AllowedTools,
@@ -347,7 +383,9 @@ func NewHTTPGovernanceMiddleware(config HTTPMiddlewareConfig) (func(http.Handler
 				return
 			}
 			statusCode := http.StatusForbidden
-			if !errors.Is(err, ErrPolicyDenied) && !errors.Is(err, ErrVerifiedAgentIdentityRequired) {
+			if !errors.Is(err, ErrPolicyDenied) &&
+				!errors.Is(err, ErrKillSwitchActive) &&
+				!errors.Is(err, ErrVerifiedAgentIdentityRequired) {
 				statusCode = http.StatusInternalServerError
 			}
 			http.Error(w, err.Error(), statusCode)
@@ -355,11 +393,33 @@ func NewHTTPGovernanceMiddleware(config HTTPMiddlewareConfig) (func(http.Handler
 	}, nil
 }
 
+// GovernOperationOption configures GovernOperation without changing existing call sites.
+type GovernOperationOption func(*governOperationConfig)
+
+type governOperationConfig struct {
+	killSwitches *KillSwitchRegistry
+}
+
+// WithGovernOperationKillSwitches enables kill switch enforcement for GovernOperation.
+func WithGovernOperationKillSwitches(registry *KillSwitchRegistry) GovernOperationOption {
+	return func(config *governOperationConfig) {
+		config.killSwitches = registry
+	}
+}
+
 // GovernOperation executes a single operation behind the standard governance stack.
-func GovernOperation(action string, policyContext map[string]interface{}, policy *PolicyEngine, audit *AuditLogger, slo *SLOEngine, sloObjective string, operation func() error) error {
+func GovernOperation(action string, policyContext map[string]interface{}, policy *PolicyEngine, audit *AuditLogger, slo *SLOEngine, sloObjective string, operation func() error, opts ...GovernOperationOption) error {
+	config := &governOperationConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(config)
+		}
+	}
+
 	stack, err := CreateGovernanceMiddlewareStack(MiddlewareStackConfig{
 		Policy:       policy,
 		Audit:        audit,
+		KillSwitches: config.killSwitches,
 		SLO:          slo,
 		SLOObjective: sloObjective,
 	})
@@ -369,7 +429,7 @@ func GovernOperation(action string, policyContext map[string]interface{}, policy
 	return stack.Execute(&GovernedOperation{
 		AgentID:  stringValueFromContext(policyContext, "agent_id", "agent", ""),
 		Action:   action,
-		ToolName: action,
+		ToolName: stringValueFromContext(policyContext, "tool_name", "tool", action),
 		Input:    policyContext,
 	}, func(*GovernedOperation) error {
 		return operation()

--- a/agent-governance-golang/packages/agentmesh/middleware_test.go
+++ b/agent-governance-golang/packages/agentmesh/middleware_test.go
@@ -94,6 +94,44 @@ func TestGovernanceMiddlewareStackPromptDefenseDenies(t *testing.T) {
 	}
 }
 
+func TestGovernanceMiddlewareStackKillSwitchDenies(t *testing.T) {
+	policy := NewPolicyEngine([]PolicyRule{{
+		Action: "tool.run",
+		Effect: Allow,
+	}})
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(AgentKillSwitchScope("agent-1"), KillSwitchReasonSecurityIncident, "containment"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	stack, err := CreateGovernanceMiddlewareStack(MiddlewareStackConfig{
+		Policy:       policy,
+		KillSwitches: registry,
+	})
+	if err != nil {
+		t.Fatalf("CreateGovernanceMiddlewareStack: %v", err)
+	}
+
+	operation := &GovernedOperation{
+		AgentID:  "agent-1",
+		Action:   "tool.run",
+		ToolName: "calculator",
+	}
+	err = stack.Execute(operation, func(*GovernedOperation) error {
+		t.Fatal("expected kill switch denial before handler execution")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected kill switch denial")
+	}
+	if !errors.Is(err, ErrKillSwitchActive) {
+		t.Fatalf("expected ErrKillSwitchActive, got %v", err)
+	}
+	if operation.Metadata == nil {
+		t.Fatal("expected kill switch metadata to be populated")
+	}
+}
+
 func TestNewHTTPGovernanceMiddleware(t *testing.T) {
 	policy := NewPolicyEngine([]PolicyRule{{
 		Action:     "http.post",
@@ -157,6 +195,38 @@ func TestNewHTTPGovernanceMiddlewareFailsClosedWithoutVerifiedIdentity(t *testin
 	}
 	if !strings.Contains(response.Body.String(), ErrVerifiedAgentIdentityRequired.Error()) {
 		t.Fatalf("body = %q, want verified identity error", response.Body.String())
+	}
+}
+
+func TestNewHTTPGovernanceMiddlewareKillSwitchReturnsForbidden(t *testing.T) {
+	policy := NewPolicyEngine([]PolicyRule{{
+		Action: "http.post",
+		Effect: Allow,
+	}})
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(GlobalKillSwitchScope(), KillSwitchReasonOperatorRequest, "maintenance"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	middleware, err := NewHTTPGovernanceMiddleware(HTTPMiddlewareConfig{
+		Policy:          policy,
+		KillSwitches:    registry,
+		AgentIDResolver: LegacyTrustedHeaderAgentIDResolver("X-Agent-ID"),
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPGovernanceMiddleware: %v", err)
+	}
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("expected kill switch to short-circuit request")
+	}))
+
+	request := httptest.NewRequest(http.MethodPost, "/run", nil)
+	request.Header.Set("X-Agent-ID", "did:agentmesh:kill-switch")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
 	}
 }
 
@@ -411,5 +481,50 @@ func TestGovernOperationDenied(t *testing.T) {
 	}
 	if !errors.Is(err, ErrPolicyDenied) {
 		t.Fatalf("expected ErrPolicyDenied, got %v", err)
+	}
+}
+
+func TestGovernOperationKillSwitchDenied(t *testing.T) {
+	policy := NewPolicyEngine([]PolicyRule{{
+		Action: "tool.run",
+		Effect: Allow,
+	}})
+	registry := NewKillSwitchRegistry()
+	if _, err := registry.Activate(CapabilityKillSwitchScope("calculator"), KillSwitchReasonOperatorRequest, "maintenance"); err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+
+	handlerCalled := false
+	err := GovernOperation(
+		"tool.run",
+		map[string]interface{}{"agent_id": "agent-1", "tool_name": "calculator"},
+		policy,
+		nil,
+		nil,
+		"",
+		func() error {
+			handlerCalled = true
+			return nil
+		},
+		WithGovernOperationKillSwitches(registry),
+	)
+	if err == nil {
+		t.Fatal("expected kill switch denial")
+	}
+	if !errors.Is(err, ErrKillSwitchActive) {
+		t.Fatalf("expected ErrKillSwitchActive, got %v", err)
+	}
+	if handlerCalled {
+		t.Fatal("expected kill switch to stop operation handler")
+	}
+}
+
+func TestKillSwitchDecisionErrorFailsClosedWithoutScope(t *testing.T) {
+	err := killSwitchDecisionError(KillSwitchDecision{Allowed: false})
+	if err == nil {
+		t.Fatal("expected kill switch denial")
+	}
+	if !errors.Is(err, ErrKillSwitchActive) {
+		t.Fatalf("expected ErrKillSwitchActive, got %v", err)
 	}
 }


### PR DESCRIPTION
## Description
Add first-class kill switch support to the Go package with scoped global/agent/capability controls, middleware enforcement, regression tests, and README updates. This keeps the change scoped to `agent-governance-golang` while aligning the Go surface with the other SDKs.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [x] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):
GitHub Copilot for implementation assistance, with manual review of all logic and tests.

## Related Issues