### PR TITLE
fix(marketplace/cli): anchor plugins/registry paths to absolute AGENTMESH_HOME

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/cli_commands.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/cli_commands.py
@@ -18,6 +18,7 @@ Commands:
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 import click
@@ -48,17 +49,37 @@ from agent_marketplace.schema_adapters import (
 console = Console()
 logger = logging.getLogger(__name__)
 
-# Default paths
-DEFAULT_PLUGINS_DIR = Path(".agentmesh") / "plugins"
-DEFAULT_REGISTRY_FILE = Path(".agentmesh") / "registry.json"
+# Cached absolute path to the AgentMesh state directory. Resolved on first
+# access from ``$AGENTMESH_HOME`` if set, else ``<cwd-at-first-call>/.agentmesh``.
+# Caching guards against cwd-dependent registry split-brain when a long-running
+# process (tests, embedded CLI usage) chdirs between commands.
+_agentmesh_home_cache: Path | None = None
+
+
+def _agentmesh_home() -> Path:
+    """Return the absolute path to the AgentMesh state directory."""
+    global _agentmesh_home_cache
+    if _agentmesh_home_cache is None:
+        env = os.environ.get("AGENTMESH_HOME")
+        base = Path(env) if env else Path.cwd() / ".agentmesh"
+        _agentmesh_home_cache = base.resolve()
+    return _agentmesh_home_cache
+
+
+def _plugins_dir() -> Path:
+    return _agentmesh_home() / "plugins"
+
+
+def _registry_file() -> Path:
+    return _agentmesh_home() / "registry.json"
 
 
 def _get_registry() -> PluginRegistry:
-    return PluginRegistry(storage_path=DEFAULT_REGISTRY_FILE)
+    return PluginRegistry(storage_path=_registry_file())
 
 
 def _get_installer() -> PluginInstaller:
-    return PluginInstaller(plugins_dir=DEFAULT_PLUGINS_DIR, registry=_get_registry())
+    return PluginInstaller(plugins_dir=_plugins_dir(), registry=_get_registry())
 
 
 @click.group()
@@ -322,10 +343,10 @@ def evaluate_plugin(manifest_path: str, marketplace_policy: str) -> None:
 @click.option(
     "--store",
     "store_path",
-    default=str(Path(".agentmesh") / "trust.json"),
-    help="Path to the trust store JSON file",
+    default=None,
+    help="Path to the trust store JSON file (default: $AGENTMESH_HOME/trust.json)",
 )
-def trust_plugin(plugin_name: str, store_path: str) -> None:
+def trust_plugin(plugin_name: str, store_path: str | None) -> None:
     """Show trust score and tier for a plugin."""
     from agent_marketplace.trust_tiers import (
         PluginTrustStore,
@@ -333,7 +354,8 @@ def trust_plugin(plugin_name: str, store_path: str) -> None:
         get_trust_tier,
     )
 
-    store = PluginTrustStore(store_path=Path(store_path))
+    resolved_store = Path(store_path) if store_path else _agentmesh_home() / "trust.json"
+    store = PluginTrustStore(store_path=resolved_store)
     score = store.get_score(plugin_name)
     tier = get_trust_tier(score)
     config = get_tier_config(tier)

--- a/agent-governance-python/agent-marketplace/tests/test_cli_paths.py
+++ b/agent-governance-python/agent-marketplace/tests/test_cli_paths.py
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for AgentMesh state-directory resolution in the CLI.
+
+Previously ``DEFAULT_PLUGINS_DIR`` / ``DEFAULT_REGISTRY_FILE`` were relative
+to whatever ``cwd`` happened to be at first use, so a long-running process
+that called ``_get_registry()`` and then ``os.chdir`` would see two
+different registries. The resolver now snapshots an absolute path on first
+call and honours ``$AGENTMESH_HOME``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_home_cache(monkeypatch):
+    """Clear the cached home and any env override between tests."""
+    monkeypatch.delenv("AGENTMESH_HOME", raising=False)
+    from agent_marketplace import cli_commands
+    monkeypatch.setattr(cli_commands, "_agentmesh_home_cache", None)
+    yield
+    monkeypatch.setattr(cli_commands, "_agentmesh_home_cache", None)
+
+
+class TestAgentmeshHome:
+    def test_env_var_honoured(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_HOME", str(tmp_path / "custom-home"))
+        from agent_marketplace.cli_commands import _agentmesh_home
+
+        assert _agentmesh_home() == (tmp_path / "custom-home").resolve()
+
+    def test_default_uses_cwd_at_first_call(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from agent_marketplace.cli_commands import _agentmesh_home
+
+        assert _agentmesh_home() == (tmp_path / ".agentmesh").resolve()
+
+    def test_default_is_absolute(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        from agent_marketplace.cli_commands import _agentmesh_home
+
+        result = _agentmesh_home()
+        assert result.is_absolute()
+
+    def test_cached_across_calls_even_when_cwd_changes(self, tmp_path, monkeypatch):
+        """Regression: cwd changes after first call must not switch registries."""
+        first_cwd = tmp_path / "first"
+        second_cwd = tmp_path / "second"
+        first_cwd.mkdir()
+        second_cwd.mkdir()
+
+        monkeypatch.chdir(first_cwd)
+        from agent_marketplace.cli_commands import _agentmesh_home
+
+        initial = _agentmesh_home()
+
+        monkeypatch.chdir(second_cwd)
+        subsequent = _agentmesh_home()
+
+        assert initial == subsequent
+        assert initial == (first_cwd / ".agentmesh").resolve()
+
+    def test_plugins_dir_and_registry_under_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_HOME", str(tmp_path / "h"))
+        from agent_marketplace.cli_commands import _plugins_dir, _registry_file
+
+        home = (tmp_path / "h").resolve()
+        assert _plugins_dir() == home / "plugins"
+        assert _registry_file() == home / "registry.json"
+
+
+class TestRegistryAndInstallerHelpers:
+    def test_get_registry_targets_resolved_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_HOME", str(tmp_path))
+        from agent_marketplace.cli_commands import _get_registry
+
+        registry = _get_registry()
+        # The internal path is private but the contract is "this storage_path".
+        assert registry._storage_path == (tmp_path / "registry.json").resolve()
+
+    def test_get_installer_targets_resolved_paths(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_HOME", str(tmp_path))
+        from agent_marketplace.cli_commands import _get_installer
+
+        installer = _get_installer()
+        assert installer._plugins_dir == (tmp_path / "plugins").resolve()


### PR DESCRIPTION
## Summary

`agent_marketplace.cli_commands` defines:

```python
DEFAULT_PLUGINS_DIR = Path(".agentmesh") / "plugins"
DEFAULT_REGISTRY_FILE = Path(".agentmesh") / "registry.json"

def _get_registry() -> PluginRegistry:
    return PluginRegistry(storage_path=DEFAULT_REGISTRY_FILE)
```

Both constants are relative paths re-evaluated at every helper call. Any process that changes cwd between commands — pytest runs, an embedded CLI, a workflow that invokes multiple commands in sequence — sees a different registry per call. The `trust` command had the same bug in its `--store` default (`default=str(Path(".agentmesh") / "trust.json")`).

## Change

Resolve the AgentMesh state directory once via a new `_agentmesh_home()` helper:

- `$AGENTMESH_HOME` is honoured when set (matches the `CARGO_HOME` / `GOPATH` convention).
- Otherwise: `Path.cwd() / ".agentmesh"`, resolved to absolute at first call and cached for the rest of the process.

`_plugins_dir()` and `_registry_file()` derive from the cached home so every helper agrees. The `trust` command's `--store` default is computed lazily inside the handler instead of at decorator-evaluation time.

The default behavior is unchanged for the common case (CLI invoked from a project root): you get `<project>/.agentmesh/...`, just resolved to absolute so it doesn't drift mid-process.

## Tests

New `tests/test_cli_paths.py` covers:

- `$AGENTMESH_HOME` is honoured
- The default snapshots cwd-at-first-call
- The resolved path is always absolute
- Cache stability across cwd changes (the actual regression)
- `_plugins_dir()` / `_registry_file()` sit under the resolved home
- `_get_registry()` / `_get_installer()` see the resolved path

`cd agent-governance-python/agent-marketplace && PYTHONPATH=src python -m pytest tests/ -q` → 282 passed.

## Test plan

- [x] New `_agentmesh_home()` tests cover env override, cwd-snapshot, absolute path, and cache stability
- [x] Existing CLI exit-code tests still pass
- [x] Full marketplace suite: 282/282 pass

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Extensions]