### PR TITLE
fix(lint-policy): track every prior action per condition key, JSON-canonical (HIGH Governance #13)

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/lint_policy.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/lint_policy.py
@@ -10,6 +10,7 @@ empty rule lists, and invalid priority values.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -205,8 +206,13 @@ def _lint_rules(
     result: LintResult,
 ) -> None:
     """Validate individual rules and detect conflicts."""
-    # Track (field, operator, value) -> action for conflict detection
-    seen: dict[tuple[str, str, str], str] = {}
+    # Track every (field, operator, value) -> [(rule_name, action), ...]
+    # so conflict detection sees every prior rule against the same key,
+    # not just the first one. The previous implementation stored only
+    # the first action per key and skipped seen[key] = action after a
+    # conflict was reported, so a third rule against the same key was
+    # silently swallowed.
+    seen: dict[tuple[str, str, str], list[tuple[str, str]]] = {}
 
     for idx, rule in enumerate(rules):
         if not isinstance(rule, dict):
@@ -298,25 +304,42 @@ def _lint_rules(
         # ── Conflict detection ────────────────────────────────
         if action in ("allow", "deny") and all_conditions:
             for cond in all_conditions:
+                # JSON-canonical form for the value key — collapses
+                # equivalent dicts/lists with reordered members and
+                # preserves int-vs-string distinctions that str()
+                # would lose. Falls back to repr() for objects that
+                # aren't JSON-serialisable (rare in YAML, but defended
+                # against rather than crashing).
+                try:
+                    canonical_value = json.dumps(
+                        cond.get("value"), sort_keys=True, default=str
+                    )
+                except (TypeError, ValueError):
+                    canonical_value = repr(cond.get("value"))
+
                 key = (
                     cond.get("field", ""),
                     cond.get("operator", ""),
-                    str(cond.get("value", "")),
+                    canonical_value,
                 )
-                prev_action = seen.get(key)
-                if prev_action is not None and prev_action != action:
-                    result.messages.append(
-                        LintMessage(
-                            "warning",
-                            f"Rule '{rule_name}': conflicts with a prior rule "
-                            f"— same condition has both '{prev_action}' and "
-                            f"'{action}'",
-                            filepath,
-                            rule_line,
+                history = seen.setdefault(key, [])
+                # Compare against EVERY prior rule that targets this
+                # key so the third, fourth, ... rule each surface as
+                # individual conflict warnings rather than being
+                # silently swallowed.
+                for prior_name, prior_action in history:
+                    if prior_action != action:
+                        result.messages.append(
+                            LintMessage(
+                                "warning",
+                                f"Rule '{rule_name}': conflicts with rule "
+                                f"'{prior_name}' — same condition has both "
+                                f"'{prior_action}' and '{action}'",
+                                filepath,
+                                rule_line,
+                            )
                         )
-                    )
-                elif prev_action is None:
-                    seen[key] = action
+                history.append((rule_name, action))
 
 
 def lint_path(path: str | Path) -> LintResult:

--- a/agent-governance-python/agent-compliance/tests/test_lint_policy.py
+++ b/agent-governance-python/agent-compliance/tests/test_lint_policy.py
@@ -226,6 +226,79 @@ class TestLintFileConflictingRules:
         result = lint_file(p)
         assert any("conflicts" in m.message.lower() for m in result.warnings)
 
+    def test_third_rule_against_same_key_not_silently_swallowed(self, tmp_path):
+        """Regression: previously seen[key] = action only when no
+        prior action existed. Once the first conflict was reported,
+        further rules against the same key were compared only against
+        the FIRST action and never recorded themselves, so the third
+        rule and beyond were silently dropped from conflict reporting.
+        Fix: track every (rule_name, action) seen for a key.
+        """
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: rule-a
+                condition: {field: tool_name, operator: eq, value: read_file}
+                action: allow
+              - name: rule-b
+                condition: {field: tool_name, operator: eq, value: read_file}
+                action: deny
+              - name: rule-c
+                condition: {field: tool_name, operator: eq, value: read_file}
+                action: allow
+        """)
+        result = lint_file(p)
+        conflict_msgs = [m for m in result.warnings if "conflicts" in m.message.lower()]
+        # rule-b conflicts with rule-a; rule-c conflicts with rule-b.
+        # Both must surface — not just the first.
+        assert any("rule-b" in m.message and "rule-a" in m.message for m in conflict_msgs)
+        assert any("rule-c" in m.message and "rule-b" in m.message for m in conflict_msgs)
+
+    def test_canonical_value_form_collapses_equivalent_dicts(self, tmp_path):
+        """Two conditions that differ only in dict key order in the
+        ``value`` field should be treated as equivalent for conflict
+        detection — JSON-canonical form collapses them.
+        """
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: allow-x
+                condition:
+                  field: metadata
+                  operator: eq
+                  value: {a: 1, b: 2}
+                action: allow
+              - name: deny-x
+                condition:
+                  field: metadata
+                  operator: eq
+                  value: {b: 2, a: 1}
+                action: deny
+        """)
+        result = lint_file(p)
+        assert any("conflicts" in m.message.lower() for m in result.warnings)
+
+    def test_int_vs_string_value_distinguished(self, tmp_path):
+        """A condition on the integer 1 vs the string "1" should NOT
+        conflict — JSON-canonical form preserves the type distinction
+        that the prior str() approach erased.
+        """
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: test
+            rules:
+              - name: allow-int
+                condition: {field: count, operator: eq, value: 1}
+                action: allow
+              - name: deny-string
+                condition: {field: count, operator: eq, value: "1"}
+                action: deny
+        """)
+        result = lint_file(p)
+        assert not any("conflicts" in m.message.lower() for m in result.warnings)
+
 
 class TestLintFileDeprecatedFields:
     def test_deprecated_top_level(self, tmp_path):


### PR DESCRIPTION
## Summary

`_lint_rules` (`agent_compliance/lint_policy.py:298-319`) used a dict keyed on `(field, operator, str(value))` to spot rules that conflict with a prior rule on the same condition. Two defects:

1. **Third+ rule silently swallowed.** `seen[key] = action` was only assigned on the `elif prev_action is None` branch (i.e. the first time a key was seen). Once a conflict was reported, the new action was *not* recorded. A third rule against the same key was compared against the very first action only. If the third rule matched the first, no warning fired — it was silently swallowed despite being part of the conflict cluster.

2. **`str(value)` keying.** Collapses int `1` / string `"1"` to the same key (false conflict) and treats `{"a":1,"b":2}` and `{"b":2,"a":1}` as different keys (missed conflict).

## Fix

Switch the `seen` map to `dict[key, list[(rule_name, action)]]` and compare every new rule against the full history of prior rules at that key. Each prior rule with a different action surfaces as its own warning, naming the specific conflicting rule.

The value component is now `json.dumps(value, sort_keys=True, default=str)` which canonicalises dict ordering and preserves the int/string distinction. Falls back to `repr(value)` if the value isn't JSON-serialisable (rare in YAML, but defended against rather than crashing).

Warning text now names the prior rule (`"conflicts with rule 'rule-a'"`) instead of the previous generic `"conflicts with a prior rule"` — the existing test only checked for `"conflicts"` substring so it still passes.

## Tests

Three new regression tests in `TestLintFileConflictingRules`:

- `test_third_rule_against_same_key_not_silently_swallowed` — three rules against the same condition (allow / deny / allow). Asserts both `rule-b vs rule-a` AND `rule-c vs rule-b` conflicts surface.
- `test_canonical_value_form_collapses_equivalent_dicts` — `{a: 1, b: 2}` vs `{b: 2, a: 1}` is detected as a conflict.
- `test_int_vs_string_value_distinguished` — int `1` vs string `"1"` is NOT a conflict (preserved type distinction).

```
tests/test_lint_policy.py — 37 passed in 0.54s
```

(34 existing + 3 new.)

## Test plan

- [x] All 37 `test_lint_policy.py` tests pass on Python 3.14.
- [x] Third+ rules in a conflict cluster surface independently.
- [x] Canonical-form key collapses equivalent dicts and preserves int/str types.
- [x] No new false-positive conflicts on previously-clean rule sets.

This closes the Python Governance HIGH section (13/13 items).

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)