### PR TITLE
fix(py-mesh-capability): handle malformed capability requests in matches()

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
@@ -121,8 +121,15 @@ class CapabilityGrant(BaseModel):
         elif self.capability == requested:
             pass
         else:
-            # Fall back to component matching
-            req_action, req_resource, req_qualifier = self.parse_capability(requested)
+            # Fall back to component matching. parse_capability raises
+            # ValueError on inputs that don't contain a colon (e.g.
+            # bare verbs like "read") — fail-closed for those rather
+            # than crashing the caller. The grant simply doesn't match
+            # a malformed request.
+            try:
+                req_action, req_resource, req_qualifier = self.parse_capability(requested)
+            except ValueError:
+                return False
             if self.action != "*" and self.action != req_action:
                 return False
             if self.resource != "*" and self.resource != req_resource:


### PR DESCRIPTION
## Summary

`CapabilityGrant.matches()` in `agent-mesh/.../trust/capability.py:101-139` falls through to `parse_capability(requested)` when none of the wildcard/colon-prefix branches match. `parse_capability` raises `ValueError` on inputs without a colon (bare verbs like `"read"`, empty strings, or anything that doesn't decompose into the documented `action:resource[:qualifier]` grammar) — that exception bubbles up through `matches()` and crashes the caller.

## Change

Wrap `parse_capability` in `try/except ValueError` and fail-closed (return `False`) on malformed input. A malformed capability request simply doesn't match the grant; the caller doesn't need to know whether the no-match came from a real mismatch or a parse failure.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Mesh]