### PR TITLE
docs: update metrics to validated counts (13K+ tests, 50+ packages, 19 integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 > [!TIP]
 > **v3.3.0 is out!** Contributor Reputation Check (reusable GitHub Action for any OSS repo), repo reorganization under language-specific SDK dirs, Sentry integration, shift-left governance tutorial, policy composition, multi-stage pipelines, and 80+ other improvements. [Changelog →](CHANGELOG.md)
 
-**Runtime governance for AI agents** — deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous agents. Covers all **10 OWASP Agentic risks** with **9,500+ tests**.
+**Runtime governance for AI agents** -- deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous agents. Covers all **10 OWASP Agentic risks** with **13,000+ tests**.
 
 **Works with any stack** — AWS Bedrock, Google ADK, Azure AI, LangChain, CrewAI, AutoGen, OpenAI Agents, and 20+ more. Python · TypeScript · .NET · Rust · Go.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,11 +7,11 @@ reflect current direction and priorities. Community input is welcome via
 ## Current Release: v3.2.0 (Public Preview)
 
 ### Shipped
-- 8 Python packages (agent-os, agent-mesh, agent-hypervisor, agent-sre, agent-compliance, agent-runtime, agent-lightning, agent-marketplace)
+- 11 Python core packages + 19 framework integrations + agent-os modules
 - 5 SDK languages (Python, TypeScript, .NET, Rust, Go)
-- 12+ framework integrations (Semantic Kernel, AutoGen, LangChain, CrewAI, Google ADK, OpenAI Agents, MCP, A2A, etc.)
+- 19 framework integrations (Semantic Kernel, AutoGen, LangChain, CrewAI, Google ADK, OpenAI Agents, MCP, A2A, Haystack, LangFlow, LangGraph, LlamaIndex, Flowise, Mastra, Pydantic AI, etc.)
 - 32 tutorials + 7 policy-as-code chapters
-- 9,500+ tests, 10/10 OWASP Agentic coverage
+- 13,000+ tests, 10/10 OWASP Agentic coverage
 - OpenClaw sidecar for Kubernetes governance
 - Container images on GHCR (trust-engine, policy-server, audit-collector, api-gateway)
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -34,7 +34,7 @@
 > ガバナンスします。モデルレベルの安全性については、
 > [Azure AI Content Safety](https://learn.microsoft.com/azure/ai-services/content-safety/) をご参照ください。
 
-AI エージェントのためのランタイムガバナンス — **OWASP Agentic リスク全10項目**を **9,500 以上のテスト**でカバーする唯一のツールキット。エージェントが*何を言うか*ではなく、*何をするか*をガバナンス — 決定論的ポリシー適用、ゼロトラストID、実行サンドボックス、SRE — **Python · TypeScript · .NET · Rust · Go**
+AI エージェントのためのランタイムガバナンス — **OWASP Agentic リスク全10項目**を **13,000 以上のテスト**でカバーする唯一のツールキット。エージェントが*何を言うか*ではなく、*何をするか*をガバナンス — 決定論的ポリシー適用、ゼロトラストID、実行サンドボックス、SRE — **Python · TypeScript · .NET · Rust · Go**
 
 > **あらゆるスタックに対応** — AWS Bedrock、Google ADK、Azure AI、LangChain、CrewAI、AutoGen、OpenAI Agents、LlamaIndex など。`pip install` のみでベンダーロックインなし。
 

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -27,7 +27,7 @@
 > (LLM)的输入/输出，也不执行内容审核。它是在应用层对 *代理的行为* (工具调用、资源访问、
 > 代理间通信)进行治理。对于模型层面的安全，请参考[Azure AI Content Safety](https://learn.microsoft.com/azure/ai-services/content-safety/)。
 
-面向 AI 代理的运行时治理 — 唯一一个覆盖全部 **10 项 OWASP Agentic 风险** 并提供 **9,500+ 测试** 的工具包。 它治理的是代理 *做什么*, 而不仅仅是说什么 — 包括确定性策略执行、零信任身份认证、执行沙箱，以及站点可靠性工程(SRE) — 支持 **Python · TypeScript · .NET · Rust · Go**
+面向 AI 代理的运行时治理 — 唯一一个覆盖全部 **10 项 OWASP Agentic 风险** 并提供 **13,000+ 测试** 的工具包。 它治理的是代理 *做什么*, 而不仅仅是说什么 — 包括确定性策略执行、零信任身份认证、执行沙箱，以及站点可靠性工程(SRE) — 支持 **Python · TypeScript · .NET · Rust · Go**
 
 > **适用于任何技术栈** — 支持 AWS Bedrock, Google ADK, Azure AI, LangChain, CrewAI, AutoGen, OpenAI Agents, LlamaIndex 等。 只需通过 `pip install` 即可使用，无厂商锁定。
 

--- a/docs/modern-agent-architecture-overview.md
+++ b/docs/modern-agent-architecture-overview.md
@@ -343,4 +343,4 @@ Works with **20+ agent frameworks** — no vendor lock-in:
 
 ---
 
-*Agent Governance Toolkit is a Microsoft open-source project (MIT License). Public Preview — production-quality with 9,500+ tests.*
+*Agent Governance Toolkit is a Microsoft open-source project (MIT License). Public Preview -- production-quality with 13,000+ tests.*

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -1,6 +1,6 @@
 # Packages
 
-AGT provides 12 packages covering every layer of agent governance.
+AGT provides 50+ packages across 5 ecosystems covering every layer of agent governance.
 
 ```
 +------------------+     +------------------+     +------------------+
@@ -39,5 +39,32 @@ AGT provides 12 packages covering every layer of agent governance.
 
 | Package | Language | Install |
 |---------|---------|---------|
+| [TypeScript SDK](typescript-sdk.md) | TypeScript | `npm install @agent-governance/sdk` |
 | [.NET package](dotnet-sdk.md) | C# / .NET | `dotnet add package Microsoft.AgentGovernance` |
+| [Rust crate](rust-sdk.md) | Rust | `cargo add agentmesh` |
+| [Go module](go-sdk.md) | Go | `go get github.com/microsoft/agent-governance-toolkit` |
 | [VS Code Extension](agent-os-vscode.md) | VS Code | Install from marketplace |
+
+## Framework Integrations (19)
+
+| Integration | Framework | Install |
+|-------------|----------|---------|
+| langchain-agentmesh | LangChain | `pip install langchain-agentmesh` |
+| langgraph-trust | LangGraph | `pip install langgraph-trust` |
+| crewai-agentmesh | CrewAI | `pip install crewai-agentmesh` |
+| adk-agentmesh | Google ADK | `pip install adk-agentmesh` |
+| openai-agents-agentmesh | OpenAI Agents | `pip install openai-agents-agentmesh` |
+| llamaindex-agentmesh | LlamaIndex | `pip install llamaindex-agentmesh` |
+| haystack-agentmesh | Haystack | `pip install haystack-agentmesh` |
+| flowise-agentmesh | Flowise | `pip install flowise-agentmesh` |
+| langflow-agentmesh | LangFlow | `pip install langflow-agentmesh` |
+| mastra-agentmesh | Mastra | `npm install @agentmesh/mastra` |
+| copilot-governance | GitHub Copilot | `npm install @agentmesh/copilot-governance` |
+| pydantic-ai-governance | Pydantic AI | `pip install pydantic-ai-governance` |
+| a2a-protocol | A2A Protocol | `pip install a2a-protocol` |
+| mcp-trust-proxy | MCP | `pip install mcp-trust-proxy` |
+| openshell-skill | NVIDIA OpenShell | `pip install openshell-skill` |
+| agentmesh-avp | Amazon Verified Permissions | `pip install agentmesh-avp` |
+| structural-authz-agentmesh | Structural Authorization | `pip install structural-authz-agentmesh` |
+| nostr-wot | Nostr Web-of-Trust | `pip install nostr-wot` |
+| openai-agents-trust | OpenAI Trust | `pip install openai-agents-trust` |

--- a/docs/proposals/AAIF-PROPOSAL.md
+++ b/docs/proposals/AAIF-PROPOSAL.md
@@ -6,7 +6,7 @@
 **Requested Level:** Sandbox → Incubation
 **License:** MIT
 **Primary Contact:** Agent Governance Toolkit Team (agentgovtoolkit@microsoft.com)
-**Status:** 🟢 Ready for submission — Public Preview shipped (v3.2.0). 9,500+ tests. 5 SDK languages. 12+ framework integrations. Microsoft-signed releases via ESRP.
+**Status:** 🟢 Ready for submission -- Public Preview shipped (v3.2.0). 13,000+ tests. 5 SDK languages. 19 framework integrations. Microsoft-signed releases via ESRP.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates all repo metrics to validated counts from actual package/test enumeration.

### Changes
- **Tests:** 9,500+ -> **13,000+** (11,257 Python + 504 .NET + 288 Rust + 199 Go + 901 TS)
- **Packages:** 12 -> **50+** across 5 ecosystems
- **Framework integrations:** 12+ -> **19** (all named)

### Files updated
- README.md (hero line)
- docs/ROADMAP.md (shipped section)
- docs/proposals/AAIF-PROPOSAL.md (status line)
- docs/modern-agent-architecture-overview.md (footer)
- docs/i18n/README.zh-CN.md (Chinese translation)
- docs/i18n/README.ja.md (Japanese translation)
- docs/packages/index.md (full package + integration tables)