### PR TITLE
chore(ci): rename Maintainer approval gate UX

### DIFF
--- a/.github/workflows/require-maintainer-approval.yml
+++ b/.github/workflows/require-maintainer-approval.yml
@@ -1,11 +1,11 @@
-# Blocks merge of external contributor PRs unless a maintainer has approved.
+# Shows a policy signal when a PR is awaiting named-maintainer approval.
 # AI-only approvals do NOT count. Bot approvals do NOT count.
-# This is a safety net — branch protection rules should also enforce this.
+# Branch protection rules enforce the merge-blocking code-owner review requirement.
 #
 # Context: PRs #357 and #362 were auto-merged without maintainer review,
 # reintroducing shell=True (CWE-78) that was previously fixed.
 
-name: Require Maintainer Approval
+name: "Policy: Awaiting maintainer review"
 
 on:
   pull_request_target:
@@ -19,13 +19,13 @@ permissions:
 # SECURITY: pull_request_target runs in BASE context. Never checkout PR head ref.
 jobs:
   check-approval:
-    name: Maintainer approval gate
+    name: "Policy: Awaiting maintainer review"
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.author_association != 'MEMBER' &&
       github.event.pull_request.author_association != 'OWNER'
     steps:
-      - name: Check for maintainer approval
+      - name: Check for named-maintainer review
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -46,9 +46,9 @@ jobs:
 
             if (!maintainerApproval) {
               core.setFailed(
-                `❌ This PR requires approval from a maintainer (${MAINTAINERS.join(', ')}) before merge.\n` +
-                `AI and bot approvals do not satisfy this requirement.\n` +
-                `This policy exists because PRs #357/#362 reintroduced security vulnerabilities when auto-merged without human review.`
+                `Policy: this PR is awaiting a named-maintainer review.\n` +
+                `This is a policy gate, not a CI failure — the PR is mergeable once a named maintainer (see CODEOWNERS or .github/MAINTAINERS) approves.\n` +
+                `For more details, see docs/policies/maintainer-review-gate.md.`
               );
             } else {
               core.info(`✅ Maintainer @${maintainerApproval.user.login} approved this PR.`);

--- a/docs/policies/maintainer-review-gate.md
+++ b/docs/policies/maintainer-review-gate.md
@@ -1,0 +1,21 @@
+# Maintainer review gate
+
+The maintainer review gate is a policy signal for pull requests that still need an approving review from a named maintainer. It exists because PRs #357 and #362 reintroduced security issues when they were auto-merged without human maintainer review.
+
+## When the gate fires
+
+For PRs where this workflow applies, the gate fires when the PR does not yet have an `APPROVED` review from a named maintainer listed in the workflow and aligned with CODEOWNERS ownership. The workflow currently applies to PRs whose author association is not `MEMBER` or `OWNER`, so this can include internal contributors who are not classified as members. AI-only approvals and bot approvals do not satisfy the gate.
+
+## Why this is not a CI failure
+
+A red result from this workflow means the PR is awaiting policy review. It is not a test, build, lint, or dependency failure. The workflow is intentionally labeled as a policy gate so contributors know the next action is review, not debugging CI.
+
+## How to satisfy it
+
+Request review from a CODEOWNER for the files changed by the PR. The CODEOWNERS file is at [`../../.github/CODEOWNERS`](../../.github/CODEOWNERS). If a named maintainer list is added at `.github/MAINTAINERS`, use that list as well.
+
+Once a named maintainer approves, rerun or update the PR so the workflow can observe the approval and report success.
+
+## Merge-blocking enforcement
+
+This workflow is a UX signal. The actual merge-blocking enforcement comes from the repository branch-protection `pull_request` ruleset, which requires code-owner review. The required-check snapshot from P0 does not include this workflow as a required check.


### PR DESCRIPTION
## Summary
- Rename the maintainer approval UX label to `Policy: Awaiting maintainer review`.
- Clarify the failure message as a policy signal with `not a CI failure` wording.
- Add `docs/policies/maintainer-review-gate.md` explaining when the gate fires and how to satisfy it.

## AC linkage
- AC9: verified the workflow/check label contains `Policy: Awaiting maintainer review` and the `core.setFailed` body contains `not a CI failure` plus the policy-doc link.
- AC8: untouched. This PR does not modify the `pull_request` ruleset or required-check snapshot; P0 showed this workflow is not required, so code-owner review enforcement remains with branch protection. Snapshot diff for this PR is empty.

## Notes
- UX-only change: no merge semantics changed.
- P0 DTM found the gate fires on internal non-MEMBER PRs too, so the new wording avoids external-contributor framing.
- Future improvement: only fail this workflow when it is required by ruleset; otherwise warn and exit 0, if observed UX can be verified unchanged.

## Rollback
Revert this commit to restore the previous gate name and message.

## Validation
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/require-maintainer-approval.yml'))"`
- Confirmed `docs/policies/maintainer-review-gate.md` exists and the workflow message link resolves.