### PR TITLE
fix(dotnet-middleware): publish rule-lookup cache as a single immutable snapshot

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Integration/GovernanceMiddleware.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Integration/GovernanceMiddleware.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 
+using System.Threading;
 using AgentGovernance.Audit;
 using AgentGovernance.Hypervisor;
 using AgentGovernance.Policy;
@@ -58,12 +59,25 @@ public sealed class GovernanceMiddleware
 {
     private readonly PolicyEngine _policyEngine;
     private readonly AuditEmitter _auditEmitter;
-    private Dictionary<string, PolicyRule>? _ruleLookupCache;
-    private int _cachedPolicyCount = -1;
+    // Immutable lookup snapshot. (Rules, PolicyCount) are packaged together so concurrent
+    // callers cannot observe a torn pairing of rule-table and the count it was built for.
+    // Publication is via Volatile.Write; reads use Volatile.Read.
+    private RuleLookupSnapshot? _ruleLookupSnapshot;
     private readonly RateLimiter? _rateLimiter;
     private readonly GovernanceMetrics? _metrics;
     private readonly RingEnforcer? _ringEnforcer;
     private readonly PromptInjectionDetector? _injectionDetector;
+
+    private sealed class RuleLookupSnapshot
+    {
+        public RuleLookupSnapshot(Dictionary<string, PolicyRule> rules, int policyCount)
+        {
+            Rules = rules;
+            PolicyCount = policyCount;
+        }
+        public Dictionary<string, PolicyRule> Rules { get; }
+        public int PolicyCount { get; }
+    }
 
     /// <summary>
     /// Initializes a new <see cref="GovernanceMiddleware"/> instance.
@@ -301,12 +315,20 @@ public sealed class GovernanceMiddleware
     /// Searches loaded policies for a rule by name using a cached lookup.
     /// Cache is invalidated when the policy count changes.
     /// </summary>
+    /// <remarks>
+    /// Thread-safe: the (rule-table, policy-count) pair lives in a single immutable
+    /// snapshot record published via <see cref="Volatile.Write{T}(ref T, T)"/>, so
+    /// callers either observe the previous fully-built snapshot or the new one.
+    /// Concurrent invalidations may redundantly rebuild the cache, but every caller
+    /// returns a lookup from a self-consistent snapshot.
+    /// </remarks>
     private PolicyRule? FindMatchingRule(string ruleName)
     {
         var policies = _policyEngine.ListPolicies();
         var currentCount = policies.Count;
+        var snapshot = Volatile.Read(ref _ruleLookupSnapshot);
 
-        if (_ruleLookupCache is null || _cachedPolicyCount != currentCount)
+        if (snapshot is null || snapshot.PolicyCount != currentCount)
         {
             var cache = new Dictionary<string, PolicyRule>(StringComparer.Ordinal);
             foreach (var policy in policies)
@@ -316,10 +338,10 @@ public sealed class GovernanceMiddleware
                     cache.TryAdd(rule.Name, rule);
                 }
             }
-            _ruleLookupCache = cache;
-            _cachedPolicyCount = currentCount;
+            snapshot = new RuleLookupSnapshot(cache, currentCount);
+            Volatile.Write(ref _ruleLookupSnapshot, snapshot);
         }
 
-        return _ruleLookupCache.TryGetValue(ruleName, out var cached) ? cached : null;
+        return snapshot.Rules.TryGetValue(ruleName, out var cached) ? cached : null;
     }
 }

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceMiddlewareAdvancedTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceMiddlewareAdvancedTests.cs
@@ -266,4 +266,76 @@ rules:
         Assert.True(mw.EvaluateToolCall("did:agentmesh:a", "file_read").Allowed);
         Assert.False(mw.EvaluateToolCall("did:agentmesh:a", "file_write").Allowed);
     }
+
+    // ── Concurrency ─────────────────────────────────────────────────
+
+    [Fact]
+    public void EvaluateToolCall_ConcurrentRateLimitedCalls_NoTornCache()
+    {
+        // Hammer FindMatchingRule (via the rate-limit branch) from many threads
+        // while concurrently invalidating its cache by adding a new policy.
+        // The (rule-table, policy-count) pair must always be observed as a unit;
+        // a torn pair would surface as a missed rule lookup that drops the
+        // request into the "no rate limiter configured" fallback path or
+        // produces a NullReferenceException inside the dictionary.
+        var yaml = @"
+name: rate-test
+default_action: allow
+rules:
+  - name: limit-http
+    condition: ""tool_name == 'http_request'""
+    action: rate_limit
+    limit: ""1000000/minute""
+";
+        var engine = new PolicyEngine();
+        engine.LoadYaml(yaml);
+        var mw = new GovernanceMiddleware(engine, new AuditEmitter(), new RateLimiter());
+
+        const int threadCount = 16;
+        const int iterations = 200;
+        var errors = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+        var threads = new Thread[threadCount];
+        var started = new ManualResetEventSlim(false);
+
+        for (int t = 0; t < threadCount; t++)
+        {
+            int tid = t;
+            threads[t] = new Thread(() =>
+            {
+                started.Wait();
+                try
+                {
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        // Periodically invalidate the cache by loading a new policy.
+                        if (tid == 0 && i % 25 == 0 && i > 0)
+                        {
+                            engine.LoadYaml($@"
+name: extra-policy-{i}
+default_action: allow
+rules:
+  - name: extra-rule-{i}
+    condition: ""tool_name == 'noop'""
+    action: allow
+");
+                        }
+                        var result = mw.EvaluateToolCall($"did:agentmesh:t{tid}", "http_request");
+                        // Reason must indicate the rate-limit rule fired with the
+                        // configured limit, not the lenient "no limiter" fallback.
+                        Assert.Contains("rate limit", result.Reason, StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    errors.Add(ex);
+                }
+            });
+            threads[t].Start();
+        }
+
+        started.Set();
+        foreach (var th in threads) th.Join();
+
+        Assert.Empty(errors);
+    }
 }


### PR DESCRIPTION
## Summary

`GovernanceMiddleware.FindMatchingRule` caches a rule-name → `PolicyRule` dictionary so that the rate-limit branch in `EvaluateToolCall` can resolve the matched rule's `Limit` expression without re-scanning every policy. The cache lives in two separate mutable fields on a **singleton** middleware instance:

```csharp
private Dictionary<string, PolicyRule>? _ruleLookupCache;
private int _cachedPolicyCount = -1;
```

`GovernanceMiddleware` is invoked from concurrent agent calls. With no synchronization around these fields, concurrent callers can observe:

- A **torn pairing** — the dictionary belongs to one policy generation and the count belongs to another, so a stale cache appears valid and a rule that exists in the current policy set is reported as missing (request falls through to the lenient "no rate limiter configured" branch, silently allowing what should be rate-limited).
- A **half-populated dictionary** — a reader can observe the publishing assignment `_ruleLookupCache = cache` before the `cache.TryAdd` writes from the building thread are visible on its CPU, producing missing keys or, on some runtimes, NREs inside `Dictionary<,>` internals.
- **Lost invalidations** — write reordering between the cache and the count field defeats the count-based invalidation check.

## Fix

Package the cache dictionary and the count it was built for into a single immutable `RuleLookupSnapshot`, and publish via `Volatile.Write` (paired with `Volatile.Read` on consumers).

```csharp
private RuleLookupSnapshot? _ruleLookupSnapshot;

private PolicyRule? FindMatchingRule(string ruleName)
{
    var policies = _policyEngine.ListPolicies();
    var currentCount = policies.Count;
    var snapshot = Volatile.Read(ref _ruleLookupSnapshot);

    if (snapshot is null || snapshot.PolicyCount != currentCount)
    {
        var cache = new Dictionary<string, PolicyRule>(StringComparer.Ordinal);
        foreach (var policy in policies)
            foreach (var rule in policy.Rules)
                cache.TryAdd(rule.Name, rule);
        snapshot = new RuleLookupSnapshot(cache, currentCount);
        Volatile.Write(ref _ruleLookupSnapshot, snapshot);
    }

    return snapshot.Rules.TryGetValue(ruleName, out var cached) ? cached : null;
}
```

Concurrent rebuilders may redundantly construct snapshots — that's benign. The key invariant is that any reader either sees the previous fully-built snapshot or the new one, never a torn pair. Each caller's lookup is always against a self-consistent `(rules, count)` snapshot.

## Tests

Added `EvaluateToolCall_ConcurrentRateLimitedCalls_NoTornCache`: 16 threads run 200 iterations each (3200 total calls) against the rate-limit branch while one thread periodically loads a new policy to force cache invalidation. Each call asserts that the response carries the rate-limit-rule reason (i.e., the rule was found in the lookup snapshot), guarding against the silent fall-through case the race condition produces.

Full .NET suite: **613 / 613** passing.

## Caveats / future work

The count-based invalidation is still imperfect: if policies are added and removed in matching numbers between two calls, the count check won't trigger a rebuild. That's pre-existing and out of scope for this PR; a generational version counter on `PolicyEngine` would be the right follow-up.

## Provenance

Bug found during the AEGIS Initiative security review of `microsoft/agent-governance-toolkit` (HIGH-severity bucket, .NET section).