### PR TITLE
fix(vscode): allowlist commands the onboarding webview may dispatch

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/webviews/onboarding/OnboardingPanel.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/webviews/onboarding/OnboardingPanel.ts
@@ -113,7 +113,7 @@ export class OnboardingPanel {
                         await this._completeStep(message.stepId);
                         break;
                     case 'executeAction':
-                        await this._executeAction(message.command, message.args);
+                        await this._executeAction(message.command);
                         break;
                     case 'skipOnboarding':
                         await this._skipOnboarding();
@@ -177,9 +177,27 @@ export class OnboardingPanel {
         }
     }
 
-    private async _executeAction(command: string, args?: any[]): Promise<void> {
+    private async _executeAction(command: string): Promise<void> {
+        // Only run commands declared by a configured onboarding step, and
+        // use the step's own ``args`` rather than anything supplied by the
+        // webview. A compromised renderer therefore cannot smuggle in an
+        // arbitrary VS Code command (e.g. one that opens a folder, runs a
+        // task, or sends keystrokes to the integrated terminal) or attach
+        // attacker-controlled arguments to a legitimate one.
+        const step = typeof command === 'string'
+            ? this._steps.find(s => s.action?.command === command)
+            : undefined;
+        if (!step?.action) {
+            vscode.window.showErrorMessage(
+                `Onboarding tried to run an unrecognized command: ${command}`
+            );
+            return;
+        }
         try {
-            await vscode.commands.executeCommand(command, ...(args || []));
+            await vscode.commands.executeCommand(
+                step.action.command,
+                ...(step.action.args || [])
+            );
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to execute: ${error}`);
         }


### PR DESCRIPTION
## Summary

[`OnboardingPanel._executeAction`](src/webviews/onboarding/OnboardingPanel.ts) forwards any `command` (and `args`) field the webview includes in an `executeAction` postMessage straight to `vscode.commands.executeCommand`:

```ts
case 'executeAction':
    await this._executeAction(message.command, message.args);
    break;
// ...
private async _executeAction(command: string, args?: any[]): Promise<void> {
    try {
        await vscode.commands.executeCommand(command, ...(args || []));
    ...
```

The webview content is trusted today, but its CSP and DOM are not unconditionally safe — escaped step content, a future regression in CSP enforcement, or any XSS in the rendered tutorial (e.g. an externally sourced step description) would give attacker-controlled markup a clean handle on **any** VS Code command in the host: opening folders, running tasks, writing files, sending keystrokes into the integrated terminal, etc. The renderer effectively has the user's full command surface.

This is a defense-in-depth fix on a control-flow boundary that should have been narrow from the start: the onboarding flow only ever invokes a fixed, configured set of commands.

## Fix

`_executeAction` now looks up a matching step by command name and dispatches the **step's own static `command` and `args`** — not the webview-supplied ones. Mismatched / unknown commands surface as a user-visible error instead of running silently.

```ts
private async _executeAction(command: string): Promise<void> {
    const step = typeof command === 'string'
        ? this._steps.find(s => s.action?.command === command)
        : undefined;
    if (!step?.action) {
        vscode.window.showErrorMessage(
            `Onboarding tried to run an unrecognized command: ${command}`
        );
        return;
    }
    try {
        await vscode.commands.executeCommand(
            step.action.command,
            ...(step.action.args || [])
        );
    } ...
```

UI behavior is unchanged for the legitimate flow — the four configured step buttons (`agent-os.openPolicyEditor`, `agent-os.createFirstAgent`, `agent-os.runSafetyTest`, `agent-os.openDocs`) all continue to work, and no current step declares `args`, so ignoring the webview's `args` is a no-op for legitimate calls.

## Test plan

- [ ] Click each per-step "Open Policy Editor" / "Create Agent" / "Run Safety Test" / "View Documentation" button — each still runs the configured command.
- [ ] Send a forged postMessage with `type: 'executeAction', command: 'workbench.action.terminal.sendSequence'` from the dev-tools console; verify it produces the "unrecognized command" error and does not invoke that command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
