### PR TITLE
docs: add Dayos to ADOPTERS.md

### DIFF
--- a/docs/ADOPTERS.md
+++ b/docs/ADOPTERS.md
@@ -12,6 +12,7 @@ momentum and credibility. Submit a PR editing this file — see
 |---|---|---|---|
 | Microsoft (internal AI agent platform) | AI / Developer Tools | Policy enforcement and governance workflows for multi-agent orchestration | [@imran-siddique](https://github.com/imran-siddique) |
 | Microsoft (internal engineering tools) | Engineering Productivity | Agent SRE integration for incident management and reliability monitoring | [@imran-siddique](https://github.com/imran-siddique) |
+| [Dayos](https://dayos.com) | Enterprise AI / ERP Automation | Policy enforcement and prompt-injection detection for a multi-agent system built on Google ADK — Cedar-based tool-dispatch governance across finance and operations workflows | [@miyannishar](https://github.com/miyannishar) |
 
 ## Evaluation / Pilot
 


### PR DESCRIPTION
## Summary

Adds [Dayos](https://dayos.com) to the **Production** adopters table.

## Use Case

Dayos uses AGT for governance of our enterprise AI agent system built on [Google ADK](https://google.github.io/adk-docs/). Specifically:

- **Cedar-based policy enforcement** — deterministic tool-dispatch governance via `PolicyEvaluator` across finance and operations workflows (AP, GL, expense reporting)
- **Prompt-injection detection** — `PromptInjectionDetector` with allowlist filtering for multi-agent request routing
- **Multi-adapter integration** — native AGT adapters for ADK agent orchestration

## Context

Closes #1714 — invited by @imran-siddique.

Dayos has contributed 6 framework integrations to AGT (OpenAI, LangChain, CrewAI, AutoGen, ADK, Cedar/PolicyEvaluator).