### PR TITLE
fix(atr): reject protocol specifiers and non-semver tags in version_matches

### DIFF
--- a/agent-governance-python/agent-os/modules/atr/atr/registry.py
+++ b/agent-governance-python/agent-os/modules/atr/atr/registry.py
@@ -59,6 +59,13 @@ def parse_version(version: str) -> Tuple[int, int, int]:
     return (0, 0, 0)
 
 
+_PROTOCOL_PREFIXES = (
+    "git+", "file:", "http:", "https:", "ssh:", "npm:", "workspace:",
+)
+
+_NON_SEMVER_WILDCARDS = {"latest", "next", "canary", "nightly"}
+
+
 def version_matches(version: str, constraint: str) -> bool:
     """Check if a version matches a constraint.
 
@@ -72,6 +79,9 @@ def version_matches(version: str, constraint: str) -> bool:
     - "~1.0.0" - approximately (same major.minor)
     - "*" - any version
 
+    Protocol specifiers (git+, file:, http:, etc.) and non-semver
+    tags (latest, next, canary) are rejected as non-matching.
+
     Args:
         version: The version to check.
         constraint: The version constraint.
@@ -81,6 +91,13 @@ def version_matches(version: str, constraint: str) -> bool:
     """
     if constraint == "*" or constraint == "":
         return True
+
+    # Reject protocol specifiers and non-semver tags
+    constraint_lower = constraint.lower()
+    if any(constraint_lower.startswith(p) for p in _PROTOCOL_PREFIXES):
+        return False
+    if constraint_lower in _NON_SEMVER_WILDCARDS:
+        return False
 
     v = parse_version(version)
 

--- a/agent-governance-python/agent-os/modules/atr/tests/test_registry.py
+++ b/agent-governance-python/agent-os/modules/atr/tests/test_registry.py
@@ -272,6 +272,60 @@ def test_clear_registry():
     assert len(registry) == 0
 
 
+# --- version_matches tests ---
+
+from atr.registry import version_matches, parse_version
+
+
+class TestVersionMatches:
+    """Tests for version_matches constraint checking."""
+
+    def test_exact_match(self):
+        assert version_matches("1.2.3", "1.2.3") is True
+
+    def test_exact_mismatch(self):
+        assert version_matches("1.2.3", "1.2.4") is False
+
+    def test_wildcard(self):
+        assert version_matches("9.9.9", "*") is True
+
+    def test_empty_constraint(self):
+        assert version_matches("1.0.0", "") is True
+
+    def test_gte(self):
+        assert version_matches("2.0.0", ">=1.0.0") is True
+        assert version_matches("0.9.0", ">=1.0.0") is False
+
+    def test_caret(self):
+        assert version_matches("1.5.0", "^1.0.0") is True
+        assert version_matches("2.0.0", "^1.0.0") is False
+
+    def test_tilde(self):
+        assert version_matches("1.0.5", "~1.0.0") is True
+        assert version_matches("1.1.0", "~1.0.0") is False
+
+    @pytest.mark.parametrize("specifier", [
+        "git+https://github.com/evil/repo.git",
+        "file:../local-pkg",
+        "http://example.com/pkg.tar.gz",
+        "https://registry.npmjs.org/pkg",
+        "ssh://git@github.com/evil/repo.git",
+        "npm:@scope/pkg",
+        "workspace:*",
+    ])
+    def test_protocol_specifiers_rejected(self, specifier: str):
+        """Protocol specifiers must never match any version."""
+        assert version_matches("0.0.0", specifier) is False
+        assert version_matches("1.0.0", specifier) is False
+
+    @pytest.mark.parametrize("tag", ["latest", "next", "canary", "nightly"])
+    def test_non_semver_tags_rejected(self, tag: str):
+        """Non-semver distribution tags must not match."""
+        assert version_matches("0.0.0", tag) is False
+        assert version_matches("1.0.0", tag) is False
+
+
+
 def test_contains_operator():
     """Test 'in' operator for registry."""
     registry = Registry()


### PR DESCRIPTION
## Problem
\ersion_matches\ fell through to the exact-match branch for protocol specifiers (\git+https://...\, \ile:...\, \http://...\, etc.). \parse_version\ returns \(0,0,0)\ for non-semver strings, so \git+https://evil.git\ would match any version that also parses to \(0,0,0)\.

Non-semver distribution tags (\latest\, \
ext\, \canary\, \
ightly\) had the same problem.

## Fix
Add early rejection for protocol prefixes and non-semver wildcards before falling through to comparison logic.

## Tests
18 new tests in \TestVersionMatches\:
- Exact match/mismatch, wildcard, empty, gte, caret, tilde
- 7 parametrized protocol specifier rejections (git+, file:, http:, https:, ssh:, npm:, workspace:)
- 4 parametrized non-semver tag rejections (latest, next, canary, nightly)

Pattern from finnoybu PR #1936 (incomplete version specifier validation) applied to ATR registry.