### PR TITLE
fix: publish Microsoft.Agents NuGet package and clarify .NET install docs

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -537,6 +537,10 @@ stages:
                 --configuration Release \
                 --no-build \
                 --output ./nupkg
+              dotnet pack src/AgentGovernance.Extensions.Microsoft.Agents/AgentGovernance.Extensions.Microsoft.Agents.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
               echo "=== Packed NuGet artifacts ==="
               ls -la ./nupkg/
             workingDirectory: 'agent-governance-dotnet'
@@ -844,4 +848,3 @@ stages:
                 echo "Tagged ${TAG} — Go module proxy will index automatically"
               fi
             displayName: 'Tag Go module for proxy indexing'
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -250,9 +250,12 @@ jobs:
         working-directory: agent-governance-dotnet
         run: dotnet test --configuration Release --no-build
 
-      - name: Pack NuGet package
+      - name: Pack NuGet packages
         working-directory: agent-governance-dotnet
-        run: dotnet pack src/AgentGovernance/AgentGovernance.csproj --configuration Release --no-build --output ./nupkg
+        run: |
+          dotnet pack src/AgentGovernance/AgentGovernance.csproj --configuration Release --no-build --output ./nupkg
+          dotnet pack src/AgentGovernance.Extensions.ModelContextProtocol/AgentGovernance.Extensions.ModelContextProtocol.csproj --configuration Release --no-build --output ./nupkg
+          dotnet pack src/AgentGovernance.Extensions.Microsoft.Agents/AgentGovernance.Extensions.Microsoft.Agents.csproj --configuration Release --no-build --output ./nupkg
 
       # ----------------------------------------------------------------
       # ESRP Signing — Authenticode sign DLLs + NuGet package signing

--- a/agent-governance-dotnet/README.md
+++ b/agent-governance-dotnet/README.md
@@ -11,6 +11,20 @@ Part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-govern
 
 ## Install
 
+Run `dotnet add package` from the directory that contains your `.csproj`. If you're in another folder, pass the project path explicitly:
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance
+```
+
+In Visual Studio Package Manager Console, use `Install-Package` and make sure the correct app is selected in the **Default project** dropdown. Typing a bare package name at the prompt fails because PowerShell treats it as a command.
+
+| Package | .NET CLI | Package Manager Console |
+|---------|----------|-------------------------|
+| Core SDK | `dotnet add package Microsoft.AgentGovernance` | `Install-Package Microsoft.AgentGovernance` |
+| MCP extension | `dotnet add package Microsoft.AgentGovernance.Extensions.ModelContextProtocol` | `Install-Package Microsoft.AgentGovernance.Extensions.ModelContextProtocol` |
+| Microsoft Agents extension | `dotnet add package Microsoft.AgentGovernance.Extensions.Microsoft.Agents` | `Install-Package Microsoft.AgentGovernance.Extensions.Microsoft.Agents` |
+
 ```bash
 dotnet add package Microsoft.AgentGovernance
 ```

--- a/agent-governance-dotnet/src/AgentGovernance.Extensions.Microsoft.Agents/README.md
+++ b/agent-governance-dotnet/src/AgentGovernance.Extensions.Microsoft.Agents/README.md
@@ -4,6 +4,22 @@ Public Preview companion package for `Microsoft.AgentGovernance` that makes it e
 
 ## Install
 
+Run `dotnet add package` from the directory that contains your `.csproj`. If you're elsewhere, pass the project path explicitly:
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance
+dotnet add YourApp.csproj package Microsoft.AgentGovernance.Extensions.Microsoft.Agents
+```
+
+In Visual Studio Package Manager Console, use:
+
+```powershell
+Install-Package Microsoft.AgentGovernance
+Install-Package Microsoft.AgentGovernance.Extensions.Microsoft.Agents
+```
+
+Make sure the correct app is selected in the **Default project** dropdown. Typing the package name by itself at the prompt fails because PowerShell treats it as a command.
+
 ```bash
 dotnet add package Microsoft.AgentGovernance
 dotnet add package Microsoft.AgentGovernance.Extensions.Microsoft.Agents

--- a/agent-governance-dotnet/src/AgentGovernance.Extensions.ModelContextProtocol/README.md
+++ b/agent-governance-dotnet/src/AgentGovernance.Extensions.ModelContextProtocol/README.md
@@ -4,6 +4,20 @@ Public Preview companion package for the official Model Context Protocol C# SDK.
 
 ## Install
 
+Run `dotnet add package` from the directory that contains your `.csproj`. If you're elsewhere, pass the project path explicitly:
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance.Extensions.ModelContextProtocol
+```
+
+In Visual Studio Package Manager Console, use:
+
+```powershell
+Install-Package Microsoft.AgentGovernance.Extensions.ModelContextProtocol
+```
+
+Make sure the correct app is selected in the **Default project** dropdown. Typing the package name by itself at the prompt fails because PowerShell treats it as a command.
+
 ```bash
 dotnet add package Microsoft.AgentGovernance.Extensions.ModelContextProtocol
 ```

--- a/docs/i18n/quickstart.ja.md
+++ b/docs/i18n/quickstart.ja.md
@@ -51,6 +51,18 @@ npm install @microsoft/agentmesh-sdk
 dotnet add package Microsoft.AgentGovernance
 ```
 
+`.csproj` を含むディレクトリ以外で実行する場合は、プロジェクト パスを明示します。
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance
+```
+
+Visual Studio の Package Manager Console では、**Default project** で対象プロジェクトを選択してから次を実行します。
+
+```powershell
+Install-Package Microsoft.AgentGovernance
+```
+
 ## 2. インストールの確認
 
 付属の検証スクリプトを実行します。
@@ -221,4 +233,3 @@ agent-governance integrity --manifest integrity.json
 ---
 
 *本クイックスタートは、 [@davidequarracino](https://github.com/davidequarracino) による初期の貢献 ([#106](https://github.com/microsoft/agent-governance-toolkit/pull/106), [#108](https://github.com/microsoft/agent-governance-toolkit/pull/108)) に基づいています。*
-

--- a/docs/i18n/quickstart.ko.md
+++ b/docs/i18n/quickstart.ko.md
@@ -51,6 +51,18 @@ npm install @microsoft/agent-governance-sdk
 dotnet add package Microsoft.AgentGovernance
 ```
 
+`.csproj` 파일이 있는 디렉터리가 아니라면 프로젝트 경로를 명시해서 실행하세요.
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance
+```
+
+Visual Studio Package Manager Console에서는 **Default project** 드롭다운에서 대상 프로젝트를 고른 뒤 다음 명령을 사용하세요.
+
+```powershell
+Install-Package Microsoft.AgentGovernance
+```
+
 ## 2. 설치 확인
 
 미리 포함된 점검 스크립트를 실행합니다.

--- a/docs/i18n/quickstart.zh-CN.md
+++ b/docs/i18n/quickstart.zh-CN.md
@@ -51,6 +51,18 @@ npm install @microsoft/agentmesh-sdk
 dotnet add package Microsoft.AgentGovernance
 ```
 
+如果你当前不在包含 `.csproj` 的目录中，请显式传入项目路径：
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance
+```
+
+在 Visual Studio 的 Package Manager Console 中，请先在 **Default project** 下拉框中选中目标项目，再运行：
+
+```powershell
+Install-Package Microsoft.AgentGovernance
+```
+
 ## 2. 验证安装
 
 运行内置的验证脚本：
@@ -152,4 +164,3 @@ agent-governance verify --badge
 ---
 
 *基于 [@davidequarracino](https://github.com/davidequarracino) 的初始快速入门贡献。*
-

--- a/docs/packages/dotnet-sdk.md
+++ b/docs/packages/dotnet-sdk.md
@@ -11,6 +11,20 @@ Part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-govern
 
 ## Install
 
+Run `dotnet add package` from the directory that contains your `.csproj`. If you're in another folder, pass the project path explicitly:
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance
+```
+
+In Visual Studio Package Manager Console, use `Install-Package` and make sure the correct app is selected in the **Default project** dropdown. Typing a bare package name at the prompt fails because PowerShell treats it as a command.
+
+| Package | .NET CLI | Package Manager Console |
+|---------|----------|-------------------------|
+| Core SDK | `dotnet add package Microsoft.AgentGovernance` | `Install-Package Microsoft.AgentGovernance` |
+| MCP extension | `dotnet add package Microsoft.AgentGovernance.Extensions.ModelContextProtocol` | `Install-Package Microsoft.AgentGovernance.Extensions.ModelContextProtocol` |
+| Microsoft Agents extension | `dotnet add package Microsoft.AgentGovernance.Extensions.Microsoft.Agents` | `Install-Package Microsoft.AgentGovernance.Extensions.Microsoft.Agents` |
+
 ```bash
 dotnet add package Microsoft.AgentGovernance
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -51,6 +51,18 @@ npm install @microsoft/agent-governance-sdk
 dotnet add package Microsoft.AgentGovernance
 ```
 
+If you are not in the directory that contains your `.csproj`, use:
+
+```bash
+dotnet add YourApp.csproj package Microsoft.AgentGovernance
+```
+
+From Visual Studio Package Manager Console, use:
+
+```powershell
+Install-Package Microsoft.AgentGovernance
+```
+
 ## 2. Verify Your Installation
 
 Run the included verification script:
@@ -341,4 +353,3 @@ agt integrity --manifest integrity.json
 ---
 
 *Based on the initial quickstart contribution by [@davidequarracino](https://github.com/davidequarracino) ([#106](https://github.com/microsoft/agent-governance-toolkit/pull/106), [#108](https://github.com/microsoft/agent-governance-toolkit/pull/108)).*
-


### PR DESCRIPTION
## Description
- add `Microsoft.AgentGovernance.Extensions.Microsoft.Agents` to the NuGet pack/publish flows so the package is actually produced alongside the core .NET SDK and MCP extension
- align the .NET install docs and package READMEs with the supported install paths: `dotnet add package`, explicit-project `dotnet add <YourApp>.csproj package ...`, and Visual Studio Package Manager Console `Install-Package`
- document why typing a bare package name in Package Manager Console fails so issue #1706 is addressed end-to-end

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [x] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
- Related issue: #1706
- Related docs-only PR: #1759

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
- GitHub Copilot CLI for investigation, patching, and local package-pack verification; all output reviewed.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
Fixes #1706