### PR TITLE
fix(lint): remove unused imports in openai_agents_sdk and autogen_adapter

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
@@ -52,7 +52,7 @@ _PII_PATTERNS = [
 
 try:
     from autogen_core import DropMessage
-    from autogen_core.intervention import DefaultInterventionHandler
+    from autogen_core import intervention as _autogen_intervention  # noqa: F401 — feature detection
     _INTERVENTION_AVAILABLE = True
 except ImportError:
     _INTERVENTION_AVAILABLE = False

--- a/agent-governance-python/agent-os/src/agent_os/integrations/openai_agents_sdk.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/openai_agents_sdk.py
@@ -49,9 +49,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-import uuid
 import warnings
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import wraps
 from typing import Any, Callable, Optional


### PR DESCRIPTION
Fix ruff lint failures (F401) introduced by the native-hooks PRs (#1582, #1591). Removes unused uuid, dataclass, field imports from openai_agents_sdk.py and unused DefaultInterventionHandler from autogen_adapter.py.