### PR TITLE
fix(py-redis-config): keep password out of the URL string

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/stateless.py
+++ b/agent-governance-python/agent-os/src/agent_os/stateless.py
@@ -185,9 +185,16 @@ class RedisConfig:
     retry_on_timeout: bool = True
 
     def to_url(self) -> str:
-        """Build a Redis URL from host/port/db."""
-        auth = f":{self.password}@" if self.password else ""
-        return f"redis://{auth}{self.host}:{self.port}/{self.db}"
+        """Build a password-free Redis URL from host/port/db.
+
+        The password is intentionally NOT embedded in the URL. Anything
+        that reads back the URL — exception messages from the redis
+        client, structured logs at the connection layer, debug
+        introspection, traceback decorations — would otherwise leak the
+        password verbatim. Pass `password` separately via the redis
+        client's `password=` argument (see `RedisBackend._get_client`).
+        """
+        return f"redis://{self.host}:{self.port}/{self.db}"
 
 
 class RedisBackend:
@@ -217,12 +224,19 @@ class RedisBackend:
             import redis.asyncio as aioredis
 
             if self._config is not None:
+                # Password is passed via the keyword argument so it
+                # never enters the URL string (see RedisConfig.to_url).
+                pool_kwargs = {
+                    "max_connections": self._config.pool_size,
+                    "socket_connect_timeout": self._config.connect_timeout,
+                    "socket_timeout": self._config.read_timeout,
+                    "retry_on_timeout": self._config.retry_on_timeout,
+                }
+                if self._config.password:
+                    pool_kwargs["password"] = self._config.password
                 self._pool = aioredis.ConnectionPool.from_url(
                     self.url,
-                    max_connections=self._config.pool_size,
-                    socket_connect_timeout=self._config.connect_timeout,
-                    socket_timeout=self._config.read_timeout,
-                    retry_on_timeout=self._config.retry_on_timeout,
+                    **pool_kwargs,
                 )
                 self._client = aioredis.Redis(connection_pool=self._pool)
             else:

--- a/agent-governance-python/agent-os/tests/test_stateless.py
+++ b/agent-governance-python/agent-os/tests/test_stateless.py
@@ -305,12 +305,20 @@ class TestRedisConfig:
         cfg = RedisConfig(host="myhost", port=6380, db=3)
         assert cfg.to_url() == "redis://myhost:6380/3"
 
-    def test_to_url_with_password(self):
-        """Test URL generation with password."""
+    def test_to_url_omits_password(self):
+        """to_url() must NOT embed the password into the URL.
+
+        The password is passed separately to the redis client via the
+        keyword argument so it cannot leak into tracebacks, structured
+        logs at the connection layer, or any consumer that round-trips
+        the URL string.
+        """
         from agent_os.stateless import RedisConfig
 
         cfg = RedisConfig(host="myhost", port=6380, db=1, password="s3cret")
-        assert cfg.to_url() == "redis://:s3cret@myhost:6380/1"
+        url = cfg.to_url()
+        assert url == "redis://myhost:6380/1"
+        assert "s3cret" not in url
 
     def test_backend_uses_config_url(self):
         """Test that RedisBackend.url is derived from RedisConfig."""


### PR DESCRIPTION
## Summary

`RedisConfig.to_url` embedded the password as URL userinfo (`redis://:s3cret@host:6379/0`). Anything that round-trips that URL — exception messages from the redis client, structured logs at the connection layer, `repr()` introspection — carries the password verbatim. The leak surface is wide because the URL flows through `aioredis.ConnectionPool.from_url` which exposes it in the connection object's repr and any pool error.

## Change

- `RedisConfig.to_url` returns a password-free URL.
- `RedisBackend._get_client` passes the password via the keyword argument when building the connection pool. Same redis client behavior, password never enters the URL string.
- Test `test_to_url_with_password` renamed to `test_to_url_omits_password` and updated to assert password absence.

## Test plan

- [ ] CI passes (41 stateless tests pass locally)

---

Surfaced as part of the AEGIS Initiative review (MEDIUM, Python Core). Filed by Ken Tannenbaum (AEGIS Initiative).