### PR TITLE
fix(go-audit): return cloned AuditEntry pointers from Log and GetEntries

### DIFF
--- a/agent-governance-golang/packages/agentmesh/audit.go
+++ b/agent-governance-golang/packages/agentmesh/audit.go
@@ -22,6 +22,19 @@ type AuditEntry struct {
 	PreviousHash string         `json:"previous_hash"`
 }
 
+// Clone returns a value-copy of the entry. Used at the AuditLogger
+// API boundary so callers cannot mutate the in-store record (and
+// thereby break the hash chain) through the returned pointer.
+// AuditEntry contains only value types, so a struct copy is a deep
+// copy.
+func (ae *AuditEntry) Clone() *AuditEntry {
+	if ae == nil {
+		return nil
+	}
+	c := *ae
+	return &c
+}
+
 // AuditLogger maintains an append-only hash-chained audit log.
 type AuditLogger struct {
 	mu         sync.Mutex
@@ -63,7 +76,9 @@ func (al *AuditLogger) Log(agentID, action string, decision PolicyDecision) *Aud
 	}
 	entry.Hash = computeHash(entry)
 	al.entries = append(al.entries, entry)
-	return entry
+	// Return a clone so callers cannot mutate the in-store entry
+	// (and break the chain) through the returned pointer.
+	return entry.Clone()
 }
 
 // Verify checks the integrity of the entire hash chain. After rollover
@@ -113,7 +128,7 @@ func (al *AuditLogger) GetEntries(filter AuditFilter) []*AuditEntry {
 		if filter.EndTime != nil && e.Timestamp.After(*filter.EndTime) {
 			continue
 		}
-		result = append(result, e)
+		result = append(result, e.Clone())
 	}
 	return result
 }

--- a/agent-governance-golang/packages/agentmesh/audit_test.go
+++ b/agent-governance-golang/packages/agentmesh/audit_test.go
@@ -442,3 +442,48 @@ func TestAuditSingleEntryVerifies(t *testing.T) {
 		t.Error("single entry chain should verify")
 	}
 }
+
+// Regression: prior to this fix, Log() returned the same *AuditEntry
+// it stored in al.entries; GetEntries() returned the same pointers.
+// A caller could mutate Hash on the returned pointer and break the
+// chain. Now Log/GetEntries return value-copies; mutations to the
+// caller's pointer must not affect the in-store record.
+func TestReturnedEntryIsClone(t *testing.T) {
+	al := NewAuditLogger()
+	returned := al.Log("agent", "action", Allow)
+
+	originalHash := returned.Hash
+	returned.Hash = "tampered-by-caller"
+
+	stored := al.GetEntries(AuditFilter{})
+	if len(stored) != 1 {
+		t.Fatalf("entries = %d, want 1", len(stored))
+	}
+	if stored[0].Hash == "tampered-by-caller" {
+		t.Errorf("caller's mutation propagated into store; Log return is shared")
+	}
+	if stored[0].Hash != originalHash {
+		t.Errorf("stored hash = %q, want %q", stored[0].Hash, originalHash)
+	}
+	if !al.Verify() {
+		t.Error("chain verify should still pass after a caller mutates their copy")
+	}
+}
+
+func TestGetEntriesReturnsClones(t *testing.T) {
+	al := NewAuditLogger()
+	al.Log("agent", "a1", Allow)
+	al.Log("agent", "a2", Deny)
+
+	first := al.GetEntries(AuditFilter{})
+	first[0].Hash = "tampered"
+	first[1].AgentID = "spoofed"
+
+	second := al.GetEntries(AuditFilter{})
+	if second[0].Hash == "tampered" || second[1].AgentID == "spoofed" {
+		t.Error("mutations on GetEntries result propagated to subsequent reads")
+	}
+	if !al.Verify() {
+		t.Error("chain verify should still pass after caller mutates a GetEntries result")
+	}
+}


### PR DESCRIPTION
## Summary

`AuditLogger.Log()` returned the same `*AuditEntry` it stored in `al.entries`; `GetEntries()` returned those same pointers. Any caller could mutate fields (`Hash`, `AgentID`, `Decision`) on the returned pointer and silently break the hash chain — `Verify()` would then flag the in-store entry as tampered, even though the logger itself never produced bad data.

This is a quiet hazard: nothing in the API contract suggests the returned pointer is read-only, but mutation is corrupting in a way that doesn't show up until a later `Verify()` call.

## Change

`audit.go`:

- Add a value-copy `Clone()` helper on `*AuditEntry`. The struct contains only value types (`time.Time`, `string`, `PolicyDecision`), so a struct-copy is a deep copy.
- Return `entry.Clone()` from `Log()` instead of the in-store pointer.
- Return `e.Clone()` in the `GetEntries()` accumulator loop.

## API note

This is a behavior change. Callers that previously relied on mutation-visibility through the returned pointer will no longer see their mutations reflected in subsequent reads. The codebase has no production caller that depends on this:

- `middleware.go:256` only reads `Hash` from the returned entry.
- Existing audit tampering tests in `audit_test.go` mutate via `al.entries[...]` directly (internal indexing for test setup), not via `Log()`'s return value, so they continue to exercise the chain-verification paths unchanged.

External consumers that depend on mutation-visibility would now silently fail to mutate; this PR description and the new test cases make the intent explicit.

## Tests

- `TestReturnedEntryIsClone` — mutates `Hash` on `Log()`'s return value; verifies `GetEntries()` sees the original hash and `Verify()` still passes.
- `TestGetEntriesReturnsClones` — mutates fields on a `GetEntries()` result; verifies a subsequent `GetEntries()` call returns clean copies.

```
go test ./...
  ok  github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh
```

## Test plan

- [ ] CI passes
- [ ] All existing audit chain-verification tests (`TestAuditVerifyAfterMultipleTamperTypes`, `TestMaxEntriesVerify`, `TestMaxEntriesVerifyDetectsForgedSeam`) continue to pass

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).