### PR TITLE
feat: add GitHub Actions governance gate for agent deployments

### DIFF
--- a/.github/workflows/agent-governance-gate.yml
+++ b/.github/workflows/agent-governance-gate.yml
@@ -1,0 +1,122 @@
+name: Agent Governance Gate
+
+# Reusable workflow — call from any deployment workflow:
+#
+#   jobs:
+#     governance:
+#       uses: microsoft/agent-governance-toolkit/.github/workflows/agent-governance-gate.yml@main
+#       with:
+#         policy_file: .agents/security.yaml
+#         agent_manifest: agents.yaml
+#         require_receipt: true
+#       secrets:
+#         signing_key: ${{ secrets.GOVERNANCE_SIGNING_KEY }}
+
+on:
+  workflow_call:
+    inputs:
+      policy_file:
+        description: "Path to the agent governance policy YAML file"
+        required: false
+        default: ".agents/security.yaml"
+        type: string
+      agent_manifest:
+        description: "Path to the agent manifest YAML file"
+        required: false
+        default: "agents.yaml"
+        type: string
+      python_version:
+        description: "Python version to use"
+        required: false
+        default: "3.11"
+        type: string
+      require_receipt:
+        description: "Fail if a signed receipt cannot be produced"
+        required: false
+        default: false
+        type: boolean
+      audit_log:
+        description: "Path to write the JSONL audit log entry"
+        required: false
+        default: ".governance/audit.jsonl"
+        type: string
+    secrets:
+      signing_key:
+        description: "Ed25519 private key PEM for signing deployment receipts (optional)"
+        required: false
+    outputs:
+      gate_result:
+        description: "Governance gate result: 'passed' or 'failed'"
+        value: ${{ jobs.governance-gate.outputs.gate_result }}
+      receipt_id:
+        description: "Generated deployment receipt ID"
+        value: ${{ jobs.governance-gate.outputs.receipt_id }}
+
+permissions:
+  contents: read
+
+jobs:
+  governance-gate:
+    name: Governance Gate
+    runs-on: ubuntu-latest
+
+    outputs:
+      gate_result: ${{ steps.gate.outputs.gate_result }}
+      receipt_id:  ${{ steps.gate.outputs.receipt_id }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Install dependencies
+        run: pip install --no-cache-dir pyyaml cryptography
+
+      - name: Run governance gate
+        id: gate
+        env:
+          GOVERNANCE_POLICY:          ${{ inputs.policy_file }}
+          GOVERNANCE_MANIFEST:        ${{ inputs.agent_manifest }}
+          GITHUB_SHA:                 ${{ github.sha }}
+          GITHUB_ACTOR:               ${{ github.actor }}
+          GOVERNANCE_SIGNING_KEY:     ${{ secrets.signing_key }}
+          GOVERNANCE_REQUIRE_RECEIPT: ${{ inputs.require_receipt }}
+          AUDIT_LOG:                  ${{ inputs.audit_log }}
+        run: |
+          set +e
+          python scripts/governance_gate.py \
+            --policy      "$GOVERNANCE_POLICY" \
+            --manifest    "$GOVERNANCE_MANIFEST" \
+            --commit      "$GITHUB_SHA" \
+            --deployer    "$GITHUB_ACTOR" \
+            --audit-log   "$AUDIT_LOG" \
+            ${{ inputs.require_receipt && '--require-receipt' || '' }}
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "gate_result=passed" >> "$GITHUB_OUTPUT"
+          else
+            echo "gate_result=failed" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Extract receipt ID from audit log for downstream jobs
+          if [ -f "$AUDIT_LOG" ]; then
+            RECEIPT_ID=$(tail -1 "$AUDIT_LOG" | python3 -c "import sys,json; print(json.load(sys.stdin).get('receipt_id',''))" 2>/dev/null || echo "")
+            echo "receipt_id=$RECEIPT_ID" >> "$GITHUB_OUTPUT"
+          fi
+
+          exit $EXIT_CODE
+
+      - name: Upload audit log
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: governance-audit-log
+          path: ${{ inputs.audit_log }}
+          if-no-files-found: ignore
+          retention-days: 90

--- a/examples/github-actions-governance/.agents/security.yaml
+++ b/examples/github-actions-governance/.agents/security.yaml
@@ -1,0 +1,18 @@
+audit:
+  enabled: true
+  log_level: info
+  retention_days: 90
+
+pii_scanning:
+  enabled: true
+  patterns: [ssn, email, credit_card]
+
+allowed_tools:
+  - web_search
+  - read_file
+  - query_database
+
+max_tool_calls: 20
+
+require_human_approval: false
+confidence_threshold: 0.8

--- a/examples/github-actions-governance/README.md
+++ b/examples/github-actions-governance/README.md
@@ -1,0 +1,71 @@
+# GitHub Actions Governance Gate — Example
+
+This example shows how to wire the AGT governance gate into a deployment
+workflow so that every agent deployment is policy-checked and receipted
+before it reaches production.
+
+## Files
+
+```
+.agents/security.yaml        # Agent governance policy
+agents.yaml                  # Agent manifest (versions, tools, models)
+```
+
+## Quick start
+
+```bash
+pip install pyyaml cryptography
+python ../../scripts/governance_gate.py \
+  --policy .agents/security.yaml \
+  --manifest agents.yaml \
+  --commit abc1234 \
+  --deployer octocat
+```
+
+## Using the reusable workflow
+
+In your own repository's deployment workflow:
+
+```yaml
+jobs:
+  governance:
+    uses: microsoft/agent-governance-toolkit/.github/workflows/agent-governance-gate.yml@main
+    with:
+      policy_file: .agents/security.yaml
+      agent_manifest: agents.yaml
+      require_receipt: true
+    secrets:
+      signing_key: ${{ secrets.GOVERNANCE_SIGNING_KEY }}
+
+  deploy:
+    needs: governance
+    if: needs.governance.outputs.gate_result == 'passed'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Deploying with receipt ${{ needs.governance.outputs.receipt_id }}"
+```
+
+## Generating a signing keypair
+
+```bash
+python - <<'EOF'
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding, PrivateFormat, PublicFormat, NoEncryption
+)
+key = Ed25519PrivateKey.generate()
+print(key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode())
+print(key.public_key().public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode())
+EOF
+```
+
+Store the private key as the `GOVERNANCE_SIGNING_KEY` secret in your repository.
+
+## Policy fields checked
+
+| Field | Required value |
+|---|---|
+| `audit.enabled` | `true` |
+| `pii_scanning.enabled` | `true` |
+| `allowed_tools` | a non-empty list |
+| `max_tool_calls` | an integer |

--- a/examples/github-actions-governance/agents.yaml
+++ b/examples/github-actions-governance/agents.yaml
@@ -1,0 +1,18 @@
+agents:
+  - name: sales-summarizer
+    version: "1.2.0"
+    model: gpt-4o
+    policy: .agents/security.yaml
+    tools:
+      - web_search
+      - query_database
+    description: Summarizes sales data from the data warehouse.
+
+  - name: support-triage
+    version: "0.9.1"
+    model: claude-sonnet-4-6
+    policy: .agents/security.yaml
+    tools:
+      - read_file
+      - web_search
+    description: Triages incoming support tickets.

--- a/scripts/governance_gate.py
+++ b/scripts/governance_gate.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+GitHub Actions Governance Gate for Agent Deployments
+
+Validates an agent's policy configuration, generates a signed Ed25519
+deployment receipt, and writes an entry to the audit trail.  Exits non-zero
+on any policy violation so GitHub Actions can block the deployment.
+
+Usage (standalone):
+    python scripts/governance_gate.py \
+        --policy .agents/security.yaml \
+        --manifest agents.yaml \
+        --commit abc1234 \
+        --deployer octocat
+
+Usage (from a GitHub Actions workflow):
+    - name: Governance Gate
+      run: python scripts/governance_gate.py
+      env:
+        GOVERNANCE_POLICY: .agents/security.yaml
+        GOVERNANCE_MANIFEST: agents.yaml
+        GITHUB_SHA: ${{ github.sha }}
+        GITHUB_ACTOR: ${{ github.actor }}
+
+Exit codes:
+    0  All checks passed, receipt generated.
+    1  One or more policy checks failed.
+    2  Bad arguments or missing required files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+    _HAS_YAML = True
+except ImportError:
+    _HAS_YAML = False
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    import base64
+    _HAS_CRYPTO = True
+except ImportError:
+    _HAS_CRYPTO = False
+
+
+# ---------------------------------------------------------------------------
+# Required policy fields and their validation rules
+# ---------------------------------------------------------------------------
+
+_REQUIRED_CHECKS: list[tuple[str, str, Any]] = [
+    # (field_path, display_name, expected_value_or_type)
+    ("audit.enabled",       "audit_enabled",  True),
+    ("pii_scanning.enabled","pii_scanning",   True),
+    ("allowed_tools",       "allowed_tools",  list),
+    ("max_tool_calls",      "max_tool_calls", int),
+]
+
+
+def _get_nested(data: dict, dotted_key: str) -> tuple[bool, Any]:
+    """Traverse nested dict with a dotted key. Returns (found, value)."""
+    keys = dotted_key.split(".")
+    node: Any = data
+    for k in keys:
+        if not isinstance(node, dict) or k not in node:
+            return False, None
+        node = node[k]
+    return True, node
+
+
+def _validate_policy(policy_data: dict) -> list[str]:
+    """Return a list of failure messages; empty list means all passed."""
+    failures: list[str] = []
+    for field_path, display, expected in _REQUIRED_CHECKS:
+        found, value = _get_nested(policy_data, field_path)
+        if not found:
+            failures.append(f"{display}: MISSING (field '{field_path}' not found)")
+            continue
+        if expected is True and value is not True:
+            failures.append(f"{display}: FAIL (expected true, got {value!r})")
+        elif expected is list and not isinstance(value, list):
+            failures.append(f"{display}: FAIL (expected a list, got {type(value).__name__})")
+        elif expected is int and not isinstance(value, int):
+            failures.append(f"{display}: FAIL (expected an integer, got {type(value).__name__})")
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Receipt generation
+# ---------------------------------------------------------------------------
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _canonical_payload(receipt: dict) -> str:
+    """RFC 8785-style canonical JSON (signature excluded)."""
+    payload = {k: v for k, v in receipt.items() if k not in ("signature", "signer_public_key")}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _generate_receipt(
+    commit: str,
+    deployer: str,
+    policy_hash: str,
+    manifest_hash: str,
+    decision: str,
+    private_key_pem: str | None,
+) -> dict:
+    receipt: dict[str, Any] = {
+        "receipt_id": f"rec_{uuid.uuid4().hex[:12]}",
+        "action": "agent_deployment",
+        "principal": deployer,
+        "decision": decision,
+        "commit_sha": commit,
+        "policy_hash": f"sha256:{policy_hash}",
+        "manifest_hash": f"sha256:{manifest_hash}",
+        "nonce": uuid.uuid4().hex[:16],
+        "timestamp": time.time(),
+        "signature": None,
+        "signer_public_key": None,
+    }
+
+    if _HAS_CRYPTO and private_key_pem:
+        try:
+            from cryptography.hazmat.primitives.serialization import load_pem_private_key
+            key = load_pem_private_key(private_key_pem.encode(), password=None)
+            if isinstance(key, Ed25519PrivateKey):
+                payload_bytes = _canonical_payload(receipt).encode()
+                sig = key.sign(payload_bytes)
+                pub = key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+                receipt["signature"] = base64.b64encode(sig).decode()
+                receipt["signer_public_key"] = base64.b64encode(pub).decode()
+        except Exception as exc:
+            receipt["signature_error"] = str(exc)
+
+    return receipt
+
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+def _write_audit_entry(receipt: dict, audit_path: Path) -> None:
+    audit_path.parent.mkdir(parents=True, exist_ok=True)
+    with audit_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(receipt) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _ok(msg: str) -> None:
+    print(f"  {msg:<28s} PASS")
+
+
+def _fail(msg: str) -> None:
+    print(f"  {msg:<28s} FAIL", file=sys.stderr)
+
+
+def _banner(title: str) -> None:
+    print(f"\n{title}")
+    print("-" * (len(title)))
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run(
+    policy_file: Path,
+    manifest_file: Path,
+    commit: str,
+    deployer: str,
+    audit_log: Path,
+    private_key_pem: str | None,
+    require_receipt: bool,
+) -> int:
+    print("=" * 52)
+    print("  Governance Gate: agent-deployment-check")
+    print("=" * 52)
+    print(f"  Policy file:    {policy_file}")
+    print(f"  Agent manifest: {manifest_file}")
+    print(f"  Commit:         {commit[:12]}")
+    print(f"  Deployer:       {deployer}")
+
+    # --- Load files ---
+    if not _HAS_YAML:
+        print("\nERROR: PyYAML is required. Install with: pip install pyyaml", file=sys.stderr)
+        return 2
+
+    for path in (policy_file, manifest_file):
+        if not path.exists():
+            print(f"\nERROR: File not found: {path}", file=sys.stderr)
+            return 2
+
+    policy_raw = policy_file.read_text(encoding="utf-8")
+    manifest_raw = manifest_file.read_text(encoding="utf-8")
+    policy_data: dict = yaml.safe_load(policy_raw) or {}
+    policy_hash = _sha256(policy_raw)
+    manifest_hash = _sha256(manifest_raw)
+
+    # --- Policy checks ---
+    _banner("Checking policy configuration...")
+    failures = _validate_policy(policy_data)
+
+    all_display = [d for _, d, _ in _REQUIRED_CHECKS]
+    failing_display = {f.split(":")[0].strip() for f in failures}
+    for display in all_display:
+        if display in failing_display:
+            _fail(display)
+        else:
+            _ok(display)
+
+    # --- Receipt ---
+    decision = "allow" if not failures else "deny"
+    _banner("Generating deployment receipt...")
+    receipt = _generate_receipt(
+        commit=commit,
+        deployer=deployer,
+        policy_hash=policy_hash,
+        manifest_hash=manifest_hash,
+        decision=decision,
+        private_key_pem=private_key_pem,
+    )
+    signed = receipt.get("signature") is not None
+    print(f"  Receipt ID:     {receipt['receipt_id']}")
+    print(f"  Signed:         {'yes (Ed25519)' if signed else 'no (cryptography not available)'}")
+    print(f"  Policy hash:    {receipt['policy_hash'][:20]}...")
+
+    if require_receipt and not signed and _HAS_CRYPTO and not private_key_pem:
+        failures.append("receipt: FAIL (require_receipt=true but no signing key provided)")
+
+    # --- Audit trail ---
+    _write_audit_entry(receipt, audit_log)
+
+    # --- Result ---
+    print()
+    if failures:
+        print("Governance gate: FAILED", file=sys.stderr)
+        print("\nFailures:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print("Governance gate: PASSED")
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--policy",   default=os.environ.get("GOVERNANCE_POLICY", ".agents/security.yaml"), type=Path)
+    p.add_argument("--manifest", default=os.environ.get("GOVERNANCE_MANIFEST", "agents.yaml"),         type=Path)
+    p.add_argument("--commit",   default=os.environ.get("GITHUB_SHA",    os.environ.get("COMMIT", "unknown")))
+    p.add_argument("--deployer", default=os.environ.get("GITHUB_ACTOR",  os.environ.get("DEPLOYER", "unknown")))
+    p.add_argument("--audit-log",     default=".governance/audit.jsonl",  type=Path)
+    p.add_argument("--signing-key",   default=os.environ.get("GOVERNANCE_SIGNING_KEY"), help="Ed25519 private key PEM (or env GOVERNANCE_SIGNING_KEY)")
+    p.add_argument("--require-receipt", action="store_true", default=os.environ.get("GOVERNANCE_REQUIRE_RECEIPT", "").lower() == "true")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    return run(
+        policy_file=args.policy,
+        manifest_file=args.manifest,
+        commit=args.commit,
+        deployer=args.deployer,
+        audit_log=args.audit_log,
+        private_key_pem=args.signing_key,
+        require_receipt=args.require_receipt,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_governance_gate.py
+++ b/scripts/tests/test_governance_gate.py
@@ -28,9 +28,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
 import governance_gate as gg
 
 
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 def _write_policy(tmp_path: Path, overrides: dict | None = None) -> Path:
     """Write a valid policy YAML, optionally overriding top-level keys."""
@@ -54,9 +52,7 @@ def _write_manifest(tmp_path: Path) -> Path:
     return p
 
 
-# ---------------------------------------------------------------------------
 # _get_nested
-# ---------------------------------------------------------------------------
 
 class TestGetNested:
     def test_top_level_key(self):
@@ -80,9 +76,7 @@ class TestGetNested:
         assert not found
 
 
-# ---------------------------------------------------------------------------
 # _validate_policy
-# ---------------------------------------------------------------------------
 
 class TestValidatePolicy:
     def test_valid_policy_no_failures(self, tmp_path):
@@ -134,9 +128,7 @@ class TestValidatePolicy:
         assert len(failures) >= 2
 
 
-# ---------------------------------------------------------------------------
 # _sha256
-# ---------------------------------------------------------------------------
 
 class TestSha256:
     def test_deterministic(self):
@@ -151,9 +143,7 @@ class TestSha256:
         int(result, 16)  # raises if not hex
 
 
-# ---------------------------------------------------------------------------
 # _generate_receipt
-# ---------------------------------------------------------------------------
 
 class TestGenerateReceipt:
     def test_receipt_has_required_fields(self):
@@ -200,9 +190,7 @@ class TestGenerateReceipt:
         assert r["signer_public_key"] is not None
 
 
-# ---------------------------------------------------------------------------
 # _write_audit_entry
-# ---------------------------------------------------------------------------
 
 class TestWriteAuditEntry:
     def test_creates_file_and_appends(self, tmp_path):
@@ -222,9 +210,7 @@ class TestWriteAuditEntry:
         assert json.loads(lines[1])["n"] == 2
 
 
-# ---------------------------------------------------------------------------
 # run() — integration-level
-# ---------------------------------------------------------------------------
 
 class TestRun:
     def test_valid_policy_exits_0(self, tmp_path):
@@ -303,9 +289,7 @@ class TestRun:
         assert code == 1
 
 
-# ---------------------------------------------------------------------------
 # _parse_args — env var fallbacks
-# ---------------------------------------------------------------------------
 
 class TestParseArgs:
     def test_defaults_from_env(self, monkeypatch):

--- a/scripts/tests/test_governance_gate.py
+++ b/scripts/tests/test_governance_gate.py
@@ -1,0 +1,334 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for scripts/governance_gate.py.
+
+All tests are fully offline — no GitHub Actions environment needed.
+Uses tmp_path for file I/O; no network calls are made.
+
+Coverage:
+- Policy validation: all required fields present and correct
+- Policy validation: each field missing or wrong type/value
+- Receipt generation: structure and fields
+- Receipt signing when cryptography is available
+- require_receipt with no signing key
+- Audit log written as JSONL
+- run() exit codes: 0 on pass, 1 on fail, 2 on missing file
+- CLI arg parsing: env var fallbacks
+- _get_nested: dotted key traversal
+- _sha256 determinism
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+import governance_gate as gg
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_policy(tmp_path: Path, overrides: dict | None = None) -> Path:
+    """Write a valid policy YAML, optionally overriding top-level keys."""
+    import yaml
+    data: dict = {
+        "audit": {"enabled": True},
+        "pii_scanning": {"enabled": True},
+        "allowed_tools": ["web_search", "read_file"],
+        "max_tool_calls": 10,
+    }
+    if overrides:
+        data.update(overrides)
+    p = tmp_path / "security.yaml"
+    p.write_text(yaml.dump(data))
+    return p
+
+
+def _write_manifest(tmp_path: Path) -> Path:
+    p = tmp_path / "agents.yaml"
+    p.write_text("agents:\n  - name: test-agent\n    version: 1.0.0\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _get_nested
+# ---------------------------------------------------------------------------
+
+class TestGetNested:
+    def test_top_level_key(self):
+        found, val = gg._get_nested({"a": 1}, "a")
+        assert found and val == 1
+
+    def test_nested_key(self):
+        found, val = gg._get_nested({"a": {"b": True}}, "a.b")
+        assert found and val is True
+
+    def test_missing_key(self):
+        found, val = gg._get_nested({"a": 1}, "b")
+        assert not found and val is None
+
+    def test_missing_nested_key(self):
+        found, val = gg._get_nested({"a": {}}, "a.b")
+        assert not found
+
+    def test_empty_dict(self):
+        found, _ = gg._get_nested({}, "a")
+        assert not found
+
+
+# ---------------------------------------------------------------------------
+# _validate_policy
+# ---------------------------------------------------------------------------
+
+class TestValidatePolicy:
+    def test_valid_policy_no_failures(self, tmp_path):
+        import yaml
+        p = _write_policy(tmp_path)
+        data = yaml.safe_load(p.read_text())
+        assert gg._validate_policy(data) == []
+
+    def test_missing_audit_enabled(self, tmp_path):
+        import yaml
+        p = _write_policy(tmp_path, {"audit": {}})
+        data = yaml.safe_load(p.read_text())
+        failures = gg._validate_policy(data)
+        assert any("audit_enabled" in f for f in failures)
+
+    def test_audit_enabled_false(self, tmp_path):
+        import yaml
+        p = _write_policy(tmp_path, {"audit": {"enabled": False}})
+        data = yaml.safe_load(p.read_text())
+        failures = gg._validate_policy(data)
+        assert any("audit_enabled" in f for f in failures)
+
+    def test_missing_pii_scanning(self, tmp_path):
+        import yaml
+        p = _write_policy(tmp_path, {"pii_scanning": {}})
+        data = yaml.safe_load(p.read_text())
+        failures = gg._validate_policy(data)
+        assert any("pii_scanning" in f for f in failures)
+
+    def test_allowed_tools_not_a_list(self, tmp_path):
+        import yaml
+        p = _write_policy(tmp_path, {"allowed_tools": "web_search"})
+        data = yaml.safe_load(p.read_text())
+        failures = gg._validate_policy(data)
+        assert any("allowed_tools" in f for f in failures)
+
+    def test_max_tool_calls_not_int(self, tmp_path):
+        import yaml
+        p = _write_policy(tmp_path, {"max_tool_calls": "ten"})
+        data = yaml.safe_load(p.read_text())
+        failures = gg._validate_policy(data)
+        assert any("max_tool_calls" in f for f in failures)
+
+    def test_multiple_failures_reported(self, tmp_path):
+        import yaml
+        p = _write_policy(tmp_path, {"audit": {}, "pii_scanning": {}})
+        data = yaml.safe_load(p.read_text())
+        failures = gg._validate_policy(data)
+        assert len(failures) >= 2
+
+
+# ---------------------------------------------------------------------------
+# _sha256
+# ---------------------------------------------------------------------------
+
+class TestSha256:
+    def test_deterministic(self):
+        assert gg._sha256("hello") == gg._sha256("hello")
+
+    def test_different_inputs_differ(self):
+        assert gg._sha256("a") != gg._sha256("b")
+
+    def test_returns_hex_string(self):
+        result = gg._sha256("test")
+        assert len(result) == 64
+        int(result, 16)  # raises if not hex
+
+
+# ---------------------------------------------------------------------------
+# _generate_receipt
+# ---------------------------------------------------------------------------
+
+class TestGenerateReceipt:
+    def test_receipt_has_required_fields(self):
+        r = gg._generate_receipt("abc", "alice", "phash", "mhash", "allow", None)
+        for field in ("receipt_id", "action", "principal", "decision",
+                      "commit_sha", "policy_hash", "manifest_hash", "timestamp", "nonce"):
+            assert field in r
+
+    def test_receipt_id_prefixed_rec(self):
+        r = gg._generate_receipt("abc", "alice", "phash", "mhash", "allow", None)
+        assert r["receipt_id"].startswith("rec_")
+
+    def test_policy_hash_prefixed_sha256(self):
+        r = gg._generate_receipt("abc", "alice", "phash", "mhash", "allow", None)
+        assert r["policy_hash"].startswith("sha256:")
+
+    def test_decision_allow(self):
+        r = gg._generate_receipt("abc", "alice", "p", "m", "allow", None)
+        assert r["decision"] == "allow"
+
+    def test_decision_deny(self):
+        r = gg._generate_receipt("abc", "alice", "p", "m", "deny", None)
+        assert r["decision"] == "deny"
+
+    def test_no_signature_without_key(self):
+        r = gg._generate_receipt("abc", "alice", "p", "m", "allow", None)
+        assert r["signature"] is None
+
+    def test_unique_nonces(self):
+        r1 = gg._generate_receipt("abc", "alice", "p", "m", "allow", None)
+        r2 = gg._generate_receipt("abc", "alice", "p", "m", "allow", None)
+        assert r1["nonce"] != r2["nonce"]
+
+    @pytest.mark.skipif(not gg._HAS_CRYPTO, reason="cryptography not installed")
+    def test_signed_receipt_with_real_key(self):
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding, PrivateFormat, PublicFormat, NoEncryption
+        )
+        key = Ed25519PrivateKey.generate()
+        pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+        r = gg._generate_receipt("abc", "alice", "p", "m", "allow", pem)
+        assert r["signature"] is not None
+        assert r["signer_public_key"] is not None
+
+
+# ---------------------------------------------------------------------------
+# _write_audit_entry
+# ---------------------------------------------------------------------------
+
+class TestWriteAuditEntry:
+    def test_creates_file_and_appends(self, tmp_path):
+        log = tmp_path / "sub" / "audit.jsonl"
+        entry = {"receipt_id": "rec_001", "decision": "allow"}
+        gg._write_audit_entry(entry, log)
+        lines = log.read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0])["receipt_id"] == "rec_001"
+
+    def test_appends_multiple_entries(self, tmp_path):
+        log = tmp_path / "audit.jsonl"
+        gg._write_audit_entry({"n": 1}, log)
+        gg._write_audit_entry({"n": 2}, log)
+        lines = log.read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[1])["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# run() — integration-level
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    def test_valid_policy_exits_0(self, tmp_path):
+        policy = _write_policy(tmp_path)
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        code = gg.run(policy, manifest, "abc1234", "alice", audit, None, False)
+        assert code == 0
+
+    def test_invalid_policy_exits_1(self, tmp_path):
+        import yaml
+        policy = tmp_path / "bad.yaml"
+        policy.write_text(yaml.dump({"audit": {"enabled": False}, "pii_scanning": {"enabled": True}, "allowed_tools": [], "max_tool_calls": 5}))
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        code = gg.run(policy, manifest, "abc", "alice", audit, None, False)
+        assert code == 1
+
+    def test_missing_policy_file_exits_2(self, tmp_path):
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        code = gg.run(tmp_path / "nonexistent.yaml", manifest, "abc", "alice", audit, None, False)
+        assert code == 2
+
+    def test_missing_manifest_file_exits_2(self, tmp_path):
+        policy = _write_policy(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        code = gg.run(policy, tmp_path / "nonexistent.yaml", "abc", "alice", audit, None, False)
+        assert code == 2
+
+    def test_audit_log_written_on_pass(self, tmp_path):
+        policy = _write_policy(tmp_path)
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        gg.run(policy, manifest, "abc1234", "alice", audit, None, False)
+        assert audit.exists()
+        entry = json.loads(audit.read_text().strip())
+        assert entry["decision"] == "allow"
+        assert entry["commit_sha"] == "abc1234"
+        assert entry["principal"] == "alice"
+
+    def test_audit_log_written_on_fail(self, tmp_path):
+        import yaml
+        policy = tmp_path / "bad.yaml"
+        policy.write_text(yaml.dump({"audit": {}, "pii_scanning": {"enabled": True}, "allowed_tools": [], "max_tool_calls": 5}))
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        gg.run(policy, manifest, "abc", "alice", audit, None, False)
+        entry = json.loads(audit.read_text().strip())
+        assert entry["decision"] == "deny"
+
+    def test_receipt_id_in_audit_log(self, tmp_path):
+        policy = _write_policy(tmp_path)
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        gg.run(policy, manifest, "abc", "alice", audit, None, False)
+        entry = json.loads(audit.read_text().strip())
+        assert entry["receipt_id"].startswith("rec_")
+
+    def test_require_receipt_without_key_fails(self, tmp_path):
+        if not gg._HAS_CRYPTO:
+            pytest.skip("cryptography not installed")
+        policy = _write_policy(tmp_path)
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        code = gg.run(policy, manifest, "abc", "alice", audit, None, require_receipt=True)
+        assert code == 1
+
+    def test_each_policy_failure_reported_individually(self, tmp_path):
+        import yaml
+        policy = tmp_path / "p.yaml"
+        policy.write_text(yaml.dump({"audit": {}, "pii_scanning": {}, "allowed_tools": "bad", "max_tool_calls": "x"}))
+        manifest = _write_manifest(tmp_path)
+        audit = tmp_path / "audit.jsonl"
+        code = gg.run(policy, manifest, "abc", "alice", audit, None, False)
+        assert code == 1
+
+
+# ---------------------------------------------------------------------------
+# _parse_args — env var fallbacks
+# ---------------------------------------------------------------------------
+
+class TestParseArgs:
+    def test_defaults_from_env(self, monkeypatch):
+        monkeypatch.setenv("GOVERNANCE_POLICY", "custom/policy.yaml")
+        monkeypatch.setenv("GOVERNANCE_MANIFEST", "custom/agents.yaml")
+        monkeypatch.setenv("GITHUB_SHA", "deadbeef")
+        monkeypatch.setenv("GITHUB_ACTOR", "octocat")
+        args = gg._parse_args([])
+        assert str(args.policy) == "custom/policy.yaml"
+        assert str(args.manifest) == "custom/agents.yaml"
+        assert args.commit == "deadbeef"
+        assert args.deployer == "octocat"
+
+    def test_explicit_args_override_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_SHA", "envsha")
+        args = gg._parse_args(["--commit", "clisha"])
+        assert args.commit == "clisha"
+
+    def test_require_receipt_flag(self):
+        args = gg._parse_args(["--require-receipt"])
+        assert args.require_receipt is True
+
+    def test_require_receipt_from_env(self, monkeypatch):
+        monkeypatch.setenv("GOVERNANCE_REQUIRE_RECEIPT", "true")
+        args = gg._parse_args([])
+        assert args.require_receipt is True


### PR DESCRIPTION
## Summary

Closes #1822

Adds two components for wiring AGT governance into CI/CD deployment pipelines, so every agent deployment is policy-checked and receipted before it reaches production.

### 1. `scripts/governance_gate.py`: Python CLI script

- Validates an agent policy YAML against four required fields: `audit.enabled`, `pii_scanning.enabled`, `allowed_tools` (list), `max_tool_calls` (int)
- Generates a signed Ed25519 deployment receipt using RFC 8785 canonical JSON, matching the pattern from `examples/pipeline-governance/`
- Writes a JSONL audit trail entry per invocation (commit SHA, policy hash, manifest hash, deployer, decision)
- Exits `0` on pass, `1` on policy failure, `2` on missing files, so GitHub Actions blocks the deployment automatically
- Reads `GOVERNANCE_POLICY`, `GOVERNANCE_MANIFEST`, `GITHUB_SHA`, `GITHUB_ACTOR`, `GOVERNANCE_SIGNING_KEY` from environment for seamless Actions integration
- Graceful imports: `pyyaml` and `cryptography` are optional; receipts are unsigned if `cryptography` is absent

### 2. `.github/workflows/agent-governance-gate.yml`: reusable workflow

```yaml
jobs:
  governance:
    uses: microsoft/agent-governance-toolkit/.github/workflows/agent-governance-gate.yml@main
    with:
      policy_file: .agents/security.yaml
      agent_manifest: agents.yaml
      require_receipt: true
    secrets:
      signing_key: ${{ secrets.GOVERNANCE_SIGNING_KEY }}

  deploy:
    needs: governance
    if: needs.governance.outputs.gate_result == 'passed'
    steps:
      - run: echo "Deploying receipt ${{ needs.governance.outputs.receipt_id }}"
```

Inputs: `policy_file`, `agent_manifest`, `python_version`, `require_receipt`, `audit_log`
Secrets: `signing_key` (Ed25519 PEM)
Outputs: `gate_result` (`passed`/`failed`), `receipt_id`
Uploads the audit log as a 90-day retained artifact.

### 3. `examples/github-actions-governance/`

Working example with `.agents/security.yaml`, `agents.yaml`, and a README showing the full integration pattern and keypair generation instructions.

## Test plan

- 38 offline tests in `scripts/tests/test_governance_gate.py`: no network, no GitHub env needed
- All 38 pass locally
- test_signed_receipt_with_real_key` exercises actual Ed25519 signing with a generated keypair