### PR TITLE
fix(py-gov-rate-limiter): periodic compaction of stale per-agent deques

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/rate_limiter.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/rate_limiter.py
@@ -29,10 +29,14 @@ class RateLimiter:
             raise RateLimitExceededError(...)
     """
 
+    # Run the per-agent compaction sweep every Nth check() call.
+    _COMPACTION_INTERVAL = 1000
+
     def __init__(self, window_seconds: int = 60) -> None:
         self._window = window_seconds
         self._lock = threading.Lock()
         self._timestamps: dict[str, deque[float]] = {}
+        self._check_count = 0
 
     def check(self, agent_id: str, limit: int) -> bool:
         """Return ``True`` if the agent is within its limit, ``False`` if exceeded.
@@ -64,7 +68,30 @@ class RateLimiter:
                 return False
 
             dq.append(now)
+
+            # Periodic compaction so long-running services with a
+            # churning set of agent_ids don't leak per-agent deques.
+            # Without this, an entry persists as long as the process
+            # lives even if the agent never made another call after
+            # its window expired.
+            self._check_count += 1
+            if self._check_count >= self._COMPACTION_INTERVAL:
+                self._check_count = 0
+                self._compact_locked(cutoff)
             return True
+
+    def _compact_locked(self, cutoff: float) -> None:
+        """Drop agent entries whose deques are entirely outside the window.
+
+        Caller must hold self._lock.
+        """
+        stale = [
+            agent_id
+            for agent_id, dq in self._timestamps.items()
+            if not dq or dq[-1] < cutoff
+        ]
+        for agent_id in stale:
+            del self._timestamps[agent_id]
 
     def reset(self, agent_id: str) -> None:
         """Clear all recorded timestamps for *agent_id* (useful in tests)."""


### PR DESCRIPTION
## Summary

`RateLimiter._timestamps` (`agent-rag-governance/.../rate_limiter.py:69-72`) grew on every new `agent_id`. The only way to free an entry was an explicit `reset()` call from a test — long-running services with a churning set of agent_ids leaked one deque per distinct agent_id ever seen.

## Change

Add a periodic in-place compaction. Every `_COMPACTION_INTERVAL` (1000) `check()` calls, walk `_timestamps` and drop entries whose deques are empty or whose newest timestamp is older than the current window. Runs inside the existing lock so no extra synchronization is needed.

The interval bounds amortized overhead: at 1k checks per sweep, even a huge agent fleet pays one O(n) walk per ~1k checks.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Governance]