### PR TITLE
fix(hypervisor/breach-detector): use elapsed window for early-burst rate

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/breach_detector.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/breach_detector.py
@@ -127,8 +127,24 @@ class RingBreachDetector:
             window.popleft()
 
         # --- 3. Compute actual rate (calls / second) ---
+        # Dividing by the full ``window_seconds`` underestimates the rate
+        # when the window has just begun — 10 calls in the first 2s of a
+        # 60s window would read as 0.16/s instead of 5/s, missing real
+        # bursts. Use the shorter of (window, time_since_first_event)
+        # as the denominator so early bursts surface accurately. A single
+        # call has no rate to measure (need ≥2 samples for an interval),
+        # so fall back to the conservative full-window divisor.
         call_count = len(window)
-        actual_rate = call_count / self.window_seconds if self.window_seconds > 0 else 0.0
+        if self.window_seconds <= 0 or call_count == 0:
+            actual_rate = 0.0
+        elif call_count < 2:
+            actual_rate = call_count / self.window_seconds
+        else:
+            time_since_first = max(now - window[0], 0.0)
+            # Floor at 1ms: prevents divide-by-zero for ultra-tight
+            # bursts while still surfacing them with a high rate.
+            denominator = max(min(self.window_seconds, time_since_first), 1e-3)
+            actual_rate = call_count / denominator
 
         # --- 4. Ring-distance amplifier ---
         #   Upward calls (low value = higher privilege) are escalations.

--- a/agent-governance-python/agent-hypervisor/tests/test_breach_detector.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_breach_detector.py
@@ -250,3 +250,47 @@ class TestRingBreachDetector:
         detector = RingBreachDetector()
         detector.reset_breaker("did:example:a", "s1")
         assert detector.breach_count == 0
+
+
+class TestRateDenominator:
+    """Regression: early-window bursts must surface, not get diluted by
+    a stale full-window divisor."""
+
+    def test_early_burst_uses_elapsed_window(self):
+        """A burst of 20 calls in ~1ms of a 60s window must read as a
+        high rate, not 20/60≈0.33/s."""
+        detector = RingBreachDetector(
+            window_seconds=60.0,
+            baseline_rate=1.0,
+        )
+        last = None
+        for _ in range(20):
+            last = detector.record_call(
+                "did:example:a",
+                "s1",
+                ExecutionRing.RING_2_STANDARD,
+                ExecutionRing.RING_2_STANDARD,
+            )
+        # The actual measured rate over a ~1ms span of 20 events must
+        # be well above baseline_rate=1.0/s — confirming the burst is
+        # not diluted by the full 60s denominator.
+        assert last is not None
+        assert last.actual_rate > 1.0
+        # And the burst should rise above NONE severity.
+        assert last.severity != BreachSeverity.NONE
+
+    def test_single_call_uses_window_divisor(self):
+        """A single call has no rate to measure; fall back to the
+        conservative full-window divisor so we don't trip on noise."""
+        detector = RingBreachDetector(
+            window_seconds=60.0,
+            baseline_rate=1.0,
+        )
+        result = detector.record_call(
+            "did:example:a",
+            "s1",
+            ExecutionRing.RING_2_STANDARD,
+            ExecutionRing.RING_2_STANDARD,
+        )
+        # 1 call / 60s = 0.0167/s ≪ baseline; must not trip.
+        assert result is None or result.severity == BreachSeverity.NONE


### PR DESCRIPTION
## Summary

`RingBreachDetector.record_call` measures the rate of ring transitions over a sliding window. The denominator was a constant `window_seconds`, which dilutes early bursts: with `window_seconds=60` and `baseline_rate=1.0/s`, a burst of 20 calls within the first 2 seconds of the window reads as 0.33/s — well *below* baseline — and the detector misses the breach entirely.

Fix: use `min(window_seconds, time_since_first_event)` as the denominator so the measurement window matches what has actually elapsed within the current sliding window.

Edge cases:

- `call_count < 2`: no rate can be measured from a single sample; fall back to the conservative full-window divisor so we don't trip on noise.
- Sub-millisecond bursts: floor the denominator at 1ms (1e-3) to prevent divide-by-zero while still surfacing the burst with a high rate.
- Empty window or zero `window_seconds`: `actual_rate = 0`, unchanged.

## Test plan

- [x] `pytest agent-governance-python/agent-hypervisor/tests/test_breach_detector.py` — 19 pass (existing 17 + 2 new)
- [x] `test_early_burst_uses_elapsed_window`: 20 calls in ~1ms of a 60s window yields a rate well above baseline and a non-NONE severity
- [x] `test_single_call_uses_window_divisor`: a single call still uses the conservative `1/window_seconds` divisor and does not trip

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Isolation]