### PR TITLE
docs: add Rust contributor commands

### DIFF
--- a/agent-governance-rust/README.md
+++ b/agent-governance-rust/README.md
@@ -14,6 +14,16 @@ cargo build --release --workspace
 cargo test --release --workspace
 ```
 
+## Contributing: Build, Test, and Lint
+
+Install Rust 1.70 or newer, then run these checks from `agent-governance-rust/`:
+
+```bash
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace
+```
+
 ## Crates
 
 ### `agentmesh`


### PR DESCRIPTION
## Summary
- add a Rust contributor section with local build, test, and clippy commands
- document the workspace Rust 1.70+ toolchain requirement

Fixes #1628

## Testing
- cargo --version
- git diff --check