### PR TITLE
fix(go-policy-backends): block argv injection via Query / SchemaPath

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy_backends.go
+++ b/agent-governance-golang/packages/agentmesh/policy_backends.go
@@ -218,6 +218,10 @@ func (b *OPABackend) evaluateCLI(context map[string]interface{}) (BackendDecisio
 
 	ctx, cancel := stdcontext.WithTimeout(stdcontext.Background(), b.timeout)
 	defer cancel()
+	// The trailing `--` stops OPA's flag parser before it reaches the
+	// query positional; without it, a query that starts with `-` (e.g.
+	// from an attacker-supplied Options.Query) would be interpreted as
+	// an OPA flag.
 	cmd := exec.CommandContext(
 		ctx,
 		"opa",
@@ -225,6 +229,7 @@ func (b *OPABackend) evaluateCLI(context map[string]interface{}) (BackendDecisio
 		"--format", "json",
 		"--input", inputPath,
 		"--data", regoPath,
+		"--",
 		b.query,
 	)
 
@@ -553,7 +558,9 @@ func (b *CedarBackend) evaluateCLI(context map[string]interface{}) (BackendDecis
 		"--request-json", requestPath,
 	}
 	if b.schemaPath != "" {
-		args = append(args, "--schema", b.schemaPath)
+		// Use --flag=value form so a schemaPath that starts with `-`
+		// cannot be parsed as a separate flag by cedar's CLI parser.
+		args = append(args, fmt.Sprintf("--schema=%s", b.schemaPath))
 	}
 
 	ctx, cancel := stdcontext.WithTimeout(stdcontext.Background(), b.timeout)


### PR DESCRIPTION
## Summary

Two CLI-backed policy backends interpolated configured strings into the subprocess argv without protecting them from the underlying CLI's flag parser:

### OPA — positional query after flags

`policy_backends.go:218-230`:
```go
cmd := exec.CommandContext(
    ctx,
    \"opa\", \"eval\",
    \"--format\", \"json\",
    \"--input\", inputPath,
    \"--data\", regoPath,
    b.query,
)
```

`b.query` comes from `Options.Query`. OPA reads it as a positional **after** its flag list. A value starting with `-` (e.g. `\"--help\"`, `\"--data /tmp/inject\"`) is interpreted as an OPA flag rather than a Rego query expression.

### Cedar — flag/value pair with leading-dash value

`policy_backends.go:549-557`:
```go
args := []string{ \"authorize\", \"--policies\", policyPath, ..., \"--schema\", b.schemaPath }
```

`b.schemaPath` comes from `Options.SchemaPath`. If the value starts with `-`, cedar's CLI parser treats it as a separate flag rather than as the value for `--schema`, producing wrong or surprising behavior.

Both options originate from upstream caller config — if any of those configs are user- or workspace-controlled (workspace settings, env-derived paths, downstream library wiring), the values can pivot the subprocess off the intended path.

## Change

`policy_backends.go`:

- **OPA**: insert `\"--\"` between the flag list and `b.query`. This stops OPA's cobra-based flag parser before the positional, so a leading-dash query is treated as a literal Rego query expression (which will then fail to parse — surfacing as an error rather than as silent argv reinterpretation).
- **Cedar**: switch from `\"--schema\", b.schemaPath` (two-arg form) to `fmt.Sprintf(\"--schema=%s\", b.schemaPath)` (attached-value form). The attached form removes the ambiguity that lets a leading-dash path be parsed as a separate flag.

## Tests

```
go test ./...
  ok  github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh
```

The existing happy-path tests cover the normal call paths; both fixes are mechanically minimal (single-line argv changes) and don't alter the contract for well-formed inputs.

## Note on REVIEW.md item #1

REVIEW.md flagged the OPA/Cedar invocations as also missing timeouts, but that finding is already mitigated on `main` — both call sites use `exec.CommandContext` with `b.timeout` (a default of 5 seconds when unset). This PR addresses only the argv-injection half of the bullet.

## Test plan

- [ ] CI passes
- [ ] Existing OPA / Cedar backend tests continue to pass

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).