### PR TITLE
docs(tutorials): add What You'll Learn sections to 8 tutorials

### DIFF
--- a/docs/tutorials/31-entra-agent-id-bridge.md
+++ b/docs/tutorials/31-entra-agent-id-bridge.md
@@ -2,7 +2,14 @@
 
 > **Level:** Advanced · **Time:** 45 min · **Prerequisites:** Tutorial 02 (Trust & Identity), Azure subscription with Entra ID
 
-This tutorial shows how to bridge Agent Governance Toolkit (AGT) DID-based identities with **Microsoft Entra Agent ID**, enabling enterprise lifecycle management, Conditional Access, and sponsor accountability through **Agent365**.
+---
+
+## What You'll Learn
+
+- Mapping AGT `did:agentmesh:` identities to Entra Agent ID objects
+- Synchronizing trust scores and kill-switch signals between AGT and Entra
+- Configuring Conditional Access policies for governed agents
+- Sponsor accountability through Agent365 directory integration
 
 ## Why Bridge?
 

--- a/docs/tutorials/34-maf-integration.md
+++ b/docs/tutorials/34-maf-integration.md
@@ -4,7 +4,14 @@
 >
 > **Status:** ✅ Implemented — Middleware adapter with 18 passing tests. Joint integration with MAF team in progress.
 
-This tutorial shows how to add AGT governance to agents built with the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework). You'll wire policy enforcement, capability guards, and audit logging into MAF's middleware pipeline so governance is transparent to the agent.
+---
+
+## What You'll Learn
+
+- Wiring AGT policy enforcement into MAF's middleware pipeline
+- Capability guards that restrict tool access per agent role
+- Audit logging for every governed MAF message
+- Three governance middleware layers (run, function, tool)
 
 ### Implementation Reference
 

--- a/docs/tutorials/43-dotnet-maf-hook-integration.md
+++ b/docs/tutorials/43-dotnet-maf-hook-integration.md
@@ -2,7 +2,14 @@
 
 > **Level:** Intermediate · **Prerequisites:** Tutorial 01 (Policy Engine), .NET 8.0+, an existing `Microsoft.Agents.AI` agent
 
-This tutorial shows how to add AGT governance to a real .NET agent built with the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework). The goal is not to replace MAF. The goal is to hook AGT policy, audit, and tool-call controls into MAF's existing run and function middleware pipeline.
+---
+
+## What You'll Learn
+
+- Hooking AGT policy evaluation into MAF run and function middleware
+- Translating MAF-native types into AGT policy inputs
+- Consistent deny behavior across agent tool calls
+- Audit events and metrics from the .NET governance extension
 
 ## Why this exists
 

--- a/docs/tutorials/47-red-team-testing.md
+++ b/docs/tutorials/47-red-team-testing.md
@@ -2,7 +2,14 @@
 
 > **Package:** `agent-governance-toolkit[full]` · **Time:** 20 minutes · **Level:** Intermediate
 
-This tutorial shows how to use AGT's built-in red-team CLI to assess your agent's security posture before deployment. You'll scan system prompts for defense gaps and run adversarial attack playbooks against governance controls.
+---
+
+## What You'll Learn
+
+- Scanning system prompts for defense gaps using the `agt red-team` CLI
+- Running adversarial attack playbooks against governance controls
+- Interpreting security posture scores and vulnerability reports
+- Integrating red-team scans into CI/CD pipelines
 
 **Prerequisites:** Install AGT with the full extras:
 

--- a/docs/tutorials/48-intent-based-authorization.md
+++ b/docs/tutorials/48-intent-based-authorization.md
@@ -2,9 +2,14 @@
 
 > **Package:** `agent-os-kernel` · **Time:** 20 minutes · **Level:** Advanced
 
-Agents say what they plan to do, the system approves the plan, and then
-verifies that the agent stuck to it. This tutorial walks through the full
-intent lifecycle: **declare, approve, execute, verify**.
+---
+
+## What You'll Learn
+
+- The declare/approve/execute/verify intent lifecycle
+- Detecting intent drift when agents deviate from declared plans
+- Child intent scope narrowing for delegated tasks
+- Combining intent authorization with existing policy rules
 
 **Prerequisites:** Install AGT with the agent-os kernel:
 

--- a/docs/tutorials/49-multi-agent-policies.md
+++ b/docs/tutorials/49-multi-agent-policies.md
@@ -2,10 +2,14 @@
 
 > **Package:** `agentmesh-platform` · **Time:** 20 minutes · **Level:** Advanced
 
-When multiple agents operate together, individual agent policies are not enough.
-A single transfer is fine, but five agents each transferring funds in the same
-minute is a coordinated attack. This tutorial shows how to enforce collective
-constraints across all agents in a mesh.
+---
+
+## What You'll Learn
+
+- Enforcing aggregate rate limits and concurrent caps across agent meshes
+- Detecting coordinated multi-agent activity with collective policies
+- Alert-only monitoring mode for observing before enforcing
+- Combining per-agent and collective policy rules
 
 **Prerequisites:** Install AGT with the mesh package:
 

--- a/docs/tutorials/50-decision-bom.md
+++ b/docs/tutorials/50-decision-bom.md
@@ -2,10 +2,14 @@
 
 > **Package:** `agentmesh-platform` · **Time:** 15 minutes · **Level:** Advanced
 
-Every governance decision has inputs: who requested it, what policies applied,
-what the trust score was, what trace it belongs to. The Decision BOM
-reconstructs all of these factors on demand, without requiring agents to
-report anything extra.
+---
+
+## What You'll Learn
+
+- Reconstructing full decision context from observability signals
+- Completeness scoring to verify all governance factors are captured
+- Batch audit workflows for compliance reviews
+- Correlating decisions with OTel traces and delegation chains
 
 **Prerequisites:** Install AGT with the mesh package:
 

--- a/docs/tutorials/51-cost-governance.md
+++ b/docs/tutorials/51-cost-governance.md
@@ -2,9 +2,14 @@
 
 > **Package:** `agent-sre` · **Time:** 15 minutes · **Level:** Intermediate
 
-AI agents spend real money on every LLM call, tool invocation, and external API.
-This tutorial shows how to enforce per-agent and organization-wide budgets with
-tiered alerts, auto-throttling, and kill switches.
+---
+
+## What You'll Learn
+
+- Setting per-agent and organization-wide spending limits
+- Tiered alerts (warn at 80%, throttle at 90%, kill at 100%)
+- Auto-throttling agents approaching budget limits
+- Kill-switch integration for runaway cost scenarios
 
 **Prerequisites:** Install AGT with the SRE package:
 


### PR DESCRIPTION
Add consistent learning objectives sections to tutorials that were missing them:

- Tutorial 31 (Entra Agent ID Bridge)
- Tutorial 34 (MAF Integration)
- Tutorial 43 (.NET MAF Hook Integration)
- Tutorial 47 (Red-Team Testing)
- Tutorial 48 (Intent-Based Authorization)
- Tutorial 49 (Multi-Agent Collective Policies)
- Tutorial 50 (Decision BOM)
- Tutorial 51 (Cost Governance)

All 52 tutorials now have a 'What You'll Learn' or 'What You'll Build' section near the top, giving readers a clear overview before diving in.