### PR TITLE
fix(marketplace/batch): dedupe manifest discovery by canonical path

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/batch.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/batch.py
@@ -174,23 +174,40 @@ def _evaluate_manifest(
 
 
 def _discover_manifests(directory: Path) -> list[Path]:
-    """Find all plugin manifest files in immediate subdirectories."""
+    """Find all plugin manifest files in immediate subdirectories.
+
+    The directory root is also inspected so a single-plugin layout
+    (manifest at the top of ``directory`` rather than in a subdirectory)
+    still resolves. Symlink loops would otherwise cause the same
+    manifest to surface twice — once via the canonical subdirectory
+    walk and once via the root check — so we dedupe by the resolved
+    absolute path.
+    """
     if not directory.is_dir():
         raise MarketplaceError(f"Not a directory: {directory}")
 
     manifests: list[Path] = []
+    seen: set[Path] = set()
 
-    # Check each immediate subdirectory for a manifest
+    def _add(p: Path) -> None:
+        try:
+            canonical = p.resolve()
+        except OSError:
+            canonical = p.absolute()
+        if canonical in seen:
+            return
+        seen.add(canonical)
+        manifests.append(p)
+
     for child in sorted(directory.iterdir()):
         if child.is_dir():
             manifest_path = child / MANIFEST_FILENAME
             if manifest_path.exists():
-                manifests.append(manifest_path)
+                _add(manifest_path)
 
-    # Also check the directory root
     root_manifest = directory / MANIFEST_FILENAME
     if root_manifest.exists():
-        manifests.append(root_manifest)
+        _add(root_manifest)
 
     return manifests
 

--- a/agent-governance-python/agent-marketplace/tests/test_batch.py
+++ b/agent-governance-python/agent-marketplace/tests/test_batch.py
@@ -15,6 +15,7 @@ from agent_marketplace.batch import (
     BatchResult,
     PluginResult,
     Violation,
+    _discover_manifests,
     evaluate_batch,
     evaluate_batch_command,
     format_report,
@@ -336,3 +337,53 @@ class TestCLICommand:
         assert out_file.exists()
         parsed = json.loads(out_file.read_text())
         assert parsed["total"] == 1
+
+
+class TestDiscoverManifestsDedupe:
+    """Regression: a symlink loop must not surface the same manifest twice."""
+
+    def test_root_only_layout(self, tmp_path: Path):
+        # Manifest at root, no subdirectories -> one entry.
+        _write_manifest(tmp_path, "plugin-a")
+        # Promote the subdirectory's manifest to root, mimicking a
+        # single-plugin layout.
+        root_manifest = tmp_path / "agent-plugin.yaml"
+        root_manifest.write_text((tmp_path / "plugin-a" / "agent-plugin.yaml").read_text())
+        # Discover at root only.
+        single_root = tmp_path / "only-root"
+        single_root.mkdir()
+        (single_root / "agent-plugin.yaml").write_text(root_manifest.read_text())
+        manifests = _discover_manifests(single_root)
+        assert len(manifests) == 1
+
+    def test_subdirectory_layout(self, tmp_path: Path):
+        _write_manifest(tmp_path, "plugin-a")
+        _write_manifest(tmp_path, "plugin-b")
+        manifests = _discover_manifests(tmp_path)
+        # Two distinct plugins, two distinct paths.
+        assert len(manifests) == 2
+        assert len({m.resolve() for m in manifests}) == 2
+
+    def test_symlink_loop_does_not_double_report(self, tmp_path: Path):
+        """A subdirectory symlinked to its parent must not cause the
+        root manifest to be reported twice."""
+        import os
+
+        _write_manifest(tmp_path, "plugin-a")
+        # Add a root manifest too (so both root and subdir would be found).
+        root_manifest = tmp_path / "agent-plugin.yaml"
+        root_manifest.write_text((tmp_path / "plugin-a" / "agent-plugin.yaml").read_text())
+
+        # Create a symlink-to-parent inside the directory; on platforms
+        # where symlinks aren't permitted (Windows without dev mode),
+        # skip the test rather than masking the dedupe behavior.
+        loop = tmp_path / "loop-child"
+        try:
+            os.symlink(tmp_path, loop, target_is_directory=True)
+        except (OSError, NotImplementedError, AttributeError):
+            pytest.skip("symlinks not permitted in this test environment")
+
+        manifests = _discover_manifests(tmp_path)
+        # The root manifest must appear exactly once after dedupe.
+        resolved = [m.resolve() for m in manifests]
+        assert resolved.count(root_manifest.resolve()) == 1


### PR DESCRIPTION
## Summary

`agent_marketplace.batch._discover_manifests` walks immediate subdirectories for an `agent-plugin.yaml`, then also checks the directory root. If a subdirectory is a symlink that resolves back to the parent (or to another scanned subdir), the same manifest is discovered twice and downstream batch reports include the plugin multiple times.

Dedupe by canonical (`Path.resolve()`) path. The list order is preserved — subdirectories first, then root — so existing report ordering does not change.

## Test plan

- [x] `pytest tests/test_batch.py` — 20 pass, 1 symlink test skipped on Windows without dev mode
- [x] `test_root_only_layout`: single-plugin layout yields one entry
- [x] `test_subdirectory_layout`: two subdirs yield two distinct manifests
- [x] `test_symlink_loop_does_not_double_report`: a child symlink to the parent does not surface the root manifest twice

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Extensions]