### PR TITLE
perf(rust-regex-cache): compile instance-level governance patterns at most once

### DIFF
--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -369,7 +369,9 @@ impl TrustCondition {
             (ConditionOperator::Matches, Some(Value::String(actual))) => self
                 .value
                 .as_str()
-                .and_then(|pattern| Regex::new(pattern).ok().map(|regex| regex.is_match(actual)))
+                .and_then(|pattern| {
+                    crate::regex_cache::compiled_regex(pattern).map(|regex| regex.is_match(actual))
+                })
                 .unwrap_or(false),
             _ => false,
         }
@@ -952,8 +954,7 @@ impl PolicyCondition {
                 .as_str()
                 .zip(self.expected.as_str())
                 .and_then(|(actual, expected)| {
-                    Regex::new(expected)
-                        .ok()
+                    crate::regex_cache::compiled_regex(expected)
                         .map(|regex| regex.is_match(actual))
                 })
                 .unwrap_or(false),

--- a/agent-governance-rust/agentmesh/src/integration_support.rs
+++ b/agent-governance-rust/agentmesh/src/integration_support.rs
@@ -104,10 +104,10 @@ impl GovernancePattern {
             PatternType::Substring => text
                 .to_ascii_lowercase()
                 .contains(&self.pattern.to_ascii_lowercase()),
-            PatternType::Regex => Regex::new(&self.pattern)
+            PatternType::Regex => crate::regex_cache::compiled_regex(&self.pattern)
                 .map(|regex| regex.is_match(text))
                 .unwrap_or(false),
-            PatternType::Glob => Regex::new(&glob_to_regex(&self.pattern))
+            PatternType::Glob => crate::regex_cache::compiled_regex(&glob_to_regex(&self.pattern))
                 .map(|regex| regex.is_match(text))
                 .unwrap_or(false),
         }

--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -28,6 +28,7 @@ pub mod integration_support;
 pub mod lifecycle;
 pub mod mcp;
 pub mod policy;
+pub(crate) mod regex_cache;
 pub mod reward_support;
 pub mod rings;
 pub mod sandbox;

--- a/agent-governance-rust/agentmesh/src/regex_cache.rs
+++ b/agent-governance-rust/agentmesh/src/regex_cache.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared cache for runtime-compiled regex patterns.
+//!
+//! Several governance evaluation paths compile a `Regex` from a string
+//! that comes from deserialized config (policy conditions, governance
+//! patterns). Each evaluation previously re-parsed the same pattern,
+//! turning every policy check into a regex-compile workload.
+//!
+//! [`compiled_regex`] caches by pattern string: each unique pattern is
+//! parsed once, then served from a `HashMap` for subsequent callers.
+//! The compile step happens outside the cache lock so a slow parse
+//! doesn't block readers looking up other patterns.
+
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+fn cache() -> &'static Mutex<HashMap<String, Arc<Regex>>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Arc<Regex>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Return the compiled form of `pattern`, parsing it on first use and
+/// reusing the cached value on subsequent calls. Returns `None` if the
+/// pattern fails to compile; the failure is not cached, so a later
+/// caller with a corrected pattern is unaffected.
+pub(crate) fn compiled_regex(pattern: &str) -> Option<Arc<Regex>> {
+    {
+        let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(re) = guard.get(pattern) {
+            return Some(Arc::clone(re));
+        }
+    }
+
+    // Compile outside the lock — regex parsing can be non-trivial and
+    // we don't want to block other lookups while it runs.
+    let compiled = Arc::new(Regex::new(pattern).ok()?);
+
+    let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    Some(Arc::clone(
+        guard.entry(pattern.to_string()).or_insert(compiled),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_same_compiled_regex_across_calls() {
+        let first = compiled_regex(r"^foo\d+$").unwrap();
+        let second = compiled_regex(r"^foo\d+$").unwrap();
+        // Both arcs point to the same compiled Regex.
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn caches_distinct_patterns_independently() {
+        let a = compiled_regex(r"^a+$").unwrap();
+        let b = compiled_regex(r"^b+$").unwrap();
+        assert!(!Arc::ptr_eq(&a, &b));
+        assert!(a.is_match("aaaa"));
+        assert!(b.is_match("bbbb"));
+        assert!(!a.is_match("bbbb"));
+    }
+
+    #[test]
+    fn invalid_pattern_returns_none_without_caching() {
+        assert!(compiled_regex(r"(unclosed").is_none());
+        // A valid pattern still works after a prior failure.
+        assert!(compiled_regex(r"^x$").is_some());
+    }
+}


### PR DESCRIPTION
## Summary

Four governance evaluation sites pulled a pattern string out of a deserialized config struct and called `Regex::new(pattern)` on every evaluation:

| File | Line | Context |
|---|---|---|
| `governance_support.rs` | 372 | `TrustCondition::evaluate` (operator `ConditionOperator::Matches`, `self.value` as regex) |
| `governance_support.rs` | 955 | `PolicyCondition::matches` (operator `PolicyOperator::RegexMatch`, `self.expected` as regex) |
| `integration_support.rs` | 107 | `GovernancePattern::matches`, `PatternType::Regex` |
| `integration_support.rs` | 110 | `GovernancePattern::matches`, `PatternType::Glob` (after `glob_to_regex` translation) |

Each call re-parsed the pattern. For policy evaluation paths reached per-request, that's pure waste.

## Why not `OnceLock` statics

These patterns live on deserialized instances, not at module scope, so the static `OnceLock<Regex>` approach from #2011 doesn't apply. A per-struct `compiled: OnceLock<Regex>` field would work but requires touching the public API of three different structs (serde skip, Clone semantics, factory methods) for what's mechanically the same fix.

## Change

Add a small private `regex_cache` module exposing one helper:

```rust
pub(crate) fn compiled_regex(pattern: &str) -> Option<Arc<Regex>>
```

A single global `Mutex<HashMap<String, Arc<Regex>>>` keyed by pattern string. Unique patterns are parsed once and reused process-wide; the parse step runs outside the cache lock so a slow compile doesn't block other lookups. Invalid patterns return `None` and are not cached — a corrected pattern works on the next call.

All four sites switch from `Regex::new(...)` to `crate::regex_cache::compiled_regex(...)`. Same matching semantics, no struct surgery, no changes to any public type.

## Tests

```
cargo test -p agentmesh --lib
  test result: ok. 282 passed; 0 failed
cargo test -p agentmesh regex_cache:: --lib
  test result: ok. 3 passed; 0 failed
```

New `regex_cache` test module covers:

- `returns_same_compiled_regex_across_calls` — second call to `compiled_regex` returns the same `Arc<Regex>` (cache hit verified by `Arc::ptr_eq`).
- `caches_distinct_patterns_independently` — different patterns get different compiled values.
- `invalid_pattern_returns_none_without_caching` — bad pattern returns `None`, a subsequent valid pattern still compiles.

## Companion PR

This is the second of a split pair: #2011 handles the 3 static patterns at the prompt-defense loop with `OnceLock` statics. This PR handles the 4 instance-level patterns with the global cache. Both target the same REVIEW.md finding.

## Test plan

- [ ] CI passes
- [ ] No regression in `TrustCondition`, `PolicyCondition`, or `GovernancePattern` semantics (existing tests pass)

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Rust section). Filed by Ken Tannenbaum (AEGIS Initiative).