### PR TITLE
fix(marketplace): canonical JSON signing for PluginManifest.signable_bytes (HIGH Extensions #1)

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/manifest.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/manifest.py
@@ -10,6 +10,7 @@ Supports plugin types: policy_template, integration, agent, validator.
 from __future__ import annotations
 
 import enum
+import json
 import logging
 from pathlib import Path
 from typing import Optional
@@ -99,10 +100,26 @@ class PluginManifest(BaseModel):
         return v
 
     def signable_bytes(self) -> bytes:
-        """Return the canonical bytes used for signing (excludes signature field)."""
+        """Return the canonical bytes used for signing (excludes signature field).
+
+        Uses JSON with ``sort_keys=True``, ASCII-safe escaping, no
+        whitespace, and ``allow_nan=False`` so the output is
+        byte-identical across machines, Python builds, and YAML
+        library versions. The prior ``yaml.dump(..., sort_keys=True)``
+        path was NOT a stable canonicalization — it emitted
+        Python-specific tags, used the host's default flow style,
+        and varied with PyYAML release — so a signature produced on
+        one machine could fail to verify on another even when the
+        manifest content was logically identical.
+        """
         data = self.model_dump(exclude={"signature"})
-        # Deterministic YAML serialization
-        return yaml.dump(data, sort_keys=True).encode()
+        return json.dumps(
+            data,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("ascii")
 
 
 def load_manifest(path: Path) -> PluginManifest:

--- a/agent-governance-python/agent-marketplace/tests/test_marketplace.py
+++ b/agent-governance-python/agent-marketplace/tests/test_marketplace.py
@@ -7,6 +7,81 @@ from __future__ import annotations
 import pytest
 
 
+def test_signable_bytes_is_canonical_json():
+    """Regression: signable_bytes used to be yaml.dump(sort_keys=True),
+    which is not stable across Python builds or PyYAML versions and
+    embeds Python-specific tags. A signature produced on one machine
+    could fail to verify on another even with identical manifest
+    content. Use JSON with sort_keys / ascii / no-nan instead.
+    """
+    import json
+    from agent_marketplace.manifest import PluginManifest, PluginType
+
+    m = PluginManifest(
+        name="x",
+        version="1.0.0",
+        plugin_type=PluginType.POLICY_TEMPLATE,
+        author="a@example.com",
+        description="desc",
+    )
+    encoded = m.signable_bytes()
+
+    # Decodable as JSON (would NOT be true for yaml.dump output).
+    decoded = json.loads(encoded.decode("ascii"))
+    assert decoded["name"] == "x"
+    assert decoded["version"] == "1.0.0"
+    # signature field must be excluded.
+    assert "signature" not in decoded
+
+
+def test_signable_bytes_independent_of_field_order():
+    """Two manifests with the same logical content but different
+    Python field insertion order must produce byte-identical signable
+    output. ``sort_keys=True`` is the load-bearing primitive.
+    """
+    from agent_marketplace.manifest import PluginManifest, PluginType
+
+    a = PluginManifest(
+        name="x",
+        version="1.0.0",
+        plugin_type=PluginType.POLICY_TEMPLATE,
+        author="a@example.com",
+        description="desc",
+    )
+    # Construct b via dict to vary insertion order; pydantic will
+    # canonicalise it, and signable_bytes should produce the same
+    # output as a.
+    b = PluginManifest.model_validate({
+        "description": "desc",
+        "plugin_type": PluginType.POLICY_TEMPLATE.value,
+        "version": "1.0.0",
+        "author": "a@example.com",
+        "name": "x",
+    })
+    assert a.signable_bytes() == b.signable_bytes()
+
+
+def test_signable_bytes_omits_signature_field():
+    """The signature field is set AFTER signing; it must not be part
+    of the signable representation, or verification would have to
+    strip it back out and bugs in that path would silently invalidate
+    every signature.
+    """
+    from agent_marketplace.manifest import PluginManifest, PluginType
+
+    m = PluginManifest(
+        name="x",
+        version="1.0.0",
+        plugin_type=PluginType.POLICY_TEMPLATE,
+        author="a@example.com",
+        description="desc",
+    )
+    unsigned = m.signable_bytes()
+    m.signature = "deadbeef" * 16
+    signed = m.signable_bytes()
+    assert unsigned == signed
+
+
 def test_top_level_imports():
     """All public symbols are importable from the top-level package."""
     from agent_marketplace import (


### PR DESCRIPTION
## Summary

`PluginManifest.signable_bytes` (`agent-marketplace/src/agent_marketplace/manifest.py:101-105`) used `yaml.dump(data, sort_keys=True)` to produce the bytes that get signed and verified. That is **not** a stable canonicalization:

- PyYAML can emit Python-specific tags (`!!python/...`)
- default flow style varies with the input shape
- whitespace and quoting can differ across PyYAML releases
- `sort_keys=True` doesn't sort nested mappings in some configurations

So a signature produced on machine A could fail to verify on machine B even when the manifest content was logically identical. The signature pipeline was advisory in real-world deployment — anyone redistributing manifests between environments hit silent verification failures.

## Fix

Switch to JSON with strict canonicalization:

```python
json.dumps(
    data,
    sort_keys=True,
    separators=(",", ":"),
    ensure_ascii=True,
    allow_nan=False,
).encode("ascii")
```

This is byte-identical across machines, Python builds, and stdlib versions; JSON is also defined by RFC 8259, which gives the signing pipeline a stable spec to reason about. No Python-specific tags, no flow-style variance, no whitespace drift.

## Tests

Three new regression tests in `tests/test_marketplace.py`:

- `test_signable_bytes_is_canonical_json` — decode the output as JSON (would fail for `yaml.dump` output), assert content correctness, assert signature field is excluded.
- `test_signable_bytes_independent_of_field_order` — two manifests with the same logical content but constructed with different Python field-insertion order produce byte-identical signable output (the `sort_keys` invariant).
- `test_signable_bytes_omits_signature_field` — mutating `.signature` does not change `signable_bytes` output.

```
tests/test_marketplace.py — 9 passed in 0.47s
tests/ — 243 passed in 0.92s (full marketplace suite)
```

## Test plan

- [x] All 9 `test_marketplace.py` tests pass on Python 3.14.
- [x] Full marketplace suite (243 tests) passes.
- [x] Signature stable across field-ordering perturbations.
- [x] Signature field correctly excluded from signable form.

Reported via the AEGIS Initiative review of `microsoft/agent-governance-toolkit`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)