### PR TITLE
feat(ci): scope spell-check and link-check to diff lines only

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,4 +1,4 @@
-# Checks all Markdown files for broken links (internal and external).
+# Checks changed Markdown files for broken links (internal and external).
 # Uses lychee (https://github.com/lycheeverse/lychee) with configuration
 # from .lychee.toml at the repository root.
 
@@ -11,6 +11,8 @@ on:
       - '**/*.md'
       - 'docs/**'
       - '.lychee.toml'
+      - '.github/workflows/link-check.yml'
+      - 'scripts/ci/changed_lines.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -25,10 +27,37 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR base
+        run: |
+          set -e
+          git fetch origin "${{ github.base_ref }}" --depth=1 || \
+            git fetch --unshallow origin "${{ github.base_ref }}" || \
+            git fetch origin "${{ github.base_ref }}"
+
+      - name: Compute changed markdown
+        id: diff
+        run: |
+          set -e
+          changed=$(python scripts/ci/changed_lines.py \
+            --base "origin/${{ github.base_ref }}" \
+            --extensions ".md" \
+            --mode changed-files)
+          if [ -z "$changed" ]; then
+            echo "No changed markdown; skipping link-check."
+            echo "changed=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$changed" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        if: steps.diff.outputs.changed != ''
         with:
           args: >-
             --no-progress
-            '**/*.md'
+            ${{ steps.diff.outputs.changed }}
           fail: false  # Non-blocking until pre-existing broken links are fixed (see #320)

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -5,13 +5,23 @@ on:
     branches: [main]
     paths:
       - "**/*.md"
+      - "**/*.txt"
+      - "**/*.rst"
+      - "**/*.py"
+      - "**/*.ts"
+      - "**/*.js"
+      - "**/*.go"
+      - "**/*.rs"
+      - "**/*.cs"
+      - "**/*.yml"
+      - "**/*.yaml"
       - ".cspell.json"
       - ".cspell-repo-terms.txt"
       - ".github/workflows/spell-check.yml"
+      - "scripts/ci/changed_lines.py"
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   spell-check:
@@ -21,18 +31,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get changed markdown files
-        id: changed-markdown
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          files: |
-            **/*.md
+      - name: Fetch PR base
+        run: |
+          set -e
+          git fetch origin "${{ github.base_ref }}" --depth=1 || \
+            git fetch --unshallow origin "${{ github.base_ref }}" || \
+            git fetch origin "${{ github.base_ref }}"
+
+      - name: Compute changed lines
+        id: diff
+        run: |
+          set -e
+          mkdir -p ci-diff
+          added_file="ci-diff/spell-check-added-lines.txt"
+          python scripts/ci/changed_lines.py \
+            --base "origin/${{ github.base_ref }}" \
+            --extensions ".md,.txt,.rst,.py,.ts,.js,.go,.rs,.cs,.yml,.yaml" \
+            --mode added-lines \
+            --output "$added_file"
+          if [ ! -s "$added_file" ]; then
+            echo "No changed lines to spell-check; skipping."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "added_file=$added_file" >> "$GITHUB_OUTPUT"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
       - name: Install cspell
         run: npm install --ignore-scripts --global cspell@8.17.3
 
-      - name: Check spelling
-        if: steps.changed-markdown.outputs.any_changed == 'true'
-        env:
-          CHANGED_FILES: ${{ steps.changed-markdown.outputs.all_changed_files }}
-        run: cspell --config .cspell.json --no-progress $CHANGED_FILES
+      - name: cspell on changed lines
+        if: steps.diff.outputs.has_changes == 'true'
+        run: cspell "${{ steps.diff.outputs.added_file }}" --config .cspell.json --no-progress --no-summary

--- a/scripts/ci/changed_lines.py
+++ b/scripts/ci/changed_lines.py
@@ -1,0 +1,117 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Utilities for scoping CI checks to changed files or added diff lines."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+DEFAULT_REPO = Path.cwd()
+
+
+def normalize_extensions(extensions: str) -> list[str]:
+    """Return normalized extension filters from a comma-separated string."""
+    normalized: list[str] = []
+    for extension in extensions.split(","):
+        value = extension.strip()
+        if not value:
+            continue
+        normalized.append(value if value.startswith(".") else f".{value}")
+    return normalized
+
+
+def pathspecs_for_extensions(extensions: Iterable[str]) -> list[str]:
+    """Build git pathspecs matching files with the requested extensions."""
+    return [f"*{extension}" for extension in extensions]
+
+
+def extract_added_lines(diff_text: str) -> str:
+    """Extract only added content lines from a unified diff."""
+    added_lines: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith("+++"):
+            continue
+        if line.startswith("+"):
+            added_lines.append(line[1:])
+    return "\n".join(added_lines) + ("\n" if added_lines else "")
+
+
+def run_git_diff(
+    repo: Path,
+    base: str,
+    pathspecs: Sequence[str],
+    *,
+    name_only: bool,
+) -> str:
+    """Run git diff for the requested pathspecs and return stdout."""
+    command = [
+        "git",
+        "diff",
+        "--no-ext-diff",
+        "--diff-filter=ACMRT",
+    ]
+    if name_only:
+        command.append("--name-only")
+    else:
+        command.append("--unified=0")
+    command.extend([base, "--", *pathspecs])
+    result = subprocess.run(
+        command,
+        cwd=repo,
+        check=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def write_or_print(content: str, output: Path | None) -> None:
+    """Write content to the requested output file, or print it to stdout."""
+    if output is None:
+        print(content, end="")
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="Git ref to diff against, for example origin/main.")
+    parser.add_argument(
+        "--extensions",
+        required=True,
+        help="Comma-separated file extensions to include, for example .md,.txt,.py.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("added-lines", "changed-files"),
+        default="added-lines",
+        help="Whether to emit added diff lines or changed file names.",
+    )
+    parser.add_argument("--repo", type=Path, default=DEFAULT_REPO, help="Repository working tree path.")
+    parser.add_argument("--output", type=Path, help="Optional output file path.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the changed-lines helper."""
+    args = parse_args()
+    extensions = normalize_extensions(args.extensions)
+    pathspecs = pathspecs_for_extensions(extensions)
+    if args.mode == "changed-files":
+        content = run_git_diff(args.repo, args.base, pathspecs, name_only=True)
+    else:
+        diff_text = run_git_diff(args.repo, args.base, pathspecs, name_only=False)
+        content = extract_added_lines(diff_text)
+    write_or_print(content, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_changed_lines.py
+++ b/tests/ci/test_changed_lines.py
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "changed_lines.py"
+SPEC = importlib.util.spec_from_file_location("changed_lines", SCRIPT_PATH)
+assert SPEC is not None
+changed_lines = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(changed_lines)
+
+
+def test_extract_added_lines_ignores_context_removed_and_file_headers() -> None:
+    diff_text = """diff --git a/docs/example.md b/docs/example.md
+index 1111111..2222222 100644
+--- a/docs/example.md
++++ b/docs/example.md
+@@ -1,3 +1,4 @@
+ Existing typoo remains in context.
+-Removed misspeled text.
++Added misspeled text.
++https://example.invalid/new-link
+"""
+
+    assert changed_lines.extract_added_lines(diff_text) == (
+        "Added misspeled text.\nhttps://example.invalid/new-link\n"
+    )
+
+
+def test_extract_added_lines_combines_multiple_files_without_diff_metadata() -> None:
+    diff_text = """diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1 +1,2 @@
++New README tokenn.
+diff --git a/src/example.py b/src/example.py
+--- a/src/example.py
++++ b/src/example.py
+@@ -10 +10,2 @@
++print(\"neew token\")
+"""
+
+    assert changed_lines.extract_added_lines(diff_text) == "New README tokenn.\nprint(\"neew token\")\n"
+
+
+def test_extension_pathspecs_are_normalized_for_git_diff() -> None:
+    extensions = changed_lines.normalize_extensions("md,.txt, py,,")
+
+    assert extensions == [".md", ".txt", ".py"]
+    assert changed_lines.pathspecs_for_extensions(extensions) == ["*.md", "*.txt", "*.py"]


### PR DESCRIPTION
## Summary
- scope spell-check to added diff lines using scripts/ci/changed_lines.py
- scope link-check to Markdown files changed in the PR instead of all Markdown files
- add CI helper unit tests for synthetic unified diffs

## AC linkage
- AC5: spell-check failures only flag tokens in added lines.
- AC16: link-check runs on PR diff scope.

## P0 baseline
- spell-check failure rate: 84% (58 fails / 69 visible rows).
- link-check failure rate: 62% (32 fails / 52 visible rows).

## Rollback
Revert this PR to restore the previous full-file spell-check and repository-wide link-check behavior.

## Validation
- python -c "import yaml; yaml.safe_load(open('.github/workflows/spell-check.yml')); yaml.safe_load(open('.github/workflows/link-check.yml'))"
- python -m pytest tests\ci\test_changed_lines.py -v
- ruff check --select E,F,W --ignore E501 scripts\ci\changed_lines.py tests\ci\test_changed_lines.py
- Scratch git repo simulation confirmed only newly added Markdown lines are emitted.