### PR TITLE
docs(py-mesh-trust-bridge): clarify HMAC scope — in-process integrity only

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/bridge.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/bridge.py
@@ -103,17 +103,40 @@ class TrustBridge(BaseModel):
             identity=identity,
             registry=registry,
         )
-        # P06: HMAC key for peer record integrity
+        # P06: In-process integrity check on peer records.
+        # NOTE: This is NOT a security primitive against an attacker
+        # with write access to TrustBridge state. The HMAC key
+        # (_peer_hmac_key), the data being protected (self.peers),
+        # and the signatures (_peer_signatures) all live in the same
+        # process memory. Any attacker who can write _peer_signatures
+        # can also read _peer_hmac_key and recompute valid signatures
+        # for forged peer records. The check guards only against
+        # accidental in-process corruption (bit flips, programmer
+        # error writing to peer records without going through the
+        # accessor). For real tamper-resistance against an adversary
+        # with code execution, move the HMAC key and signature store
+        # off-process — to a sidecar with restricted IPC, to a TEE
+        # like SGX/SEV, or to a remote signing service.
         self._peer_hmac_key = os.urandom(32)
         self._peer_signatures: dict[str, str] = {}
 
     def _sign_peer(self, peer: PeerInfo) -> str:
-        """Compute HMAC over peer's critical fields."""
+        """Compute HMAC over peer's critical fields.
+
+        See class docstring on `_peer_hmac_key` — this HMAC is an
+        in-process integrity check, not protection against an
+        attacker with TrustBridge write access.
+        """
         payload = f"{peer.peer_did}:{peer.trust_score}:{peer.trust_verified}:{','.join(peer.capabilities)}"
         return hmac.new(self._peer_hmac_key, payload.encode(), hashlib.sha256).hexdigest()
 
     def _verify_peer_integrity(self, peer_did: str) -> bool:
-        """Verify that a stored peer record has not been tampered with."""
+        """Verify that a stored peer record has not been tampered with.
+
+        Detects accidental in-process corruption only. An adversary
+        with read+write access to TrustBridge memory can forge valid
+        signatures (see `_peer_hmac_key` docstring).
+        """
         peer = self.peers.get(peer_did)
         if not peer:
             return False


### PR DESCRIPTION
## Summary

`TrustBridge` (`trust/bridge.py:107-124`) maintains an HMAC over stored peer records for tamper-detection. The HMAC key (`_peer_hmac_key`), the data it protects (`self.peers`), and the signatures (`_peer_signatures`) all live in the same process memory. An attacker with write access to TrustBridge state can also read the key and recompute valid signatures for forged peer records — so the HMAC is **not a security primitive against any adversary with code execution on the process**.

The construction is still useful as an integrity check against accidental in-process corruption (bit flips, programmer error writing peer records without going through the accessor), so the mechanism stays.

## Change

Update the docstrings on `_peer_hmac_key`, `_sign_peer`, and `_verify_peer_integrity` to spell out what this protects against (in-process accidental corruption) and what it does not (an adversary with code execution). Point readers at off-process alternatives — sidecar with restricted IPC, TEE (SGX/SEV), remote signing service — for real tamper-resistance.

No code change to the protection logic itself; just disclosure of the threat model the existing HMAC actually covers.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Mesh]