### PR TITLE
chore(ci): document cflite.yml SHA pin verification

### DIFF
--- a/.github/workflows/cflite.yml
+++ b/.github/workflows/cflite.yml
@@ -1,5 +1,17 @@
 name: ClusterFuzzLite
 
+# google/clusterfuzzlite has had no commits since 2023-08-09 and ships
+# its actions under a single mutable `v1` tag. The SHAs pinned below
+# (`884713a6c30a92e5e8544c39945cd7cb630abcd1`) are the `v1` tag's
+# resolved commit, verified against the upstream API on 2026-05-12.
+# If `v1` is ever moved upstream, this workflow continues to use the
+# pinned commit (good for reproducibility) but stops tracking what the
+# tag points at — Dependabot's action-version updater will surface
+# the drift.
+#
+# If a `v2` release is published, replace the SHA via the same pinning
+# pattern (Dependabot's commit-SHA mode handles this automatically).
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

REVIEW.md flagged the four ``# v1`` comments next to pinned ``google/clusterfuzzlite/actions/...`` references in [`cflite.yml`](.github/workflows/cflite.yml) as misleading and asked for verification that the pinned SHA still resolves.

## Verification

Checked against the GitHub API on 2026-05-12:

````
$ gh api repos/google/clusterfuzzlite/tags?per_page=5
{
  \"name\": \"v1\",
  \"commit\": {
    \"sha\": \"884713a6c30a92e5e8544c39945cd7cb630abcd1\",
    ...
  }
}
````

* The pinned SHA ``884713a6c30a92e5e8544c39945cd7cb630abcd1`` IS the upstream ``v1`` tag's commit.
* The ``# v1`` annotations on lines 32, 39, 57, 64 are accurate.
* The pin itself is sound — the SHA cannot drift even if ``v1`` is later moved upstream (Dependabot's commit-SHA mode would surface the drift).

The underlying repo ``google/clusterfuzzlite`` has had no commits since the same SHA's commit date, **2023-08-09** (now ~21 months old), and operates on a single mutable ``v1`` tag rather than versioned releases. That maintenance state is itself a separate signal worth considering, but the pin is correct.

## Change

Adds a header comment at the top of the workflow recording the verification — date-stamped, with the SHA, so the next reviewer doesn't have to re-verify the SHA-to-tag binding from scratch.

No SHA changes. No behavioural change. The four ``uses:`` lines are unchanged.

## Test plan

- [ ] CI passes (no functional change)
- [ ] If maintainers later decide to drop or replace this action entirely (the maintenance state would be a reasonable reason), that is a separate decision

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].