### PR TITLE
fix(go-middleware): stop leaking wrapped error detail in HTTP response body

### DIFF
--- a/agent-governance-golang/packages/agentmesh/middleware.go
+++ b/agent-governance-golang/packages/agentmesh/middleware.go
@@ -6,6 +6,7 @@ package agentmesh
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -396,13 +397,27 @@ func NewHTTPGovernanceMiddleware(config HTTPMiddlewareConfig) (func(http.Handler
 			if recorder.WroteHeader() {
 				return
 			}
+			// Map governance errors to a stable client-facing message: the
+			// sentinel's `.Error()` for known cases (no wrapped detail
+			// leaked), `http.StatusText` for everything else. Wrapped
+			// errors can carry policy rule names, tool names, action
+			// identifiers, or risk-score numbers; the audit log already
+			// captures them server-side via the audit middleware.
 			statusCode := http.StatusForbidden
-			if !errors.Is(err, ErrPolicyDenied) &&
-				!errors.Is(err, ErrKillSwitchActive) &&
-				!errors.Is(err, ErrVerifiedAgentIdentityRequired) {
+			var clientMessage string
+			switch {
+			case errors.Is(err, ErrPolicyDenied):
+				clientMessage = ErrPolicyDenied.Error()
+			case errors.Is(err, ErrKillSwitchActive):
+				clientMessage = ErrKillSwitchActive.Error()
+			case errors.Is(err, ErrVerifiedAgentIdentityRequired):
+				clientMessage = ErrVerifiedAgentIdentityRequired.Error()
+			default:
 				statusCode = http.StatusInternalServerError
+				clientMessage = http.StatusText(http.StatusInternalServerError)
+				log.Printf("agentmesh: governance middleware unexpected error: %v", err)
 			}
-			http.Error(w, err.Error(), statusCode)
+			http.Error(w, clientMessage, statusCode)
 		})
 	}, nil
 }

--- a/agent-governance-golang/packages/agentmesh/middleware_test.go
+++ b/agent-governance-golang/packages/agentmesh/middleware_test.go
@@ -208,6 +208,11 @@ func TestNewHTTPGovernanceMiddlewarePolicyDenialReturnsForbidden(t *testing.T) {
 	if !strings.Contains(response.Body.String(), ErrPolicyDenied.Error()) {
 		t.Fatalf("body = %q, want policy denial", response.Body.String())
 	}
+	// The wrapped detail (action name, tool name, etc.) must not leak.
+	body := strings.TrimSpace(response.Body.String())
+	if body != ErrPolicyDenied.Error() {
+		t.Fatalf("body = %q leaks wrapped detail; want exactly %q", body, ErrPolicyDenied.Error())
+	}
 }
 
 func TestNewHTTPGovernanceMiddlewareUsesCustomActionAndContext(t *testing.T) {
@@ -510,8 +515,15 @@ func TestNewHTTPGovernanceMiddlewarePromptDefenseMaxRiskScore(t *testing.T) {
 	if response.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
 	}
-	if !strings.Contains(response.Body.String(), "prompt defense risk score") {
-		t.Fatalf("body = %q, want prompt defense denial", response.Body.String())
+	// Body should carry the stable sentinel message and must NOT leak
+	// the wrapped detail ("prompt defense risk score N exceeded max M")
+	// — that detail is captured in the audit log instead.
+	body := response.Body.String()
+	if !strings.Contains(body, ErrPolicyDenied.Error()) {
+		t.Fatalf("body = %q, want policy denial sentinel", body)
+	}
+	if strings.Contains(body, "risk score") {
+		t.Fatalf("body = %q leaks wrapped error detail", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

[`NewHTTPGovernanceMiddleware`](agent-governance-golang/packages/agentmesh/middleware.go) echoed the full ``err.Error()`` to the client whenever the governance stack returned an error:

````go
http.Error(w, err.Error(), statusCode)
````

That error was a ``fmt.Errorf(\"%w: ...\", ErrPolicyDenied, ...)`` chain carrying the wrapped detail — tool name, action identifier, prompt-defense risk score and threshold, kill-switch scope. The wrapping convention was for ``errors.Is`` callers, not for end users.

Each governed-operation error path leaked something the audit log already captured. Concrete example: a payload that trips prompt defense sent the client:

````
policy denied action: prompt defense risk score 47 exceeded max 5
````

— revealing both the evaluator's verdict and the configured threshold to an unauthenticated caller. The existing test ``TestNewHTTPGovernanceMiddlewarePromptDefenseMaxRiskScore`` actually asserted on that leaked detail.

## Change

Map sentinel errors to their stable ``.Error()`` for the client; for unrecognised errors emit ``http.StatusText(http.StatusInternalServerError)`` and log the wrapped detail server-side via stdlib ``log.Printf``:

````go
statusCode := http.StatusForbidden
var clientMessage string
switch {
case errors.Is(err, ErrPolicyDenied):
    clientMessage = ErrPolicyDenied.Error()
case errors.Is(err, ErrKillSwitchActive):
    clientMessage = ErrKillSwitchActive.Error()
case errors.Is(err, ErrVerifiedAgentIdentityRequired):
    clientMessage = ErrVerifiedAgentIdentityRequired.Error()
default:
    statusCode = http.StatusInternalServerError
    clientMessage = http.StatusText(http.StatusInternalServerError)
    log.Printf(\"agentmesh: governance middleware unexpected error: %v\", err)
}
http.Error(w, clientMessage, statusCode)
````

The audit middleware path already records full violation context for server-side triage, so no detail is lost — just no longer reflected back to the caller.

## Tests

* ``TestNewHTTPGovernanceMiddlewarePolicyDenialReturnsForbidden`` extended: body must be exactly ``ErrPolicyDenied.Error()`` — no wrapped detail.
* ``TestNewHTTPGovernanceMiddlewarePromptDefenseMaxRiskScore`` updated: was asserting ``strings.Contains(body, \"prompt defense risk score\")`` — the exact leak this PR fixes. New assertion: body carries the sentinel and does NOT contain ``\"risk score\"``.

````
go test ./...
  ok    github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh    2.018s
````

## Test plan

- [ ] CI passes
- [ ] All agentmesh tests pass
- [ ] No regression in existing middleware assertions

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Middleware].