### PR TITLE
perf(go-discovery): replace handrolled O(n²) sorts with stdlib sort

### DIFF
--- a/agent-governance-golang/packages/agentmesh/discovery.go
+++ b/agent-governance-golang/packages/agentmesh/discovery.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -888,21 +889,11 @@ func truncateForFingerprint(value string, max int) string {
 }
 
 func sortStrings(values []string) {
-	for index := 0; index < len(values); index++ {
-		for inner := index + 1; inner < len(values); inner++ {
-			if values[inner] < values[index] {
-				values[index], values[inner] = values[inner], values[index]
-			}
-		}
-	}
+	sort.Strings(values)
 }
 
 func sortDiscoveredAgents(values []DiscoveredAgent) {
-	for index := 0; index < len(values); index++ {
-		for inner := index + 1; inner < len(values); inner++ {
-			if values[inner].Fingerprint < values[index].Fingerprint {
-				values[index], values[inner] = values[inner], values[index]
-			}
-		}
-	}
+	sort.Slice(values, func(i, j int) bool {
+		return values[i].Fingerprint < values[j].Fingerprint
+	})
 }


### PR DESCRIPTION
## Summary

[`sortStrings`](agent-governance-golang/packages/agentmesh/discovery.go#L890) and [`sortDiscoveredAgents`](agent-governance-golang/packages/agentmesh/discovery.go#L900) were nested-loop selection sorts:

````go
func sortStrings(values []string) {
    for index := 0; index < len(values); index++ {
        for inner := index + 1; inner < len(values); inner++ {
            if values[inner] < values[index] {
                values[index], values[inner] = values[inner], values[index]
            }
        }
    }
}
````

That is O(n²) regardless of input shape — every pair is compared even if the slice is already sorted. ``sortDiscoveredAgents`` is the same pattern over ``DiscoveredAgent.Fingerprint``.

## Change

Use the stdlib:

````go
func sortStrings(values []string) {
    sort.Strings(values)
}

func sortDiscoveredAgents(values []DiscoveredAgent) {
    sort.Slice(values, func(i, j int) bool {
        return values[i].Fingerprint < values[j].Fingerprint
    })
}
````

Same comparison semantics (lexicographic ordering on the string / ``Fingerprint`` field), same in-place mutation, O(n log n) average and worst case, fewer lines. The call sites (``ComputeDiscoveryFingerprint`` and the inventory sort path) are unchanged.

``\"sort\"`` added to the import block, alphabetised between ``\"runtime\"`` and ``\"strconv\"``.

## Tests

No new tests — the public behaviour is the comparison ordering, which is unchanged. Existing tests that depend on stable ordering still pass:

````
go test ./...
  ok    github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh    0.877s
````

## Test plan

- [ ] CI passes
- [ ] All agentmesh tests pass
- [ ] No observable ordering change in tests that depend on sorted output

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Discovery].