### PR TITLE
fix: require authenticated execute identity in python agent-os

### DIFF
--- a/agent-governance-python/agent-os/CHANGELOG.md
+++ b/agent-governance-python/agent-os/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to Agent OS will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- `POST /api/v1/execute` now fails closed by default and no longer trusts
+  caller-asserted `agent_id` values before policy, audit, and rate-limit
+  enforcement.
+
+### Changed
+- Execute requests must now present `Authorization: Bearer <token>` bound to an
+  agent identity through `MCPSessionAuthenticator`, unless you explicitly opt
+  into local-only unsafe mode.
+- `ExecuteRequest.agent_id` is now optional; when present, it must match the
+  authenticated agent identity derived from the bearer token.
+- If execute auth is not configured, unauthenticated requests now return `503`
+  instead of running with a caller-supplied identity.
+
+### Added
+- `AGENT_OS_EXECUTION_TOKENS="agent-id=token"` for packaged-server bootstrap
+  credentials. These tokens remain valid for the life of the process unless
+  revoked explicitly.
+
+### Migration Notes
+- Configure `GovServer(execute_authenticator=...)` or set
+  `AGENT_OS_EXECUTION_TOKENS` before exposing `/api/v1/execute`.
+- `AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE=true` is available only as an unsafe
+  local-development escape hatch. It restores caller-asserted identity behavior
+  and should not be used in shared or production environments.
+
 ## [1.0.0] - 2026-01-26
 
 ### Added - Monorepo Creation

--- a/agent-governance-python/agent-os/src/agent_os/mcp_session_auth.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_session_auth.py
@@ -24,12 +24,12 @@ class MCPSession:
     agent_id: str
     user_id: str | None
     created_at: datetime
-    expires_at: datetime
+    expires_at: datetime | None
     rate_limit_key: str
 
     @property
     def is_expired(self) -> bool:
-        return _utcnow() >= self.expires_at
+        return self.expires_at is not None and _utcnow() >= self.expires_at
 
 
 def _utcnow() -> datetime:
@@ -94,7 +94,7 @@ class MCPSessionAuthenticator:
                 for token in self._agent_sessions.get(agent_id, set())
                 if (
                     (session := self._session_store.get(token)) is not None
-                    and session.expires_at > now
+                    and (session.expires_at is None or session.expires_at > now)
                 )
             )
             if active_for_agent >= self.max_concurrent_sessions:
@@ -117,6 +117,60 @@ class MCPSessionAuthenticator:
         logger.info("Created MCP session for agent %s", agent_id)
         return token
 
+    def bootstrap_session(
+        self,
+        agent_id: str,
+        session_token: str,
+        user_id: str | None = None,
+    ) -> str:
+        """Persist a pre-provisioned session token bound to an agent.
+
+        This is intended for environments that need deterministic bootstrap
+        credentials (for example, wiring a FastAPI server to a deployment-time
+        token map). Bootstrapped sessions do not expire automatically; they
+        remain valid until explicitly revoked or the process restarts.
+        """
+        if not agent_id or not agent_id.strip():
+            raise ValueError("agent_id must not be empty")
+        if not session_token or not session_token.strip():
+            raise ValueError("session_token must not be empty")
+
+        now = _utcnow()
+        with self._lock:
+            self._cleanup_expired_locked(now)
+            active_for_agent = sum(
+                1
+                for token in self._agent_sessions.get(agent_id, set())
+                if (
+                    (session := self._session_store.get(token)) is not None
+                    and (session.expires_at is None or session.expires_at > now)
+                )
+            )
+            if active_for_agent >= self.max_concurrent_sessions:
+                raise RuntimeError(
+                    f"Agent '{agent_id}' exceeded maximum concurrent sessions "
+                    f"({self.max_concurrent_sessions})."
+                )
+
+            existing = self._session_store.get(session_token)
+            if existing is not None and not getattr(existing, "is_expired", False):
+                raise RuntimeError("session_token is already bound to an active session")
+            if existing is not None:
+                self._delete_session_locked(session_token, existing)
+
+            session = MCPSession(
+                token=session_token,
+                agent_id=agent_id,
+                user_id=user_id,
+                created_at=now,
+                expires_at=None,
+                rate_limit_key=f"{user_id}:{agent_id}" if user_id else agent_id,
+            )
+            self._store_session_locked(session)
+
+        logger.info("Bootstrapped MCP session for agent %s", agent_id)
+        return session_token
+
     def validate_session(self, agent_id: str, session_token: str) -> MCPSession | None:
         """Validate a session token for a specific agent.
 
@@ -135,18 +189,25 @@ class MCPSessionAuthenticator:
 
         try:
             with self._lock:
-                session = self._session_store.get(session_token)
-                if session is None:
-                    self._delete_session_locked(session_token)
-                    return None
-                if session.agent_id != agent_id:
-                    return None
-                if session.is_expired:
-                    self._delete_session_locked(session_token, session)
+                session = self._get_valid_session_locked(session_token)
+                if session is None or session.agent_id != agent_id:
                     return None
                 return session
         except Exception:
             logger.error("MCP session validation failed closed", exc_info=True)
+            return None
+
+    def validate_token(self, session_token: str) -> MCPSession | None:
+        """Validate a session token without trusting a caller-asserted agent ID."""
+        if not session_token or not session_token.strip():
+            logger.warning("MCP session token validation failed due to missing token")
+            return None
+
+        try:
+            with self._lock:
+                return self._get_valid_session_locked(session_token)
+        except Exception:
+            logger.error("MCP session token validation failed closed", exc_info=True)
             return None
 
     def revoke_session(self, session_token: str) -> bool:
@@ -202,7 +263,9 @@ class MCPSessionAuthenticator:
 
     def _cleanup_expired_locked(self, now: datetime) -> int:
         expired_tokens = [
-            token for token, expires_at in self._session_expirations.items() if expires_at <= now
+            token
+            for token, expires_at in self._session_expirations.items()
+            if expires_at is not None and expires_at <= now
         ]
         for token in expired_tokens:
             session = self._session_store.get(token)
@@ -211,7 +274,10 @@ class MCPSessionAuthenticator:
 
     def _store_session_locked(self, session: MCPSession) -> None:
         self._session_store.set(session)
-        self._session_expirations[session.token] = session.expires_at
+        if session.expires_at is not None:
+            self._session_expirations[session.token] = session.expires_at
+        else:
+            self._session_expirations.pop(session.token, None)
         self._agent_sessions.setdefault(session.agent_id, set()).add(session.token)
 
     def _delete_session_locked(
@@ -229,3 +295,13 @@ class MCPSessionAuthenticator:
                 if not tokens:
                     self._agent_sessions.pop(stored_session.agent_id, None)
         return deleted or stored_session is not None
+
+    def _get_valid_session_locked(self, session_token: str) -> MCPSession | None:
+        session = self._session_store.get(session_token)
+        if session is None:
+            self._delete_session_locked(session_token)
+            return None
+        if session.is_expired:
+            self._delete_session_locked(session_token, session)
+            return None
+        return session

--- a/agent-governance-python/agent-os/src/agent_os/server/app.py
+++ b/agent-governance-python/agent-os/src/agent_os/server/app.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from datetime import datetime, timezone
 from typing import Any
@@ -28,6 +29,9 @@ from agent_os.server.models import (
 
 logger = logging.getLogger(__name__)
 
+_EXECUTE_TOKENS_ENV = "AGENT_OS_EXECUTION_TOKENS"
+_ALLOW_UNAUTHENTICATED_EXECUTE_ENV = "AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE"
+
 
 def _detection_result_to_response(result: Any) -> DetectionResponse:
     """Convert a ``DetectionResult`` dataclass to a Pydantic response."""
@@ -49,9 +53,12 @@ class GovServer:
         *,
         title: str = "Agent OS Governance API",
         version: str | None = None,
+        execute_authenticator: Any | None = None,
+        allow_unauthenticated_execute: bool | None = None,
     ) -> None:
         from agent_os import __version__
         from agent_os.health import HealthChecker
+        from agent_os.mcp_session_auth import MCPSessionAuthenticator
         from agent_os.metrics import GovernanceMetrics
         from agent_os.prompt_injection import DetectionConfig, PromptInjectionDetector
 
@@ -59,6 +66,20 @@ class GovServer:
         self._detector = PromptInjectionDetector(DetectionConfig(sensitivity="balanced"))
         self._metrics = GovernanceMetrics()
         self._health_checker = HealthChecker(version=self._version)
+        self._execute_authenticator: MCPSessionAuthenticator | None = (
+            execute_authenticator or _build_execute_authenticator_from_env()
+        )
+        self._allow_unauthenticated_execute = (
+            _read_bool_env(_ALLOW_UNAUTHENTICATED_EXECUTE_ENV, default=False)
+            if allow_unauthenticated_execute is None
+            else allow_unauthenticated_execute
+        )
+        if not self._allow_unauthenticated_execute and self._execute_authenticator is None:
+            logger.warning(
+                "Execute authentication is enabled but no bearer tokens are configured. "
+                "/api/v1/execute will return 503 until %s or execute_authenticator is set.",
+                _EXECUTE_TOKENS_ENV,
+            )
         self._app = create_app(self, title=title)
 
     @property
@@ -77,6 +98,91 @@ class GovServer:
     def health_checker(self) -> Any:
         return self._health_checker
 
+    @property
+    def execute_authenticator(self) -> Any:
+        return self._execute_authenticator
+
+    @property
+    def allow_unauthenticated_execute(self) -> bool:
+        return self._allow_unauthenticated_execute
+
+
+def _read_bool_env(name: str, *, default: bool) -> bool:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_execute_tokens(raw_tokens: str) -> dict[str, str]:
+    tokens: dict[str, str] = {}
+    seen_tokens: set[str] = set()
+    for item in re.split(r"[,\n;]+", raw_tokens):
+        entry = item.strip()
+        if not entry:
+            continue
+        agent_id, separator, token = entry.partition("=")
+        if separator == "" or not agent_id.strip() or not token.strip():
+            raise ValueError(
+                f"Invalid {_EXECUTE_TOKENS_ENV} entry '{entry}'. Use 'agent-id=token'."
+            )
+        normalized_agent_id = agent_id.strip()
+        normalized_token = token.strip()
+        if normalized_agent_id in tokens:
+            raise ValueError(f"Duplicate execute token mapping for agent '{normalized_agent_id}'.")
+        if normalized_token in seen_tokens:
+            raise ValueError("Execute bearer tokens must be unique per agent.")
+        tokens[normalized_agent_id] = normalized_token
+        seen_tokens.add(normalized_token)
+    return tokens
+
+
+def _build_execute_authenticator_from_env() -> Any | None:
+    from agent_os.mcp_session_auth import MCPSessionAuthenticator
+
+    raw_tokens = os.environ.get(_EXECUTE_TOKENS_ENV, "").strip()
+    if not raw_tokens:
+        return None
+
+    authenticator = MCPSessionAuthenticator()
+    for agent_id, token in _parse_execute_tokens(raw_tokens).items():
+        authenticator.bootstrap_session(agent_id, token)
+    return authenticator
+
+
+def _extract_bearer_token(request: Request) -> str:
+    authorization = request.headers.get("Authorization", "")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or invalid Authorization header. Use 'Bearer <session-token>'.",
+        )
+    return token.strip()
+
+
+def _authenticate_execute_request(
+    request: Request,
+    *,
+    execute_authenticator: Any | None,
+    allow_unauthenticated_execute: bool,
+) -> Any | None:
+    if allow_unauthenticated_execute:
+        return None
+    if execute_authenticator is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Execute authentication is not configured. Set AGENT_OS_EXECUTION_TOKENS or "
+                "provide GovServer(execute_authenticator=...)."
+            ),
+        )
+
+    session = execute_authenticator.validate_token(_extract_bearer_token(request))
+    if session is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired execute bearer token.")
+    return session
+
 
 def create_app(
     server: GovServer | None = None,
@@ -87,6 +193,12 @@ def create_app(
     from agent_os import __version__
 
     version = server._version if server else __version__
+    execute_authenticator = server.execute_authenticator if server else _build_execute_authenticator_from_env()
+    allow_unauthenticated_execute = (
+        server.allow_unauthenticated_execute
+        if server
+        else _read_bool_env(_ALLOW_UNAUTHENTICATED_EXECUTE_ENV, default=False)
+    )
 
     app = FastAPI(
         title=title,
@@ -229,13 +341,36 @@ def create_app(
     # -- execute -----------------------------------------------------------
 
     @app.post("/api/v1/execute", response_model=ExecuteResponse)
-    async def execute(req: ExecuteRequest) -> ExecuteResponse:
+    async def execute(req: ExecuteRequest, request: Request) -> ExecuteResponse:
         """Execute an action through the stateless kernel."""
         from agent_os.stateless import ExecutionContext, StatelessKernel
 
+        authenticated_session = _authenticate_execute_request(
+            request,
+            execute_authenticator=execute_authenticator,
+            allow_unauthenticated_execute=allow_unauthenticated_execute,
+        )
+        if authenticated_session is not None:
+            if req.agent_id and req.agent_id != authenticated_session.agent_id:
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "Request agent_id does not match the identity bound to the "
+                        "execute bearer token."
+                    ),
+                )
+            effective_agent_id = authenticated_session.agent_id
+        else:
+            if not req.agent_id:
+                raise HTTPException(
+                    status_code=422,
+                    detail="agent_id is required when unauthenticated execute mode is enabled.",
+                )
+            effective_agent_id = req.agent_id
+
         kernel = StatelessKernel()
         ctx = ExecutionContext(
-            agent_id=req.agent_id,
+            agent_id=effective_agent_id,
             policies=req.policies,
         )
         try:

--- a/agent-governance-python/agent-os/src/agent_os/server/models.py
+++ b/agent-governance-python/agent-os/src/agent_os/server/models.py
@@ -17,7 +17,14 @@ class ExecuteRequest(BaseModel):
 
     action: str = Field(..., description="Action to execute")
     params: dict = Field(default_factory=dict, description="Action parameters")
-    agent_id: str = Field(..., description="Unique agent identifier")
+    agent_id: str | None = Field(
+        default=None,
+        description=(
+            "Deprecated caller-asserted agent identifier. When execute authentication "
+            "is enabled, omit this field or set it to the same agent bound to the "
+            "bearer token."
+        ),
+    )
     policies: list[str] = Field(default_factory=list, description="Policy names to enforce")
 
 

--- a/agent-governance-python/agent-os/tests/test_mcp_session_auth.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_session_auth.py
@@ -32,6 +32,39 @@ def test_validate_rejects_wrong_agent():
     assert authenticator.validate_session("did:mesh:agent-002", token) is None
 
 
+def test_validate_token_returns_bound_session_without_caller_asserted_agent():
+    authenticator = MCPSessionAuthenticator()
+    token = authenticator.create_session("did:mesh:agent-001", user_id="user@example.com")
+
+    session = authenticator.validate_token(token)
+
+    assert session is not None
+    assert session.agent_id == "did:mesh:agent-001"
+    assert session.user_id == "user@example.com"
+
+
+def test_bootstrap_session_supports_static_server_tokens():
+    authenticator = MCPSessionAuthenticator()
+
+    authenticator.bootstrap_session("did:mesh:agent-001", "server-bootstrap-token")
+
+    session = authenticator.validate_token("server-bootstrap-token")
+    assert session is not None
+    assert session.agent_id == "did:mesh:agent-001"
+    assert session.expires_at is None
+
+
+def test_bootstrap_session_does_not_expire_with_runtime_ttl():
+    authenticator = MCPSessionAuthenticator(session_ttl=timedelta(milliseconds=10))
+
+    authenticator.bootstrap_session("did:mesh:agent-001", "server-bootstrap-token")
+    time.sleep(0.05)
+
+    session = authenticator.validate_token("server-bootstrap-token")
+    assert session is not None
+    assert session.agent_id == "did:mesh:agent-001"
+
+
 def test_expired_session_is_rejected():
     authenticator = MCPSessionAuthenticator(session_ttl=timedelta(milliseconds=10))
     token = authenticator.create_session("did:mesh:agent-001")

--- a/agent-governance-python/agent-os/tests/test_server.py
+++ b/agent-governance-python/agent-os/tests/test_server.py
@@ -5,13 +5,22 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from agent_os.server.app import GovServer, create_app
+from agent_os.mcp_session_auth import MCPSessionAuthenticator
+from agent_os.server.app import GovServer, _build_execute_authenticator_from_env
 
 
 @pytest.fixture
 def client():
     server = GovServer()
     return TestClient(server.app)
+
+
+@pytest.fixture
+def authenticated_execute_client():
+    authenticator = MCPSessionAuthenticator()
+    token = authenticator.create_session("test-agent", user_id="user@example.com")
+    server = GovServer(execute_authenticator=authenticator)
+    return TestClient(server.app), token
 
 
 # =========================================================================
@@ -246,7 +255,32 @@ class TestAuditEndpoint:
 # =========================================================================
 
 class TestExecuteEndpoint:
-    def test_execute_simple_action(self, client):
+    def test_env_configured_execute_token_authenticates_server(self, monkeypatch):
+        monkeypatch.setenv("AGENT_OS_EXECUTION_TOKENS", "test-agent=env-token")
+        monkeypatch.delenv("AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE", raising=False)
+
+        authenticator = _build_execute_authenticator_from_env()
+
+        assert authenticator is not None
+        session = authenticator.validate_token("env-token")
+        assert session is not None
+        assert session.agent_id == "test-agent"
+        assert session.expires_at is None
+
+        server = GovServer(execute_authenticator=authenticator)
+        client = TestClient(server.app)
+        resp = client.post(
+            "/api/v1/execute",
+            json={
+                "action": "database_query",
+                "params": {"query": "SELECT 1"},
+            },
+            headers={"Authorization": "Bearer env-token"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_execute_returns_503_when_auth_not_configured(self, client):
         resp = client.post(
             "/api/v1/execute",
             json={
@@ -255,20 +289,60 @@ class TestExecuteEndpoint:
                 "agent_id": "test-agent",
             },
         )
+        assert resp.status_code == 503
+        assert "AGENT_OS_EXECUTION_TOKENS" in resp.json()["detail"]
+
+    def test_execute_requires_bearer_token(self, authenticated_execute_client):
+        client, _ = authenticated_execute_client
+        resp = client.post(
+            "/api/v1/execute",
+            json={
+                "action": "database_query",
+                "params": {"query": "SELECT 1"},
+            },
+        )
+        assert resp.status_code == 401
+        assert "Bearer" in resp.json()["detail"]
+
+    def test_execute_rejects_spoofed_agent_id(self, authenticated_execute_client):
+        client, token = authenticated_execute_client
+        resp = client.post(
+            "/api/v1/execute",
+            json={
+                "action": "database_query",
+                "params": {"query": "SELECT 1"},
+                "agent_id": "spoofed-agent",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 403
+        assert "does not match" in resp.json()["detail"]
+
+    def test_execute_uses_authenticated_agent_identity(self, authenticated_execute_client):
+        client, token = authenticated_execute_client
+        resp = client.post(
+            "/api/v1/execute",
+            json={
+                "action": "database_query",
+                "params": {"query": "SELECT 1"},
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
         assert resp.status_code == 200
         body = resp.json()
         assert body["success"] is True
         assert body["data"] is not None
 
-    def test_execute_with_policies(self, client):
+    def test_execute_with_policies(self, authenticated_execute_client):
+        client, token = authenticated_execute_client
         resp = client.post(
             "/api/v1/execute",
             json={
                 "action": "file_write",
                 "params": {"path": "/tmp/test.txt"},
-                "agent_id": "test-agent",
                 "policies": ["read_only"],
             },
+            headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -279,7 +353,7 @@ class TestExecuteEndpoint:
     def test_execute_missing_action(self, client):
         resp = client.post(
             "/api/v1/execute",
-            json={"params": {}, "agent_id": "test-agent"},
+            json={"params": {}},
         )
         assert resp.status_code == 422  # validation error
 

--- a/agent-governance-python/agent-os/tests/test_server.py
+++ b/agent-governance-python/agent-os/tests/test_server.py
@@ -280,6 +280,41 @@ class TestExecuteEndpoint:
         assert resp.status_code == 200
         assert resp.json()["success"] is True
 
+    def test_execute_allows_unauthenticated_when_escape_hatch_enabled(self, monkeypatch):
+        monkeypatch.delenv("AGENT_OS_EXECUTION_TOKENS", raising=False)
+        monkeypatch.setenv("AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE", "true")
+
+        server = GovServer()
+        client = TestClient(server.app)
+        resp = client.post(
+            "/api/v1/execute",
+            json={
+                "action": "database_query",
+                "params": {"query": "SELECT 1"},
+                "agent_id": "unauthenticated-agent",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+    def test_execute_escape_hatch_requires_agent_id(self, monkeypatch):
+        monkeypatch.delenv("AGENT_OS_EXECUTION_TOKENS", raising=False)
+        monkeypatch.setenv("AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE", "true")
+
+        server = GovServer()
+        client = TestClient(server.app)
+        resp = client.post(
+            "/api/v1/execute",
+            json={
+                "action": "database_query",
+                "params": {"query": "SELECT 1"},
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "agent_id is required" in resp.json()["detail"]
+
     def test_execute_returns_503_when_auth_not_configured(self, client):
         resp = client.post(
             "/api/v1/execute",


### PR DESCRIPTION
## Description
Fixes a Python auth-bypass in `agent-os` where `POST /api/v1/execute` trusted caller-supplied `agent_id` before policy, audit, and rate-limit enforcement. The endpoint now fails closed by default, derives the effective agent identity from a bearer-authenticated `MCPSessionAuthenticator` session, rejects spoofed `agent_id` values, and supports static bootstrap server tokens for packaged deployments.

This PR is intentionally scoped to Python only.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [x] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
- Aligns with the same fail-closed, authenticated-identity approach already applied in the .NET MCP and Go HTTP middleware fixes in this repo.

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):
- GitHub Copilot for implementation assistance, with manual review of all logic and tests.

## Related Issues
- Security hardening for Python `agent-os` execute entry points to prevent caller-asserted identity spoofing before enforcement.

## Migration Notes
- `POST /api/v1/execute` now requires `Authorization: Bearer <token>` unless `AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE=true` is explicitly set for local-only unsafe development.
- `agent_id` in the execute payload is now optional; when present, it must match the identity bound to the bearer token.
- If execute auth is not configured, unauthenticated execute requests now return `503` instead of running under caller-asserted identity.
- `AGENT_OS_EXECUTION_TOKENS="agent-id=token"` can be used to bootstrap static process-lifetime execute tokens for packaged server deployments.

## Validation
- `python -m ruff check src\agent_os\server\app.py src\agent_os\server\models.py src\agent_os\mcp_session_auth.py tests\test_server.py tests\test_mcp_session_auth.py`
- `python -m pytest tests\test_server.py tests\test_mcp_session_auth.py`

Result: `46 passed, 2 warnings` (pre-existing Pydantic deprecation warnings)