### PR TITLE
docs(dotnet): clarify quickstart line count and simulated values

### DIFF
--- a/agent-governance-dotnet/examples/Quickstart/Program.cs
+++ b/agent-governance-dotnet/examples/Quickstart/Program.cs
@@ -70,6 +70,8 @@ internal static class Program
         EvaluateAndReport(kernel, "file_read",
             new() { ["path"] = "/var/log/agent.log" });
 
+        // Simulated tool arguments for demo purposes only.
+        // These values trigger specific policy rules to show allow/deny behavior.
         EvaluateAndReport(kernel, "file_write",
             new() { ["path"] = "/etc/passwd", ["content"] = "..." });
 
@@ -129,7 +131,7 @@ internal static class Program
         }
 
         Console.WriteLine();
-        Console.WriteLine("Done. You just governed an agent in ~30 lines of C#.");
+        Console.WriteLine("Done. You just governed an agent in C#.");
         Console.WriteLine();
         Console.WriteLine("Next steps:");
         Console.WriteLine("  - Edit  policies/quickstart.yaml to add your own rules");

--- a/agent-governance-dotnet/examples/Quickstart/README.md
+++ b/agent-governance-dotnet/examples/Quickstart/README.md
@@ -3,7 +3,7 @@
 A minimal, runnable console app that shows how to add the
 [Microsoft.AgentGovernance](../../README.md) SDK to a .NET application.
 
-In about 30 lines of `Program.cs` it covers:
+In about 30 lines of core logic in `Program.cs` it covers:
 
 - Creating a `GovernanceKernel` with a YAML policy file
 - Subscribing to audit events


### PR DESCRIPTION
- Fix '30 lines' claim to '30 lines of core logic' (file is ~180 lines with comments/helpers)
- Add comment clarifying dangerous-looking tool args (/etc/passwd, rm -rf /) are simulated demo values
- Remove inaccurate line count from completion message