### PR TITLE
fix(typescript/agent-os-vscode): catch rejections from showInformationMessage / showWarningMessage Thenables

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/enterprise/auth/ssoProvider.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/enterprise/auth/ssoProvider.ts
@@ -238,6 +238,13 @@ export class EnterpriseAuthProvider {
                 if (selection === 'Sign In') {
                     this.signIn();
                 }
+            }, (err) => {
+                // Surface rejection rather than letting it float — the VS
+                // Code Thenable can reject if the host is shutting down or
+                // the message dialog is torn down by an extension-host
+                // crash. Floating rejections fail noisily on recent Node
+                // defaults and silently elsewhere.
+                console.error('SsoProvider: requireAuth dialog failed', err);
             });
             return false;
         }

--- a/agent-governance-typescript/agent-os-vscode/src/extension.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/extension.ts
@@ -1151,5 +1151,12 @@ function showWelcomeMessage(): void {
         } else if (selection === 'Learn More') {
             vscode.env.openExternal(vscode.Uri.parse('https://github.com/microsoft/agent-governance-toolkit'));
         }
+    }, (err) => {
+        // Surface rejection rather than letting it float — VS Code's
+        // showInformationMessage Thenable can reject if the host is
+        // shutting down or the dialog is dismissed by an extension-host
+        // crash. Floating rejections fail noisily on recent Node defaults
+        // and silently elsewhere.
+        console.error('Agent OS: showWelcomeMessage failed', err);
     });
 }


### PR DESCRIPTION
## Problem

Two VS Code dialog Thenables in the extension had `.then(selection => ...)` without an attached rejection handler:

- [`showWelcomeMessage()` in `extension.ts`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/extension.ts#L1148-L1154)
- [`requireAuth()` in `ssoProvider.ts`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/enterprise/auth/ssoProvider.ts#L237-L241)

`vscode.window.show*Message` returns a `Thenable<T | undefined>` that can reject — extension-host shutdown, dialog torn down by a host crash, or internal VS Code errors. A floating rejection either crashes the extension host on recent Node defaults or vanishes silently, and the operator never sees the failure.

## Fix

Attach a rejection handler using the two-argument `.then(onFulfilled, onRejected)` form so we don't introduce an extra microtask, and surface the error via `console.error` so it shows up in the VS Code Developer Tools console:

```typescript
.then(selection => {
    // ...existing success handling...
}, (err) => {
    console.error('<context>: <op> failed', err);
});
```

The success path is unchanged. No public API changes.

## Test

Both call sites are wired through live VS Code dialog APIs and are not unit-tested in the extension package today (the existing `test` script wraps an integration runner that needs the VS Code download). The change is shape-only on the success path; behaviour for `showInformationMessage`'s standard \"clicked / cancelled / dismissed\" results is preserved exactly.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript agent-os-vscode]