### PR TITLE
fix(dotnet/policy): bound OpaPolicyBackend HttpClient connection lifetime

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -33,7 +33,20 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
     private static readonly Regex AllowBlockRegex = new(@"allow\s*\{(?<body>.*?)\}", RegexOptions.Singleline | RegexOptions.CultureInvariant);
     private static readonly Regex EqualityRegex = new(@"^input\.(?<field>[A-Za-z0-9_]+)\s*(?<op>==|!=)\s*(?<value>true|false|""[^""]*"")$", RegexOptions.CultureInvariant);
     private static readonly Regex NotRegex = new(@"^not\s+input\.(?<field>[A-Za-z0-9_]+)$", RegexOptions.CultureInvariant);
-    private static readonly HttpClient HttpClient = new();
+
+    // Static HttpClient backed by a SocketsHttpHandler with a bounded
+    // PooledConnectionLifetime so long-running processes recycle the
+    // connection (and re-resolve DNS) every two minutes. Without this, a
+    // process-lifetime singleton HttpClient holds the original DNS answer
+    // forever and ignores rolling-deploy / scale-out / blue-green moves of
+    // the OPA endpoint. Per-request deadlines are enforced via CancellationToken
+    // (CancellationTokenSource.CancelAfter(_timeout)); HttpClient.Timeout is
+    // left at its default and not used as the primary deadline.
+    private static readonly HttpClient HttpClient = new(new SocketsHttpHandler
+    {
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+        PooledConnectionIdleTimeout = TimeSpan.FromMinutes(1)
+    });
 
     private readonly string? _regoContent;
     private readonly string? _regoPath;


### PR DESCRIPTION
## Problem

`OpaPolicyBackend` exposes a process-lifetime singleton HttpClient:

```csharp
private static readonly HttpClient HttpClient = new();
```

The default `SocketsHttpHandler` has `PooledConnectionLifetime = Timeout.InfiniteTimeSpan`, which means a single resolved `(host, port) -> IP` mapping is reused for as long as the process lives. When the OPA endpoint is moved by a rolling deploy, blue/green cutover, scale-out, or DNS TTL expiry, the client keeps sending requests to the dead/old IP until the host process restarts.

This is the well-known [static-HttpClient DNS-staleness pitfall](https://learn.microsoft.com/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use). For agent-governance services that run for days, this can quietly turn into ``500 from upstream`` patterns after any OPA topology change.

Per-request deadlines were already correctly enforced via `CancellationTokenSource.CancelAfter(_timeout)` on both the sync and async paths, so the original ``no timeout`` half of the finding was already mitigated. The remaining gap was the DNS / connection-lifetime half.

## Fix

Swap the static HttpClient for one backed by a `SocketsHttpHandler` with a bounded lifetime:

```csharp
private static readonly HttpClient HttpClient = new(new SocketsHttpHandler
{
    PooledConnectionLifetime = TimeSpan.FromMinutes(2),
    PooledConnectionIdleTimeout = TimeSpan.FromMinutes(1)
});
```

- `PooledConnectionLifetime = 2m` forces each pooled connection (and its DNS resolution) to be recycled every two minutes.
- `PooledConnectionIdleTimeout = 1m` reclaims connections that stop being used, keeping the pool small in low-traffic processes.
- The public ctor is unchanged. No `IHttpClientFactory` / DI plumbing is introduced; this is the documented Microsoft pattern for static-singleton HttpClients in libraries that can't assume a DI container.

`HttpClient.Timeout` is intentionally left at the default — per-request deadlines are owned by the existing `CancellationTokenSource.CancelAfter(_timeout)` path, and adding a second deadline on the HttpClient would only add a fallback floor (already documented in the new comment).

## Test

No behavioural test added — DNS-recycling timing isn't observable without a real OPA server and a controlled clock. Full .NET test suite continues to pass (649 / 649 on a clean run; one unrelated metrics test exhibits a known parallel-test-ordering flake that reproduces against `main` as well).

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, .NET Policy]