### PR TITLE
fix(py-mesh-websocket): broaden _auto_reconnect except clause

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/transport/websocket.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/transport/websocket.py
@@ -238,7 +238,17 @@ class WebSocketTransport(Transport):
                     await self.send("trust.subscribe", {"agent_did": agent_did})
                 logger.info("Reconnected on attempt %d", attempt)
                 return
-            except ConnectionError:
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                # Catch any transient failure (TimeoutError, OSError,
+                # websockets.ConnectionClosed, DNS errors, etc.). The
+                # previous narrow `except ConnectionError` aborted the
+                # reconnect loop on any non-ConnectionError exception,
+                # which left the transport stuck in RECONNECTING with
+                # no retries fired. Log at debug so the operator can
+                # still trace what failed each attempt.
+                logger.debug("Reconnect attempt %d failed: %s", attempt, exc)
                 continue
         self._state = TransportState.DISCONNECTED
         logger.error("Failed to reconnect after %d attempts", self.config.max_retries)


### PR DESCRIPTION
## Summary

`WebSocketTransport._auto_reconnect` in `agent-mesh/.../transport/websocket.py:228-244` retried only on `ConnectionError`. Any other transient failure during reconnect — `TimeoutError` on the TCP handshake, `OSError` from the socket layer, `websockets.ConnectionClosed` on the upgrade response, DNS-resolution errors — propagated out of the back-off loop and left the transport stuck in `RECONNECTING` with no retries fired.

## Change

Broaden the `except` clause to catch any non-`CancelledError` exception, log at debug for traceability, and continue the back-off loop. `CancelledError` still propagates so an explicit shutdown isn't swallowed.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Mesh]