### PR TITLE
fix(rust-policy): recover from poisoned locks instead of panic-cascading

### DIFF
--- a/agent-governance-rust/agentmesh/src/policy.rs
+++ b/agent-governance-rust/agentmesh/src/policy.rs
@@ -161,7 +161,7 @@ impl PolicyEngine {
     pub fn is_loaded(&self) -> bool {
         self.profile
             .read()
-            .expect("policy profile lock poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .is_some()
     }
 
@@ -169,7 +169,7 @@ impl PolicyEngine {
     pub fn load_from_yaml(&self, yaml: &str) -> Result<(), PolicyError> {
         let profile: PolicyProfile =
             serde_yaml::from_str(yaml).map_err(PolicyError::InvalidYaml)?;
-        *self.profile.write().expect("policy profile lock poisoned") = Some(profile);
+        *self.profile.write().unwrap_or_else(|e| e.into_inner()) = Some(profile);
         Ok(())
     }
 
@@ -188,7 +188,7 @@ impl PolicyEngine {
         action: &str,
         context: Option<&HashMap<String, serde_yaml::Value>>,
     ) -> PolicyDecision {
-        let guard = self.profile.read().expect("policy profile lock poisoned");
+        let guard = self.profile.read().unwrap_or_else(|e| e.into_inner());
         let profile = match guard.as_ref() {
             Some(p) => p,
             None => return PolicyDecision::Allow,
@@ -274,7 +274,7 @@ impl PolicyEngine {
         let mut counters = self
             .rate_counters
             .lock()
-            .expect("rate counter lock poisoned");
+            .unwrap_or_else(|e| e.into_inner());
         let entry = counters
             .entry(name.to_string())
             .or_insert((0, Instant::now()));
@@ -991,5 +991,72 @@ policies:
         assert!(!action_matches("data", "data.read"));
         // "data.rea" does not match "data.read"
         assert!(!action_matches("data.rea", "data.read"));
+    }
+
+    /// Regression: a panic in any thread holding the profile or
+    /// rate-counter lock previously poisoned the lock and cascaded
+    /// panics into every subsequent policy evaluation. The recovery
+    /// pattern (`unwrap_or_else(|e| e.into_inner())`) keeps the engine
+    /// usable after a poisoning event.
+    #[test]
+    fn test_evaluates_after_profile_lock_poisoned() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let engine = Arc::new(PolicyEngine::new());
+        engine.load_from_yaml(POLICY_YAML).unwrap();
+
+        // Poison the profile lock by panicking inside a write guard.
+        let engine_for_panic = Arc::clone(&engine);
+        let handle = thread::spawn(move || {
+            let _guard = engine_for_panic.profile.write().unwrap();
+            panic!("simulated thread death while holding profile lock");
+        });
+        let _ = handle.join();
+        assert!(engine.profile.is_poisoned());
+
+        // Public methods must remain usable after poisoning.
+        assert!(engine.is_loaded());
+        assert_eq!(engine.evaluate("data.read", None), PolicyDecision::Allow);
+        engine
+            .load_from_yaml(POLICY_YAML)
+            .expect("re-load after poison must succeed");
+    }
+
+    #[test]
+    fn test_evaluates_after_rate_counter_lock_poisoned() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let yaml = r#"
+version: "1.0"
+agent: test
+policies:
+  - name: api-rate-limit
+    type: rate_limit
+    actions:
+      - "api.call"
+    max_calls: 10
+    window: "60s"
+"#;
+        let engine = Arc::new(PolicyEngine::new());
+        engine.load_from_yaml(yaml).unwrap();
+
+        // Poison the rate-counter lock.
+        let engine_for_panic = Arc::clone(&engine);
+        let handle = thread::spawn(move || {
+            let _guard = engine_for_panic.rate_counters.lock().unwrap();
+            panic!("simulated thread death while holding rate counter lock");
+        });
+        let _ = handle.join();
+        assert!(engine.rate_counters.is_poisoned());
+
+        // Rate-limit evaluation must still produce a decision rather
+        // than propagating the poison.
+        let decision = engine.evaluate("api.call", None);
+        assert!(matches!(
+            decision,
+            PolicyDecision::Allow | PolicyDecision::Deny(_)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

`PolicyEngine` in `agent-governance-rust/agentmesh/src/policy.rs` had four `.expect("...poisoned")` calls:

| Line | Method | Lock |
|---|---|---|
| 164 | `is_loaded` | `profile: RwLock<Option<PolicyProfile>>` — `.read()` |
| 172 | `load_from_yaml` | same `profile` — `.write()` |
| 191 | `evaluate` | same `profile` — `.read()` |
| 277 | `check_rate_limit` | `rate_counters: Mutex<HashMap<...>>` — `.lock()` |

A panic in any thread holding either lock poisons the lock. Every subsequent caller then hits the `.expect` and panics too, turning a single thread's death into a cascading panic across every consumer of the policy engine.

## Change

Each `.expect("...poisoned")` is replaced with `.unwrap_or_else(|e| e.into_inner())`. The recovered guard sees the data exactly as the poisoned thread left it — for these locks, that's either a fully-written state (a complete profile or counter map) or no change at all, both safe to read or overwrite.

This is the same pattern already used elsewhere in the crate: `audit.rs:51,98,113`, `trust.rs:83,110,130,150,170,217,229`.

## Tests

Two regression tests in `policy.rs` test module:

- `test_evaluates_after_profile_lock_poisoned` — spawns a worker that panics while holding the profile write guard, asserts the lock is poisoned, then verifies `is_loaded()`, `evaluate()`, and `load_from_yaml()` all continue to work.
- `test_evaluates_after_rate_counter_lock_poisoned` — same shape against the rate-counter mutex; verifies `evaluate()` against a rate-limited action still produces a decision.

```
cargo test -p agentmesh policy:: --lib
  test result: ok. 44 passed; 0 failed; 0 ignored; 0 measured
```

## Test plan

- [ ] CI passes
- [ ] No regression in existing policy tests (44/44 pass)

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Rust section). Filed by Ken Tannenbaum (AEGIS Initiative).