### PR TITLE
fix(dotnet-policy): expose EvaluateAsync; drop sync-over-async read in OPA Remote path (HIGH .NET #2)

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/ExternalPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/ExternalPolicyBackend.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace AgentGovernance.Policy;
 
 /// <summary>
@@ -50,7 +53,27 @@ public interface IExternalPolicyBackend
     string Name { get; }
 
     /// <summary>
-    /// Evaluate the request context.
+    /// Evaluate the request context synchronously.
     /// </summary>
     ExternalPolicyDecision Evaluate(IReadOnlyDictionary<string, object> context);
+
+    /// <summary>
+    /// Evaluate the request context asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// Default implementation wraps <see cref="Evaluate"/> in a completed
+    /// <see cref="Task"/>. Backends whose evaluation involves real I/O
+    /// (HTTP, subprocess wait, etc.) should override this with a genuine
+    /// async path so callers in async contexts (ASP.NET handlers,
+    /// background workers, agent loops) can avoid blocking a thread on
+    /// the wait. Overrides must not call back into <see cref="Evaluate"/>
+    /// to produce their result — that re-introduces the very
+    /// sync-over-async pattern this method exists to escape.
+    /// </remarks>
+    /// <param name="context">Evaluation input.</param>
+    /// <param name="cancellationToken">Token to cancel the evaluation.</param>
+    Task<ExternalPolicyDecision> EvaluateAsync(
+        IReadOnlyDictionary<string, object> context,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(Evaluate(context));
 }

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AgentGovernance.Policy;
 
@@ -99,6 +102,57 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
         }
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Overrides the default <see cref="IExternalPolicyBackend.EvaluateAsync"/>
+    /// to use genuine async I/O for the Remote path
+    /// (<see cref="HttpClient.SendAsync(HttpRequestMessage, CancellationToken)"/> +
+    /// <see cref="HttpContent.ReadAsStringAsync(CancellationToken)"/>) so callers
+    /// in async contexts (ASP.NET handlers, agent loops, background workers) do
+    /// not block a thread-pool thread on HTTP I/O. The Local path (CLI /
+    /// builtin) remains synchronous because it waits on a subprocess or a
+    /// regex match, neither of which has a meaningful async surface.
+    /// </remarks>
+    public async Task<ExternalPolicyDecision> EvaluateAsync(
+        IReadOnlyDictionary<string, object> context,
+        CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            var decision = ResolveMode() switch
+            {
+                OpaEvaluationMode.Remote
+                    => await EvaluateRemoteAsync(context, cancellationToken).ConfigureAwait(false),
+                _ => EvaluateLocal(context)
+            };
+
+            sw.Stop();
+            return new ExternalPolicyDecision
+            {
+                Backend = decision.Backend,
+                Allowed = decision.Allowed,
+                Reason = decision.Reason,
+                Error = decision.Error,
+                Metadata = decision.Metadata,
+                EvaluationMs = sw.Elapsed.TotalMilliseconds
+            };
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            return new ExternalPolicyDecision
+            {
+                Backend = Name,
+                Allowed = false,
+                Reason = $"OPA evaluation failed: {ex.Message}",
+                Error = ex.Message,
+                EvaluationMs = sw.Elapsed.TotalMilliseconds
+            };
+        }
+    }
+
     private OpaEvaluationMode ResolveMode()
     {
         if (_mode != OpaEvaluationMode.Auto)
@@ -113,49 +167,91 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
 
     private ExternalPolicyDecision EvaluateRemote(IReadOnlyDictionary<string, object> context)
     {
-        if (!Regex.IsMatch(_query, @"^[a-zA-Z0-9._\-]+$"))
+        var validationFailure = ValidateRemoteQuery();
+        if (validationFailure is not null)
         {
-            return new ExternalPolicyDecision
-            {
-                Backend = Name,
-                Allowed = false,
-                Reason = $"Invalid OPA query path '{_query}'.",
-                Error = "invalid_query"
-            };
+            return validationFailure;
         }
 
+        using var request = BuildRemoteRequest(context);
+        using var cts = new CancellationTokenSource(_timeout);
+        using var response = HttpClient.Send(request, cts.Token);
+        // Read the body via the synchronous ``HttpContent.ReadAsStream`` API
+        // rather than ``ReadAsStringAsync(...).GetAwaiter().GetResult()`` —
+        // the latter blocks a thread-pool thread on an async operation and
+        // exhausts the pool under load. Callers in async contexts should
+        // use ``EvaluateAsync`` instead, which awaits the real async path.
+        using var stream = response.Content.ReadAsStream(cts.Token);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var content = reader.ReadToEnd();
+        return InterpretRemoteResponse(response.StatusCode, content);
+    }
+
+    private async Task<ExternalPolicyDecision> EvaluateRemoteAsync(
+        IReadOnlyDictionary<string, object> context,
+        CancellationToken cancellationToken)
+    {
+        var validationFailure = ValidateRemoteQuery();
+        if (validationFailure is not null)
+        {
+            return validationFailure;
+        }
+
+        using var request = BuildRemoteRequest(context);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(_timeout);
+        using var response = await HttpClient.SendAsync(request, cts.Token).ConfigureAwait(false);
+        var content = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+        return InterpretRemoteResponse(response.StatusCode, content);
+    }
+
+    private ExternalPolicyDecision? ValidateRemoteQuery()
+    {
+        if (Regex.IsMatch(_query, @"^[a-zA-Z0-9._\-]+$"))
+        {
+            return null;
+        }
+        return new ExternalPolicyDecision
+        {
+            Backend = Name,
+            Allowed = false,
+            Reason = $"Invalid OPA query path '{_query}'.",
+            Error = "invalid_query"
+        };
+    }
+
+    private HttpRequestMessage BuildRemoteRequest(IReadOnlyDictionary<string, object> context)
+    {
         var path = _query.StartsWith("data.", StringComparison.Ordinal)
             ? _query["data.".Length..]
             : _query;
-
         var payload = JsonSerializer.Serialize(new Dictionary<string, object?>
         {
             ["input"] = context
         });
-
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{_opaUrl}/v1/data/{path.Replace('.', '/')}")
+        return new HttpRequestMessage(HttpMethod.Post, $"{_opaUrl}/v1/data/{path.Replace('.', '/')}")
         {
             Content = new StringContent(payload, Encoding.UTF8, "application/json")
         };
+    }
 
-        using var cts = new CancellationTokenSource(_timeout);
-        using var response = HttpClient.Send(request, cts.Token);
-        var content = response.Content.ReadAsStringAsync(cts.Token).GetAwaiter().GetResult();
-
-        if (!response.IsSuccessStatusCode)
+    private ExternalPolicyDecision InterpretRemoteResponse(
+        System.Net.HttpStatusCode statusCode,
+        string content)
+    {
+        if ((int)statusCode < 200 || (int)statusCode >= 300)
         {
             return new ExternalPolicyDecision
             {
                 Backend = Name,
                 Allowed = false,
-                Reason = $"OPA server returned {(int)response.StatusCode}.",
+                Reason = $"OPA server returned {(int)statusCode}.",
                 Error = content
             };
         }
 
         using var document = JsonDocument.Parse(content);
         var allowed = document.RootElement.TryGetProperty("result", out var result) && EvaluateJsonTruthiness(result);
-
         return new ExternalPolicyDecision
         {
             Backend = Name,

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/OpaPolicyBackendAsyncTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/OpaPolicyBackendAsyncTests.cs
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+/// <summary>
+/// Tests for the OPA backend's Remote evaluation path. The REVIEW.md HIGH
+/// .NET #2 finding called out
+/// <c>response.Content.ReadAsStringAsync(...).GetAwaiter().GetResult()</c>
+/// inside the synchronous <c>Evaluate</c> as a thread-pool starvation
+/// hazard. The fix is two-fold:
+/// <list type="bullet">
+///   <item>The sync path reads via <see cref="HttpContent.ReadAsStream(System.Threading.CancellationToken)"/>
+///   instead of blocking on an async read.</item>
+///   <item>A new <see cref="OpaPolicyBackend.EvaluateAsync"/> override exposes
+///   a genuine async path that uses
+///   <see cref="HttpClient.SendAsync(HttpRequestMessage, System.Threading.CancellationToken)"/>
+///   + <see cref="HttpContent.ReadAsStringAsync(System.Threading.CancellationToken)"/>
+///   for callers in async contexts.</item>
+/// </list>
+/// </summary>
+public sealed class OpaPolicyBackendAsyncTests : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly string _baseUrl;
+    private readonly CancellationTokenSource _stopServer = new();
+    private readonly Task _serverTask;
+
+    public OpaPolicyBackendAsyncTests()
+    {
+        // Find a free port and start a minimal local HTTP listener.
+        // The handler returns a fixed JSON document mimicking OPA's
+        // /v1/data/<path> response shape: { "result": true|false }
+        var port = GetFreePort();
+        _baseUrl = $"http://127.0.0.1:{port}";
+        _listener = new HttpListener();
+        _listener.Prefixes.Add($"{_baseUrl}/");
+        _listener.Start();
+
+        _serverTask = Task.Run(async () =>
+        {
+            while (!_stopServer.IsCancellationRequested)
+            {
+                HttpListenerContext ctx;
+                try
+                {
+                    ctx = await _listener.GetContextAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    return; // listener stopped
+                }
+                try
+                {
+                    // Default: allow. Query path determines decision.
+                    var pathSegments = ctx.Request.Url!.AbsolutePath.TrimStart('/').Split('/');
+                    var deny = pathSegments.Contains("deny");
+                    var body = Encoding.UTF8.GetBytes(
+                        deny ? "{\"result\":false}" : "{\"result\":true}");
+                    ctx.Response.StatusCode = (int)HttpStatusCode.OK;
+                    ctx.Response.ContentType = "application/json";
+                    ctx.Response.ContentLength64 = body.Length;
+                    await ctx.Response.OutputStream.WriteAsync(body).ConfigureAwait(false);
+                    ctx.Response.OutputStream.Close();
+                }
+                catch
+                {
+                    // Best-effort: any I/O error in the test server is fatal.
+                }
+            }
+        });
+    }
+
+    public void Dispose()
+    {
+        _stopServer.Cancel();
+        try
+        {
+            _listener.Stop();
+            _listener.Close();
+        }
+        catch { /* swallow */ }
+    }
+
+    private static int GetFreePort()
+    {
+        using var sock = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        sock.Start();
+        var port = ((IPEndPoint)sock.LocalEndpoint).Port;
+        sock.Stop();
+        return port;
+    }
+
+    // ---------------------------------------------------------------------
+    // EvaluateAsync — the new async path
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task EvaluateAsync_RemoteAllow_ReturnsAllowed()
+    {
+        var backend = new OpaPolicyBackend(
+            opaUrl: _baseUrl,
+            mode: OpaEvaluationMode.Remote,
+            query: "data.agentgovernance.allow");
+
+        var decision = await backend.EvaluateAsync(new Dictionary<string, object>
+        {
+            ["tool_name"] = "file_read"
+        });
+
+        Assert.Equal("opa", decision.Backend);
+        Assert.True(decision.Allowed);
+        Assert.Null(decision.Error);
+        Assert.Equal("remote", decision.Metadata?["mode"]);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RemoteDeny_ReturnsDenied()
+    {
+        var backend = new OpaPolicyBackend(
+            opaUrl: _baseUrl,
+            mode: OpaEvaluationMode.Remote,
+            query: "data.agentgovernance.deny");
+
+        var decision = await backend.EvaluateAsync(new Dictionary<string, object>
+        {
+            ["tool_name"] = "file_write"
+        });
+
+        Assert.False(decision.Allowed);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RemoteInvalidQuery_FailsClosedWithoutHttpCall()
+    {
+        // A query containing characters outside the validated set must be
+        // rejected before any HTTP request is dispatched. Point the URL at
+        // an unrouteable host to confirm no network call occurs — if it
+        // did, the test would hang or throw a connection error.
+        var backend = new OpaPolicyBackend(
+            opaUrl: "http://127.0.0.1:1",  // closed port
+            mode: OpaEvaluationMode.Remote,
+            query: "data.evil;`drop`");
+
+        var decision = await backend.EvaluateAsync(new Dictionary<string, object>());
+
+        Assert.False(decision.Allowed);
+        Assert.Equal("invalid_query", decision.Error);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_RespectsCallerCancellation()
+    {
+        // Point at an unrouteable address with a long backend timeout, but
+        // cancel via the caller-supplied token. The cancellation must
+        // propagate and surface as a failed evaluation, not a hang.
+        var backend = new OpaPolicyBackend(
+            opaUrl: "http://10.255.255.1",  // RFC 6890 unreachable
+            mode: OpaEvaluationMode.Remote,
+            query: "data.x.allow",
+            timeout: TimeSpan.FromSeconds(30));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var decision = await backend.EvaluateAsync(
+            new Dictionary<string, object>(),
+            cts.Token);
+        sw.Stop();
+
+        // Should return well before the 30s backend timeout — caller's
+        // 250 ms cancellation must drive the deadline.
+        Assert.True(
+            sw.Elapsed < TimeSpan.FromSeconds(5),
+            $"EvaluateAsync took {sw.Elapsed} — caller cancellation was not honoured.");
+        Assert.False(decision.Allowed);
+        Assert.NotNull(decision.Error);
+    }
+
+    // ---------------------------------------------------------------------
+    // Sync path still works, no thread-pool starvation
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void Evaluate_RemoteAllow_StillWorksAfterSyncReadFix()
+    {
+        // The sync path now reads via HttpContent.ReadAsStream, not
+        // ReadAsStringAsync(...).GetAwaiter().GetResult(). The decision
+        // contract is unchanged.
+        var backend = new OpaPolicyBackend(
+            opaUrl: _baseUrl,
+            mode: OpaEvaluationMode.Remote,
+            query: "data.agentgovernance.allow");
+
+        var decision = backend.Evaluate(new Dictionary<string, object>
+        {
+            ["tool_name"] = "file_read"
+        });
+
+        Assert.True(decision.Allowed);
+        Assert.Equal("remote", decision.Metadata?["mode"]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Interface default implementation — backends that don't override
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task IExternalPolicyBackend_EvaluateAsync_DefaultsToSyncEvaluate()
+    {
+        // A backend that does NOT override EvaluateAsync must still expose
+        // a working async surface via the interface's default
+        // implementation. CedarPolicyBackend (in Builtin mode) is a
+        // genuinely sync implementor with no async I/O — exercising
+        // EvaluateAsync against it confirms the default wraps Evaluate in
+        // Task.FromResult correctly.
+        IExternalPolicyBackend cedar = new CedarPolicyBackend(
+            policyContent: """
+                permit(
+                    principal,
+                    action == Action::"ReadData",
+                    resource
+                );
+                """,
+            mode: CedarEvaluationMode.Builtin);
+
+        var decision = await cedar.EvaluateAsync(new Dictionary<string, object>
+        {
+            ["tool_name"] = "read_data",
+            ["agent_did"] = "did:mesh:test"
+        });
+
+        Assert.Equal("cedar", decision.Backend);
+        Assert.True(decision.Allowed);
+    }
+}


### PR DESCRIPTION
## Summary

[OpaPolicyBackend.cs:141-143](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs#L141-L143) — `EvaluateRemote` calls `HttpClient.Send` (genuinely synchronous in .NET 5+) and then reads the body via `response.Content.ReadAsStringAsync(ct).GetAwaiter().GetResult()`. The `.GetAwaiter().GetResult()` pattern parks a thread-pool thread on an async operation; under load the pool starves and unrelated work backs up. Callers in async contexts (ASP.NET handlers, agent loops, background workers) also had no async surface to opt into — they had to either accept the same hazard or wrap in `Task.Run`.

## Changes

**Tier 1 — eliminate sync-over-async in the existing sync path.** `EvaluateRemote` now reads the body via the synchronous `HttpContent.ReadAsStream(ct)` + `StreamReader.ReadToEnd()`, removing the `.GetAwaiter().GetResult()` block entirely. The decision contract is unchanged.

**Tier 2 — expose a real async path.** `IExternalPolicyBackend` gains an `EvaluateAsync(context, cancellationToken)` default interface method that wraps `Evaluate` in `Task.FromResult`. Existing implementors (anyone implementing `IExternalPolicyBackend` outside this repo) keep working without code changes. `OpaPolicyBackend` overrides `EvaluateAsync` with a genuine `await HttpClient.SendAsync` + `await ReadAsStringAsync` implementation. `CedarPolicyBackend` inherits the default — subprocess waits and regex matches have no meaningful async surface, so the wrapped-sync default is the right behaviour for it.

**Shared shape.** Sync `EvaluateRemote` and the new `EvaluateRemoteAsync` are factored to share three helpers — `ValidateRemoteQuery`, `BuildRemoteRequest`, and `InterpretRemoteResponse` — so they diverge only at the I/O step.

**Out of scope.** `PolicyEngine` continues to call `backend.Evaluate(...)` synchronously. Threading async through the engine and its callers is a larger architectural change deliberately not included here; the surface added by this PR is enough to unblock async-context consumers via the backend interface directly.

## Test plan

New `OpaPolicyBackendAsyncTests` (6 tests, spinning up a local `HttpListener` to mimic OPA's `/v1/data/...` shape):

- [x] `EvaluateAsync_RemoteAllow_ReturnsAllowed` / `EvaluateAsync_RemoteDeny_ReturnsDenied` — both decision paths against the in-process listener.
- [x] `EvaluateAsync_RemoteInvalidQuery_FailsClosedWithoutHttpCall` — points at a closed port; an injection-attempt query must short-circuit before any HTTP request is dispatched.
- [x] `EvaluateAsync_RespectsCallerCancellation` — points at an unrouteable RFC 6890 address with a 30-s backend timeout but a 250-ms caller `CancellationToken`; the caller's deadline must drive the wall-clock outcome (asserts `Elapsed < 5s`).
- [x] `Evaluate_RemoteAllow_StillWorksAfterSyncReadFix` — the sync path retains its contract after the `ReadAsStream` swap.
- [x] `IExternalPolicyBackend_EvaluateAsync_DefaultsToSyncEvaluate` — `CedarPolicyBackend` does not override `EvaluateAsync`; the default interface method must still produce a correct decision.
- [x] Full `agent-governance-dotnet` suite (618 tests, 6 new) passes.

Signed-off-by: Kenneth Tannenbaum <ktannenbaum@aegis-initiative.com>