### PR TITLE
fix(rag-governor): thread collection and query into rate-limit audit (HIGH Governance #2)

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
@@ -150,7 +150,7 @@ class RAGGovernor:
         self._check_collection(collection)
 
         # 2. Rate limiting
-        self._check_rate()
+        self._check_rate(collection=collection, query=query)
 
         # 3. Retrieve
         docs = self._retrieve(retriever, query, kwargs)
@@ -185,14 +185,14 @@ class RAGGovernor:
                 self._audit_logger.emit(entry)
             raise CollectionDeniedError(collection, self.agent_id, reason)
 
-    def _check_rate(self) -> None:
+    def _check_rate(self, *, collection: str, query: str) -> None:
         limit = self.policy.max_retrievals_per_minute
         if not self._rate_limiter.check(self.agent_id, limit):
             if self._audit_logger:
                 entry = make_entry(
                     agent_id=self.agent_id,
-                    collection="",
-                    query="",
+                    collection=collection,
+                    query=query,
                     num_chunks_retrieved=0,
                     num_chunks_blocked=0,
                     decision="rate_limited",

--- a/agent-governance-python/agent-rag-governance/tests/test_governor.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_governor.py
@@ -138,6 +138,45 @@ def test_no_content_policies_passes_all_chunks():
     assert len(result) == 2
 
 
+def test_rate_limit_audit_records_collection_and_query():
+    """Regression: previously rate-limit audit entries logged
+    collection="" and query="", so a hashed empty query was the only
+    breadcrumb the operator had — they could not tie the rate-limit
+    event back to which collection or query the agent had been
+    hammering. Now the actual collection and query thread through.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+        log_path = f.name
+
+    policy = RAGPolicy(
+        max_retrievals_per_minute=2,
+        audit_enabled=True,
+        audit_log_path=log_path,
+    )
+    governor = RAGGovernor(policy=policy, agent_id="rate-limited-agent")
+    governed = governor.wrap(_FakeRetriever([_FakeDoc("clean")]), collection="public_docs")
+
+    governed.invoke("how do I reset my password?")
+    governed.invoke("how do I reset my password?")
+    with pytest.raises(RateLimitExceededError):
+        governed.invoke("how do I reset my password?")
+
+    import hashlib
+
+    lines = Path(log_path).read_text().strip().splitlines()
+    rate_limit_entries = [json.loads(line) for line in lines if json.loads(line)["decision"] == "rate_limited"]
+    assert len(rate_limit_entries) == 1
+    entry = rate_limit_entries[0]
+    assert entry["collection"] == "public_docs"
+    # The query is hashed before storage; what matters is that the
+    # hash is *the* hash of the actual query, not the hash of an
+    # empty string (which is what the previous code wrote).
+    empty_hash = hashlib.sha256(b"").hexdigest()
+    expected_hash = hashlib.sha256(b"how do I reset my password?").hexdigest()
+    assert entry["query_hash"] != empty_hash
+    assert entry["query_hash"] == expected_hash
+
+
 def test_get_relevant_documents_compat():
     docs = [_FakeDoc("clean text")]
     retriever = _FakeRetriever(docs)


### PR DESCRIPTION
## Summary

`RAGGovernor._check_rate` (`agent_rag_governance/governor.py:188-202`) wrote a rate-limit audit entry with `collection=""` and `query=""`. Since the entry is hashed before storage, every rate-limit event in the log looked like:

```json
{"collection": "", "query_hash": "e3b0c44...855", "decision": "rate_limited", ...}
```

That's the SHA-256 of empty string — identical for every rate-limit hit ever recorded, regardless of which collection or query the agent was actually hammering. Operators investigating a rate-limit storm had no way to tie the events back to anything actionable.

## Fix

Pass `collection` and `query` from `_execute` into `_check_rate(*, collection, query)` so the audit record matches the call that triggered it. The `make_entry`/`RAGAuditEntry` interface is unchanged — this just stops synthesizing empty values at the call site.

## Tests

Adds `test_rate_limit_audit_records_collection_and_query`:
- Configures `max_retrievals_per_minute=2`.
- Issues 3 calls with `collection="public_docs"` and a known query string.
- Parses the audit log; finds the single `rate_limited` entry.
- Asserts `entry["collection"] == "public_docs"`.
- Asserts `entry["query_hash"]` is the SHA-256 of the actual query, NOT the SHA-256 of empty string.

```
tests/test_governor.py — 11 passed in 0.21s
```

## Test plan

- [x] All 11 `test_governor.py` tests pass on Python 3.14.
- [x] Rate-limit audit entries now carry the actual collection and query hash.
- [x] Other audit code paths (`_check_collection`, `_audit`) unchanged.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)