### PR TITLE
fix(marketplace): freeze trusted_keys in canonical PluginInstaller

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/installer.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/installer.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import logging
 import shutil
 from pathlib import Path
-from typing import Optional
+from types import MappingProxyType
+from typing import Any, Mapping, Optional
 
 from agent_marketplace.manifest import (
     MANIFEST_FILENAME,
@@ -55,11 +56,14 @@ class PluginInstaller:
         self,
         plugins_dir: Path,
         registry: PluginRegistry,
-        trusted_keys: Optional[dict] = None,  # type: ignore[type-arg]
+        trusted_keys: Optional[Mapping[str, Any]] = None,
     ) -> None:
         self._plugins_dir = plugins_dir
         self._registry = registry
-        self._trusted_keys = trusted_keys or {}
+        # Freeze trusted keys at construction time to prevent runtime mutation.
+        self._trusted_keys: MappingProxyType[str, Any] = MappingProxyType(
+            dict(trusted_keys) if trusted_keys else {}
+        )
         self._plugins_dir.mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------

--- a/agent-governance-python/agent-marketplace/tests/test_marketplace.py
+++ b/agent-governance-python/agent-marketplace/tests/test_marketplace.py
@@ -51,3 +51,38 @@ def test_plugin_type_enum():
     assert hasattr(PluginType, "INTEGRATION")
     assert hasattr(PluginType, "AGENT")
     assert hasattr(PluginType, "VALIDATOR")
+
+
+class TestTrustedKeysImmutability:
+    """Verify that PluginInstaller.trusted_keys is frozen at construction."""
+
+    def test_trusted_keys_cannot_be_mutated(self, tmp_path):
+        """Attempting to add a key after construction must raise TypeError."""
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        from agent_marketplace import PluginInstaller, PluginRegistry
+
+        registry = PluginRegistry()
+        installer = PluginInstaller(
+            plugins_dir=tmp_path / "plugins",
+            registry=registry,
+            trusted_keys={"author": ed25519.Ed25519PrivateKey.generate().public_key()},
+        )
+        with pytest.raises(TypeError):
+            installer._trusted_keys["evil"] = "injected"  # type: ignore[index]
+
+    def test_original_dict_mutation_does_not_affect_installer(self, tmp_path):
+        """Mutating the original dict after construction must not change installer state."""
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        from agent_marketplace import PluginInstaller, PluginRegistry
+
+        registry = PluginRegistry()
+        original = {"author": ed25519.Ed25519PrivateKey.generate().public_key()}
+        installer = PluginInstaller(
+            plugins_dir=tmp_path / "plugins",
+            registry=registry,
+            trusted_keys=original,
+        )
+        original["evil"] = "injected"
+        assert "evil" not in installer._trusted_keys


### PR DESCRIPTION
## Description

Completes the `trusted_keys` immutability hardening started in #1517 by applying the same `MappingProxyType` freeze + defensive `dict()` copy to the **canonical** `agent_marketplace.PluginInstaller`, and mirrors the regression tests into the canonical package so the gap cannot recur silently.

### Background

`agentmesh/marketplace/__init__.py` is a backward-compat shim that prefers the canonical `agent_marketplace` package when installed and only falls back to `agentmesh.marketplace._marketplace_impl` when it isn't:

```python
try:
    from agent_marketplace import (..., PluginInstaller, ...)   # canonical
except ImportError:
    from agentmesh.marketplace._marketplace_impl import (...)    # fallback
```

PR #1517 hardened the **fallback** impl in `agent-mesh` and added two `TestTrustedKeysImmutability` tests, but missed the canonical `agent_marketplace.PluginInstaller`. Because the per-package CI matrix runs `agent-mesh` in isolation (without `agent_marketplace` installed), the shim falls through to the already-hardened fallback and the regression tests pass — silently exercising the wrong code path.

In any environment where both packages are installed (the recommended end-user setup, and the `docker compose run --rm test` environment), the shim resolves to the unhardened canonical impl and `_trusted_keys` is a mutable `dict` that aliases the caller's input.

### What this PR changes

1. **`agent_marketplace/installer.py`** — Wrap `_trusted_keys` in `MappingProxyType(dict(trusted_keys) if trusted_keys else {})` (matching the agent-mesh fallback). Tighten the parameter type from `Optional[dict]` to `Optional[Mapping[str, Any]]`.
2. **`agent_marketplace/tests/test_marketplace.py`** — Add a `TestTrustedKeysImmutability` class mirroring the two test cases that already exist in `agent-mesh/tests/test_marketplace.py`, but importing directly from `agent_marketplace` so the canonical package owns the coverage.

### Verification

- `docker compose run --rm test` now exits 0 (previously 2 failures in `agent-mesh/tests/test_marketplace.py::TestTrustedKeysImmutability`).
- `agent-mesh`: 2474 passed, 38 skipped (was 2472 passed, 2 failed).
- `agent-marketplace`: full suite passes including the two new tests.
- All other packages green.

### Why CI didn't catch this on #1517

The per-package `test-python` matrix in `ci.yml` only installs the package under test plus a small set of explicitly-listed sibling packages. For the `agent-mesh` matrix entry, `agent_marketplace` is not installed, so the import-time shim falls through to the hardened fallback. Future hardening of this class of bug should consider adding an integrated-install gate (this is the motivating example for a separate planning effort to gate PRs on `docker compose run --rm test`).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [x] agent-mesh <!-- via the backward-compat shim -->
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root
- [x] agent-marketplace (canonical impl + new tests)

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed <!-- N/A — no public API change; behavior tightening only -->
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

This PR uses the same `types.MappingProxyType` pattern already established in this repo by #1517 (the agent-mesh fallback impl). No external prior art.

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):

GitHub Copilot CLI assisted with tracing the shim/canonical drift and drafting the PR body. All code changes — the `MappingProxyType` wrapping pattern and the mirrored tests — are direct ports of existing patterns already in the repo (PR #1517) and were manually reviewed.

## Related Issues

Completes the hardening started in #1517 — the `TestTrustedKeysImmutability` tests added there cannot fail in CI as configured but will fail (and now pass) in the integrated install used by `docker compose run --rm test`.
