### PR TITLE
docs: add MAINTAINERS.md and CODEOWNERS for foundation readiness

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,29 @@
+# Core maintainers own everything by default
+* @imran-siddique @jackbatzner @eltoncarr-ms
+
+# Python packages
+/agent-governance-python/ @imran-siddique @jackbatzner
+
+# TypeScript packages
+/agent-governance-typescript/ @imran-siddique @jackbatzner
+
+# .NET packages
+/agent-governance-dotnet/ @eltoncarr-ms @imran-siddique
+
+# Rust packages
+/agent-governance-rust/ @imran-siddique
+
+# Go packages
+/agent-governance-golang/ @imran-siddique
+
+# CI/CD and workflows
+/.github/ @imran-siddique @eltoncarr-ms
+
+# Documentation
+/docs/ @imran-siddique @jackbatzner
+
+# Scripts (contributor check, security tooling)
+/scripts/ @imran-siddique
+
+# Examples
+/examples/ @imran-siddique @jackbatzner

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,13 +33,9 @@ The project lead sets overall technical direction, resolves disputes when consen
 
 ## Current Maintainers
 
-| Name | Organization | GitHub | Role |
-|------|-------------|--------|------|
-| Imran Siddique | Microsoft | [@imran-siddique](https://github.com/imran-siddique) | Project lead, creator |
-| Jack Batzner | Microsoft | [@jackbatzner](https://github.com/jackbatzner) | Maintainer |
-| Elton Carr | Microsoft | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | Maintainer |
+See [MAINTAINERS.md](MAINTAINERS.md) for the full list of current maintainers, their areas of ownership, and affiliation details.
 
-We are actively working to grow the maintainer group to include contributors from other organizations. If you are interested in becoming a maintainer, start by contributing and engaging with the project.
+We are actively working to grow the maintainer group to include contributors from other organizations. If you are interested in becoming a maintainer, start by contributing and engaging with the project. Code ownership areas are defined in [CODEOWNERS](CODEOWNERS).
 
 ## Decision-Making
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,45 @@
+# Maintainers
+
+This file lists the current maintainers of the Agent Governance Toolkit.
+For governance rules, decision-making process, and how to become a maintainer,
+see [GOVERNANCE.md](GOVERNANCE.md).
+
+**Last updated:** May 2026
+
+## Project Lead
+
+| Name | Organization | GitHub | Role | Since |
+|------|-------------|--------|------|-------|
+| Imran Siddique | Microsoft | [@imran-siddique](https://github.com/imran-siddique) | Project lead, creator | Oct 2024 |
+
+## Core Maintainers
+
+| Name | Organization | GitHub | Area | Since |
+|------|-------------|--------|------|-------|
+| Jack Batzner | Microsoft | [@jackbatzner](https://github.com/jackbatzner) | Python SDK, Agent OS | Jan 2025 |
+| Elton Carr | Microsoft | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | .NET SDK, CI/CD | Feb 2025 |
+
+## Package Maintainers
+
+| Name | Organization | GitHub | Package(s) | Since |
+|------|-------------|--------|-----------|-------|
+| | | | | |
+
+_We are actively growing the maintainer group to include contributors from
+other organizations. See [Contributing](#becoming-a-maintainer) below._
+
+## Becoming a Maintainer
+
+Maintainer nominations follow the process in [GOVERNANCE.md](GOVERNANCE.md):
+
+1. **Contributor** — submit PRs, file issues, participate in discussions
+2. **Reviewer** — 3+ merged PRs in a specific area, 1+ months of activity
+3. **Maintainer** — 5+ merged PRs, 2+ months sustained contribution, nomination by existing maintainer
+
+We especially welcome maintainers from non-Microsoft organizations to strengthen
+the project's vendor-neutral governance. If you are interested, start by
+contributing and reach out in [GitHub Discussions](https://github.com/microsoft/agent-governance-toolkit/discussions).
+
+## Emeritus Maintainers
+
+None yet.


### PR DESCRIPTION
Adds governance infrastructure files expected by foundation reviewers (modeled after ACP and agentgateway patterns):

- **MAINTAINERS.md**: Structured maintainer list with organization, role, area, and tenure. Includes path-to-maintainer guidance and call for non-MS maintainers.
- **CODEOWNERS**: Package-level ownership mapping for automated review routing.
- **GOVERNANCE.md**: Updated to reference MAINTAINERS.md and CODEOWNERS instead of inline table.

Part of AAIF submission readiness work.