### PR TITLE
fix(marketplace): tighten version validator + defensive _semver_tuple to prevent registry crash

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/manifest.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/manifest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -22,6 +23,13 @@ from agent_marketplace.exceptions import MarketplaceError
 logger = logging.getLogger(__name__)
 
 MANIFEST_FILENAME = "agent-plugin.yaml"
+
+# Tighter than ``str.isdigit()``: matches only ASCII decimal digits 0-9.
+# isdigit() returns True for many Unicode digit-like characters (e.g.
+# superscript ``²``, circled ``⒈``) that ``int()`` cannot parse, so an
+# isdigit()-based check lets through versions whose components later
+# crash ``_semver_tuple``'s sort path in the registry.
+_ASCII_DIGITS_RE = re.compile(r"^[0-9]+$")
 
 
 class PluginType(str, enum.Enum):
@@ -82,12 +90,21 @@ class PluginManifest(BaseModel):
     @field_validator("version")
     @classmethod
     def validate_version(cls, v: str) -> str:
-        """Validate basic semver format (MAJOR.MINOR.PATCH)."""
+        """Validate basic semver format (MAJOR.MINOR.PATCH).
+
+        Each component must consist of ASCII decimal digits 0-9 only.
+        ``str.isdigit()`` was insufficient — it returns True for Unicode
+        digits like superscripts (``"²"``) and circled numerals (``"⒈"``)
+        that ``int()`` cannot parse. A version like ``"1.0.²"`` would
+        slip past an ``isdigit()``-based check and then crash the
+        registry's sort path (``_semver_tuple``) on every lookup,
+        DoSing the marketplace.
+        """
         parts = v.split(".")
         if len(parts) < 2 or len(parts) > 3:
             raise MarketplaceError(f"Invalid version format: {v} (expected MAJOR.MINOR[.PATCH])")
         for part in parts:
-            if not part.isdigit():
+            if not part or not _ASCII_DIGITS_RE.match(part):
                 raise MarketplaceError(f"Invalid version component: {part}")
         return v
 

--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py
@@ -227,5 +227,23 @@ class PluginRegistry:
 
 
 def _semver_tuple(version: str) -> tuple[int, ...]:
-    """Convert a version string to a comparable tuple."""
-    return tuple(int(p) for p in version.split("."))
+    """Convert a version string to a comparable tuple.
+
+    Defensive against versions that slipped past
+    :func:`PluginManifest.validate_version` — for example, manifests
+    loaded from a tampered storage file or from a future schema
+    migration that loosened the validator. An unparseable version sorts
+    as ``(0,)`` (oldest possible) rather than crashing the registry's
+    ``max(...)`` / ``sorted(...)`` calls and DoSing every consumer that
+    asks for ``get_plugin``, ``search``, or ``list_plugins``.
+    """
+    try:
+        return tuple(int(p) for p in version.split("."))
+    except (ValueError, TypeError) as exc:
+        logger.warning(
+            "Cannot parse version %r as ASCII semver tuple (%s); "
+            "sorting as (0,)",
+            version,
+            exc,
+        )
+        return (0,)

--- a/agent-governance-python/agent-marketplace/tests/test_marketplace.py
+++ b/agent-governance-python/agent-marketplace/tests/test_marketplace.py
@@ -86,3 +86,111 @@ class TestTrustedKeysImmutability:
         )
         original["evil"] = "injected"
         assert "evil" not in installer._trusted_keys
+
+
+# ---------------------------------------------------------------------------
+# Version-validator and registry-sort regression tests
+# ---------------------------------------------------------------------------
+#
+# `PluginManifest.validate_version` previously used `part.isdigit()` which
+# returns True for many Unicode digit-like characters that `int()` cannot
+# parse — superscripts, circled numerals, etc. A version like "1.0.²" passed
+# the validator and then crashed `_semver_tuple` on every registry sort,
+# DoSing every consumer of `get_plugin`, `search`, or `list_plugins`.
+# Tightening the validator to ASCII-only digits closes the bypass; making
+# `_semver_tuple` defensive ensures a tampered storage file can never crash
+# the registry.
+
+
+from agent_marketplace.manifest import (  # noqa: E402
+    MarketplaceError,
+    PluginManifest,
+    PluginType,
+)
+from agent_marketplace.registry import _semver_tuple  # noqa: E402
+
+
+class TestVersionValidatorRejectsUnicodeDigits:
+    """isdigit() lets through values int() cannot parse; the validator
+    must use an ASCII-only check to keep registry sorts safe."""
+
+    @pytest.mark.parametrize(
+        "bad_version",
+        [
+            "1.0.²",         # superscript 2 — isdigit() True, int() fails
+            "1.0.⒈",         # digit-one-full-stop — same
+            "1.0.⓵",         # circled digit one — same
+            "¹.0.0",         # superscript in major
+            "1.²⁰.0",        # superscripts in minor
+        ],
+    )
+    def test_unicode_digit_components_rejected(self, bad_version: str):
+        with pytest.raises(MarketplaceError, match="Invalid version"):
+            PluginManifest(
+                name="test",
+                version=bad_version,
+                description="x",
+                author="alice",
+                plugin_type=PluginType.INTEGRATION,
+            )
+
+    def test_legitimate_ascii_versions_still_accepted(self):
+        for good_version in ("1.0.0", "0.1.2", "10.20.30", "1.0", "999.999.999"):
+            m = PluginManifest(
+                name="test",
+                version=good_version,
+                description="x",
+                author="alice",
+                plugin_type=PluginType.INTEGRATION,
+            )
+            assert m.version == good_version
+
+    def test_empty_component_rejected(self):
+        with pytest.raises(MarketplaceError, match="Invalid version"):
+            PluginManifest(
+                name="test",
+                version="1..0",
+                description="x",
+                author="alice",
+                plugin_type=PluginType.INTEGRATION,
+            )
+
+    def test_signed_or_hex_components_rejected(self):
+        for bad in ("1.-1.0", "1.+1.0", "1.0x1.0"):
+            with pytest.raises(MarketplaceError, match="Invalid version"):
+                PluginManifest(
+                    name="test",
+                    version=bad,
+                    description="x",
+                    author="alice",
+                    plugin_type=PluginType.INTEGRATION,
+                )
+
+
+class TestSemverTupleDefensive:
+    """_semver_tuple must never crash, even on values that slipped past
+    the validator (e.g. via a tampered storage file or a future schema
+    change)."""
+
+    def test_well_formed_version_parses(self):
+        assert _semver_tuple("1.2.3") == (1, 2, 3)
+        assert _semver_tuple("0.0.1") == (0, 0, 1)
+        assert _semver_tuple("10.20") == (10, 20)
+
+    def test_unicode_digit_falls_back_to_zero_tuple(self):
+        # "1.0.²" — passed the old isdigit() validator pre-fix and would
+        # raise ValueError under int(); under the defensive helper it
+        # sorts as (0,) and the registry stays operational.
+        assert _semver_tuple("1.0.²") == (0,)
+
+    def test_garbage_version_falls_back_to_zero_tuple(self):
+        for garbage in ("not-a-version", "1.x.0", "abc", "", "1.0.0-rc1"):
+            assert _semver_tuple(garbage) == (0,)
+
+    def test_max_over_mixed_versions_does_not_crash(self):
+        # Simulates `get_plugin(name)` against a registry whose storage
+        # contains one tampered version. Pre-fix this raised; post-fix
+        # the legitimate "1.0.0" wins.
+        versions = ["1.0.0", "0.5.0", "1.0.²"]
+        latest = max(versions, key=_semver_tuple)
+        assert latest == "1.0.0"


### PR DESCRIPTION
## Summary

`PluginManifest.validate_version` at [`manifest.py:84-92`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/manifest.py#L84-L92) used `part.isdigit()` to check each dotted version component. `str.isdigit()` returns `True` for many Unicode digit-like characters that `int()` cannot parse — superscripts (`"²"`), circled numerals (`"⒈"`, `"⓵"`), digit-with-period forms — so a manifest with version `"1.0.²"` passed the validator and later crashed `registry._semver_tuple` on every sort.

The crash propagated to:

- `get_plugin(name)` — registry default-version resolution ([line 140](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py#L140))
- `search(query)` ([line 159](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py#L159))
- `list_plugins(...)` ([line 175](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py#L175))

A single bad-version manifest in registry storage DoSed every consumer of any of those calls with `ValueError: invalid literal for int() with base 10: '²'`.

## Fix

**1. Tighten the validator** — replace `part.isdigit()` with a regex `^[0-9]+$` (ASCII decimal digits only). Components containing superscripts, circled numerals, or anything `int()` can't round-trip are rejected at construction time:

```python
_ASCII_DIGITS_RE = re.compile(r"^[0-9]+$")
# ...
for part in parts:
    if not part or not _ASCII_DIGITS_RE.match(part):
        raise MarketplaceError(f"Invalid version component: {part}")
```

**2. Make `_semver_tuple` defensive** — catch `ValueError`/`TypeError` and fall back to `(0,)` with a warning log, so a version that slips past the validator (via a tampered storage file or a future schema migration that loosens the validator) sorts as oldest rather than crashing the registry-wide sort. The legitimate `"1.0.0"` still wins over a tampered `"1.0.²"` in `max(...)`.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_marketplace.py -v` — 18 passed
- [x] All 6 pre-existing tests pass without modification
- [x] `TestVersionValidatorRejectsUnicodeDigits` (5 parametrized cases + 3 sanity checks) — superscript-2, digit-one-full-stop, circled digit, superscript-in-major, superscripts-in-minor; legitimate ASCII versions still accepted; empty/signed/hex components rejected
- [x] `TestSemverTupleDefensive` (4 cases) — well-formed parses correctly, Unicode-digit falls back to `(0,)`, garbage versions fall back to `(0,)`, `max(...)` over mixed legitimate+tampered versions does not crash and resolves to the legitimate one
- [x] Full marketplace suite: `PYTHONPATH=src python -m pytest tests/ -q` — 252 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
