### PR TITLE
fix(dependabot): correct pip + docker paths and complete per-package Python coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
-  # Python packages
+  # Python packages — one entry per package under agent-governance-python/.
   - package-ecosystem: "pip"
-    directory: "/agent-os"
+    directory: "/agent-governance-python/agent-os"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -10,7 +10,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "pip"
-    directory: "/agent-mesh"
+    directory: "/agent-governance-python/agent-mesh"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -18,7 +18,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "pip"
-    directory: "/agent-hypervisor"
+    directory: "/agent-governance-python/agent-hypervisor"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -26,7 +26,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "pip"
-    directory: "/agent-sre"
+    directory: "/agent-governance-python/agent-sre"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
@@ -34,7 +34,71 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "pip"
-    directory: "/agent-compliance"
+    directory: "/agent-governance-python/agent-compliance"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-discovery"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-lightning"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-marketplace"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-mcp-governance"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-primitives"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-rag-governance"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-runtime"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/agent-governance-python/agent-sandbox"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -159,7 +159,7 @@ updates:
 
   # Docker
   - package-ecosystem: "docker"
-    directory: "/agent-os"
+    directory: "/agent-governance-python/agent-os"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

The `.github/dependabot.yml` had five pip entries and one docker entry pointing at directories that do not exist at the repo root. Dependabot was silently scanning nothing for those ecosystems — the only feedback would be "directory not found" warnings in the dependabot job logs, which most maintainers don't watch.

### What's broken on `main`

| Ecosystem | Configured `directory` | Actual location | Status |
|---|---|---|---|
| pip | `/agent-os` | `/agent-governance-python/agent-os` | does not exist at repo root |
| pip | `/agent-mesh` | `/agent-governance-python/agent-mesh` | does not exist at repo root |
| pip | `/agent-hypervisor` | `/agent-governance-python/agent-hypervisor` | does not exist at repo root |
| pip | `/agent-sre` | `/agent-governance-python/agent-sre` | does not exist at repo root |
| pip | `/agent-compliance` | `/agent-governance-python/agent-compliance` | does not exist at repo root |
| docker | `/agent-os` | `/agent-governance-python/agent-os/Dockerfile` | does not exist at repo root |

All other ecosystems (npm × 3, nuget, cargo, gomod, github-actions) point at paths that do exist and were not touched.

### Fix

**Commit 1 — pip:** Correct the five existing paths to `/agent-governance-python/<package>`. Complete the existing per-package coverage convention by adding entries for the eight remaining packages that have a `pyproject.toml` but no dependabot entry:

- `agent-discovery`
- `agent-lightning`
- `agent-marketplace`
- `agent-mcp-governance`
- `agent-primitives`
- `agent-rag-governance`
- `agent-runtime`
- `agent-sandbox`

All thirteen paths are verified to contain a `pyproject.toml` at HEAD. Same `interval: weekly`, `open-pull-requests-limit: 5`, and `labels: [dependencies]` as the existing entries — no behaviour change beyond "dependabot now actually scans these packages."

**Commit 2 — docker:** Correct the single docker entry's path to `/agent-governance-python/agent-os` where the canonical `Dockerfile` lives. The repo contains additional Dockerfiles under `examples/` and `modules/`; extending dependabot to those is a design decision (more streams of update PRs) rather than a bug fix and is intentionally left out of this PR.

### Why complete the pip coverage rather than just fix the wrong paths

The five existing pip entries already implied a per-package convention (one entry per Python package). The eight missing packages all have `pyproject.toml`, all ship as part of the toolkit, none is marked deprecated or internal-only. Leaving them uncovered after fixing the five wrong paths would still leave most of the Python tree without supply-chain vulnerability scanning. Completing the convention seemed like a single coherent piece of work rather than a separate scope question; happy to split into a follow-up if the maintainers prefer to triage the eight packages individually.

## Test plan

- [x] All thirteen pip `directory:` paths verified to contain a `pyproject.toml` at HEAD
- [x] Docker `directory:` path verified to contain a `Dockerfile` at HEAD
- [ ] Dependabot picks up the new entries and runs at least one scan cycle (visible in the security tab once the config is applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)