### PR TITLE
fix(typescript/sandbox): narrow ExecException.code to number explicitly when synthesising the sandbox exit code

### DIFF
--- a/agent-governance-typescript/src/sandbox.ts
+++ b/agent-governance-typescript/src/sandbox.ts
@@ -225,7 +225,18 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       execFile('docker', execArgs, { timeout: 60_000 }, (error, stdout, stderr) => {
         const durationSeconds = (Date.now() - startTime) / 1000.0;
-        const exitCode = error && 'code' in error ? (error.code as number ?? 1) : 0;
+        // Node's ExecException.code can be: a numeric exit code (child exited
+        // non-zero), `null` (child killed by a signal — `error.signal` is set
+        // instead), or a string like 'ENOENT' (the spawn itself failed). The
+        // previous `error.code as number ?? 1` cast handled the `null` case
+        // by accident — `null ?? 1` is `1` — but on the spawn-failure path it
+        // let the string ('ENOENT') flow through as a `number`-typed exit
+        // code, and downstream consumers treating `exitCode` as numeric saw
+        // a string. Narrow explicitly: only accept a numeric code; otherwise
+        // synthesise 1 for any error (signal kill, spawn failure, etc.).
+        const exitCode = error
+          ? typeof error.code === 'number' ? error.code : 1
+          : 0;
         const killed = error !== null && 'killed' in error && (error as { killed: boolean }).killed;
 
         const result: SandboxResult = {


### PR DESCRIPTION
## Problem

[`sandbox.ts:228`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/src/sandbox.ts#L226-L228) synthesised the exit code from `execFile`'s callback as:

```typescript
const exitCode = error && 'code' in error ? (error.code as number ?? 1) : 0;
```

Node's `child_process.execFile` callback receives an `ExecException` whose `.code` field can be:

- a numeric exit code (child exited non-zero),
- `null` (child killed by a signal — `.signal` is set instead), or
- a string like `'ENOENT'` (the spawn itself failed before the child started).

The previous expression handled the `null` case by accident — `null ?? 1` is `1` — but on the spawn-failure path it let the string (`'ENOENT'`) flow through with a `number`-typed alias. Downstream consumers that read `exitCode` as a numeric value (JSON serialisation, `exitCode === N` equality, arithmetic) saw a string masquerading as a number, and the `success: exitCode === 0` check below produced `false` only because `'ENOENT' === 0` happens to also be false.

## Fix

Narrow with `typeof error.code === 'number'` and synthesise `1` for any non-numeric error condition (signal kill, spawn failure, etc.). The success path (`error === null`) still produces `0`:

```typescript
const exitCode = error
  ? typeof error.code === 'number' ? error.code : 1
  : 0;
```

## Test

Full sandbox suite (10 / 10) passes; the docker-backed integration tests skip cleanly when Docker is unavailable (the local case). The fix is the recommended ExecException-narrowing pattern in [Node's child_process docs](https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback).

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, TypeScript Sandbox]