### PR TITLE
docs(notebooks): fix install paths and working directory in READMEs

### DIFF
--- a/agent-governance-python/agent-hypervisor/notebooks/README.md
+++ b/agent-governance-python/agent-hypervisor/notebooks/README.md
@@ -11,7 +11,8 @@ Interactive Jupyter notebooks for exploring the **agent-hypervisor** runtime.
 ## Quick Start
 
 ```bash
-# From the repository root
+# From the agent-hypervisor package root
+cd agent-governance-python/agent-hypervisor
 pip install -e ".[dev]" plotly nest-asyncio
 jupyter notebook notebooks/
 ```

--- a/agent-governance-python/agent-mesh/notebooks/README.md
+++ b/agent-governance-python/agent-mesh/notebooks/README.md
@@ -10,14 +10,15 @@ Interactive Jupyter notebooks for exploring agent-mesh concepts.
 
 ## Getting Started
 
-1. Install dependencies:
+1. Install dependencies (from the `agent-mesh` package root):
 
    ```bash
+   cd agent-governance-python/agent-mesh
    pip install -e ".[dev]"
    pip install jupyter matplotlib
    ```
 
-2. Launch Jupyter:
+2. Launch Jupyter from the `agent-mesh` directory:
 
    ```bash
    jupyter notebook notebooks/


### PR DESCRIPTION
Fix agent-mesh and agent-hypervisor notebook READMEs:
- Add explicit cd to package root before pip install -e
- Fix jupyter notebook command that resolved to wrong path
- Clarify working directory context