### PR TITLE
fix(go-policy): parse Cedar CLI decision from first-line token, not substring sniffing

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy_backends.go
+++ b/agent-governance-golang/packages/agentmesh/policy_backends.go
@@ -574,14 +574,49 @@ func (b *CedarBackend) evaluateCLI(context map[string]interface{}) (BackendDecis
 		return BackendDecision{}, fmt.Errorf("cedar authorize failed: %s", strings.TrimSpace(string(output)))
 	}
 
-	normalized := strings.ToLower(string(output))
-	allowed := strings.Contains(normalized, "allow") && !strings.Contains(normalized, "deny")
+	allowed, parsed := cedarDecisionFromCLIOutput(string(output))
+	if !parsed {
+		return BackendDecision{}, fmt.Errorf("cedar authorize: unrecognised output %q", strings.TrimSpace(string(output)))
+	}
 	return BackendDecision{
 		Allowed:   allowed,
 		Decision:  boolToDecision(allowed),
 		Reason:    fmt.Sprintf("Cedar cli: %s", strings.TrimSpace(string(output))),
 		RawResult: map[string]interface{}{"stdout": string(output)},
 	}, nil
+}
+
+// cedarDecisionFromCLIOutput inspects `cedar authorize` stdout and
+// returns (allowed, true) when the first non-empty line is an
+// unambiguous "ALLOW" or "DENY" token (case-insensitive). Returns
+// (_, false) if the output cannot be interpreted unambiguously.
+//
+// The previous implementation used
+// `strings.Contains(stdout, "allow") && !strings.Contains(stdout, "deny")`,
+// which mis-matches inside words and adjective phrases — output like
+// "DENY (request was disallowed)" contains both substrings and would
+// be classified DENY by coincidence, and "ALLOW: caveats include the
+// deny-list scoping" would be mis-classified DENY.
+//
+// A future improvement is to invoke `cedar authorize --json` and parse
+// the structured response, once the project pins a Cedar CLI version
+// known to support that flag.
+func cedarDecisionFromCLIOutput(stdout string) (allowed bool, parsed bool) {
+	for _, line := range strings.Split(stdout, "\n") {
+		token := strings.TrimSpace(strings.ToLower(line))
+		if token == "" {
+			continue
+		}
+		switch token {
+		case "allow":
+			return true, true
+		case "deny":
+			return false, true
+		}
+		// First non-empty line is neither token — refuse to guess.
+		return false, false
+	}
+	return false, false
 }
 
 func (b *CedarBackend) evaluateBuiltin(context map[string]interface{}) (BackendDecision, error) {

--- a/agent-governance-golang/packages/agentmesh/policy_backends_test.go
+++ b/agent-governance-golang/packages/agentmesh/policy_backends_test.go
@@ -302,3 +302,39 @@ func TestCedarBackendAutoUsesBuiltinWhenFallbackExplicitlyEnabled(t *testing.T) 
 		t.Fatalf("reason = %q, want explicit fallback marker", result.Reason)
 	}
 }
+
+func TestCedarDecisionFromCLIOutput(t *testing.T) {
+	tests := []struct {
+		name        string
+		stdout      string
+		wantAllowed bool
+		wantParsed  bool
+	}{
+		{name: "bare allow", stdout: "ALLOW\n", wantAllowed: true, wantParsed: true},
+		{name: "bare deny", stdout: "DENY\n", wantAllowed: false, wantParsed: true},
+		{name: "lowercase allow", stdout: "allow", wantAllowed: true, wantParsed: true},
+		{name: "lowercase deny", stdout: "deny", wantAllowed: false, wantParsed: true},
+		{name: "allow with trailing whitespace", stdout: "  ALLOW  \n", wantAllowed: true, wantParsed: true},
+		{name: "leading blank lines then deny", stdout: "\n\nDENY\n", wantAllowed: false, wantParsed: true},
+		// The substring approach this PR removes would have mis-classified
+		// the following outputs. The first-line parse refuses them rather
+		// than guessing.
+		{name: "deny with allow inside reason — must not coincide", stdout: "DENY (request disallowed by policy)\n", wantParsed: false},
+		{name: "allow with deny mentioned in caveat — must not coincide", stdout: "ALLOW: caveats reference the deny-list scoping\n", wantParsed: false},
+		// Genuine garbage.
+		{name: "garbage", stdout: "I am not a Cedar decision\n", wantParsed: false},
+		{name: "empty", stdout: "", wantParsed: false},
+		{name: "only whitespace", stdout: "   \n\n", wantParsed: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, parsed := cedarDecisionFromCLIOutput(tt.stdout)
+			if parsed != tt.wantParsed {
+				t.Fatalf("parsed = %v, want %v (stdout = %q)", parsed, tt.wantParsed, tt.stdout)
+			}
+			if parsed && allowed != tt.wantAllowed {
+				t.Fatalf("allowed = %v, want %v", allowed, tt.wantAllowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

[`CedarBackend.evaluateCLI`](agent-governance-golang/packages/agentmesh/policy_backends.go#L577) decided ALLOW/DENY by sniffing substrings inside the entire ``cedar authorize`` stdout:

````go
normalized := strings.ToLower(string(output))
allowed := strings.Contains(normalized, \"allow\") && !strings.Contains(normalized, \"deny\")
````

That mis-matches adjective phrases that future Cedar CLI versions may plausibly emit as diagnostic context:

| Output | Substring check | Correct |
|---|---|---|
| ``\"DENY (request disallowed by policy)\"`` | classified DENY (contains both — and ``!Contains(deny)`` is false) | DENY |
| ``\"ALLOW: caveats reference the deny-list scoping\"`` | classified DENY (contains both — falsey ``!Contains(deny)``) | ALLOW |
| ``\"ALLOW\"`` | classified ALLOW | ALLOW |
| ``\"DENY\"`` | classified DENY | DENY |

The trap is a coincidence: the words \"allow\" and \"disallow\" share a stem, and \"deny\" appears in compound nouns like \"deny-list\". A single character difference between the actual ALLOW/DENY token and the rest of the line flips the verdict.

## Change

Extract a small helper:

````go
// cedarDecisionFromCLIOutput inspects `cedar authorize` stdout and
// returns (allowed, true) when the first non-empty line is an
// unambiguous \"ALLOW\" or \"DENY\" token (case-insensitive). Returns
// (_, false) if the output cannot be interpreted unambiguously.
func cedarDecisionFromCLIOutput(stdout string) (allowed bool, parsed bool) {
    for _, line := range strings.Split(stdout, \"\n\") {
        token := strings.TrimSpace(strings.ToLower(line))
        if token == \"\" { continue }
        switch token {
        case \"allow\": return true, true
        case \"deny\":  return false, true
        }
        return false, false  // first non-empty line unrecognised
    }
    return false, false
}
````

``evaluateCLI`` calls the helper and propagates an error (``cedar authorize: unrecognised output %q``) when the parse fails. The caller's existing fail-closed path takes over from there (``AllowBuiltinFallback`` if configured, otherwise the error bubbles up).

### Why not ``--json``?

REVIEW.md suggested ``cedar authorize --json``. Cedar CLI 4.x supports a structured-output flag, but the project does not currently pin a Cedar CLI version, and older Cedar releases would reject the flag with ``unknown argument``. The first-line parse keeps backward compatibility with every Cedar CLI version while eliminating the substring trap, and a future PR can switch to JSON once the project pins a minimum Cedar CLI version.

## Tests

11 sub-tests in ``TestCedarDecisionFromCLIOutput`` pin the contract:

| Case | Stdout | Result |
|---|---|---|
| Bare ALLOW | ``\"ALLOW\n\"`` | parsed, allowed |
| Bare DENY | ``\"DENY\n\"`` | parsed, denied |
| Lowercase | ``\"allow\"`` / ``\"deny\"`` | parsed |
| Trailing whitespace | ``\"  ALLOW  \n\"`` | parsed, allowed |
| Leading blank lines | ``\"\n\nDENY\n\"`` | parsed, denied |
| Adjective phrase (DENY) | ``\"DENY (request disallowed)\"`` | **rejected** (regression for the substring trap) |
| Adjective phrase (ALLOW) | ``\"ALLOW: caveats reference the deny-list scoping\"`` | **rejected** |
| Garbage / empty / whitespace-only | various | rejected |

````
go test -run TestCedar -v
  PASS: TestCedarBackendAutoFailsClosedWithoutCLI
  PASS: TestCedarBackendAutoUsesBuiltinWhenFallbackExplicitlyEnabled
  PASS: TestCedarDecisionFromCLIOutput (11 subtests)
````

## Test plan

- [ ] CI passes
- [ ] All ``TestCedar*`` tests pass
- [ ] No regression in existing CedarBackend tests

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Policy].