### PR TITLE
fix(ci): surface safety check exit code and fail on Critical CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,13 +281,58 @@ jobs:
         env:
           GIT_TERMINAL_PROMPT: "0"
         run: |
+          set -e
+          # Install each package. A failure here means safety would scan
+          # against the wrong dependency set, so surface it instead of
+          # silently `|| true`-ing past it.
           for pkg in agent-os agent-mesh agent-hypervisor agent-sre agent-compliance agent-runtime agent-lightning; do
             echo "=== $pkg ==="
-            cd agent-governance-python/$pkg
-            pip install --no-cache-dir -e . 2>/dev/null || true  # Install local package (Scorecard: pinned via pyproject.toml)
-            cd ../..
+            (cd "agent-governance-python/$pkg" \
+              && pip install --no-cache-dir -e .)
           done
-          safety check 2>/dev/null || echo "Safety check completed with warnings"
+
+          # Capture safety's exit code and stdout. The previous
+          # invocation discarded stderr and `|| echo`-d a placeholder
+          # message, so the step always exited 0 regardless of findings.
+          set +e
+          safety check --output json > safety-report.json
+          EXIT_CODE=$?
+          set -e
+
+          echo "safety check exit code: $EXIT_CODE"
+          echo "---- safety-report.json ----"
+          cat safety-report.json
+          echo "---- end safety-report.json ----"
+
+          # safety v3 exit codes: 0 = clean, 64 = vulnerabilities found,
+          # anything else = real failure (network, parse error, etc.).
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "No vulnerabilities detected."
+            exit 0
+          fi
+          if [ "$EXIT_CODE" -ne 64 ]; then
+            echo "::error::safety check failed with unexpected exit code $EXIT_CODE"
+            exit 1
+          fi
+
+          # Vulnerabilities found — fail the build on Critical severity,
+          # warn otherwise. Tolerant of safety's slightly-varying JSON
+          # shape across versions (severity may be a nested cvssv3
+          # block or a flat string).
+          CRITICAL=$(jq -r '
+            [.vulnerabilities[]?
+              | (.severity.cvssv3.base_severity? // .severity? // "")
+              | tostring
+              | ascii_downcase
+              | select(test("critical"))
+            ] | length
+          ' safety-report.json 2>/dev/null || echo 0)
+          echo "Critical CVE count: $CRITICAL"
+          if [ "$CRITICAL" -gt 0 ]; then
+            echo "::error::$CRITICAL critical CVE(s) detected; failing build"
+            exit 1
+          fi
+          echo "::warning::Non-critical CVEs detected; see safety-report.json above"
 
   # ── .NET build + test (only when C# files change) ────────────────────
   test-dotnet:


### PR DESCRIPTION
## Summary

[`.github/workflows/ci.yml:290`](.github/workflows/ci.yml) ran:

````bash
safety check 2>/dev/null || echo \"Safety check completed with warnings\"
````

* ``2>/dev/null`` discarded stderr (where some safety versions print findings).
* ``|| echo`` masked any non-zero exit — the step always exited 0.
* No JSON output, no severity gating — critical CVE reports were emitted to logs (if at all) and silently buried.

The surrounding ``pip install -e . 2>/dev/null || true`` loop had the same anti-pattern: a failed editable install meant safety scanned an incomplete dependency set with no signal that anything was wrong.

## Change

* ``pip install -e .`` now runs without ``2>/dev/null || true``; failures abort the step. A broken local install is worse than noisy logs.
* ``safety check --output json > safety-report.json`` with explicit ``$?`` capture. The full report is cat-ed to the log for visibility.
* Exit-code interpretation:

  | Exit code | Meaning | Action |
  |---:|---|---|
  | 0 | Clean | succeed |
  | 64 | Vulnerabilities found | parse for severity (see below) |
  | other | Unexpected failure | fail loudly with the exit code |

* On the 64 path, ``jq`` extracts Critical-severity entries. **Build fails on any Critical**. Non-Critical CVEs surface as a ``::warning::`` annotation but do not block.
* The jq filter tolerates safety's slightly-varying severity shapes across versions (nested ``severity.cvssv3.base_severity`` or flat ``severity`` string) by coalescing both.

````bash
CRITICAL=$(jq -r '
  [.vulnerabilities[]?
    | (.severity.cvssv3.base_severity? // .severity? // \"\")
    | tostring | ascii_downcase
    | select(test(\"critical\"))
  ] | length
' safety-report.json 2>/dev/null || echo 0)
````

## Threshold note

Critical was chosen as the failure threshold because it's the bright-line case (\"reachable RCE / data exfiltration with public exploit\") that should never be merged silently. Non-Critical CVEs still get logged via ``::warning::`` annotation for triage, but do not block merges — that's a deliberate trade-off between zero-false-positives and zero-rot. Maintainers can tighten to High by changing the jq ``test(\"critical\")`` filter once the High-severity baseline is clean.

## Tests

CI workflow YAML; verified in PR CI run.

## Test plan

- [ ] CI passes
- [ ] If the safety scan finds a Critical CVE in a future run, the workflow visibly fails (not silently green)
- [ ] If a non-Critical CVE is found, the workflow annotates with a warning but still passes

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].