### PR TITLE
fix(py-gov-rag-governor): always emit audit, including on exception paths

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
@@ -211,30 +211,48 @@ class RAGGovernor:
         query: str,
         kwargs: dict[str, Any],
     ) -> List[Any]:
-        """Run the full governance pipeline for one retrieval call."""
+        """Run the full governance pipeline for one retrieval call.
 
-        # 1. Collection access control
+        Audit emission is wrapped in try/except/finally so a retrieval
+        attempt is always logged, regardless of whether it succeeded,
+        was denied by the collection/rate gates, or raised inside the
+        underlying retriever/scanner. Without this, a thrown exception
+        in the retrieve or scan steps produced no audit record, hiding
+        the access attempt from compliance reviews.
+        """
+
+        # 1. Collection access control. _check_collection emits its
+        # own "denied" audit before raising.
         self._check_collection(collection)
 
-        # 2. Rate limiting
+        # 2. Rate limiting. _check_rate emits its own audit before
+        # raising.
         self._check_rate(collection=collection, query=query)
 
-        # 3. Retrieve
-        docs = self._retrieve(retriever, query, kwargs)
+        num_retrieved = 0
+        num_blocked = 0
+        decision = "allowed"
+        try:
+            # 3. Retrieve
+            docs = self._retrieve(retriever, query, kwargs)
+            num_retrieved = len(docs)
 
-        # 4. Content scanning
-        clean_docs, num_blocked = self._scan_chunks(docs)
-
-        # 5. Audit
-        self._audit(
-            collection=collection,
-            query=query,
-            num_retrieved=len(docs),
-            num_blocked=num_blocked,
-            decision="allowed",
-        )
-
-        return clean_docs
+            # 4. Content scanning
+            clean_docs, num_blocked = self._scan_chunks(docs)
+            return clean_docs
+        except Exception:
+            decision = "error"
+            raise
+        finally:
+            # 5. Audit — always fires so the attempt is logged even on
+            # retriever/scanner exceptions.
+            self._audit(
+                collection=collection,
+                query=query,
+                num_retrieved=num_retrieved,
+                num_blocked=num_blocked,
+                decision=decision,
+            )
 
     def _check_collection(self, collection: str) -> None:
         allowed, reason = self.policy.is_collection_allowed(collection)


### PR DESCRIPTION
## Summary

`RAGGovernor._execute` (`agent-rag-governance/.../governor.py:140-170`) called `self._audit` only on the success path after `_retrieve` + `_scan_chunks` completed. If either step raised — a retriever exception, a scanner crash, a transient I/O error — the call returned no audit record, leaving the attempt invisible to compliance reviews.

## Change

Wrap the retrieve + scan steps in try/except/finally. The finally block always emits an audit entry with the actual `num_retrieved` / `num_blocked` seen so far, and `decision="error"` if an exception was raised (the exception is re-raised). Collection and rate-limit gates still emit their own `"denied"`/`"rate_limited"` audits before raising, so all three outcomes — allowed, denied, errored — now produce one record.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Governance]