### PR TITLE
docs(tutorials): fix broken link and add prerequisites

### DIFF
--- a/docs/tutorials/36-govern-quickstart.md
+++ b/docs/tutorials/36-govern-quickstart.md
@@ -1,6 +1,6 @@
 # Tutorial 36: 2-Line Governance with govern()
 
-> **Time**: 10 minutes · **Level**: Beginner · **Prerequisites**: None
+> **Time**: 10 minutes · **Level**: Beginner · **Prerequisites**: `pip install agent-governance-toolkit`
 
 ## What You'll Build
 
@@ -8,7 +8,7 @@ A governed AI tool with full policy enforcement, audit logging, and denial handl
 
 ## The Problem
 
-Traditional AGT integration requires understanding PolicyEngine, TrustManager, AuditLog, and how to wire them:
+Traditional AGT integration requires understanding multiple components and how to wire them:
 
 ```python
 # ❌ The old way (10+ lines)

--- a/docs/tutorials/policy-as-code/README.md
+++ b/docs/tutorials/policy-as-code/README.md
@@ -3,7 +3,10 @@
 A step-by-step guide to governing AI agents with declarative policies, progressing
 from basic allow/deny rules to production-grade policy management.
 
-**Prerequisites:** Python 3.9+, basic YAML and Python familiarity.
+## Prerequisites
+
+- Python 3.9+
+- Basic YAML and Python familiarity
 
 ## Installation
 
@@ -37,7 +40,7 @@ python examples/01_first_policy.py
 
 - [Tutorial 01 — Policy Engine](../01-policy-engine.md) — Full YAML syntax and operator reference
 - [Policy Schema Source](../../../agent-governance-python/agent-os/src/agent_os/policies/schema.py) — PolicyDocument and PolicyRule models
-- [quickstart.md](../../../quickstart.md) — 10-minute getting started guide
+- [quickstart.md](../../quickstart.md) — 10-minute getting started guide
 
 ## Supplemental Guides
 


### PR DESCRIPTION
- Fix policy-as-code quickstart.md relative link (was pointing to repo root instead of docs/)
- Add pip install prerequisite to govern() quickstart tutorial
- Structure prerequisites section in policy-as-code README