### PR TITLE
refactor(ci): consolidate contributor-check into Python entrypoint and fix ESRP publish

### DIFF
--- a/.github/actions/contributor-check/action.yml
+++ b/.github/actions/contributor-check/action.yml
@@ -1,8 +1,8 @@
-name: "Contributor Reputation Check"
+name: "Contributor Check"
 description: >
-  Reusable composite action that screens GitHub contributors for coordinated
-  inauthentic behavior: account-shape anomalies, cross-repo spray, credential
-  laundering, and network coordination. Part of AGT's shift-left governance.
+  Reusable composite action that screens GitHub contributors for
+  account-shape anomalies, cross-repo patterns, and credential signals.
+  Delegates to scripts/contributor_check_action.py for orchestration.
 
 inputs:
   github-token:
@@ -24,16 +24,16 @@ inputs:
 outputs:
   risk:
     description: "Overall risk level: LOW, MEDIUM, HIGH, or UNKNOWN"
-    value: ${{ steps.aggregate.outputs.risk }}
+    value: ${{ steps.run.outputs.risk }}
   profile-risk:
     description: "Profile analysis risk level"
-    value: ${{ steps.profile.outputs.risk }}
+    value: ${{ steps.run.outputs.profile-risk }}
   credential-risk:
     description: "Credential audit risk level"
-    value: ${{ steps.credential.outputs.risk }}
+    value: ${{ steps.run.outputs.credential-risk }}
   cluster-risk:
     description: "Cluster detection risk level (empty if not run)"
-    value: ${{ steps.cluster.outputs.risk }}
+    value: ${{ steps.run.outputs.cluster-risk }}
 
 runs:
   using: "composite"
@@ -42,15 +42,6 @@ runs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: "3.12"
-
-    - name: Validate inputs
-      shell: bash
-      run: |
-        threshold="${{ inputs.risk-threshold }}"
-        if [ -n "$threshold" ] && [ "$threshold" != "LOW" ] && [ "$threshold" != "MEDIUM" ] && [ "$threshold" != "HIGH" ]; then
-          echo "::error::Invalid risk-threshold '$threshold'. Must be LOW, MEDIUM, or HIGH."
-          exit 1
-        fi
 
     - name: Resolve inputs
       id: inputs
@@ -85,367 +76,20 @@ runs:
         fi
         echo "target_repo=$target" >> "$GITHUB_OUTPUT"
 
-        scripts="${{ github.action_path }}/../../../scripts"
-        echo "scripts_dir=$scripts" >> "$GITHUB_OUTPUT"
-
-    # ── Profile check ──
-    - name: Run profile check
-      id: profile
-      if: contains(inputs.checks, 'profile')
+    - name: Run contributor check
+      id: run
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        scripts="${{ steps.inputs.outputs.scripts_dir }}"
-        username="${{ steps.inputs.outputs.username }}"
-        target="${{ steps.inputs.outputs.target_repo }}"
+        python "${{ github.action_path }}/../../../scripts/contributor_check_action.py" \
+          --username "${{ steps.inputs.outputs.username }}" \
+          --checks "${{ inputs.checks }}" \
+          --target-repo "${{ steps.inputs.outputs.target_repo }}" \
+          --risk-threshold "${{ inputs.risk-threshold }}" \
+          --number "${{ steps.inputs.outputs.number }}" \
+          --item-type "${{ steps.inputs.outputs.type }}"
 
-        if [ -z "$username" ]; then
-          echo "risk=UNKNOWN" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        set +e
-        python "$scripts/contributor_check.py" \
-          --username "$username" \
-          --repo "$target" \
-          --json > /tmp/agt-profile.json 2>/tmp/agt-profile.log
-        set -e
-
-        risk=$(python -c "import json; print(json.load(open('/tmp/agt-profile.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
-        echo "risk=$risk" >> "$GITHUB_OUTPUT"
-
-        signals=$(python -c "
-        import json
-        r = json.load(open('/tmp/agt-profile.json'))
-        for s in r.get('signals', []):
-            print(f\"- **[{s['severity']}]** {s['name']}: {s['detail']}\")
-        " 2>/dev/null || echo "")
-        {
-          echo "signals<<PROFILE_SIGNALS_EOF"
-          echo "$signals"
-          echo "PROFILE_SIGNALS_EOF"
-        } >> "$GITHUB_OUTPUT"
-
-    # ── Credential audit ──
-    - name: Run credential audit
-      id: credential
-      if: contains(inputs.checks, 'credential')
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts="${{ steps.inputs.outputs.scripts_dir }}"
-        username="${{ steps.inputs.outputs.username }}"
-        target="${{ steps.inputs.outputs.target_repo }}"
-
-        if [ -z "$username" ]; then
-          echo "risk=UNKNOWN" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        set +e
-        python "$scripts/credential_audit.py" \
-          --username "$username" \
-          --repo "$target" \
-          --json > /tmp/agt-cred.json 2>/tmp/agt-cred.log
-        set -e
-
-        risk=$(python -c "import json; print(json.load(open('/tmp/agt-cred.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
-        echo "risk=$risk" >> "$GITHUB_OUTPUT"
-
-        merges=$(python -c "import json; print(len(json.load(open('/tmp/agt-cred.json')).get('merges', [])))" 2>/dev/null || echo "0")
-        citations=$(python -c "import json; print(len(json.load(open('/tmp/agt-cred.json')).get('citations', [])))" 2>/dev/null || echo "0")
-        spray_repos=$(python -c "import json; print(json.load(open('/tmp/agt-cred.json')).get('spray_repos_count', 0))" 2>/dev/null || echo "0")
-        echo "merges=$merges" >> "$GITHUB_OUTPUT"
-        echo "citations=$citations" >> "$GITHUB_OUTPUT"
-        echo "spray_repos=$spray_repos" >> "$GITHUB_OUTPUT"
-
-    # ── Cluster detection (opt-in) ──
-    - name: Run cluster detection
-      id: cluster
-      if: contains(inputs.checks, 'cluster')
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        scripts="${{ steps.inputs.outputs.scripts_dir }}"
-        username="${{ steps.inputs.outputs.username }}"
-
-        if [ -z "$username" ]; then
-          echo "risk=UNKNOWN" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        set +e
-        python "$scripts/cluster_detect.py" \
-          --seed "$username" \
-          --json > /tmp/agt-cluster.json 2>/tmp/agt-cluster.log
-        set -e
-
-        risk=$(python -c "import json; print(json.load(open('/tmp/agt-cluster.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
-        echo "risk=$risk" >> "$GITHUB_OUTPUT"
-
-        accounts=$(python -c "import json; print(json.load(open('/tmp/agt-cluster.json')).get('account_count', 0))" 2>/dev/null || echo "0")
-        edges=$(python -c "import json; print(json.load(open('/tmp/agt-cluster.json')).get('edge_count', 0))" 2>/dev/null || echo "0")
-        echo "accounts=$accounts" >> "$GITHUB_OUTPUT"
-        echo "edges=$edges" >> "$GITHUB_OUTPUT"
-
-    # ── Aggregate risk ──
-    - name: Compute overall risk
-      id: aggregate
-      shell: bash
-      run: |
-        risk_to_num() {
-          case "$1" in
-            HIGH) echo 3 ;; MEDIUM) echo 2 ;; LOW) echo 1 ;; *) echo 0 ;;
-          esac
-        }
-
-        p=$(risk_to_num "${{ steps.profile.outputs.risk }}")
-        c=$(risk_to_num "${{ steps.credential.outputs.risk }}")
-        k=$(risk_to_num "${{ steps.cluster.outputs.risk }}")
-
-        max=$p
-        [ "$c" -gt "$max" ] && max=$c
-        [ "$k" -gt "$max" ] && max=$k
-
-        case "$max" in
-          3) overall="HIGH" ;; 2) overall="MEDIUM" ;; 1) overall="LOW" ;; *) overall="LOW" ;;
-        esac
-        echo "risk=$overall" >> "$GITHUB_OUTPUT"
-
-    # ── Post comment (idempotent via marker) ──
-    - name: Post review comment
-      if: >-
-        steps.inputs.outputs.type != 'manual' &&
-        (steps.aggregate.outputs.risk == 'HIGH' ||
-         (inputs.risk-threshold == 'MEDIUM' && steps.aggregate.outputs.risk == 'MEDIUM'))
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        username="${{ steps.inputs.outputs.username }}"
-        number="${{ steps.inputs.outputs.number }}"
-        type="${{ steps.inputs.outputs.type }}"
-        overall="${{ steps.aggregate.outputs.risk }}"
-        profile_risk="${{ steps.profile.outputs.risk }}"
-        cred_risk="${{ steps.credential.outputs.risk }}"
-        owner="${{ github.repository_owner }}"
-        repo="${{ github.event.repository.name }}"
-
-        if [ "$overall" = "HIGH" ]; then icon="🔴"; else icon="🟡"; fi
-
-        body="<!-- agt-contributor-check -->
-        $icon **Contributor Reputation Check: $overall risk**
-
-        | Check | Risk |
-        |-------|------|
-        | Profile analysis | $profile_risk |
-        | Credential audit | $cred_risk |
-        "
-
-        profile_signals="${{ steps.profile.outputs.signals }}"
-        if [ -n "$profile_signals" ]; then
-          body="$body
-        <details>
-        <summary>Profile signals</summary>
-
-        $profile_signals
-
-        </details>
-        "
-        fi
-
-        citations="${{ steps.credential.outputs.citations }}"
-        if [ "$citations" != "0" ] && [ -n "$citations" ]; then
-          spray_repos="${{ steps.credential.outputs.spray_repos }}"
-          merges="${{ steps.credential.outputs.merges }}"
-          body="$body
-        <details>
-        <summary>Credential audit: $merges merged PRs, $citations citations across $spray_repos repos</summary>
-
-        The contributor cites merged PRs from this repo in issues filed across other repositories.
-        This pattern may indicate credential laundering.
-
-        </details>
-        "
-        fi
-
-        body="$body
-        ---
-        *Automated check by [AGT Contributor Reputation](https://github.com/microsoft/agent-governance-toolkit/tree/main/scripts#contributor-reputation-tools). Not a judgment.*"
-
-        # Idempotent comment: find and update existing, or create new
-        python3 << 'PYEOF'
-        import json, os, sys
-        from urllib.request import Request, urlopen
-        from urllib.error import HTTPError
-
-        token = os.environ["GITHUB_TOKEN"]
-        owner = os.environ.get("owner", "")
-        repo_name = os.environ.get("repo", "")
-        number = os.environ.get("number", "0")
-        body = os.environ.get("body", "")
-        item_type = os.environ.get("type", "issue")
-        marker = "<!-- agt-contributor-check -->"
-
-        base = "https://api.github.com"
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-
-        def api(method, path, data=None):
-            url = f"{base}{path}"
-            req = Request(url, method=method, headers=headers)
-            if data:
-                req.add_header("Content-Type", "application/json")
-                req.data = json.dumps(data).encode()
-            with urlopen(req, timeout=15) as resp:
-                return json.loads(resp.read())
-
-        # Search for existing comment with our marker
-        existing_id = None
-        page = 1
-        while True:
-            comments = api("GET", f"/repos/{owner}/{repo_name}/issues/{number}/comments?per_page=100&page={page}")
-            for c in comments:
-                if marker in (c.get("body") or ""):
-                    existing_id = c["id"]
-                    break
-            if existing_id or len(comments) < 100:
-                break
-            page += 1
-
-        if existing_id:
-            api("PATCH", f"/repos/{owner}/{repo_name}/issues/comments/{existing_id}", {"body": body})
-            print(f"Updated existing comment {existing_id}")
-        else:
-            api("POST", f"/repos/{owner}/{repo_name}/issues/{number}/comments", {"body": body})
-            print("Created new comment")
-        PYEOF
-
-    # ── Label (idempotent) ──
-    - name: Add risk label
-      if: >-
-        steps.inputs.outputs.type != 'manual' &&
-        (steps.aggregate.outputs.risk == 'HIGH' ||
-         (inputs.risk-threshold == 'MEDIUM' && steps.aggregate.outputs.risk == 'MEDIUM'))
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-      run: |
-        number="${{ steps.inputs.outputs.number }}"
-        type="${{ steps.inputs.outputs.type }}"
-        risk="${{ steps.aggregate.outputs.risk }}"
-        owner="${{ github.repository_owner }}"
-        repo="${{ github.event.repository.name }}"
-
-        # Use Python for portability (no gh CLI dependency)
-        python3 << PYEOF
-        import json, os, sys
-        from urllib.request import Request, urlopen
-        from urllib.error import HTTPError
-
-        token = os.environ["GITHUB_TOKEN"]
-        owner = "$owner"
-        repo = "$repo"
-        number = "$number"
-        risk = "$risk"
-
-        base = "https://api.github.com"
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github+json",
-            "X-GitHub-Api-Version": "2022-11-28",
-        }
-
-        def api(method, path, data=None):
-            url = f"{base}{path}"
-            req = Request(url, method=method, headers=headers)
-            if data:
-                req.add_header("Content-Type", "application/json")
-                req.data = json.dumps(data).encode()
-            try:
-                with urlopen(req, timeout=15) as resp:
-                    return json.loads(resp.read())
-            except HTTPError as e:
-                if e.code == 422:
-                    return None  # label already exists or already applied
-                raise
-
-        color = "D93F0B" if risk == "HIGH" else "FFA500"
-
-        # Create label if missing
-        try:
-            api("POST", f"/repos/{owner}/{repo}/labels", {
-                "name": f"needs-review:{risk}",
-                "description": f"Contributor reputation check flagged {risk} risk",
-                "color": color,
-            })
-        except HTTPError:
-            pass
-
-        # Remove stale risk labels
-        for level in ["LOW", "MEDIUM", "HIGH"]:
-            if level != risk:
-                try:
-                    req = Request(
-                        f"{base}/repos/{owner}/{repo}/issues/{number}/labels/needs-review:{level}",
-                        method="DELETE", headers=headers,
-                    )
-                    urlopen(req, timeout=15)
-                except Exception:
-                    pass
-
-        # Apply current label
-        api("POST", f"/repos/{owner}/{repo}/issues/{number}/labels", {
-            "labels": [f"needs-review:{risk}"],
-        })
-        print(f"Applied label needs-review:{risk}")
-        PYEOF
-
-    # ── Job summary ──
-    - name: Write job summary
-      if: always()
-      shell: bash
-      run: |
-        username="${{ steps.inputs.outputs.username }}"
-        overall="${{ steps.aggregate.outputs.risk }}"
-        profile_risk="${{ steps.profile.outputs.risk }}"
-        cred_risk="${{ steps.credential.outputs.risk }}"
-        cluster_risk="${{ steps.cluster.outputs.risk }}"
-
-        {
-          echo "## Contributor Reputation Check: \`$username\`"
-          echo ""
-          echo "| Check | Risk |"
-          echo "|-------|------|"
-          echo "| **Overall** | **$overall** |"
-          if [ -n "$profile_risk" ]; then echo "| Profile analysis | $profile_risk |"; fi
-          if [ -n "$cred_risk" ]; then echo "| Credential audit | $cred_risk |"; fi
-          if [ -n "$cluster_risk" ]; then echo "| Cluster detection | $cluster_risk |"; fi
-          echo ""
-
-          profile_signals="${{ steps.profile.outputs.signals }}"
-          if [ -n "$profile_signals" ]; then
-            echo "### Profile signals"
-            echo "$profile_signals"
-            echo ""
-          fi
-
-          citations="${{ steps.credential.outputs.citations }}"
-          if [ "$citations" != "0" ] && [ -n "$citations" ]; then
-            echo "### Credential audit"
-            echo "- Merged PRs: ${{ steps.credential.outputs.merges }}"
-            echo "- Spray citations: $citations across ${{ steps.credential.outputs.spray_repos }} repos"
-            echo ""
-          fi
-        } >> "$GITHUB_STEP_SUMMARY"
-
-    # ── Cleanup temp files ──
     - name: Cleanup temporary files
       if: always()
       shell: bash

--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -69,93 +69,132 @@ parameters:
     type: object
     displayName: 'Python packages to publish'
     default:
-      # Core packages (7)
+      # Wave 1: Core packages (already registered on PyPI)
       - name: agent-os
         path: agent-governance-python/agent-os
+        wave: 1
       - name: agent-mesh
         path: agent-governance-python/agent-mesh
+        wave: 1
       - name: agent-hypervisor
         path: agent-governance-python/agent-hypervisor
+        wave: 1
       - name: agent-sre
         path: agent-governance-python/agent-sre
+        wave: 1
       - name: agent-compliance
         path: agent-governance-python/agent-compliance
+        wave: 1
       - name: agent-runtime
         path: agent-governance-python/agent-runtime
+        wave: 1
       - name: agent-lightning
         path: agent-governance-python/agent-lightning
-      # Standalone packages (4)
+        wave: 1
       - name: agent-marketplace
         path: agent-governance-python/agent-marketplace
+        wave: 1
       - name: agent-mcp-governance
         path: agent-governance-python/agent-mcp-governance
-      - name: agentmesh-discovery
-        path: agent-governance-python/agent-discovery
-      - name: agentmesh-primitives
-        path: agent-governance-python/agent-primitives
-      # Agent-OS modules (10)
+        wave: 1
       - name: agentmesh-message-bus
         path: agent-governance-python/agent-os/modules/amb
-      - name: agentmesh-tool-registry
-        path: agent-governance-python/agent-os/modules/atr
+        wave: 1
       - name: agentmesh-context
         path: agent-governance-python/agent-os/modules/caas
+        wave: 1
       - name: agentmesh-drift
         path: agent-governance-python/agent-os/modules/cmvk
-      - name: agentmesh-control-plane
-        path: agent-governance-python/agent-os/modules/control-plane
-      - name: agentmesh-memory
-        path: agent-governance-python/agent-os/modules/emk
-      - name: agentmesh-trust-protocol
-        path: agent-governance-python/agent-os/modules/iatp
+        wave: 1
       - name: agentmesh-mcp-server
         path: agent-governance-python/agent-os/modules/mcp-kernel-server
+        wave: 1
       - name: agentmesh-nexus
         path: agent-governance-python/agent-os/modules/nexus
+        wave: 1
+      # Wave 2: Renamed/new standalone + modules
+      - name: agentmesh-discovery
+        path: agent-governance-python/agent-discovery
+        wave: 2
+      - name: agentmesh-primitives
+        path: agent-governance-python/agent-primitives
+        wave: 2
+      - name: agentmesh-tool-registry
+        path: agent-governance-python/agent-os/modules/atr
+        wave: 2
+      - name: agentmesh-control-plane
+        path: agent-governance-python/agent-os/modules/control-plane
+        wave: 2
+      - name: agentmesh-memory
+        path: agent-governance-python/agent-os/modules/emk
+        wave: 2
+      - name: agentmesh-trust-protocol
+        path: agent-governance-python/agent-os/modules/iatp
+        wave: 2
       - name: agentmesh-observability
         path: agent-governance-python/agent-os/modules/observability
-      # AgentMesh sub-packages (1)
+        wave: 2
       - name: agentmesh-mcp-trust
         path: agent-governance-python/agent-mesh/packages/mcp-trust-server
-      # Framework integrations (18)
+        wave: 2
       - name: a2a-protocol
         path: agent-governance-python/agentmesh-integrations/a2a-protocol
+        wave: 2
       - name: adk-agentmesh
         path: agent-governance-python/agentmesh-integrations/adk-agentmesh
+        wave: 2
       - name: avp-agentmesh
         path: agent-governance-python/agentmesh-integrations/agentmesh-avp
+        wave: 2
       - name: agentmesh-audit-export
         path: agent-governance-python/agentmesh-integrations/audit-accountability-export
-      - name: crewai-agentmesh
-        path: agent-governance-python/agentmesh-integrations/crewai-agentmesh
-      - name: flowise-agentmesh
-        path: agent-governance-python/agentmesh-integrations/flowise-agentmesh
-      - name: haystack-agentmesh
-        path: agent-governance-python/agentmesh-integrations/haystack-agentmesh
-      - name: langchain-agentmesh
-        path: agent-governance-python/agentmesh-integrations/langchain-agentmesh
-      - name: langflow-agentmesh
-        path: agent-governance-python/agentmesh-integrations/langflow-agentmesh
-      - name: langgraph-agentmesh
-        path: agent-governance-python/agentmesh-integrations/langgraph-trust
-      - name: llamaindex-agentmesh
-        path: agent-governance-python/agentmesh-integrations/llamaindex-agentmesh
+        wave: 2
       - name: agentmesh-mcp-receipts
         path: agent-governance-python/agentmesh-integrations/mcp-receipt-governed
+        wave: 2
       - name: agentmesh-mcp-proxy
         path: agent-governance-python/agentmesh-integrations/mcp-trust-proxy
+        wave: 2
+      # Wave 3: Framework integrations
+      - name: crewai-agentmesh
+        path: agent-governance-python/agentmesh-integrations/crewai-agentmesh
+        wave: 3
+      - name: flowise-agentmesh
+        path: agent-governance-python/agentmesh-integrations/flowise-agentmesh
+        wave: 3
+      - name: haystack-agentmesh
+        path: agent-governance-python/agentmesh-integrations/haystack-agentmesh
+        wave: 3
+      - name: langchain-agentmesh
+        path: agent-governance-python/agentmesh-integrations/langchain-agentmesh
+        wave: 3
+      - name: langflow-agentmesh
+        path: agent-governance-python/agentmesh-integrations/langflow-agentmesh
+        wave: 3
+      - name: langgraph-agentmesh
+        path: agent-governance-python/agentmesh-integrations/langgraph-trust
+        wave: 3
+      - name: llamaindex-agentmesh
+        path: agent-governance-python/agentmesh-integrations/llamaindex-agentmesh
+        wave: 3
       - name: nostr-wot-agentmesh
         path: agent-governance-python/agentmesh-integrations/nostr-wot
+        wave: 3
       - name: openai-agents-agentmesh
         path: agent-governance-python/agentmesh-integrations/openai-agents-agentmesh
+        wave: 3
       - name: openai-agents-trust
         path: agent-governance-python/agentmesh-integrations/openai-agents-trust
+        wave: 3
       - name: openshell-skill
         path: agent-governance-python/agentmesh-integrations/openshell-skill
+        wave: 3
       - name: pydantic-ai-agentmesh
         path: agent-governance-python/agentmesh-integrations/pydantic-ai-governance
+        wave: 3
       - name: structural-authz-agentmesh
         path: agent-governance-python/agentmesh-integrations/structural-authz-agentmesh
+        wave: 3
 
   - name: npmPackages
     type: object
@@ -249,39 +288,117 @@ stages:
                 publishLocation: 'pipeline'
               displayName: 'Publish ${{ pkg.name }} artifacts'
 
-  - stage: Publish_PyPI
-    displayName: 'Publish to PyPI via ESRP'
+  # Publish in 3 waves to avoid PyPI "Too many new projects" rate limits.
+  # Wave 1: established packages (already registered on PyPI)
+  # Wave 2: renamed/new standalone + modules
+  # Wave 3: framework integrations
+  - stage: Publish_PyPI_Wave1
+    displayName: 'Publish to PyPI — Wave 1 (core)'
     dependsOn: Build_PyPI
     condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
     jobs:
       - ${{ each pkg in parameters.pypiPackages }}:
-        - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
-          displayName: 'Publish ${{ pkg.name }} to PyPI'
-          steps:
-            - task: DownloadPipelineArtifact@2
-              inputs:
-                artifact: 'pypi-${{ pkg.name }}'
-                targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-              displayName: 'Download ${{ pkg.name }} artifacts'
+        - ${{ if eq(pkg.wave, 1) }}:
+          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
+            displayName: 'Publish ${{ pkg.name }} to PyPI'
+            steps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifact: 'pypi-${{ pkg.name }}'
+                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                displayName: 'Download ${{ pkg.name }} artifacts'
 
-            - task: EsrpRelease@11
-              displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
-              inputs:
-                connectedservicename: 'Agent Governance Toolkit'
-                usemanagedidentity: true
-                keyvaultname: '$(ESRP_KEYVAULT_NAME)'
-                signcertname: '$(ESRP_CERT_IDENTIFIER)'
-                clientid: '$(ESRP_CLIENT_ID)'
-                intent: 'PackageDistribution'
-                contenttype: 'PyPi'
-                contentsource: 'Folder'
-                folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                waitforreleasecompletion: true
-                owners: '$(ESRP_OWNERS)'
-                approvers: '$(ESRP_APPROVERS)'
-                serviceendpointurl: 'https://api.esrp.microsoft.com'
-                mainpublisher: 'ESRPRELPACMAN'
-                domaintenantid: '$(MICROSOFT_TENANT_ID)'
+              - task: EsrpRelease@11
+                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
+                retryCountOnTaskFailure: 2
+                inputs:
+                  connectedservicename: 'Agent Governance Toolkit'
+                  usemanagedidentity: true
+                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+                  signcertname: '$(ESRP_CERT_IDENTIFIER)'
+                  clientid: '$(ESRP_CLIENT_ID)'
+                  intent: 'PackageDistribution'
+                  contenttype: 'PyPi'
+                  contentsource: 'Folder'
+                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                  waitforreleasecompletion: true
+                  owners: '$(ESRP_OWNERS)'
+                  approvers: '$(ESRP_APPROVERS)'
+                  serviceendpointurl: 'https://api.esrp.microsoft.com'
+                  mainpublisher: 'ESRPRELPACMAN'
+                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
+
+  - stage: Publish_PyPI_Wave2
+    displayName: 'Publish to PyPI — Wave 2 (modules)'
+    dependsOn: Publish_PyPI_Wave1
+    condition: and(not(failed()), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - ${{ each pkg in parameters.pypiPackages }}:
+        - ${{ if eq(pkg.wave, 2) }}:
+          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
+            displayName: 'Publish ${{ pkg.name }} to PyPI'
+            steps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifact: 'pypi-${{ pkg.name }}'
+                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                displayName: 'Download ${{ pkg.name }} artifacts'
+
+              - task: EsrpRelease@11
+                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
+                retryCountOnTaskFailure: 2
+                inputs:
+                  connectedservicename: 'Agent Governance Toolkit'
+                  usemanagedidentity: true
+                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+                  signcertname: '$(ESRP_CERT_IDENTIFIER)'
+                  clientid: '$(ESRP_CLIENT_ID)'
+                  intent: 'PackageDistribution'
+                  contenttype: 'PyPi'
+                  contentsource: 'Folder'
+                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                  waitforreleasecompletion: true
+                  owners: '$(ESRP_OWNERS)'
+                  approvers: '$(ESRP_APPROVERS)'
+                  serviceendpointurl: 'https://api.esrp.microsoft.com'
+                  mainpublisher: 'ESRPRELPACMAN'
+                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
+
+  - stage: Publish_PyPI_Wave3
+    displayName: 'Publish to PyPI — Wave 3 (integrations)'
+    dependsOn: Publish_PyPI_Wave2
+    condition: and(not(failed()), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - ${{ each pkg in parameters.pypiPackages }}:
+        - ${{ if eq(pkg.wave, 3) }}:
+          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
+            displayName: 'Publish ${{ pkg.name }} to PyPI'
+            steps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifact: 'pypi-${{ pkg.name }}'
+                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                displayName: 'Download ${{ pkg.name }} artifacts'
+
+              - task: EsrpRelease@11
+                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
+                retryCountOnTaskFailure: 2
+                inputs:
+                  connectedservicename: 'Agent Governance Toolkit'
+                  usemanagedidentity: true
+                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+                  signcertname: '$(ESRP_CERT_IDENTIFIER)'
+                  clientid: '$(ESRP_CLIENT_ID)'
+                  intent: 'PackageDistribution'
+                  contenttype: 'PyPi'
+                  contentsource: 'Folder'
+                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                  waitforreleasecompletion: true
+                  owners: '$(ESRP_OWNERS)'
+                  approvers: '$(ESRP_APPROVERS)'
+                  serviceendpointurl: 'https://api.esrp.microsoft.com'
+                  mainpublisher: 'ESRPRELPACMAN'
+                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
 
   # =======================================================
   # NPM — 7 packages (@microsoft scope)

--- a/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45,<46.0", "wheel"]
+requires = ["setuptools>=64.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/agent-governance-python/agent-os/modules/emk/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/emk/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45,<46.0", "wheel"]
+requires = ["setuptools>=64.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/scripts/contributor_check_action.py
+++ b/scripts/contributor_check_action.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Entrypoint for the contributor-check composite action.
+
+Orchestrates profile analysis, credential audit, and cluster detection,
+then posts a summary comment and applies labels on PRs/issues that meet
+the risk threshold.
+
+Usage (from the composite action):
+    python scripts/contributor_check_action.py \
+        --username <login> \
+        --checks profile,credential \
+        --target-repo owner/repo \
+        --risk-threshold MEDIUM \
+        --number 42 \
+        --item-type pr
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+MARKER = "<!-- agt-contributor-check -->"
+RISK_ORDER = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "UNKNOWN": 0}
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _api(token: str, method: str, path: str, data: dict | None = None) -> dict | None:
+    """Minimal GitHub API helper (no third-party deps)."""
+    url = f"https://api.github.com{path}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    req = Request(url, method=method, headers=headers)
+    if data:
+        req.add_header("Content-Type", "application/json")
+        req.data = json.dumps(data).encode()
+    try:
+        with urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read())
+    except HTTPError as exc:
+        if exc.code == 422:
+            return None
+        raise
+
+
+def _run_check(script: str, args: list[str], out_path: str) -> str:
+    """Run a check script and return the risk level from its JSON output."""
+    try:
+        result = subprocess.run(
+            [sys.executable, script, *args, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        Path(out_path).write_text(result.stdout)
+        data = json.loads(result.stdout)
+        return data.get("risk", "UNKNOWN")
+    except Exception:
+        return "UNKNOWN"
+
+
+def _aggregate_risk(*levels: str) -> str:
+    """Return the highest risk level from a set of check results."""
+    max_val = max(RISK_ORDER.get(r, 0) for r in levels)
+    for label, val in RISK_ORDER.items():
+        if val == max_val and label != "UNKNOWN":
+            return label
+    return "LOW"
+
+
+def _set_output(name: str, value: str) -> None:
+    """Write a value to $GITHUB_OUTPUT."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{name}={value}\n")
+
+
+def _write_summary(text: str) -> None:
+    """Append text to $GITHUB_STEP_SUMMARY."""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write(text)
+
+
+# ── Comment / label helpers ───────────────────────────────────────
+
+
+def _build_comment(username: str, overall: str, profile_risk: str,
+                   cred_risk: str, cluster_risk: str) -> str:
+    """Build a concise comment body with risk levels only."""
+    icon = "\U0001f534" if overall == "HIGH" else "\U0001f7e1"
+
+    lines = [
+        MARKER,
+        f"{icon} **Contributor Check: {overall}**",
+        "",
+        "| Check | Result |",
+        "|-------|--------|",
+    ]
+    if profile_risk:
+        lines.append(f"| Profile | {profile_risk} |")
+    if cred_risk:
+        lines.append(f"| Credential | {cred_risk} |")
+    if cluster_risk:
+        lines.append(f"| Cluster | {cluster_risk} |")
+    lines.append(f"| **Overall** | **{overall}** |")
+    lines.append("")
+    lines.append(
+        "*Automated check by "
+        "[AGT Contributor Check]"
+        "(https://github.com/microsoft/agent-governance-toolkit"
+        "/tree/main/scripts#contributor-reputation-tools).*"
+    )
+    return "\n".join(lines)
+
+
+def _post_comment(token: str, owner: str, repo: str, number: int,
+                  body: str) -> None:
+    """Create or update the contributor-check comment (idempotent)."""
+    page = 1
+    existing_id = None
+    while True:
+        comments = _api(
+            token, "GET",
+            f"/repos/{owner}/{repo}/issues/{number}/comments?per_page=100&page={page}",
+        ) or []
+        for c in comments:
+            if MARKER in (c.get("body") or ""):
+                existing_id = c["id"]
+                break
+        if existing_id or len(comments) < 100:
+            break
+        page += 1
+
+    if existing_id:
+        _api(token, "PATCH",
+             f"/repos/{owner}/{repo}/issues/comments/{existing_id}",
+             {"body": body})
+    else:
+        _api(token, "POST",
+             f"/repos/{owner}/{repo}/issues/{number}/comments",
+             {"body": body})
+
+
+def _apply_label(token: str, owner: str, repo: str, number: int,
+                 risk: str) -> None:
+    """Ensure the correct needs-review label is applied."""
+    color = "D93F0B" if risk == "HIGH" else "FFA500"
+    try:
+        _api(token, "POST", f"/repos/{owner}/{repo}/labels", {
+            "name": f"needs-review:{risk}",
+            "description": f"Contributor check flagged {risk} risk",
+            "color": color,
+        })
+    except HTTPError:
+        pass
+
+    for level in ("LOW", "MEDIUM", "HIGH"):
+        if level != risk:
+            try:
+                req = Request(
+                    f"https://api.github.com/repos/{owner}/{repo}"
+                    f"/issues/{number}/labels/needs-review:{level}",
+                    method="DELETE",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/vnd.github+json",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                    },
+                )
+                urlopen(req, timeout=15)
+            except Exception:
+                pass
+
+    _api(token, "POST", f"/repos/{owner}/{repo}/issues/{number}/labels", {
+        "labels": [f"needs-review:{risk}"],
+    })
+
+
+# ── Main ──────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Contributor check action entrypoint")
+    parser.add_argument("--username", required=True)
+    parser.add_argument("--checks", default="profile,credential")
+    parser.add_argument("--target-repo", required=True)
+    parser.add_argument("--risk-threshold", default="MEDIUM")
+    parser.add_argument("--number", type=int, default=0)
+    parser.add_argument("--item-type", default="manual",
+                        choices=["pr", "issue", "manual"])
+    args = parser.parse_args()
+
+    if not args.username:
+        print("No username provided, skipping.")
+        _set_output("risk", "UNKNOWN")
+        return
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    scripts_dir = Path(__file__).resolve().parent
+    checks = [c.strip() for c in args.checks.split(",")]
+
+    profile_risk = ""
+    cred_risk = ""
+    cluster_risk = ""
+
+    if "profile" in checks:
+        profile_risk = _run_check(
+            str(scripts_dir / "contributor_check.py"),
+            ["--username", args.username, "--repo", args.target_repo],
+            "/tmp/agt-profile.json",
+        )
+
+    if "credential" in checks:
+        cred_risk = _run_check(
+            str(scripts_dir / "credential_audit.py"),
+            ["--username", args.username, "--repo", args.target_repo],
+            "/tmp/agt-cred.json",
+        )
+
+    if "cluster" in checks:
+        cluster_risk = _run_check(
+            str(scripts_dir / "cluster_detect.py"),
+            ["--seed", args.username],
+            "/tmp/agt-cluster.json",
+        )
+
+    overall = _aggregate_risk(
+        profile_risk or "LOW",
+        cred_risk or "LOW",
+        cluster_risk or "LOW",
+    )
+
+    # Set action outputs
+    _set_output("risk", overall)
+    _set_output("profile-risk", profile_risk)
+    _set_output("credential-risk", cred_risk)
+    _set_output("cluster-risk", cluster_risk)
+
+    print(f"Contributor check for {args.username}: {overall}")
+
+    # Post comment and label for PR/issue if risk meets threshold
+    threshold_val = RISK_ORDER.get(args.risk_threshold, 2)
+    risk_val = RISK_ORDER.get(overall, 0)
+
+    if args.item_type != "manual" and args.number > 0 and risk_val >= threshold_val:
+        owner, repo = args.target_repo.split("/", 1)
+        body = _build_comment(
+            args.username, overall, profile_risk, cred_risk, cluster_risk,
+        )
+        _post_comment(token, owner, repo, args.number, body)
+        _apply_label(token, owner, repo, args.number, overall)
+        print(f"Posted comment and label on #{args.number}")
+
+    # Job summary
+    summary_lines = [
+        f"## Contributor Check: `{args.username}`\n",
+        "| Check | Result |",
+        "|-------|--------|",
+    ]
+    if profile_risk:
+        summary_lines.append(f"| Profile | {profile_risk} |")
+    if cred_risk:
+        summary_lines.append(f"| Credential | {cred_risk} |")
+    if cluster_risk:
+        summary_lines.append(f"| Cluster | {cluster_risk} |")
+    summary_lines.append(f"| **Overall** | **{overall}** |")
+    summary_lines.append("")
+    _write_summary("\n".join(summary_lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Changes

### Contributor Check Refactoring
- Consolidate the 456-line contributor-check composite action into a clean Python entrypoint (\scripts/contributor_check_action.py\)
- Action.yml reduced to ~100 lines: setup Python, resolve inputs, call the script, cleanup
- PR/issue comments now show concise result tables (Check | Result) instead of verbose signal breakdowns
- All check logic (profile, credential, cluster) orchestrated from a single script

### ESRP PyPI Publish Fixes
- **Wave-based publishing**: Split 41-package parallel publish into 3 sequential waves (core -> modules -> integrations) to avoid PyPI 429 rate-limit errors (\Too many new projects created\)
- **Retry on failure**: Added \etryCountOnTaskFailure: 2\ to all ESRP publish tasks for transient failures
- **setuptools version fix**: Updated \control-plane\ and \mk\ modules from \setuptools>=45,<46.0\ to \setuptools>=64.0\ so PEP 621 \[project]\ metadata is parsed correctly during builds (the old constraint caused empty or incorrect package names, leading to 400/403 errors)

### Remaining Manual Actions
- PyPI project ownership transfer needed for \openai-agents-trust\ and \langchain-agentmesh\ (403 Forbidden: owned by another account)
- NuGet code signing certificate configuration (separate infrastructure issue)