### PR TITLE
docs: add i18n contribution guide

### DIFF
--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -1,0 +1,21 @@
+# Internationalization
+
+This directory contains translated entry points for the Agent Governance Toolkit documentation.
+
+## Language Availability
+
+| Language | README | Quickstart | Status |
+|---|---|---|---|
+| English | [`/README.md`](/README.md) | [`/docs/QUICKSTART.md`](/docs/QUICKSTART.md) | Source |
+| Japanese | [`README.ja.md`](./README.ja.md) | [`QUICKSTART.ja.md`](./QUICKSTART.ja.md) | Available |
+| Chinese (Simplified) | [`README.zh-CN.md`](./README.zh-CN.md) | [`QUICKSTART.zh-CN.md`](./QUICKSTART.zh-CN.md) | Available |
+
+Wanted languages include Spanish, French, German, Korean, Portuguese, and Hindi.
+
+## Contributing a Translation
+
+1. Start from the English source file and keep headings, code blocks, links, and admonitions intact.
+2. Name new files with a BCP 47 language tag, such as `README.es.md` or `QUICKSTART.ko.md`.
+3. Add the translated files to this table and update the language switcher in the translated document.
+4. Keep product names, package names, commands, and API identifiers in English unless there is an established localized name.
+5. Open a pull request with the language in the title, for example `docs(i18n): add Spanish README`.


### PR DESCRIPTION
## Summary
- add an English docs/i18n index with language availability
- list current Japanese and Simplified Chinese translations
- document how to contribute new translations and wanted languages

Fixes #1630

## Testing
- test -f docs/QUICKSTART.md
- git diff --check