### PR TITLE
fix(docker-sandbox): broaden env blocklist, tighten container hardening, warn on unpinned images

### DIFF
--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -57,6 +57,15 @@ _PROTECTED_PATHS_WINDOWS = frozenset(
     )
 )
 
+# Paths blocked only when mounted at their exact root — not their
+# subdirectories. Mounting ``C:\Users`` exposes every user's profile
+# (documents, browser data, SSH keys); mounting a specific subdir like
+# ``C:\Users\agent\workspace`` is a legitimate per-user pattern and
+# remains allowed.
+_PROTECTED_PATHS_WINDOWS_ROOT_ONLY = frozenset(
+    p.lower() for p in ("C:\\Users",)
+)
+
 # Docker resource-name pattern (containers, image repos, tags).
 # Must start with [a-zA-Z0-9] and may include _.- afterwards, max 128 chars.
 _DOCKER_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$")
@@ -77,8 +86,12 @@ def _validate_resource_name(value: str, label: str) -> None:
 
 
 # Environment variables that could break container hardening.
+# Anything an interpreter/loader will source at startup belongs here:
+# each variable below redirects code execution before the sandbox's
+# entrypoint runs, defeating the cap_drop / no-new-privileges hardening.
 _BLOCKED_ENV_VARS = frozenset(
     {
+        # glibc dynamic linker
         "LD_PRELOAD",
         "LD_LIBRARY_PATH",
         "LD_AUDIT",
@@ -86,8 +99,23 @@ _BLOCKED_ENV_VARS = frozenset(
         "LD_PROFILE",
         "LD_SHOW_AUXV",
         "LD_DYNAMIC_WEAK",
+        # POSIX shell startup hooks (bash, dash, sh)
+        "BASH_ENV",
+        "ENV",
+        # Python
         "PYTHONSTARTUP",
         "PYTHONPATH",
+        "PYTHONHOME",
+        # Node.js
+        "NODE_OPTIONS",
+        # Ruby
+        "RUBYOPT",
+        # Perl
+        "PERL5LIB",
+        "PERL5OPT",
+        # Java
+        "JAVA_TOOL_OPTIONS",
+        "_JAVA_OPTIONS",
     }
 )
 
@@ -120,6 +148,8 @@ def _is_protected_path(path: str) -> bool:
             return True
         # Block well-known Windows system directories (case-insensitive).
         lowered = normalised.lower()
+        if lowered in _PROTECTED_PATHS_WINDOWS_ROOT_ONLY:
+            return True
         for protected in _PROTECTED_PATHS_WINDOWS:
             if lowered == protected or lowered.startswith(protected + "\\"):
                 return True
@@ -348,13 +378,29 @@ class DockerSandboxProvider(SandboxProvider):
 
         logger.info("Pulling image '%s' ...", target)
 
-        # Split image:tag for the pull API
-        if ":" in target and not target.startswith("sha256:"):
+        # Split image:tag for the pull API. We treat references that
+        # include neither an explicit tag nor a digest as unpinned and
+        # warn loudly: ``image:latest`` resolves differently on every
+        # pull and undermines reproducibility, which is precisely the
+        # property a sandbox image needs.
+        if "@sha256:" in target:
+            repo, tag = target, None
+        elif ":" in target and not target.startswith("sha256:"):
             repo, tag = target.rsplit(":", 1)
         else:
             repo, tag = target, "latest"
+            logger.warning(
+                "Image '%s' has no tag or digest; pulling '%s:latest'. "
+                "Pin to a digest (image@sha256:...) for reproducible "
+                "sandbox provisioning.",
+                target,
+                target,
+            )
 
-        self._client.images.pull(repo, tag=tag)
+        if tag is None:
+            self._client.images.pull(repo)
+        else:
+            self._client.images.pull(repo, tag=tag)
         logger.info("Pulled image '%s' successfully", target)
 
     # ------------------------------------------------------------------
@@ -734,11 +780,22 @@ class DockerSandboxProvider(SandboxProvider):
             "network_disabled": not config.network_enabled,
             "read_only": config.read_only_fs,
             "tmpfs": tmpfs,
-            "security_opt": ["no-new-privileges"],
+            # Be explicit about seccomp and apparmor so that hosts which
+            # have customized the Docker daemon defaults to weaker policies
+            # do not silently weaken the sandbox. `default` resolves to
+            # Docker's built-in profile on hosts that ship one.
+            "security_opt": [
+                "no-new-privileges",
+                "seccomp=default",
+                "apparmor=docker-default",
+            ],
             "cap_drop": ["ALL"],
             "user": "65534:65534",
             "working_dir": "/workspace",
-            "pids_limit": 256,
+            # 128 covers Python interpreters with thread pools and modest
+            # subprocess fan-out; 256 was generous enough to mask fork-bomb
+            # style misbehavior in tests.
+            "pids_limit": 128,
             # Resolve host.docker.internal on native Linux Docker
             # (Docker Desktop on macOS/Windows does this automatically)
             "extra_hosts": {"host.docker.internal": "host-gateway"},

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -815,12 +815,16 @@ class TestContainerCreationHardening:
         p, client = self._make_raw_provider()
         p._create_container("a1", "s1", SandboxConfig())
         kw = client.containers.run.call_args[1]
-        assert kw["security_opt"] == ["no-new-privileges"]
+        assert kw["security_opt"] == [
+            "no-new-privileges",
+            "seccomp=default",
+            "apparmor=docker-default",
+        ]
         assert kw["cap_drop"] == ["ALL"]
         assert kw["read_only"] is True
         assert kw["user"] == "65534:65534"
         assert kw["working_dir"] == "/workspace"
-        assert kw["pids_limit"] == 256
+        assert kw["pids_limit"] == 128
         assert kw["network_disabled"] is True
         assert kw["mem_limit"] == "512m"
         assert kw["detach"] is True
@@ -1560,9 +1564,22 @@ class TestEnvVarSanitization:
     def test_blocked_vars_constant_complete(self):
         """Ensure all known dangerous vars are in the blocklist."""
         expected = {
+            # glibc dynamic linker
             "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT",
             "LD_DEBUG", "LD_PROFILE", "LD_SHOW_AUXV",
-            "LD_DYNAMIC_WEAK", "PYTHONSTARTUP", "PYTHONPATH",
+            "LD_DYNAMIC_WEAK",
+            # POSIX shell startup hooks
+            "BASH_ENV", "ENV",
+            # Python
+            "PYTHONSTARTUP", "PYTHONPATH", "PYTHONHOME",
+            # Node.js
+            "NODE_OPTIONS",
+            # Ruby
+            "RUBYOPT",
+            # Perl
+            "PERL5LIB", "PERL5OPT",
+            # Java
+            "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS",
         }
         assert _BLOCKED_ENV_VARS == expected
 
@@ -1884,3 +1901,134 @@ class TestThreadSafety:
         assert docker_provider._containers == {}
         assert docker_provider._evaluators == {}
         assert docker_provider._session_configs == {}
+
+
+class TestHardeningAdditions:
+    """Regression coverage for the audit-driven hardening changes."""
+
+    def test_security_opt_includes_seccomp_and_apparmor(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        with patch(
+            "agent_sandbox.docker_provider.provider.DockerSandboxProvider.__init__",
+            return_value=None,
+        ):
+            p = DockerSandboxProvider.__new__(DockerSandboxProvider)
+            p._image = "python:3.11-slim"
+            p._runtime = IsolationRuntime.RUNC
+            client = MagicMock()
+            client.images.get.return_value = MagicMock()
+            client.containers.run.return_value = MagicMock()
+            p._client = client
+
+        p._create_container("a1", "s1", SandboxConfig())
+        kw = client.containers.run.call_args[1]
+        assert "seccomp=default" in kw["security_opt"]
+        assert "apparmor=docker-default" in kw["security_opt"]
+
+    def test_pids_limit_tightened_to_128(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        with patch(
+            "agent_sandbox.docker_provider.provider.DockerSandboxProvider.__init__",
+            return_value=None,
+        ):
+            p = DockerSandboxProvider.__new__(DockerSandboxProvider)
+            p._image = "python:3.11-slim"
+            p._runtime = IsolationRuntime.RUNC
+            client = MagicMock()
+            client.images.get.return_value = MagicMock()
+            client.containers.run.return_value = MagicMock()
+            p._client = client
+
+        p._create_container("a1", "s1", SandboxConfig())
+        kw = client.containers.run.call_args[1]
+        assert kw["pids_limit"] == 128
+
+    def test_blocked_envs_new_loaders(self):
+        env = {
+            "BASH_ENV": "/x",
+            "PYTHONHOME": "/x",
+            "NODE_OPTIONS": "--inspect",
+            "RUBYOPT": "-rmal",
+            "PERL5LIB": "/x",
+            "JAVA_TOOL_OPTIONS": "-javaagent:/x",
+            "_JAVA_OPTIONS": "-X",
+            "APP_SAFE": "ok",
+        }
+        result = _sanitize_env_vars(env)
+        for k in ("BASH_ENV", "PYTHONHOME", "NODE_OPTIONS", "RUBYOPT",
+                  "PERL5LIB", "JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS"):
+            assert k not in result, f"{k} must be blocked"
+        assert result["APP_SAFE"] == "ok"
+
+    def test_users_root_blocked_but_subdir_allowed(self, monkeypatch):
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+        monkeypatch.setattr("os.path.realpath", lambda p: p)
+        assert _is_protected_path("C:\\Users") is True
+        # Existing maintainer design: a specific user's working subdir is fine.
+        assert _is_protected_path("C:\\Users\\agent\\workspace") is False
+
+    def test_ensure_image_warns_when_unpinned(self, caplog):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        with patch(
+            "agent_sandbox.docker_provider.provider.DockerSandboxProvider.__init__",
+            return_value=None,
+        ):
+            p = DockerSandboxProvider.__new__(DockerSandboxProvider)
+            p._image = "python"
+            client = MagicMock()
+            # First call: images.get raises -> need to pull.
+            client.images.get.side_effect = Exception("not present")
+            client.images.pull.return_value = MagicMock()
+            p._client = client
+
+        with caplog.at_level("WARNING", logger="agent_sandbox.docker_provider.provider"):
+            p.ensure_image()
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert any("digest" in r.getMessage() for r in warnings)
+        # And: pull was actually attempted with ('python', tag='latest')
+        client.images.pull.assert_called_once_with("python", tag="latest")
+
+    def test_ensure_image_no_warning_when_tagged(self, caplog):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        with patch(
+            "agent_sandbox.docker_provider.provider.DockerSandboxProvider.__init__",
+            return_value=None,
+        ):
+            p = DockerSandboxProvider.__new__(DockerSandboxProvider)
+            p._image = "python:3.11-slim"
+            client = MagicMock()
+            client.images.get.side_effect = Exception("not present")
+            client.images.pull.return_value = MagicMock()
+            p._client = client
+
+        with caplog.at_level("WARNING", logger="agent_sandbox.docker_provider.provider"):
+            p.ensure_image()
+
+        assert not any(
+            "digest" in r.getMessage() for r in caplog.records
+            if r.levelname == "WARNING"
+        )
+
+    def test_ensure_image_digest_uses_no_tag(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        with patch(
+            "agent_sandbox.docker_provider.provider.DockerSandboxProvider.__init__",
+            return_value=None,
+        ):
+            p = DockerSandboxProvider.__new__(DockerSandboxProvider)
+            p._image = "python@sha256:abc123"
+            client = MagicMock()
+            client.images.get.side_effect = Exception("not present")
+            client.images.pull.return_value = MagicMock()
+            p._client = client
+
+        p.ensure_image()
+        # Digest-pinned images must NOT have a tag passed; Docker SDK requires
+        # the digest reference to be the full repo argument with no tag.
+        client.images.pull.assert_called_once_with("python@sha256:abc123")


### PR DESCRIPTION
## Summary

Three same-file hardening gaps in `agent_sandbox/docker_provider/provider.py`:

1. **Loader env blocklist was narrow.** `_BLOCKED_ENV_VARS` covered the glibc `LD_*` family, `PYTHONSTARTUP`, and `PYTHONPATH`. It missed every other interpreter / loader startup hook. Added: `BASH_ENV`, `ENV` (POSIX shell), `PYTHONHOME`, `NODE_OPTIONS`, `RUBYOPT`, `PERL5LIB`, `PERL5OPT`, `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`. Each is sourced by its language runtime at startup and would redirect code execution before the sandbox's entrypoint runs.

2. **Container hardening was implicit.** `security_opt` was just `[\"no-new-privileges\"]`. Hosts that have customized the Docker daemon to weaker seccomp/apparmor defaults would silently get a less-hardened sandbox. Now explicit: `[\"no-new-privileges\", \"seccomp=default\", \"apparmor=docker-default\"]`. Also tightened `pids_limit` from 256 → 128 (still ample for Python interpreters with thread pools and modest subprocess fan-out).

3. **`ensure_image` silently pulled `:latest`.** When a caller passed an image reference without a tag or digest, the provider would resolve it to `:latest` with no warning, undermining the reproducibility a sandbox base image needs. Now logs a `WARNING` pointing operators at digest pinning. Behavior preserved for callers who pin. Digest-pinned references (`image@sha256:...`) now correctly pull with no tag argument — the previous code split on the colon inside the digest.

4. **`C:\Users` was not in the Windows protected-path set.** Mounting `C:\Users` exposes every user profile (documents, browser profiles, SSH keys). The existing test suite explicitly allows specific subdirectories like `C:\Users\agent\workspace` as a legitimate per-user pattern, so a prefix-match would have over-blocked. Added a separate exact-match-only set for paths where only the root is dangerous; subdirectories remain mountable.

## Test plan

- [x] `pytest agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py` — 191 pass, 5 unrelated skips, 1 pre-existing failure (`test_drive_letter_only_blocked`, fails on `main` too — `os.path.realpath(\"D:\")` resolves the current dir on D: on Windows hosts where that drive exists)
- [x] Updated `test_hardening_flags` to assert the new `security_opt` triplet and `pids_limit=128`
- [x] Updated `test_blocked_vars_constant_complete` to assert the broader `_BLOCKED_ENV_VARS` set
- [x] New `test_security_opt_includes_seccomp_and_apparmor` / `test_pids_limit_tightened_to_128`
- [x] New `test_blocked_envs_new_loaders` covers every newly-blocked var
- [x] New `test_users_root_blocked_but_subdir_allowed` confirms `C:\Users` exact match blocks but `C:\Users\agent\workspace` still allowed
- [x] New `test_ensure_image_warns_when_unpinned` / `test_ensure_image_no_warning_when_tagged` / `test_ensure_image_digest_uses_no_tag`

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Isolation]