### PR TITLE
fix(ci): add .shellcheckrc to suppress style-level shellcheck codes

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,14 @@
+# Shellcheck configuration for GitHub Actions workflow scripts
+#
+# SC2129: "Consider using { cmd1; cmd2; } >> file instead of individual
+#         redirects" — style preference; individual redirects are clearer
+#         in workflow scripts where each echo is a distinct logical step.
+#
+# SC2001: "See if you can use ${variable//search/replace} instead" — sed
+#         is preferred for per-line substitution on multiline strings.
+#
+# SC2317: "Command appears to be unreachable" — false positive caused by
+#         extract_workflow_shell.py concatenating independent run: blocks
+#         into a single script for analysis.
+
+disable=SC2129,SC2001,SC2317


### PR DESCRIPTION
## Description

Adds a \.shellcheckrc\ configuration file to suppress style/info-level shellcheck codes that cause false failures in the \workflow-lint\ CI job.

Follow-up to #1696 which fixed the real bugs (SC2044, SC2034, SC2046, SC2016, SC2296). The remaining failures are all style or false-positive codes:

- **SC2129** (style): individual redirects vs grouped - present in 5+ workflow files, intentional for readability
- **SC2001** (style): sed vs variable substitution - sed is correct for per-line multiline processing
- **SC2317** (info): unreachable code - false positive from \xtract_workflow_shell.py\ concatenating independent \un:\ blocks

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the project style guidelines
- [x] Suppressions are documented with rationale in the file

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>