### PR TITLE
docs(tutorials): standardize headers and add missing sections

### DIFF
--- a/docs/tutorials/16-protocol-bridges.md
+++ b/docs/tutorials/16-protocol-bridges.md
@@ -651,4 +651,10 @@ intercepting JSON-RPC 2.0 messages. On every `tools/call`:
 | Trust Bridge | `TrustBridge` | Peer verification with HMAC-protected caching |
 | Protocol Bridge | `ProtocolBridge` | Cross-protocol message translation (A2A ↔ MCP ↔ IATP) |
 
-**Next:** [Tutorial 18 — Compliance Verification](18-compliance-verification.md)
+---
+
+## Next Steps
+
+- [Tutorial 17 -- Advanced Trust & Behavior](17-advanced-trust-and-behavior.md): Dynamic trust scoring and behavioral analysis
+- [Tutorial 18 -- Compliance Verification](18-compliance-verification.md): Automated regulatory compliance checks
+- [Tutorial 44 -- A2A Conversation Policy](44-a2a-conversation-policy.md): Govern A2A conversations with feedback loop prevention

--- a/docs/tutorials/19-dotnet-sdk.md
+++ b/docs/tutorials/19-dotnet-sdk.md
@@ -21,7 +21,7 @@ beyond YamlDotNet**.
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/21-rust-sdk.md
+++ b/docs/tutorials/21-rust-sdk.md
@@ -16,7 +16,7 @@ smaller standalone dependency.
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/22-go-sdk.md
+++ b/docs/tutorials/22-go-sdk.md
@@ -12,7 +12,7 @@ and hash-chain audit logging — all in a single `go get`.
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/23-delegation-chains.md
+++ b/docs/tutorials/23-delegation-chains.md
@@ -13,7 +13,7 @@ that enforce the principle of least privilege across multi-agent systems.
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/24-cost-and-token-budgets.md
+++ b/docs/tutorials/24-cost-and-token-budgets.md
@@ -14,7 +14,7 @@ budget enforcement with the "scale by subtraction" philosophy — 90% lookup,
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/25-security-hardening.md
+++ b/docs/tutorials/25-security-hardening.md
@@ -13,7 +13,7 @@ branch protection — everything you need to secure a production agent system.
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/26-sbom-and-signing.md
+++ b/docs/tutorials/26-sbom-and-signing.md
@@ -13,7 +13,7 @@ integrating everything into CI/CD pipelines.
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/27-mcp-scan-cli.md
+++ b/docs/tutorials/27-mcp-scan-cli.md
@@ -14,7 +14,7 @@ your agent can act on a compromised tool definition.
 
 ---
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|

--- a/docs/tutorials/32-chaos-testing-agents.md
+++ b/docs/tutorials/32-chaos-testing-agents.md
@@ -1,8 +1,17 @@
-# Tutorial: Chaos Testing Your AI Agents with Agent SRE
+# Tutorial 32: Chaos Testing Your AI Agents
 
-This tutorial walks through chaos testing patterns for AI agents governed by AGT. You will inject failures into a running agent system and observe how governance policies respond.
+> **Package:** `agent-sre` · **Time:** 20 minutes · **Level:** Intermediate
 
-**Prerequisites:** Complete [Tutorial 01: Policy Engine](01-policy-engine.md) before starting.
+---
+
+## What You'll Learn
+
+- Injecting tool failures, policy conflicts, and resource exhaustion into governed agents
+- Measuring governance resilience under stress with audit logging
+- Using chaos scenarios (latency, error rates, dependency outages) to validate policy enforcement
+- Interpreting governance events during degraded conditions
+
+**Prerequisites:** Complete [Tutorial 01: Policy Engine](01-policy-engine.md) and [Tutorial 05: Agent Reliability](05-agent-reliability.md) before starting.
 
 ## What is Chaos Testing for AI Agents?
 

--- a/docs/tutorials/42-csharp-mcp-extension.md
+++ b/docs/tutorials/42-csharp-mcp-extension.md
@@ -12,7 +12,7 @@ be sanitized before they go back to the client.
 > **Important:** the shipped NuGet package name in this repository is
 > `Microsoft.AgentGovernance.Extensions.ModelContextProtocol`.
 
-## What you'll learn
+## What You'll Learn
 
 | Section | Topic |
 |---------|-------|


### PR DESCRIPTION
Standardize tutorial formatting across 11 files:

- Capitalize 'What You'll Learn' headers consistently (9 tutorials)
- Add metadata banner to tutorial 32 (chaos testing) matching other tutorials
- Add 'What You'll Learn' section to tutorial 32
- Expand Next Steps in tutorial 16 (protocol bridges) with related tutorials

No code changes, docs only.