### PR TITLE
fix(ci): update ESRP pipeline Python package paths

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -70,21 +70,21 @@ parameters:
     displayName: 'Python packages to publish'
     default:
       - name: agent-os
-        path: agent-os
+        path: agent-governance-python/agent-os
       - name: agent-mesh
-        path: agent-mesh
+        path: agent-governance-python/agent-mesh
       - name: agent-hypervisor
-        path: agent-hypervisor
+        path: agent-governance-python/agent-hypervisor
       - name: agent-sre
-        path: agent-sre
+        path: agent-governance-python/agent-sre
       - name: agent-compliance
-        path: agent-compliance
+        path: agent-governance-python/agent-compliance
       - name: agent-runtime
-        path: agent-runtime
+        path: agent-governance-python/agent-runtime
       - name: agent-lightning
-        path: agent-lightning
+        path: agent-governance-python/agent-lightning
       - name: agent-marketplace
-        path: agent-marketplace
+        path: agent-governance-python/agent-marketplace
 
   - name: npmPackages
     type: object
@@ -524,13 +524,13 @@ stages:
 
           - script: |
               mkdir -p $(Pipeline.Workspace)/rust-packages
-              for CRATE in agent-governance agent-governance-mcp; do
+              for CRATE in agentmesh agentmesh-mcp; do
                 echo "=== Packaging $CRATE ==="
                 cargo package -p $CRATE --allow-dirty
               done
               echo "=== Packaged crates ==="
               ls -la target/package/*.crate
-              cp target/package/*.crate $(Pipeline.Workspace)/rust-./
+              cp target/package/*.crate $(Pipeline.Workspace)/rust-packages/
             workingDirectory: 'agent-governance-rust'
             displayName: 'Package all crates'
 
@@ -547,7 +547,7 @@ stages:
     condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'rust'), eq('${{ parameters.target }}', 'all')))
     jobs:
       - job: PublishCrates
-        displayName: 'ESRP Publish agent-governance + agent-governance-mcp to crates.io'
+        displayName: 'ESRP Publish agentmesh + agentmesh-mcp to crates.io'
         steps:
           - task: DownloadPipelineArtifact@2
             inputs:


### PR DESCRIPTION
## Summary

Fixes all 8 Python PyPI build jobs failing in the ESRP publish pipeline with
`Not found workingDirectory`.

After the repo reorganization (PR #1471), Python packages moved from root-level
paths (e.g., `agent-os`) to `agent-governance-python/agent-os`, but the ESRP
pipeline was not updated.

### Changes

Updates `pypiPackages` default paths in `esrp-publish.yml`:
- `agent-os` -> `agent-governance-python/agent-os`
- `agent-mesh` -> `agent-governance-python/agent-mesh`
- `agent-hypervisor` -> `agent-governance-python/agent-hypervisor`
- `agent-sre` -> `agent-governance-python/agent-sre`
- `agent-compliance` -> `agent-governance-python/agent-compliance`
- `agent-runtime` -> `agent-governance-python/agent-runtime`
- `agent-lightning` -> `agent-governance-python/agent-lightning`
- `agent-marketplace` -> `agent-governance-python/agent-marketplace`

npm package paths were already correct (they referenced `agent-governance-python/` subdirs).
The TypeScript lockfile corruption (`node-docs/releases` URL) was fixed in PR #1531.