### PR TITLE
fix(typescript/policy): split conjunctions on out-of-quote boundaries in evaluateExpression

### DIFF
--- a/agent-governance-typescript/src/policy.ts
+++ b/agent-governance-typescript/src/policy.ts
@@ -153,6 +153,41 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
 }
 
 /**
+ * Split `expr` on the literal separator `sep` only at positions that are
+ * outside of single- or double-quoted string literals. A naive
+ * `String.split(' or ')` mis-splits expressions like
+ * `name == 'foo or bar'` because the operator substring also appears inside
+ * the string literal; this helper walks the expression once, tracking quote
+ * state, and only treats separator occurrences outside quotes as boundaries.
+ * If no out-of-quote occurrence is found, the result has length 1 and the
+ * caller falls through to the comparison-operator branches.
+ */
+function splitOutsideQuotes(expr: string, sep: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i <= expr.length - sep.length; i++) {
+    const ch = expr[i];
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (!inSingle && !inDouble && expr.startsWith(sep, i)) {
+      parts.push(expr.slice(start, i));
+      start = i + sep.length;
+      i += sep.length - 1;
+    }
+  }
+  parts.push(expr.slice(start));
+  return parts;
+}
+
+/**
  * Evaluate a condition expression string against a context dictionary.
  * Supports: equality, inequality, numeric comparisons, `in` operator,
  * boolean attributes, and compound `and`/`or`.
@@ -160,16 +195,17 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
 function evaluateExpression(expr: string, context: Record<string, unknown>): boolean {
   const trimmed = expr.trim();
 
-  // OR conditions (lowest precedence)
-  if (trimmed.includes(' or ')) {
-    const parts = trimmed.split(' or ');
-    return parts.some((p) => evaluateExpression(p.trim(), context));
+  // OR conditions (lowest precedence) — only split on out-of-quote separators
+  // so `name == 'foo or bar'` is not mis-tokenised.
+  const orParts = splitOutsideQuotes(trimmed, ' or ');
+  if (orParts.length > 1) {
+    return orParts.some((p) => evaluateExpression(p.trim(), context));
   }
 
-  // AND conditions
-  if (trimmed.includes(' and ')) {
-    const parts = trimmed.split(' and ');
-    return parts.every((p) => evaluateExpression(p.trim(), context));
+  // AND conditions — same out-of-quote split.
+  const andParts = splitOutsideQuotes(trimmed, ' and ');
+  if (andParts.length > 1) {
+    return andParts.every((p) => evaluateExpression(p.trim(), context));
   }
 
   // NOT IN: path not in ['a', 'b']

--- a/agent-governance-typescript/tests/policy-parity.test.ts
+++ b/agent-governance-typescript/tests/policy-parity.test.ts
@@ -200,6 +200,35 @@ rules:
       expect(evalResult(engine, { user: { role: 'viewer' } }).allowed).toBe(false);
     });
 
+    it('does not split on ` or ` / ` and ` substrings inside string literals', () => {
+      // Before this guard, `String.split(' or ')` on the condition string
+      // sliced the literal `'foo or bar'` in half, the resulting fragments
+      // never matched any comparison branch, and the rule silently
+      // evaluated to deny.
+      const orEngine = makeEngine("name == 'foo or bar'");
+      expect(evalResult(orEngine, { name: 'foo or bar' }).allowed).toBe(true);
+      expect(evalResult(orEngine, { name: 'foo' }).allowed).toBe(false);
+
+      const andEngine = makeEngine("name == 'big and tall'");
+      expect(evalResult(andEngine, { name: 'big and tall' }).allowed).toBe(true);
+      expect(evalResult(andEngine, { name: 'big' }).allowed).toBe(false);
+
+      // Double-quoted literals get the same treatment.
+      const dqEngine = makeEngine('label == "ham or eggs"');
+      expect(evalResult(dqEngine, { label: 'ham or eggs' }).allowed).toBe(true);
+
+      // Mixed: a real out-of-quote `and` plus a literal ` or ` inside a string.
+      const mixedEngine = makeEngine(
+        "name == 'foo or bar' and role == 'admin'",
+      );
+      expect(
+        evalResult(mixedEngine, { name: 'foo or bar', role: 'admin' }).allowed,
+      ).toBe(true);
+      expect(
+        evalResult(mixedEngine, { name: 'foo or bar', role: 'user' }).allowed,
+      ).toBe(false);
+    });
+
     it('handles nested dot paths', () => {
       const engine = makeEngine("request.metadata.source == 'internal'");
       expect(evalResult(engine, { request: { metadata: { source: 'internal' } } }).allowed).toBe(true);


### PR DESCRIPTION
## Problem

`evaluateExpression` ([policy.ts:160-173](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/src/policy.ts#L160-L173)) splits the condition string on literal `\" or \"` and `\" and \"` substrings before any other parsing step:

```typescript
if (trimmed.includes(' or ')) {
  const parts = trimmed.split(' or ');
  return parts.some((p) => evaluateExpression(p.trim(), context));
}

if (trimmed.includes(' and ')) {
  const parts = trimmed.split(' and ');
  return parts.every((p) => evaluateExpression(p.trim(), context));
}
```

The substrings ` or ` and ` and ` can legitimately appear inside string literals — `name == 'foo or bar'` gets split into `[\"name == 'foo\", \"bar'\"]`. Neither half matches any of the downstream comparison-operator regexes (they require balanced quotes), the OR-branch returns `false`, and the rule silently evaluates to deny under the default fail-closed policy.

This is a correctness rather than a security primitive — a misauthored allow rule with the right shape would silently never fire — but the fix is small and well-contained.

## Fix

Introduce `splitOutsideQuotes(expr, sep)`: walk the expression once, track single- and double-quote state, and only treat separator occurrences outside of quotes as split boundaries. If the result has length 1, no out-of-quote separator existed and the caller falls through to the comparison-operator branches with the literal intact:

```typescript
const orParts = splitOutsideQuotes(trimmed, ' or ');
if (orParts.length > 1) {
  return orParts.some((p) => evaluateExpression(p.trim(), context));
}

const andParts = splitOutsideQuotes(trimmed, ' and ');
if (andParts.length > 1) {
  return andParts.every((p) => evaluateExpression(p.trim(), context));
}
```

No public API change; the new helper is module-local.

## Test

Adds `evaluateExpression` parity tests in `policy-parity.test.ts` covering:

1. Single-quoted ` or ` literal: `name == 'foo or bar'`.
2. Single-quoted ` and ` literal: `name == 'big and tall'`.
3. Double-quoted ` or ` literal: `label == \"ham or eggs\"`.
4. The mixed case: a real out-of-quote ` and ` operand whose left side has a literal ` or ` inside its string.

Full TypeScript policy-suite is 84 / 84 green.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript Policy]