### PR TITLE
fix(rag-governor): raise on legacy retriever path when kwargs would be dropped (HIGH Governance #4)

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
@@ -205,6 +205,18 @@ class RAGGovernor:
         if hasattr(retriever, "invoke"):
             return retriever.invoke(query, **kwargs)
         if hasattr(retriever, "get_relevant_documents"):
+            # Legacy LangChain v0.1 API only accepts the query string —
+            # silently dropping kwargs (e.g., tenant filters, search
+            # arguments) would let governance pass while the underlying
+            # retrieval ran with a wider scope than the caller intended.
+            if kwargs:
+                raise TypeError(
+                    f"Retriever {type(retriever).__name__!r} only exposes "
+                    ".get_relevant_documents(query) (LangChain v0.1 API) "
+                    "and cannot accept kwargs "
+                    f"{sorted(kwargs.keys())!r}. Upgrade the retriever to "
+                    "the .invoke(query, **kwargs) API or drop the kwargs."
+                )
             return retriever.get_relevant_documents(query)
         raise TypeError(
             f"Retriever {type(retriever).__name__!r} has no .invoke() or "

--- a/agent-governance-python/agent-rag-governance/tests/test_governor.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_governor.py
@@ -145,3 +145,42 @@ def test_get_relevant_documents_compat():
     governed = governor.wrap(retriever, collection="docs")
     result = governed.get_relevant_documents("query")
     assert len(result) == 1
+
+
+class _LegacyOnlyRetriever:
+    """Retriever exposing only the legacy v0.1 API (no .invoke())."""
+
+    def __init__(self, docs: List[_FakeDoc]):
+        self._docs = docs
+
+    def get_relevant_documents(self, query: str) -> List[_FakeDoc]:
+        return self._docs
+
+
+def test_legacy_retriever_rejects_kwargs_loudly():
+    """Regression: previously _retrieve fell back to
+    .get_relevant_documents(query) when .invoke was unavailable, and
+    silently dropped any kwargs the caller had passed via
+    governed.invoke(query, **kwargs). Tenant-scoping filters and
+    similar arguments vanished, so governance approved a query that
+    then ran against a wider scope than the caller intended.
+    Now this case raises TypeError so the caller knows to upgrade the
+    retriever or drop the kwargs.
+    """
+    retriever = _LegacyOnlyRetriever([_FakeDoc("clean")])
+    governor = _make_governor(RAGPolicy())
+    governed = governor.wrap(retriever, collection="docs")
+
+    with pytest.raises(TypeError, match="cannot accept kwargs"):
+        governed.invoke("query", filter={"tenant": "tenant-a"})
+
+
+def test_legacy_retriever_accepts_no_kwargs():
+    """Bare .get_relevant_documents path (no kwargs) still works."""
+    retriever = _LegacyOnlyRetriever([_FakeDoc("clean")])
+    governor = _make_governor(RAGPolicy())
+    governed = governor.wrap(retriever, collection="docs")
+
+    # Both invoke (no kwargs) and the explicit shim should work.
+    assert len(governed.invoke("query")) == 1
+    assert len(governed.get_relevant_documents("query")) == 1


### PR DESCRIPTION
## Summary

`RAGGovernor._retrieve` (`agent_rag_governance/governor.py:204-212`) fell back to `retriever.get_relevant_documents(query)` when `.invoke` was unavailable, but the legacy LangChain v0.1 API only accepts the query string. Any kwargs the caller had passed via `governed.invoke(query, filter={...})` — typically tenant-scoping filters or per-call search arguments — were silently dropped.

The governance pipeline (collection ACL, rate limit, content scan, audit) ran against the caller-intended scope; then the underlying retrieval ran without the kwargs and pulled documents from a **wider** scope than governance had reviewed.

## Fix

Make the silent drop loud: when only the legacy path is available **and** the caller passed kwargs, raise `TypeError` listing the dropped keys and pointing at the `.invoke(query, **kwargs)` API. The bare-query case (no kwargs) is unchanged.

## Tests

- `test_legacy_retriever_rejects_kwargs_loudly` — passes `filter={"tenant": "tenant-a"}` to a legacy-only retriever; asserts `TypeError("cannot accept kwargs")`.
- `test_legacy_retriever_accepts_no_kwargs` — verifies the no-kwargs path still works for both `.invoke` and `.get_relevant_documents`.

```
tests/test_governor.py — 12 passed in 0.20s
```

## Test plan

- [x] All 12 `test_governor.py` tests pass on Python 3.14.
- [x] Tenant filters can no longer be silently dropped.
- [x] Bare-query legacy path still works.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)