### PR TITLE
Add TypeScript core governance tests

### DIFF
--- a/agent-governance-typescript/tests/client.test.ts
+++ b/agent-governance-typescript/tests/client.test.ts
@@ -28,6 +28,14 @@ describe('AgentMeshClient', () => {
       expect(client.audit).toBeDefined();
       expect(client.lifecycle).toBeDefined();
     });
+
+    it('honors disabled kill switch configuration', () => {
+      const killSwitchDisabledClient = AgentMeshClient.create('no-kill-switch-agent', {
+        killSwitch: { enabled: false },
+      });
+
+      expect(killSwitchDisabledClient.killSwitch).toBeUndefined();
+    });
   });
 
   describe('executeWithGovernance()', () => {
@@ -76,6 +84,20 @@ describe('AgentMeshClient', () => {
     it('returns execution time', async () => {
       const result = await client.executeWithGovernance('data.read');
       expect(typeof result.executionTime).toBe('number');
+    });
+
+    it('returns review decisions without changing trust', async () => {
+      const reviewClient = AgentMeshClient.create('review-agent', {
+        policyRules: [{ action: 'deploy.production', effect: 'review' }],
+      });
+      const before = reviewClient.trust.getTrustScore(reviewClient.identity.did);
+
+      const result = await reviewClient.executeWithGovernance('deploy.production');
+      const after = reviewClient.trust.getTrustScore(reviewClient.identity.did);
+
+      expect(result.decision).toBe('review');
+      expect(result.auditEntry.decision).toBe('review');
+      expect(after.overall).toBe(before.overall);
     });
 
     it('activates lifecycle on first governance execution', async () => {

--- a/agent-governance-typescript/tests/policy.test.ts
+++ b/agent-governance-typescript/tests/policy.test.ts
@@ -156,4 +156,64 @@ describe('PolicyEngine', () => {
       expect(engine.evaluate('extra')).toBe('review');
     });
   });
+
+  describe('loadJson()', () => {
+    it('throws for invalid JSON policy input', () => {
+      const engine = new PolicyEngine();
+      expect(() => engine.loadJson('{not valid json')).toThrow();
+      expect(engine.listPolicies()).toEqual([]);
+    });
+  });
+
+  describe('evaluateWithBackends()', () => {
+    it('does not call external backends when local policy denies', async () => {
+      const backend = jest.fn(() => 'allow' as const);
+      const engine = new PolicyEngine([{ action: 'data.read', effect: 'deny' }]);
+      engine.registerBackend({
+        name: 'network-policy',
+        evaluateAction: backend,
+      });
+
+      const result = await engine.evaluateWithBackends('data.read');
+
+      expect(result.effectiveDecision).toBe('deny');
+      expect(result.deniedBy).toEqual(['local']);
+      expect(result.backendResults).toEqual([]);
+      expect(backend).not.toHaveBeenCalled();
+    });
+
+    it('preserves backend review decisions for locally allowed actions', async () => {
+      const engine = new PolicyEngine([{ action: 'deploy.production', effect: 'allow' }]);
+      engine.registerBackend({
+        name: 'approval-service',
+        evaluateAction: () => 'review',
+      });
+
+      const result = await engine.evaluateWithBackends('deploy.production', {
+        environment: 'production',
+      });
+
+      expect(result.localDecision).toBe('allow');
+      expect(result.effectiveDecision).toBe('review');
+      expect(result.deniedBy).toEqual([]);
+      expect(result.backendResults).toEqual([{
+        backend: 'approval-service',
+        decision: 'review',
+      }]);
+    });
+
+    it('allows missing backend evaluators without blocking local allows', async () => {
+      const engine = new PolicyEngine([{ action: 'data.read', effect: 'allow' }]);
+      engine.registerBackend({ name: 'metadata-only-backend' });
+
+      const result = await engine.evaluateWithBackends('data.read');
+
+      expect(result.effectiveDecision).toBe('allow');
+      expect(result.backendResults).toEqual([{
+        backend: 'metadata-only-backend',
+        decision: 'allow',
+        reason: 'No action evaluator registered',
+      }]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add AgentMeshClient coverage for disabled kill switches and review decisions
- add PolicyEngine coverage for invalid JSON policy input
- cover backend evaluation edge cases including local-deny short-circuiting and backend review results

Fixes #1648

## Testing
- npm test -- --runTestsByPath tests/client.test.ts tests/policy.test.ts