### PR TITLE
docs(contributing): add pre-push checklist with Docker integrated test step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,50 @@ To launch the optional Agent Hypervisor dashboard:
 docker compose --profile dashboard up --build dashboard
 ```
 
+### Pre-push checklist (recommended)
+
+Run these before pushing a PR. Each step catches a different class of bug
+and has a different cycle-time cost.
+
+1. **Inner loop — test the package you changed:**
+
+   ```bash
+   cd agent-governance-python/<package>
+   pytest tests/ -q
+   ```
+
+   *Cycle time: seconds. Catches: the bug you just wrote.*
+
+2. **Inner loop — lint the package you changed:**
+
+   ```bash
+   ruff check agent-governance-python/<package>/src --select E,F,W --ignore E501
+   ```
+
+   *Cycle time: seconds. Catches: lint failures CI would flag.*
+
+3. **Pre-push integration — run the full Docker test suite:**
+
+   ```bash
+   docker compose up --build dev -d
+   docker compose run --rm test
+   ```
+
+   *Cycle time: ~3 min cold, ~30 s warm. **This catches integration bugs
+   that per-package tests cannot see**, including shim/canonical drift,
+   sibling-package conflicts, Dockerfile drift, and line-ending issues.
+   This is the same flow CI gates on (`docker-compose-test` job).*
+
+4. **Push and let CI handle the rest** — multi-version Python, .NET,
+   TypeScript, Rust, Go, lint, build, security scanners, supply-chain
+   audits. Don't try to replicate all of CI locally.
+
+> **Why step 3 matters:** PR #1517 hardened a `trusted_keys` field but
+> missed the canonical implementation behind a backward-compat shim.
+> Per-package CI passed (the canonical impl wasn't installed in
+> isolation). The bug only surfaced under `docker compose run --rm test`,
+> which exercises the integrated install end users actually receive.
+
 ### Package Structure
 
 This repo includes these core packages and standalone SDKs today:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,12 +229,6 @@ and has a different cycle-time cost.
    TypeScript, Rust, Go, lint, build, security scanners, supply-chain
    audits. Don't try to replicate all of CI locally.
 
-> **Why step 3 matters:** PR #1517 hardened a `trusted_keys` field but
-> missed the canonical implementation behind a backward-compat shim.
-> Per-package CI passed (the canonical impl wasn't installed in
-> isolation). The bug only surfaced under `docker compose run --rm test`,
-> which exercises the integrated install end users actually receive.
-
 ### Package Structure
 
 This repo includes these core packages and standalone SDKs today:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,18 @@ docker compose --profile dashboard up --build dashboard
 Run these before pushing a PR. Each step catches a different class of bug
 and has a different cycle-time cost.
 
+**Local prerequisites:**
+
+- **Python 3.10+** (CI tests on 3.10, 3.11, 3.12, and 3.13)
+- **pytest** — `pip install pytest` (or install the package's dev extras)
+- **ruff** — `pip install ruff==0.12.4` (matches `agent-governance-python/requirements/ci-lint.txt`)
+- **Docker** with Compose v2 — required for step 3
+- For a given package, run `pip install -e .` from inside the package
+  directory before its first `pytest`. Sibling packages (e.g.
+  `agent-mesh`) may also need to be installed when their canonical
+  modules are imported by the package under test. Step 3's Docker flow
+  handles this automatically.
+
 1. **Inner loop — test the package you changed:**
 
    ```bash


### PR DESCRIPTION
## Description

Adds a **"Pre-push checklist (recommended)"** section to `CONTRIBUTING.md` documenting the four-tier inner loop contributors should run before pushing a PR: per-package `pytest`, per-package `ruff`, the full Docker integrated test (`docker compose run --rm test`), and finally `git push` to delegate the rest to CI.

The checklist mirrors the gates that now live in CI after #1549 (run-tests.sh covering all 10 Python packages) and #1563 (the `docker-compose-test` job added to ci.yml).

This is a docs-only change. No code, workflow, dependency, or CI changes.

**Why this PR exists / closing the loop:**
- #1549 made `run-tests.sh` cover all 10 Python packages.
- #1563 added the `docker-compose-test` CI job that gates merges on the integrated test flow.
- Without this PR, contributors discover the new gate by tripping over it in CI. With this PR, they have a documented local-equivalent inner loop.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

> **Tests N/A justification:** Docs-only change to `CONTRIBUTING.md`. No executable surface added or modified, so there is nothing to add a unit/integration test for. The commands referenced in the checklist (`pytest`, `ruff`, `docker compose run --rm test`) are themselves already covered by the CI workflows landed in #1549 and #1563.

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
None. The "fast-feedback inner loop → integration → push → CI" layered checklist is a generic dev-loop pattern, not adapted from any specific project.

## AI & IP Disclosure
- [x] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

**AI tools used** (if any):
GitHub Copilot CLI assisted with drafting the checklist wording. All content was manually reviewed and edited by the author. The cross-references to #1549 and #1563 are based on direct review of the merged commits, not LLM speculation.

## Related Issues
Follow-up to #1549 and #1563. Completes the third and final PR in the Docker-CI-gating mini-plan (β/γ/ε). No issue link.