### PR TITLE
docs: fix Agent SRE PyPI link

### DIFF
--- a/agent-governance-python/agent-sre/README.md
+++ b/agent-governance-python/agent-sre/README.md
@@ -9,7 +9,7 @@
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
-[![PyPI](https://img.shields.io/pypi/v/agent-sre)](https://pypi.org/project/agent-governance-python/agent-sre/)
+[![PyPI](https://img.shields.io/pypi/v/agent-sre)](https://pypi.org/project/agent-sre/)
 
 > [!IMPORTANT]
 > **Public Preview** — The `agent-sre` package on PyPI is a Microsoft-signed


### PR DESCRIPTION
## Summary
- update the Agent SRE README PyPI badge link to the live agent-sre project page

Fixes #1625

## Testing
- curl -fsS -o /dev/null -w "%{http_code}\n" https://pypi.org/project/agent-sre/
- git diff --check