### PR TITLE
docs: add AgentMesh quick start

### DIFF
--- a/agent-governance-python/agent-mesh/README.md
+++ b/agent-governance-python/agent-mesh/README.md
@@ -245,6 +245,22 @@ sequenceDiagram
 
 ## Quick Start
 
+### Install, Configure, Run
+
+```bash
+pip install agentmesh-platform
+```
+
+```python
+from agentmesh import AgentMeshClient
+
+client = AgentMeshClient("orders-agent", capabilities=["orders.read"])
+result = client.execute_with_governance("orders.read", {"resource": "orders"})
+print(result.decision, result.trust_score)
+```
+
+For the full registration flow, see the [Registration Hello World tutorial](./examples/00-registration-hello-world/).
+
 ### Option 1: Secure Claude Desktop (Recommended)
 
 ```bash


### PR DESCRIPTION
## Summary
- add a compact install/configure/run quick-start block to the AgentMesh README
- include a minimal Python example using AgentMeshClient
- link to the registration tutorial for the full flow

Fixes #1624

## Testing
- git diff --check

Note: I also attempted to smoke-test the snippet with Python 3.12, but this workspace does not have the package dependencies installed for that interpreter.