### PR TITLE
fix(agent-lightning): preserve caller-supplied PolicyViolation penalty (HIGH Extensions #11)

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
@@ -31,24 +31,36 @@ class PolicyViolationType(Enum):
 
 @dataclass
 class PolicyViolation:
-    """Record of a policy violation during execution."""
+    """Record of a policy violation during execution.
+
+    ``penalty`` defaults to ``None``; on construction it is derived from
+    ``severity`` via :attr:`SEVERITY_PENALTIES` (with a 10.0 fallback for
+    unrecognised severities). Callers that pass an explicit ``penalty``
+    keep that value — the previous implementation unconditionally
+    overwrote any caller-supplied penalty from the severity table, which
+    silently broke callers that intentionally weighted individual
+    violations.
+    """
+
+    SEVERITY_PENALTIES = {
+        "critical": 100.0,
+        "high": 50.0,
+        "medium": 10.0,
+        "low": 1.0,
+    }
+
     violation_type: PolicyViolationType
     policy_name: str
     description: str
     severity: str  # critical, high, medium, low
     timestamp: datetime = field(default_factory=datetime.utcnow)
     action_blocked: bool = False
-    penalty: float = 0.0
+    penalty: float | None = None
 
     def __post_init__(self):
-        """Calculate penalty based on severity."""
-        severity_penalties = {
-            "critical": 100.0,
-            "high": 50.0,
-            "medium": 10.0,
-            "low": 1.0,
-        }
-        self.penalty = severity_penalties.get(self.severity, 10.0)
+        """Derive penalty from severity only when the caller didn't supply one."""
+        if self.penalty is None:
+            self.penalty = self.SEVERITY_PENALTIES.get(self.severity, 10.0)
 
 
 @dataclass

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -239,6 +239,28 @@ class TestPolicyViolation:
         v = PolicyViolation(PolicyViolationType.WARNED, "P", "d", "unknown")
         assert v.penalty == 10.0
 
+    def test_caller_supplied_penalty_preserved(self):
+        """Regression for REVIEW.md HIGH Extensions #11.
+
+        Previously ``__post_init__`` unconditionally overwrote whatever
+        ``penalty`` the caller passed with the severity-table value, so
+        custom weighting silently broke. The fix keeps the caller's
+        value when they supply one, and only derives from severity when
+        the field is left at its default (``None``).
+        """
+        v = PolicyViolation(
+            PolicyViolationType.BLOCKED, "P", "d", "high", penalty=999.0
+        )
+        assert v.penalty == 999.0
+
+    def test_caller_supplied_zero_penalty_preserved(self):
+        """An explicit ``penalty=0.0`` is a valid weighting decision and
+        must not be re-derived as if it were the default."""
+        v = PolicyViolation(
+            PolicyViolationType.WARNED, "P", "d", "critical", penalty=0.0
+        )
+        assert v.penalty == 0.0
+
 
 class TestGovernedRollout:
     def test_total_penalty_calculated(self):


### PR DESCRIPTION
## Summary

[agent-lightning/src/agent_lightning_gov/runner.py:39, 65-67](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py#L32-L51) — `PolicyViolation.__post_init__` unconditionally overwrote any caller-supplied `penalty` with the value from a severity lookup table. The dataclass field defaulted to `0.0`, but every construction path landed in `__post_init__`, so the default was unreachable AND explicit caller values were silently clobbered. Code that intentionally weighted individual violations (a critical at 200, a low at 0 for informational logging, etc.) had its weighting erased.

## Changes

- `penalty` defaults to `None` (sentinel meaning "derive from severity").
- `__post_init__` only derives when `self.penalty is None`; caller-supplied values pass through unchanged.
- The severity → penalty mapping is promoted to a class-level `SEVERITY_PENALTIES` constant so callers can read or override it.

## Test plan

- [x] `test_caller_supplied_penalty_preserved` — explicit `penalty=999.0` survives `__post_init__`.
- [x] `test_caller_supplied_zero_penalty_preserved` — explicit `penalty=0.0` (e.g. an informational violation that should not affect the rollout's total) survives too.
- [x] Existing severity-derivation tests (critical/high/medium/low/unknown) still pass — they don't supply a penalty, so the sentinel path is taken.
- [x] Full agent-lightning suite (85 passed, 1 skipped) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>