### PR TITLE
docs: make documentation site discoverable from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,17 @@
 
 # Agent Governance Toolkit
 
+<p align="center">
+  <strong>
+    📖 <a href="https://microsoft.github.io/agent-governance-toolkit">Documentation Site</a> ·
+    🚀 <a href="#get-started-in-90-seconds">Quick Start</a> ·
+    📦 <a href="https://pypi.org/project/agent-governance-toolkit/">PyPI</a> ·
+    📝 <a href="CHANGELOG.md">Changelog</a>
+  </strong>
+</p>
+
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-microsoft.github.io%2Fagent--governance--toolkit-blue?logo=github)](https://microsoft.github.io/agent-governance-toolkit)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/agent-governance-toolkit)](https://pypi.org/project/agent-governance-toolkit/)
 [![OWASP Agentic Top 10](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10_Covered-blue)](docs/OWASP-COMPLIANCE.md)


### PR DESCRIPTION
Adds the GitHub Pages documentation site link prominently to the top of the README:

- **Centered nav bar** with docs site, quick start, PyPI, and changelog links (first thing visitors see after the banner)
- **Docs badge** (shields.io) in the badge row linking to https://microsoft.github.io/agent-governance-toolkit

Before: the docs site was not linked anywhere in the README. Visitors had to know the URL or find it in the repo settings.

After: the docs site is the first link in a centered bold nav bar, plus a blue badge in the badge row.