### PR TITLE
feat(ci): add registry and relay to container publish workflow

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -15,6 +15,8 @@ on:
           - policy-server
           - audit-collector
           - api-gateway
+          - registry
+          - relay
           - governance-sidecar
       tag:
         description: "Image tag (default: latest)"
@@ -56,6 +58,14 @@ jobs:
             dockerfile: agent-governance-python/agent-mesh/docker/Dockerfile
             context: .
             port: 8446
+          - component: registry
+            dockerfile: agent-governance-python/agent-mesh/docker/Dockerfile
+            context: .
+            port: 8082
+          - component: relay
+            dockerfile: agent-governance-python/agent-mesh/docker/Dockerfile
+            context: .
+            port: 8083
           - component: governance-sidecar
             dockerfile: agent-governance-python/agent-os/Dockerfile.sidecar
             context: .


### PR DESCRIPTION
## Summary

Adds AgentMesh **registry** and **relay** components to the GHCR container publish workflow so they are published alongside the existing images on release.

## Changes

- Added `registry` (port 8082) and `relay` (port 8083) to the build matrix in `publish-containers.yml`
- Added both to the `workflow_dispatch` component picker for manual builds
- Both use the existing `agent-mesh/docker/Dockerfile` with the `COMPONENT` build arg (same pattern as trust-engine, policy-server, etc.)

## Published images after merge

| Component | Image | Port |
|-----------|-------|------|
| registry | `ghcr.io/microsoft/agentmesh/registry` | 8082 |
| relay | `ghcr.io/microsoft/agentmesh/relay` | 8083 |

## Type of Change
- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update
- [x] Maintenance (CI/CD)

## Checklist
- [x] No code changes, CI-only
- [x] Dockerfile already supports both components via COMPONENT build arg
- [x] Both `agentmesh.registry` and `agentmesh.relay` modules exist with `__main__.py`