### PR TITLE
fix(marketplace/installer): parse PEP 508 specifiers via packaging.Requirement

### DIFF
--- a/agent-governance-python/agent-marketplace/pyproject.toml
+++ b/agent-governance-python/agent-marketplace/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pydantic>=2.0,<3.0",
     "pyyaml>=6.0,<7.0",
     "cryptography>=46.0.7,<49.0",
+    "packaging>=21.0",
 ]
 
 [project.optional-dependencies]

--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/installer.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/installer.py
@@ -18,6 +18,7 @@ from types import MappingProxyType
 from typing import Any, Mapping, Optional
 
 import yaml
+from packaging.requirements import InvalidRequirement, Requirement
 
 from agent_marketplace.manifest import (
     MANIFEST_FILENAME,
@@ -282,14 +283,24 @@ def _atomic_write_yaml(path: Path, data: Any) -> None:
 
 
 def _parse_dependency(dep_spec: str) -> tuple[str, Optional[str]]:
-    """Parse a dependency specifier like ``plugin-name>=1.0.0``.
+    """Parse a PEP 508 dependency specifier like ``plugin-name>=1.0.0``.
 
-    Returns:
-        Tuple of (name, version_or_none).
+    Returns a ``(name, version_or_none)`` tuple. ``version`` is the pinned
+    string from an ``==X`` specifier when one is present; otherwise ``None``
+    so the registry resolves the latest matching version. Compound
+    specifiers (``>=1.0,<2.0``), inequality (``!=``), and compatible-release
+    (``~=``) all return ``None`` instead of being mis-parsed as a literal
+    version string.
+
+    Raises:
+        MarketplaceError: If ``dep_spec`` is not a valid PEP 508 requirement.
     """
-    for op in (">=", "==", "<=", ">", "<"):
-        if op in dep_spec:
-            name, version = dep_spec.split(op, 1)
-            return name.strip(), version.strip()
-    return dep_spec.strip(), None
+    try:
+        req = Requirement(dep_spec)
+    except InvalidRequirement as exc:
+        raise MarketplaceError(f"Invalid dependency specifier {dep_spec!r}: {exc}") from exc
+    for spec in req.specifier:
+        if spec.operator == "==":
+            return req.name, spec.version
+    return req.name, None
 

--- a/agent-governance-python/agent-marketplace/tests/test_parse_dependency.py
+++ b/agent-governance-python/agent-marketplace/tests/test_parse_dependency.py
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for ``_parse_dependency``.
+
+Regression coverage for the PEP 508 parser used during dependency
+resolution. Previously the parser scanned for operators in a fixed order
+and split at the first match, mis-handling compound specifiers like
+``>=1.0,<2.0`` (parsed as ``(name, "1.0,<2.0")``) and never recognising
+``!=`` / ``~=``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_marketplace.installer import _parse_dependency
+from agent_marketplace.manifest import MarketplaceError
+
+
+class TestParseDependency:
+    def test_no_specifier_returns_none_version(self):
+        assert _parse_dependency("plugin-name") == ("plugin-name", None)
+
+    def test_exact_pin_returns_version_string(self):
+        assert _parse_dependency("plugin-name==1.2.3") == ("plugin-name", "1.2.3")
+
+    def test_lower_bound_only_returns_none_version(self):
+        # `>=1.0` is a range, not a pin; registry should resolve latest.
+        assert _parse_dependency("plugin-name>=1.0") == ("plugin-name", None)
+
+    def test_compound_specifier_returns_none_version(self):
+        # Regression: previously parsed as ("plugin-name", "1.0,<2.0").
+        assert _parse_dependency("plugin-name>=1.0,<2.0") == ("plugin-name", None)
+
+    def test_compound_with_exact_pin_returns_pin(self):
+        # `==X` always wins over surrounding range bounds.
+        assert _parse_dependency("plugin-name>=1.0,==1.5") == ("plugin-name", "1.5")
+
+    def test_inequality_returns_none_version(self):
+        # Regression: previously fell through and returned ("plugin-name!=1.0", None).
+        assert _parse_dependency("plugin-name!=1.0") == ("plugin-name", None)
+
+    def test_compatible_release_returns_none_version(self):
+        # Regression: previously fell through and returned ("plugin-name~=1.0", None).
+        assert _parse_dependency("plugin-name~=1.0") == ("plugin-name", None)
+
+    def test_whitespace_around_operator(self):
+        assert _parse_dependency("plugin-name == 1.2.3") == ("plugin-name", "1.2.3")
+
+    def test_invalid_specifier_raises(self):
+        with pytest.raises(MarketplaceError, match="Invalid dependency"):
+            _parse_dependency("not a valid spec!!!")


### PR DESCRIPTION
## Summary

`agent_marketplace.installer._parse_dependency` scans for `>=`, `==`, `<=`, `>`, `<` in fixed order and splits at the first hit. Compound specifiers like `plugin-name>=1.0,<2.0` end up as `(name, "1.0,<2.0")` — the trailing range gets handed to `PluginRegistry.get_plugin(name, version)` as an exact-version string and the lookup raises. `!=` and `~=` are never matched, so the whole spec becomes the plugin name (`get_plugin("plugin-name!=1.0", None)` → `Plugin not found`).

## Change

Swap the ad-hoc operator scan for `packaging.requirements.Requirement`:

- `name==X` → `(name, "X")` (pinned; unchanged for the common case)
- `name>=X`, `name>=X,<Y`, `name!=X`, `name~=X`, bare `name` → `(name, None)` so the registry resolves the latest matching version
- Invalid specifiers raise `MarketplaceError` instead of being silently treated as a literal plugin name

Add `packaging>=21.0` to the runtime dependencies. `packaging` is dependency-free and is the canonical PEP 508 parser (it's the same library pip uses).

## Tests

New unit tests in `tests/test_parse_dependency.py` cover bare name, exact pin, lower bound, compound range, compound with exact pin, `!=`, `~=`, whitespace around the operator, and the invalid-spec error path.

`cd agent-governance-python/agent-marketplace && PYTHONPATH=src python -m pytest tests/ -q` → 284 passed.

## Test plan

- [x] New `_parse_dependency` unit tests cover every operator class and the compound-specifier regression
- [x] Existing dependency-resolution tests (`test_dependency_verification.py`, `test_installer_atomic_and_verify.py`) still pass — they use `name>=1.0.0` specifiers and now resolve via the registry's latest-version path rather than via accidental exact-version coincidence
- [x] Full marketplace suite: 284/284 pass

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Extensions]