### PR TITLE
fix(dotnet/policy): walk nested context before flat dotted-key fallback

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
@@ -298,43 +298,52 @@ public sealed class PolicyRule
     internal static object? ResolveField(string path, IReadOnlyDictionary<string, object> context)
     {
         var segments = path.Split('.');
-        object? current = null;
 
-        // Try the full key first (some contexts use dotted keys directly).
+        // Walk nested dictionaries first — that's the documented dot-notation
+        // behaviour. The flat full-key lookup that used to run first masked
+        // nested semantics whenever a context happened to carry the same
+        // dotted name as a flat key (and let a caller bypass nested
+        // resolution by injecting a flat dotted entry).
+        if (context.TryGetValue(segments[0], out object? current))
+        {
+            bool walkComplete = true;
+            for (int i = 1; i < segments.Length; i++)
+            {
+                if (current is IReadOnlyDictionary<string, object> roDict)
+                {
+                    if (!roDict.TryGetValue(segments[i], out current))
+                    {
+                        walkComplete = false;
+                        break;
+                    }
+                }
+                else if (current is IDictionary<string, object> dict)
+                {
+                    if (!dict.TryGetValue(segments[i], out current))
+                    {
+                        walkComplete = false;
+                        break;
+                    }
+                }
+                else
+                {
+                    walkComplete = false;
+                    break;
+                }
+            }
+            if (walkComplete)
+            {
+                return current;
+            }
+        }
+
+        // Fallback: legacy contexts that use the dotted name as a flat key.
         if (context.TryGetValue(path, out var directValue))
         {
             return directValue;
         }
 
-        // Walk nested dictionaries.
-        if (!context.TryGetValue(segments[0], out current))
-        {
-            return null;
-        }
-
-        for (int i = 1; i < segments.Length; i++)
-        {
-            if (current is IReadOnlyDictionary<string, object> roDict)
-            {
-                if (!roDict.TryGetValue(segments[i], out current))
-                {
-                    return null;
-                }
-            }
-            else if (current is IDictionary<string, object> dict)
-            {
-                if (!dict.TryGetValue(segments[i], out current))
-                {
-                    return null;
-                }
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        return current;
+        return null;
     }
 
     /// <summary>

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
@@ -281,4 +281,51 @@ public class PolicyRuleTests
         public override string ToString() =>
             throw new NotSupportedException("simulated rule-data bug");
     }
+
+    [Fact]
+    public void Evaluate_NestedDotNotation_WinsOverFlatDottedKey()
+    {
+        // Regression: a flat key shaped like "data.classification" used to
+        // win over the nested structure, so a caller injecting a flat dotted
+        // entry could bypass nested-walk semantics. The nested walk must run
+        // first, so a rule against the nested "secret" matches even when a
+        // shadow flat key with value "public" is also present.
+        var rule = new PolicyRule
+        {
+            Name = "nested-wins",
+            Condition = "data.classification == 'secret'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["data"] = new Dictionary<string, object>
+            {
+                ["classification"] = "secret",
+            },
+            ["data.classification"] = "public",  // would-be shadow
+        };
+
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_FallsBackToFlatDottedKey_WhenNoNestedShape()
+    {
+        // When the nested walk can't resolve (no intermediate dict), the
+        // flat dotted key is still honoured so legacy contexts keep working.
+        var rule = new PolicyRule
+        {
+            Name = "flat-fallback",
+            Condition = "data.classification == 'public'",
+            Action = PolicyAction.Allow
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["data.classification"] = "public",
+        };
+
+        Assert.True(rule.Evaluate(context));
+    }
 }


### PR DESCRIPTION
## Summary

`PolicyRule.ResolveField` tried the full dotted string as a flat key first, then fell back to nested-walk:

```csharp
if (context.TryGetValue(path, out var directValue))   // flat first
    return directValue;
// then walk segments...
```

But the docstring documents nested-walk as the primary behaviour:

> Supports nested dictionaries (e.g., "data.contains_pii" resolves context["data"]["contains_pii"]).

Two consequences:

1. **Doc/runtime mismatch.** Anyone reading the API gets a different model from how it actually evaluates.
2. **Shadowing.** A flat dotted entry like `context["data.classification"] = "public"` silently shadows the genuine nested `context["data"]["classification"]`. A caller that controls part of the context — say, an enrichment middleware that flattens or a user-supplied tag — can bypass nested-walk-based deny rules just by injecting the flat shape.

## Change

Walk the dotted segments first. If the walk completes, return that value. Only fall back to the flat full-key lookup when the walk can't resolve. That matches the docstring's intent and preserves backward compatibility for any context that legitimately uses the dotted name as a flat key.

## Tests

Two new tests via the public `Evaluate` API (no internals exposed):

- `Evaluate_NestedDotNotation_WinsOverFlatDottedKey` — nested `data.classification = "secret"` plus flat `"data.classification" = "public"` matches the deny rule against `"secret"`.
- `Evaluate_FallsBackToFlatDottedKey_WhenNoNestedShape` — flat `"data.classification" = "public"` still resolves when no nested structure exists.

`cd agent-governance-dotnet && dotnet test --nologo` → 614/614 passed.

## Test plan

- [x] Nested shape wins when both flat and nested are present
- [x] Flat fallback still works when only flat exists
- [x] Existing `Evaluate_NestedDotNotation_ResolvesCorrectly` still passes
- [x] Full .NET suite: 614/614 pass

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, .NET]