### PR TITLE
fix(py-stateless-policy): detect actual PII values, not just keyword substrings

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/stateless.py
+++ b/agent-governance-python/agent-os/src/agent_os/stateless.py
@@ -93,6 +93,28 @@ except ImportError:  # pragma: no cover
 # third-party clients (e.g. DynamoDB, Cosmos DB) as backends.
 # =============================================================================
 
+
+def _iter_string_values(value: Any):
+    """Yield every string contained in a nested params structure.
+
+    Used by the no_pii policy check so the PII detector runs against
+    every string value the caller passed in, not just the JSON-dumped
+    blob (which loses type information and matches keyword substrings
+    like 'lesson' contains 'sson').
+    """
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            if isinstance(k, str):
+                yield k
+            yield from _iter_string_values(v)
+    elif isinstance(value, (list, tuple, set)):
+        for item in value:
+            yield from _iter_string_values(item)
+    # numbers / bools / None: nothing to scan
+
+
 class StateBackend(Protocol):
     """Protocol for external state storage.
 
@@ -616,18 +638,40 @@ class StatelessKernel:
                     "reason": f"Action '{action}' blocked by '{policy_name}' policy. {suggestion}."
                 }
 
-            # Check blocked patterns in params
+            # Check blocked patterns in params. The keyword-substring
+            # check catches references to PII categories ("ssn",
+            # "password") in either keys or values. CredentialRedactor
+            # adds the harder check: detect actual PII data formats
+            # (real SSN strings, credit-card-shaped numbers, emails,
+            # phone numbers) that the keyword list cannot anticipate.
             params_str = json.dumps(params).lower()
-            for pattern in policy.get("blocked_patterns", []):
-                if pattern.lower() in params_str:
-                    return {
-                        "allowed": False,
-                        "reason": (
-                            f"Content blocked: '{pattern}' detected in request parameters. "
-                            f"Policy '{policy_name}' prohibits this pattern. "
-                            f"Remove the sensitive content and retry."
-                        )
-                    }
+            blocked_patterns = policy.get("blocked_patterns", [])
+            if blocked_patterns:
+                for pattern in blocked_patterns:
+                    if pattern.lower() in params_str:
+                        return {
+                            "allowed": False,
+                            "reason": (
+                                f"Content blocked: '{pattern}' detected in request parameters. "
+                                f"Policy '{policy_name}' prohibits this pattern. "
+                                f"Remove the sensitive content and retry."
+                            )
+                        }
+                # Second pass: walk all string-typed values and check
+                # for actual PII patterns (regex-based, not keyword).
+                from agent_os.credential_redactor import CredentialRedactor
+                for piece in _iter_string_values(params):
+                    matches = CredentialRedactor.find_pii_matches(piece)
+                    if matches:
+                        kind = matches[0].name
+                        return {
+                            "allowed": False,
+                            "reason": (
+                                f"Content blocked: {kind} detected in request parameters. "
+                                f"Policy '{policy_name}' prohibits PII. "
+                                f"Remove the sensitive content and retry."
+                            )
+                        }
 
             # Check requires approval
             if action in policy.get("require_approval", []):


### PR DESCRIPTION
## Summary

`DEFAULT_POLICIES['no_pii']` in `agent-governance-python/agent-os/src/agent_os/stateless.py` matched against `json.dumps(params).lower()` looking for the keyword strings `ssn`, `credit_card`, `password`. Two failure modes:

1. **False positives**: text like `lesson` contains `sson`, `passwords-not-allowed` contains `password`.
2. **False negatives**: actual PII like a literal `123-45-6789` SSN value didn't match because the keyword wasn't present.

## Change

Keep the keyword check (backward-compatible) and add a second pass that walks every string in the params structure and runs `CredentialRedactor.find_pii_matches` against each. The redactor already implements regex-based detection for email, phone, SSN-shape, credit-card-shape, and IP address — the right tool for "is this PII?".

Adds `_iter_string_values` helper that recurses through dicts, lists, tuples, and sets and yields every string (both keys and values).

## Test plan

- [ ] CI passes
- [ ] Existing policy tests pass (10 pre-existing failures on main are unrelated env issues: Python 3.14 `asyncio.get_event_loop()` deprecation, missing cedar CLI, missing cedarpy attributes)

---

Surfaced as part of the AEGIS Initiative review (MEDIUM, Python Core). Filed by Ken Tannenbaum (AEGIS Initiative).