### PR TITLE
fix(saga): retry via reset_for_retry, not direct state mutation (HIGH Isolation #2)

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
@@ -127,9 +127,11 @@ class SagaOrchestrator:
                 step.error = str(last_error)
                 step.transition(StepState.FAILED)
                 if attempt < attempts - 1:
-                    # Reset to PENDING for retry
-                    step.state = StepState.PENDING
-                    step.error = None
+                    # Move FAILED → PENDING through the state table,
+                    # not by direct mutation. Bypassing transition()
+                    # would skip the validity check and the timestamp
+                    # bookkeeping.
+                    step.reset_for_retry()
                     await asyncio.sleep(
                         self.DEFAULT_RETRY_DELAY_SECONDS * (attempt + 1)
                     )
@@ -138,8 +140,7 @@ class SagaOrchestrator:
                 step.error = str(e)
                 step.transition(StepState.FAILED)
                 if attempt < attempts - 1:
-                    step.state = StepState.PENDING
-                    step.error = None
+                    step.reset_for_retry()
                     await asyncio.sleep(
                         self.DEFAULT_RETRY_DELAY_SECONDS * (attempt + 1)
                     )

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/state_machine.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/state_machine.py
@@ -45,7 +45,11 @@ STEP_TRANSITIONS: dict[StepState, set[StepState]] = {
     StepState.COMPENSATING: {StepState.COMPENSATED, StepState.COMPENSATION_FAILED},
     StepState.COMPENSATED: set(),
     StepState.COMPENSATION_FAILED: set(),
-    StepState.FAILED: set(),
+    # FAILED → PENDING is allowed only via reset_for_retry, which is
+    # the documented retry path. The transition table mirrors that
+    # explicitly so reset_for_retry can call transition() instead of
+    # mutating state directly and bypassing the table.
+    StepState.FAILED: {StepState.PENDING},
 }
 
 SAGA_TRANSITIONS: dict[SagaState, set[SagaState]] = {
@@ -95,6 +99,22 @@ class SagaStep:
             StepState.FAILED,
         ):
             self.completed_at = now
+
+    def reset_for_retry(self) -> None:
+        """Move a FAILED step back to PENDING for another execution attempt.
+
+        Goes through ``transition()`` rather than mutating ``state``
+        directly so the move is recorded in the state table. Also
+        clears the per-attempt error and completion timestamp so the
+        next attempt starts from a clean slate.
+
+        Raises:
+            SagaStateError: If the step is not currently in FAILED
+                state. Retries are only valid from FAILED.
+        """
+        self.transition(StepState.PENDING)
+        self.error = None
+        self.completed_at = None
 
 
 @dataclass

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_saga.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_saga.py
@@ -37,6 +37,40 @@ class TestStepStateMachine:
         step.transition(StepState.COMPENSATED)
         assert step.state == StepState.COMPENSATED
 
+    def test_reset_for_retry_moves_failed_back_to_pending(self):
+        """Regression: the orchestrator's retry path used to reach into
+        ``step.state = StepState.PENDING`` directly, bypassing the
+        STEP_TRANSITIONS table entirely. Now FAILED → PENDING is a
+        documented edge and reset_for_retry() funnels through
+        transition() so the state machine remains the single source
+        of truth.
+        """
+        step = SagaStep(step_id="s1", action_id="a1", agent_did="did:a", execute_api="/api")
+        step.transition(StepState.EXECUTING)
+        step.error = "boom"
+        step.transition(StepState.FAILED)
+
+        step.reset_for_retry()
+
+        assert step.state == StepState.PENDING
+        assert step.error is None
+        assert step.completed_at is None
+
+    def test_reset_for_retry_rejects_non_failed_state(self):
+        """reset_for_retry must NOT silently allow retries from
+        arbitrary states. The state-table guarantee is FAILED →
+        PENDING only.
+        """
+        step = SagaStep(step_id="s1", action_id="a1", agent_did="did:a", execute_api="/api")
+        # PENDING → PENDING is not a valid edge; reset_for_retry must reject.
+        with pytest.raises(SagaStateError, match="Invalid step transition"):
+            step.reset_for_retry()
+
+        step.transition(StepState.EXECUTING)
+        step.transition(StepState.COMMITTED)
+        with pytest.raises(SagaStateError, match="Invalid step transition"):
+            step.reset_for_retry()
+
 
 class TestSagaStateMachine:
     def test_valid_saga_transitions(self):


### PR DESCRIPTION
## Summary

`SagaOrchestrator.execute` (`agent-hypervisor/src/hypervisor/saga/orchestrator.py:131,141`) recycled a FAILED step for another attempt by writing `step.state = StepState.PENDING` directly:

```python
step.transition(StepState.FAILED)
if attempt < attempts - 1:
    step.state = StepState.PENDING       # ← bypasses transition()
    step.error = None
```

That bypassed two things:

1. **STEP_TRANSITIONS table.** The `FAILED → PENDING` edge was never listed in the state-machine table. Any reader of the state machine — humans, external runners, future async retry workers — had no way to know retries were a documented transition. New code that respects the table would refuse exactly what the orchestrator was doing.
2. **`transition()` side effects.** `completed_at` (and other timestamp bookkeeping inside `transition()`) was not cleared, so a step about to run again carried stale completion metadata.

## Fix

- Add an explicit `StepState.FAILED → {StepState.PENDING}` edge to `STEP_TRANSITIONS`.
- Add `SagaStep.reset_for_retry()` that funnels through `transition(StepState.PENDING)` and clears `self.error` and `self.completed_at`.
- Update both retry sites in the orchestrator (TimeoutError and generic Exception branches) to call `step.reset_for_retry()` instead of the direct mutation.

The state machine is now the single source of truth: every state change goes through `transition()`, every reader can trust the `STEP_TRANSITIONS` table.

## Tests

Two new regression tests in `TestStepStateMachine`:

- `test_reset_for_retry_moves_failed_back_to_pending` — sets up FAILED with an error message, calls `reset_for_retry()`, asserts `state == PENDING`, `error is None`, `completed_at is None`.
- `test_reset_for_retry_rejects_non_failed_state` — calling `reset_for_retry()` from PENDING or COMMITTED raises `SagaStateError`.

```
tests/unit/test_saga.py — 15 passed in 0.29s
tests/unit/test_saga_improvements.py — 18 passed, 12 skipped
```

## Test plan

- [x] All 33 saga tests pass on Python 3.14.
- [x] FAILED → PENDING is now a documented edge in STEP_TRANSITIONS.
- [x] Retries clear stale `completed_at` and `error`.
- [x] Non-FAILED states still cannot reset.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)