### PR TITLE
fix(go-discovery): aggregate evidence confidence via noisy-OR, not max

### DIFF
--- a/agent-governance-golang/packages/agentmesh/discovery.go
+++ b/agent-governance-golang/packages/agentmesh/discovery.go
@@ -79,11 +79,33 @@ type DiscoveredAgent struct {
 }
 
 // AddEvidence appends evidence and updates the aggregate confidence and timestamps.
+//
+// Confidence is combined using a noisy-OR formula:
+//
+//	combined = 1 - (1 - prior) * (1 - new)
+//
+// rather than `max(...)`. This lets multiple corroborating low-confidence
+// signals raise the aggregate: two 0.5 hits combine to 0.75, three to
+// 0.875, etc., asymptoting at 1. `max(...)` would have left the aggregate
+// stuck at 0.5 forever no matter how many independent confirmations
+// arrived.
+//
+// The formula assumes independence between evidence sources. Callers
+// must NOT add the same observation twice (e.g. the same file path
+// twice via two scanners) — a duplicate would falsely inflate the
+// score. The discovery pipeline deduplicates via `Fingerprint` before
+// calling this method.
+//
+// Confidence inputs outside [0, 1] are clamped before combining.
 func (a *DiscoveredAgent) AddEvidence(evidence DiscoveryEvidence) {
 	a.Evidence = append(a.Evidence, evidence)
-	if evidence.Confidence > a.Confidence {
-		a.Confidence = evidence.Confidence
+	c := evidence.Confidence
+	if c < 0 {
+		c = 0
+	} else if c > 1 {
+		c = 1
 	}
+	a.Confidence = 1 - (1-a.Confidence)*(1-c)
 	if a.FirstSeenAt.IsZero() || evidence.Timestamp.Before(a.FirstSeenAt) {
 		a.FirstSeenAt = evidence.Timestamp
 	}

--- a/agent-governance-golang/packages/agentmesh/discovery_test.go
+++ b/agent-governance-golang/packages/agentmesh/discovery_test.go
@@ -6,13 +6,68 @@ package agentmesh
 import (
 	"encoding/base64"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestAddEvidenceCombinesConfidenceViaNoisyOR(t *testing.T) {
+	agent := &DiscoveredAgent{}
+	agent.AddEvidence(DiscoveryEvidence{Confidence: 0.5, Timestamp: time.Unix(1, 0)})
+	if math.Abs(agent.Confidence-0.5) > 1e-9 {
+		t.Fatalf("after one 0.5 evidence: Confidence = %v, want 0.5", agent.Confidence)
+	}
+	agent.AddEvidence(DiscoveryEvidence{Confidence: 0.5, Timestamp: time.Unix(2, 0)})
+	// 1 - (1 - 0.5) * (1 - 0.5) = 0.75
+	if math.Abs(agent.Confidence-0.75) > 1e-9 {
+		t.Fatalf("after two 0.5 evidences: Confidence = %v, want 0.75", agent.Confidence)
+	}
+	agent.AddEvidence(DiscoveryEvidence{Confidence: 0.5, Timestamp: time.Unix(3, 0)})
+	// 1 - (1 - 0.75) * (1 - 0.5) = 0.875
+	if math.Abs(agent.Confidence-0.875) > 1e-9 {
+		t.Fatalf("after three 0.5 evidences: Confidence = %v, want 0.875", agent.Confidence)
+	}
+}
+
+func TestAddEvidenceSaturatesAtOne(t *testing.T) {
+	agent := &DiscoveredAgent{Confidence: 1.0}
+	agent.AddEvidence(DiscoveryEvidence{Confidence: 0.9, Timestamp: time.Unix(1, 0)})
+	if agent.Confidence != 1.0 {
+		t.Fatalf("Confidence = %v after combining 1.0 with 0.9, want 1.0", agent.Confidence)
+	}
+}
+
+func TestAddEvidenceClampsOutOfRangeInputs(t *testing.T) {
+	// Negative confidence clamps to 0 — should not move the aggregate.
+	agent := &DiscoveredAgent{Confidence: 0.5}
+	agent.AddEvidence(DiscoveryEvidence{Confidence: -1.0, Timestamp: time.Unix(1, 0)})
+	if agent.Confidence != 0.5 {
+		t.Fatalf("Confidence = %v after combining 0.5 with -1.0 (clamps to 0), want 0.5", agent.Confidence)
+	}
+	// > 1 clamps to 1 — should saturate the aggregate.
+	agent.AddEvidence(DiscoveryEvidence{Confidence: 5.0, Timestamp: time.Unix(2, 0)})
+	if agent.Confidence != 1.0 {
+		t.Fatalf("Confidence = %v after combining 0.5 with 5.0 (clamps to 1), want 1.0", agent.Confidence)
+	}
+}
+
+func TestAddEvidenceLowConfidencesCorroborate(t *testing.T) {
+	// The whole point of this change: ten 0.1 hits should aggregate
+	// well above 0.1 (which the old max() implementation produced).
+	agent := &DiscoveredAgent{}
+	for i := 0; i < 10; i++ {
+		agent.AddEvidence(DiscoveryEvidence{Confidence: 0.1, Timestamp: time.Unix(int64(i+1), 0)})
+	}
+	// 1 - 0.9^10 ≈ 0.6513
+	if agent.Confidence < 0.6 || agent.Confidence > 0.7 {
+		t.Fatalf("Confidence = %v after ten 0.1 evidences, want ~0.65", agent.Confidence)
+	}
+}
 
 func TestShadowDiscoveryScannerScanText(t *testing.T) {
 	scanner := NewShadowDiscoveryScanner()


### PR DESCRIPTION
## Summary

[`DiscoveredAgent.AddEvidence`](agent-governance-golang/packages/agentmesh/discovery.go#L82) combined confidences with ``max(prior, new)``:

````go
if evidence.Confidence > a.Confidence {
    a.Confidence = evidence.Confidence
}
````

Multiple independent corroborating low-confidence signals never raised the aggregate past their single best. Three independent 0.5 hits stayed pinned at 0.5, even though \"three independent observers each 50% sure\" is meaningfully stronger evidence than \"one observer 50% sure.\" Ten 0.1 hits stayed pinned at 0.1.

## Change

Switch to noisy-OR aggregation, the standard Bayesian combination for independent binary observations:

````go
a.Confidence = 1 - (1 - a.Confidence) * (1 - c)
````

Behaviour:

| Input series | Old (max) | New (noisy-OR) |
|---|---:|---:|
| one 0.5 | 0.5 | 0.5 |
| two 0.5 | 0.5 | 0.75 |
| three 0.5 | 0.5 | 0.875 |
| ten 0.1 | 0.1 | ~0.65 |
| one 1.0 then anything | 1.0 | 1.0 (saturates) |

The formula assumes independence between evidence sources. The doc comment calls this out: callers must not feed the same observation through twice. The discovery pipeline already dedupes via ``Fingerprint`` before reaching ``AddEvidence``, so duplicate-inflation is not a concern for existing call sites.

Inputs outside ``[0, 1]`` are clamped before combining so a buggy signal source can't push the aggregate outside the valid range or produce a non-finite result.

## Tests

Four regression tests pin the contract:

| Test | Asserts |
|---|---|
| ``TestAddEvidenceCombinesConfidenceViaNoisyOR`` | repeated 0.5 hits → 0.5, 0.75, 0.875 |
| ``TestAddEvidenceSaturatesAtOne`` | prior = 1.0 stays 1.0 regardless of input |
| ``TestAddEvidenceClampsOutOfRangeInputs`` | -1.0 → no movement; 5.0 → saturates |
| ``TestAddEvidenceLowConfidencesCorroborate`` | ten 0.1 hits → ~0.65 (was 0.1 under max) |

````
go test -run TestAddEvidence -v
  PASS (4 subtests)
go test ./...
  ok    github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh
````

## Test plan

- [ ] CI passes
- [ ] All agentmesh tests pass
- [ ] No regression in tests that observe the ``DiscoveredAgent.Confidence`` field

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Discovery].