### PR TITLE
fix: narrow go coverage test scope

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -803,7 +803,7 @@ stages:
 
           - script: |
               export CGO_ENABLED=1
-              go test -v -race -coverprofile=coverage.out ./...
+              go test -v -race -covermode=atomic -coverprofile=coverage.out ./packages/...
             workingDirectory: 'agent-governance-golang'
             displayName: 'Run tests with coverage'
 


### PR DESCRIPTION
## Description
Fix the Go ESRP test step by scoping the coverage run to `./packages/...` and using `-covermode=atomic` with `-race`.

The previous command ran against `./...`, which includes example packages that are not real test targets. That can cause the coverage step to exit non-zero even when the `packages/agentmesh` tests themselves pass.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [ ] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
GitHub Copilot CLI to identify the CI failure mode and prepare the YAML fix; output reviewed.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
N/A