### PR TITLE
fix(cost-guard): add atomic check_and_charge to close check/record race (HIGH Isolation #8)

### DIFF
--- a/agent-governance-python/agent-sre/src/agent_sre/cost/guard.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/cost/guard.py
@@ -188,6 +188,13 @@ class CostGuard:
         """Check if a task should be allowed to proceed.
 
         Returns (allowed, reason).
+
+        WARNING — this is an advisory check. ``check_task`` does NOT
+        reserve budget, so two concurrent callers that both pass the
+        check can both proceed and overshoot the limit. For
+        budget-critical paths use :meth:`check_and_charge` instead,
+        which atomically combines the check with the cost reservation
+        under a single lock.
         """
         if not math.isfinite(estimated_cost):
             return False, f"Invalid estimated cost: {estimated_cost}"
@@ -195,33 +202,79 @@ class CostGuard:
             return False, f"Invalid negative estimated cost: {estimated_cost}"
 
         with self._lock:
-            if self._org_killed:
-                return False, "Organization budget exhausted"
+            allowed, reason = self._check_locked(agent_id, estimated_cost)
+            return allowed, reason
 
-            budget = self._get_or_create_budget_locked(agent_id)
+    def _check_locked(
+        self, agent_id: str, estimated_cost: float
+    ) -> tuple[bool, str]:
+        """Caller must hold ``self._lock``. Pure check; no mutation."""
+        if self._org_killed:
+            return False, "Organization budget exhausted"
 
-            if budget.killed:
-                return False, "Agent killed — budget exhausted"
+        budget = self._get_or_create_budget_locked(agent_id)
 
-            if budget.throttled:
-                return False, "Agent throttled — approaching daily limit"
+        if budget.killed:
+            return False, "Agent killed — budget exhausted"
 
-            if estimated_cost > self.per_task_limit:
-                return False, f"Estimated cost ${estimated_cost:.2f} exceeds per-task limit ${self.per_task_limit:.2f}"
+        if budget.throttled:
+            return False, "Agent throttled — approaching daily limit"
 
-            if budget.spent_today_usd + estimated_cost > budget.daily_limit_usd:
-                remaining = max(0.0, budget.daily_limit_usd - budget.spent_today_usd)
-                return False, f"Would exceed daily budget (${remaining:.2f} remaining)"
+        if estimated_cost > self.per_task_limit:
+            return False, f"Estimated cost ${estimated_cost:.2f} exceeds per-task limit ${self.per_task_limit:.2f}"
 
-            if self.org_monthly_budget > 0:
-                if self._org_spent_month + estimated_cost > self.org_monthly_budget:
-                    org_remaining = max(0.0, self.org_monthly_budget - self._org_spent_month)
-                    return False, (
-                        f"Would exceed org monthly budget "
-                        f"(${org_remaining:.2f} remaining)"
-                    )
+        if budget.spent_today_usd + estimated_cost > budget.daily_limit_usd:
+            remaining = max(0.0, budget.daily_limit_usd - budget.spent_today_usd)
+            return False, f"Would exceed daily budget (${remaining:.2f} remaining)"
 
-            return True, "ok"
+        if self.org_monthly_budget > 0:
+            if self._org_spent_month + estimated_cost > self.org_monthly_budget:
+                org_remaining = max(0.0, self.org_monthly_budget - self._org_spent_month)
+                return False, (
+                    f"Would exceed org monthly budget "
+                    f"(${org_remaining:.2f} remaining)"
+                )
+
+        return True, "ok"
+
+    def check_and_charge(
+        self,
+        agent_id: str,
+        task_id: str,
+        cost_usd: float,
+        breakdown: dict[str, float] | None = None,
+    ) -> tuple[bool, str, list[CostAlert]]:
+        """Atomically check budget and record a cost.
+
+        Combines :meth:`check_task` and :meth:`record_cost` in a
+        single locked transaction so two concurrent callers cannot
+        both pass the check and both record costs that overshoot the
+        limit. This is the correct primitive for any path that needs
+        budget enforcement to actually hold under concurrency.
+
+        Returns:
+            ``(allowed, reason, alerts)``. When ``allowed`` is
+            ``False``, ``alerts`` is an empty list and no cost was
+            recorded; the caller should not proceed with the work.
+            When ``allowed`` is ``True``, the cost has already been
+            charged and any threshold/anomaly alerts are returned.
+        """
+        if not math.isfinite(cost_usd):
+            raise ValueError(f"cost_usd must be finite, got {cost_usd}")
+        if cost_usd < 0:
+            raise ValueError(f"cost_usd must be non-negative, got {cost_usd}")
+
+        with self._lock:
+            allowed, reason = self._check_locked(agent_id, cost_usd)
+            if not allowed:
+                return False, reason, []
+            alerts = self._record_cost_locked(
+                agent_id=agent_id,
+                task_id=task_id,
+                cost_usd=cost_usd,
+                breakdown=breakdown,
+            )
+            return True, reason, alerts
 
     def record_cost(
         self,
@@ -233,12 +286,32 @@ class CostGuard:
         """Record a task cost and check budgets.
 
         Returns any alerts triggered.
+
+        WARNING — this method records cost unconditionally; it does
+        NOT check budgets first. For budget-critical paths use
+        :meth:`check_and_charge`.
         """
         if not math.isfinite(cost_usd):
             raise ValueError(f"cost_usd must be finite, got {cost_usd}")
         if cost_usd < 0:
             raise ValueError(f"cost_usd must be non-negative, got {cost_usd}")
 
+        with self._lock:
+            return self._record_cost_locked(
+                agent_id=agent_id,
+                task_id=task_id,
+                cost_usd=cost_usd,
+                breakdown=breakdown,
+            )
+
+    def _record_cost_locked(
+        self,
+        agent_id: str,
+        task_id: str,
+        cost_usd: float,
+        breakdown: dict[str, float] | None = None,
+    ) -> list[CostAlert]:
+        """Caller must hold ``self._lock``. Recording + alerts only."""
         alerts: list[CostAlert] = []
         record = CostRecord(
             agent_id=agent_id,
@@ -247,7 +320,7 @@ class CostGuard:
             breakdown=breakdown or {},
         )
 
-        with self._lock:
+        if True:  # preserved indent for minimal diff against the prior body
             budget = self._get_or_create_budget_locked(agent_id)
             self._records.append(record)
             self._cost_history.append(cost_usd)

--- a/agent-governance-python/agent-sre/tests/unit/test_cost_hardened.py
+++ b/agent-governance-python/agent-sre/tests/unit/test_cost_hardened.py
@@ -157,6 +157,86 @@ class TestSameAgentConcurrency:
         # Should have hit kill switch
         assert budget.killed is True
 
+    def test_check_and_charge_is_atomic_under_concurrency(self):
+        """Regression: previously check_task and record_cost were two
+        separate locked operations. Two concurrent callers could both
+        pass check_task (each saw spent_today < limit) and then both
+        record_cost (overshooting the limit). check_and_charge fuses
+        them into one locked transaction so this race is closed.
+
+        This test runs many concurrent check_and_charge calls against
+        a daily limit of $10 with $1 charges. Some calls succeed,
+        some are rejected. The total recorded spend MUST never
+        exceed the limit.
+        """
+        from agent_sre.cost.guard import CostGuard
+
+        guard = CostGuard(
+            per_task_limit=5.0,
+            per_agent_daily_limit=10.0,
+            auto_throttle=False,  # disable kill so we can observe limit-only behaviour
+        )
+
+        successes: list[bool] = []
+        errors: list[str] = []
+        results_lock = threading.Lock()
+
+        def attempt() -> None:
+            try:
+                for i in range(20):
+                    allowed, _reason, _alerts = guard.check_and_charge(
+                        "race-agent",
+                        f"t-{threading.current_thread().name}-{i}",
+                        1.0,
+                    )
+                    with results_lock:
+                        successes.append(allowed)
+            except Exception as e:
+                errors.append(str(e))
+
+        threads = [threading.Thread(target=attempt) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        budget = guard.get_budget("race-agent")
+        # Hard invariant: never overshoot the limit, regardless of how
+        # many threads raced through. Pre-fix this could exceed $10.
+        assert budget.spent_today_usd <= 10.0, (
+            f"Overshot daily limit: ${budget.spent_today_usd:.2f} > $10.00 "
+            f"({successes.count(True)} successes)"
+        )
+        # Exactly $10 worth (10 successes at $1) should have been
+        # charged once concurrent check+charge serialises correctly.
+        assert successes.count(True) == 10
+
+    def test_check_and_charge_rejects_when_killed_or_throttled(self):
+        """check_and_charge must surface the same rejection reasons as
+        check_task, and must NOT record cost when rejected.
+        """
+        from agent_sre.cost.guard import CostGuard
+
+        guard = CostGuard(
+            per_task_limit=10.0,
+            per_agent_daily_limit=5.0,
+            auto_throttle=False,
+        )
+
+        # First call burns $5 — fits exactly under the daily limit.
+        allowed, _, _ = guard.check_and_charge("a1", "t1", 5.0)
+        assert allowed is True
+        assert guard.get_budget("a1").spent_today_usd == 5.0
+
+        # Second call would exceed the limit — must be rejected, and
+        # must NOT touch the budget.
+        allowed, reason, alerts = guard.check_and_charge("a1", "t2", 1.0)
+        assert allowed is False
+        assert "exceed" in reason.lower()
+        assert alerts == []
+        assert guard.get_budget("a1").spent_today_usd == 5.0  # unchanged
+
 
 # ---------------------------------------------------------------------------
 # Org Reset After Kill


### PR DESCRIPTION
## Summary

`CostGuard.check_task` (`agent-sre/src/agent_sre/cost/guard.py:182-218`) and `CostGuard.record_cost` (`:247-250`) each take `self._lock` and release it before returning. A budget-critical caller does check → work → record, but those are **two separate locked operations**.

Concurrent callers near the daily limit:

| Time | Thread A                           | Thread B                           | Spent |
|------|------------------------------------|------------------------------------|-------|
| t1   | `check_task("a1", $5)` → True (spent=$0, room=$10) | …                            | $0    |
| t2   | (releases lock)                    | `check_task("a1", $5)` → True (spent=$0, room=$10) | $0    |
| t3   | `record_cost("a1", $5)`            | …                                  | $5    |
| t4   | …                                  | `record_cost("a1", $5)`            | **$10** ← would have rejected $5 if check were atomic |
| ...  |                                    | both threads now charge, can overshoot the limit by however many concurrent threads raced through |       |

The advertised "$10 daily budget" was advisory under concurrency, not enforced.

## Fix

Add a `check_and_charge` method that fuses both halves into a single locked transaction:

```python
with self._lock:
    allowed, reason = self._check_locked(agent_id, cost_usd)
    if not allowed:
        return False, reason, []
    alerts = self._record_cost_locked(...)
    return True, "ok", alerts
```

The pure-check and pure-record halves are factored into `_check_locked` and `_record_cost_locked` helpers so `check_and_charge` can compose them without re-acquiring the lock. `check_task` and `record_cost` continue to work unchanged for callers that genuinely need separate steps (e.g., async tasks where the actual cost is only known after the work finishes); their docstrings now warn about the race and point at `check_and_charge`.

## Tests

Two new regression tests in `TestSameAgentConcurrency`:

- `test_check_and_charge_is_atomic_under_concurrency` — 8 threads × 20 attempts at $1 against a $10 limit. Asserts `spent_today_usd <= 10.0` (hard invariant) and `successes.count(True) == 10` (exactly 10 succeed). Pre-fix the equivalent of this with separate check + record could overshoot the limit.
- `test_check_and_charge_rejects_when_killed_or_throttled` — burns the $5 limit with one $5 charge, then calls `check_and_charge` for $1; asserts `allowed=False`, no alerts emitted, and `spent_today_usd` unchanged at $5.

```
tests/unit/test_cost.py + test_cost_hardened.py — 57 passed in 0.48s
```

## Test plan

- [x] All 55 existing cost tests pass on Python 3.14.
- [x] 2 new regression tests pass.
- [x] Daily limit can no longer be overshot under concurrent `check_and_charge`.
- [x] Rejected calls do not record cost.
- [x] `check_task` and `record_cost` continue to work for legacy callers.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)