### PR TITLE
docs(tutorials): add consistent metadata banners to tutorials 44-51

### DIFF
--- a/docs/tutorials/44-a2a-conversation-policy.md
+++ b/docs/tutorials/44-a2a-conversation-policy.md
@@ -1,7 +1,9 @@
 # Tutorial 44 — A2A Conversation Policy & Feedback Loop Prevention
 
-> Govern agent-to-agent (A2A) protocol interactions with skill-level access
-> control, trust scoring, and automatic feedback loop detection.
+> **Package:** `agentmesh-platform` · **Time:** 20 minutes · **Level:** Advanced
+
+Govern agent-to-agent (A2A) protocol interactions with skill-level access
+control, trust scoring, and automatic feedback loop detection.
 
 ## What You'll Build
 

--- a/docs/tutorials/47-red-team-testing.md
+++ b/docs/tutorials/47-red-team-testing.md
@@ -1,5 +1,7 @@
 # Tutorial 47: Red-Team Testing Your AI Agents
 
+> **Package:** `agent-governance-toolkit[full]` · **Time:** 20 minutes · **Level:** Intermediate
+
 This tutorial shows how to use AGT's built-in red-team CLI to assess your agent's security posture before deployment. You'll scan system prompts for defense gaps and run adversarial attack playbooks against governance controls.
 
 **Prerequisites:** Install AGT with the full extras:

--- a/docs/tutorials/48-intent-based-authorization.md
+++ b/docs/tutorials/48-intent-based-authorization.md
@@ -1,5 +1,7 @@
 # Tutorial 48: Intent-Based Authorization
 
+> **Package:** `agent-os-kernel` · **Time:** 20 minutes · **Level:** Advanced
+
 Agents say what they plan to do, the system approves the plan, and then
 verifies that the agent stuck to it. This tutorial walks through the full
 intent lifecycle: **declare, approve, execute, verify**.

--- a/docs/tutorials/49-multi-agent-policies.md
+++ b/docs/tutorials/49-multi-agent-policies.md
@@ -1,5 +1,7 @@
 # Tutorial 49: Multi-Agent Collective Policies
 
+> **Package:** `agentmesh-platform` · **Time:** 20 minutes · **Level:** Advanced
+
 When multiple agents operate together, individual agent policies are not enough.
 A single transfer is fine, but five agents each transferring funds in the same
 minute is a coordinated attack. This tutorial shows how to enforce collective

--- a/docs/tutorials/50-decision-bom.md
+++ b/docs/tutorials/50-decision-bom.md
@@ -1,5 +1,7 @@
 # Tutorial 50: Decision Bill of Materials (Decision BOM)
 
+> **Package:** `agentmesh-platform` · **Time:** 15 minutes · **Level:** Advanced
+
 Every governance decision has inputs: who requested it, what policies applied,
 what the trust score was, what trace it belongs to. The Decision BOM
 reconstructs all of these factors on demand, without requiring agents to

--- a/docs/tutorials/51-cost-governance.md
+++ b/docs/tutorials/51-cost-governance.md
@@ -1,5 +1,7 @@
 # Tutorial 51: Cost Governance and Budget Enforcement
 
+> **Package:** `agent-sre` · **Time:** 15 minutes · **Level:** Intermediate
+
 AI agents spend real money on every LLM call, tool invocation, and external API.
 This tutorial shows how to enforce per-agent and organization-wide budgets with
 tiered alerts, auto-throttling, and kill switches.


### PR DESCRIPTION
Add Package/Time/Level banners to 6 tutorials matching the format used in the 35-41 series. Gives readers immediate context on prerequisites and time commitment.