### PR TITLE
fix(supply-chain): parse Cargo.toml with tomllib, flag git/path deps

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
@@ -450,42 +450,104 @@ class SupplyChainGuard:
                         ))
 
     # ------------------------------------------------------------------
-    # Cargo.toml (simple parser – stdlib only)
+    # Cargo.toml (tomllib-based, stdlib only)
     # ------------------------------------------------------------------
 
     def check_cargo_toml(self, path: str) -> list[SupplyChainFinding]:
-        """Check Cargo.toml for unpinned versions."""
+        """Check Cargo.toml for unpinned versions.
+
+        Uses ``tomllib`` (Python 3.11+) so the following layouts are all
+        covered, including ones the prior regex-based parser silently
+        skipped:
+
+          * ``[dependencies]``                   (standard)
+          * ``[dev-dependencies]``               (dev)
+          * ``[build-dependencies]``             (build scripts)
+          * ``[target.'cfg(...)'.dependencies]``  (platform-specific)
+          * Table-form deps: ``foo = { git = "...", rev = "..." }``
+          * Table-form deps: ``foo = { path = "../local" }``
+          * Workspace-inherited: ``foo = { workspace = true }``
+        """
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib  # type: ignore[no-redef]
+
         findings: list[SupplyChainFinding] = []
-        text = Path(path).read_text(encoding="utf-8")
+        try:
+            with open(path, "rb") as fh:
+                data = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError):
+            return findings
 
-        in_deps = False
-        for line in text.splitlines():
-            stripped = line.strip()
+        dep_tables: list[dict] = []
+        for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+            deps = data.get(key)
+            if isinstance(deps, dict):
+                dep_tables.append(deps)
 
-            if re.match(r"\[.*dependencies.*\]", stripped):
-                in_deps = True
-                continue
-            if stripped.startswith("[") and "dependencies" not in stripped:
-                in_deps = False
-                continue
+        # Target-specific: [target.'cfg(...)'.dependencies]
+        for target_cfg in (data.get("target") or {}).values():
+            if isinstance(target_cfg, dict):
+                for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+                    deps = target_cfg.get(key)
+                    if isinstance(deps, dict):
+                        dep_tables.append(deps)
 
-            if in_deps:
-                kv = re.match(r'^(\S+)\s*=\s*"([^"]+)"', stripped)
-                if kv:
-                    name, version = kv.group(1), kv.group(2)
-                    if not re.match(r"^\d+\.\d+\.\d+$", version):
-                        findings.append(SupplyChainFinding(
-                            package=name,
-                            version=version,
-                            severity="medium",
-                            rule="unpinned-cargo",
-                            message=(
-                                f"Crate '{name}' version '{version}' is not "
-                                f"pinned to an exact semver."
-                            ),
-                        ))
+        for deps in dep_tables:
+            for name, spec in deps.items():
+                self._emit_cargo_finding(findings, name, spec)
 
         return findings
+
+    def _emit_cargo_finding(
+        self, findings: list[SupplyChainFinding], name: str, spec: object,
+    ) -> None:
+        """Classify a single Cargo dependency and emit a finding if needed."""
+        if isinstance(spec, str):
+            if not _EXACT_SEMVER.match(spec.strip()):
+                findings.append(SupplyChainFinding(
+                    package=name,
+                    version=spec,
+                    severity="medium",
+                    rule="unpinned-cargo",
+                    message=(
+                        f"Crate '{name}' version '{spec}' is not "
+                        f"pinned to an exact semver."
+                    ),
+                ))
+        elif isinstance(spec, dict):
+            for protocol_key in ("git", "path"):
+                if protocol_key in spec:
+                    findings.append(SupplyChainFinding(
+                        package=name,
+                        version=str(spec.get(protocol_key, "")),
+                        severity="high",
+                        rule="non-registry-source",
+                        message=(
+                            f"Crate '{name}' is sourced via "
+                            f"'{protocol_key}=' ({spec.get(protocol_key)!r})"
+                            "; pin to an exact version published on "
+                            "crates.io instead."
+                        ),
+                    ))
+                    return
+            if spec.get("workspace") is True:
+                return
+            inline_version = spec.get("version")
+            if isinstance(inline_version, str) and not _EXACT_SEMVER.match(
+                inline_version.strip()
+            ):
+                findings.append(SupplyChainFinding(
+                    package=name,
+                    version=inline_version,
+                    severity="medium",
+                    rule="unpinned-cargo",
+                    message=(
+                        f"Crate '{name}' version '{inline_version}' is not "
+                        f"pinned to an exact semver."
+                    ),
+                ))
 
     # ------------------------------------------------------------------
     # Freshness (offline)

--- a/agent-governance-python/agent-compliance/tests/test_supply_chain.py
+++ b/agent-governance-python/agent-compliance/tests/test_supply_chain.py
@@ -414,6 +414,113 @@ class TestCheckCargoToml:
         findings = guard.check_cargo_toml(str(cargo))
         assert not any(f.rule == "unpinned-cargo" for f in findings)
 
+    def test_git_source_flagged(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Regression: table-form deps like {git="..."} were invisible
+        to the regex parser, which only matched 'name = "version"'.
+        """
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'evil = { git = "https://github.com/attacker/evil.git", rev = "abc123" }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "non-registry-source" and f.package == "evil"
+            for f in findings
+        )
+
+    def test_path_source_flagged(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Regression: path deps bypass crates.io entirely."""
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'local-crate = { path = "../local-crate" }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "non-registry-source" and f.package == "local-crate"
+            for f in findings
+        )
+
+    def test_inline_table_unpinned_version(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Table-form with version key: {version="^1.0", features=[...]}."""
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'serde = { version = "^1.0", features = ["derive"] }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "serde"
+            for f in findings
+        )
+
+    def test_inline_table_pinned_version_passes(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'serde = { version = "1.0.193", features = ["derive"] }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert not any(f.package == "serde" for f in findings)
+
+    def test_workspace_inherited_passes(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Workspace-inherited deps get their version from the root."""
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'serde = { workspace = true }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert not any(f.package == "serde" for f in findings)
+
+    def test_dev_dependencies_checked(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dev-dependencies]\n'
+            'criterion = "0.5"\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "criterion"
+            for f in findings
+        )
+
+    def test_build_dependencies_checked(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[build-dependencies]\n'
+            'cc = "1.0"\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "cc"
+            for f in findings
+        )
+
+    def test_target_specific_deps_checked(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Regression: target-specific deps were in a different TOML
+        section and invisible to the regex parser.
+        """
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            "[target.'cfg(windows)'.dependencies]\n"
+            'winapi = "0.3"\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "winapi"
+            for f in findings
+        )
+
 
 # ---------------------------------------------------------------------------
 # check_typosquatting


### PR DESCRIPTION
Same pattern as the pyproject.toml fix in PR #1939. The regex Cargo.toml parser only matched bare string versions, silently missing table-form deps, inline version tables, dev/build-dependencies, target-specific deps, and workspace-inherited deps. Replaced with tomllib (stdlib 3.11+). Added 8 new regression tests.