### PR TITLE
fix(py-core-failures): replace deprecated datetime.utcnow with tz-aware UTC

### DIFF
--- a/agent-governance-python/agent-os/tests/test_layer1_primitives.py
+++ b/agent-governance-python/agent-os/tests/test_layer1_primitives.py
@@ -36,7 +36,7 @@ class TestAgentPrimitives:
         """Test creating an AgentFailure."""
         from agent_primitives import AgentFailure, FailureType, FailureSeverity
         from datetime import datetime, timezone
-        
+
         failure = AgentFailure(
             agent_id="test-agent",
             failure_type=FailureType.TIMEOUT,
@@ -44,9 +44,35 @@ class TestAgentPrimitives:
             context={"action": "test"},
             timestamp=datetime.now(timezone.utc),
         )
-        
+
         assert failure.agent_id == "test-agent"
         assert failure.failure_type == FailureType.TIMEOUT
+
+    def test_default_timestamps_are_timezone_aware(self):
+        """Default-factory timestamps must be tz-aware UTC, not naive.
+
+        Regression guard: ``datetime.utcnow()`` returns a naive datetime that
+        silently misrepresents UTC. Switching to ``datetime.now(timezone.utc)``
+        produces a tz-aware value that survives JSON / ISO-8601 round-trips
+        with the correct ``+00:00`` suffix.
+        """
+        from agent_primitives import AgentFailure, FailureTrace, FailureType
+
+        failure = AgentFailure(
+            agent_id="agent-1",
+            failure_type=FailureType.TIMEOUT,
+            error_message="boom",
+        )
+        assert failure.timestamp.tzinfo is not None
+        assert failure.timestamp.utcoffset().total_seconds() == 0
+
+        trace = FailureTrace(
+            user_prompt="prompt",
+            failed_action={"action": "noop"},
+            error_details="details",
+        )
+        assert trace.timestamp.tzinfo is not None
+        assert trace.timestamp.utcoffset().total_seconds() == 0
 
 
 class TestCMVK:

--- a/agent-governance-python/agent-primitives/agent_primitives/failures.py
+++ b/agent-governance-python/agent-primitives/agent_primitives/failures.py
@@ -8,9 +8,20 @@ Extracted to Layer 1 to allow proper dependency layering.
 """
 
 from typing import Dict, List, Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pydantic import BaseModel, Field, ConfigDict
+
+
+def _utcnow() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime.
+
+    ``datetime.utcnow()`` was deprecated in Python 3.12; it returns a naive
+    datetime that silently misrepresents UTC. This helper returns a proper
+    tz-aware UTC datetime, which is what callers expect when they read these
+    timestamps back later (e.g. for audit log serialisation).
+    """
+    return datetime.now(timezone.utc)
 
 
 class FailureType(str, Enum):
@@ -38,7 +49,7 @@ class FailureTrace(BaseModel):
     chain_of_thought: List[str] = Field(default_factory=list, description="Agent's reasoning steps")
     failed_action: Dict[str, Any] = Field(..., description="The action that failed")
     error_details: str = Field(..., description="Detailed error information")
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=_utcnow)
     
     model_config = ConfigDict(
         json_schema_extra={
@@ -65,7 +76,7 @@ class AgentFailure(BaseModel):
     agent_id: str = Field(..., description="Unique identifier for the agent")
     failure_type: FailureType = Field(..., description="Type of failure")
     severity: FailureSeverity = Field(default=FailureSeverity.MEDIUM)
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=_utcnow)
     error_message: str = Field(..., description="Error message from the failure")
     context: Dict[str, Any] = Field(default_factory=dict, description="Additional context")
     stack_trace: Optional[str] = Field(None, description="Stack trace if available")


### PR DESCRIPTION
## Summary

[`agent-primitives/failures.py`](agent-governance-python/agent-primitives/agent_primitives/failures.py) used `datetime.utcnow()` as the default factory for both `AgentFailure.timestamp` and `FailureTrace.timestamp`.

`datetime.utcnow()` was deprecated in Python 3.12: it returns a *naive* datetime that silently misrepresents UTC, and the deprecation will harden into removal in a future release. Timestamps produced by these models serialised without a UTC offset, so any tz-aware consumer downstream (audit log writers, the OS-layer telemetry that emits ISO-8601 with offsets) had to special-case them.

## Change

Introduce a small `_utcnow()` helper returning `datetime.now(timezone.utc)`, and swap both default factories to it. The helper carries a docstring explaining the deprecation context so future maintainers don't reach for `datetime.utcnow()` again.

Behaviour change is minimal and externally invisible apart from the `tzinfo` slot now being populated. Pydantic v2 will continue to serialise both shapes (`Field(default_factory=...)` returns whatever the callable produces), but consumers that ISO-format the value now get the `+00:00` suffix they should always have had.

## Tests

Adds `test_default_timestamps_are_timezone_aware` to [`test_layer1_primitives.py`](agent-governance-python/agent-os/tests/test_layer1_primitives.py) as a regression guard, asserting both default factories produce tz-aware datetimes with a zero UTC offset.

```
$ PYTHONPATH="src;../agent-primitives" python -m pytest tests/test_layer1_primitives.py -q
20 passed, 4 skipped in 1.06s
```

## Test plan

- [ ] CI passes
- [ ] `test_layer1_primitives.py` runs green with `agent_primitives` installed
- [ ] No regression in existing primitives tests

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Core].