### PR TITLE
fix(ci): replace unmaintained actions/first-interaction with inline github-script

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -9,20 +9,62 @@ permissions:
   issues: write
   pull-requests: write
 # SECURITY: pull_request_target runs in BASE context. Never checkout PR head ref.
+# This workflow reads contributor history via the GitHub API and posts a
+# welcome comment. No PR head code is checked out or executed.
 jobs:
   welcome:
     runs-on: ubuntu-latest
-    # SECURITY: pull_request_target — uses actions/first-interaction which only
-    # reads contributor history via API. No checkout of PR head code.
     steps:
-      - uses: actions/first-interaction@a1db7729b356323c7988c20ed6f0d33fe31297be # v1.3.0
+      # Implemented via actions/github-script rather than the historical
+      # actions/first-interaction action — first-interaction has had no
+      # commits since 2022 and is effectively unmaintained. Inlining the
+      # logic via github-script (already pinned in this repo) avoids a
+      # stale third-party dependency without adding a new one.
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          issue_message: |
-            Welcome to the Agent Governance Toolkit! Thanks for opening your first issue.
-            A maintainer will review this shortly. Check our [Contributing Guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/CONTRIBUTING.md).
-            For security issues, use [private vulnerability reporting](https://github.com/microsoft/agent-governance-toolkit/security/advisories/new).
-          pr_message: |
-            Welcome to the Agent Governance Toolkit! Thanks for your first pull request.
-            Please ensure tests pass, code follows style (ruff check), and you have signed the [CLA](https://cla.opensource.microsoft.com/).
-            See our [Contributing Guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/CONTRIBUTING.md).
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const isIssue = context.eventName === 'issues';
+            const target = isIssue
+              ? context.payload.issue
+              : context.payload.pull_request;
+            const author = target.user.login;
+            const number = target.number;
+
+            // Skip bots — first-interaction historically did the same.
+            if (target.user.type === 'Bot' || author.endsWith('[bot]')) {
+              core.info(`Skipping bot author ${author}`);
+              return;
+            }
+
+            // First-contribution check: count this author's issues+PRs in
+            // the repo. Anything > 1 means this is not their first.
+            // `per_page: 2` keeps the query cheap.
+            const { data: search } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} author:${author}`,
+              per_page: 2,
+            });
+            if (search.total_count > 1) {
+              core.info(`${author} has ${search.total_count} prior issues/PRs — not first contribution`);
+              return;
+            }
+
+            const body = isIssue
+              ? [
+                  'Welcome to the Agent Governance Toolkit! Thanks for opening your first issue.',
+                  'A maintainer will review this shortly. Check our [Contributing Guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/CONTRIBUTING.md).',
+                  'For security issues, use [private vulnerability reporting](https://github.com/microsoft/agent-governance-toolkit/security/advisories/new).',
+                ].join('\n')
+              : [
+                  'Welcome to the Agent Governance Toolkit! Thanks for your first pull request.',
+                  'Please ensure tests pass, code follows style (ruff check), and you have signed the [CLA](https://cla.opensource.microsoft.com/).',
+                  'See our [Contributing Guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/CONTRIBUTING.md).',
+                ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body,
+            });
+            core.info(`Posted welcome comment on #${number} for ${author}`);


### PR DESCRIPTION
## Summary

[`welcome.yml:18`](.github/workflows/welcome.yml) used [`actions/first-interaction@v1.3.0`](https://github.com/actions/first-interaction):

````yaml
- uses: actions/first-interaction@a1db7729b356323c7988c20ed6f0d33fe31297be # v1.3.0
````

The upstream repo has had **no commits since November 2022**. For a ``pull_request_target``-triggered workflow with ``pull-requests: write`` and ``issues: write`` — one that posts comments on behalf of the repo — leaning on a stale third-party action is a supply-chain risk that grows quietly over time.

## Change

Inline the welcome logic via [`actions/github-script`](https://github.com/actions/github-script), which is **already pinned** elsewhere in this repo (``ai-pr-review.yml``, ``require-maintainer-approval.yml``) at the same SHA. This consolidates onto a trusted dependency rather than adding a new one.

Behaviour preserved:

* **First-time-contributor detection** — same search API heuristic the original used (``repo:<repo> author:<login>``, anything > 1 means not first).
* **Separate messages** for issues vs PRs.
* **Same exact message text** — copy-paste from the original ``with:`` blocks.
* **Security posture unchanged** — ``pull_request_target`` still runs in base context; no PR head checkout, no PR head code execution. Only API reads + a single comment write.

Improved:

* **Bot skip** — explicit ``target.user.type === 'Bot' || author.endsWith('[bot]')`` check. The historical action skipped bots by accident (their search count exceeds 1), the inline version makes it explicit so dependabot / github-actions PRs never get a welcome comment.

## Diff shape

````
- - uses: actions/first-interaction@a1db... # v1.3.0
-   with:
-     repo_token: \"...\"
-     issue_message: |\n      Welcome ...
-     pr_message: |\n      Welcome ...
+ - uses: actions/github-script@3a2844b... # v9.0.0
+   with:
+     github-token: ...
+     script: |
+       const isIssue = context.eventName === 'issues';
+       const target = isIssue ? context.payload.issue : context.payload.pull_request;
+       // ... bot skip, first-time check, post comment ...
````

Net diff: -12 lines / +54 lines. Direct trade for removing a stale third-party action with write permissions.

## Tests

Workflow YAML; no local test harness. Validation strategy:

1. Open a fresh non-maintainer PR or issue (or use ``act``) and observe the welcome message.
2. Open a second PR/issue from the same author and confirm no comment is posted.
3. Confirm dependabot PRs do not receive the welcome message.

These are the same validation criteria the original ``actions/first-interaction`` would have been judged against.

## Test plan

- [ ] CI passes (YAML syntax)
- [ ] First PR from a new contributor receives the welcome comment
- [ ] Second PR from the same contributor does NOT
- [ ] Dependabot PR does NOT

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [MEDIUM, Infrastructure/CI].