### PR TITLE
ci: remove dependency-scan compatibility shim (#1661 step 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,29 +339,6 @@ jobs:
       - name: Dependency confusion scan
         run: python3 scripts/check_dependency_confusion.py --strict
 
-  # ── Compatibility shim: preserves the legacy `dependency-scan` check name
-  # so the existing branch-protection ruleset stays satisfied while it is
-  # migrated (independently) to require the two granular checks above.
-  # Remove this job in a follow-up PR after the ruleset is updated to require
-  # `dep-confusion-scan` and `notebook-pip-audit` directly.
-  dependency-scan:
-    needs: [dep-confusion-scan, notebook-pip-audit]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Aggregate dependency-scan result
-        env:
-          DEP_CONFUSION: ${{ needs.dep-confusion-scan.result }}
-          NOTEBOOK_AUDIT: ${{ needs.notebook-pip-audit.result }}
-        run: |
-          echo "dep-confusion-scan: $DEP_CONFUSION"
-          echo "notebook-pip-audit: $NOTEBOOK_AUDIT"
-          if [ "$DEP_CONFUSION" = "success" ] && [ "$NOTEBOOK_AUDIT" = "success" ]; then
-            exit 0
-          fi
-          echo "::error::dependency-scan compatibility shim failed: dep-confusion-scan=$DEP_CONFUSION, notebook-pip-audit=$NOTEBOOK_AUDIT"
-          exit 1
-
   # ── Notebook pip-install audit (always runs — security gate) ─────────
   notebook-pip-audit:
     runs-on: ubuntu-latest
@@ -630,7 +607,6 @@ jobs:
         test-integrations,
         dep-confusion-scan,
         notebook-pip-audit,
-        dependency-scan,
         workflow-security,
         test-integrations-ts,
         build-npm,


### PR DESCRIPTION
## Summary

Step 2 — and final cleanup — of the `dependency-scan` ruleset migration that began in #1661.

The branch-protection ruleset has now been updated to require `dep-confusion-scan` and `notebook-pip-audit` directly. The legacy `dependency-scan` check name is no longer required by the ruleset, so the compatibility shim job that was added in #1661 is dead weight on every PR.

## Pre-merge confirmation

Step 1 (the ruleset edit) has been verified:

* `dep-confusion-scan` ✅ now required
* `notebook-pip-audit` ✅ now required
* `dependency-scan` ❌ no longer required
* All other rules unchanged (only `updated_at` metadata differs between pre/post snapshots)

## Changes

* Delete the `dependency-scan` aggregator job (~24 lines) and its descriptive comment block.
* Remove `dependency-scan` from the `ci-complete` job's `needs:` list. The underlying jobs `dep-confusion-scan` and `notebook-pip-audit` remain in `needs:` so failure-aggregation by `ci-complete` is unaffected.

## Validation

* `yaml.safe_load` on `ci.yml` — parses; `dependency-scan` job removed; `ci-complete needs:` no longer references it.
* `actionlint v1.7.7` against `ci.yml` — clean.
* CI on this PR will exercise the change directly: `dep-confusion-scan` and `notebook-pip-audit` should report Required and gate merge; no `dependency-scan` check should appear.

## Risk

Low. Single-file change. Reverting is one `git revert`.
