### PR TITLE
fix(ci): detect unresolved git merge conflict markers in no-stubs gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,6 @@ go there rather than into the repo root or an older shared SDK path.
 | Published Python packages | `agent-governance-python/` | First-party reusable Python packages and SDK surfaces meant for direct external consumption |
 | Python runtime and product code | `*/` | Runtime code, applications, policy engines, trust, SRE, compliance, and other Python product surfaces that have not moved into the standalone package home |
 | Current shared SDK paths | `agent-governance-python/agent-mesh/sdks/` | Public SDK APIs and language-specific packaging that still live in the shared layout today |
-<<<<<<< HEAD
 | Standalone language implementations | `agent-governance-python/`, `agent-governance-dotnet/`, `agent-governance-golang/`, `agent-governance-rust/`, and other `agent-governance-*` siblings | Top-level language-specific implementations at the repository root; use these as the canonical contributor-facing paths |
 | Docs site | `docs/` | Reference docs, tutorials, architecture, package pages |
 | Runnable examples | `examples/` | Self-contained integrations and worked examples |

--- a/scripts/ci/no-stubs.sh
+++ b/scripts/ci/no-stubs.sh
@@ -23,6 +23,7 @@ FORBIDDEN=(
 
 # Build a combined grep pattern
 PATTERN=$(IFS='|'; echo "${FORBIDDEN[*]}")
+CONFLICT_PATTERN='^(<<<<<<< .*$|=======$|>>>>>>> .*$)'
 
 # Get only added lines from the diff, excluding test files and this script
 ADDED=$(git diff "$BASE_REF"...HEAD --diff-filter=ACMR -U0 -- \
@@ -33,6 +34,19 @@ ADDED=$(git diff "$BASE_REF"...HEAD --diff-filter=ACMR -U0 -- \
 if [ -z "$ADDED" ]; then
   echo "✅ no-stubs: no new production lines to check"
   exit 0
+fi
+
+# Detect unresolved git merge conflict markers in added lines only.
+# Use content-only lines (strip leading diff '+') so patterns remain anchored.
+ADDED_CONTENT=$(echo "$ADDED" | sed 's/^+//')
+CONFLICT_HITS=$(echo "$ADDED_CONTENT" | grep -E "$CONFLICT_PATTERN" || true)
+
+if [ -n "$CONFLICT_HITS" ]; then
+  echo "❌ no-stubs: found unresolved merge conflict markers in new code:"
+  echo "$CONFLICT_HITS"
+  echo ""
+  echo "Fix: resolve the conflict and remove marker lines before committing."
+  exit 1
 fi
 
 HITS=$(echo "$ADDED" | grep -iE "$PATTERN" || true)

--- a/tests/ci/test_no_stubs.py
+++ b/tests/ci/test_no_stubs.py
@@ -1,0 +1,124 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "no-stubs.sh"
+HAS_GIT = shutil.which("git") is not None
+HAS_BASH = shutil.which("bash") is not None
+CAN_RUN_SHELL_GATE = HAS_GIT and HAS_BASH and os.name != "nt"
+
+
+@pytest.mark.skipif(not CAN_RUN_SHELL_GATE, reason="requires git/bash on non-Windows host")
+def test_conflict_start_marker_fails(tmp_path: Path) -> None:
+    result = _run_gate_with_added_line(tmp_path, "sample.py", "<<<<<<< HEAD")
+
+    assert result.returncode == 1
+    assert "unresolved merge conflict markers" in result.stdout
+    assert "<<<<<<< HEAD" in result.stdout
+
+
+@pytest.mark.skipif(not CAN_RUN_SHELL_GATE, reason="requires git/bash on non-Windows host")
+def test_conflict_separator_line_fails(tmp_path: Path) -> None:
+    result = _run_gate_with_added_line(tmp_path, "sample.py", "=======")
+
+    assert result.returncode == 1
+    assert "unresolved merge conflict markers" in result.stdout
+    assert "=======" in result.stdout
+
+
+@pytest.mark.skipif(not CAN_RUN_SHELL_GATE, reason="requires git/bash on non-Windows host")
+def test_conflict_end_marker_fails(tmp_path: Path) -> None:
+    result = _run_gate_with_added_line(tmp_path, "sample.py", ">>>>>>> feature-branch")
+
+    assert result.returncode == 1
+    assert "unresolved merge conflict markers" in result.stdout
+    assert ">>>>>>> feature-branch" in result.stdout
+
+
+@pytest.mark.skipif(not CAN_RUN_SHELL_GATE, reason="requires git/bash on non-Windows host")
+def test_markdown_separator_does_not_fail(tmp_path: Path) -> None:
+    result = _run_gate_with_added_line(tmp_path, "README.md", "=======")
+
+    assert result.returncode == 0
+    assert "no new production lines to check" in result.stdout
+
+
+@pytest.mark.skipif(not CAN_RUN_SHELL_GATE, reason="requires git/bash on non-Windows host")
+def test_existing_todo_stub_detection_preserved(tmp_path: Path) -> None:
+    result = _run_gate_with_added_line(tmp_path, "sample.py", "# TODO: implement this")
+
+    assert result.returncode == 1
+    assert "found stub/TODO markers" in result.stdout
+    assert "TODO" in result.stdout
+
+
+@pytest.mark.skipif(not CAN_RUN_SHELL_GATE, reason="requires git/bash on non-Windows host")
+def test_non_conflict_separator_comment_does_not_fail(tmp_path: Path) -> None:
+    result = _run_gate_with_added_line(tmp_path, "sample.py", "# =======")
+
+    assert result.returncode == 0
+    assert "no stub markers found in new code" in result.stdout
+
+
+def _run_gate_with_added_line(tmp_path: Path, relative_file: str, added_line: str) -> subprocess.CompletedProcess[str]:
+    _init_git_repo(tmp_path)
+
+    target = tmp_path / relative_file
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("print('base')\n", encoding="utf-8")
+
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "base")
+
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(f"{added_line}\n")
+
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "change")
+
+    env = os.environ.copy()
+    env.setdefault("LC_ALL", "C")
+    script_path = _to_bash_path(SCRIPT_PATH)
+
+    return subprocess.run(
+        ["bash", "-lc", f"'{script_path}' HEAD~1"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _init_git_repo(repo_dir: Path) -> None:
+    _git(repo_dir, "init")
+    _git(repo_dir, "config", "user.name", "AGT Test")
+    _git(repo_dir, "config", "user.email", "agt-test@example.com")
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _to_bash_path(path: Path) -> str:
+    resolved = path.resolve()
+    as_posix = resolved.as_posix()
+    if resolved.drive:
+        drive = resolved.drive.rstrip(":").lower()
+        remainder = as_posix.split(":", 1)[1]
+        return f"/{drive}{remainder}"
+    return as_posix


### PR DESCRIPTION
## Summary
- Removed the committed merge conflict artifact from AGENTS.md.
- Updated no-stubs.sh to fail when unresolved git conflict markers are present in added lines.
- Added regression tests for conflict-marker detection while preserving existing TODO/stub behavior.

## Why
Issue #1988 identified a gap in the contributor quality gate: unresolved merge conflict markers were not being detected by CI.

## Validation
- Local check: pytest test_no_stubs.py -q
- Confirmed no-stubs logic now checks added lines for anchored conflict-marker patterns:
  - ^<<<<<<< .*
  - ^=======$
  - ^>>>>>>> .*
- Existing TODO/stub detection behavior remains unchanged.

Closes #1988

---

Requesting maintainer review for policy gate. All checks are green except the named-maintainer approval check. Could @imran-siddique please review when available? Thank you.