### PR TITLE
fix(compliance): hash all attestation fields to prevent forgery

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/verify.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/verify.py
@@ -325,28 +325,47 @@ class GovernanceAttestation:
         return json.dumps(payload, indent=2)
 
     def recalculate_hash(self) -> None:
-        """Refresh the attestation hash."""
+        """Refresh the attestation hash.
+
+        Hashes all semantically meaningful fields so that any
+        modification to the attestation (flipping ``passed``, altering
+        control presence/names, changing evidence observations, etc.)
+        produces a different digest. Fields omitted from the hash in
+        prior versions allowed an attacker to forge the JSON without
+        invalidating the hash.
+        """
         payload = {
             "mode": self.mode,
             "strict": self.strict,
+            "passed": self.passed,
+            "controls_passed": self.controls_passed,
+            "controls_total": self.controls_total,
             "controls": [
                 {
                     "id": c.control_id,
+                    "name": c.name,
                     "present": c.present,
+                    "module": c.module,
+                    "component": c.component,
+                    "error": c.error,
                 }
                 for c in self.controls
             ],
             "evidence_checks": [
                 {
                     "id": c.check_id,
+                    "title": c.title,
                     "status": c.status,
                     "message": c.message,
+                    "observed": c.observed,
                 }
                 for c in self.evidence_checks
             ],
             "failures": self.failures,
             "verified_at": self.verified_at,
             "toolkit_version": self.toolkit_version,
+            "python_version": self.python_version,
+            "platform_info": self.platform_info,
             "evidence_source": self.evidence_source,
         }
         self.attestation_hash = hashlib.sha256(

--- a/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
+++ b/agent-governance-python/agent-compliance/tests/test_integrity_and_verify.py
@@ -375,6 +375,41 @@ class TestGovernanceVerifier:
         assert len(attestation.attestation_hash) == 64
         assert attestation.attestation_hash == attestation.attestation_hash
 
+    def test_attestation_hash_changes_when_passed_flipped(self):
+        """Regression: recalculate_hash previously omitted ``passed``,
+        ``controls_passed``, ``controls_total``, and control detail
+        fields. An attacker could flip passed=False to True in the JSON
+        without invalidating the hash.
+        """
+        verifier = GovernanceVerifier()
+        attestation = verifier.verify()
+        hash_original = attestation.attestation_hash
+
+        # Flip passed and recalculate
+        attestation.passed = not attestation.passed
+        attestation.recalculate_hash()
+        assert attestation.attestation_hash != hash_original
+
+    def test_attestation_hash_changes_when_controls_total_changed(self):
+        """controls_total was not hashed, so forging the count was free."""
+        verifier = GovernanceVerifier()
+        attestation = verifier.verify()
+        hash_original = attestation.attestation_hash
+
+        attestation.controls_total += 100
+        attestation.recalculate_hash()
+        assert attestation.attestation_hash != hash_original
+
+    def test_attestation_hash_changes_when_platform_changed(self):
+        """python_version and platform_info were not hashed."""
+        verifier = GovernanceVerifier()
+        attestation = verifier.verify()
+        hash_original = attestation.attestation_hash
+
+        attestation.python_version = "fake-3.99"
+        attestation.recalculate_hash()
+        assert attestation.attestation_hash != hash_original
+
     def test_custom_controls(self):
         verifier = GovernanceVerifier(controls=_CUSTOM_VERIFY_CONTROLS)
 


### PR DESCRIPTION
## Problem
\ecalculate_hash()\ omitted several semantically meaningful fields from the attestation hash: \passed\, \controls_passed\, \controls_total\, \python_version\, \platform_info\, and detail fields on controls (\
ame\, \module\, \component\, \rror\) and evidence checks (\	itle\, \observed\).

An attacker who obtained the attestation JSON could flip \passed\ from \False\ to \True\, alter control counts, or change platform info without invalidating the hash.

## Fix
Include all fields in the hash payload, matching what \	o_json()\ serializes.

## Tests
- \	est_attestation_hash_changes_when_passed_flipped\
- \	est_attestation_hash_changes_when_controls_total_changed\
- \	est_attestation_hash_changes_when_platform_changed\

Pattern from finnoybu PR #1944 (incomplete object hashing) applied to attestation verification.