### PR TITLE
fix(cli/agt): log plugin discovery failures at WARNING

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/agt.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/agt.py
@@ -18,12 +18,15 @@ Plugin subcommands from other AGT packages are discovered via the
 
 from __future__ import annotations
 
+import logging
 import sys
 from typing import Any, Dict, Optional
 
 import click
 
 from agent_compliance.cli.red_team import red_team
+
+_logger = logging.getLogger(__name__)
 
 try:
     from rich import box as _rich_box
@@ -59,7 +62,14 @@ def _get_package_version(package_name: str) -> Optional[str]:
 
 
 def _discover_plugins() -> Dict[str, click.Command]:
-    """Discover plugin commands from the ``agt.commands`` entry-point group."""
+    """Discover plugin commands from the ``agt.commands`` entry-point group.
+
+    Plugin discovery failures must not block the host CLI, but they should
+    be surfaced at WARNING — a broken plugin that silently disappears makes
+    misconfiguration impossible to diagnose. Individual entry-point load
+    failures and the outer discovery failure are both logged with the
+    entry-point name (or group) and the exception class.
+    """
     plugins: Dict[str, click.Command] = {}
 
     try:
@@ -82,10 +92,19 @@ def _discover_plugins() -> Dict[str, click.Command]:
                     result = obj()
                     if isinstance(result, click.Command):
                         plugins[ep.name] = result
-            except Exception:  # noqa: S110 — plugin load failures are non-critical
-                pass
-    except Exception:  # noqa: S110 — plugin discovery failures are non-critical
-        pass
+            except Exception as exc:  # noqa: BLE001
+                _logger.warning(
+                    "agt: failed to load plugin entry-point %r (%s: %s)",
+                    ep.name,
+                    type(exc).__name__,
+                    exc,
+                )
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning(
+            "agt: plugin discovery failed for group 'agt.commands' (%s: %s)",
+            type(exc).__name__,
+            exc,
+        )
 
     return plugins
 

--- a/agent-governance-python/agent-compliance/tests/test_agt_cli.py
+++ b/agent-governance-python/agent-compliance/tests/test_agt_cli.py
@@ -352,6 +352,36 @@ class TestPluginDiscovery:
 
         assert plugins == {}
 
+    def test_load_failure_logs_warning(self, caplog):
+        mock_ep = mock.Mock()
+        mock_ep.name = "broken"
+        mock_ep.load.side_effect = ImportError("no such module")
+
+        with caplog.at_level("WARNING", logger="agent_compliance.cli.agt"):
+            with mock.patch(
+                "importlib.metadata.entry_points", return_value=[mock_ep]
+            ):
+                plugins = _discover_plugins()
+
+        assert "broken" not in plugins
+        # The plugin name and exception class must surface in WARNING output,
+        # so operators can diagnose the bad plugin instead of guessing.
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "broken" in joined
+        assert "ImportError" in joined
+
+    def test_discovery_api_failure_logs_warning(self, caplog):
+        with caplog.at_level("WARNING", logger="agent_compliance.cli.agt"):
+            with mock.patch(
+                "importlib.metadata.entry_points", side_effect=Exception("boom")
+            ):
+                plugins = _discover_plugins()
+
+        assert plugins == {}
+        joined = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "agt.commands" in joined
+        assert "boom" in joined
+
 
 class TestAgtGroup:
     def test_list_commands_sorted(self, runner: CliRunner):


### PR DESCRIPTION
## Summary

`_discover_plugins` had two nested `except Exception: pass` blocks that silently swallowed every entry-point load failure and every outer discovery error:

```python
try:
    eps = entry_points(group=\"agt.commands\")
    for ep in eps:
        try:
            obj = ep.load()
            ...
        except Exception:  # noqa: S110 — plugin load failures are non-critical
            pass
except Exception:  # noqa: S110 — plugin discovery failures are non-critical
    pass
```

A broken plugin (bad install, missing dep, import-time crash) would vanish from `agt --help` with no signal — operators investigating *\"why isn't my plugin showing up?\"* had nowhere to look. The reviewer's recommendation in the audit: log at WARNING.

This PR keeps the non-blocking behavior (plugin failures should not crash the host CLI) but emits a `WARNING` that includes the failing entry-point name (or group, for outer failures), the exception class, and the exception message. `logging.WARNING` is the right level — it surfaces in default config and in CI logs but does not interrupt normal CLI output.

## Test plan

- [x] `pytest agent-governance-python/agent-compliance/tests/test_agt_cli.py::TestPluginDiscovery` — 12 pass (existing 10 + 2 new)
- [x] New `test_load_failure_logs_warning`: failing plugin yields a WARNING with entry-point name + exception class
- [x] New `test_discovery_api_failure_logs_warning`: outer `entry_points()` failure logs the group name + message
- [x] Pre-existing behavior preserved: failed plugins are excluded from the returned dict; the host CLI still starts

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Governance]