### PR TITLE
fix(typescript/agent-os-vscode): catch rejections from KernelDebuggerProvider setInterval polling

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/views/kernelDebuggerView.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/views/kernelDebuggerView.ts
@@ -72,8 +72,19 @@ export class KernelDebuggerProvider implements vscode.TreeDataProvider<DebuggerI
     }
 
     private startPolling(): void {
+        // `updateKernelState` is async and returns a Promise; `setInterval`
+        // discards the return value, so any rejection from the kernel-state
+        // refresh (network failure once the simulated body is replaced with a
+        // real client, transient kernel access error, etc.) would be a
+        // floating unhandled rejection and either crash the extension host on
+        // recent Node defaults or, more often, vanish silently. Attach a
+        // `.catch` that surfaces the failure via `console.error` so the
+        // refresh keeps running on the next tick without losing the
+        // diagnostic.
         this._refreshInterval = setInterval(() => {
-            this.updateKernelState();
+            this.updateKernelState().catch((err) => {
+                console.error('KernelDebuggerProvider: updateKernelState failed', err);
+            });
             this._onDidChangeTreeData.fire();
         }, 1000);
     }


### PR DESCRIPTION
## Problem

[`KernelDebuggerProvider.startPolling`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/views/kernelDebuggerView.ts#L74-L79) fires an `async updateKernelState()` from inside `setInterval` and discards the returned `Promise`:

```typescript
private startPolling(): void {
    this._refreshInterval = setInterval(() => {
        this.updateKernelState();          // floating promise
        this._onDidChangeTreeData.fire();
    }, 1000);
}
```

The body of `updateKernelState` today is simulated and never rejects. Once it is replaced with a real kernel client (network, IPC, etc.) any rejection would be a floating unhandled rejection — and either crash the VS Code extension host on recent Node defaults or, more often, vanish silently. The interval keeps running but the operator never sees the failure.

## Fix

Attach `.catch` that surfaces the error via `console.error` so the next tick continues to run and the failure shows up in the VS Code Developer Tools console:

```typescript
this._refreshInterval = setInterval(() => {
    this.updateKernelState().catch((err) => {
        console.error('KernelDebuggerProvider: updateKernelState failed', err);
    });
    this._onDidChangeTreeData.fire();
}, 1000);
```

No public-API or behavioural change for the success path.

## Test

The view is wired to live VS Code TreeView APIs and is not unit-tested in the extension package today (the `test` script wraps an integration runner that needs the VS Code download). The single-line change is shape-only and the success path is unchanged.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript agent-os-vscode]