### PR TITLE
fix: harden governance gate - pin deps, fix policy check, ISO timestamps

### DIFF
--- a/.github/workflows/agent-governance-gate.yml
+++ b/.github/workflows/agent-governance-gate.yml
@@ -74,7 +74,7 @@ jobs:
           python-version: ${{ inputs.python_version }}
 
       - name: Install dependencies
-        run: pip install --no-cache-dir pyyaml cryptography
+        run: pip install --no-cache-dir pyyaml==6.0.2 cryptography==44.0.3
 
       - name: Run governance gate
         id: gate

--- a/scripts/governance_gate.py
+++ b/scripts/governance_gate.py
@@ -89,7 +89,7 @@ def _validate_policy(policy_data: dict) -> list[str]:
         if not found:
             failures.append(f"{display}: MISSING (field '{field_path}' not found)")
             continue
-        if expected is True and value is not True:
+        if expected is True and not value:
             failures.append(f"{display}: FAIL (expected true, got {value!r})")
         elif expected is list and not isinstance(value, list):
             failures.append(f"{display}: FAIL (expected a list, got {type(value).__name__})")
@@ -128,8 +128,8 @@ def _generate_receipt(
         "commit_sha": commit,
         "policy_hash": f"sha256:{policy_hash}",
         "manifest_hash": f"sha256:{manifest_hash}",
-        "nonce": uuid.uuid4().hex[:16],
-        "timestamp": time.time(),
+        "nonce": uuid.uuid4().hex,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "signature": None,
         "signer_public_key": None,
     }
@@ -145,6 +145,7 @@ def _generate_receipt(
                 receipt["signature"] = base64.b64encode(sig).decode()
                 receipt["signer_public_key"] = base64.b64encode(pub).decode()
         except Exception as exc:
+            print(f"  WARNING: signing failed: {exc}", file=sys.stderr)
             receipt["signature_error"] = str(exc)
 
     return receipt

--- a/scripts/tests/test_governance_gate.py
+++ b/scripts/tests/test_governance_gate.py
@@ -298,8 +298,8 @@ class TestParseArgs:
         monkeypatch.setenv("GITHUB_SHA", "deadbeef")
         monkeypatch.setenv("GITHUB_ACTOR", "octocat")
         args = gg._parse_args([])
-        assert str(args.policy) == "custom/policy.yaml"
-        assert str(args.manifest) == "custom/agents.yaml"
+        assert args.policy == Path("custom/policy.yaml")
+        assert args.manifest == Path("custom/agents.yaml")
         assert args.commit == "deadbeef"
         assert args.deployer == "octocat"
 


### PR DESCRIPTION
Follow-up to #2102 (prashansapkota's governance gate contribution).

**Fixes:**
- **Blocker**: Pin pyyaml==6.0.2 and cryptography==44.0.3 in workflow (Scorecard PinnedDependencies compliance)
- **Blocker**: Fix `value is not True` identity check to `not value` (YAML 1.2 compatibility for yes/on values)
- Use ISO 8601 timestamps instead of float epoch for auditable receipts
- Use full 128-bit nonce (uuid4.hex) instead of truncated 64-bit
- Log signing failures to stderr instead of silently swallowing
- Fix Windows path separator test failure in test_defaults_from_env

All 38 tests pass.