### PR TITLE
fix(sre/runbook-registry): validate YAML structure and bound list sizes

### DIFF
--- a/agent-governance-python/agent-sre/src/agent_sre/incidents/runbook_registry.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/incidents/runbook_registry.py
@@ -59,10 +59,25 @@ class RunbookRegistry:
         return matched
 
 
+# Bounds on YAML-loaded runbooks to guard against memory exhaustion
+# from a malicious or accidental dump (e.g. a misconfigured generator
+# producing a million entries). Operators wanting more than this should
+# split the catalog across files.
+_MAX_RUNBOOKS_PER_FILE = 1_000
+_MAX_STEPS_PER_RUNBOOK = 500
+
+
 def load_runbooks_from_yaml(path: str | Path) -> list[Runbook]:
     """Load runbook definitions from a YAML file.
 
-    YAML format:
+    Validates the document structure and rejects entries that would
+    silently corrupt the registry — empty ``id``, duplicate ``id``,
+    non-list ``runbooks`` or ``trigger_conditions``, or step entries
+    missing required fields. Raises :class:`ValueError` with a
+    file-and-entry reference on any violation.
+
+    YAML format::
+
         runbooks:
           - id: my-runbook
             name: My Runbook
@@ -81,14 +96,85 @@ def load_runbooks_from_yaml(path: str | Path) -> list[Runbook]:
     """
     path = Path(path)
     with open(path) as f:
-        data: dict[str, Any] = yaml.safe_load(f)
+        data: Any = yaml.safe_load(f)
+
+    if data is None:
+        return []
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{path}: top-level YAML must be a mapping, got {type(data).__name__}"
+        )
+
+    entries = data.get("runbooks", [])
+    if entries is None:
+        return []
+    if not isinstance(entries, list):
+        raise ValueError(
+            f"{path}: 'runbooks' must be a list, got {type(entries).__name__}"
+        )
+    if len(entries) > _MAX_RUNBOOKS_PER_FILE:
+        raise ValueError(
+            f"{path}: {len(entries)} runbooks exceeds limit "
+            f"({_MAX_RUNBOOKS_PER_FILE}); split the catalog across files"
+        )
 
     runbooks: list[Runbook] = []
-    for entry in data.get("runbooks", []):
+    seen_ids: set[str] = set()
+    for idx, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"{path}: runbook[{idx}] must be a mapping, got "
+                f"{type(entry).__name__}"
+            )
+
+        rb_id = entry.get("id")
+        if not isinstance(rb_id, str) or not rb_id.strip():
+            raise ValueError(
+                f"{path}: runbook[{idx}] is missing a non-empty 'id'"
+            )
+        if rb_id in seen_ids:
+            raise ValueError(
+                f"{path}: runbook[{idx}] duplicates id '{rb_id}'"
+            )
+        seen_ids.add(rb_id)
+
+        trigger_conditions = entry.get("trigger_conditions", [])
+        if not isinstance(trigger_conditions, list):
+            raise ValueError(
+                f"{path}: runbook '{rb_id}': trigger_conditions must be a list"
+            )
+
+        labels = entry.get("labels", {}) or {}
+        if not isinstance(labels, dict):
+            raise ValueError(
+                f"{path}: runbook '{rb_id}': labels must be a mapping"
+            )
+
+        raw_steps = entry.get("steps", []) or []
+        if not isinstance(raw_steps, list):
+            raise ValueError(
+                f"{path}: runbook '{rb_id}': steps must be a list"
+            )
+        if len(raw_steps) > _MAX_STEPS_PER_RUNBOOK:
+            raise ValueError(
+                f"{path}: runbook '{rb_id}': {len(raw_steps)} steps "
+                f"exceeds limit ({_MAX_STEPS_PER_RUNBOOK})"
+            )
+
         steps: list[RunbookStep] = []
-        for step_data in entry.get("steps", []):
+        for step_idx, step_data in enumerate(raw_steps):
+            if not isinstance(step_data, dict):
+                raise ValueError(
+                    f"{path}: runbook '{rb_id}' step[{step_idx}] must be a mapping"
+                )
+            name = step_data.get("name")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(
+                    f"{path}: runbook '{rb_id}' step[{step_idx}] is missing 'name'"
+                )
             steps.append(RunbookStep(
-                name=step_data["name"],
+                name=name,
                 action=step_data.get("action", ""),
                 timeout_seconds=step_data.get("timeout_seconds", 300),
                 requires_approval=step_data.get("requires_approval", False),
@@ -96,12 +182,12 @@ def load_runbooks_from_yaml(path: str | Path) -> list[Runbook]:
             ))
 
         runbooks.append(Runbook(
-            id=entry.get("id", ""),
+            id=rb_id,
             name=entry.get("name", ""),
             description=entry.get("description", ""),
-            trigger_conditions=entry.get("trigger_conditions", []),
+            trigger_conditions=trigger_conditions,
             steps=steps,
-            labels=entry.get("labels", {}),
+            labels=labels,
         ))
 
     return runbooks

--- a/agent-governance-python/agent-sre/tests/test_runbooks.py
+++ b/agent-governance-python/agent-sre/tests/test_runbooks.py
@@ -344,6 +344,81 @@ class TestRunbookRegistry:
 # YAML loading tests
 # ---------------------------------------------------------------------------
 
+class TestYamlLoadingValidation:
+    """Regression: malformed runbook YAML must be rejected with a clear
+    error rather than silently corrupting the registry."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        p = tmp_path / "rb.yaml"
+        p.write_text(content)
+        return p
+
+    def test_empty_file_returns_empty_list(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, "")
+        assert load_runbooks_from_yaml(p) == []
+
+    def test_non_mapping_top_level_rejected(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, "[1, 2, 3]\n")
+        with pytest.raises(ValueError, match="top-level YAML"):
+            load_runbooks_from_yaml(p)
+
+    def test_runbooks_must_be_list(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, "runbooks: just-a-string\n")
+        with pytest.raises(ValueError, match="'runbooks' must be a list"):
+            load_runbooks_from_yaml(p)
+
+    def test_missing_id_rejected(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, """
+runbooks:
+  - name: Anonymous
+    steps:
+      - name: do
+""")
+        with pytest.raises(ValueError, match="missing a non-empty 'id'"):
+            load_runbooks_from_yaml(p)
+
+    def test_empty_id_rejected(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, """
+runbooks:
+  - id: "   "
+    name: Whitespace
+""")
+        with pytest.raises(ValueError, match="non-empty 'id'"):
+            load_runbooks_from_yaml(p)
+
+    def test_duplicate_id_rejected(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, """
+runbooks:
+  - id: same
+    name: First
+  - id: same
+    name: Second
+""")
+        with pytest.raises(ValueError, match="duplicates id 'same'"):
+            load_runbooks_from_yaml(p)
+
+    def test_step_missing_name_rejected(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, """
+runbooks:
+  - id: rb-1
+    name: Has bad step
+    steps:
+      - action: "echo hi"
+""")
+        with pytest.raises(ValueError, match=r"step\[0\] is missing 'name'"):
+            load_runbooks_from_yaml(p)
+
+    def test_trigger_conditions_must_be_list(self, tmp_path: Path) -> None:
+        p = self._write(tmp_path, """
+runbooks:
+  - id: rb-1
+    name: Bad triggers
+    trigger_conditions: not-a-list
+""")
+        with pytest.raises(ValueError, match="trigger_conditions must be a list"):
+            load_runbooks_from_yaml(p)
+
+
 class TestYamlLoading:
     def test_load_runbooks_from_yaml(self, tmp_path: Path) -> None:
         yaml_content = """


### PR DESCRIPTION
## Summary

`load_runbooks_from_yaml` accepted malformed input silently and produced a corrupt registry:

- `data.get(\"runbooks\", [])` raised `AttributeError` when the YAML document was empty (`None`).
- A runbook entry with no `id` (or an empty one) registered under the key `\"\"` and collided with every other unnamed runbook — later entries overwrote earlier ones.
- Duplicate `id` overwrote silently.
- `step_data[\"name\"]` raised `KeyError` mid-loop, leaving partial registration in an undefined state.
- No bound on list sizes — a hostile or accidental dump could declare millions of runbooks/steps and exhaust memory.

This PR validates the document structure up-front and rejects violations with a clear `ValueError` that names the file, the offending entry, and the field. Empty files return an empty list. Caps `_MAX_RUNBOOKS_PER_FILE=1000` and `_MAX_STEPS_PER_RUNBOOK=500` keep loader memory bounded; operators wanting more should split the catalog across files.

## Test plan

- [x] `pytest agent-governance-python/agent-sre/tests/test_runbooks.py` — 33 pass (existing 25 + 8 new)
- [x] Empty file → empty list (no crash)
- [x] Non-mapping top level / non-list `runbooks` / non-list `trigger_conditions` rejected
- [x] Missing or whitespace-only `id` rejected
- [x] Duplicate `id` rejected
- [x] Step missing `name` rejected with file + index in the error
- [x] All 4 built-in runbook YAMLs still load and register correctly

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Isolation]