### PR TITLE
fix: remove accidental GHA expression in security audit workflow

### DIFF
--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -186,7 +186,7 @@ jobs:
           )
 
           for pattern in "${UNSAFE_PATTERNS[@]}"; do
-            # Find ${{ pattern }} in run: blocks (not in env: blocks which are safe)
+            # Find expression interpolation of pattern in run: blocks (not in env: which are safe)
             GHA_OPEN='${{'
             MATCHES=$(grep -rn "${GHA_OPEN}.*${pattern}" .github/workflows/*.yml \
               | grep -v "env:" | grep -v "#" || true)


### PR DESCRIPTION
A bash comment containing a GHA expression syntax was being parsed by GitHub Actions as a workflow expression, causing all weekly-security-audit runs to fail with 'Unrecognized named-value: pattern' since ~May 1.

**Root cause**: Line 189 had a comment with literal expression syntax that GHA evaluates before bash runs, even inside comments.

**Fix**: Replaced with plain text description.