### PR TITLE
fix(dotnet/aspnet-example): drop X-Agent-Id header trust to close identity-spoof vector

### DIFF
--- a/agent-governance-dotnet/examples/AspNetMiddleware/GovernanceCheckMiddleware.cs
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/GovernanceCheckMiddleware.cs
@@ -24,7 +24,6 @@ namespace AgentGovernance.Examples.AspNetMiddleware;
 public sealed class GovernanceCheckMiddleware
 {
     private const string AnonymousAgentId = "did:agentmesh:http-anonymous";
-    private const string AgentIdHeader = "X-Agent-Id";
 
     private readonly RequestDelegate _next;
     private readonly GovernanceKernel _kernel;
@@ -133,21 +132,26 @@ public sealed class GovernanceCheckMiddleware
 
     private static string ResolveAgentId(HttpContext context)
     {
-        // Prefer an authenticated identity when present.
+        // The agent identity comes from the authenticated user populated by
+        // ASP.NET Core's authentication middleware (JWT bearer, cookies,
+        // mTLS client certificates, OIDC, etc.). Wire whichever scheme your
+        // deployment uses upstream of this middleware so `context.User`
+        // carries a verified identity by the time governance evaluates.
+        // Unauthenticated requests fall through to the anonymous DID, where
+        // policy rules can apply blanket allow/deny on `agent_id`.
+        //
+        // An earlier revision of this example also accepted a caller-supplied
+        // ``X-Agent-Id`` header as a fallback. That was an identity-spoof
+        // vector — anyone setting the header became any DID for governance
+        // purposes — and was removed. If you genuinely need a header-based
+        // identity (dev/test against a deployment that hasn't wired up
+        // authentication yet), do it in a *separate* middleware that runs
+        // BEFORE the auth pipeline and that you only register in
+        // non-production environments.
         var name = context.User?.Identity?.Name;
         if (!string.IsNullOrWhiteSpace(name))
         {
             return $"did:agentmesh:{name}";
-        }
-
-        // Fall back to a caller-supplied header (illustrative — tighten for production).
-        if (context.Request.Headers.TryGetValue(AgentIdHeader, out var headerValues))
-        {
-            var headerValue = headerValues.ToString();
-            if (!string.IsNullOrWhiteSpace(headerValue))
-            {
-                return headerValue;
-            }
         }
 
         return AnonymousAgentId;

--- a/agent-governance-dotnet/examples/AspNetMiddleware/README.md
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/README.md
@@ -105,14 +105,22 @@ Example denial body:
 
 ## Identifying the agent
 
-The middleware resolves the calling agent in this order:
+The middleware resolves the calling agent from `HttpContext.User.Identity.Name`,
+populated by your ASP.NET Core authentication middleware (JWT bearer, cookies,
+mTLS, OIDC, etc.). Wire `AddAuthentication(...)` and the appropriate scheme
+upstream of `GovernanceCheckMiddleware` so `context.User` carries a verified
+identity by the time governance runs. Unauthenticated requests fall back to
+the anonymous DID `did:agentmesh:http-anonymous`, which policy rules can
+match on with blanket allow/deny.
 
-1. `HttpContext.User.Identity.Name` (when authentication is configured)
-2. `X-Agent-Id` request header
-3. Falls back to `did:agentmesh:http-anonymous`
-
-For production, replace step 2 with a verified token (JWT / mTLS / DID auth)
-and rely solely on `User.Identity`.
+Authentication is intentionally not the governance middleware's job. An
+earlier revision accepted a caller-supplied `X-Agent-Id` header as a
+fallback — that path was an identity-spoof vector (any caller could become
+any DID for governance purposes) and has been removed. If you need a
+header-based identity for dev or testing against a deployment that hasn't
+wired up authentication yet, do it in a *separate* middleware that runs
+BEFORE the auth pipeline and that you only register in non-production
+environments.
 
 ## Try it yourself
 

--- a/agent-governance-dotnet/examples/AspNetMiddleware/README.md
+++ b/agent-governance-dotnet/examples/AspNetMiddleware/README.md
@@ -13,10 +13,19 @@ status code (`403` for policy denials, `429` for rate limits).
 
 - Registering the kernel as a singleton in `IServiceCollection`
 - A reusable `GovernanceCheckMiddleware` that:
-  - resolves an agent identity (authenticated user → `X-Agent-Id` header → anonymous DID)
+  - reads the agent identity from `context.User?.Identity?.Name` (populated by your
+    ASP.NET Core authentication middleware — JWT bearer, cookies, mTLS, OIDC, etc.),
+    falling back to the anonymous DID when no authenticated user is present
   - normalizes the route template (strips constraints like `{id:int}` → `{id}`)
   - calls `kernel.EvaluateToolCall(...)` and translates the decision to HTTP
   - **fails closed** if evaluation throws
+
+> **Identity boundary.** Authentication is *not* the governance middleware's job;
+> wire `AddAuthentication(...)` and the appropriate scheme upstream so
+> `context.User` carries a verified identity by the time governance runs.
+> An earlier revision of this example accepted a caller-supplied `X-Agent-Id`
+> header as a fallback — that path was an identity-spoof vector (any caller
+> could become any DID for governance purposes) and has been removed.
 - An opt-out marker (`SkipGovernanceAttribute`) for endpoints like `/healthz`
 - Two controllers (`ItemsController`, `AdminController`) and a YAML policy
   exercising `allow`, `deny`, `rate_limit`, and `require_approval` actions


### PR DESCRIPTION
## Summary

The ASP.NET Core middleware example at [`examples/AspNetMiddleware/GovernanceCheckMiddleware.cs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/examples/AspNetMiddleware/GovernanceCheckMiddleware.cs#L134-L154) read an `X-Agent-Id` header at face value when no authenticated user was present, and used the value as the agent's DID for governance evaluation:

```csharp
// Fall back to a caller-supplied header (illustrative — tighten for production).
if (context.Request.Headers.TryGetValue(AgentIdHeader, out var headerValues))
{
    var headerValue = headerValues.ToString();
    if (!string.IsNullOrWhiteSpace(headerValue))
    {
        return headerValue;
    }
}
```

Anyone sending `X-Agent-Id: did:agentmesh:admin` became "admin" for capability checks, trust scoring, rate-limit buckets, and audit-log attribution — no signature, no proof-of-possession, no trusted-proxy gate.

The in-line comment honestly flagged the path as unsafe ("*tighten for production*"), but the [README](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/examples/AspNetMiddleware/README.md#L16) documented the unsafe behaviour as the intended identity chain:

> "resolves an agent identity (authenticated user → X-Agent-Id header → anonymous DID)"

Operators who copy the example into production deployments ship the spoof unless they notice the in-line warning and rewrite the resolver. Examples are exactly the artefact that gets copied into production.

## Fix

Remove the header fallback. The chain becomes `context.User?.Identity?.Name` → `AnonymousAgentId`, with a docstring directing operators at ASP.NET Core's authentication middleware (JWT bearer, cookies, mTLS, OIDC) as the canonical place to resolve identity. Drop the now-unused `AgentIdHeader` constant. Update the README to describe the new chain and add an "Identity boundary" callout explaining what was removed and why.

## Scope

- **In scope**: only `examples/AspNetMiddleware/GovernanceCheckMiddleware.cs` and its `README.md`.
- **Not affected**: the production [`src/AgentGovernance/Integration/GovernanceMiddleware.cs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Integration/GovernanceMiddleware.cs) takes `agentId` as a method parameter — the caller resolves identity, not the middleware. The other `ResolveAgentId` methods in the .NET tree ([`AgentFrameworkGovernanceAdapter.cs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance.Extensions.Microsoft.Agents/AgentFrameworkGovernanceAdapter.cs#L149), [`McpGovernanceRuntime.cs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance.Extensions.ModelContextProtocol/McpGovernanceRuntime.cs#L28)) take typed objects rather than raw HTTP headers and are also unaffected.

## Test plan

- [x] `dotnet build examples/AspNetMiddleware/AspNetMiddleware.csproj` — 0 warnings, 0 errors.
- The example has no test project (it's a runnable web app), so behavioural verification is by code review of the resolver and the README. The replaced method has no header read, so the `X-Agent-Id`-based identity-spoof path no longer compiles in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
