### PR TITLE
chore(dotnet-format): apply dotnet format whitespace to three lagging files

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Mcp/McpSecurityScanner.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Mcp/McpSecurityScanner.cs
@@ -164,10 +164,18 @@ public sealed class McpSecurityScanner
 
     private static readonly Dictionary<char, char> HomoglyphMap = new()
     {
-        ['\u0430'] = 'a', ['\u0435'] = 'e', ['\u043E'] = 'o',
-        ['\u0440'] = 'p', ['\u0441'] = 'c', ['\u0443'] = 'y',
-        ['\u0445'] = 'x', ['\u0456'] = 'i', ['\u0458'] = 'j',
-        ['\u03B1'] = 'a', ['\u03BF'] = 'o', ['\u03C1'] = 'p'
+        ['\u0430'] = 'a',
+        ['\u0435'] = 'e',
+        ['\u043E'] = 'o',
+        ['\u0440'] = 'p',
+        ['\u0441'] = 'c',
+        ['\u0443'] = 'y',
+        ['\u0445'] = 'x',
+        ['\u0456'] = 'i',
+        ['\u0458'] = 'j',
+        ['\u03B1'] = 'a',
+        ['\u03BF'] = 'o',
+        ['\u03C1'] = 'p'
     };
 
     private static readonly Regex[] InstructionPatterns =

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/ComprehensiveAdvancedTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/ComprehensiveAdvancedTests.cs
@@ -79,8 +79,10 @@ public class ExecutionRingsAdvancedTests
     {
         var e = new RingEnforcer(new Dictionary<ExecutionRing, double>
         {
-            [ExecutionRing.Ring0] = 0.99, [ExecutionRing.Ring1] = 0.95,
-            [ExecutionRing.Ring2] = 0.80, [ExecutionRing.Ring3] = 0.0
+            [ExecutionRing.Ring0] = 0.99,
+            [ExecutionRing.Ring1] = 0.95,
+            [ExecutionRing.Ring2] = 0.80,
+            [ExecutionRing.Ring3] = 0.0
         });
         Assert.Equal(ExecutionRing.Ring3, e.ComputeRing(0.70));
         Assert.Equal(ExecutionRing.Ring2, e.ComputeRing(0.85));
@@ -319,8 +321,11 @@ public class GovernanceKernelAdvancedTests
     {
         var k = new GovernanceKernel(new GovernanceOptions
         {
-            EnableRings = true, EnablePromptInjectionDetection = true,
-            EnableCircuitBreaker = true, EnableMetrics = true, EnableAudit = true
+            EnableRings = true,
+            EnablePromptInjectionDetection = true,
+            EnableCircuitBreaker = true,
+            EnableMetrics = true,
+            EnableAudit = true
         });
         Assert.NotNull(k.Rings);
         Assert.NotNull(k.InjectionDetector);
@@ -335,8 +340,11 @@ public class GovernanceKernelAdvancedTests
     {
         var k = new GovernanceKernel(new GovernanceOptions
         {
-            EnableRings = false, EnablePromptInjectionDetection = false,
-            EnableCircuitBreaker = false, EnableMetrics = false, EnableAudit = false
+            EnableRings = false,
+            EnablePromptInjectionDetection = false,
+            EnableCircuitBreaker = false,
+            EnableMetrics = false,
+            EnableAudit = false
         });
         Assert.Null(k.Rings); Assert.Null(k.InjectionDetector); Assert.Null(k.CircuitBreaker); Assert.Null(k.Metrics);
         Assert.NotNull(k.SagaOrchestrator); Assert.NotNull(k.SloEngine);

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/SreAdvancedTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/SreAdvancedTests.cs
@@ -149,7 +149,9 @@ public class SloEngineAdvancedTests
     {
         var slo = new SloSpec
         {
-            Name = "test", Sli = new SliSpec { Metric = "m", Threshold = 99.0 }, Target = 99.0,
+            Name = "test",
+            Sli = new SliSpec { Metric = "m", Threshold = 99.0 },
+            Target = 99.0,
             Window = TimeSpan.FromMinutes(5),
             ErrorBudgetPolicy = new ErrorBudgetPolicy
             {


### PR DESCRIPTION
## Summary

`dotnet format --verify-no-changes` currently fails on `main` because of three files where multi-element collection / object initializers are packed onto a single line:

- `src/AgentGovernance/Mcp/McpSecurityScanner.cs` — `HomoglyphMap` dictionary
- `tests/AgentGovernance.Tests/ComprehensiveAdvancedTests.cs` — `RingEnforcer` dictionary and two `GovernanceOptions` object initializers
- `tests/AgentGovernance.Tests/SreAdvancedTests.cs` — `SloSpec` initializer

This PR applies the formatter's preferred one-per-line layout to make `dotnet format --verify-no-changes` clean across the .NET tree.

## Notes

- Zero semantic changes; test output identical (612 / 612 passing).
- All edits are exactly what `dotnet format whitespace` produces with the existing `.editorconfig` — no manual style choices.

## Provenance

Caught while running `dotnet format --verify-no-changes` against the .NET sources during the AEGIS Initiative security review.