### PR TITLE
fix(docker): correct package paths and enforce LF for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Default: let Git auto-detect text vs binary, normalize to LF in repo
+* text=auto eol=lf
+
+# Files that MUST always be LF, regardless of host OS,
+# because they are executed by Linux shells / containers
+*.sh         text eol=lf
+Dockerfile   text eol=lf
+*.dockerfile text eol=lf
+
+# Keep Windows-only files as CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Treat as binary (no line-ending conversion, no diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz  binary
+*.tar binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,14 @@ COPY . /workspace
 RUN python -m pip install --no-cache-dir \
         -e "agent-governance-python/agent-primitives[dev]" \
         -e "agent-governance-python/agent-mcp-governance[dev]" \
-        -e "agent-os[full,dev]" \
-        -e "agent-mesh[agent-os,dev,server]" \
-        -e "agent-hypervisor[api,dev,nexus]" \
-        -e "agent-runtime" \
-        -e "agent-sre[api,dev]" \
-        -e "agent-compliance" \
-        -e "agent-marketplace[cli,dev]" \
-        -e "agent-lightning[agent-os,dev]" \
+        -e "agent-governance-python/agent-os[full,dev]" \
+        -e "agent-governance-python/agent-mesh[agent-os,dev,server]" \
+        -e "agent-governance-python/agent-hypervisor[api,dev,nexus]" \
+        -e "agent-governance-python/agent-runtime" \
+        -e "agent-governance-python/agent-sre[api,dev]" \
+        -e "agent-governance-python/agent-compliance" \
+        -e "agent-governance-python/agent-marketplace[cli,dev]" \
+        -e "agent-governance-python/agent-lightning[agent-os,dev]" \
     && python -m pip install --no-cache-dir \
         -r agent-governance-python/agent-hypervisor/examples/dashboard/requirements.txt \
     && cd /workspace/agent-governance-typescript \

--- a/scripts/docker/run-tests.sh
+++ b/scripts/docker/run-tests.sh
@@ -4,11 +4,11 @@
 set -euo pipefail
 
 packages=(
-  "agent-os"
-  "agent-mesh"
-  "agent-hypervisor"
-  "agent-sre"
-  "agent-compliance"
+  "agent-governance-python/agent-os"
+  "agent-governance-python/agent-mesh"
+  "agent-governance-python/agent-hypervisor"
+  "agent-governance-python/agent-sre"
+  "agent-governance-python/agent-compliance"
 )
 
 for package_dir in "${packages[@]}"; do


### PR DESCRIPTION
Fixes the broken `docker compose run --rm test` flow documented in `CONTRIBUTING.md`. Today on `main` the dev image build fails with:

```
ERROR: agent-os[full,dev] is not a valid editable requirement.
```

Root cause: PR #1471 moved 10 Python packages from the repo root into `agent-governance-python/` and updated 160 files of path references, but in the `Dockerfile` only line 52 (the dashboard `requirements.txt` path) was rewritten. The eight `pip install -e` targets on lines 43–50 were left at bare names. PR #1502 later prefixed two of them (`agent-primitives`, `agent-mcp-governance`) but missed the rest.

This PR finishes the sweep and also pins `*.sh` / `Dockerfile` to LF so the Docker flow works on Windows checkouts.

### Changes
- **`Dockerfile`** — prefix the remaining eight `pip install -e` targets with `agent-governance-python/` (`agent-os`, `agent-mesh`, `agent-hypervisor`, `agent-runtime`, `agent-sre`, `agent-compliance`, `agent-marketplace`, `agent-lightning`).
- **`scripts/docker/run-tests.sh`** — update the `packages` array to use the new layout so the per-package `cd` + `pytest` loop finds the test directories.
- **`.gitattributes`** (new) — pin `*.sh` and `Dockerfile` to `eol=lf`. On Windows checkouts with the default `core.autocrlf=true`, shell scripts arrive on disk with CRLF endings; `COPY . /workspace` carries them into the image, and bash inside the Linux container then fails with `set: pipefail: invalid option name`. Pinning these file types to LF makes the Docker flow reproducible regardless of host OS.

### Verification
With this change applied locally on Windows, `docker compose run --rm test` builds the dev image successfully and runs the per-package pytest suite end to end (2472 passed, 38 skipped). The two pre-existing `TestTrustedKeysImmutability` failures in `agent-mesh/tests/test_marketplace.py` are unrelated to this change and reproduce on `main` once the Docker build is fixed.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root  *(`Dockerfile`, `scripts/docker/run-tests.sh`, `.gitattributes`)*

## Checklist
- [x] My code follows the project style guidelines (ruff check) — N/A, no Python changed
- [ ] I have added tests that prove my fix/feature works — manual verification only; no test harness exists for the Docker flow itself
- [x] All new and existing tests pass (pytest) — verified via `docker compose run --rm test`; 2 pre-existing `TestTrustedKeysImmutability` failures noted above are unrelated
- [x] I have updated documentation as needed — `CONTRIBUTING.md`'s documented flow now actually works; no doc edits required
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
None. The `.gitattributes` pattern (`*.sh text eol=lf`) is the standard Git-recommended approach for cross-platform repos and is not derived from any specific project.

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):
GitHub Copilot CLI was used to investigate the broken Docker build, identify the root cause via `git blame` / `git log`, propose the fix, and draft this PR description. All changes were reviewed before commit.

## Related Issues
Follow-up to #1471 and #1502 (each completed only part of the path migration in the `Dockerfile`).
