### PR TITLE
fix(rust-mcp): make CredentialRedactor::new infallible

### DIFF
--- a/agent-governance-rust/agentmesh-mcp/README.md
+++ b/agent-governance-rust/agentmesh-mcp/README.md
@@ -33,7 +33,7 @@ let signer = McpMessageSigner::new(
 let signed: McpSignedMessage = signer.sign("hello from mcp")?;
 signer.verify(&signed)?;
 
-let redactor = CredentialRedactor::new()?;
+let redactor = CredentialRedactor::new();
 let result = redactor.redact("Authorization: Bearer super-secret-token");
 assert!(result.sanitized.contains("[REDACTED_BEARER_TOKEN]"));
 # Ok::<(), agentmesh_mcp::McpError>(())
@@ -55,7 +55,7 @@ use agentmesh_mcp::{
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-let redactor = CredentialRedactor::new()?;
+let redactor = CredentialRedactor::new();
 let audit = Arc::new(InMemoryAuditSink::new(redactor.clone()));
 let metrics = McpMetricsCollector::default();
 let scanner = McpResponseScanner::new(

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/audit.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/audit.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn in_memory_audit_sink_redacts_secrets() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let sink = InMemoryAuditSink::new(redactor);
         sink.record(McpAuditEntry {
             event_type: "test".into(),

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/gateway.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/gateway.rs
@@ -289,7 +289,7 @@ mod tests {
         config: McpGatewayConfig,
         max_requests: usize,
     ) -> (McpGateway, String, Arc<InMemoryAuditSink>) {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let audit = Arc::new(InMemoryAuditSink::new(redactor.clone()));
         let metrics = McpMetricsCollector::default();
         let scanner = McpResponseScanner::new(
@@ -326,7 +326,7 @@ mod tests {
     }
 
     fn unauthenticated_gateway(config: McpGatewayConfig) -> McpGateway {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let audit = Arc::new(InMemoryAuditSink::new(redactor.clone()));
         let metrics = McpMetricsCollector::default();
         let scanner = McpResponseScanner::new(

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs
@@ -3,7 +3,6 @@
 
 //! Credential redaction for audit-safe storage and display.
 
-use crate::mcp::error::McpError;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -51,33 +50,44 @@ pub struct CredentialRedactor {
 }
 
 impl CredentialRedactor {
-    pub fn new() -> Result<Self, McpError> {
-        Ok(Self {
+    /// Build a redactor with the built-in credential patterns.
+    ///
+    /// All patterns are static string literals compiled at this call site;
+    /// any compilation failure is a programmer bug, not a runtime
+    /// condition, so this constructor is infallible. The `.expect`
+    /// strings name the pattern that would have failed so a regression
+    /// points at the offending literal.
+    pub fn new() -> Self {
+        Self {
             patterns: vec![
                 (
                     CredentialKind::BearerToken,
-                    Regex::new(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")?,
+                    Regex::new(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")
+                        .expect("BearerToken regex literal must compile"),
                 ),
                 (
                     CredentialKind::ApiKey,
                     Regex::new(
                         r#"(?i)(?:api[_-]?key|x-api-key)\s*[:=]\s*["']?[a-z0-9_\-]{8,}["']?"#,
-                    )?,
+                    )
+                    .expect("ApiKey regex literal must compile"),
                 ),
                 (
                     CredentialKind::ConnectionString,
                     Regex::new(
                         r"(?i)\b(?:server|host|endpoint)=[^;]+;[^;\n]*(?:password|sharedaccesskey)=[^;\n]+",
-                    )?,
+                    )
+                    .expect("ConnectionString regex literal must compile"),
                 ),
                 (
                     CredentialKind::SecretAssignment,
                     Regex::new(
                         r#"(?i)\b(?:password|secret|token)\s*[:=]\s*["']?[^\s"';,]{4,}["']?"#,
-                    )?,
+                    )
+                    .expect("SecretAssignment regex literal must compile"),
                 ),
             ],
-        })
+        }
     }
 
     pub fn redact(&self, input: &str) -> RedactionResult {
@@ -130,6 +140,12 @@ impl CredentialRedactor {
     }
 }
 
+impl Default for CredentialRedactor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub(crate) fn key_hint(key: &str) -> Option<CredentialKind> {
     let lower = key.to_lowercase();
     if lower.contains("authorization") || lower.contains("bearer") {
@@ -156,7 +172,7 @@ mod tests {
 
     #[test]
     fn redacts_multiple_secret_types() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let result = redactor
             .redact("Authorization: Bearer abcdefghijklmnop api_key=123456789012 secret=hunter2");
         assert!(result.sanitized.contains("[REDACTED_BEARER_TOKEN]"));
@@ -167,7 +183,7 @@ mod tests {
 
     #[test]
     fn redacts_nested_json_values() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let value = serde_json::json!({
             "headers": {"authorization": "Bearer abcdefghi"},
             "password": "hunter2"
@@ -182,7 +198,7 @@ mod tests {
 
     #[test]
     fn redacts_x_api_key_fields() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let value = serde_json::json!({
             "headers": {
                 "x-api-key": "abcd1234567890",

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/response.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/response.rs
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn scan_text_redacts_prompt_tags_and_secrets() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpResponseScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn scan_value_preserves_shape() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpResponseScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn scan_value_sanitizes_keys_and_keyed_secrets() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpResponseScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/security.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/security.rs
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn detects_rug_pulls_and_typosquatting() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpSecurityScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn detects_schema_abuse() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpSecurityScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),

--- a/agent-governance-rust/agentmesh/README.md
+++ b/agent-governance-rust/agentmesh/README.md
@@ -92,7 +92,7 @@ let signer = McpMessageSigner::new(
 let message = signer.sign("hello from mcp")?;
 signer.verify(&message)?;
 
-let redactor = CredentialRedactor::new()?;
+let redactor = CredentialRedactor::new();
 let result = redactor.redact("Authorization: Bearer super-secret-token");
 assert!(result.sanitized.contains("[REDACTED_BEARER_TOKEN]"));
 # Ok::<(), agentmesh_mcp::McpError>(())
@@ -113,7 +113,7 @@ use agentmesh::{
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-let redactor = CredentialRedactor::new()?;
+let redactor = CredentialRedactor::new();
 let audit = Arc::new(InMemoryAuditSink::new(redactor.clone()));
 let metrics = McpMetricsCollector::default();
 let scanner = McpResponseScanner::new(

--- a/agent-governance-rust/agentmesh/src/mcp/audit.rs
+++ b/agent-governance-rust/agentmesh/src/mcp/audit.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn in_memory_audit_sink_redacts_secrets() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let sink = InMemoryAuditSink::new(redactor);
         sink.record(McpAuditEntry {
             event_type: "test".into(),

--- a/agent-governance-rust/agentmesh/src/mcp/gateway.rs
+++ b/agent-governance-rust/agentmesh/src/mcp/gateway.rs
@@ -289,7 +289,7 @@ mod tests {
         config: McpGatewayConfig,
         max_requests: usize,
     ) -> (McpGateway, String, Arc<InMemoryAuditSink>) {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let audit = Arc::new(InMemoryAuditSink::new(redactor.clone()));
         let metrics = McpMetricsCollector::default();
         let scanner = McpResponseScanner::new(
@@ -326,7 +326,7 @@ mod tests {
     }
 
     fn unauthenticated_gateway(config: McpGatewayConfig) -> McpGateway {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let audit = Arc::new(InMemoryAuditSink::new(redactor.clone()));
         let metrics = McpMetricsCollector::default();
         let scanner = McpResponseScanner::new(

--- a/agent-governance-rust/agentmesh/src/mcp/redactor.rs
+++ b/agent-governance-rust/agentmesh/src/mcp/redactor.rs
@@ -3,7 +3,6 @@
 
 //! Credential redaction for audit-safe storage and display.
 
-use crate::mcp::error::McpError;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -51,33 +50,44 @@ pub struct CredentialRedactor {
 }
 
 impl CredentialRedactor {
-    pub fn new() -> Result<Self, McpError> {
-        Ok(Self {
+    /// Build a redactor with the built-in credential patterns.
+    ///
+    /// All patterns are static string literals compiled at this call site;
+    /// any compilation failure is a programmer bug, not a runtime
+    /// condition, so this constructor is infallible. The `.expect`
+    /// strings name the pattern that would have failed so a regression
+    /// points at the offending literal.
+    pub fn new() -> Self {
+        Self {
             patterns: vec![
                 (
                     CredentialKind::BearerToken,
-                    Regex::new(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")?,
+                    Regex::new(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")
+                        .expect("BearerToken regex literal must compile"),
                 ),
                 (
                     CredentialKind::ApiKey,
                     Regex::new(
                         r#"(?i)(?:api[_-]?key|x-api-key)\s*[:=]\s*["']?[a-z0-9_\-]{8,}["']?"#,
-                    )?,
+                    )
+                    .expect("ApiKey regex literal must compile"),
                 ),
                 (
                     CredentialKind::ConnectionString,
                     Regex::new(
                         r"(?i)\b(?:server|host|endpoint)=[^;]+;[^;\n]*(?:password|sharedaccesskey)=[^;\n]+",
-                    )?,
+                    )
+                    .expect("ConnectionString regex literal must compile"),
                 ),
                 (
                     CredentialKind::SecretAssignment,
                     Regex::new(
                         r#"(?i)\b(?:password|secret|token)\s*[:=]\s*["']?[^\s"';,]{4,}["']?"#,
-                    )?,
+                    )
+                    .expect("SecretAssignment regex literal must compile"),
                 ),
             ],
-        })
+        }
     }
 
     pub fn redact(&self, input: &str) -> RedactionResult {
@@ -130,6 +140,12 @@ impl CredentialRedactor {
     }
 }
 
+impl Default for CredentialRedactor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub(crate) fn key_hint(key: &str) -> Option<CredentialKind> {
     let lower = key.to_lowercase();
     if lower.contains("authorization") || lower.contains("bearer") {
@@ -156,7 +172,7 @@ mod tests {
 
     #[test]
     fn redacts_multiple_secret_types() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let result = redactor
             .redact("Authorization: Bearer abcdefghijklmnop api_key=123456789012 secret=hunter2");
         assert!(result.sanitized.contains("[REDACTED_BEARER_TOKEN]"));
@@ -167,7 +183,7 @@ mod tests {
 
     #[test]
     fn redacts_nested_json_values() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let value = serde_json::json!({
             "headers": {"authorization": "Bearer abcdefghi"},
             "password": "hunter2"
@@ -182,7 +198,7 @@ mod tests {
 
     #[test]
     fn redacts_x_api_key_fields() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let value = serde_json::json!({
             "headers": {
                 "x-api-key": "abcd1234567890",

--- a/agent-governance-rust/agentmesh/src/mcp/response.rs
+++ b/agent-governance-rust/agentmesh/src/mcp/response.rs
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn scan_text_redacts_prompt_tags_and_secrets() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpResponseScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn scan_value_preserves_shape() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpResponseScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn scan_value_sanitizes_keys_and_keyed_secrets() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpResponseScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),

--- a/agent-governance-rust/agentmesh/src/mcp/security.rs
+++ b/agent-governance-rust/agentmesh/src/mcp/security.rs
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn detects_rug_pulls_and_typosquatting() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpSecurityScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),
@@ -496,7 +496,7 @@ mod tests {
 
     #[test]
     fn detects_schema_abuse() {
-        let redactor = CredentialRedactor::new().unwrap();
+        let redactor = CredentialRedactor::new();
         let scanner = McpSecurityScanner::new(
             redactor.clone(),
             Arc::new(InMemoryAuditSink::new(redactor)),


### PR DESCRIPTION
## Summary

[`CredentialRedactor::new`](agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs#L54) returned ``Result<Self, McpError>`` even though its body only compiled four ``&'static str`` literals via ``Regex::new(...)?``:

````rust
pub fn new() -> Result<Self, McpError> {
    Ok(Self {
        patterns: vec![
            (CredentialKind::BearerToken,
             Regex::new(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")?),
            // ... three more, all literals ...
        ],
    })
}
````

Those literals are validated at edit time, never at runtime. A failure would mean the source literal itself is broken — a bug in this repo, not a caller-supplied condition. The fallible signature still forced every caller to either ``?`` it or ``.unwrap()`` it; this repo has 13 call sites that all wrap the call in ``.unwrap()``.

## Change

* ``CredentialRedactor::new() -> Self``. Each ``Regex::new(...)`` becomes ``Regex::new(...).expect(\"<PatternName> regex literal must compile\")``, so a regression on any literal still produces a precise panic message naming the offending pattern.
* ``impl Default for CredentialRedactor`` so ``CredentialRedactor::default()`` is a drop-in alternative.
* All callers drop ``?`` / ``.unwrap()`` and just call ``CredentialRedactor::new()``. Updated in both crate trees (the upstream-tracked duplication, issue #2013):
  * ``agentmesh-mcp/src/mcp/{redactor,audit,gateway,security,response}.rs``
  * ``agentmesh/src/mcp/{redactor,audit,gateway,security,response}.rs``
  * ``agentmesh-mcp/README.md`` and ``agentmesh/README.md`` quickstart code.
* ``use crate::mcp::error::McpError`` dropped from both ``redactor.rs`` files — no longer referenced.

### Public-API note: ``McpError::Regex``

``McpError::Regex(#[from] regex::Error)`` is now unreferenced inside the crate but is left in place: the enum lacks ``#[non_exhaustive]``, so removing the variant would break downstream callers doing exhaustive ``match`` on ``McpError``. Cleanup can be a separate breaking-change PR if maintainers want it.

## Tests

The existing in-file tests at the call sites (13 ``.unwrap()`` sites across both crates) now exercise the infallible path directly — same assertions, no ``Result`` to unwrap.

````
cargo build --workspace
  Finished `dev` profile
cargo test --workspace --lib
  test result: ok. 285 passed; 0 failed   (agentmesh)
  test result: ok.  26 passed; 0 failed   (agentmesh-mcp)
````

## Test plan

- [ ] CI passes
- [ ] All ``agentmesh`` lib tests pass (285/285)
- [ ] All ``agentmesh-mcp`` lib tests pass (26/26)
- [ ] No new warnings in workspace ``cargo build``

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Rust MCP].