### PR TITLE
feat: Citadel integration - docs, exporter, policy binding, example

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/exporters/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/exporters/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AGT Audit Exporters
+
+Export governance events to external observability systems.
+"""
+
+from __future__ import annotations
+
+from agent_os.exporters.citadel_exporter import CitadelAuditExporter
+
+__all__ = ["CitadelAuditExporter"]

--- a/agent-governance-python/agent-os/src/agent_os/exporters/citadel_exporter.py
+++ b/agent-governance-python/agent-os/src/agent_os/exporters/citadel_exporter.py
@@ -1,0 +1,440 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Citadel Audit Exporter
+
+Exports AGT governance events to Azure Event Hub and Application Insights,
+enabling Citadel's observability pipeline to include agent-level governance data.
+
+Events include correlation IDs linking AGT decisions to APIM request traces
+and Foundry execution traces, enabling unified observability dashboards.
+
+Usage:
+    from agent_os.exporters import CitadelAuditExporter
+
+    exporter = CitadelAuditExporter.from_env()
+    exporter.export_event(event)
+    await exporter.flush()
+    await exporter.close()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class GovernanceEventType(str, Enum):
+    """Types of governance events exported to Citadel."""
+
+    POLICY_DECISION = "policy_decision"
+    POLICY_VIOLATION = "policy_violation"
+    TRUST_SCORE_CHANGE = "trust_score_change"
+    ACTION_INTERCEPTED = "action_intercepted"
+    BUNDLE_LOADED = "bundle_loaded"
+
+
+class Decision(str, Enum):
+    """Outcome of a policy evaluation."""
+
+    ALLOW = "allow"
+    DENY = "deny"
+    FLAG = "flag"
+
+
+@dataclass
+class CorrelationContext:
+    """Correlation IDs tying together traces across systems.
+
+    Attributes:
+        apim_request_id: The APIM gateway request ID (from x-ms-request-id header).
+        foundry_trace_id: The Foundry Control Plane trace ID (OpenTelemetry).
+        agt_decision_id: The AGT policy decision ID.
+        session_id: Optional agent session/conversation ID.
+    """
+
+    apim_request_id: str = ""
+    foundry_trace_id: str = ""
+    agt_decision_id: str = ""
+    session_id: str = ""
+
+
+@dataclass
+class GovernanceEvent:
+    """A governance event to be exported to Citadel's observability pipeline.
+
+    Attributes:
+        event_type: Category of governance event.
+        timestamp: ISO 8601 timestamp.
+        agent_id: The governed agent's identifier.
+        action: The action being evaluated.
+        decision: Allow/deny/flag outcome.
+        policy_name: Which policy was evaluated.
+        policy_bundle_id: The policy bundle version.
+        trust_score: Current trust score (0-1000).
+        correlation: Cross-system correlation IDs.
+        hash_chain_prev: Previous hash in the tamper-evidence chain.
+        hash_chain_current: Current hash after this event.
+        detail: Human-readable explanation of the decision.
+        metadata: Additional context.
+    """
+
+    event_type: GovernanceEventType
+    agent_id: str
+    action: str
+    decision: Decision
+    policy_name: str = ""
+    policy_bundle_id: str = ""
+    trust_score: int = 0
+    correlation: CorrelationContext = field(default_factory=CorrelationContext)
+    hash_chain_prev: str = ""
+    hash_chain_current: str = ""
+    detail: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    timestamp: str = field(
+        default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime())
+    )
+    event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dictionary for export."""
+        data = asdict(self)
+        data["event_type"] = self.event_type.value
+        data["decision"] = self.decision.value
+        return data
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict(), default=str)
+
+
+class CitadelAuditExporter:
+    """Exports AGT governance events to Azure Event Hub and Application Insights.
+
+    Supports batching, async flush, and graceful degradation when Azure
+    services are unavailable. Events are queued locally and retried on
+    reconnection (fail-open for telemetry).
+
+    Usage:
+        exporter = CitadelAuditExporter.from_env()
+        exporter.export_event(event)
+        await exporter.flush()
+        await exporter.close()
+    """
+
+    def __init__(
+        self,
+        eventhub_connection_string: str = "",
+        appinsights_connection_string: str = "",
+        batch_size: int = 50,
+        flush_interval_seconds: int = 10,
+        eventhub_name: str = "agt-governance-events",
+    ) -> None:
+        """Initialize the exporter.
+
+        Args:
+            eventhub_connection_string: Azure Event Hub connection string.
+            appinsights_connection_string: Application Insights connection string.
+            batch_size: Number of events to batch before auto-flushing.
+            flush_interval_seconds: Maximum seconds between flushes.
+            eventhub_name: Event Hub name for governance events.
+        """
+        self._eventhub_conn = eventhub_connection_string
+        self._appinsights_conn = appinsights_connection_string
+        self._batch_size = batch_size
+        self._flush_interval = flush_interval_seconds
+        self._eventhub_name = eventhub_name
+
+        self._buffer: list[GovernanceEvent] = []
+        self._failed_buffer: list[GovernanceEvent] = []
+        self._last_flush: float = time.time()
+        self._total_exported: int = 0
+        self._total_failed: int = 0
+
+        # Lazy-initialized clients
+        self._eventhub_producer: Any = None
+        self._appinsights_logger: Any = None
+
+    @classmethod
+    def from_env(cls) -> CitadelAuditExporter:
+        """Create an exporter from environment variables.
+
+        Environment variables:
+            CITADEL_EVENTHUB_CONNECTION_STRING: Event Hub connection string.
+            CITADEL_APPINSIGHTS_CONNECTION_STRING: App Insights connection string.
+            CITADEL_EVENTHUB_NAME: Event Hub name (default: agt-governance-events).
+            CITADEL_EXPORT_BATCH_SIZE: Batch size (default: 50).
+            CITADEL_EXPORT_FLUSH_INTERVAL: Flush interval in seconds (default: 10).
+        """
+        return cls(
+            eventhub_connection_string=os.environ.get(
+                "CITADEL_EVENTHUB_CONNECTION_STRING", ""
+            ),
+            appinsights_connection_string=os.environ.get(
+                "CITADEL_APPINSIGHTS_CONNECTION_STRING", ""
+            ),
+            eventhub_name=os.environ.get(
+                "CITADEL_EVENTHUB_NAME", "agt-governance-events"
+            ),
+            batch_size=int(os.environ.get("CITADEL_EXPORT_BATCH_SIZE", "50")),
+            flush_interval_seconds=int(
+                os.environ.get("CITADEL_EXPORT_FLUSH_INTERVAL", "10")
+            ),
+        )
+
+    @property
+    def has_eventhub(self) -> bool:
+        """Whether Event Hub export is configured."""
+        return bool(self._eventhub_conn)
+
+    @property
+    def has_appinsights(self) -> bool:
+        """Whether Application Insights export is configured."""
+        return bool(self._appinsights_conn)
+
+    @property
+    def stats(self) -> dict[str, int]:
+        """Export statistics."""
+        return {
+            "buffered": len(self._buffer),
+            "failed_pending_retry": len(self._failed_buffer),
+            "total_exported": self._total_exported,
+            "total_failed": self._total_failed,
+        }
+
+    def export_event(self, event: GovernanceEvent) -> None:
+        """Add a governance event to the export buffer.
+
+        Events are batched and flushed periodically or when the buffer
+        reaches batch_size. Call flush() to force immediate export.
+
+        Args:
+            event: The governance event to export.
+        """
+        self._buffer.append(event)
+        logger.debug(
+            "Buffered event: %s %s -> %s (buffer: %d/%d)",
+            event.event_type.value,
+            event.action,
+            event.decision.value,
+            len(self._buffer),
+            self._batch_size,
+        )
+
+        # Auto-flush if buffer is full
+        if len(self._buffer) >= self._batch_size:
+            # Schedule async flush if running in event loop, else log warning
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self.flush())
+            except RuntimeError:
+                logger.debug(
+                    "Buffer full (%d events), call flush() to export",
+                    len(self._buffer),
+                )
+
+    async def flush(self) -> int:
+        """Flush buffered events to configured destinations.
+
+        Returns:
+            Number of events successfully exported.
+        """
+        if not self._buffer and not self._failed_buffer:
+            return 0
+
+        # Combine current buffer with any previously failed events
+        events_to_send = self._failed_buffer + self._buffer
+        self._buffer = []
+        self._failed_buffer = []
+        self._last_flush = time.time()
+
+        exported = 0
+        failed: list[GovernanceEvent] = []
+
+        # Export to Event Hub
+        if self.has_eventhub:
+            success, failures = await self._send_to_eventhub(events_to_send)
+            exported += success
+            failed.extend(failures)
+        else:
+            # Log locally as fallback
+            for event in events_to_send:
+                logger.info(
+                    "Governance event (local): %s agent=%s action=%s decision=%s",
+                    event.event_type.value,
+                    event.agent_id,
+                    event.action,
+                    event.decision.value,
+                )
+                exported += 1
+
+        # Export to Application Insights (independent of Event Hub)
+        if self.has_appinsights:
+            await self._send_to_appinsights(events_to_send)
+
+        # Track failures for retry
+        self._failed_buffer = failed
+        self._total_exported += exported
+        self._total_failed += len(failed)
+
+        if exported > 0:
+            logger.info("Flushed %d governance events to Citadel", exported)
+        if failed:
+            logger.warning(
+                "%d events failed to export, queued for retry", len(failed)
+            )
+
+        return exported
+
+    async def _send_to_eventhub(
+        self, events: list[GovernanceEvent]
+    ) -> tuple[int, list[GovernanceEvent]]:
+        """Send events to Azure Event Hub.
+
+        Returns:
+            Tuple of (success_count, failed_events).
+        """
+        try:
+            from azure.eventhub import EventData
+            from azure.eventhub.aio import EventHubProducerClient
+        except ImportError:
+            logger.warning(
+                "azure-eventhub not installed. Install with: "
+                "pip install azure-eventhub"
+            )
+            return 0, events
+
+        try:
+            if self._eventhub_producer is None:
+                self._eventhub_producer = EventHubProducerClient.from_connection_string(
+                    self._eventhub_conn,
+                    eventhub_name=self._eventhub_name,
+                )
+
+            async with self._eventhub_producer:
+                batch = await self._eventhub_producer.create_batch()
+                sent = 0
+                overflow: list[GovernanceEvent] = []
+
+                for event in events:
+                    event_data = EventData(event.to_json())
+                    event_data.properties = {
+                        "event_type": event.event_type.value,
+                        "agent_id": event.agent_id,
+                        "decision": event.decision.value,
+                    }
+                    try:
+                        batch.add(event_data)
+                        sent += 1
+                    except ValueError:
+                        # Batch is full, send and start new batch
+                        await self._eventhub_producer.send_batch(batch)
+                        batch = await self._eventhub_producer.create_batch()
+                        batch.add(event_data)
+                        sent += 1
+
+                if sent > 0:
+                    await self._eventhub_producer.send_batch(batch)
+
+                # Reset producer for next use
+                self._eventhub_producer = None
+                return sent, overflow
+
+        except Exception as e:
+            logger.error("Failed to send events to Event Hub: %s", e)
+            self._eventhub_producer = None
+            return 0, events
+
+    async def _send_to_appinsights(self, events: list[GovernanceEvent]) -> None:
+        """Send events to Application Insights as custom events."""
+        try:
+            from azure.monitor.opentelemetry.exporter import (
+                AzureMonitorTraceExporter,
+            )
+            from opentelemetry import trace
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        except ImportError:
+            logger.debug(
+                "azure-monitor-opentelemetry-exporter not installed. "
+                "App Insights export skipped."
+            )
+            return
+
+        try:
+            if self._appinsights_logger is None:
+                exporter = AzureMonitorTraceExporter(
+                    connection_string=self._appinsights_conn
+                )
+                provider = TracerProvider()
+                provider.add_span_processor(BatchSpanProcessor(exporter))
+                self._appinsights_logger = provider.get_tracer("agt-governance")
+
+            tracer = self._appinsights_logger
+            for event in events:
+                with tracer.start_as_current_span(
+                    name=f"agt.{event.event_type.value}",
+                    attributes={
+                        "agt.agent_id": event.agent_id,
+                        "agt.action": event.action,
+                        "agt.decision": event.decision.value,
+                        "agt.policy_name": event.policy_name,
+                        "agt.trust_score": event.trust_score,
+                        "agt.policy_bundle_id": event.policy_bundle_id,
+                        "agt.hash_chain": event.hash_chain_current,
+                        "citadel.apim_request_id": event.correlation.apim_request_id,
+                        "citadel.foundry_trace_id": event.correlation.foundry_trace_id,
+                    },
+                ):
+                    pass  # Span creation is the export mechanism
+
+        except Exception as e:
+            logger.error("Failed to send events to Application Insights: %s", e)
+
+    async def close(self) -> None:
+        """Flush remaining events and close connections."""
+        await self.flush()
+        if self._eventhub_producer:
+            try:
+                await self._eventhub_producer.close()
+            except Exception:
+                pass
+            self._eventhub_producer = None
+        logger.info(
+            "Citadel exporter closed. Total exported: %d, Total failed: %d",
+            self._total_exported,
+            self._total_failed,
+        )
+
+    def flush_sync(self) -> int:
+        """Synchronous flush for non-async contexts.
+
+        Returns:
+            Number of events exported.
+        """
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                # Cannot run async in running loop, just log count
+                count = len(self._buffer)
+                logger.info(
+                    "Sync flush requested in async context, %d events pending", count
+                )
+                return 0
+            return loop.run_until_complete(self.flush())
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(self.flush())
+            finally:
+                loop.close()

--- a/agent-governance-python/agent-os/src/agent_os/integrations/citadel/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/citadel/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Citadel Integration Module
+
+Provides integration between AGT and the Foundry Citadel Platform:
+- Policy bundle binding for Citadel Access Contracts
+- Audit event export to Azure Event Hub / Application Insights
+- Correlation ID management for unified observability
+"""
+
+from __future__ import annotations
+
+from agent_os.integrations.citadel.policy_bundle import (
+    PolicyBundle,
+    PolicyBundleResolver,
+)
+
+__all__ = [
+    "PolicyBundle",
+    "PolicyBundleResolver",
+]

--- a/agent-governance-python/agent-os/src/agent_os/integrations/citadel/policy_bundle.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/citadel/policy_bundle.py
@@ -1,0 +1,344 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Policy Bundle Resolver for Citadel Access Contracts
+
+Loads and validates AGT policy bundles that are bound to Citadel Access
+Contracts. When a Citadel Access Contract provisions an agent environment,
+it references an AGT policy bundle ID/version. This module resolves that
+reference to a concrete policy configuration.
+
+The resolver supports multiple sources:
+- Local file (for development)
+- Azure Key Vault (for production)
+- URL (for centralized policy management)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PolicyBundle:
+    """An AGT policy bundle bound to a Citadel Access Contract.
+
+    Attributes:
+        bundle_id: Unique identifier for the bundle.
+        version: Semantic version of the bundle.
+        name: Human-readable name.
+        data_classification: Sensitivity level (public/internal/confidential/restricted).
+        allowed_actions: Actions the agent is permitted to perform.
+        blocked_actions: Actions explicitly denied.
+        rate_limits: Per-action rate limits.
+        requires_justification: Actions that need a reason before execution.
+        min_trust_score: Minimum trust score required for any action.
+        audit_config: Audit settings (hash_chain, export_to_citadel, etc.).
+        raw_config: The full raw configuration dict.
+        content_hash: SHA-256 hash of the bundle content for integrity verification.
+    """
+
+    bundle_id: str = ""
+    version: str = "0.0.0"
+    name: str = ""
+    data_classification: str = "internal"
+    allowed_actions: list[str] = field(default_factory=list)
+    blocked_actions: list[str] = field(default_factory=list)
+    rate_limits: dict[str, dict[str, int]] = field(default_factory=dict)
+    requires_justification: list[str] = field(default_factory=list)
+    min_trust_score: int = 0
+    audit_config: dict[str, Any] = field(default_factory=dict)
+    raw_config: dict[str, Any] = field(default_factory=dict)
+    content_hash: str = ""
+
+    def __post_init__(self) -> None:
+        """Compute content hash if not already set."""
+        if not self.content_hash and self.raw_config:
+            content = json.dumps(self.raw_config, sort_keys=True).encode()
+            self.content_hash = hashlib.sha256(content).hexdigest()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PolicyBundle:
+        """Create a PolicyBundle from a configuration dictionary.
+
+        Args:
+            data: Raw configuration dict (typically loaded from YAML).
+
+        Returns:
+            A validated PolicyBundle instance.
+        """
+        policy = data.get("policy", data)
+        trust = policy.get("trust", {})
+        audit = policy.get("audit", {})
+
+        return cls(
+            bundle_id=data.get("bundle_id", policy.get("name", "")),
+            version=policy.get("version", "0.0.0"),
+            name=policy.get("name", ""),
+            data_classification=policy.get("data_classification", "internal"),
+            allowed_actions=policy.get("allowed_actions", []),
+            blocked_actions=policy.get("blocked_actions", []),
+            rate_limits=policy.get("rate_limits", {}),
+            requires_justification=policy.get("requires_justification", []),
+            min_trust_score=trust.get("minimum_score", 0),
+            audit_config=audit,
+            raw_config=data,
+        )
+
+    def validate_against_contract(
+        self, contract_params: dict[str, Any]
+    ) -> list[str]:
+        """Validate that this bundle is compatible with a Citadel Access Contract.
+
+        Checks that AGT policy constraints do not exceed what the contract
+        allows. For example, AGT rate limits should not exceed Citadel quotas.
+
+        Args:
+            contract_params: Parsed Citadel Access Contract parameters.
+
+        Returns:
+            List of validation warnings (empty if compatible).
+        """
+        warnings: list[str] = []
+
+        # Check bundle ID/version match
+        contract_bundle = contract_params.get("agtPolicyBundle", {})
+        if contract_bundle:
+            expected_id = contract_bundle.get("bundleId", "")
+            expected_version = contract_bundle.get("version", "")
+            if expected_id and expected_id != self.bundle_id:
+                warnings.append(
+                    f"Bundle ID mismatch: contract expects '{expected_id}', "
+                    f"got '{self.bundle_id}'"
+                )
+            if expected_version and expected_version != self.version:
+                warnings.append(
+                    f"Version mismatch: contract expects '{expected_version}', "
+                    f"got '{self.version}'"
+                )
+
+        return warnings
+
+
+class PolicyBundleResolver:
+    """Resolves AGT policy bundles from various sources.
+
+    Supports loading bundles from:
+    - Local filesystem (YAML files)
+    - Azure Key Vault secrets
+    - HTTP URLs
+
+    The resolver is typically called at agent startup to load the policy
+    bundle that was bound to the agent's Citadel Access Contract.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, PolicyBundle] = {}
+
+    def resolve_from_file(self, path: str) -> PolicyBundle:
+        """Load a policy bundle from a local YAML file.
+
+        Args:
+            path: Path to the YAML policy file.
+
+        Returns:
+            The loaded PolicyBundle.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file cannot be parsed.
+        """
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Policy bundle file not found: {path}")
+
+        try:
+            import yaml
+        except ImportError:
+            raise ImportError(
+                "PyYAML is required to load policy bundles from YAML files. "
+                "Install with: pip install pyyaml"
+            )
+
+        with open(file_path) as f:
+            data = yaml.safe_load(f)
+
+        bundle = PolicyBundle.from_dict(data)
+        logger.info(
+            "Loaded policy bundle '%s' v%s from %s (hash: %s)",
+            bundle.name,
+            bundle.version,
+            path,
+            bundle.content_hash[:12],
+        )
+        self._cache[bundle.bundle_id] = bundle
+        return bundle
+
+    def resolve_from_keyvault(
+        self,
+        vault_url: str,
+        secret_name: str,
+    ) -> PolicyBundle:
+        """Load a policy bundle from Azure Key Vault.
+
+        The secret value should be a JSON-serialized policy bundle.
+
+        Args:
+            vault_url: The Key Vault URL (e.g., https://myvault.vault.azure.net).
+            secret_name: The name of the secret containing the bundle.
+
+        Returns:
+            The loaded PolicyBundle.
+
+        Raises:
+            ImportError: If azure-keyvault-secrets is not installed.
+            RuntimeError: If the secret cannot be retrieved.
+        """
+        try:
+            from azure.identity import DefaultAzureCredential
+            from azure.keyvault.secrets import SecretClient
+        except ImportError:
+            raise ImportError(
+                "Azure Key Vault SDK required. "
+                "Install with: pip install azure-keyvault-secrets azure-identity"
+            )
+
+        try:
+            credential = DefaultAzureCredential()
+            client = SecretClient(vault_url=vault_url, credential=credential)
+            secret = client.get_secret(secret_name)
+            data = json.loads(secret.value)
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load policy bundle from Key Vault "
+                f"({vault_url}/{secret_name}): {e}"
+            )
+
+        bundle = PolicyBundle.from_dict(data)
+        logger.info(
+            "Loaded policy bundle '%s' v%s from Key Vault %s/%s",
+            bundle.name,
+            bundle.version,
+            vault_url,
+            secret_name,
+        )
+        self._cache[bundle.bundle_id] = bundle
+        return bundle
+
+    def resolve_from_url(self, url: str) -> PolicyBundle:
+        """Load a policy bundle from an HTTP URL.
+
+        Args:
+            url: The URL to fetch the bundle from (JSON or YAML).
+
+        Returns:
+            The loaded PolicyBundle.
+
+        Raises:
+            RuntimeError: If the URL cannot be fetched.
+        """
+        import urllib.request
+
+        try:
+            with urllib.request.urlopen(url, timeout=30) as response:
+                content = response.read().decode("utf-8")
+        except Exception as e:
+            raise RuntimeError(f"Failed to fetch policy bundle from {url}: {e}")
+
+        # Try JSON first, then YAML
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            try:
+                import yaml
+                data = yaml.safe_load(content)
+            except ImportError:
+                raise ImportError(
+                    "PyYAML is required to parse YAML policy bundles. "
+                    "Install with: pip install pyyaml"
+                )
+
+        bundle = PolicyBundle.from_dict(data)
+        logger.info(
+            "Loaded policy bundle '%s' v%s from %s",
+            bundle.name,
+            bundle.version,
+            url,
+        )
+        self._cache[bundle.bundle_id] = bundle
+        return bundle
+
+    def resolve(self, config: dict[str, Any]) -> PolicyBundle:
+        """Resolve a policy bundle from a Citadel Access Contract config.
+
+        Reads the ``agtPolicyBundle`` parameter from the contract and loads
+        the bundle from the appropriate source.
+
+        Args:
+            config: Parsed Access Contract parameters containing agtPolicyBundle.
+
+        Returns:
+            The resolved PolicyBundle.
+
+        Raises:
+            ValueError: If the bundle config is invalid.
+        """
+        bundle_config = config.get("agtPolicyBundle", {})
+        if not bundle_config:
+            raise ValueError(
+                "No agtPolicyBundle parameter found in Access Contract config"
+            )
+
+        source = bundle_config.get("source", "file")
+        bundle_id = bundle_config.get("bundleId", "")
+
+        # Check cache first
+        if bundle_id in self._cache:
+            logger.info("Using cached policy bundle '%s'", bundle_id)
+            return self._cache[bundle_id]
+
+        if source == "file":
+            file_path = bundle_config.get("filePath", "")
+            if not file_path:
+                raise ValueError("agtPolicyBundle.filePath is required for file source")
+            return self.resolve_from_file(file_path)
+
+        elif source == "keyvault":
+            vault_url = bundle_config.get("vaultUrl", "")
+            secret_name = bundle_config.get("secretName", "")
+            if not vault_url or not secret_name:
+                raise ValueError(
+                    "agtPolicyBundle.vaultUrl and .secretName are required "
+                    "for keyvault source"
+                )
+            return self.resolve_from_keyvault(vault_url, secret_name)
+
+        elif source == "url":
+            url = bundle_config.get("url", "")
+            if not url:
+                raise ValueError("agtPolicyBundle.url is required for url source")
+            return self.resolve_from_url(url)
+
+        else:
+            raise ValueError(
+                f"Unknown policy bundle source: '{source}'. "
+                f"Expected: file, keyvault, or url"
+            )
+
+    def get_cached(self, bundle_id: str) -> Optional[PolicyBundle]:
+        """Get a previously resolved bundle from cache.
+
+        Args:
+            bundle_id: The bundle ID to look up.
+
+        Returns:
+            The cached PolicyBundle, or None if not found.
+        """
+        return self._cache.get(bundle_id)

--- a/docs/integrations/citadel-integration.md
+++ b/docs/integrations/citadel-integration.md
@@ -1,0 +1,181 @@
+# Citadel + AGT Integration Architecture
+
+This document describes how the Agent Governance Toolkit (AGT) integrates with
+the [Foundry Citadel Platform](https://aka.ms/foundry-citadel), Microsoft's
+layered architecture for AI governance.
+
+## Positioning
+
+Citadel and AGT address **different enforcement boundaries** that are complementary,
+not competing:
+
+| Concern | Citadel (Gateway) | AGT (Agent Runtime) |
+|---------|-------------------|---------------------|
+| **What it governs** | Model/tool/agent access at the infrastructure perimeter | Individual agent actions, tool calls, inter-agent messages |
+| **Enforcement point** | APIM gateway (centralized) | Agent runtime sidecar/library (local) |
+| **Latency model** | Network hop through gateway | Sub-millisecond in-process evaluation |
+| **Policy granularity** | Coarse: rate limits, content filters, quotas, JWT validation | Fine: per-action allow/deny, capability model, caller restrictions |
+| **Identity model** | Entra ID / subscription keys | Ed25519 / SPIFFE cryptographic identity |
+| **Audit target** | Event Hub / App Insights / Log Analytics | Hash-chain audit logs (exportable to Azure Monitor) |
+
+## How AGT Maps to Citadel's 4 Layers
+
+AGT is not confined to a single Citadel layer. It spans the architecture:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Foundry Citadel Platform                      │
+│                                                                 │
+│  Layer 4: Security Fabric (Defender, Purview, Entra)            │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │  AGT trust scores surface as risk labels in Defender    │    │
+│  │  AGT data_classification aligns with Purview labels     │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                                                                 │
+│  Layer 3: Agent Identity (Agent 365 / Entra)                    │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │  AGT agent identities federate with Entra agent IDs     │    │
+│  │  Entra = enterprise identity, AGT = runtime credentials │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                                                                 │
+│  Layer 2: AI Control Plane (Foundry Control Plane)              │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │  AGT exports governance evidence and traces             │    │
+│  │  Policy decisions enrich Foundry/OTEL traces            │    │
+│  │  Fleet-wide compliance visibility via Azure Monitor     │    │
+│  └─────────────────────────────────────────────────────────┘    │
+│                                                                 │
+│  Layer 1: Governance Hub (APIM Gateway)                         │
+│  ┌─────────────────────────────────────────────────────────┐    │
+│  │  Access Contracts reference AGT policy bundles          │    │
+│  │  AGT metadata headers pass through APIM for correlation │    │
+│  │  Gateway = coarse rules, AGT = action-level rules       │    │
+│  └─────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Layer 1: Governance Hub
+
+Citadel's APIM gateway enforces infrastructure-level controls: which models an
+agent can access, at what rate, with what content safety filters. AGT integrates
+through **Access Contract policy bundle binding**: when a Citadel Access Contract
+provisions an agent environment, it references an AGT policy bundle ID/version.
+The agent runtime loads this bundle at startup.
+
+**Policy precedence**: Gateway rules (rate limits, content filters, JWT) are
+enforced first at the APIM layer. AGT action-level policies are enforced second,
+inside the agent runtime. Both must pass for an action to proceed.
+
+### Layer 2: AI Control Plane
+
+AGT's primary Layer 2 contribution is **governance evidence and trace enrichment**.
+The `CitadelAuditExporter` sends policy decisions, trust score changes, and
+action interception events to Azure Event Hub and Application Insights. These
+events include correlation IDs that tie AGT decisions to APIM request traces
+and Foundry execution traces, enabling unified observability dashboards.
+
+### Layer 3: Agent Identity
+
+Entra ID / Agent 365 remains the authoritative source for enterprise agent
+identity and lifecycle management. AGT's Ed25519/SPIFFE identities remain
+authoritative for runtime cryptographic credentials. The integration is
+**federation, not replacement**: AGT trust scores (0-1000) surface as risk
+labels in telemetry, not as primary Entra metadata.
+
+### Layer 4: Security Fabric
+
+AGT's `data_classification` labels on policies align with Purview sensitivity
+labels. AGT trust scores can surface as risk signals in Defender for AI. This
+integration is primarily through the telemetry pipeline (Layer 2 export) rather
+than direct API integration.
+
+## Data Flow
+
+```
+Agent Runtime                    Citadel Gateway              Azure Monitor
+┌──────────────────┐            ┌──────────────────┐         ┌──────────────┐
+│                  │            │                  │         │              │
+│  Agent Code      │   LLM     │  APIM Gateway    │         │  App Insights│
+│  ┌────────────┐  │  request  │  ┌────────────┐  │         │              │
+│  │ AGT Policy ├──┼──────────►│  │ Rate Limit ├──┼────►LLM │  Event Hub   │
+│  │ Engine     │  │           │  │ Content    │  │         │              │
+│  │            │  │           │  │ JWT Auth   │  │         │  Log         │
+│  │ Decision:  │  │           │  └────────────┘  │         │  Analytics   │
+│  │ allow/deny │  │           │                  │         │              │
+│  └─────┬──────┘  │           └──────────────────┘         └──────┬───────┘
+│        │         │                                               │
+│  ┌─────▼──────┐  │           ┌──────────────────┐               │
+│  │ Citadel    ├──┼──────────►│  Event Hub /      │───────────────┘
+│  │ Audit      │  │  events   │  App Insights     │
+│  │ Exporter   │  │           └──────────────────┘
+│  └────────────┘  │
+└──────────────────┘
+```
+
+1. Agent action triggers AGT policy evaluation (sub-millisecond, in-process)
+2. If allowed, the request passes through the Citadel APIM gateway
+3. APIM enforces gateway-level policies (rate limit, content filter, JWT)
+4. AGT audit exporter sends governance events to Azure Event Hub / App Insights
+5. Events include correlation IDs linking AGT decision to APIM request trace
+
+## Policy Bundle Binding
+
+Citadel Access Contracts use `.bicepparam` files to declare what resources an
+agent environment can access. AGT extends this with a policy bundle reference:
+
+```bicep
+// In the Access Contract .bicepparam file
+param agtPolicyBundle object = {
+  bundleId: 'customer-support-v2'
+  version: '1.3.0'
+  source: 'https://vault.azure.net/secrets/agt-policy-bundle'
+}
+```
+
+At deployment time, the policy bundle is fetched and injected into the agent
+environment. The AGT runtime loads it at startup via `PolicyBundleResolver`.
+
+## Coverage Boundaries
+
+Understanding what each system handles avoids duplication:
+
+| Concern | Handled By |
+|---------|-----------|
+| LLM model access control | Citadel Layer 1 (APIM products/subscriptions) |
+| Token rate limiting | Citadel Layer 1 (APIM policies) |
+| Content safety filtering | Citadel Layer 1 (Azure Content Safety) |
+| PII detection at gateway | Citadel Layer 1 (Azure Language Service) |
+| Per-action policy evaluation | AGT Policy Engine |
+| Tool call allow/deny | AGT Capability Model |
+| Agent-to-agent trust | AGT Trust Layer (Ed25519, SPIFFE) |
+| Trust scoring (0-1000) | AGT AgentMesh |
+| Hash-chain audit logs | AGT Audit System |
+| Fleet observability | Citadel Layer 2 + AGT Exporter |
+| Agent enterprise identity | Citadel Layer 3 (Entra) |
+| Agent runtime credentials | AGT (Ed25519/SPIFFE) |
+| Threat detection | Citadel Layer 4 (Defender) |
+| Data governance labels | Citadel Layer 4 (Purview) + AGT data_classification |
+
+## Failure Modes
+
+| Component Unavailable | Behavior |
+|----------------------|----------|
+| Azure Event Hub / App Insights | AGT continues operating. Events queue locally and retry on reconnection. Fail-open for telemetry. |
+| Citadel APIM Gateway | Agent cannot reach LLM/tools. AGT policy engine still operational locally. |
+| AGT Policy Engine | Agent actions proceed ungoverned (fail-open by default, configurable to fail-closed). |
+| Entra ID | AGT uses local cryptographic identity. Enterprise identity federation paused. |
+
+## Getting Started
+
+1. **Deploy Citadel Governance Hub**: Follow the [Citadel quickstart](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/tree/citadel-v1)
+2. **Install AGT**: `pip install agent-governance-toolkit`
+3. **Configure the exporter**: Set `CITADEL_EVENTHUB_CONNECTION_STRING` and `CITADEL_APPINSIGHTS_CONNECTION_STRING`
+4. **See the example**: [`examples/citadel-governed-agent/`](../../examples/citadel-governed-agent/)
+
+## References
+
+- [Foundry Citadel Platform](https://aka.ms/foundry-citadel): Full 4-layer architecture
+- [Citadel Governance Hub](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/tree/citadel-v1): Layer 1 reference implementation
+- [Citadel Access Contracts](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/tree/citadel-v1/bicep/infra/citadel-access-contracts): Contract-based onboarding
+- [Agent 365 / Entra Agent Governance](https://learn.microsoft.com/en-us/entra/id-governance/agent-id-governance-overview): Layer 3
+- [AGT Architecture](../ARCHITECTURE.md): AGT system design

--- a/examples/citadel-governed-agent/README.md
+++ b/examples/citadel-governed-agent/README.md
@@ -1,0 +1,104 @@
+# Citadel + AGT Governed Agent Example
+
+This example demonstrates an AI agent that uses both **Citadel** (gateway-level
+governance) and **AGT** (agent-level governance) working together.
+
+## Architecture
+
+```
+┌──────────────────────────┐       ┌──────────────────────┐
+│  Agent Runtime           │       │  Citadel APIM        │
+│                          │       │  Gateway             │
+│  ┌────────────────────┐  │       │                      │
+│  │ AGT Policy Engine  │  │       │  - Rate limiting     │
+│  │ - Action allow/deny│  │       │  - Content filtering │
+│  │ - Trust scoring    │  │       │  - JWT validation    │
+│  │ - Audit logging    │  │       │  - Cost attribution  │
+│  └────────┬───────────┘  │       └──────────┬───────────┘
+│           │              │                  │
+│  ┌────────▼───────────┐  │  LLM request    │
+│  │ Governed Agent     ├──┼─────────────────►│──────► LLM
+│  │ (OpenAI / SK)      │  │                  │
+│  └────────────────────┘  │                  │
+│                          │       ┌──────────┴───────────┐
+│  ┌────────────────────┐  │       │  Azure Event Hub /   │
+│  │ Citadel Exporter   ├──┼──────►│  App Insights        │
+│  └────────────────────┘  │       └──────────────────────┘
+└──────────────────────────┘
+```
+
+## What This Example Shows
+
+1. **Policy enforcement**: Agent actions are evaluated against an AGT policy
+   bundle before execution. Blocked actions are logged and denied.
+2. **Gateway integration**: LLM calls route through a Citadel APIM gateway
+   (or mock gateway for local testing).
+3. **Audit export**: Governance events flow to Azure Event Hub / Application
+   Insights via the `CitadelAuditExporter`.
+4. **Policy bundle binding**: The agent loads its policy bundle from a file
+   that would normally be injected by a Citadel Access Contract deployment.
+5. **Trust scoring**: Trust scores change based on agent behavior and
+   policy compliance.
+
+## Prerequisites
+
+```bash
+pip install agent-governance-toolkit
+```
+
+For Azure integration (optional, not needed for local mock mode):
+```bash
+pip install azure-eventhub azure-monitor-opentelemetry-exporter
+```
+
+## Running the Example
+
+### Local mode (no Azure required)
+
+```bash
+python src/agent.py --mock
+```
+
+This uses a mock gateway and mock exporter to demonstrate the governance
+flow without any Azure dependencies.
+
+### With Citadel gateway
+
+```bash
+export CITADEL_GATEWAY_URL=https://your-apim.azure-api.net
+export CITADEL_API_KEY=your-subscription-key
+export CITADEL_EVENTHUB_CONNECTION_STRING=Endpoint=sb://...
+python src/agent.py
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `src/agent.py` | Main governed agent with AGT policy engine |
+| `src/citadel_config.py` | Citadel gateway configuration and helpers |
+| `policies/agent-policy.yaml` | AGT policy bundle for this agent |
+| `sample-access-contract/main.bicepparam` | Sample Citadel Access Contract with AGT binding |
+
+## Policy Precedence
+
+This example demonstrates the two-layer policy model:
+
+1. **Citadel gateway** enforces coarse rules first:
+   - Rate limits (e.g., 100 calls/hour)
+   - Content safety filters
+   - JWT / subscription key validation
+
+2. **AGT policy engine** enforces fine-grained rules second:
+   - Per-action allow/deny (e.g., block `delete_record` action)
+   - Caller restrictions (only specific agents can invoke certain tools)
+   - Data classification constraints
+   - Justification requirements
+
+Both layers must pass for an action to proceed.
+
+## Related
+
+- [Citadel + AGT Integration Architecture](../../docs/integrations/citadel-integration.md)
+- [Foundry Citadel Platform](https://aka.ms/foundry-citadel)
+- [AGT Documentation](https://github.com/microsoft/agent-governance-toolkit)

--- a/examples/citadel-governed-agent/policies/agent-policy.yaml
+++ b/examples/citadel-governed-agent/policies/agent-policy.yaml
@@ -1,0 +1,62 @@
+# AGT Policy Bundle: Customer Support Agent
+# This policy bundle would normally be injected by a Citadel Access Contract
+# deployment. For this example, it is loaded from a local file.
+#
+# Bundle ID: customer-support-v2
+# Version: 1.3.0
+
+policy:
+  name: customer-support-policy
+  version: "1.3.0"
+  description: >
+    Governance policy for a customer support agent operating behind a
+    Citadel APIM gateway. Complements gateway-level controls with
+    agent-level action restrictions.
+
+  # Data classification (aligns with Citadel/Purview labels)
+  data_classification: confidential
+
+  # Actions the agent is allowed to perform
+  allowed_actions:
+    - query_customer_database
+    - search_knowledge_base
+    - send_email
+    - create_ticket
+    - escalate_to_human
+
+  # Actions explicitly blocked
+  blocked_actions:
+    - delete_customer_record
+    - modify_billing
+    - access_internal_systems
+    - execute_code
+
+  # Rate limits (complementary to Citadel gateway rate limits)
+  # Citadel enforces 100 calls/hour at gateway; AGT enforces
+  # tighter limits per action type.
+  rate_limits:
+    query_customer_database:
+      max_calls: 50
+      window_seconds: 3600
+    send_email:
+      max_calls: 10
+      window_seconds: 3600
+
+  # Actions requiring justification
+  requires_justification:
+    - send_email
+    - escalate_to_human
+
+  # Trust score thresholds
+  trust:
+    minimum_score: 400
+    degraded_threshold: 600
+    actions_when_degraded:
+      - query_customer_database
+      - search_knowledge_base
+
+  # Audit settings
+  audit:
+    log_all_decisions: true
+    hash_chain: true
+    export_to_citadel: true

--- a/examples/citadel-governed-agent/requirements.txt
+++ b/examples/citadel-governed-agent/requirements.txt
@@ -1,0 +1,2 @@
+agent-governance-toolkit
+pyyaml>=6.0

--- a/examples/citadel-governed-agent/sample-access-contract/main.bicepparam
+++ b/examples/citadel-governed-agent/sample-access-contract/main.bicepparam
@@ -1,0 +1,71 @@
+// Sample Citadel Access Contract with AGT Policy Bundle Binding
+//
+// This file extends a standard Citadel Access Contract to include
+// an AGT policy bundle reference. When the agent environment is
+// deployed, the policy bundle is fetched and injected into the
+// agent runtime configuration.
+//
+// See: https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/tree/citadel-v1/bicep/infra/citadel-access-contracts
+
+using 'main.bicep'
+
+// ── Standard Citadel parameters ──
+
+param apim = {
+  subscriptionId: '<your-subscription-id>'
+  resourceGroupName: '<your-apim-rg>'
+  name: '<your-apim-instance>'
+}
+
+param keyVault = {
+  subscriptionId: '<your-subscription-id>'
+  resourceGroupName: '<your-kv-rg>'
+  name: '<your-kv-name>'
+}
+
+param useTargetAzureKeyVault = true
+
+param useCase = {
+  businessUnit: 'customer-support'
+  useCaseName: 'governed-agent'
+  environment: 'dev'
+}
+
+param apiNameMapping = {
+  LLM: ['azure-openai-service-api']
+}
+
+param services = [
+  {
+    code: 'LLM'
+    displayName: 'Azure OpenAI for Customer Support Agent'
+    description: 'LLM access for AGT-governed customer support agent'
+    policies: {
+      jwtAuth: {
+        enabled: true
+      }
+    }
+  }
+]
+
+// ── AGT Policy Bundle Binding ──
+//
+// This parameter references an AGT policy bundle that will be
+// injected into the agent runtime at deployment time. The bundle
+// defines agent-level governance rules (per-action allow/deny,
+// trust scoring, audit settings) that complement the gateway-level
+// controls defined in this Access Contract.
+//
+// The bundle can be stored in:
+// - Azure Key Vault (recommended for production)
+// - A file in the agent environment (for development)
+// - A URL (for centralized policy management)
+
+param agtPolicyBundle = {
+  bundleId: 'customer-support-v2'
+  version: '1.3.0'
+  source: 'keyvault'  // 'keyvault' | 'file' | 'url'
+  secretName: 'agt-policy-bundle-customer-support'
+  // For 'file' source: filePath: './policies/agent-policy.yaml'
+  // For 'url' source: url: 'https://policy-store.example.com/bundles/customer-support-v2'
+}

--- a/examples/citadel-governed-agent/src/agent.py
+++ b/examples/citadel-governed-agent/src/agent.py
@@ -1,0 +1,401 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Citadel + AGT Governed Agent Example
+
+Demonstrates an AI agent governed by both Citadel (gateway-level) and
+AGT (agent-level) policies working together. Supports local mock mode
+for testing without Azure dependencies.
+
+Usage:
+    python agent.py --mock      # Local mode, no Azure required
+    python agent.py             # With Citadel gateway (requires env vars)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger("citadel-governed-agent")
+
+
+# ---------------------------------------------------------------------------
+# Policy bundle loader
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PolicyBundle:
+    """An AGT policy bundle loaded from YAML configuration."""
+
+    name: str = ""
+    version: str = ""
+    data_classification: str = "internal"
+    allowed_actions: list[str] = field(default_factory=list)
+    blocked_actions: list[str] = field(default_factory=list)
+    rate_limits: dict[str, dict[str, int]] = field(default_factory=dict)
+    requires_justification: list[str] = field(default_factory=list)
+    min_trust_score: int = 0
+    log_all_decisions: bool = True
+    hash_chain: bool = True
+
+    @classmethod
+    def from_yaml(cls, path: str) -> PolicyBundle:
+        """Load a policy bundle from a YAML file."""
+        try:
+            import yaml
+        except ImportError:
+            logger.warning("PyYAML not installed, using default policy")
+            return cls(name="default", version="0.0.0")
+
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        policy = data.get("policy", {})
+        trust = policy.get("trust", {})
+        audit = policy.get("audit", {})
+
+        return cls(
+            name=policy.get("name", "unnamed"),
+            version=policy.get("version", "0.0.0"),
+            data_classification=policy.get("data_classification", "internal"),
+            allowed_actions=policy.get("allowed_actions", []),
+            blocked_actions=policy.get("blocked_actions", []),
+            rate_limits=policy.get("rate_limits", {}),
+            requires_justification=policy.get("requires_justification", []),
+            min_trust_score=trust.get("minimum_score", 0),
+            log_all_decisions=audit.get("log_all_decisions", True),
+            hash_chain=audit.get("hash_chain", True),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Governance engine
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GovernanceDecision:
+    """Result of a policy evaluation."""
+
+    action: str
+    allowed: bool
+    reason: str
+    policy_name: str
+    trust_score: int
+    decision_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = field(
+        default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    )
+
+
+class GovernanceEngine:
+    """AGT-style policy engine that evaluates agent actions against a policy bundle."""
+
+    def __init__(self, policy: PolicyBundle) -> None:
+        self.policy = policy
+        self.trust_score = 800  # Start with high trust
+        self._call_counts: dict[str, list[float]] = {}
+        self._hash_chain: str = hashlib.sha256(b"genesis").hexdigest()
+        self._decisions: list[GovernanceDecision] = []
+
+    def evaluate(
+        self,
+        action: str,
+        justification: Optional[str] = None,
+        context: Optional[dict[str, Any]] = None,
+    ) -> GovernanceDecision:
+        """Evaluate an action against the policy bundle.
+
+        Args:
+            action: The action the agent wants to perform.
+            justification: Optional justification for the action.
+            context: Optional context for the evaluation.
+
+        Returns:
+            A GovernanceDecision indicating whether the action is allowed.
+        """
+        # Check blocked actions
+        if action in self.policy.blocked_actions:
+            decision = GovernanceDecision(
+                action=action,
+                allowed=False,
+                reason=f"Action '{action}' is explicitly blocked by policy",
+                policy_name=self.policy.name,
+                trust_score=self.trust_score,
+            )
+            self._record_decision(decision)
+            self.trust_score = max(0, self.trust_score - 50)
+            return decision
+
+        # Check allowed actions
+        if self.policy.allowed_actions and action not in self.policy.allowed_actions:
+            decision = GovernanceDecision(
+                action=action,
+                allowed=False,
+                reason=f"Action '{action}' is not in the allowed actions list",
+                policy_name=self.policy.name,
+                trust_score=self.trust_score,
+            )
+            self._record_decision(decision)
+            return decision
+
+        # Check trust score
+        if self.trust_score < self.policy.min_trust_score:
+            decision = GovernanceDecision(
+                action=action,
+                allowed=False,
+                reason=(
+                    f"Trust score {self.trust_score} is below minimum "
+                    f"{self.policy.min_trust_score}"
+                ),
+                policy_name=self.policy.name,
+                trust_score=self.trust_score,
+            )
+            self._record_decision(decision)
+            return decision
+
+        # Check justification requirement
+        if action in self.policy.requires_justification and not justification:
+            decision = GovernanceDecision(
+                action=action,
+                allowed=False,
+                reason=f"Action '{action}' requires justification",
+                policy_name=self.policy.name,
+                trust_score=self.trust_score,
+            )
+            self._record_decision(decision)
+            return decision
+
+        # Check rate limits
+        if action in self.policy.rate_limits:
+            limit = self.policy.rate_limits[action]
+            now = time.time()
+            window = limit.get("window_seconds", 3600)
+            max_calls = limit.get("max_calls", 100)
+
+            timestamps = self._call_counts.get(action, [])
+            timestamps = [t for t in timestamps if now - t < window]
+            self._call_counts[action] = timestamps
+
+            if len(timestamps) >= max_calls:
+                decision = GovernanceDecision(
+                    action=action,
+                    allowed=False,
+                    reason=(
+                        f"Rate limit exceeded for '{action}': "
+                        f"{max_calls} calls per {window}s"
+                    ),
+                    policy_name=self.policy.name,
+                    trust_score=self.trust_score,
+                )
+                self._record_decision(decision)
+                return decision
+
+            timestamps.append(now)
+            self._call_counts[action] = timestamps
+
+        # Action is allowed
+        decision = GovernanceDecision(
+            action=action,
+            allowed=True,
+            reason="Policy check passed",
+            policy_name=self.policy.name,
+            trust_score=self.trust_score,
+        )
+        self._record_decision(decision)
+        return decision
+
+    def _record_decision(self, decision: GovernanceDecision) -> None:
+        """Record a decision and update the hash chain."""
+        if self.policy.hash_chain:
+            decision_bytes = json.dumps({
+                "id": decision.decision_id,
+                "action": decision.action,
+                "allowed": decision.allowed,
+                "prev": self._hash_chain,
+            }).encode()
+            self._hash_chain = hashlib.sha256(decision_bytes).hexdigest()
+
+        self._decisions.append(decision)
+
+        level = logging.INFO if decision.allowed else logging.WARNING
+        logger.log(
+            level,
+            "Policy %s: action=%s allowed=%s reason=%s trust=%d",
+            decision.policy_name,
+            decision.action,
+            decision.allowed,
+            decision.reason,
+            decision.trust_score,
+        )
+
+    @property
+    def decisions(self) -> list[GovernanceDecision]:
+        """All recorded decisions."""
+        return list(self._decisions)
+
+    @property
+    def current_hash(self) -> str:
+        """Current hash chain value for tamper evidence."""
+        return self._hash_chain
+
+
+# ---------------------------------------------------------------------------
+# Mock audit exporter (for local testing)
+# ---------------------------------------------------------------------------
+
+class MockCitadelExporter:
+    """Mock exporter that logs events locally instead of sending to Azure."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def export_decision(
+        self,
+        decision: GovernanceDecision,
+        apim_request_id: str = "",
+        hash_chain: str = "",
+    ) -> None:
+        """Export a governance decision event."""
+        event = {
+            "event_type": "policy_violation" if not decision.allowed else "policy_decision",
+            "timestamp": decision.timestamp,
+            "agent_id": "customer-support-agent-01",
+            "action": decision.action,
+            "decision": "allow" if decision.allowed else "deny",
+            "policy_name": decision.policy_name,
+            "trust_score": decision.trust_score,
+            "correlation": {
+                "apim_request_id": apim_request_id,
+                "agt_decision_id": decision.decision_id,
+            },
+            "hash_chain": hash_chain,
+            "detail": decision.reason,
+        }
+        self.events.append(event)
+        logger.info(
+            "Exported to Citadel (mock): %s %s -> %s",
+            event["event_type"],
+            event["action"],
+            event["decision"],
+        )
+
+    def flush(self) -> None:
+        """Flush pending events."""
+        logger.info("Flushed %d events to Citadel (mock)", len(self.events))
+
+
+# ---------------------------------------------------------------------------
+# Main demo
+# ---------------------------------------------------------------------------
+
+def run_demo(mock: bool = True) -> None:
+    """Run the governed agent demo.
+
+    Args:
+        mock: If True, use mock gateway and exporter. If False, use real Azure.
+    """
+    # Load policy bundle
+    policy_path = Path(__file__).parent.parent / "policies" / "agent-policy.yaml"
+    if policy_path.exists():
+        policy = PolicyBundle.from_yaml(str(policy_path))
+        logger.info("Loaded policy bundle: %s v%s", policy.name, policy.version)
+    else:
+        policy = PolicyBundle(name="default", version="0.0.0")
+        logger.warning("Policy file not found, using defaults")
+
+    # Initialize governance engine
+    engine = GovernanceEngine(policy)
+
+    # Initialize gateway and exporter
+    if mock:
+        from citadel_config import MockGateway
+        gateway = MockGateway()
+        exporter = MockCitadelExporter()
+        logger.info("Running in mock mode (no Azure dependencies)")
+    else:
+        logger.info("Running with live Citadel gateway")
+        # In production, would use real CitadelAuditExporter
+        exporter = MockCitadelExporter()
+
+    print("\n" + "=" * 60)
+    print("  Citadel + AGT Governed Agent Demo")
+    print("=" * 60)
+
+    # Scenario 1: Allowed action
+    print("\n--- Scenario 1: Query customer database (allowed) ---")
+    decision = engine.evaluate("query_customer_database")
+    if decision.allowed and mock:
+        result = gateway.process_request("/openai/chat", {"query": "customer lookup"})
+        exporter.export_decision(
+            decision,
+            apim_request_id=result.get("apim_request_id", ""),
+            hash_chain=engine.current_hash,
+        )
+
+    # Scenario 2: Blocked action
+    print("\n--- Scenario 2: Delete customer record (blocked) ---")
+    decision = engine.evaluate("delete_customer_record")
+    exporter.export_decision(decision, hash_chain=engine.current_hash)
+
+    # Scenario 3: Action requiring justification (no justification provided)
+    print("\n--- Scenario 3: Send email without justification (denied) ---")
+    decision = engine.evaluate("send_email")
+    exporter.export_decision(decision, hash_chain=engine.current_hash)
+
+    # Scenario 4: Action with justification (allowed)
+    print("\n--- Scenario 4: Send email with justification (allowed) ---")
+    decision = engine.evaluate(
+        "send_email",
+        justification="Customer requested order status update via email",
+    )
+    if decision.allowed and mock:
+        result = gateway.process_request("/openai/chat", {"task": "compose email"})
+        exporter.export_decision(
+            decision,
+            apim_request_id=result.get("apim_request_id", ""),
+            hash_chain=engine.current_hash,
+        )
+
+    # Scenario 5: Unknown action (not in allowed list)
+    print("\n--- Scenario 5: Execute code (not allowed) ---")
+    decision = engine.evaluate("execute_code")
+    exporter.export_decision(decision, hash_chain=engine.current_hash)
+
+    # Summary
+    exporter.flush()
+    print("\n" + "=" * 60)
+    print("  Summary")
+    print("=" * 60)
+    print(f"  Total decisions:     {len(engine.decisions)}")
+    print(f"  Allowed:             {sum(1 for d in engine.decisions if d.allowed)}")
+    print(f"  Denied:              {sum(1 for d in engine.decisions if not d.allowed)}")
+    print(f"  Current trust score: {engine.trust_score}")
+    print(f"  Hash chain head:     {engine.current_hash[:16]}...")
+    print(f"  Events exported:     {len(exporter.events)}")
+    print("=" * 60 + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Citadel + AGT Governed Agent")
+    parser.add_argument(
+        "--mock",
+        action="store_true",
+        default=True,
+        help="Use mock gateway and exporter (default: True)",
+    )
+    args = parser.parse_args()
+    run_demo(mock=args.mock)

--- a/examples/citadel-governed-agent/src/citadel_config.py
+++ b/examples/citadel-governed-agent/src/citadel_config.py
@@ -1,0 +1,159 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Citadel Gateway Configuration
+
+Handles configuration for routing requests through a Citadel APIM gateway
+and exporting audit events to Azure Monitor.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class CitadelGatewayConfig:
+    """Configuration for connecting to a Citadel APIM gateway.
+
+    Attributes:
+        gateway_url: Base URL of the Citadel APIM gateway.
+        api_key: APIM subscription key for authentication.
+        jwt_token: Optional JWT bearer token for additional auth.
+        timeout_seconds: Request timeout in seconds.
+    """
+
+    gateway_url: str = ""
+    api_key: str = ""
+    jwt_token: str = ""
+    timeout_seconds: int = 30
+
+    @classmethod
+    def from_env(cls) -> CitadelGatewayConfig:
+        """Load configuration from environment variables."""
+        return cls(
+            gateway_url=os.environ.get("CITADEL_GATEWAY_URL", ""),
+            api_key=os.environ.get("CITADEL_API_KEY", ""),
+            jwt_token=os.environ.get("CITADEL_JWT_TOKEN", ""),
+            timeout_seconds=int(os.environ.get("CITADEL_TIMEOUT", "30")),
+        )
+
+    @property
+    def is_configured(self) -> bool:
+        """Check if gateway configuration is complete."""
+        return bool(self.gateway_url and self.api_key)
+
+    def get_headers(self) -> dict[str, str]:
+        """Build request headers for Citadel gateway calls."""
+        headers: dict[str, str] = {
+            "Ocp-Apim-Subscription-Key": self.api_key,
+        }
+        if self.jwt_token:
+            headers["Authorization"] = f"Bearer {self.jwt_token}"
+        return headers
+
+
+@dataclass
+class CitadelExporterConfig:
+    """Configuration for exporting audit events to Citadel's observability stack.
+
+    Attributes:
+        eventhub_connection_string: Azure Event Hub connection string.
+        appinsights_connection_string: Application Insights connection string.
+        enabled: Whether export is enabled.
+        batch_size: Number of events to batch before sending.
+        flush_interval_seconds: Maximum time between flushes.
+    """
+
+    eventhub_connection_string: str = ""
+    appinsights_connection_string: str = ""
+    enabled: bool = True
+    batch_size: int = 50
+    flush_interval_seconds: int = 10
+
+    @classmethod
+    def from_env(cls) -> CitadelExporterConfig:
+        """Load configuration from environment variables."""
+        return cls(
+            eventhub_connection_string=os.environ.get(
+                "CITADEL_EVENTHUB_CONNECTION_STRING", ""
+            ),
+            appinsights_connection_string=os.environ.get(
+                "CITADEL_APPINSIGHTS_CONNECTION_STRING", ""
+            ),
+            enabled=os.environ.get("CITADEL_EXPORT_ENABLED", "true").lower() == "true",
+            batch_size=int(os.environ.get("CITADEL_EXPORT_BATCH_SIZE", "50")),
+            flush_interval_seconds=int(
+                os.environ.get("CITADEL_EXPORT_FLUSH_INTERVAL", "10")
+            ),
+        )
+
+    @property
+    def has_eventhub(self) -> bool:
+        """Check if Event Hub export is configured."""
+        return bool(self.eventhub_connection_string)
+
+    @property
+    def has_appinsights(self) -> bool:
+        """Check if Application Insights export is configured."""
+        return bool(self.appinsights_connection_string)
+
+
+@dataclass
+class MockGateway:
+    """Mock Citadel gateway for local testing without Azure dependencies.
+
+    Simulates gateway-level policy enforcement: rate limiting, content
+    filtering, and subscription validation.
+    """
+
+    call_count: int = 0
+    rate_limit: int = 100
+    rate_window_seconds: int = 3600
+    _call_timestamps: list[float] = field(default_factory=list)
+
+    def process_request(
+        self,
+        endpoint: str,
+        payload: dict,
+        headers: Optional[dict[str, str]] = None,
+    ) -> dict:
+        """Simulate a gateway-processed LLM request.
+
+        Args:
+            endpoint: The model endpoint path.
+            payload: The request payload.
+            headers: Optional request headers.
+
+        Returns:
+            Simulated response with gateway metadata.
+        """
+        import time
+
+        self.call_count += 1
+        now = time.time()
+        self._call_timestamps = [
+            t for t in self._call_timestamps if now - t < self.rate_window_seconds
+        ]
+        self._call_timestamps.append(now)
+
+        if len(self._call_timestamps) > self.rate_limit:
+            return {
+                "status": 429,
+                "error": "Rate limit exceeded",
+                "gateway": "citadel-mock",
+                "remaining": 0,
+            }
+
+        return {
+            "status": 200,
+            "data": {
+                "response": f"Mock LLM response for {endpoint}",
+                "model": "gpt-4o-mock",
+            },
+            "gateway": "citadel-mock",
+            "remaining": self.rate_limit - len(self._call_timestamps),
+            "apim_request_id": f"mock-{self.call_count:06d}",
+        }


### PR DESCRIPTION
## Summary

Integrates AGT with the [Foundry Citadel Platform](https://aka.ms/foundry-citadel), Microsoft's layered AI governance architecture. AGT provides agent-level governance (per-action policy evaluation, trust scoring, cryptographic identity) that complements Citadel's gateway-level controls (rate limiting, content filtering, identity validation).

## What's Included

### Architecture Documentation
- `docs/integrations/citadel-integration.md`: Reference architecture explaining how AGT maps to Citadel's 4 layers, data flow, policy precedence, coverage boundaries, and failure modes.

### Citadel Audit Exporter
- `agent_os/exporters/citadel_exporter.py`: Exports governance events to Azure Event Hub and Application Insights with:
  - Correlation IDs (APIM request, Foundry trace, AGT decision)
  - Hash-chain tamper evidence preservation
  - Batching and async flush
  - Fail-open behavior (logs locally when Azure is unavailable)

### Policy Bundle Resolver
- `agent_os/integrations/citadel/policy_bundle.py`: Loads AGT policy bundles bound to Citadel Access Contracts from file, Azure Key Vault, or URL. Validates bundle/contract compatibility.

### End-to-End Example
- `examples/citadel-governed-agent/`: Working example with mock mode showing dual-layer governance (Citadel gateway + AGT runtime policies).

## Design Decisions

- AGT spans Citadel layers (not just Layer 2): runtime enforcement near the agent, evidence to Layer 2, identity federation with Layer 3
- Policy bundle binding (not translation): Citadel contracts reference AGT bundles, not translate IaC to runtime rules
- APIM stays coarse-grained: No AGT on the gateway hot path
- Fail-open for telemetry: AGT continues operating if Azure Monitor is unavailable

## Testing

Example runs successfully in mock mode:
```
python examples/citadel-governed-agent/src/agent.py --mock
# 5 decisions, 2 allowed, 3 denied, trust score degradation, hash chain
```

## Related Issues

Closes #1770, closes #1771, closes #1772, closes #1773

Phase 2 (deferred): #1774 (Entra identity federation), #1775 (APIM metadata fragment)