### PR TITLE
fix(go-sandbox): append crypto/rand suffix to sandbox session and exec IDs

### DIFF
--- a/agent-governance-golang/packages/agentmesh/sandbox.go
+++ b/agent-governance-golang/packages/agentmesh/sandbox.go
@@ -5,6 +5,8 @@ package agentmesh
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -12,6 +14,22 @@ import (
 	"sync"
 	"time"
 )
+
+// randomHex returns 2*n hex characters drawn from crypto/rand.
+//
+// A failure from crypto/rand indicates a broken entropy source (e.g.
+// /dev/urandom is unreachable) — the sandbox cannot safely produce
+// unique session identifiers in that state, so we panic rather than
+// return a degraded fallback. This is the same convention Go uses for
+// `rand.Read` in security-critical contexts (`crypto/rsa.GenerateKey`
+// etc.).
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("sandbox: crypto/rand failed: %v", err))
+	}
+	return hex.EncodeToString(b)
+}
 
 // Docker subprocess deadlines. ``docker exec`` runs user-supplied code so
 // it falls back to SandboxConfig.TimeoutSeconds when set; the others are
@@ -161,7 +179,11 @@ func (p *DockerSandboxProvider) CreateSession(agentID string, config *SandboxCon
 		config = DefaultSandboxConfig()
 	}
 
-	sessionID := fmt.Sprintf("%d", time.Now().UnixNano())
+	// `time.Now().UnixNano()` alone collides on low-resolution clocks
+	// (Windows commonly resolves to ~100ns) and on closely-spaced
+	// concurrent calls; append a crypto/rand suffix so two sessions
+	// created in the same nanosecond cannot map to the same container.
+	sessionID := fmt.Sprintf("%d-%s", time.Now().UnixNano(), randomHex(8))
 	name := containerName(agentID, sessionID)
 
 	args := []string{
@@ -215,7 +237,9 @@ func (p *DockerSandboxProvider) ExecuteCode(agentID, sessionID, code string) (*E
 		return nil, fmt.Errorf("session %s:%s not found", agentID, sessionID)
 	}
 
-	execID := fmt.Sprintf("exec-%d", time.Now().UnixNano())
+	// Same collision concern as sessionID — keep the nanosecond prefix
+	// for human-readable ordering and append a random suffix.
+	execID := fmt.Sprintf("exec-%d-%s", time.Now().UnixNano(), randomHex(4))
 	start := time.Now()
 
 	ctx, cancel := context.WithTimeout(context.Background(), dockerExecTimeout)

--- a/agent-governance-golang/packages/agentmesh/sandbox_test.go
+++ b/agent-governance-golang/packages/agentmesh/sandbox_test.go
@@ -129,3 +129,20 @@ func TestCreateSessionAcceptsValidAgentID(t *testing.T) {
 		t.Fatalf("regex rejected a valid agentID: %v", err)
 	}
 }
+
+func TestRandomHexProducesUniqueValues(t *testing.T) {
+	// 1000 consecutive calls must all be distinct. Two collisions from
+	// crypto/rand at 16 hex characters (8 bytes) is astronomically
+	// unlikely; if this fails, the entropy source is broken.
+	seen := make(map[string]struct{}, 1000)
+	for i := 0; i < 1000; i++ {
+		v := randomHex(8)
+		if len(v) != 16 {
+			t.Fatalf("randomHex(8) returned %d chars, want 16", len(v))
+		}
+		if _, dup := seen[v]; dup {
+			t.Fatalf("randomHex collided after %d iterations: %q", i, v)
+		}
+		seen[v] = struct{}{}
+	}
+}


### PR DESCRIPTION
## Summary

[`CreateSession`](agent-governance-golang/packages/agentmesh/sandbox.go#L164) generated session IDs from wall-clock alone:

````go
sessionID := fmt.Sprintf(\"%d\", time.Now().UnixNano())
````

[`ExecuteCode`](agent-governance-golang/packages/agentmesh/sandbox.go#L218) did the same for exec IDs:

````go
execID := fmt.Sprintf(\"exec-%d\", time.Now().UnixNano())
````

Both collide on:

* **Coarse clocks** — Windows ``time.Now()`` commonly resolves to ~100ns; two ``CreateSession`` calls within that window get the same nanosecond.
* **Concurrent goroutines** — two goroutines that pass through the same line at the same physical time produce identical IDs.

A collision on ``sessionID`` is load-bearing: ``containerName(agentID, sessionID)`` becomes the Docker container ``--name``, so collision means the second ``docker run`` fails (name already taken) and the first session's entry in the container map is silently overwritten.

A collision on ``execID`` is less load-bearing (the ID is informational), but shares the same root cause and is cheap to fix in the same change.

## Change

Add a ``randomHex`` helper backed by ``crypto/rand``:

````go
func randomHex(n int) string {
    b := make([]byte, n)
    if _, err := rand.Read(b); err != nil {
        panic(fmt.Sprintf(\"sandbox: crypto/rand failed: %v\", err))
    }
    return hex.EncodeToString(b)
}
````

A failure from ``crypto/rand`` indicates a broken entropy source — the sandbox cannot safely produce unique session identifiers in that state, so we panic rather than return a degraded fallback. This matches the convention Go uses for ``rand.Read`` in security-critical contexts (``crypto/rsa.GenerateKey`` et al.).

New IDs:

* ``sessionID`` → ``<nanos>-<16 hex>`` (8 random bytes)
* ``execID`` → ``exec-<nanos>-<8 hex>`` (4 random bytes — exec ID isn't a Docker primary key)

The nanosecond prefix is retained for human-readable ordering at debug time; the hex suffix carries the collision resistance. ``containerName(agentID, sessionID)`` continues to satisfy the existing ``[a-zA-Z0-9_.-]+`` ``containerIDPattern`` regex — hex digits and ``-`` are all in the set.

## Tests

* New ``TestRandomHexProducesUniqueValues`` runs 1000 consecutive calls and asserts all 1000 outputs are distinct. Failure indicates a broken entropy source.
* Existing tests (``TestCreateExecuteDestroy``, ``TestDockerSandboxProviderNew``, etc.) continue to pass.

````
go test ./...
  ok    github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh    1.821s
````

## Test plan

- [ ] CI passes
- [ ] All agentmesh tests pass
- [ ] New randomHex uniqueness test pins the collision-resistance contract

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Sandbox].