### PR TITLE
fix(integrity): hash full code object via marshal, not co_code + str(co_consts) (HIGH Governance #9)

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/integrity.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/integrity.py
@@ -25,6 +25,7 @@ import importlib
 import inspect
 import json
 import logging
+import marshal
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -183,11 +184,24 @@ def _hash_file(path: str) -> str:
 
 
 def _hash_function_bytecode(func: Callable[..., Any]) -> str:
-    """SHA-256 hash of a function's compiled bytecode."""
-    code = func.__code__
+    """SHA-256 hash of a function's compiled code object.
+
+    Hashes the marshalled :class:`code` object (which covers
+    ``co_code``, ``co_consts``, ``co_names``, ``co_varnames``,
+    ``co_freevars``, ``co_cellvars``, ``co_argcount``, nested code
+    objects, and every other attribute marshal serialises) so that
+    swapping in a different implementation with the same opcode bytes
+    but different name references, decorators, or nested closures
+    produces a different hash.
+
+    The previous implementation hashed only ``co_code`` and
+    ``str(co_consts)`` — an attacker who could substitute a function
+    with the same opcode sequence but different ``co_names`` (renamed
+    name lookups), decorators, or nested code objects would produce
+    an identical hash and slip past the integrity check.
+    """
     h = hashlib.sha256()
-    h.update(code.co_code)
-    h.update(str(code.co_consts).encode())
+    h.update(marshal.dumps(func.__code__))
     return h.hexdigest()
 
 

--- a/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
+++ b/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
@@ -138,6 +138,69 @@ class TestHashHelpers:
 
         assert _hash_function_bytecode(func_a) != _hash_function_bytecode(func_b)
 
+    def test_hash_distinguishes_renamed_global_lookup(self):
+        """Regression: previously the hash used only co_code +
+        str(co_consts), so a function whose only difference was a
+        renamed name reference (co_names) hashed identically to the
+        original — letting an attacker swap a benign call for a
+        dangerous one without tripping the integrity check.
+        """
+        # Both compile to identical opcode sequences (LOAD_GLOBAL,
+        # CALL, RETURN_VALUE), differing only in co_names.
+        ns: dict = {}
+        exec("def f():\n    return safe_helper()", ns)
+        func_safe = ns["f"]
+        ns2: dict = {}
+        exec("def f():\n    return os_system()", ns2)
+        func_evil = ns2["f"]
+
+        # Same opcode bytes — confirm we're testing the real failure mode
+        assert func_safe.__code__.co_code == func_evil.__code__.co_code
+
+        assert _hash_function_bytecode(func_safe) != _hash_function_bytecode(func_evil)
+
+    def test_hash_distinguishes_nested_code_objects(self):
+        """A function whose nested function (e.g. a closure or inner
+        helper) was swapped should produce a different hash. The
+        previous implementation never descended into co_consts that
+        held nested code objects.
+        """
+        ns: dict = {}
+        exec(
+            "def outer():\n"
+            "    def inner():\n"
+            "        return 1\n"
+            "    return inner()\n",
+            ns,
+        )
+        func_orig = ns["outer"]
+        ns2: dict = {}
+        exec(
+            "def outer():\n"
+            "    def inner():\n"
+            "        return 999\n"
+            "    return inner()\n",
+            ns2,
+        )
+        func_tampered = ns2["outer"]
+
+        assert _hash_function_bytecode(func_orig) != _hash_function_bytecode(func_tampered)
+
+    def test_hash_distinguishes_argument_signatures(self):
+        """A function with a different argument list (different
+        co_varnames / co_argcount) but same body should hash
+        differently — a renamed parameter changes meaning at call
+        sites.
+        """
+        ns: dict = {}
+        exec("def f(a, b):\n    return a", ns)
+        f_ab = ns["f"]
+        ns2: dict = {}
+        exec("def f(a, c):\n    return a", ns2)
+        f_ac = ns2["f"]
+
+        assert _hash_function_bytecode(f_ab) != _hash_function_bytecode(f_ac)
+
 
 class TestIntegrityVerifier:
     def test_verify_without_manifest_passes(self):


### PR DESCRIPTION
## Summary

`_hash_function_bytecode` (`agent_compliance/integrity.py:185-191`) hashed only `code.co_code` (the raw opcode bytes) and `str(code.co_consts)`. That left every other part of the code object out of the integrity hash:

- `co_names` — global and attribute name references
- `co_varnames` — local and argument names
- `co_freevars`, `co_cellvars` — closure references
- `co_argcount`, `co_posonlyargcount`, `co_kwonlyargcount` — signature shape
- nested code objects inside `co_consts` (only their `str()` representation went in, which conflates two different code objects with the same `repr()`)

An attacker who can substitute a function with the same opcode bytes but different name references — e.g., swapping `return safe_helper()` for `return os_system()`, both of which compile to identical `LOAD_GLOBAL` / `CALL` / `RETURN_VALUE` sequences — produces an identical hash. The integrity check reports a clean module while the loaded function has been silently repointed at a different callable.

## Fix

Replace the partial hash with `hashlib.sha256(marshal.dumps(func.__code__)).hexdigest()`. `marshal.dumps` serialises every code-object attribute, including nested code objects recursively, so any meaningful change to the function produces a different hash. The output is stable across process invocations of the same Python version — the only guarantee the integrity check needs.

## Tests

Three new regression tests in `TestHashHelpers`:

- `test_hash_distinguishes_renamed_global_lookup` — confirms that two functions with identical `co_code` but different `co_names` (e.g., `safe_helper()` vs `os_system()`) hash to different values. The test asserts `func_safe.__code__.co_code == func_evil.__code__.co_code` first to prove we're testing the actual failure mode the old implementation missed.
- `test_hash_distinguishes_nested_code_objects` — swapping the body of a nested function changes the outer function's hash.
- `test_hash_distinguishes_argument_signatures` — renaming a parameter (different `co_varnames` / `co_argcount`) changes the hash.

Existing two tests (`test_hash_function_bytecode_deterministic`, `test_hash_different_functions`) continue to pass.

```
tests/test_integrity_and_verify.py — 39 passed in 0.79s
```

## Test plan

- [x] All 39 `test_integrity_and_verify.py` tests pass on Python 3.14.
- [x] Same-`co_code` substitution attacks are now detected.
- [x] Nested code objects participate in the hash.
- [x] Hash remains deterministic across calls within a process.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)