### PR TITLE
fix(ci): harden notebook scanners against false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
               'scipy','openai','anthropic','langchain','crewai',
               'streamlit','plotly','pandas','networkx','aioredis',
               'langchain-openai','langchain-core','python-dotenv',
-              'agent-primitives','agentmesh-memory','emk',
+              'agent-primitives','agentmesh-memory','emk','requests',
           }
           bad = []
           for nb in glob.glob('**/*.ipynb', recursive=True):
@@ -446,8 +446,11 @@ jobs:
               except Exception:
                   continue
               for c in cells:
+                  if c.get('cell_type') != 'code':
+                      continue
                   for line in c.get('source', []):
-                      if 'pip install' in line and not line.strip().startswith('#') and not line.strip().startswith('>'):
+                      stripped = line.strip()
+                      if 'pip install' in line and stripped.startswith(('!', '%')):
                           pkgs = re.findall(r'(?:pip install\s+)(.+)', line)
                           if pkgs:
                               for p in pkgs[0].split():

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -45,6 +45,7 @@ REGISTERED_PACKAGES = {
     "sentence-transformers", "prometheus-client", "opentelemetry-api",
     "opentelemetry-sdk", "fhir.resources", "hl7apy", "zenpy", "freshdesk",
     "google-adk", "safety", "jupyter", "vitest", "tsup", "typescript",
+    "requests",
     # Dashboard / visualization (used in examples)
     "streamlit", "plotly", "pandas", "networkx", "matplotlib", "pyvis",
     # Async / caching (used in examples)
@@ -166,14 +167,27 @@ PIP_INSTALL_RE = re.compile(
 def extract_package_names(install_args: str) -> list[str]:
     """Extract package names from a pip install argument string."""
     packages = []
-    for token in install_args.split():
+    tokens = install_args.split()
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
         # Skip flags
         if token.startswith("-") or token in SAFE_PATTERNS:
+            # -r/--requirement take a filename as the next argument
+            if token in ("-r", "--requirement", "-c", "--constraint"):
+                skip_next = True
             continue
         if token.startswith((".", "/", "\\", "http", "git+")):
             continue
         # Skip tokens that look like code, not package names
         if any(c in token for c in ('(', ')', '=', '"', "'", ":")):
+            continue
+        # Skip tokens that look like filenames or shell keywords
+        if any(token.rstrip(";") == kw for kw in ("if", "then", "else", "fi", "do", "done")):
+            continue
+        if re.search(r'\.\w{1,4}$', token.rstrip(";")):
             continue
         # Strip extras: package[extra] -> package
         base = re.sub(r'\[.*\]', '', token)


### PR DESCRIPTION
Fixes CI failures caused by Citadel Foundry notebook (merged in #2074/#2079/#2083).

**dep-confusion-scan fixes:**
- Add requests to REGISTERED_PACKAGES
- Skip filename token after -r/--requirement flags
- Skip shell keywords (if/then/fi) and filenames (.txt)

**notebook-pip-audit fixes:**
- Only scan code cells (skip markdown)
- Only check lines prefixed with ! or % (actual pip commands)
- Add requests to REGISTERED set