### PR TITLE
fix: exclude forks with outgoing PRs from fork burst detection

### DIFF
--- a/scripts/contributor_check.py
+++ b/scripts/contributor_check.py
@@ -272,7 +272,7 @@ def check_repo_themes(username: str, repos: list[dict] | None = None) -> list[Si
         ))
 
     # Fork burst detection: many forks created in a short window
-    fork_signals = _check_fork_burst(repos)
+    fork_signals = _check_fork_burst(repos, username=username)
     signals.extend(fork_signals)
 
     # Batch naming detection: many repos with same suffix created together
@@ -282,8 +282,34 @@ def check_repo_themes(username: str, repos: list[dict] | None = None) -> list[Si
     return signals
 
 
-def _check_fork_burst(repos: list[dict]) -> list[Signal]:
-    """Detect credibility-farming fork bursts (e.g., forking awesome lists)."""
+_fork_pr_cache: dict[str, bool] = {}
+
+
+def _fork_has_outgoing_pr(username: str, fork_name: str) -> bool:
+    """Check if a fork has at least one PR (open, merged, or closed) to its parent."""
+    cache_key = f"{username}/{fork_name}"
+    if cache_key in _fork_pr_cache:
+        return _fork_pr_cache[cache_key]
+
+    result = False
+    try:
+        prs = _api(f"/repos/{username}/{fork_name}/pulls", {
+            "state": "all", "per_page": "1",
+        })
+        result = bool(prs)
+    except Exception:
+        pass
+    _fork_pr_cache[cache_key] = result
+    return result
+
+
+def _check_fork_burst(repos: list[dict], *, username: str = "") -> list[Signal]:
+    """Detect credibility-farming fork bursts (e.g., forking awesome lists).
+
+    Forks that have at least one outgoing PR to their parent repo are
+    excluded from the burst count, since those represent legitimate
+    contributions rather than profile padding.
+    """
     signals: list[Signal] = []
     now = datetime.now(timezone.utc)
 
@@ -302,6 +328,17 @@ def _check_fork_burst(repos: list[dict]) -> list[Signal]:
 
     if not forks:
         return signals
+
+    # Exclude forks that have outgoing PRs (legitimate contributions)
+    if username:
+        awesome_forks = [
+            f for f in awesome_forks
+            if not _fork_has_outgoing_pr(username, f["name"])
+        ]
+        forks = [
+            f for f in forks
+            if not _fork_has_outgoing_pr(username, f["name"])
+        ]
 
     forks.sort(key=lambda f: f["created"])
     max_window = 0

--- a/scripts/tests/test_contributor_check.py
+++ b/scripts/tests/test_contributor_check.py
@@ -27,6 +27,7 @@ from contributor_check import (
     _check_fork_burst,
     _check_batch_naming,
     _check_self_promotion,
+    _fork_has_outgoing_pr,
 )
 
 
@@ -267,6 +268,42 @@ class TestForkBurst:
         ]
         signals = _check_fork_burst(repos)
         assert len(signals) == 0
+
+    @patch("contributor_check._fork_has_outgoing_pr", return_value=True)
+    def test_awesome_forks_with_prs_excluded(self, mock_pr):
+        """Forks that have outgoing PRs are legitimate and should not trigger."""
+        now = datetime.now(timezone.utc)
+        repos = [
+            {"name": f"awesome-list-{i}", "fork": True, "description": "curated list", "created_at": (now - timedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")}
+            for i in range(5)
+        ]
+        signals = _check_fork_burst(repos, username="testuser")
+        names = [s.name for s in signals]
+        assert "awesome_fork_burst" not in names
+
+    @patch("contributor_check._fork_has_outgoing_pr", side_effect=lambda u, n: n == "awesome-list-0")
+    def test_mixed_forks_partial_prs(self, mock_pr):
+        """Only forks without PRs count toward the burst."""
+        now = datetime.now(timezone.utc)
+        repos = [
+            {"name": f"awesome-list-{i}", "fork": True, "description": "curated list", "created_at": (now - timedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")}
+            for i in range(4)
+        ]
+        # 4 forks, 1 has PR -> 3 remain, which hits >= 3 threshold
+        signals = _check_fork_burst(repos, username="testuser")
+        names = [s.name for s in signals]
+        assert "awesome_fork_burst" in names
+
+    def test_no_username_skips_pr_check(self):
+        """Without username, PR check is skipped (backward compat)."""
+        now = datetime.now(timezone.utc)
+        repos = [
+            {"name": f"awesome-list-{i}", "fork": True, "description": "curated list", "created_at": (now - timedelta(hours=i)).strftime("%Y-%m-%dT%H:%M:%SZ")}
+            for i in range(5)
+        ]
+        signals = _check_fork_burst(repos)
+        names = [s.name for s in signals]
+        assert "awesome_fork_burst" in names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes false positives in the _check_fork_burst heuristic. Forks that have at least one outgoing PR to their parent repo are now excluded from burst counting, since those represent legitimate contributions rather than profile padding.

### Changes
- Added _fork_has_outgoing_pr() helper with result caching
- Modified _check_fork_burst() to accept username and filter out forks with PRs
- Updated check_repo_themes() to pass username through
- Added 3 new test cases covering PR exclusion, partial PR, and backward compat

### Testing
All 42 tests pass including 3 new ones.

Fixes #1692
