### PR TITLE
feat: add AWS Bedrock Agent governance adapter

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/__init__.py
@@ -73,6 +73,8 @@ _LAZY_ADAPTER_MAP: dict[str, tuple[str, str]] = {
     "AnthropicKernel": (".anthropic_adapter", "AnthropicKernel"),
     "GovernedAnthropicClient": (".anthropic_adapter", "GovernedAnthropicClient"),
     "AnthropicGovernanceHook": (".anthropic_adapter", "GovernanceMessageHook"),
+    "BedrockKernel": (".bedrock_adapter", "BedrockKernel"),
+    "GovernedBedrockClient": (".bedrock_adapter", "GovernedBedrockClient"),
     "AutoGenKernel": (".autogen_adapter", "AutoGenKernel"),
     "AutoGenGovernanceHandler": (".autogen_adapter", "GovernanceInterventionHandler"),
     "CrewAIKernel": (".crewai_adapter", "CrewAIKernel"),
@@ -198,6 +200,9 @@ __all__ = [
     "AnthropicKernel",
     "GovernedAnthropicClient",
     "AnthropicGovernanceHook",
+    # AWS Bedrock
+    "BedrockKernel",
+    "GovernedBedrockClient",
     "GeminiKernel",
     "GovernedGeminiModel",
     # Mistral AI

--- a/agent-governance-python/agent-os/src/agent_os/integrations/bedrock_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/bedrock_adapter.py
@@ -1,0 +1,415 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+AWS Bedrock Agent Governance Adapter
+
+Wraps the Bedrock Agent Runtime client with Agent OS governance: blocked
+pattern scanning on inputs, tool allow/block-list enforcement on streaming
+action-group events, rate limiting per agent ARN, and a full audit trail.
+
+Usage::
+
+    from agent_os.integrations import BedrockKernel
+    from agent_os.integrations.base import GovernancePolicy
+    import boto3
+
+    kernel = BedrockKernel(
+        policy=GovernancePolicy(
+            blocked_patterns=["DROP TABLE", "rm -rf"],
+            allowed_tools=["query_database", "summarize"],
+            max_tool_calls=20,
+        )
+    )
+
+    governed = kernel.wrap(boto3.client("bedrock-agent-runtime", region_name="us-east-1"))
+    response = governed.invoke_agent(
+        agentId="ABCDEF1234",
+        agentAliasId="ALIAS1",
+        sessionId="session-xyz",
+        inputText="Summarize last quarter sales",
+    )
+
+Cedar/OPA policy evaluation is inherited from BaseIntegration::
+
+    kernel = BedrockKernel.from_cedar("policies/bedrock.cedar")
+    governed = kernel.wrap(client)
+
+Features:
+- Graceful boto3 import (no hard dependency)
+- Blocked-pattern scanning on inputText before invocation
+- Tool allow/block-list enforced on action-group invocation events in stream
+- max_tool_calls limit enforced per session
+- Rate limiting per agent ARN via RateLimiter
+- Agent ARN mapped to AGT trust identity for audit
+- Full audit trail via GovernanceEventType events
+- health_check() endpoint
+- wrap() / unwrap() round-trip
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Iterator
+
+from .base import (
+    BaseIntegration,
+    ExecutionContext,
+    GovernanceEventType,
+    GovernancePolicy,
+    PolicyViolationError,
+)
+from .rate_limiter import RateLimiter
+
+logger = logging.getLogger("agent_os.bedrock")
+
+
+try:
+    import boto3 as _boto3  # noqa: F401
+    _HAS_BOTO3 = True
+except ImportError:
+    _HAS_BOTO3 = False
+
+_PII_RE = [
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),                                    # SSN
+    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),     # email
+    re.compile(r"\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14})\b"),          # credit card
+]
+
+
+def _check_boto3() -> None:
+    if not _HAS_BOTO3:
+        raise ImportError(
+            "The 'boto3' package is required for BedrockKernel. "
+            "Install it with: pip install boto3"
+        )
+
+
+def _scan_pii(text: str) -> list[str]:
+    return [p.pattern for p in _PII_RE if p.search(text)]
+
+
+@dataclass
+class BedrockContext(ExecutionContext):
+    """Execution context for a Bedrock Agent session.
+
+    Attributes:
+        agent_arn: Full ARN of the Bedrock agent (used as trust identity).
+        invocation_ids: Recorded invocation IDs for audit.
+        action_groups_invoked: Names of action groups triggered in the session.
+        blocked_events: Count of action-group events blocked by policy.
+    """
+
+    agent_arn: str = ""
+    invocation_ids: list[str] = field(default_factory=list)
+    action_groups_invoked: list[str] = field(default_factory=list)
+    blocked_events: int = 0
+
+
+class BedrockKernel(BaseIntegration):
+    """AWS Bedrock Agent governance adapter.
+
+    Wraps a ``boto3`` Bedrock Agent Runtime client and enforces governance
+    on every ``invoke_agent`` call.
+
+    Args:
+        policy: Governance policy.  Uses default when ``None``.
+        blocked_tools: Additional tool/action-group names to block regardless
+            of ``policy.allowed_tools``.
+        rate_limit_per_minute: Max ``invoke_agent`` calls per agent ARN per
+            minute.  ``0`` disables rate limiting.
+        evaluator: Optional ``PolicyEvaluator`` for Cedar/OPA evaluation.
+
+    Example::
+
+        kernel = BedrockKernel(
+            policy=GovernancePolicy(allowed_tools=["summarize"]),
+            blocked_tools=["delete_s3_bucket"],
+            rate_limit_per_minute=60,
+        )
+        governed = kernel.wrap(boto3.client("bedrock-agent-runtime"))
+    """
+
+    def __init__(
+        self,
+        policy: GovernancePolicy | None = None,
+        blocked_tools: list[str] | None = None,
+        rate_limit_per_minute: int = 0,
+        evaluator: Any = None,
+    ) -> None:
+        super().__init__(policy, evaluator=evaluator)
+        self._blocked_tools: set[str] = set(blocked_tools or [])
+        self._rate_limiter: RateLimiter | None = (
+            RateLimiter(max_calls=rate_limit_per_minute, time_window=60.0)
+            if rate_limit_per_minute > 0
+            else None
+        )
+        self._start_time = time.monotonic()
+        self._last_error: str | None = None
+
+
+    def wrap(self, client: Any) -> "GovernedBedrockClient":
+        """Wrap a Bedrock Agent Runtime client with governance.
+
+        Args:
+            client: A ``boto3`` ``bedrock-agent-runtime`` client.
+
+        Returns:
+            A :class:`GovernedBedrockClient` that enforces policy.
+        """
+        _check_boto3()
+        ctx = BedrockContext(
+            agent_id=f"bedrock-{id(client)}",
+            session_id=f"bdr-{int(time.time())}",
+            policy=self.policy,
+        )
+        self.contexts[ctx.agent_id] = ctx
+        return GovernedBedrockClient(client=client, kernel=self, ctx=ctx)
+
+    def unwrap(self, governed_agent: Any) -> Any:
+        if isinstance(governed_agent, GovernedBedrockClient):
+            return governed_agent._client
+        return governed_agent
+
+
+    def _check_rate_limit(self, agent_arn: str) -> None:
+        if self._rate_limiter is None:
+            return
+        status = self._rate_limiter.check(agent_arn)
+        if not status.allowed:
+            raise PolicyViolationError(
+                f"Rate limit exceeded for agent ARN '{agent_arn}': "
+                f"retry after {status.wait_seconds:.1f}s"
+            )
+
+    def _check_input(self, ctx: BedrockContext, input_text: str) -> None:
+        """Block on pattern matches and PII in input."""
+        matched = self.policy.matches_pattern(input_text)
+        if matched:
+            self.emit(GovernanceEventType.TOOL_CALL_BLOCKED, {
+                "agent_id": ctx.agent_id, "reason": f"blocked pattern: {matched[0]}",
+                "timestamp": datetime.now().isoformat(),
+            })
+            raise PolicyViolationError(
+                f"Input blocked by policy — matched pattern: {matched[0]!r}"
+            )
+        pii = _scan_pii(input_text)
+        if pii:
+            raise PolicyViolationError(
+                f"Input blocked — PII detected (pattern: {pii[0]})"
+            )
+
+    def _check_tool(self, ctx: BedrockContext, tool_name: str) -> None:
+        """Enforce tool allow/block-list and call-count limit."""
+        if tool_name in self._blocked_tools:
+            ctx.blocked_events += 1
+            raise PolicyViolationError(
+                f"Action group '{tool_name}' is explicitly blocked by policy"
+            )
+        if self.policy.allowed_tools and tool_name not in self.policy.allowed_tools:
+            ctx.blocked_events += 1
+            raise PolicyViolationError(
+                f"Action group '{tool_name}' is not in the allowed_tools list"
+            )
+        if ctx.call_count >= self.policy.max_tool_calls:
+            raise PolicyViolationError(
+                f"Tool call limit reached: {ctx.call_count} >= {self.policy.max_tool_calls}"
+            )
+
+
+    def health_check(self) -> dict[str, Any]:
+        uptime = time.monotonic() - self._start_time
+        return {
+            "status": "degraded" if self._last_error else "healthy",
+            "backend": "aws-bedrock",
+            "last_error": self._last_error,
+            "uptime_seconds": round(uptime, 2),
+            "active_sessions": len(self.contexts),
+        }
+
+
+class _GovernedEventStream:
+    """Wraps Bedrock's streaming EventStream and enforces governance on events.
+
+    Bedrock streams chunks via an ``EventStream``.  This proxy iterates the
+    stream and intercepts ``returnControl`` / ``actionGroupInvocation`` events
+    to apply tool allow/block-list checks before passing them downstream.
+    """
+
+    def __init__(
+        self,
+        stream: Any,
+        kernel: BedrockKernel,
+        ctx: BedrockContext,
+    ) -> None:
+        self._stream = stream
+        self._kernel = kernel
+        self._ctx = ctx
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        for event in self._stream:
+            # Intercept returnControl events carrying action-group invocations
+            rc = event.get("returnControl") or event.get("chunk", {}).get("returnControl")
+            if rc:
+                for inv in rc.get("invocationInputs", []):
+                    ag = inv.get("actionGroupInvocationInput", {})
+                    tool_name = ag.get("actionGroupName") or ag.get("function", "")
+                    if tool_name:
+                        try:
+                            self._kernel._check_tool(self._ctx, tool_name)
+                        except PolicyViolationError:
+                            logger.warning(
+                                "Bedrock action blocked | tool=%s agent=%s",
+                                tool_name, self._ctx.agent_id,
+                            )
+                            self._kernel.emit(GovernanceEventType.TOOL_CALL_BLOCKED, {
+                                "agent_id": self._ctx.agent_id,
+                                "tool_name": tool_name,
+                                "timestamp": datetime.now().isoformat(),
+                            })
+                            raise
+                        self._ctx.action_groups_invoked.append(tool_name)
+                        self._ctx.call_count += 1
+                        self._ctx.tool_calls.append({
+                            "name": tool_name,
+                            "timestamp": datetime.now().isoformat(),
+                        })
+                        logger.info(
+                            "Bedrock action allowed | tool=%s agent=%s",
+                            tool_name, self._ctx.agent_id,
+                        )
+            yield event
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+class GovernedBedrockClient:
+    """Bedrock Agent Runtime client wrapped with Agent OS governance.
+
+    Drop-in proxy for a ``boto3`` ``bedrock-agent-runtime`` client.
+    All ``invoke_agent`` calls are governed; all other attributes are
+    transparently proxied to the underlying client.
+
+    Example::
+
+        governed = kernel.wrap(boto3.client("bedrock-agent-runtime"))
+        response = governed.invoke_agent(
+            agentId="ABCDEF",
+            agentAliasId="ALIAS1",
+            sessionId="s-123",
+            inputText="List all orders",
+        )
+        for event in response["completion"]:
+            ...  # events already filtered by governance
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        kernel: BedrockKernel,
+        ctx: BedrockContext,
+    ) -> None:
+        self._client = client
+        self._kernel = kernel
+        self._ctx = ctx
+
+    def invoke_agent(self, **kwargs: Any) -> dict[str, Any]:
+        """Govern a Bedrock ``invoke_agent`` call.
+
+        Enforces:
+        1. Rate limiting per agent ARN.
+        2. Blocked-pattern and PII scanning on ``inputText``.
+        3. Cedar/OPA policy evaluation.
+        4. Tool allow/block-list and call-count on streaming action events.
+
+        Args:
+            **kwargs: Forwarded to ``client.invoke_agent()``.
+
+        Returns:
+            The Bedrock response dict with ``completion`` replaced by a
+            governed :class:`_GovernedEventStream`.
+
+        Raises:
+            PolicyViolationError: On any governance violation.
+        """
+        agent_id_param = kwargs.get("agentId", "")
+        agent_alias = kwargs.get("agentAliasId", "")
+        agent_arn = f"arn:aws:bedrock:::agent/{agent_id_param}/{agent_alias}"
+        self._ctx.agent_arn = agent_arn
+
+        # 1. Rate limit
+        self._kernel._check_rate_limit(agent_arn)
+
+        # 2. Input scan
+        input_text = kwargs.get("inputText", "")
+        self._kernel._check_input(self._ctx, input_text)
+
+        # 3. Cedar/OPA gate
+        cedar_ctx = self._kernel._build_cedar_context(
+            agent_id=agent_arn,
+            action_type="invoke_agent",
+            tool_name="",
+            tool_args={"inputText": input_text},
+        )
+        allowed, reason = self._kernel._evaluate_policy(cedar_ctx)
+        if not allowed:
+            raise PolicyViolationError(f"Cedar/OPA policy denied invocation: {reason}")
+
+        # Audit log
+        logger.info(
+            "Bedrock invoke_agent | arn=%s session=%s",
+            agent_arn, kwargs.get("sessionId", ""),
+        )
+        self._kernel.emit(GovernanceEventType.POLICY_CHECK, {
+            "agent_id": self._ctx.agent_id,
+            "agent_arn": agent_arn,
+            "timestamp": datetime.now().isoformat(),
+        })
+
+        # 4. Execute
+        try:
+            response = self._client.invoke_agent(**kwargs)
+        except Exception as exc:
+            self._kernel._last_error = str(exc)
+            raise
+
+        invocation_id = response.get("ResponseMetadata", {}).get("RequestId", f"req-{int(time.time())}")
+        self._ctx.invocation_ids.append(invocation_id)
+
+        # Wrap the completion stream with governance
+        if "completion" in response:
+            response = dict(response)
+            response["completion"] = _GovernedEventStream(
+                response["completion"], self._kernel, self._ctx
+            )
+
+        self._kernel.post_execute(self._ctx, response)
+        return response
+
+    def get_context(self) -> BedrockContext:
+        """Return the session execution context."""
+        return self._ctx
+
+    def get_audit_summary(self) -> dict[str, Any]:
+        """Return a structured audit summary for this session."""
+        return {
+            "agent_arn": self._ctx.agent_arn,
+            "invocation_ids": self._ctx.invocation_ids,
+            "action_groups_invoked": self._ctx.action_groups_invoked,
+            "tool_call_count": self._ctx.call_count,
+            "blocked_events": self._ctx.blocked_events,
+            "session_id": self._ctx.session_id,
+        }
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._client, name)
+
+    def __repr__(self) -> str:
+        return (
+            f"GovernedBedrockClient(agent_arn={self._ctx.agent_arn!r}, "
+            f"calls={self._ctx.call_count})"
+        )

--- a/agent-governance-python/agent-os/tests/test_bedrock_adapter.py
+++ b/agent-governance-python/agent-os/tests/test_bedrock_adapter.py
@@ -1,0 +1,482 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the AWS Bedrock Agent governance adapter.
+
+All tests are fully offline, no real AWS credentials or boto3 network
+calls are made.  The boto3 client is replaced by a MagicMock throughout.
+
+Coverage:
+- BedrockKernel construction and defaults
+- wrap() / unwrap() round-trip
+- health_check()
+- Blocked-pattern enforcement on inputText
+- PII detection on inputText (SSN, email, credit card)
+- Tool allowlist enforcement on streaming action-group events
+- Explicitly blocked_tools enforcement
+- max_tool_calls limit
+- Rate limiting per agent ARN
+- Clean invocation passes through end-to-end
+- audit summary reflects session state
+- PolicyViolationError is raised (not swallowed)
+- Cedar/OPA gate delegation
+- Graceful ImportError when boto3 is absent
+- GovernedBedrockClient __repr__
+- _GovernedEventStream passthrough for non-action events
+- _GovernedEventStream proxies unknown attributes to underlying stream
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import agent_os.integrations.bedrock_adapter as _bmod
+
+# Pretend boto3 is installed for all tests that call wrap().
+_bmod._HAS_BOTO3 = True
+
+from agent_os.integrations.base import GovernancePolicy, PolicyViolationError
+from agent_os.integrations.bedrock_adapter import (
+    BedrockContext,
+    BedrockKernel,
+    GovernedBedrockClient,
+    _GovernedEventStream,
+)
+
+# Helper functions
+def _mock_client(events: list[dict] | None = None) -> MagicMock:
+    """Return a mock boto3 bedrock-agent-runtime client."""
+    client = MagicMock()
+    stream = iter(events or [])
+    client.invoke_agent.return_value = {
+        "ResponseMetadata": {"RequestId": "req-test-001"},
+        "completion": stream,
+    }
+    return client
+
+
+def _kernel(**kw) -> BedrockKernel:
+    return BedrockKernel(policy=GovernancePolicy(**kw))
+
+
+def _action_event(tool_name: str) -> dict:
+    return {
+        "returnControl": {
+            "invocationInputs": [
+                {
+                    "actionGroupInvocationInput": {
+                        "actionGroupName": tool_name,
+                        "function": tool_name,
+                    }
+                }
+            ]
+        }
+    }
+
+
+# Construction & defaults
+class TestBedrockKernelInit:
+    def test_default_policy(self):
+        k = BedrockKernel()
+        assert isinstance(k.policy, GovernancePolicy)
+
+    def test_custom_policy(self):
+        p = GovernancePolicy(max_tool_calls=5)
+        k = BedrockKernel(policy=p)
+        assert k.policy.max_tool_calls == 5
+
+    def test_blocked_tools_stored_as_set(self):
+        k = BedrockKernel(blocked_tools=["delete_bucket", "terminate"])
+        assert "delete_bucket" in k._blocked_tools
+        assert "terminate" in k._blocked_tools
+
+    def test_no_rate_limiter_by_default(self):
+        assert BedrockKernel()._rate_limiter is None
+
+    def test_rate_limiter_created_when_nonzero(self):
+        k = BedrockKernel(rate_limit_per_minute=30)
+        assert k._rate_limiter is not None
+
+
+
+# wrap() / unwrap()
+class TestWrapUnwrap:
+    def test_wrap_returns_governed_client(self):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        assert isinstance(governed, GovernedBedrockClient)
+
+    def test_unwrap_returns_original_client(self):
+        k = BedrockKernel()
+        raw = _mock_client()
+        governed = k.wrap(raw)
+        assert k.unwrap(governed) is raw
+
+    def test_unwrap_passthrough_for_non_governed(self):
+        k = BedrockKernel()
+        obj = object()
+        assert k.unwrap(obj) is obj
+
+    def test_wrap_registers_context(self):
+        k = BedrockKernel()
+        k.wrap(_mock_client())
+        assert len(k.contexts) == 1
+
+    def test_wrap_raises_without_boto3(self):
+        _bmod._HAS_BOTO3 = False
+        try:
+            with pytest.raises(ImportError, match="boto3"):
+                BedrockKernel().wrap(_mock_client())
+        finally:
+            _bmod._HAS_BOTO3 = True
+
+
+
+# health_check()
+class TestHealthCheck:
+    def test_healthy_by_default(self):
+        h = BedrockKernel().health_check()
+        assert h["status"] == "healthy"
+        assert h["backend"] == "aws-bedrock"
+        assert h["last_error"] is None
+
+    def test_degraded_after_error(self):
+        k = BedrockKernel()
+        k._last_error = "connection timeout"
+        assert k.health_check()["status"] == "degraded"
+
+    def test_uptime_is_positive(self):
+        assert BedrockKernel().health_check()["uptime_seconds"] >= 0
+
+
+# Input scanning, blocked patterns
+class TestBlockedPatterns:
+    def test_blocked_pattern_in_input_raises(self):
+        k = _kernel(blocked_patterns=["DROP TABLE"])
+        governed = k.wrap(_mock_client())
+        with pytest.raises(PolicyViolationError, match="matched pattern"):
+            governed.invoke_agent(
+                agentId="A", agentAliasId="L", sessionId="s",
+                inputText="DROP TABLE users",
+            )
+
+    def test_clean_input_passes_through(self):
+        k = _kernel(blocked_patterns=["DROP TABLE"])
+        governed = k.wrap(_mock_client())
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s",
+            inputText="Summarize this quarter",
+        )
+        assert "completion" in resp
+
+    def test_multiple_blocked_patterns_any_match_blocks(self):
+        k = _kernel(blocked_patterns=["secret", "password"])
+        governed = k.wrap(_mock_client())
+        with pytest.raises(PolicyViolationError):
+            governed.invoke_agent(
+                agentId="A", agentAliasId="L", sessionId="s",
+                inputText="my password is 1234",
+            )
+
+
+# PII detection
+class TestPIIDetection:
+    @pytest.mark.parametrize("bad_input", [
+        "SSN: 123-45-6789",
+        "email me at test.user@example.com",
+        "card: 4111111111111111",
+    ])
+    def test_pii_in_input_raises(self, bad_input):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        with pytest.raises(PolicyViolationError, match="PII"):
+            governed.invoke_agent(
+                agentId="A", agentAliasId="L", sessionId="s",
+                inputText=bad_input,
+            )
+
+    def test_clean_input_no_pii_passes(self):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s",
+            inputText="List this week's orders",
+        )
+        assert resp is not None
+
+
+# Tool allowlist, streaming events
+class TestToolAllowlist:
+    def test_allowed_tool_passes(self):
+        k = _kernel(allowed_tools=["query_db"])
+        events = [_action_event("query_db"), {"chunk": {"bytes": b"ok"}}]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s",
+            inputText="run report",
+        )
+        consumed = list(resp["completion"])
+        assert len(consumed) == 2
+
+    def test_disallowed_tool_in_stream_raises(self):
+        k = _kernel(allowed_tools=["query_db"])
+        events = [_action_event("delete_records")]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s",
+            inputText="run report",
+        )
+        with pytest.raises(PolicyViolationError, match="not in the allowed_tools"):
+            list(resp["completion"])
+
+    def test_empty_allowed_tools_permits_anything(self):
+        k = _kernel(allowed_tools=[])
+        events = [_action_event("any_tool")]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s",
+            inputText="go",
+        )
+        consumed = list(resp["completion"])
+        assert len(consumed) == 1
+
+
+# Explicitly blocked tools
+class TestBlockedTools:
+    def test_blocked_tool_raises_even_if_in_allowlist(self):
+        k = BedrockKernel(
+            policy=GovernancePolicy(allowed_tools=["delete_bucket"]),
+            blocked_tools=["delete_bucket"],
+        )
+        events = [_action_event("delete_bucket")]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s",
+            inputText="run",
+        )
+        with pytest.raises(PolicyViolationError, match="explicitly blocked"):
+            list(resp["completion"])
+
+    def test_blocked_tool_increments_blocked_events(self):
+        k = BedrockKernel(blocked_tools=["rm_rf"])
+        events = [_action_event("rm_rf")]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+        )
+        with pytest.raises(PolicyViolationError):
+            list(resp["completion"])
+        assert governed.get_context().blocked_events == 1
+
+
+# max_tool_calls limit
+class TestMaxToolCalls:
+    def test_exceeding_limit_raises(self):
+        k = _kernel(max_tool_calls=2)
+        events = [_action_event("tool_a"), _action_event("tool_b"), _action_event("tool_c")]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+        )
+        with pytest.raises(PolicyViolationError, match="Tool call limit"):
+            list(resp["completion"])
+
+    def test_at_limit_raises_not_below(self):
+        k = _kernel(max_tool_calls=1)
+        events = [_action_event("tool_a"), _action_event("tool_b")]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+        )
+        with pytest.raises(PolicyViolationError):
+            list(resp["completion"])
+
+
+# Rate limiting
+class TestRateLimiting:
+    def test_rate_limit_exceeded_raises(self, monkeypatch):
+        from agent_os.integrations.rate_limiter import RateLimitStatus
+        k = BedrockKernel(rate_limit_per_minute=1)
+        mock_status = RateLimitStatus(allowed=False, remaining_calls=0, reset_at=0.0, wait_seconds=1.0)
+        monkeypatch.setattr(k._rate_limiter, "check", lambda _arn: mock_status)
+        governed = k.wrap(_mock_client())
+        with pytest.raises(PolicyViolationError, match="Rate limit"):
+            governed.invoke_agent(
+                agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+            )
+
+    def test_rate_limit_allowed_passes(self, monkeypatch):
+        from agent_os.integrations.rate_limiter import RateLimitStatus
+        k = BedrockKernel(rate_limit_per_minute=10)
+        mock_status = RateLimitStatus(allowed=True, remaining_calls=9, reset_at=0.0, wait_seconds=0.0)
+        monkeypatch.setattr(k._rate_limiter, "check", lambda _arn: mock_status)
+        governed = k.wrap(_mock_client())
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+        )
+        assert resp is not None
+
+
+# Audit summary
+class TestAuditSummary:
+    def test_audit_summary_structure(self):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        governed.invoke_agent(
+            agentId="AGENT1", agentAliasId="ALIAS1", sessionId="s1",
+            inputText="Hello",
+        )
+        summary = governed.get_audit_summary()
+        assert "agent_arn" in summary
+        assert "invocation_ids" in summary
+        assert "action_groups_invoked" in summary
+        assert "tool_call_count" in summary
+        assert "blocked_events" in summary
+        assert "session_id" in summary
+
+    def test_invocation_id_recorded(self):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+        )
+        assert "req-test-001" in governed.get_audit_summary()["invocation_ids"]
+
+    def test_action_groups_recorded_after_stream(self):
+        k = _kernel(allowed_tools=["my_tool"])
+        events = [_action_event("my_tool")]
+        governed = k.wrap(_mock_client(events))
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+        )
+        list(resp["completion"])
+        assert "my_tool" in governed.get_audit_summary()["action_groups_invoked"]
+
+
+# Cedar/OPA gate
+class TestCedarGate:
+    def test_cedar_deny_raises(self):
+        k = BedrockKernel()
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = SimpleNamespace(
+            allowed=False, reason="cedar denied"
+        )
+        k._evaluator = mock_evaluator
+        governed = k.wrap(_mock_client())
+        with pytest.raises(PolicyViolationError, match="Cedar/OPA"):
+            governed.invoke_agent(
+                agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+            )
+
+    def test_cedar_allow_passes_through(self):
+        k = BedrockKernel()
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = SimpleNamespace(allowed=True, reason="")
+        k._evaluator = mock_evaluator
+        governed = k.wrap(_mock_client())
+        resp = governed.invoke_agent(
+            agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+        )
+        assert resp is not None
+
+
+# Client error propagation
+class TestErrorPropagation:
+    def test_boto3_error_propagates_and_sets_last_error(self):
+        k = BedrockKernel()
+        raw = _mock_client()
+        raw.invoke_agent.side_effect = RuntimeError("Throttling")
+        governed = k.wrap(raw)
+        with pytest.raises(RuntimeError, match="Throttling"):
+            governed.invoke_agent(
+                agentId="A", agentAliasId="L", sessionId="s", inputText="go",
+            )
+        assert k._last_error == "Throttling"
+
+
+# Attribute proxy
+class TestAttributeProxy:
+    def test_getattr_proxies_to_underlying_client(self):
+        k = BedrockKernel()
+        raw = _mock_client()
+        raw.some_custom_method = lambda: "custom"
+        governed = k.wrap(raw)
+        assert governed.some_custom_method() == "custom"
+
+    def test_get_context_returns_bedrock_context(self):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        assert isinstance(governed.get_context(), BedrockContext)
+
+
+# GovernedBedrockClient __repr__
+class TestRepr:
+    def test_repr_contains_agent_arn_and_calls(self):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        governed.invoke_agent(
+            agentId="MYAGENT", agentAliasId="ALIAS", sessionId="s", inputText="go",
+        )
+        r = repr(governed)
+        assert "MYAGENT" in r
+        assert "calls=" in r
+
+
+# _GovernedEventStream
+
+class TestGovernedEventStream:
+    def test_non_action_events_pass_through(self):
+        k = BedrockKernel()
+        ctx = BedrockContext(agent_id="a", session_id="s", policy=k.policy)
+        events = [{"chunk": {"bytes": b"hello"}}, {"trace": {}}]
+        stream = _GovernedEventStream(iter(events), k, ctx)
+        result = list(stream)
+        assert result == events
+
+    def test_proxies_unknown_attrs_to_stream(self):
+        k = BedrockKernel()
+        ctx = BedrockContext(agent_id="a", session_id="s", policy=k.policy)
+        inner = MagicMock()
+        inner.close = lambda: "closed"
+        stream = _GovernedEventStream(inner, k, ctx)
+        assert stream.close() == "closed"
+
+    def test_action_event_recorded_in_context(self):
+        k = _kernel(allowed_tools=["my_action"])
+        ctx = BedrockContext(agent_id="a", session_id="s", policy=k.policy)
+        stream = _GovernedEventStream(iter([_action_event("my_action")]), k, ctx)
+        list(stream)
+        assert "my_action" in ctx.action_groups_invoked
+        assert ctx.call_count == 1
+
+
+# boto3 absent
+class TestMissingBoto3:
+    def test_import_error_message_is_helpful(self):
+        _bmod._HAS_BOTO3 = False
+        try:
+            with pytest.raises(ImportError) as exc_info:
+                BedrockKernel().wrap(MagicMock())
+            assert "pip install boto3" in str(exc_info.value)
+        finally:
+            _bmod._HAS_BOTO3 = True
+
+
+# BedrockContext fields
+class TestBedrockContext:
+    def test_default_fields(self):
+        ctx = BedrockContext(agent_id="a", session_id="s", policy=GovernancePolicy())
+        assert ctx.agent_arn == ""
+        assert ctx.invocation_ids == []
+        assert ctx.action_groups_invoked == []
+        assert ctx.blocked_events == 0
+
+    def test_agent_arn_set_on_invoke(self):
+        k = BedrockKernel()
+        governed = k.wrap(_mock_client())
+        governed.invoke_agent(
+            agentId="MYID", agentAliasId="MYALIAS", sessionId="s", inputText="go",
+        )
+        assert "MYID" in governed.get_context().agent_arn
+        assert "MYALIAS" in governed.get_context().agent_arn


### PR DESCRIPTION
## Summary

Closes #1821

Adds `BedrockKernel` at `agent-governance-python/agent-os/src/agent_os/integrations/bedrock_adapter.py`, following the same pattern as `langchain_adapter.py` and `crewai_adapter.py`.

- `BedrockKernel(BaseIntegration)`: wraps a `boto3` `bedrock-agent-runtime` client with governance
- `GovernedBedrockClient`:  drop-in proxy that intercepts `invoke_agent()` calls
- `_GovernedEventStream`: governs Bedrock's streaming `EventStream` action-group events without buffering the full response
- `BedrockContext`: extends `ExecutionContext` with `agent_arn`, `invocation_ids`, `action_groups_invoked`, `blocked_events`
- Blocked-pattern scanning on `inputText` before invocation (reuses `GovernancePolicy.matches_pattern`)
- PII detection on `inputText` (SSN, email, credit card) before invocation
- Tool allow/block-list enforced on `returnControl` action-group events in the response stream
- `max_tool_calls` limit enforced per session
- Rate limiting per agent ARN via the existing `RateLimiter`
- Cedar/OPA policy evaluation inherited from `BaseIntegration.from_cedar()`
- Graceful `boto3` import,  helpful `ImportError` if not installed, no hard dependency added
- `BedrockKernel` and `GovernedBedrockClient` registered in `integrations/__init__.py` lazy map and `__all__`

## Test plan

- 44 offline tests in `tests/test_bedrock_adapter.py`, zero real AWS calls, boto3 fully mocked
- All 44 pass locally