### PR TITLE
fix(go-policy): lift Cedar regex compilations to package-level vars

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy_backends.go
+++ b/agent-governance-golang/packages/agentmesh/policy_backends.go
@@ -18,6 +18,16 @@ import (
 	"time"
 )
 
+// Package-level Cedar parsing regexes. Compiled once at package init
+// rather than per call — `parseCedarStatements` and `toolToCedarAction`
+// can run on every policy evaluation, so the previous per-call
+// `regexp.MustCompile` was wasted work.
+var (
+	cedarStatementPattern = regexp.MustCompile(`(?s)(permit|forbid)\s*\((.*?)\)\s*;`)
+	cedarActionPattern    = regexp.MustCompile(`action\s*==\s*Action::"([^"]+)"`)
+	cedarActionTokenSplit = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+)
+
 // OPAMode controls how an OPA/Rego backend evaluates policies.
 type OPAMode string
 
@@ -654,14 +664,12 @@ func buildCedarRequest(context map[string]interface{}) map[string]interface{} {
 }
 
 func parseCedarStatements(content string) []cedarStatement {
-	pattern := regexp.MustCompile(`(?s)(permit|forbid)\s*\((.*?)\)\s*;`)
-	actionPattern := regexp.MustCompile(`action\s*==\s*Action::"([^"]+)"`)
-	matches := pattern.FindAllStringSubmatch(content, -1)
+	matches := cedarStatementPattern.FindAllStringSubmatch(content, -1)
 	statements := make([]cedarStatement, 0, len(matches))
 
 	for _, match := range matches {
 		constraint := ""
-		if actionMatch := actionPattern.FindStringSubmatch(match[2]); len(actionMatch) == 2 {
+		if actionMatch := cedarActionPattern.FindStringSubmatch(match[2]); len(actionMatch) == 2 {
 			constraint = fmt.Sprintf(`Action::"%s"`, actionMatch[1])
 		}
 		statements = append(statements, cedarStatement{
@@ -675,8 +683,7 @@ func parseCedarStatements(content string) []cedarStatement {
 }
 
 func toolToCedarAction(toolName string) string {
-	splitter := regexp.MustCompile(`[^a-zA-Z0-9]+`)
-	parts := splitter.Split(toolName, -1)
+	parts := cedarActionTokenSplit.Split(toolName, -1)
 	builder := strings.Builder{}
 	for _, part := range parts {
 		if part == "" {


### PR DESCRIPTION
## Summary

Three regex compilations in [`policy_backends.go`](agent-governance-golang/packages/agentmesh/policy_backends.go) were re-running on every call:

* ``parseCedarStatements`` — compiled both ``cedarStatementPattern`` and ``cedarActionPattern`` per invocation.
* ``toolToCedarAction`` — compiled ``cedarActionTokenSplit`` per invocation.

Both functions run on the policy-evaluation hot path: ``toolToCedarAction`` is called by ``buildCedarRequest``, which fires for every Cedar policy evaluation, and ``parseCedarStatements`` is called by the builtin Cedar evaluator on every decision when no external CLI is wired.

## Change

Hoist the three regexes to a package-level ``var (...)`` block at the top of the file:

````go
var (
    cedarStatementPattern = regexp.MustCompile(`(?s)(permit|forbid)\s*\((.*?)\)\s*;`)
    cedarActionPattern    = regexp.MustCompile(`action\s*==\s*Action::\"([^\"]+)\"`)
    cedarActionTokenSplit = regexp.MustCompile(`[^a-zA-Z0-9]+`)
)
````

Call sites reference the package-level variables. Behaviour is unchanged — same literals, same ``MustCompile`` panic semantics if a future edit ever corrupts one of them.

## Tests

No new tests needed — the public behaviour is unchanged, and the existing Cedar parsing tests already exercise both functions. Existing tests pass:

````
go test ./...
  ok    github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh    0.900s
````

## Test plan

- [ ] CI passes
- [ ] All existing agentmesh tests pass
- [ ] Cedar policy evaluation behaviour unchanged

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Policy].