### PR TITLE
fix(marketplace): lock PluginRegistry; check duplicate before mutate (HIGH Extensions #12)

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from pathlib import Path
 from typing import Optional
 
@@ -47,6 +48,9 @@ class PluginRegistry:
         self._plugins: dict[str, dict[str, PluginManifest]] = {}
         self._storage_path = storage_path
         self._marketplace_policy = marketplace_policy
+        # Re-entrant so register/unregister can call _persist (which may
+        # itself acquire the lock in future) without deadlocking.
+        self._lock = threading.RLock()
         if storage_path and storage_path.exists():
             self._load_from_file()
 
@@ -82,14 +86,24 @@ class PluginRegistry:
                     + "; ".join(result.violations)
                 )
 
-        versions = self._plugins.setdefault(manifest.name, {})
-        if manifest.version in versions:
-            raise MarketplaceError(
-                f"Plugin {manifest.name}@{manifest.version} is already registered"
-            )
-        versions[manifest.version] = manifest
-        logger.info("Registered plugin %s@%s", manifest.name, manifest.version)
-        self._persist()
+        # Check duplicate *before* mutating ``self._plugins``. Previously
+        # ``setdefault`` ran first and would leave an empty inner dict in
+        # place if any subsequent step on this code path raised; it also
+        # served as a (Python-GIL-only) defence against concurrent
+        # registrations of distinct versions of the same plugin. Both
+        # concerns are addressed by locking + check-before-insert.
+        with self._lock:
+            versions = self._plugins.get(manifest.name)
+            if versions is not None and manifest.version in versions:
+                raise MarketplaceError(
+                    f"Plugin {manifest.name}@{manifest.version} is already registered"
+                )
+            if versions is None:
+                versions = {}
+                self._plugins[manifest.name] = versions
+            versions[manifest.version] = manifest
+            logger.info("Registered plugin %s@%s", manifest.name, manifest.version)
+            self._persist()
 
     def unregister(self, name: str, version: Optional[str] = None) -> None:
         """Remove a plugin from the registry.
@@ -101,18 +115,19 @@ class PluginRegistry:
         Raises:
             MarketplaceError: If the plugin or version is not found.
         """
-        if name not in self._plugins:
-            raise MarketplaceError(f"Plugin not found: {name}")
-        if version:
-            if version not in self._plugins[name]:
-                raise MarketplaceError(f"Version not found: {name}@{version}")
-            del self._plugins[name][version]
-            if not self._plugins[name]:
+        with self._lock:
+            if name not in self._plugins:
+                raise MarketplaceError(f"Plugin not found: {name}")
+            if version:
+                if version not in self._plugins[name]:
+                    raise MarketplaceError(f"Version not found: {name}@{version}")
+                del self._plugins[name][version]
+                if not self._plugins[name]:
+                    del self._plugins[name]
+            else:
                 del self._plugins[name]
-        else:
-            del self._plugins[name]
-        logger.info("Unregistered plugin %s (version=%s)", name, version or "all")
-        self._persist()
+            logger.info("Unregistered plugin %s (version=%s)", name, version or "all")
+            self._persist()
 
     def get_plugin(self, name: str, version: Optional[str] = None) -> PluginManifest:
         """Retrieve a specific plugin manifest.
@@ -129,16 +144,17 @@ class PluginRegistry:
         Raises:
             MarketplaceError: If the plugin or version is not found.
         """
-        if name not in self._plugins:
-            raise MarketplaceError(f"Plugin not found: {name}")
-        versions = self._plugins[name]
-        if version:
-            if version not in versions:
-                raise MarketplaceError(f"Version not found: {name}@{version}")
-            return versions[version]
-        # Return latest by semver
-        latest = max(versions.keys(), key=_semver_tuple)
-        return versions[latest]
+        with self._lock:
+            if name not in self._plugins:
+                raise MarketplaceError(f"Plugin not found: {name}")
+            versions = self._plugins[name]
+            if version:
+                if version not in versions:
+                    raise MarketplaceError(f"Version not found: {name}@{version}")
+                return versions[version]
+            # Return latest by semver
+            latest = max(versions.keys(), key=_semver_tuple)
+            return versions[latest]
 
     # ------------------------------------------------------------------
     # Query helpers
@@ -155,10 +171,11 @@ class PluginRegistry:
         """
         query_lower = query.lower()
         results: list[PluginManifest] = []
-        for versions in self._plugins.values():
-            latest = max(versions.values(), key=lambda m: _semver_tuple(m.version))
-            if query_lower in latest.name.lower() or query_lower in latest.description.lower():
-                results.append(latest)
+        with self._lock:
+            for versions in self._plugins.values():
+                latest = max(versions.values(), key=lambda m: _semver_tuple(m.version))
+                if query_lower in latest.name.lower() or query_lower in latest.description.lower():
+                    results.append(latest)
         return results
 
     def list_plugins(self, type_filter: Optional[PluginType] = None) -> list[PluginManifest]:
@@ -171,10 +188,11 @@ class PluginRegistry:
             List of manifests.
         """
         results: list[PluginManifest] = []
-        for versions in self._plugins.values():
-            latest = max(versions.values(), key=lambda m: _semver_tuple(m.version))
-            if type_filter is None or latest.plugin_type == type_filter:
-                results.append(latest)
+        with self._lock:
+            for versions in self._plugins.values():
+                latest = max(versions.values(), key=lambda m: _semver_tuple(m.version))
+                if type_filter is None or latest.plugin_type == type_filter:
+                    results.append(latest)
         return results
 
     def list_for_organization(self, organization: str) -> list[PluginManifest]:
@@ -190,11 +208,12 @@ class PluginRegistry:
             List of matching manifests (all versions).
         """
         results: list[PluginManifest] = []
-        for name in self._plugins:
-            for version in self._plugins[name]:
-                manifest = self._plugins[name][version]
-                if manifest.organization is None or manifest.organization == organization:
-                    results.append(manifest)
+        with self._lock:
+            for name in self._plugins:
+                for version in self._plugins[name]:
+                    manifest = self._plugins[name][version]
+                    if manifest.organization is None or manifest.organization == organization:
+                        results.append(manifest)
         return results
 
     # ------------------------------------------------------------------

--- a/agent-governance-python/agent-marketplace/tests/test_registry_concurrency_and_dup_check.py
+++ b/agent-governance-python/agent-marketplace/tests/test_registry_concurrency_and_dup_check.py
@@ -1,0 +1,192 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for ``PluginRegistry`` concurrency and duplicate-check ordering.
+
+Regression for REVIEW.md HIGH Extensions #12: ``register`` previously
+called ``self._plugins.setdefault(name, {})`` *before* checking for a
+duplicate version. The setdefault path leaves an empty inner dict in
+place when subsequent steps on the registration path raise (today
+that's only the duplicate-version check itself, but any future early-
+return adds the failure mode). There is also no concurrency control —
+two threads registering distinct versions of the same plugin can race.
+
+The fix:
+
+* Wraps mutation in a re-entrant lock so concurrent ``register`` /
+  ``unregister`` / lookups are serialized.
+* Performs the duplicate-version check *before* mutating the registry.
+* Inserts the inner dict only on confirmed-non-duplicate registrations.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from agent_marketplace.exceptions import MarketplaceError
+from agent_marketplace.manifest import PluginManifest, PluginType
+from agent_marketplace.registry import PluginRegistry
+
+
+def _make_manifest(name: str, version: str = "1.0.0") -> PluginManifest:
+    return PluginManifest(
+        name=name,
+        version=version,
+        description=f"{name} {version}",
+        author="test@example.com",
+        plugin_type=PluginType.INTEGRATION,
+    )
+
+
+class TestRegisterDuplicateCheckOrdering:
+    def test_register_duplicate_does_not_pollute_inner_dict(self):
+        """A duplicate-version registration must not mutate ``self._plugins``."""
+        registry = PluginRegistry()
+        manifest = _make_manifest("polluter", "1.0.0")
+        registry.register(manifest)
+
+        # Snapshot state before the duplicate attempt.
+        before = {
+            n: set(versions.keys())
+            for n, versions in registry._plugins.items()
+        }
+
+        # Duplicate must raise — and must NOT add a second entry or
+        # introduce any new key.
+        with pytest.raises(MarketplaceError, match="already registered"):
+            registry.register(manifest)
+
+        after = {
+            n: set(versions.keys())
+            for n, versions in registry._plugins.items()
+        }
+        assert before == after
+
+    def test_register_unknown_plugin_does_not_leave_empty_inner_dict_on_failure(self):
+        """If duplicate-check raises for a freshly-named entry, no empty dict remains.
+
+        With the prior implementation, ``setdefault(name, {})`` ran before
+        the duplicate check; any future code path that raises between
+        those steps would orphan an empty inner dict at ``name``. The
+        new check-before-mutate ordering forecloses that class of bug.
+        """
+        registry = PluginRegistry()
+        # Force an artificial duplicate by pre-populating an empty inner
+        # dict (simulating prior pollution) and asserting register
+        # behaves sanely. With check-before-mutate, registering a NEW
+        # version under an existing-but-empty inner dict succeeds.
+        registry._plugins["preexisting"] = {}
+        registry.register(_make_manifest("preexisting", "1.0.0"))
+        assert "1.0.0" in registry._plugins["preexisting"]
+
+
+class TestRegistryConcurrentRegister:
+    def test_concurrent_distinct_versions_all_register(self):
+        """Threads registering distinct versions of the same plugin must all succeed."""
+        registry = PluginRegistry()
+        N = 32
+        errors: list[Exception] = []
+        barrier = threading.Barrier(N)
+
+        def worker(version_minor: int):
+            try:
+                barrier.wait(timeout=5)
+                registry.register(_make_manifest("racer", f"1.{version_minor}.0"))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"unexpected errors: {errors}"
+        # All N versions present, no duplicates.
+        assert len(registry._plugins["racer"]) == N
+        expected = {f"1.{i}.0" for i in range(N)}
+        assert set(registry._plugins["racer"].keys()) == expected
+
+    def test_concurrent_same_version_exactly_one_succeeds(self):
+        """When N threads register the SAME name+version, exactly one wins.
+
+        The remaining N-1 must each raise ``MarketplaceError`` with
+        the "already registered" message. None must produce a corrupt
+        state (e.g. a half-written inner dict).
+        """
+        registry = PluginRegistry()
+        N = 16
+        results: list[str] = []  # "ok" / "dup" / exception repr
+        results_lock = threading.Lock()
+        barrier = threading.Barrier(N)
+
+        def worker():
+            try:
+                barrier.wait(timeout=5)
+                registry.register(_make_manifest("hotspot", "1.0.0"))
+                with results_lock:
+                    results.append("ok")
+            except MarketplaceError as exc:
+                if "already registered" in str(exc):
+                    with results_lock:
+                        results.append("dup")
+                else:
+                    with results_lock:
+                        results.append(repr(exc))
+
+        threads = [threading.Thread(target=worker) for _ in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results.count("ok") == 1, f"expected one winner, got {results.count('ok')}: {results}"
+        assert results.count("dup") == N - 1, f"unexpected outcomes: {results}"
+        assert len(registry._plugins["hotspot"]) == 1
+
+
+class TestRegistryConcurrentMixedReadsWrites:
+    def test_reader_does_not_observe_partial_state(self):
+        """Lookups during concurrent registrations don't observe torn state.
+
+        Specifically, ``get_plugin`` must either find a fully-registered
+        manifest or raise ``not found`` — never return ``None`` or crash
+        on a half-written inner dict.
+        """
+        registry = PluginRegistry()
+        stop = threading.Event()
+        errors: list[Exception] = []
+
+        def writer():
+            i = 0
+            while not stop.is_set():
+                try:
+                    registry.register(_make_manifest("churn", f"{i}.0.0"))
+                except MarketplaceError:
+                    pass  # duplicate is fine
+                i += 1
+                if i > 500:
+                    break
+
+        def reader():
+            while not stop.is_set():
+                try:
+                    registry.get_plugin("churn")
+                except MarketplaceError:
+                    pass  # not-yet-registered is fine
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+                    return
+
+        w = threading.Thread(target=writer)
+        r = threading.Thread(target=reader)
+        w.start()
+        r.start()
+        time.sleep(0.2)
+        stop.set()
+        w.join(timeout=5)
+        r.join(timeout=5)
+
+        assert errors == [], f"reader saw torn state: {errors}"


### PR DESCRIPTION
## Summary

[agent-marketplace/src/agent_marketplace/registry.py:84-89](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py#L84-L89) had two issues:

1. **Setdefault before duplicate check.** `self._plugins.setdefault(manifest.name, {})` mutates the registry (inserts an empty inner dict for new names) *before* the duplicate-version check. With the duplicate check the only post-setdefault step that can raise, no observable pollution occurs today — but the ordering was procedurally wrong, and any future early-return between those steps would orphan an empty entry.
2. **No concurrency control.** `setdefault` plus `versions[manifest.version] = manifest` is a compound mutation; the GIL does not serialise it. Two threads registering distinct versions of the same plugin can race on the inner dict; two threads registering the same name+version can both think they're the winner.

## Changes

- `PluginRegistry` gains a `threading.RLock` (re-entrant so the in-lock `_persist()` won't deadlock if later code paths acquire the lock).
- `register` checks duplicate via `self._plugins.get(name)` *before* any mutation; inserts the inner dict + version mapping under the lock only after the check passes.
- `unregister`, `get_plugin`, `search`, `list_plugins`, and `list_for_organization` are wrapped in the lock too, so readers never observe a half-mutated inner dict.

## Test plan

New file `tests/test_registry_concurrency_and_dup_check.py` (5 tests):

- [x] `test_register_duplicate_does_not_pollute_inner_dict` — a duplicate registration must not change `self._plugins`.
- [x] `test_register_unknown_plugin_does_not_leave_empty_inner_dict_on_failure` — registering under an already-empty inner dict still works.
- [x] `test_concurrent_distinct_versions_all_register` — 32 threads register 32 distinct versions of the same plugin; all succeed, no losses.
- [x] `test_concurrent_same_version_exactly_one_succeeds` — 16 threads race on the same name+version; exactly one wins, 15 see "already registered", no corrupt state.
- [x] `test_reader_does_not_observe_partial_state` — `get_plugin` calls during writer churn return a fully-registered manifest or raise "not found"; never crash on torn state.
- [x] Full `agent-marketplace` suite (245 tests) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>