### PR TITLE
fix(verify): only count default-action as deny semantics, not per-rule deny (HIGH Governance #12)

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/verify.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/verify.py
@@ -422,43 +422,45 @@ def _load_policy_documents(policy_paths: list[Path]) -> list[dict[str, Any]]:
 
 
 def _policy_has_deny_semantics(documents: list[dict[str, Any]]) -> bool:
+    """Return True iff the policy is *default-deny*.
+
+    Default-deny means: in the absence of an explicit-allow rule
+    matching the request, the policy denies. This is a property of
+    the policy's *default*, not of whether any individual rule emits
+    a deny verdict — an allow-default policy with one targeted
+    ``action: deny`` exception (e.g. "block tool X") is still an
+    allow-default policy, and was previously misclassified as having
+    deny semantics because the rules loop returned True on the first
+    rule whose action token matched ``deny``.
+
+    The check is intentionally narrow: only the document-level and
+    ``defaults``-block default-action keys are inspected, with exact
+    case-insensitive equality. ``default_action: "deny-list-loaded"``
+    does not match because the comparison is ``==``, not ``in``.
+    """
     for document in documents:
         if bool(document.get("deny_by_default")):
             return True
 
         for key in ("default_action", "action", "effect"):
             value = document.get(key)
-            if isinstance(value, str) and value.lower() == "deny":
+            if isinstance(value, str) and value.strip().lower() == "deny":
                 return True
 
         for key in ("defaults", "default", "policy_defaults"):
             defaults = document.get(key)
 
-            if isinstance(defaults, str) and defaults.lower() == "deny":
+            if isinstance(defaults, str) and defaults.strip().lower() == "deny":
                 return True
 
             if isinstance(defaults, dict):
                 for nested_key in ("action", "effect", "default_action"):
                     nested_value = defaults.get(nested_key)
-                    if isinstance(nested_value, str) and nested_value.lower() == "deny":
+                    if (
+                        isinstance(nested_value, str)
+                        and nested_value.strip().lower() == "deny"
+                    ):
                         return True
-
-        for key in ("rules", "policies", "statements"):
-            rules = document.get(key)
-            if not isinstance(rules, list):
-                continue
-
-            for rule in rules:
-                if not isinstance(rule, dict):
-                    continue
-
-                for nested_key in ("action", "effect", "default_action"):
-                    nested_value = rule.get(nested_key)
-                    if isinstance(nested_value, str) and nested_value.lower() == "deny":
-                        return True
-
-                if bool(rule.get("deny")):
-                    return True
 
     return False
 

--- a/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
+++ b/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
@@ -377,6 +377,89 @@ rules:
             for check in attestation.evidence_checks
         )
 
+    def test_verify_evidence_allow_default_with_deny_rule_is_not_deny_semantics(
+        self, tmp_path: Path,
+    ):
+        """Regression: previously _policy_has_deny_semantics returned
+        True for any policy that contained a single rule whose action
+        token was "deny", regardless of the default. An allow-default
+        policy with one targeted ``deny`` exception is NOT
+        deny-default — it allows everything except the one exception.
+        """
+        evidence_path = _write_runtime_evidence(
+            tmp_path,
+            policy_body="""
+defaults:
+  action: allow
+rules:
+  - name: block-shell
+    action: deny
+    tool: shell_exec
+  - name: allow-crm
+    action: allow
+    tool: crm_lookup
+""".strip(),
+        )
+        verifier = GovernanceVerifier(controls=_CUSTOM_VERIFY_CONTROLS)
+        attestation = verifier.verify_evidence(evidence_path, strict=True)
+
+        assert any(
+            check.check_id == "deny-semantics" and check.status == "fail"
+            for check in attestation.evidence_checks
+        ), (
+            "allow-default policy with a single deny rule should NOT be "
+            "classified as having deny semantics"
+        )
+
+    def test_verify_evidence_default_action_deny_passes(self, tmp_path: Path):
+        """A real default-deny policy still passes the deny-semantics
+        check after the fix.
+        """
+        evidence_path = _write_runtime_evidence(
+            tmp_path,
+            policy_body="""
+default_action: deny
+rules:
+  - name: allow-crm
+    action: allow
+    tool: crm_lookup
+""".strip(),
+        )
+        verifier = GovernanceVerifier(controls=_CUSTOM_VERIFY_CONTROLS)
+        attestation = verifier.verify_evidence(evidence_path, strict=True)
+
+        assert any(
+            check.check_id == "deny-semantics" and check.status == "pass"
+            for check in attestation.evidence_checks
+        )
+
+    def test_verify_evidence_deny_substring_in_default_action_value_does_not_match(
+        self, tmp_path: Path,
+    ):
+        """``default_action: "deny-list-loaded"`` is a non-standard
+        value that contains the substring "deny" but is not an actual
+        deny verdict. Equality (``==``) is the correct comparator;
+        substring (``in``) would over-match. Confirms the comparator
+        stays exact even if a future refactor reaches for str.lower().
+        """
+        evidence_path = _write_runtime_evidence(
+            tmp_path,
+            policy_body="""
+default_action: deny-list-loaded
+rules:
+  - name: allow-crm
+    action: allow
+    tool: crm_lookup
+""".strip(),
+        )
+        verifier = GovernanceVerifier(controls=_CUSTOM_VERIFY_CONTROLS)
+        attestation = verifier.verify_evidence(evidence_path, strict=True)
+
+        assert any(
+            check.check_id == "deny-semantics" and check.status == "fail"
+            for check in attestation.evidence_checks
+        )
+
     def test_verify_evidence_strict_fails_without_identity(self, tmp_path: Path):
         evidence_path = _write_runtime_evidence(tmp_path, identity_enabled=False)
         verifier = GovernanceVerifier(controls=_CUSTOM_VERIFY_CONTROLS)


### PR DESCRIPTION
## Summary

`_policy_has_deny_semantics` (`agent_compliance/verify.py:424-463`) returned True for any policy that contained a single rule whose `action` (or `effect` or `default_action`) token was `"deny"`, regardless of what the policy's actual default action was.

An allow-default policy with one targeted deny exception — e.g. `defaults: {action: allow}` plus `rules: [{action: deny, tool: shell_exec}]` — was misclassified as having deny semantics. The function elevated "any deny rule anywhere" to "policy is deny-default," which is the opposite of what those policies actually do.

(REVIEW.md framed this as a substring-match issue — the actual code uses `value.lower() == "deny"`, not substring — but the per-rule scan has the same effect: a policy containing the right token in the wrong place gets misclassified.)

## Fix

Restrict the check to the document-level default-action keys and the `defaults` block. Drop the `rules` / `policies` / `statements` scan entirely — individual `deny` rules are exceptions, not defaults, and their presence does not change the policy's default verdict.

Comparison stays exact (`value.strip().lower() == "deny"`) so non-standard values like `default_action: deny-list-loaded` do not match. The added `strip()` defends against `" deny "` whitespace slop that YAML can produce.

The function's docstring is updated to make the narrowed contract explicit: it checks for *default-deny*, not "any deny anywhere."

## Tests

Three new regression tests in `TestGovernanceVerifier`:

- `test_verify_evidence_allow_default_with_deny_rule_is_not_deny_semantics` — `defaults: {action: allow}` + a targeted `action: deny` rule no longer passes the deny-semantics check.
- `test_verify_evidence_default_action_deny_passes` — `default_action: deny` (with an allow exception) still passes — confirms the positive case isn't regressed.
- `test_verify_evidence_deny_substring_in_default_action_value_does_not_match` — `default_action: "deny-list-loaded"` does not match. Belt-and-braces against a future refactor that swaps `==` for `in`.

```
tests/test_integrity_and_verify.py — 39 passed in 0.70s
```

## Test plan

- [x] All 39 `test_integrity_and_verify.py` tests pass on Python 3.14.
- [x] Allow-default + per-rule deny no longer misclassified as deny-default.
- [x] Real default-deny policies still pass.
- [x] `deny-list-loaded`-style substring confusion is impossible.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)