### PR TITLE
fix: make getting_started.py resolve current monorepo paths

### DIFF
--- a/examples/openai-agents-governed/getting_started.py
+++ b/examples/openai-agents-governed/getting_started.py
@@ -31,26 +31,25 @@ from pathlib import Path
 # (The sys.path lines below are only needed when running from the repo
 # checkout. With a pip install, just `from agent_os...` works directly.)
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-os" / "src"))
-sys.path.insert(0, str(_REPO_ROOT / "packages" / "agent-mesh" / "src"))
+
+
+def _resolve_repo_path(*segments: str) -> Path:
+    """Resolve a path for both current and legacy monorepo layouts."""
+    current = _REPO_ROOT.joinpath("agent-governance-python", *segments)
+    if current.exists():
+        return current
+    return _REPO_ROOT.joinpath("packages", *segments)
+
+
+sys.path.insert(0, str(_resolve_repo_path("agent-os", "src")))
+sys.path.insert(0, str(_resolve_repo_path("agent-mesh", "src")))
 sys.path.insert(
     0,
-    str(
-        _REPO_ROOT
-        / "packages"
-        / "agentmesh-integrations"
-        / "openai-agents-trust"
-        / "src"
-    ),
+    str(_resolve_repo_path("agentmesh-integrations", "openai-agents-trust", "src")),
 )
 sys.path.insert(
     0,
-    str(
-        _REPO_ROOT
-        / "packages"
-        / "agentmesh-integrations"
-        / "openai-agents-agentmesh"
-    ),
+    str(_resolve_repo_path("agentmesh-integrations", "openai-agents-agentmesh")),
 )
 
 from agent_os.policies.evaluator import PolicyEvaluator
@@ -79,10 +78,7 @@ def _load_submodule(pkg_dir: str, name: str):
     return mod
 
 _OAT_DIR = (
-    _REPO_ROOT
-    / "packages"
-    / "agentmesh-integrations"
-    / "openai-agents-trust"
+    _resolve_repo_path("agentmesh-integrations", "openai-agents-trust")
     / "src"
     / "openai_agents_trust"
 )


### PR DESCRIPTION
## Description
This PR fixes a path resolution issue in `getting_started.py` that caused failures in the current repository layout.

Previously, the script assumed a legacy monorepo structure (`packages/...`) and raised a FileNotFoundError when executed in the current layout (`agent-governance-python/...`).

This change introduces a flexible path resolution mechanism that:
- Supports both the legacy `packages` layout and the current `agent-governance-python` layout
- Dynamically resolves paths at runtime instead of relying on hardcoded assumptions

As a result, `getting_started.py` now runs successfully across different repository structures.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works (not applicable – script fix)
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed (not required for this fix)
- [x] I have signed the https://cla.opensource.microsoft.com/

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

Prior art / related projects (if any):
N/A

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
Used AI assistance (ChatGPT) to help structure the PR description. All code and changes were manually implemented and reviewed.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
Fixes path resolution issue in `getting_started.py` (no tracked issue)