### PR TITLE
fix: resolve Rust CI build error and suppress dead_code warnings

### DIFF
--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod audit;
 pub mod control_support;
+#[allow(dead_code)]
 pub mod governance_support;
 pub mod identity;
 pub mod identity_support;

--- a/agent-governance-rust/agentmesh/src/sandbox.rs
+++ b/agent-governance-rust/agentmesh/src/sandbox.rs
@@ -480,4 +480,5 @@ impl SandboxProvider for DockerSandboxProvider {
 }
 
 #[cfg(test)]
+#[path = "sandbox_test.rs"]
 mod sandbox_test;


### PR DESCRIPTION
## Summary

Fixes two Rust CI issues:

1. **Build error** (E0583): `mod sandbox_test;` inside `sandbox.rs` expected the test file at `src/sandbox/sandbox_test.rs` but it lives at `src/sandbox_test.rs`. Added `#[path = "sandbox_test.rs"]` to resolve.

2. **21 dead_code warnings**: Private utility functions in `governance_support.rs` (policy parsing, path normalization, value resolution) are building blocks for incremental adoption. Added `#[allow(dead_code)]` on the module declaration.