### PR TITLE
docs: improve example READMEs with prerequisites and expected output

### DIFF
--- a/examples/agent-mesh/README.md
+++ b/examples/agent-mesh/README.md
@@ -1,0 +1,20 @@
+# Agent Mesh Examples
+
+Runnable examples demonstrating AgentMesh multi-agent governance capabilities.
+
+## Examples
+
+| Directory | Description |
+|-----------|-------------|
+| [multi-agent-chat](multi-agent-chat/) | Governed multi-agent chat with trust scoring and policy enforcement |
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install agentmesh-platform`
+
+## Related
+
+- [AgentMesh Documentation](../../agent-governance-python/agent-mesh/)
+- [Tutorial 04: Multi-Agent Trust](../../docs/tutorials/04-multi-agent-trust.md)
+- [Tutorial 49: Multi-Agent Policies](../../docs/tutorials/49-multi-agent-policies.md)

--- a/examples/agent-sre/README.md
+++ b/examples/agent-sre/README.md
@@ -1,0 +1,20 @@
+# Agent SRE Examples
+
+Runnable examples demonstrating AGT's SRE observability and cost governance capabilities.
+
+## Examples
+
+| Directory | Description |
+|-----------|-------------|
+| [basic-runbook](basic-runbook/) | SRE runbook with SLO monitoring, alerting, and cost tracking |
+
+## Prerequisites
+
+- Python 3.10+
+- `pip install agent-sre`
+
+## Related
+
+- [Agent SRE Documentation](../../agent-governance-python/agent-sre/)
+- [Tutorial 06: SRE Dashboards](../../docs/tutorials/06-sre-dashboards.md)
+- [Tutorial 51: Cost Governance](../../docs/tutorials/51-cost-governance.md)

--- a/examples/cost-governance/README.md
+++ b/examples/cost-governance/README.md
@@ -3,11 +3,29 @@
 Demonstrates AGT's cost governance: tiered budget enforcement, per-agent and
 organization-wide caps, auto-throttle, kill switches, and anomaly detection.
 
-## Quick Start
+## Prerequisites
+
+- Python 3.10+
+- No API keys required
 
 ```bash
 pip install agent-sre
-python cost_governance_demo.py
+```
+
+## How to Run
+
+```bash
+python examples/cost-governance/cost_governance_demo.py
+```
+
+## Expected Output
+
+```
+  Budget Setup: per-task $2.00, daily $20.00, org $100.00
+  Pre-task checks: $1.50 allowed, $5.00 blocked (over limit)
+  Alert escalation: WARNING at 50%, THROTTLE at 85%, KILL at 95%
+  Org budget: cross-agent spending tracked, kill switch applied
+  Anomaly detection: $50.00 flagged against $1.00-$1.40 baseline
 ```
 
 ## What This Demo Shows

--- a/examples/decision-bom/README.md
+++ b/examples/decision-bom/README.md
@@ -3,11 +3,28 @@
 Demonstrates how AGT reconstructs a complete Bill of Materials for any
 governance decision, on demand, from existing observability signals.
 
-## Quick Start
+## Prerequisites
+
+- Python 3.10+
+- No API keys required
 
 ```bash
 pip install agentmesh-platform
-python decision_bom_demo.py
+```
+
+## How to Run
+
+```bash
+python examples/decision-bom/decision_bom_demo.py
+```
+
+## Expected Output
+
+```
+  Partial BOM (audit-only): 60% completeness, 3 fields populated
+  Full BOM (all signals):   100% completeness, 7 field categories
+  Batch: 5 decisions reconstructed for agent "analyst" in time range
+  JSON export: structured output ready for audit reporting
 ```
 
 ## What This Demo Shows

--- a/examples/intent-auth/README.md
+++ b/examples/intent-auth/README.md
@@ -4,11 +4,29 @@ Demonstrates AGT's intent-based authorization: agents declare what they
 plan to do, the system approves the plan, and drift is detected when
 agents deviate.
 
-## Quick Start
+## Prerequisites
+
+- Python 3.10+
+- No API keys required
 
 ```bash
 pip install agent-os-kernel
-python intent_auth_demo.py
+```
+
+## How to Run
+
+```bash
+python examples/intent-auth/intent_auth_demo.py
+```
+
+## Expected Output
+
+```
+  Intent declared: "read customer data" -> APPROVED
+  Execute under intent: read_file -> ALLOWED
+  Drift detected: delete_file (unplanned) -> trust drops 1.0 -> 0.7
+  Strict mode: unplanned action -> HARD BLOCK
+  Child intent: sub-agent scoped to parent permissions
 ```
 
 ## What This Demo Shows

--- a/examples/multi-agent-governance/README.md
+++ b/examples/multi-agent-governance/README.md
@@ -3,11 +3,28 @@
 Demonstrates how AGT enforces collective constraints across multiple agents:
 rate limits, concurrent agent caps, and alert-only monitoring.
 
-## Quick Start
+## Prerequisites
+
+- Python 3.10+
+- No API keys required
 
 ```bash
 pip install agentmesh-platform
-python multi_agent_policy_demo.py
+```
+
+## How to Run
+
+```bash
+python examples/multi-agent-governance/multi_agent_policy_demo.py
+```
+
+## Expected Output
+
+```
+  Rate limit: 3 transfers/min allowed, 4th BLOCKED
+  Concurrent cap: 2 agents writing OK, 3rd BLOCKED
+  Alert-only: policy logs warning but does not block
+  Window stats: real-time activity snapshot printed
 ```
 
 ## What This Demo Shows

--- a/examples/openshell-governed/README.md
+++ b/examples/openshell-governed/README.md
@@ -2,13 +2,28 @@
 
 Demonstrates AGT policy enforcement, trust scoring, and audit inside an OpenShell sandbox.
 
-## Quick Start
+## Prerequisites
+
+- Python 3.10+
+- No API keys required
+
+```bash
+pip install agent-governance-toolkit[full]
+```
+
+## How to Run
 
 ```bash
 python examples/openshell-governed/demo.py
 ```
 
-3 allowed + 3 denied. Trust decays 1.00 to 0.55.
+## Expected Output
+
+```
+  3 allowed actions + 3 denied actions
+  Trust decays from 1.00 to 0.55 as violations accumulate
+  Full audit trail with timestamps and decision reasons
+```
 
 ## Related
 


### PR DESCRIPTION
Adds missing top-level READMEs for agent-mesh/ and agent-sre/ example directories, and improves thin READMEs for cost-governance, decision-bom, intent-auth, multi-agent-governance, and openshell-governed with Prerequisites, How to Run, and Expected Output sections.