### PR TITLE
fix(hypervisor): point provider fallback imports at the real modules (HIGH Isolation #10)

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/providers.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/providers.py
@@ -69,27 +69,34 @@ def get_liability_engine(**kwargs: Any):
     """Get the best available liability engine.
 
     Advanced: Shapley-value fault attribution with vouch cascades.
-    Community: Basic vouching with linear slashing.
+    Community: ``LiabilityMatrix`` from ``hypervisor.liability``.
     """
     provider = _discover_provider(PROVIDER_GROUPS["liability"])
     if provider is not None:
         return provider(**kwargs)
 
-    from hypervisor.liability.engine import LiabilityEngine
-    return LiabilityEngine(**kwargs)
+    # Community fallback. The previous import targeted
+    # ``hypervisor.liability.engine.LiabilityEngine`` which does not
+    # exist in this tree; ``LiabilityMatrix`` is the real public-
+    # edition entry point.
+    from hypervisor.liability import LiabilityMatrix
+    return LiabilityMatrix(**kwargs)
 
 
 def get_saga_engine(**kwargs: Any):
     """Get the best available saga orchestration engine.
 
     Advanced: Multi-pattern saga with parallel fan-out and escalation.
-    Community: Sequential saga with basic compensation.
+    Community: ``SagaOrchestrator`` from ``hypervisor.saga.orchestrator``.
     """
     provider = _discover_provider(PROVIDER_GROUPS["saga_engine"])
     if provider is not None:
         return provider(**kwargs)
 
-    from hypervisor.saga.engine import SagaOrchestrator
+    # Community fallback. The previous import targeted
+    # ``hypervisor.saga.engine.SagaOrchestrator`` which does not exist
+    # in this tree; the real module is ``hypervisor.saga.orchestrator``.
+    from hypervisor.saga.orchestrator import SagaOrchestrator
     return SagaOrchestrator(**kwargs)
 
 

--- a/agent-governance-python/agent-hypervisor/tests/test_providers.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_providers.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the provider discovery / community-fallback factories.
+
+The fallback imports inside ``hypervisor.providers`` previously
+pointed at modules that don't exist in this tree
+(``hypervisor.liability.engine`` and ``hypervisor.saga.engine``), so
+any caller of ``get_liability_engine`` / ``get_saga_engine`` got an
+``ImportError`` when no advanced provider was registered. These tests
+exercise the community fallback path against the real public-edition
+classes.
+"""
+
+from __future__ import annotations
+
+from hypervisor.liability import LiabilityMatrix
+from hypervisor.providers import (
+    clear_cache,
+    get_liability_engine,
+    get_saga_engine,
+)
+from hypervisor.saga.orchestrator import SagaOrchestrator
+
+
+def setup_function(_func):
+    clear_cache()
+
+
+def test_get_liability_engine_returns_liability_matrix():
+    engine = get_liability_engine(session_id="sess-1")
+    assert isinstance(engine, LiabilityMatrix)
+    assert engine.session_id == "sess-1"
+
+
+def test_get_saga_engine_returns_saga_orchestrator():
+    engine = get_saga_engine()
+    assert isinstance(engine, SagaOrchestrator)
+
+
+def test_get_saga_engine_usable_after_construction():
+    """The fallback must produce a usable instance, not just import-clean."""
+    engine = get_saga_engine()
+    saga = engine.create_saga("session:test")
+    assert saga.session_id == "session:test"


### PR DESCRIPTION
## Summary

`hypervisor.providers.get_liability_engine` and `get_saga_engine` had community-fallback imports pointing at modules that don't exist in this tree:

```python
from hypervisor.liability.engine import LiabilityEngine   # ← no such module
from hypervisor.saga.engine import SagaOrchestrator       # ← no such module
```

The advanced-provider entry-points path worked, but anyone who fell through to the community fallback (i.e., anyone not running an advanced provider) hit `ImportError`. The factories were effectively dead code — `list_providers()` still reported "community" for these slots, but actually calling them blew up.

## Fix

Point the imports at the actual public-edition classes that exist in the tree:

| Function | Was | Is |
|---|---|---|
| `get_liability_engine` | `hypervisor.liability.engine.LiabilityEngine` | `hypervisor.liability.LiabilityMatrix` |
| `get_saga_engine` | `hypervisor.saga.engine.SagaOrchestrator` | `hypervisor.saga.orchestrator.SagaOrchestrator` |

Inline comments record the previous (broken) target so future readers don't reintroduce it.

## Tests

New `tests/test_providers.py` with three regression tests:

- `test_get_liability_engine_returns_liability_matrix` — `get_liability_engine(session_id="sess-1")` returns a `LiabilityMatrix` with the correct session.
- `test_get_saga_engine_returns_saga_orchestrator` — `get_saga_engine()` returns a `SagaOrchestrator`.
- `test_get_saga_engine_usable_after_construction` — the returned `SagaOrchestrator.create_saga(...)` works end-to-end (not just import-clean).

```
tests/test_providers.py — 3 passed in 0.47s
```

## Test plan

- [x] All 3 new provider tests pass on Python 3.14.
- [x] Community-fallback path returns a usable instance, not an `ImportError`.
- [x] No callers of these factories exist yet in this tree, so the change is non-breaking.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)