### PR TITLE
fix: resolve CI lint and shellcheck failures

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -21,4 +21,8 @@
 # SC2016: "Expressions don't expand in single quotes" — intentional use of
 #         single-quoted strings for literal grep patterns and markdown fences.
 
-disable=SC2129,SC2001,SC2317,SC2050,SC2086,SC2016
+# SC2153: "Possible misspelling: VAR may not be assigned" — false positive
+#         from GHA env: variables (e.g. CHANGED, PKG) that shellcheck cannot
+#         see are set by the workflow runner.
+
+disable=SC2129,SC2001,SC2317,SC2050,SC2086,SC2016,SC2153

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@
 </p>
 
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/badge/docs-microsoft.github.io%2Fagent--governance--toolkit-blue?logo=github)](https://microsoft.github.io/agent-governance-toolkit)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![PyPI](https://img.shields.io/pypi/v/agent-governance-toolkit)](https://pypi.org/project/agent-governance-toolkit/)
 [![OWASP Agentic Top 10](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10_Covered-blue)](docs/OWASP-COMPLIANCE.md)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/microsoft/agent-governance-toolkit/badge)](https://scorecard.dev/viewer/?uri=github.com/microsoft/agent-governance-toolkit)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/microsoft/agent-governance-toolkit)

--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/contributor_check.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/contributor_check.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import subprocess
 import sys

--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py
@@ -22,7 +22,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import quote

--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
@@ -17,7 +17,6 @@ Usage:
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Optional
 
@@ -142,11 +141,6 @@ def scan(path: str, min_grade: str, output_json: bool, strict: bool) -> None:
             coverage = result["coverage"]
             missing = result.get("missing", [])
 
-            # Color-code grade
-            grade_style = {
-                "A": "green", "B": "green", "C": "yellow", "D": "red", "F": "red"
-            }.get(grade, "white")
-
             name = Path(filepath).name
             status = "PASS" if not _grade_below(grade, min_grade) else "FAIL"
             icon = "+" if status == "PASS" else "!"
@@ -229,7 +223,7 @@ def list_playbooks(output_json: bool) -> None:
         click.echo()
 
     click.echo(f"  {len(playbooks)} playbook(s) available")
-    click.echo(f"  Run with: agt red-team attack --playbook <id>\n")
+    click.echo("  Run with: agt red-team attack --playbook <id>\n")
 
 
 @red_team.command()
@@ -278,7 +272,7 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
     AdversarialRunner = adversarial["AdversarialRunner"]
     ChaosExperiment = adversarial["ChaosExperiment"]
     Fault = adversarial["Fault"]
-    FaultType = adversarial["FaultType"]
+    _ = adversarial["FaultType"]  # loaded for registration side-effects
 
     # Select playbooks
     if playbook_id:
@@ -345,7 +339,7 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
         click.echo(json.dumps(data, indent=2))
     else:
         click.echo(f"\n{'='*60}")
-        click.echo(f"  AGT Red-Team: Adversarial Attack Assessment")
+        click.echo("  AGT Red-Team: Adversarial Attack Assessment")
         click.echo(f"{'='*60}")
         click.echo(f"  Target: {target}")
         click.echo(f"  Experiment: {experiment.experiment_id}\n")


### PR DESCRIPTION
Fixes CI failures on main branch.

### Changes

**Ruff lint fixes (agent-compliance):**
- Remove unused imports: \sys\ (red_team.py), \math\ (contributor_check.py), \	imezone\ (credential_audit.py)
- Remove unused variable \grade_style\, prefix \FaultType\ with \_\ for side-effect registration
- Fix f-strings without placeholders (F541) in red_team.py

**Shellcheck fix:**
- Add SC2153 to .shellcheckrc: false positive from GHA \nv:\ variables (\CHANGED\, \PKG\) that shellcheck cannot see

**README cleanup:**
- Remove duplicate Docs and PyPI shield badges (already linked in the header nav)