### PR TITLE
fix(handshake): serialise pending-challenges cap with an async lock (HIGH Mesh #9)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
@@ -216,6 +216,10 @@ class TrustHandshake:
         self._cache_ttl = timedelta(seconds=cache_ttl_seconds)
         # V10: Limit pending challenges to prevent DoS accumulation
         self._max_pending_challenges = 1000
+        # Serialise the purge/check/insert sequence on _pending_challenges so
+        # concurrent initiate() coroutines cannot all pass the size check and
+        # then each insert past the cap.
+        self._challenges_lock = asyncio.Lock()
 
     def _get_cached_result(self, peer_did: str) -> Optional[HandshakeResult]:
         """Get cached verification result if still valid."""
@@ -295,16 +299,20 @@ class TrustHandshake:
         """Execute the core handshake: generate nonce, verify it comes back."""
         challenge: Optional[HandshakeChallenge] = None
         try:
-            # V10: Purge expired challenges and enforce limit
-            self._purge_expired_challenges()
-            if len(self._pending_challenges) >= self._max_pending_challenges:
-                return HandshakeResult.failure(
-                    peer_did, "Too many pending challenges — try again later", start
-                )
+            # V10: Purge expired challenges and enforce limit. The purge,
+            # size check, and insert MUST run as one atomic step under the
+            # async lock — otherwise concurrent initiates can each pass
+            # the size check and then each insert, blowing past the cap.
+            async with self._challenges_lock:
+                self._purge_expired_challenges()
+                if len(self._pending_challenges) >= self._max_pending_challenges:
+                    return HandshakeResult.failure(
+                        peer_did, "Too many pending challenges — try again later", start
+                    )
 
-            # Generate nonce challenge (with optional RFC 9334 freshness nonce)
-            challenge = HandshakeChallenge.generate(require_freshness=require_freshness)
-            self._pending_challenges[challenge.challenge_id] = challenge
+                # Generate nonce challenge (with optional RFC 9334 freshness nonce)
+                challenge = HandshakeChallenge.generate(require_freshness=require_freshness)
+                self._pending_challenges[challenge.challenge_id] = challenge
 
             # Get peer response
             response = await self._get_peer_response(peer_did, challenge)

--- a/agent-governance-python/agent-mesh/tests/test_handshake_timeout.py
+++ b/agent-governance-python/agent-mesh/tests/test_handshake_timeout.py
@@ -109,3 +109,84 @@ class TestHandshakeTimeoutBehavior:
         from agentmesh.exceptions import HandshakeError
 
         assert issubclass(HandshakeTimeoutError, HandshakeError)
+
+
+class TestPendingChallengesCapUnderConcurrency:
+    """Regression tests for the pending-challenges DoS cap under burst load."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_initiates_cannot_exceed_cap(self):
+        """Many concurrent initiates must not blow past _max_pending_challenges.
+
+        Previously the purge/check/insert sequence was unlocked: every
+        coroutine could read len(...) < cap and then each insert past
+        the cap before any of them yielded. With the async lock added,
+        only ``cap`` insertions succeed; the rest get the
+        "Too many pending challenges" failure.
+        """
+        agent_a = _make_identity("burst-a")
+        agent_b = _make_identity("burst-b")
+        registry = _make_registry(agent_a, agent_b)
+
+        hs = TrustHandshake(
+            agent_did=str(agent_a.did),
+            identity=agent_a,
+            registry=registry,
+            timeout_seconds=2.0,
+        )
+        hs._max_pending_challenges = 5
+
+        # Block _get_peer_response so challenges accumulate in the
+        # pending dict for the duration of the test.
+        gate = asyncio.Event()
+
+        async def hold_open(*_args, **_kwargs):
+            await gate.wait()
+            return None
+
+        peak = 0
+
+        async def watch_size():
+            nonlocal peak
+            while not gate.is_set():
+                peak = max(peak, len(hs._pending_challenges))
+                await asyncio.sleep(0)
+
+        with patch.object(hs, "_get_peer_response", side_effect=hold_open):
+            watcher = asyncio.create_task(watch_size())
+            tasks = [
+                asyncio.create_task(
+                    hs.initiate(
+                        peer_did=str(agent_b.did),
+                        required_trust_score=0,
+                        use_cache=False,
+                    )
+                )
+                for _ in range(40)
+            ]
+
+            # Give the event loop time to process the burst and have all
+            # 40 attempt the purge/check/insert step.
+            await asyncio.sleep(0.05)
+            peak_observed = max(peak, len(hs._pending_challenges))
+            gate.set()
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            await watcher
+
+        assert peak_observed <= hs._max_pending_challenges, (
+            f"_pending_challenges hit {peak_observed} entries; "
+            f"cap is {hs._max_pending_challenges}"
+        )
+
+        rate_limited = sum(
+            1
+            for r in results
+            if not isinstance(r, BaseException)
+            and not r.verified
+            and r.rejection_reason
+            and "Too many pending challenges" in r.rejection_reason
+        )
+        # Of 40 attempts with cap=5, at least ~35 must have hit the cap.
+        assert rate_limited >= 30, (
+            f"Expected most attempts to be rate-limited; got {rate_limited}/40"
+        )


### PR DESCRIPTION
## Summary

`TrustHandshake._do_initiate` (`agent-mesh/src/agentmesh/trust/handshake.py:295-307`) ran its purge/size-check/insert sequence on `self._pending_challenges` without any lock:

```python
self._purge_expired_challenges()                          # mutates dict
if len(self._pending_challenges) >= self._max_pending_challenges:
    return failure(...)
challenge = HandshakeChallenge.generate(...)
self._pending_challenges[challenge.challenge_id] = challenge   # mutates dict
```

Concurrent `initiate()` coroutines could each pass the size check before any of them inserted, then each insert past the cap. The advertised `_max_pending_challenges = 1000` ceiling was advisory under load — a DoS amplifier for any caller able to spam `initiate()` with valid peer DIDs.

## Fix

Add `asyncio.Lock` to `TrustHandshake.__init__`. Wrap `_purge_expired_challenges` + size check + insert in `_do_initiate` as one `async with self._challenges_lock:` block. The lock spans only the dict-mutation window; the slow peer-response and verify steps still run without it so concurrent handshakes can still progress independently.

The cleanup `del self._pending_challenges[challenge.challenge_id]` in the `finally` block stays unlocked because each coroutine owns a unique challenge_id (generated by `HandshakeChallenge.generate`); the operation is idempotent given the existence check that guards it.

## Tests

Adds `TestPendingChallengesCapUnderConcurrency::test_concurrent_initiates_cannot_exceed_cap` in `tests/test_handshake_timeout.py`:

- Set `_max_pending_challenges = 5`.
- Patch `_get_peer_response` to block on an `asyncio.Event` so challenges accumulate.
- Spawn 40 concurrent `initiate()` tasks.
- A sampler task watches `len(_pending_challenges)` and records the peak.
- Assert peak ≤ 5.
- Assert ≥30 of the 40 attempts surface `"Too many pending challenges"` in `result.rejection_reason`.

```
tests/test_handshake_timeout.py — 9 passed in 0.65s
```

## Test plan

- [x] All 9 `test_handshake_timeout.py` tests pass.
- [x] `_pending_challenges` no longer exceeds the cap under concurrent burst.
- [x] Slow peer-response work continues to run unsynchronised.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)