### PR TITLE
fix(agent-lightning/env): pull kernel violations when no hook is wired

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/environment.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/environment.py
@@ -125,9 +125,53 @@ class GovernedEnvironment(Generic[T_state, T_action]):
         logger.info("GovernedEnvironment initialized")
 
     def _setup_hooks(self) -> None:
-        """Set up hooks to capture violations."""
+        """Set up hooks to capture violations.
+
+        Sets ``self._hooks_wired = True`` only when the kernel actually
+        accepted the callback registration. ``step`` consults this flag
+        to decide whether it must additionally poll
+        ``kernel.get_recent_violations()`` — otherwise a kernel that only
+        exposes the pull API would silently produce zero recorded
+        violations and incorrectly award the success bonus.
+        """
+        self._hooks_wired = False
         if hasattr(self.kernel, 'on_policy_violation'):
             self.kernel.on_policy_violation(self._handle_violation)
+            self._hooks_wired = True
+
+    def _pull_kernel_violations(self) -> None:
+        """Poll the kernel for violations recorded during the current step.
+
+        Used when no ``on_policy_violation`` hook was wired. The kernel
+        is expected to expose ``get_recent_violations()`` returning a
+        sequence of violation records — each either a dict matching the
+        shape produced by :meth:`_handle_violation`, or an object with
+        ``policy_name`` / ``description`` / ``severity`` /
+        ``action_blocked`` attributes.
+        """
+        get_recent = getattr(self.kernel, "get_recent_violations", None)
+        if not callable(get_recent):
+            return
+        try:
+            recent = get_recent()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("kernel.get_recent_violations() raised: %s", exc)
+            return
+
+        for v in recent or ():
+            if isinstance(v, dict):
+                policy = v.get("policy") or v.get("policy_name", "")
+                description = v.get("description", "")
+                severity = v.get("severity", "low")
+                blocked = bool(v.get("blocked") or v.get("action_blocked"))
+            else:
+                policy = getattr(v, "policy_name", getattr(v, "policy", ""))
+                description = getattr(v, "description", "")
+                severity = getattr(v, "severity", "low")
+                blocked = bool(
+                    getattr(v, "action_blocked", getattr(v, "blocked", False))
+                )
+            self._handle_violation(policy, description, severity, blocked)
 
     def _handle_violation(
         self,
@@ -228,6 +272,11 @@ class GovernedEnvironment(Generic[T_state, T_action]):
             logger.error(f"Step failed: {e}")
             result = None
             success = False
+
+        # If no callback hook is wired, pull violations from the kernel
+        # so reward shaping and termination still see them.
+        if not getattr(self, "_hooks_wired", False):
+            self._pull_kernel_violations()
 
         # Calculate reward
         reward = self.reward_fn(self._current_task, action, result)

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -566,6 +566,96 @@ class TestGovernedEnvironmentStep:
         _, _, _, truncated, _ = env.step("a2")
         assert truncated is True
 
+    def test_step_pulls_violations_when_no_hook(self):
+        """Regression: a kernel that exposes ``get_recent_violations``
+        but no ``on_policy_violation`` hook used to be invisible to the
+        environment. Violations were missed and the success bonus was
+        awarded incorrectly."""
+        kernel = MagicMock(spec=["execute", "reset", "get_recent_violations"])
+        kernel.execute = MagicMock(return_value="ok")
+        kernel.reset = MagicMock()
+        kernel.get_recent_violations = MagicMock(
+            return_value=[
+                {
+                    "policy": "SQLPolicy",
+                    "description": "DROP detected",
+                    "severity": "critical",
+                    "blocked": True,
+                }
+            ]
+        )
+        env = GovernedEnvironment(kernel)
+        env.reset()
+        _, reward, terminated, _, info = env.step("DROP TABLE x")
+
+        # Violation should have been recorded via the pull path.
+        assert len(info["violations"]) == 1
+        assert info["violations"][0]["policy"] == "SQLPolicy"
+        # Critical violation must terminate when configured.
+        # (Default config has terminate_on_critical=True.)
+        assert terminated is True
+        # Success bonus must NOT be applied when violations exist.
+        assert reward < 0
+
+    def test_step_pull_violations_object_attributes(self):
+        """``get_recent_violations`` may return objects with attributes
+        rather than dicts (e.g. dataclasses); the env should normalize."""
+        @dataclass
+        class _ObjViolation:
+            policy_name: str
+            description: str
+            severity: str
+            action_blocked: bool
+
+        kernel = MagicMock(spec=["execute", "reset", "get_recent_violations"])
+        kernel.execute = MagicMock(return_value="ok")
+        kernel.reset = MagicMock()
+        kernel.get_recent_violations = MagicMock(
+            return_value=[
+                _ObjViolation(
+                    policy_name="CostPolicy",
+                    description="budget exceeded",
+                    severity="high",
+                    action_blocked=False,
+                )
+            ]
+        )
+        env = GovernedEnvironment(kernel)
+        env.reset()
+        _, _, _, _, info = env.step("expensive-op")
+        assert len(info["violations"]) == 1
+        assert info["violations"][0]["policy"] == "CostPolicy"
+        assert info["violations"][0]["severity"] == "high"
+
+    def test_step_no_double_record_when_hook_wired(self):
+        """If the hook IS wired, the pull path must not run (would double-count)."""
+        # A kernel with the hook registers attribute and a (different) pull API.
+        captured: list = []
+
+        class _HookKernel:
+            def __init__(self):
+                self.execute = MagicMock(return_value="ok")
+                self.reset = MagicMock()
+                self.policies = []
+
+            def on_policy_violation(self, cb):
+                captured.append(cb)
+
+            def get_recent_violations(self):
+                # If the env wrongly pulls in this case, this would be
+                # double-counted with the hook's invocation. We never
+                # invoke the hook here, so a non-empty pull-result with
+                # no hook fire would expose the bug if it happened.
+                return [{"policy": "X", "description": "Y", "severity": "low", "blocked": False}]
+
+        kernel = _HookKernel()
+        env = GovernedEnvironment(kernel)
+        env.reset()
+        _, _, _, _, info = env.step("a")
+        # Hook was wired; pull must NOT have been invoked.
+        # No hook fire => no violations recorded.
+        assert info["violations"] == []
+
 
 class TestGovernedEnvironmentGymInterface:
     def test_terminated_property(self):


### PR DESCRIPTION
## Summary

`GovernedEnvironment._setup_hooks` registered `on_policy_violation` only if the kernel exposed it. When the kernel exposed a pull-only API (`get_recent_violations`) instead, no violations were recorded during `step()`:

- Violation penalties were skipped (zero reward shaping).
- The `success and not self._current_violations` check **awarded the success bonus** for steps that actually violated policy.
- `terminate_on_critical` never fired because `_current_violations` stayed empty.

Track whether the callback hook was actually wired (`self._hooks_wired`); when it wasn't, call `kernel.get_recent_violations()` after the action runs and route each record through `_handle_violation`. Records may be dicts (the shape `_handle_violation` already produces) or objects with `policy_name` / `description` / `severity` / `action_blocked` attributes — both are normalized. Hook-wired kernels are unchanged; the pull path is skipped to prevent double-counting.

## Test plan

- [x] `pytest tests -k Environment` — 20 pass (existing 17 + 3 new)
- [x] `test_step_pulls_violations_when_no_hook`: pull-only kernel surfaces violations and `terminate_on_critical` fires
- [x] `test_step_pull_violations_object_attributes`: dataclass records normalize correctly
- [x] `test_step_no_double_record_when_hook_wired`: hook-wired kernels skip the pull path entirely

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Extensions]