### PR TITLE
fix: security audit self-match and persist-credentials hardening

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           sparse-checkout: |
             scripts
             .github/actions/contributor-check

--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -132,7 +132,7 @@ jobs:
 
           # No workflow should checkout HEAD ref on pull_request_target
           HEAD_REFS=$(grep -rn 'ref:.*head\.sha\|ref:.*head_sha' .github/workflows/*.yml \
-            | grep -v '#' | grep -v 'workflow_run' || true)
+            | grep -v '#' | grep -v 'workflow_run' | grep -v 'weekly-security-audit' || true)
           if [ -n "$HEAD_REFS" ]; then
             {
               echo "🔴 CRITICAL: pull_request_target workflow checks out HEAD ref:"


### PR DESCRIPTION
Fixes the last remaining failure in weekly-security-audit workflow:

1. **Self-match false positive**: The HEAD ref grep was matching its own text in weekly-security-audit.yml. Added exclusion filter.
2. **persist-credentials hardening**: Added \persist-credentials: false\ to contributor-check.yml checkout (pull_request_target best practice).