### PR TITLE
fix(supply-chain): parse pyproject.toml with tomllib instead of string-matching (HIGH Governance #7)

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
@@ -72,6 +72,11 @@ class SupplyChainConfig:
 _RANGE_RE = re.compile(r"[\^~]")
 _PEP508_PINNED = re.compile(r"==\s*\S+")
 _LOOSE_CONSTRAINT = re.compile(r"(>=|<=|~=|!=|>|<)")
+# Strict MAJOR.MINOR.PATCH (with optional prerelease/build) used by
+# both the Poetry inline-table check and the npm version classifier.
+_EXACT_SEMVER = re.compile(
+    r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
 
 
 def _similarity(a: str, b: str) -> float:
@@ -175,45 +180,141 @@ class SupplyChainGuard:
         return findings
 
     # ------------------------------------------------------------------
-    # pyproject.toml (simple parser – stdlib only)
+    # pyproject.toml (tomllib-based, stdlib only)
     # ------------------------------------------------------------------
 
     def check_pyproject(self, path: str) -> list[SupplyChainFinding]:
-        """Check pyproject.toml for loose version constraints."""
+        """Check pyproject.toml for loose version constraints.
+
+        Uses ``tomllib`` (Python 3.11+) so the following layouts are all
+        covered, including ones the prior string-match-based parser
+        silently skipped:
+
+          * ``[project] dependencies = [...]``                (PEP 621)
+          * ``[project.optional-dependencies]``               (PEP 621)
+          * ``[tool.poetry.dependencies]``                    (Poetry)
+          * ``[tool.poetry.dev-dependencies]``                (Poetry, legacy)
+          * ``[tool.poetry.group.<name>.dependencies]``       (Poetry, modern)
+
+        Multiline list entries, comments, environment markers, and
+        Poetry table-form deps (``foo = {git = "...", rev = "..."}``)
+        are handled correctly via the TOML parser instead of being
+        misread as regular version strings.
+        """
+        try:
+            import tomllib
+        except ImportError:  # Python < 3.11 fallback
+            import tomli as tomllib  # type: ignore[no-redef]
+
         findings: list[SupplyChainFinding] = []
-        text = Path(path).read_text(encoding="utf-8")
+        try:
+            with open(path, "rb") as fh:
+                data = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError):
+            return findings
 
-        in_deps = False
-        for line in text.splitlines():
-            stripped = line.strip()
+        # PEP 621: [project] dependencies = ["pep508-string", ...]
+        project = data.get("project", {})
+        for dep_str in project.get("dependencies", []) or []:
+            self._emit_pep508_finding(findings, dep_str)
 
-            if stripped == "dependencies = [":
-                in_deps = True
-                continue
-            if in_deps and stripped == "]":
-                in_deps = False
-                continue
+        # PEP 621: [project.optional-dependencies] with grouped lists
+        optional = project.get("optional-dependencies", {}) or {}
+        for group_deps in optional.values():
+            for dep_str in group_deps or []:
+                self._emit_pep508_finding(findings, dep_str)
 
-            if in_deps:
-                match = re.match(r'"([^"]+)"', stripped.rstrip(","))
-                if match:
-                    dep_str = match.group(1)
-                    parsed = _parse_requirements_line(dep_str)
-                    if parsed:
-                        name, version_spec = parsed
-                        if not _PEP508_PINNED.search(version_spec):
-                            findings.append(SupplyChainFinding(
-                                package=name,
-                                version=version_spec or "unspecified",
-                                severity="medium",
-                                rule="loose-constraint",
-                                message=(
-                                    f"Package '{name}' in pyproject.toml uses "
-                                    f"a loose version constraint."
-                                ),
-                            ))
+        # Poetry: [tool.poetry.dependencies] / [tool.poetry.dev-dependencies]
+        poetry = data.get("tool", {}).get("poetry", {}) or {}
+        self._emit_poetry_findings(findings, poetry.get("dependencies", {}) or {})
+        self._emit_poetry_findings(findings, poetry.get("dev-dependencies", {}) or {})
+
+        # Poetry modern: [tool.poetry.group.<name>.dependencies]
+        for group in (poetry.get("group", {}) or {}).values():
+            self._emit_poetry_findings(findings, group.get("dependencies", {}) or {})
 
         return findings
+
+    def _emit_pep508_finding(
+        self, findings: list[SupplyChainFinding], dep_str: str,
+    ) -> None:
+        if not isinstance(dep_str, str):
+            return
+        parsed = _parse_requirements_line(dep_str)
+        if not parsed:
+            return
+        name, version_spec = parsed
+        if _PEP508_PINNED.search(version_spec):
+            return
+        findings.append(SupplyChainFinding(
+            package=name,
+            version=version_spec or "unspecified",
+            severity="medium",
+            rule="loose-constraint",
+            message=(
+                f"Package '{name}' in pyproject.toml uses a loose "
+                "version constraint."
+            ),
+        ))
+
+    def _emit_poetry_findings(
+        self, findings: list[SupplyChainFinding], deps: dict,
+    ) -> None:
+        for name, spec in deps.items():
+            if name == "python":
+                # The Poetry dependencies table embeds the Python version
+                # constraint under the "python" key — that's not a
+                # supply-chain dependency and shouldn't surface here.
+                continue
+            if isinstance(spec, str):
+                if not _EXACT_SEMVER.match(spec.strip()):
+                    findings.append(SupplyChainFinding(
+                        package=name,
+                        version=spec,
+                        severity="medium",
+                        rule="loose-constraint",
+                        message=(
+                            f"Package '{name}' in pyproject.toml uses a "
+                            f"loose version constraint ('{spec}')."
+                        ),
+                    ))
+            elif isinstance(spec, dict):
+                # Poetry table-form: foo = {version="^1.0"} or
+                # foo = {git="...", rev="..."} or foo = {path="..."}.
+                # The git/path/url forms bypass the package index trust
+                # boundary entirely.
+                for protocol_key in ("git", "url", "path"):
+                    if protocol_key in spec:
+                        findings.append(SupplyChainFinding(
+                            package=name,
+                            version=str(spec.get(protocol_key, "")),
+                            severity="high",
+                            rule="non-semver-specifier",
+                            message=(
+                                f"Package '{name}' in pyproject.toml is "
+                                f"sourced via '{protocol_key}=' "
+                                f"({spec.get(protocol_key)!r}); pin to an "
+                                "exact published version on the configured "
+                                "index instead."
+                            ),
+                        ))
+                        break
+                else:
+                    inline_version = spec.get("version")
+                    if isinstance(inline_version, str) and not _EXACT_SEMVER.match(
+                        inline_version.strip()
+                    ):
+                        findings.append(SupplyChainFinding(
+                            package=name,
+                            version=inline_version,
+                            severity="medium",
+                            rule="loose-constraint",
+                            message=(
+                                f"Package '{name}' in pyproject.toml uses a "
+                                f"loose version constraint "
+                                f"('{inline_version}')."
+                            ),
+                        ))
 
     # ------------------------------------------------------------------
     # Cargo.toml (simple parser – stdlib only)

--- a/agent-governance-python/agent-compliance/tests/test_supply_chain.py
+++ b/agent-governance-python/agent-compliance/tests/test_supply_chain.py
@@ -152,6 +152,156 @@ class TestCheckPyproject:
         findings = guard.check_pyproject(str(pp))
         assert not any(f.rule == "loose-constraint" for f in findings)
 
+    def test_optional_dependencies_checked(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        """Regression: PEP 621 [project.optional-dependencies] groups
+        were silently skipped by the prior string-match parser.
+        """
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[project]\nname = "test"\n'
+            'dependencies = []\n\n'
+            '[project.optional-dependencies]\n'
+            'dev = ["pytest>=7.0"]\n'
+            'docs = ["sphinx>=5"]\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        names = {f.package for f in findings if f.rule == "loose-constraint"}
+        assert "pytest" in names
+        assert "sphinx" in names
+
+    def test_poetry_dependencies_checked(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        """Regression: Poetry's [tool.poetry.dependencies] table was
+        silently skipped by the prior parser. Caret strings should
+        flag, exact versions should pass, and the special "python"
+        key (Python version constraint, not a real dependency) should
+        not surface.
+        """
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[tool.poetry]\nname = "test"\nversion = "0.1.0"\n\n'
+            '[tool.poetry.dependencies]\n'
+            'python = "^3.10"\n'
+            'requests = "^2.28"\n'
+            'pinned = "1.2.3"\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        names = {f.package for f in findings if f.rule == "loose-constraint"}
+        assert "requests" in names
+        assert "pinned" not in names
+        assert "python" not in names
+
+    def test_poetry_legacy_dev_dependencies_checked(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        """Poetry legacy [tool.poetry.dev-dependencies] table coverage."""
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[tool.poetry]\nname = "test"\nversion = "0.1.0"\n\n'
+            '[tool.poetry.dev-dependencies]\n'
+            'pytest = "^7.0"\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        assert any(f.package == "pytest" and f.rule == "loose-constraint" for f in findings)
+
+    def test_poetry_modern_group_dependencies_checked(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        """Poetry modern [tool.poetry.group.<name>.dependencies] coverage."""
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[tool.poetry]\nname = "test"\nversion = "0.1.0"\n\n'
+            '[tool.poetry.group.test.dependencies]\n'
+            'pytest = "^7.0"\n'
+            '[tool.poetry.group.docs.dependencies]\n'
+            'sphinx = "^5.0"\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        names = {f.package for f in findings if f.rule == "loose-constraint"}
+        assert {"pytest", "sphinx"} <= names
+
+    def test_poetry_table_form_git_dep_flagged(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        """Regression: Poetry inline-table deps with git/path/url
+        sources bypass the index trust boundary entirely. The prior
+        string-match parser couldn't see them at all.
+        """
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[tool.poetry]\nname = "test"\nversion = "0.1.0"\n\n'
+            '[tool.poetry.dependencies]\n'
+            'evil = {git = "https://github.com/attacker/evil.git", rev = "main"}\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        assert any(
+            f.package == "evil" and f.rule == "non-semver-specifier"
+            for f in findings
+        )
+
+    def test_poetry_table_form_path_dep_flagged(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[tool.poetry]\nname = "test"\nversion = "0.1.0"\n\n'
+            '[tool.poetry.dependencies]\n'
+            'local-evil = {path = "../malicious", develop = true}\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        assert any(
+            f.package == "local-evil" and f.rule == "non-semver-specifier"
+            for f in findings
+        )
+
+    def test_poetry_table_form_pinned_passes(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[tool.poetry]\nname = "test"\nversion = "0.1.0"\n\n'
+            '[tool.poetry.dependencies]\n'
+            'requests = {version = "2.31.0", python = ">=3.10"}\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        assert not any(f.package == "requests" for f in findings)
+
+    def test_pep621_multiline_dependencies(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        """Regression: deps split across multiple lines confused the
+        prior string-match parser. tomllib sees them as a list.
+        """
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text(
+            '[project]\nname = "test"\n'
+            'dependencies = [\n'
+            '  "requests>=2.28.0",\n'
+            '  "click==8.1.0",\n'
+            '  # comment in the middle\n'
+            '  "rich>=13",\n'
+            ']\n'
+        )
+        findings = guard.check_pyproject(str(pp))
+        names = {f.package for f in findings if f.rule == "loose-constraint"}
+        assert "requests" in names
+        assert "rich" in names
+        assert "click" not in names
+
+    def test_malformed_toml_returns_empty(
+        self, guard: SupplyChainGuard, tmp_path: Path,
+    ) -> None:
+        """A pyproject.toml that tomllib cannot parse must not crash —
+        return an empty list of findings.
+        """
+        pp = tmp_path / "pyproject.toml"
+        pp.write_text("[project\nname = unterminated\n")
+        findings = guard.check_pyproject(str(pp))
+        assert findings == []
+
 
 # ---------------------------------------------------------------------------
 # check_cargo_toml


### PR DESCRIPTION
## Summary

`check_pyproject` (`agent_compliance/supply_chain.py:181-216`) scanned for the literal string `dependencies = [` and walked subsequent lines until it saw `]`. That meant the following real-world `pyproject.toml` layouts were silently skipped:

- `[project.optional-dependencies]` (PEP 621 extras)
- `[tool.poetry.dependencies]` (Poetry primary)
- `[tool.poetry.dev-dependencies]` (Poetry legacy)
- `[tool.poetry.group.<name>.dependencies]` (Poetry modern)
- Inline-table deps: `foo = {git = "...", rev = "..."}` or `{path = "..."}`
- Multiline list entries with comments interleaved

A package whose loose version pin (or, worse, a `git+https://attacker/evil.git` source) lived in any of those locations passed the supply-chain gate with no finding at all.

## Fix

Switch to `tomllib` (Python 3.11+, already stdlib; `tomli` fallback for older runtimes). Walk every known dependency surface:

- `[project] dependencies` (list of PEP 508 strings)
- `[project.optional-dependencies]` (each group is a list of PEP 508 strings)
- `[tool.poetry.dependencies]`, `[tool.poetry.dev-dependencies]`, `[tool.poetry.group.*.dependencies]`

For PEP 508 strings, reuse `_parse_requirements_line` and the existing `_PEP508_PINNED` check.

For Poetry deps:
- string form (`"^1.0"`) → `loose-constraint` (medium) unless it matches strict `MAJOR.MINOR.PATCH[-prerelease][+build]` semver
- inline table with `git=`, `url=`, or `path=` → `non-semver-specifier` (high) — these bypass the index trust boundary entirely
- inline table with `version=` → check that field against the same exact-semver rule

Skip the special `"python"` key in Poetry deps tables — that's the project's target Python version constraint, not a real package.

Promotes the strict-semver regex to a module-level `_EXACT_SEMVER` so both this code path and any future caller (e.g., the npm version classifier from #1936) share the same definition.

Returns an empty list when `tomllib.TOMLDecodeError` or `OSError` fires — a malformed pyproject.toml shouldn't crash the scanner.

## Tests

9 new regression tests:

- `test_optional_dependencies_checked` — PEP 621 `[project.optional-dependencies]` groups now flag.
- `test_poetry_dependencies_checked` — Poetry primary table; verifies the special `python` key doesn't surface as a dep.
- `test_poetry_legacy_dev_dependencies_checked` — `[tool.poetry.dev-dependencies]`.
- `test_poetry_modern_group_dependencies_checked` — `[tool.poetry.group.<name>.dependencies]` for both `test` and `docs` groups.
- `test_poetry_table_form_git_dep_flagged` — `{git = "...", rev = "..."}` surfaces as `non-semver-specifier`.
- `test_poetry_table_form_path_dep_flagged` — `{path = "../malicious", develop = true}` likewise.
- `test_poetry_table_form_pinned_passes` — `{version = "2.31.0", python = ">=3.10"}` passes cleanly.
- `test_pep621_multiline_dependencies` — list across multiple lines with interleaved comments parses correctly.
- `test_malformed_toml_returns_empty` — broken TOML returns `[]` instead of crashing.

```
tests/test_supply_chain.py — 40 passed in 0.52s
```

## Test plan

- [x] All 40 `test_supply_chain.py` tests pass on Python 3.14.
- [x] PEP 621 extras now scanned.
- [x] All three Poetry table layouts now scanned.
- [x] Inline-table git/path/url deps flagged as `non-semver-specifier`.
- [x] Multiline list entries handled correctly.
- [x] Malformed TOML doesn't crash the scanner.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)