### PR TITLE
fix(ci): resolve pre-existing test failures blocking auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,10 @@ jobs:
       - name: Install local sibling dependencies
         run: |
           # agent-os depends on agent_primitives (local, not on PyPI at >=3.x)
+          # and agentmesh (test_cmd_sign.py imports agentmesh.marketplace)
           if [ "${{ matrix.package }}" = "agent-os" ]; then
             pip install --no-cache-dir -e agent-governance-python/agent-primitives
+            pip install --no-cache-dir -e agent-governance-python/agent-mesh
           fi
       - name: Install ${{ matrix.package }}
         working-directory: agent-governance-python/${{ matrix.package }}

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -71,6 +71,8 @@ dev = [
     "websockets>=12.0,<17.0",
     "fastapi>=0.115.0,<1.0",
     "httpx>=0.27.0,<1.0",
+    "opentelemetry-api>=1.20.0,<2.0",
+    "opentelemetry-sdk>=1.20.0,<2.0",
 ]
 redis = [
     "redis>=4.0,<8.0",

--- a/agent-governance-python/agent-mesh/src/agentmesh/marketplace/_marketplace_impl.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/marketplace/_marketplace_impl.py
@@ -255,8 +255,13 @@ class PluginInstaller:
         _seen: Optional[set[str]] = None,
     ) -> Path:
         manifest = self._registry.get_plugin(name, version)
-        # Signature verification — only when keys are configured and signature exists
-        if verify and self._trusted_keys and manifest.signature:
+        # Signature verification — fail closed (reject unsigned plugins)
+        if verify:
+            if not manifest.signature:
+                raise MarketplaceError(
+                    f"Plugin {name}@{manifest.version} has no signature; "
+                    "install with verify=False to bypass (not recommended)"
+                )
             if manifest.author not in self._trusted_keys:
                 raise MarketplaceError(
                     f"Plugin {name}@{manifest.version} signed by untrusted "

--- a/agent-governance-python/agent-mesh/tests/snapshots/handshake_challenge.json
+++ b/agent-governance-python/agent-mesh/tests/snapshots/handshake_challenge.json
@@ -1,6 +1,7 @@
 {
   "challenge_id": "challenge_67a8568ec049dab7",
   "nonce": "b174f3f32f39ec2565170cc8c3a0c838d0fa5c172954b9641d6b2680d7f83a3a",
+  "freshness_nonce": null,
   "timestamp": "2026-02-18T22:50:53.614420",
   "expires_in_seconds": 30
 }

--- a/agent-governance-python/agent-mesh/tests/snapshots/handshake_response.json
+++ b/agent-governance-python/agent-mesh/tests/snapshots/handshake_response.json
@@ -9,6 +9,7 @@
   "trust_score": 750,
   "signature": "tzEb+xuSKLiu7hDodWChvlBMV8wr3sZ/dqJM3TWgXVEVDUptPpKl23hs6GHHof7ZmLxLuvXnABXzRVZK8DvzDw==",
   "public_key": "OiBcwuYOePUqv6r/mwIef/mmgwSzlUitAVSUkxenHV0=",
+  "freshness_nonce": null,
   "user_context": null,
   "timestamp": "2026-02-18T22:50:53.621780"
 }

--- a/agent-governance-typescript/package-lock.json
+++ b/agent-governance-typescript/package-lock.json
@@ -4370,7 +4370,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-docs/releases/-/node-releases-2.0.38.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"


### PR DESCRIPTION
## Summary

Fixes 5 pre-existing CI failures that block auto-merge on all PRs.

### Changes

1. **Security fix: marketplace PluginInstaller fails closed** (`_marketplace_impl.py`)
   - Fallback `PluginInstaller` was permissive: skipped signature checks when `trusted_keys` was empty
   - Now rejects unsigned plugins with `MarketplaceError` (matches `installer.py` behavior)
   - Fixes `test_unsigned_plugin_accepted_when_no_trusted_keys`

2. **Protocol snapshot update** - Added `freshness_nonce` field to handshake challenge/response snapshots
   - Fixes `test_handshake_challenge` and `test_handshake_response`

3. **OTel dev dependency** - Added `opentelemetry-api` and `opentelemetry-sdk` to agent-mesh `[dev]` extras
   - Fixes `test_enable_sets_initialized`, `test_double_enable_is_noop`, `test_span_with_otel`

4. **CI: agent-os pre-install agent-mesh** - `test_cmd_sign.py` imports from `agentmesh.marketplace`
   - Same pattern as agent-primitives fix from PR #1513

5. **TypeScript lockfile fix** - Corrupted npm registry URL (`node-docs/releases` instead of `node-releases`)

### Test plan
All 6 previously-failing agent-mesh tests + agent-os test collection should now pass.