### PR TITLE
fix: escape remaining GHA expression syntax in security audit workflow

### DIFF
--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -187,7 +187,7 @@ jobs:
 
           for pattern in "${UNSAFE_PATTERNS[@]}"; do
             # Find expression interpolation of pattern in run: blocks (not in env: which are safe)
-            GHA_OPEN='${{'
+            GHA_OPEN=$(printf '$')'{{'
             MATCHES=$(grep -rn "${GHA_OPEN}.*${pattern}" .github/workflows/*.yml \
               | grep -v "env:" | grep -v "#" || true)
             if [ -n "$MATCHES" ]; then


### PR DESCRIPTION
Follow-up to #1749. The expression-injection-check job also had an unclosed GHA expression in a bash variable assignment that GHA tried to parse before bash execution.

**Fix**: Construct the expression open-delimiter via printf so GHA does not see it as expression syntax.