### PR TITLE
fix(py-audit-log): bound _audit_log via deque(maxlen=...) in two scanners

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_security.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_security.py
@@ -36,6 +36,7 @@ import base64
 import hashlib
 import json
 import logging
+from collections import deque
 import os
 import re
 import time
@@ -365,7 +366,9 @@ class MCPSecurityScanner:
                 stacklevel=2,
             )
         self._tool_registry: dict[str, ToolFingerprint] = {}
-        self._audit_log: list[dict[str, Any]] = []
+        # Bounded ring buffer — unbounded list grew without limit on
+        # long-running deployments.
+        self._audit_log: deque[dict[str, Any]] = deque(maxlen=10_000)
         self._injection_detector = PromptInjectionDetector()
         self._metrics = metrics or MCPMetrics()
         self._audit_sink = audit_sink or InMemoryAuditSink()

--- a/agent-governance-python/agent-os/src/agent_os/prompt_injection.py
+++ b/agent-governance-python/agent-os/src/agent_os/prompt_injection.py
@@ -39,6 +39,7 @@ import logging
 import os
 import re
 import warnings
+from collections import deque
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -399,7 +400,10 @@ class PromptInjectionDetector:
         self._config = config or DetectionConfig()
         self._injection_config = injection_config or PromptInjectionConfig()
         self._compile_injection_patterns()
-        self._audit_log: list[AuditRecord] = []
+        # Bounded ring buffer — unbounded list grew without limit on
+        # long-running deployments. 10k entries is enough headroom for
+        # any reasonable analysis window; older entries roll off.
+        self._audit_log: deque[AuditRecord] = deque(maxlen=10_000)
 
     def _compile_injection_patterns(self) -> None:
         """Compile pattern strings from ``self._injection_config`` into


### PR DESCRIPTION
## Summary

`PromptInjectionDetector._audit_log` (`prompt_injection.py:402`) and `MCPSecurityScanner._audit_log` (`mcp_security.py:368`) were plain Python lists that grew unbounded. On a long-running deployment processing prompts continuously, both lists eventually consume arbitrary memory.

## Change

Convert both to `collections.deque(maxlen=10_000)`. Each scanner retains the most recent 10k audit records and rolls older ones off on append. 10k is a reasonable headroom for any analysis window without leaking on long-lived processes.

API compatibility: callers that previously got `list(self._audit_log)` via `get_audit_log()` still get a list — the `list(...)` conversion at the accessor is unchanged.

## Test plan

- [ ] CI passes (166 affected tests pass locally)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Core]