### PR TITLE
fix(runbook-executor): honour step.timeout_seconds via ThreadPoolExecutor (HIGH Isolation #9)

### DIFF
--- a/agent-governance-python/agent-sre/src/agent_sre/incidents/runbook_executor.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/incidents/runbook_executor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -103,7 +104,7 @@ class RunbookExecutor:
 
             try:
                 if callable(step.action):
-                    output = step.action(incident)
+                    output = self._invoke_with_timeout(step, incident)
                 else:
                     # String actions are logged but treated as descriptive
                     output = f"[command] {step.action}"
@@ -153,7 +154,9 @@ class RunbookExecutor:
             self._emit_event("rollback_started", step=step, incident=incident)
             try:
                 if callable(step.rollback_action):
-                    step.rollback_action(incident)
+                    self._invoke_with_timeout(
+                        step, incident, action=step.rollback_action
+                    )
                 # String rollback actions are logged but not executed
                 self._emit_event("rollback_completed", step=step, incident=incident)
             except Exception as exc:
@@ -164,6 +167,59 @@ class RunbookExecutor:
 
         if any(s.rollback_action is not None for s, _ in completed_steps):
             execution.status = ExecutionStatus.ROLLED_BACK
+
+    def _invoke_with_timeout(
+        self,
+        step: RunbookStep,
+        incident: Incident,
+        action: Callable[..., Any] | None = None,
+    ) -> Any:
+        """Run ``step.action`` (or ``action`` override) with a deadline.
+
+        Honours ``step.timeout_seconds`` via ``ThreadPoolExecutor``.
+        On timeout, raises ``TimeoutError`` with a clear message so the
+        existing exception handlers in ``execute`` and ``_rollback``
+        record it as a failed step rather than blocking the entire
+        runbook on a hung action.
+
+        The future is left running on timeout — Python doesn't expose
+        a portable way to cancel a synchronous callable mid-flight,
+        and forcibly killing the thread would leak resources held by
+        the action. The caller's runbook continues; the orphaned
+        action eventually completes and its result is discarded.
+        """
+        target = action if action is not None else step.action
+        timeout = (
+            float(step.timeout_seconds)
+            if step.timeout_seconds and step.timeout_seconds > 0
+            else None
+        )
+        if timeout is None:
+            # No deadline configured — preserve the prior synchronous
+            # behaviour for steps that explicitly opt out.
+            return target(incident)
+
+        # max_workers=1 because each action gets its own one-shot
+        # executor; nothing is shared between calls. Note: we don't
+        # use ``with ThreadPoolExecutor(...) as pool`` because its
+        # __exit__ blocks until in-flight tasks complete — that would
+        # defeat the timeout when the action is hung. Instead we
+        # shut down with ``wait=False, cancel_futures=True`` so the
+        # caller is unblocked and the orphaned action is left to
+        # complete in the background (Python can't safely cancel a
+        # running synchronous callable).
+        pool = ThreadPoolExecutor(max_workers=1)
+        try:
+            future = pool.submit(target, incident)
+            try:
+                return future.result(timeout=timeout)
+            except FuturesTimeoutError as exc:
+                raise TimeoutError(
+                    f"Step '{step.name}' exceeded its "
+                    f"{step.timeout_seconds}s timeout"
+                ) from exc
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
 
     def _emit_event(self, event_type: str, **kwargs: Any) -> None:
         """Emit an audit event."""

--- a/agent-governance-python/agent-sre/tests/test_runbooks.py
+++ b/agent-governance-python/agent-sre/tests/test_runbooks.py
@@ -147,6 +147,58 @@ class TestRunbookExecutor:
         assert len(failed_step) == 1
         assert "step failed" in failed_step[0].error
 
+    def test_step_timeout_enforced(self) -> None:
+        """Regression: previously step.action was called synchronously
+        and step.timeout_seconds was ignored, so a hung action could
+        block the entire runbook indefinitely. Now the executor
+        enforces timeout_seconds via ThreadPoolExecutor and surfaces
+        a TimeoutError as a normal step failure.
+        """
+        import time as _time
+
+        def slow_action(incident: Incident) -> str:
+            _time.sleep(2.0)
+            return "should not reach here"
+
+        rb = Runbook(
+            id="rb-timeout",
+            name="Timeout Test",
+            steps=[
+                RunbookStep(
+                    name="hangs",
+                    action=slow_action,
+                    timeout_seconds=1,
+                ),
+            ],
+        )
+        executor = RunbookExecutor()
+        start = _time.monotonic()
+        execution = executor.execute(rb, _make_incident())
+        elapsed = _time.monotonic() - start
+
+        assert execution.status == ExecutionStatus.FAILED
+        failed = [r for r in execution.step_results if r.status == StepStatus.FAILED]
+        assert len(failed) == 1
+        assert "timeout" in failed[0].error.lower()
+        # Should have terminated near the timeout, not waited the full 2s.
+        assert elapsed < 1.8, f"executor did not honour timeout: elapsed={elapsed:.2f}s"
+
+    def test_step_timeout_zero_means_no_deadline(self) -> None:
+        """A timeout_seconds of 0 (or negative) means "no deadline"
+        — preserve the prior synchronous behaviour for steps that
+        explicitly opt out, since enforcing a zero deadline would
+        timeout instantly.
+        """
+        rb = Runbook(
+            id="rb-no-timeout",
+            name="No Timeout",
+            steps=[RunbookStep(name="ok", action=_ok_action, timeout_seconds=0)],
+        )
+        executor = RunbookExecutor()
+        execution = executor.execute(rb, _make_incident())
+        assert execution.status == ExecutionStatus.COMPLETED
+        assert execution.step_results[0].status == StepStatus.SUCCESS
+
     def test_rollback_on_failure(self) -> None:
         rb = Runbook(
             id="rb-rollback",


### PR DESCRIPTION
## Summary

`RunbookExecutor.execute` (`agent-sre/src/agent_sre/incidents/runbook_executor.py:105-106,155-156`) called `step.action(incident)` and `step.rollback_action(incident)` synchronously and never consulted `step.timeout_seconds`:

```python
try:
    if callable(step.action):
        output = step.action(incident)        # ← no timeout
    else:
        output = f"[command] {step.action}"
```

A hung action blocked the entire runbook indefinitely. Runbooks run during incident response, where "the recovery runbook is hung" turns a single-agent incident into an org-wide outage.

## Fix

Add `_invoke_with_timeout` that submits the action to a one-shot `ThreadPoolExecutor` and waits with `step.timeout_seconds`:

```python
pool = ThreadPoolExecutor(max_workers=1)
try:
    future = pool.submit(target, incident)
    return future.result(timeout=step.timeout_seconds)
except FuturesTimeoutError:
    raise TimeoutError(f"Step '{step.name}' exceeded its {step.timeout_seconds}s timeout")
finally:
    pool.shutdown(wait=False, cancel_futures=True)
```

The existing `except Exception` blocks in `execute()` and `_rollback()` already record the failure correctly (with rollback in `execute`'s case).

Two implementation notes:

- **No `with ThreadPoolExecutor(...) as pool`.** Its `__exit__` waits for in-flight tasks to complete, which would defeat the timeout when the action is hung. The manual `shutdown(wait=False, cancel_futures=True)` unblocks the caller; the orphaned action eventually completes in the background. Python can't safely cancel a running synchronous callable, so leaking the thread is the safest option.
- **`timeout_seconds=0` (or negative) means "no deadline"** — preserve the prior synchronous behaviour for steps that explicitly opt out, since a zero deadline would timeout instantly.

## Tests

Two new regression tests in `TestRunbookExecutor`:

- `test_step_timeout_enforced` — `timeout_seconds=1` against an action that sleeps 2s. Asserts: execution.status == FAILED, error contains "timeout", and `elapsed < 1.8s` (i.e., the executor didn't wait for the hung action to drain).
- `test_step_timeout_zero_means_no_deadline` — `timeout_seconds=0` still completes normally for a fast action (positive control for the opt-out path).

```
tests/test_runbooks.py — 25 passed in 1.34s
```

## Test plan

- [x] All 25 `test_runbooks.py` tests pass on Python 3.14.
- [x] Hung action no longer blocks the runbook past its declared timeout.
- [x] Existing rollback-on-failure path still triggers when timeout fires.
- [x] `timeout_seconds=0` opt-out still works.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)