### PR TITLE
fix: preserve audit chain verification across rollover eviction (TS/Rust/Go)

### DIFF
--- a/agent-governance-golang/packages/agentmesh/audit.go
+++ b/agent-governance-golang/packages/agentmesh/audit.go
@@ -26,6 +26,7 @@ type AuditEntry struct {
 type AuditLogger struct {
 	mu         sync.Mutex
 	entries    []*AuditEntry
+	seamHash   string
 	MaxEntries int
 }
 
@@ -35,16 +36,20 @@ func NewAuditLogger() *AuditLogger {
 }
 
 // Log appends a new entry to the audit chain.
-// When MaxEntries is set and exceeded, the oldest entries are evicted.
+// When MaxEntries is set and exceeded, the oldest entries are evicted and
+// their final hash is retained as a seam so Verify() can re-anchor the
+// surviving chain.
 func (al *AuditLogger) Log(agentID, action string, decision PolicyDecision) *AuditEntry {
 	al.mu.Lock()
 	defer al.mu.Unlock()
 
 	if al.MaxEntries > 0 && len(al.entries) >= al.MaxEntries {
-		al.entries = al.entries[len(al.entries)-al.MaxEntries+1:]
+		sliceFrom := len(al.entries) - al.MaxEntries + 1
+		al.seamHash = al.entries[sliceFrom-1].Hash
+		al.entries = al.entries[sliceFrom:]
 	}
 
-	prevHash := ""
+	prevHash := al.seamHash
 	if len(al.entries) > 0 {
 		prevHash = al.entries[len(al.entries)-1].Hash
 	}
@@ -61,7 +66,9 @@ func (al *AuditLogger) Log(agentID, action string, decision PolicyDecision) *Aud
 	return entry
 }
 
-// Verify checks the integrity of the entire hash chain.
+// Verify checks the integrity of the entire hash chain. After rollover
+// eviction, the surviving head's PreviousHash is checked against the seam
+// hash recorded at eviction time, so tampering with it is still detected.
 func (al *AuditLogger) Verify() bool {
 	al.mu.Lock()
 	defer al.mu.Unlock()
@@ -72,8 +79,7 @@ func (al *AuditLogger) Verify() bool {
 			return false
 		}
 		if i == 0 {
-			// Allow non-empty PreviousHash when retention eviction is active
-			if al.MaxEntries == 0 && entry.PreviousHash != "" {
+			if entry.PreviousHash != al.seamHash {
 				return false
 			}
 		} else {

--- a/agent-governance-golang/packages/agentmesh/audit_test.go
+++ b/agent-governance-golang/packages/agentmesh/audit_test.go
@@ -116,6 +116,29 @@ func TestMaxEntriesVerify(t *testing.T) {
 	}
 }
 
+// After rollover eviction, the surviving head's PreviousHash must equal the
+// seam hash (the hash of the last evicted entry). Forging both PreviousHash
+// and Hash on the head would have been undetectable when Verify() skipped the
+// genesis check during retention; the seam check closes that gap.
+func TestMaxEntriesVerifyDetectsForgedSeam(t *testing.T) {
+	al := NewAuditLogger()
+	al.MaxEntries = 3
+	for i := 0; i < 10; i++ {
+		al.Log("agent", fmt.Sprintf("action-%d", i), Allow)
+	}
+	if !al.Verify() {
+		t.Fatal("chain should verify before tampering")
+	}
+
+	// Replace the surviving head's PreviousHash and recompute its Hash so the
+	// inner hash check still passes — only the seam check should reject this.
+	al.entries[0].PreviousHash = "0000000000000000000000000000000000000000000000000000000000000000"
+	al.entries[0].Hash = computeHash(al.entries[0])
+	if al.Verify() {
+		t.Error("forged seam should be detected by Verify()")
+	}
+}
+
 // --- New comprehensive tests ---
 
 func TestAuditEmptyLogVerifies(t *testing.T) {

--- a/agent-governance-rust/agentmesh/src/audit.rs
+++ b/agent-governance-rust/agentmesh/src/audit.rs
@@ -13,15 +13,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Each entry's hash covers `seq|timestamp|agent_id|action|decision|prev_hash`,
 /// creating a tamper-evident chain from the genesis entry.
 pub struct AuditLogger {
-    entries: Mutex<Vec<AuditEntry>>,
+    state: Mutex<AuditState>,
     max_entries: Option<usize>,
+}
+
+struct AuditState {
+    entries: Vec<AuditEntry>,
+    seam_hash: Option<String>,
 }
 
 impl AuditLogger {
     /// Create an empty audit logger with no entry limit.
     pub fn new() -> Self {
         Self {
-            entries: Mutex::new(Vec::new()),
+            state: Mutex::new(AuditState {
+                entries: Vec::new(),
+                seam_hash: None,
+            }),
             max_entries: None,
         }
     }
@@ -30,16 +38,24 @@ impl AuditLogger {
     /// evicting the oldest when the limit is exceeded.
     pub fn with_max_entries(max: usize) -> Self {
         Self {
-            entries: Mutex::new(Vec::new()),
+            state: Mutex::new(AuditState {
+                entries: Vec::new(),
+                seam_hash: None,
+            }),
             max_entries: Some(max),
         }
     }
 
     /// Append a new entry to the audit chain and return it.
     pub fn log(&self, agent_id: &str, action: &str, decision: &str) -> AuditEntry {
-        let mut entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        let seq = entries.len() as u64;
-        let prev_hash = entries.last().map(|e| e.hash.clone()).unwrap_or_default();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let seq = state.entries.len() as u64;
+        let prev_hash = state
+            .entries
+            .last()
+            .map(|e| e.hash.clone())
+            .or_else(|| state.seam_hash.clone())
+            .unwrap_or_default();
         let timestamp = iso8601_now();
 
         let hash_input = format!(
@@ -58,13 +74,16 @@ impl AuditLogger {
             hash,
         };
 
-        entries.push(entry.clone());
+        state.entries.push(entry.clone());
 
-        // Evict oldest entries when the retention limit is exceeded.
+        // Evict oldest entries when the retention limit is exceeded, retaining
+        // the last evicted entry's hash as the seam so verify() can re-anchor
+        // the surviving chain.
         if let Some(max) = self.max_entries {
-            if entries.len() > max {
-                let overflow = entries.len() - max;
-                entries.drain(..overflow);
+            if state.entries.len() > max {
+                let overflow = state.entries.len() - max;
+                state.seam_hash = Some(state.entries[overflow - 1].hash.clone());
+                state.entries.drain(..overflow);
             }
         }
 
@@ -76,29 +95,31 @@ impl AuditLogger {
     /// Returns `true` if every entry's hash is correct and linked to the
     /// previous entry's hash.
     pub fn verify(&self) -> bool {
-        let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        verify_audit_entries(&entries)
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        verify_audit_entries(&state.entries, state.seam_hash.as_deref())
     }
 
     /// Return all audit entries.
     pub fn entries(&self) -> Vec<AuditEntry> {
-        self.entries
+        self.state
             .lock()
             .unwrap_or_else(|e| e.into_inner())
+            .entries
             .clone()
     }
 
     /// Serialise all audit entries to a JSON string.
     pub fn export_json(&self) -> String {
-        let entries = self.entries.lock().unwrap_or_else(|e| e.into_inner());
-        serde_json::to_string(&*entries).unwrap_or_else(|_| "[]".to_string())
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        serde_json::to_string(&state.entries).unwrap_or_else(|_| "[]".to_string())
     }
 
     /// Return entries matching the given filter.
     pub fn get_entries(&self, filter: &AuditFilter) -> Vec<AuditEntry> {
-        self.entries
+        self.state
             .lock()
             .unwrap_or_else(|e| e.into_inner())
+            .entries
             .iter()
             .filter(|e| {
                 if let Some(ref id) = filter.agent_id {
@@ -129,10 +150,10 @@ impl Default for AuditLogger {
     }
 }
 
-pub(crate) fn verify_audit_entries(entries: &[AuditEntry]) -> bool {
+pub(crate) fn verify_audit_entries(entries: &[AuditEntry], seam_hash: Option<&str>) -> bool {
     for (i, entry) in entries.iter().enumerate() {
         let expected_prev = if i == 0 {
-            String::new()
+            seam_hash.map(str::to_owned).unwrap_or_default()
         } else {
             entries[i - 1].hash.clone()
         };
@@ -232,8 +253,8 @@ mod tests {
 
         // Tamper with the first entry
         {
-            let mut entries = logger.entries.lock().unwrap();
-            entries[0].action = "tampered".to_string();
+            let mut state = logger.state.lock().unwrap();
+            state.entries[0].action = "tampered".to_string();
         }
         assert!(!logger.verify());
     }
@@ -344,8 +365,8 @@ mod tests {
             logger.log("agent", &format!("action.{}", i), "allow");
         }
         {
-            let mut entries = logger.entries.lock().unwrap();
-            entries[2].action = "tampered".to_string();
+            let mut state = logger.state.lock().unwrap();
+            state.entries[2].action = "tampered".to_string();
         }
         assert!(!logger.verify());
     }
@@ -357,8 +378,34 @@ mod tests {
         logger.log("agent", "b", "allow");
         logger.log("agent", "c", "allow");
         {
-            let mut entries = logger.entries.lock().unwrap();
-            entries[1].previous_hash =
+            let mut state = logger.state.lock().unwrap();
+            state.entries[1].previous_hash =
+                "0000000000000000000000000000000000000000000000000000000000000000".to_string();
+        }
+        assert!(!logger.verify());
+    }
+
+    #[test]
+    fn test_verify_after_rollover_eviction() {
+        let logger = AuditLogger::with_max_entries(3);
+        for i in 0..10 {
+            logger.log("agent", &format!("action-{}", i), "allow");
+        }
+        assert_eq!(logger.entries().len(), 3);
+        assert!(logger.verify());
+    }
+
+    #[test]
+    fn test_tamper_head_after_rollover_eviction() {
+        let logger = AuditLogger::with_max_entries(3);
+        for i in 0..10 {
+            logger.log("agent", &format!("action-{}", i), "allow");
+        }
+        // Replace the surviving head's previous_hash with a bogus value — the
+        // seam from the evicted prefix should still be checked.
+        {
+            let mut state = logger.state.lock().unwrap();
+            state.entries[0].previous_hash =
                 "0000000000000000000000000000000000000000000000000000000000000000".to_string();
         }
         assert!(!logger.verify());

--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -189,7 +189,7 @@ pub struct HashChainVerifier;
 
 impl HashChainVerifier {
     pub fn verify(entries: &[AuditEntry]) -> bool {
-        verify_audit_entries(entries)
+        verify_audit_entries(entries, None)
     }
 }
 

--- a/agent-governance-typescript/src/audit.ts
+++ b/agent-governance-typescript/src/audit.ts
@@ -14,6 +14,7 @@ const GENESIS_HASH = '0'.repeat(64);
 export class AuditLogger {
   private readonly maxEntries: number;
   private entries: AuditEntry[] = [];
+  private seamHash: string | null = null;
 
   constructor(config?: AuditConfig) {
     this.maxEntries = config?.maxEntries ?? 10_000;
@@ -26,7 +27,7 @@ export class AuditLogger {
     const previousHash =
       this.entries.length > 0
         ? this.entries[this.entries.length - 1].hash
-        : GENESIS_HASH;
+        : this.seamHash ?? GENESIS_HASH;
 
     const timestamp = new Date().toISOString();
 
@@ -51,9 +52,12 @@ export class AuditLogger {
 
     this.entries.push(full);
 
-    // Evict oldest entries if we exceed the limit
+    // Evict oldest entries if we exceed the limit, retaining the last evicted
+    // entry's hash as the seam so verify() can re-anchor the surviving chain.
     if (this.entries.length > this.maxEntries) {
-      this.entries = this.entries.slice(this.entries.length - this.maxEntries);
+      const overflow = this.entries.length - this.maxEntries;
+      this.seamHash = this.entries[overflow - 1].hash;
+      this.entries = this.entries.slice(overflow);
     }
 
     return full;
@@ -64,7 +68,7 @@ export class AuditLogger {
     for (let i = 0; i < this.entries.length; i++) {
       const entry = this.entries[i];
       const expectedPrev =
-        i === 0 ? GENESIS_HASH : this.entries[i - 1].hash;
+        i === 0 ? this.seamHash ?? GENESIS_HASH : this.entries[i - 1].hash;
 
       if (entry.previousHash !== expectedPrev) return false;
 

--- a/agent-governance-typescript/tests/audit.test.ts
+++ b/agent-governance-typescript/tests/audit.test.ts
@@ -119,5 +119,26 @@ describe('AuditLogger', () => {
       }
       expect(small.length).toBe(3);
     });
+
+    it('verify() returns true after rollover eviction', () => {
+      const small = new AuditLogger({ maxEntries: 3 });
+      for (let i = 0; i < 10; i++) {
+        small.log({ agentId: `a${i}`, action: 'x', decision: 'allow' });
+      }
+      expect(small.length).toBe(3);
+      expect(small.verify()).toBe(true);
+    });
+
+    it('detects tampering of the surviving head after rollover eviction', () => {
+      const small = new AuditLogger({ maxEntries: 3 });
+      for (let i = 0; i < 10; i++) {
+        small.log({ agentId: `a${i}`, action: 'x', decision: 'allow' });
+      }
+      // Replace the surviving head's previousHash with a bogus value — the
+      // seam from the evicted prefix should still be checked.
+      const entries = (small as any).entries as Array<{ previousHash: string }>;
+      entries[0].previousHash = '0'.repeat(64);
+      expect(small.verify()).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary

The hash-chain audit loggers in three SDKs handle rollover eviction (when `maxEntries` is exceeded) in ways that break `verify()`. This PR fixes all three with a consistent **seam-hash** approach: when entries are evicted, the last evicted entry's hash is retained on the logger and used as the expected predecessor for the surviving head when verifying the chain.

### Pre-fix behavior, by language

| SDK | Eviction | `verify()` after eviction |
|---|---|---|
| **TypeScript** ([`agent-governance-typescript/src/audit.ts`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/src/audit.ts)) | yes (`maxEntries`) | **false negative** — returns `false` permanently after first eviction (surviving head's `previousHash` is the evicted predecessor's hash, but `verify()` compares against `GENESIS_HASH` at `i=0`) |
| **Rust** ([`agent-governance-rust/agentmesh/src/audit.rs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-rust/agentmesh/src/audit.rs)) | yes (`with_max_entries`) | **same false negative** — `verify_audit_entries` compares head's `previous_hash` against an empty string |
| **Go** ([`agent-governance-golang/packages/agentmesh/audit.go`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-golang/packages/agentmesh/audit.go)) | yes (`MaxEntries`) | **false positive** — `Verify()` skipped the genesis check entirely when `MaxEntries > 0` (`// Allow non-empty PreviousHash when retention eviction is active`), so a forged head whose `Hash` and `PreviousHash` were rewritten consistently was undetectable |
| **.NET** | no eviction | n/a |
| **Python** | no eviction | n/a (also has Merkle tree) |

### Fix

In each affected SDK:
- Track `seamHash` / `seam_hash` — the hash of the last evicted entry — on the logger state.
- On eviction, capture it before slicing/draining.
- On `Log()`, the new entry's `previousHash` falls back to `seamHash` when `entries` is empty (Rust + Go cases where eviction can leave `entries` empty if `MaxEntries == 1`).
- On `Verify()`, the surviving head is checked against `seamHash` (or genesis when no eviction has occurred yet).

### Tests

- **TS**: `verify() returns true after rollover eviction` and `detects tampering of the surviving head after rollover eviction`.
- **Rust**: `test_verify_after_rollover_eviction` and `test_tamper_head_after_rollover_eviction`.
- **Go**: `TestMaxEntriesVerifyDetectsForgedSeam` — forges both `PreviousHash` and `Hash` on the surviving head and asserts `Verify()` rejects it (the case the previous skip-genesis-check logic let through).

The existing `TestMaxEntriesVerify` (Go) and `test_max_entries_eviction` / `evicts old entries when limit is exceeded` (Rust/TS) remain green.

### Commits

Three commits, one per language, so a maintainer can revert any single language hunk if their CI surfaces a language-specific issue:
- `fix(typescript): preserve audit chain verification across rollover eviction`
- `fix(rust): preserve audit chain verification across rollover eviction`
- `fix(go): verify seam hash at audit chain rollover boundary`

## Test plan

- [x] `npx jest tests/audit.test.ts` — 14/14 passing (12 existing + 2 new)
- [x] `cargo test --lib audit::` — 26/26 passing in `agentmesh` crate (24 existing + 2 new)
- [x] `cargo build --workspace` — Rust workspace builds clean
- [x] `go test ./...` (audit subset) — all passing including new `TestMaxEntriesVerifyDetectsForgedSeam`
- [ ] CI (Node, Rust, Go) green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)