### PR TITLE
fix(ci): add typing-extensions hash for pytest-asyncio on Python 3.12

### DIFF
--- a/agent-governance-python/requirements/ci-test.txt
+++ b/agent-governance-python/requirements/ci-test.txt
@@ -15,3 +15,6 @@ colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
 pygments==2.19.2 \
     --hash=sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
+# pytest-asyncio transitive dependencies (needed on Python <3.13)
+typing-extensions==4.15.0 \
+    --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548


### PR DESCRIPTION
Follow-up to #2030. \pytest-asyncio==1.3.0\ requires \	yping-extensions>=4.12\ which is not bundled in the Python 3.12 CI runner. Pins \	yping-extensions==4.15.0\ with hash.

This should be the last missing dependency, completing the pytest 9.0.3 migration.