### PR TITLE
perf(marketplace/registry): unify list_for_organization iteration

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/registry.py
@@ -209,9 +209,8 @@ class PluginRegistry:
         """
         results: list[PluginManifest] = []
         with self._lock:
-            for name in self._plugins:
-                for version in self._plugins[name]:
-                    manifest = self._plugins[name][version]
+            for versions in self._plugins.values():
+                for manifest in versions.values():
                     if manifest.organization is None or manifest.organization == organization:
                         results.append(manifest)
         return results


### PR DESCRIPTION
## Summary

`PluginRegistry.list_for_organization` walks the plugin store with three dict lookups per element:

```python
for name in self._plugins:
    for version in self._plugins[name]:
        manifest = self._plugins[name][version]
        ...
```

Switch to `self._plugins.values()` / `versions.values()` so we touch each manifest exactly once. Behaviour is unchanged.

## Test plan

- [x] `tests/test_org_marketplace.py::TestOrgVisibilityRules` covers global-visible, org-matched, multi-org, and unknown-org cases — all still pass
- [x] Full marketplace suite: 275/275 pass

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Python Extensions]