### PR TITLE
fix(py-mesh-handshake): serialize _verified_peers mutations under async lock

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
@@ -216,26 +216,44 @@ class TrustHandshake:
         self._cache_ttl = timedelta(seconds=cache_ttl_seconds)
         # V10: Limit pending challenges to prevent DoS accumulation
         self._max_pending_challenges = 1000
-        # Serialise the purge/check/insert sequence on _pending_challenges so
-        # concurrent initiate() coroutines cannot all pass the size check and
-        # then each insert past the cap.
+        # Serialise mutations on _pending_challenges so concurrent
+        # initiate() coroutines cannot all pass the size check and
+        # then each insert past the cap, and so the finally-block
+        # cleanup at the end of initiate() can't race a sibling's
+        # insert/lookup.
         self._challenges_lock = asyncio.Lock()
+        # Serialise mutations on _verified_peers so concurrent
+        # _cache_result / _get_cached_result / clear_cache calls
+        # cannot race the read+TTL-delete sequence. clear_cache()
+        # remains sync-callable; concurrent sync+async mixing is
+        # documented as out-of-scope (use async paths only).
+        self._peers_lock = asyncio.Lock()
 
-    def _get_cached_result(self, peer_did: str) -> Optional[HandshakeResult]:
-        """Get cached verification result if still valid."""
-        if peer_did in self._verified_peers:
-            result, timestamp = self._verified_peers[peer_did]
-            if datetime.utcnow() - timestamp < self._cache_ttl:
-                return result
-            del self._verified_peers[peer_did]
+    async def _get_cached_result(self, peer_did: str) -> Optional[HandshakeResult]:
+        """Get cached verification result if still valid.
+
+        Locked so the read+TTL-delete sequence cannot race a sibling
+        coroutine's _cache_result for the same DID.
+        """
+        async with self._peers_lock:
+            if peer_did in self._verified_peers:
+                result, timestamp = self._verified_peers[peer_did]
+                if datetime.utcnow() - timestamp < self._cache_ttl:
+                    return result
+                del self._verified_peers[peer_did]
         return None
 
-    def _cache_result(self, peer_did: str, result: HandshakeResult) -> None:
+    async def _cache_result(self, peer_did: str, result: HandshakeResult) -> None:
         """Cache a verification result with timestamp."""
-        self._verified_peers[peer_did] = (result, datetime.utcnow())
+        async with self._peers_lock:
+            self._verified_peers[peer_did] = (result, datetime.utcnow())
 
     def _purge_expired_challenges(self) -> None:
-        """Remove expired challenges to prevent unbounded growth."""
+        """Remove expired challenges to prevent unbounded growth.
+
+        Caller must hold self._challenges_lock — this method only
+        runs from within initiate()'s locked section.
+        """
         expired = [
             cid for cid, ch in self._pending_challenges.items()
             if ch.is_expired()
@@ -244,7 +262,13 @@ class TrustHandshake:
             del self._pending_challenges[cid]
 
     def clear_cache(self) -> None:
-        """Clear all cached peer verification results."""
+        """Clear all cached peer verification results.
+
+        Sync-callable for compatibility with non-async callers. Do
+        not mix sync clear_cache() with concurrent async access to
+        _verified_peers; if both code paths are in play, use the
+        async _peers_lock manually.
+        """
         self._verified_peers.clear()
 
     async def initiate(
@@ -265,7 +289,7 @@ class TrustHandshake:
                 call produces a fresh Evidence verification.
         """
         if use_cache and not require_freshness:
-            cached = self._get_cached_result(peer_did)
+            cached = await self._get_cached_result(peer_did)
             if cached:
                 return cached
 
@@ -345,11 +369,15 @@ class TrustHandshake:
                 user_context=response_user_ctx,
             )
 
-            self._cache_result(peer_did, result)
+            await self._cache_result(peer_did, result)
             return result
         finally:
-            if challenge and challenge.challenge_id in self._pending_challenges:
-                del self._pending_challenges[challenge.challenge_id]
+            # Cleanup must run under the challenges lock so a sibling
+            # initiate() can't race on the same challenge_id during
+            # its size check.
+            if challenge:
+                async with self._challenges_lock:
+                    self._pending_challenges.pop(challenge.challenge_id, None)
 
     async def respond(
         self,

--- a/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
+++ b/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
@@ -1422,10 +1422,11 @@ class TestTrustHandshake:
         th.clear_cache()
         assert len(th._verified_peers) == 0
 
-    def test_get_cached_result_expired(self):
+    @pytest.mark.asyncio
+    async def test_get_cached_result_expired(self):
         th = TrustHandshake(agent_did="did:mesh:me", cache_ttl_seconds=0)
         th._verified_peers["did:mesh:peer"] = (MagicMock(), datetime.utcnow() - timedelta(seconds=1))
-        assert th._get_cached_result("did:mesh:peer") is None
+        assert await th._get_cached_result("did:mesh:peer") is None
         assert "did:mesh:peer" not in th._verified_peers
 
 


### PR DESCRIPTION
## Summary

`TrustHandshake` (`agent-mesh/.../trust/handshake.py:170-547`) had partial concurrency coverage:

- `_challenges_lock` (asyncio.Lock) covered the purge+check+insert at the start of `initiate()`.
- The matching `finally`-block delete of `_pending_challenges` was NOT under that lock — could race a sibling's purge.
- `_verified_peers` had no lock at all; `_get_cached_result`'s read+TTL-delete sequence and `_cache_result`'s write could race.

## Change

- Add a second `asyncio.Lock` for `_verified_peers`. `_get_cached_result` and `_cache_result` become async; their callers in `initiate()` now await them.
- Wrap the `finally`-block `pop` on `_pending_challenges` in the existing `_challenges_lock`.
- `clear_cache()` stays sync-callable for non-async consumers, with a docstring caveat that mixing sync `clear_cache` with concurrent async access is out of scope.

## Test plan

- [ ] CI passes (handshake test suite — 100 passed locally)
- [ ] `test_get_cached_result_expired` updated to async (it pokes the internal method directly and the method is now a coroutine)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Mesh]