### PR TITLE
feat(rag-governance): add Cedar policy integration for collection acc…

### DIFF
--- a/agent-governance-python/agent-rag-governance/CHANGELOG.md
+++ b/agent-governance-python/agent-rag-governance/CHANGELOG.md
@@ -1,9 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `cedar_policy` field on `RAGPolicy` — inline Cedar policy string for
+  collection access control via `CedarBackend` from `agent-os`
+- `cedar_policy_path` field on `RAGPolicy` — path to a `.cedar` policy
+  file, loaded automatically at construction time
+- Cedar policy takes precedence over `allowed_collections` /
+  `denied_collections` when configured — fully opt-in, existing list
+  behaviour unchanged
+- `LlamaIndex` adapter — `GovernedQueryEngine` wraps any LlamaIndex
+  `BaseQueryEngine` or `BaseRetriever` with the same four governance
+  controls (collection ACL, rate limiting, content scanning, audit logging)
+
 ## 0.1.0 (2026-05-05)
 
 Initial release.
-
 - `RAGGovernor` — governance wrapper for LangChain-compatible retrievers
 - `RAGPolicy` — declarative allow/deny list, rate limiting, content policy config
 - `RateLimiter` — pure-Python sliding-window per-agent rate limiter

--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/policy.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/policy.py
@@ -25,14 +25,46 @@ class RAGPolicy:
         audit_enabled: Whether to emit a structured audit entry per call.
         audit_log_path: File path for audit log (JSON lines). ``None``
             writes to stdout.
+        cedar_policy: Inline Cedar policy string for collection access
+            control. When provided, takes precedence over
+            ``allowed_collections`` / ``denied_collections``.
+        cedar_policy_path: Path to a ``.cedar`` policy file. Loaded at
+            construction time. Ignored when ``cedar_policy`` is set.
 
-    Example::
+    Example — simple allow/deny lists::
 
         policy = RAGPolicy(
             allowed_collections=["public_docs", "product_manuals"],
             denied_collections=["hr_records", "financial_data"],
             max_retrievals_per_minute=100,
             content_policies=["block_pii", "block_injections"],
+            audit_enabled=True,
+        )
+
+    Example — Cedar policy for fine-grained access control::
+
+        policy = RAGPolicy(
+            cedar_policy=\\'\\'\\'
+                permit(
+                    principal == Agent::"sales-agent",
+                    action == Action::"Retrieve",
+                    resource == Collection::"public_docs"
+                );
+                forbid(
+                    principal,
+                    action == Action::"Retrieve",
+                    resource == Collection::"hr_records"
+                );
+            \\'\\'\\'
+            max_retrievals_per_minute=100,
+            content_policies=["block_pii", "block_injections"],
+            audit_enabled=True,
+        )
+
+    Example — Cedar policy from file::
+
+        policy = RAGPolicy(
+            cedar_policy_path="policies/rag_access.cedar",
             audit_enabled=True,
         )
     """
@@ -43,16 +75,111 @@ class RAGPolicy:
     content_policies: List[str] = field(default_factory=list)
     audit_enabled: bool = True
     audit_log_path: Optional[str] = None
+    cedar_policy: Optional[str] = None
+    cedar_policy_path: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Load Cedar policy from file if path is provided."""
+        if self.cedar_policy_path and not self.cedar_policy:
+            from pathlib import Path
+            path = Path(self.cedar_policy_path)
+            if path.exists():
+                self.cedar_policy = path.read_text()
 
     def is_collection_allowed(self, collection: str) -> tuple[bool, str]:
         """Check whether *collection* is permitted under this policy.
 
+        When a Cedar policy is configured, delegates to the Cedar engine.
+        Otherwise falls back to the allow/deny list check.
+
         Returns:
-            ``(allowed, reason)`` where *reason* is ``"ok"``, ``"denied"``,
-            or ``"not_allowed"``.
+            ``(allowed, reason)`` where *reason* is ``"ok"``,
+            ``"denied"``, ``"not_allowed"``, or ``"cedar_denied"``.
         """
+        if self.cedar_policy:
+            return self._check_cedar(collection)
+        return self._check_lists(collection)
+
+    def _check_lists(self, collection: str) -> tuple[bool, str]:
+        """Check collection against allow/deny lists."""
         if collection in self.denied_collections:
             return False, "denied"
         if self.allowed_collections is not None and collection not in self.allowed_collections:
             return False, "not_allowed"
         return True, "ok"
+
+    def _check_cedar(self, collection: str) -> tuple[bool, str]:
+        """Check collection access using Cedar policy engine.
+
+        Uses CedarBackend from agent-os for policy evaluation. When
+        neither cedarpy nor Cedar CLI is available, the built-in fallback
+        evaluator ignores resource constraints. In that case we apply
+        our own resource-aware logic to ensure collection-level access
+        control is enforced correctly.
+        """
+        try:
+            from agent_os.policies.backends import CedarBackend, _parse_cedar_statements
+        except ImportError:
+            # agent-os not available — fall back to list-based check
+            return self._check_lists(collection)
+
+        resource_str = f'Collection::"{collection}"'
+        backend = CedarBackend(policy_content=self.cedar_policy)
+        decision = backend.evaluate({
+            "tool_name": "retrieve",
+            "agent_id": "agent",
+            "resource": resource_str,
+            "collection": collection,
+        })
+
+        # If cedarpy or CLI evaluated — trust the result fully
+        if not ("builtin" in decision.reason.lower()):
+            return (True, "ok") if decision.allowed else (False, "cedar_denied")
+
+        # Built-in fallback ignores resource constraints — apply our own
+        # resource-aware Cedar evaluation
+        statements = _parse_cedar_statements(self.cedar_policy)
+        action_str = 'Action::"Retrieve"'
+
+        # Cedar semantics: forbid overrides permit, default deny
+        for stmt in statements:
+            if stmt["effect"] == "forbid":
+                action_matches = (
+                    stmt["action_constraint"] is None
+                    or stmt["action_constraint"] == action_str
+                )
+                resource_matches = self._cedar_resource_matches(
+                    stmt["raw"], resource_str
+                )
+                no_resource_constraint = "resource ==" not in stmt["raw"]
+                if action_matches and (resource_matches or no_resource_constraint):
+                    return False, "cedar_denied"
+
+        # Check if any permit covers this collection
+        for stmt in statements:
+            if stmt["effect"] == "permit":
+                action_matches = (
+                    stmt["action_constraint"] is None
+                    or stmt["action_constraint"] == action_str
+                )
+                resource_matches = self._cedar_resource_matches(
+                    stmt["raw"], resource_str
+                )
+                no_resource_constraint = "resource ==" not in stmt["raw"]
+                if action_matches and (resource_matches or no_resource_constraint):
+                    return True, "ok"
+
+        # No permit matched — default deny
+        return False, "cedar_denied"
+
+    @staticmethod
+    def _cedar_resource_matches(statement_raw: str, resource_str: str) -> bool:
+        """Check if a Cedar statement's resource constraint matches."""
+        import re
+        match = re.search(
+            r'resource\s*==\s*(Collection::"[^"]+")',
+            statement_raw
+        )
+        if not match:
+            return False
+        return match.group(1).strip() == resource_str

--- a/agent-governance-python/agent-rag-governance/tests/test_cedar_policy.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_cedar_policy.py
@@ -1,0 +1,219 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for Cedar policy integration in agent-rag-governance."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+from agent_rag_governance import (
+    RAGGovernor,
+    RAGPolicy,
+    CollectionDeniedError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake retriever for testing
+# ---------------------------------------------------------------------------
+
+class _FakeDoc:
+    """Minimal document object."""
+    def __init__(self, text: str):
+        self.page_content = text
+
+
+class _FakeRetriever:
+    """Retriever that returns a fixed list of documents."""
+    def __init__(self, docs: list):
+        self._docs = docs
+
+    def invoke(self, query: str, **kwargs: Any) -> list:
+        return self._docs
+
+
+def _make_governor(policy: RAGPolicy) -> RAGGovernor:
+    return RAGGovernor(policy=policy, agent_id="test-agent")
+
+
+# ---------------------------------------------------------------------------
+# Cedar policy tests
+# ---------------------------------------------------------------------------
+
+CEDAR_PERMIT_PUBLIC = """
+permit(
+    principal,
+    action == Action::"Retrieve",
+    resource == Collection::"public_docs"
+);
+"""
+
+CEDAR_FORBID_HR = """
+permit(
+    principal,
+    action == Action::"Retrieve",
+    resource == Collection::"public_docs"
+);
+forbid(
+    principal,
+    action == Action::"Retrieve",
+    resource == Collection::"hr_records"
+);
+"""
+
+CEDAR_PERMIT_ALL = """
+permit(
+    principal,
+    action == Action::"Retrieve",
+    resource
+);
+"""
+
+
+def test_cedar_permits_allowed_collection():
+    """Cedar policy permits access to allowed collection."""
+    policy = RAGPolicy(cedar_policy=CEDAR_PERMIT_PUBLIC)
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([_FakeDoc("clean text")])
+    governed = governor.wrap(retriever, collection="public_docs")
+    docs = governed.invoke("query")
+    assert len(docs) == 1
+
+
+def test_cedar_denies_unlisted_collection():
+    """Cedar policy denies access to collection not in permit rules."""
+    policy = RAGPolicy(cedar_policy=CEDAR_PERMIT_PUBLIC)
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([])
+    governed = governor.wrap(retriever, collection="hr_records")
+    with pytest.raises(CollectionDeniedError) as exc:
+        governed.invoke("query")
+    assert exc.value.collection == "hr_records"
+    assert exc.value.agent_id == "test-agent"
+
+
+def test_cedar_explicit_forbid_overrides_permit():
+    """Cedar forbid rule blocks even if collection appears accessible."""
+    policy = RAGPolicy(cedar_policy=CEDAR_FORBID_HR)
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([])
+    governed = governor.wrap(retriever, collection="hr_records")
+    with pytest.raises(CollectionDeniedError) as exc:
+        governed.invoke("query")
+    assert exc.value.reason == "cedar_denied"
+
+
+def test_cedar_permit_all_allows_any_collection():
+    """Cedar catch-all permit allows any collection."""
+    policy = RAGPolicy(cedar_policy=CEDAR_PERMIT_ALL)
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([_FakeDoc("clean text")])
+    for collection in ["public_docs", "internal_wiki", "product_docs"]:
+        governed = governor.wrap(retriever, collection=collection)
+        docs = governed.invoke("query")
+        assert len(docs) == 1
+
+
+def test_cedar_policy_from_file():
+    """Cedar policy loaded from file works correctly."""
+    with tempfile.NamedTemporaryFile(
+        suffix=".cedar", mode="w", delete=False
+    ) as f:
+        f.write(CEDAR_PERMIT_PUBLIC)
+        policy_path = f.name
+
+    policy = RAGPolicy(cedar_policy_path=policy_path)
+    assert policy.cedar_policy is not None
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([_FakeDoc("clean text")])
+    governed = governor.wrap(retriever, collection="public_docs")
+    docs = governed.invoke("query")
+    assert len(docs) == 1
+
+
+def test_cedar_policy_file_not_found_falls_back_to_lists():
+    """Non-existent Cedar policy file falls back to list-based check."""
+    policy = RAGPolicy(
+        cedar_policy_path="/nonexistent/path/policy.cedar",
+        allowed_collections=["public_docs"],
+    )
+    # cedar_policy should be None since file doesn't exist
+    assert policy.cedar_policy is None
+    # List-based check should still work
+    allowed, reason = policy.is_collection_allowed("public_docs")
+    assert allowed is True
+    assert reason == "ok"
+
+
+def test_cedar_takes_precedence_over_lists():
+    """Cedar policy takes precedence over allowed/denied lists."""
+    policy = RAGPolicy(
+        cedar_policy=CEDAR_PERMIT_PUBLIC,
+        # These list rules would normally deny hr_records
+        # but Cedar is checked first and permits it if no forbid rule
+        allowed_collections=["public_docs"],
+        denied_collections=["hr_records"],
+    )
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([])
+    governed = governor.wrap(retriever, collection="hr_records")
+    # Cedar has no forbid for hr_records but also no permit
+    # so Cedar default deny applies — Cedar takes precedence
+    with pytest.raises(CollectionDeniedError):
+        governed.invoke("query")
+
+
+def test_cedar_audit_logged_on_denial():
+    """Cedar denial is logged to audit trail."""
+    import json
+
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+        log_path = f.name
+
+    policy = RAGPolicy(
+        cedar_policy=CEDAR_PERMIT_PUBLIC,
+        audit_enabled=True,
+        audit_log_path=log_path,
+    )
+    governor = RAGGovernor(policy=policy, agent_id="audit-agent")
+    governed = governor.wrap(_FakeRetriever([]), collection="hr_records")
+
+    with pytest.raises(CollectionDeniedError):
+        governed.invoke("query")
+
+    lines = Path(log_path).read_text().strip().splitlines()
+    assert len(lines) == 1
+    data = json.loads(lines[0])
+    assert data["decision"] == "denied"
+    assert data["agent_id"] == "audit-agent"
+
+
+def test_no_cedar_falls_back_to_list_allow():
+    """Without Cedar policy, allowed_collections list still works."""
+    policy = RAGPolicy(allowed_collections=["public_docs"])
+    allowed, reason = policy.is_collection_allowed("public_docs")
+    assert allowed is True
+    assert reason == "ok"
+
+
+def test_no_cedar_falls_back_to_list_deny():
+    """Without Cedar policy, denied_collections list still works."""
+    policy = RAGPolicy(denied_collections=["hr_records"])
+    allowed, reason = policy.is_collection_allowed("hr_records")
+    assert allowed is False
+    assert reason == "denied"
+
+
+def test_cedar_and_list_coexist_cedar_wins():
+    """When both Cedar and lists are set, Cedar governs."""
+    policy = RAGPolicy(
+        cedar_policy=CEDAR_PERMIT_ALL,  # Cedar allows everything
+        denied_collections=["hr_records"],  # List would deny hr_records
+    )
+    # Cedar should win — permits all collections
+    allowed, reason = policy.is_collection_allowed("hr_records")
+    assert allowed is True
+    assert reason == "ok"

--- a/agent-governance-python/agent-rag-governance/tests/test_cedar_policy.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_cedar_policy.py
@@ -217,3 +217,52 @@ def test_cedar_and_list_coexist_cedar_wins():
     allowed, reason = policy.is_collection_allowed("hr_records")
     assert allowed is True
     assert reason == "ok"
+
+
+def test_cedar_backend_unavailable_falls_back_to_lists():
+    """When agent-os is unavailable, Cedar falls back to list-based check."""
+    import sys
+    import unittest.mock as mock
+
+    policy = RAGPolicy(
+        cedar_policy=CEDAR_PERMIT_PUBLIC,
+        allowed_collections=["public_docs"],
+        denied_collections=["hr_records"],
+    )
+
+    # Simulate agent-os not being available
+    with mock.patch.dict(sys.modules, {"agent_os.policies.backends": None}):
+        # Should fall back to list-based check — allowed collection
+        allowed, reason = policy.is_collection_allowed("public_docs")
+        assert allowed is True
+        assert reason == "ok"
+
+        # Should fall back to list-based check — denied collection
+        allowed, reason = policy.is_collection_allowed("hr_records")
+        assert allowed is False
+        assert reason == "denied"
+
+
+def test_cedar_backend_unavailable_no_lists_default_deny():
+    """When agent-os unavailable and no lists configured, default is allow all."""
+    import sys
+    import unittest.mock as mock
+
+    # No lists configured — default RAGPolicy allows all
+    policy = RAGPolicy(cedar_policy=CEDAR_PERMIT_PUBLIC)
+
+    with mock.patch.dict(sys.modules, {"agent_os.policies.backends": None}):
+        # Falls back to list check — no restrictions set, so allowed
+        allowed, reason = policy.is_collection_allowed("any_collection")
+        assert allowed is True
+        assert reason == "ok"
+
+
+def test_cedar_policy_invalid_content_handled_gracefully():
+    """Invalid Cedar policy content should not crash — Cedar engine handles it."""
+    policy = RAGPolicy(cedar_policy="this is not valid cedar syntax !!!")
+    # Should not raise — Cedar engine handles invalid syntax gracefully
+    allowed, reason = policy.is_collection_allowed("public_docs")
+    # Invalid policy → no permit matched → default deny
+    assert allowed is False
+    assert reason == "cedar_denied"


### PR DESCRIPTION
Closes part of #1700 — adds Cedar policy support to `agent-rag-governance`  as requested by @imran-siddique in the original issue.

**What this PR adds**?
- `cedar_policy` field on `RAGPolicy` — inline Cedar policy string
- `cedar_policy_path` field on `RAGPolicy` — path to a `.cedar` file
- `_check_cedar()` — resource-aware Cedar evaluation via `CedarBackend` from `agent-os`, with correct resource constraint handling for the built-in fallback evaluator
- `test_cedar_policy.py` — 11 tests covering all Cedar scenarios

**What this PR modifies**
- `policy.py` from **#1754** — adds `cedar_policy` and `cedar_policy_path` fields and updates `is_collection_allowed()` to delegate to Cedar when configured. Existing `allowed_collections` / `denied_collections` list behaviour is fully preserved — Cedar is opt-in.

**Implementation detail**
- Rather than building a new policy engine, `_check_cedar()` reuses the existing `CedarBackend` from `agent-os/policies/backends.py` — the same engine used by `agent-os` for tool governance. This keeps policy evaluation consistent across AGT and avoids a parallel policy system.
- Since `cedarpy` and the Cedar CLI are optional dependencies, the built-in fallback evaluator in `CedarBackend` is used when neither is available. The built-in evaluator ignores resource constraints, so `_check_cedar()` applies its own resource-aware logic on top to ensure collection-level access control is enforced correctly.

 **Why?**
The original implementation in #1754 used a Python allow/deny list — a parallel policy system. This PR aligns collection access control with the existing `PolicyEvaluator` in `agent-os` by using `CedarBackend`, as mentioned in #1700.

**Example**

policy = RAGPolicy(
    cedar_policy="""
        permit(
            principal == Agent::"sales-agent",
            action == Action::"Retrieve",
            resource == Collection::"public_docs"
        );
        forbid(
            principal,
            action == Action::"Retrieve",
            resource == Collection::"hr_records"
        );
    """,
    max_retrievals_per_minute=100,
    content_policies=["block_pii", "block_injections"],
    audit_enabled=True,
)