### PR TITLE
fix: remove unused import and add apt retry in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 WORKDIR /workspace
 
-RUN apt-get update \
+RUN for i in 1 2 3; do apt-get update && break || sleep 5; done \
     && apt-get install -y --no-install-recommends \
         bash \
         build-essential \
@@ -26,7 +26,7 @@ RUN apt-get update \
         | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
         > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
+    && for i in 1 2 3; do apt-get update && break || sleep 5; done \
     && apt-get install -y --no-install-recommends nodejs \
     && python -m pip install --upgrade pip==24.3.1 setuptools==75.8.0 wheel==0.45.1 \
     && rm -rf /var/lib/apt/lists/*

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/multi_agent_policy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/multi_agent_policy.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 


### PR DESCRIPTION
Fixes CI failures on main:

1. **Lint (agent-mesh)**: Removes unused \	imedelta\ import from \multi_agent_policy.py\ (F401)
2. **docker-compose-test**: Adds retry loop to \pt-get update\ in root Dockerfile to handle transient Debian mirror sync failures

Run: https://github.com/microsoft/agent-governance-toolkit/actions/runs/25564203108