### PR TITLE
fix(go-policy): check rate-limit threshold before incrementing counter

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy.go
+++ b/agent-governance-golang/packages/agentmesh/policy.go
@@ -171,10 +171,16 @@ func (pe *PolicyEngine) checkRateLimit(rule PolicyRule, context map[string]inter
 		return Allow
 	}
 
-	state.count++
-	if state.count > rule.MaxCalls {
+	// Check BEFORE incrementing. The previous order incremented first
+	// and then compared, so once the limit was reached the counter
+	// kept growing on every subsequent call until the window expired.
+	// The growth itself was harmless internally, but it meant the
+	// counter no longer reflected the (admit/reject) state and tests
+	// asserting on `count` after a deny would observe spurious values.
+	if state.count >= rule.MaxCalls {
 		return RateLimit
 	}
+	state.count++
 	return Allow
 }
 

--- a/agent-governance-golang/packages/agentmesh/policy_test.go
+++ b/agent-governance-golang/packages/agentmesh/policy_test.go
@@ -626,3 +626,42 @@ func TestRateLimitNilContextRetainsGlobalBehavior(t *testing.T) {
 		t.Fatalf("call 3: got %q, want rate-limit", d)
 	}
 }
+
+// Regression: prior to this fix, checkRateLimit incremented `count`
+// then compared; once over the limit, count grew unboundedly for the
+// remainder of the window. This test asserts the counter is bounded
+// by MaxCalls — subsequent denied calls must not advance it further.
+//
+// Note: after #2022 the rateLimits map is keyed by the composite
+// (action \x1f agent_id \x1f tenant). A nil context collapses both
+// agent_id and tenant to empty strings, so the resulting key is
+// "api.call\x1f\x1f".
+func TestRateLimitCounterDoesNotGrowAfterDeny(t *testing.T) {
+	pe := NewPolicyEngine([]PolicyRule{
+		{Action: "api.call", Effect: Allow, MaxCalls: 3, Window: "60s"},
+	})
+	const key = "api.call\x1f\x1f"
+
+	// First three calls allowed; counter goes 0→1→2→3.
+	for i := 0; i < 3; i++ {
+		if d := pe.Evaluate("api.call", nil); d != Allow {
+			t.Fatalf("call %d: decision = %q, want allow", i+1, d)
+		}
+	}
+
+	// 4th call denied — counter must remain at 3, not grow to 4.
+	if d := pe.Evaluate("api.call", nil); d != RateLimit {
+		t.Fatalf("call 4: decision = %q, want rate-limit", d)
+	}
+	if got := pe.rateLimits[key].count; got != 3 {
+		t.Errorf("after first deny, count = %d, want 3 (no growth past MaxCalls)", got)
+	}
+
+	// 5th and 6th calls denied — counter still 3.
+	for i := 4; i < 6; i++ {
+		_ = pe.Evaluate("api.call", nil)
+	}
+	if got := pe.rateLimits[key].count; got != 3 {
+		t.Errorf("after multiple denies, count = %d, want 3", got)
+	}
+}


### PR DESCRIPTION
## Summary

`checkRateLimit` in `agent-governance-golang/packages/agentmesh/policy.go:153-156` incremented the counter first and then compared:

```go
state.count++
if state.count > rule.MaxCalls {
    return RateLimit
}
return Allow
```

Once the limit was reached, every subsequent call within the same window continued to increment the counter on its way to returning `RateLimit`. The counter grew unboundedly until the window expired.

The growth was internally harmless — the next window reset to 1 — but the counter no longer represented the admit/reject state, so any test or observability hook reading `state.count` after a deny would see values larger than `MaxCalls`.

## Change

Reorder to check-then-increment, using `>=` so `MaxCalls` is the inclusive bound:

```go
if state.count >= rule.MaxCalls {
    return RateLimit
}
state.count++
return Allow
```

A 3-call limit now goes: counter 0→1→2→3 across three allowed calls; the 4th call sees `count >= 3`, returns `RateLimit`, leaves `count` at 3.

## Tests

New `TestRateLimitCounterDoesNotGrowAfterDeny`: log 3 allowed calls then 3 denied calls; assert `state.count == 3` after each phase. The existing `TestRateLimiting` continues to pass — its semantics ("admit N, then deny") are unchanged.

```
go test -run TestRateLimit ./... -v
  --- PASS: TestRateLimiting (0.00s)
  --- PASS: TestRateLimitCounterDoesNotGrowAfterDeny (0.00s)
```

## Note on REVIEW.md item #7

This is part 1 of REVIEW.md item #7. **Part 2** — keying the rate limiter by `(action, agent_id, tenant)` so one noisy caller doesn't starve all others — ships as a separate PR because it requires threading `context` through to `checkRateLimit` and updating the in-tree caller (`middleware.go:256` currently passes `nil` context).

## Test plan

- [ ] CI passes
- [ ] Existing rate-limit tests continue to pass

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).