### PR TITLE
ci: add markdown link checker to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,6 +579,20 @@ jobs:
         if: always()
         run: docker compose down -v
 
+  # ── Markdown link checker (always runs — catches broken docs links) ─
+  # Checks all .md files for broken links. External URLs may fail
+  # gracefully due to rate limiting; the config retries on HTTP 429.
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Check markdown links
+        uses: gaurav-nelson/github-action-markdown-link-check@4a1af151f4d7cf4d8f8ac5780597672a3671b88b # v1.0.17
+        with:
+          config-file: ".github/workflows/markdown-link-check.json"
+          use-quiet-mode: "yes"
+          use-verbose-mode: "no"
+
   # ── CI Gate — required status check that handles skipped jobs ────────
   # When path-filters skip jobs (e.g. docs-only PRs skip tests), those
   # jobs report "skipped" which doesn't satisfy required status checks.
@@ -602,6 +616,7 @@ jobs:
         build-rust,
         build-go,
         docker-compose-test,
+        markdown-link-check,
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -1,0 +1,19 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^https?://localhost" },
+    { "pattern": "^https?://127\\.0\\.0\\.1" },
+    { "pattern": "^#" },
+    { "pattern": "mailto:" },
+    { "pattern": "^https?://example\\.com" }
+  ],
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206, 301, 302, 403],
+  "timeout": "30s",
+  "httpHeaders": [
+    {
+      "urls": ["https://docs.github.com"],
+      "headers": { "Accept": "text/html" }
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

Add a CI job that checks all markdown files for broken links using [`gaurav-nelson/github-action-markdown-link-check`](https://github.com/gaurav-nelson/github-action-markdown-link-check).

### Changes

- **New job `markdown-link-check`** in `.github/workflows/ci.yml` — runs on every PR and daily schedule
- **Config file** `.github/workflows/markdown-link-check.json` with:
  - Retries on HTTP 429 (rate limiting)
  - Treats 403 as alive (GitHub rate-limits unauthenticated requests)
  - 30-second timeout per link
  - Ignores localhost, anchor-only links, `mailto:` URLs, and `example.com`
- Added `markdown-link-check` to the `ci-complete` gate's dependency list

### How to test

1. Open a PR that only touches `.md` files — the `markdown-link-check` job should run alongside the `ci-complete` gate
2. Verify the job reports broken links if any exist
3. Confirm external URL 403/429 responses don't cause false failures

Closes #1652
