### PR TITLE
fix(adapters): address review feedback from #1593 — error suppression, session IDs, test bug

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py
@@ -175,10 +175,11 @@ class AnthropicKernel(BaseIntegration):
             stacklevel=2,
         )
         _check_anthropic_available()
+        import uuid
         client_id = id(client)
         ctx = AnthropicContext(
             agent_id=f"anthropic-{client_id}",
-            session_id=f"ant-{int(time.time())}",
+            session_id=f"ant-{uuid.uuid4().hex[:12]}",
             policy=self.policy,
         )
         self.contexts[ctx.agent_id] = ctx
@@ -475,11 +476,12 @@ class GovernanceMessageHook:
     """
 
     def __init__(self, kernel: AnthropicKernel, *, name: str = "anthropic-governance") -> None:
+        import uuid
         self._kernel = kernel
         self._name = name
         self._ctx = AnthropicContext(
             agent_id=name,
-            session_id=f"ant-hook-{int(time.time())}",
+            session_id=f"ant-hook-{uuid.uuid4().hex[:12]}",
             policy=kernel.policy,
         )
         kernel.contexts[name] = self._ctx
@@ -623,5 +625,9 @@ def wrap_client(
         DeprecationWarning,
         stacklevel=2,
     )
-    return AnthropicKernel(policy=policy).wrap(client)
+    # Suppress the nested DeprecationWarning from kernel.wrap() so users
+    # only see a single deprecation notice.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return AnthropicKernel(policy=policy).wrap(client)
 

--- a/agent-governance-python/agent-os/src/agent_os/integrations/pydantic_ai_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/pydantic_ai_adapter.py
@@ -457,9 +457,8 @@ def wrap(agent: Any, policy: GovernancePolicy | None = None, **kwargs) -> Any:
         stacklevel=2,
     )
     kernel = PydanticAIKernel(policy, **kwargs)
-    # Suppress nested deprecation from kernel.wrap()
-    import contextlib
-    with contextlib.suppress(Exception), warnings.catch_warnings():
+    # Suppress only the nested DeprecationWarning (not real errors)
+    with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         return kernel.wrap(agent)
 

--- a/agent-governance-python/agent-os/src/agent_os/integrations/semantic_kernel_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/semantic_kernel_adapter.py
@@ -806,9 +806,8 @@ def wrap_kernel(
         stacklevel=2,
     )
     wrapper = SemanticKernelWrapper(policy=policy, timeout_seconds=timeout_seconds)
-    # Suppress the deprecation from wrap() since we already emitted one
-    import contextlib
-    with contextlib.suppress(Exception), warnings.catch_warnings():
+    # Suppress only the nested DeprecationWarning (not real errors)
+    with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         return wrapper.wrap(kernel)
 
@@ -859,14 +858,16 @@ class GovernanceFunctionFilter:
     """
 
     def __init__(self, wrapper: SemanticKernelWrapper) -> None:
+        import uuid
         self._wrapper = wrapper
+        _filter_id = f"sk-filter-{uuid.uuid4().hex[:12]}"
         self._ctx = SKContext(
-            agent_id="sk-filter",
-            session_id=f"sk-filter-{int(datetime.now().timestamp())}",
+            agent_id=_filter_id,
+            session_id=_filter_id,
             policy=wrapper.policy,
-            kernel_id="sk-filter",
+            kernel_id=_filter_id,
         )
-        wrapper._contexts["sk-filter"] = self._ctx
+        wrapper._contexts[_filter_id] = self._ctx
 
     @property
     def wrapper(self) -> SemanticKernelWrapper:

--- a/agent-governance-python/agent-os/tests/test_smolagents_hooks.py
+++ b/agent-governance-python/agent-os/tests/test_smolagents_hooks.py
@@ -134,23 +134,33 @@ class TestBlockedPatterns:
         with pytest.raises(Exception, match="Blocked pattern"):
             callback(step, mock_agent)
 
-    def test_blocks_pattern_in_observation(self, callback, mock_agent):
-        step = _make_step(observation="Result: rm -rf / completed")
-        callback(step, mock_agent)  # Step without tool calls passes...
-
-        # But a step with tool calls + blocked observation:
+    def test_blocks_pattern_in_observation(self, mock_agent):
+        # Observation scanning is unconditional — even steps with no tool
+        # calls raise PolicyViolationError if the observation is blocked.
         kernel2 = SmolagentsKernel(
             allowed_tools=["web_search"],
             blocked_patterns=["rm -rf"],
         )
         cb2 = kernel2.as_step_callback()
-        step2 = SimpleNamespace(
+
+        # A step with no tool calls but a blocked observation → should raise
+        step_no_calls = SimpleNamespace(
             tool_calls=[],
             action=None,
             observation="Dangerous output: rm -rf /",
         )
         with pytest.raises(Exception, match="Blocked pattern.*observation"):
-            cb2(step2, mock_agent)
+            cb2(step_no_calls, mock_agent)
+
+        # A step with an allowed tool call but a blocked observation → also raises
+        cb3 = kernel2.as_step_callback()
+        step_with_calls = SimpleNamespace(
+            tool_calls=[],
+            action=SimpleNamespace(tool_name="web_search", tool_arguments={}),
+            observation="rm -rf / executed successfully",
+        )
+        with pytest.raises(Exception, match="Blocked pattern.*observation"):
+            cb3(step_with_calls, mock_agent)
 
     def test_clean_args_pass(self, callback, mock_agent):
         step = _make_step(


### PR DESCRIPTION
## Summary

Addresses all 5 issues raised by @imran-siddique in #1593 before it was closed and rebased as #1605.  The original native-hook adapter code has already been merged via #1605; this PR contains only the correctness fixes from the review.

---

## Fixes Applied

### 🔴 Blocking — Error suppression

**Files:** `semantic_kernel_adapter.py` (`wrap_kernel()`), `pydantic_ai_adapter.py` (module-level `wrap()`)

`contextlib.suppress(Exception)` was silently swallowing **all** exceptions, not just `DeprecationWarning`. This meant a real failure (invalid kernel, failed policy validation) inside `wrap()` would return `None` with no indication of the problem.

**Fix:** Removed `contextlib.suppress(Exception)`. Both functions now use only `warnings.catch_warnings()` to suppress the nested `DeprecationWarning`.

```python
# Before (broken — swallows ALL exceptions)
with contextlib.suppress(Exception), warnings.catch_warnings():
    warnings.simplefilter("ignore", DeprecationWarning)
    return wrapper.wrap(kernel)

# After
with warnings.catch_warnings():
    warnings.simplefilter("ignore", DeprecationWarning)
    return wrapper.wrap(kernel)
```

---

### 🔴 Bug — Test `test_blocks_pattern_in_observation`

**File:** `tests/test_smolagents_hooks.py`

The test incorrectly assumed `callback(step_with_blocked_obs, agent)` would pass when the step had no tool-call action. `GovernanceStepCallback` scans observations unconditionally, so it always raises for a blocked observation regardless of whether tool calls are present.

**Fix:** Rewrote the test to correctly assert that `PolicyViolationError` is raised in both the no-tool-call and the allowed-tool-call-with-blocked-observation cases.

---

### 🟡 Warning — Double deprecation in `wrap_client()`

**File:** `anthropic_adapter.py`

`wrap_client()` called `kernel.wrap()` without suppressing the inner deprecation, so users saw two `DeprecationWarning` messages per invocation.

**Fix:** Wrapped the inner call with `warnings.catch_warnings()` to suppress the nested warning, matching the pattern already used in SK/PydanticAI.

---

### 🟡 Warning — Session ID collisions

**Files:** `anthropic_adapter.py`, `semantic_kernel_adapter.py`

Session IDs used `int(time.time())`, causing two hooks created within the same second to share a session ID and corrupt audit trails.

**Fix:** Replaced with `uuid.uuid4().hex[:12]` for guaranteed uniqueness.

```python
# Before
session_id=f"ant-{int(time.time())}"

# After
session_id=f"ant-{uuid.uuid4().hex[:12]}"
```

---

### 🟡 Warning — `as_filter()` overwrites context on repeated calls

**File:** `semantic_kernel_adapter.py` — `GovernanceFunctionFilter.__init__`

The context was stored under the hardcoded key `"sk-filter"`, so calling `as_filter()` twice on the same wrapper silently discarded the first filter's execution context.

**Fix:** The context key is now the same uuid-based `_filter_id` generated per-instance, so each filter has its own isolated entry in `wrapper._contexts`.

---

## Testing

- All four changed files parse cleanly (`ast.parse`)
- `grep` confirms zero remaining `contextlib.suppress(Exception)` or `int(time.time())` session IDs across the three adapter files
- `test_smolagents_hooks.py` now correctly specifies the unconditional observation-scan behaviour

Closes the feedback loop on #1593.