### PR TITLE
fix(go-middleware): stop demoing the insecure header resolver in the live example

### DIFF
--- a/agent-governance-golang/examples/http-middleware/main.go
+++ b/agent-governance-golang/examples/http-middleware/main.go
@@ -1,15 +1,81 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+// Example: HTTP governance middleware with a cryptographically-verified
+// agent identity resolver.
+//
+// The agent-governance toolkit ships LegacyTrustedHeaderAgentIDResolver
+// for fixtures and short-lived migrations, but that resolver trusts a
+// plain header — anyone who can reach the endpoint can claim to be any
+// agent. Production deployments need to bind the asserted identity to
+// something the caller can't forge. This example demonstrates one such
+// pattern: an HMAC-SHA256 signature over (agent_id || timestamp) keyed
+// by a shared secret, with a five-minute timestamp window to bound
+// replay.
+//
+// Wire it to a real key store (KMS, Vault, file with restricted ACL —
+// not a literal in production source) before deploying.
 package main
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	agentmesh "github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh"
 )
+
+// signedHeaderResolver verifies a signed agent-identity header set of the form:
+//   X-Agent-Id: <agent_id>
+//   X-Agent-Timestamp: <unix-seconds>
+//   X-Agent-Signature: hex(HMAC-SHA256(secret, agent_id || ":" || timestamp))
+//
+// The timestamp window prevents indefinite replay of a captured header
+// set. The shared secret must come from a real key store; the literal
+// here is for example purposes only.
+func signedHeaderResolver(sharedSecret []byte, maxAge time.Duration) agentmesh.HTTPAgentIDResolver {
+	return func(request *http.Request) (agentmesh.HTTPResolvedAgentIdentity, error) {
+		agentID := strings.TrimSpace(request.Header.Get("X-Agent-Id"))
+		tsStr := strings.TrimSpace(request.Header.Get("X-Agent-Timestamp"))
+		sigHex := strings.TrimSpace(request.Header.Get("X-Agent-Signature"))
+		if agentID == "" || tsStr == "" || sigHex == "" {
+			return agentmesh.HTTPResolvedAgentIdentity{}, fmt.Errorf("%w: missing X-Agent-{Id,Timestamp,Signature}", agentmesh.ErrVerifiedAgentIdentityRequired)
+		}
+
+		ts, err := strconv.ParseInt(tsStr, 10, 64)
+		if err != nil {
+			return agentmesh.HTTPResolvedAgentIdentity{}, fmt.Errorf("%w: invalid timestamp", agentmesh.ErrVerifiedAgentIdentityRequired)
+		}
+		age := time.Since(time.Unix(ts, 0))
+		if age < -maxAge || age > maxAge {
+			return agentmesh.HTTPResolvedAgentIdentity{}, fmt.Errorf("%w: timestamp outside %s window", agentmesh.ErrVerifiedAgentIdentityRequired, maxAge)
+		}
+
+		expectedSig, err := hex.DecodeString(sigHex)
+		if err != nil {
+			return agentmesh.HTTPResolvedAgentIdentity{}, fmt.Errorf("%w: signature not hex", agentmesh.ErrVerifiedAgentIdentityRequired)
+		}
+
+		mac := hmac.New(sha256.New, sharedSecret)
+		mac.Write([]byte(agentID + ":" + tsStr))
+		computed := mac.Sum(nil)
+		if !hmac.Equal(computed, expectedSig) {
+			return agentmesh.HTTPResolvedAgentIdentity{}, fmt.Errorf("%w: signature mismatch", agentmesh.ErrVerifiedAgentIdentityRequired)
+		}
+
+		return agentmesh.HTTPResolvedAgentIdentity{
+			AgentID:            agentID,
+			Verified:           true,
+			VerificationSource: "hmac_signed_header",
+		}, nil
+	}
+}
 
 func main() {
 	policy := agentmesh.NewPolicyEngine([]agentmesh.PolicyRule{{
@@ -18,9 +84,13 @@ func main() {
 		Conditions: map[string]interface{}{"path": "/run"},
 	}})
 
+	// SECRET HANDLING: in production, load this from KMS / Vault / a
+	// restricted-ACL file. Never commit a real secret.
+	sharedSecret := []byte("replace-with-secret-from-real-key-store")
+
 	middleware, err := agentmesh.NewHTTPGovernanceMiddleware(agentmesh.HTTPMiddlewareConfig{
 		Policy:          policy,
-		AgentIDResolver: agentmesh.LegacyTrustedHeaderAgentIDResolver("X-Agent-ID"),
+		AgentIDResolver: signedHeaderResolver(sharedSecret, 5*time.Minute),
 		AllowedTools:    []string{"http.get"},
 	})
 	if err != nil {

--- a/agent-governance-golang/packages/agentmesh/middleware.go
+++ b/agent-governance-golang/packages/agentmesh/middleware.go
@@ -89,6 +89,20 @@ type HTTPResolvedAgentIdentity struct {
 type HTTPAgentIDResolver func(*http.Request) (HTTPResolvedAgentIdentity, error)
 
 // LegacyTrustedHeaderAgentIDResolver explicitly trusts a caller-supplied header for short-lived migrations.
+//
+// SECURITY: This resolver sets Verified=true based solely on an
+// attacker-controllable HTTP header. ANY caller that can reach the
+// endpoint can claim to be any agent. The "verified" flag downstream
+// callers see is meaningless. Production deployments MUST replace
+// this with a resolver that validates a cryptographic credential:
+// signed JWT, mTLS client cert, or an HMAC-of-(agent_id || timestamp)
+// over a shared secret.
+//
+// Deprecated: Use a signed-credential resolver in production. This
+// helper exists only to ease the migration of a service that has no
+// agent-identity story yet and to keep test fixtures concise; the
+// example in `examples/http-middleware/main.go` documents the
+// required production pattern.
 func LegacyTrustedHeaderAgentIDResolver(headerName string) HTTPAgentIDResolver {
 	if strings.TrimSpace(headerName) == "" {
 		headerName = "X-Agent-ID"


### PR DESCRIPTION
## Summary

`LegacyTrustedHeaderAgentIDResolver` in `agent-governance-golang/packages/agentmesh/middleware.go:91-108` sets `Verified: true` based solely on an attacker-controllable HTTP header. Any caller that can reach the endpoint can claim to be any agent — the \"verified\" flag downstream callers see is meaningless.

The function is still useful as a fixture for tests and as an escape hatch during migrations, but **the example in `examples/http-middleware/main.go:23` wires it up as the production middleware**, which normalizes the insecure pattern for downstream readers who copy the example.

## Change

1. **Deprecate the resolver, don't remove it.** Removing breaks anyone consuming it for tests or in-progress migrations. Add a `// Deprecated:` marker plus an explicit `SECURITY:` block in the docstring spelling out the threat model and the required replacement (signed JWT, mTLS client cert, or HMAC-of-(agent_id || timestamp) over a shared secret).

2. **Rewrite the example with an inline production-shape resolver.** The example now demonstrates HMAC-SHA256 signed headers:
   - `X-Agent-Id`, `X-Agent-Timestamp`, `X-Agent-Signature` header triple
   - HMAC-SHA256 over `(agent_id || \":\" || timestamp)` keyed by a shared secret
   - 5-minute timestamp window to bound replay
   - Constant-time comparison via `hmac.Equal`
   - Explicit comment that the literal `sharedSecret` is for example purposes only and must come from a real key store (KMS / Vault / restricted-ACL file) in production

## Why a real resolver in the example, not just a deprecation tag

A pure `// Deprecated:` tag on the resolver wouldn't move the needle for someone reading `examples/http-middleware/main.go` first. The example IS the documentation for many readers; demonstrating the wrong pattern there is the actual harm. Replacing the example body keeps the demo working (still a runnable governance-middleware example) while showing the correct identity-verification shape.

## Tests

```
go build ./...
go test ./...
  ok  github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh
```

The legacy resolver's behavior is unchanged — backward-compatibility for current consumers is preserved.

## Test plan

- [ ] CI passes
- [ ] Example builds cleanly (manual `go run examples/http-middleware/main.go` from a fresh clone)
- [ ] Existing middleware tests using `LegacyTrustedHeaderAgentIDResolver` continue to pass

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Go section). Filed by Ken Tannenbaum (AEGIS Initiative).