### PR TITLE
fix(kill-switch): bound callback runtime; lock-protect kill state

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/security/kill_switch.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/security/kill_switch.py
@@ -10,6 +10,7 @@ in-flight saga steps to a substitute agent when one is available.
 from __future__ import annotations
 
 import logging
+import threading
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -17,6 +18,11 @@ from datetime import UTC, datetime
 from enum import Enum
 
 _logger = logging.getLogger(__name__)
+
+# Maximum wall time we wait for an agent's termination callback to complete
+# before declaring it hung. The kill switch must remain responsive — a slow
+# callback should not block the entire kill flow.
+DEFAULT_CALLBACK_TIMEOUT_SECONDS = 5.0
 
 
 class KillReason(str, Enum):
@@ -76,10 +82,16 @@ class KillSwitch:
     callback to stop the agent process.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self, callback_timeout: float = DEFAULT_CALLBACK_TIMEOUT_SECONDS
+    ) -> None:
         self._kill_history: list[KillResult] = []
         self._substitutes: dict[str, list[str]] = {}
         self._agents: dict[str, Callable[[], None]] = {}
+        self._callback_timeout = callback_timeout
+        # RLock so a callback that itself re-enters the kill switch
+        # (e.g. unregisters another agent) does not deadlock.
+        self._lock = threading.RLock()
 
     # ── Agent process registry ─────────────────────────────────────
 
@@ -87,11 +99,13 @@ class KillSwitch:
         self, agent_did: str, process_handle: Callable[[], None]
     ) -> None:
         """Register an agent with its termination callback."""
-        self._agents[agent_did] = process_handle
+        with self._lock:
+            self._agents[agent_did] = process_handle
 
     def unregister_agent(self, agent_did: str) -> None:
         """Remove an agent from the process registry."""
-        self._agents.pop(agent_did, None)
+        with self._lock:
+            self._agents.pop(agent_did, None)
 
     # ── Substitute management ──────────────────────────────────────
 
@@ -99,14 +113,16 @@ class KillSwitch:
         self, session_id: str, agent_did: str
     ) -> None:
         """Register a substitute agent for a session."""
-        self._substitutes.setdefault(session_id, []).append(agent_did)
+        with self._lock:
+            self._substitutes.setdefault(session_id, []).append(agent_did)
 
     def unregister_substitute(
         self, session_id: str, agent_did: str
     ) -> None:
-        subs = self._substitutes.get(session_id, [])
-        if agent_did in subs:
-            subs.remove(agent_did)
+        with self._lock:
+            subs = self._substitutes.get(session_id, [])
+            if agent_did in subs:
+                subs.remove(agent_did)
 
     # ── Kill ───────────────────────────────────────────────────────
 
@@ -121,8 +137,9 @@ class KillSwitch:
         """Kill an agent, handing off in-flight steps to a substitute if available."""
         in_flight = in_flight_steps or []
 
-        # Attempt to find a substitute for handoff
-        substitute = self._find_substitute(session_id, agent_did)
+        with self._lock:
+            substitute = self._find_substitute(session_id, agent_did)
+            callback = self._agents.get(agent_did)
 
         handoffs: list[StepHandoff] = []
         handoff_success_count = 0
@@ -148,12 +165,14 @@ class KillSwitch:
                     )
                 )
 
-        # Terminate the agent process
+        # Invoke the termination callback *outside* the lock and with a
+        # wall-clock timeout. A slow or hung callback must not freeze the
+        # kill flow — the whole point of a kill switch is responsiveness.
         terminated = False
-        callback = self._agents.get(agent_did)
         if callback is not None:
-            callback()
-            terminated = True
+            terminated = self._invoke_callback_with_timeout(
+                agent_did, callback
+            )
         else:
             _logger.warning(
                 "No termination callback registered for agent %s",
@@ -172,10 +191,52 @@ class KillSwitch:
             terminated=terminated,
             details=details,
         )
-        self._kill_history.append(result)
+        with self._lock:
+            self._kill_history.append(result)
         self.unregister_substitute(session_id, agent_did)
         self.unregister_agent(agent_did)
         return result
+
+    def _invoke_callback_with_timeout(
+        self, agent_did: str, callback: Callable[[], None]
+    ) -> bool:
+        """Run *callback* in a daemon thread bounded by ``callback_timeout``.
+
+        Returns ``True`` if the callback completed cleanly within the
+        timeout, ``False`` if it timed out or raised. A hung callback
+        is left to its fate (daemon thread); the kill switch returns
+        and remains usable for the next kill.
+        """
+        error_box: list[BaseException] = []
+
+        def _runner() -> None:
+            try:
+                callback()
+            except BaseException as exc:  # noqa: BLE001 — surface but don't propagate
+                error_box.append(exc)
+
+        thread = threading.Thread(
+            target=_runner, name=f"kill-callback:{agent_did}", daemon=True
+        )
+        thread.start()
+        thread.join(timeout=self._callback_timeout)
+
+        if thread.is_alive():
+            _logger.error(
+                "Termination callback for %s exceeded %.2fs; leaving daemon thread to drain",
+                agent_did,
+                self._callback_timeout,
+            )
+            return False
+        if error_box:
+            _logger.error(
+                "Termination callback for %s raised %s: %s",
+                agent_did,
+                type(error_box[0]).__name__,
+                error_box[0],
+            )
+            return False
+        return True
 
     def _find_substitute(
         self, session_id: str, exclude_did: str

--- a/agent-governance-python/agent-hypervisor/tests/test_kill_switch.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_kill_switch.py
@@ -234,3 +234,74 @@ class TestKillSwitch:
         ks.register_substitute("s1", "backup")
         ks.kill("a1", "s1", KillReason.MANUAL, [{"step_id": "s1", "saga_id": "sg1"}])
         assert ks.total_handoffs == 1
+
+
+class TestKillSwitchCallbackSafety:
+    """Regression: callback must not block kill flow, and exceptions / hangs
+    must not corrupt kill history or registry state."""
+
+    def test_hung_callback_times_out(self):
+        """A callback that never returns must not freeze kill()."""
+        import threading
+        import time
+
+        ks = KillSwitch(callback_timeout=0.1)
+        started = threading.Event()
+        # Use an Event that nothing sets — the callback hangs forever.
+        never_set = threading.Event()
+
+        def hung_callback() -> None:
+            started.set()
+            never_set.wait()
+
+        ks.register_agent("a1", hung_callback)
+
+        t0 = time.monotonic()
+        result = ks.kill("a1", "s1", KillReason.MANUAL)
+        elapsed = time.monotonic() - t0
+
+        assert started.wait(timeout=1.0), "callback never ran"
+        # Must return within roughly the timeout (allow generous slack).
+        assert elapsed < 2.0, f"kill() took {elapsed:.2f}s — should be ~0.1s"
+        # `terminated=False` signals the callback didn't complete cleanly.
+        assert result.terminated is False
+        # Daemon thread keeps spinning, but the switch is usable.
+        # Set the event so the hung thread cleans up before test exit.
+        never_set.set()
+
+    def test_callback_exception_treated_as_failure(self):
+        ks = KillSwitch(callback_timeout=1.0)
+
+        def crashy() -> None:
+            raise RuntimeError("boom")
+
+        ks.register_agent("a1", crashy)
+        result = ks.kill("a1", "s1", KillReason.MANUAL)
+        assert result.terminated is False
+        # The kill flow still completes and the history is recorded.
+        assert len(ks.kill_history) == 1
+
+    def test_concurrent_kills_preserve_history(self):
+        """Multiple concurrent kills must each land exactly once in history."""
+        import threading
+
+        ks = KillSwitch(callback_timeout=1.0)
+
+        # Register many agents with quick callbacks.
+        N = 20
+        for i in range(N):
+            ks.register_agent(f"a{i}", lambda: None)
+
+        def killer(i: int) -> None:
+            ks.kill(f"a{i}", "s1", KillReason.MANUAL)
+
+        threads = [threading.Thread(target=killer, args=(i,)) for i in range(N)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All N kills must be recorded; no entry lost to a race.
+        assert len(ks.kill_history) == N
+        recorded_dids = {r.agent_did for r in ks.kill_history}
+        assert recorded_dids == {f"a{i}" for i in range(N)}


### PR DESCRIPTION
## Summary

`KillSwitch.kill` invoked the registered termination callback inline with no timeout. A slow or hung callback (waiting for a subprocess that never exits, blocked on a socket, etc.) freezes the entire kill flow — precisely the responsiveness property a kill switch must guarantee. The class also mutated `_kill_history`, `_agents`, and `_substitutes` without a lock; concurrent kills could lose history entries or corrupt the registry.

Changes:

- Run the callback in a daemon thread bounded by `callback_timeout` (default 5s, configurable via the constructor). If the callback exceeds the timeout, log `ERROR` and continue with `terminated=False`; the daemon thread is left to drain on its own and the switch remains usable for the next kill.
- Catch exceptions from the callback (log + mark `terminated=False`) rather than propagating into the kill flow.
- Wrap every read/mutate of `_kill_history`, `_agents`, `_substitutes` in an `RLock`. `RLock` (not `Lock`) so a callback that re-enters the switch — e.g. unregisters another agent — does not deadlock.
- Invoke the callback **outside** the lock so a slow callback cannot block `register_agent`, `kill` on other agents, or `kill_history` reads.

## Test plan

- [x] `pytest agent-governance-python/agent-hypervisor/tests/test_kill_switch.py` — 32 pass (existing 29 + 3 new)
- [x] `test_hung_callback_times_out`: callback that hangs forever returns within ~timeout; `terminated=False`
- [x] `test_callback_exception_treated_as_failure`: a callback that raises is logged, kill returns with `terminated=False`, kill_history still records the kill
- [x] `test_concurrent_kills_preserve_history`: 20 concurrent kills all land exactly once in history (would race without the lock)

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Isolation]