### PR TITLE
fix(attestation-validator): strip fenced code blocks before section parse

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/governance/attestation_validator.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/governance/attestation_validator.py
@@ -40,6 +40,20 @@ def _normalize_line_endings(text: str) -> str:
     return text.replace("\r\n", "\n")
 
 
+_FENCED_CODE_BLOCK_RE = re.compile(r"```.*?(?:```|\Z)", re.DOTALL)
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    """Remove fenced code blocks so their content can't be mistaken for headings.
+
+    A code fence may contain text that looks like a ``##`` heading or a
+    ``- [x]`` checkbox, but those are render-time literals — they should
+    not terminate sections or count as user-checked attestations.
+    Unclosed fences run to end-of-text.
+    """
+    return _FENCED_CODE_BLOCK_RE.sub("", text)
+
+
 def _count_section_checkboxes(section_title: str, pr_body: str) -> dict:
     """Count checked boxes in a specific section.
 
@@ -53,6 +67,8 @@ def _count_section_checkboxes(section_title: str, pr_body: str) -> dict:
             - checked: int (number of checked boxes)
             - details: str (section content) or None
     """
+    body = _strip_fenced_code_blocks(pr_body)
+
     # Escape special regex characters in section title
     escaped_title = re.escape(section_title)
 
@@ -60,7 +76,7 @@ def _count_section_checkboxes(section_title: str, pr_body: str) -> dict:
     # Supports both ## (h2) and ### (h3) headings for compatibility with
     # GitHub Issue Forms, which render checkbox group labels as ### headings.
     pattern = rf"(^|\n)#{{2,3}}\s+{escaped_title}\n([\s\S]*?)(?=\n#{{2,3}}\s+|$)"
-    match = re.search(pattern, pr_body, re.IGNORECASE)
+    match = re.search(pattern, body, re.IGNORECASE)
 
     if not match:
         return {"found": False, "checked": 0, "details": None}

--- a/agent-governance-python/agent-compliance/tests/test_governance_attestation.py
+++ b/agent-governance-python/agent-compliance/tests/test_governance_attestation.py
@@ -525,3 +525,59 @@ End.
         result = validate_attestation(pr_body, required_sections=custom_sections)
         assert result.valid is False
         assert any("Missing section" in e for e in result.errors)
+
+
+class TestFencedCodeBlockSafety:
+    """Section headings and checkboxes inside fenced code blocks must not affect parsing."""
+
+    def test_fenced_pseudo_heading_does_not_truncate_section(self):
+        """A `## ...` inside a code fence must not terminate the enclosing section."""
+        pr_body = """
+## 1) Security review
+
+Example template the user might paste:
+
+```markdown
+## 99) Not a real heading
+- [ ] sample
+```
+
+- [x] ✅ Yes
+"""
+        custom_sections = ["1) Security review"]
+        result = validate_attestation(pr_body, required_sections=custom_sections)
+        assert result.valid is True, result.errors
+        assert result.sections_found["1) Security review"] == 1
+
+    def test_checkbox_inside_fence_does_not_count(self):
+        """A `[x]` inside a fenced block must not satisfy the section requirement."""
+        pr_body = """
+## 1) Security review
+
+Example users paste:
+
+```markdown
+- [x] would be checked
+```
+"""
+        custom_sections = ["1) Security review"]
+        result = validate_attestation(pr_body, required_sections=custom_sections)
+        assert result.valid is False
+        assert any("found 0" in e for e in result.errors)
+
+    def test_unclosed_fence_does_not_crash(self):
+        """An unterminated code fence runs to end-of-body without raising."""
+        pr_body = """
+## 1) Security review
+- [x] ✅ Yes
+
+```python
+# unclosed fence, no closing backticks
+print("oops")
+"""
+        custom_sections = ["1) Security review"]
+        # Must not raise; the section before the fence is intact and the
+        # box outside the fence is counted.
+        result = validate_attestation(pr_body, required_sections=custom_sections)
+        assert result.valid is True, result.errors
+        assert result.sections_found["1) Security review"] == 1


### PR DESCRIPTION
## Summary

`_count_section_checkboxes` finds attestation sections with the regex `#{2,3}\s+<title>` and captures until the next `#{2,3}` heading. When a section body included a fenced code block whose content contained pseudo-markdown like `## not really a header`, the regex captured up to (and stopped at) the in-fence text — truncating the real section. The first `[x]` after the fence was then attributed to a non-existent later section, or dropped entirely. The mirror case is equally wrong: an `- [x]` written inside a fence (e.g. a template snippet a maintainer pasted) was *counted* as a real attestation, even though GitHub renders it as a code literal.

Both failure modes flip the validator's verdict. A real-world attestation PR with a code-fenced example would either fail wrongly (section truncated → checkbox not seen) or pass wrongly (template `[x]` counted).

Fix: strip fenced code blocks before running the section regex. The stripper handles both well-formed fences and unterminated fences that run to end-of-body (so a malformed PR body cannot crash the validator).

## Test plan

- [x] `pytest agent-governance-python/agent-compliance/tests/test_governance_attestation.py` — 28 pass (existing 25 + 3 new regression tests)
- [x] `## pseudo-heading` inside a fence no longer truncates its enclosing section
- [x] `[x]` inside a fence no longer satisfies the section requirement (counted as 0)
- [x] Unterminated fence does not raise

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Governance]