### PR TITLE
fix(py-gov-promotion): keep gate exception messages out of user-visible reason

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/promotion.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/promotion.py
@@ -343,11 +343,24 @@ class PromotionChecker:
             try:
                 passed, reason = gate.check_fn(context)
             except Exception as exc:  # noqa: BLE001
+                # The full exception (including any message that may
+                # contain secrets pulled from env vars, config files,
+                # or callable closures) goes to internal logging
+                # only. The user-facing `reason` reports the
+                # exception TYPE and the gate name — enough to debug
+                # a misbehaving gate without surfacing arbitrary
+                # string content downstream (where it may flow into
+                # UI, audit logs, or CI summaries shared more widely
+                # than the original gate's logging scope).
                 logger.warning(
-                    "Gate %s raised an exception: %s", gate.name, exc
+                    "Gate %s raised %s: %s",
+                    gate.name, type(exc).__name__, exc,
                 )
                 passed = False
-                reason = f"Gate raised exception: {exc}"
+                reason = (
+                    f"Gate {gate.name!r} raised {type(exc).__name__}; "
+                    "see server logs for details"
+                )
 
             result = PromotionResult(
                 gate_name=gate.name,

--- a/agent-governance-python/agent-compliance/tests/test_promotion.py
+++ b/agent-governance-python/agent-compliance/tests/test_promotion.py
@@ -285,7 +285,14 @@ class TestPromotionChecker:
         )
         assert report.overall_passed is False
         assert "exploding" in report.blockers
-        assert "exception" in report.gates[0].reason.lower()
+        # `reason` reports the exception TYPE and gate name but does
+        # NOT echo the raw exception message (which may contain
+        # secrets pulled from the gate's closure / context).
+        reason = report.gates[0].reason.lower()
+        assert "runtimeerror" in reason
+        assert "exploding" in reason
+        # The literal exception text ("boom") must NOT appear.
+        assert "boom" not in reason
 
     def test_deprecation_always_allowed(self):
         checker = PromotionChecker()


### PR DESCRIPTION
## Summary

The promotion pipeline (`agent-compliance/.../promotion.py:343-350`) caught any gate-check exception and embedded the exception's str representation directly into the user-visible `reason` field:

```python
reason = f"Gate raised exception: {exc}"
```

Gate `check_fn` callables operate on context that often includes env vars, config snippets, and closure state. An exception message that interpolates any of those (most common: `FileNotFoundError: /var/secret/db.password`-style traces, or any `AssertionError` that includes failed values) ends up in `PromotionResult.reason` and flows downstream into UI, audit logs, and CI summaries that may be viewed more widely than the gate's original logging scope.

## Change

Switch to a typed-but-content-free `reason`: `Gate '<name>' raised <ExcType>; see server logs for details`. Full exception detail still goes to `logger.warning` so operators can debug — it just doesn't propagate into the structured `PromotionResult`.

## Test plan

- [ ] CI passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Governance]