### PR TITLE
fix(typescript/agent-os-vscode): associate quick-fix metadata with diagnostics via WeakMap instead of mutating vscode.Diagnostic

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/language/diagnosticProvider.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/language/diagnosticProvider.ts
@@ -22,6 +22,24 @@ interface DiagnosticRule {
     };
 }
 
+interface QuickFixInfo {
+    title: string;
+    replacement: string;
+}
+
+// Side-table that associates a rule's quick-fix metadata with the
+// `vscode.Diagnostic` object the provider creates for it. The previous
+// implementation stashed the info as `(diagnostic as any).quickFix`, which
+// mutates a VS Code public type with an undeclared property — brittle, and
+// would collide with any future VS Code-internal property of the same name.
+// A WeakMap keyed by the Diagnostic reference fixes both: the entry vanishes
+// when the diagnostic itself is garbage-collected, and the public type stays
+// untouched. The map is module-level so the diagnostic producer
+// (`AgentOSDiagnosticProvider`) and the code-action consumer
+// (`AgentOSCodeActionProvider`) can share it without an additional
+// constructor wiring.
+const QUICK_FIX_TABLE = new WeakMap<vscode.Diagnostic, QuickFixInfo>();
+
 export class AgentOSDiagnosticProvider {
     private diagnosticCollection: vscode.DiagnosticCollection;
     private disposables: vscode.Disposable[] = [];
@@ -288,9 +306,9 @@ export class AgentOSDiagnosticProvider {
                 diagnostic.tags = rule.tags;
             }
 
-            // Store quick fix info in the diagnostic
+            // Store quick fix info in the side-table keyed by diagnostic.
             if (rule.quickFix) {
-                (diagnostic as any).quickFix = rule.quickFix;
+                QUICK_FIX_TABLE.set(diagnostic, rule.quickFix);
             }
 
             diagnostics.push(diagnostic);
@@ -315,7 +333,7 @@ class AgentOSCodeActionProvider implements vscode.CodeActionProvider {
         for (const diagnostic of context.diagnostics) {
             if (diagnostic.source?.startsWith('Agent OS')) {
                 // Check for quick fix
-                const quickFix = (diagnostic as any).quickFix;
+                const quickFix = QUICK_FIX_TABLE.get(diagnostic);
                 if (quickFix) {
                     const action = new vscode.CodeAction(
                         quickFix.title,


### PR DESCRIPTION
## Problem

[`AgentOSDiagnosticProvider`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/language/diagnosticProvider.ts) was stashing rule-level quick-fix metadata on the diagnostic instance itself:

```typescript
if (rule.quickFix) {
    (diagnostic as any).quickFix = rule.quickFix;
}
```

And then reading it back in `AgentOSCodeActionProvider.provideCodeActions`:

```typescript
const quickFix = (diagnostic as any).quickFix;
```

Two problems:

1. **Mutating `vscode.Diagnostic` with an undeclared property is brittle.** It can collide with any future VS Code-internal property of the same name on the public type, and the `as any` cast bypasses the type system entirely.
2. **The `quickFix` field is not part of the Diagnostic contract.** Any VS Code internal that serialises diagnostics across an RPC boundary (history persistence, file-link round-trips, copy-paste reconstitution, future provider workers) will silently drop it.

## Fix

Module-level `WeakMap<vscode.Diagnostic, QuickFixInfo>` instead:

```typescript
interface QuickFixInfo { title: string; replacement: string; }
const QUICK_FIX_TABLE = new WeakMap<vscode.Diagnostic, QuickFixInfo>();
```

- The producer (`AgentOSDiagnosticProvider`) does `QUICK_FIX_TABLE.set(diagnostic, rule.quickFix)`.
- The consumer (`AgentOSCodeActionProvider`) does `QUICK_FIX_TABLE.get(diagnostic)`.
- Entries vanish automatically when the underlying Diagnostic is garbage-collected — no explicit cleanup required.
- Both `as any` casts are removed.

No behavioural change to the produced quick fixes or to the surface of the Diagnostic objects exposed to other consumers.

## Test

Both call sites are wired through the live VS Code Code Actions API and are not unit-tested in the extension package today (the existing `test` script wraps an integration runner that needs the VS Code download). The fix is shape-only on the success path; behaviour for diagnostics with no `quickFix` rule, and the quick-fix-action rendering for diagnostics that do have one, is preserved exactly.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript agent-os-vscode]