### PR TITLE
fix(sre/alerts/dedup): add atomic consume() to close check-then-act race

### DIFF
--- a/agent-governance-python/agent-sre/src/agent_sre/alerts/dedup.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/alerts/dedup.py
@@ -64,8 +64,44 @@ class AlertDeduplicator:
 
     # -- public API ----------------------------------------------------------
 
+    def consume(self, alert: Alert) -> bool:
+        """Atomically check-and-record an alert for delivery.
+
+        Returns ``True`` if the caller should deliver *alert*, in which
+        case the alert is already recorded as sent so subsequent
+        concurrent callers see it as suppressed. Use this in place of
+        the separate ``should_send`` / ``record`` pair when delivery is
+        driven from multiple threads — the pair has a check-then-act
+        race that lets two threads both deliver the same alert.
+        """
+        with self._lock:
+            self._total_received += 1
+            fp = alert_fingerprint(alert, self._group_by)
+
+            if alert.severity == AlertSeverity.RESOLVED:
+                self._sent.pop(fp, None)
+                return True
+
+            now = time.time()
+            last = self._sent.get(fp)
+            if last is not None and (now - last) < self._window_seconds:
+                self._total_deduplicated += 1
+                return False
+
+            self._sent[fp] = now
+            return True
+
     def should_send(self, alert: Alert) -> bool:
-        """Return True if *alert* is novel and should be delivered."""
+        """Return True if *alert* is novel and should be delivered.
+
+        .. note::
+            For multi-threaded delivery, prefer :meth:`consume`, which
+            atomically combines this check with :meth:`record`. The
+            ``should_send`` → send → ``record`` pattern has a race:
+            two threads can both observe "no last-sent" between the
+            ``should_send`` check and the ``record`` write, and both
+            deliver the alert.
+        """
         with self._lock:
             self._total_received += 1
 
@@ -84,7 +120,10 @@ class AlertDeduplicator:
             return True
 
     def record(self, alert: Alert) -> None:
-        """Record that *alert* was sent (update window timestamp)."""
+        """Record that *alert* was sent (update window timestamp).
+
+        See :meth:`consume` for the atomic check-and-record alternative.
+        """
         with self._lock:
             fp = alert_fingerprint(alert, self._group_by)
             if alert.severity == AlertSeverity.RESOLVED:

--- a/agent-governance-python/agent-sre/tests/test_alert_dedup.py
+++ b/agent-governance-python/agent-sre/tests/test_alert_dedup.py
@@ -358,3 +358,76 @@ class TestDeduplicatorWithManager:
         for alert in batcher.flush():
             manager.send(alert)
         assert len(received) == 3
+
+
+class TestConsumeAtomic:
+    """Regression: ``consume`` must be a check-and-record atom, so two
+    threads racing on the same fingerprint cannot both win."""
+
+    def _make_alert(self, agent_id: str = "a1", title: str = "x"):
+        from agent_sre.alerts import Alert, AlertSeverity
+
+        return Alert(
+            severity=AlertSeverity.WARNING,
+            title=title,
+            message="test",
+            agent_id=agent_id,
+            timestamp=time.time(),
+        )
+
+    def test_consume_first_returns_true_then_false(self):
+        dedup = AlertDeduplicator(window_seconds=10)
+        alert = self._make_alert()
+        assert dedup.consume(alert) is True
+        assert dedup.consume(alert) is False
+
+    def test_consume_atomic_under_threads(self):
+        """Hammer the same fingerprint from many threads; at most one
+        consume() call may return True. The should_send/record pair
+        cannot guarantee this — it has a check-then-act gap."""
+        import threading
+
+        dedup = AlertDeduplicator(window_seconds=60)
+        alert = self._make_alert()
+
+        wins: list[bool] = []
+        wins_lock = threading.Lock()
+        start = threading.Event()
+
+        def worker() -> None:
+            start.wait()
+            ok = dedup.consume(alert)
+            with wins_lock:
+                wins.append(ok)
+
+        threads = [threading.Thread(target=worker) for _ in range(50)]
+        for t in threads:
+            t.start()
+        start.set()
+        for t in threads:
+            t.join()
+
+        # Exactly one thread can have won; the rest must see a
+        # suppressed return.
+        assert sum(1 for w in wins if w) == 1
+        assert sum(1 for w in wins if not w) == 49
+
+    def test_consume_resolved_always_passes(self):
+        from agent_sre.alerts import Alert, AlertSeverity
+
+        dedup = AlertDeduplicator(window_seconds=60)
+        # Prime with a warning so the fingerprint window is active.
+        warning = self._make_alert()
+        assert dedup.consume(warning) is True
+        assert dedup.consume(warning) is False
+
+        resolved = Alert(
+            severity=AlertSeverity.RESOLVED,
+            title=warning.title,
+            message="cleared",
+            agent_id=warning.agent_id,
+        )
+        # RESOLVED always passes through and clears the window.
+        assert dedup.consume(resolved) is True
+        # Window cleared: the next warning consume returns True again.
+        assert dedup.consume(self._make_alert()) is True


### PR DESCRIPTION
## Summary

`AlertDeduplicator` exposed two methods (`should_send` and `record`) that each take the lock individually but cannot be safely composed across threads. The recommended delivery pattern was:

```python
if dedup.should_send(alert):
    notifier.send(alert)
    dedup.record(alert)
```

Two threads racing on the same fingerprint can both observe "no last-sent" between the `should_send` check and the `record` write, and both deliver the same alert. The window between the two calls is exactly where the race lives.

This PR adds `AlertDeduplicator.consume(alert) -> bool` which atomically checks and records under a single lock acquisition. Returns `True` exactly once per fingerprint per window across racing threads; subsequent callers see the alert as suppressed.

`should_send` and `record` are retained for back-compat with a docstring note pointing users at the atomic alternative. RESOLVED-severity semantics (always passes, clears the window) are preserved in `consume`.

## Test plan

- [x] `pytest tests/test_alert_dedup.py` — 33 pass (existing 30 + 3 new)
- [x] `test_consume_first_returns_true_then_false` — sequential atomicity
- [x] `test_consume_atomic_under_threads` — 50 threads hammer the same fingerprint; **exactly one** consume() returns True; the other 49 return False
- [x] `test_consume_resolved_always_passes` — RESOLVED clears the window and the next WARNING passes again

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Isolation]