### PR TITLE
fix(ts-identity): stripKeyPrefix preserves content after first colon

### DIFF
--- a/agent-governance-typescript/src/identity.ts
+++ b/agent-governance-typescript/src/identity.ts
@@ -476,10 +476,10 @@ export function stripKeyPrefix(keyStr: string, expectedPrefix: string): string {
   if (keyStr.startsWith(expectedPrefix)) {
     return keyStr.slice(expectedPrefix.length);
   }
-  if (keyStr.includes(':')) {
-    const [, rest] = keyStr.split(':', 2);
+  const colonIdx = keyStr.indexOf(':');
+  if (colonIdx !== -1) {
     console.warn(`Key has unexpected prefix, expected '${expectedPrefix}'`);
-    return rest ?? keyStr;
+    return keyStr.slice(colonIdx + 1);
   }
   // No prefix at all — still valid, just not prefixed
   return keyStr;

--- a/agent-governance-typescript/tests/key-prefix.test.ts
+++ b/agent-governance-typescript/tests/key-prefix.test.ts
@@ -30,6 +30,23 @@ describe('stripKeyPrefix', () => {
   it('handles empty string', () => {
     expect(stripKeyPrefix('', 'ed25519:')).toBe('');
   });
+
+  it('preserves content after the first colon when the rest contains colons', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    // Prior bug: split(':', 2) destructured `[, rest]` returns only "abc",
+    // silently dropping ":def". The full remainder should round-trip.
+    expect(stripKeyPrefix('ed25519:abc:def', 'x25519:')).toBe('abc:def');
+    warnSpy.mockRestore();
+  });
+
+  it('preserves the full remainder when the expected prefix appears mid-string', () => {
+    // No expected-prefix match → unexpected-prefix branch. The remainder
+    // after the first colon must be returned verbatim, including any
+    // further colons.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    expect(stripKeyPrefix('unknown:a:b:c', 'ed25519:')).toBe('a:b:c');
+    warnSpy.mockRestore();
+  });
 });
 
 describe('safeBase64Decode', () => {


### PR DESCRIPTION
## Summary

`stripKeyPrefix` in `src/identity.ts` silently truncated key payloads that contained more than one colon. For input like `ed25519:abc:def`, the destructure `const [, rest] = keyStr.split(':', 2);` produced `['ed25519', 'abc']`, dropping `:def` without any warning. The function is exported and consumed by `safeBase64Decode` / `AgentIdentity.fromJSON`, so any serialized identity whose stored key happened to round-trip with a colon-containing payload would silently decode to the wrong bytes.

Base64 alphabet is `A-Za-z0-9+/=`, so colons aren't valid in well-formed base64 — but the function explicitly accepts unknown / unexpected prefixes (case 2 in its docstring), at which point the contents after the first colon are no longer guaranteed to be base64.

## Change

`src/identity.ts:479-483`:

- Replace `keyStr.split(':', 2)` destructure with `indexOf(':') + slice(colonIdx + 1)` so the full remainder after the first colon is returned verbatim.

## Tests

Two new cases in `tests/key-prefix.test.ts`:

- `stripKeyPrefix('ed25519:abc:def', 'x25519:')` → `'abc:def'` (unexpected-prefix branch).
- `stripKeyPrefix('unknown:a:b:c', 'ed25519:')` → `'a:b:c'`.

```
npx jest tests/key-prefix.test.ts --no-coverage
  Tests: 15 passed, 15 total
```

## Test plan

- [ ] CI passes
- [ ] Existing single-colon prefix tests still pass (they do)

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, TypeScript section). Filed by Ken Tannenbaum (AEGIS Initiative).