### PR TITLE
fix(docs): enable mermaid diagram rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,11 @@ plugins:
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.highlight:


### PR DESCRIPTION
Fixes #1978

Mermaid code blocks were rendering as plain text on the docs site because \pymdownx.superfences\ lacked the \custom_fences\ configuration for mermaid.

Adds the standard mermaid fence configuration per [mkdocs-material docs](https://squidfunk.github.io/mkdocs-material/reference/diagrams/). Affects 10+ pages across quickstart, packages, and compliance docs.