### PR TITLE
docs: add AI attestation checkboxes to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,14 +34,21 @@
 <!-- Example: "Sandboxing approach inspired by https://github.com/example/project (Apache-2.0)" -->
 <!-- Leave blank if not applicable -->
 
-## AI & IP Disclosure
-- [ ] This contribution is not substantially AI-generated, OR I have disclosed AI tool usage below
+## AI Assistance
+<!-- See CONTRIBUTING.md "AI-Assisted Contributions" for full policy -->
+- [ ] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
+- [ ] I have run tests and verification appropriate for this change
+- [ ] No part of this PR was autonomously submitted by an AI agent without my review
+- [ ] I have not used AI to generate review comments on others' PRs
+
+If AI tools materially shaped this change, briefly note what was used:
+<!-- Example: "GitHub Copilot for boilerplate, Codex for test generation — all output reviewed" -->
+<!-- Leave blank if AI was not used or was only used for minor assistance -->
+
+## IP, Patents, and Licensing
 - [ ] This contribution does not implement patent-pending or patent-encumbered techniques
 - [ ] This contribution does not require an NDA or licensing agreement to understand or use
-
-**AI tools used** (if any):
-<!-- Example: "GitHub Copilot for boilerplate, manually reviewed all logic" -->
-<!-- Leave blank if not applicable -->
+- [ ] Any AI tools used have terms compatible with the MIT License
 
 ## Related Issues
 <!-- Link related issues: Fixes #123, Closes #456 -->


### PR DESCRIPTION
Aligns the PR template with the expanded AI contribution policy from PR #1662.

**Changes:**
- Replaced minimal 'AI & IP Disclosure' section with two focused sections
- **AI Assistance**: 4 attestation checkboxes covering understanding, testing, non-autonomous submission, and no AI-generated reviews
- **IP, Patents, and Licensing**: separated from AI section, added AI tool license compatibility check
- Freeform field for disclosing AI tools when they materially shaped the change
- Links to CONTRIBUTING.md for full policy details

Gap #2 of 6 from the OpenSSF AI policy alignment.