### PR TITLE
perf(docker): split npm ci from source COPY; add BuildKit pip cache mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,29 @@ RUN for i in 1 2 3; do apt-get update && break || sleep 5; done \
 
 FROM base AS dev
 
+# Stage 1: TypeScript dependencies cache on package-lock.json alone, so
+# a Python-only source change doesn't trigger a full `npm ci` rebuild
+# (the slowest part of the dev image). Only package-lock.json / package.json
+# changes will invalidate this layer.
+COPY agent-governance-typescript/package.json \
+     agent-governance-typescript/package-lock.json \
+     /workspace/agent-governance-typescript/
+RUN cd /workspace/agent-governance-typescript \
+    && npm ci --legacy-peer-deps
+
+# Stage 2: bring in the full source. Subsequent layers are invalidated
+# by any source change, but the `npm ci` above is preserved.
 COPY . /workspace
 
-# Install local packages (Scorecard: pinned via pyproject.toml)
-# Requirements file dependencies have version constraints
-RUN python -m pip install --no-cache-dir \
+# Stage 3: Python editable installs. A BuildKit cache mount on the pip
+# download cache preserves wheel downloads across rebuilds even when
+# this layer is re-executed (editable installs need source, so the
+# layer itself can't be reused — but the download cache can).
+#
+# Scorecard: pinned via pyproject.toml. Requirements file dependencies
+# have version constraints.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install \
         -e "agent-governance-python/agent-primitives[dev]" \
         -e "agent-governance-python/agent-mcp-governance[dev]" \
         -e "agent-governance-python/agent-os[full,dev]" \
@@ -48,10 +66,8 @@ RUN python -m pip install --no-cache-dir \
         -e "agent-governance-python/agent-compliance" \
         -e "agent-governance-python/agent-marketplace[cli,dev]" \
         -e "agent-governance-python/agent-lightning[agent-os,dev]" \
-    && python -m pip install --no-cache-dir \
-        -r agent-governance-python/agent-hypervisor/examples/dashboard/requirements.txt \
-    && cd /workspace/agent-governance-typescript \
-    && npm ci --legacy-peer-deps
+    && python -m pip install \
+        -r agent-governance-python/agent-hypervisor/examples/dashboard/requirements.txt
 
 # Run as non-root for the developer workflow. The compose `dev` and
 # `dashboard` services bind-mount the repo at /workspace; running the


### PR DESCRIPTION
## Summary

[`Dockerfile:36`](Dockerfile) did:

````dockerfile
COPY . /workspace

RUN python -m pip install ... \
    && cd /workspace/agent-governance-typescript \
    && npm ci --legacy-peer-deps
````

The chained ``COPY . /workspace`` invalidated the layer cache for the subsequent ``RUN`` on every source change — including the npm install, the slowest single step in the dev image (often 30s–2min on a fresh network). A docstring fix or comment update forced a full Node dependency reinstall on rebuild.

## Change

Restructure the ``dev`` stage into three layers:

````dockerfile
# 1. TypeScript deps — cached on manifest alone
COPY agent-governance-typescript/package.json \
     agent-governance-typescript/package-lock.json \
     /workspace/agent-governance-typescript/
RUN cd /workspace/agent-governance-typescript && npm ci --legacy-peer-deps

# 2. Full source — needed for Python editable installs
COPY . /workspace

# 3. Python editable installs with pip download cache mount
RUN --mount=type=cache,target=/root/.cache/pip \
    python -m pip install -e \"agent-governance-python/...[dev]\" ... \
    && python -m pip install -r .../dashboard/requirements.txt
````

``.dockerignore`` already excludes ``**/node_modules``, so the ``node_modules/`` directory from Stage 1 survives the subsequent ``COPY . /workspace`` (Docker COPY merges directories — existing files are preserved unless overwritten by name).

### Why not also cache the Python install layer?

Python editable installs (``pip install -e``) need the package source tree at install time, so the layer itself is invalidated by source changes. The BuildKit cache mount (``--mount=type=cache,target=/root/.cache/pip``) preserves the pip *download* cache across rebuilds, which captures the dominant cost — wheel downloads — even when this layer re-executes.

Fully caching the Python install would require either restructuring to non-editable installs (incompatible with the dev compose flow that bind-mounts the repo) or extracting a lockfile (larger architectural change). The cache mount is the minimum-effort, maximum-impact compromise.

### Performance shape

| Edit | Old behaviour | New behaviour |
|---|---|---|
| Python-only source change | Full Python + Full npm | Skip npm; Python pip skips wheel downloads |
| TS-only source change | Full Python + Full npm | npm re-runs; Python pip skips wheel downloads |
| Manifest change (``package-lock.json``) | Full Python + Full npm | npm re-runs (correctly); Python pip skips |
| Clean build (no cache) | Same | Same |

## Tests

Dockerfile changes; no local test harness. The Dockerfile header ``# syntax=docker/dockerfile:1.7`` already opts into BuildKit so ``--mount=type=cache`` works without caller-side changes.

## Test plan

- [ ] CI passes (docker build succeeds)
- [ ] Local rebuild after a Python-only edit visibly skips ``npm ci``
- [ ] Local rebuild after a TS-only edit re-runs ``npm ci``

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].