### PR TITLE
fix(typescript/agent-os-vscode): validate WebSocket session token in constant time

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/server/serverHelpers.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/server/serverHelpers.ts
@@ -8,7 +8,7 @@
  */
 
 import * as http from 'http';
-import { randomBytes } from 'crypto';
+import { randomBytes, timingSafeEqual } from 'crypto';
 
 /** Default host for the governance server — bound to loopback only. */
 export const DEFAULT_HOST = '127.0.0.1';
@@ -149,7 +149,23 @@ export function validateWebSocketToken(
         // Header value is comma-separated: "governance-v1, <token>"
         const protocols = (typeof protocolHeader === 'string' ? protocolHeader : protocolHeader[0] ?? '')
             .split(',').map(s => s.trim());
-        return protocols.includes(expectedToken);
+        // `Array.prototype.includes` short-circuits on first match and uses
+        // V8's per-byte `===` for each comparison, which leaks a timing
+        // signal proportional to the longest matching prefix between an
+        // attacker's guess and the real token. Compare with
+        // `crypto.timingSafeEqual` and iterate every protocol unconditionally
+        // so neither the matching position nor the match-prefix length is
+        // observable from response time.
+        const expectedBuf = Buffer.from(expectedToken, 'utf8');
+        let matched = false;
+        for (const protocol of protocols) {
+            const candidateBuf = Buffer.from(protocol, 'utf8');
+            if (candidateBuf.length !== expectedBuf.length) { continue; }
+            if (timingSafeEqual(candidateBuf, expectedBuf)) {
+                matched = true;
+            }
+        }
+        return matched;
     } catch {
         return false;
     }


### PR DESCRIPTION
## Problem

[`validateWebSocketToken`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/server/serverHelpers.ts#L141-L156) resolved the candidate token list from `Sec-WebSocket-Protocol` and then matched with `Array.prototype.includes`:

```typescript
const protocols = (typeof protocolHeader === 'string' ? protocolHeader : protocolHeader[0] ?? '')
    .split(',').map(s => s.trim());
return protocols.includes(expectedToken);
```

`includes` short-circuits on first match and falls back to V8's per-byte `===` for each string comparison, leaking a timing signal proportional to the longest matching prefix between the attacker's candidate and the real session token. An attacker who controls the subprotocol header (every WebSocket client does) and can measure server response time can brute-force the token a few bytes at a time.

Today the governance server binds to `127.0.0.1` only, so the attacker would also need to be on the loopback interface — a co-located process or a future bind-to-host configuration would put this in reach. The token is the bearer credential that gates every WebSocket subscription to the governance server, so it is worth fixing now even with the current binding.

## Fix

Replace `includes` with a loop that compares each candidate against the expected token using `crypto.timingSafeEqual`, iterating every protocol unconditionally:

```typescript
const expectedBuf = Buffer.from(expectedToken, 'utf8');
let matched = false;
for (const protocol of protocols) {
    const candidateBuf = Buffer.from(protocol, 'utf8');
    if (candidateBuf.length !== expectedBuf.length) { continue; }
    if (timingSafeEqual(candidateBuf, expectedBuf)) {
        matched = true;
    }
}
return matched;
```

Neither the matching position nor the match-prefix length is observable from response time. Length-mismatch candidates are skipped before `timingSafeEqual` to avoid Node's `RangeError` on unequal-length inputs (the length of an attacker-supplied candidate is information the attacker already has).

No public-API change; existing happy-path and failure-path test cases (`accepts valid token`, `rejects invalid token`, etc.) keep their semantics.

## Test

The test file is wired into the VS Code integration test harness, which requires downloading VS Code locally and cannot be run in CI without the extension test runner. The fix is shape-compatible with all five existing `validateWebSocketToken` cases (accept valid, reject invalid, missing protocol header, missing headers, token-as-array). `tsc -p ./` is clean for `serverHelpers.ts` on this branch.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript agent-os-vscode]