### PR TITLE
feat: wire Cedar/OPA PolicyEvaluator into ADK GovernancePlugin

### DIFF
--- a/agent-governance-python/agent-os/CHANGELOG.md
+++ b/agent-governance-python/agent-os/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plugin registration.
 - **Enhanced `health_check()`**: Now includes `model_calls`, `token_usage`,
   `cancelled_runs`, and `context_count` metrics.
+- **Cedar / OPA policy integration**: `GoogleADKKernel` now accepts an optional
+  `PolicyEvaluator` for external policy backends (Cedar, OPA/Rego). Cedar
+  evaluation runs before built-in `PolicyConfig` checks with fail-closed
+  composition — the more restrictive result always wins.
+- **`GoogleADKKernel.from_cedar()`**: Convenience factory method for one-line
+  Cedar policy configuration: `GoogleADKKernel.from_cedar(policy_path="...")`.
+- **`_build_cedar_context()`**: Maps ADK lifecycle data (agent, tool, tokens,
+  budget) to the principal/action/resource triple that Cedar backends expect.
+- **Model-call authorization**: `GovernancePlugin.before_model_callback` now
+  consults the `PolicyEvaluator` to authorize LLM invocations, not just tools.
 
 ### Migration Notes
 - Configure `GovServer(execute_authenticator=...)` or set

--- a/agent-governance-python/agent-os/README.md
+++ b/agent-governance-python/agent-os/README.md
@@ -84,7 +84,7 @@
 | Semantic Kernel | 27K ⭐ | [microsoft/semantic-kernel#13556](https://github.com/microsoft/semantic-kernel/issues/13556) |
 | smolagents | 25K ⭐ | ✅ Adapter built — [huggingface/smolagents#1989](https://github.com/huggingface/smolagents/issues/1989) |
 | LangGraph | 24K ⭐ | [langchain-ai/langgraph#6824](https://github.com/langchain-ai/langgraph/issues/6824) |
-| Google ADK | 18K ⭐ | ✅ Adapter + GovernancePlugin — [google/adk-python#4517](https://github.com/google/adk-python/issues/4517) |
+| Google ADK | 18K ⭐ | ✅ Adapter + GovernancePlugin + Cedar/OPA policies — [google/adk-python#4517](https://github.com/google/adk-python/issues/4517) |
 | PydanticAI | 15K ⭐ | ✅ Adapter built — [pydantic/pydantic-ai#4335](https://github.com/pydantic/pydantic-ai/issues/4335) |
 | OpenAI Agents SDK | — | [openai/openai-agents-python#2515](https://github.com/openai/openai-agents-python/issues/2515) |
 | A2A Protocol | 21K ⭐ | [a2aproject/A2A#1501](https://github.com/a2aproject/A2A/issues/1501) |

--- a/agent-governance-python/agent-os/examples/policies/agent-governance.cedar
+++ b/agent-governance-python/agent-os/examples/policies/agent-governance.cedar
@@ -1,0 +1,90 @@
+// Agent Governance Cedar Policy — Example
+// =========================================
+//
+// This policy demonstrates how to use Cedar with the Agent Governance
+// Toolkit's GovernancePlugin for Google ADK agents.
+//
+// Usage:
+//   from agent_os.integrations.google_adk_adapter import GoogleADKKernel
+//   from google.adk import Runner
+//
+//   kernel = GoogleADKKernel.from_cedar(
+//       policy_path="policies/agent-governance.cedar",
+//       blocked_tools=["shell"],
+//   )
+//   runner = Runner(
+//       agent=root_agent,
+//       plugins=[kernel.as_plugin()],
+//   )
+//
+// Cedar evaluates permit/forbid statements against a principal (agent),
+// action (tool or model call), and resource.  The toolkit maps ADK
+// lifecycle data to these triples automatically via _build_cedar_context().
+//
+// Default: deny-by-default. Only explicitly permitted actions are allowed.
+
+// ── Read-only tools are always permitted ─────────────────────────
+permit(
+    principal,
+    action == Action::"ReadData",
+    resource
+);
+
+permit(
+    principal,
+    action == Action::"ListFiles",
+    resource
+);
+
+permit(
+    principal,
+    action == Action::"SearchDocuments",
+    resource
+);
+
+// ── Model calls are permitted (LLM invocations) ─────────────────
+permit(
+    principal,
+    action == Action::"ModelCall",
+    resource
+);
+
+// ── Dangerous tools are explicitly forbidden ─────────────────────
+forbid(
+    principal,
+    action == Action::"DeleteFile",
+    resource
+);
+
+forbid(
+    principal,
+    action == Action::"Shell",
+    resource
+);
+
+forbid(
+    principal,
+    action == Action::"ExecCode",
+    resource
+);
+
+forbid(
+    principal,
+    action == Action::"DropTable",
+    resource
+);
+
+// ── Write tools require scoped permission ────────────────────────
+// Uncomment and modify for your environment:
+//
+// permit(
+//     principal == Agent::"finance-agent",
+//     action == Action::"WriteData",
+//     resource == Resource::"finance-db"
+// );
+//
+// permit(
+//     principal == Agent::"ops-agent",
+//     action == Action::"SendEmail",
+//     resource == Resource::"internal-smtp"
+// );

--- a/agent-governance-python/agent-os/src/agent_os/integrations/google_adk_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/google_adk_adapter.py
@@ -19,6 +19,7 @@ Features:
 - Token/call budget tracking
 - SIGKILL / cancellation support for running invocations
 - Full audit trail of tool calls and agent runs
+- Cedar/OPA policy integration via PolicyEvaluator
 - Works without google-adk installed (graceful import handling)
 - Compatible with LlmAgent, SequentialAgent, ParallelAgent, LoopAgent
 
@@ -47,6 +48,16 @@ Example:
     >>>
     >>> # Option C: Runner-scoped plugin (recommended for production)
     >>> from google.adk import Runner
+    >>> runner = Runner(
+    ...     agent=root_agent,
+    ...     plugins=[kernel.as_plugin()],
+    ... )
+    >>>
+    >>> # Option D: Cedar policy integration
+    >>> kernel = GoogleADKKernel.from_cedar(
+    ...     policy_path="policies/agent-governance.cedar",
+    ...     blocked_tools=["shell"],
+    ... )
     >>> runner = Runner(
     ...     agent=root_agent,
     ...     plugins=[kernel.as_plugin()],
@@ -196,6 +207,7 @@ class GoogleADKKernel(BaseIntegration):
         require_human_approval: bool = False,
         sensitive_tools: list[str] | None = None,
         max_budget: float | None = None,
+        evaluator: Any | None = None,
     ):
         if policy is not None:
             self._adk_config = policy
@@ -211,6 +223,9 @@ class GoogleADKKernel(BaseIntegration):
                 sensitive_tools=sensitive_tools or [],
                 max_budget=max_budget,
             )
+
+        # Optional Cedar/OPA policy evaluator
+        self._evaluator = evaluator
 
         # Initialize BaseIntegration with a GovernancePolicy mapped from PolicyConfig
         governance_policy = GovernancePolicy(
@@ -422,6 +437,10 @@ class GoogleADKKernel(BaseIntegration):
         """
         ADK before_tool_callback — called before each tool execution.
 
+        When a ``PolicyEvaluator`` is configured, it is consulted
+        **before** the built-in PolicyConfig checks (fail-closed
+        composition: the *more restrictive* result wins).
+
         Compatible with ADK's ToolContext. If tool_context is not an ADK
         ToolContext (e.g., in tests), falls back to kwargs for tool_name/tool_args.
 
@@ -433,6 +452,22 @@ class GoogleADKKernel(BaseIntegration):
         agent_name = getattr(tool_context, "agent_name", kwargs.get("agent_name", "unknown"))
 
         self._record("before_tool", agent_name, {"tool": tool_name, "args": tool_args})
+
+        # ── Cedar / PolicyEvaluator gate (runs first) ──────────────
+        ok, reason = self._evaluate_policy(
+            action=tool_name,
+            agent_name=agent_name,
+            tool_args=tool_args if isinstance(tool_args, dict) else {},
+        )
+        if not ok:
+            error = self._raise_violation("cedar_policy", reason)
+            self._record(
+                "cedar_denied", agent_name,
+                {"tool": tool_name, "reason": reason, "policy_backend": "cedar"},
+            )
+            return {"error": str(error)}
+
+        # ── PolicyConfig checks ────────────────────────────────────
 
         # Check timeout
         ok, reason = self._check_timeout()
@@ -737,6 +772,124 @@ class GoogleADKKernel(BaseIntegration):
         return invocation_id in self._cancelled_runs
 
     # ------------------------------------------------------------------
+    # Cedar / PolicyEvaluator integration
+    # ------------------------------------------------------------------
+
+    def _build_cedar_context(
+        self,
+        *,
+        action: str,
+        agent_name: str = "unknown",
+        tool_args: dict[str, Any] | None = None,
+        resource: str = "default",
+    ) -> dict[str, Any]:
+        """Build a context dict for PolicyEvaluator/CedarBackend.
+
+        Maps ADK lifecycle data to the principal/action/resource triple
+        that Cedar and OPA backends expect.
+
+        Args:
+            action: Tool name, ``"model_call"``, or ``"agent_call"``.
+            agent_name: The ADK agent name (maps to Cedar principal).
+            tool_args: Tool arguments for context enrichment.
+            resource: Resource identifier for the Cedar request.
+
+        Returns:
+            A context dict consumable by ``PolicyEvaluator.evaluate()``.
+        """
+        return {
+            "agent_id": agent_name,
+            "tool_name": action,
+            "resource": resource,
+            "token_count": self._prompt_tokens + self._completion_tokens,
+            "tool_call_count": self._tool_call_count,
+            "model_call_count": self._model_call_count,
+            "budget_spent": self._budget_spent,
+            "tool_args": tool_args or {},
+        }
+
+    def _evaluate_policy(
+        self,
+        *,
+        action: str,
+        agent_name: str = "unknown",
+        tool_args: dict[str, Any] | None = None,
+        resource: str = "default",
+    ) -> tuple[bool, str]:
+        """Consult the PolicyEvaluator if one is configured.
+
+        Returns (allowed, reason).  When no evaluator is set, returns
+        ``(True, "")`` so callers can fall through to PolicyConfig.
+
+        Fail-closed: if the evaluator raises, the call is denied.
+        """
+        if self._evaluator is None:
+            return True, ""
+
+        try:
+            ctx = self._build_cedar_context(
+                action=action,
+                agent_name=agent_name,
+                tool_args=tool_args,
+                resource=resource,
+            )
+            decision = self._evaluator.evaluate(ctx)
+            if not decision.allowed:
+                return False, decision.reason
+            return True, ""
+        except Exception as exc:
+            logger.error(
+                "PolicyEvaluator error — denying access (fail-closed): %s",
+                exc,
+                exc_info=True,
+            )
+            return False, f"Policy evaluation error (fail-closed): {exc}"
+
+    @classmethod
+    def from_cedar(
+        cls,
+        policy_path: str | None = None,
+        policy_content: str | None = None,
+        entities: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> "GoogleADKKernel":
+        """Create a kernel with Cedar policy evaluation.
+
+        Convenience factory that configures a ``PolicyEvaluator`` with a
+        ``CedarBackend`` and passes it to the kernel constructor.  All
+        standard ``GoogleADKKernel`` kwargs are forwarded.
+
+        Example::
+
+            kernel = GoogleADKKernel.from_cedar(
+                policy_path="policies/agent-governance.cedar",
+                blocked_tools=["shell"],
+            )
+            runner = Runner(
+                agent=root_agent,
+                plugins=[kernel.as_plugin()],
+            )
+
+        Args:
+            policy_path: Path to a ``.cedar`` policy file.
+            policy_content: Inline Cedar policy string.
+            entities: Cedar entities for authorization context.
+            **kwargs: Forwarded to ``GoogleADKKernel.__init__``.
+
+        Returns:
+            A configured GoogleADKKernel with Cedar evaluation enabled.
+        """
+        from agent_os.policies.evaluator import PolicyEvaluator
+
+        evaluator = PolicyEvaluator()
+        evaluator.load_cedar(
+            policy_path=policy_path,
+            policy_content=policy_content,
+            entities=entities,
+        )
+        return cls(evaluator=evaluator, **kwargs)
+
+    # ------------------------------------------------------------------
     # Plugin Factory
     # ------------------------------------------------------------------
 
@@ -942,10 +1095,25 @@ class GovernancePlugin(_PluginBase):  # type: ignore[misc]
     async def before_model_callback(
         self, *, callback_context: Any = None, llm_request: Any = None
     ) -> Any:
-        """Token budget pre-check and model call counting."""
+        """Token budget pre-check, model call counting, and Cedar policy."""
         cancelled = self._check_cancelled(callback_context)
         if cancelled:
             return cancelled  # type: ignore[return-value]
+
+        agent_name = self._extract_agent_name(ctx=callback_context)
+
+        # Cedar / PolicyEvaluator gate for model calls
+        ok, reason = self._kernel._evaluate_policy(
+            action="model_call",
+            agent_name=agent_name,
+        )
+        if not ok:
+            self._kernel._raise_violation("cedar_policy", reason)
+            self._kernel._record(
+                "cedar_denied", agent_name,
+                {"action": "model_call", "reason": reason, "policy_backend": "cedar"},
+            )
+            return {"error": reason}
 
         self._kernel._model_call_count += 1
 
@@ -956,7 +1124,7 @@ class GovernancePlugin(_PluginBase):  # type: ignore[misc]
 
         self._kernel._record(
             "before_model",
-            self._extract_agent_name(ctx=callback_context),
+            agent_name,
             {"model_call": self._kernel._model_call_count},
         )
         return None

--- a/agent-governance-python/agent-os/tests/test_google_adk_adapter.py
+++ b/agent-governance-python/agent-os/tests/test_google_adk_adapter.py
@@ -1343,3 +1343,233 @@ class TestEdgeCases:
         assert result is None
         # Should have recorded an audit event with "unknown" error
         assert any(e.event_type == "model_error" for e in k._audit_log)
+
+
+# =====================================================================
+# Cedar / PolicyEvaluator Integration Tests
+# =====================================================================
+
+
+class MockPolicyDecision:
+    """Stand-in for PolicyDecision returned by PolicyEvaluator."""
+
+    def __init__(self, allowed: bool = True, reason: str = ""):
+        self.allowed = allowed
+        self.reason = reason
+
+
+class MockPolicyEvaluator:
+    """Controllable mock for PolicyEvaluator."""
+
+    def __init__(self, *, allowed: bool = True, reason: str = "", should_raise: bool = False):
+        self._allowed = allowed
+        self._reason = reason
+        self._should_raise = should_raise
+        self.calls: list[dict] = []
+
+    def evaluate(self, context: dict) -> MockPolicyDecision:
+        self.calls.append(context)
+        if self._should_raise:
+            raise RuntimeError("Cedar engine unavailable")
+        return MockPolicyDecision(allowed=self._allowed, reason=self._reason)
+
+
+class TestCedarPolicyIntegration:
+    """Tests for PolicyEvaluator/CedarBackend wiring in GoogleADKKernel."""
+
+    def test_kernel_accepts_evaluator(self):
+        """GoogleADKKernel accepts an optional evaluator parameter."""
+        evaluator = MockPolicyEvaluator()
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        assert kernel._evaluator is evaluator
+
+    def test_kernel_no_evaluator_by_default(self):
+        """Without evaluator, _evaluator is None and policy check is a no-op."""
+        kernel = GoogleADKKernel()
+        assert kernel._evaluator is None
+        ok, reason = kernel._evaluate_policy(action="test_tool")
+        assert ok is True
+        assert reason == ""
+
+    def test_cedar_permit_allows_tool(self):
+        """When evaluator returns allowed=True, tool call proceeds."""
+        evaluator = MockPolicyEvaluator(allowed=True)
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        result = kernel.before_tool_callback(tool_name="read_data", tool_args={})
+        assert result is None  # Allowed
+        assert len(evaluator.calls) == 1
+        assert evaluator.calls[0]["tool_name"] == "read_data"
+
+    def test_cedar_forbid_blocks_tool(self):
+        """When evaluator returns allowed=False, tool call is blocked with cedar_policy violation."""
+        evaluator = MockPolicyEvaluator(allowed=False, reason="Cedar: forbid matched for DeleteFile")
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        result = kernel.before_tool_callback(tool_name="delete_file", tool_args={})
+        assert result is not None
+        assert "error" in result
+        assert "cedar_policy" in result["error"]
+        # Violation should be recorded
+        assert any(v.policy_name == "cedar_policy" for v in kernel._violations)
+        # Audit log should include cedar_denied event
+        assert any(e.event_type == "cedar_denied" for e in kernel._audit_log)
+
+    def test_cedar_fail_closed_on_error(self):
+        """When PolicyEvaluator raises, the call is denied (fail-closed)."""
+        evaluator = MockPolicyEvaluator(should_raise=True)
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        result = kernel.before_tool_callback(tool_name="safe_tool", tool_args={})
+        assert result is not None
+        assert "error" in result
+        assert "fail-closed" in result["error"]
+
+    def test_cedar_runs_before_policy_config(self):
+        """Cedar evaluation runs BEFORE PolicyConfig checks — denied by Cedar
+        even if the tool would pass PolicyConfig checks."""
+        evaluator = MockPolicyEvaluator(allowed=False, reason="Cedar denied")
+        kernel = GoogleADKKernel(
+            evaluator=evaluator,
+            allowed_tools=["delete_file"],  # PolicyConfig would allow it
+        )
+        result = kernel.before_tool_callback(tool_name="delete_file", tool_args={})
+        assert result is not None
+        assert "error" in result
+        assert "cedar" in result["error"].lower()
+
+    def test_cedar_allow_then_policy_config_denies(self):
+        """Cedar allows but PolicyConfig blocks — most restrictive wins."""
+        evaluator = MockPolicyEvaluator(allowed=True)
+        kernel = GoogleADKKernel(
+            evaluator=evaluator,
+            blocked_tools=["dangerous_tool"],
+        )
+        result = kernel.before_tool_callback(tool_name="dangerous_tool", tool_args={})
+        assert result is not None
+        assert "error" in result
+        assert "blocked" in result["error"].lower()
+
+    def test_build_cedar_context_shape(self):
+        """_build_cedar_context produces the expected context dict shape."""
+        kernel = GoogleADKKernel()
+        kernel._tool_call_count = 5
+        kernel._model_call_count = 3
+        kernel._prompt_tokens = 100
+        kernel._completion_tokens = 50
+        kernel._budget_spent = 2.5
+
+        ctx = kernel._build_cedar_context(
+            action="file_read",
+            agent_name="my-agent",
+            tool_args={"path": "/tmp/data.csv"},
+            resource="workspace",
+        )
+        assert ctx["agent_id"] == "my-agent"
+        assert ctx["tool_name"] == "file_read"
+        assert ctx["resource"] == "workspace"
+        assert ctx["token_count"] == 150
+        assert ctx["tool_call_count"] == 5
+        assert ctx["model_call_count"] == 3
+        assert ctx["budget_spent"] == 2.5
+        assert ctx["tool_args"] == {"path": "/tmp/data.csv"}
+
+    @pytest.mark.asyncio
+    async def test_plugin_before_tool_with_cedar(self):
+        """GovernancePlugin's before_tool_callback respects Cedar via kernel."""
+        evaluator = MockPolicyEvaluator(allowed=False, reason="Cedar forbid")
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        plugin = kernel.as_plugin()
+
+        tool = MagicMock()
+        tool.name = "shell"
+        result = await plugin.before_tool_callback(
+            tool=tool,
+            tool_args={"cmd": "ls"},
+            tool_context=MagicMock(),
+        )
+        assert result is not None
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_plugin_before_model_with_cedar_deny(self):
+        """GovernancePlugin's before_model_callback blocks on Cedar deny."""
+        evaluator = MockPolicyEvaluator(allowed=False, reason="Cedar: model_call forbidden")
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        plugin = kernel.as_plugin()
+
+        # Need to set up invocation context first
+        inv = MagicMock()
+        inv.invocation_id = "inv-cedar-model"
+        inv.session_id = "session-cedar-1"
+        await plugin.before_run_callback(invocation_context=inv)
+
+        result = await plugin.before_model_callback(
+            callback_context=inv,
+            llm_request=MagicMock(),
+        )
+        assert result is not None
+        assert "error" in result
+        assert "model_call" in result["error"]
+        # Model call count should NOT have incremented since Cedar denied first
+        assert kernel._model_call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_plugin_before_model_with_cedar_allow(self):
+        """GovernancePlugin's before_model_callback allows when Cedar allows."""
+        evaluator = MockPolicyEvaluator(allowed=True)
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        plugin = kernel.as_plugin()
+
+        inv = MagicMock()
+        inv.invocation_id = "inv-cedar-model-ok"
+        inv.session_id = "session-cedar-2"
+        await plugin.before_run_callback(invocation_context=inv)
+
+        result = await plugin.before_model_callback(
+            callback_context=inv,
+            llm_request=MagicMock(),
+        )
+        assert result is None  # Allowed
+        assert kernel._model_call_count == 1
+        assert len(evaluator.calls) == 1
+        assert evaluator.calls[0]["tool_name"] == "model_call"
+
+    def test_cedar_context_includes_tool_args(self):
+        """Cedar context should pass tool_args to evaluator for fine-grained policy."""
+        evaluator = MockPolicyEvaluator(allowed=True)
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        kernel.before_tool_callback(
+            tool_name="sql_query",
+            tool_args={"query": "SELECT * FROM users"},
+        )
+        assert evaluator.calls[0]["tool_args"] == {"query": "SELECT * FROM users"}
+
+    def test_from_cedar_factory_invalid_without_deps(self):
+        """from_cedar() raises ImportError when agent_os.policies is missing.
+        (In real environments with the package, it works seamlessly.)"""
+        # We can't test the happy path without the real PolicyEvaluator import,
+        # but we verify the method exists and has the right signature.
+        assert hasattr(GoogleADKKernel, "from_cedar")
+        assert callable(GoogleADKKernel.from_cedar)
+
+    def test_evaluator_receives_correct_agent_name(self):
+        """Cedar context receives agent_name from tool_context."""
+        evaluator = MockPolicyEvaluator(allowed=True)
+        kernel = GoogleADKKernel(evaluator=evaluator)
+
+        tc = MagicMock()
+        tc.agent_name = "finance-agent"
+        tc.tool_name = "read_report"
+        tc.tool_args = {}
+
+        kernel.before_tool_callback(tool_context=tc)
+        assert evaluator.calls[0]["agent_id"] == "finance-agent"
+
+    def test_cedar_deny_does_not_increment_tool_count(self):
+        """When Cedar denies, the tool_call_count should NOT be incremented."""
+        evaluator = MockPolicyEvaluator(allowed=False, reason="denied")
+        kernel = GoogleADKKernel(evaluator=evaluator)
+        initial_count = kernel._tool_call_count
+
+        kernel.before_tool_callback(tool_name="blocked_tool", tool_args={})
+
+        # Count should NOT have increased since Cedar short-circuits before counting
+        assert kernel._tool_call_count == initial_count


### PR DESCRIPTION
## Superseded

This PR is being superseded by a broader change that promotes Cedar/PolicyEvaluator to `BaseIntegration` so all 9 adapters (ADK, OpenAI, SK, LangChain, CrewAI, etc.) get Cedar support consistently via the base class.

See the tracking issue for the replacement approach.

---

_Original description:_

Wires the existing `PolicyEvaluator` + `CedarBackend` into `GoogleADKKernel` and `GovernancePlugin`, enabling declarative Cedar/OPA authorization for Google ADK agents. The implementation is correct and tested (130/130 AGT + 30/30 ai-ms), but the approach of adding Cedar only to the ADK adapter creates duplication when the same pattern needs to be applied to other adapters. The base-class approach is architecturally cleaner.