### PR TITLE
fix(x3dh): make KDF salt and IKM spec-compliant for Signal X3DH (HIGH Mesh #8)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/encryption/x3dh.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/encryption/x3dh.py
@@ -358,13 +358,31 @@ class X3DHKeyManager:
 
 
 def _kdf(ikm: bytes) -> bytes:
-    """Derive a 32-byte shared secret from the concatenated DH outputs."""
-    # Prepend 32 bytes of 0xFF as specified by Signal X3DH
-    salt = b"\xff" * 32
+    """Derive a 32-byte shared secret from the concatenated DH outputs.
+
+    Implements the KDF as specified by the Signal X3DH protocol §2.2:
+
+      F  = 0xFF repeated 32 times (for X25519)
+      KM = the concatenation of the DH outputs
+      KDF input = F || KM
+      HKDF(salt=zero-filled[32], info="<protocol-info>")
+
+    The previous implementation passed 0xFF×32 as the HKDF *salt* while
+    feeding raw ``dh_concat`` as IKM, which produces a different
+    derived key than a spec-compliant peer would compute. Two
+    implementations using the old logic could interop with each other,
+    but neither could interop with anyone following the spec.
+
+    NOTE: This is a wire-format change. Existing sessions established
+    with the prior KDF cannot decrypt messages produced by the fixed
+    KDF and vice-versa; both peers must rerun X3DH after upgrade.
+    """
+    # F = 0xFF repeated 32 times, prepended to the DH concat per spec.
+    f = b"\xff" * 32
     hkdf = HKDF(
         algorithm=SHA256(),
         length=KEY_LEN,
-        salt=salt,
+        salt=b"\x00" * 32,
         info=X3DH_INFO,
     )
-    return hkdf.derive(ikm)
+    return hkdf.derive(f + ikm)

--- a/agent-governance-python/agent-mesh/tests/test_x3dh.py
+++ b/agent-governance-python/agent-mesh/tests/test_x3dh.py
@@ -314,6 +314,35 @@ class TestX3DHExchange:
         assert bundle.identity_key_ed == mgr.ed25519_public
 
 
+class TestKDFSpecCompliance:
+    """The KDF must match the Signal X3DH spec: F||IKM with zero salt."""
+
+    def test_kdf_uses_zero_salt_and_prepends_f_to_ikm(self):
+        """Regression: previously _kdf used 0xFF*32 as the HKDF salt and
+        passed raw ``dh_concat`` as IKM. The Signal X3DH spec §2.2
+        requires zero salt and IKM = F||KM where F = 0xFF*32 (X25519).
+        """
+        from cryptography.hazmat.primitives.hashes import SHA256
+        from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+        from agentmesh.encryption.x3dh import KEY_LEN, X3DH_INFO, _kdf
+
+        dh_concat = bytes(range(96))  # 3*32-byte DH outputs
+
+        actual = _kdf(dh_concat)
+
+        spec_hkdf = HKDF(
+            algorithm=SHA256(),
+            length=KEY_LEN,
+            salt=b"\x00" * 32,
+            info=X3DH_INFO,
+        )
+        expected = spec_hkdf.derive(b"\xff" * 32 + dh_concat)
+
+        assert actual == expected
+        assert len(actual) == KEY_LEN
+
+
 class TestInMemoryPreKeyStore:
     def test_store_and_retrieve(self):
         store = InMemoryPreKeyStore()


### PR DESCRIPTION
## Summary

`x3dh._kdf` (`agent-mesh/src/agentmesh/encryption/x3dh.py:360-370`) deviates from the Signal X3DH protocol §2.2:

| Component | Spec (X25519) | This implementation |
|---|---|---|
| `F` | 32 × 0xFF | (used as salt) |
| HKDF salt | zero-filled 32 bytes | 32 × 0xFF |
| HKDF IKM | `F \|\| KM` | raw `dh_concat` |

The leading comment in `_kdf` even said *"Prepend 32 bytes of 0xFF as specified by Signal X3DH"* — but the implementation put those bytes in the wrong slot. The result: this implementation could only interop with itself. A peer running standard Signal X3DH would silently derive a different shared secret and fail to decrypt traffic.

## Fix

- Use a 32-byte zero-filled `salt`.
- Build the HKDF input as `F || ikm` where `F = b"\xff" * 32`.

This is a wire-format change. Sessions established under the old KDF cannot decrypt traffic encrypted with the new KDF and vice-versa; both peers must rerun X3DH after upgrade. There is no opt-in flag — the old KDF was never spec-compliant and there is no value in preserving it as a compatibility mode for non-interoperable peers.

## Tests

Adds `TestKDFSpecCompliance::test_kdf_uses_zero_salt_and_prepends_f_to_ikm` in `tests/test_x3dh.py`. The test re-derives the expected key directly via `HKDF(salt=zero, info=X3DH_INFO).derive(F || ikm)` and asserts equality with `_kdf`'s actual output. Existing 25 X3DH tests still pass — they were testing internal consistency, not spec compliance, so the structural change doesn't break them.

```
tests/test_x3dh.py — 26 passed in 0.48s
```

## Test plan

- [x] All 26 `test_x3dh.py` tests pass on Python 3.14.
- [x] New regression asserts the spec-compliant derivation explicitly.
- [x] Output is verified against an independent HKDF computation, not just self-consistency.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)