### PR TITLE
perf(go-policy): split Evaluate lock into RLock scan + scoped checkRateLimit Lock

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy.go
+++ b/agent-governance-golang/packages/agentmesh/policy.go
@@ -81,27 +81,34 @@ func (pe *PolicyEngine) LoadCedar(options CedarOptions) {
 
 // Evaluate returns the decision for the given action and context.
 // Rules are evaluated in order; first match wins. Default is Deny.
+//
+// Concurrency: the rule scan and backend snapshot run under RLock so
+// concurrent evaluations don't serialize on the same lock. Only the
+// rate-limit branch needs to mutate state, and it acquires its own
+// write lock internally.
 func (pe *PolicyEngine) Evaluate(action string, context map[string]interface{}) PolicyDecision {
-	pe.mu.Lock()
+	pe.mu.RLock()
 
-	for _, rule := range pe.rules {
-		if matchAction(rule.Action, action) && matchConditions(rule.Conditions, context) {
-			if rule.MaxCalls > 0 {
-				decision := pe.checkRateLimit(rule, context)
-				pe.mu.Unlock()
-				return decision
-			}
-			if rule.MinApprovals > 0 {
-				pe.mu.Unlock()
-				return RequiresApproval
-			}
-			pe.mu.Unlock()
-			return rule.Effect
+	var matched *PolicyRule
+	for i := range pe.rules {
+		r := &pe.rules[i]
+		if matchAction(r.Action, action) && matchConditions(r.Conditions, context) {
+			matched = r
+			break
 		}
 	}
-
 	backends := append([]ExternalPolicyBackend(nil), pe.backends...)
-	pe.mu.Unlock()
+	pe.mu.RUnlock()
+
+	if matched != nil {
+		if matched.MaxCalls > 0 {
+			return pe.checkRateLimit(*matched, context)
+		}
+		if matched.MinApprovals > 0 {
+			return RequiresApproval
+		}
+		return matched.Effect
+	}
 
 	backendContext := clonePolicyContext(context)
 	if _, ok := backendContext["action"]; !ok {
@@ -148,7 +155,13 @@ func rateLimitContextString(v interface{}) string {
 // noisy caller does not exhaust the budget for all other agents or tenants.
 // Missing context keys collapse to an empty segment — callers that don't
 // supply agent_id / tenant retain the previous globally-scoped behavior.
+//
+// Acquires the engine's write lock; callers must NOT already hold either
+// the read or write lock when invoking this method.
 func (pe *PolicyEngine) checkRateLimit(rule PolicyRule, context map[string]interface{}) PolicyDecision {
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+
 	agentID := rateLimitContextString(context["agent_id"])
 	tenant := rateLimitContextString(context["tenant"])
 	key := rule.Action + "\x1f" + agentID + "\x1f" + tenant


### PR DESCRIPTION
## Summary

`PolicyEngine.Evaluate` in `agent-governance-golang/packages/agentmesh/policy.go:84` held the engine's write lock from entry through the entire rule scan, even though most evaluations only READ `pe.rules` and `pe.backends`. The only mutation is in the rate-limit branch (`pe.rateLimits[key].count++`). All concurrent `Evaluate` calls — across all agents, all actions, all tenants — serialized on the same write lock for the duration of the scan and any backend snapshot.

## Change

`policy.go`:

- `Evaluate` now acquires `pe.mu.RLock()`, scans for the first matching rule + snapshots `pe.backends`, then releases the read lock before any decision-dependent work.
- If the matched rule needs rate-limiting, `Evaluate` calls `checkRateLimit`, which now acquires the write lock **internally** rather than relying on the caller to already hold it.
- If the rule is approval-only or a simple effect, `Evaluate` returns the decision without re-acquiring any lock.
- Backend fallback runs lock-free over the snapshotted slice.

## Visibility note

Between `RUnlock` and the rate-limit `Lock`, another goroutine could mutate `pe.rules`. In this codebase, rule mutation is initialization-only (`AddBackend`, `LoadFromYAML` at startup), not a hot path — so the race window is microseconds and "first match wins" ordering is unaffected for any realistic policy lifecycle.

## Tests

```
go test ./...
  ok  github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh
```

No new test added — concurrency correctness is best validated by the race detector under `go test -race` in CI. (Local Windows toolchain lacks gcc for CGO, so the race detector couldn't run here; CI has it.)

## Test plan

- [ ] CI passes, including `go test -race`
- [ ] Existing tests `TestRateLimiting`, `TestRateLimitWindow`, `TestEvaluate*` continue to pass

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).