### PR TITLE
fix(publish): rename conflicting PyPI packages

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -165,7 +165,7 @@ parameters:
       - name: haystack-agentmesh
         path: agent-governance-python/agentmesh-integrations/haystack-agentmesh
         wave: 3
-      - name: langchain-agentmesh
+      - name: agentmesh-langchain
         path: agent-governance-python/agentmesh-integrations/langchain-agentmesh
         wave: 3
       - name: langflow-agentmesh
@@ -183,7 +183,7 @@ parameters:
       - name: openai-agents-agentmesh
         path: agent-governance-python/agentmesh-integrations/openai-agents-agentmesh
         wave: 3
-      - name: openai-agents-trust
+      - name: agentmesh-openai-agents-trust
         path: agent-governance-python/agentmesh-integrations/openai-agents-trust
         wave: 3
       - name: openshell-skill

--- a/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "langchain_agentmesh"
+name = "agentmesh_langchain"
 version = "3.3.0"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust-gated tool execution"
 readme = "README.md"

--- a/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "openai_agents_trust"
+name = "agentmesh_openai_agents_trust"
 version = "3.3.0"
 description = "Trust & governance layer for OpenAI Agents SDK — policy enforcement, trust-gated handoffs, and hash-chained audit trails"
 readme = "README.md"


### PR DESCRIPTION
Rename two packages whose names are already registered by other PyPI accounts (403 Forbidden during ESRP publish):

- \openai-agents-trust\ → \gentmesh-openai-agents-trust\
- \langchain-agentmesh\ → \gentmesh-langchain\

Python import names are unchanged (\import openai_agents_trust\, \import langchain_agentmesh\). Only the pip distribution name changes to avoid the conflict.