### PR TITLE
fix(go): fail closed go trust verification

### DIFF
--- a/agent-governance-golang/README.md
+++ b/agent-governance-golang/README.md
@@ -62,7 +62,7 @@ Decay-based trust scoring with asymmetric reward/penalty.
 | Function / Method | Description |
 |---|---|
 | `NewTrustManager(config)` | Create a trust manager |
-| `(*TrustManager).VerifyPeer(id, identity)` | Verify a peer |
+| `(*TrustManager).VerifyPeer(id, identity)` | Fail closed unless independent verification evidence is available |
 | `(*TrustManager).GetTrustScore(agentID)` | Get current trust score |
 | `(*TrustManager).RecordSuccess(agentID, reward)` | Record a successful interaction |
 | `(*TrustManager).RecordFailure(agentID, penalty)` | Record a failed interaction |

--- a/agent-governance-golang/packages/agentmesh/trust.go
+++ b/agent-governance-golang/packages/agentmesh/trust.go
@@ -4,12 +4,17 @@
 package agentmesh
 
 import (
+	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
 	"sync"
 )
+
+// ErrPeerVerificationEvidenceRequired is returned when VerifyPeer lacks independent verification evidence.
+var ErrPeerVerificationEvidenceRequired = errors.New("peer verification requires independent evidence")
 
 // TrustScore represents an agent's current trust standing.
 type TrustScore struct {
@@ -51,15 +56,33 @@ func NewTrustManager(config TrustConfig) *TrustManager {
 	return tm
 }
 
-// VerifyPeer verifies a peer's identity and returns the current trust score.
+// VerifyPeer returns the current trust score but fails closed unless the caller has
+// independent verification evidence beyond the peer's self-attested identity data.
 func (tm *TrustManager) VerifyPeer(peerID string, peerIdentity *AgentIdentity) (*TrustVerificationResult, error) {
-	verified := peerIdentity != nil && peerIdentity.PublicKey != nil && len(peerIdentity.PublicKey) == 32
 	score := tm.GetTrustScore(peerID)
-	return &TrustVerificationResult{
+	result := &TrustVerificationResult{
 		PeerID:   peerID,
-		Verified: verified,
+		Verified: false,
 		Score:    score,
-	}, nil
+	}
+
+	if peerIdentity == nil {
+		return result, fmt.Errorf("%w: no peer identity provided for %q", ErrPeerVerificationEvidenceRequired, peerID)
+	}
+	if len(peerIdentity.PublicKey) != ed25519.PublicKeySize {
+		return result, fmt.Errorf(
+			"%w: peer %q presented a self-attested public key with invalid length %d",
+			ErrPeerVerificationEvidenceRequired,
+			peerID,
+			len(peerIdentity.PublicKey),
+		)
+	}
+
+	return result, fmt.Errorf(
+		"%w: peer %q only presented self-attested identity data",
+		ErrPeerVerificationEvidenceRequired,
+		peerID,
+	)
 }
 
 // GetTrustScore returns the current trust score for an agent.

--- a/agent-governance-golang/packages/agentmesh/trust_test.go
+++ b/agent-governance-golang/packages/agentmesh/trust_test.go
@@ -1,8 +1,8 @@
 package agentmesh
 
 import (
+	"errors"
 	"path/filepath"
-
 	"sync"
 	"testing"
 )
@@ -74,15 +74,18 @@ func TestTierAssignment(t *testing.T) {
 	}
 }
 
-func TestVerifyPeer(t *testing.T) {
+func TestVerifyPeerFailsClosedForSelfAttestedIdentity(t *testing.T) {
 	tm := NewTrustManager(DefaultTrustConfig())
 	id, _ := GenerateIdentity("peer1", nil)
 	result, err := tm.VerifyPeer("peer1", id)
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, ErrPeerVerificationEvidenceRequired) {
+		t.Fatalf("expected ErrPeerVerificationEvidenceRequired, got %v", err)
 	}
-	if !result.Verified {
-		t.Error("expected peer to be verified")
+	if result.Verified {
+		t.Error("self-attested identity should not be verified")
+	}
+	if result.Score.Overall != 0.5 {
+		t.Errorf("score = %f, want default 0.5", result.Score.Overall)
 	}
 }
 
@@ -255,10 +258,10 @@ func TestTrustTierBoundaries(t *testing.T) {
 		{0.0, "low"},
 		{0.1, "low"},
 		{0.49, "low"},
-{0.5, "medium"},  // boundary: exactly at medium threshold
+		{0.5, "medium"}, // boundary: exactly at medium threshold
 		{0.6, "medium"},
 		{0.79, "medium"},
-{0.8, "high"},    // boundary: exactly at high threshold
+		{0.8, "high"}, // boundary: exactly at high threshold
 		{0.9, "high"},
 		{1.0, "high"},
 	}
@@ -301,8 +304,8 @@ func TestGetTrustScoreForUnknownAgent(t *testing.T) {
 func TestVerifyPeerWithNilIdentity(t *testing.T) {
 	tm := NewTrustManager(DefaultTrustConfig())
 	result, err := tm.VerifyPeer("nil-peer", nil)
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, ErrPeerVerificationEvidenceRequired) {
+		t.Fatalf("expected ErrPeerVerificationEvidenceRequired, got %v", err)
 	}
 	if result.Verified {
 		t.Error("nil identity should not be verified")
@@ -316,8 +319,8 @@ func TestVerifyPeerWithInvalidKeyLength(t *testing.T) {
 		PublicKey: []byte("too-short"),
 	}
 	result, err := tm.VerifyPeer("short-key-peer", id)
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, ErrPeerVerificationEvidenceRequired) {
+		t.Fatalf("expected ErrPeerVerificationEvidenceRequired, got %v", err)
 	}
 	if result.Verified {
 		t.Error("identity with short key should not be verified")


### PR DESCRIPTION
## Description
- Fail closed `(*TrustManager).VerifyPeer` so it no longer marks peers verified from self-attested identity data alone
- Return `ErrPeerVerificationEvidenceRequired` while still returning the current trust score with `Verified=false`
- Add regression coverage for nil, malformed, and structurally valid self-attested identities
- Update the Go README trust API entry to reflect the new fail-closed contract

Validation: `go test ./packages/agentmesh/...`

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [x] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):
- GitHub Copilot for implementation assistance; manually reviewed and narrowed to the scoped Go trust-verifier fix

## Related Issues