### PR TITLE
fix(relay): keep pending messages in inbox until recipient acks (HIGH Mesh #2)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
@@ -216,13 +216,20 @@ class RelayServer:
             logger.debug("Stored offline message %s for %s", message_id, recipient_did)
 
     async def _deliver_pending(self, agent_did: str, ws: WebSocket) -> None:
-        """Push all pending messages to a newly connected agent."""
+        """Push all pending messages to a newly connected agent.
+
+        Messages stay in the inbox until the recipient explicitly sends
+        an ``ack`` frame for them — see the ``ack`` branch in
+        :meth:`_handle_frame`. Acknowledging on send (the previous
+        behaviour) silently dropped messages whenever the recipient
+        disconnected after ``send_json`` returned but before the frame
+        actually reached them.
+        """
         pending = self._inbox.fetch_pending(agent_did)
         for msg in pending:
             try:
                 frame = json.loads(msg.payload)
                 await ws.send_json(frame)
-                self._inbox.acknowledge(msg.message_id)
                 self._stats["messages_delivered"] += 1
             except Exception as e:
                 logger.warning("Failed to deliver pending %s: %s", msg.message_id, e)

--- a/agent-governance-python/agent-mesh/tests/test_relay.py
+++ b/agent-governance-python/agent-mesh/tests/test_relay.py
@@ -226,8 +226,51 @@ class TestRelayServer:
             # Receive pending message
             msg = ws.receive_json()
             assert msg["id"] == "ack-test"
+            # Recipient explicitly acks — only then is it removed.
+            ws.send_json({"v": 1, "type": "ack", "id": "ack-test"})
 
-        # Message should be acknowledged (delivered removes from inbox)
+        assert inbox.message_count == 0
+
+    def test_pending_message_survives_disconnect_before_ack(self):
+        """Regression: previously _deliver_pending acknowledged immediately
+        after send_json, so a recipient that received the frame but
+        disconnected before processing it lost the message permanently.
+        Now the message stays in the inbox until an explicit ack frame
+        is received, and a reconnect re-delivers it.
+        """
+        server = RelayServer()
+        inbox = server._inbox
+
+        inbox.store(StoredMessage(
+            message_id="survives-001",
+            sender_did="alice",
+            recipient_did="did:agentmesh:bob",
+            payload=json.dumps({
+                "v": 1, "type": "message",
+                "from": "alice", "to": "did:agentmesh:bob",
+                "id": "survives-001", "ciphertext": "important",
+            }),
+        ))
+        assert inbox.message_count == 1
+
+        client = TestClient(server.app)
+        # First connect: receive frame, disconnect WITHOUT acking.
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:bob"})
+            msg = ws.receive_json()
+            assert msg["id"] == "survives-001"
+            # Drop the connection without sending an ack.
+
+        # Inbox must still contain the message.
+        assert inbox.message_count == 1
+
+        # Reconnect: message must be re-delivered.
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:bob"})
+            msg = ws.receive_json()
+            assert msg["id"] == "survives-001"
+            ws.send_json({"v": 1, "type": "ack", "id": "survives-001"})
+
         assert inbox.message_count == 0
 
 


### PR DESCRIPTION
## Summary

`RelayServer._deliver_pending` (`agent-mesh/src/agentmesh/relay/app.py:218-229`) called `self._inbox.acknowledge(msg.message_id)` immediately after `await ws.send_json(frame)` returned. `send_json` returning only confirms that the framework queued the bytes onto the WebSocket; it does **not** confirm the recipient processed (or even received) the frame. If the recipient dropped the connection between those two events the message was permanently deleted from the inbox with no recovery path.

## Fix

Drop the immediate `acknowledge` call. The relay's `_handle_frame` already handles an explicit `ack` frame from the recipient (`relay/app.py:165-168`) — that's the only reliable signal that the recipient has the message. Messages stay in the inbox until that ack arrives; if the connection drops, the next reconnect's `_deliver_pending` re-delivers them.

The cost is one re-delivery on reconnect when a recipient is buggy and never acks; that's a far better outcome than silently losing the message.

## Tests

- `test_ack_removes_from_inbox` updated to send an explicit `{"type": "ack", "id": ...}` frame after receiving the pending message — delivery alone no longer removes it from the inbox.
- New `test_pending_message_survives_disconnect_before_ack` reproduces the disconnect-mid-delivery scenario: connect, receive pending, disconnect without acking; assert the message is still in the inbox; reconnect; receive again; ack; verify inbox empty.

```
tests\test_relay.py ..................                                   [100%]
18 passed in 0.78s
```

## Test plan

- [x] All 18 `test_relay.py` tests pass on Python 3.14.
- [x] Disconnect-mid-delivery no longer drops the message.
- [x] Explicit ack still cleans up the inbox correctly.
- [x] Reconnect re-delivery works.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)