### PR TITLE
fix(tests): fix 48 native-hooks test failures in docker CI

### DIFF
--- a/agent-governance-python/agent-os/tests/test_adapter_exception_identity.py
+++ b/agent-governance-python/agent-os/tests/test_adapter_exception_identity.py
@@ -52,7 +52,6 @@ _PENDING_CONVERSION = pytest.mark.xfail(
         ),
         pytest.param(
             "agent_os.integrations.openai_agents_sdk",
-            marks=_PENDING_CONVERSION,
             id="openai_agents_sdk",
         ),
         pytest.param(

--- a/agent-governance-python/agent-os/tests/test_crewai_hooks.py
+++ b/agent-governance-python/agent-os/tests/test_crewai_hooks.py
@@ -51,6 +51,14 @@ _crewai_module = types.ModuleType("crewai")
 sys.modules["crewai"] = _crewai_module
 sys.modules["crewai.hooks"] = _hooks_module
 
+# The adapter may have been imported before the stubs were installed (e.g.
+# via __init__.py), so _HOOKS_AVAILABLE could already be False.  Force a
+# reload so the try/except picks up our stub module.
+import importlib
+import agent_os.integrations.crewai_adapter as _crewai_adapter_mod
+
+importlib.reload(_crewai_adapter_mod)
+
 from agent_os.integrations.crewai_adapter import (
     CrewAIKernel,
     GovernanceHooks,

--- a/agent-governance-python/agent-os/tests/test_semantic_kernel_hooks.py
+++ b/agent-governance-python/agent-os/tests/test_semantic_kernel_hooks.py
@@ -93,7 +93,7 @@ class TestFunctionAllowlist:
         ctx = _make_context("safe_func", "MyPlugin")
         next_fn = AsyncMock()
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             governance_filter(ctx, next_fn)
         )
         next_fn.assert_awaited_once_with(ctx)
@@ -102,7 +102,7 @@ class TestFunctionAllowlist:
         ctx = _make_context("any_func", "MyPlugin")
         next_fn = AsyncMock()
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             governance_filter(ctx, next_fn)
         )
         next_fn.assert_awaited_once()
@@ -112,7 +112,7 @@ class TestFunctionAllowlist:
         next_fn = AsyncMock()
 
         with pytest.raises(Exception, match="Function not allowed"):
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 governance_filter(ctx, next_fn)
             )
         next_fn.assert_not_awaited()
@@ -129,7 +129,7 @@ class TestBlockedPatterns:
         next_fn = AsyncMock()
 
         with pytest.raises(Exception, match="Blocked pattern"):
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 governance_filter(ctx, next_fn)
             )
 
@@ -137,7 +137,7 @@ class TestBlockedPatterns:
         ctx = _make_context("safe_func", "MyPlugin", args={"query": "SELECT * FROM users"})
         next_fn = AsyncMock()
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             governance_filter(ctx, next_fn)
         )
         next_fn.assert_awaited_once()
@@ -155,14 +155,14 @@ class TestCallCount:
         # Exhaust the call limit
         for i in range(5):
             ctx = _make_context("safe_func", "MyPlugin")
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 governance_filter(ctx, next_fn)
             )
 
         # 6th call should be blocked
         ctx = _make_context("safe_func", "MyPlugin")
         with pytest.raises(Exception, match="Tool call limit exceeded"):
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 governance_filter(ctx, next_fn)
             )
 
@@ -170,7 +170,7 @@ class TestCallCount:
         next_fn = AsyncMock()
         ctx = _make_context("safe_func", "MyPlugin")
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             governance_filter(ctx, next_fn)
         )
         assert governance_filter.context.call_count == 1
@@ -186,7 +186,7 @@ class TestAuditTrail:
         next_fn = AsyncMock()
         ctx = _make_context("safe_func", "MyPlugin")
 
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             governance_filter(ctx, next_fn)
         )
         assert len(governance_filter.context.functions_invoked) == 1

--- a/agent-governance-python/agent-os/tests/test_smolagents_hooks.py
+++ b/agent-governance-python/agent-os/tests/test_smolagents_hooks.py
@@ -135,8 +135,8 @@ class TestBlockedPatterns:
             callback(step, mock_agent)
 
     def test_blocks_pattern_in_observation(self, callback, mock_agent):
-        step = _make_step(observation="Result: rm -rf / completed")
-        callback(step, mock_agent)  # Step without tool calls passes...
+        step = _make_step(observation="Result: some clean output")
+        callback(step, mock_agent)  # Step without blocked pattern passes...
 
         # But a step with tool calls + blocked observation:
         kernel2 = SmolagentsKernel(


### PR DESCRIPTION
Fixes all 48 test failures introduced by the native-hooks PRs (#1582, #1585, #1588, #1591, #1605):

- **crewai_hooks (38 tests)**: Reload adapter module after installing stubs so _HOOKS_AVAILABLE picks up the mock
- **semantic_kernel_hooks (8 tests)**: Replace deprecated asyncio.get_event_loop() with asyncio.run() for Python 3.11+
- **smolagents_hooks (1 test)**: Fix test that used a blocked pattern in a step expected to pass
- **adapter_exception_identity (1 test)**: Remove xfail from openai_agents_sdk now that native hooks conversion is done