### PR TITLE
fix(agent-lightning): emitter.stream as AsyncIterator with stop_event (HIGH Extensions #9)

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/emitter.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/emitter.py
@@ -10,9 +10,10 @@ span format for unified training and audit trail.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -201,22 +202,32 @@ class FlightRecorderEmitter:
         self._last_position = len(all_spans)
         return new_spans
 
-    async def stream(self) -> Iterator[LightningSpan]:
+    async def stream(
+        self,
+        *,
+        stop_event: asyncio.Event | None = None,
+        poll_interval: float = 0.1,
+    ) -> AsyncIterator[LightningSpan]:
         """
         Stream spans as they are recorded.
 
-        Yields:
-            LightningSpan objects as they become available
-        """
-        import asyncio
+        Args:
+            stop_event: Optional cooperative-stop signal. When set, the
+                stream completes cleanly after draining the next poll.
+                Without it, callers must cancel the consuming task to
+                terminate the stream.
+            poll_interval: Delay between polls of the underlying recorder,
+                in seconds.
 
-        while True:
+        Yields:
+            LightningSpan objects as they become available.
+        """
+        while stop_event is None or not stop_event.is_set():
             new_spans = self.get_new_spans()
             for span in new_spans:
                 yield span
 
-            # Wait before checking again
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(poll_interval)
 
     def emit_to_store(self, store: Any) -> int:
         """

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -698,6 +698,93 @@ class TestFlightRecorderEmitterViolationSummary:
         assert summary["violation_rate"] == 0.0
 
 
+class TestFlightRecorderEmitterStream:
+    """``stream()`` is an async generator with a cooperative stop signal.
+
+    Regression for REVIEW.md HIGH Extensions #9: previously
+    ``async def stream()`` was annotated as returning
+    ``Iterator[LightningSpan]`` (wrong — it's an async generator) and
+    had no exit condition, so consumers could only terminate it by
+    cancelling the surrounding task.
+    """
+
+    def test_stream_return_type_is_async_iterator(self):
+        import inspect
+        import typing
+        from collections.abc import AsyncIterator
+
+        hints = typing.get_type_hints(FlightRecorderEmitter.stream)
+        ret = hints["return"]
+        assert typing.get_origin(ret) is AsyncIterator
+        # The method must itself be an async generator function.
+        assert inspect.isasyncgenfunction(FlightRecorderEmitter.stream)
+
+    def test_stream_stops_when_event_is_set(self):
+        """``stream()`` exits cleanly after the next poll when stop_event fires."""
+
+        async def _run():
+            recorder = _make_recorder([_FakeEntry(), _FakeEntry(id="e2")])
+            emitter = FlightRecorderEmitter(recorder)
+            stop = asyncio.Event()
+            stop.set()  # request stop before iteration
+
+            collected = [s async for s in emitter.stream(stop_event=stop)]
+            return collected
+
+        spans = asyncio.run(_run())
+        # With the event already set, the loop body must NOT execute and
+        # no spans must be yielded. This is the contract: ``stop_event``
+        # gives a clean exit, not "drain then stop".
+        assert spans == []
+
+    def test_stream_drains_then_stops(self):
+        """``stream()`` yields spans available before the stop fires, then exits."""
+
+        async def _run():
+            recorder = _make_recorder([_FakeEntry(), _FakeEntry(id="e2")])
+            emitter = FlightRecorderEmitter(recorder)
+            stop = asyncio.Event()
+
+            results: list = []
+            async for span in emitter.stream(stop_event=stop, poll_interval=0.0):
+                results.append(span)
+                if len(results) == 2:
+                    stop.set()
+            return results
+
+        spans = asyncio.run(_run())
+        assert len(spans) == 2
+
+    def test_stream_no_event_runs_until_cancelled(self):
+        """Without a stop_event, ``stream()`` runs until the caller cancels."""
+
+        async def _run():
+            recorder = _make_recorder([_FakeEntry()])
+            emitter = FlightRecorderEmitter(recorder)
+
+            results: list = []
+
+            async def consume():
+                async for span in emitter.stream(poll_interval=0.0):
+                    results.append(span)
+
+            task = asyncio.create_task(consume())
+            # Give the generator a few ticks to surface the initial entry.
+            for _ in range(5):
+                await asyncio.sleep(0)
+                if results:
+                    break
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            return results
+
+        spans = asyncio.run(_run())
+        assert len(spans) >= 1
+
+
 class TestFlightRecorderEmitterStreaming:
     def test_get_new_spans_incremental(self):
         entries = [_FakeEntry(), _FakeEntry(id="e2")]


### PR DESCRIPTION
## Summary

[agent-lightning/src/agent_lightning_gov/emitter.py:204-219](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-lightning/src/agent_lightning_gov/emitter.py#L204-L219):

- `async def stream(...)` was annotated as returning `Iterator[LightningSpan]` but the function `yield`s — it's an async generator whose correct return annotation is `AsyncIterator[LightningSpan]`. Annotation readers see the wrong shape.
- The loop has no exit condition; consumers can only terminate it by cancelling the surrounding task. The README example (`async for span in emitter.stream(): store.emit_span(span)`) gives no clean way to stop the stream short of cancellation, which is awkward inside a larger orchestration.

## Changes

- Move `import asyncio` to module top; switch import from `collections.abc.Iterator` to `AsyncIterator`.
- `stream(stop_event=None, poll_interval=0.1)` accepts an optional `asyncio.Event` cooperative-stop signal. When set, the loop exits cleanly after the current poll. `poll_interval` exposes the previously-hard-coded 0.1s sleep for tighter polling (tests use 0.0).
- Return annotation is now `AsyncIterator[LightningSpan]`.

## Test plan

- [x] `TestFlightRecorderEmitterStream::test_stream_return_type_is_async_iterator` — resolves type hints; verifies the method is an async generator function and the return type's origin is `AsyncIterator`.
- [x] `test_stream_stops_when_event_is_set` — passing an already-set `stop_event` yields no spans (clean exit).
- [x] `test_stream_drains_then_stops` — events fired mid-iteration cause a clean exit after the current poll.
- [x] `test_stream_no_event_runs_until_cancelled` — without a stop event, the stream runs until the consuming task is cancelled (legacy behaviour preserved).
- [x] Full agent-lightning suite (87 passed, 1 skipped) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>