### PR TITLE
feat: intent-based authorization with full lifecycle

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/intent.py
+++ b/agent-governance-python/agent-os/src/agent_os/intent.py
@@ -1,0 +1,778 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Intent-Based Authorization for AI Agents.
+
+First-class intent objects with a full lifecycle:
+    declare_intent() -> approve_intent() -> execute actions -> verify_intent()
+
+Intent is an opt-in layer that sits between the caller and StatelessKernel.
+When an agent declares intent before acting, the system can detect drift
+(actions that deviate from what was declared) and respond according to the
+configured drift policy.
+
+Design decisions:
+    - Intent is a first-class object with its own lifecycle and state machine.
+    - IntentManager is async and backed by StateBackend for stateless compat.
+    - Optimistic concurrency via version fields prevents lost updates.
+    - Child intents must narrow parent scope (subset of planned actions).
+    - Three drift policies: soft_block (default), hard_block, re_declare.
+    - Execution records are structured (not bare strings) for audit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class IntentState(str, Enum):
+    """Lifecycle states for an ExecutionIntent."""
+
+    DECLARED = "declared"
+    APPROVED = "approved"
+    EXECUTING = "executing"
+    COMPLETED = "completed"
+    VIOLATED = "violated"
+    EXPIRED = "expired"
+
+
+class DriftPolicy(str, Enum):
+    """How the system responds when an action drifts from declared intent.
+
+    - SOFT_BLOCK: Action proceeds but trust score drops and alert fires.
+    - HARD_BLOCK: Action is denied outright.
+    - RE_DECLARE: Action is denied; agent must declare a new intent.
+    """
+
+    SOFT_BLOCK = "soft_block"
+    HARD_BLOCK = "hard_block"
+    RE_DECLARE = "re_declare"
+
+
+# Terminal states: once entered, the intent cannot transition further.
+_TERMINAL_STATES = frozenset({
+    IntentState.COMPLETED,
+    IntentState.VIOLATED,
+    IntentState.EXPIRED,
+})
+
+# Valid state transitions (from -> set of allowed targets).
+_TRANSITIONS: dict[IntentState, frozenset[IntentState]] = {
+    IntentState.DECLARED: frozenset({IntentState.APPROVED, IntentState.EXPIRED}),
+    IntentState.APPROVED: frozenset({
+        IntentState.EXECUTING, IntentState.EXPIRED,
+    }),
+    IntentState.EXECUTING: frozenset({
+        IntentState.COMPLETED, IntentState.VIOLATED, IntentState.EXPIRED,
+    }),
+}
+
+
+# ---------------------------------------------------------------------------
+# Data Models
+# ---------------------------------------------------------------------------
+
+@dataclass
+class IntentAction:
+    """A single planned action within an intent declaration.
+
+    Attributes:
+        action: The action name (e.g. "database_query", "file_write").
+        params_schema: Optional constraints on allowed parameters.
+            Keys are param names, values are allowed values or patterns.
+    """
+
+    action: str
+    params_schema: dict[str, Any] | None = None
+
+    def matches(self, action: str, params: dict[str, Any] | None = None) -> bool:
+        """Return True if the given action + params match this planned action."""
+        if self.action != action:
+            return False
+        if self.params_schema and params:
+            for key, allowed in self.params_schema.items():
+                if key in params and params[key] != allowed:
+                    return False
+        return True
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"action": self.action}
+        if self.params_schema:
+            d["params_schema"] = self.params_schema
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> IntentAction:
+        return cls(action=d["action"], params_schema=d.get("params_schema"))
+
+
+@dataclass
+class ExecutionRecord:
+    """A structured record of an action attempted under an intent.
+
+    Captures enough detail for audit and planned-vs-actual verification.
+    """
+
+    action: str
+    agent_id: str
+    request_id: str
+    was_planned: bool
+    outcome: str  # "executed", "blocked", "re_declare_required"
+    drift_policy_applied: DriftPolicy | None = None
+    trust_penalty: float = 0.0
+    params_hash: str | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "agent_id": self.agent_id,
+            "request_id": self.request_id,
+            "was_planned": self.was_planned,
+            "outcome": self.outcome,
+            "drift_policy_applied": self.drift_policy_applied.value if self.drift_policy_applied else None,
+            "trust_penalty": self.trust_penalty,
+            "params_hash": self.params_hash,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ExecutionRecord:
+        return cls(
+            action=d["action"],
+            agent_id=d["agent_id"],
+            request_id=d["request_id"],
+            was_planned=d["was_planned"],
+            outcome=d["outcome"],
+            drift_policy_applied=DriftPolicy(d["drift_policy_applied"]) if d.get("drift_policy_applied") else None,
+            trust_penalty=d.get("trust_penalty", 0.0),
+            params_hash=d.get("params_hash"),
+            timestamp=datetime.fromisoformat(d["timestamp"]),
+        )
+
+
+@dataclass
+class DriftEvent:
+    """An event recorded when an action drifts from declared intent."""
+
+    intent_id: str
+    agent_id: str
+    request_id: str
+    action_attempted: str
+    was_planned: bool
+    drift_policy_applied: DriftPolicy
+    result: str  # "allowed_with_penalty", "blocked", "re_declare_required"
+    trust_penalty: float
+    params_hash: str | None = None
+    parent_intent_id: str | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "intent_id": self.intent_id,
+            "agent_id": self.agent_id,
+            "request_id": self.request_id,
+            "action_attempted": self.action_attempted,
+            "was_planned": self.was_planned,
+            "drift_policy_applied": self.drift_policy_applied.value,
+            "result": self.result,
+            "trust_penalty": self.trust_penalty,
+            "params_hash": self.params_hash,
+            "parent_intent_id": self.parent_intent_id,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> DriftEvent:
+        return cls(
+            intent_id=d["intent_id"],
+            agent_id=d["agent_id"],
+            request_id=d["request_id"],
+            action_attempted=d["action_attempted"],
+            was_planned=d["was_planned"],
+            drift_policy_applied=DriftPolicy(d["drift_policy_applied"]),
+            result=d["result"],
+            trust_penalty=d.get("trust_penalty", 0.0),
+            params_hash=d.get("params_hash"),
+            parent_intent_id=d.get("parent_intent_id"),
+            timestamp=datetime.fromisoformat(d["timestamp"]),
+        )
+
+
+@dataclass
+class ExecutionIntent:
+    """A first-class intent object representing an agent's declared plan.
+
+    Lifecycle: DECLARED -> APPROVED -> EXECUTING -> COMPLETED | VIOLATED | EXPIRED
+
+    Attributes:
+        intent_id: Unique identifier for this intent.
+        agent_id: The agent that declared the intent.
+        planned_actions: Actions the agent plans to perform.
+        drift_policy: How to handle actions not in the plan.
+        state: Current lifecycle state.
+        version: Optimistic concurrency version (incremented on each update).
+        parent_intent_id: If this is a child intent, the parent's ID.
+        declared_at: When the intent was declared.
+        approved_at: When the intent was approved (None if not yet approved).
+        expires_at: When the intent expires (None for no expiry).
+        execution_records: Structured records of all attempted actions.
+        drift_events: Events recorded when drift is detected.
+    """
+
+    intent_id: str = field(default_factory=lambda: f"intent:{uuid.uuid4().hex[:12]}")
+    agent_id: str = ""
+    planned_actions: list[IntentAction] = field(default_factory=list)
+    drift_policy: DriftPolicy = DriftPolicy.SOFT_BLOCK
+    state: IntentState = IntentState.DECLARED
+    version: int = 1
+    parent_intent_id: str | None = None
+    declared_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    approved_at: datetime | None = None
+    expires_at: datetime | None = None
+    execution_records: list[ExecutionRecord] = field(default_factory=list)
+    drift_events: list[DriftEvent] = field(default_factory=list)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state in _TERMINAL_STATES
+
+    @property
+    def is_expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return datetime.now(UTC) >= self.expires_at
+
+    @property
+    def planned_action_names(self) -> set[str]:
+        return {a.action for a in self.planned_actions}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "intent_id": self.intent_id,
+            "agent_id": self.agent_id,
+            "planned_actions": [a.to_dict() for a in self.planned_actions],
+            "drift_policy": self.drift_policy.value,
+            "state": self.state.value,
+            "version": self.version,
+            "parent_intent_id": self.parent_intent_id,
+            "declared_at": self.declared_at.isoformat(),
+            "approved_at": self.approved_at.isoformat() if self.approved_at else None,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "execution_records": [r.to_dict() for r in self.execution_records],
+            "drift_events": [e.to_dict() for e in self.drift_events],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ExecutionIntent:
+        return cls(
+            intent_id=d["intent_id"],
+            agent_id=d["agent_id"],
+            planned_actions=[IntentAction.from_dict(a) for a in d.get("planned_actions", [])],
+            drift_policy=DriftPolicy(d.get("drift_policy", "soft_block")),
+            state=IntentState(d.get("state", "declared")),
+            version=d.get("version", 1),
+            parent_intent_id=d.get("parent_intent_id"),
+            declared_at=datetime.fromisoformat(d["declared_at"]),
+            approved_at=datetime.fromisoformat(d["approved_at"]) if d.get("approved_at") else None,
+            expires_at=datetime.fromisoformat(d["expires_at"]) if d.get("expires_at") else None,
+            execution_records=[ExecutionRecord.from_dict(r) for r in d.get("execution_records", [])],
+            drift_events=[DriftEvent.from_dict(e) for e in d.get("drift_events", [])],
+        )
+
+
+@dataclass
+class IntentCheckResult:
+    """Result of checking an action against a declared intent."""
+
+    allowed: bool
+    was_planned: bool
+    drift_policy_applied: DriftPolicy | None = None
+    trust_penalty: float = 0.0
+    reason: str = ""
+    drift_event: DriftEvent | None = None
+
+
+@dataclass
+class IntentVerification:
+    """Summary produced when an intent is completed.
+
+    Compares planned actions vs actual execution for audit.
+    """
+
+    intent_id: str
+    agent_id: str
+    planned_actions: list[str]
+    executed_actions: list[str]
+    unplanned_actions: list[str]
+    missed_actions: list[str]
+    total_drift_events: int
+    total_trust_penalty: float
+    state: IntentState
+    duration_seconds: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "intent_id": self.intent_id,
+            "agent_id": self.agent_id,
+            "planned_actions": self.planned_actions,
+            "executed_actions": self.executed_actions,
+            "unplanned_actions": self.unplanned_actions,
+            "missed_actions": self.missed_actions,
+            "total_drift_events": self.total_drift_events,
+            "total_trust_penalty": self.total_trust_penalty,
+            "state": self.state.value,
+            "duration_seconds": self.duration_seconds,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class IntentError(Exception):
+    """Base exception for intent operations."""
+
+
+class IntentNotFoundError(IntentError):
+    """Raised when an intent_id does not exist."""
+
+
+class IntentStateError(IntentError):
+    """Raised for invalid state transitions."""
+
+
+class IntentVersionConflict(IntentError):
+    """Raised when optimistic concurrency check fails."""
+
+
+class IntentScopeError(IntentError):
+    """Raised when a child intent tries to expand parent scope."""
+
+
+# ---------------------------------------------------------------------------
+# IntentManager
+# ---------------------------------------------------------------------------
+
+# Default trust penalty for unplanned actions under soft_block.
+DEFAULT_DRIFT_PENALTY = 50.0
+
+
+class IntentManager:
+    """Manages intent lifecycle backed by a StateBackend.
+
+    All state is persisted externally, so multiple IntentManager instances
+    can operate against the same backend without conflicts (optimistic
+    concurrency via version fields).
+
+    Usage:
+        >>> from agent_os.stateless import MemoryBackend
+        >>> manager = IntentManager(backend=MemoryBackend())
+        >>> intent = await manager.declare_intent(
+        ...     agent_id="agent-1",
+        ...     planned_actions=[IntentAction(action="database_query")],
+        ... )
+        >>> intent = await manager.approve_intent(intent.intent_id)
+        >>> check = await manager.check_action(
+        ...     intent.intent_id, "database_query", {}, "agent-1", "req-1"
+        ... )
+        >>> assert check.allowed and check.was_planned
+    """
+
+    # Key prefix for intent storage.
+    KEY_PREFIX = "intent:"
+
+    def __init__(
+        self,
+        backend: Any,
+        drift_penalty: float = DEFAULT_DRIFT_PENALTY,
+    ) -> None:
+        """Initialize IntentManager.
+
+        Args:
+            backend: A StateBackend instance (MemoryBackend, RedisBackend, etc.)
+            drift_penalty: Trust penalty applied per unplanned action under soft_block.
+        """
+        self._backend = backend
+        self._drift_penalty = drift_penalty
+
+    # ----- persistence helpers -----
+
+    def _key(self, intent_id: str) -> str:
+        # intent_id already starts with "intent:" by default, so use it directly.
+        return f"agt:{intent_id}"
+
+    async def _load(self, intent_id: str) -> ExecutionIntent:
+        data = await self._backend.get(self._key(intent_id))
+        if data is None:
+            raise IntentNotFoundError(f"Intent '{intent_id}' not found")
+        return ExecutionIntent.from_dict(data)
+
+    async def _save(
+        self,
+        intent: ExecutionIntent,
+        expected_version: int | None = None,
+        ttl: int | None = None,
+    ) -> None:
+        """Save intent with optional optimistic concurrency check."""
+        if expected_version is not None:
+            existing = await self._backend.get(self._key(intent.intent_id))
+            if existing and existing.get("version", 1) != expected_version:
+                raise IntentVersionConflict(
+                    f"Version conflict for '{intent.intent_id}': "
+                    f"expected {expected_version}, got {existing.get('version')}"
+                )
+        intent.version += 1
+        await self._backend.set(self._key(intent.intent_id), intent.to_dict(), ttl)
+
+    def _transition(self, intent: ExecutionIntent, target: IntentState) -> None:
+        """Validate and apply a state transition."""
+        if intent.is_terminal:
+            raise IntentStateError(
+                f"Intent '{intent.intent_id}' is in terminal state '{intent.state.value}'"
+            )
+        allowed = _TRANSITIONS.get(intent.state, frozenset())
+        if target not in allowed:
+            raise IntentStateError(
+                f"Cannot transition from '{intent.state.value}' to '{target.value}'"
+            )
+        intent.state = target
+
+    # ----- public API -----
+
+    async def declare_intent(
+        self,
+        agent_id: str,
+        planned_actions: list[IntentAction],
+        drift_policy: DriftPolicy = DriftPolicy.SOFT_BLOCK,
+        parent_intent_id: str | None = None,
+        ttl_seconds: int | None = None,
+    ) -> ExecutionIntent:
+        """Declare an execution intent.
+
+        Args:
+            agent_id: The declaring agent's identifier.
+            planned_actions: Actions the agent intends to perform.
+            drift_policy: How to handle actions not in the plan.
+            parent_intent_id: If set, this intent must narrow the parent's scope.
+            ttl_seconds: Optional time-to-live in seconds.
+
+        Returns:
+            The newly created ExecutionIntent in DECLARED state.
+
+        Raises:
+            IntentScopeError: If child scope exceeds parent scope.
+            IntentNotFoundError: If parent_intent_id does not exist.
+        """
+        expires_at = (
+            datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+            if ttl_seconds else None
+        )
+
+        # Validate child scope against parent.
+        if parent_intent_id:
+            parent = await self._load(parent_intent_id)
+            parent_action_names = parent.planned_action_names
+            child_action_names = {a.action for a in planned_actions}
+            excess = child_action_names - parent_action_names
+            if excess:
+                raise IntentScopeError(
+                    f"Child intent cannot expand parent scope. "
+                    f"Excess actions: {excess}"
+                )
+
+        intent = ExecutionIntent(
+            agent_id=agent_id,
+            planned_actions=planned_actions,
+            drift_policy=drift_policy,
+            parent_intent_id=parent_intent_id,
+            expires_at=expires_at,
+        )
+
+        backend_ttl = ttl_seconds * 2 if ttl_seconds else None
+        await self._save(intent, ttl=backend_ttl)
+
+        logger.info(
+            "Intent declared: %s by %s with %d planned actions",
+            intent.intent_id, agent_id, len(planned_actions),
+        )
+        return intent
+
+    async def approve_intent(self, intent_id: str) -> ExecutionIntent:
+        """Approve a declared intent, allowing execution to begin.
+
+        Args:
+            intent_id: The intent to approve.
+
+        Returns:
+            The updated intent in APPROVED state.
+
+        Raises:
+            IntentNotFoundError: If intent does not exist.
+            IntentStateError: If intent is not in DECLARED state.
+        """
+        intent = await self._load(intent_id)
+
+        if intent.is_expired:
+            self._transition(intent, IntentState.EXPIRED)
+            await self._save(intent, expected_version=intent.version)
+            raise IntentStateError(f"Intent '{intent_id}' has expired")
+
+        self._transition(intent, IntentState.APPROVED)
+        intent.approved_at = datetime.now(UTC)
+        await self._save(intent, expected_version=intent.version)
+
+        logger.info("Intent approved: %s", intent_id)
+        return intent
+
+    async def check_action(
+        self,
+        intent_id: str,
+        action: str,
+        params: dict[str, Any] | None,
+        agent_id: str,
+        request_id: str,
+    ) -> IntentCheckResult:
+        """Check whether an action is allowed under the declared intent.
+
+        This is the core method called by the kernel before executing each action.
+        It also transitions the intent to EXECUTING on first action.
+
+        Args:
+            intent_id: The active intent.
+            action: The action being attempted.
+            params: The action parameters.
+            agent_id: The agent attempting the action.
+            request_id: Correlation ID for the request.
+
+        Returns:
+            IntentCheckResult indicating whether the action is allowed.
+        """
+        intent = await self._load(intent_id)
+
+        # Check expiry.
+        if intent.is_expired:
+            self._transition(intent, IntentState.EXPIRED)
+            await self._save(intent, expected_version=intent.version)
+            return IntentCheckResult(
+                allowed=False,
+                was_planned=False,
+                reason=f"Intent '{intent_id}' has expired",
+            )
+
+        # Must be APPROVED or already EXECUTING.
+        if intent.state not in (IntentState.APPROVED, IntentState.EXECUTING):
+            return IntentCheckResult(
+                allowed=False,
+                was_planned=False,
+                reason=f"Intent '{intent_id}' is in state '{intent.state.value}', "
+                       f"must be APPROVED or EXECUTING",
+            )
+
+        # Transition to EXECUTING on first action.
+        if intent.state == IntentState.APPROVED:
+            self._transition(intent, IntentState.EXECUTING)
+
+        # Check if action is in the plan.
+        params_hash = _hash_params(params) if params else None
+        was_planned = any(
+            pa.matches(action, params) for pa in intent.planned_actions
+        )
+
+        if was_planned:
+            record = ExecutionRecord(
+                action=action,
+                agent_id=agent_id,
+                request_id=request_id,
+                was_planned=True,
+                outcome="executed",
+                params_hash=params_hash,
+            )
+            intent.execution_records.append(record)
+            await self._save(intent, expected_version=intent.version)
+            return IntentCheckResult(allowed=True, was_planned=True)
+
+        # Drift detected: apply drift policy.
+        drift_policy = intent.drift_policy
+
+        if drift_policy == DriftPolicy.SOFT_BLOCK:
+            result_str = "allowed_with_penalty"
+            allowed = True
+            outcome = "executed"
+        elif drift_policy == DriftPolicy.HARD_BLOCK:
+            result_str = "blocked"
+            allowed = False
+            outcome = "blocked"
+        else:  # RE_DECLARE
+            result_str = "re_declare_required"
+            allowed = False
+            outcome = "re_declare_required"
+
+        drift_event = DriftEvent(
+            intent_id=intent.intent_id,
+            agent_id=agent_id,
+            request_id=request_id,
+            action_attempted=action,
+            was_planned=False,
+            drift_policy_applied=drift_policy,
+            result=result_str,
+            trust_penalty=self._drift_penalty,
+            params_hash=params_hash,
+            parent_intent_id=intent.parent_intent_id,
+        )
+
+        record = ExecutionRecord(
+            action=action,
+            agent_id=agent_id,
+            request_id=request_id,
+            was_planned=False,
+            outcome=outcome,
+            drift_policy_applied=drift_policy,
+            trust_penalty=self._drift_penalty,
+            params_hash=params_hash,
+        )
+
+        intent.drift_events.append(drift_event)
+        intent.execution_records.append(record)
+        await self._save(intent, expected_version=intent.version)
+
+        logger.warning(
+            "Drift detected for intent %s: action '%s' not planned, policy=%s",
+            intent.intent_id, action, drift_policy.value,
+        )
+
+        return IntentCheckResult(
+            allowed=allowed,
+            was_planned=False,
+            drift_policy_applied=drift_policy,
+            trust_penalty=self._drift_penalty,
+            reason=f"Action '{action}' not in declared plan, policy={drift_policy.value}",
+            drift_event=drift_event,
+        )
+
+    async def verify_intent(self, intent_id: str) -> IntentVerification:
+        """Complete an intent and produce a verification report.
+
+        Compares planned actions against what was actually executed.
+
+        Args:
+            intent_id: The intent to verify and complete.
+
+        Returns:
+            IntentVerification summary of planned vs actual.
+
+        Raises:
+            IntentNotFoundError: If intent does not exist.
+            IntentStateError: If intent is not in EXECUTING state.
+        """
+        intent = await self._load(intent_id)
+
+        if intent.state not in (IntentState.EXECUTING, IntentState.APPROVED):
+            raise IntentStateError(
+                f"Cannot verify intent in state '{intent.state.value}'"
+            )
+
+        # Compute planned vs actual.
+        planned_names = [a.action for a in intent.planned_actions]
+        executed_names = [
+            r.action for r in intent.execution_records
+            if r.outcome == "executed"
+        ]
+        unplanned = [
+            r.action for r in intent.execution_records
+            if not r.was_planned and r.outcome == "executed"
+        ]
+        executed_set = set(executed_names)
+        missed = [a for a in planned_names if a not in executed_set]
+
+        total_penalty = sum(e.trust_penalty for e in intent.drift_events)
+        duration = None
+        if intent.approved_at:
+            duration = (datetime.now(UTC) - intent.approved_at).total_seconds()
+
+        # Transition to terminal state.
+        if intent.drift_events:
+            self._transition(intent, IntentState.VIOLATED)
+        else:
+            self._transition(intent, IntentState.COMPLETED)
+
+        await self._save(intent, expected_version=intent.version)
+
+        return IntentVerification(
+            intent_id=intent.intent_id,
+            agent_id=intent.agent_id,
+            planned_actions=planned_names,
+            executed_actions=executed_names,
+            unplanned_actions=unplanned,
+            missed_actions=missed,
+            total_drift_events=len(intent.drift_events),
+            total_trust_penalty=total_penalty,
+            state=intent.state,
+            duration_seconds=duration,
+        )
+
+    async def get_intent(self, intent_id: str) -> ExecutionIntent | None:
+        """Get an intent by ID, or None if not found."""
+        try:
+            return await self._load(intent_id)
+        except IntentNotFoundError:
+            return None
+
+    async def create_child_intent(
+        self,
+        parent_intent_id: str,
+        agent_id: str,
+        planned_actions: list[IntentAction],
+        drift_policy: DriftPolicy | None = None,
+        ttl_seconds: int | None = None,
+    ) -> ExecutionIntent:
+        """Create a child intent that narrows the parent's scope.
+
+        Child intents are used in multi-agent orchestration where the
+        orchestrator declares intent and sub-agents inherit a narrowed scope.
+
+        Args:
+            parent_intent_id: The parent intent to inherit from.
+            agent_id: The sub-agent's identifier.
+            planned_actions: Must be a subset of parent's planned actions.
+            drift_policy: Override drift policy, or inherit from parent.
+            ttl_seconds: Optional TTL for the child intent.
+
+        Returns:
+            The child intent in DECLARED state.
+
+        Raises:
+            IntentScopeError: If child scope exceeds parent scope.
+        """
+        parent = await self._load(parent_intent_id)
+        effective_policy = drift_policy if drift_policy is not None else parent.drift_policy
+
+        return await self.declare_intent(
+            agent_id=agent_id,
+            planned_actions=planned_actions,
+            drift_policy=effective_policy,
+            parent_intent_id=parent_intent_id,
+            ttl_seconds=ttl_seconds,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _hash_params(params: dict[str, Any]) -> str:
+    """Create a deterministic hash of action parameters for audit."""
+    import json
+    normalized = json.dumps(params, sort_keys=True, default=str)
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]

--- a/agent-governance-python/agent-os/src/agent_os/stateless.py
+++ b/agent-governance-python/agent-os/src/agent_os/stateless.py
@@ -305,15 +305,19 @@ class ExecutionContext:
     history: list[dict[str, Any]] = field(default_factory=list)
     state_ref: str | None = None  # Reference to external state
     metadata: dict[str, Any] = field(default_factory=dict)
+    intent_id: str | None = None  # Opt-in intent-based authorization
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d = {
             "agent_id": self.agent_id,
             "policies": self.policies,
             "history": self.history,
             "state_ref": self.state_ref,
-            "metadata": self.metadata
+            "metadata": self.metadata,
         }
+        if self.intent_id is not None:
+            d["intent_id"] = self.intent_id
+        return d
 
 
 @dataclass
@@ -413,6 +417,7 @@ class StatelessKernel:
         policies: dict[str, Any] | None = None,
         enable_tracing: bool = False,
         circuit_breaker_config: CircuitBreakerConfig | None = None,
+        intent_manager: Any | None = None,
     ):
         self.backend = backend or MemoryBackend()
         self.policies = {**self.DEFAULT_POLICIES, **(policies or {})}
@@ -422,6 +427,7 @@ class StatelessKernel:
         )
         self._backend_type = type(self.backend).__name__
         self.circuit_breaker = CircuitBreaker(circuit_breaker_config)
+        self.intent_manager = intent_manager
 
     async def execute(
         self,
@@ -499,6 +505,38 @@ class StatelessKernel:
                 }
             )
 
+        # 2b. Check intent (opt-in: only when intent_id is present)
+        intent_metadata: dict[str, Any] = {}
+        if context.intent_id and self.intent_manager:
+            intent_check = await self.intent_manager.check_action(
+                intent_id=context.intent_id,
+                action=action,
+                params=params,
+                agent_id=context.agent_id,
+                request_id=request.request_id or "",
+            )
+            if not intent_check.allowed:
+                return ExecutionResult(
+                    success=False,
+                    data=None,
+                    error=intent_check.reason,
+                    signal="SIGKILL",
+                    metadata={
+                        "request_id": request.request_id,
+                        "intent_drift": True,
+                        "drift_policy": intent_check.drift_policy_applied.value
+                        if intent_check.drift_policy_applied else None,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                )
+            if not intent_check.was_planned:
+                intent_metadata["intent_drift"] = True
+                intent_metadata["trust_penalty"] = intent_check.trust_penalty
+                intent_metadata["drift_policy"] = (
+                    intent_check.drift_policy_applied.value
+                    if intent_check.drift_policy_applied else None
+                )
+
         # 3. Execute action
         try:
             result = await self._execute_action(action, params, external_state)
@@ -528,17 +566,21 @@ class StatelessKernel:
                 "success": True
             }],
             state_ref=new_state_ref,
-            metadata=context.metadata
+            metadata=context.metadata,
+            intent_id=context.intent_id,
         )
+
+        result_metadata = {
+            "request_id": request.request_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **intent_metadata,
+        }
 
         return ExecutionResult(
             success=True,
             data=result.get("data"),
             updated_context=updated_context,
-            metadata={
-                "request_id": request.request_id,
-                "timestamp": datetime.now(timezone.utc).isoformat()
-            }
+            metadata=result_metadata,
         )
 
     def _check_policies(

--- a/agent-governance-python/agent-os/tests/test_intent.py
+++ b/agent-governance-python/agent-os/tests/test_intent.py
@@ -1,0 +1,601 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for Intent-Based Authorization (agent_os.intent)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agent_os.intent import (
+    DEFAULT_DRIFT_PENALTY,
+    DriftEvent,
+    DriftPolicy,
+    ExecutionIntent,
+    ExecutionRecord,
+    IntentAction,
+    IntentCheckResult,
+    IntentManager,
+    IntentNotFoundError,
+    IntentScopeError,
+    IntentState,
+    IntentStateError,
+    IntentVerification,
+    IntentVersionConflict,
+    _hash_params,
+)
+from agent_os.stateless import ExecutionContext, MemoryBackend, StatelessKernel
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def backend():
+    return MemoryBackend()
+
+
+@pytest.fixture
+def manager(backend):
+    return IntentManager(backend=backend)
+
+
+def _run(coro):
+    """Helper to run async in sync tests."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# IntentAction Tests
+# ---------------------------------------------------------------------------
+
+class TestIntentAction:
+    def test_matches_same_action(self):
+        ia = IntentAction(action="database_query")
+        assert ia.matches("database_query")
+
+    def test_no_match_different_action(self):
+        ia = IntentAction(action="database_query")
+        assert not ia.matches("file_write")
+
+    def test_matches_with_params_schema(self):
+        ia = IntentAction(action="database_query", params_schema={"mode": "read"})
+        assert ia.matches("database_query", {"mode": "read", "query": "SELECT 1"})
+
+    def test_no_match_wrong_param(self):
+        ia = IntentAction(action="database_query", params_schema={"mode": "read"})
+        assert not ia.matches("database_query", {"mode": "write"})
+
+    def test_roundtrip_dict(self):
+        ia = IntentAction(action="file_read", params_schema={"path": "/tmp"})
+        restored = IntentAction.from_dict(ia.to_dict())
+        assert restored.action == ia.action
+        assert restored.params_schema == ia.params_schema
+
+
+# ---------------------------------------------------------------------------
+# ExecutionRecord Tests
+# ---------------------------------------------------------------------------
+
+class TestExecutionRecord:
+    def test_roundtrip_dict(self):
+        rec = ExecutionRecord(
+            action="database_query",
+            agent_id="a1",
+            request_id="r1",
+            was_planned=True,
+            outcome="executed",
+        )
+        restored = ExecutionRecord.from_dict(rec.to_dict())
+        assert restored.action == rec.action
+        assert restored.was_planned == rec.was_planned
+
+
+# ---------------------------------------------------------------------------
+# DriftEvent Tests
+# ---------------------------------------------------------------------------
+
+class TestDriftEvent:
+    def test_roundtrip_dict(self):
+        evt = DriftEvent(
+            intent_id="intent:abc",
+            agent_id="a1",
+            request_id="r1",
+            action_attempted="file_write",
+            was_planned=False,
+            drift_policy_applied=DriftPolicy.SOFT_BLOCK,
+            result="allowed_with_penalty",
+            trust_penalty=50.0,
+        )
+        restored = DriftEvent.from_dict(evt.to_dict())
+        assert restored.intent_id == evt.intent_id
+        assert restored.drift_policy_applied == DriftPolicy.SOFT_BLOCK
+
+
+# ---------------------------------------------------------------------------
+# ExecutionIntent Tests
+# ---------------------------------------------------------------------------
+
+class TestExecutionIntent:
+    def test_roundtrip_dict(self):
+        intent = ExecutionIntent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="query")],
+            drift_policy=DriftPolicy.HARD_BLOCK,
+        )
+        restored = ExecutionIntent.from_dict(intent.to_dict())
+        assert restored.agent_id == "a1"
+        assert restored.drift_policy == DriftPolicy.HARD_BLOCK
+        assert len(restored.planned_actions) == 1
+
+    def test_is_terminal(self):
+        intent = ExecutionIntent(agent_id="a1", state=IntentState.COMPLETED)
+        assert intent.is_terminal
+
+    def test_not_terminal(self):
+        intent = ExecutionIntent(agent_id="a1", state=IntentState.DECLARED)
+        assert not intent.is_terminal
+
+    def test_planned_action_names(self):
+        intent = ExecutionIntent(
+            agent_id="a1",
+            planned_actions=[
+                IntentAction(action="read"),
+                IntentAction(action="write"),
+            ],
+        )
+        assert intent.planned_action_names == {"read", "write"}
+
+
+# ---------------------------------------------------------------------------
+# IntentManager Lifecycle Tests
+# ---------------------------------------------------------------------------
+
+class TestIntentLifecycle:
+    """Full lifecycle: declare -> approve -> execute -> verify."""
+
+    def test_full_lifecycle(self, manager):
+        # Declare
+        intent = _run(manager.declare_intent(
+            agent_id="agent-1",
+            planned_actions=[
+                IntentAction(action="database_query"),
+                IntentAction(action="file_read"),
+            ],
+        ))
+        assert intent.state == IntentState.DECLARED
+        assert intent.agent_id == "agent-1"
+        assert len(intent.planned_actions) == 2
+
+        # Approve
+        intent = _run(manager.approve_intent(intent.intent_id))
+        assert intent.state == IntentState.APPROVED
+        assert intent.approved_at is not None
+
+        # Execute a planned action
+        check = _run(manager.check_action(
+            intent.intent_id, "database_query", {}, "agent-1", "req-1"
+        ))
+        assert check.allowed
+        assert check.was_planned
+
+        # Execute another planned action
+        check2 = _run(manager.check_action(
+            intent.intent_id, "file_read", {}, "agent-1", "req-2"
+        ))
+        assert check2.allowed
+        assert check2.was_planned
+
+        # Verify
+        verification = _run(manager.verify_intent(intent.intent_id))
+        assert verification.planned_actions == ["database_query", "file_read"]
+        assert verification.executed_actions == ["database_query", "file_read"]
+        assert verification.unplanned_actions == []
+        assert verification.missed_actions == []
+        assert verification.total_drift_events == 0
+        assert verification.state == IntentState.COMPLETED
+
+    def test_declare_creates_unique_ids(self, manager):
+        i1 = _run(manager.declare_intent("a1", [IntentAction(action="x")]))
+        i2 = _run(manager.declare_intent("a1", [IntentAction(action="x")]))
+        assert i1.intent_id != i2.intent_id
+
+
+# ---------------------------------------------------------------------------
+# Drift Detection Tests
+# ---------------------------------------------------------------------------
+
+class TestDriftDetection:
+    def test_soft_block_allows_with_penalty(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.SOFT_BLOCK,
+        ))
+        _run(manager.approve_intent(intent.intent_id))
+
+        # Attempt unplanned action
+        check = _run(manager.check_action(
+            intent.intent_id, "write", {}, "a1", "r1"
+        ))
+        assert check.allowed
+        assert not check.was_planned
+        assert check.trust_penalty == DEFAULT_DRIFT_PENALTY
+        assert check.drift_policy_applied == DriftPolicy.SOFT_BLOCK
+        assert check.drift_event is not None
+
+    def test_hard_block_denies(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.HARD_BLOCK,
+        ))
+        _run(manager.approve_intent(intent.intent_id))
+
+        check = _run(manager.check_action(
+            intent.intent_id, "write", {}, "a1", "r1"
+        ))
+        assert not check.allowed
+        assert not check.was_planned
+        assert check.drift_policy_applied == DriftPolicy.HARD_BLOCK
+
+    def test_re_declare_denies(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.RE_DECLARE,
+        ))
+        _run(manager.approve_intent(intent.intent_id))
+
+        check = _run(manager.check_action(
+            intent.intent_id, "delete", {}, "a1", "r1"
+        ))
+        assert not check.allowed
+        assert check.drift_policy_applied == DriftPolicy.RE_DECLARE
+
+    def test_drift_recorded_in_verification(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.SOFT_BLOCK,
+        ))
+        _run(manager.approve_intent(intent.intent_id))
+        _run(manager.check_action(intent.intent_id, "read", {}, "a1", "r1"))
+        _run(manager.check_action(intent.intent_id, "write", {}, "a1", "r2"))  # drift
+
+        v = _run(manager.verify_intent(intent.intent_id))
+        assert v.total_drift_events == 1
+        assert v.unplanned_actions == ["write"]
+        assert v.state == IntentState.VIOLATED
+
+
+# ---------------------------------------------------------------------------
+# Child Intent Tests
+# ---------------------------------------------------------------------------
+
+class TestChildIntent:
+    def test_child_narrows_scope(self, manager):
+        parent = _run(manager.declare_intent(
+            agent_id="orchestrator",
+            planned_actions=[
+                IntentAction(action="read"),
+                IntentAction(action="write"),
+                IntentAction(action="delete"),
+            ],
+        ))
+
+        child = _run(manager.create_child_intent(
+            parent_intent_id=parent.intent_id,
+            agent_id="sub-agent-1",
+            planned_actions=[IntentAction(action="read")],
+        ))
+        assert child.parent_intent_id == parent.intent_id
+        assert child.agent_id == "sub-agent-1"
+        assert len(child.planned_actions) == 1
+
+    def test_child_cannot_expand_scope(self, manager):
+        parent = _run(manager.declare_intent(
+            agent_id="orchestrator",
+            planned_actions=[IntentAction(action="read")],
+        ))
+
+        with pytest.raises(IntentScopeError, match="Excess actions"):
+            _run(manager.create_child_intent(
+                parent_intent_id=parent.intent_id,
+                agent_id="sub-agent",
+                planned_actions=[
+                    IntentAction(action="read"),
+                    IntentAction(action="delete"),
+                ],
+            ))
+
+    def test_child_inherits_drift_policy(self, manager):
+        parent = _run(manager.declare_intent(
+            agent_id="orchestrator",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.HARD_BLOCK,
+        ))
+
+        child = _run(manager.create_child_intent(
+            parent_intent_id=parent.intent_id,
+            agent_id="sub",
+            planned_actions=[IntentAction(action="read")],
+        ))
+        assert child.drift_policy == DriftPolicy.HARD_BLOCK
+
+    def test_child_can_override_drift_policy(self, manager):
+        parent = _run(manager.declare_intent(
+            agent_id="orch",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.HARD_BLOCK,
+        ))
+
+        child = _run(manager.create_child_intent(
+            parent_intent_id=parent.intent_id,
+            agent_id="sub",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.SOFT_BLOCK,
+        ))
+        assert child.drift_policy == DriftPolicy.SOFT_BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Expiry Tests
+# ---------------------------------------------------------------------------
+
+class TestIntentExpiry:
+    def test_expired_intent_blocked_on_check(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            ttl_seconds=0,
+        ))
+        _run(manager.approve_intent(intent.intent_id))
+
+        # Force expiry by setting expires_at in the past
+        loaded = _run(manager.get_intent(intent.intent_id))
+        loaded.expires_at = datetime.now(UTC) - timedelta(seconds=10)
+        # Save directly via backend
+        _run(manager._backend.set(manager._key(loaded.intent_id), loaded.to_dict()))
+
+        check = _run(manager.check_action(
+            loaded.intent_id, "read", {}, "a1", "r1"
+        ))
+        assert not check.allowed
+        assert "expired" in check.reason
+
+    def test_ttl_sets_expires_at(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            ttl_seconds=300,
+        ))
+        assert intent.expires_at is not None
+
+
+# ---------------------------------------------------------------------------
+# State Machine Tests
+# ---------------------------------------------------------------------------
+
+class TestStateMachine:
+    def test_cannot_approve_executing_intent(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+        ))
+        _run(manager.approve_intent(intent.intent_id))
+        _run(manager.check_action(intent.intent_id, "read", {}, "a1", "r1"))
+
+        with pytest.raises(IntentStateError):
+            _run(manager.approve_intent(intent.intent_id))
+
+    def test_cannot_check_unapproved_intent(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+        ))
+        check = _run(manager.check_action(
+            intent.intent_id, "read", {}, "a1", "r1"
+        ))
+        assert not check.allowed
+        assert "declared" in check.reason.lower()
+
+    def test_cannot_verify_completed_intent(self, manager):
+        intent = _run(manager.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+        ))
+        _run(manager.approve_intent(intent.intent_id))
+        _run(manager.check_action(intent.intent_id, "read", {}, "a1", "r1"))
+        _run(manager.verify_intent(intent.intent_id))
+
+        with pytest.raises(IntentStateError):
+            _run(manager.verify_intent(intent.intent_id))
+
+
+# ---------------------------------------------------------------------------
+# Backwards Compatibility Tests
+# ---------------------------------------------------------------------------
+
+class TestBackwardsCompat:
+    def test_execution_context_without_intent(self):
+        """Existing code without intent_id works unchanged."""
+        ctx = ExecutionContext(agent_id="a1", policies=["read_only"])
+        assert ctx.intent_id is None
+        d = ctx.to_dict()
+        assert "intent_id" not in d
+
+    def test_execution_context_with_intent(self):
+        ctx = ExecutionContext(
+            agent_id="a1",
+            policies=["read_only"],
+            intent_id="intent:abc123",
+        )
+        assert ctx.intent_id == "intent:abc123"
+        d = ctx.to_dict()
+        assert d["intent_id"] == "intent:abc123"
+
+    def test_kernel_without_intent_manager(self):
+        """Kernel works without intent_manager, just like before."""
+        kernel = StatelessKernel()
+        assert kernel.intent_manager is None
+
+        result = _run(kernel.execute(
+            "database_query",
+            {"query": "SELECT 1"},
+            ExecutionContext(agent_id="a1"),
+        ))
+        assert result.success
+
+
+# ---------------------------------------------------------------------------
+# Kernel Integration Tests
+# ---------------------------------------------------------------------------
+
+class TestKernelIntegration:
+    def test_kernel_with_intent_planned_action(self, backend):
+        mgr = IntentManager(backend=backend)
+        kernel = StatelessKernel(intent_manager=mgr)
+
+        intent = _run(mgr.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="database_query")],
+        ))
+        _run(mgr.approve_intent(intent.intent_id))
+
+        ctx = ExecutionContext(
+            agent_id="a1",
+            intent_id=intent.intent_id,
+        )
+        result = _run(kernel.execute("database_query", {"q": "SELECT 1"}, ctx))
+        assert result.success
+        assert result.metadata.get("intent_drift") is None
+
+    def test_kernel_with_intent_soft_block_drift(self, backend):
+        mgr = IntentManager(backend=backend)
+        kernel = StatelessKernel(intent_manager=mgr)
+
+        intent = _run(mgr.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.SOFT_BLOCK,
+        ))
+        _run(mgr.approve_intent(intent.intent_id))
+
+        ctx = ExecutionContext(agent_id="a1", intent_id=intent.intent_id)
+        result = _run(kernel.execute("write", {}, ctx))
+        assert result.success  # soft block allows
+        assert result.metadata.get("intent_drift") is True
+        assert result.metadata.get("trust_penalty") == DEFAULT_DRIFT_PENALTY
+
+    def test_kernel_with_intent_hard_block_drift(self, backend):
+        mgr = IntentManager(backend=backend)
+        kernel = StatelessKernel(intent_manager=mgr)
+
+        intent = _run(mgr.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="read")],
+            drift_policy=DriftPolicy.HARD_BLOCK,
+        ))
+        _run(mgr.approve_intent(intent.intent_id))
+
+        ctx = ExecutionContext(agent_id="a1", intent_id=intent.intent_id)
+        result = _run(kernel.execute("write", {}, ctx))
+        assert not result.success
+        assert result.metadata.get("intent_drift") is True
+        assert result.signal == "SIGKILL"
+
+    def test_kernel_intent_id_preserved_in_updated_context(self, backend):
+        mgr = IntentManager(backend=backend)
+        kernel = StatelessKernel(intent_manager=mgr)
+
+        intent = _run(mgr.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="chat")],
+        ))
+        _run(mgr.approve_intent(intent.intent_id))
+
+        ctx = ExecutionContext(agent_id="a1", intent_id=intent.intent_id)
+        result = _run(kernel.execute("chat", {}, ctx))
+        assert result.success
+        assert result.updated_context.intent_id == intent.intent_id
+
+    def test_policy_denied_before_intent_check(self, backend):
+        """Action denied by policy should not reach intent check."""
+        mgr = IntentManager(backend=backend)
+        kernel = StatelessKernel(intent_manager=mgr)
+
+        intent = _run(mgr.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="file_write")],
+        ))
+        _run(mgr.approve_intent(intent.intent_id))
+
+        ctx = ExecutionContext(
+            agent_id="a1",
+            policies=["read_only"],
+            intent_id=intent.intent_id,
+        )
+        result = _run(kernel.execute("file_write", {}, ctx))
+        assert not result.success
+        assert result.signal == "SIGKILL"
+        # Intent should have no execution records (policy blocked first)
+        loaded = _run(mgr.get_intent(intent.intent_id))
+        assert len(loaded.execution_records) == 0
+
+
+# ---------------------------------------------------------------------------
+# Error Handling Tests
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    def test_get_nonexistent_intent(self, manager):
+        result = _run(manager.get_intent("intent:doesnotexist"))
+        assert result is None
+
+    def test_approve_nonexistent_intent(self, manager):
+        with pytest.raises(IntentNotFoundError):
+            _run(manager.approve_intent("intent:doesnotexist"))
+
+    def test_check_nonexistent_intent(self, manager):
+        with pytest.raises(IntentNotFoundError):
+            _run(manager.check_action("intent:nope", "x", {}, "a1", "r1"))
+
+
+# ---------------------------------------------------------------------------
+# Persistence / Round-trip Tests
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_intent_survives_new_manager_instance(self, backend):
+        """Intent persisted in backend is accessible from a new manager."""
+        mgr1 = IntentManager(backend=backend)
+        intent = _run(mgr1.declare_intent(
+            agent_id="a1",
+            planned_actions=[IntentAction(action="query")],
+        ))
+
+        mgr2 = IntentManager(backend=backend)
+        loaded = _run(mgr2.get_intent(intent.intent_id))
+        assert loaded is not None
+        assert loaded.agent_id == "a1"
+        assert loaded.planned_actions[0].action == "query"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_hash_params_deterministic(self):
+        h1 = _hash_params({"a": 1, "b": 2})
+        h2 = _hash_params({"b": 2, "a": 1})
+        assert h1 == h2
+
+    def test_hash_params_different_values(self):
+        h1 = _hash_params({"a": 1})
+        h2 = _hash_params({"a": 2})
+        assert h1 != h2


### PR DESCRIPTION
## Summary

Adds **ExecutionIntent** as a first-class object with a complete lifecycle:
\declare_intent()\ -> \pprove_intent()\ -> \xecute_under_intent()\ -> \erify_intent()\

## Key Design Decisions

- **Option B**: Intent as first-class object (per architecture review)
- **Soft block default**: Action proceeds but trust score drops + alert fires
- **Opt-in**: No breaking API changes; existing \xecute()\ works without intent
- **Standalone**: Intent at agent level; orchestrated: intent at orchestrator level, sub-agents inherit narrowed scope

## What's Included

### New: \gent_os/intent.py\
- \ExecutionIntent\ with state machine (DECLARED -> APPROVED -> EXECUTING -> COMPLETED/VIOLATED/EXPIRED)
- \IntentManager\ backed by \StateBackend\ (stateless-compatible, no in-memory state)
- Three drift policies: \soft_block\, \hard_block\, \e_declare\
- Structured \ExecutionRecord\ for planned-vs-actual audit
- Child intents must narrow parent scope (prevents privilege expansion)
- Optimistic concurrency via version fields
- \DriftEvent\ with full audit fields (intent_id, agent_id, request_id, params_hash)

### Modified: \gent_os/stateless.py\
- \ExecutionContext\ gains optional \intent_id\ field (opt-in, no breaking changes)
- \StatelessKernel\ gains optional \intent_manager\ parameter
- Intent check runs after policy check, before action execution
- Drift metadata included in \ExecutionResult\ for observability

### Tests: 40 new tests
- Full lifecycle, drift detection (all 3 policies), child intent scoping
- Expiry, state machine validation, backwards compatibility
- Kernel integration, persistence round-trip, error handling

## Test Results
81 tests pass (40 new intent + 41 existing stateless)

## Addresses
Gartner gap #1: intent-based runtime authorization