### PR TITLE
examples: add Go HTTP middleware demo

### DIFF
--- a/agent-governance-golang/examples/http-middleware/README.md
+++ b/agent-governance-golang/examples/http-middleware/README.md
@@ -1,0 +1,16 @@
+# HTTP Middleware Example
+
+Run a minimal `net/http` server protected by AgentMesh governance middleware.
+
+```bash
+cd agent-governance-golang
+go run ./examples/http-middleware
+```
+
+Send an allowed request with a trusted migration header:
+
+```bash
+curl -H "X-Agent-ID: did:agentmesh:demo" http://localhost:8080/run
+```
+
+Requests without `X-Agent-ID` are rejected because `NewHTTPGovernanceMiddleware` requires a verified agent identity resolver.

--- a/agent-governance-golang/examples/http-middleware/main.go
+++ b/agent-governance-golang/examples/http-middleware/main.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	agentmesh "github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh"
+)
+
+func main() {
+	policy := agentmesh.NewPolicyEngine([]agentmesh.PolicyRule{{
+		Action:     "http.get",
+		Effect:     agentmesh.Allow,
+		Conditions: map[string]interface{}{"path": "/run"},
+	}})
+
+	middleware, err := agentmesh.NewHTTPGovernanceMiddleware(agentmesh.HTTPMiddlewareConfig{
+		Policy:          policy,
+		AgentIDResolver: agentmesh.LegacyTrustedHeaderAgentIDResolver("X-Agent-ID"),
+		AllowedTools:    []string{"http.get"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "governed request accepted")
+	}))
+
+	http.Handle("/run", handler)
+	log.Println("listening on http://localhost:8080/run")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
## Summary
- add a runnable Go net/http middleware example using NewHTTPGovernanceMiddleware
- include a README with go run and curl instructions
- demonstrate the trusted header resolver required for migration scenarios

Fixes #1631

## Testing
- GOCACHE=/tmp/agent-governance-go-build go test ./examples/http-middleware
- GOCACHE=/tmp/agent-governance-go-build go test ./packages/agentmesh -run TestNewHTTPGovernanceMiddleware
- git diff --check

Note: the full ./packages/agentmesh suite was not used for this PR because an unrelated discovery test needs httptest to bind a local port, which is blocked in this sandbox.