### PR TITLE
fix: show agent names in EU AI Act deployment gate demo

### DIFF
--- a/agent-governance-python/agent-mesh/examples/06-eu-ai-act-compliance/demo.py
+++ b/agent-governance-python/agent-mesh/examples/06-eu-ai-act-compliance/demo.py
@@ -135,7 +135,7 @@ def main() -> None:
         deployable = checker.can_deploy(agent)
         icon = "✅" if deployable else "🚫"
         status = "APPROVED" if deployable else "BLOCKED"
-        print(f"  {icon}  {_redact(label, 20):40s} → {status}")
+        print(f"  {icon}  {label:40s} → {status}")
 
     # ------------------------------------------------------------------
     # Demo 5 — Prohibited (unacceptable-risk) system


### PR DESCRIPTION
The \_redact()\ call was hashing agent labels in Demo 4 output, making the deployment gate demo less readable for presentations. Now displays clear agent names so the APPROVED/BLOCKED verdict is obvious.