### PR TITLE
fix(handshake): return structured failure for untrusted peers (HIGH Mesh #4)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
@@ -484,7 +484,10 @@ class TrustHandshake:
             }
 
         if not self.registry.is_trusted(response.agent_did):
-            raise HandshakeError(f"Agent {response.agent_did} is not trusted in registry")
+            return {
+                "valid": False,
+                "reason": f"Agent {response.agent_did} is not trusted in registry",
+            }
 
         # Verify Ed25519 signature over the challenge payload
         payload = f"{response.challenge_id}:{challenge.nonce}:{response.response_nonce}:{response.agent_did}"

--- a/agent-governance-python/agent-mesh/tests/test_handshake_security.py
+++ b/agent-governance-python/agent-mesh/tests/test_handshake_security.py
@@ -456,6 +456,85 @@ class TestCapabilityInflation:
         assert set(result.capabilities) == {"read:data", "write:reports"}
 
 
+class TestUntrustedPeerStructuredFailure:
+    """is_trusted=False returns a structured failure, not a raised exception."""
+
+    @pytest.mark.asyncio
+    async def test_untrusted_peer_returns_structured_failure(self):
+        """Regression: previously _verify_response raised HandshakeError for
+        an untrusted peer, which the broad ``except Exception`` in
+        _do_initiate flattened into a generic ``Handshake error: ...``
+        result. Untrusted peers should produce the same ``{"valid":
+        False, "reason": ...}`` shape as every other failure path so
+        callers can distinguish failure modes without parsing exception
+        message strings.
+        """
+        agent_a = _make_identity("verifier")
+        agent_b = _make_identity("untrusted-peer")
+        registry = _make_registry(agent_a, agent_b)
+
+        hs = TrustHandshake(
+            agent_did=str(agent_a.did), identity=agent_a, registry=registry,
+        )
+
+        # Force is_trusted to return False to exercise the not-trusted branch
+        # without depending on attestation/revocation plumbing.
+        original_is_trusted = registry.is_trusted
+
+        def _untrusted_for_b(did: str) -> bool:
+            if did == str(agent_b.did):
+                return False
+            return original_is_trusted(did)
+
+        registry.is_trusted = _untrusted_for_b  # type: ignore[method-assign]
+
+        challenge = HandshakeChallenge.generate()
+        peer_hs = TrustHandshake(
+            agent_did=str(agent_b.did), identity=agent_b, registry=registry,
+        )
+        response = await peer_hs.respond(
+            challenge=challenge,
+            my_capabilities=["read:data"],
+            my_trust_score=500,
+            identity=agent_b,
+        )
+
+        verification = await hs._verify_response(response, challenge, 0, None)
+
+        assert isinstance(verification, dict)
+        assert verification["valid"] is False
+        assert "not trusted" in verification["reason"].lower()
+
+    @pytest.mark.asyncio
+    async def test_untrusted_peer_in_initiate_returns_structured_result(self):
+        """The full initiate() flow must surface the not-trusted reason in
+        HandshakeResult, not a generic 'Handshake error: ...' wrapper.
+        """
+        agent_a = _make_identity("verifier")
+        agent_b = _make_identity("untrusted-peer")
+        registry = _make_registry(agent_a, agent_b)
+
+        original_is_trusted = registry.is_trusted
+
+        def _untrusted_for_b(did: str) -> bool:
+            if did == str(agent_b.did):
+                return False
+            return original_is_trusted(did)
+
+        registry.is_trusted = _untrusted_for_b  # type: ignore[method-assign]
+
+        hs = TrustHandshake(
+            agent_did=str(agent_a.did), identity=agent_a, registry=registry,
+        )
+        result = await hs.initiate(peer_did=str(agent_b.did), required_trust_score=0)
+        assert result.verified is False
+        # Must NOT be wrapped in the generic "Handshake error:" prefix that the
+        # broad except Exception used to produce.
+        reason = result.rejection_reason or ""
+        assert "Handshake error" not in reason
+        assert "not trusted" in reason.lower()
+
+
 class TestDIDBindingEnforcement:
     """Response DID must match the expected peer DID."""
 


### PR DESCRIPTION
## Summary

`TrustHandshake._verify_response` (`agent-mesh/src/agentmesh/trust/handshake.py:486-487`) raised `HandshakeError` when `self.registry.is_trusted(response.agent_did)` returned False, while every other failure path in the same function returned a `{"valid": False, "reason": "..."}` dict. The exception escaped to `_do_initiate`'s broad `except Exception` block, where it was flattened into a generic `"Handshake error: Agent X is not trusted in registry"` `HandshakeResult.rejection_reason` rather than the clean structured failure callers expect.

## Fix

Return the structured failure shape used by every other check in `_verify_response`:

```python
if not self.registry.is_trusted(response.agent_did):
    return {
        "valid": False,
        "reason": f"Agent {response.agent_did} is not trusted in registry",
    }
```

Callers now see the same shape for not-trusted as for signature-mismatch, public-key-mismatch, expired-challenge, etc., and `result.rejection_reason` carries the clean message instead of the `"Handshake error: ..."` wrapper.

## Tests

Adds two regression tests in a new `TestUntrustedPeerStructuredFailure` class:

- `test_untrusted_peer_returns_structured_failure` — calls `_verify_response` directly with a stubbed `is_trusted` that returns False; asserts the result is a dict, `valid is False`, and the `reason` mentions "not trusted".
- `test_untrusted_peer_in_initiate_returns_structured_result` — exercises the full `initiate()` flow; asserts `HandshakeResult.rejection_reason` does NOT contain the `"Handshake error"` wrapper text and DOES contain `"not trusted"`.

```
tests/test_handshake_security.py — 19 passed, 167 warnings in 0.48s
```

## Test plan

- [x] All 19 `test_handshake_security.py` tests pass.
- [x] Untrusted-peer failures now share the same shape as every other failure path.
- [x] Generic `"Handshake error: ..."` wrapping is no longer produced for this case.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)