### PR TITLE
fix(vscode): make webview toolbars work under strict CSP

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/webviews/metricsDashboard/MetricsDashboardPanel.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/webviews/metricsDashboard/MetricsDashboardPanel.ts
@@ -447,14 +447,14 @@ export class MetricsDashboardPanel {
             Agent OS Metrics Dashboard
         </h1>
         <div class="controls">
-            <select id="timeRange" onchange="setTimeRange(this.value)">
+            <select id="timeRange">
                 <option value="today">Today</option>
                 <option value="week">This Week</option>
                 <option value="month">This Month</option>
             </select>
-            <button onclick="refresh()">🔄 Refresh</button>
-            <button onclick="exportReport('json')">📥 Export JSON</button>
-            <button onclick="exportReport('csv')">📥 Export CSV</button>
+            <button data-action="refresh">🔄 Refresh</button>
+            <button data-action="export" data-format="json">📥 Export JSON</button>
+            <button data-action="export" data-format="csv">📥 Export CSV</button>
         </div>
     </div>
 
@@ -567,6 +567,31 @@ export class MetricsDashboardPanel {
                     <span class="violation-count">\${v.count}</span>
                 </div>
             \`).join('');
+        }
+
+        // Buttons and the time-range select use ``data-action`` rather than
+        // inline ``onclick=``/``onchange=`` attributes so the page is
+        // CSP-compliant under ``script-src 'nonce-...'`` (which blocks inline
+        // event handlers). Listeners are bound from this nonce-gated script.
+        document.addEventListener('click', (event) => {
+            const target = event.target.closest('[data-action]');
+            if (!target) return;
+            switch (target.dataset.action) {
+                case 'refresh':
+                    refresh();
+                    break;
+                case 'export':
+                    if (target.dataset.format) {
+                        exportReport(target.dataset.format);
+                    }
+                    break;
+            }
+        });
+        const __timeRange = document.getElementById('timeRange');
+        if (__timeRange) {
+            __timeRange.addEventListener('change', (event) => {
+                setTimeRange(event.target.value);
+            });
         }
 
         window.addEventListener('message', event => {

--- a/agent-governance-typescript/agent-os-vscode/src/webviews/onboarding/OnboardingPanel.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/webviews/onboarding/OnboardingPanel.ts
@@ -452,8 +452,8 @@ export class OnboardingPanel {
                 <a href="https://github.com/microsoft/agent-governance-toolkit" target="_blank">⭐ Star on GitHub</a>
             </div>
             <div class="footer-actions">
-                <button class="secondary" onclick="resetProgress()">Reset Progress</button>
-                <button class="secondary" onclick="skipOnboarding()">Skip Onboarding</button>
+                <button class="secondary" data-action="reset">Reset Progress</button>
+                <button class="secondary" data-action="skip">Skip Onboarding</button>
             </div>
         </div>
     </div>
@@ -482,12 +482,12 @@ export class OnboardingPanel {
                             <p class="step-description">\${escapeHtml(step.description)}</p>
                             <div class="step-actions">
                                 \${step.action ? \`
-                                    <button onclick="executeAction('\${escapeHtml(step.action.command)}')" \${step.completed ? 'disabled' : ''}>
+                                    <button data-action="execute" data-command="\${escapeHtml(step.action.command)}" \${step.completed ? 'disabled' : ''}>
                                         \${escapeHtml(step.action.label)}
                                     </button>
                                 \` : ''}
                                 \${!step.completed ? \`
-                                    <button class="secondary" onclick="completeStep('\${escapeHtml(step.id)}')">
+                                    <button class="secondary" data-action="complete" data-step-id="\${escapeHtml(step.id)}">
                                         Mark Complete
                                     </button>
                                 \` : ''}
@@ -545,6 +545,35 @@ export class OnboardingPanel {
                     renderSteps();
                     updateProgress();
                 }
+            }
+        });
+
+        // Buttons use ``data-action`` rather than inline ``onclick=``
+        // attributes so the page is CSP-compliant under
+        // ``script-src 'nonce-...'`` (which blocks inline event handlers).
+        // A single delegated click listener inside this nonce-gated script
+        // block dispatches to the right function and pulls any arguments
+        // from sibling ``data-*`` attributes on the button.
+        document.addEventListener('click', (event) => {
+            const target = event.target.closest('[data-action]');
+            if (!target) return;
+            switch (target.dataset.action) {
+                case 'reset':
+                    resetProgress();
+                    break;
+                case 'skip':
+                    skipOnboarding();
+                    break;
+                case 'execute':
+                    if (target.dataset.command) {
+                        executeAction(target.dataset.command);
+                    }
+                    break;
+                case 'complete':
+                    if (target.dataset.stepId) {
+                        completeStep(target.dataset.stepId);
+                    }
+                    break;
             }
         });
 

--- a/agent-governance-typescript/agent-os-vscode/src/webviews/policyEditor/PolicyEditorPanel.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/webviews/policyEditor/PolicyEditorPanel.ts
@@ -830,11 +830,11 @@ policies:
                     <option value="json">JSON</option>
                     <option value="rego">Rego</option>
                 </select>
-                <button onclick="validate()">✓ Validate</button>
-                <button onclick="testPolicy()">🧪 Test</button>
-                <button onclick="savePolicy()">💾 Save</button>
-                <button class="secondary" onclick="importPolicy()">📥 Import</button>
-                <button class="secondary" onclick="exportPolicy()">📤 Export</button>
+                <button data-action="validate">✓ Validate</button>
+                <button data-action="test">🧪 Test</button>
+                <button data-action="save">💾 Save</button>
+                <button class="secondary" data-action="import">📥 Import</button>
+                <button class="secondary" data-action="export">📤 Export</button>
             </div>
             <div class="editor-wrapper">
                 <div class="line-numbers" id="lineNumbers">1</div>
@@ -993,6 +993,27 @@ policies:
                 container.appendChild(div);
             });
         }
+
+        // Toolbar buttons use ``data-action`` rather than inline ``onclick=``
+        // attributes so the page is CSP-compliant under
+        // ``script-src 'nonce-...'`` (which blocks inline event handlers).
+        // A single delegated click listener inside this nonce-gated script
+        // block dispatches to the appropriate function.
+        const __toolbarActions = {
+            validate: validate,
+            test: testPolicy,
+            save: savePolicy,
+            import: importPolicy,
+            export: exportPolicy,
+        };
+        document.addEventListener('click', (event) => {
+            const target = event.target.closest('[data-action]');
+            if (!target) return;
+            const handler = __toolbarActions[target.dataset.action];
+            if (handler) {
+                handler();
+            }
+        });
 
         // Initialize
         updateLineNumbers();

--- a/agent-governance-typescript/agent-os-vscode/src/webviews/workflowDesigner/WorkflowDesignerPanel.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/webviews/workflowDesigner/WorkflowDesignerPanel.ts
@@ -910,9 +910,9 @@ ${functionDefs}
         <section class="canvas-container" aria-labelledby="workflow-canvas-heading">
             <h2 id="workflow-canvas-heading" class="sr-only">Workflow canvas</h2>
             <div class="toolbar" role="toolbar" aria-label="Workflow actions">
-                <button onclick="simulate()">▶️ Simulate</button>
-                <button onclick="saveWorkflow()">💾 Save</button>
-                <button class="secondary" onclick="loadWorkflow()">📂 Load</button>
+                <button data-action="simulate">▶️ Simulate</button>
+                <button data-action="save">💾 Save</button>
+                <button class="secondary" data-action="load">📂 Load</button>
                 <div style="flex:1"></div>
                 <label class="sr-only" for="exportLang">Export language</label>
                 <select id="exportLang" aria-label="Export language">
@@ -920,7 +920,7 @@ ${functionDefs}
                     <option value="typescript">TypeScript</option>
                     <option value="go">Go</option>
                 </select>
-                <button onclick="exportCode()">📤 Export Code</button>
+                <button data-action="export">📤 Export Code</button>
             </div>
             <div class="canvas" id="canvas" tabindex="0" role="region" aria-label="Workflow canvas">
                 <svg class="connections" id="connections"></svg>
@@ -1315,6 +1315,26 @@ ${functionDefs}
                             : '0 0 10px #ffc107';
                     }
                     break;
+            }
+        });
+
+        // Toolbar buttons use ``data-action`` rather than inline ``onclick=``
+        // attributes so the page is CSP-compliant under
+        // ``script-src 'nonce-...'`` (which blocks inline event handlers).
+        // A single delegated click listener bound from this nonce-gated
+        // script dispatches to the appropriate function.
+        const __toolbarActions = {
+            simulate: simulate,
+            save: saveWorkflow,
+            load: loadWorkflow,
+            export: exportCode,
+        };
+        document.addEventListener('click', (event) => {
+            const target = event.target.closest('[data-action]');
+            if (!target) return;
+            const handler = __toolbarActions[target.dataset.action];
+            if (handler) {
+                handler();
             }
         });
 


### PR DESCRIPTION
## Summary

The four webview panels (`OnboardingPanel`, `PolicyEditorPanel`, `MetricsDashboardPanel`, `WorkflowDesignerPanel`) declare a strict CSP of `script-src 'nonce-${nonce}'`, which the [VS Code webview docs](https://code.visualstudio.com/api/extension-guides/webview#content-security-policy) recommend. That policy forbids inline event handlers (`onclick="..."`, `onchange="..."`).

Today every toolbar in those panels is wired with inline handlers. With the CSP active, clicks are silently blocked: the inline script never runs, no `postMessage` reaches the extension host, and the buttons appear inert. Affected actions:

| Panel | Affected controls |
|---|---|
| `PolicyEditorPanel` | Validate / Test / Save / Import / Export buttons |
| `OnboardingPanel` | Reset / Skip footer buttons + per-step Execute / Mark Complete |
| `MetricsDashboardPanel` | Refresh / Export JSON / Export CSV + Time-range select |
| `WorkflowDesignerPanel` | Simulate / Save / Load / Export Code |

## Fix

Replace the inline handlers with `data-action` attributes (plus `data-command` / `data-step-id` / `data-format` where the handler needed an argument), and bind a single delegated `click` (or `change`) listener inside each nonce-gated script block. The listener reads `target.dataset.action` and dispatches to the existing function — no behavioral change beyond the buttons now actually firing.

This keeps the strict CSP intact rather than relaxing it to `'unsafe-inline'`.

## Test plan

- [ ] Open Policy Editor; confirm Validate / Test / Save / Import / Export all dispatch their messages
- [ ] Open Onboarding panel; confirm Reset, Skip, per-step Execute, and Mark Complete work
- [ ] Open Metrics Dashboard; confirm Refresh, Export JSON / CSV, and the Time-range select all post messages
- [ ] Open Workflow Designer; confirm Simulate / Save / Load / Export Code work
- [ ] Verify no CSP violations in the webview Developer Tools console

🤖 Generated with [Claude Code](https://claude.com/claude-code)
