### PR TITLE
fix(go-policy): key rate-limit state by (action, agent_id, tenant)

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy.go
+++ b/agent-governance-golang/packages/agentmesh/policy.go
@@ -4,6 +4,7 @@
 package agentmesh
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -86,7 +87,7 @@ func (pe *PolicyEngine) Evaluate(action string, context map[string]interface{}) 
 	for _, rule := range pe.rules {
 		if matchAction(rule.Action, action) && matchConditions(rule.Conditions, context) {
 			if rule.MaxCalls > 0 {
-				decision := pe.checkRateLimit(rule)
+				decision := pe.checkRateLimit(rule, context)
 				pe.mu.Unlock()
 				return decision
 			}
@@ -128,9 +129,29 @@ func (pe *PolicyEngine) Evaluate(action string, context map[string]interface{}) 
 	return Allow
 }
 
+// rateLimitContextString returns a stable string representation of a
+// context value for use in the rate-limit composite key. Non-string
+// values fall through to fmt.Sprint to handle the common case where
+// an upstream caller plumbs int agent IDs or similar.
+func rateLimitContextString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprint(v)
+}
+
 // checkRateLimit tracks and enforces per-rule call limits within a time window.
-func (pe *PolicyEngine) checkRateLimit(rule PolicyRule) PolicyDecision {
-	key := rule.Action
+// The window state is keyed by (rule action, agent_id, tenant) so a single
+// noisy caller does not exhaust the budget for all other agents or tenants.
+// Missing context keys collapse to an empty segment — callers that don't
+// supply agent_id / tenant retain the previous globally-scoped behavior.
+func (pe *PolicyEngine) checkRateLimit(rule PolicyRule, context map[string]interface{}) PolicyDecision {
+	agentID := rateLimitContextString(context["agent_id"])
+	tenant := rateLimitContextString(context["tenant"])
+	key := rule.Action + "\x1f" + agentID + "\x1f" + tenant
 	now := time.Now()
 
 	window, err := time.ParseDuration(rule.Window)

--- a/agent-governance-golang/packages/agentmesh/policy_test.go
+++ b/agent-governance-golang/packages/agentmesh/policy_test.go
@@ -554,3 +554,75 @@ func TestLoadFromYAMLEmptyRules(t *testing.T) {
 		t.Errorf("empty YAML rules: got %q, want deny", d)
 	}
 }
+
+// Regression: rate-limit state was previously keyed by rule.Action only,
+// so one agent / tenant making rapid calls could starve all others for
+// the rest of the window. Now keyed by (action, agent_id, tenant).
+func TestRateLimitIsolatedPerAgent(t *testing.T) {
+	pe := NewPolicyEngine([]PolicyRule{
+		{Action: "api.call", Effect: Allow, MaxCalls: 2, Window: "60s"},
+	})
+
+	alice := map[string]interface{}{"agent_id": "alice", "tenant": "acme"}
+	bob := map[string]interface{}{"agent_id": "bob", "tenant": "acme"}
+
+	// Alice exhausts her budget.
+	if d := pe.Evaluate("api.call", alice); d != Allow {
+		t.Fatalf("alice call 1: got %q, want allow", d)
+	}
+	if d := pe.Evaluate("api.call", alice); d != Allow {
+		t.Fatalf("alice call 2: got %q, want allow", d)
+	}
+	if d := pe.Evaluate("api.call", alice); d != RateLimit {
+		t.Fatalf("alice call 3: got %q, want rate-limit", d)
+	}
+
+	// Bob must NOT be rate-limited by Alice's traffic.
+	if d := pe.Evaluate("api.call", bob); d != Allow {
+		t.Errorf("bob call 1 (independent of alice): got %q, want allow", d)
+	}
+	if d := pe.Evaluate("api.call", bob); d != Allow {
+		t.Errorf("bob call 2: got %q, want allow", d)
+	}
+}
+
+func TestRateLimitIsolatedPerTenant(t *testing.T) {
+	pe := NewPolicyEngine([]PolicyRule{
+		{Action: "api.call", Effect: Allow, MaxCalls: 1, Window: "60s"},
+	})
+
+	acmeUser := map[string]interface{}{"agent_id": "u", "tenant": "acme"}
+	otherUser := map[string]interface{}{"agent_id": "u", "tenant": "other"}
+
+	if d := pe.Evaluate("api.call", acmeUser); d != Allow {
+		t.Fatalf("acme: got %q, want allow", d)
+	}
+	if d := pe.Evaluate("api.call", acmeUser); d != RateLimit {
+		t.Fatalf("acme follow-up: got %q, want rate-limit", d)
+	}
+
+	// Same agent_id but different tenant must have an independent budget.
+	if d := pe.Evaluate("api.call", otherUser); d != Allow {
+		t.Errorf("other-tenant: got %q, want allow", d)
+	}
+}
+
+func TestRateLimitNilContextRetainsGlobalBehavior(t *testing.T) {
+	// Callers that pass nil context (e.g. middleware paths) collapse
+	// to the empty agent/tenant segments — preserving the previous
+	// globally-scoped behavior rather than splitting the budget across
+	// unrelated callers.
+	pe := NewPolicyEngine([]PolicyRule{
+		{Action: "api.call", Effect: Allow, MaxCalls: 2, Window: "60s"},
+	})
+
+	if d := pe.Evaluate("api.call", nil); d != Allow {
+		t.Fatalf("call 1: got %q, want allow", d)
+	}
+	if d := pe.Evaluate("api.call", nil); d != Allow {
+		t.Fatalf("call 2: got %q, want allow", d)
+	}
+	if d := pe.Evaluate("api.call", nil); d != RateLimit {
+		t.Fatalf("call 3: got %q, want rate-limit", d)
+	}
+}


### PR DESCRIPTION
## Summary

`PolicyEngine.checkRateLimit` keyed `pe.rateLimits` by `rule.Action` alone. With a 60-second window of N calls, **any** caller's traffic counted against the same budget — one noisy agent (or tenant) could exhaust the budget and starve every other caller for the rest of the window.

In a multi-tenant deployment that's a denial-of-service vector: agent A's misbehavior reaches agent B's API budget through nothing more than sharing an action name.

## Change

`policy.go`:

- `checkRateLimit` now takes `context map[string]interface{}` and composes the key from `(rule.Action, agent_id, tenant)`. Both context keys are pulled with a small helper that handles non-string values via `fmt.Sprint`.
- `Evaluate` passes `context` through to `checkRateLimit`.
- The key delimiter is `0x1f` (ASCII Unit Separator) so the join is unambiguous even if action / agent_id / tenant contain `\":\"` or other printable characters.

### Compatibility note

Callers that pass `nil` context — for example `middleware.go:256` — collapse to empty segments for both agent_id and tenant, so they retain the previous globally-scoped behavior. This is a deliberate safe fallback: nothing in the codebase currently relies on cross-caller starvation, and upgrading callers later to plumb `agent_id` is a no-op for the nil case until they actually pass real values.

## Tests

```
go test -run TestRateLimit ./... -v
  --- PASS: TestRateLimiting
  --- PASS: TestRateLimitIsolatedPerAgent
  --- PASS: TestRateLimitIsolatedPerTenant
  --- PASS: TestRateLimitNilContextRetainsGlobalBehavior
```

- `TestRateLimitIsolatedPerAgent` — alice exhausts her budget; bob's calls are unaffected.
- `TestRateLimitIsolatedPerTenant` — same agent_id, different tenant, independent budget.
- `TestRateLimitNilContextRetainsGlobalBehavior` — nil context still rate-limits at the action level (legacy caller compatibility).

## Companion

This is **part 2** of REVIEW.md item #7. Part 1 — the check-then-increment counter fix — is filed as #2021. The two PRs can be merged in either order; this one depends only on the public `Evaluate` / `checkRateLimit` signatures.

## Test plan

- [ ] CI passes
- [ ] Existing `TestRateLimiting` continues to pass under the nil-context default

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).