### PR TITLE
docs: fix docs site gaps, broken links, and missing navigation

### DIFF
--- a/docs/adr/0011-additive-policy-check-contract.md
+++ b/docs/adr/0011-additive-policy-check-contract.md
@@ -1,6 +1,6 @@
 # ADR 0011: Additive Policy Check Contract
 
-- Status: Proposed
+- Status: proposed
 - Date: 2026-04-29
 
 ## Context

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -13,5 +13,6 @@ Key architectural decisions and their rationale.
 | [ADR-0007](0007-external-jwks-federation-for-cross-org-identity.md) | External JWKS federation for cross-org identity |
 | [ADR-0008](0008-cross-org-policy-federation.md) | Cross-org policy federation above identity |
 | [ADR-0009](0009-rfc-9334-rats-architecture-alignment.md) | RFC 9334 (RATS) architecture alignment |
+| [ADR-0010](0010-tee-keystore-sevsnp-attestation.md) | TEE keystore with SEV-SNP attestation |
 | [ADR-0011](0011-additive-policy-check-contract.md) | Additive policy check contract |
 | [ADR-0012](0012-cost-governance-observability-policies.md) | Cost governance via observability policies in Agent SRE |

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -1,10 +1,12 @@
 # Deployment Guides
 
-Deploy AGT across Azure services and container platforms.
+Deploy AGT on any cloud or container platform. AGT is pure Python/TypeScript/.NET with zero cloud-vendor lock-in.
 
 | Guide | Platform |
 |-------|----------|
 | [Azure Container Apps](azure-container-apps.md) | Managed containers on Azure |
 | [Azure Foundry Agent Service](azure-foundry-agent-service.md) | Foundry-native agent hosting |
+| [AWS ECS / Fargate](aws-ecs.md) | Containers on AWS |
+| [Google Cloud GKE](gcp-gke.md) | Kubernetes on GCP |
 | [OpenClaw Sidecar](openclaw-sidecar.md) | Sidecar deployment pattern |
 | [Private Endpoints](private-endpoints.md) | Secure networking with private links |

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,9 +9,9 @@ The Agent Governance Toolkit (AGT) provides a comprehensive set of packages for 
 | | |
 |---|---|
 | :material-rocket-launch: [**Quick Start**](quickstart.md) | Get running in 5 minutes |
-| :material-cube-outline: [**Packages**](packages/index.md) | 11 packages for every governance layer |
+| :material-cube-outline: [**Packages**](packages/index.md) | 8 core + 5 language SDKs + 19 integrations |
 | :material-school: [**Tutorials**](tutorials/index.md) | 40+ step-by-step guides |
-| :material-cloud-upload: [**Deployment**](deployment/index.md) | Azure Container Apps, Foundry, OpenClaw |
+| :material-cloud-upload: [**Deployment**](deployment/index.md) | Azure, AWS, GCP, and sidecar patterns |
 | :material-shield-check: [**Security**](security/threat-model.md) | Threat model, OWASP compliance, scanning |
 
 ## Packages at a Glance

--- a/docs/reference/nist-rfi-mapping.md
+++ b/docs/reference/nist-rfi-mapping.md
@@ -1,3 +1,19 @@
 # NIST RFI Mapping
 
-Documentation coming soon.
+AGT provides detailed NIST alignment documentation in the compliance section:
+
+| Document | Description |
+|----------|-------------|
+| [NIST AI RMF 1.0 Alignment](../compliance/nist-ai-rmf-alignment.md) | Full mapping across GOVERN, MAP, MEASURE, and MANAGE functions |
+| [NIST RFI 2026-00206 Response](../compliance/nist-rfi-2026-00206.md) | Response to NIST's request for information on AI agent governance |
+
+## Quick Summary
+
+AGT maps to all four NIST AI RMF functions:
+
+- **GOVERN**: Deterministic YAML policy engine, role-based access, audit logging
+- **MAP**: Threat modeling (OWASP Agentic Top 10), risk classification per agent
+- **MEASURE**: 13,000+ automated tests, SLO monitoring, chaos testing via Agent SRE
+- **MANAGE**: Kill switch, rate limiting, cost governance, incident response workflows
+
+For the complete assessment with coverage matrices and gap analysis, see the [NIST AI RMF Alignment](../compliance/nist-ai-rmf-alignment.md) document.

--- a/docs/tutorials/retrofit-governance.md
+++ b/docs/tutorials/retrofit-governance.md
@@ -240,5 +240,5 @@ block — is written to the audit trail automatically.
   cryptographic agent identity and trust scoring.
 - **[Tutorial 04 — Audit & Compliance](04-audit-and-compliance.md):** Persist
   your audit trail and generate OWASP ASI compliance reports.
-- **[Example policies](../../examples/policies/):** Drop-in YAML files for
+- **[Example policies](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/policies):** Drop-in YAML files for
   SQL safety, PII detection, MCP security, and more.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,8 @@ docs_dir: docs
 
 theme:
   name: material
+  logo: assets/agent-governance-toolkit.svg
+  favicon: assets/agent-governance-toolkit.svg
   palette:
     - scheme: default
       primary: indigo
@@ -133,6 +135,8 @@ nav:
     - Overview: deployment/index.md
     - Azure Container Apps: deployment/azure-container-apps.md
     - Azure Foundry Agent Service: deployment/azure-foundry-agent-service.md
+    - AWS ECS / Fargate: deployment/aws-ecs.md
+    - Google Cloud GKE: deployment/gcp-gke.md
     - OpenClaw Sidecar: deployment/openclaw-sidecar.md
     - Private Endpoints: deployment/private-endpoints.md
   - Security:
@@ -148,6 +152,12 @@ nav:
     - "ADR-0004: Deterministic Policy": adr/0004-keep-policy-evaluation-deterministic.md
     - "ADR-0005: Liveness Attestation": adr/0005-add-liveness-attestation-to-trust-handshake.md
     - "ADR-0006: Constitutional Constraints": adr/0006-constitutional-constraint-layer-as-community-extension.md
+    - "ADR-0007: JWKS Federation": adr/0007-external-jwks-federation-for-cross-org-identity.md
+    - "ADR-0008: Cross-Org Policy Federation": adr/0008-cross-org-policy-federation.md
+    - "ADR-0009: RFC 9334 RATS Alignment": adr/0009-rfc-9334-rats-architecture-alignment.md
+    - "ADR-0010: TEE Keystore SEV-SNP": adr/0010-tee-keystore-sevsnp-attestation.md
+    - "ADR-0011: Additive Policy Contract": adr/0011-additive-policy-check-contract.md
+    - "ADR-0012: Cost Governance": adr/0012-cost-governance-observability-policies.md
   - Reference:
     - Benchmarks: reference/benchmarks.md
     - Comparison: reference/comparison.md


### PR DESCRIPTION
Fixes several issues found on the live docs site:

**Deployment** (was Azure-only)
- Add AWS ECS/Fargate and GCP GKE to deployment index and sidebar nav
- Update homepage deployment description to mention multi-cloud

**ADR sidebar** (was missing 7 of 13 ADRs)
- Add ADR-0007 through ADR-0012 to mkdocs sidebar navigation
- Add missing ADR-0010 to index table
- Fix ADR-0011 status capitalization inconsistency

**Homepage**
- Fix package count to accurate description

**Broken links**
- Fix /examples/policies/ 404 in retrofit tutorial (point to GitHub tree)
- Replace NIST RFI coming soon stub with summary linking to full compliance docs

**Branding**
- Add repo logo (shield SVG) as site logo and favicon