### PR TITLE
fix(rust-identity): saturate Credential::issue TTL addition to avoid u64 wrap

### DIFF
--- a/agent-governance-rust/agentmesh/src/identity_support.rs
+++ b/agent-governance-rust/agentmesh/src/identity_support.rs
@@ -152,7 +152,13 @@ impl Credential {
         issued_for: Option<String>,
     ) -> Self {
         let issued_at_secs = unix_secs_now();
-        let expires_at_secs = issued_at_secs + ttl_seconds.max(1);
+        // `saturating_add` is preferred over the raw `+`: a caller passing
+        // `u64::MAX` (or any value large enough to wrap when added to
+        // `issued_at_secs`) used to panic in debug or silently wrap in
+        // release. Saturating to `u64::MAX` keeps the credential "expires
+        // effectively never" — semantically the same as what the caller
+        // appears to have asked for — without invoking arithmetic UB.
+        let expires_at_secs = issued_at_secs.saturating_add(ttl_seconds.max(1));
         let signing_key = SigningKey::generate(&mut OsRng);
         let token = URL_SAFE_NO_PAD.encode(signing_key.to_bytes());
         Self {
@@ -1338,6 +1344,25 @@ mod tests {
             AgentDID::parse(did.as_str()).unwrap().agent_name(),
             "analyst"
         );
+    }
+
+    #[test]
+    fn credential_issue_saturates_on_ttl_overflow() {
+        // Previously this triggered an arithmetic overflow on
+        // `issued_at_secs + ttl_seconds` — a panic in debug builds and a
+        // silent wrap in release. Now the addition saturates at
+        // `u64::MAX` so the call returns a usable credential whose
+        // `expires_at_secs` cannot have wrapped.
+        let credential = Credential::issue(
+            "did:agentmesh:test",
+            vec!["data.read".into()],
+            vec!["reports".into()],
+            u64::MAX,
+            None,
+        );
+        assert_eq!(credential.expires_at_secs, u64::MAX);
+        assert!(credential.expires_at_secs > credential.issued_at_secs);
+        assert!(credential.is_valid());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

[`Credential::issue`](agent-governance-rust/agentmesh/src/identity_support.rs#L147) computed:

````rust
let issued_at_secs = unix_secs_now();
let expires_at_secs = issued_at_secs + ttl_seconds.max(1);
````

Raw ``+`` on ``u64`` will panic in debug builds and silently wrap in release if ``issued_at_secs + ttl_seconds`` exceeds ``u64::MAX``. ``u64::MAX`` as TTL is the obvious trigger — but anything large enough to push the sum past ``u64::MAX`` flips an "effectively never expires" intent into a near-zero ``expires_at_secs``, i.e. an immediately-expired credential.

## Change

````rust
let expires_at_secs = issued_at_secs.saturating_add(ttl_seconds.max(1));
````

``u64::MAX`` seconds past the Unix epoch is ~584 billion years — well past any meaningful "this credential will never expire" semantics. Saturating there preserves the caller's apparent intent rather than inverting it.

### Why ``saturating_add`` instead of ``checked_add``?

REVIEW.md suggested ``checked_add``. Both are valid; ``saturating_add`` was chosen because the function returns ``Self`` (not ``Result``), and the meaningful answer for "huge TTL" is "credential lives a very long time" — saturating expresses that directly without forcing a signature change. ``checked_add(...).unwrap_or(u64::MAX)`` is semantically equivalent and would have been the same fix in two lines.

## Tests

New ``credential_issue_saturates_on_ttl_overflow`` in ``identity_support::tests`` exercises ``ttl_seconds = u64::MAX``, asserting the call:

* does not panic
* yields ``expires_at_secs == u64::MAX``
* yields ``expires_at_secs > issued_at_secs`` (no wrap)
* yields ``is_valid() == true``

````
cargo test -p agentmesh --lib identity_support::
  test result: ok. 12 passed; 0 failed
````

## Test plan

- [ ] CI passes
- [ ] ``identity_support::tests`` 12/12 pass
- [ ] No regression in ``credential_manager_issues_rotates_and_revokes``

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Rust Identity].