### PR TITLE
fix(async-evaluator): drop redundant asyncio.Lock from evaluate (+ thread-safe RW lock prerequisite)

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/async_evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/async_evaluator.py
@@ -84,34 +84,49 @@ class ConcurrencyStats:
 # ---------------------------------------------------------------------------
 
 class _ReadWriteLock:
-    """Simple readers-writer lock built on :class:`threading.RLock`.
+    """Simple readers-writer lock built on :class:`threading.Condition`.
 
     Multiple readers can hold the lock concurrently; a writer gets
     exclusive access (no readers **and** no other writers).
+
+    Implemented with a :class:`threading.Condition` rather than a pair
+    of nested ``RLock``s because the previous implementation acquired
+    the underlying writer ``RLock`` on the **first** reader thread and
+    released it on the **last** reader thread to drop the count to
+    zero — and ``RLock.release`` raises ``RuntimeError`` when invoked
+    on a different thread than the one that acquired it. With true
+    parallel execution the first/last threads are routinely different,
+    which manifested as intermittent ``RuntimeError: cannot release
+    un-acquired lock`` from the executor pool.
     """
 
     def __init__(self) -> None:
+        self._cond = threading.Condition()
         self._readers: int = 0
-        self._lock = threading.RLock()  # protects ``_readers``
-        self._write_lock = threading.RLock()  # exclusive writer access
+        self._writers: int = 0
 
     def acquire_read(self) -> None:
-        with self._lock:
+        with self._cond:
+            while self._writers > 0:
+                self._cond.wait()
             self._readers += 1
-            if self._readers == 1:
-                self._write_lock.acquire()
 
     def release_read(self) -> None:
-        with self._lock:
+        with self._cond:
             self._readers -= 1
             if self._readers == 0:
-                self._write_lock.release()
+                self._cond.notify_all()
 
     def acquire_write(self) -> None:
-        self._write_lock.acquire()
+        with self._cond:
+            while self._readers > 0 or self._writers > 0:
+                self._cond.wait()
+            self._writers += 1
 
     def release_write(self) -> None:
-        self._write_lock.release()
+        with self._cond:
+            self._writers -= 1
+            self._cond.notify_all()
 
 
 # ---------------------------------------------------------------------------

--- a/agent-governance-python/agent-os/src/agent_os/policies/async_evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/async_evaluator.py
@@ -9,8 +9,8 @@ from multiple OS threads simultaneously.
 
 Concurrency guarantees
 ----------------------
-* **asyncio.Lock** guards coroutine-level access so that only one
-  ``await evaluate(...)`` executes the underlying evaluator at a time.
+* **asyncio.Lock** serialises *policy reloads* across the event loop;
+  evaluations themselves are not gated by this lock.
 * **threading.RLock** guards thread-level access for the synchronous
   :meth:`evaluate_sync` entry-point.
 * A lightweight **read-write lock** pattern allows multiple concurrent
@@ -138,8 +138,9 @@ class AsyncPolicyEvaluator:
 
     Wraps :class:`PolicyEvaluator` with proper concurrency controls:
 
-    * :pyobj:`asyncio.Lock` for coroutine safety within a single event
-      loop.
+    * :pyobj:`asyncio.Lock` serialises policy reloads across the event
+      loop. It is intentionally NOT held during ``evaluate`` so that
+      concurrent async evaluations can run in parallel via the executor.
     * :class:`_ReadWriteLock` for thread safety — multiple concurrent
       reads (evaluations) are allowed; writes (policy reloads) acquire
       exclusive access.
@@ -171,10 +172,12 @@ class AsyncPolicyEvaluator:
     async def evaluate(self, context: dict[str, Any]) -> PolicyDecision:
         """Evaluate policies against *context* with async + thread safety.
 
-        Acquires the async lock (coroutine safety) and the read side of
-        the RW lock (thread safety) so that concurrent evaluations can
-        proceed but a policy reload will block until all in-flight
-        evaluations complete.
+        Submits the evaluation to the default executor and acquires the
+        read side of the RW lock (thread safety). Multiple concurrent
+        evaluations run in parallel — concurrency is bounded only by
+        the executor pool size and the underlying RW lock, which lets
+        readers run concurrently while a writer (policy reload) gets
+        exclusive access.
 
         Thread-safety: YES — safe to call from multiple threads via
         ``asyncio.run_coroutine_threadsafe``.
@@ -184,10 +187,14 @@ class AsyncPolicyEvaluator:
         PolicyDecision
             The result of evaluating the loaded policies.
         """
-        async with self._async_lock:
-            return await asyncio.get_running_loop().run_in_executor(
-                None, self._evaluate_with_read_lock, context
-            )
+        # No coroutine-level lock here: the inner read-write lock and
+        # ConcurrencyStats updates are already thread-safe, and wrapping
+        # the executor call in self._async_lock used to fully serialize
+        # async evaluations across the event loop, defeating the whole
+        # point of using an executor.
+        return await asyncio.get_running_loop().run_in_executor(
+            None, self._evaluate_with_read_lock, context
+        )
 
     def evaluate_sync(self, context: dict[str, Any]) -> PolicyDecision:
         """Thread-safe synchronous policy evaluation.

--- a/agent-governance-python/agent-os/tests/test_async_evaluator.py
+++ b/agent-governance-python/agent-os/tests/test_async_evaluator.py
@@ -294,6 +294,39 @@ class TestAsyncConcurrency:
         assert all(not r.allowed for r in denies)
         assert all(r.allowed for r in defaults)
 
+    async def test_async_evaluations_run_concurrently(self, evaluator):
+        """Regression: previously the asyncio.Lock around the executor call
+        serialized async evaluations. Several concurrent ``await
+        evaluate(...)`` calls should run in parallel — concurrent_peak
+        in the stats reflects how many executor threads were inside
+        ``_evaluate_with_read_lock`` at once.
+        """
+        import time as _time
+
+        # Use a slow evaluator so concurrent calls overlap detectably.
+        original_evaluate = evaluator.evaluate
+
+        def slow_evaluate(ctx):
+            _time.sleep(0.05)
+            return original_evaluate(ctx)
+
+        evaluator.evaluate = slow_evaluate
+        async_eval = AsyncPolicyEvaluator(evaluator)
+
+        await asyncio.gather(*[
+            async_eval.evaluate({"tool_name": "read_file"}) for _ in range(8)
+        ])
+
+        stats = async_eval.get_stats()
+        assert stats["evaluation_count"] == 8
+        # If asyncio.Lock still wrapped the executor call, concurrent_peak
+        # would top out at 1. Real concurrency on the default thread pool
+        # should comfortably exceed 1 with 8 50ms tasks.
+        assert stats["concurrent_peak"] > 1, (
+            f"Expected concurrent async evaluations, got concurrent_peak="
+            f"{stats['concurrent_peak']}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Batch evaluation


### PR DESCRIPTION
## Summary

`AsyncPolicyEvaluator.evaluate` (`agent_os/policies/async_evaluator.py:172-175`) wrapped its `run_in_executor` call in `async with self._async_lock`, fully serializing every async evaluation across the event loop. The lock served no correctness purpose — the underlying `_ReadWriteLock` and `ConcurrencyStats` updates are already thread-safe — but it forced concurrent `await evaluate(...)` calls to run one at a time, defeating the whole reason for using an executor.

While building the regression test for that fix, the executor's actual concurrent execution exposed a latent thread-affinity bug in `_ReadWriteLock`: it acquired the inner `threading.RLock` writer lock on the *first* reader thread that took the count from 0 to 1, and released it on whichever reader thread later took the count back to 0. With true parallel execution those are different threads, and `RLock.release` raises `RuntimeError` from any thread other than the one that acquired it. The asyncio.Lock had been masking this by serializing everything to the same executor thread at any given moment.

This PR is two commits: the prerequisite RW-lock fix, then the named HIGH item.

## Commit 1 — `fix(async-evaluator): make _ReadWriteLock writer release thread-safe`

Replace the two nested `RLock`s with a single `threading.Condition` that counts active readers and writers. Acquire/release are no longer thread-affine; readers and writers signal each other via `notify_all` when their counts drop to zero. This is the standard readers-writer-lock pattern and unblocks landing the asyncio.Lock removal without intermittent crashes.

## Commit 2 — `fix(async-evaluator): drop redundant asyncio.Lock from evaluate (HIGH #7)`

- Remove `async with self._async_lock:` from `evaluate`. The executor call now stands alone; concurrency is bounded by the executor pool size and the inner RW lock.
- The asyncio.Lock is retained for `reload_policies`, where coroutine-level serialization across reload requests is still useful.
- Class- and module-level docstrings updated to reflect that the asyncio.Lock now applies to reloads only.

## Tests

Adds `test_async_evaluations_run_concurrently` — 8 concurrent `await evaluate(...)` calls against an evaluator artificially slowed by a 50ms sleep. Asserts `concurrent_peak > 1`. Before this PR (with the asyncio.Lock holding the executor in serial), `concurrent_peak` topped out at 1; after, it comfortably exceeds 1 in the default thread pool.

```
tests\test_async_evaluator.py ................................           [100%]
======================== 32 passed, 1 warning in 1.55s ========================
```

(31 existing + 1 new.)

## Test plan

- [x] All 32 `test_async_evaluator.py` tests pass on Python 3.14 (Windows).
- [x] Regression test demonstrates real parallel async evaluation.
- [x] RW-lock thread-safety fix verified independently — commit 1 alone keeps existing 31 tests green.
- [x] No change to `evaluate_sync` or `reload_policies` semantics.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)