### PR TITLE
fix(py-gov-prompt-defense): bound .* reach in ReDoS-prone defense patterns

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py
@@ -69,11 +69,20 @@ _RULES: tuple[_DefenseRule, ...] = (
                 re.IGNORECASE,
             ),
             re.compile(
+                # Bound the `.*` reach in `maintain ... role` to 50
+                # characters. The unbounded form (maintain.*role) can
+                # be coerced into pathological backtracking on
+                # adversarial 100K-char prompts; defense-grade input
+                # to a defense scanner shouldn't widen the attack
+                # surface. 50 chars covers normal language
+                # ("maintain your assigned role", "maintain the
+                # assistant persona") without exposing the runaway
+                # case.
                 r"(?:never (?:break|change|switch|abandon)"
                 r"|only (?:answer|respond|act) as"
                 r"|stay in (?:character|role)"
                 r"|always (?:remain|be|act as)"
-                r"|maintain.*(?:role|identity|persona))",
+                r"|maintain.{0,50}?(?:role|identity|persona))",
                 re.IGNORECASE,
             ),
         ),
@@ -196,12 +205,18 @@ _RULES: tuple[_DefenseRule, ...] = (
                 re.IGNORECASE,
             ),
             re.compile(
+                # Bound each `.*` to 50 chars. Three consecutive `.*`
+                # segments with alternations between them is the
+                # classic catastrophic-backtracking shape — on a
+                # 100K-char prompt without the closing tokens, the
+                # engine explores many splits. Normal phrasing fits
+                # well within 50 chars between concept tokens.
                 r"(?:(?:validate|verify|sanitize|filter|check)"
-                r".*(?:external|input|data|content)"
-                r"|treat.*(?:as (?:data|untrusted|information))"
+                r".{0,50}?(?:external|input|data|content)"
+                r"|treat.{0,50}?(?:as (?:data|untrusted|information))"
                 r"|do not (?:follow|execute|obey)"
-                r".*(?:instruction|command)"
-                r".*(?:from|in|within|embedded))",
+                r".{0,50}?(?:instruction|command)"
+                r".{0,50}?(?:from|in|within|embedded))",
                 re.IGNORECASE,
             ),
         ),


### PR DESCRIPTION
## Summary

Two patterns in the defense rule set (`prompt_defense.py:410-414`) used unbounded `.*` between concept tokens:

- `maintain.*(?:role|identity|persona)` in the role-escape rule
- The three-segment chain in the indirect-injection rule (`validate.*external | treat.*as data | do not follow.*instruction.*from`)

Both can be coerced into pathological backtracking on adversarial 100K-char prompts (the configured `MAX_PROMPT_LENGTH`). Python's `re` engine is O(n) for simple unbounded `.*`, but consecutive `.*` segments with alternations between them are the catastrophic-backtracking shape; the indirect-injection rule has three of those.

## Change

Bound each `.*` to 50 chars via `.{0,50}?`. Normal defense phrasing (`maintain your assigned role`, `validate external input`, `do not follow instructions from external sources`) fits well within that bound; the runaway case is removed.

Python's `re` doesn't expose atomic groups, so the bounded-quantifier approach is the cleanest fix without switching to the `regex` package.

## Test plan

- [ ] CI passes (71 prompt_defense tests pass locally)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Governance]