### PR TITLE
docs(examples): fix SRE example install paths and error handling

### DIFF
--- a/agent-governance-python/agent-sre/examples/README.md
+++ b/agent-governance-python/agent-sre/examples/README.md
@@ -7,8 +7,9 @@ Examples demonstrating SLO monitoring, cost guardrails, incident detection, and 
 The fastest way to see Agent-SRE in action:
 
 ```bash
-pip install -e "agent-sre[dev]"
-python agent-governance-python/agent-sre/examples/quickstart.py
+cd agent-governance-python/agent-sre
+pip install -e ".[dev]"
+python examples/quickstart.py
 ```
 
 This simulates 100 agent tasks with a 93% success rate (below the 95% target) and 8% hallucination rate (above the 5% target), then shows SLO status, error budget consumption, cost tracking, and burn rate alerts.
@@ -41,6 +42,6 @@ This simulates 100 agent tasks with a 93% success rate (below the 95% target) an
 ## Prerequisites
 
 - Python 3.10+
-- `pip install -e "agent-sre[dev]"`
+- From the `agent-sre` package root: `pip install -e ".[dev]"`
 - For the dashboard: `pip install streamlit plotly`
 - For LangChain examples: `pip install langchain`

--- a/agent-governance-python/agent-sre/examples/canary_rollout.py
+++ b/agent-governance-python/agent-sre/examples/canary_rollout.py
@@ -90,7 +90,10 @@ while rollout.current_step is not None:
         rollout.rollback(reason="Canary metrics breached rollback thresholds")
         print()
         print(f"  🛑 ROLLBACK triggered!")
-        print(f"     Reason: hallucination_rate {metrics['hallucination_rate']:.1%} >= 8% threshold")
+        for cond in rollout.rollback_conditions:
+            val = metrics.get(cond.metric)
+            if val is not None and val >= cond.threshold:
+                print(f"     {cond.metric} {val:.1%} >= {cond.threshold:.0%} threshold")
         break
 
     # Advance to next stage

--- a/agent-governance-python/agent-sre/examples/chaos_test.py
+++ b/agent-governance-python/agent-sre/examples/chaos_test.py
@@ -43,49 +43,54 @@ print(f"Duration:   {experiment.duration_seconds}s")
 print(f"Faults:     {len(experiment.faults)}")
 print()
 
-# Simulate injecting faults and observing results
-print("Injecting faults...")
-for fault in experiment.faults:
-    experiment.inject_fault(fault, applied=True, details={"simulated": True})
-    print(f"  💉 {fault.fault_type.value}: {fault.target} (rate={fault.rate:.0%})")
+try:
+    # Simulate injecting faults and observing results
+    print("Injecting faults...")
+    for fault in experiment.faults:
+        experiment.inject_fault(fault, applied=True, details={"simulated": True})
+        print(f"  💉 {fault.fault_type.value}: {fault.target} (rate={fault.rate:.0%})")
 
-print()
+    print()
 
-# Simulate metrics during chaos
-simulated_metrics = {
-    "error_rate": 0.12,       # Elevated but manageable
-    "success_rate": 0.88,
-    "avg_latency_ms": 3500,   # Slower due to retries
-    "cost_per_task": 0.55,    # Slightly higher cost from retries
-}
+    # Simulate metrics during chaos
+    simulated_metrics = {
+        "error_rate": 0.12,       # Elevated but manageable
+        "success_rate": 0.88,
+        "avg_latency_ms": 3500,   # Slower due to retries
+        "cost_per_task": 0.55,    # Slightly higher cost from retries
+    }
 
-print("Observed metrics under chaos:")
-for metric, value in simulated_metrics.items():
-    print(f"  {metric}: {value}")
+    print("Observed metrics under chaos:")
+    for metric, value in simulated_metrics.items():
+        print(f"  {metric}: {value}")
 
-# Check abort conditions
-should_abort = experiment.check_abort(simulated_metrics)
-if should_abort:
-    experiment.abort(reason="Abort threshold exceeded")
-    print("\n🛑 Experiment ABORTED — error rate too high")
-else:
-    print("\n✅ Agent is handling faults gracefully")
+    # Check abort conditions
+    should_abort = experiment.check_abort(simulated_metrics)
+    if should_abort:
+        experiment.abort(reason="Abort threshold exceeded")
+        print("\n🛑 Experiment ABORTED — error rate too high")
+    else:
+        print("\n✅ Agent is handling faults gracefully")
 
-    # Calculate fault impact score
-    resilience = experiment.calculate_resilience(
-        baseline_success_rate=0.98,
-        experiment_success_rate=0.88,
-        recovery_time_ms=2500,
-        cost_increase_percent=15.0,
-    )
+        # Calculate fault impact score
+        resilience = experiment.calculate_resilience(
+            baseline_success_rate=0.98,
+            experiment_success_rate=0.88,
+            recovery_time_ms=2500,
+            cost_increase_percent=15.0,
+        )
 
-    experiment.complete(resilience=resilience)
+        experiment.complete(resilience=resilience)
 
-    print(f"\nFault Impact Score: {resilience.overall:.0f}/100")
-    print(f"  Fault Tolerance:    {resilience.fault_tolerance:.1%}")
-    print(f"  Recovery Time:      {resilience.recovery_time_ms:.0f}ms")
-    print(f"  Degradation:        {resilience.degradation_percent:.1f}%")
-    print(f"  Cost Impact:        +{resilience.cost_impact_percent:.1f}%")
+        print(f"\nFault Impact Score: {resilience.overall:.0f}/100")
+        print(f"  Fault Tolerance:    {resilience.fault_tolerance:.1%}")
+        print(f"  Recovery Time:      {resilience.recovery_time_ms:.0f}ms")
+        print(f"  Degradation:        {resilience.degradation_percent:.1f}%")
+        print(f"  Cost Impact:        +{resilience.cost_impact_percent:.1f}%")
+except Exception as e:
+    experiment.abort(reason=f"Unexpected error: {e}")
+    print(f"\n🛑 Experiment ABORTED due to error: {e}")
+    raise
 
 print()
 print("─" * 60)

--- a/agent-governance-python/agent-sre/examples/quickstart.py
+++ b/agent-governance-python/agent-sre/examples/quickstart.py
@@ -4,7 +4,8 @@
 Agent-SRE Quickstart — Monitor an AI agent in 30 lines.
 
 Run:
-    pip install agent-sre
+    cd agent-governance-python/agent-sre
+    pip install -e ".[dev]"
     python examples/quickstart.py
 """
 
@@ -78,8 +79,12 @@ print("Indicators:")
 for ind in slo.indicators:
     val = ind.current_value()
     comp = ind.compliance()
-    label = "✅" if comp and comp >= ind.target else "❌"
-    print(f"  {label} {ind.name}: {val:.3f} (target: {ind.target:.3f}, compliance: {comp:.1%})")
+    if comp is not None and comp >= ind.target:
+        label = "✅"
+    else:
+        label = "❌"
+    comp_str = f"{comp:.1%}" if comp is not None else "N/A"
+    print(f"  {label} {ind.name}: {val:.3f} (target: {ind.target:.3f}, compliance: {comp_str})")
 
 print()
 


### PR DESCRIPTION
- Fix README install command to use correct editable install from package root
- Fix quickstart.py format crash when compliance() returns None
- Fix canary_rollout.py hardcoded rollback threshold message
- Add try/except to chaos_test.py for clean experiment abort on errors