### PR TITLE
fix(mtls): write ephemeral cert and key into a 0o700 temp directory (HIGH Mesh #10)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/mtls.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/mtls.py
@@ -128,26 +128,30 @@ class MTLSIdentityVerifier:
         if self.config.cert_path and self.config.key_path:
             ctx.load_cert_chain(self.config.cert_path, self.config.key_path)
         else:
-            # Generate and load ephemeral self-signed cert
+            # Generate and load ephemeral self-signed cert. The cert and
+            # private key live on disk only for the duration of
+            # ``load_cert_chain``, but the previous NamedTemporaryFile
+            # path used the process umask, which on default-configured
+            # shared hosts left the *private key* world-readable while
+            # OpenSSL parsed it. TemporaryDirectory is created with
+            # 0o700 on POSIX and ACL'd to the current user on Windows,
+            # so neither file is reachable by other local users.
             cert_pem, key_pem = self.create_self_signed_cert()
-            cert_file = key_file = None
-            try:
-                with tempfile.NamedTemporaryFile(
-                    delete=False, suffix=".pem", mode="wb"
-                ) as cf:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                cert_file = os.path.join(tmpdir, "cert.pem")
+                key_file = os.path.join(tmpdir, "key.pem")
+                with open(cert_file, "wb") as cf:
                     cf.write(cert_pem)
-                    cert_file = cf.name
-                with tempfile.NamedTemporaryFile(
-                    delete=False, suffix=".pem", mode="wb"
-                ) as kf:
+                with open(key_file, "wb") as kf:
                     kf.write(key_pem)
-                    key_file = kf.name
+                # Best-effort 0o600 on POSIX as defense in depth on top
+                # of the restrictive directory permissions.
+                for path in (cert_file, key_file):
+                    try:
+                        os.chmod(path, 0o600)
+                    except (NotImplementedError, OSError):
+                        pass
                 ctx.load_cert_chain(cert_file, key_file)
-            finally:
-                if cert_file:
-                    os.unlink(cert_file)
-                if key_file:
-                    os.unlink(key_file)
 
         if self.config.ca_cert_path:
             ctx.load_verify_locations(self.config.ca_cert_path)


### PR DESCRIPTION
## Summary

`MTLSManager.create_ssl_context` (`agent-mesh/src/agentmesh/identity/mtls.py:130-150`) wrote the self-signed certificate **and its private key** into per-file `NamedTemporaryFile(delete=False)` handles. Both files inherited the process umask — on default-configured shared hosts (`umask 022`) that leaves them world-readable during the brief window OpenSSL needed to parse them. A co-tenant on the same host could race-read the freshly minted private key.

## Fix

Replace the two `NamedTemporaryFile`s with a single `tempfile.TemporaryDirectory()`. The directory is created with `0o700` on POSIX and ACL'd to the current user on Windows, so neither `cert.pem` nor `key.pem` inside it is reachable by other local users.

Best-effort `os.chmod(path, 0o600)` on each file as defense in depth on top of the directory permissions; ignored on platforms / filesystems that don't support it.

`TemporaryDirectory`'s context manager handles cleanup automatically, so the explicit `os.unlink` calls in the `finally` block are no longer needed.

## Tests

`tests/test_mtls.py` already exercises `create_ssl_context()` (the ephemeral-cert path is hit by every test that doesn't supply `cert_path`/`key_path`). All 18 existing tests pass:

```
tests/test_mtls.py — 18 passed in 0.56s
```

I considered adding a permission-assertion test, but verifying that a TempFile *would have been* world-readable on a stripped-down macOS/Linux umask requires platform-specific test scaffolding that doesn't run cleanly on Windows. The structural change (NamedTemporaryFile → TemporaryDirectory) is the load-bearing fix.

## Test plan

- [x] All 18 `test_mtls.py` tests pass on Python 3.14.
- [x] mTLS handshake still works end-to-end (verified by existing tests).
- [x] No reliance on the process umask for private-key confidentiality.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)