### PR TITLE
fix(marketplace-cli): exit non-zero on MarketplaceError in 4 commands (HIGH Extensions #6)

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/cli_commands.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/cli_commands.py
@@ -71,24 +71,28 @@ def plugin() -> None:
 @click.option("--version", "-v", default=None, help="Specific version to install")
 def install_plugin(name: str, version: str | None) -> None:
     """Install a plugin from the registry."""
+    import sys
     try:
         installer = _get_installer()
         dest = installer.install(name, version)
         console.print(f"[green]✓[/green] Installed {name} to {dest}")
     except MarketplaceError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
 
 
 @plugin.command("uninstall")
 @click.argument("name")
 def uninstall_plugin(name: str) -> None:
     """Uninstall a plugin."""
+    import sys
     try:
         installer = _get_installer()
         installer.uninstall(name)
         console.print(f"[green]✓[/green] Uninstalled {name}")
     except MarketplaceError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
 
 
 @plugin.command("list")
@@ -148,6 +152,7 @@ def search_plugins(query: str) -> None:
 def verify_plugin(path: str, manifest_format: str) -> None:
     """Verify a plugin manifest, with optional format detection for Copilot/Claude plugins."""
     import json
+    import sys
 
     import yaml
 
@@ -203,6 +208,7 @@ def verify_plugin(path: str, manifest_format: str) -> None:
 
     except MarketplaceError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
 
 
 def _print_verify_result(manifest: "PluginManifest") -> None:
@@ -220,6 +226,7 @@ def _print_verify_result(manifest: "PluginManifest") -> None:
 @click.argument("path", type=click.Path(exists=True))
 def publish_plugin(path: str) -> None:
     """Sign and register a plugin with the registry."""
+    import sys
     try:
         manifest = load_manifest(Path(path))
         registry = _get_registry()
@@ -229,6 +236,7 @@ def publish_plugin(path: str) -> None:
         )
     except MarketplaceError as exc:
         console.print(f"[red]Error:[/red] {exc}")
+        sys.exit(1)
 
 
 @plugin.command("evaluate")

--- a/agent-governance-python/agent-marketplace/tests/test_cli_exit_codes.py
+++ b/agent-governance-python/agent-marketplace/tests/test_cli_exit_codes.py
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Regression tests for CLI exit codes.
+
+Each CLI command must exit non-zero when its core operation fails.
+Previously, ``install``, ``uninstall``, ``verify``, and ``publish``
+caught ``MarketplaceError``, printed a red error message, and
+returned with exit code 0. CI gates and pre-commit hooks that piped
+the CLI's exit status treated installation or signature failures as
+successes — a silent supply-chain risk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agent_marketplace.cli_commands import plugin
+
+
+def test_install_nonexistent_plugin_exits_nonzero() -> None:
+    runner = CliRunner()
+    result = runner.invoke(plugin, ["install", "this-plugin-does-not-exist"])
+    assert result.exit_code != 0, (
+        f"install of missing plugin must exit non-zero, "
+        f"got exit_code={result.exit_code}; output={result.output!r}"
+    )
+
+
+def test_uninstall_nonexistent_plugin_exits_nonzero() -> None:
+    runner = CliRunner()
+    result = runner.invoke(plugin, ["uninstall", "this-plugin-does-not-exist"])
+    assert result.exit_code != 0
+
+
+def test_verify_missing_manifest_exits_nonzero(tmp_path: Path) -> None:
+    """A directory with no manifest should fail verify with non-zero exit."""
+    runner = CliRunner()
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    result = runner.invoke(plugin, ["verify", str(empty_dir)])
+    assert result.exit_code != 0
+
+
+def test_publish_invalid_manifest_exits_nonzero(tmp_path: Path) -> None:
+    """An invalid manifest (missing required fields) should fail publish."""
+    bad = tmp_path / "agent-plugin.yaml"
+    bad.write_text("name: missing-required-fields\n", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(plugin, ["publish", str(bad)])
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Every CLI subcommand in `agent_marketplace.cli_commands` caught `MarketplaceError`, printed a red message via `console.print`, and returned. Click's default exit code is 0, so:

```
agent-mp plugin install nonexistent-package      # ← exit 0
agent-mp plugin verify malformed/path            # ← exit 0
agent-mp plugin publish unsigned-manifest        # ← exit 0
agent-mp plugin uninstall not-installed          # ← exit 0
```

CI gates, pre-commit hooks, and deployment scripts that pipe the CLI's exit status treated installation or signature failures as **successes**. A silent supply-chain failure surface: the plugin "installed" cleanly per the exit code, but actually didn't.

(`evaluate` already had `sys.exit(1)` on error paths; the four broken commands now match that pattern.)

## Fix

Add `sys.exit(1)` after the error print in every `except MarketplaceError` block on `install_plugin`, `uninstall_plugin`, `verify_plugin`, and `publish_plugin`.

## Tests

New `tests/test_cli_exit_codes.py` with one regression test per fixed command:

- `test_install_nonexistent_plugin_exits_nonzero`
- `test_uninstall_nonexistent_plugin_exits_nonzero`
- `test_verify_missing_manifest_exits_nonzero` — empty directory, no manifest
- `test_publish_invalid_manifest_exits_nonzero` — manifest missing required fields

```
tests/test_cli_exit_codes.py — 4 passed in 0.37s
```

## Test plan

- [x] All 4 new CLI exit-code tests pass on Python 3.14.
- [x] Existing 240 marketplace tests still pass.
- [x] CI gates piping exit status no longer mistake failure for success.

Reported via the AEGIS Initiative review of \`microsoft/agent-governance-toolkit\`.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)