### PR TITLE
feat(ci): name failed jobs in ci-complete; split dependency-scan into two jobs

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -132,3 +132,8 @@ Pydantic
 pytest
 pyupgrade
 xfail
+elif
+frozenset
+isinstance
+pathlib
+returncode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,29 @@ jobs:
       - name: Dependency confusion scan
         run: python3 scripts/check_dependency_confusion.py --strict
 
+  # ── Compatibility shim: preserves the legacy `dependency-scan` check name
+  # so the existing branch-protection ruleset stays satisfied while it is
+  # migrated (independently) to require the two granular checks above.
+  # Remove this job in a follow-up PR after the ruleset is updated to require
+  # `dep-confusion-scan` and `notebook-pip-audit` directly.
+  dependency-scan:
+    needs: [dep-confusion-scan, notebook-pip-audit]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate dependency-scan result
+        env:
+          DEP_CONFUSION: ${{ needs.dep-confusion-scan.result }}
+          NOTEBOOK_AUDIT: ${{ needs.notebook-pip-audit.result }}
+        run: |
+          echo "dep-confusion-scan: $DEP_CONFUSION"
+          echo "notebook-pip-audit: $NOTEBOOK_AUDIT"
+          if [ "$DEP_CONFUSION" = "success" ] && [ "$NOTEBOOK_AUDIT" = "success" ]; then
+            exit 0
+          fi
+          echo "::error::dependency-scan compatibility shim failed: dep-confusion-scan=$DEP_CONFUSION, notebook-pip-audit=$NOTEBOOK_AUDIT"
+          exit 1
+
   # ── Notebook pip-install audit (always runs — security gate) ─────────
   notebook-pip-audit:
     runs-on: ubuntu-latest
@@ -607,6 +630,7 @@ jobs:
         test-integrations,
         dep-confusion-scan,
         notebook-pip-audit,
+        dependency-scan,
         workflow-security,
         test-integrations-ts,
         build-npm,
@@ -628,10 +652,12 @@ jobs:
           set -e
           if [ "$status" -eq 1 ]; then
             echo "::error::Failed jobs: $failed"
-            echo "## ci-complete: failures" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "Failed jobs:" >> "$GITHUB_STEP_SUMMARY"
-            echo "$failed" | tr ',' '\n' | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## ci-complete: failures"
+              echo ""
+              echo "Failed jobs:"
+              echo "$failed" | tr ',' '\n' | sed 's/^/- /'
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 1
           elif [ "$status" -ne 0 ]; then
             echo "::error::Unable to parse ci-complete dependency results"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
           fi
 
   # ── Dependency confusion scan (always runs — security gate) ──────────
-  dependency-scan:
+  dep-confusion-scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -337,10 +337,19 @@ jobs:
         with:
           python-version: "3.11"
       - name: Dependency confusion scan
-        run: python scripts/check_dependency_confusion.py --strict
+        run: python3 scripts/check_dependency_confusion.py --strict
+
+  # ── Notebook pip-install audit (always runs — security gate) ─────────
+  notebook-pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
       - name: Notebook pip-install audit
         run: |
-          python -c "
+          python3 -c "
           import json, glob, sys, re
           REGISTERED = {
               'agent-os-kernel','agentmesh-platform','agent-hypervisor',
@@ -358,7 +367,8 @@ jobs:
               if 'node_modules' in nb or '.ipynb_checkpoints' in nb:
                   continue
               try:
-                  cells = json.load(open(nb))['cells']
+                  with open(nb, encoding='utf-8') as fh:
+                      cells = json.load(fh)['cells']
               except Exception:
                   continue
               for c in cells:
@@ -595,7 +605,8 @@ jobs:
         security,
         test-dotnet,
         test-integrations,
-        dependency-scan,
+        dep-confusion-scan,
+        notebook-pip-audit,
         workflow-security,
         test-integrations-ts,
         build-npm,
@@ -605,13 +616,26 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check job results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          results='${{ toJSON(needs.*.result) }}'
-          echo "Job results: $results"
-          if echo "$results" | grep -qE '"failure"|"cancelled"'; then
-            echo "::error::One or more required jobs failed or were cancelled"
+          echo "Job results: $NEEDS"
+          set +e
+          failed=$(printf '%s' "$NEEDS" | python3 scripts/ci_complete_check.py)
+          status=$?
+          set -e
+          if [ "$status" -eq 1 ]; then
+            echo "::error::Failed jobs: $failed"
+            echo "## ci-complete: failures" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Failed jobs:" >> "$GITHUB_STEP_SUMMARY"
+            echo "$failed" | tr ',' '\n' | sed 's/^/- /' >> "$GITHUB_STEP_SUMMARY"
             exit 1
+          elif [ "$status" -ne 0 ]; then
+            echo "::error::Unable to parse ci-complete dependency results"
+            exit "$status"
           fi
 
           # AC3.4 — docker-compose-test must not be silently skipped on relevant PRs
@@ -627,5 +651,5 @@ jobs:
             fi
           fi
 
-          echo "All jobs passed or were correctly skipped"
+          echo "All required jobs succeeded."
 

--- a/scripts/ci_complete_check.py
+++ b/scripts/ci_complete_check.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Report failed GitHub Actions needs entries for the ci-complete gate."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+FAILED_RESULTS = frozenset({"failure", "cancelled", "timed_out", "action_required"})
+
+
+def failed_job_names(needs: dict[str, Any]) -> list[str]:
+    """Return names of required jobs that did not complete successfully."""
+    return [
+        name
+        for name, info in needs.items()
+        if isinstance(info, dict) and info.get("result") in FAILED_RESULTS
+    ]
+
+
+def main() -> int:
+    try:
+        needs = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"Invalid needs JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not isinstance(needs, dict):
+        print("Invalid needs JSON: expected an object", file=sys.stderr)
+        return 2
+
+    failed = failed_job_names(needs)
+    print(",".join(failed))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_ci_complete_logic.py
+++ b/tests/ci/test_ci_complete_logic.py
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ci_complete_check.py"
+
+
+def run_check(needs: dict[str, dict[str, str]]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input=json.dumps(needs),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_all_success_outputs_empty_and_exits_zero() -> None:
+    result = run_check({"lint": {"result": "success"}, "test": {"result": "success"}})
+
+    assert result.returncode == 0
+    assert result.stdout == "\n"
+    assert result.stderr == ""
+
+
+def test_one_failure_outputs_name_and_exits_one() -> None:
+    result = run_check({"lint": {"result": "success"}, "test": {"result": "failure"}})
+
+    assert result.returncode == 1
+    assert result.stdout == "test\n"
+    assert result.stderr == ""
+
+
+def test_multiple_failures_are_comma_joined_in_order() -> None:
+    result = run_check(
+        {
+            "lint": {"result": "failure"},
+            "test": {"result": "success"},
+            "build-pypi": {"result": "timed_out"},
+        }
+    )
+
+    assert result.returncode == 1
+    assert result.stdout == "lint,build-pypi\n"
+    assert result.stderr == ""
+
+
+def test_cancelled_counts_as_failed() -> None:
+    result = run_check({"security": {"result": "cancelled"}})
+
+    assert result.returncode == 1
+    assert result.stdout == "security\n"
+    assert result.stderr == ""
+
+
+def test_success_with_skipped_outputs_empty_and_exits_zero() -> None:
+    result = run_check(
+        {"changes": {"result": "success"}, "lint": {"result": "skipped"}}
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "\n"
+    assert result.stderr == ""


### PR DESCRIPTION
## Description

Two CI observability improvements:

1. **`ci-complete` now names the failing jobs.** Previously the aggregator emitted `One or more required jobs failed or were cancelled` without saying which job. It now lists the failing/cancelled/timed-out/action-required job names in both the error annotation and the run step summary.
2. **`dependency-scan` is split into two named jobs**: `dep-confusion-scan` (registered-package allowlist enforcement) and `notebook-pip-audit` (notebook `pip install` line audit). Both are added to `ci-complete needs:`.

The aggregator logic is moved out of an inline shell heredoc into `scripts/ci_complete_check.py` so it can be unit-tested.

A thin **`dependency-scan` compatibility shim** is preserved (depends on both granular jobs, passes iff both pass) so this PR can merge **without** a coordinated branch-protection ruleset edit. See "Additional actions needed after this PR is merged" below.

### Validation

- `pytest tests/ci/test_ci_complete_logic.py -v` — 5 tests passed
- `python3 scripts/check_dependency_confusion.py --strict` — passes standalone
- `python -c "import yaml; yaml.safe_load(open(\".github/workflows/ci.yml\", encoding=\"utf-8\"))"` — passes
- Workflow run on the PR head reports `dep-confusion-scan` ✅, `notebook-pip-audit` ✅, and the `dependency-scan` shim ✅, confirming the decoupled design works as intended.

### Additional actions needed after this PR is merged

This PR is intentionally decoupled from the branch-protection ruleset edit so that merge timing is not coupled to ruleset timing. The legacy required check name `dependency-scan` keeps reporting green via a shim, so existing branch protection continues to pass without any other action. The two follow-up steps below can be performed on an independent schedule.

#### Step 1 — Migrate the required-checks ruleset (any time after merge)

The required-checks ruleset (`13514920`) currently requires a check named `dependency-scan`. The granular checks `dep-confusion-scan` and `notebook-pip-audit` will already be reporting green on every PR after this merges, so they are eligible to be required directly.

1. Snapshot the ruleset for rollback:
   `gh api repos/microsoft/agent-governance-toolkit/rulesets/13514920 > ruleset-13514920-pre-migration.json`
2. Confirm both granular checks have run on a recent PR head:
   `gh pr checks <recent-pr-number> | grep -E "dep-confusion-scan|notebook-pip-audit"` — both should be green.
3. Edit ruleset `13514920` (Settings → Rules → Rulesets → "Require status checks to pass"):
   - **Add:** `dep-confusion-scan`, `notebook-pip-audit`
   - **Remove:** `dependency-scan`
4. Verify on the next opened PR that the two granular checks appear as **Required** and `dependency-scan` no longer does.

Rollback: `gh api --method PUT repos/microsoft/agent-governance-toolkit/rulesets/13514920 --input ruleset-13514920-pre-migration.json`

#### Step 2 — Remove the compatibility shim (after Step 1)

Open a follow-up PR that deletes the `dependency-scan` job from `.github/workflows/ci.yml` and removes `dependency-scan` from `ci-complete needs:`. This PR carries no functional change once the ruleset has been migrated. It must not land before Step 1 is complete.

## Type of Change

- [x] Maintenance (dependency updates, CI/CD, refactoring)

## Package(s) Affected

- [x] docs / root

## Checklist

- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any): none.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used: GitHub Copilot CLI used to draft the workflow edits and unit tests; all output reviewed and verified locally.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

None.
