### PR TITLE
fix(go-policy): guard Cedar builtin request action with comma-ok type assertion

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy_backends.go
+++ b/agent-governance-golang/packages/agentmesh/policy_backends.go
@@ -590,7 +590,15 @@ func (b *CedarBackend) evaluateBuiltin(context map[string]interface{}) (BackendD
 	}
 
 	request := buildCedarRequest(context)
-	action := request["action"].(string)
+	// `buildCedarRequest` always stuffs a `string` under "action", but
+	// guard with the comma-ok form so a future change to the request
+	// shape can't panic the policy evaluator. On the (currently
+	// unreachable) wrong-type path we fall through to default-deny via
+	// the ordinary statement loop, which is fail-closed.
+	action, ok := request["action"].(string)
+	if !ok {
+		return BackendDecision{}, fmt.Errorf("cedar builtin: request action has unexpected type %T", request["action"])
+	}
 	statements := parseCedarStatements(b.policyContent)
 	hasPermit := false
 


### PR DESCRIPTION
## Summary

[`CedarBackend.evaluateBuiltin`](agent-governance-golang/packages/agentmesh/policy_backends.go#L593) did:

````go
action := request[\"action\"].(string)
````

That is an unchecked type assertion. If a future change to ``buildCedarRequest`` ever stuffs a non-string (or a ``nil``) under ``\"action\"``, the policy evaluator panics with a runtime ``interface conversion`` failure instead of returning a clean error.

The panic is unreachable today — ``buildCedarRequest`` always writes a ``string`` via ``fmt.Sprintf`` — but the guard is cheap and the failure mode (panic in policy evaluation) is the kind that turns a benign change into an outage.

## Change

Switch to the comma-ok form:

````go
action, ok := request[\"action\"].(string)
if !ok {
    return BackendDecision{}, fmt.Errorf(\"cedar builtin: request action has unexpected type %T\", request[\"action\"])
}
````

The policy engine's existing backend-failure path then handles this as a backend error and falls closed. Same observable behaviour as the panic case from the caller's perspective, minus the stack trace and process-wide collateral damage.

## Tests

No new tests — the failure path is unreachable from the public API, and forcing it via reflection or a mock would defeat the guard's purpose. Existing ``TestCedar*`` suite passes:

````
go test -run TestCedar
  ok    github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh    6.094s
````

## Test plan

- [ ] CI passes
- [ ] Existing Cedar tests pass
- [ ] Defensive guard does not change observable behaviour for any current code path

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Policy].