### PR TITLE
fix(agent-lightning): correct GovernedRunner violation_callback annotation (HIGH Extensions #7)

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
@@ -14,7 +14,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +96,7 @@ class GovernedRunner(Generic[T_task]):
         *,
         fail_on_violation: bool = False,
         log_violations: bool = True,
-        violation_callback: callable | None = None,
+        violation_callback: Callable[[PolicyViolation], None] | None = None,
     ):
         """
         Initialize governed runner.

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -166,6 +166,35 @@ class TestGovernedRunnerViolationTracking:
         assert runner._current_signals == []
 
 
+class TestGovernedRunnerCallableAnnotation:
+    """Regression: `violation_callback` was annotated `callable | None`.
+
+    `callable` is a builtin function, not a type. `typing.get_type_hints`
+    raises ``TypeError`` on the original annotation, which breaks Pydantic
+    auto-derivation, inspect-based config helpers, and runtime hint readers.
+    """
+
+    def test_get_type_hints_resolves_violation_callback(self):
+        import typing
+
+        hints = typing.get_type_hints(GovernedRunner.__init__)
+        assert "violation_callback" in hints
+        # Resolving without raising is the load-bearing assertion.
+
+    def test_callback_typing_includes_callable(self):
+        import typing
+
+        hint = typing.get_type_hints(GovernedRunner.__init__)["violation_callback"]
+        # Hint is `Callable[[PolicyViolation], None] | None` — a Union with
+        # NoneType. ``typing.get_args`` returns the union members.
+        args = typing.get_args(hint)
+        assert type(None) in args
+        # The non-None arg should be a Callable, not the builtin `callable`.
+        non_none = [a for a in args if a is not type(None)]
+        assert len(non_none) == 1
+        assert typing.get_origin(non_none[0]) in (typing.Callable, __import__("collections.abc", fromlist=["Callable"]).Callable)
+
+
 class TestGovernedRunnerCallbacks:
     def test_violation_callback_invoked(self):
         cb = MagicMock()


### PR DESCRIPTION
## Summary

[agent-lightning/src/agent_lightning_gov/runner.py:99](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py#L99) annotated `violation_callback: callable | None`. `callable` is the builtin function, not a type — `typing.get_type_hints` raises `TypeError` on this annotation, which breaks any annotation reader (Pydantic auto-derivation, `inspect`-based config helpers, runtime hint resolution).

The constructor already passes the value straight to `self.violation_callback` and later invokes it as `self.violation_callback(violation)`, so the practical signature has always been `Callable[[PolicyViolation], None] | None`. Annotating it explicitly closes the gap.

## Changes

- `runner.py`: import `Callable` from `typing`; replace `callable | None` with `Callable[[PolicyViolation], None] | None`.

## Test plan

- [x] New `TestGovernedRunnerCallableAnnotation::test_get_type_hints_resolves_violation_callback` — `typing.get_type_hints(GovernedRunner.__init__)` no longer raises.
- [x] New `TestGovernedRunnerCallableAnnotation::test_callback_typing_includes_callable` — resolved hint is `Callable[...] | None`, not `callable | None`.
- [x] Full agent-lightning suite (85 passed, 1 skipped) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>