### PR TITLE
perf(rust-prompt-defense): precompile static regex patterns via OnceLock

### DIFF
--- a/agent-governance-rust/agentmesh/src/integration_support.rs
+++ b/agent-governance-rust/agentmesh/src/integration_support.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn integration_now() -> u64 {
@@ -663,39 +663,52 @@ impl PromptDefenseEvaluator {
                 });
             }
         }
-        for (pattern, vector, severity, message, recommendation) in [
+        // The three regex patterns below are static; compile each one
+        // exactly once and share the compiled Regex across all calls.
+        // Previously `Regex::new(pattern)` ran inside the loop on every
+        // evaluate_internal invocation, re-parsing the pattern per call.
+        static INSTRUCTION_OVERRIDE_RE: OnceLock<Regex> = OnceLock::new();
+        static SECRET_EXFILTRATION_RE: OnceLock<Regex> = OnceLock::new();
+        static CHANNEL_CONFUSION_RE: OnceLock<Regex> = OnceLock::new();
+
+        let instruction_override = INSTRUCTION_OVERRIDE_RE
+            .get_or_init(|| Regex::new(r"(?i)ignore\s+all\s+previous").unwrap());
+        let secret_exfiltration = SECRET_EXFILTRATION_RE
+            .get_or_init(|| Regex::new(r"(?i)api[_ -]?key|token|secret").unwrap());
+        let channel_confusion = CHANNEL_CONFUSION_RE
+            .get_or_init(|| Regex::new(r"(?i)<\/?(system|developer|assistant)>").unwrap());
+
+        for (regex, vector, severity, message, recommendation) in [
             (
-                r"(?i)ignore\s+all\s+previous",
+                instruction_override,
                 "instruction_override",
                 PromptRiskLevel::High,
                 "prompt attempts to discard prior governance context",
                 "reject prompts that attempt to discard prior governance context",
             ),
             (
-                r"(?i)api[_ -]?key|token|secret",
+                secret_exfiltration,
                 "secret_exfiltration",
                 PromptRiskLevel::High,
                 "prompt references secret-bearing material",
                 "refuse access to secrets and redact sensitive output",
             ),
             (
-                r"(?i)<\/?(system|developer|assistant)>",
+                channel_confusion,
                 "channel_confusion",
                 PromptRiskLevel::Medium,
                 "prompt includes channel-like tags",
                 "treat system/developer channel tags as suspicious input",
             ),
         ] {
-            if let Ok(regex) = Regex::new(pattern) {
-                if let Some(matched) = regex.find(prompt) {
-                    findings.push(PromptDefenseFinding {
-                        vector: vector.to_string(),
-                        severity,
-                        message: message.to_string(),
-                        evidence: Some(matched.as_str().to_string()),
-                        recommendation: Some(recommendation.to_string()),
-                    });
-                }
+            if let Some(matched) = regex.find(prompt) {
+                findings.push(PromptDefenseFinding {
+                    vector: vector.to_string(),
+                    severity,
+                    message: message.to_string(),
+                    evidence: Some(matched.as_str().to_string()),
+                    recommendation: Some(recommendation.to_string()),
+                });
             }
         }
         findings


### PR DESCRIPTION
## Summary

`PromptDefense::evaluate_internal` in `agent-governance-rust/agentmesh/src/integration_support.rs:666-700` ran `Regex::new(pattern)` on three hardcoded patterns inside a loop on every call:

```rust
for (pattern, vector, severity, message, recommendation) in [
    (r"(?i)ignore\s+all\s+previous", "instruction_override", ...),
    (r"(?i)api[_ -]?key|token|secret", "secret_exfiltration", ...),
    (r"(?i)<\/?(system|developer|assistant)>", "channel_confusion", ...),
] {
    if let Ok(regex) = Regex::new(pattern) {  // ← parsed per call
        ...
    }
}
```

Three regex parses on every prompt scan. For a per-request defense path, that's pure waste.

## Change

`integration_support.rs:666-700` — move each pattern into a module-level `static OnceLock<Regex>` initialized on first use. Same matching semantics, three fewer regex parses per call.

```rust
static INSTRUCTION_OVERRIDE_RE: OnceLock<Regex> = OnceLock::new();
static SECRET_EXFILTRATION_RE: OnceLock<Regex> = OnceLock::new();
static CHANNEL_CONFUSION_RE: OnceLock<Regex> = OnceLock::new();

let instruction_override = INSTRUCTION_OVERRIDE_RE
    .get_or_init(|| Regex::new(r"(?i)ignore\s+all\s+previous").unwrap());
// ... similarly for the other two
```

The `.unwrap()` on `Regex::new` for these literal patterns is safe — they're compile-time strings the test suite verifies parse cleanly.

## Scope note

REVIEW.md cited 5 sites for this finding. Only the 3 patterns above are truly static. The remaining 4 (`governance_support.rs:372,955` and `integration_support.rs:107,110`) use **instance-level** patterns deserialized from policy/condition config — `OnceLock` doesn't apply because each instance has a different pattern. The fix shape for those is a per-instance `compiled: OnceLock<Regex>` field populated lazily on first match call; that ships as a separate PR rather than mixing two fix shapes in one diff.

## Tests

```
cargo test -p agentmesh integration_support:: --lib
  test result: ok. 14 passed; 0 failed
```

`prompt_defense_flags_override_attempts` exercises the precompiled regex path and continues to pass — same matching semantics.

## Test plan

- [ ] CI passes
- [ ] No regression in `PromptDefense::evaluate` semantics (14/14 tests pass)

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Rust section). Filed by Ken Tannenbaum (AEGIS Initiative).