### PR TITLE
docs(adopters): add adoption dates to all entries

### DIFF
--- a/docs/ADOPTERS.md
+++ b/docs/ADOPTERS.md
@@ -8,27 +8,27 @@ momentum and credibility. Submit a PR editing this file — see
 
 ## Production
 
-| Organization | Industry | Use Case | Contact |
-|---|---|---|---|
-| Microsoft (internal AI agent platform) | AI / Developer Tools | Policy enforcement and governance workflows for multi-agent orchestration | [@imran-siddique](https://github.com/imran-siddique) |
-| Microsoft (internal engineering tools) | Engineering Productivity | Agent SRE integration for incident management and reliability monitoring | [@imran-siddique](https://github.com/imran-siddique) |
-| [Dayos](https://dayos.com) | Enterprise AI / ERP Automation | Policy enforcement and prompt-injection detection for a multi-agent system built on Google ADK — Cedar-based tool-dispatch governance across finance and operations workflows | [@miyannishar](https://github.com/miyannishar) |
+| Organization | Industry | Use Case | Since | Contact |
+|---|---|---|---|---|
+| Microsoft (internal AI agent platform) | AI / Developer Tools | Policy enforcement and governance workflows for multi-agent orchestration | Mar 2026 | [@imran-siddique](https://github.com/imran-siddique) |
+| Microsoft (internal engineering tools) | Engineering Productivity | Agent SRE integration for incident management and reliability monitoring | Apr 2026 | [@imran-siddique](https://github.com/imran-siddique) |
+| [Dayos](https://dayos.com) | Enterprise AI / ERP Automation | Policy enforcement and prompt-injection detection for a multi-agent system built on Google ADK -- Cedar-based tool-dispatch governance across finance and operations workflows | May 2026 | [@miyannishar](https://github.com/miyannishar) |
 
 ## Evaluation / Pilot
 
-| Organization | Industry | Use Case | Contact |
-|---|---|---|---|
-| [Nobulex](https://github.com/arian-gogani/nobulex) | AI Agent Security | Bilateral receipt primitive for tamper-evident agent audit trails (PRs #1302, #1333) | [@arian-gogani](https://github.com/arian-gogani) |
-| [GitHub — awesome-copilot](https://github.com/github/awesome-copilot) | Developer Tools | AGT contributor reputation check (`agt-contributor-check`) integrated into CI for PR risk scoring | [@imran-siddique](https://github.com/imran-siddique) |
-| Azure (internal project) | Cloud Infrastructure | AGT identity layer integration for agent mesh trust verification | [@imran-siddique](https://github.com/imran-siddique) |
-| [chamber](https://github.com/ianphil/chamber) | AI Agent Infrastructure | AGT governance workflows for agent execution policy enforcement | [@ianphil](https://github.com/ianphil) |
-| [MythologIQ Labs, LLC](https://github.com/MythologIQ-Labs-LLC) | AI Governance / Agent Security | Evaluating AGT as an isolated upstream governance dependency for [Qortara](https://qortara.com), including LangChain/LangGraph tool-dispatch governance through [`qortara-governance-langchain`](https://github.com/MythologIQ-Labs-LLC/qortara-governance). | [@Knapp-Kevin](https://github.com/Knapp-Kevin) |
+| Organization | Industry | Use Case | Since | Contact |
+|---|---|---|---|---|
+| [Nobulex](https://github.com/arian-gogani/nobulex) | AI Agent Security | Bilateral receipt primitive for tamper-evident agent audit trails (PRs #1302, #1333) | Mar 2026 | [@arian-gogani](https://github.com/arian-gogani) |
+| [GitHub -- awesome-copilot](https://github.com/github/awesome-copilot) | Developer Tools | AGT contributor reputation check (`agt-contributor-check`) integrated into CI for PR risk scoring | Apr 2026 | [@imran-siddique](https://github.com/imran-siddique) |
+| Azure (internal project) | Cloud Infrastructure | AGT identity layer integration for agent mesh trust verification | Apr 2026 | [@imran-siddique](https://github.com/imran-siddique) |
+| [chamber](https://github.com/ianphil/chamber) | AI Agent Infrastructure | AGT governance workflows for agent execution policy enforcement | Apr 2026 | [@ianphil](https://github.com/ianphil) |
+| [MythologIQ Labs, LLC](https://github.com/MythologIQ-Labs-LLC) | AI Governance / Agent Security | Evaluating AGT as an isolated upstream governance dependency for [Qortara](https://qortara.com), including LangChain/LangGraph tool-dispatch governance through [`qortara-governance-langchain`](https://github.com/MythologIQ-Labs-LLC/qortara-governance). | May 2026 | [@Knapp-Kevin](https://github.com/Knapp-Kevin) |
 
 ## Academic / Research
 
-| Organization | Focus Area | Contact |
-|---|---|---|
-| [Data Quality-Aware Agent Governance](https://github.com/SomeshZanwar/data-quality-aware-agent-governance) | Combining AGT policy evaluation with external data quality signals — agent actions are blocked when the target dataset fails freshness or validation checks, not only when the agent lacks authorization. | [@SomeshZanwar](https://github.com/SomeshZanwar) |
+| Organization | Focus Area | Since | Contact |
+|---|---|---|---|
+| [Data Quality-Aware Agent Governance](https://github.com/SomeshZanwar/data-quality-aware-agent-governance) | Combining AGT policy evaluation with external data quality signals -- agent actions are blocked when the target dataset fails freshness or validation checks, not only when the agent lacks authorization. | Apr 2026 | [@SomeshZanwar](https://github.com/SomeshZanwar) |
 
 ---
 


### PR DESCRIPTION
Add 'Since' column to all adopter tables. Dates help foundation reviewers gauge adoption trajectory and time-to-production.