### PR TITLE
fix(rust-federation-store): fallibilize FederationStore::save_policy

### DIFF
--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -1403,7 +1403,12 @@ pub struct FederationDecision {
 }
 
 pub trait FederationStore: Send + Sync {
-    fn save_policy(&self, policy: OrgPolicy);
+    /// Persist a policy for an organization.
+    ///
+    /// Implementations may fail for I/O reasons (file-backed stores) or
+    /// serialization reasons; callers must handle the error rather than
+    /// silently lose the write.
+    fn save_policy(&self, policy: OrgPolicy) -> std::io::Result<()>;
     fn get_policy(&self, organization_id: &str) -> Option<OrgPolicy>;
 }
 
@@ -1413,11 +1418,12 @@ pub struct InMemoryFederationStore {
 }
 
 impl FederationStore for InMemoryFederationStore {
-    fn save_policy(&self, policy: OrgPolicy) {
+    fn save_policy(&self, policy: OrgPolicy) -> std::io::Result<()> {
         self.policies
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .insert(policy.organization_id.clone(), policy);
+        Ok(())
     }
 
     fn get_policy(&self, organization_id: &str) -> Option<OrgPolicy> {
@@ -1451,15 +1457,13 @@ impl FileFederationStore {
 }
 
 impl FederationStore for FileFederationStore {
-    fn save_policy(&self, policy: OrgPolicy) {
-        self.inner.save_policy(policy.clone());
+    fn save_policy(&self, policy: OrgPolicy) -> std::io::Result<()> {
+        self.inner.save_policy(policy.clone())?;
         let mut policies = self.read_policy_map();
         policies.insert(policy.organization_id.clone(), policy);
-        let _ = fs::write(
-            &self.path,
-            serde_json::to_string_pretty(&policies)
-                .expect("failed to serialize federation policy store"),
-        );
+        let serialized =
+            serde_json::to_string_pretty(&policies).map_err(std::io::Error::other)?;
+        fs::write(&self.path, serialized)
     }
 
     fn get_policy(&self, organization_id: &str) -> Option<OrgPolicy> {
@@ -1672,15 +1676,17 @@ mod tests {
     #[test]
     fn federation_engine_applies_rules() {
         let store = Arc::new(InMemoryFederationStore::default());
-        store.save_policy(OrgPolicy {
-            organization_id: "contoso".into(),
-            rules: vec![OrgPolicyRule {
-                name: "deny-shell".into(),
-                category: PolicyCategory::Execution,
-                action_pattern: "shell".into(),
-                decision: "deny".into(),
-            }],
-        });
+        store
+            .save_policy(OrgPolicy {
+                organization_id: "contoso".into(),
+                rules: vec![OrgPolicyRule {
+                    name: "deny-shell".into(),
+                    category: PolicyCategory::Execution,
+                    action_pattern: "shell".into(),
+                    decision: "deny".into(),
+                }],
+            })
+            .unwrap();
         let engine = FederationEngine::new(store);
         assert!(!engine.evaluate("contoso", "shell:rm").allowed);
     }
@@ -1688,15 +1694,17 @@ mod tests {
     #[test]
     fn federation_engine_denies_without_policy_or_rule_match() {
         let store = Arc::new(InMemoryFederationStore::default());
-        store.save_policy(OrgPolicy {
-            organization_id: "contoso".into(),
-            rules: vec![OrgPolicyRule {
-                name: "allow-data".into(),
-                category: PolicyCategory::DataAccess,
-                action_pattern: "data.read".into(),
-                decision: "allow".into(),
-            }],
-        });
+        store
+            .save_policy(OrgPolicy {
+                organization_id: "contoso".into(),
+                rules: vec![OrgPolicyRule {
+                    name: "allow-data".into(),
+                    category: PolicyCategory::DataAccess,
+                    action_pattern: "data.read".into(),
+                    decision: "allow".into(),
+                }],
+            })
+            .unwrap();
         let engine = FederationEngine::new(store);
         assert!(!engine.evaluate("missing", "data.read").allowed);
         assert!(!engine.evaluate("contoso", "shell:rm").allowed);
@@ -1900,17 +1908,43 @@ mod tests {
         let temp = tempfile::NamedTempFile::new().unwrap();
         let store = FileFederationStore::new(temp.path());
 
-        store.save_policy(OrgPolicy {
-            organization_id: "org-a".into(),
-            rules: vec![],
-        });
-        store.save_policy(OrgPolicy {
-            organization_id: "org-b".into(),
-            rules: vec![],
-        });
+        store
+            .save_policy(OrgPolicy {
+                organization_id: "org-a".into(),
+                rules: vec![],
+            })
+            .unwrap();
+        store
+            .save_policy(OrgPolicy {
+                organization_id: "org-b".into(),
+                rules: vec![],
+            })
+            .unwrap();
 
         assert!(store.get_policy("org-a").is_some());
         assert!(store.get_policy("org-b").is_some());
+    }
+
+    /// Regression: prior to fallibilizing the trait, FileFederationStore
+    /// used `let _ = fs::write(...)` and silently swallowed I/O errors.
+    /// A path pointing into a non-existent directory now surfaces as an
+    /// Err instead of being lost.
+    #[test]
+    fn file_federation_store_returns_err_on_unwriteable_path() {
+        let unwriteable = std::env::temp_dir()
+            .join("agentmesh-federation-store-tests-nonexistent-parent")
+            .join("policies.json");
+        let _ = fs::remove_dir_all(unwriteable.parent().unwrap());
+
+        let store = FileFederationStore::new(&unwriteable);
+        let result = store.save_policy(OrgPolicy {
+            organization_id: "ghost".into(),
+            rules: vec![],
+        });
+        assert!(
+            result.is_err(),
+            "expected save_policy to surface the I/O error, got Ok"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`FederationStore::save_policy` was infallible:

```rust
pub trait FederationStore: Send + Sync {
    fn save_policy(&self, policy: OrgPolicy);
    fn get_policy(&self, organization_id: &str) -> Option<OrgPolicy>;
}
```

The file-backed `FileFederationStore` handled the lack of return type by **silently swallowing I/O errors** (`let _ = fs::write(...)`) and **panicking on serialize errors** (`.expect("failed to serialize federation policy store")`). Net effect: a write to a path that couldn't be created lost the policy without any signal, and a serialize failure crashed the process on the policy-persist path.

## Change

`governance_support.rs:1405-1470`:

- Trait signature: `fn save_policy(&self, policy: OrgPolicy) -> std::io::Result<()>`.
- `InMemoryFederationStore::save_policy` returns `Ok(())` (the HashMap insert is infallible; the existing poisoned-mutex recovery is unchanged).
- `FileFederationStore::save_policy` propagates the inner store's result, then propagates the serialize error (via `map_err(std::io::Error::other)`) and the `fs::write` error. The `.expect()` is gone.

The trait has 5 call sites, all in `governance_support.rs`: one internal self-delegation (`FileFederationStore::save_policy` → `InMemoryFederationStore::save_policy`) and four in tests. Tests now `.unwrap()` the result; the internal call uses `?`.

## Tests

```
cargo test -p agentmesh governance_support:: --lib
  test result: ok. 14 passed; 0 failed
cargo test -p agentmesh --lib
  test result: ok. 280 passed; 0 failed
```

New regression test: `file_federation_store_returns_err_on_unwriteable_path` points the store at a path under a non-existent parent directory and asserts `save_policy` returns `Err` instead of silently losing the write.

## Test plan

- [ ] CI passes
- [ ] No regression in `FederationEngine` consumers (none in tree outside this file)

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Rust section). Filed by Ken Tannenbaum (AEGIS Initiative).