### PR TITLE
fix(py-base-agent): deep size check on metadata values

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/base_agent.py
+++ b/agent-governance-python/agent-os/src/agent_os/base_agent.py
@@ -319,7 +319,15 @@ class BaseAgent(ABC):
         metadata = {**self._config.metadata, **extra_metadata}
         max_size = self._config.max_metadata_size_bytes
         for key, value in metadata.items():
-            size = sys.getsizeof(value)
+            # sys.getsizeof reports only the immediate object header — a
+            # dict containing a large nested list reports ~232 bytes and
+            # slips through. Use serialized JSON size for a meaningful
+            # bound on what the metadata actually contributes to wire
+            # payloads, on-disk audit lines, and downstream storage.
+            try:
+                size = len(json.dumps(value, default=str).encode())
+            except (TypeError, ValueError):
+                size = sys.getsizeof(value)  # fall back for non-serializable
             if size > max_size:
                 raise ValueError(
                     f"Metadata key {key!r} value size ({size} bytes) "


### PR DESCRIPTION
## Summary

`BaseAgent._new_context` in `agent-governance-python/agent-os/src/agent_os/base_agent.py:319-328` enforced `max_metadata_size_bytes` via `sys.getsizeof(value)`, which returns only the immediate object header. A dict whose value is a 100-MB nested list returns ~232 bytes and slips through.

The intent of the limit is to bound what metadata contributes to wire payloads, audit lines, and downstream storage — none of which care about the Python object header.

## Change

Use `len(json.dumps(value, default=str).encode())` so the check matches the actual size downstream consumers will see. Fall back to `sys.getsizeof` for non-JSON-serializable values to preserve existing behavior on that edge case.

## Test plan

- [ ] CI passes
- [ ] Existing metadata-related tests continue to pass (26 passed locally)

---

Surfaced as part of the AEGIS Initiative review (MEDIUM, Python Core). Filed by Ken Tannenbaum (AEGIS Initiative).