### PR TITLE
fix(agent-lightning): cursor-based get_new_spans (HIGH Extensions #10)

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/emitter.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/emitter.py
@@ -161,44 +161,61 @@ class FlightRecorderEmitter:
             attributes=attributes,
         )
 
+    def _get_entries(self) -> list:
+        """Return the recorder's full entry list, normalising the three
+        supported accessors (``get_entries``, ``entries``, ``get_logs``)."""
+        if hasattr(self.recorder, 'get_entries'):
+            return list(self.recorder.get_entries())
+        if hasattr(self.recorder, 'entries'):
+            return self.recorder.entries
+        if hasattr(self.recorder, 'get_logs'):
+            return list(self.recorder.get_logs())
+        logger.warning("Flight recorder has no recognized entry accessor")
+        return []
+
     def get_spans(self) -> list[LightningSpan]:
         """
         Get all Flight Recorder entries as Lightning spans.
 
+        Note: walks the full entry list every call. For polling loops
+        prefer :meth:`get_new_spans`, which only converts entries added
+        since the last call.
+
         Returns:
             List of LightningSpan objects
         """
-        spans = []
-
-        # Get entries from recorder
-        if hasattr(self.recorder, 'get_entries'):
-            entries = self.recorder.get_entries()
-        elif hasattr(self.recorder, 'entries'):
-            entries = self.recorder.entries
-        elif hasattr(self.recorder, 'get_logs'):
-            entries = self.recorder.get_logs()
-        else:
-            logger.warning("Flight recorder has no recognized entry accessor")
-            return []
-
-        for entry in entries:
+        spans: list[LightningSpan] = []
+        for entry in self._get_entries():
             span = self._convert_entry(entry)
             if span:
                 spans.append(span)
                 self._emitted_count += 1
-
         return spans
 
     def get_new_spans(self) -> list[LightningSpan]:
         """
-        Get only new entries since last call.
+        Get only entries added since the last call.
+
+        Previous implementation called :meth:`get_spans` (which walks all
+        entries) on every poll, producing O(n) work per call and O(n²)
+        cumulative work over the lifetime of a polling consumer. This
+        version maintains a real cursor (``self._last_position``) into
+        the recorder's entry list and only converts the suffix added
+        since the prior call.
 
         Returns:
-            List of new LightningSpan objects
+            List of new LightningSpan objects.
         """
-        all_spans = self.get_spans()
-        new_spans = all_spans[self._last_position:]
-        self._last_position = len(all_spans)
+        entries = self._get_entries()
+        new_entries = entries[self._last_position:]
+        self._last_position = len(entries)
+
+        new_spans: list[LightningSpan] = []
+        for entry in new_entries:
+            span = self._convert_entry(entry)
+            if span:
+                new_spans.append(span)
+                self._emitted_count += 1
         return new_spans
 
     async def stream(self) -> Iterator[LightningSpan]:

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -711,6 +711,46 @@ class TestFlightRecorderEmitterStreaming:
         second = emitter.get_new_spans()
         assert len(second) == 0
 
+    def test_get_new_spans_only_converts_new_entries(self):
+        """Regression for REVIEW.md HIGH Extensions #10.
+
+        Previously ``get_new_spans`` called ``get_spans`` (which converts
+        every entry) on every poll and then sliced the tail. With N entries
+        already converted in prior polls, each new poll did N+k conversions
+        for k new entries — O(N²) over the lifetime of a polling consumer.
+
+        The fix keeps a cursor and only converts the suffix that arrived
+        since the last call. This test instruments ``_convert_entry`` so
+        every call is counted; the second poll, with only one *new* entry,
+        must invoke the converter exactly once — not N+1 times.
+        """
+        # Start with 10 entries, drain via get_new_spans (first poll).
+        entries = [_FakeEntry(id=f"e{i}") for i in range(10)]
+        recorder = _make_recorder(entries)
+        emitter = FlightRecorderEmitter(recorder)
+
+        first = emitter.get_new_spans()
+        assert len(first) == 10
+
+        # Spy on _convert_entry and add ONE new entry.
+        call_count = 0
+        original = emitter._convert_entry
+
+        def counting_convert(entry):
+            nonlocal call_count
+            call_count += 1
+            return original(entry)
+
+        emitter._convert_entry = counting_convert
+        entries.append(_FakeEntry(id="e10"))
+
+        new = emitter.get_new_spans()
+        assert len(new) == 1
+        assert call_count == 1, (
+            f"get_new_spans converted {call_count} entries; expected 1 "
+            f"(O(n²) behaviour returned)"
+        )
+
     def test_stats(self):
         entries = [_FakeEntry()]
         emitter = FlightRecorderEmitter(_make_recorder(entries))


### PR DESCRIPTION
## Summary

[agent-lightning/src/agent_lightning_gov/emitter.py:192-202](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-lightning/src/agent_lightning_gov/emitter.py#L192-L202): `get_new_spans` called `get_spans` (which converts every entry into a `LightningSpan`) on every poll and then sliced the resulting list to the tail past `self._last_position`. With N entries already drained in prior polls and a polling consumer like `stream()` calling it at 100 ms cadence, each poll did N+k conversions for k new entries — O(N²) cumulative work over the consumer's lifetime, plus N extra `_emitted_count` increments per poll for entries already counted.

## Changes

- New `_get_entries()` helper extracts the entry-accessor normalisation (`get_entries` / `entries` / `get_logs`) so both code paths share one source of truth.
- `get_spans()` keeps its existing semantic (walks all entries) and is documented as the heavy path; `get_new_spans()` is the hot-loop path.
- `get_new_spans()` slices entries past `self._last_position` and only converts those, updating the cursor to `len(entries)`. `_emitted_count` is incremented per newly-converted span exactly once.

## Test plan

- [x] New `test_get_new_spans_only_converts_new_entries` — first poll drains 10 entries; spy on `_convert_entry`; one new entry appended; second poll must invoke the converter exactly once (pre-fix: 11 times).
- [x] Existing `test_get_new_spans_incremental` and `test_stats` still pass — no semantic change.
- [x] Full agent-lightning suite (84 passed, 1 skipped) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>