### PR TITLE
fix(vscode): defer SSO state restore behind an awaitable init()

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/enterprise/auth/ssoProvider.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/enterprise/auth/ssoProvider.ts
@@ -40,14 +40,31 @@ export class EnterpriseAuthProvider {
     private _state: AuthState = { isAuthenticated: false };
     private _onAuthStateChanged = new vscode.EventEmitter<AuthState>();
     readonly onAuthStateChanged = this._onAuthStateChanged.event;
-    
+
     private _context: vscode.ExtensionContext;
     private _providers: Map<string, SSOProvider> = new Map();
+    private _initPromise: Promise<void> | undefined;
 
     constructor(context: vscode.ExtensionContext) {
         this._context = context;
-        this._loadState();
         this._registerProviders();
+    }
+
+    /**
+     * Load persisted state and restore the token from SecretStorage.
+     * Must be awaited before consumers read `isAuthenticated` or
+     * `currentUser` — otherwise the constructor leaves the provider
+     * in a transient state where `isAuthenticated` can be true while
+     * `currentUser.token` is undefined.
+     *
+     * Safe to call more than once; subsequent calls return the same
+     * promise.
+     */
+    init(): Promise<void> {
+        if (!this._initPromise) {
+            this._initPromise = this._loadState();
+        }
+        return this._initPromise;
     }
 
     private async _loadState(): Promise<void> {

--- a/agent-governance-typescript/agent-os-vscode/src/extension.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/extension.ts
@@ -103,6 +103,9 @@ export async function activate(context: vscode.ExtensionContext) {
         // Initialize enterprise components
         console.log('Initializing enterprise components...');
         authProvider = new EnterpriseAuthProvider(context);
+        // Await persisted-state restore so consumers cannot observe
+        // isAuthenticated=true while currentUser.token is still undefined.
+        await authProvider.init();
         rbacManager = new RBACManager(authProvider);
         cicdIntegration = new CICDIntegration();
         complianceManager = new ComplianceManager();


### PR DESCRIPTION
## Summary

`EnterpriseAuthProvider` in `enterprise/auth/ssoProvider.ts:47-51` had an async-constructor race:

```ts
constructor(context: vscode.ExtensionContext) {
    this._context = context;
    this._loadState();          // async, fire-and-forget
    this._registerProviders();  // sync
}
```

`_loadState()` restores `isAuthenticated` from `globalState` immediately (line 56) but `await`s the token fetch from `SecretStorage` (line 64-68). Between the two, consumers reading `provider.isAuthenticated` saw `true` while `provider.currentUser.token` was still `undefined`.

Any code that branched on auth status — RBAC checks, audited operations, SSO-gated commands — could fire signed requests with a missing bearer token in the window between construction and the SecretStorage fetch completing.

## Change

`enterprise/auth/ssoProvider.ts`:

- Add an `init()` method that wraps `_loadState()` in a memoized promise (safe to call multiple times — subsequent calls return the same promise).
- Remove the fire-and-forget `_loadState()` call from the constructor. The constructor still calls the synchronous `_registerProviders()`.

`extension.ts:105-108`:

- `await authProvider.init()` between construction and `RBACManager` wiring, so the rest of the `activate()` path observes a fully-restored auth state.

`RBACManager`'s constructor only stores the provider reference and doesn't read auth state, so its position in `activate()` is unchanged.

## Test plan

- [ ] CI passes
- [ ] Manual: start the extension with a persisted authState in globalState (representing a previously-signed-in user); confirm `isAuthenticated` and `currentUser.token` are both correct by the time any consumer reads them
- [ ] Manual: confirm fresh-install path (no persisted state) still activates cleanly

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, TypeScript section). Filed by Ken Tannenbaum (AEGIS Initiative).