### PR TITLE
feat(openai): native RunHooks lifecycle + BaseIntegration inheritance

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/openai_agents_sdk.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/openai_agents_sdk.py
@@ -4,33 +4,44 @@
 OpenAI Agents SDK Integration for Agent-OS
 ============================================
 
-Provides kernel-level governance for OpenAI Agents SDK workflows.
+Provides kernel-level governance for OpenAI Agents SDK workflows using
+the SDK's native ``RunHooks`` lifecycle system.
 
-Features:
-- Policy enforcement for agent tool calls
-- Guardrails integration with Agent-OS policies
-- Handoff monitoring and approval
-- Streaming response governance
+**Preferred (native hooks)**::
 
-Example:
-    >>> from agent_os.integrations.openai_agents import OpenAIAgentsKernel
-    >>> from agent_os.policies import GovernancePolicy
-    >>> from agents import Agent, Runner
-    >>>
-    >>> # Create governed kernel
-    >>> policy = GovernancePolicy(
-    ...     max_tool_calls=10,
-    ...     allowed_tools=["file_search", "code_interpreter"],
-    ...     blocked_patterns=["rm -rf", "DROP TABLE"],
-    ... )
-    >>> kernel = OpenAIAgentsKernel(policy=policy)
-    >>>
-    >>> # Wrap agent
-    >>> agent = Agent(name="assistant", model="gpt-4o")
-    >>> governed_agent = kernel.wrap(agent)
-    >>>
-    >>> # Run with governance
-    >>> result = await Runner.run(governed_agent, "Analyze this data")
+    from agent_os.integrations.openai_agents_sdk import OpenAIAgentsKernel
+    from agents import Agent, Runner
+
+    kernel = OpenAIAgentsKernel(
+        blocked_tools=["shell_exec"],
+        blocked_patterns=["DROP TABLE"],
+    )
+
+    agent = Agent(name="assistant", model="gpt-4o")
+    result = await Runner.run(agent, "Analyze data", hooks=kernel.as_hooks())
+
+**With Cedar/OPA policy evaluation**::
+
+    kernel = OpenAIAgentsKernel.from_cedar("policies/governance.cedar")
+    result = await Runner.run(agent, "...", hooks=kernel.as_hooks())
+
+**Legacy (deprecated — kept for backward compatibility)**::
+
+    governed_agent = kernel.wrap(agent)
+    GovernedRunner = kernel.wrap_runner(Runner)
+    result = await GovernedRunner.run(governed_agent, "input")
+
+Features
+--------
+- Native ``RunHooks`` lifecycle integration (agent/tool/handoff callbacks)
+- Inherits ``BaseIntegration`` — Cedar/OPA, ``pre_execute``, ``post_execute``
+- Tool allowlist/blocklist enforcement via ``on_tool_start``
+- Content filtering via ``on_agent_start``
+- Handoff monitoring and limit enforcement via ``on_handoff``
+- Full audit trail with event recording
+- Health check endpoint
+- Backward-compatible ``wrap()`` / ``wrap_runner()`` / ``create_tool_guard()``
+  (deprecated, will be removed in a future release)
 """
 
 from __future__ import annotations
@@ -38,150 +49,276 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import uuid
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import wraps
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
-logger = logging.getLogger(__name__)
+from .base import BaseIntegration, ExecutionContext, GovernancePolicy
 
-
-@dataclass
-class GovernancePolicy:
-    """Policy configuration for OpenAI Agents."""
-    # Tool limits
-    max_tool_calls: int = 50
-    max_handoffs: int = 5
-    timeout_seconds: int = 300
-
-    # Tool filtering
-    allowed_tools: list[str] = field(default_factory=list)
-    blocked_tools: list[str] = field(default_factory=list)
-
-    # Content filtering
-    blocked_patterns: list[str] = field(default_factory=list)
-    pii_detection: bool = True
-
-    # Approval flows
-    require_human_approval: bool = False
-    approval_threshold: float = 0.8
-
-    # Audit
-    log_all_calls: bool = True
-    checkpoint_frequency: int = 5
+logger = logging.getLogger("agent_os.openai_agents")
 
 
-@dataclass
-class ExecutionContext:
-    """Runtime context for governed execution."""
-    session_id: str
-    agent_id: str
-    policy: GovernancePolicy
+# ── Graceful import of OpenAI Agents SDK ──────────────────────────────
+try:
+    from agents import RunHooks as _SDKRunHooks  # type: ignore[import-untyped]
 
-    # Counters
-    tool_calls: int = 0
-    handoffs: int = 0
+    _HAS_AGENTS_SDK = True
+except ImportError:
+    _SDKRunHooks = None
+    _HAS_AGENTS_SDK = False
 
-    # Timing
-    started_at: datetime = field(default_factory=datetime.utcnow)
-
-    # Audit trail
-    events: list[dict[str, Any]] = field(default_factory=list)
-
-    def record_event(self, event_type: str, data: dict[str, Any]) -> None:
-        self.events.append({
-            "type": event_type,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "data": data,
-        })
+# Re-export PolicyViolationError for backward compatibility
+from agent_os.exceptions import PolicyViolationError as PolicyViolationError  # noqa: F401
 
 
-class PolicyViolationError(Exception):
-    """Raised when a policy violation is detected."""
-    def __init__(self, policy_name: str, description: str, severity: str = "high"):
-        self.policy_name = policy_name
-        self.description = description
-        self.severity = severity
-        super().__init__(f"Policy violation ({policy_name}): {description}")
+# =====================================================================
+# OpenAI Agents Kernel
+# =====================================================================
 
 
-class OpenAIAgentsKernel:
-    """
-    Governance kernel for OpenAI Agents SDK.
+class OpenAIAgentsKernel(BaseIntegration):
+    """Governance kernel for the OpenAI Agents SDK.
 
-    Wraps Agent and Runner to enforce policies during execution.
+    Extends :class:`BaseIntegration` so that it inherits Cedar/OPA policy
+    evaluation, ``pre_execute`` / ``post_execute`` governance, and
+    ``from_cedar`` factory support.
+
+    The primary integration path is via :meth:`as_hooks`, which returns a
+    :class:`GovernanceRunHooks` instance that can be passed directly to
+    ``Runner.run(hooks=...)``.
+
+    Example::
+
+        kernel = OpenAIAgentsKernel(
+            blocked_tools=["shell"],
+            blocked_patterns=["DROP TABLE"],
+        )
+        result = await Runner.run(agent, "input", hooks=kernel.as_hooks())
     """
 
     def __init__(
         self,
-        policy: GovernancePolicy | None = None,
-        on_violation: Callable[[PolicyViolationError], None] | None = None,
+        policy: Optional[GovernancePolicy] = None,
+        on_violation: Optional[Callable[[PolicyViolationError], None]] = None,
+        *,
+        evaluator: Any = None,
+        # Convenience kwargs
+        max_tool_calls: int = 50,
+        max_handoffs: int = 5,
+        timeout_seconds: int = 300,
+        allowed_tools: Optional[list[str]] = None,
+        blocked_tools: Optional[list[str]] = None,
+        blocked_patterns: Optional[list[str]] = None,
+        require_human_approval: bool = False,
     ) -> None:
-        self.policy: GovernancePolicy = policy or GovernancePolicy()
+        """Initialise the OpenAI Agents governance kernel.
+
+        Args:
+            policy: Full governance policy.  When ``None`` a policy is
+                built from the convenience kwargs.
+            on_violation: Optional callback invoked on every policy
+                violation.
+            evaluator: Optional ``PolicyEvaluator`` for Cedar/OPA policy
+                evaluation.
+            max_tool_calls: Max tool invocations before blocking.
+            max_handoffs: Max agent handoffs before blocking.
+            timeout_seconds: Global timeout in seconds.
+            allowed_tools: If non-empty, only these tools may execute.
+            blocked_tools: Tools that are always denied.
+            blocked_patterns: Content substrings that are always denied.
+            require_human_approval: When ``True``, violations raise
+                immediately; otherwise they are logged via *on_violation*.
+        """
+        if policy is None:
+            policy = GovernancePolicy(
+                max_tool_calls=max_tool_calls,
+                timeout_seconds=timeout_seconds,
+                allowed_tools=allowed_tools or [],
+                blocked_patterns=blocked_patterns or [],
+                require_human_approval=require_human_approval,
+            )
+        super().__init__(policy, evaluator=evaluator)
+
         self.on_violation: Callable[[PolicyViolationError], None] = (
             on_violation or self._default_violation_handler
         )
-        self._contexts: dict[str, ExecutionContext] = {}
-        self._wrapped_agents: dict[str, Any] = {}
-        self._start_time: float = time.monotonic()
-        self._last_error: str | None = None
-
-    def _default_violation_handler(self, error: PolicyViolationError) -> None:
-        logger.error(f"Policy violation: {error}")
-
-    def _create_context(self, agent_id: str) -> ExecutionContext:
-        """Create execution context for an agent."""
-        import uuid
-        session_id = str(uuid.uuid4())[:8]
-        ctx = ExecutionContext(
-            session_id=session_id,
-            agent_id=agent_id,
-            policy=self.policy,
+        self._blocked_tools: set[str] = set(blocked_tools or [])
+        self._allowed_tools: set[str] = set(
+            policy.allowed_tools if policy.allowed_tools else (allowed_tools or [])
         )
-        self._contexts[session_id] = ctx
-        return ctx
+        self._max_handoffs: int = max_handoffs
+        self._require_human_approval: bool = (
+            policy.require_human_approval
+            if policy.require_human_approval
+            else require_human_approval
+        )
+
+        # ── Runtime state ─────────────────────────────────────────
+        self._agent_contexts: dict[str, ExecutionContext] = {}
+        self._tool_call_count: int = 0
+        self._handoff_count: int = 0
+        self._start_time: float = time.monotonic()
+        self._last_error: Optional[str] = None
+
+        # Audit trail
+        self._audit_events: list[dict[str, Any]] = []
+
+        # Legacy wrapped agents registry (used by deprecated wrap())
+        self._wrapped_agents: dict[str, Any] = {}
+
+    # ── Violation Handling ─────────────────────────────────────────
+
+    @staticmethod
+    def _default_violation_handler(error: PolicyViolationError) -> None:
+        """Log a policy violation at ERROR level.
+
+        This is the default handler used when no custom ``on_violation``
+        callback is provided.
+
+        Args:
+            error: The policy violation that was detected.
+        """
+        logger.error("Policy violation: %s", error)
+
+    # ── Tool / Content Checks ─────────────────────────────────────
 
     def _check_tool_allowed(self, tool_name: str) -> tuple[bool, str]:
-        """Check if tool is allowed by policy."""
-        # Check blocked list
-        if tool_name in self.policy.blocked_tools:
+        """Check whether *tool_name* is permitted by the active policy.
+
+        Evaluation order:
+
+        1. If *tool_name* is in ``_blocked_tools`` → deny.
+        2. If ``_allowed_tools`` is non-empty and *tool_name* is absent → deny.
+        3. Otherwise → allow.
+
+        Args:
+            tool_name: The name of the tool to evaluate.
+
+        Returns:
+            A ``(allowed, reason)`` tuple.  *reason* is the empty string
+            when *allowed* is ``True``.
+        """
+        if tool_name in self._blocked_tools:
             return False, f"Tool '{tool_name}' is blocked by policy"
-
-        # Check allowed list (if specified)
-        if self.policy.allowed_tools:
-            if tool_name not in self.policy.allowed_tools:
-                return False, f"Tool '{tool_name}' not in allowed list"
-
+        if self._allowed_tools and tool_name not in self._allowed_tools:
+            return False, f"Tool '{tool_name}' not in allowed list"
         return True, ""
 
     def _check_content(self, content: str) -> tuple[bool, str]:
-        """Check content against blocked patterns."""
+        """Check *content* against ``blocked_patterns`` in the policy.
+
+        Matching is case-insensitive substring search.
+
+        Args:
+            content: The text to scan.
+
+        Returns:
+            A ``(ok, reason)`` tuple.  *reason* describes the matched
+            pattern when *ok* is ``False``.
+        """
         content_lower = content.lower()
         for pattern in self.policy.blocked_patterns:
             if pattern.lower() in content_lower:
                 return False, f"Content matches blocked pattern: {pattern}"
         return True, ""
 
-    def wrap(self, agent: Any) -> Any:
-        """
-        Wrap an OpenAI Agent with governance.
+    # ── Event Recording ───────────────────────────────────────────
+
+    def _record_event(
+        self, event_type: str, data: dict[str, Any]
+    ) -> None:
+        """Append a timestamped audit event to the internal log.
 
         Args:
-            agent: OpenAI Agents SDK Agent instance
+            event_type: Short label (e.g. ``"agent_start"``, ``"tool_end"``).
+            data: Arbitrary metadata dict attached to the event.
+        """
+        self._audit_events.append({
+            "type": event_type,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "data": data,
+        })
+
+    # ── Context Management ────────────────────────────────────────
+
+    def _get_or_create_context(self, agent_name: str) -> ExecutionContext:
+        """Return the ``ExecutionContext`` for *agent_name*, creating one if needed.
+
+        Contexts are cached in ``_agent_contexts`` keyed by agent name so
+        that the same context is reused across hook invocations within a
+        single run.
+
+        Args:
+            agent_name: Identifier for the agent.
 
         Returns:
-            Governed agent wrapper
+            The existing or newly created :class:`ExecutionContext`.
         """
+        if agent_name not in self._agent_contexts:
+            ctx = self.create_context(agent_name)
+            self._agent_contexts[agent_name] = ctx
+        return self._agent_contexts[agent_name]
+
+    # ================================================================
+    # Native RunHooks Integration  (PRIMARY API)
+    # ================================================================
+
+    def as_hooks(self, name: str = "governance") -> "GovernanceRunHooks":
+        """Return a :class:`GovernanceRunHooks` backed by this kernel.
+
+        Pass the returned object to ``Runner.run(hooks=...)``::
+
+            kernel = OpenAIAgentsKernel(blocked_tools=["shell"])
+            result = await Runner.run(
+                agent, "input", hooks=kernel.as_hooks()
+            )
+
+        Args:
+            name: Optional label for logging/identification.
+
+        Returns:
+            A :class:`GovernanceRunHooks` instance.
+        """
+        return GovernanceRunHooks(kernel=self, name=name)
+
+    # ================================================================
+    # Deprecated wrap()-Based API  (BACKWARD COMPAT)
+    # ================================================================
+
+    def wrap(self, agent: Any) -> Any:
+        """Wrap an OpenAI Agent with a governance proxy.
+
+        .. deprecated::
+            Use :meth:`as_hooks` instead.  The ``wrap()`` approach creates
+            a fragile proxy object that cannot intercept all SDK
+            lifecycle events.  Prefer the native ``RunHooks`` path::
+
+                result = await Runner.run(agent, "input",
+                                          hooks=kernel.as_hooks())
+
+        Args:
+            agent: An OpenAI Agents SDK ``Agent`` instance.
+
+        Returns:
+            A ``GovernedAgent`` wrapper that delegates attribute access
+            to *agent* and stores a governance :class:`ExecutionContext`.
+        """
+        warnings.warn(
+            "OpenAIAgentsKernel.wrap() is deprecated. "
+            "Use kernel.as_hooks() with Runner.run(hooks=...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         agent_id = getattr(agent, "name", str(id(agent)))
 
-        # Create wrapper class
         class GovernedAgent:
             def __init__(wrapper_self, original: Any, kernel: OpenAIAgentsKernel):
                 wrapper_self._original = original
                 wrapper_self._kernel = kernel
-                wrapper_self._context = kernel._create_context(agent_id)
-
-                # Copy attributes
+                wrapper_self._context = kernel._get_or_create_context(agent_id)
                 for attr in ["name", "model", "instructions", "tools"]:
                     if hasattr(original, attr):
                         setattr(wrapper_self, attr, getattr(original, attr))
@@ -195,68 +332,84 @@ class OpenAIAgentsKernel:
 
         wrapped = GovernedAgent(agent, self)
         self._wrapped_agents[agent_id] = wrapped
-        logger.info(f"Wrapped agent '{agent_id}' with governance kernel")
+        logger.info("Wrapped agent '%s' with governance kernel (deprecated)", agent_id)
         return wrapped
 
     def unwrap(self, governed_agent: Any) -> Any:
-        """Remove governance wrapper."""
+        """Remove the governance wrapper and return the original agent.
+
+        Args:
+            governed_agent: A previously wrapped agent or any object.
+
+        Returns:
+            The original unwrapped agent.  If *governed_agent* was never
+            wrapped, it is returned unchanged.
+        """
         if hasattr(governed_agent, "_original"):
             return governed_agent._original
         return governed_agent
 
     def wrap_runner(self, runner_class: Any) -> Any:
-        """
-        Wrap the Runner class to intercept executions.
+        """Wrap the SDK ``Runner`` class to intercept ``run()`` calls.
+
+        .. deprecated::
+            Use :meth:`as_hooks` instead.  The ``wrap_runner()`` approach
+            relies on class-level monkey-patching that cannot access
+            lifecycle events between agent turns.
 
         Args:
-            runner_class: OpenAI Agents SDK Runner class
+            runner_class: The ``agents.Runner`` class to wrap.
 
         Returns:
-            Governed Runner class
+            A ``GovernedRunner`` class with ``run()`` and ``run_sync()``
+            class methods that apply governance before delegating.
         """
+        warnings.warn(
+            "OpenAIAgentsKernel.wrap_runner() is deprecated. "
+            "Use kernel.as_hooks() with Runner.run(hooks=...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         kernel = self
 
         class GovernedRunner:
             @classmethod
-            async def run(
-                cls,
-                agent: Any,
-                input_text: str,
-                **kwargs,
-            ) -> Any:
-                # Get context
-                ctx = None
-                if hasattr(agent, "_context"):
-                    ctx = agent._context
-
-                # Pre-execution checks
+            async def run(cls, agent: Any, input_text: str, **kwargs) -> Any:
+                ctx = getattr(agent, "_context", None)
                 if ctx:
-                    # Check content
                     ok, reason = kernel._check_content(input_text)
                     if not ok:
-                        error = PolicyViolationError("content_filter", reason)
+                        error = PolicyViolationError(
+                            f"Content blocked: {reason}"
+                        )
                         kernel.on_violation(error)
-                        if kernel.policy.require_human_approval:
+                        if kernel._require_human_approval:
                             raise error
+                    ctx.tool_calls.append({
+                        "type": "run_start",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "data": {"input_length": len(input_text)},
+                    })
 
-                    ctx.record_event("run_start", {"input_length": len(input_text)})
-
-                # Get original agent
-                original_agent = agent
-                if hasattr(agent, "_original"):
-                    original_agent = agent._original
-
-                # Run with monitoring
+                original_agent = getattr(agent, "_original", agent)
                 try:
-                    result = await runner_class.run(original_agent, input_text, **kwargs)
-
+                    result = await runner_class.run(
+                        original_agent, input_text, **kwargs
+                    )
                     if ctx:
-                        ctx.record_event("run_complete", {"success": True})
-
+                        ctx.tool_calls.append({
+                            "type": "run_complete",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "data": {"success": True},
+                        })
                     return result
                 except Exception as e:
                     if ctx:
-                        ctx.record_event("run_error", {"error": str(e)})
+                        ctx.tool_calls.append({
+                            "type": "run_error",
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "data": {"error": str(e)},
+                        })
                     raise
 
             @classmethod
@@ -266,43 +419,57 @@ class OpenAIAgentsKernel:
         return GovernedRunner
 
     def create_tool_guard(self) -> Callable:
-        """
-        Create a tool execution guard.
+        """Create a decorator that applies governance checks to tool functions.
 
-        Use as a decorator or wrapper for tool functions.
+        .. deprecated::
+            Tool governance is now handled automatically via
+            :meth:`as_hooks` through the ``on_tool_start`` hook.
+
+        Returns:
+            A decorator that wraps sync or async callables with tool
+            allow/block and content-filter checks.
+
+        Raises:
+            PolicyViolationError: When the decorated tool's name is
+                blocked or its arguments contain blocked content.
         """
+        warnings.warn(
+            "OpenAIAgentsKernel.create_tool_guard() is deprecated. "
+            "Tool governance is handled via as_hooks() on_tool_start.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         kernel = self
 
         def guard(func: Callable) -> Callable:
             @wraps(func)
             async def wrapper(*args, **kwargs):
                 tool_name = func.__name__
-
-                # Check if tool is allowed
                 ok, reason = kernel._check_tool_allowed(tool_name)
                 if not ok:
-                    error = PolicyViolationError("tool_filter", reason)
+                    error = PolicyViolationError(f"Tool blocked: {reason}")
                     kernel.on_violation(error)
                     raise error
 
-                # Check content in arguments
                 for arg in args:
                     if isinstance(arg, str):
                         ok, reason = kernel._check_content(arg)
                         if not ok:
-                            error = PolicyViolationError("content_filter", reason)
+                            error = PolicyViolationError(
+                                f"Content blocked: {reason}"
+                            )
                             kernel.on_violation(error)
                             raise error
-
                 for value in kwargs.values():
                     if isinstance(value, str):
                         ok, reason = kernel._check_content(value)
                         if not ok:
-                            error = PolicyViolationError("content_filter", reason)
+                            error = PolicyViolationError(
+                                f"Content blocked: {reason}"
+                            )
                             kernel.on_violation(error)
                             raise error
 
-                # Execute
                 if asyncio.iscoroutinefunction(func):
                     return await func(*args, **kwargs)
                 return func(*args, **kwargs)
@@ -311,15 +478,21 @@ class OpenAIAgentsKernel:
         return guard
 
     def create_guardrail(self) -> Any:
-        """
-        Create an OpenAI Agents SDK compatible guardrail.
+        """Create an OpenAI Agents SDK compatible guardrail callable.
 
-        Returns a guardrail that can be added to an agent.
+        The returned object is an async callable with the guardrail
+        signature ``(context, agent, input_text) -> str | None``.
+        Returns ``None`` when the input passes all checks, or a
+        human-readable rejection string when content or tool calls
+        violate the active policy.
+
+        Returns:
+            A ``PolicyGuardrail`` instance.
         """
         kernel = self
 
         class PolicyGuardrail:
-            """Agent-OS policy guardrail for OpenAI Agents SDK."""
+            """OpenAI Agents SDK guardrail backed by Agent-OS governance."""
 
             async def __call__(
                 self,
@@ -327,80 +500,439 @@ class OpenAIAgentsKernel:
                 agent: Any,
                 input_text: str,
             ) -> str | None:
-                """
-                Check input against policies.
+                """Evaluate governance rules and return a rejection or None.
 
-                Returns None if allowed, or a rejection message if blocked.
+                Args:
+                    context: SDK run context (may contain ``tool_calls``).
+                    agent: The agent being guarded.
+                    input_text: The user input to check.
+
+                Returns:
+                    A rejection message string, or ``None`` if allowed.
                 """
-                # Check content patterns
                 ok, reason = kernel._check_content(input_text)
                 if not ok:
-                    logger.warning(f"Guardrail blocked: {reason}")
+                    logger.warning("Guardrail blocked: %s", reason)
                     return f"Request blocked by policy: {reason}"
 
-                # Check tool calls if in context
                 if hasattr(context, "tool_calls"):
                     for tool_call in context.tool_calls:
                         tool_name = getattr(tool_call, "name", "")
                         ok, reason = kernel._check_tool_allowed(tool_name)
                         if not ok:
-                            logger.warning(f"Guardrail blocked tool: {reason}")
+                            logger.warning("Guardrail blocked tool: %s", reason)
                             return f"Tool blocked by policy: {reason}"
-
-                return None  # Allowed
+                return None
 
         return PolicyGuardrail()
 
-    def get_context(self, session_id: str) -> ExecutionContext | None:
-        """Get execution context by session ID."""
-        return self._contexts.get(session_id)
+    # ================================================================
+    # Observability
+    # ================================================================
 
-    def get_audit_log(self, session_id: str) -> list[dict[str, Any]]:
-        """Get audit log for a session."""
-        ctx = self._contexts.get(session_id)
-        if ctx:
-            return ctx.events
-        return []
+    def get_audit_log(self) -> list[dict[str, Any]]:
+        """Return all recorded audit events as a list of dicts.
+
+        Each entry contains ``type``, ``timestamp`` (ISO-8601), and
+        ``data`` keys.  The list is a shallow copy — mutations do not
+        affect the internal log.
+
+        Returns:
+            List of audit event dicts, oldest first.
+        """
+        return list(self._audit_events)
 
     def get_stats(self) -> dict[str, Any]:
-        """Get governance statistics."""
-        total_tool_calls: int = sum(ctx.tool_calls for ctx in self._contexts.values())
-        total_handoffs: int = sum(ctx.handoffs for ctx in self._contexts.values())
+        """Return aggregate governance statistics.
 
+        Returns:
+            A dict containing ``total_sessions``, ``total_tool_calls``,
+            ``total_handoffs``, ``wrapped_agents``, and a ``policy``
+            sub-dict with the active configuration.
+        """
         return {
-            "total_sessions": len(self._contexts),
+            "total_sessions": len(self._agent_contexts),
+            "total_tool_calls": self._tool_call_count,
+            "total_handoffs": self._handoff_count,
             "wrapped_agents": len(self._wrapped_agents),
-            "total_tool_calls": total_tool_calls,
-            "total_handoffs": total_handoffs,
             "policy": {
                 "max_tool_calls": self.policy.max_tool_calls,
-                "max_handoffs": self.policy.max_handoffs,
-                "blocked_tools": self.policy.blocked_tools,
+                "max_handoffs": self._max_handoffs,
+                "blocked_tools": sorted(self._blocked_tools),
+                "allowed_tools": sorted(self._allowed_tools),
             },
         }
 
     def health_check(self) -> dict[str, Any]:
-        """Return adapter health status.
+        """Return a health-check snapshot for monitoring integrations.
 
         Returns:
-            A dict with ``status``, ``backend``, ``last_error``, and
-            ``uptime_seconds`` keys.
+            A dict with ``status`` (``"healthy"`` or ``"degraded"``),
+            ``backend``, ``backend_connected``, ``last_error``, and
+            ``uptime_seconds``.
         """
         uptime: float = time.monotonic() - self._start_time
+        has_activity = bool(self._agent_contexts) or bool(self._wrapped_agents)
         status: str = "degraded" if self._last_error else "healthy"
         return {
             "status": status,
             "backend": "openai_agents_sdk",
-            "backend_connected": bool(self._wrapped_agents),
+            "backend_connected": has_activity,
             "last_error": self._last_error,
             "uptime_seconds": round(uptime, 2),
         }
 
 
+# =====================================================================
+# GovernanceRunHooks — Native RunHooks Implementation
+# =====================================================================
+
+
+_HooksBase: type = _SDKRunHooks if _SDKRunHooks is not None else object
+
+
+class GovernanceRunHooks(_HooksBase):  # type: ignore[misc]
+    """Native ``RunHooks`` implementation for Agent-OS governance.
+
+    Implements the OpenAI Agents SDK lifecycle callbacks to enforce
+    governance at every stage of agent execution — without wrapping or
+    monkey-patching agent/runner objects.
+
+    The hooks delegate all governance decisions to the backing
+    :class:`OpenAIAgentsKernel`, which in turn uses
+    :class:`BaseIntegration`'s ``pre_execute``, Cedar/OPA evaluation,
+    and ``GovernancePolicy`` checks.
+
+    Register via :meth:`OpenAIAgentsKernel.as_hooks`::
+
+        kernel = OpenAIAgentsKernel(blocked_tools=["shell"])
+        runner = Runner(agent=agent)
+        result = await Runner.run(agent, "input", hooks=kernel.as_hooks())
+
+    Lifecycle coverage:
+
+    +-----------------------+-------------------------------------------+
+    | Callback              | Governance action                         |
+    +=======================+===========================================+
+    | ``on_agent_start``    | Content filter, Cedar gate,               |
+    |                       | ``pre_execute``                           |
+    +-----------------------+-------------------------------------------+
+    | ``on_agent_end``      | ``post_execute``, audit recording         |
+    +-----------------------+-------------------------------------------+
+    | ``on_tool_start``     | Tool allowlist/blocklist, Cedar gate,     |
+    |                       | tool call budget enforcement               |
+    +-----------------------+-------------------------------------------+
+    | ``on_tool_end``       | Output content filter, audit recording    |
+    +-----------------------+-------------------------------------------+
+    | ``on_handoff``        | Handoff limit enforcement, audit          |
+    +-----------------------+-------------------------------------------+
+    """
+
+    def __init__(
+        self, kernel: OpenAIAgentsKernel, name: str = "governance"
+    ) -> None:
+        if _SDKRunHooks is not None:
+            super().__init__()
+        self._kernel = kernel
+        self._name = name
+
+    @property
+    def hook_name(self) -> str:
+        """Human-readable label for this hooks instance."""
+        return self._name
+
+    # ── Helpers ────────────────────────────────────────────────────
+
+    def _extract_agent_name(self, agent: Any) -> str:
+        """Extract a stable name for *agent*, falling back to ``id()``.
+
+        Args:
+            agent: Any object with an optional ``name`` attribute.
+
+        Returns:
+            The agent's ``name`` attribute as a string, or a
+            generated ``"openai-agent-<id>"`` fallback.
+        """
+        name = getattr(agent, "name", None)
+        if name:
+            return str(name)
+        return f"openai-agent-{id(agent)}"
+
+    # ── 1. Agent Start ────────────────────────────────────────────
+
+    async def on_agent_start(
+        self, context: Any, agent: Any
+    ) -> None:
+        """Called when an agent begins execution.
+
+        Governance actions performed:
+
+        1. **Content filter** — scans available input text against
+           ``blocked_patterns`` (local fast check).
+        2. **Cedar/OPA gate** — delegates to ``pre_execute()`` for
+           policy evaluation (skipped if the content filter already
+           caught a violation to avoid double-blocking).
+        3. **Audit** — records an ``agent_start`` event.
+
+        Args:
+            context: SDK run context.
+            agent: The agent that is about to execute.
+
+        Raises:
+            PolicyViolationError: When content or policy evaluation
+                blocks the input and ``require_human_approval`` is
+                ``True``.
+        """
+        agent_name = self._extract_agent_name(agent)
+        ctx = self._kernel._get_or_create_context(agent_name)
+
+        # Extract input text from context if available
+        input_text = ""
+        if hasattr(context, "input"):
+            input_text = str(context.input)
+        elif hasattr(context, "messages"):
+            msgs = context.messages
+            if msgs and hasattr(msgs[-1], "content"):
+                input_text = str(msgs[-1].content)
+
+        # Content filter (local fast check)
+        content_violated = False
+        if input_text:
+            ok, reason = self._kernel._check_content(input_text)
+            if not ok:
+                content_violated = True
+                error = PolicyViolationError(
+                    f"Agent start blocked: {reason}"
+                )
+                self._kernel.on_violation(error)
+                if self._kernel._require_human_approval:
+                    raise error
+
+        # Cedar/OPA + GovernancePolicy gate (skip if content already
+        # failed locally and was logged — avoids double-block)
+        if input_text and not content_violated:
+            allowed, reason = self._kernel.pre_execute(ctx, input_text)
+            if not allowed:
+                raise PolicyViolationError(
+                    f"Agent '{agent_name}' blocked by governance: {reason}"
+                )
+
+        self._kernel._record_event(
+            "agent_start",
+            {"agent": agent_name, "input_length": len(input_text)},
+        )
+        logger.debug("on_agent_start: %s (input_len=%d)", agent_name, len(input_text))
+
+    # ── 2. Agent End ──────────────────────────────────────────────
+
+    async def on_agent_end(
+        self, context: Any, agent: Any, output: Any
+    ) -> None:
+        """Called when an agent finishes execution.
+
+        Governance actions performed:
+
+        1. **Post-check** — validates output via ``post_execute()``.
+        2. **Audit** — records an ``agent_end`` event.
+
+        Args:
+            context: SDK run context.
+            agent: The agent that just completed.
+            output: The agent's output value.
+        """
+        agent_name = self._extract_agent_name(agent)
+        ctx = self._kernel._get_or_create_context(agent_name)
+
+        # Post-check output
+        output_str = str(output) if output else ""
+        if output_str:
+            valid, reason = self._kernel.post_execute(ctx, output_str)
+            if not valid:
+                logger.warning(
+                    "Agent '%s' output violated policy: %s", agent_name, reason
+                )
+
+        self._kernel._record_event(
+            "agent_end",
+            {
+                "agent": agent_name,
+                "output_length": len(output_str),
+                "success": True,
+            },
+        )
+        logger.debug("on_agent_end: %s", agent_name)
+
+    # ── 3. Tool Start ─────────────────────────────────────────────
+
+    async def on_tool_start(
+        self, context: Any, agent: Any, tool: Any
+    ) -> None:
+        """Called before a tool is invoked.
+
+        Governance actions performed:
+
+        1. **Tool allow/block** — checks the tool name against
+           ``_blocked_tools`` and ``_allowed_tools``.
+        2. **Budget** — increments the call counter and raises if
+           ``max_tool_calls`` is exceeded.
+        3. **Cedar/OPA gate** — delegates to ``pre_execute()`` with
+           ``tool_name`` and ``tool_args`` in the input data.
+        4. **Content filter** — scans tool argument values against
+           ``blocked_patterns``.
+
+        Args:
+            context: SDK run context.
+            agent: The agent that triggered the tool.
+            tool: The tool about to execute.
+
+        Raises:
+            PolicyViolationError: When any governance check fails.
+        """
+        agent_name = self._extract_agent_name(agent)
+        tool_name = getattr(tool, "name", "") or getattr(tool, "__name__", str(tool))
+        ctx = self._kernel._get_or_create_context(agent_name)
+
+        # (a) Tool allow/block check
+        ok, reason = self._kernel._check_tool_allowed(tool_name)
+        if not ok:
+            error = PolicyViolationError(
+                f"Tool '{tool_name}' blocked: {reason}"
+            )
+            self._kernel.on_violation(error)
+            raise error
+
+        # (b) Budget check
+        self._kernel._tool_call_count += 1
+        if self._kernel._tool_call_count > self._kernel.policy.max_tool_calls:
+            error = PolicyViolationError(
+                f"Tool call budget exceeded: "
+                f"{self._kernel._tool_call_count}/{self._kernel.policy.max_tool_calls}"
+            )
+            self._kernel.on_violation(error)
+            raise error
+
+        # (c) Cedar/OPA gate with tool identity
+        tool_args = {}
+        if hasattr(tool, "args"):
+            tool_args = dict(tool.args) if tool.args else {}
+        allowed, reason = self._kernel.pre_execute(
+            ctx,
+            {"tool_name": tool_name, "tool_args": tool_args},
+        )
+        if not allowed:
+            raise PolicyViolationError(
+                f"Tool '{tool_name}' blocked by governance: {reason}"
+            )
+
+        # (d) Content filter on args
+        for value in tool_args.values():
+            if isinstance(value, str):
+                ok, reason = self._kernel._check_content(value)
+                if not ok:
+                    error = PolicyViolationError(
+                        f"Tool argument blocked: {reason}"
+                    )
+                    self._kernel.on_violation(error)
+                    raise error
+
+        self._kernel._record_event(
+            "tool_start",
+            {"agent": agent_name, "tool": tool_name},
+        )
+        logger.debug("on_tool_start: %s.%s", agent_name, tool_name)
+
+    # ── 4. Tool End ───────────────────────────────────────────────
+
+    async def on_tool_end(
+        self, context: Any, agent: Any, tool: Any, result: Any
+    ) -> None:
+        """Called after a tool completes execution.
+
+        Governance actions performed:
+
+        1. **Output filter** — scans the tool's result against
+           ``blocked_patterns`` and logs a warning on match.
+        2. **Audit** — records a ``tool_end`` event.
+
+        Args:
+            context: SDK run context.
+            agent: The agent that invoked the tool.
+            tool: The tool that just completed.
+            result: The tool's return value.
+        """
+        agent_name = self._extract_agent_name(agent)
+        tool_name = getattr(tool, "name", "") or getattr(tool, "__name__", str(tool))
+
+        # Content filter on output
+        result_str = str(result) if result else ""
+        if result_str:
+            ok, reason = self._kernel._check_content(result_str)
+            if not ok:
+                logger.warning(
+                    "Tool '%s' output contains blocked pattern: %s",
+                    tool_name,
+                    reason,
+                )
+
+        self._kernel._record_event(
+            "tool_end",
+            {
+                "agent": agent_name,
+                "tool": tool_name,
+                "result_length": len(result_str),
+            },
+        )
+        logger.debug("on_tool_end: %s.%s", agent_name, tool_name)
+
+    # ── 5. Handoff ────────────────────────────────────────────────
+
+    async def on_handoff(
+        self, context: Any, from_agent: Any, to_agent: Any
+    ) -> None:
+        """Called when control transfers from one agent to another.
+
+        Governance actions performed:
+
+        1. **Handoff limit** — increments the handoff counter and
+           raises if ``max_handoffs`` is exceeded.
+        2. **Audit** — records a ``handoff`` event with source and
+           destination agent names.
+
+        Args:
+            context: SDK run context.
+            from_agent: The agent yielding control.
+            to_agent: The agent receiving control.
+
+        Raises:
+            PolicyViolationError: When the handoff limit is exceeded.
+        """
+        from_name = self._extract_agent_name(from_agent)
+        to_name = self._extract_agent_name(to_agent)
+
+        self._kernel._handoff_count += 1
+
+        if self._kernel._handoff_count > self._kernel._max_handoffs:
+            error = PolicyViolationError(
+                f"Handoff limit exceeded: "
+                f"{self._kernel._handoff_count}/{self._kernel._max_handoffs}"
+            )
+            self._kernel.on_violation(error)
+            raise error
+
+        self._kernel._record_event(
+            "handoff",
+            {"from": from_name, "to": to_name},
+        )
+        logger.info("on_handoff: %s -> %s", from_name, to_name)
+
+
+# =====================================================================
 # Convenience exports
+# =====================================================================
+
 __all__ = [
     "OpenAIAgentsKernel",
+    "GovernanceRunHooks",
     "GovernancePolicy",
-    "ExecutionContext",
     "PolicyViolationError",
 ]

--- a/agent-governance-python/agent-os/tests/test_coverage_boost.py
+++ b/agent-governance-python/agent-os/tests/test_coverage_boost.py
@@ -16,32 +16,26 @@ import pytest
 # 1. OpenAI Agents SDK Integration
 # ---------------------------------------------------------------------------
 from agent_os.integrations.openai_agents_sdk import (
-    GovernancePolicy as OAIGovernancePolicy,
-    ExecutionContext as OAIExecutionContext,
-    PolicyViolationError as OAIPolicyViolationError,
     OpenAIAgentsKernel,
+    GovernanceRunHooks,
 )
+from agent_os.integrations.base import GovernancePolicy as OAIGovernancePolicy
+from agent_os.integrations.base import ExecutionContext as OAIExecutionContext
+from agent_os.exceptions import PolicyViolationError as OAIPolicyViolationError
 
 
 class TestOAIGovernancePolicy:
     def test_defaults(self):
         p = OAIGovernancePolicy()
-        assert p.max_tool_calls == 50
-        assert p.max_handoffs == 5
+        assert p.max_tool_calls == 10
         assert p.timeout_seconds == 300
         assert p.allowed_tools == []
-        assert p.blocked_tools == []
         assert p.blocked_patterns == []
-        assert p.pii_detection is True
         assert p.require_human_approval is False
-        assert p.approval_threshold == 0.8
-        assert p.log_all_calls is True
-        assert p.checkpoint_frequency == 5
 
     def test_custom(self):
-        p = OAIGovernancePolicy(max_tool_calls=10, blocked_tools=["rm"])
+        p = OAIGovernancePolicy(max_tool_calls=10)
         assert p.max_tool_calls == 10
-        assert p.blocked_tools == ["rm"]
 
 
 class TestOAIExecutionContext:
@@ -50,39 +44,32 @@ class TestOAIExecutionContext:
         ctx = OAIExecutionContext(session_id="s1", agent_id="a1", policy=p)
         assert ctx.session_id == "s1"
         assert ctx.agent_id == "a1"
-        assert ctx.tool_calls == 0
-        assert ctx.handoffs == 0
-        assert ctx.events == []
-        assert isinstance(ctx.started_at, datetime)
+        assert ctx.tool_calls == []
+        assert ctx.call_count == 0
 
-    def test_record_event(self):
+    def test_tool_calls_list(self):
         p = OAIGovernancePolicy()
         ctx = OAIExecutionContext(session_id="s1", agent_id="a1", policy=p)
-        ctx.record_event("test_event", {"key": "val"})
-        assert len(ctx.events) == 1
-        assert ctx.events[0]["type"] == "test_event"
-        assert ctx.events[0]["data"] == {"key": "val"}
-        assert "timestamp" in ctx.events[0]
+        ctx.tool_calls.append({"type": "test_event", "data": {"key": "val"}})
+        assert len(ctx.tool_calls) == 1
+        assert ctx.tool_calls[0]["type"] == "test_event"
 
 
 class TestOAIPolicyViolationError:
     def test_basic(self):
-        err = OAIPolicyViolationError("tool_filter", "blocked tool")
-        assert err.policy_name == "tool_filter"
-        assert err.description == "blocked tool"
-        assert err.severity == "high"
-        assert "tool_filter" in str(err)
+        err = OAIPolicyViolationError("blocked tool")
+        assert "blocked tool" in str(err)
 
-    def test_custom_severity(self):
-        err = OAIPolicyViolationError("x", "y", severity="low")
-        assert err.severity == "low"
+    def test_is_exception(self):
+        err = OAIPolicyViolationError("something")
+        assert isinstance(err, Exception)
 
 
 class TestOpenAIAgentsKernel:
     def test_init_defaults(self):
         k = OpenAIAgentsKernel()
         assert isinstance(k.policy, OAIGovernancePolicy)
-        assert k._contexts == {}
+        assert k._agent_contexts == {}
         assert k._wrapped_agents == {}
 
     def test_init_custom_policy(self):
@@ -97,7 +84,7 @@ class TestOpenAIAgentsKernel:
 
     def test_default_violation_handler_logs(self):
         k = OpenAIAgentsKernel()
-        err = OAIPolicyViolationError("p", "d")
+        err = OAIPolicyViolationError("d")
         # Should not raise
         k._default_violation_handler(err)
 
@@ -109,22 +96,19 @@ class TestOpenAIAgentsKernel:
         assert reason == ""
 
     def test_tool_blocked(self):
-        p = OAIGovernancePolicy(blocked_tools=["dangerous"])
-        k = OpenAIAgentsKernel(policy=p)
+        k = OpenAIAgentsKernel(blocked_tools=["dangerous"])
         ok, reason = k._check_tool_allowed("dangerous")
         assert ok is False
         assert "blocked" in reason
 
     def test_tool_not_in_allowed_list(self):
-        p = OAIGovernancePolicy(allowed_tools=["safe"])
-        k = OpenAIAgentsKernel(policy=p)
+        k = OpenAIAgentsKernel(allowed_tools=["safe"])
         ok, reason = k._check_tool_allowed("unsafe")
         assert ok is False
         assert "not in allowed" in reason
 
     def test_tool_in_allowed_list(self):
-        p = OAIGovernancePolicy(allowed_tools=["safe"])
-        k = OpenAIAgentsKernel(policy=p)
+        k = OpenAIAgentsKernel(allowed_tools=["safe"])
         ok, reason = k._check_tool_allowed("safe")
         assert ok is True
 
@@ -135,43 +119,50 @@ class TestOpenAIAgentsKernel:
         assert ok is True
 
     def test_content_blocked(self):
-        p = OAIGovernancePolicy(blocked_patterns=["DROP TABLE"])
-        k = OpenAIAgentsKernel(policy=p)
+        k = OpenAIAgentsKernel(blocked_patterns=["DROP TABLE"])
         ok, reason = k._check_content("please DROP TABLE users")
         assert ok is False
         assert "DROP TABLE" in reason
 
     def test_content_blocked_case_insensitive(self):
-        p = OAIGovernancePolicy(blocked_patterns=["secret"])
-        k = OpenAIAgentsKernel(policy=p)
+        k = OpenAIAgentsKernel(blocked_patterns=["secret"])
         ok, reason = k._check_content("this is SECRET data")
         assert ok is False
 
-    # wrap / unwrap
+    # wrap / unwrap (deprecated)
     def test_wrap_creates_governed_agent(self):
+        import warnings
         k = OpenAIAgentsKernel()
         agent = MagicMock()
         agent.name = "test-agent"
         agent.model = "gpt-4o"
         agent.instructions = "do stuff"
         agent.tools = []
-        wrapped = k.wrap(agent)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            wrapped = k.wrap(agent)
         assert wrapped.name == "test-agent"
         assert wrapped.original is agent
-        assert len(k._contexts) == 1
+        assert "test-agent" in k._agent_contexts
         assert "test-agent" in k._wrapped_agents
 
     def test_wrap_agent_without_name(self):
+        import warnings
         k = OpenAIAgentsKernel()
         agent = MagicMock(spec=[])  # no 'name' attribute
-        wrapped = k.wrap(agent)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            wrapped = k.wrap(agent)
         assert wrapped._original is agent
 
     def test_unwrap_returns_original(self):
+        import warnings
         k = OpenAIAgentsKernel()
         agent = MagicMock()
         agent.name = "a"
-        wrapped = k.wrap(agent)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            wrapped = k.wrap(agent)
         assert k.unwrap(wrapped) is agent
 
     def test_unwrap_non_wrapped(self):
@@ -180,18 +171,24 @@ class TestOpenAIAgentsKernel:
         assert k.unwrap(obj) is obj
 
     def test_wrapped_getattr_passthrough(self):
+        import warnings
         k = OpenAIAgentsKernel()
         agent = MagicMock()
         agent.name = "a"
         agent.custom_field = 42
-        wrapped = k.wrap(agent)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            wrapped = k.wrap(agent)
         assert wrapped.custom_field == 42
 
     # create_tool_guard
     @pytest.mark.asyncio
     async def test_tool_guard_allows(self):
+        import warnings
         k = OpenAIAgentsKernel()
-        guard = k.create_tool_guard()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         async def my_tool(x):
@@ -202,9 +199,11 @@ class TestOpenAIAgentsKernel:
 
     @pytest.mark.asyncio
     async def test_tool_guard_blocks_tool(self):
-        p = OAIGovernancePolicy(blocked_tools=["blocked_func"])
-        k = OpenAIAgentsKernel(policy=p)
-        guard = k.create_tool_guard()
+        import warnings
+        k = OpenAIAgentsKernel(blocked_tools=["blocked_func"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         async def blocked_func():
@@ -215,9 +214,11 @@ class TestOpenAIAgentsKernel:
 
     @pytest.mark.asyncio
     async def test_tool_guard_blocks_content_in_args(self):
-        p = OAIGovernancePolicy(blocked_patterns=["rm -rf"])
-        k = OpenAIAgentsKernel(policy=p)
-        guard = k.create_tool_guard()
+        import warnings
+        k = OpenAIAgentsKernel(blocked_patterns=["rm -rf"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         async def run_cmd(cmd):
@@ -228,9 +229,11 @@ class TestOpenAIAgentsKernel:
 
     @pytest.mark.asyncio
     async def test_tool_guard_blocks_content_in_kwargs(self):
-        p = OAIGovernancePolicy(blocked_patterns=["DROP TABLE"])
-        k = OpenAIAgentsKernel(policy=p)
-        guard = k.create_tool_guard()
+        import warnings
+        k = OpenAIAgentsKernel(blocked_patterns=["DROP TABLE"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         async def query(sql=""):
@@ -241,8 +244,11 @@ class TestOpenAIAgentsKernel:
 
     @pytest.mark.asyncio
     async def test_tool_guard_sync_function(self):
+        import warnings
         k = OpenAIAgentsKernel()
-        guard = k.create_tool_guard()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         def sync_tool(x):
@@ -261,8 +267,7 @@ class TestOpenAIAgentsKernel:
 
     @pytest.mark.asyncio
     async def test_guardrail_blocks_content(self):
-        p = OAIGovernancePolicy(blocked_patterns=["bad_word"])
-        k = OpenAIAgentsKernel(policy=p)
+        k = OpenAIAgentsKernel(blocked_patterns=["bad_word"])
         guardrail = k.create_guardrail()
         result = await guardrail(MagicMock(), MagicMock(), "this has bad_word")
         assert result is not None
@@ -270,8 +275,7 @@ class TestOpenAIAgentsKernel:
 
     @pytest.mark.asyncio
     async def test_guardrail_blocks_tool_calls(self):
-        p = OAIGovernancePolicy(blocked_tools=["evil_tool"])
-        k = OpenAIAgentsKernel(policy=p)
+        k = OpenAIAgentsKernel(blocked_tools=["evil_tool"])
         guardrail = k.create_guardrail()
         ctx = MagicMock()
         tc = MagicMock()
@@ -281,41 +285,28 @@ class TestOpenAIAgentsKernel:
         assert result is not None
         assert "blocked" in result.lower()
 
-    # get_context / get_audit_log / get_stats
-    def test_get_context_found(self):
+    # get_audit_log / get_stats
+    def test_get_audit_log(self):
         k = OpenAIAgentsKernel()
-        agent = MagicMock()
-        agent.name = "x"
-        wrapped = k.wrap(agent)
-        session_id = wrapped._context.session_id
-        assert k.get_context(session_id) is wrapped._context
-
-    def test_get_context_not_found(self):
-        k = OpenAIAgentsKernel()
-        assert k.get_context("nonexistent") is None
-
-    def test_get_audit_log_with_events(self):
-        k = OpenAIAgentsKernel()
-        agent = MagicMock()
-        agent.name = "a"
-        wrapped = k.wrap(agent)
-        session_id = wrapped._context.session_id
-        wrapped._context.record_event("test", {"x": 1})
-        log = k.get_audit_log(session_id)
+        k._record_event("test", {"x": 1})
+        log = k.get_audit_log()
         assert len(log) == 1
         assert log[0]["type"] == "test"
 
-    def test_get_audit_log_no_session(self):
+    def test_get_audit_log_empty(self):
         k = OpenAIAgentsKernel()
-        assert k.get_audit_log("nope") == []
+        assert k.get_audit_log() == []
 
     def test_get_stats(self):
+        import warnings
         k = OpenAIAgentsKernel()
         agent = MagicMock()
         agent.name = "s"
-        k.wrap(agent)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            k.wrap(agent)
         stats = k.get_stats()
-        assert stats["total_sessions"] == 1
+        assert stats["total_sessions"] >= 1
         assert stats["wrapped_agents"] == 1
         assert stats["total_tool_calls"] == 0
         assert stats["total_handoffs"] == 0

--- a/agent-governance-python/agent-os/tests/test_openai_agents_sdk_adapter.py
+++ b/agent-governance-python/agent-os/tests/test_openai_agents_sdk_adapter.py
@@ -1,24 +1,31 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """
-Integration tests for OpenAI Agents SDK governance adapter.
+Tests for OpenAI Agents SDK governance adapter.
 
-No real OpenAI Agents SDK dependency required — uses mock Agent/Runner objects.
+Covers:
+1. Native RunHooks lifecycle (primary API)
+2. BaseIntegration / Cedar / OPA inheritance
+3. Deprecated wrap() / wrap_runner() / create_tool_guard() backward-compat
+4. Audit, stats, and health check
+
+No real OpenAI Agents SDK dependency required — uses mock objects.
 
 Run with: python -m pytest tests/test_openai_agents_sdk_adapter.py -v --tb=short
 """
 
 import asyncio
+import warnings
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from agent_os.integrations.openai_agents_sdk import (
-    ExecutionContext,
-    GovernancePolicy,
+    GovernanceRunHooks,
     OpenAIAgentsKernel,
-    PolicyViolationError,
 )
+from agent_os.integrations.base import GovernancePolicy
+from agent_os.exceptions import PolicyViolationError
 
 
 # =============================================================================
@@ -43,46 +50,50 @@ def _make_runner(result="run result"):
     return runner
 
 
+def _make_context(input_text="hello"):
+    """Create a mock RunHooks context."""
+    ctx = MagicMock()
+    ctx.input = input_text
+    return ctx
+
+
+def _make_tool(name="search", args=None):
+    """Create a mock tool."""
+    tool = MagicMock()
+    tool.name = name
+    tool.__name__ = name
+    tool.args = args or {}
+    return tool
+
+
+class _FakeEvaluator:
+    """Minimal evaluator for Cedar/OPA testing."""
+
+    def __init__(self, allowed=True, reason=""):
+        self._allowed = allowed
+        self._reason = reason
+        self.last_context = None
+
+    def evaluate(self, ctx):
+        self.last_context = ctx
+
+        class _Decision:
+            def __init__(d, allowed, reason):
+                d.allowed = allowed
+                d.reason = reason
+
+        return _Decision(self._allowed, self._reason)
+
+
 # =============================================================================
-# GovernancePolicy tests
-# =============================================================================
-
-
-class TestGovernancePolicy:
-    def test_defaults(self):
-        p = GovernancePolicy()
-        assert p.max_tool_calls == 50
-        assert p.max_handoffs == 5
-        assert p.timeout_seconds == 300
-        assert p.allowed_tools == []
-        assert p.blocked_tools == []
-        assert p.blocked_patterns == []
-        assert p.pii_detection is True
-        assert p.require_human_approval is False
-        assert p.log_all_calls is True
-        assert p.checkpoint_frequency == 5
-
-    def test_custom(self):
-        p = GovernancePolicy(
-            max_tool_calls=5,
-            blocked_tools=["shell"],
-            blocked_patterns=["DROP TABLE"],
-            require_human_approval=True,
-        )
-        assert p.max_tool_calls == 5
-        assert p.blocked_tools == ["shell"]
-        assert p.blocked_patterns == ["DROP TABLE"]
-        assert p.require_human_approval is True
-
-
-# =============================================================================
-# Kernel initialisation
+# 1. Kernel initialisation & BaseIntegration inheritance
 # =============================================================================
 
 
 class TestKernelInit:
     def test_default_policy(self):
         k = OpenAIAgentsKernel()
+        assert isinstance(k.policy, GovernancePolicy)
         assert k.policy.max_tool_calls == 50
 
     def test_explicit_policy(self):
@@ -90,153 +101,614 @@ class TestKernelInit:
         k = OpenAIAgentsKernel(policy=p)
         assert k.policy.max_tool_calls == 3
 
+    def test_convenience_kwargs(self):
+        k = OpenAIAgentsKernel(
+            max_tool_calls=10,
+            blocked_tools=["shell"],
+            allowed_tools=["search"],
+            blocked_patterns=["DROP TABLE"],
+        )
+        assert k.policy.max_tool_calls == 10
+        assert "shell" in k._blocked_tools
+        assert "search" in k._allowed_tools
+        assert "DROP TABLE" in k.policy.blocked_patterns
+
     def test_custom_violation_handler(self):
         captured = []
         k = OpenAIAgentsKernel(on_violation=lambda e: captured.append(e))
-        err = PolicyViolationError("test", "oops")
+        err = PolicyViolationError("oops")
         k.on_violation(err)
         assert len(captured) == 1
         assert captured[0] is err
 
+    def test_inherits_base_integration(self):
+        """Kernel inherits from BaseIntegration, getting Cedar/pre_execute."""
+        from agent_os.integrations.base import BaseIntegration
+        k = OpenAIAgentsKernel()
+        assert isinstance(k, BaseIntegration)
+
+    def test_evaluator_parameter_accepted(self):
+        """Cedar/OPA evaluator can be passed through."""
+        evaluator = _FakeEvaluator()
+        k = OpenAIAgentsKernel(evaluator=evaluator)
+        assert k._evaluator is evaluator
+
 
 # =============================================================================
-# Wrapping / unwrapping agents
+# 2. as_hooks() — primary API  (GovernanceRunHooks)
 # =============================================================================
 
 
-class TestWrapAgent:
-    def test_wrap_copies_attributes(self):
-        agent = _make_agent(name="bot", model="gpt-4o")
+class TestAsHooks:
+    def test_returns_governance_run_hooks(self):
         k = OpenAIAgentsKernel()
-        governed = k.wrap(agent)
+        hooks = k.as_hooks()
+        assert isinstance(hooks, GovernanceRunHooks)
 
-        assert governed.name == "bot"
-        assert governed.model == "gpt-4o"
-        assert governed.instructions == "You are a helpful assistant."
-
-    def test_wrap_creates_context(self):
-        agent = _make_agent(name="bot")
+    def test_custom_name(self):
         k = OpenAIAgentsKernel()
-        governed = k.wrap(agent)
+        hooks = k.as_hooks(name="my-governance")
+        assert hooks.hook_name == "my-governance"
 
-        assert governed._context is not None
-        assert isinstance(governed._context, ExecutionContext)
-        assert governed._context.agent_id == "bot"
-
-    def test_wrap_registers_agent(self):
-        agent = _make_agent(name="bot")
+    def test_hooks_reference_kernel(self):
         k = OpenAIAgentsKernel()
-        k.wrap(agent)
+        hooks = k.as_hooks()
+        assert hooks._kernel is k
 
-        assert "bot" in k._wrapped_agents
 
-    def test_unwrap_returns_original(self):
+# =============================================================================
+# 3. RunHooks lifecycle callbacks
+# =============================================================================
+
+
+class TestOnAgentStart:
+    def test_allows_safe_input(self):
+        k = OpenAIAgentsKernel(blocked_patterns=["DROP TABLE"])
+        hooks = k.as_hooks()
+        ctx = _make_context(input_text="Hello world")
         agent = _make_agent()
-        k = OpenAIAgentsKernel()
-        governed = k.wrap(agent)
 
-        assert k.unwrap(governed) is agent
+        # Should not raise
+        asyncio.run(hooks.on_agent_start(ctx, agent))
 
-    def test_unwrap_plain_object_returns_itself(self):
-        k = OpenAIAgentsKernel()
-        obj = MagicMock(spec=[])  # no _original attribute
-        assert k.unwrap(obj) is obj
-
-    def test_original_property(self):
-        agent = _make_agent()
-        k = OpenAIAgentsKernel()
-        governed = k.wrap(agent)
-
-        assert governed.original is agent
-
-    def test_getattr_proxies_to_original(self):
-        agent = _make_agent()
-        agent.custom_attr = "hello"
-        k = OpenAIAgentsKernel()
-        governed = k.wrap(agent)
-
-        assert governed.custom_attr == "hello"
-
-
-# =============================================================================
-# Tool policy enforcement
-# =============================================================================
-
-
-class TestToolPolicyEnforcement:
-    def test_allowed_tool_passes(self):
+    def test_blocks_bad_content_with_human_approval(self):
         k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(allowed_tools=["file_search", "code_interpreter"])
+            blocked_patterns=["DROP TABLE"],
+            require_human_approval=True,
         )
-        ok, reason = k._check_tool_allowed("file_search")
-        assert ok is True
-        assert reason == ""
+        hooks = k.as_hooks()
+        ctx = _make_context(input_text="DROP TABLE users")
+        agent = _make_agent()
+
+        with pytest.raises(PolicyViolationError, match="blocked"):
+            asyncio.run(hooks.on_agent_start(ctx, agent))
+
+    def test_logs_violation_without_human_approval(self):
+        violations = []
+        k = OpenAIAgentsKernel(
+            blocked_patterns=["DROP TABLE"],
+            require_human_approval=False,
+            on_violation=lambda e: violations.append(e),
+        )
+        hooks = k.as_hooks()
+        ctx = _make_context(input_text="DROP TABLE users")
+        agent = _make_agent()
+
+        # Should not raise, but should record violation
+        asyncio.run(hooks.on_agent_start(ctx, agent))
+        assert len(violations) == 1
+
+    def test_records_audit_event(self):
+        k = OpenAIAgentsKernel()
+        hooks = k.as_hooks()
+        ctx = _make_context(input_text="test")
+        agent = _make_agent(name="bot")
+
+        asyncio.run(hooks.on_agent_start(ctx, agent))
+
+        events = k.get_audit_log()
+        assert any(e["type"] == "agent_start" for e in events)
+        assert events[-1]["data"]["agent"] == "bot"
+
+
+class TestOnAgentEnd:
+    def test_records_audit_event(self):
+        k = OpenAIAgentsKernel()
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent(name="bot")
+
+        asyncio.run(hooks.on_agent_end(ctx, agent, "result text"))
+
+        events = k.get_audit_log()
+        assert any(e["type"] == "agent_end" for e in events)
+        assert events[-1]["data"]["success"] is True
+
+    def test_post_execute_validation(self):
+        """post_execute is called on agent output."""
+        k = OpenAIAgentsKernel(blocked_patterns=["SECRET_API_KEY"])
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+
+        # Should not raise, but should log warning
+        asyncio.run(hooks.on_agent_end(ctx, agent, "The SECRET_API_KEY is..."))
+
+
+class TestOnToolStart:
+    def test_allowed_tool_passes(self):
+        k = OpenAIAgentsKernel(allowed_tools=["search", "calculator"])
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+        tool = _make_tool(name="search")
+
+        asyncio.run(hooks.on_tool_start(ctx, agent, tool))
+        assert k._tool_call_count == 1
+
+    def test_blocked_tool_raises(self):
+        k = OpenAIAgentsKernel(blocked_tools=["shell"])
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+        tool = _make_tool(name="shell")
+
+        with pytest.raises(PolicyViolationError, match="blocked"):
+            asyncio.run(hooks.on_tool_start(ctx, agent, tool))
 
     def test_tool_not_in_allowed_list_blocked(self):
+        k = OpenAIAgentsKernel(allowed_tools=["search"])
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+        tool = _make_tool(name="shell")
+
+        with pytest.raises(PolicyViolationError, match="not in allowed list"):
+            asyncio.run(hooks.on_tool_start(ctx, agent, tool))
+
+    def test_tool_call_budget_enforced(self):
+        k = OpenAIAgentsKernel(max_tool_calls=2)
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+        tool = _make_tool(name="search")
+
+        asyncio.run(hooks.on_tool_start(ctx, agent, tool))  # 1
+        asyncio.run(hooks.on_tool_start(ctx, agent, tool))  # 2
+
+        with pytest.raises(PolicyViolationError, match="budget exceeded"):
+            asyncio.run(hooks.on_tool_start(ctx, agent, tool))  # 3 = over
+
+    def test_content_filter_on_tool_args(self):
+        k = OpenAIAgentsKernel(blocked_patterns=["password"])
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+        tool = _make_tool(name="search", args={"query": "find the password"})
+
+        with pytest.raises(PolicyViolationError, match="blocked"):
+            asyncio.run(hooks.on_tool_start(ctx, agent, tool))
+
+    def test_records_audit_event(self):
+        k = OpenAIAgentsKernel()
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent(name="bot")
+        tool = _make_tool(name="search")
+
+        asyncio.run(hooks.on_tool_start(ctx, agent, tool))
+
+        events = k.get_audit_log()
+        assert any(e["type"] == "tool_start" for e in events)
+
+    def test_cedar_gate_on_tool(self):
+        """Cedar evaluator receives tool_name and can block specific tools."""
+
+        class ToolBlockEvaluator:
+            def evaluate(self, ctx):
+                class D:
+                    def __init__(d):
+                        d.allowed = ctx.get("tool_name") != "shell_exec"
+                        d.reason = "shell blocked" if not d.allowed else ""
+                return D()
+
+        k = OpenAIAgentsKernel(evaluator=ToolBlockEvaluator())
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+
+        # Allowed tool
+        tool_ok = _make_tool(name="search")
+        asyncio.run(hooks.on_tool_start(ctx, agent, tool_ok))
+
+        # Blocked by Cedar
+        tool_bad = _make_tool(name="shell_exec")
+        with pytest.raises(PolicyViolationError, match="blocked by governance"):
+            asyncio.run(hooks.on_tool_start(ctx, agent, tool_bad))
+
+
+class TestOnToolEnd:
+    def test_records_audit_event(self):
+        k = OpenAIAgentsKernel()
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent(name="bot")
+        tool = _make_tool(name="search")
+
+        asyncio.run(hooks.on_tool_end(ctx, agent, tool, "result data"))
+
+        events = k.get_audit_log()
+        assert any(e["type"] == "tool_end" for e in events)
+
+    def test_content_filter_on_output(self):
+        """Blocked pattern in tool output is logged (not raised)."""
+        k = OpenAIAgentsKernel(blocked_patterns=["SECRET"])
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+        tool = _make_tool(name="search")
+
+        # Should not raise, just log warning
+        asyncio.run(hooks.on_tool_end(ctx, agent, tool, "output: SECRET"))
+
+
+class TestOnHandoff:
+    def test_handoff_recorded(self):
+        k = OpenAIAgentsKernel(max_handoffs=10)
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        from_agent = _make_agent(name="agent-a")
+        to_agent = _make_agent(name="agent-b")
+
+        asyncio.run(hooks.on_handoff(ctx, from_agent, to_agent))
+
+        assert k._handoff_count == 1
+        events = k.get_audit_log()
+        assert any(e["type"] == "handoff" for e in events)
+        assert events[-1]["data"]["from"] == "agent-a"
+        assert events[-1]["data"]["to"] == "agent-b"
+
+    def test_handoff_limit_enforced(self):
+        k = OpenAIAgentsKernel(max_handoffs=2)
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        a = _make_agent(name="a")
+        b = _make_agent(name="b")
+
+        asyncio.run(hooks.on_handoff(ctx, a, b))  # 1
+        asyncio.run(hooks.on_handoff(ctx, b, a))  # 2
+
+        with pytest.raises(PolicyViolationError, match="Handoff limit"):
+            asyncio.run(hooks.on_handoff(ctx, a, b))  # 3 = over
+
+
+# =============================================================================
+# 4. Full RunHooks lifecycle integration
+# =============================================================================
+
+
+class TestFullHooksLifecycle:
+    def test_end_to_end_hooks_lifecycle(self):
+        """Simulate a full agent execution via RunHooks callbacks."""
         k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(allowed_tools=["file_search"])
+            blocked_tools=["shell"],
+            blocked_patterns=["DROP TABLE"],
+            allowed_tools=["search", "calculator"],
+            max_tool_calls=10,
+            max_handoffs=3,
         )
+        hooks = k.as_hooks()
+        ctx = _make_context(input_text="Analyze this data")
+        primary = _make_agent(name="primary")
+        helper = _make_agent(name="helper")
+
+        # Agent start
+        asyncio.run(hooks.on_agent_start(ctx, primary))
+
+        # Tool calls
+        search_tool = _make_tool(name="search")
+        asyncio.run(hooks.on_tool_start(ctx, primary, search_tool))
+        asyncio.run(hooks.on_tool_end(ctx, primary, search_tool, "results"))
+
+        calc_tool = _make_tool(name="calculator")
+        asyncio.run(hooks.on_tool_start(ctx, primary, calc_tool))
+        asyncio.run(hooks.on_tool_end(ctx, primary, calc_tool, "42"))
+
+        # Blocked tool
+        shell_tool = _make_tool(name="shell")
+        with pytest.raises(PolicyViolationError, match="blocked"):
+            asyncio.run(hooks.on_tool_start(ctx, primary, shell_tool))
+
+        # Handoff
+        asyncio.run(hooks.on_handoff(ctx, primary, helper))
+
+        # Agent end
+        asyncio.run(hooks.on_agent_end(ctx, primary, "analysis complete"))
+
+        # Verify state
+        assert k._tool_call_count == 2  # search + calculator (shell was blocked)
+        assert k._handoff_count == 1
+        events = k.get_audit_log()
+        event_types = [e["type"] for e in events]
+        assert "agent_start" in event_types
+        assert "tool_start" in event_types
+        assert "tool_end" in event_types
+        assert "handoff" in event_types
+        assert "agent_end" in event_types
+
+        # Stats
+        stats = k.get_stats()
+        assert stats["total_tool_calls"] == 2
+        assert stats["total_handoffs"] == 1
+
+    def test_hooks_with_cedar_evaluator(self):
+        """RunHooks callbacks correctly wire through Cedar evaluation."""
+        evaluator = _FakeEvaluator(allowed=True)
+        k = OpenAIAgentsKernel(evaluator=evaluator)
+        hooks = k.as_hooks()
+        ctx = _make_context(input_text="test")
+        agent = _make_agent(name="bot")
+        tool = _make_tool(name="search")
+
+        asyncio.run(hooks.on_agent_start(ctx, agent))
+        asyncio.run(hooks.on_tool_start(ctx, agent, tool))
+
+        assert evaluator.last_context is not None
+        assert evaluator.last_context["tool_name"] == "search"
+
+    def test_hooks_cedar_deny_blocks_tool(self):
+        """Cedar deny blocks tool via on_tool_start."""
+        evaluator = _FakeEvaluator(allowed=False, reason="policy denied")
+        k = OpenAIAgentsKernel(evaluator=evaluator)
+        hooks = k.as_hooks()
+        ctx = _make_context()
+        agent = _make_agent()
+        tool = _make_tool(name="search")
+
+        with pytest.raises(PolicyViolationError, match="blocked by governance"):
+            asyncio.run(hooks.on_tool_start(ctx, agent, tool))
+
+
+# =============================================================================
+# 5. Observability: stats, health, audit
+# =============================================================================
+
+
+class TestObservability:
+    def test_get_audit_log(self):
+        k = OpenAIAgentsKernel()
+        k._record_event("test_event", {"key": "value"})
+        log = k.get_audit_log()
+        assert len(log) == 1
+        assert log[0]["type"] == "test_event"
+
+    def test_get_stats(self):
+        k = OpenAIAgentsKernel(
+            max_tool_calls=10,
+            max_handoffs=3,
+            blocked_tools=["shell"],
+        )
+        k._tool_call_count = 5
+        k._handoff_count = 2
+
+        stats = k.get_stats()
+        assert stats["total_tool_calls"] == 5
+        assert stats["total_handoffs"] == 2
+        assert "shell" in stats["policy"]["blocked_tools"]
+
+    def test_health_check_healthy(self):
+        k = OpenAIAgentsKernel()
+        # Create a context to simulate activity
+        k._get_or_create_context("agent-1")
+        h = k.health_check()
+
+        assert h["status"] == "healthy"
+        assert h["backend"] == "openai_agents_sdk"
+        assert h["backend_connected"] is True
+        assert h["last_error"] is None
+        assert h["uptime_seconds"] >= 0
+
+    def test_health_check_degraded(self):
+        k = OpenAIAgentsKernel()
+        k._last_error = "something broke"
+        h = k.health_check()
+        assert h["status"] == "degraded"
+        assert h["last_error"] == "something broke"
+
+
+# =============================================================================
+# 6. Tool / content checks (unit-level)
+# =============================================================================
+
+
+class TestToolPolicyChecks:
+    def test_allowed_tool_passes(self):
+        k = OpenAIAgentsKernel(allowed_tools=["search", "calculator"])
+        ok, _ = k._check_tool_allowed("search")
+        assert ok is True
+
+    def test_tool_not_in_allowed_list_blocked(self):
+        k = OpenAIAgentsKernel(allowed_tools=["search"])
         ok, reason = k._check_tool_allowed("shell")
         assert ok is False
         assert "not in allowed list" in reason
 
     def test_blocked_tool_rejected(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_tools=["shell", "exec"])
-        )
+        k = OpenAIAgentsKernel(blocked_tools=["shell", "exec"])
         ok, reason = k._check_tool_allowed("shell")
         assert ok is False
         assert "blocked by policy" in reason
 
     def test_no_restrictions_allows_all(self):
-        k = OpenAIAgentsKernel(policy=GovernancePolicy())
-        ok, reason = k._check_tool_allowed("anything")
+        k = OpenAIAgentsKernel()
+        ok, _ = k._check_tool_allowed("anything")
         assert ok is True
 
 
-# =============================================================================
-# Blocked patterns / content filtering
-# =============================================================================
-
-
-class TestBlockedPatterns:
+class TestContentFilter:
     def test_blocked_pattern_detected(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_patterns=["rm -rf", "DROP TABLE"])
-        )
+        k = OpenAIAgentsKernel(blocked_patterns=["rm -rf", "DROP TABLE"])
         ok, reason = k._check_content("please run rm -rf /")
         assert ok is False
         assert "rm -rf" in reason
 
     def test_blocked_pattern_case_insensitive(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_patterns=["DROP TABLE"])
-        )
-        ok, reason = k._check_content("drop table users")
+        k = OpenAIAgentsKernel(blocked_patterns=["DROP TABLE"])
+        ok, _ = k._check_content("drop table users")
         assert ok is False
 
     def test_safe_content_passes(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_patterns=["DROP TABLE"])
-        )
-        ok, reason = k._check_content("SELECT * FROM users")
+        k = OpenAIAgentsKernel(blocked_patterns=["DROP TABLE"])
+        ok, _ = k._check_content("SELECT * FROM users")
         assert ok is True
 
     def test_no_patterns_allows_all(self):
-        k = OpenAIAgentsKernel(policy=GovernancePolicy())
-        ok, reason = k._check_content("anything goes")
+        k = OpenAIAgentsKernel()
+        ok, _ = k._check_content("anything goes")
         assert ok is True
 
 
 # =============================================================================
-# Tool guard decorator
+# 7. Deprecated wrap() / wrap_runner() / create_tool_guard()
 # =============================================================================
 
 
-class TestToolGuard:
+class TestDeprecatedWrap:
+    def test_wrap_emits_deprecation_warning(self):
+        k = OpenAIAgentsKernel()
+        agent = _make_agent()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            k.wrap(agent)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+            assert "as_hooks" in str(w[0].message)
+
+    def test_wrap_copies_attributes(self):
+        k = OpenAIAgentsKernel()
+        agent = _make_agent(name="bot", model="gpt-4o")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            governed = k.wrap(agent)
+        assert governed.name == "bot"
+        assert governed.model == "gpt-4o"
+
+    def test_unwrap_returns_original(self):
+        k = OpenAIAgentsKernel()
+        agent = _make_agent()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            governed = k.wrap(agent)
+        assert k.unwrap(governed) is agent
+
+    def test_unwrap_plain_object(self):
+        k = OpenAIAgentsKernel()
+        obj = MagicMock(spec=[])
+        assert k.unwrap(obj) is obj
+
+
+class TestDeprecatedWrapRunner:
+    def test_wrap_runner_emits_deprecation(self):
+        k = OpenAIAgentsKernel()
+        runner = _make_runner()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            k.wrap_runner(runner)
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
+    def test_governed_runner_delegates_to_original(self):
+        k = OpenAIAgentsKernel()
+        agent = _make_agent()
+        runner = _make_runner(result="hello")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            governed = k.wrap(agent)
+            GovernedRunner = k.wrap_runner(runner)
+
+        result = asyncio.run(GovernedRunner.run(governed, "hi"))
+        assert result == "hello"
+        runner.run.assert_awaited_once()
+
+    def test_governed_runner_records_events(self):
+        k = OpenAIAgentsKernel()
+        agent = _make_agent()
+        runner = _make_runner()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            governed = k.wrap(agent)
+            GovernedRunner = k.wrap_runner(runner)
+
+        asyncio.run(GovernedRunner.run(governed, "hi"))
+        entries = governed._context.tool_calls
+        types = [e["type"] for e in entries]
+        assert "run_start" in types
+        assert "run_complete" in types
+
+    def test_governed_runner_blocks_content_with_approval(self):
+        k = OpenAIAgentsKernel(
+            blocked_patterns=["DROP TABLE"],
+            require_human_approval=True,
+        )
+        runner = _make_runner()
+        agent = _make_agent()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            governed = k.wrap(agent)
+            GovernedRunner = k.wrap_runner(runner)
+
+        with pytest.raises(PolicyViolationError):
+            asyncio.run(GovernedRunner.run(governed, "DROP TABLE users"))
+
+    def test_governed_runner_error_event(self):
+        k = OpenAIAgentsKernel()
+        runner = _make_runner()
+        runner.run = AsyncMock(side_effect=RuntimeError("boom"))
+        agent = _make_agent()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            governed = k.wrap(agent)
+            GovernedRunner = k.wrap_runner(runner)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(GovernedRunner.run(governed, "hi"))
+
+        entries = governed._context.tool_calls
+        types = [e["type"] for e in entries]
+        assert "run_error" in types
+
+    def test_run_sync(self):
+        k = OpenAIAgentsKernel()
+        runner = _make_runner(result="sync result")
+        agent = _make_agent()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            governed = k.wrap(agent)
+            GovernedRunner = k.wrap_runner(runner)
+
+        result = GovernedRunner.run_sync(governed, "hello")
+        assert result == "sync result"
+
+
+class TestDeprecatedToolGuard:
+    def test_tool_guard_emits_deprecation(self):
+        k = OpenAIAgentsKernel()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            k.create_tool_guard()
+            assert len(w) == 1
+            assert issubclass(w[0].category, DeprecationWarning)
+
     def test_allowed_tool_executes(self):
-        k = OpenAIAgentsKernel(policy=GovernancePolicy())
-        guard = k.create_tool_guard()
+        k = OpenAIAgentsKernel()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         async def search(query: str) -> str:
@@ -246,47 +718,36 @@ class TestToolGuard:
         assert result == "results for test"
 
     def test_blocked_tool_raises(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_tools=["dangerous_tool"])
-        )
-        guard = k.create_tool_guard()
+        k = OpenAIAgentsKernel(blocked_tools=["dangerous_tool"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         async def dangerous_tool(cmd: str) -> str:
             return cmd
 
-        with pytest.raises(PolicyViolationError, match="blocked by policy"):
+        with pytest.raises(PolicyViolationError, match="blocked"):
             asyncio.run(dangerous_tool("hello"))
 
     def test_blocked_pattern_in_args_raises(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_patterns=["password"])
-        )
-        guard = k.create_tool_guard()
+        k = OpenAIAgentsKernel(blocked_patterns=["password"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         async def search(query: str) -> str:
             return query
 
-        with pytest.raises(PolicyViolationError, match="blocked pattern"):
+        with pytest.raises(PolicyViolationError, match="blocked"):
             asyncio.run(search("find the password"))
 
-    def test_blocked_pattern_in_kwargs_raises(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_patterns=["secret"])
-        )
-        guard = k.create_tool_guard()
-
-        @guard
-        async def lookup(key: str) -> str:
-            return key
-
-        with pytest.raises(PolicyViolationError, match="blocked pattern"):
-            asyncio.run(lookup(key="the secret value"))
-
     def test_sync_function_wrapped(self):
-        k = OpenAIAgentsKernel(policy=GovernancePolicy())
-        guard = k.create_tool_guard()
+        k = OpenAIAgentsKernel()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            guard = k.create_tool_guard()
 
         @guard
         def add(a: int, b: int) -> int:
@@ -297,23 +758,19 @@ class TestToolGuard:
 
 
 # =============================================================================
-# Guardrail
+# 8. Guardrail
 # =============================================================================
 
 
 class TestGuardrail:
     def test_guardrail_allows_safe_input(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_patterns=["DROP TABLE"])
-        )
+        k = OpenAIAgentsKernel(blocked_patterns=["DROP TABLE"])
         guardrail = k.create_guardrail()
         result = asyncio.run(guardrail(MagicMock(), _make_agent(), "hello world"))
-        assert result is None  # None = allowed
+        assert result is None
 
     def test_guardrail_blocks_bad_input(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_patterns=["DROP TABLE"])
-        )
+        k = OpenAIAgentsKernel(blocked_patterns=["DROP TABLE"])
         guardrail = k.create_guardrail()
         result = asyncio.run(
             guardrail(MagicMock(), _make_agent(), "please DROP TABLE users")
@@ -322,9 +779,7 @@ class TestGuardrail:
         assert "blocked" in result.lower()
 
     def test_guardrail_checks_tool_calls(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_tools=["shell"])
-        )
+        k = OpenAIAgentsKernel(blocked_tools=["shell"])
         guardrail = k.create_guardrail()
 
         ctx = MagicMock()
@@ -338,400 +793,47 @@ class TestGuardrail:
 
 
 # =============================================================================
-# Runner governance (async)
+# 9. Cross-framework parity (Cedar integration via BaseIntegration)
 # =============================================================================
 
 
-class TestGovernedRunner:
-    def test_run_delegates_to_original(self):
-        agent = _make_agent()
-        runner = _make_runner(result="hello")
+class TestCedarParity:
+    def test_evaluator_deny_blocks_pre_execute(self):
+        """Same test pattern as other adapters — Cedar deny blocks."""
+        evaluator = _FakeEvaluator(allowed=False, reason="enterprise deny")
+        k = OpenAIAgentsKernel(evaluator=evaluator)
+        ctx = k.create_context("test-agent")
+
+        allowed, reason = k.pre_execute(ctx, "test input")
+        assert allowed is False
+        assert "enterprise deny" in reason
+
+    def test_evaluator_allow_passes_through(self):
+        evaluator = _FakeEvaluator(allowed=True)
+        k = OpenAIAgentsKernel(evaluator=evaluator)
+        ctx = k.create_context("test-agent")
+
+        allowed, _ = k.pre_execute(ctx, "test input")
+        assert allowed is True
+
+    def test_fail_closed_on_evaluator_exception(self):
+        """Evaluator crash = fail-closed (deny)."""
+
+        class _CrashEvaluator:
+            def evaluate(self, ctx):
+                raise RuntimeError("boom")
+
+        k = OpenAIAgentsKernel(evaluator=_CrashEvaluator())
+        ctx = k.create_context("test-agent")
+
+        allowed, reason = k.pre_execute(ctx, "test")
+        assert allowed is False
+        assert "fail-closed" in reason.lower() or "error" in reason.lower()
+
+    def test_no_evaluator_skips_cedar_gate(self):
+        """Without evaluator, pre_execute still works (local policy only)."""
         k = OpenAIAgentsKernel()
-        governed_agent = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
+        ctx = k.create_context("test-agent")
 
-        result = asyncio.run(GovernedRunner.run(governed_agent, "hi"))
-        assert result == "hello"
-        runner.run.assert_awaited_once()
-
-    def test_run_records_events(self):
-        agent = _make_agent()
-        runner = _make_runner()
-        k = OpenAIAgentsKernel()
-        governed_agent = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
-
-        asyncio.run(GovernedRunner.run(governed_agent, "hi"))
-
-        events = governed_agent._context.events
-        types = [e["type"] for e in events]
-        assert "run_start" in types
-        assert "run_complete" in types
-
-    def test_run_blocks_content_with_human_approval(self):
-        policy = GovernancePolicy(
-            blocked_patterns=["DROP TABLE"],
-            require_human_approval=True,
-        )
-        agent = _make_agent()
-        runner = _make_runner()
-        k = OpenAIAgentsKernel(policy=policy)
-        governed_agent = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
-
-        with pytest.raises(PolicyViolationError, match="content_filter"):
-            asyncio.run(
-                GovernedRunner.run(governed_agent, "DROP TABLE users")
-            )
-
-    def test_run_violation_without_human_approval_continues(self):
-        """Without require_human_approval, violations are logged but run continues."""
-        violations = []
-        policy = GovernancePolicy(
-            blocked_patterns=["DROP TABLE"],
-            require_human_approval=False,
-        )
-        k = OpenAIAgentsKernel(
-            policy=policy, on_violation=lambda e: violations.append(e)
-        )
-        agent = _make_agent()
-        runner = _make_runner(result="done")
-        governed_agent = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
-
-        result = asyncio.run(
-            GovernedRunner.run(governed_agent, "DROP TABLE users")
-        )
-        assert result == "done"
-        assert len(violations) == 1
-
-    def test_run_records_error_on_failure(self):
-        agent = _make_agent()
-        runner = _make_runner()
-        runner.run = AsyncMock(side_effect=RuntimeError("boom"))
-        k = OpenAIAgentsKernel()
-        governed_agent = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
-
-        with pytest.raises(RuntimeError, match="boom"):
-            asyncio.run(GovernedRunner.run(governed_agent, "hi"))
-
-        events = governed_agent._context.events
-        types = [e["type"] for e in events]
-        assert "run_error" in types
-
-    def test_run_sync(self):
-        agent = _make_agent()
-        runner = _make_runner(result="sync result")
-        k = OpenAIAgentsKernel()
-        governed_agent = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
-
-        result = GovernedRunner.run_sync(governed_agent, "hello")
-        assert result == "sync result"
-
-
-# =============================================================================
-# Handoff governance
-# =============================================================================
-
-
-class TestHandoffGovernance:
-    def test_handoff_counter_tracked(self):
-        k = OpenAIAgentsKernel(policy=GovernancePolicy(max_handoffs=3))
-        agent_a = _make_agent(name="agent-a")
-        agent_b = _make_agent(name="agent-b")
-
-        wrapped_a = k.wrap(agent_a)
-        wrapped_b = k.wrap(agent_b)
-
-        # Simulate handoffs by incrementing context
-        wrapped_a._context.handoffs += 1
-        wrapped_b._context.handoffs += 1
-
-        stats = k.get_stats()
-        assert stats["total_handoffs"] == 2
-
-    def test_multiple_agents_wrapped(self):
-        k = OpenAIAgentsKernel()
-        agents = [_make_agent(name=f"agent-{i}") for i in range(3)]
-        for a in agents:
-            k.wrap(a)
-
-        assert k.get_stats()["wrapped_agents"] == 3
-
-
-# =============================================================================
-# Max calls enforcement
-# =============================================================================
-
-
-class TestMaxCallsEnforcement:
-    def test_tool_guard_respects_max_calls_via_blocked_tools(self):
-        """Tool guard blocks tools on the blocked list immediately."""
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_tools=["tool_x"])
-        )
-        guard = k.create_tool_guard()
-
-        @guard
-        async def tool_x():
-            return "should not run"
-
-        with pytest.raises(PolicyViolationError):
-            asyncio.run(tool_x())
-
-    def test_context_tracks_tool_calls(self):
-        agent = _make_agent()
-        k = OpenAIAgentsKernel(policy=GovernancePolicy(max_tool_calls=3))
-        governed = k.wrap(agent)
-
-        governed._context.tool_calls += 1
-        governed._context.tool_calls += 1
-        governed._context.tool_calls += 1
-
-        assert governed._context.tool_calls == 3
-        assert governed._context.policy.max_tool_calls == 3
-
-
-# =============================================================================
-# Human approval workflow
-# =============================================================================
-
-
-class TestHumanApproval:
-    def test_approval_required_blocks_on_violation(self):
-        policy = GovernancePolicy(
-            require_human_approval=True,
-            blocked_patterns=["sudo"],
-        )
-        k = OpenAIAgentsKernel(policy=policy)
-        agent = _make_agent()
-        runner = _make_runner()
-        governed = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
-
-        with pytest.raises(PolicyViolationError):
-            asyncio.run(GovernedRunner.run(governed, "sudo rm -rf /"))
-
-    def test_approval_not_required_logs_only(self):
-        violations = []
-        policy = GovernancePolicy(
-            require_human_approval=False,
-            blocked_patterns=["sudo"],
-        )
-        k = OpenAIAgentsKernel(
-            policy=policy, on_violation=lambda e: violations.append(e)
-        )
-        agent = _make_agent()
-        runner = _make_runner(result="ok")
-        governed = k.wrap(agent)
-        GovernedRunner = k.wrap_runner(runner)
-
-        result = asyncio.run(GovernedRunner.run(governed, "sudo rm -rf /"))
-        assert result == "ok"
-        assert len(violations) == 1
-
-
-# =============================================================================
-# Error handling
-# =============================================================================
-
-
-class TestErrorHandling:
-    def test_policy_violation_error_fields(self):
-        e = PolicyViolationError("tool_filter", "blocked", severity="critical")
-        assert e.policy_name == "tool_filter"
-        assert e.description == "blocked"
-        assert e.severity == "critical"
-        assert "tool_filter" in str(e)
-        assert "blocked" in str(e)
-
-    def test_policy_violation_default_severity(self):
-        e = PolicyViolationError("test", "desc")
-        assert e.severity == "high"
-
-    def test_violation_handler_receives_error(self):
-        captured = []
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(blocked_tools=["bad_tool"]),
-            on_violation=lambda e: captured.append(e),
-        )
-        guard = k.create_tool_guard()
-
-        @guard
-        async def bad_tool():
-            return "nope"
-
-        with pytest.raises(PolicyViolationError):
-            asyncio.run(bad_tool())
-
-        assert len(captured) == 1
-        assert captured[0].policy_name == "tool_filter"
-
-
-# =============================================================================
-# Audit & stats
-# =============================================================================
-
-
-class TestAuditAndStats:
-    def test_get_context(self):
-        agent = _make_agent(name="bot")
-        k = OpenAIAgentsKernel()
-        governed = k.wrap(agent)
-
-        ctx = k.get_context(governed._context.session_id)
-        assert ctx is not None
-        assert ctx.agent_id == "bot"
-
-    def test_get_context_missing(self):
-        k = OpenAIAgentsKernel()
-        assert k.get_context("nonexistent") is None
-
-    def test_get_audit_log(self):
-        agent = _make_agent()
-        k = OpenAIAgentsKernel()
-        governed = k.wrap(agent)
-        governed._context.record_event("test_event", {"key": "value"})
-
-        log = k.get_audit_log(governed._context.session_id)
-        assert len(log) == 1
-        assert log[0]["type"] == "test_event"
-
-    def test_get_audit_log_missing_session(self):
-        k = OpenAIAgentsKernel()
-        assert k.get_audit_log("missing") == []
-
-    def test_get_stats(self):
-        k = OpenAIAgentsKernel(
-            policy=GovernancePolicy(
-                max_tool_calls=10,
-                max_handoffs=3,
-                blocked_tools=["shell"],
-            )
-        )
-        agent = _make_agent()
-        governed = k.wrap(agent)
-        governed._context.tool_calls = 5
-        governed._context.handoffs = 2
-
-        stats = k.get_stats()
-        assert stats["total_sessions"] == 1
-        assert stats["wrapped_agents"] == 1
-        assert stats["total_tool_calls"] == 5
-        assert stats["total_handoffs"] == 2
-        assert stats["policy"]["max_tool_calls"] == 10
-        assert stats["policy"]["blocked_tools"] == ["shell"]
-
-    def test_health_check_healthy(self):
-        k = OpenAIAgentsKernel()
-        k.wrap(_make_agent())
-        h = k.health_check()
-
-        assert h["status"] == "healthy"
-        assert h["backend"] == "openai_agents_sdk"
-        assert h["backend_connected"] is True
-        assert h["last_error"] is None
-        assert h["uptime_seconds"] >= 0
-
-    def test_health_check_degraded(self):
-        k = OpenAIAgentsKernel()
-        k._last_error = "something broke"
-        h = k.health_check()
-
-        assert h["status"] == "degraded"
-        assert h["last_error"] == "something broke"
-
-
-# =============================================================================
-# ExecutionContext
-# =============================================================================
-
-
-class TestExecutionContext:
-    def test_record_event(self):
-        ctx = ExecutionContext(
-            session_id="s1", agent_id="a1", policy=GovernancePolicy()
-        )
-        ctx.record_event("tool_call", {"tool": "search"})
-
-        assert len(ctx.events) == 1
-        assert ctx.events[0]["type"] == "tool_call"
-        assert ctx.events[0]["data"]["tool"] == "search"
-        assert "timestamp" in ctx.events[0]
-
-    def test_defaults(self):
-        ctx = ExecutionContext(
-            session_id="s1", agent_id="a1", policy=GovernancePolicy()
-        )
-        assert ctx.tool_calls == 0
-        assert ctx.handoffs == 0
-        assert ctx.events == []
-
-
-# =============================================================================
-# Integration: full lifecycle
-# =============================================================================
-
-
-class TestFullLifecycle:
-    def test_end_to_end_governed_run(self):
-        """Simulate a full governed agent run with tool guard + runner."""
-        violations = []
-        policy = GovernancePolicy(
-            max_tool_calls=10,
-            blocked_tools=["shell"],
-            blocked_patterns=["DROP TABLE", "password"],
-            allowed_tools=["search", "calculator"],
-        )
-        k = OpenAIAgentsKernel(
-            policy=policy, on_violation=lambda e: violations.append(e)
-        )
-
-        # Wrap agent
-        agent = _make_agent(name="assistant")
-        governed = k.wrap(agent)
-        assert governed.name == "assistant"
-
-        # Create tool guard
-        guard = k.create_tool_guard()
-
-        @guard
-        async def search(query: str) -> str:
-            return f"results: {query}"
-
-        @guard
-        async def calculator(expr: str) -> str:
-            return f"answer: {expr}"
-
-        @guard
-        async def shell(cmd: str) -> str:
-            return cmd
-
-        # Allowed tool works
-        result = asyncio.run(search("weather"))
-        assert result == "results: weather"
-
-        # Another allowed tool works
-        result = asyncio.run(calculator("2+2"))
-        assert result == "answer: 2+2"
-
-        # Blocked tool raises
-        with pytest.raises(PolicyViolationError):
-            asyncio.run(shell("ls"))
-
-        # Blocked pattern in args raises
-        with pytest.raises(PolicyViolationError):
-            asyncio.run(search("find the password"))
-
-        # Verify violations captured
-        assert len(violations) == 2
-
-        # Stats reflect wrapped agent
-        stats = k.get_stats()
-        assert stats["wrapped_agents"] == 1
-
-        # Health is good
-        health = k.health_check()
-        assert health["status"] == "healthy"
+        allowed, reason = k.pre_execute(ctx, "test input")
+        assert allowed is True


### PR DESCRIPTION
## Summary

Refactors `OpenAIAgentsKernel` to extend `BaseIntegration` and implement the OpenAI Agents SDK's native `RunHooks` lifecycle interface, replacing the fragile proxy-based `wrap()`/`wrap_runner()` workarounds with first-class framework hooks.

Closes #1576

## Motivation

The existing OpenAI adapter relied on **proxy wrapping** (`wrap()`, `wrap_runner()`) to intercept agent and tool execution. This approach:
- Could not intercept lifecycle events between agent turns (e.g., handoffs)
- Required fragile `__getattr__` delegation that broke with SDK updates
- Was inconsistent with the ADK adapter's native `BasePlugin` integration pattern
- Did not inherit `BaseIntegration`'s Cedar/OPA policy evaluation

This PR aligns the OpenAI adapter with the ADK adapter's architecture by using the SDK's native `RunHooks` interface.

## Changes

### Core Adapter (`openai_agents_sdk.py`)

| Area | Before | After |
|---|---|---|
| **Base class** | Standalone class | Extends `BaseIntegration` |
| **Primary API** | `kernel.wrap(agent)` + `kernel.wrap_runner(Runner)` | `Runner.run(agent, hooks=kernel.as_hooks())` |
| **Lifecycle hooks** | None (proxy-based interception) | `GovernanceRunHooks(RunHooks)` with 5 callbacks |
| **Policy evaluation** | Local checks only | Cedar/OPA via `pre_execute()`/`post_execute()` + local checks |
| **Tool identity** | Not available in Cedar context | `tool_name`/`tool_args` threaded into Cedar context |

### `GovernanceRunHooks` Lifecycle Coverage

| Callback | Governance Action |
|---|---|
| `on_agent_start` | Content filter, Cedar/OPA gate, `pre_execute()` |
| `on_agent_end` | Output validation via `post_execute()`, audit recording |
| `on_tool_start` | Tool allow/blocklist, budget enforcement, Cedar gate with tool identity |
| `on_tool_end` | Output content filter, audit recording |
| `on_handoff` | Handoff limit enforcement, audit trail |

### Backward Compatibility

All three legacy methods are preserved with `DeprecationWarning`:
- `wrap()` → use `as_hooks()`
- `wrap_runner()` → use `as_hooks()`
- `create_tool_guard()` → handled by `on_tool_start`

### Bug Fixes
- **`ctx.events` → `ctx.tool_calls`**: Fixed `wrap_runner()` to use the correct `ExecutionContext` field
- **Double-block in `on_agent_start`**: Prevented content filter and Cedar/OPA gate from both triggering on the same violation

### Code Quality
- Standardized all docstrings/comments to match ADK/LangChain adapter conventions (RST-style `Args:`/`Returns:`/`Raises:`, consistent section separators)

## Test Results

| Suite | Result |
|---|---|
| `test_openai_agents_sdk_adapter.py` | **63/63 ✅** |
| `test_coverage_boost.py` (OAI section) | **21/21 ✅** |
| Full regression | **3070 passed, 46 skipped, 0 failures** |

## Usage Example

```python
from agent_os.integrations.openai_agents_sdk import OpenAIAgentsKernel
from agents import Agent, Runner

# Basic governance
kernel = OpenAIAgentsKernel(
    blocked_tools=["shell_exec"],
    blocked_patterns=["DROP TABLE"],
)
result = await Runner.run(agent, "Analyze data", hooks=kernel.as_hooks())

# With Cedar policy evaluation
kernel = OpenAIAgentsKernel.from_cedar("policies/governance.cedar")
result = await Runner.run(agent, "...", hooks=kernel.as_hooks())
```