### PR TITLE
fix(vscode): await + surface errors for 5 enterprise command callbacks

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/extension.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/extension.ts
@@ -665,28 +665,48 @@ safe_query = "SELECT * FROM users WHERE id = ?"
     // ========================================
 
     // SSO Sign In
-    const signInCmd = vscode.commands.registerCommand('agent-os.signIn', () => {
-        authProvider.signIn();
+    const signInCmd = vscode.commands.registerCommand('agent-os.signIn', async () => {
+        try {
+            await authProvider.signIn();
+        } catch (error) {
+            vscode.window.showErrorMessage(`Sign-in failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
     });
 
     // SSO Sign Out
-    const signOutCmd = vscode.commands.registerCommand('agent-os.signOut', () => {
-        authProvider.signOut();
+    const signOutCmd = vscode.commands.registerCommand('agent-os.signOut', async () => {
+        try {
+            await authProvider.signOut();
+        } catch (error) {
+            vscode.window.showErrorMessage(`Sign-out failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
     });
 
     // CI/CD Integration
-    const setupCICDCmd = vscode.commands.registerCommand('agent-os.setupCICD', () => {
-        cicdIntegration.showConfigWizard();
+    const setupCICDCmd = vscode.commands.registerCommand('agent-os.setupCICD', async () => {
+        try {
+            await cicdIntegration.showConfigWizard();
+        } catch (error) {
+            vscode.window.showErrorMessage(`CI/CD setup failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
     });
 
     // Pre-commit Hook
-    const installHooksCmd = vscode.commands.registerCommand('agent-os.installHooks', () => {
-        cicdIntegration.installPreCommitHook();
+    const installHooksCmd = vscode.commands.registerCommand('agent-os.installHooks', async () => {
+        try {
+            await cicdIntegration.installPreCommitHook();
+        } catch (error) {
+            vscode.window.showErrorMessage(`Pre-commit hook install failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
     });
 
     // Compliance Check
-    const checkComplianceCmd = vscode.commands.registerCommand('agent-os.checkCompliance', () => {
-        complianceManager.showComplianceWizard();
+    const checkComplianceCmd = vscode.commands.registerCommand('agent-os.checkCompliance', async () => {
+        try {
+            await complianceManager.showComplianceWizard();
+        } catch (error) {
+            vscode.window.showErrorMessage(`Compliance check failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
     });
 
     // Register configuration change listener


### PR DESCRIPTION
## Summary

Five command callbacks registered via `vscode.commands.registerCommand` in `extension.ts` invoked async methods without `await` and without attaching a `.catch` handler:

| Line | Command | Method called |
|---|---|---|
| 668 | `agent-os.signIn` | `authProvider.signIn()` (async) |
| 673 | `agent-os.signOut` | `authProvider.signOut()` (async) |
| 678 | `agent-os.setupCICD` | `cicdIntegration.showConfigWizard()` (async) |
| 683 | `agent-os.installHooks` | `cicdIntegration.installPreCommitHook()` (async) |
| 688 | `agent-os.checkCompliance` | `complianceManager.showComplianceWizard()` (async) |

A rejected promise from any of these paths became an unhandled rejection. From the user's perspective, the command appeared to silently do nothing — there's no surface error.

## Change

Each of the five callbacks is converted to `async` + `await` inside a `try/catch`, with the error surfaced via `vscode.window.showErrorMessage`. This is the same pattern already in use by the other 20+ async command registrations in this file (e.g., `agent-os.reviewCode` at line 281).

## Test plan

- [ ] CI passes
- [ ] Manual: trigger a failing path on any of the five commands (e.g., SSO sign-in with no providers configured) and confirm an error message surfaces in VS Code

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, TypeScript section). Filed by Ken Tannenbaum (AEGIS Initiative).