### PR TITLE
fix(ci): drop continue-on-error on Gitleaks; skip cleanly on fork PRs instead

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -31,8 +31,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Gitleaks requires the `GITLEAKS_LICENSE` secret to run with its
+      # full ruleset. Secrets are not exposed to workflows triggered by
+      # fork PRs, so the step is skipped cleanly in that case (the
+      # upstream maintainer will see the run on the rebased branch or
+      # on the post-merge push event). For every other trigger
+      # (in-tree PR, push to main, schedule, manual dispatch) the step
+      # MUST succeed — the previous `continue-on-error: true` made a
+      # licensed-but-failing scan indistinguishable from a successful
+      # one, undermining the gate the workflow is supposed to provide.
       - name: Run Gitleaks
-        continue-on-error: true
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

[`secret-scanning.yml:35`](.github/workflows/secret-scanning.yml) had ``continue-on-error: true`` on the Gitleaks step:

````yaml
- name: Run Gitleaks
  continue-on-error: true
  uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.8
  env:
    GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
    GITLEAKS_LICENSE: \${{ secrets.GITLEAKS_LICENSE }}
````

A licensed-but-failing scan is indistinguishable from a successful one — the workflow always reports green regardless of whether secrets were actually detected. The fall-back high-entropy regex scan below only matches a handful of well-known prefixes (``sk-``, ``ghp_``, ``AKIA``, ...); real Gitleaks coverage was effectively disabled.

## Why ``continue-on-error`` was originally added

Secrets are not exposed to workflows triggered by fork PRs, so without ``GITLEAKS_LICENSE`` the action fails on fork PRs. ``continue-on-error: true`` was a blunt way to keep the workflow green in that case — at the cost of also masking real Gitleaks failures everywhere else.

## Change

Replace the swallowing with a fork-PR skip:

````yaml
- name: Run Gitleaks
  if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
  uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.8
  env:
    GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
    GITLEAKS_LICENSE: \${{ secrets.GITLEAKS_LICENSE }}
````

| Trigger | Old behaviour | New behaviour |
|---|---|---|
| Fork PR | Run, fail (no license), continue green | Skip cleanly (no false green, no false red) |
| Same-repo PR | Run, may fail silently | Run, failure = real failure |
| Push to main | Run, may fail silently | Run, failure = real failure |
| Schedule / dispatch | Run, may fail silently | Run, failure = real failure |

The ``head.repo.full_name != github.repository`` test is GitHub's documented pattern for distinguishing fork PRs from same-repo PRs.

The fall-back high-entropy regex scan below this step is unchanged; it remains a defence-in-depth signal but is no longer covering for a silently-disabled Gitleaks.

## Tests

Workflow YAML; no local test harness. The skip-on-fork pattern is identical to dozens of other workflows in the GitHub Actions ecosystem.

## Test plan

- [ ] CI passes on this same-repo PR (Gitleaks runs as before)
- [ ] After merge, a future fork PR sees a skipped (not failed) Gitleaks step
- [ ] After merge, a maintainer who deliberately commits a test secret on an in-tree branch sees a red Gitleaks step (not a green run with a warning)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].