### PR TITLE
fix(vscode): make audit-log persistence Thenable; mark fire-and-forget explicit

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/auditLogger.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/auditLogger.ts
@@ -46,7 +46,7 @@ export class AuditLogger {
             this.logs = this.logs.slice(0, this.maxLogs);
         }
 
-        this.saveLogs();
+        void this.saveLogs();
         this._onDidChange.fire();
     }
 
@@ -118,7 +118,7 @@ export class AuditLogger {
      */
     clear(): void {
         this.logs = [];
-        this.saveLogs();
+        void this.saveLogs();
         this._onDidChange.fire();
     }
 
@@ -134,10 +134,18 @@ export class AuditLogger {
     }
 
     /**
-     * Save logs to storage
+     * Persist the in-memory log buffer to globalState.
+     *
+     * `globalState.update` writes synchronously to its in-memory map and
+     * returns a Thenable that resolves once the value reaches durable
+     * storage. The Memento serializes successive updates internally, so
+     * call ordering is preserved; the only loss window is host death
+     * between the call and the Thenable resolving. Callers that don't
+     * need to await persistence should explicitly fire-and-forget with
+     * `void this.saveLogs()`.
      */
-    private saveLogs(): void {
-        this.context.globalState.update(this.storageKey, this.logs);
+    private saveLogs(): Thenable<void> {
+        return this.context.globalState.update(this.storageKey, this.logs);
     }
 
     /**
@@ -154,7 +162,7 @@ export class AuditLogger {
         this.logs = this.logs.filter(log => new Date(log.timestamp) >= cutoff);
 
         if (this.logs.length !== originalCount) {
-            this.saveLogs();
+            void this.saveLogs();
             this._onDidChange.fire();
         }
     }


### PR DESCRIPTION
## Summary

`AuditLogger.saveLogs()` called `this.context.globalState.update(...)` and discarded the returned Thenable. If the extension host dies (crash, force-reload, OS kill) between the unawaited `update()` call and the async disk-write resolution, the most recent audit entry is lost.

### Note on the REVIEW.md framing

The underlying review item described this as *"on rapid log bursts, writes interleave; entries can be silently lost."* That's not what actually happens — `globalState.update` updates the in-memory Memento **synchronously**, and VS Code internally serializes successive updates in FIFO order. A burst of three `log()` calls produces three sequential, ordered writes; the persisted state is a correct superset of all three.

The real exposure is narrower: **lost-last-write on extension-host death** between the unawaited `update()` and its async resolution. No write interleaving, no silently-dropped queued entries.

Given that narrower exposure, the fix is correspondingly small.

## Change

`src/auditLogger.ts`:

- Return `Thenable<void>` from `saveLogs()` instead of discarding the promise. The method gains a docstring describing the actual semantics — synchronous in-memory state update, asynchronous persistence, host-death loss window.
- Prefix each call site (`log`, `clear`, `cleanOldLogs`) with `void` to make the fire-and-forget explicit and lint-clean. Callers stay sync; no cascading interface changes.

A future shutdown hook or test harness that needs to ensure persistence completes can `await` the returned Thenable directly. No internal write queue is added because the VS Code Memento already provides ordered, serialized writes — a custom queue on top would solve a problem that doesn't exist.

## Test plan

- [ ] CI passes
- [ ] Manual: induce a host-reload immediately after `log()` and confirm at most the very last entry is missing (i.e., the current upper-bound on the loss window is unchanged but now matches what the code documents)

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, TypeScript section). Filed by Ken Tannenbaum (AEGIS Initiative).