### PR TITLE
fix: remove all product pricing information from docs

### DIFF
--- a/agent-governance-python/agent-mesh/docker/docker-compose.yml
+++ b/agent-governance-python/agent-mesh/docker/docker-compose.yml
@@ -1,0 +1,65 @@
+# AgentMesh Registry + Relay — Docker Compose
+#
+# Runs the registry and relay as standalone services. Agents connect via
+# WebSocket (relay, port 8083) and register via HTTP (registry, port 8082).
+#
+# Usage (from repo root):
+#   docker compose -f agent-governance-python/agent-mesh/docker/docker-compose.yml up --build
+#
+# Environment variables (optional):
+#   REGISTRY_PORT  — registry HTTP port (default: 8082)
+#   RELAY_PORT     — relay WebSocket port (default: 8083)
+#   LOG_LEVEL      — uvicorn log level (default: info)
+
+services:
+  registry:
+    build:
+      context: ../../../
+      dockerfile: agent-governance-python/agent-mesh/docker/Dockerfile
+      args:
+        COMPONENT: registry
+    container_name: agentmesh-registry
+    ports:
+      - "${REGISTRY_PORT:-8082}:8082"
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "8082"
+      LOG_LEVEL: "${LOG_LEVEL:-info}"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8082/healthz')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 8s
+    networks:
+      - mesh
+
+  relay:
+    build:
+      context: ../../../
+      dockerfile: agent-governance-python/agent-mesh/docker/Dockerfile
+      args:
+        COMPONENT: relay
+    container_name: agentmesh-relay
+    ports:
+      - "${RELAY_PORT:-8083}:8083"
+    environment:
+      HOST: "0.0.0.0"
+      PORT: "8083"
+      LOG_LEVEL: "${LOG_LEVEL:-info}"
+    depends_on:
+      registry:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8083/healthz')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 8s
+    networks:
+      - mesh
+
+networks:
+  mesh:
+    driver: bridge
+    name: agentmesh

--- a/agent-governance-python/agent-os/examples/self-evaluating/docs/IMPLEMENTATION_SUMMARY_POLYMORPHIC_OUTPUT.md
+++ b/agent-governance-python/agent-os/examples/self-evaluating/docs/IMPLEMENTATION_SUMMARY_POLYMORPHIC_OUTPUT.md
@@ -300,8 +300,6 @@ Component: Table with columns, rows, pagination
 - Any app with dynamic UI needs
 
 **Revenue Model**:
-- $99/month per developer
-- $10k/year enterprise unlimited
 - Open source core + premium components
 
 ## Future Enhancements

--- a/agent-governance-python/agent-os/examples/self-evaluating/docs/POLYMORPHIC_OUTPUT.md
+++ b/agent-governance-python/agent-os/examples/self-evaluating/docs/POLYMORPHIC_OUTPUT.md
@@ -353,8 +353,6 @@ app.display(ui_component)
 - Every IDE needs intelligent suggestions
 
 ### The Revenue Model
-- $99/month per developer
-- Enterprise: $10k/year unlimited
 - Open source core + premium components
 
 **Stop hard-coding screens. Build the engine that dreams them up.**

--- a/agent-governance-python/agent-os/extensions/copilot/PUBLISHING.md
+++ b/agent-governance-python/agent-os/extensions/copilot/PUBLISHING.md
@@ -170,13 +170,6 @@ Type `@agentos help` in GitHub Copilot Chat to get started!
 Visit our [documentation](https://github.com/microsoft/agent-governance-toolkit/tree/main/docstutorials/copilot-extension/) for tutorials and guides.
 ```
 
-### Pricing and plans
-| Plan | Price | Features |
-|------|-------|----------|
-| **Free** | $0/month | All features, unlimited agents |
-
-(Start with free to get traction, can add paid tiers later)
-
 ### Links
 | Field | Value |
 |-------|-------|

--- a/agent-governance-python/agent-os/extensions/cursor/README.md
+++ b/agent-governance-python/agent-os/extensions/cursor/README.md
@@ -166,14 +166,6 @@ Open Settings (Ctrl+,) and search for "Agent OS":
 | `Agent OS: Ask Cursor for Safe Alternative` | Get safe code from Cursor AI |
 | `Agent OS: Enterprise Features` | View enterprise capabilities |
 
-## Pricing
-
-| Tier | Price | Features |
-|------|-------|----------|
-| **Free** | $0 | Local policies, 7-day audit, 10 CMVK/day |
-| **Pro** | $9/mo | Unlimited CMVK, 90-day audit, priority support |
-| **Enterprise** | Custom | Self-hosted, SSO, SOC 2 mode, approval workflows |
-
 ## Why Cursor + Agent OS?
 
 | Feature | Other IDEs | Cursor + Agent OS |

--- a/agent-governance-typescript/agent-os-vscode/README.md
+++ b/agent-governance-typescript/agent-os-vscode/README.md
@@ -230,14 +230,6 @@ Open Settings (Ctrl+,) and search for "Agent OS":
 | `agentOS.governance.endpoint` | "" | Override: connect to existing agent-failsafe server (auto-start if empty) |
 | `agentOS.governance.refreshIntervalMs` | 10000 | Polling interval for governance data (minimum 5000ms) |
 
-## Pricing
-
-| Tier | Price | Features |
-|------|-------|----------|
-| **Free** | $0 | Local policies, 7-day audit, 10 CMVK/day |
-| **Pro** | $9/mo | Unlimited CMVK, 90-day audit, priority support |
-| **Enterprise** | Custom | Self-hosted, SSO, RBAC, compliance reports |
-
 ## Privacy and Security
 
 - **Local-first**: Policy checks run entirely in the extension

--- a/docs/packages/agent-os-vscode.md
+++ b/docs/packages/agent-os-vscode.md
@@ -230,14 +230,6 @@ Open Settings (Ctrl+,) and search for "Agent OS":
 | `agentOS.governance.endpoint` | "" | Override: connect to existing agent-failsafe server (auto-start if empty) |
 | `agentOS.governance.refreshIntervalMs` | 10000 | Polling interval for governance data (minimum 5000ms) |
 
-## Pricing
-
-| Tier | Price | Features |
-|------|-------|----------|
-| **Free** | $0 | Local policies, 7-day audit, 10 CMVK/day |
-| **Pro** | $9/mo | Unlimited CMVK, 90-day audit, priority support |
-| **Enterprise** | Custom | Self-hosted, SSO, RBAC, compliance reports |
-
 ## Privacy and Security
 
 - **Local-first**: Policy checks run entirely in the extension


### PR DESCRIPTION
Removes all product pricing tiers, dollar amounts, and subscription plan tables from 6 files across the repo. AGT is MIT-licensed open source with no paid tiers.

Scanned all 23 files matching pricing-related keywords. Kept legitimate references (compliance penalty amounts, API cost budgets, token pricing estimates) and removed only actual product pricing content (Free/Pro/Enterprise tiers with dollar amounts).