### PR TITLE
fix(agent-sre): import logging in api/server.py (fixes lint F821)

### DIFF
--- a/agent-governance-python/agent-sre/src/agent_sre/api/server.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/api/server.py
@@ -12,6 +12,7 @@ Run with::
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from contextlib import asynccontextmanager


### PR DESCRIPTION
## Description

`src/agent_sre/api/server.py` uses `logging.getLogger(__name__)` on line 62 but never imports the `logging` module. This causes `ruff check src/ --select E,F,W --ignore E501` to fail with:

```
src/agent_sre/api/server.py:62:10: F821 Undefined name `logging`
```

The `lint (agent-sre)` CI job consequently fails on every PR that touches any Python file anywhere in the repo (because the package's `python` path filter is broad). At runtime, the same line would raise `NameError: name 'logging' is not defined` whenever `agent_sre.api.server` is imported, so this is a latent runtime bug as well as a CI noise source.

The fix is a single missing import added in alphabetical order with the other stdlib imports.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Package(s) Affected

- [x] agent-sre (`agent-governance-python/agent-sre/`)

## Checklist

- [x] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

A dedicated regression test was not added: the fix simply restores a previously implied import, and existing static analysis (`ruff F821`) plus the smoke import tests cover the regression path.

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any): none.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used: GitHub Copilot CLI used to identify the missing import and craft this PR; the change was reviewed and verified locally.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Validation

- `ruff check src/ --select E,F,W --ignore E501` (run inside `agent-governance-python/agent-sre/`) — `All checks passed!` (was 1 error before)

## Related Issues

None.
