### PR TITLE
fix(supply-chain): clamp freshness delta and emit future-timestamp finding (HIGH Governance #5)

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
@@ -268,12 +268,37 @@ class SupplyChainGuard:
 
         Does NOT call external APIs — compares against a provided timestamp.
         For actual freshness checks, use ``check_freshness_live()``.
+
+        A future ``publish_time`` (clock skew, tampered registry response,
+        or a deliberately spoofed timestamp meant to dodge the
+        backdated-package defense) is reported as a separate
+        ``future-timestamp`` finding rather than silently triggering the
+        "fresh-publish" branch via a negative delta.
         """
         now = datetime.now(timezone.utc)
         if publish_time.tzinfo is None:
             publish_time = publish_time.replace(tzinfo=timezone.utc)
 
-        if now - publish_time < timedelta(days=self.config.freshness_days):
+        # A future publish_time is itself a red flag — clamp the delta to
+        # zero for the recent-publish check and emit a distinct finding so
+        # the operator can see the spoofed/tampered timestamp directly
+        # instead of having it masquerade as a normal recent publish.
+        if publish_time > now:
+            return SupplyChainFinding(
+                package=package,
+                version=version,
+                severity="high",
+                rule="future-timestamp",
+                message=(
+                    f"Package '{package}=={version}' has a publish timestamp "
+                    f"{(publish_time - now).total_seconds():.0f}s in the "
+                    "future — possible clock skew, tampered registry "
+                    "response, or backdating-defense evasion."
+                ),
+            )
+
+        delta = now - publish_time
+        if delta < timedelta(days=self.config.freshness_days):
             return SupplyChainFinding(
                 package=package,
                 version=version,
@@ -281,7 +306,7 @@ class SupplyChainGuard:
                 rule="fresh-publish",
                 message=(
                     f"Package '{package}=={version}' was published only "
-                    f"{(now - publish_time).days} day(s) ago "
+                    f"{delta.days} day(s) ago "
                     f"(threshold: {self.config.freshness_days} days)."
                 ),
             )

--- a/agent-governance-python/agent-compliance/tests/test_supply_chain.py
+++ b/agent-governance-python/agent-compliance/tests/test_supply_chain.py
@@ -238,6 +238,44 @@ class TestCheckFreshness:
         finding = strict_guard.check_freshness("new-pkg", "0.1.0", ten_days_ago)
         assert finding is not None  # threshold is 14 days
 
+    def test_future_publish_time_emits_future_timestamp_finding(
+        self, guard: SupplyChainGuard
+    ) -> None:
+        """Regression: a future publish_time previously made
+        ``now - publish_time`` negative, which is always less than the
+        freshness window — so the fresh-publish branch fired and the
+        actual signal (timestamp tampering) got buried in noise. The
+        backdated-package defense was unreachable from a future-stamped
+        publish. Future timestamps must surface as their own finding.
+        """
+        future = datetime.now(timezone.utc) + timedelta(days=30)
+        finding = guard.check_freshness("evil-pkg", "1.0.0", future)
+        assert finding is not None
+        assert finding.rule == "future-timestamp"
+        assert finding.severity == "high"
+        assert "future" in finding.message.lower()
+
+    def test_future_publish_time_naive_datetime_handled(
+        self, guard: SupplyChainGuard
+    ) -> None:
+        """Naive future timestamps must be coerced to UTC and still flagged."""
+        future_naive = (datetime.now(timezone.utc) + timedelta(days=1)).replace(tzinfo=None)
+        finding = guard.check_freshness("evil-pkg", "1.0.0", future_naive)
+        assert finding is not None
+        assert finding.rule == "future-timestamp"
+
+    def test_clock_skew_does_not_emit_fresh_publish(
+        self, guard: SupplyChainGuard
+    ) -> None:
+        """A small future delta (typical clock skew) is still a future
+        timestamp, not a fresh publish — they must be distinguishable.
+        """
+        skewed = datetime.now(timezone.utc) + timedelta(seconds=30)
+        finding = guard.check_freshness("evil-pkg", "1.0.0", skewed)
+        assert finding is not None
+        assert finding.rule == "future-timestamp"
+        assert finding.rule != "fresh-publish"
+
 
 # ---------------------------------------------------------------------------
 # scan_directory


### PR DESCRIPTION
## Summary

`SupplyChainGuard.check_freshness` (`agent_compliance/supply_chain.py:266-288`) emitted a `"fresh-publish"` finding when:

```python
if now - publish_time < timedelta(days=self.config.freshness_days):
    emit("fresh-publish")
```

When `publish_time` was in the **future** — clock skew, a tampered registry response, or a deliberate attempt to dodge the backdated-package defense — `now - publish_time` was negative, the comparison was always true, and a future-stamped publish silently masqueraded as a normal recent publish.

The defense this check exists for (an attacker pushing `publish_time` into the future to make a fresh malicious package look "old and trusted") was unreachable — every spoofed-future timestamp produced the same noise as a benign recent publish, so nobody could tell the two apart in operator dashboards.

## Fix

Reorder the checks: if `publish_time > now`, return a distinct `"future-timestamp"` finding (severity `high`) and skip the recent-publish branch entirely. The recent-publish branch then only fires for genuinely recent packages, on a non-negative delta.

`check_freshness_live` calls into `check_freshness`, so the live (PyPI / npm) path inherits the fix automatically.

## Tests

Adds three regression tests in `TestCheckFreshness`:

- `test_future_publish_time_emits_future_timestamp_finding` — 30 days in the future, asserts `rule == "future-timestamp"` and severity `high`.
- `test_future_publish_time_naive_datetime_handled` — naive future timestamp is coerced to UTC and still flagged.
- `test_clock_skew_does_not_emit_fresh_publish` — 30-second future skew surfaces as `future-timestamp`, NOT `fresh-publish`.

```
tests/test_supply_chain.py — 34 passed in 0.62s
```

(31 existing + 3 new.)

## Test plan

- [x] All 34 `test_supply_chain.py` tests pass on Python 3.14.
- [x] Future-stamped publishes surface as their own finding rule.
- [x] Recent-publish branch only fires for non-negative deltas now.
- [x] `check_freshness_live` (PyPI / npm) path inherits the fix.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)