### PR TITLE
fix(typescript/encryption): use crypto.timingSafeEqual for ratchet DH public-key comparison

### DIFF
--- a/agent-governance-typescript/src/encryption/ratchet.ts
+++ b/agent-governance-typescript/src/encryption/ratchet.ts
@@ -13,7 +13,7 @@ import { chacha20poly1305 } from "@noble/ciphers/chacha.js";
 import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { hmac } from "@noble/hashes/hmac.js";
-import { webcrypto } from "node:crypto";
+import { timingSafeEqual, webcrypto } from "node:crypto";
 
 const randomBytes = (n: number): Uint8Array => {
   const buf = new Uint8Array(n);
@@ -98,13 +98,19 @@ function skippedKeyId(dhPub: Uint8Array, n: number): string {
   return `${Buffer.from(dhPub).toString("hex")}:${n}`;
 }
 
+// Used to detect a DH ratchet step by comparing the locally-cached
+// `dhRemotePublic` against the attacker-controlled header's `dhPublicKey`.
+// The per-byte early-return loop leaked match-prefix length via timing; the
+// X25519 public keys involved are exchanged in the clear over the wire so
+// the leak yields no new information in the current protocol, but
+// `crypto.timingSafeEqual` is the right primitive for key-shaped material
+// and protects against the same comparison being lifted into a future caller
+// that does treat the public key as sensitive (e.g. an unpublished one-time
+// pre-key the recipient committed to but never broadcast).
 function arraysEqual(a: Uint8Array | null, b: Uint8Array | null): boolean {
   if (a === null || b === null) return a === b;
   if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
+  return timingSafeEqual(a, b);
 }
 
 export class DoubleRatchet {


### PR DESCRIPTION
## Problem

[`arraysEqual` in `encryption/ratchet.ts`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/src/encryption/ratchet.ts#L101-L108) is a per-byte early-return loop:

```typescript
function arraysEqual(a: Uint8Array | null, b: Uint8Array | null): boolean {
  if (a === null || b === null) return a === b;
  if (a.length !== b.length) return false;
  for (let i = 0; i < a.length; i++) {
    if (a[i] !== b[i]) return false;
  }
  return true;
}
```

It is called from `decrypt()` to test whether the incoming header's `dhPublicKey` differs from the locally-cached `dhRemotePublic` — the trigger for a DH ratchet step. The attacker-controlled header value reaches the comparison on every received message, and per-byte early return leaks the match-prefix length via response time.

In the current AGENTMESH-WIRE-1.0 protocol the X25519 public keys involved are exchanged in the clear over the wire, so the leak yields no new information today. The fix is still worth shipping as defence-in-depth: `crypto.timingSafeEqual` is the right primitive for key-shaped material and protects the comparison from being lifted into a future caller that does treat the public key as sensitive (e.g. an unpublished one-time pre-key the recipient committed to but never broadcast).

## Fix

```typescript
import { timingSafeEqual, webcrypto } from \"node:crypto\";

function arraysEqual(a: Uint8Array | null, b: Uint8Array | null): boolean {
  if (a === null || b === null) return a === b;
  if (a.length !== b.length) return false;
  return timingSafeEqual(a, b);
}
```

The null- and length-mismatch short circuits are preserved (Node's `timingSafeEqual` throws `RangeError` on length mismatch, so the explicit length check is still needed). No public API change.

## Test

No new test added — runtime timing is not a property the test runner can assert. All existing encryption tests (25 / 25) continue to pass.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript Encryption]