### PR TITLE
docs: fix TypeScript README encoding

### DIFF
--- a/agent-governance-typescript/README.md
+++ b/agent-governance-typescript/README.md
@@ -1,10 +1,10 @@
 # @microsoft/agent-governance-sdk
 
 > [!IMPORTANT]
-> **Public Preview** ΓÇö This npm package is a Microsoft-signed public preview release.
+> **Public Preview** — This npm package is a Microsoft-signed public preview release.
 > APIs may change before GA.
 
-TypeScript SDK for [AgentMesh](../README.md) ΓÇö a governance-first framework for multi-agent systems.
+TypeScript SDK for [AgentMesh](../README.md) — a governance-first framework for multi-agent systems.
 
 Provides agent identity (Ed25519 DIDs), trust scoring, policy evaluation, hash-chain audit logging, and a unified `AgentMeshClient`.
 
@@ -122,7 +122,7 @@ const logger = new AuditLogger();
 logger.log({ agentId: 'agent-1', action: 'data.read', decision: 'allow' });
 logger.log({ agentId: 'agent-1', action: 'data.write', decision: 'deny' });
 
-logger.verify();  // true ΓÇö chain is intact
+logger.verify();  // true — chain is intact
 logger.getEntries({ agentId: 'agent-1' }); // filtered results
 logger.exportJSON(); // full log as JSON string
 ```
@@ -144,7 +144,7 @@ const result = await client.executeWithGovernance('data.read', { user: 'alice' }
 
 ### `McpSecurityScanner`
 
-Scan MCP tool definitions for security threats ΓÇö tool poisoning, typosquatting, hidden instructions, and rug-pull payloads.
+Scan MCP tool definitions for security threats — tool poisoning, typosquatting, hidden instructions, and rug-pull payloads.
 
 ```typescript
 import { McpSecurityScanner } from '@microsoft/agent-governance-sdk';
@@ -181,11 +181,11 @@ import { LifecycleManager, LifecycleState } from '@microsoft/agent-governance-sd
 
 const lm = new LifecycleManager('agent-1');
 
-lm.activate('Ready to serve');         // provisioning ΓåÆ active
-lm.suspend('Scheduled maintenance');   // active ΓåÆ suspended
-lm.activate('Back online');            // suspended ΓåÆ active
-lm.quarantine('Trust violation');      // active ΓåÆ quarantined
-lm.decommission('End of life');        // quarantined ΓåÆ decommissioning
+lm.activate('Ready to serve');         // provisioning → active
+lm.suspend('Scheduled maintenance');   // active → suspended
+lm.activate('Back online');            // suspended → active
+lm.quarantine('Trust violation');      // active → quarantined
+lm.decommission('End of life');        // quarantined → decommissioning
 
 console.log(lm.state);   // 'decommissioning'
 console.log(lm.events);  // full transition history
@@ -194,11 +194,11 @@ console.log(lm.events);  // full transition history
 **State machine:**
 
 ```
-provisioning ΓåÆ active ΓåÆ suspended Γåö active
-                     ΓåÆ rotating  ΓåÆ active | degraded
-                     ΓåÆ degraded  ΓåÆ active | quarantined | decommissioning
-                     ΓåÆ quarantined ΓåÆ active | decommissioning
-                     ΓåÆ decommissioning ΓåÆ decommissioned
+provisioning → active → suspended ↔ active
+                     → rotating  → active | degraded
+                     → degraded  → active | quarantined | decommissioning
+                     → quarantined → active | decommissioning
+                     → decommissioning → decommissioned
 ```
 
 ### `RingEnforcer` and `KillSwitch`
@@ -357,4 +357,4 @@ npm run lint     # Lint with ESLint
 
 ## License
 
-MIT ΓÇö see [LICENSE](../LICENSE).
+MIT — see [LICENSE](../LICENSE).


### PR DESCRIPTION
## Summary
- replace mojibake sequences in the TypeScript SDK README with intended dashes and arrows
- verify no remaining garbled marker characters are present

Fixes #1622

## Testing
- rg -n 'Γ|Ç|ö|å|€' agent-governance-typescript/README.md
- git diff --check