### PR TITLE
fix(ci): shorten AI bot PR comments for actionability

### DIFF
--- a/.github/workflows/ai-breaking-change-detector.yml
+++ b/.github/workflows/ai-breaking-change-detector.yml
@@ -47,39 +47,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           model: gpt-4o
           fallback-model: gpt-4o-mini
-          max-tokens: "4000"
+          max-tokens: "1000"
           context-mode: pr-diff
           output-mode: pr-comment
           custom-instructions: |
             You are an API compatibility analyzer for microsoft/agent-governance-toolkit.
-            These packages are published to PyPI — breaking changes affect downstream users.
+            These packages are published to PyPI/NuGet/crates.io.
 
-            Analyze the diff for:
-            1. **🔴 Removed/renamed** public functions, classes, or methods
-            2. **🔴 Changed function signatures** — removed params, changed types, new required params
-            3. **🔴 Removed/changed exports** in `__init__.py` files
-            4. **🔴 Changed exception types** — different exceptions raised
-            5. **🟡 Changed default values** — may alter existing behavior
-            6. **🟡 Changed return types** — may break callers
-            7. **🔵 New public API** — not breaking, but should be documented
-
-            Classification:
-            - 🔴 **BREAKING** — will break existing code
-            - 🟡 **POTENTIALLY BREAKING** — may break depending on usage
-            - 🔵 **ADDITIVE** — new API, not breaking
-
-            If NO breaking changes found, say so clearly with ✅.
+            BE CONCISE. Only list actual breaking or potentially breaking changes.
+            Do NOT list additive (non-breaking) changes.
 
             Format:
-            ## 🔍 API Compatibility Report
+            ### API Compatibility
+            | Severity | Change | Impact |
+            |----------|--------|--------|
+            | 🔴 BREAKING | `func()` removed param `x` | Callers using `x` will fail |
 
-            ### Summary
-            (brief overall assessment)
-
-            ### Findings
-            | Severity | Package | Change | Impact |
-            |----------|---------|--------|--------|
-            | 🔴 | agent-os | `PolicyEngine.evaluate()` removed `strict` param | Callers using `strict=True` will fail |
-
-            ### Migration Guide
-            (if breaking changes found, suggest migration steps)
+            If NO breaking changes: ✅ No breaking changes detected.

--- a/.github/workflows/ai-contributor-guide.yml
+++ b/.github/workflows/ai-contributor-guide.yml
@@ -48,32 +48,19 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           model: gpt-4o
           fallback-model: gpt-4o-mini
-          max-tokens: "4000"
+          max-tokens: "800"
           context-mode: issue
           output-mode: issue-comment
           custom-instructions: |
             You are a friendly OSS community helper for microsoft/agent-governance-toolkit.
-            A first-time contributor has opened an issue. Welcome them warmly!
+            A first-time contributor has opened an issue.
 
-            Your response should:
-            1. **Welcome** them to the project
-            2. **Analyze** their issue and suggest which package(s) might be relevant:
-               - agent-os: Core policy engine, agent lifecycle
-               - agent-mesh: Agent discovery, routing, trust mesh
-               - agent-hypervisor: Execution sandboxing, resource isolation
-               - agent-sre: Reliability, chaos testing, SLOs
-               - agent-compliance: Compliance frameworks, audit logging
-               - agentmesh-marketplace: Agent registry
-               - agentmesh-lightning: High-performance inference
-               - agentmesh-runtime: Runtime execution environment
-            3. **Point to relevant code** — suggest specific directories to look at
-            4. **Link to resources**:
-               - [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
-               - [docs/QUICKSTART.md](../blob/main/docs/QUICKSTART.md)
-               - [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
-            5. **Offer next steps** — what they can do to help resolve this
+            Keep it SHORT (5-8 lines max). Include:
+            1. A warm one-line welcome
+            2. Which package(s) are relevant to their issue
+            3. One link: [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
 
-            Be encouraging and specific. Avoid generic boilerplate.
+            Do NOT list all packages, conventions, or boilerplate. Be specific to their issue.
 
   guide-pr:
     name: Guide First-Time PR Author
@@ -106,26 +93,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           model: gpt-4o
           fallback-model: gpt-4o-mini
-          max-tokens: "4000"
+          max-tokens: "800"
           context-mode: pr-diff
           output-mode: pr-comment
           custom-instructions: |
             You are a friendly OSS community helper for microsoft/agent-governance-toolkit.
-            A first-time contributor has opened a pull request. Welcome them!
+            A first-time contributor has opened a pull request.
 
-            Your response should:
-            1. **Welcome** them and thank them for contributing
-            2. **Review their PR** with extra kindness — explain WHY things should be
-               different, not just what to change
-            3. **Highlight what they did well** before suggesting improvements
-            4. **Explain project conventions**:
-               - We use ruff for linting (select E,F,W)
-               - Tests go in {name}/tests/
-               - We follow conventional commits (feat:, fix:, docs:, etc.)
-               - Security-sensitive code gets extra scrutiny
-            5. **Link to resources**:
-               - [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
-               - [docs/QUICKSTART.md](../blob/main/docs/QUICKSTART.md)
-            6. **Explain next steps** — what happens in the review process
+            Keep it SHORT (8-10 lines max). Include:
+            1. A warm one-line welcome and thanks
+            2. One thing they did well
+            3. Actionable items only (if any): what specifically to fix before merge
+            4. Link: [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)
 
-            Be warm, specific, and constructive. First impressions matter for OSS!
+            Do NOT explain project conventions, review process, or general advice.
+            Only mention issues that would block merge.

--- a/.github/workflows/ai-docs-sync.yml
+++ b/.github/workflows/ai-docs-sync.yml
@@ -47,39 +47,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           model: gpt-4o
           fallback-model: gpt-4o-mini
-          max-tokens: "4000"
+          max-tokens: "1000"
           context-mode: pr-diff
           output-mode: pr-comment
           custom-instructions: |
             You are a documentation freshness checker for microsoft/agent-governance-toolkit.
 
-            Analyze the PR diff and check:
-            1. **New public APIs without docstrings** — all public functions, classes, and
-               methods should have docstrings explaining purpose, parameters, return values,
-               and exceptions
-            2. **README sections out of date** — if behavior changes, does the package README
-               reflect it?
-            3. **CHANGELOG missing entries** — behavioral changes should have a CHANGELOG.md entry
-            4. **Example code outdated** — if API signatures change, examples/ should be updated
-            5. **Type hints** — new public APIs should have complete type annotations
+            BE CONCISE. Only flag actual issues, no suggestions or nice-to-haves.
 
-            Monorepo structure:
-            - {name}/src/ — source code
-            - {name}/README.md — package documentation
-            - {name}/tests/ — test files
-            - docs/ — project-level documentation
-            - CHANGELOG.md — project changelog
+            Check for:
+            1. New public APIs without docstrings
+            2. README sections outdated by this change
+            3. CHANGELOG missing entry for behavioral changes
 
             Format:
-            ## 📝 Documentation Sync Report
+            ### Docs Sync
+            - ❌ `func()` in `module.py` -- missing docstring
+            - ⚠️ `README.md` -- section X needs update
+            - ⚠️ CHANGELOG.md -- no entry for this change
 
-            ### Issues Found
-            - ❌ `function_name()` in `package/module.py` — missing docstring
-            - ⚠️ `package/README.md` — section X may need update for new behavior
-            - ⚠️ CHANGELOG.md — no entry for this change
-
-            ### Suggestions
-            - 💡 Add docstring for `function_name(param1: str, param2: int) -> bool`
-            - 💡 Update README section "Configuration" to mention new option
-
-            If everything looks good, say ✅ Documentation is in sync.
+            If everything is in sync: ✅ Documentation is in sync.

--- a/.github/workflows/ai-security-scan.yml
+++ b/.github/workflows/ai-security-scan.yml
@@ -62,28 +62,32 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           model: gpt-4o
           fallback-model: gpt-4o-mini
-          max-tokens: "4000"
+          max-tokens: "1500"
           context-mode: pr-diff
           output-mode: pr-comment
           custom-instructions: |
-            You are a security analyst reviewing changes to microsoft/agent-governance-toolkit —
-            a security-focused AI agent governance library.
+            You are a security analyst reviewing changes to microsoft/agent-governance-toolkit.
 
-            This is CRITICAL: the toolkit itself IS the security layer. Bugs here mean
-            security bypasses for all downstream users.
+            BE CONCISE. Only report actual findings, not a methodology walkthrough.
+            Skip categories with no issues. No boilerplate, no "no changes needed" rows.
 
             Scan for:
-            1. **Prompt injection defense bypass** — can crafted input circumvent policy guards?
-            2. **Policy engine circumvention** — can policies be skipped or weakened?
-            3. **Trust chain weaknesses** — SPIFFE/SVID validation gaps, cert pinning issues
-            4. **Credential exposure** — secrets in logs, error messages, or debug output
-            5. **Sandbox escape** — container/process isolation breakouts
-            6. **Deserialization attacks** — unsafe pickle/yaml/json loading
-            7. **Race conditions** — TOCTOU in policy checks, concurrent trust evaluation
-            8. **Supply chain** — dependency confusion, typosquatting in imports
+            1. Prompt injection defense bypass
+            2. Policy engine circumvention
+            3. Trust chain weaknesses
+            4. Credential exposure
+            5. Sandbox escape
+            6. Deserialization attacks
+            7. Race conditions
+            8. Supply chain risks
 
-            Rate each finding: 🔴 CRITICAL / 🟠 HIGH / 🟡 MEDIUM / 🔵 LOW
-            For each finding, explain the attack vector and suggest a fix.
+            Format (compact):
+            ### Security Review
+            | Severity | Finding | Fix |
+            |----------|---------|-----|
+            | 🔴 CRITICAL | [one-line description] | [one-line fix] |
+
+            If NO security issues found, reply only: ✅ No security issues found.
 
   weekly-full-scan:
     name: Weekly Full Security Audit
@@ -105,26 +109,19 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           model: gpt-4o
           fallback-model: gpt-4o-mini
-          max-tokens: "4000"
+          max-tokens: "1500"
           context-mode: repo-scan
           output-mode: none
           custom-instructions: |
-            You are performing a weekly security audit of microsoft/agent-governance-toolkit.
+            Perform a weekly security audit of microsoft/agent-governance-toolkit.
+            Be concise. Findings table only, no methodology.
 
-            Review the repository structure and recent changes for:
-            1. Prompt injection defense bypass vectors
-            2. Policy engine circumvention paths
-            3. Trust chain weaknesses (SPIFFE/SVID)
-            4. Credential exposure risks
-            5. Sandbox escape vectors
-            6. Deserialization attack surfaces
-            7. Race conditions in security-critical paths
-            8. Supply chain vulnerabilities
+            Format:
+            ### Weekly Security Audit
+            | Severity | Category | Finding | Location |
+            |----------|----------|---------|----------|
 
-            Format as a security report with:
-            - Executive summary
-            - Findings table (Severity | Category | Description | Location)
-            - Recommendations
+            If clean, say: ✅ No issues found this week.
 
       - name: Create security audit issue
         env:


### PR DESCRIPTION
## Problem
AI bot comments on PRs were extremely verbose (4000 max tokens, no brevity constraints), creating walls of text that obscured actionable findings.

## Changes
- **max-tokens**: Reduced from 4000 to 800-1500 depending on agent role
- **Security scanner** (1500 tokens): Table-only findings, single line if clean
- **Breaking change detector** (1000 tokens): Only actual breaking changes, skip additive
- **Docs sync checker** (1000 tokens): Only flag issues, no suggestions
- **Contributor guide** (800 tokens): 5-10 lines max, specific to the issue/PR
- **All agents**: Single-line all-clear when no issues found

## Impact
- ~60 fewer lines of prompt across 4 workflows
- Expected 60-75% shorter bot comments
- upsertComment already handles replacing old comments (no change needed there)