### PR TITLE
fix(py-audit-logger): serialize JsonlFileBackend writes + chmod 0o600

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/audit_logger.py
+++ b/agent-governance-python/agent-os/src/agent_os/audit_logger.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import sys
+import threading
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,21 +46,48 @@ class AuditBackend(Protocol):
 
 
 class JsonlFileBackend:
-    """Writes audit entries as JSONL to a file."""
+    """Writes audit entries as JSONL to a file.
+
+    Concurrency: writes are serialized via an internal lock so concurrent
+    callers can't interleave lines (a partially-written JSON object on
+    one line is unrecoverable). The lock is per-instance; sharing the
+    same backend across threads is the supported pattern.
+
+    File permissions: created with 0o600 (owner read/write only) so the
+    audit log isn't world-readable. The chmod runs after open() so a
+    pre-existing file with permissive perms gets tightened.
+    """
 
     def __init__(self, path: str | Path) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._file = open(self.path, "a", encoding="utf-8")
+        self._lock = threading.Lock()
+        # Restrict to owner-only on POSIX. chmod is a no-op on Windows
+        # for the most part, but tightening when we can is the right
+        # default for an audit log.
+        if not sys.platform.startswith("win"):
+            try:
+                os.chmod(self.path, 0o600)
+            except OSError:
+                # Best effort — surfacing this as an exception would
+                # block audit writes on filesystems that don't support
+                # POSIX permissions (FAT-mounted volumes, some network
+                # filesystems). Log and continue.
+                logger.warning("Could not chmod %s to 0o600", self.path)
 
     def write(self, entry: AuditEntry) -> None:
-        self._file.write(entry.to_json() + "\n")
+        line = entry.to_json() + "\n"
+        with self._lock:
+            self._file.write(line)
 
     def flush(self) -> None:
-        self._file.flush()
+        with self._lock:
+            self._file.flush()
 
     def close(self) -> None:
-        self._file.close()
+        with self._lock:
+            self._file.close()
 
 
 class InMemoryBackend:


### PR DESCRIPTION
## Summary

`JsonlFileBackend` in `agent-governance-python/agent-os/src/agent_os/audit_logger.py:45-57` had two issues:

1. **No write serialization.** Concurrent callers could interleave bytes mid-line, producing unparseable JSONL the next reader can't recover from.
2. **Default file permissions.** The audit log file was created with the process umask — world-readable on typical Unix systems, exposing audit content to any local user.

## Change

- Add an internal `threading.Lock` that serializes `write`, `flush`, and `close`.
- Apply `chmod 0o600` to the file at open time on POSIX so the audit log is owner-only. Best-effort: filesystems that don't support POSIX perms get a logged warning instead of an exception, so audit writes never fail just because the host can't tighten file modes.

## Test plan

- [ ] CI passes
- [ ] Existing audit-related tests (169 passed locally) continue to pass

---

Surfaced as part of the AEGIS Initiative review of the agent-governance-toolkit (MEDIUM, Python Core). Filed by Ken Tannenbaum (AEGIS Initiative).