### PR TITLE
fix(ci): fix AI PR review matrix skip and add cspell words

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -81,3 +81,6 @@ Rego
 Sandboxed
 Serialise
 sybil
+davidequarracino
+Marp
+Slidev

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -34,9 +34,8 @@ jobs:
     name: ${{ matrix.label }}
     runs-on: ubuntu-latest
     if: >-
-      github.event.pull_request.draft == false &&
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'github-actions[bot]'
+      github.event.pull_request.draft != true &&
+      github.actor != 'dependabot[bot]'
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

Two CI issues affecting PR #1548 and all recent PRs:

1. **AI PR review agents all skipped**: The \i-pr-review.yml\ matrix job's \if\ condition used \github.event.pull_request.draft == false\, which evaluates to \alse\ when the \draft\ field is null/undefined (e.g., on workflow re-runs after approval, or for bot-initiated PRs). This caused all 5 AI review agents to silently skip, leaving the summary permanently stuck at 'Awaiting results'.

2. **Spell-check failures**: Three words not in the cspell dictionary caused failures on docs PRs.

## Changes

- **\i-pr-review.yml\**: Changed \== false\ to \!= true\ for the draft check (handles null/undefined). Removed \github-actions[bot]\ exclusion so Copilot SWE agent PRs get AI review.
- **\.cspell-repo-terms.txt\**: Added \davidequarracino\, \Marp\, \Slidev\.

## Verification

- jackbatzner's PR (#1524) ran successfully with the current workflow, confirming the matrix strategy itself works. The skip only occurs when the \if\ condition fails on null/undefined \draft\ values.
- After this fix, all PRs (human and bot) should get AI review coverage.

Unblocks #1548