### PR TITLE
fix(ts-mesh-client): guard onmessage against malformed frames

### DIFF
--- a/agent-governance-typescript/src/encryption/mesh-client.ts
+++ b/agent-governance-typescript/src/encryption/mesh-client.ts
@@ -108,7 +108,18 @@ export class MeshClient {
         resolve();
       };
       this.ws!.onerror = (e) => reject(new Error(`WebSocket error: ${e}`));
-      this.ws!.onmessage = (event) => this.handleFrame(JSON.parse(String(event.data)));
+      this.ws!.onmessage = (event) => {
+        let frame: Record<string, unknown>;
+        try {
+          frame = JSON.parse(String(event.data));
+        } catch (err) {
+          console.warn(`MeshClient: dropping malformed frame (JSON parse): ${err}`);
+          return;
+        }
+        this.handleFrame(frame).catch((err) => {
+          console.warn(`MeshClient: handler error for frame type=${String(frame.type)}: ${err}`);
+        });
+      };
       this.ws!.onclose = () => {
         this.connected = false;
       };

--- a/agent-governance-typescript/tests/mesh-client-malformed-frame.test.ts
+++ b/agent-governance-typescript/tests/mesh-client-malformed-frame.test.ts
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Tests for MeshClient resilience to malformed relay frames.
+ *
+ * The WebSocket onmessage handler must not crash the client when the
+ * relay sends non-JSON data or when async frame handling rejects.
+ */
+
+import { MeshClient, type MeshClientOptions } from "../src/encryption/mesh-client";
+import { X3DHKeyManager } from "../src/encryption/x3dh";
+import { ed25519 } from "@noble/curves/ed25519";
+
+class MockWebSocket {
+  sent: Array<Record<string, unknown>> = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(_url: string) {
+    queueMicrotask(() => {
+      if (this.onopen) this.onopen();
+    });
+  }
+
+  send(data: string): void {
+    this.sent.push(JSON.parse(data));
+  }
+
+  close(): void {
+    if (this.onclose) this.onclose();
+  }
+
+  /** Push raw data into the onmessage handler — caller controls JSON validity. */
+  pushRaw(data: string): void {
+    if (this.onmessage) this.onmessage({ data });
+  }
+
+  /** Push a structured frame (always valid JSON). */
+  simulateFrame(frame: Record<string, unknown>): void {
+    if (this.onmessage) this.onmessage({ data: JSON.stringify(frame) });
+  }
+}
+
+let lastMockWs: MockWebSocket | null = null;
+
+function mockWsFactory(url: string): WebSocket {
+  const ws = new MockWebSocket(url);
+  lastMockWs = ws;
+  return ws as unknown as WebSocket;
+}
+
+function makeKeyManager(): X3DHKeyManager {
+  const priv = ed25519.utils.randomSecretKey();
+  const pub = ed25519.getPublicKey(priv);
+  return new X3DHKeyManager(priv, pub);
+}
+
+function makeClient(overrides?: Partial<MeshClientOptions>): MeshClient {
+  return new MeshClient({
+    relayUrl: "http://localhost:8080",
+    registryUrl: "http://localhost:8081",
+    keyManager: makeKeyManager(),
+    agentDid: "did:agentmesh:test-agent",
+    wsFactory: mockWsFactory,
+    ...overrides,
+  });
+}
+
+describe("MeshClient malformed frame handling", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    lastMockWs = null;
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("non-JSON frame does not throw out of the WebSocket dispatcher", async () => {
+    const client = makeClient();
+    await client.connect();
+
+    expect(() => lastMockWs!.pushRaw("not json {{{")).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("malformed frame"));
+  });
+
+  test("client survives malformed frame and processes subsequent valid frame", async () => {
+    const client = makeClient({ plaintextPeers: ["did:agentmesh:peer-a"] });
+    const received: unknown[] = [];
+
+    client.onMessage((from, payload) => {
+      received.push({ from, payload });
+    });
+
+    await client.connect();
+
+    lastMockWs!.pushRaw("garbage");
+    lastMockWs!.pushRaw("{not even json}");
+
+    lastMockWs!.simulateFrame({
+      v: 1,
+      type: "message",
+      from: "did:agentmesh:peer-a",
+      to: "did:agentmesh:test-agent",
+      id: "msg-after-garbage",
+      ts: new Date().toISOString(),
+      ciphertext: btoa(JSON.stringify({ text: "recovered" })),
+      plaintext: true,
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({
+      from: "did:agentmesh:peer-a",
+      payload: { text: "recovered" },
+    });
+  });
+
+  test("async handleFrame rejection is caught, not raised as unhandled rejection", async () => {
+    const client = makeClient({ plaintextPeers: ["did:agentmesh:peer-a"] });
+    await client.connect();
+
+    const unhandled: unknown[] = [];
+    const listener = (err: unknown) => unhandled.push(err);
+    process.on("unhandledRejection", listener);
+
+    try {
+      // Plaintext message with non-base64 ciphertext — atob throws,
+      // handleMessage rejects. Must be caught by the onmessage wrapper.
+      lastMockWs!.simulateFrame({
+        v: 1,
+        type: "message",
+        from: "did:agentmesh:peer-a",
+        to: "did:agentmesh:test-agent",
+        id: "msg-bad-ct",
+        ts: new Date().toISOString(),
+        ciphertext: "***not-base64***",
+        plaintext: true,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(unhandled).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("handler error"));
+    } finally {
+      process.off("unhandledRejection", listener);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The WebSocket `onmessage` handler in `mesh-client.ts` had two failure modes that allowed a single bad relay frame to take down the client:

1. **Synchronous parse failure.** Line 111 called `JSON.parse(String(event.data))` directly inside the dispatcher. Any non-JSON payload threw synchronously into the WebSocket `onmessage` callback.
2. **Fire-and-forget async handler.** `handleFrame` is `async` but the lambda did not chain `.then/.catch` on the returned promise. A rejection inside `handleMessage` (bad ciphertext via `atob`, malformed `header`, downstream throws in `JSON.parse(plaintext)`) surfaced as an unhandled rejection.

Both paths were reachable by a single malformed frame from the relay — exactly the input the client should be most defensive about.

## Change

`src/encryption/mesh-client.ts`:

- Wrap `JSON.parse` in `try/catch`; log via `console.warn` and drop on parse failure.
- Chain `.catch()` on the `handleFrame` promise so async failures log and drop rather than escape the dispatcher.

The `console.warn` style mirrors the existing precedent in `src/identity.ts:481`.

## Tests

New file `tests/mesh-client-malformed-frame.test.ts`:

- Non-JSON frame does not throw out of the WebSocket dispatcher.
- Client survives malformed frames and continues to dispatch the next valid message.
- Async rejection from `handleMessage` does not surface as a Node `unhandledRejection`.

Reuses the existing `MockWebSocket` pattern from `mesh-client-reconnect.test.ts`, extended with a `pushRaw` helper so tests can simulate non-JSON data.

```
npx jest tests/mesh-client-malformed-frame.test.ts --no-coverage
  Tests: 3 passed, 3 total

npx jest tests/mesh-client-reconnect.test.ts --no-coverage
  Tests: 9 passed, 9 total  (regression check)
```

## Test plan

- [ ] CI passes
- [ ] Reconnect / inbox-replay path still works after the wrapper change
- [ ] No unhandled rejection surfaces in the malformed-frame test under the project's Jest config

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, TypeScript section). Filed by Ken Tannenbaum (AEGIS Initiative).