### PR TITLE
fix(mcp-gateway): consume rate-limit budget only on approved tool calls

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_gateway.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_gateway.py
@@ -448,7 +448,7 @@ class MCPGateway:
                         "builtin_pattern",
                     )
 
-        # 4. Rate limiting
+        # 4. Rate limiting (check only — do not consume budget yet)
         with self._rate_limit_lock:
             count = int(self._rate_limit_store.get_bucket(agent_id) or 0)
             if count >= self.policy.max_tool_calls:
@@ -458,10 +458,6 @@ class MCPGateway:
                     None,
                     "rate_limit",
                 )
-
-            # Increment call counter (only on successful evaluation past this point)
-            self._tracked_agents.add(agent_id)
-            self._rate_limit_store.set_bucket(agent_id, count + 1)
 
         # 5. Human approval
         if self.policy.require_human_approval or tool_name in self.sensitive_tools:
@@ -488,10 +484,42 @@ class MCPGateway:
                 return False, "Human approval denied", status, "approval_denied"
             if status == ApprovalStatus.PENDING:
                 return False, "Awaiting human approval", status, "approval_pending"
-            # APPROVED — fall through
+            # APPROVED — consume budget and return success
+            if not self._consume_budget(agent_id):
+                return (
+                    False,
+                    f"Agent '{agent_id}' exceeded call budget ({self.policy.max_tool_calls})",
+                    None,
+                    "rate_limit",
+                )
             return True, "Approved by human reviewer", status, "approval_granted"
 
+        # No approval required — consume budget and return success
+        if not self._consume_budget(agent_id):
+            return (
+                False,
+                f"Agent '{agent_id}' exceeded call budget ({self.policy.max_tool_calls})",
+                None,
+                "rate_limit",
+            )
         return True, "Allowed by policy", None, "allowed"
+
+    def _consume_budget(self, agent_id: str) -> bool:
+        """Atomically reserve one call slot from the agent's rate-limit budget.
+
+        Returns False if the bucket is at or above ``max_tool_calls`` — callers
+        should map this to a rate-limit failure rather than letting the call
+        proceed. Reserving the slot atomically (rather than checking earlier
+        and incrementing here) prevents two concurrent callers from racing
+        the read-modify-write of the bucket.
+        """
+        with self._rate_limit_lock:
+            count = int(self._rate_limit_store.get_bucket(agent_id) or 0)
+            if count >= self.policy.max_tool_calls:
+                return False
+            self._tracked_agents.add(agent_id)
+            self._rate_limit_store.set_bucket(agent_id, count + 1)
+            return True
 
     # ── Server wrapping ──────────────────────────────────────────────────
 

--- a/agent-governance-python/agent-os/tests/test_mcp_gateway.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_gateway.py
@@ -375,6 +375,63 @@ class TestHumanApproval:
         gw.intercept_tool_call("a1", "deploy", {})
         assert gw.audit_log[0].approval_status == ApprovalStatus.APPROVED
 
+    def test_denied_approval_does_not_consume_budget(self):
+        def deny(*_args):
+            return ApprovalStatus.DENIED
+
+        gw = MCPGateway(
+            _make_policy(require_human_approval=True, max_tool_calls=2),
+            approval_callback=deny,
+            enable_builtin_sanitization=False,
+        )
+        for _ in range(5):
+            allowed, _ = gw.intercept_tool_call("a1", "t", {})
+            assert allowed is False
+        assert gw.get_agent_call_count("a1") == 0
+
+    def test_pending_approval_does_not_consume_budget(self):
+        gw = MCPGateway(
+            _make_policy(require_human_approval=True, max_tool_calls=2),
+            enable_builtin_sanitization=False,
+        )
+        for _ in range(5):
+            allowed, reason = gw.intercept_tool_call("a1", "t", {})
+            assert allowed is False
+            assert "Awaiting human approval" in reason
+        assert gw.get_agent_call_count("a1") == 0
+
+    def test_approval_callback_error_does_not_consume_budget(self):
+        def boom(*_args):
+            raise RuntimeError("approval service unreachable")
+
+        gw = MCPGateway(
+            _make_policy(require_human_approval=True, max_tool_calls=2),
+            approval_callback=boom,
+            enable_builtin_sanitization=False,
+        )
+        for _ in range(5):
+            allowed, _ = gw.intercept_tool_call("a1", "t", {})
+            assert allowed is False
+        assert gw.get_agent_call_count("a1") == 0
+
+    def test_approved_call_consumes_budget(self):
+        def approve(*_args):
+            return ApprovalStatus.APPROVED
+
+        gw = MCPGateway(
+            _make_policy(require_human_approval=True, max_tool_calls=2),
+            approval_callback=approve,
+            enable_builtin_sanitization=False,
+        )
+        a1, _ = gw.intercept_tool_call("a1", "t", {})
+        a2, _ = gw.intercept_tool_call("a1", "t", {})
+        a3, reason = gw.intercept_tool_call("a1", "t", {})
+        assert a1 is True
+        assert a2 is True
+        assert a3 is False
+        assert "exceeded call budget" in reason
+        assert gw.get_agent_call_count("a1") == 2
+
 
 # ── wrap_mcp_server ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`MCPGateway._evaluate` incremented the agent rate-limit counter before running the human-approval branch (`agent_os/mcp_gateway.py:462-490`). When approval returned `DENIED` or `PENDING`, the budget was already burned — denied or pending approvals permanently consumed the agent's call budget even though no tool ever ran.

This creates a denial-of-service vector: an attacker who can trigger denied/pending decisions on any sensitive tool can exhaust a legitimate agent's call budget without ever executing a single tool.

## Fix

Split rate-limit handling into two steps:
- **Check** before approval: short-circuit over-budget callers without paying for approval work.
- **Consume** only on the success paths (after `APPROVED`, or when no approval is needed). The new `_consume_budget` helper preserves the original read-modify-write atomicity under `_rate_limit_lock` so concurrent callers can't race past the limit.

The approval-error / denied / pending paths now return without touching the bucket.

## Tests

Adds four regression tests in `TestHumanApproval`:
- `test_denied_approval_does_not_consume_budget` — five DENIED calls leave count at 0.
- `test_pending_approval_does_not_consume_budget` — five PENDING calls leave count at 0.
- `test_approval_callback_error_does_not_consume_budget` — five callback errors leave count at 0.
- `test_approved_call_consumes_budget` — APPROVED calls still consume budget and the budget cap still triggers.

Existing tests (37 total in `test_mcp_gateway.py`) all pass, including the concurrency-safety test `test_rate_limit_counting_is_serialized` (8 threads racing for `max_tool_calls=1` — exactly one wins).

```
tests\test_mcp_gateway.py .....................................          [100%]
======================== 37 passed, 1 warning in 1.58s ========================
```

## Test plan

- [x] All 37 `test_mcp_gateway.py` tests pass on Python 3.14.
- [x] Concurrency test confirms `_consume_budget` preserves single-winner semantics under lock contention.
- [x] Denied/pending/error approval paths verified not to mutate the bucket.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)