### PR TITLE
docs(agentmesh): fix quickstart scaffold commands

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/cli/main.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/cli/main.py
@@ -7,7 +7,6 @@ Commands:
 - init: Scaffold a governed agent in 30 seconds
 - proxy: Start an MCP proxy with governance
 - register: Register an agent with AgentMesh
-- run: Run a governed agent
 - status: Check agent status and trust score
 - audit: View audit logs
 - policy: Manage policies
@@ -184,47 +183,34 @@ def init(name: str, sponsor: str, output: str, output_json: bool):
 This agent is secured by AgentMesh with:
 - Cryptographic identity
 - Trust scoring
-- Policy enforcement
+- Policy evaluation
 - Audit logging
 """
 
-from agentmesh import AgentMesh, AgentIdentity, PolicyEngine
+from agentmesh import AgentMeshClient
 
-# Initialize AgentMesh
-mesh = AgentMesh.from_config("agentmesh.yaml")
+client = AgentMeshClient(
+    "{name}",
+    capabilities=[
+        "text_processing",
+        "data_analysis",
+    ],
+)
 
-# Create identity
-identity = mesh.create_identity()
-print(f"Agent DID: {{identity.did}}")
+print(f"Agent DID: {{client.agent_did}}")
+print(f"Initial trust score: {{client.trust_score.total_score}}")
 
-# Load policies
-policies = mesh.load_policies()
-print(f"Loaded {{len(policies)}} policies")
+result = client.execute_with_governance(
+    "data_analysis",
+    context={{
+        "resource": "sample_dataset",
+        "purpose": "quickstart_verification",
+    }},
+)
 
-# Start the agent
-async def main():
-    """Main agent loop."""
-    async with mesh.run(identity) as agent:
-        # Your agent logic here
-        print(f"Agent {{identity.name}} is running with trust score: {{agent.trust_score}}")
-
-        # Example: Register capabilities
-        await agent.register_capabilities([
-            "text_processing",
-            "data_analysis",
-        ])
-
-        # Example: Handle incoming requests
-        async for request in agent.requests():
-            # Policy is automatically enforced
-            # Audit is automatically logged
-            response = await agent.process(request)
-            await agent.respond(response)
-
-
-if __name__ == "__main__":
-    import asyncio
-    asyncio.run(main())
+print(f"Decision: {{result.decision}}")
+print(f"Allowed: {{result.allowed}}")
+print(f"Updated trust score: {{result.trust_score}}")
 '''
 
     main_path = agent_dir / "src" / "main.py"
@@ -240,7 +226,7 @@ version = "0.1.0"
 description = "A governed agent secured by AgentMesh"
 requires-python = ">=3.11"
 dependencies = [
-    "agentmesh>=1.0.0",
+    "agentmesh-platform>=3.5.0",
 ]
 
 [build-system]
@@ -272,8 +258,7 @@ build-backend = "hatchling.build"
 
 [bold]Next steps:[/bold]
 1. cd {agent_dir}
-2. pip install -e .
-3. python src/main.py
+2. python src/main.py
 
 [bold]Configuration:[/bold]
 - Edit agentmesh.yaml for agent settings

--- a/docs/packages/agent-mesh.md
+++ b/docs/packages/agent-mesh.md
@@ -265,11 +265,11 @@ Claude will now route tool calls through AgentMesh for policy enforcement and tr
 # Initialize a governed agent in 30 seconds
 agentmesh init --name my-agent --sponsor alice@company.com
 
-# Register with the mesh
-agentmesh register
+# Enter the generated project
+cd my-agent
 
-# Start with governance enabled
-agentmesh run
+# Run the generated governance smoke test
+python src/main.py
 ```
 
 ### Option 3: Wrap Any MCP Server


### PR DESCRIPTION
## Summary

Fixes the AgentMesh quickstart scaffold path after verifying the tutorial end-to-end for #1643.

While running the AgentMesh quickstart on Windows, I found that the documented and generated commands no longer matched the current CLI/API behavior.

## What changed

- Updated the AgentMesh docs quickstart to use the generated project flow:
  - `cd my-agent`
  - `python src/main.py`
- Removed the stale `agentmesh run` command from the quickstart path.
- Updated the generated `src/main.py` scaffold to use `AgentMeshClient`, which is part of the current public API.
- Updated the generated dependency from `agentmesh>=1.0.0` to `agentmesh-platform>=3.5.0`.
- Removed `pip install -e .` from the generated next steps because the scaffold is not structured as an installable Hatch package.

## Verification

Tested the patched scaffold locally:

python -m agentmesh.cli.main init --name patched-agent --sponsor alice@company.com
cd patched-agent
python src/main.py

Output:

Agent DID: did:mesh:...
Initial trust score: 500
Decision: allow
Allowed: True
Updated trust score: 510.0

Also ran:

git diff --check
python -m py_compile agent-governance-python/agent-mesh/src/agentmesh/cli/main.py
findstr /S /I /N /C:"agentmesh run" docs\packages\agent-mesh.md agent-governance-python\agent-mesh\src\agentmesh\cli\main.py

No whitespace errors, compile errors, or remaining agentmesh run references in the touched files.

Closes #1643.