### PR TITLE
fix(rust-audit-sink): propagate serde_json errors instead of unwrapping

### DIFF
--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -181,7 +181,12 @@ impl AuditSink for FileAuditSink {
             Vec::new()
         };
         entries.push(entry.clone());
-        fs::write(&self.path, serde_json::to_string_pretty(&entries).unwrap())
+        // serde_json::to_string_pretty fails on non-finite floats (NaN, ±Inf)
+        // inside `details` because JSON has no representation for them.
+        // Propagate the error instead of panicking on the audit-write path.
+        let serialized =
+            serde_json::to_string_pretty(&entries).map_err(std::io::Error::other)?;
+        fs::write(&self.path, serialized)
     }
 }
 


### PR DESCRIPTION
## Summary

`FileAuditSink::record` in `agent-governance-rust/agentmesh/src/governance_support.rs:184` called `serde_json::to_string_pretty(&entries).unwrap()` on every audit write. The method already returns `std::io::Result<()>` and callers must already handle `Err`, so the unwrap was strictly worse than propagating — a serialize failure would panic on the audit-write path instead of surfacing a recoverable error.

### Note on the REVIEW.md framing

The underlying review item cited *"non-finite f64 inside `details`"* as the trigger. Inspecting the current `AuditEntry` struct (`types.rs:79`):

```rust
pub struct AuditEntry {
    pub seq: u64,
    pub timestamp: String,
    pub agent_id: String,
    pub action: String,
    pub decision: String,
    pub previous_hash: String,
    pub hash: String,
}
```

All fields are `String` or `u64`; there's no `f64` and no `details` map. The NaN/Inf panic described in REVIEW.md isn't currently reachable through this struct's schema. The fix is therefore **anticipatory hardening** rather than a live bug: if the schema later grows a non-finite-friendly numeric (a `details: serde_json::Value`, an f64 metric, etc.) the audit path will return a recoverable error instead of panicking on a `.unwrap()` that today only happens to be safe.

## Change

`governance_support.rs:184` — replace:

```rust
fs::write(&self.path, serde_json::to_string_pretty(&entries).unwrap())
```

with:

```rust
let serialized = serde_json::to_string_pretty(&entries)
    .map_err(std::io::Error::other)?;
fs::write(&self.path, serialized)
```

## Tests

No regression test added. Fabricating a failure mode via a custom Serialize impl would test a hypothetical contract rather than a real one. The change is a strict simplification — `unwrap()` → `map_err(io::Error::other)?` — and the existing audit-flow tests continue to exercise the happy path.

```
cargo build -p agentmesh
  Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## Test plan

- [ ] CI passes
- [ ] No regression in existing audit tests

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Rust section). Filed by Ken Tannenbaum (AEGIS Initiative).