### PR TITLE
fix(ci): add pyproject_hooks hash to ci-build.txt

### DIFF
--- a/agent-governance-python/requirements/ci-build.txt
+++ b/agent-governance-python/requirements/ci-build.txt
@@ -7,3 +7,5 @@ setuptools==78.1.1 \
 # build transitive dependencies
 packaging==25.0 \
     --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484
+pyproject_hooks==1.2.0 \
+    --hash=sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913


### PR DESCRIPTION
build==1.2.2 depends on \pyproject_hooks\ which was missing from the hashed requirements, causing all build-pypi jobs to fail on CI.