### PR TITLE
fix(py-mcp-auth): require_tls gate must check scheme, not http:// prefix

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -145,14 +146,27 @@ class McpAuthPolicy:
         entry = self._servers.get(server_name)
         if entry:
             if auth_method in entry.allowed_auth_methods:
-                # TLS check
-                if entry.require_tls and url and url.startswith("http://"):
-                    return AuthCheckResult(
-                        allowed=False,
-                        server_name=server_name,
-                        auth_method=auth_method,
-                        reason=f"Server '{server_name}' requires TLS but URL uses http://",
-                    )
+                # TLS check: parse the URL's scheme rather than testing
+                # for the literal "http://" prefix. Previously, a URL
+                # using `ftp://`, `ws://`, `gopher://`, or no scheme at
+                # all bypassed the require_tls gate because none of
+                # them start with "http://" — only `https://` and
+                # `wss://` represent actual TLS-secured transports.
+                if entry.require_tls and url:
+                    try:
+                        scheme = urlparse(url).scheme.lower()
+                    except (ValueError, AttributeError):
+                        scheme = ""
+                    if scheme not in {"https", "wss"}:
+                        return AuthCheckResult(
+                            allowed=False,
+                            server_name=server_name,
+                            auth_method=auth_method,
+                            reason=(
+                                f"Server '{server_name}' requires TLS but URL scheme "
+                                f"{scheme!r} is not in the TLS allowlist (https, wss)"
+                            ),
+                        )
                 return AuthCheckResult(
                     allowed=True,
                     server_name=server_name,


### PR DESCRIPTION
## Summary

The `require_tls` gate in `McpAuthPolicy.check_connection` (`mcp_auth_enforcement.py:149`) tested `url.startswith("http://")` to decide whether the URL was unencrypted. That misses every URL scheme that isn't `http` but also isn't TLS:

- `ftp://` — cleartext file transfer
- `ws://` — cleartext WebSocket (TLS variant is `wss://`)
- `gopher://` — cleartext
- Scheme-less URLs (e.g. `mcp.internal/finance`, which url-parses to a path with no scheme)

All of these slip past `require_tls=True` because none start with the literal string `http://`.

## Change

Parse the URL's scheme via `urllib.parse.urlparse` and check membership against the TLS-scheme allowlist `{"https", "wss"}`. Schemes outside that set fail the TLS gate with a clearer reason string.

The companion `min_tls_version` field is configurable but not enforced anywhere in this module — only the schemes are checked. Enforcing a minimum TLS version requires reading the actual handshake, which is the transport layer's job, not the policy layer's. Out of scope for this PR.

## Test plan

- [ ] CI passes (17 mcp_auth tests pass locally)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Core]