### PR TITLE
fix(rust-governance): score compliance against per-framework control count, not hardcoded 10

### DIFF
--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -37,6 +37,40 @@ pub enum ComplianceFramework {
     Gdpr,
 }
 
+impl ComplianceFramework {
+    /// Approximate count of high-level controls for this framework, used
+    /// as the denominator when computing a compliance score.
+    ///
+    /// Each value reflects the framework's published top-level groupings:
+    ///
+    /// * **EU AI Act** — 8 obligations for high-risk AI systems
+    ///   (Articles 8–15: risk management, data governance, technical
+    ///   documentation, record-keeping, transparency, human oversight,
+    ///   accuracy/robustness/cybersecurity, quality management).
+    /// * **SOC 2** — 5 Trust Services Criteria categories (Security,
+    ///   Availability, Confidentiality, Processing Integrity, Privacy).
+    /// * **HIPAA** — 3 Security Rule safeguard categories
+    ///   (Administrative, Physical, Technical) plus the Privacy Rule and
+    ///   Breach Notification Rule = 5.
+    /// * **GDPR** — 7 data-protection principles enumerated in
+    ///   Article 5(1) (lawfulness, purpose limitation, data minimisation,
+    ///   accuracy, storage limitation, integrity & confidentiality,
+    ///   accountability).
+    ///
+    /// These are coarse approximations chosen because the framework
+    /// publishes them at this level; deployments with a richer control
+    /// catalogue should compute their own score rather than rely on this
+    /// engine's report.
+    pub fn default_control_count(self) -> u32 {
+        match self {
+            ComplianceFramework::EuAiAct => 8,
+            ComplianceFramework::Soc2 => 5,
+            ComplianceFramework::Hipaa => 5,
+            ComplianceFramework::Gdpr => 7,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComplianceViolation {
     pub violation_id: String,
@@ -120,9 +154,12 @@ impl ComplianceEngine {
             .cloned()
             .collect::<Vec<_>>();
         let controls_failed = violations.len() as u32;
-        let total_controls: u32 = 10;
-        let compliance_score = ((total_controls.saturating_sub(controls_failed)) as f64
-            / total_controls as f64)
+        let total_controls = framework.default_control_count();
+        // `.max(1)` is a defensive floor: if a future variant ever returns
+        // 0 the score becomes 0 rather than `0/0 == NaN`.
+        let denominator = total_controls.max(1);
+        let compliance_score = ((denominator.saturating_sub(controls_failed)) as f64
+            / denominator as f64)
             * 100.0;
         ComplianceReport {
             report_id: format!("report_{:016x}", rand::random::<u64>()),
@@ -1616,6 +1653,85 @@ mod tests {
         let report = engine.generate_report(ComplianceFramework::Soc2);
         assert_eq!(report.controls_failed, 1);
         assert!(report.compliance_score < 100.0);
+    }
+
+    #[test]
+    fn compliance_report_uses_framework_specific_control_count() {
+        let engine = ComplianceEngine::new(vec![
+            ComplianceFramework::Soc2,
+            ComplianceFramework::Gdpr,
+            ComplianceFramework::Hipaa,
+            ComplianceFramework::EuAiAct,
+        ]);
+        for framework in [
+            ComplianceFramework::Soc2,
+            ComplianceFramework::Gdpr,
+            ComplianceFramework::Hipaa,
+            ComplianceFramework::EuAiAct,
+        ] {
+            let report = engine.generate_report(framework);
+            assert_eq!(
+                report.total_controls,
+                framework.default_control_count(),
+                "report denominator must match the framework's published \
+                 top-level control count, not a hardcoded value"
+            );
+        }
+    }
+
+    #[test]
+    fn compliance_score_is_full_when_no_violations() {
+        let engine = ComplianceEngine::default();
+        let report = engine.generate_report(ComplianceFramework::Soc2);
+        assert_eq!(report.controls_failed, 0);
+        assert_eq!(report.compliance_score, 100.0);
+    }
+
+    #[test]
+    fn compliance_score_reflects_one_violation_relative_to_framework_size() {
+        let engine = ComplianceEngine::default();
+        engine.record_violation(
+            ComplianceFramework::Soc2,
+            "did:agentmesh:test",
+            "x",
+            "c",
+            "low",
+            "d",
+        );
+        let report = engine.generate_report(ComplianceFramework::Soc2);
+        // SOC 2 = 5 top-level criteria, 1 failed → 4/5 = 80%.
+        assert_eq!(report.compliance_score, 80.0);
+    }
+
+    #[test]
+    fn compliance_score_floors_at_zero_when_violations_exceed_controls() {
+        let engine = ComplianceEngine::default();
+        for i in 0..10 {
+            engine.record_violation(
+                ComplianceFramework::Soc2,
+                "did:agentmesh:test",
+                "x",
+                &format!("c{i}"),
+                "low",
+                "d",
+            );
+        }
+        let report = engine.generate_report(ComplianceFramework::Soc2);
+        assert_eq!(report.compliance_score, 0.0);
+    }
+
+    #[test]
+    fn each_framework_publishes_a_nonzero_control_count() {
+        // Guards the divide-by-zero floor in `generate_report`: every
+        // variant must contribute a positive denominator.
+        for framework in [
+            ComplianceFramework::EuAiAct,
+            ComplianceFramework::Soc2,
+            ComplianceFramework::Hipaa,
+            ComplianceFramework::Gdpr,
+        ] {
+            assert!(framework.default_control_count() > 0);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ComplianceEngine::generate_report` in [agent-governance-rust/agentmesh/src/governance_support.rs](agent-governance-rust/agentmesh/src/governance_support.rs) divided ``controls_failed`` by a hardcoded ``total_controls: u32 = 10`` for **every** framework:

````rust
let controls_failed = violations.len() as u32;
let total_controls: u32 = 10;
let compliance_score = ((total_controls.saturating_sub(controls_failed)) as f64
    / total_controls as f64) * 100.0;
````

That meant:

* SOC 2 (5 Trust Services Criteria), GDPR (7 Article 5 principles), HIPAA (5 top-level safeguards), and EU AI Act (8 high-risk-system obligations) all reported a denominator of 10 — none of which match what those frameworks actually publish.
* The ``total_controls`` field on the public ``ComplianceReport`` was also the same ``10`` regardless of framework, so downstream consumers reading it saw a number that contradicted the framework's own catalogue.
* When a deployment recorded more than 10 violations, the score saturated to 0% by accident through ``saturating_sub``, hiding the bug.

## Change

* New ``ComplianceFramework::default_control_count(self) -> u32`` returns the framework's published top-level grouping count, with each value documented inline against the source articles / criteria:

  | Framework | Count | Source |
  |---|---:|---|
  | EU AI Act | 8 | high-risk system obligations, Articles 8–15 |
  | SOC 2 | 5 | Trust Services Criteria categories |
  | HIPAA | 5 | Security Rule safeguards (Admin/Physical/Technical) + Privacy Rule + Breach Notification Rule |
  | GDPR | 7 | Article 5(1) data-protection principles |

* ``generate_report`` now uses ``framework.default_control_count()`` as both the score denominator and the ``total_controls`` field on the returned report.
* The divisor is floored at 1 (``.max(1)``) as defence-in-depth in case a future variant ever returns 0 — keeps the score finite instead of ``0/0 == NaN``.

The doc comment on ``default_control_count`` flags these counts as coarse approximations matching what the framework publishes at the top level, and points operators with a fuller control catalogue at computing their own score rather than relying on this engine's report.

### Public-API note

``ComplianceReport.total_controls`` is a public ``u32``. Existing readers that hard-coded an expectation of ``10`` will see different numbers per framework now (5/5/7/8). The struct shape and field types are unchanged.

## Tests

Existing ``compliance_engine_reports_violations`` still passes (its only assertion is ``compliance_score < 100.0`` after one violation — true for any denominator > 1).

New tests in ``governance_support::tests``:

| Test | Asserts |
|---|---|
| ``compliance_report_uses_framework_specific_control_count`` | ``report.total_controls`` matches ``framework.default_control_count()`` for all four variants |
| ``compliance_score_is_full_when_no_violations`` | 0 violations → 100% (any framework) |
| ``compliance_score_reflects_one_violation_relative_to_framework_size`` | SOC 2 with 1 violation → 80% (4/5), not the prior 90% (9/10) |
| ``compliance_score_floors_at_zero_when_violations_exceed_controls`` | 10 violations against SOC 2's 5 controls → 0% (saturating_sub preserved) |
| ``each_framework_publishes_a_nonzero_control_count`` | guards the divide-by-zero floor — every variant must return ``> 0`` |

````
cargo test -p agentmesh --lib governance_support::
  test result: ok. 19 passed; 0 failed
cargo test -p agentmesh --lib
  test result: ok. 290 passed; 0 failed
````

## Test plan

- [ ] CI passes
- [ ] ``governance_support::tests`` 19/19 pass
- [ ] All 290 ``agentmesh`` lib tests still pass

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Rust Governance].