### PR TITLE
fix(agent-lightning): isolate per-step state via contextvars (HIGH Extensions #8)

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
@@ -10,6 +10,7 @@ Policy violations during training become learning signals.
 
 from __future__ import annotations
 
+import contextvars
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -19,6 +20,16 @@ from typing import Any, Callable, Generic, TypeVar
 logger = logging.getLogger(__name__)
 
 T_task = TypeVar("T_task")
+
+# Per-step state. Each ``step()`` call sets these to its local list before
+# invoking the kernel; the kernel's policy/signal callbacks then append into
+# the active step's list (whichever asyncio task is running them). This keeps
+# concurrent ``step()`` calls on the same ``GovernedRunner`` from mixing
+# violations or signals across rollouts.
+_active_violations_ctx: contextvars.ContextVar[list["PolicyViolation"] | None] = \
+    contextvars.ContextVar("agent_lightning_gov_active_violations", default=None)
+_active_signals_ctx: contextvars.ContextVar[list[str] | None] = \
+    contextvars.ContextVar("agent_lightning_gov_active_signals", default=None)
 
 
 class PolicyViolationType(Enum):
@@ -182,7 +193,13 @@ class GovernedRunner(Generic[T_task]):
         severity: str,
         blocked: bool,
     ) -> None:
-        """Handle a policy violation from the kernel."""
+        """Handle a policy violation from the kernel.
+
+        When an active ``step()`` has bound its per-rollout violation list to
+        the current asyncio context, the violation is appended there. When
+        called outside a step (direct test usage, ad-hoc callers), the
+        instance-level ``_current_violations`` list is used for back-compat.
+        """
         violation = PolicyViolation(
             violation_type=PolicyViolationType.BLOCKED if blocked else PolicyViolationType.WARNED,
             policy_name=policy_name,
@@ -191,7 +208,11 @@ class GovernedRunner(Generic[T_task]):
             action_blocked=blocked,
         )
 
-        self._current_violations.append(violation)
+        active = _active_violations_ctx.get()
+        if active is not None:
+            active.append(violation)
+        else:
+            self._current_violations.append(violation)
         self._total_violations += 1
 
         if self.log_violations:
@@ -207,12 +228,23 @@ class GovernedRunner(Generic[T_task]):
             raise PolicyViolationError(violation)
 
     def _handle_signal(self, signal: str, agent_id: str) -> None:
-        """Handle a kernel signal."""
-        self._current_signals.append(signal)
+        """Handle a kernel signal.
+
+        Same context-aware routing as ``_handle_violation``.
+        """
+        active = _active_signals_ctx.get()
+        if active is not None:
+            active.append(signal)
+        else:
+            self._current_signals.append(signal)
         logger.debug(f"Signal {signal} sent to agent {agent_id}")
 
     def _clear_current_state(self) -> None:
-        """Clear state for new rollout."""
+        """Clear instance-level fallback state.
+
+        ``step()`` no longer uses the instance lists; this exists for callers
+        that drive ``_handle_violation`` / ``_handle_signal`` directly.
+        """
         self._current_violations = []
         self._current_signals = []
 
@@ -240,31 +272,41 @@ class GovernedRunner(Generic[T_task]):
         """
         import time
 
-        self._clear_current_state()
+        # Per-step state: bind fresh lists to the asyncio context so concurrent
+        # ``step()`` calls on the same runner don't share violation/signal
+        # buffers via instance state.
+        local_violations: list[PolicyViolation] = []
+        local_signals: list[str] = []
+        v_token = _active_violations_ctx.set(local_violations)
+        s_token = _active_signals_ctx.set(local_signals)
         start_time = time.perf_counter()
 
         try:
-            # Execute through kernel
-            if hasattr(self.kernel, 'execute_async'):
-                result = await self.kernel.execute_async(self.agent, input)
-            elif hasattr(self.kernel, 'execute'):
-                result = self.kernel.execute(self.agent, input)
-            else:
-                # Fallback: direct agent call (no governance)
-                logger.warning("Kernel has no execute method, running agent directly")
-                result = await self.agent(input)
+            try:
+                # Execute through kernel
+                if hasattr(self.kernel, 'execute_async'):
+                    result = await self.kernel.execute_async(self.agent, input)
+                elif hasattr(self.kernel, 'execute'):
+                    result = self.kernel.execute(self.agent, input)
+                else:
+                    # Fallback: direct agent call (no governance)
+                    logger.warning("Kernel has no execute method, running agent directly")
+                    result = await self.agent(input)
 
-            success = True
+                success = True
 
-        except PolicyViolationError as e:
-            result = None
-            success = False
-            logger.error(f"Execution blocked by policy: {e.violation.description}")
+            except PolicyViolationError as e:
+                result = None
+                success = False
+                logger.error(f"Execution blocked by policy: {e.violation.description}")
 
-        except Exception as e:
-            result = None
-            success = False
-            logger.error(f"Execution failed: {e}")
+            except Exception as e:
+                result = None
+                success = False
+                logger.error(f"Execution failed: {e}")
+        finally:
+            _active_violations_ctx.reset(v_token)
+            _active_signals_ctx.reset(s_token)
 
         execution_time = (time.perf_counter() - start_time) * 1000
         self._total_rollouts += 1
@@ -273,8 +315,8 @@ class GovernedRunner(Generic[T_task]):
             task_input=input,
             task_output=result,
             success=success,
-            violations=self._current_violations.copy(),
-            signals_sent=self._current_signals.copy(),
+            violations=local_violations,
+            signals_sent=local_signals,
             execution_time_ms=execution_time,
         )
 

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -195,6 +195,91 @@ class TestGovernedRunnerCallableAnnotation:
         assert typing.get_origin(non_none[0]) in (typing.Callable, __import__("collections.abc", fromlist=["Callable"]).Callable)
 
 
+class TestGovernedRunnerStepConcurrency:
+    """Concurrent ``step()`` calls must not share violation buffers.
+
+    Regression for REVIEW.md HIGH Extensions #8: previously ``step()`` used
+    instance-level ``self._current_violations`` / ``self._current_signals``
+    lists. Two concurrent rollouts interleaving at every ``await`` shared
+    those lists, so violations raised during rollout A appeared in rollout
+    B's ``GovernedRollout.violations`` (and vice versa).
+
+    The fix binds per-step lists to ``contextvars.ContextVar``s; each
+    asyncio task sees only its own list.
+    """
+
+    def test_two_concurrent_steps_do_not_share_violations(self):
+        """Run two ``step()`` calls concurrently. Each rollout's violations
+        must reflect only the violations raised during *its* execution."""
+
+        # Track which step is currently running by name, so the test can
+        # verify the per-rollout buckets correctly partition violations.
+        async def _run():
+            # A custom kernel that lets us interleave violation emission
+            # between the two step calls.
+            class InterleaveKernel:
+                def __init__(self):
+                    self._cb = None
+                    # gate_a triggers step A's violation; gate_b triggers B's.
+                    self.gate_a = asyncio.Event()
+                    self.gate_b = asyncio.Event()
+                    self.policies = []
+
+                def on_policy_violation(self, cb):
+                    self._cb = cb
+
+                def on_signal(self, _cb):
+                    pass
+
+                async def execute_async(self, _agent, input):
+                    # Each step's kernel call awaits its own gate, then emits
+                    # a violation that should ONLY land in that step's bucket.
+                    if input == "A":
+                        await self.gate_a.wait()
+                        self._cb("PolicyA", "violation-A", "high", True)
+                    else:
+                        await self.gate_b.wait()
+                        self._cb("PolicyB", "violation-B", "medium", False)
+                    return f"result-{input}"
+
+            kernel = InterleaveKernel()
+            runner = GovernedRunner(kernel)
+            runner.agent = AsyncMock(return_value="x")
+            # Wire the kernel hooks manually (init() expects an agent).
+            kernel.on_policy_violation(runner._handle_violation)
+
+            # Kick off both steps concurrently.
+            task_a = asyncio.create_task(runner.step("A"))
+            task_b = asyncio.create_task(runner.step("B"))
+
+            # Let both reach the await on their gates, then interleave the
+            # violations so step A's violation is dispatched while step B is
+            # also mid-flight — this is the precise race the old code mixed.
+            await asyncio.sleep(0)  # yield once so both tasks start
+            kernel.gate_a.set()
+            await asyncio.sleep(0)
+            kernel.gate_b.set()
+
+            rollout_a, rollout_b = await asyncio.gather(task_a, task_b)
+            return rollout_a, rollout_b
+
+        rollout_a, rollout_b = asyncio.run(_run())
+
+        # Each rollout has exactly its own violation, with no cross-over.
+        assert [v.policy_name for v in rollout_a.violations] == ["PolicyA"]
+        assert [v.policy_name for v in rollout_b.violations] == ["PolicyB"]
+        assert rollout_a.violations[0].description == "violation-A"
+        assert rollout_b.violations[0].description == "violation-B"
+
+    def test_direct_handle_violation_still_uses_instance_list(self):
+        """Calling ``_handle_violation`` directly (outside a step) keeps the
+        legacy instance-list path so existing test usage still works."""
+        runner = GovernedRunner(_make_mock_kernel())
+        runner._handle_violation("P", "d", "low", False)
+        assert len(runner._current_violations) == 1
+        assert runner._current_violations[0].policy_name == "P"
+
+
 class TestGovernedRunnerCallbacks:
     def test_violation_callback_invoked(self):
         cb = MagicMock()


### PR DESCRIPTION
## Summary

[agent-lightning/src/agent_lightning_gov/runner.py:202-272](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py#L202-L272) — `GovernedRunner.step()` used instance-level `self._current_violations` / `self._current_signals` lists, cleared at the start of each call. Two `step()` calls running concurrently on the same runner interleaved at every `await`, so the kernel's policy violation callback would land in whichever step's bucket happened to be most recently-bound — typically resulting in violations from rollout A appearing in rollout B's `GovernedRollout.violations` (and vice versa).

This is a working cross-rollout contamination primitive for any user running multiple workers against the same `GovernedRunner` instance — the documented multi-worker pattern (`init_worker`).

## Changes

- New module-level `contextvars.ContextVar`s (`_active_violations_ctx`, `_active_signals_ctx`).
- `step()` creates per-call `local_violations` and `local_signals` lists, binds them to the ctx vars, awaits the kernel, then unbinds in a `finally`. The returned `GovernedRollout` is constructed from those local lists.
- `_handle_violation` and `_handle_signal` read the active list from context. When called outside a step (direct test/ad-hoc usage), they fall back to the instance lists for back-compat.

## Test plan

- [x] `TestGovernedRunnerStepConcurrency::test_two_concurrent_steps_do_not_share_violations` — two `step()` calls run concurrently with a custom kernel that emits one violation per step via gates tripped in sequence; each rollout must contain exactly its own violation. Pre-fix this would produce both violations in both rollouts.
- [x] `TestGovernedRunnerStepConcurrency::test_direct_handle_violation_still_uses_instance_list` — direct calls outside a step still populate the instance fallback list, preserving existing test behaviour.
- [x] Full agent-lightning suite (85 passed, 1 skipped) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>