### PR TITLE
fix(rag-governor): raise on legacy retriever path when kwargs would be dropped

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
@@ -272,6 +272,18 @@ class RAGGovernor:
         if hasattr(retriever, "invoke"):
             return retriever.invoke(query, **kwargs)
         if hasattr(retriever, "get_relevant_documents"):
+            # Legacy LangChain v0.1 API only accepts the query string.
+            # Silently dropping kwargs (e.g., tenant filters, search
+            # arguments) would let governance pass while the underlying
+            # retrieval ran with a wider scope than the caller intended.
+            if kwargs:
+                raise TypeError(
+                    f"Retriever {type(retriever).__name__!r} only exposes "
+                    ".get_relevant_documents(query) (LangChain v0.1 API) "
+                    "and cannot accept kwargs "
+                    f"{sorted(kwargs.keys())!r}. Upgrade the retriever to "
+                    "the .invoke(query, **kwargs) API or drop the kwargs."
+                )
             return retriever.get_relevant_documents(query)
         raise TypeError(
             f"Retriever {type(retriever).__name__!r} has no .invoke() or "

--- a/agent-governance-python/agent-rag-governance/tests/test_governor.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_governor.py
@@ -273,3 +273,38 @@ def test_non_method_attributes_still_proxy_through():
     governor = _make_governor(RAGPolicy())
     governed = governor.wrap(inner, collection="docs")
     assert governed.search_kwargs == {"k": 5}
+
+
+class _LegacyOnlyRetriever:
+    """Retriever exposing only the legacy v0.1 API (no .invoke())."""
+
+    def __init__(self, docs: List[_FakeDoc]):
+        self._docs = docs
+
+    def get_relevant_documents(self, query: str) -> List[_FakeDoc]:
+        return self._docs
+
+
+def test_legacy_retriever_rejects_kwargs_loudly():
+    """Regression: previously _retrieve fell back to
+    .get_relevant_documents(query) when .invoke was unavailable, and
+    silently dropped any kwargs the caller had passed. Tenant-scoping
+    filters and similar arguments vanished, so governance approved a
+    query that then ran against a wider scope than the caller intended.
+    """
+    retriever = _LegacyOnlyRetriever([_FakeDoc("clean")])
+    governor = _make_governor(RAGPolicy())
+    governed = governor.wrap(retriever, collection="docs")
+
+    with pytest.raises(TypeError, match="cannot accept kwargs"):
+        governed.invoke("query", filter={"tenant": "tenant-a"})
+
+
+def test_legacy_retriever_accepts_no_kwargs():
+    """Bare .get_relevant_documents path (no kwargs) still works."""
+    retriever = _LegacyOnlyRetriever([_FakeDoc("clean")])
+    governor = _make_governor(RAGPolicy())
+    governed = governor.wrap(retriever, collection="docs")
+
+    assert len(governed.invoke("query")) == 1
+    assert len(governed.get_relevant_documents("query")) == 1


### PR DESCRIPTION
Rebased version of #1931 (resolved merge conflicts with main).

Prevents silently dropping kwargs on the legacy .get_relevant_documents() fallback path. Without this fix, tenant-scoping filters and similar arguments vanish when the retriever lacks .invoke(), so governance approves a query that runs with wider scope than intended.

All 20 governor tests pass.

Supersedes #1931.
Co-authored-by: finnoybu