### PR TITLE
examples: add Rust audit logging demo

### DIFF
--- a/agent-governance-rust/agentmesh/Cargo.toml
+++ b/agent-governance-rust/agentmesh/Cargo.toml
@@ -27,3 +27,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[[example]]
+name = "audit-logging"
+path = "../examples/audit-logging.rs"

--- a/agent-governance-rust/examples/audit-logging.rs
+++ b/agent-governance-rust/examples/audit-logging.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use agentmesh::{AuditFilter, AuditLogger};
+
+fn main() {
+    let logger = AuditLogger::new();
+
+    // Append entries to the tamper-evident hash chain.
+    logger.log("agent-1", "data.read", "allow");
+    logger.log("agent-1", "shell:rm", "deny");
+    logger.log("agent-2", "deploy.prod", "requires_approval");
+
+    // Query entries for one agent.
+    let filter = AuditFilter {
+        agent_id: Some("agent-1".to_string()),
+        ..Default::default()
+    };
+    let agent_entries = logger.get_entries(&filter);
+    println!("agent-1 entries: {}", agent_entries.len());
+
+    // Verify the chain before exporting evidence.
+    println!("audit chain valid: {}", logger.verify());
+    println!("{}", logger.export_json());
+}


### PR DESCRIPTION
## Summary
- add a runnable Rust audit logging example
- demonstrate appending audit entries, filtering by agent, verifying the chain, and exporting JSON
- wire the example into the agentmesh crate as a Cargo example

Fixes #1634

## Testing
- cargo fmt -- examples/audit-logging.rs
- cargo run -p agentmesh --example audit-logging
- git diff --check

Note: cargo emitted existing dead-code warnings from agentmesh/src/governance_support.rs while building.