### PR TITLE
fix(go-policy): log Cedar/OPA backend file-read and JSON-parse failures

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy_backends.go
+++ b/agent-governance-golang/packages/agentmesh/policy_backends.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -56,11 +57,19 @@ type OPABackend struct {
 var opaLookPath = exec.LookPath
 
 // NewOPABackend creates an OPA/Rego backend.
+//
+// A `RegoPath` that cannot be read is logged at construction time and
+// the backend falls back to an empty `regoContent` — previously the
+// error was silently discarded, producing an OPA backend that always
+// failed evaluation without any signal that the configuration was
+// broken.
 func NewOPABackend(options OPAOptions) *OPABackend {
 	regoContent := options.RegoContent
 	if regoContent == "" && options.RegoPath != "" {
 		data, err := os.ReadFile(options.RegoPath)
-		if err == nil {
+		if err != nil {
+			log.Printf("agentmesh: opa backend: failed to read RegoPath %q: %v", options.RegoPath, err)
+		} else {
 			regoContent = string(data)
 		}
 	}
@@ -439,11 +448,21 @@ type CedarBackend struct {
 var cedarLookPath = exec.LookPath
 
 // NewCedarBackend creates a Cedar backend.
+//
+// File-system reads (PolicyPath, EntitiesPath) and JSON parsing of the
+// entities file are best-effort: failures are logged at construction
+// time and the backend is created with the corresponding field unset.
+// Previously these errors were silently discarded — a typo in the
+// EntitiesPath produced an empty entity set and policies evaluated
+// against zero entities without any signal that the configuration was
+// broken.
 func NewCedarBackend(options CedarOptions) *CedarBackend {
 	policyContent := options.PolicyContent
 	if policyContent == "" && options.PolicyPath != "" {
 		data, err := os.ReadFile(options.PolicyPath)
-		if err == nil {
+		if err != nil {
+			log.Printf("agentmesh: cedar backend: failed to read PolicyPath %q: %v", options.PolicyPath, err)
+		} else {
 			policyContent = string(data)
 		}
 	}
@@ -451,8 +470,11 @@ func NewCedarBackend(options CedarOptions) *CedarBackend {
 	entities := options.Entities
 	if len(entities) == 0 && options.EntitiesPath != "" {
 		data, err := os.ReadFile(options.EntitiesPath)
-		if err == nil {
-			_ = json.Unmarshal(data, &entities)
+		if err != nil {
+			log.Printf("agentmesh: cedar backend: failed to read EntitiesPath %q: %v", options.EntitiesPath, err)
+		} else if uerr := json.Unmarshal(data, &entities); uerr != nil {
+			log.Printf("agentmesh: cedar backend: failed to parse entities JSON at %q: %v", options.EntitiesPath, uerr)
+			entities = nil
 		}
 	}
 


### PR DESCRIPTION
## Summary

Three constructors in [`policy_backends.go`](agent-governance-golang/packages/agentmesh/policy_backends.go) silently discarded errors that change observable backend behaviour:

* ``NewCedarBackend`` ignored ``os.ReadFile(PolicyPath)`` failures.
* ``NewCedarBackend`` ignored ``os.ReadFile(EntitiesPath)`` failures.
* ``NewCedarBackend`` had ``_ = json.Unmarshal(data, &entities)`` — a malformed entities JSON file silently produced an empty entity set and policy evaluations ran against zero entities.
* ``NewOPABackend`` ignored ``os.ReadFile(RegoPath)`` failures.

````go
// before
data, err := os.ReadFile(options.EntitiesPath)
if err == nil {
    _ = json.Unmarshal(data, &entities)
}
````

A typo in any of these paths produced a backend that always failed or always defaulted, with no signal that the configuration was broken. Operators were left to discover the misconfiguration from empty policy decisions in production.

## Change

Switch each silent-ignore to ``log.Printf`` with the path and the underlying error:

````go
// after
data, err := os.ReadFile(options.EntitiesPath)
if err != nil {
    log.Printf(\"agentmesh: cedar backend: failed to read EntitiesPath %q: %v\", options.EntitiesPath, err)
} else if uerr := json.Unmarshal(data, &entities); uerr != nil {
    log.Printf(\"agentmesh: cedar backend: failed to parse entities JSON at %q: %v\", options.EntitiesPath, uerr)
    entities = nil
}
````

The constructors still succeed with the corresponding field unset (so existing call sites that rely on \"construction never fails\" don't regress); the log line becomes the configuration-error breadcrumb. A failed ``json.Unmarshal`` also explicitly resets ``entities = nil`` so a partially-populated map from a half-parsed file does not leak into evaluation.

### Scope note

REVIEW.md flagged only the ``EntitiesPath`` ``json.Unmarshal``. The ``RegoPath`` and ``PolicyPath`` file-reads are the same anti-pattern in the same file and are bundled here because the fix shape is identical (one branch = one logical change). The doc comments on both constructors now spell out the best-effort semantics so the behaviour is part of the contract.

## Tests

No new tests — capturing ``log.Printf`` output requires redirecting ``log.SetOutput`` and would need to coordinate with any other test using the default logger. The existing test suite covers the success paths and confirms no regression:

````
go test ./...
  ok    github.com/microsoft/agent-governance-toolkit/agent-governance-golang/packages/agentmesh    1.850s
````

## Test plan

- [ ] CI passes
- [ ] All agentmesh tests pass
- [ ] No regression in existing Cedar/OPA backend tests

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Go Policy].