### PR TITLE
docs: update pip install names for renamed PyPI packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
       package:
         description: >
           Package to publish. Use "all" for everything, "all-python" for all
-          Python packages, or a specific name (e.g. "agent-os", "langchain-agentmesh").
+          Python packages, or a specific name (e.g. "agent-os", "agentmesh-langchain").
         required: true
         type: string
         default: "all"
@@ -70,7 +70,7 @@ jobs:
             {"name":"crewai-agentmesh","path":"agent-governance-python/agentmesh-integrations/crewai-agentmesh"},
             {"name":"flowise-agentmesh","path":"agent-governance-python/agentmesh-integrations/flowise-agentmesh"},
             {"name":"haystack-agentmesh","path":"agent-governance-python/agentmesh-integrations/haystack-agentmesh"},
-            {"name":"langchain-agentmesh","path":"agent-governance-python/agentmesh-integrations/langchain-agentmesh"},
+            {"name":"agentmesh-langchain","path":"agent-governance-python/agentmesh-integrations/langchain-agentmesh"},
             {"name":"langflow-agentmesh","path":"agent-governance-python/agentmesh-integrations/langflow-agentmesh"},
             {"name":"langgraph-agentmesh","path":"agent-governance-python/agentmesh-integrations/langgraph-trust"},
             {"name":"llamaindex-agentmesh","path":"agent-governance-python/agentmesh-integrations/llamaindex-agentmesh"},
@@ -78,7 +78,7 @@ jobs:
             {"name":"agentmesh-mcp-proxy","path":"agent-governance-python/agentmesh-integrations/mcp-trust-proxy"},
             {"name":"nostr-wot-agentmesh","path":"agent-governance-python/agentmesh-integrations/nostr-wot"},
             {"name":"openai-agents-agentmesh","path":"agent-governance-python/agentmesh-integrations/openai-agents-agentmesh"},
-            {"name":"openai-agents-trust","path":"agent-governance-python/agentmesh-integrations/openai-agents-trust"},
+            {"name":"agentmesh-openai-agents-trust","path":"agent-governance-python/agentmesh-integrations/openai-agents-trust"},
             {"name":"openshell-skill","path":"agent-governance-python/agentmesh-integrations/openshell-skill"},
             {"name":"pydantic-ai-agentmesh","path":"agent-governance-python/agentmesh-integrations/pydantic-ai-governance"},
             {"name":"structural-authz-agentmesh","path":"agent-governance-python/agentmesh-integrations/structural-authz-agentmesh"}

--- a/agent-governance-python/agent-mesh/README.md
+++ b/agent-governance-python/agent-mesh/README.md
@@ -37,7 +37,7 @@
   <a href="https://github.com/run-llama/llama_index/pull/20644"><img src="https://img.shields.io/badge/LlamaIndex-47K_⭐_Merged-success?style=flat-square" alt="LlamaIndex"></a>
   <a href="https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478"><img src="https://img.shields.io/badge/Agent--Lightning-15K_⭐_Merged-success?style=flat-square" alt="Agent-Lightning"></a>
   <a href="https://pypi.org/project/langgraph-trust/"><img src="https://img.shields.io/badge/LangGraph-PyPI-blue?style=flat-square" alt="LangGraph"></a>
-  <a href="https://pypi.org/project/openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
+  <a href="https://pypi.org/project/agentmesh-openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
   <a href="https://clawhub.ai/microsoft/agentmesh-governance"><img src="https://img.shields.io/badge/OpenClaw-ClawHub-purple?style=flat-square" alt="OpenClaw"></a>
 </p>
 

--- a/agent-governance-python/agent-mesh/integrations/README.md
+++ b/agent-governance-python/agent-mesh/integrations/README.md
@@ -18,7 +18,7 @@ AgentMesh core is a lean, zero-external-dependency library. Moving integrations 
 
 - **Core stays stable** — no risk of breaking changes from integration dependencies
 - **Independent releases** — integrations ship on their own cadence
-- **Clean installs** — users only install what they need (`pip install langchain-agentmesh`)
+- **Clean installs** — users only install what they need (`pip install agentmesh-langchain`)
 - **Community ownership** — contributors can own their integrations end-to-end
 
 ## Contributing New Integrations

--- a/agent-governance-python/agent-os/README.md
+++ b/agent-governance-python/agent-os/README.md
@@ -35,7 +35,7 @@
   <a href="https://github.com/run-llama/llama_index/pull/20644"><img src="https://img.shields.io/badge/LlamaIndex-Merged-success?style=flat-square" alt="LlamaIndex"></a>
   <a href="https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478"><img src="https://img.shields.io/badge/Agent--Lightning-Merged-success?style=flat-square" alt="Agent-Lightning"></a>
   <a href="https://pypi.org/project/langgraph-trust/"><img src="https://img.shields.io/badge/LangGraph-PyPI-blue?style=flat-square" alt="LangGraph"></a>
-  <a href="https://pypi.org/project/openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
+  <a href="https://pypi.org/project/agentmesh-openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
   <a href="https://clawhub.ai/microsoft/agentmesh-governance"><img src="https://img.shields.io/badge/OpenClaw-ClawHub-purple?style=flat-square" alt="OpenClaw"></a>
 </p>
 
@@ -48,7 +48,7 @@
   <a href="https://github.com/heilcheng/awesome-agent-skills/pull/34"><img src="https://img.shields.io/badge/awesome--agent--skills-listed-orange?style=flat-square" alt="awesome-agent-skills"></a>
   <a href="https://github.com/TensorBlock/awesome-mcp-servers/pull/66"><img src="https://img.shields.io/badge/awesome--mcp--servers-listed-orange?style=flat-square" alt="awesome-mcp-servers"></a>
   <a href="https://github.com/rohitg00/awesome-devops-mcp-servers/pull/27"><img src="https://img.shields.io/badge/awesome--devops--mcp-listed-orange?style=flat-square" alt="awesome-devops-mcp"></a>
-</p>across 170K+ GitHub stars. Governance for [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/openai-agents-trust/), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
+</p>across 170K+ GitHub stars. Governance for [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/agentmesh-openai-agents-trust/), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
 
 ## 📊 By The Numbers
 
@@ -70,7 +70,7 @@
 | **LlamaIndex** | 47K ⭐ | ✅ Merged | [llama_index#20644](https://github.com/run-llama/llama_index/pull/20644) |
 | **Microsoft Agent-Lightning** | 15K ⭐ | ✅ Merged | [agent-lightning#478](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478) |
 | **LangGraph** | 24K ⭐ | 📦 Published on PyPI | [langgraph-trust](https://pypi.org/project/langgraph-trust/) |
-| **OpenAI Agents SDK** | — | 📦 Published on PyPI | [openai-agents-trust](https://pypi.org/project/openai-agents-trust/) |
+| **OpenAI Agents SDK** | — | 📦 Published on PyPI | [agentmesh-openai-agents-trust](https://pypi.org/project/agentmesh-openai-agents-trust/) |
 | **OpenClaw** | — | 📦 Published on ClawHub | [agentmesh-governance](https://clawhub.ai/microsoft/agentmesh-governance) |
 
 <details>
@@ -1138,7 +1138,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 Prompt-based guardrails ask the LLM to self-police, which is probabilistic. Agent OS enforces governance at the middleware level using deterministic policy engines and POSIX-inspired access controls. It controls what agents *can* do (capability-based), not just what they *should not* do (filter-based).
 
 **How does Agent OS work with other frameworks?**
-Agent OS integrates with 14+ frameworks via adapters. Install the governance layer alongside your existing framework: use `langgraph-trust` for LangGraph, `openai-agents-trust` for OpenAI Agents, or the MCP server for any MCP-compatible client. Agent OS acts as a kernel layer underneath your agent framework.
+Agent OS integrates with 14+ frameworks via adapters. Install the governance layer alongside your existing framework: use `langgraph-trust` for LangGraph, `agentmesh-openai-agents-trust` for OpenAI Agents, or the MCP server for any MCP-compatible client. Agent OS acts as a kernel layer underneath your agent framework.
 
 **What is the Agent Governance Ecosystem?**
 Agent OS is part of a suite of seven packages: Agent OS (policy engine), [AgentMesh](https://github.com/microsoft/agent-governance-toolkit) (trust infrastructure), [Agent Runtime](https://github.com/microsoft/agent-governance-toolkit) (execution supervisor), [Agent SRE](https://github.com/microsoft/agent-governance-toolkit) (reliability), [Agent Compliance](https://github.com/microsoft/agent-governance-toolkit) (regulatory compliance), [Agent Marketplace](https://github.com/microsoft/agent-governance-toolkit) (plugin lifecycle), and [Agent Lightning](https://github.com/microsoft/agent-governance-toolkit) (RL training governance). Together they provide 4,310+ tests across 17 modules.

--- a/agent-governance-python/agent-sre/README.md
+++ b/agent-governance-python/agent-sre/README.md
@@ -32,11 +32,11 @@
   <a href="https://github.com/run-llama/llama_index/pull/20644"><img src="https://img.shields.io/badge/LlamaIndex-47K_⭐_Merged-success?style=flat-square" alt="LlamaIndex"></a>
   <a href="https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478"><img src="https://img.shields.io/badge/Agent--Lightning-15K_⭐_Merged-success?style=flat-square" alt="Agent-Lightning"></a>
   <a href="https://pypi.org/project/langgraph-trust/"><img src="https://img.shields.io/badge/LangGraph-PyPI-blue?style=flat-square" alt="LangGraph"></a>
-  <a href="https://pypi.org/project/openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
+  <a href="https://pypi.org/project/agentmesh-openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
   <a href="https://clawhub.ai/microsoft/agentmesh-governance"><img src="https://img.shields.io/badge/OpenClaw-ClawHub-purple?style=flat-square" alt="OpenClaw"></a>
 </p>
 
-Reliability layer across **170K+ combined GitHub stars** of integrated projects — [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478) (15K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/openai-agents-trust/), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
+Reliability layer across **170K+ combined GitHub stars** of integrated projects — [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478) (15K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/agentmesh-openai-agents-trust/), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
 
 ---
 

--- a/agent-governance-python/agentmesh-integrations/README.md
+++ b/agent-governance-python/agentmesh-integrations/README.md
@@ -40,7 +40,7 @@ AgentMesh core is a lean, zero-external-dependency library. Platform integration
 
 | Integration | Package | Status | Description |
 |---|---|---|---|
-| [LangChain](langchain-agentmesh/) | `langchain-agentmesh` | ✅ Stable | Ed25519 identity, trust-gated tools, scope chains, callbacks |
+| [LangChain](langchain-agentmesh/) | `agentmesh-langchain` | ✅ Stable | Ed25519 identity, trust-gated tools, scope chains, callbacks |
 | [LangGraph](langgraph-trust/) | [`langgraph-trust`](https://pypi.org/project/langgraph-trust/) | ✅ Published (PyPI) | Trust-gated checkpoint nodes, governance policy enforcement, trust-aware routing |
 | [LlamaIndex](llamaindex-agentmesh/) | `llama-index-agent-agentmesh` | ✅ Merged Upstream | Trust-verified workers, identity-aware query engines, scope chains |
 | [Agent Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/tree/main/contrib/recipes/agentos) | — | ✅ Merged Upstream | Agent-OS governance adapters, reward shaping, governed RL training — maintained in [microsoft/agent-lightning](https://github.com/microsoft/agent-lightning) |
@@ -48,7 +48,7 @@ AgentMesh core is a lean, zero-external-dependency library. Platform integration
 | [Dify Middleware](dify/) | — | 📦 Archived | Flask middleware (archived — use the plugin instead) |
 | [Moltbook](moltbook/) | — | ✅ Stable | AgentMesh governance skill for [Moltbook](https://moltbook.com) agent registry |
 | [Nostr Web of Trust](nostr-wot/) | `agentmesh-nostr-wot` | 🚧 Scaffold | Trust scoring via [MaximumSats](https://github.com/joelklabo/maximumsats-mcp) NIP-85 WoT |
-| [OpenAI Agents](openai-agents-trust/) | [`openai-agents-trust`](https://pypi.org/project/openai-agents-trust/) | ✅ Published (PyPI) | Trust guardrails, policy enforcement, governance hooks, trust-gated handoffs for OpenAI Agents SDK |
+| [OpenAI Agents](openai-agents-trust/) | [`agentmesh-openai-agents-trust`](https://pypi.org/project/agentmesh-openai-agents-trust/) | ✅ Published (PyPI) | Trust guardrails, policy enforcement, governance hooks, trust-gated handoffs for OpenAI Agents SDK |
 | [OpenClaw Skill](openclaw-skill/) | [`agentmesh-governance`](https://clawhub.ai/microsoft/agentmesh-governance) | ✅ Published (ClawHub) | Governance skill for [OpenClaw](https://openclaw.im) agents — policy enforcement, trust scoring, Ed25519 DIDs, hash-chain audit |
 
 ## Quick Start
@@ -56,7 +56,7 @@ AgentMesh core is a lean, zero-external-dependency library. Platform integration
 ### LangChain — Trust-Gated Tool Execution
 
 ```bash
-pip install langchain-agentmesh
+pip install agentmesh-langchain
 ```
 
 ```python

--- a/agent-governance-python/agentmesh-integrations/langchain-agentmesh/README.md
+++ b/agent-governance-python/agentmesh-integrations/langchain-agentmesh/README.md
@@ -5,7 +5,7 @@ Cryptographic identity verification and trust-gated tool execution for LangChain
 ## Installation
 
 ```bash
-pip install langchain-agentmesh
+pip install agentmesh-langchain
 ```
 
 ## Features

--- a/agent-governance-python/agentmesh-integrations/openai-agents-trust/README.md
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-trust/README.md
@@ -1,4 +1,4 @@
-# openai-agents-trust
+# agentmesh-openai-agents-trust
 
 Trust & governance layer for the [OpenAI Agents SDK](https://github.com/openai/openai-agents-python). Adds policy enforcement, trust-gated handoffs, and tamper-evident audit trails using native SDK guardrails and hooks.
 
@@ -7,7 +7,7 @@ Trust & governance layer for the [OpenAI Agents SDK](https://github.com/openai/o
 ## Install
 
 ```bash
-pip install openai-agents-trust
+pip install agentmesh-openai-agents-trust
 ```
 
 ## Quick Start

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -129,7 +129,7 @@ In practice:
 | AutoGen | Adapter | `AutoGenKernel` | Wrap your AutoGen agent. Governance injected at tool-call boundaries. |
 | LangChain / LangGraph | Adapter | `LangChainKernel` / `LangGraphKernel` | Wrap chains/graphs. Published on PyPI (`langgraph-trust`). |
 | CrewAI | Adapter | `CrewAIKernel` | Wrap crew tasks. Trust verification before inter-agent delegation. |
-| OpenAI Agents SDK | Middleware | `OpenAIAgentsKernel` | Async hooks on tool calls. Published on PyPI (`openai-agents-trust`). |
+| OpenAI Agents SDK | Middleware | `OpenAIAgentsKernel` | Async hooks on tool calls. Published on PyPI (`agentmesh-openai-agents-trust`). |
 | Google ADK | Adapter | `GoogleADKKernel` | Plugin-style integration via ADK's extension system. |
 | LlamaIndex | Middleware | `LlamaIndexAdapter` | `TrustedAgentWorker` + `TrustGatedQueryEngine` merged upstream. |
 | Haystack | Pipeline | `HaystackAdapter` | `GovernancePolicyChecker` + `TrustGate` pipeline components. |
@@ -346,7 +346,7 @@ In sidecar deployments, the governance sidecar can be updated independently of t
 
 | Ecosystem | Package | Status |
 |-----------|---------|--------|
-| PyPI | `agent-governance-toolkit[full]`, `agent-os-kernel`, `agentmesh-platform`, `agentmesh-runtime`, `agent-sre`, `agentmesh-marketplace`, `agentmesh-lightning`, `openai-agents-trust`, `langgraph-trust` | ✅ Published |
+| PyPI | `agent-governance-toolkit[full]`, `agent-os-kernel`, `agentmesh-platform`, `agentmesh-runtime`, `agent-sre`, `agentmesh-marketplace`, `agentmesh-lightning`, `agentmesh-openai-agents-trust`, `langgraph-trust` | ✅ Published |
 | npm | `@microsoft/agentmesh-sdk` | ✅ Published |
 | NuGet | `Microsoft.AgentGovernance` | ✅ Published |
 | crates.io | `agentmesh` | ✅ Published |

--- a/docs/INDEPENDENCE.md
+++ b/docs/INDEPENDENCE.md
@@ -33,7 +33,7 @@ Framework integrations are published as **separate packages** that depend on AGT
 
 | Adapter Package | Framework | Install |
 |-----------------|-----------|---------|
-| `langchain-agentmesh` | LangChain | `pip install langchain-agentmesh` |
+| `langchain-agentmesh` | LangChain | `pip install agentmesh-langchain` |
 | `llamaindex-agentmesh` | LlamaIndex | `pip install llamaindex-agentmesh` |
 | `crewai-agentmesh` | CrewAI | `pip install crewai-agentmesh` |
 | `openai-agents-agentmesh` | OpenAI Agents | `pip install openai-agents-agentmesh` |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -276,7 +276,7 @@ else:
 For deeper integration, use framework-specific adapters:
 
 ```bash
-pip install langchain-agentmesh      # LangChain adapter
+pip install agentmesh-langchain      # LangChain adapter
 pip install llamaindex-agentmesh     # LlamaIndex adapter
 pip install crewai-agentmesh         # CrewAI adapter
 ```

--- a/docs/i18n/QUICKSTART.zh-CN.md
+++ b/docs/i18n/QUICKSTART.zh-CN.md
@@ -121,7 +121,7 @@ python governed_agent.py
 工具包与所有主要智能体框架集成：
 
 ```bash
-pip install langchain-agentmesh      # LangChain 适配器
+pip install agentmesh-langchain      # LangChain 适配器
 pip install llamaindex-agentmesh     # LlamaIndex 适配器
 pip install crewai-agentmesh         # CrewAI 适配器
 ```

--- a/docs/modern-agent-architecture-overview.md
+++ b/docs/modern-agent-architecture-overview.md
@@ -262,7 +262,7 @@ else:
 For deeper integration, use framework-specific adapters:
 
 ```bash
-pip install langchain-agentmesh      # LangChain
+pip install agentmesh-langchain      # LangChain
 pip install llamaindex-agentmesh     # LlamaIndex
 pip install crewai-agentmesh         # CrewAI
 ```

--- a/docs/packages/agent-mesh.md
+++ b/docs/packages/agent-mesh.md
@@ -37,7 +37,7 @@
   <a href="https://github.com/run-llama/llama_index/pull/20644"><img src="https://img.shields.io/badge/LlamaIndex-47K_⭐_Merged-success?style=flat-square" alt="LlamaIndex"></a>
   <a href="https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478"><img src="https://img.shields.io/badge/Agent--Lightning-15K_⭐_Merged-success?style=flat-square" alt="Agent-Lightning"></a>
   <a href="https://pypi.org/project/langgraph-trust/"><img src="https://img.shields.io/badge/LangGraph-PyPI-blue?style=flat-square" alt="LangGraph"></a>
-  <a href="https://pypi.org/project/openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
+  <a href="https://pypi.org/project/agentmesh-openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
   <a href="https://clawhub.ai/microsoft/agentmesh-governance"><img src="https://img.shields.io/badge/OpenClaw-ClawHub-purple?style=flat-square" alt="OpenClaw"></a>
 </p>
 

--- a/docs/packages/agent-os.md
+++ b/docs/packages/agent-os.md
@@ -35,7 +35,7 @@
   <a href="https://github.com/run-llama/llama_index/pull/20644"><img src="https://img.shields.io/badge/LlamaIndex-Merged-success?style=flat-square" alt="LlamaIndex"></a>
   <a href="https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478"><img src="https://img.shields.io/badge/Agent--Lightning-Merged-success?style=flat-square" alt="Agent-Lightning"></a>
   <a href="https://pypi.org/project/langgraph-trust/"><img src="https://img.shields.io/badge/LangGraph-PyPI-blue?style=flat-square" alt="LangGraph"></a>
-  <a href="https://pypi.org/project/openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
+  <a href="https://pypi.org/project/agentmesh-openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
   <a href="https://clawhub.ai/microsoft/agentmesh-governance"><img src="https://img.shields.io/badge/OpenClaw-ClawHub-purple?style=flat-square" alt="OpenClaw"></a>
 </p>
 
@@ -48,7 +48,7 @@
   <a href="https://github.com/heilcheng/awesome-agent-skills/pull/34"><img src="https://img.shields.io/badge/awesome--agent--skills-listed-orange?style=flat-square" alt="awesome-agent-skills"></a>
   <a href="https://github.com/TensorBlock/awesome-mcp-servers/pull/66"><img src="https://img.shields.io/badge/awesome--mcp--servers-listed-orange?style=flat-square" alt="awesome-mcp-servers"></a>
   <a href="https://github.com/rohitg00/awesome-devops-mcp-servers/pull/27"><img src="https://img.shields.io/badge/awesome--devops--mcp-listed-orange?style=flat-square" alt="awesome-devops-mcp"></a>
-</p>across 170K+ GitHub stars. Governance for [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/openai-agents-trust/), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
+</p>across 170K+ GitHub stars. Governance for [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/agentmesh-openai-agents-trust/), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
 
 ## 📊 By The Numbers
 
@@ -70,7 +70,7 @@
 | **LlamaIndex** | 47K ⭐ | ✅ Merged | [llama_index#20644](https://github.com/run-llama/llama_index/pull/20644) |
 | **Microsoft Agent-Lightning** | 15K ⭐ | ✅ Merged | [agent-lightning#478](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478) |
 | **LangGraph** | 24K ⭐ | 📦 Published on PyPI | [langgraph-trust](https://pypi.org/project/langgraph-trust/) |
-| **OpenAI Agents SDK** | — | 📦 Published on PyPI | [openai-agents-trust](https://pypi.org/project/openai-agents-trust/) |
+| **OpenAI Agents SDK** | — | 📦 Published on PyPI | [agentmesh-openai-agents-trust](https://pypi.org/project/agentmesh-openai-agents-trust/) |
 | **OpenClaw** | — | 📦 Published on ClawHub | [agentmesh-governance](https://clawhub.ai/microsoft/agentmesh-governance) |
 
 <details>
@@ -1138,7 +1138,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 Prompt-based guardrails ask the LLM to self-police, which is probabilistic. Agent OS enforces governance at the middleware level using deterministic policy engines and POSIX-inspired access controls. It controls what agents *can* do (capability-based), not just what they *should not* do (filter-based).
 
 **How does Agent OS work with other frameworks?**
-Agent OS integrates with 14+ frameworks via adapters. Install the governance layer alongside your existing framework: use `langgraph-trust` for LangGraph, `openai-agents-trust` for OpenAI Agents, or the MCP server for any MCP-compatible client. Agent OS acts as a kernel layer underneath your agent framework.
+Agent OS integrates with 14+ frameworks via adapters. Install the governance layer alongside your existing framework: use `langgraph-trust` for LangGraph, `agentmesh-openai-agents-trust` for OpenAI Agents, or the MCP server for any MCP-compatible client. Agent OS acts as a kernel layer underneath your agent framework.
 
 **What is the Agent Governance Ecosystem?**
 Agent OS is part of a suite of seven packages: Agent OS (policy engine), [AgentMesh](https://github.com/microsoft/agent-governance-toolkit) (trust infrastructure), [Agent Runtime](https://github.com/microsoft/agent-governance-toolkit) (execution supervisor), [Agent SRE](https://github.com/microsoft/agent-governance-toolkit) (reliability), [Agent Compliance](https://github.com/microsoft/agent-governance-toolkit) (regulatory compliance), [Agent Marketplace](https://github.com/microsoft/agent-governance-toolkit) (plugin lifecycle), and [Agent Lightning](https://github.com/microsoft/agent-governance-toolkit) (RL training governance). Together they provide 4,310+ tests across 17 modules.

--- a/docs/packages/agent-sre.md
+++ b/docs/packages/agent-sre.md
@@ -32,11 +32,11 @@
   <a href="https://github.com/run-llama/llama_index/pull/20644"><img src="https://img.shields.io/badge/LlamaIndex-47K_⭐_Merged-success?style=flat-square" alt="LlamaIndex"></a>
   <a href="https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478"><img src="https://img.shields.io/badge/Agent--Lightning-15K_⭐_Merged-success?style=flat-square" alt="Agent-Lightning"></a>
   <a href="https://pypi.org/project/langgraph-trust/"><img src="https://img.shields.io/badge/LangGraph-PyPI-blue?style=flat-square" alt="LangGraph"></a>
-  <a href="https://pypi.org/project/openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
+  <a href="https://pypi.org/project/agentmesh-openai-agents-trust/"><img src="https://img.shields.io/badge/OpenAI_Agents-PyPI-blue?style=flat-square" alt="OpenAI Agents"></a>
   <a href="https://clawhub.ai/microsoft/agentmesh-governance"><img src="https://img.shields.io/badge/OpenClaw-ClawHub-purple?style=flat-square" alt="OpenClaw"></a>
 </p>
 
-Reliability layer across **170K+ combined GitHub stars** of integrated projects — [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478) (15K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/openai-agents-trust/), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
+Reliability layer across **170K+ combined GitHub stars** of integrated projects — [Dify](https://github.com/langgenius/dify-plugins/pull/2060) (65K ⭐), [LlamaIndex](https://github.com/run-llama/llama_index/pull/20644) (47K ⭐), [Agent-Lightning](https://github.com/microsoft/agent-governance-python/agent-lightning/pull/478) (15K ⭐), [LangGraph](https://pypi.org/project/langgraph-trust/), [OpenAI Agents](https://pypi.org/project/agentmesh-openai-agents-trust/), and [OpenClaw](https://clawhub.ai/microsoft/agentmesh-governance).
 
 ---
 

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -49,7 +49,7 @@ AGT provides 50+ packages across 5 ecosystems covering every layer of agent gove
 
 | Integration | Framework | Install |
 |-------------|----------|---------|
-| langchain-agentmesh | LangChain | `pip install langchain-agentmesh` |
+| langchain-agentmesh | LangChain | `pip install agentmesh-langchain` |
 | langgraph-trust | LangGraph | `pip install langgraph-trust` |
 | crewai-agentmesh | CrewAI | `pip install crewai-agentmesh` |
 | adk-agentmesh | Google ADK | `pip install adk-agentmesh` |
@@ -67,4 +67,4 @@ AGT provides 50+ packages across 5 ecosystems covering every layer of agent gove
 | agentmesh-avp | Amazon Verified Permissions | `pip install agentmesh-avp` |
 | structural-authz-agentmesh | Structural Authorization | `pip install structural-authz-agentmesh` |
 | nostr-wot | Nostr Web-of-Trust | `pip install nostr-wot` |
-| openai-agents-trust | OpenAI Trust | `pip install openai-agents-trust` |
+| openai-agents-trust | OpenAI Trust | `pip install agentmesh-openai-agents-trust` |

--- a/docs/proposals/AAIF-PROPOSAL.md
+++ b/docs/proposals/AAIF-PROPOSAL.md
@@ -90,7 +90,7 @@ The OWASP Agentic Top 10 codifies these risks. The Agent Governance Toolkit addr
 | **LangChain** | Callback handler + trust-verified tools | ✅ Shipped |
 | **CrewAI** | Trust-aware task delegation | ✅ Shipped |
 | **Google ADK** | GovernancePlugin (BasePlugin) | 📋 Proposed ([#4543](https://github.com/google/adk-python/issues/4543)) |
-| **OpenAI Agents SDK** | Published `openai-agents-trust` on PyPI | ✅ Shipped |
+| **OpenAI Agents SDK** | Published `agentmesh-openai-agents-trust` on PyPI | ✅ Shipped |
 | **Mastra** | `@agentmesh/mastra` npm package | ✅ Shipped, 19 tests |
 | **MCP** | MCP Kernel Server (stdio + HTTP) | ✅ Shipped, on npm + Glama |
 | **A2A Protocol** | A2A trust provider | ✅ Shipped |

--- a/examples/openai-agents-governed/README.md
+++ b/examples/openai-agents-governed/README.md
@@ -43,7 +43,7 @@ except MiddlewareTermination:
     # Governance blocked the request BEFORE the LLM was called
     pass
 
-# 3. Use openai-agents-trust for trust scoring
+# 3. Use agentmesh-openai-agents-trust for trust scoring
 scorer = TrustScorer(default_score=0.8)
 if scorer.check_trust("my-agent", min_score=0.6):
     # Agent is trusted enough for this operation
@@ -93,7 +93,7 @@ python examples/openai-agents-governed/openai_agents_governance_demo.py
 │  └──────────────────────┬──────────────────────────────────┘    │
 │                         │                                       │
 │  ┌──────────────────────┴──────────────────────────────────┐    │
-│  │          openai-agents-trust Integration                 │    │
+│  │          agentmesh-openai-agents-trust Integration          │    │
 │  │                                                         │    │
 │  │  TrustedFunctionGuard   (trust-scored tool gating)      │    │
 │  │  HandoffVerifier        (trust-gated agent handoffs)    │    │
@@ -158,7 +158,7 @@ Each agent has declared capabilities enforced at two levels:
 | Editor | `edit_text`, `check_grammar`, `read_file` | `shell_exec`, `publish_content` |
 | Publisher | `publish_content`, `read_file` | `shell_exec`, `write_file` |
 
-**Level 2 — TrustedFunctionGuard (openai-agents-trust):**
+**Level 2 — TrustedFunctionGuard (agentmesh-openai-agents-trust):**
 - Per-function trust thresholds (e.g., `publish_content` requires trust ≥ 500)
 - Globally blocked functions (e.g., `shell_exec`)
 - All decisions logged with trust scores
@@ -174,7 +174,7 @@ Policy evaluation happens **before** the LLM call, saving API tokens.
 
 ### 3. Output Quality Gates
 
-Uses `TrustScorer` from `openai-agents-trust`:
+Uses `TrustScorer` from `agentmesh-openai-agents-trust`:
 - Publisher starts with trust score 0.3 (below the 0.6 threshold)
 - Trust is earned through successful task completions (+0.05 per success)
 - After enough successful tasks, Publisher's trust reaches the threshold
@@ -264,8 +264,8 @@ The core governance middleware (`GovernancePolicyMiddleware`, `CapabilityGuardMi
 `RogueDetectionMiddleware`) works with any agent framework. Wrap your LLM calls with
 middleware `process()` to enforce governance before/after each call.
 
-### Approach 2: Native SDK Integration (openai-agents-trust)
-The `openai-agents-trust` package provides SDK-native constructs:
+### Approach 2: Native SDK Integration (agentmesh-openai-agents-trust)
+The `agentmesh-openai-agents-trust` package provides SDK-native constructs:
 - **Guardrails** — `trust_input_guardrail`, `policy_input_guardrail`, `content_output_guardrail`
 - **Hooks** — `GovernanceHooks` for lifecycle instrumentation
 - **Handoffs** — `trust_gated_handoff` for trust-scored agent delegation


### PR DESCRIPTION
Follow-up to #1617. Updates all references across 19 files for the two renamed packages:

- \openai-agents-trust\ → \gentmesh-openai-agents-trust\
- \langchain-agentmesh\ → \gentmesh-langchain\

**Updated:** READMEs, pip install commands, PyPI badge URLs, package tables, publish workflow matrix, FAQ, quickstart guides, examples.

**Not changed:** Python import names (\openai_agents_trust\, \langchain_agentmesh\), directory paths, CI test matrix, labeler config.