### PR TITLE
fix(go-audit): break backing-array reference chain on rollover eviction

### DIFF
--- a/agent-governance-golang/packages/agentmesh/audit.go
+++ b/agent-governance-golang/packages/agentmesh/audit.go
@@ -59,7 +59,16 @@ func (al *AuditLogger) Log(agentID, action string, decision PolicyDecision) *Aud
 	if al.MaxEntries > 0 && len(al.entries) >= al.MaxEntries {
 		sliceFrom := len(al.entries) - al.MaxEntries + 1
 		al.seamHash = al.entries[sliceFrom-1].Hash
-		al.entries = al.entries[sliceFrom:]
+		// Allocate a fresh slice and copy the retained tail; a plain
+		// reslice (`al.entries = al.entries[sliceFrom:]`) keeps the
+		// original backing array alive, so the evicted *AuditEntry
+		// values stay reachable from the dropped prefix region and the
+		// GC cannot collect them. The leak grows proportional to the
+		// total number of entries ever logged, not the bounded
+		// MaxEntries retention.
+		retained := make([]*AuditEntry, len(al.entries)-sliceFrom)
+		copy(retained, al.entries[sliceFrom:])
+		al.entries = retained
 	}
 
 	prevHash := al.seamHash

--- a/agent-governance-golang/packages/agentmesh/audit_test.go
+++ b/agent-governance-golang/packages/agentmesh/audit_test.go
@@ -487,3 +487,27 @@ func TestGetEntriesReturnsClones(t *testing.T) {
 		t.Error("chain verify should still pass after caller mutates a GetEntries result")
 	}
 }
+
+// Regression: prior to this fix, eviction did `al.entries =
+// al.entries[sliceFrom:]`, which keeps the original backing array
+// alive. After many rollovers the array's capacity (and the
+// *AuditEntry pointers in the dropped prefix) grew unboundedly even
+// though len() stayed pinned to MaxEntries. The fix allocates a fresh
+// slice on each eviction, so cap() stays close to len().
+func TestMaxEntriesNoBackingArrayLeak(t *testing.T) {
+	al := NewAuditLogger()
+	al.MaxEntries = 5
+	for i := 0; i < 1000; i++ {
+		al.Log("agent", fmt.Sprintf("action-%d", i), Allow)
+	}
+	if got := len(al.entries); got != al.MaxEntries {
+		t.Fatalf("len(entries) = %d, want %d", got, al.MaxEntries)
+	}
+	// After 1000 logs with MaxEntries=5 the underlying capacity must
+	// not have grown to the total-logged count. Allow a small headroom
+	// for the make-and-copy step but require it to be bounded close to
+	// MaxEntries.
+	if got := cap(al.entries); got > al.MaxEntries*4 {
+		t.Errorf("cap(entries) = %d, want close to %d (backing array leak)", got, al.MaxEntries)
+	}
+}


### PR DESCRIPTION
## Summary

`AuditLogger.Log` in `agent-governance-golang/packages/agentmesh/audit.go:46-49` performed eviction with:

```go
if al.MaxEntries > 0 && len(al.entries) >= al.MaxEntries {
    sliceFrom := len(al.entries) - al.MaxEntries + 1
    al.seamHash = al.entries[sliceFrom-1].Hash
    al.entries = al.entries[sliceFrom:]
}
```

The slice expression `al.entries[sliceFrom:]` only adjusts the slice header — the underlying backing array still has its full capacity, and the dropped-prefix region still holds the evicted `*AuditEntry` pointers. The GC can't collect those entries.

With `MaxEntries=N` and total-logs-ever-seen of `K`, the in-memory footprint grows proportional to `K`, not bounded by `N`, even though `len(entries)` stays pinned to `N`. A long-running service that logs continuously leaks memory at the rate of `sizeof(*AuditEntry)` per log call.

## Change

`audit.go:46-58`:

```go
retained := make([]*AuditEntry, len(al.entries)-sliceFrom)
copy(retained, al.entries[sliceFrom:])
al.entries = retained
```

Allocate a fresh slice on each eviction and copy the retained tail into it. The original backing array (and its prefix of dropped pointers) becomes unreachable and gets collected on the next GC cycle.

## Tests

New `TestMaxEntriesNoBackingArrayLeak`: log 1000 entries with `MaxEntries=5` and assert `cap(entries)` stays close to `MaxEntries`. Without the fix, capacity would grow proportional to the total-logged count.

```
go test -run TestMaxEntries ./...
  ok  github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh
```

## Test plan

- [ ] CI passes
- [ ] Existing chain-verification tests (`TestMaxEntriesVerify`, `TestMaxEntriesVerifyDetectsForgedSeam`) still pass — the seam-hash logic is untouched

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).