### PR TITLE
fix(docker-provider): keep destroy_session entry until container is removed (HIGH Isolation #6)

### DIFF
--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -465,32 +465,69 @@ class DockerSandboxProvider(SandboxProvider):
 
     def destroy_session(self, agent_id: str, session_id: str) -> None:
         key = (agent_id, session_id)
+        # Look up the container without popping — we only remove it
+        # from the registry once both Docker calls succeed. The
+        # previous version popped first and left a leaked container
+        # with no recovery handle if both stop() and remove() failed.
         with self._state_lock:
-            container = self._containers.pop(key, None)
-            self._evaluators.pop(key, None)
-            self._session_configs.pop(key, None)
+            container = self._containers.get(key)
 
-        if container is not None:
-            try:
-                container.stop(timeout=5)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to stop container for agent '%s' "
-                    "session '%s': %s",
-                    agent_id,
-                    session_id,
-                    exc,
-                )
-            try:
-                container.remove(force=True)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to remove container for agent '%s' "
-                    "session '%s': %s",
-                    agent_id,
-                    session_id,
-                    exc,
-                )
+        if container is None:
+            # No container to destroy. Auxiliary per-session state may
+            # still exist if create_session failed mid-way, so clean
+            # those up unconditionally.
+            with self._state_lock:
+                self._evaluators.pop(key, None)
+                self._session_configs.pop(key, None)
+            return
+
+        stop_ok = False
+        remove_ok = False
+        try:
+            container.stop(timeout=5)
+            stop_ok = True
+        except Exception as exc:
+            logger.warning(
+                "Failed to stop container for agent '%s' session '%s': %s",
+                agent_id,
+                session_id,
+                exc,
+            )
+        try:
+            container.remove(force=True)
+            remove_ok = True
+        except Exception as exc:
+            logger.warning(
+                "Failed to remove container for agent '%s' session '%s': %s",
+                agent_id,
+                session_id,
+                exc,
+            )
+
+        if remove_ok:
+            # remove(force=True) actually deletes the container from
+            # Docker (and kills it first if needed), so the container
+            # is gone regardless of whether stop() succeeded. Drop
+            # the registry entry and all per-session bookkeeping.
+            with self._state_lock:
+                self._containers.pop(key, None)
+                self._evaluators.pop(key, None)
+                self._session_configs.pop(key, None)
+        else:
+            # remove() failed: the container is still alive in Docker
+            # somewhere. Keep the entry so a follow-up
+            # destroy_session() can find it and retry, instead of
+            # leaking the container with no recovery handle.
+            logger.error(
+                "destroy_session: agent='%s' session='%s' could not be "
+                "removed (stop_ok=%s remove_ok=%s); container retained in "
+                "registry for retry. Call destroy_session again once the "
+                "underlying Docker issue is resolved.",
+                agent_id,
+                session_id,
+                stop_ok,
+                remove_ok,
+            )
 
     def is_available(self) -> bool:
         return self._available

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -631,6 +631,52 @@ class TestDockerDestroySession:
         docker_provider.destroy_session("a1", h.session_id)
         docker_provider.destroy_session("a1", h.session_id)
 
+    def test_remove_failure_keeps_entry_for_retry(self, docker_provider):
+        """Regression: previously the container was popped from the
+        registry BEFORE stop()/remove() were called, so if both Docker
+        calls failed there was no handle left to retry. Now the entry
+        is retained when remove() fails, and a follow-up destroy_session
+        can complete the cleanup once the underlying Docker issue
+        clears.
+        """
+        h = docker_provider.create_session("a1")
+        c = docker_provider._containers[(h.agent_id, h.session_id)]
+        c.stop.side_effect = Exception("daemon unreachable")
+        c.remove.side_effect = Exception("daemon unreachable")
+
+        docker_provider.destroy_session("a1", h.session_id)
+
+        # Entry must be retained so the caller can retry.
+        assert ("a1", h.session_id) in docker_provider._containers
+
+        # Once Docker comes back, retry succeeds and the entry is
+        # finally removed.
+        c.stop.side_effect = None
+        c.remove.side_effect = None
+        docker_provider.destroy_session("a1", h.session_id)
+        assert ("a1", h.session_id) not in docker_provider._containers
+
+    def test_remove_failure_keeps_evaluator_and_config(self, docker_provider):
+        """When destroy_session fails to remove the container, it must
+        also keep the evaluator and session config so a retry has the
+        full per-session state to operate on.
+        """
+        try:
+            from agent_os.policies.schema import PolicyDocument
+        except ImportError:
+            pytest.skip("agent-os-kernel not installed")
+
+        doc = PolicyDocument(name="test")
+        h = docker_provider.create_session("a1", policy=doc)
+        c = docker_provider._containers[(h.agent_id, h.session_id)]
+        c.stop.side_effect = Exception("daemon unreachable")
+        c.remove.side_effect = Exception("daemon unreachable")
+
+        docker_provider.destroy_session("a1", h.session_id)
+
+        assert ("a1", h.session_id) in docker_provider._containers
+        assert ("a1", h.session_id) in docker_provider._evaluators
+
 
 # -- get_session_status ----------------------------------------------------
 


### PR DESCRIPTION
## Summary

`DockerSandboxProvider.destroy_session` (`agent-sandbox/src/agent_sandbox/docker_provider/provider.py:474-493`) popped the container from `self._containers` **before** calling `container.stop()` / `container.remove()`:

```python
with self._state_lock:
    container = self._containers.pop(key, None)   # ← popped first
    self._evaluators.pop(key, None)
    ...

if container is not None:
    try: container.stop(timeout=5)
    except: ...   # logged, swallowed
    try: container.remove(force=True)
    except: ...   # logged, swallowed
```

If both Docker calls failed (daemon down, network partition, transient API hiccup), the container kept running in Docker with **no handle left in our registry**. A follow-up `destroy_session` call could not find it. The session was effectively leaked, with cleanup possible only by manual `docker rm` against the container name.

## Fix

Look up the container without popping. Run `stop()` / `remove()` outside the lock as before. Pop the registry entry only when `remove()` succeeds — `remove(force=True)` actually deletes the container from Docker (and kills it first if needed), so its success is the load-bearing signal that the container is gone.

When `remove()` fails, log at ERROR and retain every per-session entry (`_containers`, `_evaluators`, `_session_configs`) so a retry call has the full state to operate on.

`stop()` failure alone does not block the cleanup: it's best-effort graceful shutdown; if `remove(force=True)` later succeeds the container is gone regardless. The existing `test_tolerates_stop_error` test confirms that behaviour and still passes unchanged.

## Tests

Two new regression tests in `TestDockerDestroySession`:

- `test_remove_failure_keeps_entry_for_retry` — sets both `stop.side_effect` and `remove.side_effect` to raise, calls `destroy_session`, asserts the registry entry is retained. Then clears the side effects and calls `destroy_session` again — confirms the retry succeeds and the entry is cleaned up.
- `test_remove_failure_keeps_evaluator_and_config` — same scenario with a policy evaluator attached; asserts both `_containers` and `_evaluators` entries are retained.

```
tests/test_docker_sandbox.py::TestDockerDestroySession — 6 passed, 2 skipped
```

## Test plan

- [x] All 6 `TestDockerDestroySession` tests pass on Python 3.14.
- [x] `stop` failure alone still cleans up (existing test).
- [x] `remove` failure now retains the entry for retry (new test).
- [x] Retry after Docker recovers completes the cleanup.
- [x] Auxiliary state (evaluator, session config) is retained on retry.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)