### PR TITLE
fix(mesh): harden message handlers, key validation, and reputation auth

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
@@ -209,6 +209,11 @@ class RegistryServer:
                 agent.identity_key = base64.urlsafe_b64decode(req.identity_key + "==")
                 if req.identity_key_ed:
                     agent.identity_key_ed = base64.urlsafe_b64decode(req.identity_key_ed + "==")
+                    if len(agent.identity_key_ed) != 32:
+                        raise HTTPException(
+                            status_code=400,
+                            detail="identity_key_ed must be exactly 32 bytes (Ed25519 public key)",
+                        )
                 spk = req.signed_pre_key
                 agent.signed_pre_key = base64.urlsafe_b64decode(spk["public_key"] + "==")
                 agent.signed_pre_key_signature = base64.urlsafe_b64decode(spk["signature"] + "==")
@@ -314,7 +319,20 @@ class RegistryServer:
               - timeout → score 0.2 toward the receiver (initiator unchanged)
 
             Missing agents are silently skipped (best-effort telemetry).
+            The reporter must be a registered agent (either initiator or receiver).
             """
+            # Validate reporter is a session participant
+            if req.reporter_amid not in (req.initiator_amid, req.receiver_amid):
+                raise HTTPException(
+                    status_code=403,
+                    detail="reporter_amid must be a session participant",
+                )
+            reporter = store.get_agent(req.reporter_amid)
+            if not reporter:
+                raise HTTPException(
+                    status_code=403,
+                    detail="reporter_amid is not a registered agent",
+                )
             outcome = (req.outcome or "").lower()
             alpha = 0.2
             updated: dict[str, float] = {}

--- a/agent-governance-typescript/src/encryption/mesh-client.ts
+++ b/agent-governance-typescript/src/encryption/mesh-client.ts
@@ -742,7 +742,7 @@ export class MeshClient {
 
     // Notify handlers
     for (const handler of this.messageHandlers) {
-      handler(from, payload, isPlaintext);
+      try { handler(from, payload, isPlaintext); } catch { /* swallow handler errors */ }
     }
   }
 


### PR DESCRIPTION
Follow-up security hardening for #2090.

**3 fixes:**

1. **messageHandlers try/catch** (mesh-client.ts:744) - One throwing handler was killing all subsequent handlers. Now wrapped in try/catch, matching the existing pattern for errorHandlers and disconnectHandlers.

2. **identity_key_ed length validation** (app.py) - After base64 decoding, validate the Ed25519 public key is exactly 32 bytes. Rejects garbage that would silently break downstream verification.

3. **Session reputation auth** (app.py) - reporter_amid must be a registered agent AND a session participant (initiator or receiver). Prevents anonymous callers from tanking any agent's reputation score to 0.