### PR TITLE
docs: add CHARTER.md, RELEASE.md, and DCO enforcement for AAIF readiness

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,54 @@
+name: DCO Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Developer Certificate of Origin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off on commits
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          MISSING=()
+
+          for SHA in $(git rev-list "$BASE".."$HEAD"); do
+            # Skip merge commits
+            PARENTS=$(git rev-parse --verify "$SHA^2" 2>/dev/null && echo "merge" || echo "normal")
+            if [ "$PARENTS" = "merge" ]; then
+              continue
+            fi
+
+            # Check for Signed-off-by trailer
+            if ! git log -1 --format='%B' "$SHA" | grep -qiE '^Signed-off-by: .+ <.+>'; then
+              AUTHOR=$(git log -1 --format='%an <%ae>' "$SHA")
+              SHORT=$(git log -1 --format='%h' "$SHA")
+              MISSING+=("$SHORT by $AUTHOR")
+            fi
+          done
+
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::The following commits are missing a DCO sign-off (Signed-off-by trailer):"
+            for M in "${MISSING[@]}"; do
+              echo "  - $M"
+            done
+            echo ""
+            echo "To fix, amend your commits with: git commit --amend --signoff"
+            echo "Or for all commits: git rebase --signoff HEAD~N"
+            echo ""
+            echo "See https://developercertificate.org for details."
+            exit 1
+          fi
+
+          echo "All commits have valid DCO sign-off."
+

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,200 @@
+## Technical Charter (the "Charter") for Agent Governance Toolkit, a Series of LF Projects, LLC
+
+This Charter sets forth the responsibilities and procedures for technical contribution to, and
+oversight of, the Agent Governance Toolkit open source project, which has been established as
+Agent Governance Toolkit a Series of LF Projects, LLC (the "Project"). LF Projects, LLC
+("LF Projects") is a Delaware series limited liability company. All contributors (including
+committers, maintainers, and other technical positions) and other participants in the Project
+(collectively, "Collaborators") must comply with the terms of this Charter.
+
+### 1. Mission and Scope of the Project
+
+a. The mission of the Project is to provide open source libraries, tools, and
+   reference implementations that help developers build, deploy, and operate
+   AI agent systems with built-in governance, safety, and compliance controls,
+   covering identity, policy enforcement, capability sandboxing, auditability,
+   and human oversight.
+
+b. The scope of the Project includes collaborative development under the Project
+   License (as defined herein) supporting the mission, including documentation,
+   testing, integration and the creation of other artifacts that aid the development,
+   deployment, operation or adoption of the open source project.
+
+### 2. Technical Steering Committee
+
+a. The Technical Steering Committee (the "TSC") will be responsible for all
+   technical oversight of the open source Project.
+
+b. The TSC voting members are initially the Project's Maintainers. At the inception
+   of the project, the Maintainers of the Project will be as set forth within the
+   "MAINTAINERS.md" file within the Project's code repository. The TSC may
+   choose an alternative approach for determining the voting members of the TSC,
+   and any such alternative approach will be documented in the CONTRIBUTING
+   file. Any meetings of the Technical Steering Committee are intended to be open
+   to the public, and can be conducted electronically, via teleconference, or in
+   person.
+
+c. TSC projects generally will involve Contributors and Maintainers. The TSC may
+   adopt or modify roles so long as the roles are documented in the
+   CONTRIBUTING file. Unless otherwise documented:
+   - Contributors include anyone in the technical community that contributes
+     code, documentation, or other technical artifacts to the Project;
+   - Maintainers are Contributors who have earned the ability to modify
+     ("commit") source code, documentation or other technical artifacts in a
+     project's repository; and
+   - A Contributor may become a Maintainer by a majority approval of the
+     TSC. A Maintainer may be removed by a majority approval of the TSC.
+
+d. Participation in the Project through becoming a Contributor and Maintainer is
+   open to anyone so long as they abide by the terms of this Charter.
+
+e. The TSC may (1) establish work flow procedures for the submission, approval,
+   and closure/archiving of projects, (2) set requirements for the promotion of
+   Contributors to Maintainer status, as applicable, and (3) amend, adjust, refine
+   and/or eliminate the roles of Contributors, and Maintainer, and create new roles,
+   and publicly document any TSC roles, as it sees fit.
+
+f. The TSC may elect a TSC Chair, who will preside over meetings of the TSC and
+   will serve until their resignation or replacement by the TSC.
+
+g. Responsibilities: The TSC will be responsible for all aspects of oversight relating
+   to the Project, which may include:
+   - coordinating the technical direction of the Project;
+   - approving project or system proposals (including, but not limited to,
+     incubation, deprecation, and changes to a sub-project's scope);
+   - organizing sub-projects and removing sub-projects;
+   - creating sub-committees or working groups to focus on cross-project
+     technical issues and requirements;
+   - appointing representatives to work with other open source or open
+     standards communities;
+   - establishing community norms, workflows, issuing releases, and security
+     issue reporting policies;
+   - approving and implementing policies and processes for contributing (to be
+     published in the CONTRIBUTING file) and coordinating with the series
+     manager of the Project (as provided for in the Series Agreement, the
+     "Series Manager") to resolve matters or concerns that may arise as set
+     forth in Section 7 of this Charter;
+   - discussions, seeking consensus, and where necessary, voting on technical
+     matters relating to the code base that affect multiple projects; and
+   - coordinating any marketing, events, or communications regarding the
+     Project.
+
+### 3. TSC Voting
+
+a. While the Project aims to operate as a consensus-based community, if any TSC
+   decision requires a vote to move the Project forward, the voting members of the
+   TSC will vote on a one vote per voting member basis.
+
+b. Quorum for TSC meetings requires at least fifty percent of all voting members of
+   the TSC to be present. The TSC may continue to meet if quorum is not met but
+   will be prevented from making any decisions at the meeting.
+
+c. Except as provided in Section 7.c. and 8.a, decisions by vote at a meeting require
+   a majority vote of those in attendance, provided quorum is met. Decisions made
+   by electronic vote without a meeting require a majority vote of all voting
+   members of the TSC.
+
+d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC
+   may refer the matter to the Series Manager for assistance in reaching a resolution.
+
+### 4. Compliance with Policies
+
+a. This Charter is subject to the Series Agreement for the Project and the Operating
+   Agreement of LF Projects. Contributors will comply with the policies of LF
+   Projects as may be adopted and amended by LF Projects, including, without
+   limitation the policies listed at https://lfprojects.org/policies/.
+
+b. The TSC may adopt a code of conduct ("CoC") for the Project, which is subject to
+   approval by the Series Manager. In the event that a Project-specific CoC has not
+   been approved, the LF Projects Code of Conduct listed at
+   https://lfprojects.org/policies will apply for all Collaborators in the Project.
+
+c. When amending or adopting any policy applicable to the Project, LF Projects will
+   publish such policy, as to be amended or adopted, on its web site at least 30 days
+   prior to such policy taking effect; provided, however, that in the case of any
+   amendment of the Trademark Policy or Terms of Use of LF Projects, any such
+   amendment is effective upon publication on LF Project's web site.
+
+d. All Collaborators must allow open participation from any individual or
+   organization meeting the requirements for contributing under this Charter and any
+   policies adopted for all Collaborators by the TSC, regardless of competitive
+   interests. Put another way, the Project community must not seek to exclude any
+   participant based on any criteria, requirement, or reason other than those that are
+   reasonable and applied on a non-discriminatory basis to all Collaborators in the
+   Project community.
+
+e. The Project will operate in a transparent, open, collaborative, and ethical manner
+   at all times. The output of all Project discussions, proposals, timelines, decisions,
+   and status should be made open and easily visible to all. Any potential violations
+   of this requirement should be reported immediately to the Series Manager.
+
+### 5. Community Assets
+
+a. LF Projects (or an associated hosting entity) will hold title to all trade or service
+   marks used by the Project ("Project Trademarks"), whether based on common law
+   or registered rights. Project Trademarks will be transferred and assigned to LF
+   Projects (or, where applicable, the associated hosting entity) to hold on behalf of
+   the Project. Any use of any Project Trademarks by Collaborators in the Project
+   will (a) either be (i) in a way that constitutes fair use or (ii) in accordance with the
+   license from LF Projects to the Project and the applicable trademark usage
+   guidelines and (b) inure to the benefit of LF Projects (or the associated hosting
+   entity).
+
+b. The Project will, as permitted and in accordance with such license from LF
+   Projects, develop and own all Project GitHub and social media accounts, and
+   domain name registrations created by the Project community.
+
+c. Under no circumstances will LF Projects be expected or required to undertake any
+   action on behalf of the Project that is inconsistent with the tax-exempt status or
+   purpose, as applicable, of the Joint Development Foundation or LF Projects, LLC.
+
+### 6. General Rules and Operations
+
+a. The Project will:
+   - engage in the work of the Project in a professional manner consistent with
+     maintaining a cohesive community, while also maintaining the goodwill
+     and esteem of LF Projects, Joint Development Foundation and other
+     partner organizations in the open source community; and
+   - respect the rights of all trademark owners, including any branding and
+     trademark usage guidelines.
+
+### 7. Intellectual Property Policy
+
+a. Collaborators acknowledge that the copyright in all new contributions will be
+   retained by the copyright holder as independent works of authorship and that no
+   contributor or copyright holder will be required to assign copyrights to the
+   Project.
+
+b. Except as described in Section 7.c., all contributions to the Project are subject to
+   the following:
+   - All new inbound code contributions to the Project must be made using the
+     MIT License (the "Project License").
+   - All new inbound code contributions must also be accompanied by a
+     Developer Certificate of Origin (http://developercertificate.org) sign-off in
+     the source code system that is submitted through a TSC-approved
+     contribution process which will bind the authorized contributor and, if not
+     self-employed, their employer to the applicable license.
+   - All outbound code will be made available under the Project License.
+   - Documentation will be received and made available by the Project under
+     the Project License.
+   - The Project may seek to integrate and contribute back to other open source
+     projects ("Upstream Projects"). In such cases, the Project will conform to
+     all license requirements of the Upstream Projects, including dependencies,
+     leveraged by the Project. Upstream Project code contributions not stored
+     within the Project's main code repository will comply with the
+     contribution process and license terms for the applicable Upstream
+     Project.
+
+c. The TSC may approve the use of an alternative license or licenses for inbound or
+   outbound contributions on an exception basis. To request an exception, please
+   describe the contribution, the alternative open source license(s), and the
+   justification for using an alternative open source license for the Project. License
+   exceptions must be approved by a two-thirds vote of the entire TSC.
+
+d. Contributed files should contain license information, such as SPDX short form
+   identifiers, indicating the open source license or licenses pertaining to the file.
+
+### 8. Amendments
+
+a. This charter may be amended by a two-thirds vote of the entire TSC and is subject
+   to approval by LF Projects.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,21 @@ When you submit a pull request, a CLA bot will automatically determine whether y
 CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
+### Developer Certificate of Origin (DCO)
+
+In addition to the CLA, all commits must include a `Signed-off-by` trailer certifying that you
+wrote the code or have the right to submit it under the project's license. This is the
+[Developer Certificate of Origin](https://developercertificate.org) (DCO).
+
+To sign off on a commit, use the `-s` flag:
+
+```bash
+git commit -s -m "feat: add new policy engine"
+```
+
+This adds a line like `Signed-off-by: Your Name <your.email@example.com>` to the commit message.
+A CI check will verify that all commits in a pull request include this trailer.
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -53,7 +53,11 @@ If maintainers cannot reach consensus, the project lead makes the final decision
 
 ## Releases
 
-Releases follow [Semantic Versioning](https://semver.org/). Any maintainer can propose a release. The release process is automated via GitHub Actions with trusted publishing and SLSA build provenance.
+Releases follow [Semantic Versioning](https://semver.org/). Any maintainer can propose a release. The release process is documented in [RELEASE.md](RELEASE.md) and automated via GitHub Actions with trusted publishing and SLSA build provenance.
+
+## Project Charter
+
+The project operates under the [Technical Charter](CHARTER.md), which defines the TSC structure, IP policy, and amendment process for foundation governance.
 
 ## Code of Conduct
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,84 @@
+# Release Process
+
+This document describes how the Agent Governance Toolkit ships releases across its multi-language SDK ecosystem.
+
+## Versioning
+
+All packages follow [Semantic Versioning 2.0.0](https://semver.org/):
+
+- **MAJOR**: Breaking API changes (removed public classes, changed method signatures, incompatible config format changes)
+- **MINOR**: New features, new packages, new CLI commands (backward-compatible)
+- **PATCH**: Bug fixes, documentation corrections, dependency updates (backward-compatible)
+
+Each SDK package is versioned independently. There is no monorepo-wide version number.
+
+## Release Cadence
+
+- **Regular releases**: As needed, typically 1-2 times per month
+- **Security patches**: Released within 48 hours of confirmed vulnerability
+- **Dependabot updates**: Merged continuously and included in the next release
+
+## Supported Registries
+
+| Ecosystem | Registry | Packages |
+|-----------|----------|----------|
+| Python | [PyPI](https://pypi.org/) | agent-os, agent-mesh, agent-compliance, agent-sre, agent-hypervisor, agent-runtime, agent-lightning, framework integrations (40+ packages) |
+| TypeScript | [npm](https://www.npmjs.com/) | @agent-governance/\* |
+| .NET | [NuGet](https://www.nuget.org/) | AgentGovernance.\* |
+| Rust | [crates.io](https://crates.io/) | agent-governance-\* |
+| Go | Go modules | github.com/microsoft/agent-governance-toolkit/agent-governance-go/\* |
+| Containers | [GitHub Container Registry](https://ghcr.io) | trust-engine, policy-server, audit-collector, api-gateway, registry, relay, governance-sidecar |
+
+## How to Create a Release
+
+### 1. Pre-release Checklist
+
+- [ ] All CI checks pass on `main` (CI, CodeQL, Secret Scanning, Scorecard)
+- [ ] CHANGELOG.md is updated with notable changes
+- [ ] No open security advisories or critical bugs
+- [ ] Version numbers bumped in affected package manifests (`pyproject.toml`, `package.json`, `*.csproj`, `Cargo.toml`)
+
+### 2. Create a GitHub Release
+
+1. Go to [Releases](https://github.com/microsoft/agent-governance-toolkit/releases)
+2. Click "Draft a new release"
+3. Create a new tag following the pattern `v<MAJOR>.<MINOR>.<PATCH>` (e.g., `v0.8.0`)
+4. Use the auto-generated release notes as a starting point, then edit for clarity
+5. Mark as pre-release if appropriate (e.g., `v0.8.0-rc.1`)
+6. Publish the release
+
+### 3. Automated Publishing
+
+Publishing is triggered automatically when a GitHub Release is published:
+
+- **Python packages**: The `publish.yml` workflow builds wheels with provenance attestation, then publishes to PyPI
+- **Container images**: The `publish-containers.yml` workflow builds and pushes multi-arch images to GHCR
+- **.NET packages**: Built and published to NuGet via the CI pipeline
+- **npm packages**: Built and published to npm via the CI pipeline
+
+The `workflow_dispatch` trigger on `publish.yml` also allows publishing individual packages on demand.
+
+### 4. Post-release
+
+- Verify packages appear on their respective registries
+- Verify container images are pullable: `docker pull ghcr.io/microsoft/agent-governance-toolkit/<component>:<tag>`
+- Monitor for any regression reports in the first 24 hours
+
+## Hotfix Process
+
+For critical bugs or security issues in a released version:
+
+1. Create a branch from the release tag: `git checkout -b hotfix/v0.8.1 v0.8.0`
+2. Apply the minimal fix with tests
+3. Follow the standard release process with a PATCH version bump
+4. Cherry-pick the fix back to `main` if not already there
+
+## Supply Chain Security
+
+Every release includes:
+
+- **SBOM generation**: Software Bill of Materials for all packages (`sbom.yml`)
+- **Provenance attestation**: Build provenance via GitHub Attestations (Sigstore-based)
+- **Dependency review**: Automated review of dependency changes on every PR
+- **Secret scanning**: Pre-commit and CI scanning for leaked credentials
+- **OpenSSF Scorecard**: Weekly scoring with SARIF upload to GitHub Security tab


### PR DESCRIPTION
Adds three governance artifacts required for AAIF (AI Alliance Innovation Foundation) Sandbox acceptance:

**CHARTER.md** - LF Projects Technical Charter adapted from the [agentgateway template](https://github.com/agentgateway/agentgateway/blob/main/CHARTER.md). Defines TSC structure, voting rules (quorum 50%, majority vote), IP policy (MIT license, DCO sign-off), and amendment process (2/3 TSC vote).

**RELEASE.md** - Documents the project's release process: semver policy, release cadence, supported registries (PyPI, npm, NuGet, crates.io, GHCR), automated publishing workflows, hotfix process, and supply chain security (SBOM, Sigstore provenance, dependency review).

**DCO workflow** (\.github/workflows/dco.yml\) - GitHub Actions check that verifies all PR commits include a \Signed-off-by\ trailer per the [Developer Certificate of Origin](https://developercertificate.org). Required by the CHARTER.md IP policy and AAIF contribution standards.

Also updates:
- **CONTRIBUTING.md**: Added DCO section with \git commit -s\ instructions
- **GOVERNANCE.md**: References RELEASE.md and CHARTER.md