### PR TITLE
fix(ci): make test-policies always report status for branch protection

### DIFF
--- a/.github/workflows/policy-validation.yml
+++ b/.github/workflows/policy-validation.yml
@@ -3,23 +3,32 @@ name: Policy Validation
 on:
   push:
     branches: [main]
-    paths:
-      - "**/*.yaml"
-      - "**/*.yml"
-      - "agent-governance-python/agent-os/src/agent_os/policies/**"
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.yaml"
-      - "**/*.yml"
-      - "agent-governance-python/agent-os/src/agent_os/policies/**"
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      policies: ${{ steps.filter.outputs.policies }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            policies:
+              - '**/*.yaml'
+              - '**/*.yml'
+              - 'agent-governance-python/agent-os/src/agent_os/policies/**'
+
   validate-policies:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.policies == 'true'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -55,18 +64,23 @@ jobs:
 
   test-policies:
     runs-on: ubuntu-latest
-    needs: validate-policies
+    needs: [changes, validate-policies]
+    if: always() && needs.validate-policies.result != 'failure'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: needs.changes.outputs.policies == 'true'
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        if: needs.changes.outputs.policies == 'true'
         with:
           python-version: "3.11"
 
       - name: Install agent-primitives (local sibling)
+        if: needs.changes.outputs.policies == 'true'
         run: pip install --no-cache-dir -e agent-governance-python/agent-primitives
 
       - name: Install agent-os-kernel
+        if: needs.changes.outputs.policies == 'true'
         working-directory: agent-governance-python/agent-os
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
@@ -76,5 +90,10 @@ jobs:
             2>/dev/null || pip install --no-cache-dir pyyaml==6.0.2 pytest==8.4.1
 
       - name: Run policy CLI tests
+        if: needs.changes.outputs.policies == 'true'
         working-directory: agent-governance-python/agent-os
         run: pytest tests/test_policy_cli.py -v --tb=short
+
+      - name: Skip (no policy changes)
+        if: needs.changes.outputs.policies != 'true'
+        run: echo "No policy file changes detected, skipping."


### PR DESCRIPTION
The policy-validation workflow used paths filter at the workflow level, so it never triggered for non-YAML PRs (like dotnet-only changes). Since test-policies is a required check in the branch protection ruleset, this left those PRs permanently stuck on "Expected - Waiting for status to be reported".

Fix: remove the workflow-level paths filter, add a changes job using dorny/paths-filter, and make test-policies always run with step-level conditions to skip actual work when no policy files changed. Same pattern used in PR #1800 for the Python test matrix.