### PR TITLE
fix(sandbox-provider): raise NotImplementedError for default run()

### DIFF
--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/sandbox_provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/sandbox_provider.py
@@ -163,18 +163,18 @@ class SandboxProvider(ABC):
     ) -> SandboxResult:
         """Run a raw command in the sandbox (low-level helper).
 
-        The default implementation returns a failure result so that
-        providers that do not support raw commands behave predictably
-        instead of raising ``NotImplementedError``.  Subclasses such as
-        :class:`DockerSandboxProvider` override this with a real impl.
+        Default raises :class:`NotImplementedError` so that a custom
+        provider that forgets to override the method surfaces as a
+        programming error instead of silently returning a failure
+        result that callers might confuse with a normal command
+        failure. Providers that intentionally do not support raw
+        commands (e.g. Hyperlight, where the sandbox is wasm-only)
+        should override and either raise the same error or return an
+        explicit :class:`SandboxResult` documenting the reason.
         """
-        return SandboxResult(
-            success=False,
-            exit_code=-1,
-            stderr=(
-                f"{type(self).__name__}.run() is not implemented for "
-                f"this provider"
-            ),
+        raise NotImplementedError(
+            f"{type(self).__name__}.run() is not implemented; this "
+            "provider does not support raw command execution"
         )
 
     # --- Status tracking (defaults; cloud providers override) ---------------

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -239,12 +239,11 @@ class TestSandboxProviderABC:
             def is_available(self):
                 return True
 
-        # Default ``run()`` returns a failure ``SandboxResult`` so providers
-        # that do not support raw commands behave predictably (no stub raise).
-        result = Minimal().run("a", ["echo"])
-        assert result.success is False
-        assert result.exit_code == -1
-        assert "not implemented" in result.stderr.lower()
+        # Default ``run()`` raises ``NotImplementedError`` so a custom
+        # provider that forgets to override surfaces as a programming
+        # error rather than silently returning a failure ``SandboxResult``.
+        with pytest.raises(NotImplementedError, match="does not support"):
+            Minimal().run("a", ["echo"])
 
     def test_async_delegates_to_sync(self):
         class Minimal(SandboxProvider):


### PR DESCRIPTION
## Summary

`SandboxProvider.run()` had a default implementation that returned a failure `SandboxResult` with `stderr=\"...not implemented for this provider\"` instead of raising. A custom subclass that forgets to override silently returns that failure, and callers downstream cannot distinguish a real command failure from a missing implementation — both produce `success=False, exit_code=-1`.

Raise `NotImplementedError` instead so the missing override surfaces immediately as a programming error. Providers that intentionally do not support raw command execution (Hyperlight, where the sandbox is wasm-only) should override and document the reason explicitly.

## Test plan

- [x] `pytest agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py::TestSandboxProviderABC` — 5 pass
- [x] Updated `test_default_run_raises` (its name already implied the new contract; the prior implementation pinned the failure-result behavior). Now asserts `NotImplementedError` with a meaningful message.
- [x] No production callers of base `.run()` exist; `DockerSandboxProvider` overrides with a real implementation; `HyperlightSandboxProvider` does not call its base `.run()` either.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Isolation]