### PR TITLE
fix(typescript/identity): break parentDid cycles in IdentityRegistry.revoke

### DIFF
--- a/agent-governance-typescript/src/identity.ts
+++ b/agent-governance-typescript/src/identity.ts
@@ -429,14 +429,29 @@ export class IdentityRegistry {
 
   /** Revoke an identity and all its delegates. */
   revoke(did: string, reason: string): boolean {
+    return this.revokeRecursive(did, reason, new Set<string>());
+  }
+
+  /**
+   * Recurse through the parent→child delegation graph, revoking each
+   * reachable identity exactly once. `visited` is shared across the whole
+   * traversal so a cycle in the `parentDid` relation (which should not
+   * arise via the public `delegate()` API, but could be constructed from a
+   * corrupted store, a custom builder, or a bug elsewhere) terminates
+   * after each node is processed once instead of recursing forever and
+   * eventually overflowing the JS call stack.
+   */
+  private revokeRecursive(did: string, reason: string, visited: Set<string>): boolean {
+    if (visited.has(did)) return false;
+    visited.add(did);
+
     const identity = this._identities.get(did);
     if (!identity) return false;
     identity.revoke(reason);
 
-    // Revoke children
     for (const [childDid, child] of this._identities) {
       if (child.parentDid === did) {
-        this.revoke(childDid, `Parent revoked: ${reason}`);
+        this.revokeRecursive(childDid, `Parent revoked: ${reason}`, visited);
       }
     }
     return true;

--- a/agent-governance-typescript/tests/identity-parity.test.ts
+++ b/agent-governance-typescript/tests/identity-parity.test.ts
@@ -305,6 +305,23 @@ describe('IdentityRegistry', () => {
     expect(child.status).toBe('revoked');
   });
 
+  it('terminates revocation even when parentDid forms a cycle', () => {
+    // A legitimate `delegate()` call cannot create a parentDid cycle, but a
+    // corrupted persistence store, a custom builder, or a future bug could.
+    // The cascade walks all reachable children, so without a visited-set
+    // guard a cycle would recurse forever and overflow the JS call stack.
+    const child = id1.delegate('child', ['read']);
+    registry.register(id1);
+    registry.register(child);
+
+    // Force the cycle: id1.parentDid -> child.did, child.parentDid -> id1.did.
+    (id1 as unknown as { _parentDid: string | null })._parentDid = child.did;
+
+    expect(registry.revoke(id1.did, 'cycle test')).toBe(true);
+    expect(id1.status).toBe('revoked');
+    expect(child.status).toBe('revoked');
+  });
+
   it('returns false revoking unknown DID', () => {
     expect(registry.revoke('did:nonexistent', 'reason')).toBe(false);
   });


### PR DESCRIPTION
## Problem

[`IdentityRegistry.revoke`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/src/identity.ts#L431-L443) cascades revocation by iterating every registered entry and recursing whenever `child.parentDid === did`:

```typescript
revoke(did: string, reason: string): boolean {
  const identity = this._identities.get(did);
  if (!identity) return false;
  identity.revoke(reason);

  for (const [childDid, child] of this._identities) {
    if (child.parentDid === did) {
      this.revoke(childDid, `Parent revoked: ${reason}`);
    }
  }
  return true;
}
```

A legitimate `delegate()` call cannot create a `parentDid` cycle — `delegate()` only sets the child's `_parentDid` to its caller. But a corrupted persistence store, a custom builder that bypasses `delegate()`, or a future bug elsewhere could leave the store with `A.parentDid = B` and `B.parentDid = A`. With no visited-set guard, `revoke(A, ...)` recurses into `revoke(B, ...)` recurses back into `revoke(A, ...)` and so on, until the JS call stack overflows.

## Fix

Split into a public `revoke(did, reason)` wrapper and a private `revokeRecursive(did, reason, visited)` helper. The wrapper allocates a fresh `Set<string>` per top-level call; the helper short-circuits on re-entry into an already-visited DID:

```typescript
revoke(did: string, reason: string): boolean {
  return this.revokeRecursive(did, reason, new Set<string>());
}

private revokeRecursive(did: string, reason: string, visited: Set<string>): boolean {
  if (visited.has(did)) return false;
  visited.add(did);

  const identity = this._identities.get(did);
  if (!identity) return false;
  identity.revoke(reason);

  for (const [childDid, child] of this._identities) {
    if (child.parentDid === did) {
      this.revokeRecursive(childDid, `Parent revoked: ${reason}`, visited);
    }
  }
  return true;
}
```

Each reachable identity is still revoked exactly once. Cascade behaviour for legitimate (acyclic) parent→child chains is unchanged.

## Test

Adds a cycle test in `identity-parity.test.ts` that builds a legitimate child via `delegate()`, then forces `id1.parentDid = child.did` to create the cycle. The test asserts `revoke()` terminates (no stack overflow) and that both identities are marked revoked. Existing identity / trust tests (55 / 55) continue to pass.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript Identity]