### PR TITLE
fix: use Git Tree API and add rate limit handling in GitHub scanner

### DIFF
--- a/agent-governance-python/agent-discovery/src/agent_discovery/scanners/github.py
+++ b/agent-governance-python/agent-discovery/src/agent_discovery/scanners/github.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""GitHub scanner — find agent configurations in GitHub repositories.
+"""GitHub scanner -- find agent configurations in GitHub repositories.
 
 Scans repositories for files and patterns that indicate AI agent deployments:
 - Agent framework config files (agentmesh.yaml, crewai.yaml, etc.)
@@ -12,13 +12,17 @@ Requires: httpx (install with `pip install agent-discovery[github]`)
 
 Security:
 - Read-only GitHub API access (repo scope or public repos)
-- Respects rate limits
-- No repository content is stored — only metadata
+- Respects rate limits with automatic backoff
+- No repository content is stored -- only metadata
 """
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import logging
 import os
+import time
 from datetime import datetime, timezone
 from typing import Any
 
@@ -29,6 +33,8 @@ from ..models import (
     ScanResult,
 )
 from .base import BaseScanner, registry
+
+logger = logging.getLogger(__name__)
 
 # Files that strongly indicate an agent deployment
 AGENT_CONFIG_FILES = [
@@ -43,6 +49,13 @@ AGENT_CONFIG_FILES = [
     {"path": ".mcp/config.json", "type": "mcp-server", "confidence": 0.85},
     {"path": "claude_desktop_config.json", "type": "mcp-server", "confidence": 0.80},
 ]
+
+# Set of config file paths for fast lookup
+_CONFIG_PATHS = {c["path"] for c in AGENT_CONFIG_FILES}
+_CONFIG_BY_PATH = {c["path"]: c for c in AGENT_CONFIG_FILES}
+
+# Dependency files to check for agent framework imports
+_DEP_FILES = {"requirements.txt", "pyproject.toml", "package.json"}
 
 # Dependency patterns in requirements files
 AGENT_DEPENDENCIES = [
@@ -59,6 +72,11 @@ AGENT_DEPENDENCIES = [
     {"pattern": "mcp", "type": "mcp-server", "confidence": 0.60},
 ]
 
+# Rate limit safety margin: pause when remaining requests drop below this
+_RATE_LIMIT_FLOOR = 50
+_BACKOFF_BASE = 1.0
+_BACKOFF_MAX = 60.0
+
 
 def _get_httpx():  # type: ignore[no-untyped-def]
     """Lazy import httpx to keep it optional."""
@@ -73,12 +91,62 @@ def _get_httpx():  # type: ignore[no-untyped-def]
         )
 
 
+async def _rate_limit_wait(resp: Any) -> None:
+    """Sleep if the response indicates we are close to the rate limit."""
+    remaining = resp.headers.get("x-ratelimit-remaining")
+    reset = resp.headers.get("x-ratelimit-reset")
+    if remaining is not None and int(remaining) < _RATE_LIMIT_FLOOR and reset:
+        wait = max(0, int(reset) - int(time.time())) + 1
+        wait = min(wait, _BACKOFF_MAX)
+        logger.warning("GitHub API rate limit low (%s remaining), pausing %ds", remaining, wait)
+        await asyncio.sleep(wait)
+
+
+async def _request_with_backoff(client: Any, method: str, url: str, **kwargs: Any) -> Any:
+    """Make an HTTP request with exponential backoff on rate limit errors."""
+    delay = _BACKOFF_BASE
+    for attempt in range(4):
+        resp = getattr(client, method) if isinstance(method, str) else method
+        resp = await client.get(url, **kwargs) if method == "get" else await client.get(url, **kwargs)
+
+        if resp.status_code == 403 or resp.status_code == 429:
+            retry_after = resp.headers.get("retry-after")
+            reset = resp.headers.get("x-ratelimit-reset")
+            if retry_after:
+                wait = int(retry_after)
+            elif reset:
+                wait = max(0, int(reset) - int(time.time())) + 1
+            else:
+                wait = delay
+
+            wait = min(wait, _BACKOFF_MAX)
+            if attempt < 3:
+                logger.warning(
+                    "Rate limited (HTTP %d) on %s, retrying in %ds (attempt %d/4)",
+                    resp.status_code, url, wait, attempt + 1,
+                )
+                await asyncio.sleep(wait)
+                delay = min(delay * 2, _BACKOFF_MAX)
+                continue
+            else:
+                logger.error("Rate limited on %s after 4 attempts, giving up", url)
+
+        await _rate_limit_wait(resp)
+        return resp
+
+    return resp  # type: ignore[possibly-undefined]
+
+
 @registry.register
 class GitHubScanner(BaseScanner):
     """Scan GitHub repositories for AI agent configurations.
 
     Searches for agent framework config files, MCP server setups,
     and agent-related dependencies across specified repos or orgs.
+
+    Uses the Git Tree API to minimize API calls (1 call per repo
+    instead of 13+). Includes automatic rate limit detection and
+    exponential backoff.
     """
 
     @property
@@ -102,6 +170,12 @@ class GitHubScanner(BaseScanner):
         token = kwargs.get("token") or os.environ.get("GITHUB_TOKEN", "")
         repos: list[str] = kwargs.get("repos", [])
         org: str | None = kwargs.get("org")
+
+        if not token:
+            logger.warning(
+                "No GITHUB_TOKEN set. Unauthenticated requests are limited to "
+                "60/hour. Set GITHUB_TOKEN for 5,000/hour."
+            )
 
         headers = {"Accept": "application/vnd.github+json"}
         if token:
@@ -137,8 +211,10 @@ class GitHubScanner(BaseScanner):
         repos = []
         page = 1
         while True:
-            resp = await client.get(
-                f"/orgs/{org}/repos", params={"per_page": 100, "page": page, "type": "all"}
+            resp = await _request_with_backoff(
+                client, "get",
+                f"/orgs/{org}/repos",
+                params={"per_page": 100, "page": page, "type": "all"},
             )
             resp.raise_for_status()
             data = resp.json()
@@ -151,83 +227,102 @@ class GitHubScanner(BaseScanner):
         return repos
 
     async def _scan_repo(self, client: Any, repo: str) -> list[DiscoveredAgent]:
-        """Scan a single repository for agent indicators."""
+        """Scan a single repository for agent indicators.
+
+        Uses the Git Tree API to fetch the full file tree in a single
+        request, then checks locally for config files and fetches only
+        the dependency files that exist. This reduces API calls from
+        13+ per repo down to 1-4.
+        """
         agents: list[DiscoveredAgent] = []
 
-        # Check for known config files
+        # Fetch repo file tree in one call (recursive)
+        resp = await _request_with_backoff(
+            client, "get",
+            f"/repos/{repo}/git/trees/HEAD",
+            params={"recursive": "1"},
+        )
+
+        if resp.status_code != 200:
+            logger.debug("Could not fetch tree for %s (HTTP %d)", repo, resp.status_code)
+            return agents
+
+        tree = resp.json().get("tree", [])
+        tree_paths = {item["path"] for item in tree}
+
+        # Check for known config files using the tree (no extra API calls)
         for config in AGENT_CONFIG_FILES:
-            try:
-                resp = await client.get(f"/repos/{repo}/contents/{config['path']}")
-                if resp.status_code == 200:
-                    merge_keys = {"repo": repo, "config_path": config["path"]}
-                    fingerprint = DiscoveredAgent.compute_fingerprint(merge_keys)
+            if config["path"] in tree_paths:
+                merge_keys = {"repo": repo, "config_path": config["path"]}
+                fingerprint = DiscoveredAgent.compute_fingerprint(merge_keys)
 
-                    agent = DiscoveredAgent(
-                        fingerprint=fingerprint,
-                        name=f"{config['type']} agent in {repo}",
-                        agent_type=config["type"],
-                        description=f"Config file {config['path']} found in {repo}",
-                        merge_keys=merge_keys,
-                        tags={"repo": repo, "config_file": config["path"]},
+                agent = DiscoveredAgent(
+                    fingerprint=fingerprint,
+                    name=f"{config['type']} agent in {repo}",
+                    agent_type=config["type"],
+                    description=f"Config file {config['path']} found in {repo}",
+                    merge_keys=merge_keys,
+                    tags={"repo": repo, "config_file": config["path"]},
+                )
+                agent.add_evidence(
+                    Evidence(
+                        scanner=self.name,
+                        basis=DetectionBasis.GITHUB_REPO,
+                        source=f"https://github.com/{repo}/blob/HEAD/{config['path']}",
+                        detail=f"Agent config file {config['path']} exists",
+                        raw_data={"repo": repo, "path": config["path"]},
+                        confidence=config["confidence"],
                     )
-                    agent.add_evidence(
-                        Evidence(
-                            scanner=self.name,
-                            basis=DetectionBasis.GITHUB_REPO,
-                            source=f"https://github.com/{repo}/blob/main/{config['path']}",
-                            detail=f"Agent config file {config['path']} exists",
-                            raw_data={"repo": repo, "path": config["path"]},
-                            confidence=config["confidence"],
+                )
+                agents.append(agent)
+
+        # Only fetch dependency files that actually exist in the tree
+        for dep_file in _DEP_FILES:
+            if dep_file not in tree_paths:
+                continue
+            try:
+                resp = await _request_with_backoff(
+                    client, "get", f"/repos/{repo}/contents/{dep_file}"
+                )
+                if resp.status_code != 200:
+                    continue
+
+                content = base64.b64decode(resp.json().get("content", "")).decode(
+                    "utf-8", errors="replace"
+                )
+                for dep in AGENT_DEPENDENCIES:
+                    if dep["pattern"] in content.lower():
+                        merge_keys = {"repo": repo, "dep": dep["pattern"]}
+                        fingerprint = DiscoveredAgent.compute_fingerprint(merge_keys)
+
+                        if any(a.fingerprint == fingerprint for a in agents):
+                            continue
+
+                        agent = DiscoveredAgent(
+                            fingerprint=fingerprint,
+                            name=f"{dep['type']} dependency in {repo}",
+                            agent_type=dep["type"],
+                            description=(
+                                f"Dependency '{dep['pattern']}' found in {dep_file}"
+                            ),
+                            merge_keys=merge_keys,
+                            tags={"repo": repo, "dep_file": dep_file},
                         )
-                    )
-                    agents.append(agent)
-            except Exception:  # noqa: S110
-                pass  # file doesn't exist, skip
-
-        # Check requirements.txt / pyproject.toml for agent deps
-        for dep_file in ["requirements.txt", "pyproject.toml", "package.json"]:
-            try:
-                resp = await client.get(f"/repos/{repo}/contents/{dep_file}")
-                if resp.status_code == 200:
-                    import base64
-
-                    content = base64.b64decode(resp.json().get("content", "")).decode(
-                        "utf-8", errors="replace"
-                    )
-                    for dep in AGENT_DEPENDENCIES:
-                        if dep["pattern"] in content.lower():
-                            merge_keys = {"repo": repo, "dep": dep["pattern"]}
-                            fingerprint = DiscoveredAgent.compute_fingerprint(merge_keys)
-
-                            # Check if we already found this agent via config
-                            if any(a.fingerprint == fingerprint for a in agents):
-                                continue
-
-                            agent = DiscoveredAgent(
-                                fingerprint=fingerprint,
-                                name=f"{dep['type']} dependency in {repo}",
-                                agent_type=dep["type"],
-                                description=(
-                                    f"Dependency '{dep['pattern']}' found in {dep_file}"
-                                ),
-                                merge_keys=merge_keys,
-                                tags={"repo": repo, "dep_file": dep_file},
+                        agent.add_evidence(
+                            Evidence(
+                                scanner=self.name,
+                                basis=DetectionBasis.GITHUB_REPO,
+                                source=f"https://github.com/{repo}/blob/HEAD/{dep_file}",
+                                detail=f"Agent dependency '{dep['pattern']}' in {dep_file}",
+                                raw_data={
+                                    "repo": repo,
+                                    "dep_file": dep_file,
+                                    "dependency": dep["pattern"],
+                                },
+                                confidence=dep["confidence"],
                             )
-                            agent.add_evidence(
-                                Evidence(
-                                    scanner=self.name,
-                                    basis=DetectionBasis.GITHUB_REPO,
-                                    source=f"https://github.com/{repo}/blob/main/{dep_file}",
-                                    detail=f"Agent dependency '{dep['pattern']}' in {dep_file}",
-                                    raw_data={
-                                        "repo": repo,
-                                        "dep_file": dep_file,
-                                        "dependency": dep["pattern"],
-                                    },
-                                    confidence=dep["confidence"],
-                                )
-                            )
-                            agents.append(agent)
+                        )
+                        agents.append(agent)
             except Exception:  # noqa: S110
                 pass
 


### PR DESCRIPTION
## Summary

Fix GitHub API rate limit exhaustion in the agent-discovery GitHub scanner.

## Problem

The GitHubScanner was making **13+ API calls per repo** (10 config file checks + 3 dependency file fetches). Scanning an org with 50 repos = 650+ calls, which exhausts the unauthenticated rate limit (60/hr) in under a minute and even hits the authenticated limit (5,000/hr) for larger orgs.

## Fix

1. **Git Tree API**: Fetch the entire repo file tree in 1 call, then check config files locally (no extra API calls needed for config detection)
2. **Smart dep file fetching**: Only fetch dependency files that exist in the tree (skip 404s)
3. **Exponential backoff**: Retry on HTTP 403/429 with backoff derived from `retry-after` / `x-ratelimit-reset` headers
4. **Proactive rate detection**: Pause when `x-ratelimit-remaining` drops below 50
5. **Missing token warning**: Log a clear warning when `GITHUB_TOKEN` is not set

**API calls per repo: 13+ -> 1-4 (92% reduction)**

## Testing

- All existing scanner tests pass
- No new dependencies added (uses stdlib `asyncio`, `logging`, `time`, `base64`)
