### PR TITLE
fix(typescript/discovery): skip symlinked entries in ShadowDiscovery.walkDirectory

### DIFF
--- a/agent-governance-typescript/src/discovery.ts
+++ b/agent-governance-typescript/src/discovery.ts
@@ -231,6 +231,18 @@ export class ShadowDiscovery {
     }
 
     for (const entry of entries) {
+      // Skip symlinks entirely. `Dirent.isDirectory()` and `isFile()`
+      // describe the directory entry itself (not the symlink target), so
+      // the directory recursion below is already safe, but the downstream
+      // `readFileSync` calls in `scanConfigFile` / `scanContainerFile` /
+      // `scanSourceFile` follow symlinks. A symlink named (e.g.)
+      // `agentmesh.yaml` pointing at `/etc/passwd` would be opened and
+      // read; a symlink loop or a symlink to a large file would inflate the
+      // discovery cost without bound.
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+
       const fullPath = path.join(currentPath, entry.name);
       if (entry.isDirectory()) {
         if (!SKIP_DIRS.has(entry.name)) {

--- a/agent-governance-typescript/tests/discovery.test.ts
+++ b/agent-governance-typescript/tests/discovery.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { ShadowDiscovery } from '../src/discovery';
@@ -47,6 +47,47 @@ describe('ShadowDiscovery', () => {
     expect(shadows.some((entry) => entry.agent.agentType === 'mcp-server')).toBe(true);
     expect(shadows.some((entry) => entry.recommendedActions.some((action) => action.includes('MCP security scanner')))).toBe(true);
     expect(shadows.some((entry) => entry.risk.score >= 40)).toBe(true);
+  });
+
+  it('skips symlinked entries during walkDirectory', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'agt-discovery-symlink-'));
+    tempDirs.push(tempDir);
+
+    // Real config so we know the scanner CAN find files in this tree.
+    writeFileSync(join(tempDir, 'agentmesh.yaml'), 'name: real-agent\n');
+
+    // Out-of-tree directory containing a config file that should NEVER
+    // be reached by the scan rooted at `tempDir`.
+    const outOfTree = mkdtempSync(join(tmpdir(), 'agt-discovery-outside-'));
+    tempDirs.push(outOfTree);
+    writeFileSync(join(outOfTree, 'mcp-config.json'), '{"server":"smuggled"}');
+
+    // Symlink inside the scan root that points at the out-of-tree dir.
+    // On Windows this requires either dev-mode or admin; skip when the
+    // symlink call throws (e.g. EPERM in restricted CI sandboxes).
+    try {
+      symlinkSync(outOfTree, join(tempDir, 'sneaky-link'), 'dir');
+    } catch {
+      return;
+    }
+
+    // A symlinked CONFIG file too — the more common attack: a file with a
+    // governed-looking name that targets sensitive content out-of-tree.
+    try {
+      symlinkSync(join(outOfTree, 'mcp-config.json'), join(tempDir, 'mcp-config.json'));
+    } catch {
+      return;
+    }
+
+    const discovery = new ShadowDiscovery();
+    const result = discovery.scan({ paths: [tempDir] });
+
+    // The real in-tree config is discovered.
+    expect(result.agents.some((agent) => agent.tags.configFile === 'agentmesh.yaml')).toBe(true);
+
+    // Neither the symlinked directory nor the symlinked file produces an agent.
+    expect(result.agents.some((agent) => agent.tags.configFile?.startsWith('sneaky-link/'))).toBe(false);
+    expect(result.agents.some((agent) => agent.tags.configFile === 'mcp-config.json')).toBe(false);
   });
 
   it('respects max depth and skip directories', () => {


### PR DESCRIPTION
## Problem

[`ShadowDiscovery.walkDirectory`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/src/discovery.ts#L210-L250) iterates `readdirSync(..., { withFileTypes: true })` and dispatches by `entry.isDirectory()` / `entry.isFile()`:

```typescript
for (const entry of entries) {
  const fullPath = path.join(currentPath, entry.name);
  if (entry.isDirectory()) {
    if (!SKIP_DIRS.has(entry.name)) {
      this.walkDirectory(rootPath, fullPath, ...);
    }
    continue;
  }
  this.scanConfigFile(rootPath, fullPath, ..., entry.name, agents);
  this.scanContainerFile(rootPath, fullPath, ..., entry.name, ...);
  if (includeSourcePatterns) {
    this.scanSourceFile(rootPath, fullPath, ..., entry.name, ...);
  }
}
```

`Dirent.isDirectory()` and `isFile()` describe the directory entry itself (not the symlink target), so the directory-recursion branch is already safe — symlinks-to-directories are reported as symlinks and fail `isDirectory()`. But the downstream `readFileSync` calls in `scanConfigFile` / `scanContainerFile` / `scanSourceFile` follow symlinks. A symlink in the scanned tree named (e.g.) `agentmesh.yaml` pointing at `/etc/passwd` would be opened and read; a symlink loop, or a symlink to a large file, would inflate the discovery cost without bound.

## Fix

Skip every entry where `entry.isSymbolicLink()` is true, before the directory-vs-file dispatch:

```typescript
if (entry.isSymbolicLink()) {
  continue;
}
```

That covers both the (already-safe) recursion path and the file-scan path, in one check, and matches the REVIEW.md guidance.

## Test

Adds an integration test in `discovery.test.ts` that builds a scan-root containing:
- One legitimate `agentmesh.yaml` (in-tree config we should still find).
- An out-of-tree directory containing `mcp-config.json` (the would-be-smuggled config).
- `sneaky-link/` — a directory symlink from the scan root to the out-of-tree dir.
- `mcp-config.json` — a file symlink from the scan root to the out-of-tree config.

Asserts the in-tree config is discovered, and neither symlink produces an agent. The test bails out cleanly on platforms where `symlinkSync` requires elevated privileges (Windows without developer mode / admin) so CI on locked-down runners is unaffected.

Full discovery suite: 3 / 3 pass.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript Discovery]