### PR TITLE
fix(esrp): use separate signing cert variable for NuGet package signing

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -110,11 +110,12 @@ parameters:
 # Service connection name is hardcoded (required at compile time by ADO).
 # All other values sourced from ADO pipeline variables (mark as secret):
 #   ESRP_KEYVAULT_NAME, ESRP_CERT_IDENTIFIER, ESRP_SIGN_CERT_IDENTIFIER,
-#   ESRP_CLIENT_ID, ESRP_OWNERS, ESRP_APPROVERS
+#   ESRP_NUGET_SIGN_CERT_IDENTIFIER, ESRP_CLIENT_ID, ESRP_OWNERS, ESRP_APPROVERS
 #
-# ESRP_CERT_IDENTIFIER = authentication certificate (issued by Public CA)
-# ESRP_SIGN_CERT_IDENTIFIER = signing certificate (issued by Private CA)
-# These MUST be two different certificates from different CAs.
+# ESRP_CERT_IDENTIFIER        = authentication certificate (issued by Public CA)
+# ESRP_SIGN_CERT_IDENTIFIER   = signing certificate for Authenticode (issued by Private CA)
+# ESRP_NUGET_SIGN_CERT_IDENTIFIER = signing certificate for NuGet package signing (may differ from Authenticode)
+# These MUST be separate certificates from the appropriate CAs.
 #
 # Note: ESRP_DOMAIN_TENANT_ID was removed from pipeline variables due to
 # cyclical reference. The ESRP cert lives in the PME (Partner Managed
@@ -440,6 +441,7 @@ stages:
                 ]
 
           # Step 2: Sign the .nupkg with ESRP NuGet Signing (CP-401405)
+          # Uses ESRP_NUGET_SIGN_CERT_IDENTIFIER (separate from Authenticode signing cert)
           - task: EsrpCodeSigning@5
             displayName: 'ESRP Code Sign NuGet package'
             inputs:
@@ -448,7 +450,7 @@ stages:
               AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
               AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
               AuthCertName: '$(ESRP_CERT_IDENTIFIER)'
-              AuthSignCertName: '$(ESRP_SIGN_CERT_IDENTIFIER)'
+              AuthSignCertName: '$(ESRP_NUGET_SIGN_CERT_IDENTIFIER)'
               FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
               Pattern: '*.nupkg'
               signConfigType: 'inlineSignParams'


### PR DESCRIPTION
## Summary

Adds a new \ESRP_NUGET_SIGN_CERT_IDENTIFIER\ variable for the NuGet package signing task (Step 2, CP-401405), separate from the Authenticode DLL signing cert.

### What changed
- NuGet signing task (\EsrpCodeSigning@5\, Step 2) now uses \\\ for \AuthSignCertName\
- Authenticode DLL signing task (Step 1) unchanged, still uses \\\
- Updated config comments documenting all three cert variables

### ADO action required
Add \ESRP_NUGET_SIGN_CERT_IDENTIFIER\ as a pipeline variable in ADO with the NuGet signing certificate identifier from the Private CA.

### Context
Per Nandha/Vahe: the Authenticode and NuGet signing tasks may require different signing certificates. This separates them so each can be configured independently.