### PR TITLE
fix(hypervisor/event-bus): bound in-memory store, lock-protect emit

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/observability/event_bus.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/observability/event_bus.py
@@ -10,12 +10,20 @@ full replay debugging, post-mortem analysis, and real-time monitoring.
 
 from __future__ import annotations
 
+import threading
 import uuid
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
+
+# Default cap for the in-memory event store. Hypervisor deployments run for
+# weeks; an unbounded list eventually OOMs. The cap is configurable via the
+# ``HypervisorEventBus(max_events=...)`` constructor; ``None`` opts back into
+# unbounded growth for tests or analysis tooling that needs full history.
+DEFAULT_MAX_EVENTS = 100_000
 
 
 class EventType(str, Enum):
@@ -119,34 +127,61 @@ class HypervisorEventBus:
     - Event count and statistics
     """
 
-    def __init__(self) -> None:
-        self._events: list[HypervisorEvent] = []
+    def __init__(self, max_events: int | None = DEFAULT_MAX_EVENTS) -> None:
+        """Create an event bus.
+
+        ``max_events`` caps the in-memory store. Each per-key index list
+        (by-type, by-session, by-agent) is independently capped to the
+        same value, so a single chatty session cannot starve the
+        history of other sessions. Pass ``None`` to disable the cap
+        (testing or full-replay tooling).
+        """
+        self._max_events = max_events
+        # `deque` with `maxlen` evicts the oldest entry on overflow in
+        # O(1), avoiding the OOM cliff of an unbounded `list`.
+        self._events: deque[HypervisorEvent] = deque(maxlen=max_events)
         self._subscribers: dict[EventType | None, list[EventHandler]] = {}
-        self._by_type: dict[EventType, list[HypervisorEvent]] = {}
-        self._by_session: dict[str, list[HypervisorEvent]] = {}
-        self._by_agent: dict[str, list[HypervisorEvent]] = {}
+        self._by_type: dict[EventType, deque[HypervisorEvent]] = {}
+        self._by_session: dict[str, deque[HypervisorEvent]] = {}
+        self._by_agent: dict[str, deque[HypervisorEvent]] = {}
+        # Use an RLock so a subscriber that re-enters the bus (e.g.
+        # emits an event in response to another event) doesn't deadlock.
+        self._lock = threading.RLock()
+
+    def _new_index_deque(self) -> deque[HypervisorEvent]:
+        return deque(maxlen=self._max_events)
 
     def emit(self, event: HypervisorEvent) -> None:
         """Append an event and notify subscribers."""
-        self._events.append(event)
+        with self._lock:
+            self._events.append(event)
 
-        # Index by type
-        self._by_type.setdefault(event.event_type, []).append(event)
+            self._by_type.setdefault(
+                event.event_type, self._new_index_deque()
+            ).append(event)
 
-        # Index by session
-        if event.session_id:
-            self._by_session.setdefault(event.session_id, []).append(event)
+            if event.session_id:
+                self._by_session.setdefault(
+                    event.session_id, self._new_index_deque()
+                ).append(event)
 
-        # Index by agent
-        if event.agent_did:
-            self._by_agent.setdefault(event.agent_did, []).append(event)
+            if event.agent_did:
+                self._by_agent.setdefault(
+                    event.agent_did, self._new_index_deque()
+                ).append(event)
 
-        # Notify type-specific subscribers
-        for handler in self._subscribers.get(event.event_type, []):
+            # Snapshot subscriber lists while holding the lock so a
+            # subscriber that mutates the registry mid-notify doesn't
+            # invalidate iteration.
+            type_subs = list(self._subscribers.get(event.event_type, ()))
+            wildcard_subs = list(self._subscribers.get(None, ()))
+
+        # Invoke handlers outside the lock so a slow subscriber can't
+        # serialize the entire bus or, worse, deadlock with a caller
+        # that also holds an external lock.
+        for handler in type_subs:
             handler(event)
-
-        # Notify wildcard subscribers
-        for handler in self._subscribers.get(None, []):
+        for handler in wildcard_subs:
             handler(event)
 
     def subscribe(
@@ -155,20 +190,25 @@ class HypervisorEventBus:
         handler: EventHandler | None = None,
     ) -> None:
         """Subscribe to events. Use event_type=None for all events."""
-        if handler:
+        if not handler:
+            return
+        with self._lock:
             self._subscribers.setdefault(event_type, []).append(handler)
 
     def query_by_type(self, event_type: EventType) -> list[HypervisorEvent]:
         """Get all events of a specific type."""
-        return list(self._by_type.get(event_type, []))
+        with self._lock:
+            return list(self._by_type.get(event_type, ()))
 
     def query_by_session(self, session_id: str) -> list[HypervisorEvent]:
         """Get all events for a specific session."""
-        return list(self._by_session.get(session_id, []))
+        with self._lock:
+            return list(self._by_session.get(session_id, ()))
 
     def query_by_agent(self, agent_did: str) -> list[HypervisorEvent]:
         """Get all events involving a specific agent."""
-        return list(self._by_agent.get(agent_did, []))
+        with self._lock:
+            return list(self._by_agent.get(agent_did, ()))
 
     def query_by_time_range(
         self,
@@ -178,7 +218,8 @@ class HypervisorEventBus:
         """Get events within a time range."""
         if end is None:
             end = datetime.now(UTC)
-        return [e for e in self._events if start <= e.timestamp <= end]
+        with self._lock:
+            return [e for e in self._events if start <= e.timestamp <= end]
 
     def query(
         self,
@@ -188,7 +229,8 @@ class HypervisorEventBus:
         limit: int | None = None,
     ) -> list[HypervisorEvent]:
         """Flexible query with multiple filters."""
-        results = self._events
+        with self._lock:
+            results: list[HypervisorEvent] = list(self._events)
 
         if event_type is not None:
             results = [e for e in results if e.event_type == event_type]
@@ -204,19 +246,23 @@ class HypervisorEventBus:
 
     @property
     def event_count(self) -> int:
-        return len(self._events)
+        with self._lock:
+            return len(self._events)
 
     @property
     def all_events(self) -> list[HypervisorEvent]:
-        return list(self._events)
+        with self._lock:
+            return list(self._events)
 
     def type_counts(self) -> dict[str, int]:
         """Return count of events per type."""
-        return {t.value: len(evts) for t, evts in self._by_type.items()}
+        with self._lock:
+            return {t.value: len(evts) for t, evts in self._by_type.items()}
 
     def clear(self) -> None:
         """Clear all events (for testing)."""
-        self._events.clear()
-        self._by_type.clear()
-        self._by_session.clear()
-        self._by_agent.clear()
+        with self._lock:
+            self._events.clear()
+            self._by_type.clear()
+            self._by_session.clear()
+            self._by_agent.clear()

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_observability.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_observability.py
@@ -215,3 +215,105 @@ class TestCausalTraceId:
         for _i in range(5):
             trace = trace.child()
         assert trace.depth == 5
+
+
+class TestEventBusBounds:
+    """Regression: event bus must be bounded and emit must be lock-safe."""
+
+    def test_main_log_capped_by_max_events(self):
+        bus = HypervisorEventBus(max_events=10)
+        for i in range(25):
+            bus.emit(
+                HypervisorEvent(
+                    event_type=EventType.SESSION_CREATED,
+                    session_id=f"sess-{i}",
+                )
+            )
+        # 25 emits, cap 10 -> oldest 15 evicted; newest 10 remain.
+        assert bus.event_count == 10
+        events = bus.all_events
+        assert events[0].session_id == "sess-15"
+        assert events[-1].session_id == "sess-24"
+
+    def test_per_type_index_capped(self):
+        bus = HypervisorEventBus(max_events=5)
+        for i in range(12):
+            bus.emit(
+                HypervisorEvent(
+                    event_type=EventType.SESSION_CREATED,
+                    session_id=f"sess-{i}",
+                )
+            )
+        by_type = bus.query_by_type(EventType.SESSION_CREATED)
+        assert len(by_type) == 5
+        # Oldest entries evicted; newest 5 survive.
+        assert by_type[0].session_id == "sess-7"
+
+    def test_per_session_index_capped(self):
+        bus = HypervisorEventBus(max_events=4)
+        for i in range(20):
+            bus.emit(
+                HypervisorEvent(
+                    event_type=EventType.VFS_WRITE,
+                    session_id="busy-session",
+                )
+            )
+        # One chatty session must not starve the index: still capped at 4.
+        assert len(bus.query_by_session("busy-session")) == 4
+
+    def test_unbounded_mode_via_none(self):
+        bus = HypervisorEventBus(max_events=None)
+        for i in range(50):
+            bus.emit(HypervisorEvent(event_type=EventType.SESSION_CREATED))
+        assert bus.event_count == 50
+
+    def test_emit_is_thread_safe(self):
+        import threading
+
+        bus = HypervisorEventBus(max_events=10000)
+        N_THREADS, N_PER_THREAD = 8, 250
+
+        def producer(thread_idx: int) -> None:
+            for i in range(N_PER_THREAD):
+                bus.emit(
+                    HypervisorEvent(
+                        event_type=EventType.VFS_WRITE,
+                        session_id=f"t{thread_idx}",
+                        payload={"i": i},
+                    )
+                )
+
+        threads = [
+            threading.Thread(target=producer, args=(t,))
+            for t in range(N_THREADS)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Without the lock, the indexes would race and lose entries or
+        # store duplicates. The total must match exactly.
+        assert bus.event_count == N_THREADS * N_PER_THREAD
+        for tidx in range(N_THREADS):
+            assert len(bus.query_by_session(f"t{tidx}")) == N_PER_THREAD
+
+    def test_subscriber_re_entry_does_not_deadlock(self):
+        """A handler that emits another event must not deadlock the bus."""
+        bus = HypervisorEventBus(max_events=100)
+        seen: list[HypervisorEvent] = []
+
+        def re_emit_on_first(event: HypervisorEvent) -> None:
+            seen.append(event)
+            if event.event_type == EventType.SESSION_CREATED:
+                # Re-enter: handler emits a follow-up event.
+                bus.emit(
+                    HypervisorEvent(event_type=EventType.RING_ASSIGNED)
+                )
+
+        bus.subscribe(None, re_emit_on_first)
+        bus.emit(HypervisorEvent(event_type=EventType.SESSION_CREATED))
+        # Both the original and the re-emitted event must be observed,
+        # and the call must return.
+        assert any(e.event_type == EventType.SESSION_CREATED for e in seen)
+        assert any(e.event_type == EventType.RING_ASSIGNED for e in seen)


### PR DESCRIPTION
## Summary

`HypervisorEventBus` stored every emitted event in an unbounded `list` plus three unbounded index `dict[..., list]`s. A hypervisor process typically runs for weeks at a constant emit rate — the in-memory store grows without bound and the process eventually OOMs. `emit()` was also lock-free: concurrent threads racing through `setdefault(...).append(...)` could either lose events or store duplicates in the indexes.

Changes:

- Store events in `deque(maxlen=DEFAULT_MAX_EVENTS=100_000)`. The deque evicts the oldest entry on overflow in O(1). Constructor exposes `HypervisorEventBus(max_events=N)`; pass `None` to opt back into unbounded growth for tests or full-replay tooling.
- Apply the same cap to each per-type / per-session / per-agent index deque so a single chatty session cannot starve the others' index history.
- `threading.RLock` protects every mutation and read snapshot. `RLock` (not `Lock`) so a subscriber that re-enters the bus (e.g. emits another event from its handler) cannot deadlock. Subscriber callbacks are invoked **outside** the lock so a slow handler cannot serialize the whole bus.
- Snapshot the subscriber list while holding the lock so a subscriber that mutates the registry mid-notify cannot invalidate iteration.

## Test plan

- [x] `pytest agent-governance-python/agent-hypervisor/tests/unit/test_observability.py` — 28 pass (existing 22 + 6 new)
- [x] `test_main_log_capped_by_max_events` — 25 emits with cap 10 keeps the newest 10
- [x] `test_per_type_index_capped` / `test_per_session_index_capped` — index deques honor the same cap
- [x] `test_unbounded_mode_via_none` — `max_events=None` preserves the original unbounded behavior
- [x] `test_emit_is_thread_safe` — 8 threads × 250 emits = exactly 2000 events; per-session deques have exactly 250 each
- [x] `test_subscriber_re_entry_does_not_deadlock` — a handler that emits a follow-up event completes (RLock allows re-entry)

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Isolation]