### PR TITLE
fix(rust-integration): rename token_jaccard to token_jaccard_distance (it returns distance, not similarity)

### DIFF
--- a/agent-governance-rust/agentmesh/src/integration_support.rs
+++ b/agent-governance-rust/agentmesh/src/integration_support.rs
@@ -29,7 +29,18 @@ fn sha256_hex(input: &str) -> String {
         .collect()
 }
 
-fn token_jaccard(left: &str, right: &str) -> f64 {
+/// Tokenised Jaccard *distance* on whitespace-split, lowercased terms.
+///
+/// Returns `1 - |A ∩ B| / |A ∪ B|`, so:
+///
+/// * identical inputs → `0.0` (no drift)
+/// * completely disjoint inputs → `1.0` (maximum drift)
+/// * both inputs empty → `0.0` (treated as identical rather than NaN)
+///
+/// Named for distance (not similarity) because the only caller —
+/// `DriftResult::compare` — treats higher scores as "more drift" and
+/// flags `exceeded` when the score crosses an upper-bound threshold.
+fn token_jaccard_distance(left: &str, right: &str) -> f64 {
     let left_tokens = left
         .split_whitespace()
         .map(|token| token.to_ascii_lowercase())
@@ -216,7 +227,7 @@ pub struct DriftResult {
 
 impl DriftResult {
     pub fn compare(baseline: &str, current: &str, threshold: f64) -> Self {
-        let score = token_jaccard(baseline, current);
+        let score = token_jaccard_distance(baseline, current);
         Self {
             score,
             exceeded: score > threshold,
@@ -1700,5 +1711,56 @@ mod tests {
         let agent = inventory.agents().pop().unwrap();
         assert_eq!(agent.status, DiscoveryStatus::Registered);
         assert_eq!(agent.did.as_deref(), Some("did:mesh:prod-assistant"));
+    }
+
+    #[test]
+    fn token_jaccard_distance_returns_zero_for_identical_inputs() {
+        // Identical token sets must have Jaccard distance 0 — pins the
+        // distance-not-similarity contract for `DriftResult::compare`.
+        let s = "the quick brown fox";
+        let dist = token_jaccard_distance(s, s);
+        assert!(dist.abs() < f64::EPSILON, "expected 0.0 got {dist}");
+    }
+
+    #[test]
+    fn token_jaccard_distance_returns_one_for_disjoint_inputs() {
+        // Completely disjoint token sets must have Jaccard distance 1 —
+        // confirms the function does not flip into similarity when the
+        // intersection is empty.
+        let dist = token_jaccard_distance("alpha beta gamma", "delta epsilon zeta");
+        assert!((dist - 1.0).abs() < f64::EPSILON, "expected 1.0 got {dist}");
+    }
+
+    #[test]
+    fn token_jaccard_distance_increases_with_drift() {
+        // Quarter-overlap should score around 0.6–0.7 distance — well
+        // above the typical 0.10–0.15 drift threshold used in
+        // GovernancePolicy::default().
+        let dist = token_jaccard_distance(
+            "alpha beta gamma delta",
+            "alpha epsilon zeta theta",
+        );
+        assert!(dist > 0.5, "expected drift > 0.5, got {dist}");
+        assert!(dist < 1.0, "expected drift < 1.0, got {dist}");
+    }
+
+    #[test]
+    fn drift_result_compare_exceeds_threshold_when_inputs_diverge() {
+        // `DriftResult::compare` -> exceeded uses distance > threshold;
+        // pin that semantic so a future rename or sign-flip is caught.
+        let drift = DriftResult::compare(
+            "the quick brown fox",
+            "completely unrelated content",
+            0.5,
+        );
+        assert!(drift.exceeded);
+        assert!(drift.score > 0.5);
+    }
+
+    #[test]
+    fn drift_result_compare_does_not_exceed_for_identical_inputs() {
+        let drift = DriftResult::compare("same text here", "same text here", 0.1);
+        assert!(!drift.exceeded);
+        assert!(drift.score.abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
## Summary

The private helper [`token_jaccard`](agent-governance-rust/agentmesh/src/integration_support.rs#L32) computed:

````rust
1.0 - (intersection / union.max(1.0))
````

That is Jaccard *distance*:

* identical inputs → ``0.0``
* completely disjoint inputs → ``1.0``

The function name implied similarity, which is the conventional reading of "Jaccard". The math is correct — its only caller, [`DriftResult::compare`](agent-governance-rust/agentmesh/src/integration_support.rs#L218), already treats a higher score as more drift (``exceeded: score > threshold``) — but a future maintainer reading ``token_jaccard`` and assuming similarity would invert every drift verdict by either flipping the comparison or dropping the ``1.0 -``.

## Change

* Rename ``token_jaccard`` → ``token_jaccard_distance``.
* Add a doc comment explicitly stating the return semantics (0 = identical, 1 = disjoint, double-empty = 0) and noting that ``DriftResult::compare`` is the sole caller.
* Update the call site in ``DriftResult::compare``.

The function is ``fn`` (not ``pub fn``) — no public-API impact.

## Tests

Five regression tests in ``integration_support::tests`` pin the distance-not-similarity contract:

| Test | Asserts |
|---|---|
| ``token_jaccard_distance_returns_zero_for_identical_inputs`` | identical → 0.0 |
| ``token_jaccard_distance_returns_one_for_disjoint_inputs`` | disjoint → 1.0 |
| ``token_jaccard_distance_increases_with_drift`` | quarter-overlap → > 0.5 and < 1.0 |
| ``drift_result_compare_exceeds_threshold_when_inputs_diverge`` | drift > threshold → ``exceeded == true`` |
| ``drift_result_compare_does_not_exceed_for_identical_inputs`` | identical baseline/current → ``exceeded == false`` and ``score ≈ 0`` |

If a future change flips the formula (e.g. drops the ``1.0 -``), these tests fail loudly rather than letting every drift comparison silently invert.

````
cargo test -p agentmesh --lib integration_support::
  test result: ok. 19 passed; 0 failed
````

## Test plan

- [ ] CI passes
- [ ] ``integration_support::tests`` 19/19 pass (14 previously + 5 new)
- [ ] No regression in ``framework_adapter_assesses_response_drift``

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Rust Integration].