### PR TITLE
feat: multi-agent collective policy evaluator

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/multi_agent_policy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/multi_agent_policy.py
@@ -1,0 +1,470 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Multi-Agent Policy Evaluator.
+
+A separate evaluation pass that watches all agents collectively, evaluating
+policies that span multiple agents. This runs at the AgentMesh router level,
+not inside individual agent pipelines.
+
+Design decisions:
+    - Separate evaluation pass from per-agent PolicyEngine (does not extend it).
+    - Evaluates collective constraints (aggregate behavior across all agents).
+    - Relationship constraints tracked on roadmap (not implemented here).
+    - Uses a sliding window for time-based aggregate conditions.
+    - Non-invasive: agents don't report to this evaluator. It observes
+      action records pushed by the governance pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class MultiAgentPolicyScope(str, Enum):
+    """Scope of a multi-agent policy."""
+
+    MULTI_AGENT = "multi-agent"
+    # AGENT_PAIR = "agent-pair"  # Roadmap: relationship constraints
+
+
+class AggregateFunction(str, Enum):
+    """Aggregate functions for collective constraints."""
+
+    COUNT = "count"
+    SUM = "sum"
+    MAX = "max"
+    DISTINCT_AGENTS = "distinct_agents"
+
+
+class MultiAgentAction(str, Enum):
+    """Actions taken when a multi-agent policy is violated."""
+
+    DENY = "deny"
+    ALERT = "alert"
+    THROTTLE = "throttle"
+
+
+# ---------------------------------------------------------------------------
+# Data Models
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ActionRecord:
+    """A record of an agent action observed by the multi-agent evaluator.
+
+    These are pushed by the governance pipeline after each action.
+    """
+
+    agent_id: str
+    action: str
+    tool_name: str = ""
+    params: dict[str, Any] | None = None
+    timestamp: float = field(default_factory=time.monotonic)
+    wall_time: datetime = field(default_factory=lambda: datetime.now(UTC))
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CollectiveCondition:
+    """A condition evaluated across all agents in a time window.
+
+    Attributes:
+        aggregate: The aggregate function to apply.
+        filter_action: If set, only count actions matching this name.
+        filter_tool: If set, only count actions using this tool.
+        across: Which agents to aggregate across ("all_agents" or a pattern).
+        window_seconds: Sliding window size in seconds.
+        threshold: The value that triggers the condition.
+    """
+
+    aggregate: AggregateFunction
+    filter_action: str | None = None
+    filter_tool: str | None = None
+    across: str = "all_agents"
+    window_seconds: float = 60.0
+    threshold: float = 1.0
+
+
+@dataclass
+class MultiAgentPolicy:
+    """A policy that evaluates collective agent behavior.
+
+    Example YAML representation:
+        name: no-parallel-financial-ops
+        scope: multi-agent
+        condition:
+          aggregate: count
+          filter_tool: transfer_funds
+          across: all_agents
+          window_seconds: 60
+          threshold: 3
+        action: deny
+    """
+
+    name: str
+    scope: MultiAgentPolicyScope = MultiAgentPolicyScope.MULTI_AGENT
+    condition: CollectiveCondition = field(default_factory=CollectiveCondition)
+    action: MultiAgentAction = MultiAgentAction.DENY
+    description: str = ""
+    enabled: bool = True
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> MultiAgentPolicy:
+        cond_data = d.get("condition", {})
+        condition = CollectiveCondition(
+            aggregate=AggregateFunction(cond_data.get("aggregate", "count")),
+            filter_action=cond_data.get("filter_action"),
+            filter_tool=cond_data.get("filter_tool"),
+            across=cond_data.get("across", "all_agents"),
+            window_seconds=float(cond_data.get("window_seconds", cond_data.get("window", 60))),
+            threshold=float(cond_data.get("threshold", 1)),
+        )
+        return cls(
+            name=d["name"],
+            scope=MultiAgentPolicyScope(d.get("scope", "multi-agent")),
+            condition=condition,
+            action=MultiAgentAction(d.get("action", "deny")),
+            description=d.get("description", ""),
+            enabled=d.get("enabled", True),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "scope": self.scope.value,
+            "condition": {
+                "aggregate": self.condition.aggregate.value,
+                "filter_action": self.condition.filter_action,
+                "filter_tool": self.condition.filter_tool,
+                "across": self.condition.across,
+                "window_seconds": self.condition.window_seconds,
+                "threshold": self.condition.threshold,
+            },
+            "action": self.action.value,
+            "description": self.description,
+            "enabled": self.enabled,
+        }
+
+
+@dataclass
+class MultiAgentDecision:
+    """Result of evaluating a multi-agent policy."""
+
+    policy_name: str
+    allowed: bool
+    action: MultiAgentAction
+    current_value: float
+    threshold: float
+    reason: str = ""
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "policy_name": self.policy_name,
+            "allowed": self.allowed,
+            "action": self.action.value,
+            "current_value": self.current_value,
+            "threshold": self.threshold,
+            "reason": self.reason,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+@dataclass
+class MultiAgentEvaluationResult:
+    """Aggregate result of evaluating all multi-agent policies."""
+
+    allowed: bool
+    decisions: list[MultiAgentDecision] = field(default_factory=list)
+    violated_policies: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "decisions": [d.to_dict() for d in self.decisions],
+            "violated_policies": self.violated_policies,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Multi-Agent Policy Evaluator
+# ---------------------------------------------------------------------------
+
+class MultiAgentPolicyEvaluator:
+    """Evaluates collective agent behavior against multi-agent policies.
+
+    This is a separate evaluation pass that runs at a higher level than
+    per-agent policy evaluation. It maintains a sliding window of recent
+    action records and evaluates aggregate conditions across all agents.
+
+    Usage:
+        >>> evaluator = MultiAgentPolicyEvaluator()
+        >>> evaluator.add_policy(MultiAgentPolicy(
+        ...     name="rate-limit-transfers",
+        ...     condition=CollectiveCondition(
+        ...         aggregate=AggregateFunction.COUNT,
+        ...         filter_tool="transfer_funds",
+        ...         window_seconds=60,
+        ...         threshold=3,
+        ...     ),
+        ...     action=MultiAgentAction.DENY,
+        ... ))
+        >>> evaluator.record_action(ActionRecord(
+        ...     agent_id="agent-1", action="transfer", tool_name="transfer_funds"
+        ... ))
+        >>> result = evaluator.evaluate("agent-2", "transfer", "transfer_funds")
+        >>> print(result.allowed)
+    """
+
+    def __init__(self, max_history: int = 10000) -> None:
+        """Initialize the evaluator.
+
+        Args:
+            max_history: Maximum number of action records to retain.
+                Older records are evicted when this limit is reached.
+        """
+        self._policies: dict[str, MultiAgentPolicy] = {}
+        self._action_history: list[ActionRecord] = []
+        self._max_history = max_history
+
+    # ----- Policy management -----
+
+    def add_policy(self, policy: MultiAgentPolicy) -> None:
+        """Add or update a multi-agent policy."""
+        self._policies[policy.name] = policy
+
+    def remove_policy(self, name: str) -> bool:
+        """Remove a policy by name. Returns True if found."""
+        return self._policies.pop(name, None) is not None
+
+    def list_policies(self) -> list[MultiAgentPolicy]:
+        """List all registered policies."""
+        return list(self._policies.values())
+
+    def load_policies_from_dicts(self, policies: list[dict[str, Any]]) -> int:
+        """Load multiple policies from dictionary representations.
+
+        Returns the number of policies loaded.
+        """
+        count = 0
+        for p in policies:
+            try:
+                policy = MultiAgentPolicy.from_dict(p)
+                self.add_policy(policy)
+                count += 1
+            except (KeyError, ValueError) as e:
+                logger.warning("Failed to load policy: %s", e)
+        return count
+
+    # ----- Action recording -----
+
+    def record_action(self, record: ActionRecord) -> None:
+        """Record an agent action for collective evaluation.
+
+        This should be called by the governance pipeline after each action.
+        """
+        self._action_history.append(record)
+        # Evict oldest records if over limit
+        if len(self._action_history) > self._max_history:
+            self._action_history = self._action_history[-self._max_history:]
+
+    # ----- Evaluation -----
+
+    def evaluate(
+        self,
+        agent_id: str,
+        action: str,
+        tool_name: str = "",
+        params: dict[str, Any] | None = None,
+    ) -> MultiAgentEvaluationResult:
+        """Evaluate all multi-agent policies for a proposed action.
+
+        This is the main entry point, called before an action is executed
+        to check whether collective constraints would be violated.
+
+        Args:
+            agent_id: The agent proposing the action.
+            action: The action being attempted.
+            tool_name: The tool being invoked (if applicable).
+            params: Action parameters.
+
+        Returns:
+            MultiAgentEvaluationResult with allow/deny and per-policy decisions.
+        """
+        now = time.monotonic()
+        decisions: list[MultiAgentDecision] = []
+        violated: list[str] = []
+        overall_allowed = True
+
+        for policy in self._policies.values():
+            if not policy.enabled:
+                continue
+
+            decision = self._evaluate_policy(policy, agent_id, action, tool_name, now)
+            decisions.append(decision)
+
+            if not decision.allowed:
+                violated.append(policy.name)
+                if policy.action == MultiAgentAction.DENY:
+                    overall_allowed = False
+
+        return MultiAgentEvaluationResult(
+            allowed=overall_allowed,
+            decisions=decisions,
+            violated_policies=violated,
+        )
+
+    def _evaluate_policy(
+        self,
+        policy: MultiAgentPolicy,
+        agent_id: str,
+        action: str,
+        tool_name: str,
+        now: float,
+    ) -> MultiAgentDecision:
+        """Evaluate a single multi-agent policy."""
+        cond = policy.condition
+        cutoff = now - cond.window_seconds
+
+        # Filter action history to the window
+        window_records = [
+            r for r in self._action_history
+            if r.timestamp >= cutoff
+        ]
+
+        # Apply filters
+        filtered = self._apply_filters(window_records, cond)
+
+        # Compute aggregate
+        value = self._compute_aggregate(filtered, cond.aggregate)
+
+        # Check if adding the proposed action would exceed threshold
+        # (count the proposed action as +1 if it matches the filter)
+        proposed_matches = self._matches_filter(
+            action, tool_name, cond
+        )
+        projected_value = value + (1.0 if proposed_matches and cond.aggregate == AggregateFunction.COUNT else 0.0)
+
+        if cond.aggregate == AggregateFunction.DISTINCT_AGENTS and proposed_matches:
+            existing_agents = {r.agent_id for r in filtered}
+            if agent_id not in existing_agents:
+                projected_value = value + 1.0
+            else:
+                projected_value = value
+
+        violated = projected_value >= cond.threshold
+
+        return MultiAgentDecision(
+            policy_name=policy.name,
+            allowed=not violated,
+            action=policy.action,
+            current_value=projected_value,
+            threshold=cond.threshold,
+            reason=(
+                f"Collective constraint '{policy.name}' violated: "
+                f"{cond.aggregate.value}={projected_value} >= threshold={cond.threshold} "
+                f"in {cond.window_seconds}s window"
+                if violated else ""
+            ),
+        )
+
+    def _apply_filters(
+        self,
+        records: list[ActionRecord],
+        condition: CollectiveCondition,
+    ) -> list[ActionRecord]:
+        """Filter records based on condition criteria."""
+        result = records
+        if condition.filter_action:
+            result = [r for r in result if r.action == condition.filter_action]
+        if condition.filter_tool:
+            result = [r for r in result if r.tool_name == condition.filter_tool]
+        return result
+
+    def _matches_filter(
+        self,
+        action: str,
+        tool_name: str,
+        condition: CollectiveCondition,
+    ) -> bool:
+        """Check if a proposed action matches the condition filters."""
+        if condition.filter_action and condition.filter_action != action:
+            return False
+        if condition.filter_tool and condition.filter_tool != tool_name:
+            return False
+        return True
+
+    def _compute_aggregate(
+        self,
+        records: list[ActionRecord],
+        aggregate: AggregateFunction,
+    ) -> float:
+        """Compute an aggregate value over filtered records."""
+        if aggregate == AggregateFunction.COUNT:
+            return float(len(records))
+        elif aggregate == AggregateFunction.DISTINCT_AGENTS:
+            return float(len({r.agent_id for r in records}))
+        elif aggregate == AggregateFunction.SUM:
+            return sum(
+                r.metadata.get("cost", 0.0) for r in records
+            )
+        elif aggregate == AggregateFunction.MAX:
+            if not records:
+                return 0.0
+            return max(
+                r.metadata.get("value", 0.0) for r in records
+            )
+        return 0.0
+
+    # ----- Utilities -----
+
+    def get_window_stats(self, window_seconds: float = 60.0) -> dict[str, Any]:
+        """Get statistics about recent agent activity.
+
+        Useful for monitoring and dashboards.
+        """
+        now = time.monotonic()
+        cutoff = now - window_seconds
+        window = [r for r in self._action_history if r.timestamp >= cutoff]
+
+        agents = {r.agent_id for r in window}
+        actions = {}
+        tools = {}
+        for r in window:
+            actions[r.action] = actions.get(r.action, 0) + 1
+            if r.tool_name:
+                tools[r.tool_name] = tools.get(r.tool_name, 0) + 1
+
+        return {
+            "window_seconds": window_seconds,
+            "total_actions": len(window),
+            "unique_agents": len(agents),
+            "agent_ids": sorted(agents),
+            "action_counts": actions,
+            "tool_counts": tools,
+        }
+
+    def clear_history(self) -> None:
+        """Clear all action history."""
+        self._action_history.clear()
+
+    @property
+    def action_count(self) -> int:
+        """Total number of recorded actions."""
+        return len(self._action_history)
+
+    @property
+    def policy_count(self) -> int:
+        """Total number of registered policies."""
+        return len(self._policies)

--- a/agent-governance-python/agent-mesh/tests/test_multi_agent_policy.py
+++ b/agent-governance-python/agent-mesh/tests/test_multi_agent_policy.py
@@ -1,0 +1,352 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for Multi-Agent Policy Evaluator."""
+
+import time
+
+import pytest
+
+from agentmesh.governance.multi_agent_policy import (
+    ActionRecord,
+    AggregateFunction,
+    CollectiveCondition,
+    MultiAgentAction,
+    MultiAgentPolicy,
+    MultiAgentPolicyEvaluator,
+    MultiAgentPolicyScope,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def evaluator():
+    return MultiAgentPolicyEvaluator()
+
+
+@pytest.fixture
+def rate_limit_policy():
+    return MultiAgentPolicy(
+        name="rate-limit-transfers",
+        condition=CollectiveCondition(
+            aggregate=AggregateFunction.COUNT,
+            filter_tool="transfer_funds",
+            window_seconds=60.0,
+            threshold=3.0,
+        ),
+        action=MultiAgentAction.DENY,
+    )
+
+
+@pytest.fixture
+def distinct_agents_policy():
+    return MultiAgentPolicy(
+        name="max-concurrent-agents",
+        condition=CollectiveCondition(
+            aggregate=AggregateFunction.DISTINCT_AGENTS,
+            filter_action="database_write",
+            window_seconds=30.0,
+            threshold=2.0,
+        ),
+        action=MultiAgentAction.DENY,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Policy Model Tests
+# ---------------------------------------------------------------------------
+
+class TestMultiAgentPolicy:
+    def test_from_dict(self):
+        d = {
+            "name": "test-policy",
+            "scope": "multi-agent",
+            "condition": {
+                "aggregate": "count",
+                "filter_tool": "send_email",
+                "window_seconds": 120,
+                "threshold": 5,
+            },
+            "action": "deny",
+        }
+        policy = MultiAgentPolicy.from_dict(d)
+        assert policy.name == "test-policy"
+        assert policy.condition.aggregate == AggregateFunction.COUNT
+        assert policy.condition.filter_tool == "send_email"
+        assert policy.condition.window_seconds == 120.0
+        assert policy.condition.threshold == 5.0
+        assert policy.action == MultiAgentAction.DENY
+
+    def test_to_dict_roundtrip(self):
+        policy = MultiAgentPolicy(
+            name="roundtrip",
+            condition=CollectiveCondition(
+                aggregate=AggregateFunction.DISTINCT_AGENTS,
+                filter_action="write",
+                threshold=10,
+            ),
+            action=MultiAgentAction.ALERT,
+        )
+        d = policy.to_dict()
+        restored = MultiAgentPolicy.from_dict(d)
+        assert restored.name == policy.name
+        assert restored.condition.aggregate == policy.condition.aggregate
+        assert restored.action == policy.action
+
+    def test_from_dict_with_window_shorthand(self):
+        """Support 'window' as alias for 'window_seconds'."""
+        d = {
+            "name": "shorthand",
+            "condition": {"aggregate": "count", "window": 90, "threshold": 5},
+        }
+        policy = MultiAgentPolicy.from_dict(d)
+        assert policy.condition.window_seconds == 90.0
+
+
+# ---------------------------------------------------------------------------
+# Evaluator Basic Tests
+# ---------------------------------------------------------------------------
+
+class TestEvaluatorBasics:
+    def test_add_and_list_policies(self, evaluator, rate_limit_policy):
+        evaluator.add_policy(rate_limit_policy)
+        assert evaluator.policy_count == 1
+        assert evaluator.list_policies()[0].name == "rate-limit-transfers"
+
+    def test_remove_policy(self, evaluator, rate_limit_policy):
+        evaluator.add_policy(rate_limit_policy)
+        assert evaluator.remove_policy("rate-limit-transfers")
+        assert evaluator.policy_count == 0
+
+    def test_remove_nonexistent(self, evaluator):
+        assert not evaluator.remove_policy("nope")
+
+    def test_load_policies_from_dicts(self, evaluator):
+        policies = [
+            {"name": "p1", "condition": {"aggregate": "count", "threshold": 5}},
+            {"name": "p2", "condition": {"aggregate": "count", "threshold": 10}},
+        ]
+        count = evaluator.load_policies_from_dicts(policies)
+        assert count == 2
+        assert evaluator.policy_count == 2
+
+    def test_no_policies_allows_everything(self, evaluator):
+        result = evaluator.evaluate("agent-1", "any_action")
+        assert result.allowed
+        assert len(result.decisions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Collective Constraint Tests
+# ---------------------------------------------------------------------------
+
+class TestCollectiveConstraints:
+    def test_count_under_threshold_allows(self, evaluator, rate_limit_policy):
+        evaluator.add_policy(rate_limit_policy)
+
+        # Record 1 transfer
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-1", action="transfer", tool_name="transfer_funds",
+        ))
+
+        result = evaluator.evaluate("agent-2", "transfer", "transfer_funds")
+        assert result.allowed
+
+    def test_count_at_threshold_denies(self, evaluator, rate_limit_policy):
+        evaluator.add_policy(rate_limit_policy)
+
+        # Record 2 transfers, the proposed 3rd would hit threshold of 3
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-1", action="transfer", tool_name="transfer_funds",
+        ))
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-2", action="transfer", tool_name="transfer_funds",
+        ))
+
+        result = evaluator.evaluate("agent-3", "transfer", "transfer_funds")
+        assert not result.allowed
+        assert "rate-limit-transfers" in result.violated_policies
+
+    def test_different_tool_not_counted(self, evaluator, rate_limit_policy):
+        evaluator.add_policy(rate_limit_policy)
+
+        # Record 5 actions with different tool
+        for i in range(5):
+            evaluator.record_action(ActionRecord(
+                agent_id=f"agent-{i}", action="query", tool_name="database_read",
+            ))
+
+        result = evaluator.evaluate("agent-6", "transfer", "transfer_funds")
+        assert result.allowed
+
+    def test_distinct_agents_under_threshold(self, evaluator, distinct_agents_policy):
+        evaluator.add_policy(distinct_agents_policy)
+
+        # Same agent writing multiple times
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-1", action="database_write", tool_name="db",
+        ))
+
+        # New agent would make 2 distinct agents, which hits threshold of 2
+        result = evaluator.evaluate("agent-2", "database_write", "db")
+        assert not result.allowed
+
+    def test_distinct_agents_same_agent_ok(self, evaluator, distinct_agents_policy):
+        evaluator.add_policy(distinct_agents_policy)
+
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-1", action="database_write", tool_name="db",
+        ))
+
+        # Same agent again, still 1 distinct agent
+        result = evaluator.evaluate("agent-1", "database_write", "db")
+        assert result.allowed
+
+    def test_disabled_policy_skipped(self, evaluator):
+        policy = MultiAgentPolicy(
+            name="disabled",
+            condition=CollectiveCondition(
+                aggregate=AggregateFunction.COUNT,
+                threshold=0,  # Would always trigger
+            ),
+            enabled=False,
+        )
+        evaluator.add_policy(policy)
+        result = evaluator.evaluate("agent-1", "anything")
+        assert result.allowed
+
+    def test_alert_policy_does_not_block(self, evaluator):
+        policy = MultiAgentPolicy(
+            name="alert-only",
+            condition=CollectiveCondition(
+                aggregate=AggregateFunction.COUNT,
+                threshold=1,
+            ),
+            action=MultiAgentAction.ALERT,
+        )
+        evaluator.add_policy(policy)
+
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-1", action="something",
+        ))
+
+        result = evaluator.evaluate("agent-2", "something")
+        # Alert policy violates but does not block
+        assert result.allowed
+        assert "alert-only" in result.violated_policies
+
+    def test_multiple_policies_all_must_pass(self, evaluator):
+        evaluator.add_policy(MultiAgentPolicy(
+            name="p1",
+            condition=CollectiveCondition(
+                aggregate=AggregateFunction.COUNT,
+                filter_tool="tool_a",
+                threshold=100,  # Very high, won't trigger
+            ),
+            action=MultiAgentAction.DENY,
+        ))
+        evaluator.add_policy(MultiAgentPolicy(
+            name="p2",
+            condition=CollectiveCondition(
+                aggregate=AggregateFunction.COUNT,
+                filter_tool="tool_a",
+                threshold=1,  # Will trigger immediately
+            ),
+            action=MultiAgentAction.DENY,
+        ))
+
+        result = evaluator.evaluate("agent-1", "x", "tool_a")
+        assert not result.allowed
+        assert "p2" in result.violated_policies
+        assert "p1" not in result.violated_policies
+
+
+# ---------------------------------------------------------------------------
+# Window Tests
+# ---------------------------------------------------------------------------
+
+class TestWindowBehavior:
+    def test_old_records_outside_window(self, evaluator):
+        policy = MultiAgentPolicy(
+            name="short-window",
+            condition=CollectiveCondition(
+                aggregate=AggregateFunction.COUNT,
+                threshold=2,
+                window_seconds=0.1,  # 100ms window
+            ),
+            action=MultiAgentAction.DENY,
+        )
+        evaluator.add_policy(policy)
+
+        # Record an action
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-1", action="x",
+        ))
+
+        # Wait for window to expire
+        time.sleep(0.15)
+
+        # Old record should be outside window
+        result = evaluator.evaluate("agent-2", "x")
+        assert result.allowed
+
+
+# ---------------------------------------------------------------------------
+# Stats Tests
+# ---------------------------------------------------------------------------
+
+class TestStats:
+    def test_window_stats(self, evaluator):
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-1", action="read", tool_name="db",
+        ))
+        evaluator.record_action(ActionRecord(
+            agent_id="agent-2", action="write", tool_name="db",
+        ))
+
+        stats = evaluator.get_window_stats(window_seconds=60.0)
+        assert stats["total_actions"] == 2
+        assert stats["unique_agents"] == 2
+        assert "agent-1" in stats["agent_ids"]
+
+    def test_clear_history(self, evaluator):
+        evaluator.record_action(ActionRecord(agent_id="a", action="x"))
+        assert evaluator.action_count == 1
+        evaluator.clear_history()
+        assert evaluator.action_count == 0
+
+
+# ---------------------------------------------------------------------------
+# History Eviction Tests
+# ---------------------------------------------------------------------------
+
+class TestHistoryEviction:
+    def test_max_history_evicts_old(self):
+        evaluator = MultiAgentPolicyEvaluator(max_history=5)
+        for i in range(10):
+            evaluator.record_action(ActionRecord(
+                agent_id=f"a-{i}", action="x",
+            ))
+        assert evaluator.action_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Decision Model Tests
+# ---------------------------------------------------------------------------
+
+class TestDecisionModel:
+    def test_decision_to_dict(self, evaluator, rate_limit_policy):
+        evaluator.add_policy(rate_limit_policy)
+        for i in range(3):
+            evaluator.record_action(ActionRecord(
+                agent_id=f"a-{i}", action="transfer", tool_name="transfer_funds",
+            ))
+
+        result = evaluator.evaluate("a-4", "transfer", "transfer_funds")
+        d = result.to_dict()
+        assert "allowed" in d
+        assert "decisions" in d
+        assert len(d["decisions"]) == 1
+        assert d["decisions"][0]["policy_name"] == "rate-limit-transfers"


### PR DESCRIPTION
## Summary

Adds MultiAgentPolicyEvaluator for cross-agent governance that watches collective behavior across all agents in a mesh, implementing a separate evaluation pass as designed in ADR discussions.

## Key Design Decisions (from architecture review)

- **Collective constraints first** (relationship constraints on roadmap)
- **AgentMesh router evaluates** inter-agent policies
- **Separate evaluation pass** watching all agents together at a higher level

## Features

- Aggregate functions: COUNT, SUM, MAX, DISTINCT_AGENTS
- Sliding time windows for temporal scoping
- Policy actions: DENY (block), ALERT (notify only), THROTTLE (future)
- Tool and action filters for targeted policies
- History eviction with configurable max size
- Full serialization (from_dict/to_dict) for policy loading from config

## Testing

21 tests covering:
- Collective constraint evaluation (all aggregate types)
- Sliding window behavior (records outside window excluded)
- Policy DENY vs ALERT actions
- Multiple policies evaluated together
- Action recording, stats, and history management
- Serialization roundtrip
- Edge cases: empty history, disabled policies, no matching filters