### PR TITLE
fix(ci): correctly skip merge commits in DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -23,9 +23,9 @@ jobs:
           MISSING=()
 
           for SHA in $(git rev-list "$BASE".."$HEAD"); do
-            # Skip merge commits
-            PARENTS=$(git rev-parse --verify "$SHA^2" 2>/dev/null && echo "merge" || echo "normal")
-            if [ "$PARENTS" = "merge" ]; then
+            # Skip merge commits (commits with more than one parent)
+            PARENT_COUNT=$(git cat-file -p "$SHA" | grep -c '^parent ')
+            if [ "$PARENT_COUNT" -gt 1 ]; then
               continue
             fi
 


### PR DESCRIPTION
The merge-commit detection in the DCO workflow was broken. It used git rev-parse --verify which outputs the resolved SHA to stdout before the echo runs, making the PARENTS variable contain the SHA plus "merge" rather than just "merge". The string comparison always failed, so merge commits were never skipped.

Fix: count parent lines in the commit object with git cat-file -p, which reliably returns the parent count regardless of stdout side-effects.

Fixes DCO failures on PRs where maintainers merged main into contributor branches (e.g. #1792).