### PR TITLE
fix(ci): register renamed PyPI packages in dependency-confusion scan

### DIFF
--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -34,6 +34,7 @@ REGISTERED_PACKAGES = {
     "agentmesh-lightning", "agentmesh_lightning",
     "agentmesh-marketplace", "agentmesh_marketplace",
     "agent-discovery", "agent_discovery",
+    "agentmesh-discovery", "agentmesh_discovery",
     "agent-sandbox", "agent_sandbox",
     # Common dependencies
     "pydantic", "pyyaml", "cryptography", "pynacl", "httpx", "aiohttp",
@@ -83,7 +84,11 @@ REGISTERED_PACKAGES = {
     "cedarpy", "llama-index-core", "ddtrace",
     # Internal module references
     "inter-agent-trust-protocol", "agent-control-plane", "cmvk",
+    "agentmesh-trust-protocol", "agentmesh_trust_protocol",
+    "agentmesh-control-plane", "agentmesh_control_plane",
+    "agentmesh-observability", "agentmesh_observability",
     "agent-tool-registry", "cedar", "opa", "huggingface_hub",
+    "agentmesh-tool-registry", "agentmesh_tool_registry",
     # APS adapter optional deps
     "aps", "agent-passport-system",
     # Microsoft Agent Framework (MAF) — not yet on PyPI, used in examples
@@ -93,6 +98,7 @@ REGISTERED_PACKAGES = {
     # These are flagged as HIGH RISK if found in requirements.txt with version pins
     # instead of path references. See dependency confusion attack vector.
     "agent-primitives", "agent-mcp-governance", "agent_mcp_governance", "emk",
+    "agentmesh-primitives", "agentmesh_primitives",
     # With extras (base name is what matters)
 }
 


### PR DESCRIPTION
## Summary

PR #1603 renamed six packages from `agent_*` to `agentmesh_*` in `pyproject.toml`
files but did not update `REGISTERED_PACKAGES` in `scripts/check_dependency_confusion.py`. This is causing errors like:

```
agent-governance-python/agent-os/modules/mcp-kernel-server/pyproject.toml:44:
  'agentmesh-trust-protocol' may not be registered on PyPI
agent-governance-python/agent-discovery/pyproject.toml:54:
  'agentmesh-discovery' may not be registered on PyPI
```

## Fix

Register all six renamed packages (both hyphen and underscore spellings,
matching the existing convention in this file):

| Old name (kept for compatibility) | New name (added) |
|---|---|
| `agent-discovery` | `agentmesh-discovery` |
| `agent-primitives` | `agentmesh-primitives` |
| `agent-tool-registry` | `agentmesh-tool-registry` |
| `agent-control-plane` | `agentmesh-control-plane` |
| `inter-agent-trust-protocol` | `agentmesh-trust-protocol` |
| `agent-os-observability` | `agentmesh-observability` |

The legacy names are retained for backward compatibility with any `pyproject`
files that have not yet been migrated by #1603 follow-ups.

## Verification

Run locally on the current `main` tree:

```bash
python scripts/check_dependency_confusion.py --strict
echo $?  # 0
```

Without this fix, the same command exits with `1` and prints the violations
shown above.

## Scope

- 6 lines added to a single file (`scripts/check_dependency_confusion.py`).
- No production code, docs, tests, or workflow YAML changes.
- Unblocks every open PR against `main`.

Refs #1603
