### PR TITLE
fix(marketplace/trust-tiers): atomic persist; refuse to start on parse error

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/trust_tiers.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/trust_tiers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -254,15 +255,41 @@ class PluginTrustStore:
     # -- persistence -------------------------------------------------------
 
     def _load(self) -> dict:
-        if self._store_path.exists():
-            try:
-                with open(self._store_path) as f:
-                    return json.load(f)
-            except (json.JSONDecodeError, OSError):
-                logger.warning("Corrupt trust store at %s — starting fresh", self._store_path)
-        return {"scores": {}, "events": {}}
+        if not self._store_path.exists():
+            return {"scores": {}, "events": {}}
+        try:
+            with open(self._store_path) as f:
+                return json.load(f)
+        except json.JSONDecodeError as exc:
+            # A corrupt trust store is a security-relevant signal — silently
+            # zeroing all scores would re-promote previously-untrusted
+            # plugins. Surface the error and let the operator quarantine
+            # or repair the file before the registry is brought back up.
+            raise RuntimeError(
+                f"Trust store at {self._store_path} is corrupt and cannot "
+                "be parsed; refusing to start with empty scores. Inspect or "
+                "restore from backup before retrying."
+            ) from exc
+        except OSError as exc:
+            raise RuntimeError(
+                f"Failed to read trust store at {self._store_path}: {exc}"
+            ) from exc
 
     def _persist(self) -> None:
         self._store_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self._store_path, "w") as f:
+        # Write to a sibling tmp file in the same directory (so `os.replace`
+        # stays cross-device atomic) and rename over the target. A crash
+        # mid-write leaves the *.tmp file behind but the canonical store
+        # remains the last fully-written copy.
+        tmp_path = self._store_path.with_name(self._store_path.name + ".tmp")
+        with open(tmp_path, "w") as f:
             json.dump(self._data, f, indent=2)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                # fsync is best-effort; some filesystems / handles don't
+                # support it (e.g. tmpfs in containers). The os.replace
+                # below still provides atomic visibility.
+                pass
+        os.replace(tmp_path, self._store_path)

--- a/agent-governance-python/agent-marketplace/tests/test_trust_tiers.py
+++ b/agent-governance-python/agent-marketplace/tests/test_trust_tiers.py
@@ -262,12 +262,41 @@ class TestPluginTrustStore:
         assert store2.get_score("my-plugin") == 850
         assert store2.get_tier("my-plugin") == "trusted"
 
-    def test_corrupt_store_resets(self, tmp_path: Path) -> None:
+    def test_corrupt_store_refuses_to_start(self, tmp_path: Path) -> None:
+        """A corrupt trust store must surface as an error rather than
+        silently resetting to defaults — which would re-promote
+        previously-untrusted plugins on next startup.
+        """
         path = tmp_path / "trust.json"
         path.write_text("NOT VALID JSON", encoding="utf-8")
 
+        with pytest.raises(RuntimeError, match="corrupt"):
+            PluginTrustStore(store_path=path)
+
+    def test_persist_is_atomic_on_crash(self, tmp_path: Path) -> None:
+        """If the write of the *.tmp file aborts, the canonical store
+        remains intact (last fully-written copy)."""
+        path = tmp_path / "trust.json"
+
+        # Write a known-good state first.
         store = PluginTrustStore(store_path=path)
-        assert store.get_score("any") == 500
+        store.record_event("plugin-a", "install_success", 50)
+        before = path.read_text()
+
+        # Now sabotage the tmp write so os.replace never runs. The
+        # canonical file must be untouched.
+        from unittest.mock import patch
+
+        with patch("os.replace", side_effect=OSError("simulated crash")):
+            with pytest.raises(OSError):
+                store.record_event("plugin-b", "install_success", 5)
+
+        # Canonical file unchanged.
+        assert path.read_text() == before
+        # Reload sees only the pre-crash state.
+        reloaded = PluginTrustStore(store_path=path)
+        assert reloaded.get_score("plugin-a") != 500  # was bumped
+        assert reloaded.get_score("plugin-b") == 500  # default; never persisted
 
     def test_events_recorded_in_store(self, tmp_path: Path) -> None:
         path = tmp_path / "trust.json"


### PR DESCRIPTION
## Summary

`PluginTrustStore._persist` wrote JSON directly to the target path; a crash mid-write left a truncated file. `_load` swallowed the resulting `JSONDecodeError` and reset every plugin's trust score to the default, silently re-promoting plugins that operators had deliberately downscored.

Two changes:

1. **Atomic persist.** `_persist` writes to a sibling `*.tmp` file in the same directory, fsyncs, then `os.replace`s onto the canonical path. `os.replace` is atomic on POSIX and on Windows (since Python 3.3); a crash mid-write leaves the tmp file behind but the canonical store remains the last fully-written copy.
2. **Refuse to start on corrupt store.** `_load` raises `RuntimeError` rather than silently resetting. A corrupt trust store is a security-relevant signal — operators should quarantine or restore from backup before the registry comes back up.

## Test plan

- [x] `pytest tests/test_trust_tiers.py` — 44 pass (existing 42 + 2 new)
- [x] `test_corrupt_store_refuses_to_start` (renamed from `test_corrupt_store_resets`, which pinned the prior silent-reset behavior): a malformed file now raises `RuntimeError`
- [x] `test_persist_is_atomic_on_crash`: simulating a failed `os.replace` leaves the canonical store at its pre-write content

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Extensions]