### PR TITLE
examples: add Go SLO tracking demo

### DIFF
--- a/agent-governance-golang/examples/slo-tracking/README.md
+++ b/agent-governance-golang/examples/slo-tracking/README.md
@@ -1,0 +1,10 @@
+# SLO Tracking Example
+
+Run a small AgentMesh SLO engine demo that records sample agent outcomes and prints the current objective status.
+
+```bash
+cd agent-governance-golang
+go run ./examples/slo-tracking
+```
+
+The example creates an availability objective, records five sample events, and prints the actual availability, target, event count, and remaining error budget.

--- a/agent-governance-golang/examples/slo-tracking/main.go
+++ b/agent-governance-golang/examples/slo-tracking/main.go
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	agentmesh "github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh"
+)
+
+func main() {
+	engine, err := agentmesh.NewSLOEngine([]agentmesh.SLOObjective{{
+		Name:      "agent-availability",
+		Indicator: agentmesh.SLOAvailability,
+		Target:    0.95,
+		Window:    time.Hour,
+	}})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, success := range []bool{true, true, true, false, true} {
+		if err := engine.RecordEvent("agent-availability", success, 25*time.Millisecond); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	report, err := engine.Evaluate("agent-availability")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("SLO: %s\n", report.Name)
+	fmt.Printf("Actual availability: %.0f%%\n", report.Actual*100)
+	fmt.Printf("Target availability: %.0f%%\n", report.Target*100)
+	fmt.Printf("Events: %d, met: %t\n", report.TotalEvents, report.Met)
+	fmt.Printf("Error budget remaining: %.2f\n", report.ErrorBudgetRemaining)
+}


### PR DESCRIPTION
## Summary
- add a runnable Go SLO tracking example
- record sample availability events and print the evaluated report
- include README run instructions

Fixes #1632

## Testing
- GOCACHE=/tmp/agent-governance-go-build go test ./examples/slo-tracking
- GOCACHE=/tmp/agent-governance-go-build go run ./examples/slo-tracking
- GOCACHE=/tmp/agent-governance-go-build go test ./packages/agentmesh -run TestSLOEngine
- git diff --check