### PR TITLE
fix(cli/main): echo error detail for known classes; align with agt._handle_error

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/main.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/main.py
@@ -22,20 +22,42 @@ import json
 
 
 def handle_error(e: Exception, output_json: bool = False, custom_msg: Optional[str] = None):
-    """Centralized error handler for compliance CLI."""
-    is_known = isinstance(e, (IOError, ValueError, KeyError, PermissionError, FileNotFoundError))
+    """Centralized error handler for compliance CLI.
+
+    Echoes the exception detail for known (user-facing) error classes so the
+    operator can act on the failure. Unknown / internal exceptions are kept
+    opaque to avoid leaking stack details; set ``AGENTOS_DEBUG=1`` to see the
+    underlying message during development. Mirrors ``agt._handle_error``.
+    """
+    is_known = isinstance(
+        e, (IOError, ValueError, KeyError, PermissionError, FileNotFoundError)
+    )
+    err_type = "ValidationError" if is_known else "InternalError"
 
     if custom_msg:
         err_msg = custom_msg
     elif is_known:
-        err_msg = "A validation or file access error occurred."
+        err_msg = str(e) or "validation or file access error"
     else:
-        err_msg = "A governance processing error occurred."
+        err_msg = "An internal error occurred"
 
     if output_json:
-        print(json.dumps({"status": "fail" if not is_known else "error", "message": err_msg, "type": "ValidationError" if is_known else "InternalError"}, indent=2))
-    else:
-        print(f"Error: {err_msg}", file=sys.stderr)
+        print(
+            json.dumps(
+                {
+                    "status": "error" if is_known else "fail",
+                    "message": err_msg,
+                    "type": err_type,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    print(f"Error: {err_msg}", file=sys.stderr)
+
+    if not is_known and os.environ.get("AGENTOS_DEBUG"):
+        print(f"  {type(e).__name__}: {e}", file=sys.stderr)
 
 
 def cmd_verify(args: argparse.Namespace) -> int:

--- a/agent-governance-python/agent-compliance/tests/test_cli_edge_cases.py
+++ b/agent-governance-python/agent-compliance/tests/test_cli_edge_cases.py
@@ -122,3 +122,55 @@ class TestReadOnlyOutputDirectory:
             assert "Traceback" not in captured.out
         finally:
             readonly_dir.chmod(stat.S_IRWXU)
+
+
+class TestHandleErrorEchoesDetail:
+    """`handle_error` must echo the underlying error for known classes."""
+
+    def test_known_error_includes_detail_plain(self, capsys):
+        from agent_compliance.cli.main import handle_error
+
+        handle_error(ValueError("policy.yaml: missing required field 'rules'"))
+        captured = capsys.readouterr()
+        assert "missing required field 'rules'" in captured.err
+        assert "Error:" in captured.err
+
+    def test_known_error_includes_detail_json(self, capsys):
+        import json as _json
+
+        from agent_compliance.cli.main import handle_error
+
+        handle_error(FileNotFoundError("/nope/manifest.json"), output_json=True)
+        data = _json.loads(capsys.readouterr().out)
+        assert data["type"] == "ValidationError"
+        assert "/nope/manifest.json" in data["message"]
+
+    def test_unknown_error_sanitized_plain(self, capsys):
+        from agent_compliance.cli.main import handle_error
+
+        handle_error(RuntimeError("secret-internal-state-do-not-leak"))
+        captured = capsys.readouterr()
+        assert "secret-internal-state-do-not-leak" not in captured.err
+        assert "internal error" in captured.err.lower()
+
+    def test_unknown_error_sanitized_json(self, capsys):
+        import json as _json
+
+        from agent_compliance.cli.main import handle_error
+
+        handle_error(
+            RuntimeError("secret-internal-state-do-not-leak"), output_json=True
+        )
+        data = _json.loads(capsys.readouterr().out)
+        assert data["type"] == "InternalError"
+        assert "secret-internal-state-do-not-leak" not in data["message"]
+        assert "internal error" in data["message"].lower()
+
+    def test_unknown_error_debug_env_reveals_detail(self, capsys, monkeypatch):
+        from agent_compliance.cli.main import handle_error
+
+        monkeypatch.setenv("AGENTOS_DEBUG", "1")
+        handle_error(RuntimeError("low-level-detail"))
+        captured = capsys.readouterr()
+        assert "low-level-detail" in captured.err
+        assert "RuntimeError" in captured.err


### PR DESCRIPTION
## Summary

`agent_compliance.cli.main.handle_error` discarded the actual exception for every error class. Every user-facing failure ended up as `Error: A validation or file access error occurred.`, dropping the only piece of information the operator could act on (which file, which field, which key, which path).

The newer `agt._handle_error` already does the right thing: echo the detail for known user-facing classes (`IOError`, `ValueError`, `KeyError`, `PermissionError`, `FileNotFoundError`), keep unknown / internal errors opaque to avoid leaking implementation details, and surface the underlying exception when `AGENTOS_DEBUG=1` is set.

This PR realigns `main.handle_error` with that contract. The legacy `agent-governance` / `agent-compliance` / `agent-governance-toolkit` entry points are still wired (see `pyproject.toml`), so the bug was reachable until now.

## Test plan

- [x] `pytest agent-governance-python/agent-compliance/tests/test_cli_edge_cases.py` — 8 pass, 2 unrelated chmod-on-Windows skips
- [x] Known classes (`ValueError`, `FileNotFoundError`, `KeyError`, `PermissionError`, `IOError`) now include `str(e)` in both plain and JSON output
- [x] Unknown classes (`RuntimeError`) are sanitized to `An internal error occurred` in both plain and JSON output
- [x] `AGENTOS_DEBUG=1` reveals the underlying type+message on stderr after the sanitized message
- [x] JSON envelope shape (`type` / `message` / `status`) preserved

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Governance]