### PR TITLE
fix(infra-docker): run dev and test stages as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,17 @@ RUN python -m pip install --no-cache-dir \
     && cd /workspace/agent-governance-typescript \
     && npm ci --legacy-peer-deps
 
+# Run as non-root for the developer workflow. The compose `dev` and
+# `dashboard` services bind-mount the repo at /workspace; running the
+# entrypoint as root creates files on the host owned by uid 0, which
+# is both an isolation hazard and an ergonomic problem (host editor
+# can't easily fix permissions). Create the user AFTER the package
+# installs so the system-site-packages writes don't need a sudo step.
+RUN useradd --create-home --shell /bin/bash --uid 1000 dev \
+    && chown -R dev:dev /workspace
+
+USER dev
+
 ENTRYPOINT ["bash", "/workspace/scripts/docker/dev-entrypoint.sh"]
 CMD ["sleep", "infinity"]
 


### PR DESCRIPTION
## Summary

The `dev` and `test` stages in `Dockerfile` (lines 34-62) had no `USER` directive, so containers built from them ran as root by default. The compose `dev` and `dashboard` services bind-mount the repository at `/workspace`; with the entrypoint running as root, any file the container creates inside the bind mount appears on the host owned by uid 0 — both a privilege-isolation hazard inside the container and a recurring ergonomic problem for developers (the host editor / VCS can't manage those files without a sudo dance).

## Change

`Dockerfile` (after the `pip install` / `npm ci` block):

```dockerfile
RUN useradd --create-home --shell /bin/bash --uid 1000 dev \
    && chown -R dev:dev /workspace

USER dev
```

- The user is created **after** the package installs so the system-site-packages writes don't need a sudo step.
- `chown -R dev:dev /workspace` makes the editable installs from the COPY step writable by the dev user (necessary for `pip install -e` artifacts and any test-time file generation).
- The `test` stage inherits the same `USER` via `FROM dev`.

## Scope note

This fix concerns the container's **own** writes. The bind-mounted source from the host still arrives in the container as whatever uid the host file owner is; that's a runtime concern (compose `user:` directive, `--user` flag, or rootless Docker), not something the image can solve on its own.

## Test plan

- [ ] CI passes
- [ ] `docker build --target dev .` succeeds
- [ ] `docker build --target test .` succeeds
- [ ] Editable installs (`pip install -e`) still importable as `dev` user

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Infrastructure / CI section). Filed by Ken Tannenbaum (AEGIS Initiative).