### PR TITLE
fix(infra-clusterfuzzlite): fail loudly when a target package fails to install

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,10 +2,14 @@
 
 cd $SRC/agent-governance-toolkit
 
-# Install the governance packages (paths updated after mono-repo reorg)
-pip3 install ./agent-governance-python/agent-os 2>/dev/null || true
-pip3 install ./agent-governance-python/agent-mesh 2>/dev/null || true
-pip3 install ./agent-governance-python/agent-compliance 2>/dev/null || true
+# Install the governance packages (paths updated after mono-repo reorg).
+# Fail loudly if any install fails — silently building fuzzers without
+# their target packages produces fuzzers that exercise none of the code
+# under test. The script already runs with `bash -eu`, so an unswallowed
+# failure here aborts the build instead of producing empty harnesses.
+pip3 install ./agent-governance-python/agent-os
+pip3 install ./agent-governance-python/agent-mesh
+pip3 install ./agent-governance-python/agent-compliance
 pip3 install atheris==2.3.0
 
 # Build fuzz targets


### PR DESCRIPTION
## Summary

`.clusterfuzzlite/build.sh:6-8` installs each governance package with `pip3 install ... 2>/dev/null || true`. The combination of `2>/dev/null` (suppress stderr) and `|| true` (swallow failures) means a path typo, a broken `pyproject.toml`, or a transient network failure during install produces a fuzz build whose harnesses then import nothing they're meant to exercise — i.e. zero coverage with no signal.

For ClusterFuzzLite, silent install failure is the worst possible outcome: the build succeeds, the fuzzer runs, finds no bugs (because there's no code to fuzz), and reports clean. The signal that should have been \"install broken, fix CI\" becomes \"all clear.\"

## Change

`.clusterfuzzlite/build.sh:5-9`:

```bash
pip3 install ./agent-governance-python/agent-os
pip3 install ./agent-governance-python/agent-mesh
pip3 install ./agent-governance-python/agent-compliance
pip3 install atheris==2.3.0
```

The script's shebang is already `#!/bin/bash -eu`, so an install failure short-circuits the build and surfaces in the ClusterFuzzLite logs.

## Test plan

- [ ] CI passes
- [ ] If any of the three governance packages have install issues that have been quietly papered over, those surface as build failures in this PR's CI run — fix in this PR or in a follow-up

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Infrastructure / CI section). Filed by Ken Tannenbaum (AEGIS Initiative).