### PR TITLE
fix(go-discovery): drop ps lines with unparseable PID instead of storing PID=0

### DIFF
--- a/agent-governance-golang/packages/agentmesh/discovery.go
+++ b/agent-governance-golang/packages/agentmesh/discovery.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -752,8 +753,14 @@ func currentUnixProcesses() ([]ProcessInfo, error) {
 		if len(fields) < 2 {
 			continue
 		}
-		pid := 0
-		fmt.Sscanf(fields[0], "%d", &pid)
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			// `ps` output occasionally has malformed lines (header
+			// re-emit, embedded newlines in command). Drop the entry
+			// rather than silently store PID=0, which would otherwise
+			// shadow real processes.
+			continue
+		}
 		commandLine := strings.TrimSpace(strings.TrimPrefix(line, fields[0]))
 		processes = append(processes, ProcessInfo{
 			PID:         pid,


### PR DESCRIPTION
## Summary

`currentUnixProcesses` in `agent-governance-golang/packages/agentmesh/discovery.go:756` parsed `ps` output with:

```go
pid := 0
fmt.Sscanf(fields[0], "%d", &pid)
```

`fmt.Sscanf` returns `(n int, err error)`; both were ignored. On a malformed line (header re-emit, embedded newline in a command line, partial output on slow `ps`), the parse silently fails and `pid` stays at the zero-value initializer `0`. The entry is then appended to the result slice as `{PID: 0, CommandLine: ...}`, shadowing any real process whose PID happens to be 0 (the kernel itself on Linux) and confusing downstream filters that key on PID.

## Change

`discovery.go:751-762` — replace `fmt.Sscanf` with `strconv.Atoi` and explicit error handling. On parse failure, drop the entry rather than store a sentinel PID:

```go
pid, err := strconv.Atoi(fields[0])
if err != nil {
    continue
}
```

Also adds `"strconv"` to the import block.

## Tests

```
go test ./...
  ok  github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh
```

No new test added — fabricating malformed `ps` output requires mocking `exec.CommandContext`, which the existing test infrastructure doesn't currently do for this function. The fix is mechanically minimal (parse-and-check vs parse-and-discard); existing tests continue to pass.

## Test plan

- [ ] CI passes
- [ ] Discovery scan still surfaces real processes on Unix targets

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).