### PR TITLE
fix(security): exclude vendored dirs from scanner rglob and fix agent glob depth

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/security/scanner.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/security/scanner.py
@@ -550,8 +550,11 @@ class SecurityScanner:
 
     def scan_code_patterns(self) -> None:
         """Scan for dangerous code patterns using bandit (Python)."""
-        # Find Python files
-        py_files = list(self.plugin_dir.rglob("*.py"))
+        # Find Python files, excluding vendored directories
+        py_files = [
+            f for f in self.plugin_dir.rglob("*.py")
+            if self._should_scan_file(f)
+        ]
         if not py_files:
             return
 
@@ -648,7 +651,7 @@ class SecurityScanner:
         md_files = []
 
         # Scan skills and agents (primary content)
-        for pattern in ["skills/**/SKILL.md", "agents/*.md"]:
+        for pattern in ["skills/**/SKILL.md", "agents/**/*.md"]:
             md_files.extend(self.plugin_dir.glob(pattern))
 
         for md_file in md_files:

--- a/agent-governance-python/agent-compliance/tests/test_security_scanner.py
+++ b/agent-governance-python/agent-compliance/tests/test_security_scanner.py
@@ -593,6 +593,46 @@ class TestFormatSecurityReport:
         report = format_security_report("test-plugin", [])
         assert report == ""
 
+
+class TestScanCodePatternsVendoredExclusion:
+    """Regression: rglob('*.py') must skip vendored dirs."""
+
+    def test_vendored_py_files_do_not_trigger_scan(self, tmp_path: Path):
+        """If the only .py files are in node_modules / .venv, bandit should not run."""
+        vendored = tmp_path / "node_modules" / "pkg"
+        vendored.mkdir(parents=True)
+        (vendored / "evil.py").write_text("import os\nos.system('rm -rf /')\n")
+
+        scanner = SecurityScanner(tmp_path, "test-plugin")
+        scanner.scan_code_patterns()
+
+        # No findings because the file is excluded
+        assert scanner.findings == []
+
+    def test_non_vendored_py_files_included(self, tmp_path: Path):
+        """A .py file outside vendored dirs should be detected."""
+        (tmp_path / "app.py").write_text("print('hello')\n")
+
+        scanner = SecurityScanner(tmp_path, "test-plugin")
+        py_files = [
+            f for f in tmp_path.rglob("*.py")
+            if scanner._should_scan_file(f)
+        ]
+        assert len(py_files) == 1
+
+
+class TestMarkdownGlobRecursion:
+    """Regression: agents/*.md missed nested agent docs."""
+
+    def test_nested_agent_md_found(self, tmp_path: Path):
+        """agents/**/*.md should find files in subdirectories."""
+        nested = tmp_path / "agents" / "sub"
+        nested.mkdir(parents=True)
+        (nested / "README.md").write_text("# Agent\n```python\nprint(1)\n```\n")
+
+        md_files = list(tmp_path.glob("agents/**/*.md"))
+        assert len(md_files) == 1
+
     def test_format_critical_findings(self):
         """Test formatting with critical findings."""
         findings = [


### PR DESCRIPTION
## Problem
1. \scan_code_patterns\ used \glob('*.py')\ without filtering vendored directories (\
ode_modules\, \.venv\, \__pycache__\), causing unnecessary bandit invocations on third-party code.
2. \scan_markdown_code_blocks\ used \gents/*.md\ (depth-1), missing agent docs in subdirectories.

## Fix
1. Filter rglob results through \_should_scan_file\ before deciding to run bandit.
2. Change glob pattern to \gents/**/*.md\ for recursive scanning.

## Tests
- \	est_vendored_py_files_do_not_trigger_scan\: vendored-only dirs produce no findings
- \	est_non_vendored_py_files_included\: non-vendored files still detected
- \	est_nested_agent_md_found\: \gents/**/*.md\ finds nested files

Pattern from finnoybu PR #1942 (shallow directory scans) applied to security scanner.