### PR TITLE
fix(security): pin action dependencies and patch Streamlit SSRF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
             --verbose 2>/dev/null || echo "BinSkim completed with warnings"
       - name: Upload BinSkim SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4.35.2
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: agent-governance-dotnet/binskim-results.sarif
           category: binskim

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -12,7 +12,7 @@ jobs:
     name: No Stubs/TODOs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - run: chmod +x scripts/ci/no-stubs.sh && scripts/ci/no-stubs.sh origin/${{ github.base_ref }}
@@ -21,7 +21,7 @@ jobs:
     name: No Unauthorized Crypto
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - run: chmod +x scripts/ci/no-custom-crypto.sh && scripts/ci/no-custom-crypto.sh origin/${{ github.base_ref }}
@@ -30,7 +30,7 @@ jobs:
     name: Security Audit Required
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - run: chmod +x scripts/ci/security-audit-required.sh && scripts/ci/security-audit-required.sh origin/${{ github.base_ref }}
@@ -39,7 +39,7 @@ jobs:
     name: Dependency Audit Trail
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - run: chmod +x scripts/ci/vendored-patch-audit.sh && scripts/ci/vendored-patch-audit.sh origin/${{ github.base_ref }}

--- a/agent-governance-python/agent-os/modules/scak/requirements.txt
+++ b/agent-governance-python/agent-os/modules/scak/requirements.txt
@@ -35,7 +35,7 @@ pytest-asyncio==1.1.0
 # =============================================================================
 
 # Visualization and Developer Tools
-streamlit==1.41.0  # For telemetry dashboard
+streamlit>=1.54.0,<2.0  # For telemetry dashboard (>= 1.54.0 fixes SSRF CVE)
 jupyter==1.1.1  # For interactive notebooks
 
 # LangChain Integration


### PR DESCRIPTION
Improves OpenSSF Scorecard scores for Pinned-Dependencies and Vulnerabilities.

### Changes
- **Pin actions to SHA hashes** (Pinned-Dependencies: 5 → 10):
  - \ctions/checkout@v4\ → SHA in quality-gates.yml (4 instances)
  - \github/codeql-action/upload-sarif@v4.35.2\ → SHA in ci.yml
- **Fix Streamlit SSRF vulnerability** (Vulnerabilities: 0 → 10):
  - Bump streamlit from 1.41.0 to >=1.54.0 in scak/requirements.txt
  - Resolves Dependabot alert #202 (unauthenticated SSRF on Windows)

### Scorecard impact
All 5 unpinned action references are now pinned. The only open Dependabot alert is resolved.