### PR TITLE
fix(pipeline): use separate certs for ESRP auth and signing

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -109,8 +109,12 @@ parameters:
 # ESRP Configuration
 # Service connection name is hardcoded (required at compile time by ADO).
 # All other values sourced from ADO pipeline variables (mark as secret):
-#   ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER,
+#   ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER, ESRP_SIGN_CERT_IDENTIFIER,
 #   ESRP_CLIENT_ID, ESRP_OWNERS, ESRP_APPROVERS
+#
+# ESRP_CERT_IDENTIFIER = authentication certificate (issued by Public CA)
+# ESRP_SIGN_CERT_IDENTIFIER = signing certificate (issued by Private CA)
+# These MUST be two different certificates from different CAs.
 #
 # Note: ESRP_DOMAIN_TENANT_ID was removed from pipeline variables due to
 # cyclical reference. The ESRP cert lives in the PME (Partner Managed
@@ -392,7 +396,7 @@ stages:
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
               AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
-              AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
+              AuthSignCertName: '$(ESRP_SIGN_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.dll'
               signConfigType: 'inlineSignParams'
@@ -444,7 +448,7 @@ stages:
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
               AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
-              AuthSignCertName: '$(ESRP_CERT_IDENTIFIER)'
+              AuthSignCertName: '$(ESRP_SIGN_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.nupkg'
               signConfigType: 'inlineSignParams'


### PR DESCRIPTION
## Problem

Both EsrpCodeSigning@5 tasks in the ESRP publish pipeline use the same certificate (ESRP_CERT_IDENTIFIER) for both AuthCertName and AuthSignCertName. Per ESRP requirements, these must be two different certificates:

- **AuthCertName**: Authentication certificate (issued by Public CA)
- **AuthSignCertName**: Signing certificate (issued by Private CA)

## Fix

- Changed AuthSignCertName from ESRP_CERT_IDENTIFIER to ESRP_SIGN_CERT_IDENTIFIER on both code signing tasks (DLL Authenticode signing and NuGet package signing)
- Updated pipeline config comments to document both variables and their CA requirements

## Action Required

Nandhagopal needs to add ESRP_SIGN_CERT_IDENTIFIER as a new ADO pipeline variable with the Private CA signing certificate identifier, then retest the pipeline.