### PR TITLE
Add Rust core governance tests

### DIFF
--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -349,6 +349,38 @@ policies:
     }
 
     #[test]
+    fn test_approval_required_action_preserves_trust_and_audits_label() {
+        let yaml = r#"
+version: "1.0"
+agent: test
+policies:
+  - name: deploy-gate
+    type: approval
+    actions:
+      - "deploy.*"
+    min_approvals: 2
+"#;
+        let opts = ClientOptions {
+            policy_yaml: Some(yaml.to_string()),
+            ..Default::default()
+        };
+        let client = AgentMeshClient::with_options("approval-audit", opts).unwrap();
+        let did = client.identity.did.clone();
+        let before = client.trust.get_trust_score(&did).score;
+
+        let result = client.execute_with_governance("deploy.production", None);
+        let after = client.trust.get_trust_score(&did).score;
+
+        assert!(!result.allowed);
+        assert!(matches!(
+            result.decision,
+            PolicyDecision::RequiresApproval(_)
+        ));
+        assert_eq!(result.audit_entry.decision, "requires_approval");
+        assert_eq!(after, before);
+    }
+
+    #[test]
     fn test_governance_with_rate_limited_action() {
         let yaml = r#"
 version: "1.0"

--- a/agent-governance-rust/agentmesh/src/policy.rs
+++ b/agent-governance-rust/agentmesh/src/policy.rs
@@ -820,6 +820,18 @@ policies:
     }
 
     #[test]
+    fn test_loading_from_missing_file_returns_io_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing-policy.yaml");
+        let engine = PolicyEngine::new();
+        let result = engine.load_from_file(path.to_str().unwrap());
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), PolicyError::Io(_)));
+        assert!(!engine.is_loaded());
+    }
+
+    #[test]
     fn test_multiple_rate_limit_rules_for_different_actions() {
         let yaml = r#"
 version: "1.0"


### PR DESCRIPTION
## Summary
- add client coverage for approval-required actions preserving trust while recording the audit label
- add policy file-loading error coverage for missing policy files

Fixes #1649

## Testing
- cargo test --workspace
- cargo test -p agentmesh test_approval_required_action_preserves_trust_and_audits_label
- cargo test -p agentmesh test_loading_from_missing_file_returns_io_error