### PR TITLE
style(docs): polish tutorials, packages, and deployment pages

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -2,11 +2,21 @@
 
 Deploy AGT on any cloud or container platform. AGT is pure Python/TypeScript/.NET with zero cloud-vendor lock-in.
 
-| Guide | Platform |
+!!! info "Cloud-agnostic"
+    AGT has no cloud-vendor dependencies. Every deployment guide below produces the same governance behavior, whether you run on Azure, AWS, GCP, or on-prem.
+
+## Cloud Platforms
+
+| Guide | Platform | Pattern |
+|-------|----------|---------|
+| [Azure Container Apps](azure-container-apps.md) | :material-microsoft-azure: Azure | Managed containers |
+| [Azure Foundry Agent Service](azure-foundry-agent-service.md) | :material-microsoft-azure: Azure | Foundry-native hosting |
+| [AWS ECS / Fargate](aws-ecs.md) | :material-aws: AWS | Serverless containers |
+| [Google Cloud GKE](gcp-gke.md) | :material-google-cloud: GCP | Kubernetes |
+
+## Deployment Patterns
+
+| Guide | Use Case |
 |-------|----------|
-| [Azure Container Apps](azure-container-apps.md) | Managed containers on Azure |
-| [Azure Foundry Agent Service](azure-foundry-agent-service.md) | Foundry-native agent hosting |
-| [AWS ECS / Fargate](aws-ecs.md) | Containers on AWS |
-| [Google Cloud GKE](gcp-gke.md) | Kubernetes on GCP |
-| [OpenClaw Sidecar](openclaw-sidecar.md) | Sidecar deployment pattern |
+| [OpenClaw Sidecar](openclaw-sidecar.md) | Sidecar governance proxy alongside any agent |
 | [Private Endpoints](private-endpoints.md) | Secure networking with private links |

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -2,24 +2,25 @@
 
 AGT provides 50+ packages across 5 ecosystems covering every layer of agent governance.
 
-```
-+------------------+     +------------------+     +------------------+
-|    Agent OS      |     |   Agent Mesh     |     |  Agent Runtime   |
-|  Policy engine   |     |  Discovery &     |     |  Sandboxing &    |
-|  & lifecycle     |     |  trust mesh      |     |  privilege rings  |
-+------------------+     +------------------+     +------------------+
-        |                        |                        |
-+------------------+     +------------------+     +------------------+
-|   Agent SRE      |     | Agent Compliance |     | Agent Marketplace|
-|  Reliability &   |     |  Audit logging   |     |  Plugin trust    |
-|  monitoring      |     |  & frameworks    |     |  & governance    |
-+------------------+     +------------------+     +------------------+
-        |                        |                        |
-+------------------+     +------------------+     +------------------+
-| Agent Lightning  |     | Agent Hypervisor |     | Language + Tools |
-|  High-perf       |     |  HW isolation    |     |  .NET, TS, Rust  |
-|  orchestration   |     |  for workloads   |     |  Go, VS Code     |
-+------------------+     +------------------+     +------------------+
+```mermaid
+graph TB
+    subgraph Core["Core Packages"]
+        OS["Agent OS<br/>Policy engine"]
+        MESH["Agent Mesh<br/>Discovery & trust"]
+        RT["Agent Runtime<br/>Sandboxing"]
+    end
+    subgraph Operations["Operations"]
+        SRE["Agent SRE<br/>Reliability"]
+        COMP["Agent Compliance<br/>Audit & frameworks"]
+        MKT["Agent Marketplace<br/>Plugin trust"]
+    end
+    subgraph Platform["Platform"]
+        LT["Agent Lightning<br/>Orchestration"]
+        HV["Agent Hypervisor<br/>HW isolation"]
+        LANG["Language SDKs<br/>.NET, TS, Rust, Go"]
+    end
+    Core --> Operations
+    Operations --> Platform
 ```
 
 ## Core Packages

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -2,7 +2,8 @@
 
 50+ step-by-step guides covering every aspect of AI agent governance.
 
-> **New here?** Start with [Tutorial 01 -- Policy Engine](01-policy-engine.md), then work through the Foundations section. For a quick taste, try [Tutorial 36 -- 2-Line Governance](36-govern-quickstart.md).
+!!! tip "Where to start?"
+    **New here?** Start with [Tutorial 01: Policy Engine](01-policy-engine.md), then work through the Foundations section. For a quick taste, try [Tutorial 36: 2-Line Governance](36-govern-quickstart.md).
 
 ## Foundations
 


### PR DESCRIPTION
Polishes key landing pages to match the MS Learn-inspired theme from PR #1938.

- Tutorials index: convert plain blockquote to Material admonition tip box
- Packages overview: replace ASCII box diagram with Mermaid flowchart
- Deployment index: split into Cloud Platforms and Patterns sections, add cloud provider icons, add cloud-agnostic info admonition