### PR TITLE
fix(agent-lightning/runner): make PolicyViolation.timestamp timezone-aware

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Generic, TypeVar
 
@@ -53,7 +53,7 @@ class PolicyViolation:
     policy_name: str
     description: str
     severity: str  # critical, high, medium, low
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     action_blocked: bool = False
     penalty: float | None = None
 

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -290,6 +290,17 @@ class TestPolicyViolation:
         )
         assert v.penalty == 0.0
 
+    def test_timestamp_is_timezone_aware(self):
+        """Regression: ``datetime.utcnow()`` produced a naive timestamp
+        that compared-different against ``datetime.now(timezone.utc)``
+        used elsewhere in the codebase. The default must be aware."""
+        v = PolicyViolation(PolicyViolationType.BLOCKED, "P", "d", "high")
+        assert v.timestamp.tzinfo is not None
+        # Compare against an aware ``now`` without raising — naive
+        # vs. aware comparison was the symptom.
+        from datetime import datetime as _dt, timezone as _tz
+        assert v.timestamp <= _dt.now(_tz.utc)
+
 
 class TestGovernedRollout:
     def test_total_penalty_calculated(self):


### PR DESCRIPTION
## Summary

`PolicyViolation.timestamp` defaulted to `datetime.utcnow()`, which returns a *naive* datetime. The rest of the lightning package's metrics surface uses `datetime.now(timezone.utc)`. Mixed naive/aware comparisons raise `TypeError` — any flight-recorder query that ordered violations against externally-produced timestamps crashed.

Default to `lambda: datetime.now(timezone.utc)`. Naive comparisons are gone; downstream code already using aware timestamps now interoperates.

## Test plan

- [x] `pytest tests/test_lightning_comprehensive.py::TestPolicyViolation` — 8 pass (existing 7 + 1 new)
- [x] `test_timestamp_is_timezone_aware`: default timestamp has `tzinfo` and compares cleanly against an aware `datetime.now(timezone.utc)`

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Extensions]