### PR TITLE
fix: correct quickstart README and pipeline rank bug

### DIFF
--- a/examples/pipeline-governance/demo.py
+++ b/examples/pipeline-governance/demo.py
@@ -412,7 +412,7 @@ def main() -> None:
     print("\n--- normal pipeline run ---\n")
 
     shard_r0 = PipelineShard(rank=0, model="gemma-3-12b-qat4", shard_size_mb=3460, total_shards=2)
-    shard_r1 = PipelineShard(rank=0, model="gemma-3-12b-qat4", shard_size_mb=3460, total_shards=2)
+    shard_r1 = PipelineShard(rank=1, model="gemma-3-12b-qat4", shard_size_mb=3460, total_shards=2)
 
     steps = [
         # R0 loads its shard

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,12 +1,11 @@
 # Quickstart Examples
 
-Runnable examples showing AgentMesh governance enforcement across five major agent frameworks. Each script demonstrates a real policy violation being caught and a compliant call succeeding, with a printed audit trail.
-
-Refer to the individual scripts for framework-specific implementations.
+Runnable examples showing AGT governance enforcement across major agent frameworks and patterns. Each script demonstrates a real policy violation being caught and a compliant call succeeding, with a printed audit trail.
 
 ## Prerequisites
 
-- Python 3.x
+- Python 3.10+
+- No API keys required for core demos (`govern_in_60_seconds.py`, `retrofit_governed.py`)
 - OpenAI API key (for LangChain, AutoGen, OpenAI Agents examples)
 - Google ADK credentials (for ADK example)
 
@@ -17,6 +16,15 @@ pip install agent-governance-toolkit[full]
 ## How to Run
 
 ```bash
+# Govern in 60 seconds (no API key needed)
+python examples/quickstart/govern_in_60_seconds.py
+
+# Retrofit governance onto an existing agent (no API key needed)
+python examples/quickstart/retrofit_governed.py
+
+# MCP receipt signing (no API key needed)
+python examples/quickstart/mcp_receipts_in_60_seconds.py
+
 # LangChain
 python examples/quickstart/langchain_governed.py
 
@@ -33,6 +41,11 @@ python examples/quickstart/google_adk_governed.py
 python examples/quickstart/openai_agents_governed.py
 ```
 
+## Expected Output
+
+Each script prints a governance decision log showing blocked and allowed actions, followed by an audit trail summary.
+
 ## Related
 
 - [Policies](../policies/) — Sample YAML governance policies to use with these examples
+- [Tutorial 01: Policy Engine](../../docs/tutorials/01-policy-engine.md)


### PR DESCRIPTION
## Changes

- **Quickstart README**: Lists all 8 scripts (was missing \govern_in_60_seconds.py\, \etrofit_governed.py\, \mcp_receipts_in_60_seconds.py\). Updated intro wording, added Expected Output section, noted which demos need no API key.
- **Pipeline governance**: Fixed \shard_r1\ copy-paste bug where \ank=0\ should be \ank=1\.

Small, surgical doc/bug fix.