### PR TITLE
Add TypeScript SDK quickstart example

### DIFF
--- a/agent-governance-typescript/examples/README.md
+++ b/agent-governance-typescript/examples/README.md
@@ -1,0 +1,9 @@
+# TypeScript SDK Examples
+
+Run the quickstart from the TypeScript SDK directory:
+
+```bash
+cd agent-governance-typescript
+npm install
+npx tsx examples/quickstart.ts
+```

--- a/agent-governance-typescript/examples/quickstart.ts
+++ b/agent-governance-typescript/examples/quickstart.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
+
+async function main() {
+  const client = AgentMeshClient.create('quickstart-agent', {
+    capabilities: ['data.read'],
+    policyRules: [
+      { action: 'data.read', effect: 'allow' },
+      { action: '*', effect: 'deny' },
+    ],
+  });
+
+  const result = await client.executeWithGovernance('data.read', {
+    resource: 'customer-profile',
+  });
+
+  console.log(`Decision: ${result.decision}`);
+  console.log(`Trust tier: ${result.trustScore.tier}`);
+  console.log(`Audit chain valid: ${client.audit.verify()}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a standalone TypeScript SDK quickstart example for basic AgentMeshClient usage.

Closes #1635

## Changes

- Adds `agent-governance-typescript/examples/quickstart.ts` with client initialization, a governance check, and result handling.
- Adds `agent-governance-typescript/examples/README.md` with `tsx` run instructions.

## Testing

- `npm exec --yes tsx -- examples/quickstart.ts`
- `npm run build`
- `npm test -- --runInBand`
- `npm run lint`

## Prior art / related projects

None. This example uses the existing TypeScript SDK API documented in this repository.

## AI assistance

Used Codex for repository inspection and validation support. I reviewed the files and ran the listed checks locally.