### PR TITLE
feat(dotnet): add ASP.NET Core middleware example

### DIFF
--- a/agent-governance-dotnet/AgentGovernance.sln
+++ b/agent-governance-dotnet/AgentGovernance.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{B3
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quickstart", "examples\Quickstart\Quickstart.csproj", "{1C3A615B-80B8-49D0-B53A-D638187428F3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetMiddleware", "examples\AspNetMiddleware\AspNetMiddleware.csproj", "{3C8DAD80-F991-44FD-B0FE-6198A7D89071}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -85,11 +87,24 @@ Global
 		{1C3A615B-80B8-49D0-B53A-D638187428F3}.Release|x64.Build.0 = Release|Any CPU
 		{1C3A615B-80B8-49D0-B53A-D638187428F3}.Release|x86.ActiveCfg = Release|Any CPU
 		{1C3A615B-80B8-49D0-B53A-D638187428F3}.Release|x86.Build.0 = Release|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Release|x64.Build.0 = Release|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1C3A615B-80B8-49D0-B53A-D638187428F3} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
+		{3C8DAD80-F991-44FD-B0FE-6198A7D89071} = {B36A84DF-456D-A817-6EDD-3EC3E7F6E11F}
 	EndGlobalSection
 EndGlobal

--- a/agent-governance-dotnet/examples/AspNetMiddleware/AspNetMiddleware.csproj
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/AspNetMiddleware.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>AgentGovernance.Examples.AspNetMiddleware</RootNamespace>
+    <AssemblyName>AgentGovernance.Examples.AspNetMiddleware</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- Examples don't need strong naming or NuGet metadata. -->
+    <SignAssembly>false</SignAssembly>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <UserSecretsId>agt-aspnet-middleware-example</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AgentGovernance\AgentGovernance.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="policies\aspnet.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/AdminController.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/AdminController.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgentGovernance.Examples.AspNetMiddleware.Controllers;
+
+/// <summary>
+/// Sensitive admin endpoint used to demonstrate the
+/// <c>require-approval-admin</c> policy rule. Every request is blocked at
+/// the middleware with a 403 + <c>approval_required</c> until an out-of-band
+/// approval workflow grants it.
+/// </summary>
+[ApiController]
+[Route("admin")]
+public sealed class AdminController : ControllerBase
+{
+    [HttpPost("reset")]
+    public IActionResult Reset()
+    {
+        // Never reached — middleware blocks the request first.
+        return Ok(new { message = "system reset" });
+    }
+}

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
@@ -19,15 +19,15 @@ namespace AgentGovernance.Examples.AspNetMiddleware.Controllers;
 [Route("api/items")]
 public sealed class ItemsController : ControllerBase
 {
-    // A process-lifetime in-memory store — fine for a demo, not for production.
-    private static readonly Dictionary<int, Item> Store = new()
+    // An in-memory store for demo purposes.
+    private readonly Dictionary<int, Item> Store = new()
     {
         [1] = new Item(1, "alpha"),
         [2] = new Item(2, "bravo"),
     };
 
-    private static int _nextId = 3;
-    private static readonly object Sync = new();
+    private int _nextId = 3;
+    private readonly object Sync = new();
 
     [HttpGet]
     public ActionResult<IEnumerable<Item>> List()

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
@@ -30,7 +30,7 @@ public sealed class ItemsController : ControllerBase
     private static readonly object Sync = new();
 
     [HttpGet]
-    public static ActionResult<IEnumerable<Item>> List()
+    public ActionResult<IEnumerable<Item>> List()
     {
         lock (Sync)
         {
@@ -39,7 +39,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpGet("{id:int}")]
-    public static ActionResult<Item> GetById(int id)
+    public ActionResult<Item> GetById(int id)
     {
         lock (Sync)
         {
@@ -48,7 +48,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpPost]
-    public static ActionResult<Item> Create([FromBody] CreateItemRequest request)
+    public ActionResult<Item> Create([FromBody] CreateItemRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.Name))
         {
@@ -66,7 +66,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpPut("{id:int}")]
-    public static ActionResult<Item> Update(int id, [FromBody] UpdateItemRequest request)
+    public ActionResult<Item> Update(int id, [FromBody] UpdateItemRequest request)
     {
         lock (Sync)
         {
@@ -82,7 +82,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpDelete("{id:int}")]
-    public static IActionResult Delete(int id)
+    public IActionResult Delete(int id)
     {
         // Note: policy `deny-item-delete` blocks this route at the middleware
         // layer, so callers will see a 403 long before this method runs.

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
@@ -70,12 +70,12 @@ public sealed class ItemsController : ControllerBase
     {
         lock (Sync)
         {
-            if (!Store.ContainsKey(id))
+            if (!Store.TryGetValue(id, out var existing))
             {
                 return NotFound();
             }
 
-            var updated = new Item(id, request.Name ?? Store[id].Name);
+            var updated = new Item(id, request.Name ?? existing.Name);
             Store[id] = updated;
             return Ok(updated);
         }

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
@@ -30,7 +30,7 @@ public sealed class ItemsController : ControllerBase
     private static readonly object Sync = new();
 
     [HttpGet]
-    public ActionResult<IEnumerable<Item>> List()
+    public static ActionResult<IEnumerable<Item>> List()
     {
         lock (Sync)
         {
@@ -39,7 +39,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpGet("{id:int}")]
-    public ActionResult<Item> GetById(int id)
+    public static ActionResult<Item> GetById(int id)
     {
         lock (Sync)
         {
@@ -48,7 +48,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpPost]
-    public ActionResult<Item> Create([FromBody] CreateItemRequest request)
+    public static ActionResult<Item> Create([FromBody] CreateItemRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.Name))
         {
@@ -66,7 +66,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpPut("{id:int}")]
-    public ActionResult<Item> Update(int id, [FromBody] UpdateItemRequest request)
+    public static ActionResult<Item> Update(int id, [FromBody] UpdateItemRequest request)
     {
         lock (Sync)
         {
@@ -82,7 +82,7 @@ public sealed class ItemsController : ControllerBase
     }
 
     [HttpDelete("{id:int}")]
-    public IActionResult Delete(int id)
+    public static IActionResult Delete(int id)
     {
         // Note: policy `deny-item-delete` blocks this route at the middleware
         // layer, so callers will see a 403 long before this method runs.

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Controllers/ItemsController.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgentGovernance.Examples.AspNetMiddleware.Controllers;
+
+/// <summary>
+/// Tiny in-memory items API used to demonstrate governance enforcement
+/// at the HTTP layer:
+///
+///   GET    /api/items        -> always allowed
+///   GET    /api/items/{id}   -> always allowed
+///   POST   /api/items        -> rate-limited to 5/minute by policy
+///   PUT    /api/items/{id}   -> always allowed
+///   DELETE /api/items/{id}   -> blocked by policy (deny-item-delete)
+/// </summary>
+[ApiController]
+[Route("api/items")]
+public sealed class ItemsController : ControllerBase
+{
+    // A process-lifetime in-memory store — fine for a demo, not for production.
+    private static readonly Dictionary<int, Item> Store = new()
+    {
+        [1] = new Item(1, "alpha"),
+        [2] = new Item(2, "bravo"),
+    };
+
+    private static int _nextId = 3;
+    private static readonly object Sync = new();
+
+    [HttpGet]
+    public ActionResult<IEnumerable<Item>> List()
+    {
+        lock (Sync)
+        {
+            return Ok(Store.Values.ToArray());
+        }
+    }
+
+    [HttpGet("{id:int}")]
+    public ActionResult<Item> GetById(int id)
+    {
+        lock (Sync)
+        {
+            return Store.TryGetValue(id, out var item) ? Ok(item) : NotFound();
+        }
+    }
+
+    [HttpPost]
+    public ActionResult<Item> Create([FromBody] CreateItemRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            return BadRequest(new { error = "name is required" });
+        }
+
+        Item created;
+        lock (Sync)
+        {
+            created = new Item(_nextId++, request.Name);
+            Store[created.Id] = created;
+        }
+
+        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+    }
+
+    [HttpPut("{id:int}")]
+    public ActionResult<Item> Update(int id, [FromBody] UpdateItemRequest request)
+    {
+        lock (Sync)
+        {
+            if (!Store.ContainsKey(id))
+            {
+                return NotFound();
+            }
+
+            var updated = new Item(id, request.Name ?? Store[id].Name);
+            Store[id] = updated;
+            return Ok(updated);
+        }
+    }
+
+    [HttpDelete("{id:int}")]
+    public IActionResult Delete(int id)
+    {
+        // Note: policy `deny-item-delete` blocks this route at the middleware
+        // layer, so callers will see a 403 long before this method runs.
+        lock (Sync)
+        {
+            return Store.Remove(id) ? NoContent() : NotFound();
+        }
+    }
+}
+
+public sealed record Item(int Id, string Name);
+public sealed record CreateItemRequest(string Name);
+public sealed record UpdateItemRequest(string? Name);

--- a/agent-governance-dotnet/examples/AspNetMiddleware/GovernanceCheckMiddleware.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/GovernanceCheckMiddleware.cs
@@ -81,7 +81,15 @@ public sealed class GovernanceCheckMiddleware
         {
             result = _kernel.EvaluateToolCall(agentId, toolName, args);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (
+            ex is not OutOfMemoryException &&
+            ex is not StackOverflowException &&
+            ex is not AccessViolationException &&
+            ex is not AppDomainUnloadedException &&
+            ex is not BadImageFormatException &&
+            ex is not CannotUnloadAppDomainException &&
+            ex is not InvalidProgramException &&
+            ex is not System.Threading.ThreadAbortException)
         {
             // Fail-closed on evaluation errors: do not let an unexpected
             // exception silently allow a request through.

--- a/agent-governance-dotnet/examples/AspNetMiddleware/GovernanceCheckMiddleware.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/GovernanceCheckMiddleware.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using AgentGovernance.Integration;
+using AgentGovernance.Policy;
+
+namespace AgentGovernance.Examples.AspNetMiddleware;
+
+/// <summary>
+/// ASP.NET Core middleware that runs every inbound HTTP request through the
+/// <see cref="GovernanceKernel"/> before it reaches any controller or endpoint.
+///
+/// Each request is converted into a synthetic "tool call" of the form
+/// <c>HTTP_{METHOD}_{routeTemplate}</c> (falling back to the raw path when no
+/// route template is available). The path, query, route values, and the
+/// resolved agent identity are passed as evaluation arguments so that
+/// policy rules can match on any of them.
+///
+/// Endpoints decorated with <see cref="SkipGovernanceAttribute"/> bypass
+/// the check entirely (useful for health probes).
+/// </summary>
+public sealed class GovernanceCheckMiddleware
+{
+    private const string AnonymousAgentId = "did:agentmesh:http-anonymous";
+    private const string AgentIdHeader = "X-Agent-Id";
+
+    private readonly RequestDelegate _next;
+    private readonly GovernanceKernel _kernel;
+    private readonly ILogger<GovernanceCheckMiddleware> _logger;
+
+    public GovernanceCheckMiddleware(
+        RequestDelegate next,
+        GovernanceKernel kernel,
+        ILogger<GovernanceCheckMiddleware> logger)
+    {
+        _next = next;
+        _kernel = kernel;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        // Allow opt-out via endpoint metadata.
+        var endpoint = context.GetEndpoint();
+        if (endpoint?.Metadata.GetMetadata<SkipGovernanceAttribute>() is not null)
+        {
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        var agentId = ResolveAgentId(context);
+        var routeTemplate =
+            (endpoint as Microsoft.AspNetCore.Routing.RouteEndpoint)?.RoutePattern.RawText
+            ?? context.Request.Path.Value
+            ?? "/";
+        // Route templates from attribute routing are typically already prefixed
+        // with '/'. Normalize for stable rule matching.
+        if (!routeTemplate.StartsWith('/'))
+        {
+            routeTemplate = "/" + routeTemplate;
+        }
+        // Strip route constraints (e.g. "{id:int}" -> "{id}") so policy rules
+        // can be written against the simpler template form.
+        routeTemplate = RouteConstraintRegex.Replace(routeTemplate, "{$1}");
+
+        var toolName = $"HTTP_{context.Request.Method.ToUpperInvariant()}_{routeTemplate}";
+
+        var args = new Dictionary<string, object>
+        {
+            ["agent_id"] = agentId,
+            ["method"] = context.Request.Method,
+            ["route"] = routeTemplate,
+            ["path"] = context.Request.Path.Value ?? string.Empty,
+            ["query"] = context.Request.QueryString.HasValue ? context.Request.QueryString.Value! : string.Empty,
+        };
+
+        ToolCallResult result;
+        try
+        {
+            result = _kernel.EvaluateToolCall(agentId, toolName, args);
+        }
+        catch (Exception ex)
+        {
+            // Fail-closed on evaluation errors: do not let an unexpected
+            // exception silently allow a request through.
+            _logger.LogError(ex, "Governance evaluation threw for {Tool}; failing closed", toolName);
+            await WriteJsonErrorAsync(context, StatusCodes.Status500InternalServerError, new
+            {
+                error = "governance_evaluation_failed",
+                message = "An error occurred while evaluating governance policies.",
+            }).ConfigureAwait(false);
+            return;
+        }
+
+        if (result.Allowed)
+        {
+            await _next(context).ConfigureAwait(false);
+            return;
+        }
+
+        // Surface the deny in a structured response with the most relevant status code.
+        var (status, code) = ClassifyDenial(result);
+        _logger.LogWarning(
+            "[governance] BLOCK agent={AgentId} tool={Tool} rule={Rule} reason={Reason}",
+            agentId,
+            toolName,
+            result.PolicyDecision?.MatchedRule ?? "(default)",
+            result.Reason);
+
+        await WriteJsonErrorAsync(context, status, new
+        {
+            error = code,
+            agent_id = agentId,
+            tool = toolName,
+            rule = result.PolicyDecision?.MatchedRule,
+            policy = result.PolicyDecision?.PolicyName,
+            action = result.PolicyDecision?.Action,
+            reason = result.Reason,
+            approvers = result.PolicyDecision?.Approvers,
+            rate_limit_reset = result.PolicyDecision?.RateLimitReset,
+        }).ConfigureAwait(false);
+    }
+
+    private static string ResolveAgentId(HttpContext context)
+    {
+        // Prefer an authenticated identity when present.
+        var name = context.User?.Identity?.Name;
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            return $"did:agentmesh:{name}";
+        }
+
+        // Fall back to a caller-supplied header (illustrative — tighten for production).
+        if (context.Request.Headers.TryGetValue(AgentIdHeader, out var headerValues))
+        {
+            var headerValue = headerValues.ToString();
+            if (!string.IsNullOrWhiteSpace(headerValue))
+            {
+                return headerValue;
+            }
+        }
+
+        return AnonymousAgentId;
+    }
+
+    private static (int Status, string Code) ClassifyDenial(ToolCallResult result)
+    {
+        if (result.PolicyDecision?.RateLimited == true)
+        {
+            return (StatusCodes.Status429TooManyRequests, "rate_limited");
+        }
+
+        var action = result.PolicyDecision?.Action;
+        return action switch
+        {
+            "requireapproval" => (StatusCodes.Status403Forbidden, "approval_required"),
+            "deny" => (StatusCodes.Status403Forbidden, "policy_denied"),
+            _ => (StatusCodes.Status403Forbidden, "policy_denied"),
+        };
+    }
+
+    private static Task WriteJsonErrorAsync(HttpContext context, int status, object payload)
+    {
+        context.Response.StatusCode = status;
+        context.Response.ContentType = "application/json; charset=utf-8";
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, SerializerOptions));
+    }
+
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+    };
+
+    // Matches "{name:constraint}" or "{name:c1:c2}" and captures just "name".
+    private static readonly Regex RouteConstraintRegex =
+        new(@"\{([^:{}]+):[^{}]+\}", RegexOptions.Compiled);
+}

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Program.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Program.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AgentGovernance;
+using AgentGovernance.Audit;
+using AgentGovernance.Policy;
+using AgentGovernance.Examples.AspNetMiddleware;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// ---------------------------------------------------------------
+// 1. Register the GovernanceKernel as a singleton
+// ---------------------------------------------------------------
+// The kernel is thread-safe and meant to be reused for the lifetime
+// of the process. It owns the policy engine, audit emitter, rate limiter,
+// and any optional defenses you opt into.
+var policyPath = Path.Combine(AppContext.BaseDirectory, "policies", "aspnet.yaml");
+
+builder.Services.AddSingleton(_ => new GovernanceKernel(new GovernanceOptions
+{
+    PolicyPaths = new List<string> { policyPath },
+    ConflictStrategy = ConflictResolutionStrategy.PriorityFirstMatch,
+    EnablePromptInjectionDetection = true,
+}));
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+
+var app = builder.Build();
+
+// Log every governance event to the console.
+var kernel = app.Services.GetRequiredService<GovernanceKernel>();
+kernel.OnAllEvents(evt =>
+    app.Logger.LogInformation(
+        "[governance] {Type} agent={AgentId} policy={Policy}",
+        evt.Type, evt.AgentId, evt.PolicyName ?? "(none)"));
+
+// ---------------------------------------------------------------
+// 2. Plug the governance middleware into the HTTP pipeline
+// ---------------------------------------------------------------
+// Every request goes through GovernanceCheckMiddleware before reaching
+// any controller. Denied requests short-circuit with a structured 403
+// (or 429 when rate-limited).
+app.UseMiddleware<GovernanceCheckMiddleware>();
+
+app.MapControllers();
+
+// Tiny health endpoint that bypasses the middleware via route metadata.
+app.MapGet("/healthz", () => Results.Ok(new { status = "ok" }))
+   .WithMetadata(new SkipGovernanceAttribute());
+
+app.Run();

--- a/agent-governance-dotnet/examples/AspNetMiddleware/Program.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/Program.cs
@@ -14,7 +14,7 @@ var builder = WebApplication.CreateBuilder(args);
 // The kernel is thread-safe and meant to be reused for the lifetime
 // of the process. It owns the policy engine, audit emitter, rate limiter,
 // and any optional defenses you opt into.
-var policyPath = Path.Combine(AppContext.BaseDirectory, "policies", "aspnet.yaml");
+var policyPath = Path.Join(AppContext.BaseDirectory, "policies", "aspnet.yaml");
 
 builder.Services.AddSingleton(_ => new GovernanceKernel(new GovernanceOptions
 {

--- a/agent-governance-dotnet/examples/AspNetMiddleware/README.md
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/README.md
@@ -1,0 +1,129 @@
+# ASP.NET Core Middleware Example
+
+A minimal ASP.NET Core 8 web app that wires the
+[Microsoft.AgentGovernance](../../README.md) SDK in as **HTTP middleware**.
+Every inbound request is converted to a synthetic tool call of the form
+`HTTP_{METHOD}_{routeTemplate}` and evaluated by the `GovernanceKernel`
+**before** it reaches any controller.
+
+Denied requests short-circuit with a structured JSON body and the right
+status code (`403` for policy denials, `429` for rate limits).
+
+## What it shows
+
+- Registering the kernel as a singleton in `IServiceCollection`
+- A reusable `GovernanceCheckMiddleware` that:
+  - resolves an agent identity (authenticated user → `X-Agent-Id` header → anonymous DID)
+  - normalizes the route template (strips constraints like `{id:int}` → `{id}`)
+  - calls `kernel.EvaluateToolCall(...)` and translates the decision to HTTP
+  - **fails closed** if evaluation throws
+- An opt-out marker (`SkipGovernanceAttribute`) for endpoints like `/healthz`
+- Two controllers (`ItemsController`, `AdminController`) and a YAML policy
+  exercising `allow`, `deny`, `rate_limit`, and `require_approval` actions
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Program.cs` | Web host setup, kernel DI registration, middleware + controllers wiring, audit-event logging. |
+| `GovernanceCheckMiddleware.cs` | The reusable middleware. Translates `ToolCallResult` into HTTP responses. |
+| `SkipGovernanceAttribute.cs` | Endpoint metadata marker that bypasses the middleware (used by `/healthz`). |
+| `Controllers/ItemsController.cs` | Tiny in-memory CRUD API (`/api/items`). |
+| `Controllers/AdminController.cs` | Sensitive `/admin/reset` endpoint that requires approval. |
+| `policies/aspnet.yaml` | Sample policy with deny / rate-limit / require-approval rules. |
+| `appsettings.json` | Logging defaults; binds to `http://localhost:5080`. |
+| `AspNetMiddleware.csproj` | `net8.0` web project; `ProjectReference` to the in-tree SDK. |
+
+## Run it
+
+> Requires the [.NET 8 SDK](https://dotnet.microsoft.com/download).
+
+From this directory:
+
+```bash
+dotnet run
+```
+
+You should see:
+
+```text
+info: Microsoft.Hosting.Lifetime[14]
+      Now listening on: http://localhost:5080
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+```
+
+In a second terminal, drive the API:
+
+```bash
+# 200 — bypasses governance via SkipGovernanceAttribute
+curl -i http://localhost:5080/healthz
+
+# 200 — read endpoints fall through to the default-allow policy
+curl -i http://localhost:5080/api/items
+
+# 403 — blocked by the deny-item-delete rule
+curl -i -X DELETE http://localhost:5080/api/items/1
+
+# 403 with action=requireapproval — admin endpoints need a human
+curl -i -X POST http://localhost:5080/admin/reset
+
+# 5 successes followed by 429 (rate-limit-item-writes is 5/minute)
+for i in 1 2 3 4 5 6 7; do
+  curl -s -o /dev/null -w "%{http_code} " \
+    -X POST -H "Content-Type: application/json" \
+    -d "{\"name\":\"n$i\"}" \
+    http://localhost:5080/api/items
+done
+echo
+```
+
+Example denial body:
+
+```json
+{
+  "error": "policy_denied",
+  "agent_id": "did:agentmesh:http-anonymous",
+  "tool": "HTTP_DELETE_/api/items/{id}",
+  "rule": "deny-item-delete",
+  "policy": "aspnet-middleware-policy",
+  "action": "deny",
+  "reason": "Matched rule 'deny-item-delete' with action 'Deny'.",
+  "approvers": [],
+  "rate_limit_reset": null
+}
+```
+
+## Identifying the agent
+
+The middleware resolves the calling agent in this order:
+
+1. `HttpContext.User.Identity.Name` (when authentication is configured)
+2. `X-Agent-Id` request header
+3. Falls back to `did:agentmesh:http-anonymous`
+
+For production, replace step 2 with a verified token (JWT / mTLS / DID auth)
+and rely solely on `User.Identity`.
+
+## Try it yourself
+
+Edit `policies/aspnet.yaml` to:
+
+- Switch `default_action` from `allow` to `deny` for a fail-closed posture
+- Add a per-tenant rule, e.g.
+
+  ```yaml
+  - name: block-tenant-x
+    condition: "agent_id == 'did:agentmesh:tenant-x'"
+    action: deny
+    priority: 200
+  ```
+
+- Tighten the rate limit (`limit: "1/minute"`) and rerun the curl loop
+
+## Where to go next
+
+- **Quickstart console app** — [`../Quickstart/`](../Quickstart/)
+- **Full feature tour** — [`agent-governance-dotnet/README.md`](../../README.md)
+- **MCP server integration** — `Microsoft.AgentGovernance.Extensions.ModelContextProtocol`
+- **Microsoft Agent Framework integration** — `Microsoft.AgentGovernance.Extensions.Microsoft.Agents`

--- a/agent-governance-dotnet/examples/AspNetMiddleware/SkipGovernanceAttribute.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/SkipGovernanceAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AgentGovernance.Examples.AspNetMiddleware;
+
+/// <summary>
+/// Marker attribute for endpoints that should bypass the
+/// <see cref="GovernanceCheckMiddleware"/> (e.g., health probes).
+/// Apply via endpoint metadata, e.g.
+/// <c>app.MapGet(...).WithMetadata(new SkipGovernanceAttribute())</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+public sealed class SkipGovernanceAttribute : Attribute
+{
+}

--- a/agent-governance-dotnet/examples/AspNetMiddleware/appsettings.json
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Urls": "http://localhost:5080"
+}

--- a/agent-governance-dotnet/examples/AspNetMiddleware/policies/aspnet.yaml
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/policies/aspnet.yaml
@@ -1,0 +1,30 @@
+apiVersion: governance.toolkit/v1
+version: "1.0"
+name: aspnet-middleware-policy
+description: |
+  Sample governance policy for the ASP.NET Core middleware example.
+  The HTTP middleware maps every inbound request to a synthetic "tool call"
+  (HTTP_<METHOD>_<route>) and feeds it to the policy engine.
+default_action: allow
+
+rules:
+  # Block delete operations against the protected /api/items resource.
+  - name: deny-item-delete
+    condition: "tool_name == 'HTTP_DELETE_/api/items/{id}'"
+    action: deny
+    priority: 100
+
+  # Rate-limit writes (POST + PUT) against /api/items.
+  - name: rate-limit-item-writes
+    condition: "tool_name == 'HTTP_POST_/api/items'"
+    action: rate_limit
+    limit: "5/minute"
+    priority: 50
+
+  # Force human approval on /admin/* operations.
+  - name: require-approval-admin
+    condition: "route == '/admin/reset'"
+    action: require_approval
+    approvers:
+      - "security-officer@contoso.com"
+    priority: 75


### PR DESCRIPTION
Adds `agent-governance-dotnet/examples/AspNetMiddleware/` — a self-contained ASP.NET Core 8 web app showing how to use the `Microsoft.AgentGovernance` SDK as **HTTP middleware**.

Closes #1640

## Description

Issue #1640 asked for an ASP.NET Core example demonstrating the .NET SDK as HTTP middleware. This PR adds a runnable web project under `agent-governance-dotnet/examples/AspNetMiddleware/` that:

- Registers `GovernanceKernel` as a singleton in `IServiceCollection`.
- Plugs in a reusable `GovernanceCheckMiddleware` **before** MVC controllers, so every inbound request is evaluated by the policy engine first.
- Maps each request to a synthetic `HTTP_{METHOD}_{routeTemplate}` tool call (route constraints like `{id:int}` are normalized to `{id}` for stable rule matching).
- Resolves the calling agent from `HttpContext.User.Identity.Name`, then `X-Agent-Id` header, then a fallback anonymous DID.
- Translates the `ToolCallResult` into proper HTTP responses: `403 policy_denied`, `403 approval_required`, or `429 rate_limited` — with a structured JSON body that includes the matched rule, policy, action, reason, approvers, and rate-limit reset time.
- **Fails closed** if evaluation throws (returns `500` instead of silently allowing).
- Provides a `SkipGovernanceAttribute` opt-out marker (used by `/healthz`).

## What's added

`agent-governance-dotnet/examples/AspNetMiddleware/`

| File | Purpose |
|------|---------|
| `Program.cs` | Web host setup, kernel DI registration, middleware + controllers wiring, audit-event logging. |
| `GovernanceCheckMiddleware.cs` | The reusable middleware. Translates `ToolCallResult` into HTTP responses. |
| `SkipGovernanceAttribute.cs` | Endpoint metadata marker that bypasses the middleware. |
| `Controllers/ItemsController.cs` | Tiny in-memory CRUD API (`/api/items`) exercising allow / deny / rate-limit. |
| `Controllers/AdminController.cs` | `/admin/reset` endpoint demonstrating `require_approval`. |
| `policies/aspnet.yaml` | Sample policy with `deny`, `rate_limit`, and `require_approval` rules. |
| `appsettings.json` | Logging defaults; binds to `http://localhost:5080`. |
| `AspNetMiddleware.csproj` | `net8.0` web project; `ProjectReference` to the in-tree SDK (no NuGet, no signing). |
| `README.md` | Setup, `dotnet run`, full curl walkthrough, example denial body, and customization tips. |

Project added to `AgentGovernance.sln` under the existing `examples` solution folder.

## Verification

Smoke-tested live with `dotnet run` against `http://localhost:5080`:

| Request | Status | Why |
|---------|--------|-----|
| `GET  /healthz` | 200 | `SkipGovernanceAttribute` bypasses the middleware. |
| `GET  /api/items` | 200 | Default-allow rule (no matching deny). |
| `DELETE /api/items/1` | 403 `policy_denied` | Matched `deny-item-delete`. |
| `POST /admin/reset` | 403 `approval_required` | Matched `require-approval-admin`. |
| `POST /api/items` × 7 | 5×201 then 2×429 `rate_limited` | Matched `rate-limit-item-writes` (5/minute). |

Build & test:
- `dotnet build AgentGovernance.sln` → 0 warnings, 0 errors
- `dotnet test AgentGovernance.sln` → 586 passed, 0 failed (no regressions)

## Type of Change
- [ ] Bug fix
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [ ] Maintenance
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance (`agent-governance-dotnet` — example only; no SDK changes)
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines *(matches existing C# conventions)*
- [x] I have added tests that prove my fix/feature works *(N/A — runnable example; manually smoke-tested every endpoint)*
- [x] All new and existing tests pass *(`dotnet test` → 586/586)*
- [x] I have updated documentation as needed *(README inside the example directory)*
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects:** None. The middleware design follows standard ASP.NET Core patterns and uses only the public surface of `Microsoft.AgentGovernance` already in this repo.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot was used to scaffold boilerplate (controllers, policy YAML, README structure); all output was reviewed, simplified, and verified end-to-end with `dotnet build`, `dotnet run`, and live curl requests.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Closes #1640