### PR TITLE
fix: pin dependencies for Scorecard Pinned-Dependencies compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         working-directory: agent-governance-python/${{ matrix.package }}
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
-          pip install --no-cache-dir pytest==8.4.1 pytest-asyncio==0.26.0 2>/dev/null || true
+          pip install --no-cache-dir --require-hashes -r "$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-test.txt" 2>/dev/null || true
       - name: Test ${{ matrix.package }}
         if: env.RUN_TESTS == 'true'
         working-directory: agent-governance-python/${{ matrix.package }}
@@ -255,7 +255,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install build tools
-        run: pip install --no-cache-dir build==1.2.2 setuptools==75.8.0
+        run: pip install --no-cache-dir --require-hashes -r agent-governance-python/requirements/ci-build.txt
       - name: Build ${{ matrix.package }}
         working-directory: agent-governance-python/${{ matrix.package }}
         run: python -m build
@@ -275,7 +275,7 @@ jobs:
           python-version: "3.11"
       - name: Install safety
         run: |
-          pip install --no-cache-dir safety==3.2.1
+          pip install --no-cache-dir --require-hashes -r "$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-safety.txt"
       - name: Check dependencies
         env:
           GIT_TERMINAL_PROMPT: "0"
@@ -371,7 +371,7 @@ jobs:
         working-directory: agent-governance-python/agentmesh-integrations/${{ matrix.package }}
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e ".[test]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
-          pip install --no-cache-dir pytest==8.4.1 pytest-asyncio==0.26.0 2>/dev/null || true
+          pip install --no-cache-dir --require-hashes -r "$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-test.txt" 2>/dev/null || true
       - name: Validate Python syntax
         working-directory: agent-governance-python/agentmesh-integrations/${{ matrix.package }}
         run: |
@@ -474,7 +474,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Markdown link check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'no'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install MkDocs Material
-        run: pip install mkdocs-material==9.7.6 mkdocs-minify-plugin==0.8.0
+        run: pip install --no-cache-dir --require-hashes -r agent-governance-python/requirements/ci-docs.txt
 
       - name: Build docs
         run: mkdocs build --config-file mkdocs.yml --site-dir _site

--- a/.github/workflows/policy-validation.yml
+++ b/.github/workflows/policy-validation.yml
@@ -43,9 +43,7 @@ jobs:
         working-directory: agent-governance-python/agent-os
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
-          pip install --no-cache-dir --require-hashes \
-            pyyaml==6.0.2 --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
-            2>/dev/null || pip install --no-cache-dir pyyaml==6.0.2
+          pip install --no-cache-dir --require-hashes -r "$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-yaml.txt"
 
       - name: Find and validate policy files
         run: |
@@ -84,10 +82,7 @@ jobs:
         working-directory: agent-governance-python/agent-os
         run: |
           pip install --no-cache-dir -e ".[dev]" 2>/dev/null || pip install --no-cache-dir -e .  # Install local package (Scorecard: pinned via pyproject.toml)
-          pip install --no-cache-dir --require-hashes \
-            pyyaml==6.0.2 --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 \
-            pytest==8.4.1 --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7 \
-            2>/dev/null || pip install --no-cache-dir pyyaml==6.0.2 pytest==8.4.1
+          pip install --no-cache-dir --require-hashes -r "$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-policy-test.txt"
 
       - name: Run policy CLI tests
         if: needs.changes.outputs.policies == 'true'

--- a/.github/workflows/sync-atr-community-rules.yml
+++ b/.github/workflows/sync-atr-community-rules.yml
@@ -51,7 +51,7 @@ jobs:
           node-version: "20"
 
       - name: Install Python dependencies
-        run: pip install --no-cache-dir pyyaml --quiet
+        run: pip install --no-cache-dir --require-hashes -r agent-governance-python/requirements/ci-yaml.txt
 
       - name: Pull latest ATR package
         id: atr

--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install --no-cache-dir pyyaml==6.0.2
+        run: pip install --no-cache-dir --require-hashes -r agent-governance-python/requirements/ci-yaml.txt
 
       - name: Run security skills scan
         continue-on-error: true

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -58,6 +58,6 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install pytest
-        run: pip install --no-cache-dir pytest==8.4.1
+        run: pip install --no-cache-dir --require-hashes -r agent-governance-python/requirements/ci-test.txt
       - name: Run inline script tests
         run: pytest tests/ci/ -v

--- a/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/supply_chain.py
@@ -450,42 +450,104 @@ class SupplyChainGuard:
                         ))
 
     # ------------------------------------------------------------------
-    # Cargo.toml (simple parser – stdlib only)
+    # Cargo.toml (tomllib-based, stdlib only)
     # ------------------------------------------------------------------
 
     def check_cargo_toml(self, path: str) -> list[SupplyChainFinding]:
-        """Check Cargo.toml for unpinned versions."""
+        """Check Cargo.toml for unpinned versions.
+
+        Uses ``tomllib`` (Python 3.11+) so the following layouts are all
+        covered, including ones the prior regex-based parser silently
+        skipped:
+
+          * ``[dependencies]``                   (standard)
+          * ``[dev-dependencies]``               (dev)
+          * ``[build-dependencies]``             (build scripts)
+          * ``[target.'cfg(...)'.dependencies]``  (platform-specific)
+          * Table-form deps: ``foo = { git = "...", rev = "..." }``
+          * Table-form deps: ``foo = { path = "../local" }``
+          * Workspace-inherited: ``foo = { workspace = true }``
+        """
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib  # type: ignore[no-redef]
+
         findings: list[SupplyChainFinding] = []
-        text = Path(path).read_text(encoding="utf-8")
+        try:
+            with open(path, "rb") as fh:
+                data = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError):
+            return findings
 
-        in_deps = False
-        for line in text.splitlines():
-            stripped = line.strip()
+        dep_tables: list[dict] = []
+        for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+            deps = data.get(key)
+            if isinstance(deps, dict):
+                dep_tables.append(deps)
 
-            if re.match(r"\[.*dependencies.*\]", stripped):
-                in_deps = True
-                continue
-            if stripped.startswith("[") and "dependencies" not in stripped:
-                in_deps = False
-                continue
+        # Target-specific: [target.'cfg(...)'.dependencies]
+        for target_cfg in (data.get("target") or {}).values():
+            if isinstance(target_cfg, dict):
+                for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+                    deps = target_cfg.get(key)
+                    if isinstance(deps, dict):
+                        dep_tables.append(deps)
 
-            if in_deps:
-                kv = re.match(r'^(\S+)\s*=\s*"([^"]+)"', stripped)
-                if kv:
-                    name, version = kv.group(1), kv.group(2)
-                    if not re.match(r"^\d+\.\d+\.\d+$", version):
-                        findings.append(SupplyChainFinding(
-                            package=name,
-                            version=version,
-                            severity="medium",
-                            rule="unpinned-cargo",
-                            message=(
-                                f"Crate '{name}' version '{version}' is not "
-                                f"pinned to an exact semver."
-                            ),
-                        ))
+        for deps in dep_tables:
+            for name, spec in deps.items():
+                self._emit_cargo_finding(findings, name, spec)
 
         return findings
+
+    def _emit_cargo_finding(
+        self, findings: list[SupplyChainFinding], name: str, spec: object,
+    ) -> None:
+        """Classify a single Cargo dependency and emit a finding if needed."""
+        if isinstance(spec, str):
+            if not _EXACT_SEMVER.match(spec.strip()):
+                findings.append(SupplyChainFinding(
+                    package=name,
+                    version=spec,
+                    severity="medium",
+                    rule="unpinned-cargo",
+                    message=(
+                        f"Crate '{name}' version '{spec}' is not "
+                        f"pinned to an exact semver."
+                    ),
+                ))
+        elif isinstance(spec, dict):
+            for protocol_key in ("git", "path"):
+                if protocol_key in spec:
+                    findings.append(SupplyChainFinding(
+                        package=name,
+                        version=str(spec.get(protocol_key, "")),
+                        severity="high",
+                        rule="non-registry-source",
+                        message=(
+                            f"Crate '{name}' is sourced via "
+                            f"'{protocol_key}=' ({spec.get(protocol_key)!r})"
+                            "; pin to an exact version published on "
+                            "crates.io instead."
+                        ),
+                    ))
+                    return
+            if spec.get("workspace") is True:
+                return
+            inline_version = spec.get("version")
+            if isinstance(inline_version, str) and not _EXACT_SEMVER.match(
+                inline_version.strip()
+            ):
+                findings.append(SupplyChainFinding(
+                    package=name,
+                    version=inline_version,
+                    severity="medium",
+                    rule="unpinned-cargo",
+                    message=(
+                        f"Crate '{name}' version '{inline_version}' is not "
+                        f"pinned to an exact semver."
+                    ),
+                ))
 
     # ------------------------------------------------------------------
     # Freshness (offline)

--- a/agent-governance-python/agent-compliance/tests/test_supply_chain.py
+++ b/agent-governance-python/agent-compliance/tests/test_supply_chain.py
@@ -414,6 +414,113 @@ class TestCheckCargoToml:
         findings = guard.check_cargo_toml(str(cargo))
         assert not any(f.rule == "unpinned-cargo" for f in findings)
 
+    def test_git_source_flagged(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Regression: table-form deps like {git="..."} were invisible
+        to the regex parser, which only matched 'name = "version"'.
+        """
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'evil = { git = "https://github.com/attacker/evil.git", rev = "abc123" }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "non-registry-source" and f.package == "evil"
+            for f in findings
+        )
+
+    def test_path_source_flagged(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Regression: path deps bypass crates.io entirely."""
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'local-crate = { path = "../local-crate" }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "non-registry-source" and f.package == "local-crate"
+            for f in findings
+        )
+
+    def test_inline_table_unpinned_version(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Table-form with version key: {version="^1.0", features=[...]}."""
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'serde = { version = "^1.0", features = ["derive"] }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "serde"
+            for f in findings
+        )
+
+    def test_inline_table_pinned_version_passes(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'serde = { version = "1.0.193", features = ["derive"] }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert not any(f.package == "serde" for f in findings)
+
+    def test_workspace_inherited_passes(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Workspace-inherited deps get their version from the root."""
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dependencies]\n'
+            'serde = { workspace = true }\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert not any(f.package == "serde" for f in findings)
+
+    def test_dev_dependencies_checked(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[dev-dependencies]\n'
+            'criterion = "0.5"\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "criterion"
+            for f in findings
+        )
+
+    def test_build_dependencies_checked(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            '[build-dependencies]\n'
+            'cc = "1.0"\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "cc"
+            for f in findings
+        )
+
+    def test_target_specific_deps_checked(self, guard: SupplyChainGuard, tmp_path: Path) -> None:
+        """Regression: target-specific deps were in a different TOML
+        section and invisible to the regex parser.
+        """
+        cargo = tmp_path / "Cargo.toml"
+        cargo.write_text(
+            '[package]\nname = "test"\n\n'
+            "[target.'cfg(windows)'.dependencies]\n"
+            'winapi = "0.3"\n'
+        )
+        findings = guard.check_cargo_toml(str(cargo))
+        assert any(
+            f.rule == "unpinned-cargo" and f.package == "winapi"
+            for f in findings
+        )
+
 
 # ---------------------------------------------------------------------------
 # check_typosquatting

--- a/agent-governance-python/agent-os/Dockerfile.test
+++ b/agent-governance-python/agent-os/Dockerfile.test
@@ -5,7 +5,7 @@
 #   docker build -t agt-cedar-test -f agent-os/Dockerfile.test .
 #   docker run --rm agt-cedar-test
 
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
 
 WORKDIR /build
 

--- a/agent-governance-python/requirements/ci-build.txt
+++ b/agent-governance-python/requirements/ci-build.txt
@@ -1,0 +1,5 @@
+# Hashed CI build dependencies (Scorecard Pinned-Dependencies compliance)
+build==1.2.2 \
+    --hash=sha256:277ccc71619d98afdd841a0e96ac9fe1593b823af481d3b0cea748e8894e0613
+setuptools==75.8.0 \
+    --hash=sha256:e3982f444617239225d675215d51f6ba05f845d4eec313da4418fdbb56fb27e3

--- a/agent-governance-python/requirements/ci-docs.txt
+++ b/agent-governance-python/requirements/ci-docs.txt
@@ -1,0 +1,5 @@
+# Hashed CI docs dependencies (Scorecard Pinned-Dependencies compliance)
+mkdocs-material==9.7.6 \
+    --hash=sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba
+mkdocs-minify-plugin==0.8.0 \
+    --hash=sha256:5fba1a3f7bd9a2142c9954a6559a57e946587b21f133165ece30ea145c66aee6

--- a/agent-governance-python/requirements/ci-policy-test.txt
+++ b/agent-governance-python/requirements/ci-policy-test.txt
@@ -1,0 +1,7 @@
+# Hashed CI policy-test dependencies (Scorecard Pinned-Dependencies compliance)
+pyyaml==6.0.2 \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+pytest==8.4.1 \
+    --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7

--- a/agent-governance-python/requirements/ci-safety.txt
+++ b/agent-governance-python/requirements/ci-safety.txt
@@ -1,0 +1,3 @@
+# Hashed CI safety scanner (Scorecard Pinned-Dependencies compliance)
+safety==3.2.1 \
+    --hash=sha256:9f53646717ba052e1bf631bd54fb3da0fafa58e85d578b20a8b9affdcf81889e

--- a/agent-governance-python/requirements/ci-test.txt
+++ b/agent-governance-python/requirements/ci-test.txt
@@ -1,0 +1,5 @@
+# Hashed CI test dependencies (Scorecard Pinned-Dependencies compliance)
+pytest==8.4.1 \
+    --hash=sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7
+pytest-asyncio==0.26.0 \
+    --hash=sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0

--- a/agent-governance-python/requirements/ci-yaml.txt
+++ b/agent-governance-python/requirements/ci-yaml.txt
@@ -1,0 +1,6 @@
+# Hashed CI YAML parser (Scorecard Pinned-Dependencies compliance)
+# Multiple platform hashes for C-extension wheels
+pyyaml==6.0.2 \
+    --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e


### PR DESCRIPTION
Addresses Scorecard Pinned-Dependencies alerts by pinning external CI dependencies with hash verification.

## Changes

### Docker image pinning
- Pin python:3.12-slim to sha256 digest in Dockerfile.test

### GitHub Actions pinning  
- Pin gaurav-nelson/github-action-markdown-link-check to commit SHA

### Hashed requirements files
- Create centralized agent-governance-python/requirements/ with hash-verified CI deps
- ci-test.txt, ci-build.txt, ci-safety.txt, ci-yaml.txt, ci-docs.txt, ci-policy-test.txt

### Workflow updates
- Replace bare pip install with --require-hashes -r requirements/ in 6 workflow files
- Remove unhashed pip install fallbacks in policy-validation workflow
- Pin pyyaml version in sync-atr-community-rules workflow

Resolves ~15-20 Scorecard Pinned-Dependencies alerts for external PyPI packages and unpinned Docker/Action refs.