### PR TITLE
fix(opa-backend): TemporaryDirectory + --stdin-input for portable, non-leaky policy evaluation

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/backends.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/backends.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -229,55 +230,64 @@ class OPABackend:
 
     def _evaluate_cli(self, context: dict[str, Any]) -> BackendDecision:
         input_json = json.dumps(context)
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".rego", delete=False
-        ) as f:
-            f.write(self._rego_content)
-            rego_file = f.name
+        # TemporaryDirectory is created with 0o700 on POSIX and ACL'd to the
+        # current user on Windows, so the Rego file is not exposed to other
+        # local users (the previous NamedTemporaryFile path used the process
+        # umask, which on default-configured shared hosts left it
+        # world-readable).
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rego_file = Path(tmpdir) / "policy.rego"
+            rego_file.write_text(self._rego_content)
+            try:
+                os.chmod(rego_file, 0o600)
+            except (NotImplementedError, OSError):
+                # Windows or filesystems that don't support chmod — directory
+                # permissions are still restrictive.
+                pass
 
-        cmd = [
-            "opa", "eval", "--format", "json",
-            "--input", "/dev/stdin",
-            "--data", rego_file,
-            self._query,
-        ]
-        try:
-            proc = subprocess.run(  # noqa: S603 — trusted subprocess for OPA policy engine
-                cmd,
-                input=input_json,
-                capture_output=True,
-                text=True,
-                timeout=self._timeout,
-            )
-            if proc.returncode != 0:
+            # `--stdin-input` is OPA's portable way to read input from stdin;
+            # the previous `--input /dev/stdin` path failed on Windows.
+            cmd = [
+                "opa", "eval", "--format", "json",
+                "--stdin-input",
+                "--data", str(rego_file),
+                self._query,
+            ]
+            try:
+                proc = subprocess.run(  # noqa: S603 — trusted subprocess for OPA policy engine
+                    cmd,
+                    input=input_json,
+                    capture_output=True,
+                    text=True,
+                    timeout=self._timeout,
+                )
+                if proc.returncode != 0:
+                    return BackendDecision(
+                        allowed=False,
+                        action="deny",
+                        reason=f"opa eval failed: {proc.stderr.strip()}",
+                        backend="opa",
+                        error=proc.stderr.strip(),
+                    )
+                result = json.loads(proc.stdout)
+                expressions = result.get("result", [{}])[0].get("expressions", [{}])
+                value = expressions[0].get("value", False) if expressions else False
+                allowed = bool(value)
+                return BackendDecision(
+                    allowed=allowed,
+                    action="allow" if allowed else "deny",
+                    reason=f"OPA local ({self._package}): {'allowed' if allowed else 'denied'}",
+                    backend="opa",
+                    raw_result=result,
+                )
+            except subprocess.TimeoutExpired:
                 return BackendDecision(
                     allowed=False,
                     action="deny",
-                    reason=f"opa eval failed: {proc.stderr.strip()}",
+                    reason="OPA eval timed out",
                     backend="opa",
-                    error=proc.stderr.strip(),
+                    error="timeout",
                 )
-            result = json.loads(proc.stdout)
-            expressions = result.get("result", [{}])[0].get("expressions", [{}])
-            value = expressions[0].get("value", False) if expressions else False
-            allowed = bool(value)
-            return BackendDecision(
-                allowed=allowed,
-                action="allow" if allowed else "deny",
-                reason=f"OPA local ({self._package}): {'allowed' if allowed else 'denied'}",
-                backend="opa",
-                raw_result=result,
-            )
-        except subprocess.TimeoutExpired:
-            return BackendDecision(
-                allowed=False,
-                action="deny",
-                reason="OPA eval timed out",
-                backend="opa",
-                error="timeout",
-            )
-        finally:
-            Path(rego_file).unlink(missing_ok=True)
 
     def _evaluate_builtin(self, context: dict[str, Any]) -> BackendDecision:
         """Built-in simple Rego evaluator for common patterns."""

--- a/agent-governance-python/agent-os/tests/test_policy_backends.py
+++ b/agent-governance-python/agent-os/tests/test_policy_backends.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from agent_os.policies.backends import (
@@ -143,6 +145,50 @@ allow {
         backend = OPABackend(rego_content=rego, package="custom")
         decision = backend.evaluate({"role": "analyst"})
         assert decision.allowed is True
+
+    def test_opa_cli_uses_stdin_input_flag_not_dev_stdin(self, monkeypatch):
+        """Regression: the CLI invocation must not depend on /dev/stdin
+        (which doesn't exist on Windows) and must keep the rego file
+        inside a per-invocation TemporaryDirectory rather than a
+        umask-controlled NamedTemporaryFile.
+        """
+        captured: dict[str, object] = {}
+
+        class _FakeProc:
+            returncode = 0
+            stdout = '{"result":[{"expressions":[{"value":true}]}]}'
+            stderr = ""
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            captured["kwargs"] = kwargs
+            # Confirm the rego file existed during the call
+            data_idx = cmd.index("--data")
+            captured["rego_existed"] = Path(cmd[data_idx + 1]).is_file()
+            captured["rego_content"] = Path(cmd[data_idx + 1]).read_text()
+            return _FakeProc()
+
+        from agent_os.policies import backends as backends_mod
+        monkeypatch.setattr(backends_mod, "shutil", backends_mod.shutil)
+        # Force CLI path: pretend opa is available, no Python opa lib
+        monkeypatch.setattr(backends_mod.shutil, "which", lambda name: "/usr/local/bin/opa")
+        monkeypatch.setattr(backends_mod.subprocess, "run", _fake_run)
+
+        backend = OPABackend(rego_content=self.SIMPLE_REGO)
+        # Force CLI path even if python opa lib is installed
+        backend._opa_lib = None  # type: ignore[attr-defined]
+        backend._opa_cli_available = True  # type: ignore[attr-defined]
+
+        decision = backend._evaluate_cli({"tool_name": "file_read"})
+        assert decision.allowed is True
+        cmd = captured["cmd"]
+        assert "--stdin-input" in cmd
+        assert "/dev/stdin" not in cmd
+        assert captured["rego_existed"] is True
+        assert "package agentos" in captured["rego_content"]
+        # After the with-block exits, the tempdir is cleaned up
+        data_idx = cmd.index("--data")
+        assert not Path(cmd[data_idx + 1]).exists()
 
 
 # ── Cedar Backend Tests ───────────────────────────────────────


### PR DESCRIPTION
## Summary

`OPABackend._evaluate_cli` (`agent_os/policies/backends.py:230-280`) had two related defects:

1. **Rego content leaked under default umask.** The policy was written to `NamedTemporaryFile(mode=\"w\", suffix=\".rego\", delete=False)`, which uses the process umask. On default-configured shared hosts this leaves the file world-readable while OPA evaluates it — exposing the policy logic (and any inline data it embeds) to every local user.
2. **CLI path failed on Windows.** The invocation hard-coded `--input /dev/stdin`, which is a POSIX-only path. On Windows the OPA binary errored out on the missing path, making the local CLI path effectively dead.

## Fix

- Replace `NamedTemporaryFile(delete=False)` with `tempfile.TemporaryDirectory()`. The directory is created with `0o700` permissions on POSIX and ACL'd to the current user on Windows — the rego file inside isn't reachable by other local users.
- Best-effort `os.chmod(rego_file, 0o600)` for defense-in-depth on top of the directory permissions; ignored on filesystems / platforms that don't support it.
- Replace `--input /dev/stdin` with OPA's portable `--stdin-input` flag. The input JSON is already piped to OPA via `subprocess.run(input=input_json, ...)`, so the only change is how we tell OPA to consume it.
- Drops the manual `Path(rego_file).unlink(missing_ok=True)` in `finally` — `TemporaryDirectory` handles cleanup, and contains the cleanup inside the same scope as the file's existence.

This matches the pattern `CedarBackend._evaluate_cli` already uses (`backends.py:541` and following).

## Tests

Adds `test_opa_cli_uses_stdin_input_flag_not_dev_stdin` in `TestOPABackend`:

- Monkey-patches `subprocess.run` to capture the constructed argv.
- Asserts `--stdin-input` appears in the command and `/dev/stdin` does not.
- Asserts the rego file exists during the subprocess call (so OPA could read it) and is cleaned up after the with-block exits.
- Asserts the rego file's contents match the policy passed to the backend.

```
tests\test_policy_backends.py::TestOPABackend ............               [100%]
======================== 12 passed, 1 warning in 1.35s ========================
```

(The pre-existing Cedar test failures on this branch reproduce identically on `main` and are unrelated to this change — Cedar CLI tests depend on a local `cedar` binary that isn't installed in the test environment.)

## Test plan

- [x] All 12 `TestOPABackend` tests pass on Python 3.14 (Windows).
- [x] CLI invocation no longer references `/dev/stdin` — works on Windows.
- [x] Policy is now isolated in a per-invocation tempdir with restrictive permissions.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)