### PR TITLE
fix(dotnet-policy): use ProcessStartInfo.ArgumentList for Cedar/OPA CLI invocation (HIGH .NET #1)

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
@@ -125,15 +125,11 @@ public sealed class CedarPolicyBackend : IExternalPolicyBackend
         var entitiesPath = Path.Combine(tempDirectory.Path, "entities.json");
         File.WriteAllText(entitiesPath, "[]", Encoding.UTF8);
 
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = OperatingSystem.IsWindows() ? "cedar.exe" : "cedar",
-            Arguments = $"authorize --policies \"{policyPath}\" --entities \"{entitiesPath}\" --request-json \"{requestPath}\"",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
+        var startInfo = BuildCedarStartInfo(
+            OperatingSystem.IsWindows() ? "cedar.exe" : "cedar",
+            policyPath,
+            entitiesPath,
+            requestPath);
 
         using var process = Process.Start(startInfo);
         if (process is null)
@@ -317,6 +313,48 @@ public sealed class CedarPolicyBackend : IExternalPolicyBackend
         return !string.IsNullOrWhiteSpace(_policyPath) && File.Exists(_policyPath)
             ? File.ReadAllText(_policyPath, Encoding.UTF8)
             : null;
+    }
+
+    /// <summary>
+    /// Builds the <see cref="ProcessStartInfo"/> for the Cedar CLI using
+    /// <see cref="ProcessStartInfo.ArgumentList"/> so paths containing quote
+    /// characters (legal on Linux) cannot break out of the quoting that a
+    /// naive <c>Arguments</c>-string assignment would impose. Exposed so the
+    /// argv shape is inspectable by callers (e.g. for debugging or in tests)
+    /// without invoking the Cedar binary.
+    /// </summary>
+    /// <remarks>
+    /// This helper is intentionally <c>public</c> rather than <c>internal</c>
+    /// + <c>InternalsVisibleTo</c>. Strong-name signing on this assembly is
+    /// identity, not a security boundary, so <c>InternalsVisibleTo</c> would
+    /// be API hygiene rather than real isolation; the helper is a pure
+    /// argv-builder with no state or I/O, so public exposure adds no
+    /// practical attack surface. Maintainers who prefer the smaller public
+    /// surface can demote to <c>internal</c> + signed
+    /// <c>InternalsVisibleTo, PublicKey=...</c> without behavioural change.
+    /// </remarks>
+    public static ProcessStartInfo BuildCedarStartInfo(
+        string executable,
+        string policyPath,
+        string entitiesPath,
+        string requestPath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("authorize");
+        startInfo.ArgumentList.Add("--policies");
+        startInfo.ArgumentList.Add(policyPath);
+        startInfo.ArgumentList.Add("--entities");
+        startInfo.ArgumentList.Add(entitiesPath);
+        startInfo.ArgumentList.Add("--request-json");
+        startInfo.ArgumentList.Add(requestPath);
+        return startInfo;
     }
 
     private static bool CommandExists(string executable)

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -216,16 +216,7 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
 
         var regoPath = _regoPath!;
         var inputJson = JsonSerializer.Serialize(context);
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = opaExecutable,
-            Arguments = $"eval --format json --stdin-input --data \"{regoPath}\" \"{_query}\"",
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
+        var startInfo = BuildOpaStartInfo(opaExecutable, regoPath, _query);
 
         using var process = Process.Start(startInfo);
         if (process is null)
@@ -400,6 +391,50 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
         string text when bool.TryParse(text, out var parsed) => parsed,
         _ => false
     };
+
+    /// <summary>
+    /// Builds the <see cref="ProcessStartInfo"/> for the OPA CLI using
+    /// <see cref="ProcessStartInfo.ArgumentList"/> so the rego file path
+    /// (caller-supplied via <c>_regoPath</c>) and the query string
+    /// (caller-supplied via <c>_query</c>) cannot break out of quoting. The
+    /// naive <c>Arguments = $"...\"{regoPath}\" \"{_query}\""</c> form would
+    /// mis-tokenize any input containing a double-quote (legal on Linux
+    /// paths) or shell metacharacters that the underlying
+    /// CommandLineToArgvW-style parser re-splits on.
+    /// </summary>
+    /// <remarks>
+    /// This helper is intentionally <c>public</c> rather than <c>internal</c>
+    /// + <c>InternalsVisibleTo</c>. Strong-name signing on this assembly is
+    /// identity, not a security boundary, so <c>InternalsVisibleTo</c> would
+    /// be API hygiene rather than real isolation; the helper is a pure
+    /// argv-builder with no state or I/O, so public exposure adds no
+    /// practical attack surface. Maintainers who prefer the smaller public
+    /// surface can demote to <c>internal</c> + signed
+    /// <c>InternalsVisibleTo, PublicKey=...</c> without behavioural change.
+    /// </remarks>
+    public static ProcessStartInfo BuildOpaStartInfo(
+        string executable,
+        string regoPath,
+        string query)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("eval");
+        startInfo.ArgumentList.Add("--format");
+        startInfo.ArgumentList.Add("json");
+        startInfo.ArgumentList.Add("--stdin-input");
+        startInfo.ArgumentList.Add("--data");
+        startInfo.ArgumentList.Add(regoPath);
+        startInfo.ArgumentList.Add(query);
+        return startInfo;
+    }
 
     private static bool CommandExists(string executable)
     {

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyBackendArgumentListTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyBackendArgumentListTests.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+/// <summary>
+/// Regression tests for the REVIEW.md HIGH .NET #1 finding: both
+/// <see cref="CedarPolicyBackend"/> and <see cref="OpaPolicyBackend"/>
+/// previously built the CLI invocation via
+/// <c>ProcessStartInfo.Arguments = $"... \"{path}\" ..."</c>, which mis-tokenises
+/// any path or query containing a double-quote (legal on Linux) or shell
+/// metacharacters. The fix uses <see cref="ProcessStartInfo.ArgumentList"/>
+/// so each argument is passed verbatim with no string-level escaping.
+/// </summary>
+public class PolicyBackendArgumentListTests
+{
+    // ---------------------------------------------------------------------
+    // Cedar
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Cedar_BuildStartInfo_UsesArgumentListNotArgumentsString()
+    {
+        var info = CedarPolicyBackend.BuildCedarStartInfo(
+            executable: "cedar",
+            policyPath: "/tmp/policy.cedar",
+            entitiesPath: "/tmp/entities.json",
+            requestPath: "/tmp/request.json");
+
+        // The legacy `Arguments` string must be empty — all arguments go
+        // through ArgumentList so the OS-level argv builder handles quoting.
+        Assert.Equal(string.Empty, info.Arguments);
+        Assert.Equal(
+            new[]
+            {
+                "authorize",
+                "--policies",
+                "/tmp/policy.cedar",
+                "--entities",
+                "/tmp/entities.json",
+                "--request-json",
+                "/tmp/request.json",
+            },
+            info.ArgumentList);
+    }
+
+    [Fact]
+    public void Cedar_BuildStartInfo_PreservesQuoteInPath()
+    {
+        // A Linux-legal path containing a double-quote previously broke out of
+        // the naive `Arguments = $"... \"{path}\" ..."` quoting.
+        const string evilPath = "/tmp/evil\" --extra-flag /etc/passwd";
+
+        var info = CedarPolicyBackend.BuildCedarStartInfo(
+            executable: "cedar",
+            policyPath: evilPath,
+            entitiesPath: "/tmp/entities.json",
+            requestPath: "/tmp/request.json");
+
+        // The quote-bearing path must land in ArgumentList verbatim — not
+        // tokenised by a string-level argv parser.
+        Assert.Contains(evilPath, info.ArgumentList);
+        // And the injected "extra-flag" must NOT appear as a standalone arg.
+        Assert.DoesNotContain("--extra-flag", info.ArgumentList);
+    }
+
+    [Fact]
+    public void Cedar_BuildStartInfo_PreservesShellMetacharacters()
+    {
+        const string shellyPath = "/tmp/a b; rm -rf /";
+
+        var info = CedarPolicyBackend.BuildCedarStartInfo(
+            executable: "cedar",
+            policyPath: shellyPath,
+            entitiesPath: "/tmp/entities.json",
+            requestPath: "/tmp/request.json");
+
+        Assert.Contains(shellyPath, info.ArgumentList);
+        // The space-separated chunks must not appear as separate args.
+        Assert.DoesNotContain("b;", info.ArgumentList);
+        Assert.DoesNotContain("rm", info.ArgumentList);
+    }
+
+    [Fact]
+    public void Cedar_BuildStartInfo_NoShellExecuteWithRedirectedStreams()
+    {
+        var info = CedarPolicyBackend.BuildCedarStartInfo(
+            "cedar", "/p", "/e", "/r");
+
+        Assert.False(info.UseShellExecute);
+        Assert.True(info.RedirectStandardOutput);
+        Assert.True(info.RedirectStandardError);
+        Assert.True(info.CreateNoWindow);
+    }
+
+    // ---------------------------------------------------------------------
+    // OPA
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Opa_BuildStartInfo_UsesArgumentListNotArgumentsString()
+    {
+        var info = OpaPolicyBackend.BuildOpaStartInfo(
+            executable: "opa",
+            regoPath: "/tmp/policy.rego",
+            query: "data.agentgovernance.allow");
+
+        Assert.Equal(string.Empty, info.Arguments);
+        Assert.Equal(
+            new[]
+            {
+                "eval",
+                "--format",
+                "json",
+                "--stdin-input",
+                "--data",
+                "/tmp/policy.rego",
+                "data.agentgovernance.allow",
+            },
+            info.ArgumentList);
+    }
+
+    [Fact]
+    public void Opa_BuildStartInfo_PreservesQuoteInRegoPath()
+    {
+        const string evilPath = "/tmp/evil\" --insecure /etc/shadow";
+
+        var info = OpaPolicyBackend.BuildOpaStartInfo(
+            executable: "opa",
+            regoPath: evilPath,
+            query: "data.x.allow");
+
+        Assert.Contains(evilPath, info.ArgumentList);
+        Assert.DoesNotContain("--insecure", info.ArgumentList);
+    }
+
+    [Fact]
+    public void Opa_BuildStartInfo_PreservesQuoteInQuery()
+    {
+        // OPA's query is also caller-supplied via `_query`. A query string
+        // containing a double-quote previously broke out of the naive quoting.
+        const string evilQuery = "data.x.allow\"; data.evil.exec";
+
+        var info = OpaPolicyBackend.BuildOpaStartInfo(
+            executable: "opa",
+            regoPath: "/tmp/policy.rego",
+            query: evilQuery);
+
+        Assert.Contains(evilQuery, info.ArgumentList);
+        // The injected second-query chunk must not appear as a standalone arg.
+        Assert.DoesNotContain("data.evil.exec", info.ArgumentList);
+    }
+
+    [Fact]
+    public void Opa_BuildStartInfo_PipeInputViaStdinNotCommandLine()
+    {
+        // OPA still uses stdin for the JSON input (RedirectStandardInput);
+        // ArgumentList must NOT contain the input JSON.
+        var info = OpaPolicyBackend.BuildOpaStartInfo(
+            "opa", "/tmp/policy.rego", "data.x.allow");
+
+        Assert.True(info.RedirectStandardInput);
+        Assert.False(info.UseShellExecute);
+        Assert.DoesNotContain("--input", info.ArgumentList);
+        Assert.Contains("--stdin-input", info.ArgumentList);
+    }
+}


### PR DESCRIPTION
## Summary

Both .NET external-policy backends interpolated caller-supplied paths into a single `Arguments` string with naive `"..."` quoting:

- [CedarPolicyBackend.cs:131](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs#L131):
  `Arguments = $"authorize --policies \"{policyPath}\" --entities \"{entitiesPath}\" --request-json \"{requestPath}\""`
- [OpaPolicyBackend.cs:222](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs#L222):
  `Arguments = $"eval --format json --stdin-input --data \"{regoPath}\" \"{_query}\""`

A path or query containing a `"` — legal on Linux — terminates the surrounding quoting and lets the rest of the value mis-tokenise as extra command-line arguments. The same hazard applies to shell metacharacters the CommandLineToArgvW-style parser re-splits on. For OPA, both `_regoPath` and `_query` come from constructor parameters; for Cedar the paths are toolkit-generated temp files today, but the wrong-by-construction pattern would trip the moment any caller-controlled path reached the same code.

## Changes

- New `CedarPolicyBackend.BuildCedarStartInfo(executable, policyPath, entitiesPath, requestPath)` and `OpaPolicyBackend.BuildOpaStartInfo(executable, regoPath, query)` helpers that populate `ProcessStartInfo.ArgumentList` instead of building an `Arguments` string. Each argument is passed verbatim to the OS-level argv builder and is not re-tokenised.

## A note on the helpers being `public`

The helpers are `public static` rather than `internal` + `InternalsVisibleTo`. We considered both. The reasoning for going public:

- Strong-name signing on this assembly is **identity**, not a security boundary (Microsoft documents this explicitly). `InternalsVisibleTo, PublicKey=...` would be API hygiene rather than real isolation — the strong-name guarantee `InternalsVisibleTo` builds on is weaker than the API surface implies.
- The helpers are **pure argv builders** with no state, no I/O, no secrets. Public exposure adds no practical attack surface.
- Public methods are useful to consumers who want to inspect the resulting argv (e.g. for debugging) without invoking the CLI binary.

The XML `<remarks>` on each helper notes this rationale and explicitly invites maintainers who prefer a smaller public surface to demote to `internal` + signed `InternalsVisibleTo, PublicKey=...` — that's a one-line change with no behavioural impact.

## Test plan

- [x] New `PolicyBackendArgumentListTests` (8 tests):
  - Cedar + OPA happy paths assert `Arguments == ""` and exact `ArgumentList` ordering.
  - Quote-in-path: a path like `/tmp/evil" --extra-flag /etc/passwd` lands verbatim and the injected flag does NOT appear as a standalone argument.
  - Shell-metacharacters-in-path: same shape for `;`/space-separated payloads.
  - OPA: quote-in-query is preserved without splitting the injected second-query chunk into its own argument.
  - OPA: stdin remains the input channel (`--stdin-input`); no input JSON ever lands in `ArgumentList`.
  - Both: `UseShellExecute = false`, streams redirected, `CreateNoWindow`.
- [x] Full `agent-governance-dotnet` suite (620 tests) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>