### PR TITLE
fix(integrity): fail closed on corrupt or incomplete manifest (HIGH Governance #10 + #11)

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/integrity.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/integrity.py
@@ -226,14 +226,22 @@ class IntegrityVerifier:
         self._manifest: Optional[dict] = None
 
         if manifest_path and os.path.exists(manifest_path):
+            # A corrupted manifest must fail closed. Previously the
+            # JSONDecodeError was caught and verification continued
+            # with self._manifest = None, which made every "missing
+            # expected" check pass — i.e. a deliberately-broken
+            # manifest unlocked the same default-pass path as having
+            # no manifest at all.
             try:
                 with open(manifest_path, encoding="utf-8") as f:
                     self._manifest = json.load(f)
             except json.JSONDecodeError as e:
-                import logging
-                logging.getLogger(__name__).warning(
-                    "Corrupted manifest at %s: %s", manifest_path, e
-                )
+                raise ValueError(
+                    f"Integrity manifest at {manifest_path!r} is corrupt and "
+                    f"cannot be parsed: {e}. Refusing to start with a manifest "
+                    "that cannot be verified — regenerate it with "
+                    "IntegrityVerifier.generate_manifest()."
+                ) from e
 
     def verify(self) -> IntegrityReport:
         """Run full integrity verification.
@@ -256,7 +264,23 @@ class IntegrityVerifier:
                 if self._manifest and mod_name in self._manifest.get("files", {}):
                     expected = self._manifest["files"][mod_name]["sha256"]
 
-                passed = expected is None or expected == actual_hash
+                # When a manifest is configured, every covered module
+                # MUST have an entry. The previous default
+                # ``passed = expected is None or expected == actual``
+                # rule treated a missing entry as a pass, so an
+                # attacker who could write to the manifest could just
+                # delete the entry for the file they had tampered
+                # with. Now: no entry == failure when a manifest is in
+                # use; no manifest at all == baseline mode (still pass).
+                if self._manifest is None:
+                    passed = True
+                    error: Optional[str] = None
+                elif expected is None:
+                    passed = False
+                    error = "missing manifest entry"
+                else:
+                    passed = expected == actual_hash
+                    error = "hash mismatch" if not passed else None
                 if not passed:
                     report.passed = False
 
@@ -267,7 +291,7 @@ class IntegrityVerifier:
                         expected_hash=expected,
                         actual_hash=actual_hash,
                         passed=passed,
-                        error="hash mismatch" if not passed else None,
+                        error=error,
                     )
                 )
             except (ImportError, ValueError):
@@ -311,7 +335,18 @@ class IntegrityVerifier:
                 if self._manifest and key in self._manifest.get("functions", {}):
                     expected = self._manifest["functions"][key]
 
-                passed = expected is None or expected == actual_hash
+                # Same fail-closed semantics as the file-hash branch:
+                # missing entries in a configured manifest are
+                # failures, not passes.
+                if self._manifest is None:
+                    passed = True
+                    error: Optional[str] = None
+                elif expected is None:
+                    passed = False
+                    error = "missing manifest entry"
+                else:
+                    passed = expected == actual_hash
+                    error = "bytecode mismatch" if not passed else None
                 if not passed:
                     report.passed = False
 
@@ -322,6 +357,7 @@ class IntegrityVerifier:
                         expected_hash=expected,
                         actual_hash=actual_hash,
                         passed=passed,
+                        error=error,
                     )
                 )
             except ImportError:

--- a/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
+++ b/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
@@ -190,6 +190,96 @@ class TestIntegrityVerifier:
 
         assert "nonexistent.module.xyz" in report.modules_missing
 
+    def test_corrupt_manifest_raises_on_construction(self, tmp_path: Path):
+        """Regression: a corrupt manifest used to be caught silently and
+        the verifier proceeded with self._manifest = None, which made
+        every "missing entry" check pass — so a deliberately-broken
+        manifest unlocked the same default-pass path as having no
+        manifest at all. Now construction raises ValueError.
+        """
+        import pytest
+
+        manifest_path = tmp_path / "integrity.json"
+        manifest_path.write_text("{not valid json", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="corrupt"):
+            IntegrityVerifier(
+                manifest_path=str(manifest_path),
+                modules=["agent_compliance.integrity"],
+            )
+
+    def test_missing_manifest_entry_fails_closed(self, tmp_path: Path):
+        """Regression: when a manifest is configured, modules whose
+        entry was deleted from the manifest used to pass (``expected
+        is None`` short-circuited the comparison to True). An attacker
+        who could write to the manifest could simply delete the entry
+        for the module they had tampered with. Now: missing entry =
+        failure when a manifest is in use.
+        """
+        manifest_path = str(tmp_path / "integrity.json")
+        IntegrityVerifier(
+            modules=["agent_compliance.integrity"],
+        ).generate_manifest(manifest_path)
+
+        # Delete the entry an attacker would have tampered with.
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest = json.load(f)
+        manifest["files"] = {}
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        verifier = IntegrityVerifier(
+            manifest_path=manifest_path,
+            modules=["agent_compliance.integrity"],
+        )
+        report = verifier.verify()
+
+        assert report.passed is False
+        failures = [r for r in report.file_results if not r.passed]
+        assert any(r.error == "missing manifest entry" for r in failures)
+
+    def test_missing_function_entry_fails_closed(self, tmp_path: Path):
+        """Same fail-closed rule for the critical-function bytecode
+        check: a manifest that omits a covered function's entry
+        must fail rather than default-pass.
+        """
+        manifest_path = str(tmp_path / "integrity.json")
+        # Pick a real function from the integrity module itself so we
+        # can resolve and hash it without dragging in extra modules.
+        critical = [("agent_compliance.integrity", "_hash_function_bytecode")]
+
+        IntegrityVerifier(
+            modules=["agent_compliance.integrity"],
+            critical_functions=critical,
+        ).generate_manifest(manifest_path)
+
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest = json.load(f)
+        manifest["functions"] = {}
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f)
+
+        verifier = IntegrityVerifier(
+            manifest_path=manifest_path,
+            modules=["agent_compliance.integrity"],
+            critical_functions=critical,
+        )
+        report = verifier.verify()
+
+        assert report.passed is False
+        function_failures = [r for r in report.function_results if not r.passed]
+        assert any(r.error == "missing manifest entry" for r in function_failures)
+
+    def test_no_manifest_keeps_baseline_mode(self):
+        """Without any manifest configured, verification should still
+        produce a passing baseline report (no expected hashes to
+        compare against). The fail-closed change applies only when a
+        manifest IS supplied.
+        """
+        verifier = IntegrityVerifier(modules=["agent_compliance.integrity"])
+        report = verifier.verify()
+        assert report.passed is True
+
     def test_generate_manifest(self, tmp_path: Path):
         manifest_path = str(tmp_path / "integrity.json")
         verifier = IntegrityVerifier(


### PR DESCRIPTION
## Summary

Two related fail-open paths in `IntegrityVerifier` — both reduce a manifest defect to "every check passes." Bundled because they're the same security property: **manifest defects must fail closed.**

### #10 — Missing entry in a configured manifest

`agent_compliance/integrity.py:259` — the pass rule was:

```python
passed = expected is None or expected == actual_hash
```

An attacker who could write to the manifest could simply **delete the entry** for the module they had tampered with — `expected` becomes `None`, the comparison short-circuits to True, the tampered file "verifies" without any actual hash comparison. Same defect on the critical-function bytecode branch a few lines down.

### #11 — Corrupt manifest

`agent_compliance/integrity.py:228-236` — the constructor caught `json.JSONDecodeError`, logged a warning, and proceeded with `self._manifest = None`. That unlocked the same default-pass path as having no manifest at all, so an attacker who could deliberately corrupt the manifest got the same outcome as deleting it: clean integrity report, every covered module passes.

## Fix

**Corrupt manifest:** raise `ValueError` from the constructor. Refusing to start with an unparseable manifest is the only safe default.

**Missing entry:** treat the manifest's presence as a contract that every covered module/function MUST have an entry. When a manifest IS configured, a missing entry produces a failure (`error="missing manifest entry"`). Without any manifest configured, baseline mode still produces a passing report — the fail-closed semantics only apply when a manifest is actually in use.

The existing `passed = expected is None or expected == actual_hash` rule is replaced by an explicit three-branch decision that distinguishes:

- no manifest in use → pass (baseline mode)
- manifest in use, no entry for this item → fail (missing entry)
- manifest in use, entry present → pass iff hashes match

## Tests

Four new regression tests in `TestIntegrityVerifier`:

- `test_corrupt_manifest_raises_on_construction` — construction with a syntactically-broken `integrity.json` raises `ValueError("...corrupt...")`.
- `test_missing_manifest_entry_fails_closed` — generate a valid manifest, delete `manifest["files"]`, verify reports `passed=False` with `error="missing manifest entry"`.
- `test_missing_function_entry_fails_closed` — same for the critical-function branch.
- `test_no_manifest_keeps_baseline_mode` — without any manifest, verification still passes (fail-closed only applies to configured manifests).

```
tests/test_integrity_and_verify.py — 40 passed in 0.70s
```

## Test plan

- [x] All 40 `test_integrity_and_verify.py` tests pass on Python 3.14.
- [x] Corrupt manifest is no longer silently accepted.
- [x] Deleted manifest entries no longer pass verification.
- [x] No-manifest baseline mode still works.
- [x] Both file-hash and function-bytecode branches share the same fail-closed semantics.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)