### PR TITLE
docs(examples): fix compliance example paths and add error handling

### DIFF
--- a/agent-governance-python/agent-compliance/examples/README.md
+++ b/agent-governance-python/agent-compliance/examples/README.md
@@ -11,13 +11,18 @@ Runnable examples showing the unified governance stack in action.
 
 ## Prerequisites
 
+- Python 3.10+
+- Install dependencies from this directory:
+
 ```bash
 pip install -r requirements.txt
 ```
 
 ## Running
 
+From this directory (`agent-governance-python/agent-compliance/examples/`):
+
 ```bash
-python examples/quickstart.py
-python examples/governed_agent.py
+python quickstart.py
+python governed_agent.py
 ```

--- a/agent-governance-python/agent-compliance/examples/governed_agent.py
+++ b/agent-governance-python/agent-compliance/examples/governed_agent.py
@@ -11,7 +11,7 @@ Shows all four governance layers working together:
 
 Usage:
     pip install agent-governance-toolkit[full]
-    python examples/governed_agent.py
+    python governed_agent.py
 """
 
 import asyncio

--- a/agent-governance-python/agent-compliance/examples/quickstart.py
+++ b/agent-governance-python/agent-compliance/examples/quickstart.py
@@ -7,7 +7,7 @@ Boot the full governance stack and execute a governed action.
 
 Usage:
     pip install agent-governance-toolkit
-    python examples/quickstart.py
+    python quickstart.py
 """
 
 import asyncio
@@ -53,4 +53,9 @@ async def main():
     print("\n🎉 Governance stack is running! Your agent is now governed.")
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        raise


### PR DESCRIPTION
- Fix run commands in README (used wrong relative paths)
- Add Python version prerequisite and working directory context
- Add if-name-main guard and try/except to quickstart.py
- Fix usage docstring paths in both example files