### PR TITLE
feat: add SKILL-011 scan rule to detect unsafe netloc parsing

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/security_skills.py
+++ b/agent-governance-python/agent-os/src/agent_os/security_skills.py
@@ -409,6 +409,58 @@ def check_error_info_leak(source: str, path: str = "") -> list[SecurityFinding]:
 
 
 # ---------------------------------------------------------------------------
+# SKILL-011: Unsafe URL netloc parsing (SSRF bypass via userinfo)
+# ---------------------------------------------------------------------------
+
+_UNSAFE_NETLOC = re.compile(
+    r"""
+    \.netloc                          # accessing parsed.netloc
+    (?:(?!\.\bhostname\b).)*?         # not immediately followed by .hostname
+    \.split\s*\(\s*['\"]:['\"]        # then .split(":")
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+_SAFE_HOSTNAME = re.compile(
+    r"\.hostname\b",
+)
+
+
+def check_unsafe_netloc_parsing(source: str, path: str = "") -> list[SecurityFinding]:
+    """Detect manual netloc parsing that ignores userinfo (SSRF bypass).
+
+    Parsing ``parsed.netloc.split(':')`` to extract the host misses
+    RFC 3986 userinfo (``user:pass@host``), allowing URLs like
+    ``http://allowed.com:80@127.0.0.1`` to bypass domain checks.
+    """
+    if not _UNSAFE_NETLOC.search(source):
+        return []
+    # If the file also uses .hostname, it may be safe (but still suspicious)
+    if _SAFE_HOSTNAME.search(source):
+        return []
+    line = _find_line(source, _UNSAFE_NETLOC)
+    return [SecurityFinding(
+        rule_id="SKILL-011",
+        title="Unsafe URL netloc parsing (SSRF bypass via userinfo)",
+        severity=Severity.CRITICAL,
+        description=(
+            "URL domain is extracted by splitting netloc on ':' to remove the "
+            "port. This ignores RFC 3986 userinfo (user:pass@host), allowing "
+            "an attacker to bypass blocklists/allowlists with a URL like "
+            "http://allowed.com:80@127.0.0.1. Use parsed.hostname instead, "
+            "and reject URLs containing '@' in the netloc."
+        ),
+        file_path=path,
+        line_number=line,
+        suggestion=(
+            "Replace netloc.split(':')[0] with parsed.hostname. "
+            "Also reject URLs where '@' appears in parsed.netloc."
+        ),
+        owasp_risks=("AT02", "AT07"),
+    )]
+
+
+# ---------------------------------------------------------------------------
 # Aggregate scanner
 # ---------------------------------------------------------------------------
 
@@ -423,6 +475,7 @@ ALL_CHECKS: list[Callable[[str, str], list[SecurityFinding]]] = [
     check_hardcoded_secrets,
     check_trust_without_crypto,
     check_error_info_leak,
+    check_unsafe_netloc_parsing,
 ]
 
 

--- a/agent-governance-python/agent-os/tests/test_security_skills.py
+++ b/agent-governance-python/agent-os/tests/test_security_skills.py
@@ -18,6 +18,7 @@ from agent_os.security_skills import (
     check_stub_security,
     check_trust_without_crypto,
     check_unbounded_collections,
+    check_unsafe_netloc_parsing,
     check_unsafe_pickle,
     format_findings,
     scan_source,
@@ -339,6 +340,53 @@ class TestErrorInfoLeak:
                 return {"error": type(e).__name__}
         """)
         findings = check_error_info_leak(src)
+        assert len(findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# SKILL-011: Unsafe URL netloc parsing (SSRF bypass via userinfo)
+# ---------------------------------------------------------------------------
+
+class TestUnsafeNetlocParsing:
+    def test_detects_netloc_split_colon(self):
+        src = textwrap.dedent("""\
+            from urllib.parse import urlparse
+            parsed = urlparse(url)
+            domain = parsed.netloc.lower()
+            if ":" in domain:
+                domain = domain.split(":")[0]
+        """)
+        findings = check_unsafe_netloc_parsing(src)
+        assert len(findings) == 1
+        assert findings[0].rule_id == "SKILL-011"
+        assert findings[0].severity == Severity.CRITICAL
+
+    def test_safe_hostname_usage(self):
+        src = textwrap.dedent("""\
+            from urllib.parse import urlparse
+            parsed = urlparse(url)
+            domain = parsed.hostname
+        """)
+        findings = check_unsafe_netloc_parsing(src)
+        assert len(findings) == 0
+
+    def test_no_netloc_at_all(self):
+        src = textwrap.dedent("""\
+            import requests
+            response = requests.get("https://example.com")
+        """)
+        findings = check_unsafe_netloc_parsing(src)
+        assert len(findings) == 0
+
+    def test_netloc_without_split(self):
+        src = textwrap.dedent("""\
+            from urllib.parse import urlparse
+            parsed = urlparse(url)
+            netloc = parsed.netloc
+            if "@" in netloc:
+                raise ValueError("no userinfo")
+        """)
+        findings = check_unsafe_netloc_parsing(src)
         assert len(findings) == 0
 
 


### PR DESCRIPTION
## Summary

Adds a new security scan rule (SKILL-011) to AGT's security_skills scanner that detects unsafe URL netloc parsing patterns that enable SSRF bypass.

### What It Detects

Code that extracts the domain from `parsed.netloc` via `.split(':')` instead of using `parsed.hostname`. This pattern ignores RFC 3986 userinfo (`user:pass@host`) and allows SSRF bypass via URLs like `http://allowed.com:80@127.0.0.1`.

### Severity

CRITICAL: this pattern directly enables SSRF attacks that bypass all domain validation.

### CI Integration

The rule is added to `ALL_CHECKS` so it runs automatically on every PR through the existing security-scan workflow.

### Tests

4 new tests:
- Detects the vulnerable `netloc.split(':')` pattern
- Passes safe code using `parsed.hostname`
- No false positives on code without netloc usage
- No false positives on netloc usage without split