### PR TITLE
fix: address 7 security findings from exploit-hunter assessment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -462,3 +462,6 @@ dist/
 .pytest_cache/
 .ruff_cache/
 _site/
+
+# Code Security Assessment artifacts
+.security-assessment/

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/api/server.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/api/server.py
@@ -58,6 +58,34 @@ from hypervisor.observability.event_bus import EventType, HypervisorEventBus
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_cors_origins(raw: str) -> list[str]:
+    """Parse, validate, and return CORS origins.
+
+    Rejects ``*`` when credentials are enabled, and validates that each
+    origin has a scheme and a non-empty hostname.
+    """
+    origins: list[str] = []
+    for origin in raw.split(","):
+        origin = origin.strip()
+        if not origin:
+            continue
+        if origin == "*":
+            logger.warning(
+                "CORS origin '*' is not allowed with allow_credentials=True — skipping"
+            )
+            continue
+        from urllib.parse import urlparse
+        parsed = urlparse(origin)
+        if not parsed.scheme or not parsed.hostname:
+            logger.warning("Invalid CORS origin (missing scheme or host): %s — skipping", origin)
+            continue
+        origins.append(origin)
+    if not origins:
+        logger.warning("No valid CORS origins configured — falling back to localhost defaults")
+        origins = ["http://localhost:3000", "http://localhost:8080"]
+    return origins
+
 # ── Global state ────────────────────────────────────────────────────────────
 
 _hypervisor: Hypervisor | None = None
@@ -127,7 +155,7 @@ def create_app() -> FastAPI:
 
     application.add_middleware(
         CORSMiddleware,
-        allow_origins=os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080").split(","),
+        allow_origins=_parse_cors_origins(os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080")),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/credentials.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/credentials.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from typing import Callable, Optional, Literal
 from pydantic import BaseModel, Field
 import hashlib
+import hmac
 import logging
 import uuid
 import secrets
@@ -134,7 +135,7 @@ class Credential(BaseModel):
         Returns:
             True if the SHA-256 hash of the token matches the stored hash.
         """
-        return hashlib.sha256(token.encode()).hexdigest() == self.token_hash
+        return hmac.compare_digest(hashlib.sha256(token.encode()).hexdigest(), self.token_hash)
 
     def revoke(self, reason: str) -> None:
         """Revoke this credential immediately.

--- a/agent-governance-python/agent-mesh/src/agentmesh/marketplace/sandbox.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/marketplace/sandbox.py
@@ -51,6 +51,7 @@ _EXTRA_BLOCKED = frozenset({
     "pickle", "shelve", "marshal", "code", "codeop", "compileall",
     "multiprocessing", "signal", "resource", "pty", "termios",
     "fcntl", "mmap", "winreg", "_winapi",
+    "sys", "builtins",
 })
 
 ALL_BLOCKED_MODULES = RESTRICTED_MODULES | _EXTRA_BLOCKED
@@ -108,7 +109,7 @@ _RUNNER_TEMPLATE = textwrap.dedent("""\
     # ── 4. Strip dangerous builtins AFTER import ─────────────────
     # exec/eval/compile are needed by importlib during module loading,
     # but must be blocked before running plugin entry code.
-    _STRIP = ("exec", "eval", "breakpoint")
+    _STRIP = ("exec", "eval", "breakpoint", "compile", "open", "__import__")
     if isinstance(__builtins__, dict):
         for _b in _STRIP:
             __builtins__.pop(_b, None)

--- a/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import secrets
 from datetime import datetime, timezone
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
@@ -18,6 +20,14 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from agentmesh.relay.store import InMemoryInboxStore, InboxStore, StoredMessage
 
 logger = logging.getLogger(__name__)
+
+# Shared-secret token for relay authentication (optional, backward-compatible).
+_RELAY_TOKEN: str | None = os.environ.get("AGENTMESH_RELAY_TOKEN")
+if not _RELAY_TOKEN:
+    logger.warning(
+        "AGENTMESH_RELAY_TOKEN is not set — the relay will accept "
+        "unauthenticated connections.  Set this env var in production."
+    )
 
 HEARTBEAT_INTERVAL = 30  # seconds
 OFFLINE_THRESHOLD = 90  # seconds — 3 missed heartbeats
@@ -103,6 +113,18 @@ class RelayServer:
                     await ws.send_json({"type": "error", "detail": "Missing 'from' field"})
                     await ws.close(code=4002)
                     return
+
+                # Authenticate: require token when AGENTMESH_RELAY_TOKEN is set
+                if _RELAY_TOKEN is not None:
+                    client_token = frame.get("token")
+                    if not client_token or not secrets.compare_digest(
+                        client_token, _RELAY_TOKEN
+                    ):
+                        await ws.send_json(
+                            {"type": "error", "detail": "Authentication failed"}
+                        )
+                        await ws.close(code=4003)
+                        return
 
                 # Register connection
                 self._connections[agent_did] = ConnectedAgent(agent_did, ws)

--- a/agent-governance-python/agent-os/src/agent_os/policies/backends.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/backends.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
@@ -164,6 +165,16 @@ class OPABackend:
 
     def _evaluate_remote(self, context: dict[str, Any]) -> BackendDecision:
         import urllib.request
+
+        # Validate query to prevent path injection
+        if not re.fullmatch(r'[a-zA-Z0-9._\-]+', self._query):
+            return BackendDecision(
+                allowed=False,
+                action="deny",
+                reason=f"Invalid OPA query: {self._query!r}",
+                backend="opa",
+                error="Query contains invalid characters",
+            )
 
         path_parts = (
             self._query.replace("data.", "", 1).replace(".", "/")

--- a/agent-governance-python/agent-os/src/agent_os/sandbox_provider.py
+++ b/agent-governance-python/agent-os/src/agent_os/sandbox_provider.py
@@ -24,6 +24,16 @@ from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
 
+# Default set of command basenames allowed by SubprocessSandboxProvider.
+DEFAULT_COMMAND_ALLOWLIST: frozenset[str] = frozenset(
+    {"python", "python3", "node", "npm", "go", "cargo", "dotnet"}
+)
+
+# Environment variables that must never be passed through to sandboxed processes.
+_DANGEROUS_ENV_VARS: frozenset[str] = frozenset(
+    {"LD_PRELOAD", "DYLD_INSERT_LIBRARIES", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"}
+)
+
 
 @dataclass
 class SandboxConfig:
@@ -72,9 +82,31 @@ class SandboxProvider(ABC):
 class SubprocessSandboxProvider(SandboxProvider):
     """Basic subprocess sandbox (no container isolation).
 
-    Provides timeout and output capture but NOT security isolation.
+    Provides timeout, output capture, and command allowlisting.
     For production, use DockerSandboxProvider or a custom implementation.
+
+    Args:
+        allowed_commands: Set of allowed command basenames.
+            Defaults to ``DEFAULT_COMMAND_ALLOWLIST``.
     """
+
+    def __init__(
+        self,
+        allowed_commands: frozenset[str] | set[str] | None = None,
+    ) -> None:
+        self._allowed = frozenset(allowed_commands) if allowed_commands else DEFAULT_COMMAND_ALLOWLIST
+
+    @staticmethod
+    def _basename(cmd: str) -> str:
+        """Return the platform-agnostic basename without extension."""
+        import os
+        base = os.path.basename(cmd)
+        # Strip .exe / .cmd / .bat on Windows
+        for ext in (".exe", ".cmd", ".bat"):
+            if base.lower().endswith(ext):
+                base = base[: -len(ext)]
+                break
+        return base
 
     def run(
         self,
@@ -82,17 +114,42 @@ class SubprocessSandboxProvider(SandboxProvider):
         command: list[str],
         config: SandboxConfig | None = None,
     ) -> SandboxResult:
+        if not command:
+            return SandboxResult(
+                success=False, exit_code=-1, stderr="Empty command"
+            )
+
+        basename = self._basename(command[0])
+        if basename not in self._allowed:
+            return SandboxResult(
+                success=False,
+                exit_code=-1,
+                stderr=(
+                    f"Command '{basename}' is not in the sandbox allowlist. "
+                    f"Allowed: {sorted(self._allowed)}"
+                ),
+            )
+
         cfg = config or SandboxConfig()
         import time
 
+        # Filter dangerous env vars
+        env = None
+        if cfg.env_vars:
+            env = {
+                k: v
+                for k, v in cfg.env_vars.items()
+                if k not in _DANGEROUS_ENV_VARS and k != "PATH"
+            }
+
         start = time.time()
         try:
-            result = subprocess.run(  # noqa: S603 — trusted subprocess in sandbox provider
+            result = subprocess.run(  # noqa: S603 — allowlisted subprocess in sandbox provider
                 command,
                 capture_output=True,
                 text=True,
                 timeout=cfg.timeout_seconds,
-                env={**cfg.env_vars} if cfg.env_vars else None,
+                env=env,
             )
             duration = time.time() - start
             return SandboxResult(

--- a/agent-governance-python/agent-os/src/agent_os/server/app.py
+++ b/agent-governance-python/agent-os/src/agent_os/server/app.py
@@ -29,6 +29,34 @@ from agent_os.server.models import (
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_cors_origins(raw: str) -> list[str]:
+    """Parse, validate, and return CORS origins.
+
+    Rejects ``*`` when credentials are enabled, and validates that each
+    origin has a scheme and a non-empty hostname.
+    """
+    origins: list[str] = []
+    for origin in raw.split(","):
+        origin = origin.strip()
+        if not origin:
+            continue
+        if origin == "*":
+            logger.warning(
+                "CORS origin '*' is not allowed with allow_credentials=True — skipping"
+            )
+            continue
+        from urllib.parse import urlparse
+        parsed = urlparse(origin)
+        if not parsed.scheme or not parsed.hostname:
+            logger.warning("Invalid CORS origin (missing scheme or host): %s — skipping", origin)
+            continue
+        origins.append(origin)
+    if not origins:
+        logger.warning("No valid CORS origins configured — falling back to localhost defaults")
+        origins = ["http://localhost:3000", "http://localhost:8080"]
+    return origins
+
 _EXECUTE_TOKENS_ENV = "AGENT_OS_EXECUTION_TOKENS"
 _ALLOW_UNAUTHENTICATED_EXECUTE_ENV = "AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE"
 
@@ -209,7 +237,7 @@ def create_app(
     # -- CORS middleware ----------------------------------------------------
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080").split(","),
+        allow_origins=_parse_cors_origins(os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080")),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -231,7 +259,7 @@ def create_app(
         return JSONResponse(
             status_code=500,
             content=ErrorResponse(
-                detail=str(exc),
+                detail="An internal error occurred",
                 error_code="INTERNAL_ERROR",
             ).model_dump(),
         )

--- a/agent-governance-python/agent-sre/src/agent_sre/api/server.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/api/server.py
@@ -59,6 +59,36 @@ if TYPE_CHECKING:
         SLOEventRequest,
     )
 
+logger = logging.getLogger(__name__)
+
+
+def _parse_cors_origins(raw: str) -> list[str]:
+    """Parse, validate, and return CORS origins.
+
+    Rejects ``*`` when credentials are enabled, and validates that each
+    origin has a scheme and a non-empty hostname.
+    """
+    origins: list[str] = []
+    for origin in raw.split(","):
+        origin = origin.strip()
+        if not origin:
+            continue
+        if origin == "*":
+            logger.warning(
+                "CORS origin '*' is not allowed with allow_credentials=True — skipping"
+            )
+            continue
+        from urllib.parse import urlparse
+        parsed = urlparse(origin)
+        if not parsed.scheme or not parsed.hostname:
+            logger.warning("Invalid CORS origin (missing scheme or host): %s — skipping", origin)
+            continue
+        origins.append(origin)
+    if not origins:
+        logger.warning("No valid CORS origins configured — falling back to localhost defaults")
+        origins = ["http://localhost:3000", "http://localhost:8080"]
+    return origins
+
 # ---------------------------------------------------------------------------
 # In-memory stores (reset on restart)
 # ---------------------------------------------------------------------------
@@ -125,7 +155,7 @@ def create_app() -> FastAPI:
     )
     application.add_middleware(
         CORSMiddleware,
-        allow_origins=os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080").split(","),
+        allow_origins=_parse_cors_origins(os.environ.get("CORS_ALLOWED_ORIGINS", "http://localhost:3000,http://localhost:8080")),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION
## Summary

Addresses 7 confirmed security findings identified by the exploit-hunter automated assessment.

## Findings Addressed

| # | Finding | CVSS | Severity | Component |
|---|---------|------|----------|-----------|
| 1 | FINDING-002: WebSocket relay has no authentication | 9.4 | Critical | agent-mesh/relay/app.py |
| 2 | FINDING-006: Sandbox provider allows arbitrary commands | 7.8 | High | agent-os/sandbox_provider.py |
| 3 | FINDING-001: Wildcard CORS origins across all servers | 7.6 | High | agent-os, agent-sre, agent-hypervisor servers |
| 4 | FINDING-017: Plugin sandbox allows dangerous builtins | 7.1 | High | agent-mesh/marketplace/sandbox.py |
| 5 | FINDING-003: Verbose error messages leak internals | 5.3 | Medium | agent-os/server/app.py |
| 6 | FINDING-007: OPA query path lacks validation | 4.2 | Medium | agent-os/policies/backends.py |
| 7 | FINDING-004: Token comparison uses == instead of hmac.compare_digest | 3.7 | Low | agent-mesh/identity/credentials.py |

## Changes

- **relay/app.py**: Added \AGENTMESH_RELAY_TOKEN\ shared-secret auth with \secrets.compare_digest\
- **sandbox_provider.py**: Added \DEFAULT_COMMAND_ALLOWLIST\ and dangerous environment variable filtering
- **server.py (agent-os, agent-sre, agent-hypervisor)**: Added \_parse_cors_origins()\ validation replacing wildcard \*\
- **server.py (agent-os)**: Replaced \str(exc)\ in 500 responses with generic error message
- **sandbox.py (marketplace)**: Blocked \sys\/\uiltins\ modules, stripped \open()\/\compile()\/\__import__\
- **backends.py**: Added \e.fullmatch\ query path validation
- **credentials.py**: Replaced \==\ with \hmac.compare_digest\ for timing-safe comparison
- **.gitignore**: Added \.security-assessment/\ directory
