### PR TITLE
fix(vscode-cmvk): correct recommendation that suggested Function constructor

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/cmvkClient.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/cmvkClient.ts
@@ -215,7 +215,7 @@ export class CMVKClient {
         } else if (issue.includes('Synchronous')) {
             return 'Use fs.promises or async versions to avoid blocking the event loop';
         } else if (issue.includes('eval')) {
-            return 'Remove eval() and use safer alternatives like JSON.parse or Function constructor';
+            return 'Remove eval() and use safer alternatives like JSON.parse for data, or a small, purpose-built parser for expressions. The Function constructor is not a safe alternative — it executes arbitrary code with the same capability as eval().';
         } else if (issue.includes('innerHTML')) {
             return 'Use textContent or a sanitization library to prevent XSS';
         }


### PR DESCRIPTION
## Summary

The eval-issue recommendation in `cmvkClient.ts:218` said:

> Remove eval() and use safer alternatives like JSON.parse or Function constructor

`new Function(body)` evaluates an arbitrary string of code with the same capability as `eval()`. Recommending it as a "safer alternative" is actively misleading — a developer following this advice could swap one arbitrary-code-execution sink for another while believing they had fixed the issue.

This string is surfaced to users in the CMVK results webview, so it's a piece of security guidance the extension *gives*, not just internal text.

## Change

`agent-os-vscode/src/cmvkClient.ts:218` — replace the recommendation with text that:

- Names `JSON.parse` for data parsing (legitimate alternative).
- Suggests a small purpose-built parser for expressions (not eval-class).
- Explicitly states that the Function constructor is **not** a safe alternative.

## Test plan

- [ ] CI passes
- [ ] Visual check that the corrected text appears in the CMVK results panel rendered by `generateCMVKResultsHTML`

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, TypeScript section). Filed by Ken Tannenbaum (AEGIS Initiative).