### PR TITLE
fix(py-mesh-relay): bound subsequent receive_text with idle timeout

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
@@ -133,9 +133,24 @@ class RelayServer:
                 # Deliver pending messages
                 await self._deliver_pending(agent_did, ws)
 
-                # Message loop
+                # Message loop. Each receive is bounded by an idle
+                # timeout — without it, a connected agent that never
+                # sends a frame can hold its slot in self._connections
+                # indefinitely. 90s is generous for typical heartbeat
+                # cadences (~30s) and lets a stalled peer be reaped.
+                _IDLE_TIMEOUT = 90.0
                 while True:
-                    raw = await ws.receive_text()
+                    try:
+                        raw = await asyncio.wait_for(
+                            ws.receive_text(), timeout=_IDLE_TIMEOUT
+                        )
+                    except asyncio.TimeoutError:
+                        logger.info(
+                            "Idle timeout for %s after %ss; closing",
+                            agent_did, _IDLE_TIMEOUT,
+                        )
+                        await ws.close(code=4004)
+                        return
                     frame = json.loads(raw)
                     await self._handle_frame(agent_did, frame, ws)
 


### PR DESCRIPTION
## Summary

The relay's WebSocket handler (`agent-mesh/.../relay/app.py:103,138`) called `asyncio.wait_for()` with a 10s timeout on the FIRST connect frame only. All subsequent receives in the message loop used a bare `ws.receive_text()` with no timeout — a connected agent that never sends another frame held its slot in `self._connections` indefinitely, past any heartbeat cadence.

## Change

Wrap the loop receive in `asyncio.wait_for(..., timeout=90.0)`. On timeout, log and close the connection with code 4004. 90s is generous for typical heartbeat cadences (~30s) but lets a stalled peer be reaped without hand-tuning.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Mesh]