### PR TITLE
docs(dotnet): fix stale version + add version-pinning advisory in tut…

### DIFF
--- a/docs/tutorials/19-dotnet-sdk.md
+++ b/docs/tutorials/19-dotnet-sdk.md
@@ -11,7 +11,13 @@ Python packages, packaged as a single NuGet library with **zero external depende
 beyond YamlDotNet**.
 
 > **Target runtime:** .NET 8.0+
-> **NuGet package:** `Microsoft.AgentGovernance` (v2.1.0)
+> **NuGet package:** `Microsoft.AgentGovernance` (v3.3.0)\*
+>
+> \* *Version current as of this revision. Always check the latest stable
+> release on [NuGet.org](https://www.nuget.org/packages/Microsoft.AgentGovernance)
+> before pinning, and cross-reference
+> [`agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj`](../../agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj)
+> when building from source.*
 
 ---
 
@@ -45,8 +51,15 @@ dotnet add package Microsoft.AgentGovernance
 Or add it to your `.csproj` directly:
 
 ```xml
-<PackageReference Include="Microsoft.AgentGovernance" Version="3.2.2" />
+<PackageReference Include="Microsoft.AgentGovernance" Version="3.3.0" />
 ```
+
+> **Heads up:** the version above is current as of this tutorial's last
+> revision. Before copy-pasting, check the latest published version on
+> [NuGet.org](https://www.nuget.org/packages/Microsoft.AgentGovernance) and
+> the in-repo source of truth at
+> [`agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj`](../../agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj).
+> The same applies to the companion extension packages below.
 
 The package targets `net8.0` and has a single dependency — `YamlDotNet` for
 policy parsing.


### PR DESCRIPTION
Closes #1645

## Description

Issue #1645 asked for an end-to-end verification of the .NET SDK tutorial ([`docs/tutorials/19-dotnet-sdk.md`](docs/tutorials/19-dotnet-sdk.md)) and either a confirmation comment or a fix for any problems found.

I built a local verification harness that compiles and runs every documented API surface in the tutorial against the in-tree SDK (`agent-governance-dotnet/src/AgentGovernance/`). Almost everything works exactly as documented; one real issue and a small documentation-quality gap were found.

## Verification — what was exercised

| Section | Result |
|---------|--------|
| Quick Start (`GovernanceKernel`, `EvaluateToolCall`) | ✅ |
| `GovernanceOptions` — every flag, `RingThresholds`, `CircuitBreakerConfig`, `PromptInjectionConfig` | ✅ |
| `LoadPolicy`, `LoadPolicyFromYaml` (incl. inline YAML without `apiVersion`) | ✅ |
| `OnEvent` / `OnAllEvents`, `evt.Data["tool_name"]` | ✅ |
| `PolicyEngine` direct API, all 4 `ConflictResolutionStrategy` values | ✅ |
| `RingEnforcer` — `ComputeRing`, `Check`, `GetLimits`, `ShouldDemote`, custom thresholds | ✅ |
| `SagaOrchestrator` — `CreateSaga`, `AddStep`, `ExecuteAsync`, `SagaStep` (`ActionId`/`AgentDid`/`Timeout`/`MaxAttempts`/`Execute`/`Compensate`), `FailedCompensations`, all `SagaState` values | ✅ |
| `CircuitBreaker` — `ExecuteAsync<T>` / `ExecuteAsync()`, `RecordSuccess`/`RecordFailure`/`Reset`, `State`, `FailureCount`, `CircuitBreakerOpenException.RetryAfter` | ✅ |
| `SloEngine`, `SloSpec`, `SliSpec`, `ErrorBudgetPolicy`, `BurnRateThreshold`, `BurnRateSeverity`, `ComparisonOp`, tracker `Record`/`IsMet`/`CurrentSli`/`RemainingBudget`/`BurnRate`/`EventCount`/`CheckBurnRateAlerts`; engine `Get`/`All`/`Violations` | ✅ |
| `PromptInjectionDetector` — `Detect`, `DetectBatch`, `DetectionConfig` (Sensitivity / CustomPatterns / Blocklist / Allowlist / CanaryTokens), all `DetectionResult` fields | ✅ |
| `AgentIdentity.Create`, `.Sign(string)`, `.Verify(...)`, verification-only ctor `new AgentIdentity(did, publicKey)`, static `AgentIdentity.VerifySignature` | ✅ |
| `FileTrustStore` — ctor (`filePath:`/`defaultScore:`/`decayRate:`), `SetScore`, `GetScore`, `RecordPositiveSignal(boost:)`, `RecordNegativeSignal(penalty:)`, `GetAllScores`, `Remove` | ✅ |
| `RateLimiter.TryAcquire`, `GetCurrentCount`, `ParseLimit("100/minute")` | ✅ |
| `GovernanceMetrics` — `MeterName`, `RecordDecision`, `PolicyDecisions`/`ToolCallsBlocked`/`AuditEvents`, `RegisterTrustScoreGauge`, `RegisterActiveAgentsGauge` | ✅ |
| All cross-reference links (tutorials 01–06, 43, 45) resolve | ✅ |
| "Next Steps" command `dotnet test agent-governance-dotnet/AgentGovernance.sln` | ✅ (610 passing) |

## Issue found

**Version mismatch** in [`docs/tutorials/19-dotnet-sdk.md`](docs/tutorials/19-dotnet-sdk.md):

- Header advertised `v2.1.0`
- `<PackageReference>` install snippet pinned `Version="3.2.2"`
- Actual current version in [`AgentGovernance.csproj`](agent-governance-dotnet/src/AgentGovernance/AgentGovernance.csproj) is **`3.3.0`**

A reader copy-pasting either snippet would either pull a non-existent version or one that's two minor releases behind.

## Fix

1. Bumped both occurrences to **`3.3.0`** so they match the source of truth.
2. Added an asterisk footnote in the header noting the version is point-in-time and pointing to NuGet.org and the in-repo `.csproj`.
3. Added a "Heads up" callout under the install snippet, applicable to the core package and both companion extension packages, advising readers to confirm the latest version before pinning.

This makes the doc self-correcting next time we ship a new release without anyone having to remember to update the tutorial first.

## Diff scope

- 1 file changed: [`docs/tutorials/19-dotnet-sdk.md`](docs/tutorials/19-dotnet-sdk.md) (+15 / -2)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Maintenance
- [ ] Security fix

## Package(s) Affected
- [x] agent-governance (.NET tutorial only — no SDK code changes)
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines
- [x] I have added tests that prove my fix/feature works *(N/A — doc-only fix; verified by running every documented API against the in-tree SDK locally)*
- [x] All new and existing tests pass *(`dotnet test AgentGovernance.sln` → 610/610)*
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited
- [x] If this PR implements functionality similar to an existing OSS project, it is listed below

**Prior art / related projects:** None — doc fix.

## AI Assistance
- [x] I can explain every meaningful change in this PR
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot was used to draft the verification harness and the advisory wording; all changes were reviewed and verified against the live SDK before commit.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Closes #1645