### PR TITLE
fix(dotnet/policy): narrow PolicyRule.Evaluate catch so buggy rules fail closed

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
@@ -112,9 +112,19 @@ public sealed class PolicyRule
         {
             return EvaluateExpression(Condition.Trim(), context);
         }
-        catch
+        catch (Exception ex) when (
+            ex is FormatException
+            or InvalidCastException
+            or OverflowException
+            or RegexMatchTimeoutException)
         {
-            // Safe-fail: if evaluation errors, the rule does not match.
+            // Context-shape mismatch: a value couldn't be parsed, cast, or
+            // overflowed during comparison. The rule semantically can't match,
+            // so return false. Unexpected exceptions (NullReferenceException,
+            // ArgumentException, etc.) indicate a bug in the rule wiring and
+            // are intentionally allowed to propagate so the engine fails closed
+            // instead of silently masking a broken DENY rule under
+            // DefaultAction=Allow.
             return false;
         }
     }

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
@@ -253,4 +253,32 @@ public class PolicyRuleTests
     {
         Assert.Throws<ArgumentException>(() => PolicyRule.ParseAction("invalid"));
     }
+
+    [Fact]
+    public void Evaluate_UnexpectedException_Propagates_NotSilentlyFalse()
+    {
+        // Regression: Evaluate used to catch every exception and return false.
+        // Under DefaultAction=Allow, a buggy DENY rule that threw would silently
+        // fail open. Unexpected exception types (NRE, NotSupportedException,
+        // etc.) must now propagate so the engine fails closed.
+        var rule = new PolicyRule
+        {
+            Name = "broken-equality",
+            Condition = "tool_name == 'file_write'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["tool_name"] = new ThrowingToString()
+        };
+
+        Assert.Throws<NotSupportedException>(() => rule.Evaluate(context));
+    }
+
+    private sealed class ThrowingToString
+    {
+        public override string ToString() =>
+            throw new NotSupportedException("simulated rule-data bug");
+    }
 }


### PR DESCRIPTION
## Summary

`PolicyRule.Evaluate` wraps `EvaluateExpression` in a bare `catch` and returns `false` on any exception, with the comment "Safe-fail: if evaluation errors, the rule does not match."

Under `PolicyEngine` evaluation with `DefaultAction = Allow`, that's actually fail-open. A DENY rule whose evaluation throws — say, a `NullReferenceException` on a malformed nested context, or `NotSupportedException` from a custom value's `ToString()` — silently does not match, no candidate is recorded, and the engine applies the Allow default. The intended deny is silently masked.

## Change

Narrow the `catch` to the exception shapes that legitimately mean "this context value doesn't fit this comparison":

- `FormatException`
- `InvalidCastException`
- `OverflowException`
- `RegexMatchTimeoutException`

Everything else propagates. The engine then surfaces the exception (the caller fails closed) instead of treating a buggy rule as a quiet "no match."

This preserves the existing fail-soft behaviour for routine context-shape mismatches — which is what the comment was getting at — while removing the fail-open footgun for genuine logic bugs.

## Tests

New `Evaluate_UnexpectedException_Propagates_NotSilentlyFalse` test feeds `Evaluate` a context entry whose `ToString()` throws `NotSupportedException` and asserts the exception now escapes the rule. Existing 17 `PolicyRuleTests` pass.

`cd agent-governance-dotnet && dotnet test --nologo` → 613/613 passed.

## Test plan

- [x] New unexpected-exception test propagates instead of returning false
- [x] All existing routine-mismatch tests still return false without throwing (no `FormatException`/`InvalidCastException`-class regressions)
- [x] Full .NET suite: 613/613 pass

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, .NET]