### PR TITLE
fix(py-secure-codegen): use Path.relative_to for traversal check, not str-prefix

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/secure_codegen.py
+++ b/agent-governance-python/agent-os/src/agent_os/secure_codegen.py
@@ -418,15 +418,20 @@ class SecureCodeTemplate:
                     return response
         """),
         "file_read": textwrap.dedent("""\
-            import os
             from pathlib import Path
 
             def safe_read(filepath: str, *, base_dir: str = {base_dir}) -> str:
                 \"\"\"Read a file, preventing path-traversal attacks.\"\"\"
                 base = Path(base_dir).resolve()
                 target = (base / filepath).resolve()
-                if not str(target).startswith(str(base)):
-                    raise ValueError("Path traversal detected")
+                # Path.is_relative_to is component-aware. The previous
+                # str(target).startswith(str(base)) check passed for
+                # /foobar/x when base was /foo, because the substring
+                # match doesn't know about path separators.
+                try:
+                    target.relative_to(base)
+                except ValueError as exc:
+                    raise ValueError("Path traversal detected") from exc
                 if not target.is_file():
                     raise FileNotFoundError(f"{{target}} does not exist")
                 return target.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

The `file_read` template emitted by `secure_codegen.py` (line 428) uses:

```python
if not str(target).startswith(str(base)):
    raise ValueError("Path traversal detected")
```

The check is component-blind. With `base = /foo`, a target of `/foobar/x` slips through because the prefix matches as a substring without respecting the `/` separator.

Anyone copying this template as a starting point for a real file-read tool inherits the gap.

## Change

Switch to `Path.relative_to` (raises on failure). It knows about path components: `/foobar/x` is not relative to `/foo`, so it raises; `/foo/bar/x` is, so it passes. Drops the now-unused `import os`.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Core]