### PR TITLE
perf(go-sandbox): defer docker info probe to first IsAvailable() call

### DIFF
--- a/agent-governance-golang/packages/agentmesh/sandbox.go
+++ b/agent-governance-golang/packages/agentmesh/sandbox.go
@@ -105,30 +105,40 @@ type SandboxProvider interface {
 
 // DockerSandboxProvider implements SandboxProvider using the Docker CLI.
 type DockerSandboxProvider struct {
-	image      string
-	available  bool
-	containers map[string]string // key: "agentID:sessionID", value: container name
-	mu         sync.Mutex
+	image          string
+	containers     map[string]string // key: "agentID:sessionID", value: container name
+	mu             sync.Mutex
+	availableOnce  sync.Once
+	available      bool
 }
 
 // NewDockerSandboxProvider creates a DockerSandboxProvider with the given base image.
-// It probes for Docker availability via `docker info` (bounded by
-// dockerInfoTimeout so a stalled daemon does not block initialisation).
+//
+// The constructor is non-blocking: Docker daemon reachability is probed
+// lazily on the first call to [DockerSandboxProvider.IsAvailable] (or
+// equivalently on the first [DockerSandboxProvider.CreateSession]).
+// Callers that never invoke a sandbox method — for example, unit tests
+// that exercise other code paths — never pay the `docker info` cost.
 func NewDockerSandboxProvider(image string) *DockerSandboxProvider {
-	p := &DockerSandboxProvider{
+	return &DockerSandboxProvider{
 		image:      image,
 		containers: make(map[string]string),
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), dockerInfoTimeout)
-	defer cancel()
-	if err := exec.CommandContext(ctx, "docker", "info").Run(); err == nil {
-		p.available = true
-	}
-	return p
 }
 
-// IsAvailable reports whether the Docker daemon is reachable.
+// IsAvailable reports whether the Docker daemon is reachable. The
+// underlying `docker info` probe runs at most once per provider; the
+// result is cached for the lifetime of the receiver. A provider whose
+// first probe fails will not retry — construct a new provider if the
+// daemon becomes available later.
 func (p *DockerSandboxProvider) IsAvailable() bool {
+	p.availableOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), dockerInfoTimeout)
+		defer cancel()
+		if err := exec.CommandContext(ctx, "docker", "info").Run(); err == nil {
+			p.available = true
+		}
+	})
 	return p.available
 }
 
@@ -151,7 +161,7 @@ var containerIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 // CreateSession starts a hardened Docker container for the given agent.
 func (p *DockerSandboxProvider) CreateSession(agentID string, config *SandboxConfig) (*SessionHandle, error) {
-	if !p.available {
+	if !p.IsAvailable() {
 		return nil, fmt.Errorf("docker is not available")
 	}
 	if !containerIDPattern.MatchString(agentID) {

--- a/agent-governance-golang/packages/agentmesh/sandbox_test.go
+++ b/agent-governance-golang/packages/agentmesh/sandbox_test.go
@@ -6,6 +6,7 @@ package agentmesh
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // Compile-time interface satisfaction check.
@@ -48,6 +49,24 @@ func TestDockerSandboxProviderNew(t *testing.T) {
 	}
 	// available may be true or false depending on the host; just verify no panic.
 	t.Logf("Docker available: %v", p.IsAvailable())
+}
+
+func TestNewDockerSandboxProviderDoesNotProbeDocker(t *testing.T) {
+	// The constructor must not block on `docker info`. Wall-clock time
+	// is the most direct proxy for I/O having happened — a non-zero
+	// dockerInfoTimeout would dominate the duration if the probe ran
+	// here. The bound is intentionally loose (one tenth of the probe
+	// timeout) so we don't false-fail on slow CI.
+	start := time.Now()
+	p := NewDockerSandboxProvider("alpine:latest")
+	elapsed := time.Since(start)
+	if p == nil {
+		t.Fatal("NewDockerSandboxProvider returned nil")
+	}
+	if elapsed > dockerInfoTimeout/10 {
+		t.Fatalf("constructor took %s (> %s); appears to be probing docker synchronously",
+			elapsed, dockerInfoTimeout/10)
+	}
 }
 
 func TestSandboxProviderInterface(t *testing.T) {


### PR DESCRIPTION
## Summary

[`NewDockerSandboxProvider`](agent-governance-golang/packages/agentmesh/sandbox.go#L117) ran ``docker info`` synchronously in the constructor:

````go
func NewDockerSandboxProvider(image string) *DockerSandboxProvider {
    p := &DockerSandboxProvider{ image: image, containers: make(map[string]string) }
    ctx, cancel := context.WithTimeout(context.Background(), dockerInfoTimeout)
    defer cancel()
    if err := exec.CommandContext(ctx, \"docker\", \"info\").Run(); err == nil {
        p.available = true
    }
    return p
}
````

Every test or caller that touched the constructor — including those that never exercised a sandbox method — paid the probe cost. On hosts without Docker the constructor stalled for the full ``dockerInfoTimeout`` window. The HIGH-pass timeout fix (#1862-era) bounded the cost but didn't eliminate it.

## Change

Move the probe behind a ``sync.Once``-guarded ``IsAvailable()``:

````go
func NewDockerSandboxProvider(image string) *DockerSandboxProvider {
    return &DockerSandboxProvider{ image: image, containers: make(map[string]string) }
}

func (p *DockerSandboxProvider) IsAvailable() bool {
    p.availableOnce.Do(func() {
        ctx, cancel := context.WithTimeout(context.Background(), dockerInfoTimeout)
        defer cancel()
        if err := exec.CommandContext(ctx, \"docker\", \"info\").Run(); err == nil {
            p.available = true
        }
    })
    return p.available
}
````

``CreateSession``'s gate switches from ``if !p.available`` to ``if !p.IsAvailable()`` so the probe still runs before the first container is launched.

### Caching semantics

A provider whose first probe fails will not retry — construct a new provider if Docker is recovered. This is called out in the doc comment. A future enhancement could expose a re-probe helper if callers need it, but no current code path does.

## Tests

New ``TestNewDockerSandboxProviderDoesNotProbeDocker`` enforces the non-blocking-constructor contract via a wall-clock bound (one tenth of ``dockerInfoTimeout``, intentionally loose so slow CI does not false-fail):

````go
start := time.Now()
p := NewDockerSandboxProvider(\"alpine:latest\")
elapsed := time.Since(start)
if elapsed > dockerInfoTimeout/10 {
    t.Fatalf(\"constructor took %s; appears to be probing docker synchronously\", elapsed)
}
````

Existing tests use ``IsAvailable()`` directly and remain green:

````
go test -run 'TestDockerSandbox|TestSandbox|TestNewDocker' -v
  PASS: TestDockerSandboxProviderNew
  PASS: TestNewDockerSandboxProviderDoesNotProbeDocker
  PASS: TestSandboxProviderInterface
````

## Test plan

- [ ] CI passes
- [ ] All sandbox tests pass
- [ ] New constructor-timing test pins the lazy-probe contract

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Sandbox].