### PR TITLE
fix(policies/merge): drop child rules that try to override parent deny

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/merge.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/merge.py
@@ -53,13 +53,16 @@ def merge_policies(policy_chain: list[PolicyDocument]) -> list[PolicyRule]:
                 parent_rule, _parent_level = existing
 
                 if parent_rule.action == PolicyAction.DENY:
-                    # Security invariant: parent deny cannot be overridden
+                    # Security invariant: parent deny cannot be overridden.
+                    # Drop the child rule entirely — appending it would let a
+                    # higher-priority child rule defeat the parent deny at
+                    # evaluation time, which is exactly what this invariant
+                    # is meant to prevent.
                     logger.warning(
-                        "Rule '%s' at level %d tried to override parent deny — ignored",
+                        "Rule '%s' at level %d tried to override parent deny — dropped",
                         rule.name,
                         level,
                     )
-                    merged.append(rule)
                 else:
                     # Replace parent rule
                     merged = [r for r in merged if r.name != rule.name]

--- a/agent-governance-python/agent-os/tests/test_folder_governance.py
+++ b/agent-governance-python/agent-os/tests/test_folder_governance.py
@@ -236,10 +236,25 @@ class TestMergePolicies:
             PolicyRule(name="block-shell", condition=PolicyCondition(field="x", operator=PolicyOperator.EQ, value=1), action=PolicyAction.ALLOW, priority=1000, override=True),
         ])
         result = merge_policies([root, child])
-        # Both rules present — parent deny kept, child allow also added
-        assert len(result) == 2
-        deny_rules = [r for r in result if r.action == PolicyAction.DENY]
-        assert len(deny_rules) == 1  # Parent deny preserved
+        # Child override is dropped entirely — only the parent deny remains.
+        assert len(result) == 1
+        assert result[0].action == PolicyAction.DENY
+        assert result[0].name == "block-shell"
+
+    def test_higher_priority_child_cannot_defeat_parent_deny(self):
+        # Regression: previously the child rule was appended despite the
+        # "ignored" warning, so a higher-priority child ALLOW would sort
+        # above the parent DENY and win at evaluation time.
+        root = PolicyDocument(name="root", rules=[
+            PolicyRule(name="block-shell", condition=PolicyCondition(field="x", operator=PolicyOperator.EQ, value=1), action=PolicyAction.DENY, priority=100),
+        ])
+        child = PolicyDocument(name="child", rules=[
+            PolicyRule(name="block-shell", condition=PolicyCondition(field="x", operator=PolicyOperator.EQ, value=1), action=PolicyAction.ALLOW, priority=9999, override=True),
+        ])
+        result = merge_policies([root, child])
+        assert len(result) == 1
+        assert result[0].action == PolicyAction.DENY
+        assert all(r.action != PolicyAction.ALLOW for r in result)
 
     def test_empty_chain(self):
         assert merge_policies([]) == []


### PR DESCRIPTION
## Summary

`merge_policies` (`agent_os/policies/merge.py:55-77`) declared a security invariant — *parent deny cannot be overridden* — and logged a warning when a child rule with `override=True` targeted a parent `DENY`. But after the warning, line 62 appended the child rule to the merged output anyway:

```python
if parent_rule.action == PolicyAction.DENY:
    logger.warning(
        \"Rule '%s' at level %d tried to override parent deny — ignored\",
        rule.name, level,
    )
    merged.append(rule)   # ← still appended
```

Because the merged list is sorted by `priority` descending (line 78), a child rule with `priority` higher than the parent and `action=ALLOW, override=True` would land above the parent's `DENY` and win at evaluation time — defeating exactly the invariant the warning claimed to enforce.

## Fix

When a child override targets a parent `DENY`, drop the child rule. The warning text is updated from "ignored" (which it wasn't) to "dropped" (which it now is).

## Tests

`test_deny_cannot_be_overridden` previously asserted the buggy behavior (`len(result) == 2`, with both the parent deny and the child allow present). It is updated to assert the corrected single-rule outcome.

A new regression test `test_higher_priority_child_cannot_defeat_parent_deny` constructs the priority-ordering escalation explicitly: parent DENY at priority 100, child ALLOW with `override=True` at priority 9999. Before the fix, both rules survived and the higher-priority ALLOW sorted first, defeating the DENY at evaluation time. After the fix, only the parent DENY remains.

```
tests\test_folder_governance.py .......s.............                    [100%]
================== 20 passed, 1 skipped, 1 warning in 1.54s ===================
```

## Test plan

- [x] Existing `merge_policies` tests pass on Python 3.14 (`tests/test_folder_governance.py`).
- [x] New regression test demonstrates the priority-ordering escalation is closed.
- [x] Existing override-replaces-parent (non-deny) test still passes — the fix only affects the deny case.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)