### PR TITLE
fix(ci): drop unconditional Dependabot auto-approve; require maintainer approval

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,4 +1,24 @@
 # Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+#
+# Enables GitHub's auto-merge for Dependabot patch/minor updates.
+#
+# This workflow does NOT auto-approve. `gh pr merge --auto` only flips
+# the PR into "merge when all required checks pass and required
+# approvals are met" state — branch protection still gates the actual
+# merge on:
+#   * all required status checks passing
+#   * the required number of maintainer approvals
+#
+# A maintainer (or CODEOWNER) must explicitly approve the PR before
+# GitHub will complete the auto-merge. This matches REVIEW.md's
+# guidance: do not auto-approve without a CI-passed precondition;
+# require code-owner reviews via branch protection.
+#
+# Previously this workflow ran `gh pr review --approve` unconditionally
+# on PR open, which satisfied the approval requirement before CI had
+# a chance to run. With branch protection that required approvals but
+# not status checks (a misconfiguration that is easy to overlook),
+# the combination of auto-approve + auto-merge would race past CI.
 name: Auto-merge Dependabot PRs
 on: pull_request
 permissions:
@@ -13,12 +33,6 @@ jobs:
     steps:
       - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: metadata
-      - name: Auto-approve patch and minor updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: "${{ github.event.pull_request.html_url }}"
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for patch and minor
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

[`.github/workflows/auto-merge-dependabot.yml`](.github/workflows/auto-merge-dependabot.yml) ran ``gh pr review --approve`` unconditionally on PR open, then ``gh pr merge --auto``. The auto-approval satisfied GitHub's required-approvals check **before** CI had a chance to run.

The actual safety depends on branch protection configuration:

| Branch protection | Outcome |
|---|---|
| Required status checks ✓ + Required approvals ✓ | Safe — auto-merge waits for checks; auto-approve covers 1 of N approvals |
| Required approvals only ✗ no status checks | **BAD** — auto-approve + auto-merge races past CI entirely |
| Misconfigured / partial | Same as above |

The misconfiguration case is easy to introduce silently — a maintainer removes a status check from the \"required\" list during incident triage and forgets to restore it; on the next Dependabot PR, auto-approve fires before CI and auto-merge proceeds the moment the (no longer required) checks update.

## Change

Drop the auto-approve step. Keep the auto-merge enablement.

````diff
- - name: Auto-approve patch and minor updates
-   if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-   run: gh pr review --approve \"$PR_URL\"
-   env:
-     PR_URL: \"${{ github.event.pull_request.html_url }}\"
-     GH_TOKEN: \"${{ secrets.GITHUB_TOKEN }}\"
  - name: Enable auto-merge for patch and minor
    if: steps.metadata.outputs.update-type != 'version-update:semver-major'
    run: gh pr merge --auto --squash \"$PR_URL\"
````

``gh pr merge --auto`` only flips the PR into \"merge when all required checks pass and approvals are met\" state — the merge still waits for branch protection's gates. A maintainer (or CODEOWNER) must explicitly approve before GitHub completes the auto-merge.

The workflow now carries an inline doc comment explaining the deliberate divergence from GitHub's ``dependabot/fetch-metadata`` quickstart so the next reader doesn't \"helpfully\" add the auto-approve back.

### Operational note for maintainers

After this lands, Dependabot patch / minor PRs will sit in \"auto-merge enabled, waiting for review\" state until a maintainer approves them. CI still runs. The bot will not merge anything that fails CI or that lacks an approval. To preserve the previous degree of automation, the right move is server-side: ensure branch protection requires both status checks AND ≥1 maintainer approval.

## Tests

CI workflow YAML; no local test harness. Lint via the project's existing ``workflow-lint.yml`` would run on the PR.

## Test plan

- [ ] CI passes
- [ ] After merge, the next Dependabot PR enables auto-merge but does **not** carry an auto-approval — confirms the change took effect

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].