### PR TITLE
fix(ci): remove NuGetVerify from ESRP NuGet signing config

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -460,13 +460,6 @@ stages:
                     "parameters": [],
                     "toolName": "sign",
                     "toolVersion": "1.0"
-                  },
-                  {
-                    "keyCode": "CP-401405",
-                    "operationSetCode": "NuGetVerify",
-                    "parameters": [],
-                    "toolName": "sign",
-                    "toolVersion": "1.0"
                   }
                 ]
 


### PR DESCRIPTION
Remove the redundant NuGetVerify operation from the ESRP code signing inline config. Verification is already handled by the separate dotnet nuget verify step that follows.