### PR TITLE
ci(docker): add docker-compose-test gate to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,15 +535,37 @@ jobs:
 
       - name: Run documented contributor flow
         run: |
-          export HOST_UID="$(id -u)"
-          export HOST_GID="$(id -g)"
+          # Compute and validate host UID/GID so the test container can write
+          # to the bind-mounted workspace. Validate they are pure positive
+          # integers before exporting (defense-in-depth: the values come from
+          # `id` on the runner, but we still refuse to forward anything that
+          # is not a non-negative integer to docker compose).
+          HOST_UID="$(id -u)"
+          HOST_GID="$(id -g)"
+          if ! [[ "${HOST_UID}" =~ ^[0-9]+$ ]] || ! [[ "${HOST_GID}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Refusing to run: id -u/-g returned non-numeric value (uid='${HOST_UID}' gid='${HOST_GID}')"
+            exit 1
+          fi
+          export HOST_UID HOST_GID
           echo "Running compose with HOST_UID=${HOST_UID} HOST_GID=${HOST_GID}"
           docker compose up --build dev -d
           docker compose run --rm test
 
       - name: Collect dev container logs
         if: always()
-        run: docker compose logs dev > dev.log 2>&1 || true
+        run: |
+          # Capture and redact obvious secret-shaped tokens before the log is
+          # uploaded as a build artifact. The dev container does not receive
+          # GitHub secrets, but we still scrub conservatively so that any
+          # accidental leakage from a future change does not surface here.
+          docker compose logs dev > dev.log.raw 2>&1 || true
+          sed -E \
+            -e 's/(gh[pousr]_[A-Za-z0-9]{20,})/[REDACTED-GH-TOKEN]/g' \
+            -e 's/(sk-[A-Za-z0-9_-]{20,})/[REDACTED-API-KEY]/g' \
+            -e 's/(AKIA[A-Z0-9]{16})/[REDACTED-AWS-ACCESS-KEY]/g' \
+            -e 's/((password|secret|token|api_?key)[[:space:]]*[:=][[:space:]]*)[^[:space:]"]+/\1[REDACTED]/Ig' \
+            dev.log.raw > dev.log
+          rm -f dev.log.raw
 
       - name: Upload artifacts on failure
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       workflows: ${{ steps.filter.outputs.workflows }}
       docs-only: ${{ steps.filter.outputs.docs-only }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -42,6 +43,9 @@ jobs:
               - 'agent-governance-python/agent-compliance/**'
               - 'agent-governance-python/agent-runtime/**'
               - 'agent-governance-python/agent-lightning/**'
+              - 'agent-governance-python/agent-primitives/**'
+              - 'agent-governance-python/agent-mcp-governance/**'
+              - 'agent-governance-python/agent-marketplace/**'
               - 'scripts/**'
               - 'agent-governance-python/requirements/**'
             dotnet:
@@ -63,6 +67,14 @@ jobs:
               - '**/*.md'
               - 'agent-governance-python/notebooks/**'
               - 'docs/**'
+            docker:
+              - 'Dockerfile'
+              - 'docker-compose*.yml'
+              - 'scripts/docker/**'
+              - '.gitattributes'
+              - 'agent-governance-python/**/pyproject.toml'
+              - 'agent-governance-python/agent-hypervisor/examples/dashboard/requirements.txt'
+              - '.github/workflows/ci.yml'
 
   # ── Python lint + test (only when Python files change) ────────────────
   lint:
@@ -494,6 +506,54 @@ jobs:
         working-directory: agent-governance-golang
         run: go vet ./...
 
+  # ── Docker integrated test (matches the documented contributor flow) ──
+  # Runs the exact two commands from CONTRIBUTING.md "Docker Quickstart" so
+  # contributor-facing breakage is caught before merge to main. Catches
+  # shim/canonical drift, Dockerfile/compose drift, line-ending regressions,
+  # and any bug that only surfaces in the integrated install shape.
+  docker-compose-test:
+    needs: changes
+    if: |
+      needs.changes.outputs.docker == 'true' ||
+      needs.changes.outputs.python == 'true' ||
+      github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Diagnostic — Docker / Compose / Buildx versions
+        run: |
+          docker version
+          docker compose version
+          docker buildx version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Run documented contributor flow
+        run: |
+          docker compose up --build dev -d
+          docker compose run --rm test
+
+      - name: Collect dev container logs
+        if: always()
+        run: docker compose logs dev > dev.log 2>&1 || true
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docker-compose-test-logs
+          path: dev.log
+          retention-days: 7
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v
+
   # ── CI Gate — required status check that handles skipped jobs ────────
   # When path-filters skip jobs (e.g. docs-only PRs skip tests), those
   # jobs report "skipped" which doesn't satisfy required status checks.
@@ -516,6 +576,7 @@ jobs:
         build-npm,
         build-rust,
         build-go,
+        docker-compose-test,
       ]
     runs-on: ubuntu-latest
     steps:
@@ -524,8 +585,22 @@ jobs:
           results='${{ toJSON(needs.*.result) }}'
           echo "Job results: $results"
           if echo "$results" | grep -qE '"failure"|"cancelled"'; then
-            echo "One or more required jobs failed or were cancelled"
+            echo "::error::One or more required jobs failed or were cancelled"
             exit 1
           fi
+
+          # AC3.4 — docker-compose-test must not be silently skipped on relevant PRs
+          docker_changed='${{ needs.changes.outputs.docker }}'
+          python_changed='${{ needs.changes.outputs.python }}'
+          docker_test_result='${{ needs.docker-compose-test.result }}'
+          event_name='${{ github.event_name }}'
+          if [ "$docker_changed" = "true" ] || [ "$python_changed" = "true" ] || [ "$event_name" = "schedule" ]; then
+            if [ "$docker_test_result" = "skipped" ]; then
+              echo "::error::docker-compose-test was skipped on a PR that touched docker- or python-relevant paths."
+              echo "::error::This violates AC3.4 — the gate must run when changes.outputs.docker or python is true."
+              exit 1
+            fi
+          fi
+
           echo "All jobs passed or were correctly skipped"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,6 +535,9 @@ jobs:
 
       - name: Run documented contributor flow
         run: |
+          export HOST_UID="$(id -u)"
+          export HOST_GID="$(id -g)"
+          echo "Running compose with HOST_UID=${HOST_UID} HOST_GID=${HOST_GID}"
           docker compose up --build dev -d
           docker compose run --rm test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN python -m pip install --no-cache-dir \
     && python -m pip install --no-cache-dir \
         -r agent-governance-python/agent-hypervisor/examples/dashboard/requirements.txt \
     && cd /workspace/agent-governance-typescript \
-    && npm ci
+    && npm ci --legacy-peer-deps
 
 ENTRYPOINT ["bash", "/workspace/scripts/docker/dev-entrypoint.sh"]
 CMD ["sleep", "infinity"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       target: test
     command: ["bash", "/workspace/scripts/docker/run-tests.sh"]
     init: true
-    user: "1000:1000"
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     working_dir: /workspace
     volumes:
       - .:/workspace


### PR DESCRIPTION
## Description

Adds a `docker-compose-test` job to `ci.yml` that runs the two commands from `CONTRIBUTING.md` "Docker Quickstart" — `docker compose up --build dev -d` followed by `docker compose run --rm test` — as a required PR gate.

Catches shim/canonical drift, `Dockerfile` / `docker-compose*.yml` regressions, shell-script line-ending issues, and bugs that only surface in the integrated install shape across all 10 Python packages.

Wired into the existing `ci-complete` aggregator with an explicit guard: if the job is `skipped` on a PR that touched `docker`- or `python`-relevant paths, `ci-complete` fails — preventing the gate from being silently bypassed.

Also adds `agent-primitives`, `agent-mcp-governance`, and `agent-marketplace` to the `python` paths-filter (they were missing) so changes to them now trigger lint/test/docker jobs.

Builds on #1549 (which made `scripts/docker/run-tests.sh` CI-aware and expanded coverage to all 10 packages).

### Collateral fixes (the gate caught real, pre-existing breakage on `main`)

The new gate immediately surfaced two pre-existing bugs in the documented contributor flow. Both are fixed here so the gate can land green; both would have hit any contributor running the documented Docker flow.

1. **`Dockerfile`: `npm ci` → `npm ci --legacy-peer-deps`**
   `agent-governance-typescript/package.json` pins `@typescript-eslint/parser@8.59.0`, but `@typescript-eslint/eslint-plugin@8.59.1` declares a peer requirement of `^8.59.1`. `npm ci` fails with `ERESOLVE` inside the build. Per `.github/copilot-instructions.md`, this repo regenerates lockfiles with `--legacy-peer-deps`; this aligns the Dockerfile with that documented practice and does not change runtime behavior — it only loosens npm's strict peer-dep check during install. A proper version bump can be done in a follow-up; this minimal change unblocks the gate without dependency churn.

2. **`docker-compose.yml`: dynamic `user` for the `test` service**
   Was hard-coded to `user: "1000:1000"`. GitHub-hosted runners use a different UID, so the bind-mounted `/workspace` was unwritable from inside the container — `agent-sre` tests failed with `PermissionError` when creating `.agent-governance-python/agent-sre/traces`. Now uses `user: "${HOST_UID:-1000}:${HOST_GID:-1000}"` (default preserves local-dev behavior) and the CI step exports `id -u` / `id -g`.

### Security hardening (responding to AI review feedback)

- **UID/GID input validation**: the CI step asserts `HOST_UID` and `HOST_GID` match `^[0-9]+$` before exporting them to `docker compose`. The values come from `id -u`/`id -g` on the runner and are not externally injectable in this workflow, but the explicit numeric guard is cheap defense-in-depth.
- **Artifact log scrubbing**: `docker compose logs dev` is piped through `sed` to redact GitHub tokens (`gh[pousr]_…`), API keys (`sk-…`), AWS access keys (`AKIA…`), and `password=` / `secret=` / `token=` / `api_key=` patterns before `dev.log` is uploaded as a build artifact. The dev container does not receive any GitHub secrets in this workflow, but this guards against regressions where future changes might accidentally surface credentials in container logs.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**: None — mirrors the existing `ci-complete` aggregator pattern already in this repo.

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used**: GitHub Copilot CLI for drafting; all logic manually reviewed and locally validated.

## Related Issues
Builds on #1549.
