### PR TITLE
fix(rust): require peer-supplied proof in trust verification

### DIFF
--- a/agent-governance-rust/agentmesh-mcp/src/mcp/gateway.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/gateway.rs
@@ -487,8 +487,7 @@ mod tests {
 
     #[test]
     fn authenticated_requests_record_audit_entries() {
-        let (gateway, session_token, audit) =
-            gateway_with_limit(McpGatewayConfig::default(), 2);
+        let (gateway, session_token, audit) = gateway_with_limit(McpGatewayConfig::default(), 2);
         let request = McpGatewayRequest {
             agent_id: "did:agentmesh:test".into(),
             tool_name: "db.read".into(),

--- a/agent-governance-rust/agentmesh/src/mcp/gateway.rs
+++ b/agent-governance-rust/agentmesh/src/mcp/gateway.rs
@@ -487,8 +487,7 @@ mod tests {
 
     #[test]
     fn authenticated_requests_record_audit_entries() {
-        let (gateway, session_token, audit) =
-            gateway_with_limit(McpGatewayConfig::default(), 2);
+        let (gateway, session_token, audit) = gateway_with_limit(McpGatewayConfig::default(), 2);
         let request = McpGatewayRequest {
             agent_id: "did:agentmesh:test".into(),
             tool_name: "db.read".into(),

--- a/agent-governance-rust/agentmesh/src/trust.rs
+++ b/agent-governance-rust/agentmesh/src/trust.rs
@@ -181,15 +181,21 @@ impl TrustManager {
             .collect()
     }
 
-    /// Verify a peer agent's identity via challenge-response.
+    /// Verify a peer agent's signed proof for a caller-provided challenge.
     ///
-    /// Generates a random 32-byte challenge, asks the peer to sign it,
-    /// then verifies the signature against the peer's public key.
-    pub fn verify_peer(&self, _peer_id: &str, peer_identity: &AgentIdentity) -> bool {
-        let mut challenge = [0u8; 32];
-        rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut challenge);
-        let signature = peer_identity.sign(&challenge);
-        peer_identity.verify(&challenge, &signature)
+    /// The caller is responsible for generating the challenge and collecting the
+    /// peer's signature. This method fails closed unless the claimed peer
+    /// identifier matches the supplied identity and the signature verifies
+    /// against the provided challenge.
+    pub fn verify_peer(
+        &self,
+        peer_id: &str,
+        peer_identity: &AgentIdentity,
+        challenge: &[u8],
+        signature: &[u8],
+    ) -> bool {
+        claimed_peer_matches_identity(peer_id, peer_identity)
+            && peer_identity.verify(challenge, signature)
     }
 
     /// Apply time-based decay to a raw score.
@@ -234,6 +240,15 @@ fn epoch_now() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn claimed_peer_matches_identity(peer_id: &str, peer_identity: &AgentIdentity) -> bool {
+    if peer_id.is_empty() {
+        return false;
+    }
+
+    peer_id == peer_identity.did
+        || peer_identity.did.strip_prefix("did:agentmesh:") == Some(peer_id)
 }
 
 #[cfg(test)]
@@ -422,11 +437,39 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_peer_valid_identity() {
+    fn test_verify_peer_accepts_valid_peer_signature() {
         let tm = TrustManager::with_defaults();
         let peer =
             crate::identity::AgentIdentity::generate("peer-agent", vec!["cap".into()]).unwrap();
-        assert!(tm.verify_peer("peer-agent", &peer));
+        let challenge = b"peer-auth-challenge";
+        let signature = peer.sign(challenge);
+
+        assert!(tm.verify_peer("peer-agent", &peer, challenge, &signature));
+        assert!(tm.verify_peer(&peer.did, &peer, challenge, &signature));
+    }
+
+    #[test]
+    fn test_verify_peer_rejects_mismatched_claimed_peer() {
+        let tm = TrustManager::with_defaults();
+        let peer =
+            crate::identity::AgentIdentity::generate("peer-agent", vec!["cap".into()]).unwrap();
+        let challenge = b"peer-auth-challenge";
+        let signature = peer.sign(challenge);
+
+        assert!(!tm.verify_peer("other-peer", &peer, challenge, &signature));
+    }
+
+    #[test]
+    fn test_verify_peer_rejects_signature_not_created_by_peer() {
+        let tm = TrustManager::with_defaults();
+        let peer =
+            crate::identity::AgentIdentity::generate("peer-agent", vec!["cap".into()]).unwrap();
+        let impostor =
+            crate::identity::AgentIdentity::generate("impostor-agent", vec!["cap".into()]).unwrap();
+        let challenge = b"peer-auth-challenge";
+        let signature = impostor.sign(challenge);
+
+        assert!(!tm.verify_peer("peer-agent", &peer, challenge, &signature));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Harden Rust peer verification in `agent-governance-rust/agentmesh/src/trust.rs`.

This changes `TrustManager::verify_peer` so it no longer fabricates proof locally with the supplied identity. The verifier now requires caller-supplied challenge/signature proof, binds the claimed peer to the provided identity, and fails closed when the claimed peer does not match or the signature was not produced by that peer.

This is a small API break in service of a security fix: `verify_peer` now requires the caller to pass the peer-generated proof instead of allowing self-attestation inside the verifier.

The PR also adds focused regression coverage for:
- valid peer proof
- mismatched claimed peer
- signature not created by the claimed peer

Includes two trivial `cargo fmt` line-wrap changes in gateway tests.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Security fix
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)

## Package(s) Affected
- [x] agent-mesh
- [ ] agent-os-kernel
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):
GitHub Copilot for implementation assistance, with manual review of logic and tests.

## Related Issues