### PR TITLE
fix(py-mesh-ratchet): bound RatchetState.skipped_keys at 2000 entries aggregate

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/encryption/ratchet.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/encryption/ratchet.py
@@ -297,6 +297,13 @@ class DoubleRatchet:
         dh_output = crypto_scalarmult(s.dh_self_private, s.dh_remote_public)
         s.root_key, s.chain_key_send = _kdf_root(s.root_key, dh_output)
 
+    # Aggregate cap on cached skipped keys across all DH rotations.
+    # The per-call cap (_max_skip) bounds a SINGLE skip burst; this
+    # cap bounds the lifetime accumulation. Without it, a session
+    # that survives many DH ratchet steps with persistent
+    # out-of-order tails grows skipped_keys without limit.
+    _MAX_SKIPPED_KEYS_TOTAL: int = 2000
+
     def _skip_messages(self, until: int) -> None:
         """Cache skipped message keys for out-of-order delivery."""
         s = self._state
@@ -311,6 +318,13 @@ class DoubleRatchet:
             s.skipped_keys[(s.dh_remote_public, s.recv_message_number)] = message_key
             s.chain_key_recv = next_chain_key
             s.recv_message_number += 1
+            # Evict the oldest skipped key once we cross the aggregate
+            # cap. Dict iteration order is insertion order on Python
+            # 3.7+, so the first key is the oldest insertion that
+            # survived all prior evictions.
+            while len(s.skipped_keys) > self._MAX_SKIPPED_KEYS_TOTAL:
+                oldest = next(iter(s.skipped_keys))
+                del s.skipped_keys[oldest]
 
 
 # ── Primitives ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The Double Ratchet's `_max_skip` already caps per-call skip burst size, but the aggregate `skipped_keys` dict (`encryption/ratchet.py:104`) was unbounded across DH rotations — a session that survives many rotation steps with persistent out-of-order tails grows `skipped_keys` until process memory is exhausted.

## Change

Add `_MAX_SKIPPED_KEYS_TOTAL = 2000` on `DoubleRatchet`. After each key cache insertion, evict the oldest entry (dict iteration order is insertion order on Python 3.7+) until the dict is back within the cap.

Practical impact on legitimate traffic: 2000 entries is generous headroom for out-of-order delivery across the lifetime of a session.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Mesh]