### PR TITLE
chore: bump version to 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [3.4.0] - 2026-05-05
+
+### Fixed
+- **Contributor Reputation Check** — false-positive HIGH risk for established accounts. Accounts with age > 1yr, 50+ followers, and 20+ repos now have `recent_repo_burst` and `cross_repo_spray` signals dampened to LOW with bounded caps and abuse-signal guards (#1725)
+
+### Changed
+- **CI** — fixed ruff lint errors in agent-compliance CLI tools, added SC2153 to shellcheck disable list (#1724)
+- **README** — removed duplicate Docs and PyPI shield badges
+
 ## [3.3.0] - 2026-04-27
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 > [Open a GitHub issue](https://github.com/microsoft/agent-governance-toolkit/issues) for feedback.
 
 > [!TIP]
-> **v3.3.0 is out!** Contributor Reputation Check (reusable GitHub Action for any OSS repo), repo reorganization under language-specific SDK dirs, Sentry integration, shift-left governance tutorial, policy composition, multi-stage pipelines, and 80+ other improvements. [Changelog →](CHANGELOG.md)
+> **v3.4.0 is out!** False-positive fix for contributor reputation check on established accounts, CI lint fixes, and README cleanup. [Changelog →](CHANGELOG.md)
 
 **Runtime governance for AI agents** -- deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous agents. Covers all **10 OWASP Agentic risks** with **13,000+ tests**.
 

--- a/agent-governance-python/agent-compliance/pyproject.toml
+++ b/agent-governance-python/agent-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_governance_toolkit"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — Unified installer and runtime policy enforcement for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-discovery/pyproject.toml
+++ b/agent-governance-python/agent-discovery/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_discovery"
-version = "3.3.0"
+version = "3.4.0"
 description = "Shadow AI agent discovery and inventory for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-hypervisor/pyproject.toml
+++ b/agent-governance-python/agent-hypervisor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_hypervisor"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — Agent Hypervisor: Runtime supervisor for multi-agent Shared Sessions with Execution Rings, Joint Liability, Saga Orchestration, and hash-chained audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-lightning/pyproject.toml
+++ b/agent-governance-python/agent-lightning/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_lightning"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — Agent-Lightning RL integration for the Agent Governance Toolkit: governed training with policy enforcement"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-marketplace/pyproject.toml
+++ b/agent-governance-python/agent-marketplace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_marketplace"
-version = "3.3.0"
+version = "3.4.0"
 description = "Plugin marketplace for the Agent Governance Toolkit — discover, install, verify, and manage plugins"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-mcp-governance/pyproject.toml
+++ b/agent-governance-python/agent-mcp-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_mcp_governance"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — MCP governance primitives for the Agent Governance Toolkit."
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-mesh/packages/mcp-proxy/package.json
+++ b/agent-governance-python/agent-mesh/packages/mcp-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-mcp-proxy",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Public Preview \u2014 Security proxy for MCP servers: The Firewall for Model Context Protocol",
   "keywords": [
     "mcp",

--- a/agent-governance-python/agent-mesh/packages/mcp-trust-server/pyproject.toml
+++ b/agent-governance-python/agent-mesh/packages/mcp-trust-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_trust"
-version = "3.3.0"
+version = "3.4.0"
 description = "MCP server exposing AgentMesh trust management tools for Claude, GPT, and other AI agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_platform"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — The Secure Nervous System for Cloud-Native Agent Ecosystems - Identity, Trust, Reward, Governance"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-mesh/services/api/package.json
+++ b/agent-governance-python/agent-mesh/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-api",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Public Preview \u2014 AgentMesh Public API for trust verification and agent registration",
   "main": "dist/index.js",
   "scripts": {

--- a/agent-governance-python/agent-os/examples/carbon-auditor/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/carbon-auditor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon_auditor_swarm"
-version = "3.3.0"
+version = "3.4.0"
 description = "Autonomous auditing system for the Voluntary Carbon Market (VCM)"
 license = {text = "MIT"}
 readme = "README.md"

--- a/agent-governance-python/agent-os/examples/defi-sentinel/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/defi-sentinel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defi_sentinel_demo"
-version = "3.3.0"
+version = "3.4.0"
 description = "DeFi Risk Sentinel demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/examples/grid-balancing/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/grid-balancing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grid_balancing_demo"
-version = "3.3.0"
+version = "3.4.0"
 description = "Autonomous energy trading demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/examples/pharma-compliance/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/pharma-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pharma_compliance_demo"
-version = "3.3.0"
+version = "3.4.0"
 description = "Pharma Compliance demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/extensions/chrome/package.json
+++ b/agent-governance-python/agent-os/extensions/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentos-browser-extension",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "AgentOS - Safe AI Agents for GitHub, Jira & More",
   "private": true,
   "scripts": {

--- a/agent-governance-python/agent-os/extensions/copilot/package.json
+++ b/agent-governance-python/agent-os/extensions/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-os-copilot-extension",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Public Preview \u2014 AgentOS GitHub Copilot Extension: Build safe AI agents with natural language and 0% policy violations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-python/agent-os/extensions/cursor/package.json
+++ b/agent-governance-python/agent-os/extensions/cursor/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/agent-os-cursor",
   "displayName": "Agent OS for Cursor - The AI IDE with a Safety Kernel",
   "description": "Kernel-level safety for Cursor AI. Block destructive operations, verify AI suggestions with multi-model review, and audit all Composer actions. The safest AI IDE experience.",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "publisher": "agent-os",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/agent-governance-python/agent-os/extensions/mcp-server/package.json
+++ b/agent-governance-python/agent-os/extensions/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentos-mcp-server",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Public Preview \u2014 AgentOS MCP Server for Claude Desktop: Build, deploy, and manage policy-compliant autonomous agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-python/agent-os/modules/amb/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/amb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_message_bus"
-version = "3.3.0"
+version = "3.4.0"
 description = "A lightweight, broker-agnostic message bus designed specifically for AI Agents"
 license = {text = "MIT"}
 readme = "README.md"

--- a/agent-governance-python/agent-os/modules/atr/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/atr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_tool_registry"
-version = "3.3.0"
+version = "3.4.0"
 description = "A decentralized marketplace for agent capabilities - The Hands of AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/agent-governance-python/agent-os/modules/caas/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/caas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_context"
-version = "3.3.0"
+version = "3.4.0"
 description = "A pure, logic-only library for routing context, handling RAG fallacies, and managing context windows. Layer 1 Primitive - no agent dependencies."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/agent-governance-python/agent-os/modules/cmvk/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/cmvk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_drift"
-version = "3.3.0"
+version = "3.4.0"
 description = "Mathematical drift detection library for calculating drift/hallucination scores between outputs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_control_plane"
-version = "3.3.0"
+version = "3.4.0"
 description = "Layer 3: The Framework - A deterministic kernel for zero-violation governance in agentic AI systems with POSIX-style signals, VFS, and kernel/user space separation"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/agent-governance-python/agent-os/modules/emk/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/emk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_memory"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — Episodic Memory Kernel for AI agent experience storage"
 authors = [
     { name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" }

--- a/agent-governance-python/agent-os/modules/iatp/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/iatp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_trust_protocol"
-version = "3.3.0"
+version = "3.4.0"
 description = "Inter-Agent Trust Protocol (IATP) - The Envoy for AI Agents. A sidecar architecture with typed IPC pipes for preventing cascading hallucinations in autonomous agent networks."
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/mcp-kernel-server/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/mcp-kernel-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_mcp_server"
-version = "3.3.0"
+version = "3.4.0"
 description = "MCP Server for Claude Desktop - Agent OS kernel primitives including code safety verification, CMVK multi-model review, and IATP trust"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/nexus/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_nexus"
-version = "3.3.0"
+version = "3.4.0"
 description = "Agent Trust Exchange - viral registry and communication board for AI agents (RESEARCH PROTOTYPE)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/observability/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/observability/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_observability"
-version = "3.3.0"
+version = "3.4.0"
 description = "Production observability for Agent OS - OpenTelemetry traces, Prometheus metrics, Grafana dashboards"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/pyproject.toml
+++ b/agent-governance-python/agent-os/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_os_kernel"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — A kernel architecture for governing autonomous AI agents with Nexus Trust Exchange"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-primitives/pyproject.toml
+++ b/agent-governance-python/agent-primitives/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_primitives"
-version = "3.3.0"
+version = "3.4.0"
 description = "Shared primitive data models for Agent OS - failure types, severity levels, and base structures"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-runtime/pyproject.toml
+++ b/agent-governance-python/agent-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_runtime"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — AgentMesh Runtime: Execution supervisor for multi-agent sessions with privilege rings, saga orchestration, and audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-sandbox/pyproject.toml
+++ b/agent-governance-python/agent-sandbox/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_sandbox"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — Agent Sandbox: Docker-based execution isolation for AI agents with policy-driven resource limits, tool proxies, network enforcement, and filesystem checkpointing"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-sre/pyproject.toml
+++ b/agent-governance-python/agent-sre/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_sre"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — Reliability Engineering for AI Agent Systems"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/a2a-protocol/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/a2a-protocol/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "a2a_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "A2A protocol bridge for AgentMesh — trust-verified agent-to-agent communication via the A2A standard"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/adk-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/adk-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adk_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview — Agent Governance Toolkit integration for Google ADK: policy enforcement, trust verification, and audit trails for ADK agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/agentmesh-avp/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/agentmesh-avp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "avp_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "Agent Veil Protocol integration for AgentMesh trust engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/audit-accountability-export/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/audit-accountability-export/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_audit_export"
-version = "3.3.0"
+version = "3.4.0"
 description = "Example adapter from AgentMesh AuditEntry output to an external accountability export shape"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/copilot-governance/package.json
+++ b/agent-governance-python/agentmesh-integrations/copilot-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-copilot-governance",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Public Preview \u2014 GitHub Copilot Extension for agent governance code review: detects missing policy checks, unguarded tool calls, and audit logging gaps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-python/agentmesh-integrations/crewai-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/crewai-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "crewai_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh trust layer for CrewAI — trust-verified crew member selection and capability-gated task assignment"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/flowise-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/flowise-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowise_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh governance nodes for Flowise — policy enforcement, trust gating, audit logging, and rate limiting for visual AI flows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/haystack-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/haystack-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "haystack_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh governance components for Haystack pipelines — policy enforcement, trust scoring, and tamper-evident audit trails"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_langchain"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust-gated tool execution"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/langflow-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langflow-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langflow_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "Governance components for Langflow — policy enforcement, trust routing, audit logging, and compliance checking for visual AI flows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/langgraph-trust/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langgraph-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "Trust-gated checkpoint nodes for LangGraph — cryptographic identity, policy enforcement, and trust-aware routing for multi-agent graphs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
 
 [project]
 name = "llamaindex_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh trust layer integration for LlamaIndex agents"
 authors = [{name = "AgentMesh Contributors"}]
 requires-python = ">=3.9,<4.0"

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package.json
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-mastra",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Public Preview \u2014 Governance, trust verification, and audit middleware for Mastra AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_receipts"
-version = "3.3.0"
+version = "3.4.0"
 description = "MCP tool-call receipt signing — Cedar policy decisions linked to governance receipts"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_proxy"
-version = "3.3.0"
+version = "3.4.0"
 description = "MCP proxy that wraps any MCP tool with AgentMesh trust verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/nostr-wot/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/nostr-wot/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nostr_wot_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "Nostr Web of Trust integration for AgentMesh trust engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openai_agents_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh trust layer for OpenAI Agents SDK — trust-gated function calling and handoff verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_openai_agents_trust"
-version = "3.3.0"
+version = "3.4.0"
 description = "Trust & governance layer for OpenAI Agents SDK — policy enforcement, trust-gated handoffs, and hash-chained audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openshell_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "Public Preview - OpenShell + AgentMesh governance skill"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pydantic_ai_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "Governance middleware for PydanticAI — semantic policy enforcement, trust scoring, and audit trails for agent tool execution"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "structural_authz_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh adapter for structural authorization gates — consumes external policy decisions, trust grades, and delegation scope chains as AGT trust signals"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/template-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/template-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "template_agentmesh"
-version = "3.3.0"
+version = "3.4.0"
 description = "AgentMesh trust layer template — copy and rename for your framework"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-rust/Cargo.toml
+++ b/agent-governance-rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["agentmesh", "agentmesh-mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/microsoft/agent-governance-toolkit"

--- a/agent-governance-typescript/README.md
+++ b/agent-governance-typescript/README.md
@@ -269,7 +269,7 @@ const verifiedRuntime = new GovernanceVerifier().verify({
   runtimeEvidence: {
     schema: 'agt-runtime-evidence/v1',
     generatedAt: new Date().toISOString(),
-    toolkitVersion: '3.3.0',
+    toolkitVersion: '3.4.0',
     deployment: {
       identity: { enabled: true, did: 'did:mesh:agent-1' },
       policy: { failClosed: true, backends: ['opa'] },

--- a/agent-governance-typescript/agent-os-vscode/package.json
+++ b/agent-governance-typescript/agent-os-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/agent-os-vscode",
   "displayName": "Agent OS - AI Safety for Code",
   "description": "Kernel-level safety for AI coding assistants. Block destructive operations, verify with multi-model review, and audit all AI suggestions.",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "publisher": "agent-os",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/agent-governance-typescript/package-lock.json
+++ b/agent-governance-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/agent-governance-sdk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/agent-governance-sdk",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@noble/ciphers": "2.2.0",

--- a/agent-governance-typescript/package.json
+++ b/agent-governance-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-governance-sdk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Public Preview — TypeScript SDK for the Agent Governance Toolkit: agent identity, trust scoring, policy evaluation, and audit logging",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/examples/agent-mesh/multi-agent-chat/README.md
+++ b/examples/agent-mesh/multi-agent-chat/README.md
@@ -65,7 +65,7 @@ Notes on what to expect run-to-run:
 | File | Purpose |
 | --- | --- |
 | `main.py` | The runnable demo (single file, no async, no external services) |
-| `requirements.txt` | Pins `agentmesh-platform==3.3.0` |
+| `requirements.txt` | Pins `agentmesh-platform==3.4.0` |
 | `README.md` | This file |
 
 ## How It Maps to the SDK

--- a/examples/agent-mesh/multi-agent-chat/requirements.txt
+++ b/examples/agent-mesh/multi-agent-chat/requirements.txt
@@ -1,1 +1,1 @@
-agentmesh-platform==3.3.0
+agentmesh-platform==3.4.0

--- a/examples/agent-sre/basic-runbook/README.md
+++ b/examples/agent-sre/basic-runbook/README.md
@@ -62,7 +62,7 @@ Notes on what to expect run-to-run:
 | File | Purpose |
 | --- | --- |
 | `main.py` | The runnable demo (single file, no async, no external services) |
-| `requirements.txt` | Pins `agent-sre==3.3.0` |
+| `requirements.txt` | Pins `agent-sre==3.4.0` |
 | `README.md` | This file |
 
 ## How It Maps to the SDK

--- a/examples/agent-sre/basic-runbook/requirements.txt
+++ b/examples/agent-sre/basic-runbook/requirements.txt
@@ -1,1 +1,1 @@
-agent-sre==3.3.0
+agent-sre==3.4.0


### PR DESCRIPTION
## Version Bump: 3.3.0 → 3.4.0

Bumps all package versions across 66 files:
- Python packages (pyproject.toml)
- TypeScript packages (package.json, package-lock.json)
- Rust crate (Cargo.toml)
- Examples (requirements.txt)
- Documentation (README, CHANGELOG)

### What's in 3.4.0
- **fix**: Contributor reputation check false-positive dampening for established accounts (#1725)
- **fix**: CI lint errors and shellcheck warnings (#1724)
- **chore**: README badge cleanup