### PR TITLE
fix(infra-dashboard): governance-dashboard runs as non-root + binds localhost by default

### DIFF
--- a/examples/demos/governance-dashboard/Dockerfile
+++ b/examples/demos/governance-dashboard/Dockerfile
@@ -7,8 +7,20 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# Run as a non-root user. Streamlit's default behavior plus a 0.0.0.0
+# bind made the previous image trivially network-reachable as root.
+RUN useradd --create-home --shell /bin/bash --uid 1000 dashboard \
+    && chown -R dashboard:dashboard /app
+
+USER dashboard
+
 EXPOSE 8501
 
-# NOTE: Binds to 0.0.0.0 inside the container for Docker networking.
-# In production, place behind an auth proxy (OAuth2 Proxy, Nginx, etc.).
-CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=0.0.0.0"]
+# Bind to localhost by default. Docker networking still allows the
+# container to be reached from sibling containers on a user-defined
+# network; deployments that need to expose the dashboard outside the
+# Docker host must explicitly opt in by passing
+# `--server.address=0.0.0.0` AND placing the dashboard behind an auth
+# proxy (OAuth2 Proxy, Nginx, etc.). The previous default shipped
+# ready-to-deploy on a public interface without authentication.
+CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=127.0.0.1"]


### PR DESCRIPTION
## Summary

`examples/demos/governance-dashboard/Dockerfile` had **no `USER` directive** and ran Streamlit bound to `0.0.0.0` by default. The README claimed *\"place behind an auth proxy\"*, but the image shipped **ready-to-deploy on a public interface as root with no authentication** — exactly the opposite of what the comment said.

For an example image that downstream users are likely to take as a starting point, the defaults matter more than the docstring.

## Change

`Dockerfile`:

1. **Non-root user.** Add a `dashboard` user (uid 1000) with `chown -R` of `/app`; `USER dashboard` before `CMD`. Eliminates the root network listener primitive.
2. **Default bind to localhost.** Change `--server.address=0.0.0.0` to `--server.address=127.0.0.1`. Deployments that need external exposure must now explicitly pass `--server.address=0.0.0.0` to the container, making the \"is this public?\" decision visible at deploy time rather than hidden in the image default.

The comment in the Dockerfile is updated to spell out the new default and what to change for the auth-proxy use case.

## Test plan

- [ ] CI passes
- [ ] `docker build -t dash examples/demos/governance-dashboard/ && docker run --rm -p 8501:8501 dash` — verify the dashboard starts and is reachable from the container's localhost (manual)
- [ ] Verify the comment + README guidance is consistent with the new defaults

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Infrastructure / CI section). Filed by Ken Tannenbaum (AEGIS Initiative).