### PR TITLE
fix: refuse to walk above root when discovering governance policies

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/discovery.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/discovery.py
@@ -45,6 +45,20 @@ def discover_policies(
     if action_path.is_file():
         action_path = action_path.parent
 
+    # Refuse to walk above ``root``. Without this guard, an action_path
+    # that resolves outside ``root`` (e.g. via a symlink, ``..`` segment,
+    # or a callsite that forwards an attacker-influenced path field)
+    # would cause the loop below to traverse to the filesystem root,
+    # loading governance.yaml files from arbitrary locations on disk —
+    # a path-traversal-style attack on the policy chain.
+    if not action_path.is_relative_to(root):
+        logger.warning(
+            "Refusing to discover policies for %s: not under root %s",
+            action_path,
+            root,
+        )
+        return []
+
     # Collect candidates walking up
     candidates: list[Path] = []
     current = action_path

--- a/agent-governance-python/agent-os/tests/test_folder_governance.py
+++ b/agent-governance-python/agent-os/tests/test_folder_governance.py
@@ -118,6 +118,74 @@ class TestDiscoverPolicies:
         result = discover_policies(action_dir, tmp_path)
         assert len(result) == 1
 
+    # -- Path-traversal hardening ------------------------------------------
+
+    def test_action_path_outside_root_returns_empty(self, tmp_path):
+        """If ``action_path`` resolves outside ``root`` the walk must NOT
+        traverse upward to the filesystem root, picking up
+        ``governance.yaml`` files from arbitrary locations on disk.
+        """
+        root = tmp_path / "workspace"
+        root.mkdir()
+        _write_policy(root / "governance.yaml", _make_policy("root", []))
+
+        # Plant a "hostile" governance.yaml above the workspace.
+        hostile_dir = tmp_path / "outside"
+        hostile_dir.mkdir()
+        _write_policy(hostile_dir / "governance.yaml", _make_policy("hostile", []))
+
+        action = hostile_dir / "evil.py"
+        action.touch()
+
+        result = discover_policies(action, root)
+        assert result == [], (
+            "discover_policies must refuse to load policies for an action "
+            "outside the configured root; otherwise an attacker who can "
+            "influence the action path can plant a governance.yaml anywhere "
+            "above their target and have it loaded."
+        )
+
+    def test_symlink_escape_does_not_load_outside_root(self, tmp_path):
+        """A symlink inside ``root`` that points outside resolves outside
+        and must be rejected.
+        """
+        root = tmp_path / "workspace"
+        root.mkdir()
+        _write_policy(root / "governance.yaml", _make_policy("root", []))
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        _write_policy(outside / "governance.yaml", _make_policy("hostile", []))
+
+        link = root / "escape"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation not supported on this platform")
+
+        action = link / "evil.py"
+        # File doesn't exist through the symlink, but resolve() still works
+        # to compute the resolved target directory.
+        result = discover_policies(action, root)
+        assert result == []
+
+    def test_relative_dot_dot_in_action_path_is_resolved_and_checked(self, tmp_path):
+        """``..`` segments are resolved, and an action_path that resolves
+        outside root via ``..`` is rejected.
+        """
+        root = tmp_path / "workspace"
+        root.mkdir()
+        _write_policy(root / "governance.yaml", _make_policy("root", []))
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        _write_policy(outside / "governance.yaml", _make_policy("hostile", []))
+
+        # action_path uses .. to escape the workspace.
+        action = root / ".." / "outside" / "evil.py"
+        result = discover_policies(action, root)
+        assert result == []
+
 
 # =============================================================================
 # Merge tests


### PR DESCRIPTION
## Summary

[`agent-governance-python/agent-os/src/agent_os/policies/discovery.py`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-os/src/agent_os/policies/discovery.py) calls `.resolve()` on `action_path` and `root` and then walks from `action_path` upward looking for `governance.yaml`, terminating only at `root` OR the filesystem root.

If `action_path` resolves *outside* `root` — via a `..` segment, a symlink that escapes the workspace, or a callsite that forwards an attacker-influenced path field — the loop never reaches `root` and walks all the way to `/`, collecting `governance.yaml` files from arbitrary locations on disk.

### Why this is reachable

The hypervisor's [`PolicyEvaluator._evaluate_scoped`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py#L145-L151) wires it up as:

```python
action_path = Path(context["path"])
chain_paths = discover_policies(action_path, self.root_dir)
```

So the `path` value flows directly from agent runtime context. Any caller that forwards a request path, tool argument, filename, or other attacker-influenceable field into `context["path"]` opens a path-traversal-style attack on the policy chain: an attacker who can plant `governance.yaml` somewhere above their target's workspace (a multi-tenant CI runner is the canonical case) gets that policy loaded silently.

### Fix

One precondition check at the top of `discover_policies`:

```python
if not action_path.is_relative_to(root):
    logger.warning(
        "Refusing to discover policies for %s: not under root %s",
        action_path,
        root,
    )
    return []
```

On violation, return `[]` (the same value returned today when no governance files exist) with a clear logged warning. Existing behaviour for legitimate `action_path` values inside `root` is unchanged.

### Tests

Three new regression tests covering the three plausible exploit paths:

1. **`test_action_path_outside_root_returns_empty`** — `action_path` planted in a sibling directory: rejected.
2. **`test_symlink_escape_does_not_load_outside_root`** — symlink inside `root` pointing outside: rejected. (Skipped on platforms without symlink privilege.)
3. **`test_relative_dot_dot_in_action_path_is_resolved_and_checked`** — `root/../outside/evil.py`: resolved + rejected.

The existing 6 discovery tests are unchanged and still pass.

## Test plan

- [x] `pytest tests/test_folder_governance.py` — **19 passed, 1 skipped** (skipped is the symlink test on Windows without admin)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)