### PR TITLE
fix(mesh): /handshake/verify always returned verified=False due to key mismatch

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/cli/trust_cli.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/cli/trust_cli.py
@@ -22,27 +22,15 @@ from rich.table import Table
 from rich import box
 
 from agentmesh.trust.bridge import PeerInfo
-from agentmesh.constants import (
-    TIER_VERIFIED_PARTNER_THRESHOLD,
-    TIER_TRUSTED_THRESHOLD,
-    TIER_STANDARD_THRESHOLD,
-    TIER_PROBATIONARY_THRESHOLD,
-)
+from agentmesh.trust.levels import trust_level_for_score
 
 console = Console()
 
 
-def _trust_level_label(score: int) -> str:
-    """Return a human-readable trust level label for a numeric score."""
-    if score >= TIER_VERIFIED_PARTNER_THRESHOLD:
-        return "verified_partner"
-    elif score >= TIER_TRUSTED_THRESHOLD:
-        return "trusted"
-    elif score >= TIER_STANDARD_THRESHOLD:
-        return "standard"
-    elif score >= TIER_PROBATIONARY_THRESHOLD:
-        return "probationary"
-    return "untrusted"
+# Backwards-compatible alias for the canonical helper in agentmesh.trust.levels;
+# kept so internal callers and the existing test suite (test_trust_cli.py) work
+# without changes.
+_trust_level_label = trust_level_for_score
 
 
 def _trust_level_style(level: str) -> str:

--- a/agent-governance-python/agent-mesh/src/agentmesh/cli/trust_cli.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/cli/trust_cli.py
@@ -17,9 +17,9 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 import click
+from rich import box
 from rich.console import Console
 from rich.table import Table
-from rich import box
 
 from agentmesh.trust.bridge import PeerInfo
 from agentmesh.trust.levels import trust_level_for_score

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
@@ -19,6 +19,7 @@ from agentmesh.identity.agent_id import AgentDID, AgentIdentity, IdentityRegistr
 from agentmesh.server import create_base_app, run_server
 from agentmesh.trust.capability import CapabilityRegistry
 from agentmesh.trust.handshake import HandshakeChallenge, HandshakeResponse, TrustHandshake
+from agentmesh.trust.levels import trust_level_for_score
 
 logger = logging.getLogger(__name__)
 
@@ -152,11 +153,18 @@ async def verify_handshake(req: VerifyRequest) -> VerifyResponse:
             required_score=0,
             required_capabilities=None,
         )
+        # _verify_response returns the canonical shape used throughout
+        # agentmesh.trust: {"valid": bool, "reason": str | None,
+        # "registry_trust_score": int, "registry_capabilities": list[str]}.
+        # Translate to the public REST envelope here.
+        verified = bool(result.get("valid", False))
+        trust_score = int(result.get("registry_trust_score", 0)) if verified else 0
         return VerifyResponse(
-            verified=result.get("verified", False),
-            trust_score=result.get("trust_score", 0),
-            trust_level=result.get("trust_level", ""),
-            peer_did=result.get("peer_did", req.agent_did),
+            verified=verified,
+            trust_score=trust_score,
+            trust_level=trust_level_for_score(trust_score) if verified else "",
+            peer_did=req.agent_did,
+            rejection_reason=None if verified else result.get("reason"),
         )
     except Exception as exc:
         logger.warning("Handshake verification failed: %s", exc)

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
@@ -7,11 +7,11 @@ Implements IATP for agent-to-agent trust handshakes.
 Native A2A and MCP support with transparent protocol translation.
 """
 
-from .bridge import TrustBridge, ProtocolBridge
+from .bridge import ProtocolBridge, TrustBridge
+from .capability import CapabilityGrant, CapabilityRegistry, CapabilityScope
+from .cards import CardRegistry, TrustedAgentCard
 from .endorsement import Endorsement, EndorsementRegistry, EndorsementType
-from .handshake import TrustHandshake, HandshakeResult
-from .capability import CapabilityScope, CapabilityGrant, CapabilityRegistry
-from .cards import TrustedAgentCard, CardRegistry
+from .handshake import HandshakeResult, TrustHandshake
 from .levels import trust_level_for_score
 
 __all__ = [

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/__init__.py
@@ -12,6 +12,7 @@ from .endorsement import Endorsement, EndorsementRegistry, EndorsementType
 from .handshake import TrustHandshake, HandshakeResult
 from .capability import CapabilityScope, CapabilityGrant, CapabilityRegistry
 from .cards import TrustedAgentCard, CardRegistry
+from .levels import trust_level_for_score
 
 __all__ = [
     "TrustBridge",
@@ -26,4 +27,5 @@ __all__ = [
     "CapabilityRegistry",
     "TrustedAgentCard",
     "CardRegistry",
+    "trust_level_for_score",
 ]

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/levels.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/levels.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Trust-level helpers shared across CLI, servers, and integrations."""
+
+from __future__ import annotations
+
+from agentmesh.constants import (
+    TIER_PROBATIONARY_THRESHOLD,
+    TIER_STANDARD_THRESHOLD,
+    TIER_TRUSTED_THRESHOLD,
+    TIER_VERIFIED_PARTNER_THRESHOLD,
+)
+
+__all__ = ["trust_level_for_score"]
+
+
+def trust_level_for_score(score: int) -> str:
+    """Return the canonical trust-level label for a numeric score (0-1000).
+
+    The mapping mirrors the tiers defined in ``agentmesh.constants`` and is
+    the single source of truth used by the trust-engine HTTP API, the
+    ``agentmesh trust`` CLI, and any caller that needs to render a score
+    as a human-readable label.
+
+    Returns one of: ``"verified_partner"``, ``"trusted"``, ``"standard"``,
+    ``"probationary"``, ``"untrusted"``.
+    """
+    if score >= TIER_VERIFIED_PARTNER_THRESHOLD:
+        return "verified_partner"
+    if score >= TIER_TRUSTED_THRESHOLD:
+        return "trusted"
+    if score >= TIER_STANDARD_THRESHOLD:
+        return "standard"
+    if score >= TIER_PROBATIONARY_THRESHOLD:
+        return "probationary"
+    return "untrusted"

--- a/agent-governance-python/agent-mesh/tests/test_server.py
+++ b/agent-governance-python/agent-mesh/tests/test_server.py
@@ -106,6 +106,99 @@ class TestTrustEngineServer:
         })
         assert resp.status_code == 404
 
+    def _register_and_challenge(self):
+        """Register a fresh agent and issue a challenge.
+
+        Returns ``(private_key, public_key_b64, agent_did, challenge_id, nonce)``
+        ready for signing a valid handshake response.
+        """
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        import base64
+
+        key = Ed25519PrivateKey.generate()
+        pub_b64 = base64.b64encode(key.public_key().public_bytes_raw()).decode()
+
+        reg = self.client.post("/api/v1/agents/register", json={
+            "name": "verify-agent",
+            "public_key": pub_b64,
+            "sponsor_email": "verify@example.com",
+        })
+        assert reg.status_code == 200
+        agent_did = reg.json()["agent_did"]
+
+        ch = self.client.post("/api/v1/handshake/challenge", json={
+            "agent_did": agent_did,
+        })
+        assert ch.status_code == 200
+        ch_data = ch.json()
+        return key, pub_b64, agent_did, ch_data["challenge_id"], ch_data["nonce"]
+
+    def test_verify_valid_signed_response(self):
+        """A correctly signed challenge response is reported as verified.
+
+        Regression test for the dict-key mismatch where _verify_response
+        returned ``{"valid": True, ...}`` but the endpoint read keys named
+        ``verified`` / ``trust_score`` / ``trust_level`` — causing every
+        successful verification to be reported as ``verified=False``.
+        """
+        import base64
+        import secrets
+
+        key, _pub_b64, agent_did, challenge_id, challenge_nonce = self._register_and_challenge()
+
+        response_nonce = secrets.token_hex(16)
+        payload = f"{challenge_id}:{challenge_nonce}:{response_nonce}:{agent_did}"
+        signature_b64 = base64.b64encode(key.sign(payload.encode())).decode()
+
+        resp = self.client.post("/api/v1/handshake/verify", json={
+            "challenge_id": challenge_id,
+            "agent_did": agent_did,
+            "response_nonce": response_nonce,
+            "signature": signature_b64,
+            "public_key": base64.b64encode(key.public_key().public_bytes_raw()).decode(),
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["verified"] is True, f"expected verified=True, got {data}"
+        assert data["trust_score"] >= 0
+        # trust_level must be one of the canonical labels emitted by
+        # agentmesh.trust.levels.trust_level_for_score; it must not be the
+        # legacy empty-string default that masked the dict-key bug.
+        assert data["trust_level"] in {
+            "verified_partner", "trusted", "standard", "probationary", "untrusted",
+        }
+        assert data["peer_did"] == agent_did
+        assert data["rejection_reason"] is None
+
+    def test_verify_invalid_signature(self):
+        """A response with a tampered signature is reported as not verified
+        with a populated rejection_reason."""
+        import base64
+        import secrets
+
+        key, _pub_b64, agent_did, challenge_id, challenge_nonce = self._register_and_challenge()
+
+        response_nonce = secrets.token_hex(16)
+        payload = f"{challenge_id}:{challenge_nonce}:{response_nonce}:{agent_did}"
+        sig = bytearray(key.sign(payload.encode()))
+        sig[0] ^= 0xFF  # tamper the first byte
+        bad_sig_b64 = base64.b64encode(bytes(sig)).decode()
+
+        resp = self.client.post("/api/v1/handshake/verify", json={
+            "challenge_id": challenge_id,
+            "agent_did": agent_did,
+            "response_nonce": response_nonce,
+            "signature": bad_sig_b64,
+            "public_key": base64.b64encode(key.public_key().public_bytes_raw()).decode(),
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["verified"] is False
+        assert data["trust_score"] == 0
+        assert data["trust_level"] == ""
+        assert data["rejection_reason"] is not None
+        assert "signature" in data["rejection_reason"].lower()
+
     def test_capabilities_empty(self):
         resp = self.client.get("/api/v1/capabilities/did:mesh:unknown")
         assert resp.status_code == 200

--- a/agent-governance-python/agent-mesh/tests/test_server.py
+++ b/agent-governance-python/agent-mesh/tests/test_server.py
@@ -112,8 +112,9 @@ class TestTrustEngineServer:
         Returns ``(private_key, public_key_b64, agent_did, challenge_id, nonce)``
         ready for signing a valid handshake response.
         """
-        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
         import base64
+
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
         key = Ed25519PrivateKey.generate()
         pub_b64 = base64.b64encode(key.public_key().public_bytes_raw()).decode()


### PR DESCRIPTION
## Description

The trust-engine REST endpoint at `POST /api/v1/handshake/verify` is currently non-functional: every call returns `verified=False, trust_score=0, trust_level=""` regardless of whether the supplied Ed25519 signature is valid.

The bug is a dict-shape mismatch between the verifier and the endpoint:

- `TrustHandshake._verify_response` (in `agentmesh/trust/handshake.py`) returns the canonical shape used throughout `agentmesh.trust`:
  ```python
  {"valid": bool, "reason": str | None, "registry_trust_score": int, "registry_capabilities": list[str]}
  ```
- The endpoint in `agentmesh/server/trust_engine.py` was reading `result.get("verified")`, `result.get("trust_score")`, `result.get("trust_level")`, `result.get("peer_did")` — none of which the verifier emits — so every successful verification was silently coerced to "not verified."

Six other call sites already use the canonical shape (the verifier's primary internal user `_do_initiate`, plus five existing handshake security tests), confirming the REST endpoint was the lone outlier rather than an alternate convention.

### Fix

- Read the correct keys at the boundary in `agentmesh/server/trust_engine.py` and translate to the public `VerifyResponse` envelope.
- Extract the score-to-level mapping into a new public helper `trust_level_for_score()` at `agentmesh/trust/levels.py`. The same mapping was duplicated inside `agentmesh/cli/trust_cli.py` as `_trust_level_label`; alias the CLI symbol to the canonical helper so internal callers and the existing `test_trust_cli` suite work unchanged.
- Add two integration tests in `tests/test_server.py`:
  - `test_verify_valid_signed_response` — registers an agent, issues a challenge, signs the response correctly, and asserts `verified=True` with a populated `trust_level`. This is the regression guard; it would have failed against the broken code.
  - `test_verify_invalid_signature` — tampers with the signature and asserts `verified=False` with `rejection_reason` populated, confirming the new translation surfaces the verifier's reason on failure.

### Risk

Negligible. Because the endpoint always returned `verified=False` previously, no consumer can have been depending on it returning `True`. Any caller depending on the broken behavior (always-deny) would have already been blocked or worked around it. Forward fix is a strict improvement.

### Test results

| Suite | Result |
| --- | --- |
| `TestTrustEngineServer` (10 tests, 2 new) | 10/10 passing |
| `test_trust_cli` (CLI surface) | 45/45 passing |
| `test_handshake_security` (regression coverage) | 17/17 passing |

`ruff check` on the import blocks I edited or added is clean. 17 pre-existing violations elsewhere in the affected files (E501 long lines, UP045 `Optional` annotations, I001 in unrelated test methods) are out of scope for this PR.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [x] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check) — *the import blocks I edited or added are ruff-clean; 17 pre-existing violations elsewhere in the affected files are out of scope for this PR*
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed (no doc surface affected)
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any): None — this is a localized correctness fix.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

Claude (Anthropic) was used as a pair-programming assistant during analysis and patch authorship. Every change was reviewed by me before commit; the test that demonstrates the regression was authored specifically to fail against the pre-fix code.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
None filed publicly. Discovered during a private security review of the toolkit.