### PR TITLE
fix: lock shared mutable state in five governance primitives

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Hypervisor/KillSwitch.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Hypervisor/KillSwitch.cs
@@ -72,7 +72,10 @@ public class KillSwitch
     /// </summary>
     public void Arm()
     {
-        IsArmed = true;
+        lock (_lock)
+        {
+            IsArmed = true;
+        }
     }
 
     /// <summary>
@@ -80,7 +83,10 @@ public class KillSwitch
     /// </summary>
     public void Disarm()
     {
-        IsArmed = false;
+        lock (_lock)
+        {
+            IsArmed = false;
+        }
     }
 
     /// <summary>
@@ -93,15 +99,16 @@ public class KillSwitch
     /// <exception cref="InvalidOperationException">Thrown when the switch is not armed.</exception>
     public KillEvent Kill(string agentId, KillReason reason, string detail)
     {
-        if (!IsArmed)
-        {
-            throw new InvalidOperationException("Kill switch is not armed.");
-        }
-
-        var killEvent = new KillEvent(agentId, reason, detail, DateTimeOffset.UtcNow);
+        KillEvent killEvent;
 
         lock (_lock)
         {
+            if (!IsArmed)
+            {
+                throw new InvalidOperationException("Kill switch is not armed.");
+            }
+
+            killEvent = new KillEvent(agentId, reason, detail, DateTimeOffset.UtcNow);
             _history.Add(killEvent);
         }
 

--- a/agent-governance-dotnet/src/AgentGovernance/Lifecycle/LifecycleManager.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Lifecycle/LifecycleManager.cs
@@ -140,7 +140,10 @@ public class LifecycleManager
     /// </summary>
     public bool CanTransition(LifecycleState toState)
     {
-        return ValidTransitions.TryGetValue(State, out var targets) && targets.Contains(toState);
+        lock (_lock)
+        {
+            return ValidTransitions.TryGetValue(State, out var targets) && targets.Contains(toState);
+        }
     }
 
     /// <summary>
@@ -153,23 +156,21 @@ public class LifecycleManager
     /// <exception cref="InvalidOperationException">Thrown when the transition is not allowed.</exception>
     public LifecycleEvent Transition(LifecycleState toState, string reason, string initiatedBy)
     {
-        if (!CanTransition(toState))
-        {
-            throw new InvalidOperationException(
-                $"Cannot transition from {State} to {toState}.");
-        }
-
-        var fromState = State;
-        State = toState;
-
-        var evt = new LifecycleEvent(_agentId, fromState, toState, reason, DateTimeOffset.UtcNow, initiatedBy);
-
         lock (_lock)
         {
-            _events.Add(evt);
-        }
+            if (!ValidTransitions.TryGetValue(State, out var targets) || !targets.Contains(toState))
+            {
+                throw new InvalidOperationException(
+                    $"Cannot transition from {State} to {toState}.");
+            }
 
-        return evt;
+            var fromState = State;
+            State = toState;
+
+            var evt = new LifecycleEvent(_agentId, fromState, toState, reason, DateTimeOffset.UtcNow, initiatedBy);
+            _events.Add(evt);
+            return evt;
+        }
     }
 
     // ── Convenience methods ──────────────────────────────────────

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/KillSwitchTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/KillSwitchTests.cs
@@ -125,4 +125,26 @@ public class KillSwitchTests
 
         Assert.Equal(Enum.GetValues<KillReason>().Length, ks.History.Count);
     }
+
+    [Fact]
+    public async Task ConcurrentKills_AllRecorded()
+    {
+        var ks = new KillSwitch();
+        ks.Arm();
+
+        const int threads = 16;
+        const int killsPerThread = 50;
+
+        var tasks = Enumerable.Range(0, threads).Select(t => Task.Run(() =>
+        {
+            for (var i = 0; i < killsPerThread; i++)
+            {
+                ks.Kill($"agent-{t}-{i}", KillReason.PolicyViolation, "concurrent");
+            }
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(threads * killsPerThread, ks.History.Count);
+    }
 }

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/LifecycleManagerTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/LifecycleManagerTests.cs
@@ -196,4 +196,46 @@ public class LifecycleManagerTests
 
         Assert.Equal(LifecycleState.Active, mgr.State);
     }
+
+    [Fact]
+    public async Task ConcurrentTransitions_PreserveTransitionCoherence()
+    {
+        // Without locking, two threads can both observe State=Active, both
+        // pass CanTransition, and both write State / append to _events — the
+        // resulting events log contains two transitions FROM the same state,
+        // which is impossible in any sequential interleaving. Under the lock,
+        // every event's FromState must equal the previous event's ToState.
+        for (var trial = 0; trial < 50; trial++)
+        {
+            var mgr = new LifecycleManager(AgentId);
+            mgr.Activate();
+
+            var targets = new[]
+            {
+                LifecycleState.Suspended,
+                LifecycleState.Quarantined,
+                LifecycleState.Decommissioning
+            };
+
+            var tasks = targets.Select(target => Task.Run(() =>
+            {
+                try
+                {
+                    mgr.Transition(target, "concurrent", "test");
+                }
+                catch (InvalidOperationException)
+                {
+                    // Some interleavings invalidate later transitions — fine.
+                }
+            })).ToArray();
+
+            await Task.WhenAll(tasks);
+
+            var events = mgr.Events;
+            for (var i = 1; i < events.Count; i++)
+            {
+                Assert.Equal(events[i - 1].ToState, events[i].FromState);
+            }
+        }
+    }
 }

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/security/rate_limiter.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/security/rate_limiter.py
@@ -15,6 +15,7 @@ See also:
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -89,6 +90,11 @@ class AgentRateLimiter:
 
     Higher-privilege rings get more generous limits. When an agent
     is promoted/demoted, their bucket is recreated with new limits.
+
+    Thread-safe: all bucket and stats mutations are guarded by a single
+    lock. The lock also covers the underlying ``TokenBucket.consume`` /
+    ``TokenBucket.available`` calls, which mutate ``tokens`` and
+    ``last_refill`` and are not themselves synchronised.
     """
 
     def __init__(
@@ -99,6 +105,7 @@ class AgentRateLimiter:
         # (agent_did, session_id) -> TokenBucket
         self._buckets: dict[str, TokenBucket] = {}
         self._stats: dict[str, RateLimitStats] = {}
+        self._lock = threading.Lock()
 
     def check(
         self,
@@ -113,22 +120,22 @@ class AgentRateLimiter:
         Returns True if allowed, raises RateLimitExceeded if not.
         """
         key = f"{agent_did}:{session_id}"
-        bucket = self._get_or_create_bucket(key, ring)
-
-        # Track stats
-        stats = self._stats.setdefault(
-            key,
-            RateLimitStats(agent_did=agent_did, ring=ring),
-        )
-        stats.total_requests += 1
-
-        if not bucket.consume(cost):
-            stats.rejected_requests += 1
-            raise RateLimitExceeded(
-                f"Agent {agent_did} exceeded rate limit for ring "
-                f"{ring.value} ({stats.rejected_requests} rejections)"
+        with self._lock:
+            bucket = self._get_or_create_bucket_locked(key, ring)
+            stats = self._stats.setdefault(
+                key,
+                RateLimitStats(agent_did=agent_did, ring=ring),
             )
-        return True
+            stats.total_requests += 1
+
+            if not bucket.consume(cost):
+                stats.rejected_requests += 1
+                rejected = stats.rejected_requests
+                raise RateLimitExceeded(
+                    f"Agent {agent_did} exceeded rate limit for ring "
+                    f"{ring.value} ({rejected} rejections)"
+                )
+            return True
 
     def try_check(
         self,
@@ -154,28 +161,31 @@ class AgentRateLimiter:
         rate, capacity = self._limits.get(
             new_ring, RATE_LIMIT_FALLBACK
         )
-        self._buckets[key] = TokenBucket(
-            capacity=capacity,
-            tokens=capacity,  # Start full
-            refill_rate=rate,
-        )
-        if key in self._stats:
-            self._stats[key].ring = new_ring
+        with self._lock:
+            self._buckets[key] = TokenBucket(
+                capacity=capacity,
+                tokens=capacity,  # Start full
+                refill_rate=rate,
+            )
+            if key in self._stats:
+                self._stats[key].ring = new_ring
 
     def get_stats(self, agent_did: str, session_id: str) -> RateLimitStats | None:
         """Get rate limit stats for an agent."""
         key = f"{agent_did}:{session_id}"
-        stats = self._stats.get(key)
-        if stats:
-            bucket = self._buckets.get(key)
-            if bucket:
-                stats.tokens_available = bucket.available
-                stats.capacity = bucket.capacity
-        return stats
+        with self._lock:
+            stats = self._stats.get(key)
+            if stats:
+                bucket = self._buckets.get(key)
+                if bucket:
+                    stats.tokens_available = bucket.available
+                    stats.capacity = bucket.capacity
+            return stats
 
-    def _get_or_create_bucket(
+    def _get_or_create_bucket_locked(
         self, key: str, ring: ExecutionRing
     ) -> TokenBucket:
+        """Caller must hold ``self._lock``."""
         if key not in self._buckets:
             rate, capacity = self._limits.get(ring, RATE_LIMIT_FALLBACK)
             self._buckets[key] = TokenBucket(
@@ -187,4 +197,5 @@ class AgentRateLimiter:
 
     @property
     def tracked_agents(self) -> int:
-        return len(self._buckets)
+        with self._lock:
+            return len(self._buckets)

--- a/agent-governance-python/agent-hypervisor/tests/test_rate_limiter.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_rate_limiter.py
@@ -157,3 +157,79 @@ class TestAgentRateLimiter:
         assert ExecutionRing.RING_1_PRIVILEGED in DEFAULT_RING_LIMITS
         assert ExecutionRing.RING_2_STANDARD in DEFAULT_RING_LIMITS
         assert ExecutionRing.RING_3_SANDBOX in DEFAULT_RING_LIMITS
+
+
+class TestConcurrency:
+    def test_concurrent_check_does_not_overspend_tokens(self):
+        """Without locking, concurrent ``check()`` calls can both observe
+        ``tokens >= cost`` and both consume, draining the bucket below zero
+        and silently leaking the rate limit. Under the lock, exactly
+        ``capacity`` requests succeed; the rest are rejected.
+        """
+        import threading
+
+        # Tight bucket: capacity = 100 tokens, no refill (rate=0).
+        custom_limits = {ExecutionRing.RING_3_SANDBOX: (0.0, 100.0)}
+        limiter = AgentRateLimiter(ring_limits=custom_limits)
+
+        # Pre-create the bucket so all threads race the same one.
+        limiter.try_check("agent", "session", ExecutionRing.RING_3_SANDBOX, cost=0.0)
+
+        successes = 0
+        successes_lock = threading.Lock()
+
+        def hammer() -> None:
+            nonlocal successes
+            local = 0
+            for _ in range(100):
+                if limiter.try_check("agent", "session", ExecutionRing.RING_3_SANDBOX, cost=1.0):
+                    local += 1
+            with successes_lock:
+                successes += local
+
+        threads = [threading.Thread(target=hammer) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # 10 threads × 100 requests = 1000 attempts against a 100-token bucket.
+        # With locking, exactly 100 succeed; without, more than 100 may slip
+        # through as concurrent consume() calls race the token check.
+        assert successes == 100
+
+    def test_concurrent_check_and_update_ring_no_crash(self):
+        """``update_ring`` recreates the bucket while ``check`` is iterating
+        on it; without locking this can raise KeyError or yield stale
+        readings. With locking the operations serialise cleanly.
+        """
+        import threading
+
+        limiter = AgentRateLimiter()
+        errors: list[str] = []
+
+        def checker() -> None:
+            try:
+                for _ in range(200):
+                    limiter.try_check("agent", "session", ExecutionRing.RING_2_STANDARD)
+            except Exception as e:  # pragma: no cover — failure path
+                errors.append(repr(e))
+
+        def updater() -> None:
+            try:
+                for ring in (ExecutionRing.RING_0_ROOT, ExecutionRing.RING_3_SANDBOX) * 50:
+                    limiter.update_ring("agent", "session", ring)
+            except Exception as e:  # pragma: no cover — failure path
+                errors.append(repr(e))
+
+        threads = [
+            threading.Thread(target=checker),
+            threading.Thread(target=checker),
+            threading.Thread(target=updater),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []

--- a/agent-governance-python/agent-mesh/src/agentmesh/events/bus.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/events/bus.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import fnmatch
+import threading
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -80,23 +81,34 @@ class EventBus(ABC):
 
 
 class InMemoryEventBus(EventBus):
-    """Synchronous in-process event bus with glob-style pattern matching."""
+    """Synchronous in-process event bus with glob-style pattern matching.
+
+    Thread-safe: subscription mutations and emit-time iteration are guarded
+    by a lock. Handlers are invoked outside the lock against a snapshot, so
+    a handler that subscribes/unsubscribes does not deadlock and does not
+    affect the in-flight emit.
+    """
 
     def __init__(self) -> None:
         self._subscriptions: list[tuple[str, EventHandler]] = []
+        self._lock = threading.Lock()
 
     def emit(self, event: Event) -> None:
-        for pattern, handler in self._subscriptions:
+        with self._lock:
+            snapshot = list(self._subscriptions)
+        for pattern, handler in snapshot:
             if fnmatch.fnmatch(event.event_type, pattern):
                 handler(event)
 
     def subscribe(self, pattern: str, handler: EventHandler) -> None:
-        self._subscriptions.append((pattern, handler))
+        with self._lock:
+            self._subscriptions.append((pattern, handler))
 
     def unsubscribe(self, handler: EventHandler) -> None:
-        self._subscriptions = [
-            (p, h) for p, h in self._subscriptions if h is not handler
-        ]
+        with self._lock:
+            self._subscriptions = [
+                (p, h) for p, h in self._subscriptions if h is not handler
+            ]
 
 
 class AsyncEventBus(EventBus):

--- a/agent-governance-python/agent-mesh/tests/test_event_bus.py
+++ b/agent-governance-python/agent-mesh/tests/test_event_bus.py
@@ -253,3 +253,67 @@ class TestAnalyticsPlane:
         assert stats.handshakes_per_min_1m == 0.0
         assert stats.avg_trust_score_1m == 0.0
         assert stats.events_by_type == {}
+
+
+class TestInMemoryEventBusConcurrency:
+    """InMemoryEventBus must tolerate concurrent emit / subscribe / unsubscribe."""
+
+    def test_concurrent_emit_and_subscribe_no_crash(self) -> None:
+        """Without locking, list-iteration during emit() races with
+        subscribe()/unsubscribe() list mutation and can raise RuntimeError
+        ("list changed size during iteration") or yield torn views.
+        """
+        import threading
+
+        bus = InMemoryEventBus()
+        delivered = 0
+        delivered_lock = threading.Lock()
+        errors: list[str] = []
+
+        def handler(_event: Event) -> None:
+            nonlocal delivered
+            with delivered_lock:
+                delivered += 1
+
+        # Pre-populate with 10 handlers so emit has work to do.
+        for _ in range(10):
+            bus.subscribe("*", handler)
+
+        stop = threading.Event()
+
+        def emitter() -> None:
+            try:
+                while not stop.is_set():
+                    bus.emit(Event(event_type="test.event", source="src"))
+            except Exception as e:  # pragma: no cover — failure path
+                errors.append(repr(e))
+
+        def churner() -> None:
+            try:
+                local_handlers: list = []
+                for _ in range(500):
+                    h = lambda _e: None  # noqa: E731 — distinct objects per iteration
+                    bus.subscribe("test.*", h)
+                    local_handlers.append(h)
+                for h in local_handlers:
+                    bus.unsubscribe(h)
+            except Exception as e:  # pragma: no cover — failure path
+                errors.append(repr(e))
+
+        threads = [
+            threading.Thread(target=emitter),
+            threading.Thread(target=emitter),
+            threading.Thread(target=churner),
+            threading.Thread(target=churner),
+        ]
+        for t in threads:
+            t.start()
+        # Give the churners a moment to finish (they don't run forever).
+        for t in threads[2:]:
+            t.join()
+        stop.set()
+        for t in threads[:2]:
+            t.join()
+
+        assert errors == []
+        assert delivered > 0  # sanity: handlers actually fired

--- a/agent-governance-python/agent-sre/src/agent_sre/cost/guard.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/cost/guard.py
@@ -171,6 +171,11 @@ class CostGuard:
 
     def get_budget(self, agent_id: str) -> AgentBudget:
         """Get or create budget for an agent."""
+        with self._lock:
+            return self._get_or_create_budget_locked(agent_id)
+
+    def _get_or_create_budget_locked(self, agent_id: str) -> AgentBudget:
+        """Caller must hold ``self._lock``."""
         if agent_id not in self._budgets:
             self._budgets[agent_id] = AgentBudget(
                 agent_id=agent_id,
@@ -193,29 +198,30 @@ class CostGuard:
             if self._org_killed:
                 return False, "Organization budget exhausted"
 
-        budget = self.get_budget(agent_id)
+            budget = self._get_or_create_budget_locked(agent_id)
 
-        if budget.killed:
-            return False, "Agent killed — budget exhausted"
+            if budget.killed:
+                return False, "Agent killed — budget exhausted"
 
-        if budget.throttled:
-            return False, "Agent throttled — approaching daily limit"
+            if budget.throttled:
+                return False, "Agent throttled — approaching daily limit"
 
-        if estimated_cost > self.per_task_limit:
-            return False, f"Estimated cost ${estimated_cost:.2f} exceeds per-task limit ${self.per_task_limit:.2f}"
+            if estimated_cost > self.per_task_limit:
+                return False, f"Estimated cost ${estimated_cost:.2f} exceeds per-task limit ${self.per_task_limit:.2f}"
 
-        if budget.spent_today_usd + estimated_cost > budget.daily_limit_usd:
-            return False, f"Would exceed daily budget (${budget.remaining_today_usd:.2f} remaining)"
+            if budget.spent_today_usd + estimated_cost > budget.daily_limit_usd:
+                remaining = max(0.0, budget.daily_limit_usd - budget.spent_today_usd)
+                return False, f"Would exceed daily budget (${remaining:.2f} remaining)"
 
-        if self.org_monthly_budget > 0:
-            with self._lock:
+            if self.org_monthly_budget > 0:
                 if self._org_spent_month + estimated_cost > self.org_monthly_budget:
+                    org_remaining = max(0.0, self.org_monthly_budget - self._org_spent_month)
                     return False, (
                         f"Would exceed org monthly budget "
-                        f"(${self.org_remaining_month:.2f} remaining)"
+                        f"(${org_remaining:.2f} remaining)"
                     )
 
-        return True, "ok"
+            return True, "ok"
 
     def record_cost(
         self,
@@ -232,103 +238,110 @@ class CostGuard:
             raise ValueError(f"cost_usd must be finite, got {cost_usd}")
         if cost_usd < 0:
             raise ValueError(f"cost_usd must be non-negative, got {cost_usd}")
+
         alerts: list[CostAlert] = []
-        budget = self.get_budget(agent_id)
         record = CostRecord(
             agent_id=agent_id,
             task_id=task_id,
             cost_usd=cost_usd,
             breakdown=breakdown or {},
         )
-        self._records.append(record)
-        self._cost_history.append(cost_usd)
 
-        # Update budget
         with self._lock:
+            budget = self._get_or_create_budget_locked(agent_id)
+            self._records.append(record)
+            self._cost_history.append(cost_usd)
+
+            # Update budget and org spend atomically.
+            prev_spent = budget.spent_today_usd
             budget.spent_today_usd += cost_usd
             budget.task_count_today += 1
+            prev_org_spent = self._org_spent_month
             self._org_spent_month += cost_usd
 
-        # Per-task limit check
-        if cost_usd > self.per_task_limit:
-            alerts.append(CostAlert(
-                severity=CostAlertSeverity.WARNING,
-                message=f"Task cost ${cost_usd:.2f} exceeded per-task limit ${self.per_task_limit:.2f}",
-                agent_id=agent_id,
-                current_value=cost_usd,
-                threshold=self.per_task_limit,
-            ))
-
-        # Daily budget threshold alerts
-        utilization = budget.utilization_percent / 100
-        for threshold in self.alert_thresholds:
-            prev_util = (budget.spent_today_usd - cost_usd) / budget.daily_limit_usd if budget.daily_limit_usd > 0 else 0
-            if prev_util < threshold <= utilization:
-                severity = CostAlertSeverity.CRITICAL if threshold >= 0.90 else CostAlertSeverity.WARNING
+            # Per-task limit check
+            if cost_usd > self.per_task_limit:
                 alerts.append(CostAlert(
-                    severity=severity,
-                    message=f"Agent {agent_id} at {utilization * 100:.0f}% daily budget",
+                    severity=CostAlertSeverity.WARNING,
+                    message=f"Task cost ${cost_usd:.2f} exceeded per-task limit ${self.per_task_limit:.2f}",
                     agent_id=agent_id,
-                    current_value=budget.spent_today_usd,
-                    threshold=budget.daily_limit_usd * threshold,
+                    current_value=cost_usd,
+                    threshold=self.per_task_limit,
                 ))
 
-        # Auto-throttle
-        if self.auto_throttle and utilization >= self.kill_switch_threshold:
-            budget.killed = True
-            alerts.append(CostAlert(
-                severity=CostAlertSeverity.CRITICAL,
-                message=f"Agent {agent_id} KILLED — {utilization * 100:.0f}% budget consumed",
-                agent_id=agent_id,
-                current_value=budget.spent_today_usd,
-                threshold=budget.daily_limit_usd * self.kill_switch_threshold,
-                action=BudgetAction.KILL,
-            ))
-        elif self.auto_throttle and utilization >= 0.85:
-            budget.throttled = True
-            alerts.append(CostAlert(
-                severity=CostAlertSeverity.WARNING,
-                message=f"Agent {agent_id} THROTTLED — {utilization * 100:.0f}% budget consumed",
-                agent_id=agent_id,
-                current_value=budget.spent_today_usd,
-                threshold=budget.daily_limit_usd * 0.85,
-                action=BudgetAction.THROTTLE,
-            ))
-
-        # Org budget kill alert
-        if self.auto_throttle and self.org_monthly_budget > 0:
-            org_util = self._org_spent_month / self.org_monthly_budget
-            prev_org_util = (
-                (self._org_spent_month - cost_usd) / self.org_monthly_budget
-                if self.org_monthly_budget > 0 else 0.0
+            # Daily budget threshold alerts
+            utilization = (
+                budget.spent_today_usd / budget.daily_limit_usd
+                if budget.daily_limit_usd > 0 else 0.0
             )
-            if prev_org_util < self.kill_switch_threshold <= org_util:
-                self._org_killed = True
-                for b in self._budgets.values():
-                    b.killed = True
+            prev_util = (
+                prev_spent / budget.daily_limit_usd if budget.daily_limit_usd > 0 else 0.0
+            )
+            for threshold in self.alert_thresholds:
+                if prev_util < threshold <= utilization:
+                    severity = CostAlertSeverity.CRITICAL if threshold >= 0.90 else CostAlertSeverity.WARNING
+                    alerts.append(CostAlert(
+                        severity=severity,
+                        message=f"Agent {agent_id} at {utilization * 100:.0f}% daily budget",
+                        agent_id=agent_id,
+                        current_value=budget.spent_today_usd,
+                        threshold=budget.daily_limit_usd * threshold,
+                    ))
+
+            # Auto-throttle
+            if self.auto_throttle and utilization >= self.kill_switch_threshold:
+                budget.killed = True
                 alerts.append(CostAlert(
                     severity=CostAlertSeverity.CRITICAL,
-                    message=(
-                        f"Org budget kill switch triggered -- "
-                        f"{org_util * 100:.0f}% of monthly budget consumed"
-                    ),
+                    message=f"Agent {agent_id} KILLED — {utilization * 100:.0f}% budget consumed",
                     agent_id=agent_id,
-                    current_value=self._org_spent_month,
-                    threshold=self.org_monthly_budget * self.kill_switch_threshold,
+                    current_value=budget.spent_today_usd,
+                    threshold=budget.daily_limit_usd * self.kill_switch_threshold,
                     action=BudgetAction.KILL,
                 ))
+            elif self.auto_throttle and utilization >= 0.85:
+                budget.throttled = True
+                alerts.append(CostAlert(
+                    severity=CostAlertSeverity.WARNING,
+                    message=f"Agent {agent_id} THROTTLED — {utilization * 100:.0f}% budget consumed",
+                    agent_id=agent_id,
+                    current_value=budget.spent_today_usd,
+                    threshold=budget.daily_limit_usd * 0.85,
+                    action=BudgetAction.THROTTLE,
+                ))
 
-        # Anomaly detection
-        if self.anomaly_detection and len(self._cost_history) >= 10:
-            anomaly_alert = self._check_anomaly(agent_id, cost_usd)
-            if anomaly_alert:
-                alerts.append(anomaly_alert)
+            # Org budget kill alert
+            if self.auto_throttle and self.org_monthly_budget > 0:
+                org_util = self._org_spent_month / self.org_monthly_budget
+                prev_org_util = prev_org_spent / self.org_monthly_budget
+                if prev_org_util < self.kill_switch_threshold <= org_util:
+                    self._org_killed = True
+                    for b in self._budgets.values():
+                        b.killed = True
+                    alerts.append(CostAlert(
+                        severity=CostAlertSeverity.CRITICAL,
+                        message=(
+                            f"Org budget kill switch triggered -- "
+                            f"{org_util * 100:.0f}% of monthly budget consumed"
+                        ),
+                        agent_id=agent_id,
+                        current_value=self._org_spent_month,
+                        threshold=self.org_monthly_budget * self.kill_switch_threshold,
+                        action=BudgetAction.KILL,
+                    ))
 
-        self._alerts.extend(alerts)
+            # Anomaly detection
+            if self.anomaly_detection and len(self._cost_history) >= 10:
+                anomaly_alert = self._check_anomaly_locked(agent_id, cost_usd)
+                if anomaly_alert:
+                    alerts.append(anomaly_alert)
+
+            self._alerts.extend(alerts)
+
         return alerts
 
-    def _check_anomaly(self, agent_id: str, cost_usd: float) -> CostAlert | None:
-        """Check if a cost is anomalous using Z-score."""
+    def _check_anomaly_locked(self, agent_id: str, cost_usd: float) -> CostAlert | None:
+        """Check if a cost is anomalous using Z-score. Caller must hold ``self._lock``."""
         history = list(self._cost_history)
         if len(history) < 10:
             return None
@@ -353,34 +366,39 @@ class CostGuard:
 
     def reset_daily(self, agent_id: str | None = None) -> None:
         """Reset daily budgets (call at start of each day)."""
-        targets = [agent_id] if agent_id else list(self._budgets.keys())
-        for aid in targets:
-            if aid in self._budgets:
-                budget = self._budgets[aid]
-                budget.spent_today_usd = 0.0
-                budget.task_count_today = 0
-                budget.throttled = False
-                budget.killed = False
+        with self._lock:
+            targets = [agent_id] if agent_id else list(self._budgets.keys())
+            for aid in targets:
+                if aid in self._budgets:
+                    budget = self._budgets[aid]
+                    budget.spent_today_usd = 0.0
+                    budget.task_count_today = 0
+                    budget.throttled = False
+                    budget.killed = False
 
     @property
     def org_spent_month(self) -> float:
-        return self._org_spent_month
+        with self._lock:
+            return self._org_spent_month
 
     @property
     def org_remaining_month(self) -> float:
-        return max(0.0, self.org_monthly_budget - self._org_spent_month)
+        with self._lock:
+            return max(0.0, self.org_monthly_budget - self._org_spent_month)
 
     @property
     def alerts(self) -> list[CostAlert]:
-        return self._alerts
+        with self._lock:
+            return list(self._alerts)
 
     def summary(self) -> dict[str, Any]:
         """Get cost summary across all agents."""
-        return {
-            "org_monthly_budget": self.org_monthly_budget,
-            "org_spent_month": round(self._org_spent_month, 4),
-            "org_remaining_month": round(self.org_remaining_month, 4),
-            "total_records": len(self._records),
-            "total_alerts": len(self._alerts),
-            "agents": {aid: b.to_dict() for aid, b in self._budgets.items()},
-        }
+        with self._lock:
+            return {
+                "org_monthly_budget": self.org_monthly_budget,
+                "org_spent_month": round(self._org_spent_month, 4),
+                "org_remaining_month": round(max(0.0, self.org_monthly_budget - self._org_spent_month), 4),
+                "total_records": len(self._records),
+                "total_alerts": len(self._alerts),
+                "agents": {aid: b.to_dict() for aid, b in self._budgets.items()},
+            }

--- a/agent-governance-python/agent-sre/tests/unit/test_cost_hardened.py
+++ b/agent-governance-python/agent-sre/tests/unit/test_cost_hardened.py
@@ -273,3 +273,62 @@ class TestCostGuardEdgeCases:
         severities = {a.severity for a in all_alerts}
         assert CostAlertSeverity.WARNING in severities
         assert CostAlertSeverity.CRITICAL in severities
+
+
+# ---------------------------------------------------------------------------
+# Strict Concurrency — record_cost / get_budget under heavy contention must
+# preserve exact arithmetic (no race-induced drift). Older tolerant tests
+# (`< 1.0` drift) live in test_cost.py and test_cost_hardened.py above.
+# ---------------------------------------------------------------------------
+
+
+class TestStrictConcurrency:
+    def test_concurrent_record_cost_preserves_exact_total(self):
+        """With consistent locking, 1000 records of $0.01 must sum to exactly
+        $10.00 (no float drift from races). Partial locking allowed
+        ``< 1.0`` drift; this test locks in the stricter post-fix behaviour.
+        """
+        guard = CostGuard(
+            per_task_limit=100.0,
+            per_agent_daily_limit=10000.0,
+            org_monthly_budget=10000.0,
+        )
+
+        def spend(agent_id: str) -> None:
+            for i in range(100):
+                guard.record_cost(agent_id, f"t{i}", 0.01)
+
+        threads = [threading.Thread(target=spend, args=(f"bot-{i}",)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # 10 threads × 100 records × $0.01 = $10.00 exactly.
+        assert abs(guard.org_spent_month - 10.0) < 1e-9
+        assert sum(guard.get_budget(f"bot-{i}").spent_today_usd for i in range(10)) == pytest.approx(10.0, abs=1e-9)
+        assert sum(guard.get_budget(f"bot-{i}").task_count_today for i in range(10)) == 1000
+
+    def test_concurrent_get_budget_no_orphaned_instances(self):
+        """get_budget() had a TOCTOU on first-touch: two threads racing the
+        same new agent_id could both create AgentBudget instances, with the
+        loser's instance orphaned. After the fix, all callers see the same
+        instance.
+        """
+        guard = CostGuard()
+        instances: list[AgentBudget] = []
+        instances_lock = threading.Lock()
+
+        def grab() -> None:
+            b = guard.get_budget("contested-agent")
+            with instances_lock:
+                instances.append(b)
+
+        threads = [threading.Thread(target=grab) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All 20 callers must hold the same instance.
+        assert len({id(b) for b in instances}) == 1


### PR DESCRIPTION
## Summary

Five governance primitives — across .NET and Python — held shared mutable state without (or with inconsistent) synchronisation. Under concurrent access these silently corrupt: forbidden lifecycle transitions can be applied, rate limits leak, audit/event/budget state tears. None of these are exploitable from outside the trust boundary (the attacker must already have authority to issue concurrent governance commands), so this is a **correctness fix**, not a security disclosure.

### Affected classes

| Component | File | Bug |
|---|---|---|
| **`KillSwitch`** (.NET) | [`agent-governance-dotnet/src/AgentGovernance/Hypervisor/KillSwitch.cs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Hypervisor/KillSwitch.cs) | `Arm`/`Disarm` mutate `IsArmed` outside the existing `_lock`; `Kill`'s arm-check runs unsynchronised. A racing `Disarm()` can be silently overtaken by an in-flight `Kill()`. |
| **`LifecycleManager`** (.NET) | [`agent-governance-dotnet/src/AgentGovernance/Lifecycle/LifecycleManager.cs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Lifecycle/LifecycleManager.cs) | `Transition` reads `State`, calls `CanTransition`, writes `State` outside `_lock`. Two concurrent transitions can both pass the check and both apply — events log ends up with two transitions FROM the same state, impossible in any sequential interleaving. |
| **`AgentRateLimiter`** (Python) | [`agent-governance-python/agent-hypervisor/src/hypervisor/security/rate_limiter.py`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-hypervisor/src/hypervisor/security/rate_limiter.py) | `_buckets` / `_stats` dicts and `TokenBucket.consume` had **no lock at all**. Concurrent `check()` calls both observe `tokens >= cost` and both consume, leaking the rate limit. |
| **`InMemoryEventBus`** (Python) | [`agent-governance-python/agent-mesh/src/agentmesh/events/bus.py`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-mesh/src/agentmesh/events/bus.py) | `_subscriptions` list mutated by `subscribe`/`unsubscribe` while `emit` iterates it — `RuntimeError: list changed size during iteration` is reachable. (`AsyncEventBus` is unaffected: asyncio is single-threaded.) |
| **`CostGuard`** (Python) | [`agent-governance-python/agent-sre/src/agent_sre/cost/guard.py`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-sre/src/agent_sre/cost/guard.py) | `_lock` existed but was used **inconsistently**: org-spend write was locked, but `get_budget()` had a TOCTOU on first-touch, `_records.append` / `_cost_history.append` / `_alerts.extend` / threshold-alert arithmetic / `reset_daily()` all ran outside the lock. The repo's existing concurrency tests had load-bearing comments (`# allow 1.0 float drift from races`) admitting the bug. |

### Fix shape

Consistent across the five: pull every shared-state read and write under one `lock`/`Lock`. Where helpers were called both with and without the lock, split into `_locked` variants with explicit preconditions. `CostGuard` previously inlined `self.org_remaining_month` (a property) inside `summary()` — that property now acquires `self._lock`, and Python `threading.Lock` is non-reentrant, so the computation is inlined to avoid deadlock; the `.alerts` property now returns a copy rather than the live list.

### Tests added

| Class | Test | What it locks in |
|---|---|---|
| `KillSwitch` | `ConcurrentKills_AllRecorded` | 16 threads × 50 kills, all 800 entries land in history. |
| `LifecycleManager` | `ConcurrentTransitions_PreserveTransitionCoherence` | 50 trials × 3 concurrent transitions; every event's `FromState` matches the previous event's `ToState` (the invariant the lock preserves). |
| `AgentRateLimiter` | `test_concurrent_check_does_not_overspend_tokens` | 1000 attempts against a 100-token bucket — exactly 100 succeed (without the lock, more slip through). |
| `AgentRateLimiter` | `test_concurrent_check_and_update_ring_no_crash` | Concurrent `check` × `update_ring` interleaving raises no exceptions. |
| `InMemoryEventBus` | `test_concurrent_emit_and_subscribe_no_crash` | Concurrent emitters × subscribe/unsubscribe churners produce no `RuntimeError`. |
| `CostGuard` | `test_concurrent_record_cost_preserves_exact_total` | 10 × 100 records of `$0.01` sum to exactly `$10.00` (within `1e-9`). The pre-existing `< 1.0` drift assertions in `test_cost.py` / `test_cost_hardened.py` are preserved unchanged; this test asserts the stricter post-fix behaviour. |
| `CostGuard` | `test_concurrent_get_budget_no_orphaned_instances` | 20 threads racing first-touch `get_budget()` see the same `AgentBudget` instance. |

### Commits

Five commits, one per class, so a maintainer can revert any single class fix surgically:

- `fix(dotnet): lock KillSwitch arm/disarm/kill state transitions`
- `fix(dotnet): lock LifecycleManager state transitions`
- `fix(python): lock AgentRateLimiter bucket and stats access`
- `fix(python): lock InMemoryEventBus subscription mutations`
- `fix(python): close partial-lock TOCTOU and races in CostGuard`

## Test plan

- [x] `dotnet test` — full .NET suite **612/612** passing (29 KillSwitch + LifecycleManager combined)
- [x] `pytest tests/test_rate_limiter.py` — **23/23** (21 existing + 2 new)
- [x] `pytest tests/test_event_bus.py` — **17/17** (16 existing + 1 new)
- [x] `pytest tests/unit/test_cost.py tests/unit/test_cost_hardened.py` — **55/55** (53 existing + 2 new strict-concurrency)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)