### PR TITLE
fix(py-mesh-agent-did): use 128 bits of secrets entropy for unique_id

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/agent_id.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/agent_id.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, field_validator
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives import serialization
 import hashlib
+import secrets
 import logging
 import uuid
 import base64
@@ -34,10 +35,16 @@ class AgentDID(BaseModel):
 
     @classmethod
     def generate(cls, name: str, org: Optional[str] = None) -> "AgentDID":
-        """Generate a new DID for an agent."""
-        # Create deterministic but unique ID
-        seed = f"{name}:{org or 'default'}:{uuid.uuid4().hex[:8]}"
-        unique_id = hashlib.sha256(seed.encode()).hexdigest()[:32]
+        """Generate a new DID for an agent.
+
+        Uses 128 bits of random hex directly rather than hashing a seed
+        that contained only 32 hex digits (8 bytes = 64 bits) of
+        entropy. The previous construction folded the agent name and
+        org into the seed, but those are attacker-knowable so they
+        contribute zero entropy to a unique-id guess; only the
+        uuid.uuid4().hex[:8] slice was random.
+        """
+        unique_id = secrets.token_hex(16)  # 128 bits = 32 hex chars
         return cls(unique_id=unique_id)
 
     @classmethod


### PR DESCRIPTION
## Summary

`AgentDID.generate` (`agent-mesh/.../identity/agent_id.py:36-41`) built a seed of `f"{name}:{org}:{uuid.uuid4().hex[:8]}"` and SHA-256'd it down to a 32-char prefix. The name and org are attacker-knowable, so they contribute **zero** entropy to a unique-id guess; only the 8-hex-char uuid slice (~32 bits, halved by birthday bound to ~16 bits effective collision resistance) was random. SHA-256 cannot recover entropy that wasn't there.

## Change

Replace with `secrets.token_hex(16)` — 128 bits of CSPRNG output direct to the `unique_id` field. No knowable inputs in the construction; collisions are astronomically unlikely.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Mesh]