### PR TITLE
examples: add Rust quickstart

### DIFF
--- a/agent-governance-rust/README.md
+++ b/agent-governance-rust/README.md
@@ -31,6 +31,14 @@ cargo test --workspace
 cargo clippy --workspace
 ```
 
+## Examples
+
+Run the quickstart example to create a client, evaluate allowed and denied actions, and print the results:
+
+```bash
+cargo run -p agentmesh --example quickstart
+```
+
 ## Crates
 
 ### `agentmesh`

--- a/agent-governance-rust/agentmesh/Cargo.toml
+++ b/agent-governance-rust/agentmesh/Cargo.toml
@@ -31,3 +31,7 @@ tempfile.workspace = true
 [[example]]
 name = "audit-logging"
 path = "../examples/audit-logging.rs"
+
+[[example]]
+name = "quickstart"
+path = "../examples/quickstart.rs"

--- a/agent-governance-rust/examples/quickstart.rs
+++ b/agent-governance-rust/examples/quickstart.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use agentmesh::{AgentMeshClient, ClientOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let policy_yaml = r#"
+version: "1.0"
+agent: quickstart-agent
+policies:
+  - name: quickstart
+    type: capability
+    allowed_actions:
+      - "data.read"
+    denied_actions:
+      - "shell:*"
+"#;
+
+    let client = AgentMeshClient::with_options(
+        "quickstart-agent",
+        ClientOptions {
+            policy_yaml: Some(policy_yaml.to_string()),
+            capabilities: vec!["data.read".to_string()],
+            ..Default::default()
+        },
+    )?;
+
+    for action in ["data.read", "shell:rm"] {
+        let result = client.execute_with_governance(action, None);
+        println!(
+            "{action}: allowed={}, decision={:?}, trust_score={}",
+            result.allowed, result.decision, result.trust_score.score
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a runnable Rust quickstart example for AgentMeshClient
- wire the root example into the agentmesh crate as a Cargo example
- document the cargo run command in the Rust workspace README

Fixes #1633

## Testing
- cargo fmt -- examples/quickstart.rs
- cargo run -p agentmesh --example quickstart
- git diff --check

Note: cargo emitted existing dead-code warnings from agentmesh/src/governance_support.rs while building.