### PR TITLE
fix(ci): add missing cspell terms and broaden crates.io link-check ignore

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -138,3 +138,7 @@ isinstance
 pathlib
 returncode
 cref
+nameof
+aspnet
+appsettings
+requireapproval

--- a/.github/linters/markdown-link-check.json
+++ b/.github/linters/markdown-link-check.json
@@ -18,7 +18,7 @@
     { "pattern": "github\\.com/.*/stargazers" },
     { "pattern": "singapore-mgf-mapping\\.md" },
     { "pattern": "csa-atf-mapping\\.md" },
-    { "pattern": "https://crates\\.io/crates/agent-governance" },
+    { "pattern": "crates\\.io" },
     { "pattern": "^/README\\.md" }
   ],
   "timeout": "30s",


### PR DESCRIPTION
Fixes CI failures on PRs like #1796:

- **Spell-check**: adds \
ameof\, \spnet\, \ppsettings\, \equireapproval\ to .cspell-repo-terms.txt
- **Markdown link check**: broadens crates.io ignore pattern (crates not yet published, returning 404)

The Code Review failure (gpt-4o-mini 8K token limit) is non-blocking (\continue-on-error: true\).