### PR TITLE
fix(dotnet-metrics): opt-in tag policy for agent_id / tool_name (cardinality)

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Telemetry/GovernanceMetrics.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Telemetry/GovernanceMetrics.cs
@@ -5,6 +5,52 @@ using System.Diagnostics.Metrics;
 namespace AgentGovernance.Telemetry;
 
 /// <summary>
+/// Configures tag emission for <see cref="GovernanceMetrics"/>.
+/// </summary>
+/// <remarks>
+/// In production deployments the raw <c>agent_id</c> and <c>tool_name</c> tag
+/// dimensions can blow up the cardinality of the underlying meter aggregation
+/// tables — Prometheus and similar exporters allocate a distinct time-series
+/// per unique tag combination, so an environment with thousands of agents and
+/// dozens of tools produces tens of thousands of series per counter.
+///
+/// The safe defaults are: do NOT emit <c>agent_id</c> or <c>tool_name</c> as
+/// tags. Opt in to either dimension explicitly, and prefer the
+/// <see cref="AgentIdBucket"/> / <see cref="ToolNameBucket"/> hooks so that
+/// raw identifiers are reduced to a bounded label set before becoming a tag.
+/// </remarks>
+public sealed class GovernanceMetricsOptions
+{
+    /// <summary>
+    /// When <c>true</c>, includes an <c>agent_id</c> tag on per-decision metrics.
+    /// Default: <c>false</c> (raw <c>agent_id</c> is unbounded in cardinality).
+    /// </summary>
+    public bool IncludeAgentIdTag { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, includes a <c>tool_name</c> tag on per-decision metrics.
+    /// Default: <c>false</c> (tool registries are typically bounded, but
+    /// dynamically-named MCP tools can still grow without limit).
+    /// </summary>
+    public bool IncludeToolNameTag { get; init; }
+
+    /// <summary>
+    /// Optional bucketing function applied to <c>agent_id</c> before it is
+    /// emitted as a tag (only consulted when <see cref="IncludeAgentIdTag"/>
+    /// is <c>true</c>). Use this to map raw agent identifiers to a small,
+    /// bounded label set (e.g. tenant prefix, hash mod N).
+    /// </summary>
+    public Func<string, string>? AgentIdBucket { get; init; }
+
+    /// <summary>
+    /// Optional bucketing function applied to <c>tool_name</c> before it is
+    /// emitted as a tag (only consulted when <see cref="IncludeToolNameTag"/>
+    /// is <c>true</c>).
+    /// </summary>
+    public Func<string, string>? ToolNameBucket { get; init; }
+}
+
+/// <summary>
 /// OpenTelemetry-compatible metrics for governance operations using
 /// <see cref="System.Diagnostics.Metrics"/>. Consumers can collect these
 /// metrics with any OTEL-compatible exporter (Prometheus, Azure Monitor, etc.).
@@ -17,6 +63,11 @@ namespace AgentGovernance.Telemetry;
 ///     .AddPrometheusExporter()
 ///     .Build();
 /// </code>
+///
+/// <b>Tag cardinality:</b> by default only the <c>decision</c> tag is emitted
+/// on per-call metrics. Pass a <see cref="GovernanceMetricsOptions"/> to opt
+/// into <c>agent_id</c> and / or <c>tool_name</c>, and supply bucketing
+/// functions if the raw values would exceed the exporter's cardinality budget.
 /// </remarks>
 public sealed class GovernanceMetrics : IDisposable
 {
@@ -27,6 +78,7 @@ public sealed class GovernanceMetrics : IDisposable
     public const string MeterName = "AgentGovernance";
 
     private readonly Meter _meter;
+    private readonly GovernanceMetricsOptions _options;
 
     /// <summary>Total policy evaluation decisions (allowed + denied).</summary>
     public Counter<long> PolicyDecisions { get; }
@@ -53,10 +105,20 @@ public sealed class GovernanceMetrics : IDisposable
     public Counter<long> AuditEvents { get; }
 
     /// <summary>
-    /// Initializes a new <see cref="GovernanceMetrics"/> instance with the default meter.
+    /// Initializes a new <see cref="GovernanceMetrics"/> instance with the
+    /// default low-cardinality tag policy (only <c>decision</c> is emitted).
     /// </summary>
-    public GovernanceMetrics()
+    public GovernanceMetrics() : this(new GovernanceMetricsOptions()) { }
+
+    /// <summary>
+    /// Initializes a new <see cref="GovernanceMetrics"/> instance with explicit
+    /// tag-emission options.
+    /// </summary>
+    /// <param name="options">Controls which high-cardinality fields are emitted as tags.</param>
+    public GovernanceMetrics(GovernanceMetricsOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options;
         _meter = new Meter(MeterName, "1.0.0");
 
         PolicyDecisions = _meter.CreateCounter<long>(
@@ -122,12 +184,7 @@ public sealed class GovernanceMetrics : IDisposable
     /// <param name="rateLimited">Whether the request was rate-limited.</param>
     public void RecordDecision(bool allowed, string agentId, string toolName, double evaluationMs, bool rateLimited = false)
     {
-        var tags = new KeyValuePair<string, object?>[]
-        {
-            new("agent_id", agentId),
-            new("tool_name", toolName),
-            new("decision", allowed ? "allow" : "deny")
-        };
+        var tags = BuildDecisionTags(allowed, agentId, toolName);
 
         PolicyDecisions.Add(1, tags);
 
@@ -140,6 +197,27 @@ public sealed class GovernanceMetrics : IDisposable
             RateLimitHits.Add(1, tags);
 
         EvaluationLatency.Record(evaluationMs, tags);
+    }
+
+    private KeyValuePair<string, object?>[] BuildDecisionTags(bool allowed, string agentId, string toolName)
+    {
+        var capacity = 1
+            + (_options.IncludeAgentIdTag ? 1 : 0)
+            + (_options.IncludeToolNameTag ? 1 : 0);
+        var tags = new KeyValuePair<string, object?>[capacity];
+        var idx = 0;
+        tags[idx++] = new KeyValuePair<string, object?>("decision", allowed ? "allow" : "deny");
+        if (_options.IncludeAgentIdTag)
+        {
+            var value = _options.AgentIdBucket is null ? agentId : _options.AgentIdBucket(agentId);
+            tags[idx++] = new KeyValuePair<string, object?>("agent_id", value);
+        }
+        if (_options.IncludeToolNameTag)
+        {
+            var value = _options.ToolNameBucket is null ? toolName : _options.ToolNameBucket(toolName);
+            tags[idx++] = new KeyValuePair<string, object?>("tool_name", value);
+        }
+        return tags;
     }
 
     /// <inheritdoc />

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceMetricsTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceMetricsTests.cs
@@ -192,3 +192,114 @@ public class GovernanceMetricsTests : IDisposable
 
     public void Dispose() => _metrics.Dispose();
 }
+
+// Disposable wrapper so tag-tag-policy tests can each create their own
+// `GovernanceMetrics` with explicit options without colliding on the
+// instance-level field above.
+[Collection("MetricsTests")]
+public class GovernanceMetricsTagPolicyTests
+{
+    private static (HashSet<string> tagKeys, Dictionary<string, object?> lastTags) ListenForDecisionTags(GovernanceMetrics metrics, Action act)
+    {
+        var keys = new HashSet<string>();
+        var lastTags = new Dictionary<string, object?>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == GovernanceMetrics.MeterName)
+                l.EnableMeasurementEvents(instrument);
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, _, tags, _) =>
+        {
+            if (instrument.Name == "agent_governance.policy_decisions")
+            {
+                lastTags.Clear();
+                foreach (var t in tags)
+                {
+                    keys.Add(t.Key);
+                    lastTags[t.Key] = t.Value;
+                }
+            }
+        });
+        listener.Start();
+        act();
+        return (keys, lastTags);
+    }
+
+    [Fact]
+    public void DefaultOptions_EmitsOnlyDecisionTag()
+    {
+        using var metrics = new GovernanceMetrics();
+        var (keys, _) = ListenForDecisionTags(metrics, () =>
+            metrics.RecordDecision(true, "did:agentmesh:test", "file_read", 0.1));
+        Assert.Equal(new[] { "decision" }, keys);
+    }
+
+    [Fact]
+    public void IncludeAgentIdTag_EmitsAgentIdTag()
+    {
+        using var metrics = new GovernanceMetrics(new GovernanceMetricsOptions { IncludeAgentIdTag = true });
+        var (keys, last) = ListenForDecisionTags(metrics, () =>
+            metrics.RecordDecision(true, "did:agentmesh:abc", "file_read", 0.1));
+        Assert.Contains("decision", keys);
+        Assert.Contains("agent_id", keys);
+        Assert.DoesNotContain("tool_name", keys);
+        Assert.Equal("did:agentmesh:abc", last["agent_id"]);
+    }
+
+    [Fact]
+    public void IncludeToolNameTag_EmitsToolNameTag()
+    {
+        using var metrics = new GovernanceMetrics(new GovernanceMetricsOptions { IncludeToolNameTag = true });
+        var (keys, last) = ListenForDecisionTags(metrics, () =>
+            metrics.RecordDecision(true, "did:agentmesh:abc", "file_read", 0.1));
+        Assert.Contains("tool_name", keys);
+        Assert.DoesNotContain("agent_id", keys);
+        Assert.Equal("file_read", last["tool_name"]);
+    }
+
+    [Fact]
+    public void AgentIdBucket_AppliedBeforeEmission()
+    {
+        using var metrics = new GovernanceMetrics(new GovernanceMetricsOptions
+        {
+            IncludeAgentIdTag = true,
+            AgentIdBucket = id => id.StartsWith("did:agentmesh:") ? "agentmesh" : "other"
+        });
+        var (_, last) = ListenForDecisionTags(metrics, () =>
+            metrics.RecordDecision(true, "did:agentmesh:abc123", "file_read", 0.1));
+        Assert.Equal("agentmesh", last["agent_id"]);
+    }
+
+    [Fact]
+    public void ToolNameBucket_AppliedBeforeEmission()
+    {
+        using var metrics = new GovernanceMetrics(new GovernanceMetricsOptions
+        {
+            IncludeToolNameTag = true,
+            ToolNameBucket = name => name.Contains('.') ? name[..name.IndexOf('.')] : name
+        });
+        var (_, last) = ListenForDecisionTags(metrics, () =>
+            metrics.RecordDecision(true, "did:agentmesh:abc", "fs.read_file", 0.1));
+        Assert.Equal("fs", last["tool_name"]);
+    }
+
+    [Fact]
+    public void BothTagsEnabled_EmitsAllThree()
+    {
+        using var metrics = new GovernanceMetrics(new GovernanceMetricsOptions
+        {
+            IncludeAgentIdTag = true,
+            IncludeToolNameTag = true
+        });
+        var (keys, _) = ListenForDecisionTags(metrics, () =>
+            metrics.RecordDecision(true, "did:agentmesh:abc", "file_read", 0.1));
+        Assert.Equal(new[] { "agent_id", "decision", "tool_name" }, keys.OrderBy(k => k).ToArray());
+    }
+
+    [Fact]
+    public void NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new GovernanceMetrics(null!));
+    }
+}


### PR DESCRIPTION
## Summary

`GovernanceMetrics.RecordDecision` unconditionally attaches `agent_id` and `tool_name` as tag dimensions on every per-decision counter and histogram emission:

```csharp
var tags = new KeyValuePair<string, object?>[]
{
    new("agent_id", agentId),
    new("tool_name", toolName),
    new("decision", allowed ? "allow" : "deny")
};

PolicyDecisions.Add(1, tags);
ToolCallsAllowed.Add(1, tags);   // or ToolCallsBlocked
RateLimitHits.Add(1, tags);
EvaluationLatency.Record(evaluationMs, tags);
```

In production, each unique `(agent_id, tool_name, decision)` tuple becomes its own time-series in the OTEL exporter. Prometheus (and exporters with similar internals) allocate per unique tag combination, so a deployment with **N** agents and **M** tools produces **~2 · N · M** series **per counter**. Operators with thousands of agents have reported Prometheus OOMs caused by this fan-out.

## Fix

Introduce `GovernanceMetricsOptions`:

```csharp
public sealed class GovernanceMetricsOptions
{
    public bool IncludeAgentIdTag { get; init; }                  // default false
    public bool IncludeToolNameTag { get; init; }                 // default false
    public Func<string, string>? AgentIdBucket { get; init; }     // optional reducer
    public Func<string, string>? ToolNameBucket { get; init; }    // optional reducer
}
```

- `new GovernanceMetrics()` defaults to **emitting only `decision`** (cardinality 2 — `allow` / `deny`).
- `new GovernanceMetrics(new GovernanceMetricsOptions { IncludeAgentIdTag = true })` brings back per-agent dimensions for operators who want them.
- The `AgentIdBucket` / `ToolNameBucket` hooks let operators include the dimension with a **bounded** label set — e.g. tenant prefix, hash mod N, tool-family namespace — without exposing the raw identifier.

This **is** a behavior change for `new GovernanceMetrics()`: existing dashboards that filter on `agent_id` / `tool_name` will stop showing those labels until callers explicitly opt in. Operators who relied on the old fan-out and have a finite agent population pass `IncludeAgentIdTag = true` and `IncludeToolNameTag = true`. The new default is the safe one — "Prometheus OOM" is not a sensible default.

`GovernanceKernel` continues to construct `new GovernanceMetrics()` with no options; deployments that need the dimensions wire them in at the call-site.

## Tests

Seven new tests in `GovernanceMetricsTagPolicyTests` use a `MeterListener` to inspect the actual tag set emitted by `RecordDecision`:

- `DefaultOptions_EmitsOnlyDecisionTag`
- `IncludeAgentIdTag_EmitsAgentIdTag` (and not `tool_name`)
- `IncludeToolNameTag_EmitsToolNameTag` (and not `agent_id`)
- `AgentIdBucket_AppliedBeforeEmission` — the bucketed value is what's emitted
- `ToolNameBucket_AppliedBeforeEmission`
- `BothTagsEnabled_EmitsAllThree`
- `NullOptions_Throws`

Full .NET suite: **619 / 619** passing (612 baseline + 7 new).

## Provenance

Found during the AEGIS Initiative security review of `microsoft/agent-governance-toolkit` (HIGH-severity bucket, .NET section, final item).