### PR TITLE
fix(dotnet/mcp): make McpSanitizedResponse fields ctor-driven, not init-after-construct

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Mcp/McpResponseSanitizer.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Mcp/McpResponseSanitizer.cs
@@ -37,16 +37,23 @@ public sealed class McpResponseFinding
 public sealed class McpSanitizedResponse
 {
     /// <summary>The sanitized text with threats neutralized.</summary>
-    public required string Sanitized { get; init; }
+    public string Sanitized { get; }
 
     /// <summary>Findings detected during sanitization.</summary>
-    public required IReadOnlyList<McpResponseFinding> Findings { get; init; }
+    public IReadOnlyList<McpResponseFinding> Findings { get; }
 
     /// <summary>Whether the text was modified during sanitization.</summary>
-    public bool Modified => Sanitized != _original;
+    public bool Modified { get; }
 
-    private readonly string _original;
-    internal McpSanitizedResponse(string original) => _original = original;
+    internal McpSanitizedResponse(
+        string original,
+        string sanitized,
+        IReadOnlyList<McpResponseFinding> findings)
+    {
+        Sanitized = sanitized;
+        Findings = findings;
+        Modified = !string.Equals(original, sanitized, StringComparison.Ordinal);
+    }
 }
 
 /// <summary>
@@ -145,10 +152,6 @@ public sealed class McpResponseSanitizer
             sanitized = redaction.Sanitized;
         }
 
-        return new McpSanitizedResponse(text)
-        {
-            Sanitized = sanitized,
-            Findings = findings.AsReadOnly()
-        };
+        return new McpSanitizedResponse(text, sanitized, findings.AsReadOnly());
     }
 }


### PR DESCRIPTION
## Summary

`McpSanitizedResponse` was a two-phase build:

```csharp
public bool Modified => Sanitized != _original;
private readonly string _original;
internal McpSanitizedResponse(string original) => _original = original;
```

The ctor captured the original text. `Sanitized` and `Findings` were populated through `init` setters **after** construction (`new McpSanitizedResponse(text) { Sanitized = ..., Findings = ... }`). `Modified` was computed lazily by comparing those two values.

The contract — "you must set `Sanitized` to the actual sanitized output" — is implicit and easy to miss. A caller that wrote `Sanitized = text` (or simply forgot to assign it after future refactors) would silently report `Modified == false` even when `Findings` was non-empty.

## Change

Move all three fields onto a single internal ctor:

```csharp
internal McpSanitizedResponse(
    string original,
    string sanitized,
    IReadOnlyList<McpResponseFinding> findings)
{
    Sanitized = sanitized;
    Findings = findings;
    Modified = !string.Equals(original, sanitized, StringComparison.Ordinal);
}
```

`Sanitized`, `Findings`, and `Modified` are all `{ get; }` only. `Modified` is computed once at construction. The relationship between original-text-in and modified-flag-out is explicit and impossible to skip.

`ScanText` is the only ctor caller (internal ctor, never invoked elsewhere in the repo), so the public-API surface is unchanged.

## Test plan

- [x] Existing 8 `McpResponseSanitizerTests` (prompt-tag, system-tag, imperative, exfil URL, benign URL, credential leakage, mixed, clean text) all pass without modification — the contract through `ScanText` is identical.
- [x] Full .NET suite: 612/612 pass.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, .NET]