### PR TITLE
feat: Citadel Phase 2 - Entra identity bridge and APIM policy fragment

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/citadel/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/citadel/__init__.py
@@ -6,17 +6,28 @@ Citadel Integration Module
 Provides integration between AGT and the Foundry Citadel Platform:
 - Policy bundle binding for Citadel Access Contracts
 - Audit event export to Azure Event Hub / Application Insights
+- Entra agent identity federation (attestation, not write-back)
 - Correlation ID management for unified observability
 """
 
 from __future__ import annotations
 
+from agent_os.integrations.citadel.identity_bridge import (
+    AgentIdentityBinding,
+    EntraIdentityBridge,
+    IdentityAttestation,
+    TrustRiskLabel,
+)
 from agent_os.integrations.citadel.policy_bundle import (
     PolicyBundle,
     PolicyBundleResolver,
 )
 
 __all__ = [
+    "AgentIdentityBinding",
+    "EntraIdentityBridge",
+    "IdentityAttestation",
     "PolicyBundle",
     "PolicyBundleResolver",
+    "TrustRiskLabel",
 ]

--- a/agent-governance-python/agent-os/src/agent_os/integrations/citadel/identity_bridge.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/citadel/identity_bridge.py
@@ -1,0 +1,366 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Entra Agent Identity Bridge for Citadel Layer 3
+
+Maps AGT's Ed25519/SPIFFE agent identities to Microsoft Entra ID agent
+identities, enabling Citadel Layer 3 (Agent Identity) to recognize and
+track AGT-governed agents.
+
+Design principles:
+- This is **attestation/federation**, not write-back.
+- Entra/Agent 365 remains authoritative for enterprise identity and lifecycle.
+- AGT remains authoritative for runtime credentials and trust scores.
+- AGT trust scores surface as telemetry risk labels, not primary Entra metadata.
+- If Entra is unavailable, AGT continues with local identity (fail-open).
+
+Usage:
+    from agent_os.integrations.citadel.identity_bridge import (
+        EntraIdentityBridge,
+        AgentIdentityBinding,
+    )
+
+    bridge = EntraIdentityBridge.from_env()
+    binding = bridge.bind(
+        agt_agent_id="customer-support-agent-01",
+        agt_public_key="<base64-ed25519-pubkey>",
+        entra_object_id="00000000-0000-0000-0000-000000000001",
+    )
+    attestation = bridge.attest(binding, trust_score=850)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class TrustRiskLabel(str, Enum):
+    """Risk labels derived from AGT trust scores.
+
+    These are the labels surfaced in telemetry and observability pipelines.
+    They are NOT written back to Entra as primary attributes.
+    """
+
+    TRUSTED = "trusted"
+    DEGRADED = "degraded"
+    UNTRUSTED = "untrusted"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_score(cls, score: int) -> TrustRiskLabel:
+        """Derive a risk label from an AGT trust score (0-1000).
+
+        Thresholds:
+            >= 700: trusted
+            >= 400: degraded
+            < 400:  untrusted
+        """
+        if score >= 700:
+            return cls.TRUSTED
+        if score >= 400:
+            return cls.DEGRADED
+        return cls.UNTRUSTED
+
+
+@dataclass
+class AgentIdentityBinding:
+    """Binding between an AGT agent identity and an Entra agent identity.
+
+    This binding is created once (at registration/provisioning time) and
+    cached for the agent's lifetime. It does NOT grant Entra permissions
+    or modify Entra objects.
+
+    Attributes:
+        binding_id: Unique ID for this binding.
+        agt_agent_id: The AGT agent identifier.
+        agt_public_key_thumbprint: SHA-256 thumbprint of the Ed25519 public key.
+        agt_spiffe_id: Optional SPIFFE ID (spiffe://domain/agent/...).
+        entra_object_id: The Entra ID object ID for the agent's managed identity
+            or app registration.
+        entra_app_id: Optional Entra application (client) ID.
+        created_at: ISO 8601 timestamp of binding creation.
+        verified: Whether the binding has been verified via key attestation.
+    """
+
+    binding_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    agt_agent_id: str = ""
+    agt_public_key_thumbprint: str = ""
+    agt_spiffe_id: str = ""
+    entra_object_id: str = ""
+    entra_app_id: str = ""
+    created_at: str = field(
+        default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    )
+    verified: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class IdentityAttestation:
+    """An attestation record linking AGT governance state to an Entra identity.
+
+    Attestations are emitted as telemetry events. They provide a snapshot
+    of the agent's governance posture at a point in time, correlated to
+    its enterprise identity.
+
+    Attributes:
+        attestation_id: Unique ID for this attestation.
+        binding_id: The identity binding this attestation references.
+        agt_agent_id: The AGT agent identifier.
+        entra_object_id: The Entra agent object ID.
+        trust_score: Current AGT trust score (0-1000).
+        risk_label: Derived risk label (trusted/degraded/untrusted).
+        policy_bundle_id: Currently loaded policy bundle.
+        policy_bundle_hash: SHA-256 hash of the loaded policy bundle.
+        timestamp: ISO 8601 timestamp.
+        metadata: Additional attestation context.
+    """
+
+    attestation_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    binding_id: str = ""
+    agt_agent_id: str = ""
+    entra_object_id: str = ""
+    trust_score: int = 0
+    risk_label: TrustRiskLabel = TrustRiskLabel.UNKNOWN
+    policy_bundle_id: str = ""
+    policy_bundle_hash: str = ""
+    timestamp: str = field(
+        default_factory=lambda: time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    )
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dictionary."""
+        data = asdict(self)
+        data["risk_label"] = self.risk_label.value
+        return data
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(self.to_dict(), default=str)
+
+
+class EntraIdentityBridge:
+    """Bridges AGT agent identities to Entra ID agent identities.
+
+    The bridge maintains a local registry of bindings (AGT agent <-> Entra object)
+    and produces attestation events that surface AGT trust scores as risk labels
+    in telemetry pipelines.
+
+    This bridge does NOT:
+    - Write to Entra ID (no Graph API mutations)
+    - Grant or revoke permissions
+    - Replace AGT's runtime identity system
+
+    It DOES:
+    - Map AGT identities to Entra objects for correlation
+    - Produce attestation events with risk labels for observability
+    - Enable Citadel Layer 3 dashboards to show AGT governance posture
+    """
+
+    def __init__(
+        self,
+        tenant_id: str = "",
+        verify_entra: bool = False,
+    ) -> None:
+        """Initialize the bridge.
+
+        Args:
+            tenant_id: Entra tenant ID (for validation, not for Graph calls).
+            verify_entra: If True, verify Entra object IDs exist via Graph API.
+                Requires azure-identity and msgraph-sdk. Default: False.
+        """
+        self._tenant_id = tenant_id
+        self._verify_entra = verify_entra
+        self._bindings: dict[str, AgentIdentityBinding] = {}
+        self._graph_client: Any = None
+
+    @classmethod
+    def from_env(cls) -> EntraIdentityBridge:
+        """Create a bridge from environment variables.
+
+        Environment variables:
+            CITADEL_ENTRA_TENANT_ID: Entra tenant ID.
+            CITADEL_ENTRA_VERIFY: Set to "true" to verify Entra objects via Graph.
+        """
+        return cls(
+            tenant_id=os.environ.get("CITADEL_ENTRA_TENANT_ID", ""),
+            verify_entra=os.environ.get("CITADEL_ENTRA_VERIFY", "").lower() == "true",
+        )
+
+    def bind(
+        self,
+        agt_agent_id: str,
+        agt_public_key: str = "",
+        agt_spiffe_id: str = "",
+        entra_object_id: str = "",
+        entra_app_id: str = "",
+    ) -> AgentIdentityBinding:
+        """Create a binding between an AGT agent and an Entra identity.
+
+        This is typically called once at agent registration/provisioning time.
+        The binding is cached locally.
+
+        Args:
+            agt_agent_id: The AGT agent identifier.
+            agt_public_key: Base64-encoded Ed25519 public key.
+            agt_spiffe_id: SPIFFE ID for the agent.
+            entra_object_id: Entra ID object ID (managed identity or app registration).
+            entra_app_id: Entra application (client) ID.
+
+        Returns:
+            The created AgentIdentityBinding.
+        """
+        # Compute key thumbprint
+        thumbprint = ""
+        if agt_public_key:
+            thumbprint = hashlib.sha256(agt_public_key.encode()).hexdigest()
+
+        binding = AgentIdentityBinding(
+            agt_agent_id=agt_agent_id,
+            agt_public_key_thumbprint=thumbprint,
+            agt_spiffe_id=agt_spiffe_id,
+            entra_object_id=entra_object_id,
+            entra_app_id=entra_app_id,
+            verified=False,
+        )
+
+        # Optionally verify the Entra object exists
+        if self._verify_entra and entra_object_id:
+            binding.verified = self._verify_entra_object(entra_object_id)
+            if not binding.verified:
+                logger.warning(
+                    "Entra object %s could not be verified for agent %s",
+                    entra_object_id,
+                    agt_agent_id,
+                )
+
+        self._bindings[agt_agent_id] = binding
+        logger.info(
+            "Bound AGT agent '%s' (key: %s) to Entra object %s",
+            agt_agent_id,
+            thumbprint[:12] if thumbprint else "none",
+            entra_object_id or "none",
+        )
+        return binding
+
+    def attest(
+        self,
+        binding: AgentIdentityBinding,
+        trust_score: int,
+        policy_bundle_id: str = "",
+        policy_bundle_hash: str = "",
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> IdentityAttestation:
+        """Create an attestation record for an agent's current governance posture.
+
+        The attestation maps the AGT trust score to a risk label and packages
+        it with the identity binding for export to telemetry pipelines.
+
+        Args:
+            binding: The identity binding to attest.
+            trust_score: Current AGT trust score (0-1000).
+            policy_bundle_id: ID of the currently loaded policy bundle.
+            policy_bundle_hash: SHA-256 hash of the policy bundle content.
+            metadata: Additional context for the attestation.
+
+        Returns:
+            An IdentityAttestation ready for export.
+        """
+        attestation = IdentityAttestation(
+            binding_id=binding.binding_id,
+            agt_agent_id=binding.agt_agent_id,
+            entra_object_id=binding.entra_object_id,
+            trust_score=trust_score,
+            risk_label=TrustRiskLabel.from_score(trust_score),
+            policy_bundle_id=policy_bundle_id,
+            policy_bundle_hash=policy_bundle_hash,
+            metadata=metadata or {},
+        )
+
+        logger.info(
+            "Attestation for agent '%s': score=%d label=%s entra=%s",
+            binding.agt_agent_id,
+            trust_score,
+            attestation.risk_label.value,
+            binding.entra_object_id or "unbound",
+        )
+        return attestation
+
+    def get_binding(self, agt_agent_id: str) -> Optional[AgentIdentityBinding]:
+        """Look up an existing binding for an AGT agent.
+
+        Args:
+            agt_agent_id: The AGT agent identifier.
+
+        Returns:
+            The binding, or None if not found.
+        """
+        return self._bindings.get(agt_agent_id)
+
+    def list_bindings(self) -> list[AgentIdentityBinding]:
+        """List all registered identity bindings."""
+        return list(self._bindings.values())
+
+    def remove_binding(self, agt_agent_id: str) -> bool:
+        """Remove an identity binding.
+
+        Args:
+            agt_agent_id: The AGT agent identifier to unbind.
+
+        Returns:
+            True if the binding was removed, False if it didn't exist.
+        """
+        if agt_agent_id in self._bindings:
+            del self._bindings[agt_agent_id]
+            logger.info("Removed identity binding for agent '%s'", agt_agent_id)
+            return True
+        return False
+
+    def _verify_entra_object(self, object_id: str) -> bool:
+        """Verify an Entra object exists via Microsoft Graph API.
+
+        Args:
+            object_id: The Entra object ID to verify.
+
+        Returns:
+            True if the object exists, False otherwise.
+        """
+        try:
+            from azure.identity import DefaultAzureCredential
+
+            import urllib.request
+        except ImportError:
+            logger.warning(
+                "azure-identity not installed, skipping Entra verification. "
+                "Install with: pip install azure-identity"
+            )
+            return False
+
+        try:
+            if self._graph_client is None:
+                self._graph_client = DefaultAzureCredential()
+
+            token = self._graph_client.get_token("https://graph.microsoft.com/.default")
+            req = urllib.request.Request(
+                f"https://graph.microsoft.com/v1.0/directoryObjects/{object_id}",
+                headers={"Authorization": f"Bearer {token.token}"},
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.status == 200
+        except Exception as e:
+            logger.debug("Entra verification failed for %s: %s", object_id, e)
+            return False

--- a/docs/integrations/citadel-integration.md
+++ b/docs/integrations/citadel-integration.md
@@ -165,12 +165,57 @@ Understanding what each system handles avoids duplication:
 | AGT Policy Engine | Agent actions proceed ungoverned (fail-open by default, configurable to fail-closed). |
 | Entra ID | AGT uses local cryptographic identity. Enterprise identity federation paused. |
 
+## Entra Identity Federation
+
+The `EntraIdentityBridge` maps AGT agent identities to Entra ID agent identities
+for Citadel Layer 3 correlation. This is **attestation/federation**, not write-back:
+
+- Entra remains authoritative for enterprise identity and lifecycle
+- AGT remains authoritative for runtime credentials and trust scores
+- AGT trust scores surface as **risk labels** in telemetry, not Entra metadata
+
+```python
+from agent_os.integrations.citadel import EntraIdentityBridge
+
+bridge = EntraIdentityBridge.from_env()
+
+# Bind AGT agent to its Entra managed identity (one-time setup)
+binding = bridge.bind(
+    agt_agent_id="customer-support-agent-01",
+    agt_public_key="<base64-ed25519-pubkey>",
+    entra_object_id="00000000-0000-0000-0000-000000000001",
+)
+
+# Produce attestation (emitted as telemetry)
+attestation = bridge.attest(binding, trust_score=850)
+# attestation.risk_label == TrustRiskLabel.TRUSTED
+```
+
+Trust score thresholds:
+- `>= 700`: trusted
+- `>= 400`: degraded
+- `< 400`: untrusted
+
+## APIM Governance Metadata
+
+The APIM policy fragment (`agt-governance-metadata`) enables the Citadel gateway
+to log AGT governance posture without adding AGT to the request hot path:
+
+1. Agent runtime sets `X-AGT-*` headers before making LLM calls
+2. APIM fragment reads headers, logs them as custom trace dimensions
+3. Fragment strips AGT headers before forwarding to backend (defense in depth)
+4. Response includes `X-AGT-APIM-Request-Id` for cross-system correlation
+
+See [`examples/citadel-governed-agent/apim-policies/`](../../examples/citadel-governed-agent/apim-policies/)
+for the fragment XML, sample product policy, and deployment instructions.
+
 ## Getting Started
 
 1. **Deploy Citadel Governance Hub**: Follow the [Citadel quickstart](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/tree/citadel-v1)
 2. **Install AGT**: `pip install agent-governance-toolkit`
 3. **Configure the exporter**: Set `CITADEL_EVENTHUB_CONNECTION_STRING` and `CITADEL_APPINSIGHTS_CONNECTION_STRING`
-4. **See the example**: [`examples/citadel-governed-agent/`](../../examples/citadel-governed-agent/)
+4. **Deploy the APIM fragment**: See [`apim-policies/README.md`](../../examples/citadel-governed-agent/apim-policies/README.md)
+5. **See the example**: [`examples/citadel-governed-agent/`](../../examples/citadel-governed-agent/)
 
 ## References
 

--- a/examples/citadel-governed-agent/README.md
+++ b/examples/citadel-governed-agent/README.md
@@ -79,6 +79,9 @@ python src/agent.py
 | `src/citadel_config.py` | Citadel gateway configuration and helpers |
 | `policies/agent-policy.yaml` | AGT policy bundle for this agent |
 | `sample-access-contract/main.bicepparam` | Sample Citadel Access Contract with AGT binding |
+| `apim-policies/agt-governance-metadata.xml` | APIM policy fragment for governance metadata passthrough |
+| `apim-policies/agt-governed-product-policy.xml` | Sample product policy using the fragment |
+| `apim-policies/README.md` | APIM policy deployment and usage guide |
 
 ## Policy Precedence
 

--- a/examples/citadel-governed-agent/apim-policies/README.md
+++ b/examples/citadel-governed-agent/apim-policies/README.md
@@ -1,0 +1,117 @@
+# APIM Governance Metadata Policy Fragment
+
+This directory contains an APIM policy fragment and sample product policy for passing AGT governance metadata through the Citadel gateway.
+
+## Architecture
+
+```
+Agent Runtime                    APIM Gateway                     LLM Backend
+┌──────────────┐    request     ┌──────────────┐    request      ┌───────────┐
+│ AGT Policy   │  + headers     │ Fragment:    │  (headers       │           │
+│ Engine       ├───────────────>│ Read AGT     │   stripped)     │  Azure    │
+│              │                │ metadata,    ├────────────────>│  OpenAI   │
+│ Sets headers:│                │ log to trace,│                 │           │
+│ X-AGT-Trust  │                │ strip before │    response     │           │
+│ X-AGT-Risk   │    response    │ forwarding   │<────────────────┤           │
+│ X-AGT-Bundle │<───────────────┤              │                 │           │
+│ X-AGT-Version│  + X-AGT-APIM  │ Add APIM ID  │                 │           │
+│ X-AGT-DecId  │    -Request-Id  │ to response  │                 └───────────┘
+└──────────────┘                └──────────────┘
+```
+
+## Key Design Decision
+
+APIM does **not** call AGT's policy endpoint on every request. That would:
+- Add latency (extra network hop per request)
+- Create availability coupling (APIM depends on AGT service)
+- Produce split-brain decisions (two systems making allow/deny calls)
+
+Instead, the agent runtime evaluates policies locally and passes the result as **advisory metadata** through the gateway. APIM logs this metadata for observability but does not make governance decisions based on it (unless you explicitly enable the optional trust threshold block).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `agt-governance-metadata.xml` | Policy fragment. Deploy to APIM as a reusable fragment with ID `agt-governance-metadata`. |
+| `agt-governed-product-policy.xml` | Sample product policy showing how to include the fragment alongside Citadel's standard controls. |
+
+## Header Schema
+
+Headers set by the agent runtime before making LLM calls through the gateway:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `X-AGT-Trust-Score` | Integer (0-1000) | Agent's current trust score |
+| `X-AGT-Risk-Label` | String | `trusted`, `degraded`, or `untrusted` |
+| `X-AGT-Policy-Bundle` | String | Policy bundle ID (e.g., `customer-support-v2`) |
+| `X-AGT-Policy-Version` | String | Bundle version (e.g., `1.2.0`) |
+| `X-AGT-Decision-Id` | UUID | AGT policy decision ID for correlation |
+
+Response header added by the fragment:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `X-AGT-APIM-Request-Id` | UUID | APIM request ID for cross-system trace correlation |
+
+## Setting Headers from Agent Code
+
+```python
+import httpx
+from agent_os.integrations.citadel.identity_bridge import TrustRiskLabel
+
+headers = {
+    "X-AGT-Trust-Score": str(current_trust_score),
+    "X-AGT-Risk-Label": TrustRiskLabel.from_score(current_trust_score).value,
+    "X-AGT-Policy-Bundle": policy_bundle.bundle_id,
+    "X-AGT-Policy-Version": policy_bundle.version,
+    "X-AGT-Decision-Id": decision_id,
+}
+
+response = httpx.post(
+    "https://apim-gateway.azure-api.net/openai/deployments/gpt-4o/chat/completions",
+    headers={**auth_headers, **headers},
+    json=payload,
+)
+
+# Read back the APIM request ID for correlation
+apim_request_id = response.headers.get("X-AGT-APIM-Request-Id", "")
+```
+
+## Deploying the Fragment
+
+### Via Azure CLI
+
+```bash
+az apim api-management named-value create \
+    --resource-group <rg> \
+    --service-name <apim> \
+    --named-value-id agt-governance-metadata \
+    --display-name "AGT Governance Metadata Fragment" \
+    --value "$(cat agt-governance-metadata.xml)"
+```
+
+### Via Bicep
+
+The fragment can be deployed as part of your Citadel infrastructure:
+
+```bicep
+resource agtFragment 'Microsoft.ApiManagement/service/policyFragments@2023-09-01-preview' = {
+  parent: apimService
+  name: 'agt-governance-metadata'
+  properties: {
+    description: 'AGT governance metadata passthrough for agent trust correlation'
+    format: 'rawxml'
+    value: loadTextContent('policies/agt-governance-metadata.xml')
+  }
+}
+```
+
+## Optional: Trust Threshold Blocking
+
+The fragment includes a commented-out section that blocks requests from agents with an `untrusted` risk label. To enable:
+
+1. Uncomment the `<choose>` block in the inbound section of `agt-governance-metadata.xml`
+2. Customize the threshold (default: block `untrusted`, allow `degraded` and `trusted`)
+3. Test with a non-production subscription first
+
+This is a **coarse-grained safety net**, not a replacement for AGT's fine-grained policy evaluation.

--- a/examples/citadel-governed-agent/apim-policies/agt-governance-metadata.xml
+++ b/examples/citadel-governed-agent/apim-policies/agt-governance-metadata.xml
@@ -1,0 +1,107 @@
+<!--
+    AGT Governance Metadata Policy Fragment for Citadel APIM
+    
+    This fragment reads AGT governance metadata from request headers set by
+    the agent runtime and logs them alongside APIM telemetry for correlation.
+    
+    Design: APIM does NOT call AGT's policy endpoint on every request.
+    That would add latency, create availability coupling, and produce
+    split-brain decisions. Instead, the agent runtime evaluates policies
+    locally and passes the result as advisory metadata through the gateway.
+    
+    Header schema (set by agent runtime):
+      X-AGT-Trust-Score:      Integer 0-1000 (agent's current trust score)
+      X-AGT-Risk-Label:       trusted|degraded|untrusted
+      X-AGT-Policy-Bundle:    Bundle ID (e.g., customer-support-v2)
+      X-AGT-Policy-Version:   Bundle version (e.g., 1.2.0)
+      X-AGT-Decision-Id:      UUID of the AGT policy decision
+    
+    Usage:
+      Add to your Access Contract product policy:
+        <include-fragment fragment-id="agt-governance-metadata" />
+-->
+<fragment>
+    <!-- ================================================================== -->
+    <!-- INBOUND: Extract AGT governance metadata from request headers       -->
+    <!-- ================================================================== -->
+    <inbound>
+        <!-- Read AGT headers (all optional, agent may not be AGT-governed) -->
+        <set-variable name="agtTrustScore" value="@{
+            var header = context.Request.Headers.GetValueOrDefault("X-AGT-Trust-Score", "");
+            int score;
+            return int.TryParse(header, out score) ? score.ToString() : "-1";
+        }" />
+        <set-variable name="agtRiskLabel" value="@(context.Request.Headers.GetValueOrDefault("X-AGT-Risk-Label", "unknown"))" />
+        <set-variable name="agtPolicyBundle" value="@(context.Request.Headers.GetValueOrDefault("X-AGT-Policy-Bundle", ""))" />
+        <set-variable name="agtPolicyVersion" value="@(context.Request.Headers.GetValueOrDefault("X-AGT-Policy-Version", ""))" />
+        <set-variable name="agtDecisionId" value="@(context.Request.Headers.GetValueOrDefault("X-AGT-Decision-Id", ""))" />
+        <set-variable name="isAgtGoverned" value="@(context.Request.Headers.ContainsKey("X-AGT-Trust-Score") ? "true" : "false")" />
+
+        <!-- Optional: Block requests from untrusted agents.                -->
+        <!-- Uncomment this section to enforce a minimum trust threshold     -->
+        <!-- at the gateway level. This is a coarse-grained safety net,     -->
+        <!-- not a replacement for AGT's fine-grained policy evaluation.    -->
+        <!--
+        <choose>
+            <when condition="@{
+                var label = (string)context.Variables["agtRiskLabel"];
+                return label == "untrusted";
+            }">
+                <return-response>
+                    <set-status code="403" reason="Agent Governance: Untrusted" />
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/json</value>
+                    </set-header>
+                    <set-body>@{
+                        return new JObject(
+                            new JProperty("error", "agent_untrusted"),
+                            new JProperty("message", "Agent trust score is below the minimum threshold. Contact your governance administrator."),
+                            new JProperty("agt_decision_id", (string)context.Variables.GetValueOrDefault<string>("agtDecisionId", ""))
+                        ).ToString();
+                    }</set-body>
+                </return-response>
+            </when>
+        </choose>
+        -->
+
+        <!-- Strip AGT headers before forwarding to backend (defense in depth) -->
+        <set-header name="X-AGT-Trust-Score" exists-action="delete" />
+        <set-header name="X-AGT-Risk-Label" exists-action="delete" />
+        <set-header name="X-AGT-Policy-Bundle" exists-action="delete" />
+        <set-header name="X-AGT-Policy-Version" exists-action="delete" />
+        <set-header name="X-AGT-Decision-Id" exists-action="delete" />
+    </inbound>
+
+    <!-- ================================================================== -->
+    <!-- OUTBOUND: Add AGT correlation headers to response and log          -->
+    <!-- ================================================================== -->
+    <outbound>
+        <!-- Emit AGT governance metadata as custom dimensions in APIM logs -->
+        <choose>
+            <when condition="@((string)context.Variables.GetValueOrDefault<string>("isAgtGoverned", "false") == "true")">
+                <trace source="agt-governance" severity="information">
+                    <message>@{
+                        return String.Format(
+                            "AGT Governance: agent_trust={0} risk={1} bundle={2} version={3} decision_id={4}",
+                            (string)context.Variables["agtTrustScore"],
+                            (string)context.Variables["agtRiskLabel"],
+                            (string)context.Variables["agtPolicyBundle"],
+                            (string)context.Variables["agtPolicyVersion"],
+                            (string)context.Variables["agtDecisionId"]
+                        );
+                    }</message>
+                    <metadata name="agt-trust-score" value="@((string)context.Variables["agtTrustScore"])" />
+                    <metadata name="agt-risk-label" value="@((string)context.Variables["agtRiskLabel"])" />
+                    <metadata name="agt-policy-bundle" value="@((string)context.Variables["agtPolicyBundle"])" />
+                    <metadata name="agt-policy-version" value="@((string)context.Variables["agtPolicyVersion"])" />
+                    <metadata name="agt-decision-id" value="@((string)context.Variables["agtDecisionId"])" />
+                </trace>
+
+                <!-- Return APIM request ID so agent can correlate back -->
+                <set-header name="X-AGT-APIM-Request-Id" exists-action="override">
+                    <value>@(context.RequestId.ToString())</value>
+                </set-header>
+            </when>
+        </choose>
+    </outbound>
+</fragment>

--- a/examples/citadel-governed-agent/apim-policies/agt-governed-product-policy.xml
+++ b/examples/citadel-governed-agent/apim-policies/agt-governed-product-policy.xml
@@ -1,0 +1,49 @@
+<!--
+    Sample Citadel Access Contract product policy with AGT governance metadata.
+    
+    This is a complete APIM product policy that combines Citadel's standard
+    controls (model validation, token limits) with AGT governance metadata
+    passthrough. Use this as a template for your Access Contract policies.
+    
+    To use:
+    1. Deploy the agt-governance-metadata fragment to your APIM instance
+    2. Reference this policy in your Access Contract's service config:
+       { code: "OAI", policyXmlPath: "policies/agt-governed-product-policy.xml" }
+-->
+<policies>
+    <inbound>
+        <base />
+        
+        <!-- Standard Citadel controls -->
+        <include-fragment fragment-id="set-llm-requested-model" />
+        
+        <!-- Set allowed models for this use case -->
+        <set-variable name="allowedModels" value="gpt-4o,gpt-5.4-mini" />
+        
+        <!-- Token rate limiting (per-subscription) -->
+        <llm-token-limit 
+            counter-key="@(context.Subscription.Id)" 
+            tokens-per-minute="5000" 
+            estimate-prompt-tokens="false" 
+            token-quota="500000" 
+            token-quota-period="Monthly" />
+        
+        <!-- AGT governance metadata: read trust score, risk label, policy info -->
+        <include-fragment fragment-id="agt-governance-metadata" />
+        
+        <!-- Enable response headers -->
+        <set-variable name="enableResponseHeaders" value="@(true)" />
+    </inbound>
+    
+    <backend>
+        <base />
+    </backend>
+    
+    <outbound>
+        <base />
+    </outbound>
+    
+    <on-error>
+        <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
## Summary

Phase 2 of the Citadel integration, building on Phase 1 (#1778). Adds:

### 1. Entra Agent Identity Bridge (Layer 3) - Closes #1774

`identity_bridge.py` provides federation between AGT's Ed25519/SPIFFE agent identities and Microsoft Entra ID agent identities.

**Design: attestation/federation, not write-back.**
- Entra remains authoritative for enterprise identity
- AGT remains authoritative for runtime credentials and trust scores
- Trust scores surface as risk labels in telemetry, not Entra metadata

Key classes:
- `EntraIdentityBridge`: Creates bindings and attestations
- `AgentIdentityBinding`: One-time AGT-to-Entra agent mapping
- `IdentityAttestation`: Snapshot of governance posture for telemetry
- `TrustRiskLabel`: Derives trusted/degraded/untrusted from score (0-1000)

### 2. APIM Governance Metadata Policy Fragment (Layer 1) - Closes #1775

Custom APIM XML policy fragment that passes AGT governance metadata through the Citadel gateway **without** adding AGT to the request hot path.

**Design: advisory metadata, not gateway enforcement.**
- Agent runtime sets `X-AGT-*` headers (trust score, risk label, policy bundle, decision ID)
- APIM reads, logs as trace dimensions, strips before forwarding to backend
- Returns `X-AGT-APIM-Request-Id` for cross-system correlation
- Optional trust threshold blocking (commented out, opt-in)

### Files Changed

| File | Change |
|------|--------|
| `integrations/citadel/identity_bridge.py` | New: Entra identity bridge |
| `integrations/citadel/__init__.py` | Updated: exports bridge classes |
| `docs/integrations/citadel-integration.md` | Updated: Entra and APIM sections |
| `examples/citadel-governed-agent/apim-policies/` | New: fragment, sample policy, README |
| `examples/citadel-governed-agent/README.md` | Updated: references new files |

### Testing

- Identity bridge: import validation, TrustRiskLabel thresholds, bind/attest/serialize round-trip
- APIM fragment: XML structure validated, follows Citadel policy conventions

### Related

- Phase 1: #1778 (merged)
- Citadel-side PR: Azure-Samples/ai-hub-gateway-solution-accelerator#111