### PR TITLE
fix(mcp-session-auth): require explicit TTL for bootstrap_session (no never-expire mode)

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_session_auth.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_session_auth.py
@@ -122,18 +122,36 @@ class MCPSessionAuthenticator:
         agent_id: str,
         session_token: str,
         user_id: str | None = None,
+        *,
+        ttl: timedelta,
     ) -> str:
         """Persist a pre-provisioned session token bound to an agent.
 
-        This is intended for environments that need deterministic bootstrap
-        credentials (for example, wiring a FastAPI server to a deployment-time
-        token map). Bootstrapped sessions do not expire automatically; they
-        remain valid until explicitly revoked or the process restarts.
+        Intended for environments that need deterministic bootstrap
+        credentials (for example, wiring a FastAPI server to a
+        deployment-time token map). The caller MUST supply ``ttl`` —
+        bootstrapped sessions expire on a clock just like sessions issued
+        by :meth:`create_session`, and there is no never-expire mode.
+        Long-lived deployment tokens should pass an explicitly long
+        ``timedelta`` (e.g. ``timedelta(days=30)``) and rotate via
+        redeployment.
+
+        Args:
+            agent_id: Agent identifier the session is bound to.
+            session_token: Caller-supplied opaque session token.
+            user_id: Optional user or tenant identifier.
+            ttl: Positive lifetime applied to the bootstrap session.
+
+        Raises:
+            ValueError: If ``agent_id`` or ``session_token`` is empty, or
+                ``ttl`` is not strictly positive.
         """
         if not agent_id or not agent_id.strip():
             raise ValueError("agent_id must not be empty")
         if not session_token or not session_token.strip():
             raise ValueError("session_token must not be empty")
+        if ttl <= timedelta(0):
+            raise ValueError("ttl must be positive — bootstrap sessions cannot be permanent")
 
         now = _utcnow()
         with self._lock:
@@ -163,12 +181,12 @@ class MCPSessionAuthenticator:
                 agent_id=agent_id,
                 user_id=user_id,
                 created_at=now,
-                expires_at=None,
+                expires_at=now + ttl,
                 rate_limit_key=f"{user_id}:{agent_id}" if user_id else agent_id,
             )
             self._store_session_locked(session)
 
-        logger.info("Bootstrapped MCP session for agent %s", agent_id)
+        logger.info("Bootstrapped MCP session for agent %s (ttl=%s)", agent_id, ttl)
         return session_token
 
     def validate_session(self, agent_id: str, session_token: str) -> MCPSession | None:

--- a/agent-governance-python/agent-os/src/agent_os/server/app.py
+++ b/agent-governance-python/agent-os/src/agent_os/server/app.py
@@ -8,7 +8,7 @@ import logging
 import os
 import re
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -58,6 +58,8 @@ def _parse_cors_origins(raw: str) -> list[str]:
     return origins
 
 _EXECUTE_TOKENS_ENV = "AGENT_OS_EXECUTION_TOKENS"
+_EXECUTE_TOKENS_TTL_ENV = "AGENT_OS_EXECUTION_TOKEN_TTL_HOURS"
+_DEFAULT_EXECUTE_TOKEN_TTL_HOURS = 24
 _ALLOW_UNAUTHENTICATED_EXECUTE_ENV = "AGENT_OS_ALLOW_UNAUTHENTICATED_EXECUTE"
 
 
@@ -165,6 +167,23 @@ def _parse_execute_tokens(raw_tokens: str) -> dict[str, str]:
     return tokens
 
 
+def _read_bootstrap_ttl_from_env() -> timedelta:
+    raw = os.environ.get(_EXECUTE_TOKENS_TTL_ENV, "").strip()
+    if not raw:
+        return timedelta(hours=_DEFAULT_EXECUTE_TOKEN_TTL_HOURS)
+    try:
+        hours = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid {_EXECUTE_TOKENS_TTL_ENV}={raw!r}: must be a positive number of hours."
+        ) from exc
+    if hours <= 0:
+        raise ValueError(
+            f"Invalid {_EXECUTE_TOKENS_TTL_ENV}={raw!r}: must be strictly positive."
+        )
+    return timedelta(hours=hours)
+
+
 def _build_execute_authenticator_from_env() -> Any | None:
     from agent_os.mcp_session_auth import MCPSessionAuthenticator
 
@@ -172,9 +191,10 @@ def _build_execute_authenticator_from_env() -> Any | None:
     if not raw_tokens:
         return None
 
+    ttl = _read_bootstrap_ttl_from_env()
     authenticator = MCPSessionAuthenticator()
     for agent_id, token in _parse_execute_tokens(raw_tokens).items():
-        authenticator.bootstrap_session(agent_id, token)
+        authenticator.bootstrap_session(agent_id, token, ttl=ttl)
     return authenticator
 
 

--- a/agent-governance-python/agent-os/tests/test_mcp_session_auth.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_session_auth.py
@@ -46,23 +46,74 @@ def test_validate_token_returns_bound_session_without_caller_asserted_agent():
 def test_bootstrap_session_supports_static_server_tokens():
     authenticator = MCPSessionAuthenticator()
 
-    authenticator.bootstrap_session("did:mesh:agent-001", "server-bootstrap-token")
+    authenticator.bootstrap_session(
+        "did:mesh:agent-001",
+        "server-bootstrap-token",
+        ttl=timedelta(hours=1),
+    )
 
     session = authenticator.validate_token("server-bootstrap-token")
     assert session is not None
     assert session.agent_id == "did:mesh:agent-001"
-    assert session.expires_at is None
+    assert session.expires_at is not None
 
 
-def test_bootstrap_session_does_not_expire_with_runtime_ttl():
+def test_bootstrap_session_uses_its_own_ttl_independent_of_runtime():
+    # The authenticator's session_ttl applies to create_session; bootstrap
+    # sessions get their own TTL passed at bootstrap time.
     authenticator = MCPSessionAuthenticator(session_ttl=timedelta(milliseconds=10))
 
-    authenticator.bootstrap_session("did:mesh:agent-001", "server-bootstrap-token")
+    authenticator.bootstrap_session(
+        "did:mesh:agent-001",
+        "server-bootstrap-token",
+        ttl=timedelta(hours=1),
+    )
     time.sleep(0.05)
 
     session = authenticator.validate_token("server-bootstrap-token")
     assert session is not None
     assert session.agent_id == "did:mesh:agent-001"
+
+
+def test_bootstrap_session_expires_after_ttl():
+    authenticator = MCPSessionAuthenticator()
+
+    authenticator.bootstrap_session(
+        "did:mesh:agent-001",
+        "server-bootstrap-token",
+        ttl=timedelta(milliseconds=10),
+    )
+
+    time.sleep(0.05)
+    assert authenticator.validate_token("server-bootstrap-token") is None
+
+
+def test_bootstrap_session_rejects_zero_or_negative_ttl():
+    authenticator = MCPSessionAuthenticator()
+
+    with pytest.raises(ValueError, match="ttl must be positive"):
+        authenticator.bootstrap_session(
+            "did:mesh:agent-001",
+            "server-bootstrap-token",
+            ttl=timedelta(0),
+        )
+
+    with pytest.raises(ValueError, match="ttl must be positive"):
+        authenticator.bootstrap_session(
+            "did:mesh:agent-001",
+            "server-bootstrap-token",
+            ttl=timedelta(seconds=-1),
+        )
+
+
+def test_bootstrap_session_requires_ttl_keyword():
+    authenticator = MCPSessionAuthenticator()
+
+    with pytest.raises(TypeError, match="ttl"):
+        authenticator.bootstrap_session(
+            "did:mesh:agent-001",
+            "server-bootstrap-token",
+        )
 
 
 def test_expired_session_is_rejected():

--- a/agent-governance-python/agent-os/tests/test_server.py
+++ b/agent-governance-python/agent-os/tests/test_server.py
@@ -265,7 +265,7 @@ class TestExecuteEndpoint:
         session = authenticator.validate_token("env-token")
         assert session is not None
         assert session.agent_id == "test-agent"
-        assert session.expires_at is None
+        assert session.expires_at is not None
 
         server = GovServer(execute_authenticator=authenticator)
         client = TestClient(server.app)


### PR DESCRIPTION
## Summary

`MCPSessionAuthenticator.bootstrap_session` (`agent_os/mcp_session_auth.py:161-167`) created sessions with `expires_at=None`. The docstring framed this as a feature for "deterministic bootstrap credentials," but in practice it meant:

- A leaked or compromised bootstrap token stayed valid until the process restarted — no automatic mitigation, no rotation pressure.
- `_cleanup_expired_locked` had no way to garbage-collect bootstrap sessions, so the session table grew unbounded for the lifetime of the process.
- The `MCPSession.is_expired` and `_get_valid_session_locked` checks short-circuit when `expires_at is None`, so even an explicit cleanup pass left these sessions alone.

## Fix

- `bootstrap_session` now takes a **required keyword-only** `ttl: timedelta` and rejects zero/negative values. There is no never-expire mode.
- The session is stored with `expires_at = now + ttl` and participates normally in expiry-based cleanup.
- `agent_os/server/app.py::_build_execute_authenticator_from_env` reads a new `AGENT_OS_EXECUTION_TOKEN_TTL_HOURS` env var (default 24h) and passes it as `ttl` so deployment-time tokens get a sensible bound by default.
- The docstring is updated: long-lived deployment tokens should pass an explicit `timedelta(days=N)` and rotate via redeployment.

This is a deliberate API break — any caller that previously relied on permanent bootstrap sessions will now hit `TypeError: missing 1 required keyword-only argument: 'ttl'` until they pass one. The break is loud and discoverable; the security improvement is global.

## Tests

`test_mcp_session_auth.py`:
- `test_bootstrap_session_supports_static_server_tokens` updated — now asserts `expires_at is not None`.
- `test_bootstrap_session_does_not_expire_with_runtime_ttl` renamed to `test_bootstrap_session_uses_its_own_ttl_independent_of_runtime` and reframed: bootstrap honors its own `ttl` independently of the authenticator's `session_ttl`.
- New `test_bootstrap_session_expires_after_ttl` — sleeps past a 10ms TTL and verifies the token is rejected.
- New `test_bootstrap_session_rejects_zero_or_negative_ttl` — confirms the ValueError on invalid `ttl`.
- New `test_bootstrap_session_requires_ttl_keyword` — confirms calling without `ttl` raises TypeError.

`test_server.py`:
- `test_env_configured_execute_token_authenticates_server` updated to assert `expires_at is not None`.

```
tests\test_mcp_session_auth.py ..............                            [ 27%]
tests\test_server.py .....................................               [100%]
======================== 51 passed, 1 warning in 1.94s ========================
```

## Test plan

- [x] All session-auth and server tests pass on Python 3.14.
- [x] Bootstrap sessions now participate in expiry-based cleanup.
- [x] The env-driven server path passes a default 24h TTL automatically.
- [x] No silent never-expire fallback remains.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)