### PR TITLE
fix(py-core-retry): add full-jitter to exponential backoff

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/retry.py
+++ b/agent-governance-python/agent-os/src/agent_os/retry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
+import random
 import time
 from typing import Any, Callable, Sequence, TypeVar
 
@@ -14,11 +15,29 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def _compute_delay(backoff_base: float, attempt: int, jitter: bool) -> float:
+    """Return the sleep duration before the next retry attempt.
+
+    Without jitter, returns the classic exponential ``backoff_base * 2^(n-1)``.
+
+    With jitter, multiplies the exponential by a uniform sample from
+    ``[0.5, 1.5)`` so concurrent retriers reacting to the same upstream
+    incident do not all wake at the same instant ("thundering herd"). This
+    keeps the *expected* wait equal to the un-jittered value but spreads the
+    actual wakes across a 1x-window centred on it.
+    """
+    delay = backoff_base * (2 ** (attempt - 1))
+    if jitter:
+        delay *= 0.5 + random.random()
+    return delay
+
+
 def retry(
     max_attempts: int = 3,
     backoff_base: float = 1.0,
     exceptions: Sequence[type[BaseException]] = (Exception,),
     on_retry: Callable[[int, BaseException], None] | None = None,
+    jitter: bool = True,
 ) -> Callable:
     """Decorator for retrying functions with exponential backoff.
 
@@ -29,6 +48,10 @@ def retry(
         backoff_base: Base delay in seconds (doubled each retry).
         exceptions: Tuple of exception types to catch and retry.
         on_retry: Optional callback(attempt, exception) called before each retry.
+        jitter: When True (default), multiply each delay by a uniform sample
+            from ``[0.5, 1.5)`` to avoid thundering-herd retries against a
+            shared upstream. Disable only for deterministic tests; production
+            callers should leave this on.
 
     Example:
         @retry(max_attempts=3, exceptions=(ConnectionError, TimeoutError))
@@ -47,7 +70,7 @@ def retry(
                         last_exc = exc
                         if attempt == max_attempts:
                             raise
-                        delay = backoff_base * (2 ** (attempt - 1))
+                        delay = _compute_delay(backoff_base, attempt, jitter)
                         if on_retry:
                             on_retry(attempt, exc)
                         logger.warning(
@@ -68,7 +91,7 @@ def retry(
                         last_exc = exc
                         if attempt == max_attempts:
                             raise
-                        delay = backoff_base * (2 ** (attempt - 1))
+                        delay = _compute_delay(backoff_base, attempt, jitter)
                         if on_retry:
                             on_retry(attempt, exc)
                         logger.warning(

--- a/agent-governance-python/agent-os/tests/test_retry.py
+++ b/agent-governance-python/agent-os/tests/test_retry.py
@@ -100,7 +100,7 @@ class TestSyncRetry:
     @patch("agent_os.retry.time.sleep")
     def test_backoff_increases_exponentially(self, mock_sleep):
         """Sleep durations double each retry with backoff_base=1.0."""
-        @retry(max_attempts=4, backoff_base=1.0, exceptions=(IOError,))
+        @retry(max_attempts=4, backoff_base=1.0, exceptions=(IOError,), jitter=False)
         def always_fail():
             raise IOError("fail")
 
@@ -114,7 +114,7 @@ class TestSyncRetry:
     @patch("agent_os.retry.time.sleep")
     def test_custom_backoff_base(self, mock_sleep):
         """Custom backoff_base scales the delay series."""
-        @retry(max_attempts=3, backoff_base=0.5, exceptions=(IOError,))
+        @retry(max_attempts=3, backoff_base=0.5, exceptions=(IOError,), jitter=False)
         def always_fail():
             raise IOError("fail")
 
@@ -123,6 +123,59 @@ class TestSyncRetry:
 
         delays = [call.args[0] for call in mock_sleep.call_args_list]
         assert delays == [0.5, 1.0]
+
+    @patch("agent_os.retry.time.sleep")
+    def test_jitter_perturbs_delays_within_half_to_one_and_a_half_window(self, mock_sleep):
+        """With jitter=True (default), each delay is in [0.5x, 1.5x] of the
+        un-jittered exponential value.
+
+        Regression guard against the original no-jitter behaviour: every retry
+        slept the *exact* exponential backoff, so N independent callers
+        reacting to the same upstream incident would wake simultaneously and
+        re-hammer the upstream ("thundering herd").
+        """
+        @retry(max_attempts=5, backoff_base=1.0, exceptions=(IOError,))
+        def always_fail():
+            raise IOError("fail")
+
+        with pytest.raises(IOError):
+            always_fail()
+
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        # 4 sleeps for 5 attempts; base exponential is [1, 2, 4, 8]
+        assert len(delays) == 4
+        for actual, base in zip(delays, [1.0, 2.0, 4.0, 8.0]):
+            assert 0.5 * base <= actual < 1.5 * base, (
+                f"jittered delay {actual} outside [0.5x, 1.5x) of {base}"
+            )
+
+    @patch("agent_os.retry.time.sleep")
+    @patch("agent_os.retry.random.random", return_value=0.0)
+    def test_jitter_lower_bound_at_random_zero(self, mock_random, mock_sleep):
+        """random.random() == 0.0 ⇒ multiplier == 0.5 (lower bound)."""
+        @retry(max_attempts=2, backoff_base=4.0, exceptions=(IOError,))
+        def always_fail():
+            raise IOError("fail")
+
+        with pytest.raises(IOError):
+            always_fail()
+
+        assert mock_sleep.call_args_list[0].args[0] == pytest.approx(2.0)
+
+    @patch("agent_os.retry.time.sleep")
+    @patch("agent_os.retry.random.random", return_value=0.999_999)
+    def test_jitter_upper_bound_just_below_one_point_five(self, mock_random, mock_sleep):
+        """random.random() ≈ 1.0 ⇒ multiplier just under 1.5 (open upper bound)."""
+        @retry(max_attempts=2, backoff_base=4.0, exceptions=(IOError,))
+        def always_fail():
+            raise IOError("fail")
+
+        with pytest.raises(IOError):
+            always_fail()
+
+        actual = mock_sleep.call_args_list[0].args[0]
+        assert actual < 6.0
+        assert actual == pytest.approx(4.0 * (0.5 + 0.999_999))
 
     def test_preserves_return_value(self):
         """Return value is passed through unchanged."""


### PR DESCRIPTION
## Summary

[`retry.py`](agent-governance-python/agent-os/src/agent_os/retry.py)'s exponential-backoff branch slept the *exact* `backoff_base * 2^(attempt-1)` series with no jitter. N independent callers retrying against the same upstream after a shared incident (rate-limit reset, brief network blip, cold restart) all wake at the same instant and re-hammer the upstream — the textbook "thundering herd" anti-pattern.

## Change

A small `_compute_delay` helper wraps the per-attempt delay. A new `jitter: bool = True` parameter on `retry(...)` controls whether the exponential is multiplied by a uniform sample from `[0.5, 1.5)`:

```python
delay = backoff_base * (2 ** (attempt - 1)) * (0.5 + random.random())
```

The *expected* wait stays equal to the un-jittered value (mean = 1.0x), but actual wakes spread across a 1x-window centred on it, breaking the thundering herd. Callers that need deterministic timing (mainly tests) can pass `jitter=False` to opt out.

No other call sites in the repo use `agent_os.retry` (only [`test_retry.py`](agent-governance-python/agent-os/tests/test_retry.py) imports it), so the default-on jitter is a safe change.

## Tests

The pre-existing `test_backoff_increases_exponentially` and `test_custom_backoff_base` now pass `jitter=False` since they assert exact equality on the delay series. Three new tests pin the jitter contract:

| Test | Pins |
|---|---|
| `test_jitter_perturbs_delays_within_half_to_one_and_a_half_window` | Each delay lies in `[0.5x, 1.5x)` across four retries |
| `test_jitter_lower_bound_at_random_zero` | `random.random()==0.0` ⇒ 0.5x lower bound |
| `test_jitter_upper_bound_just_below_one_point_five` | `random.random()`≈1.0 ⇒ just under 1.5x (open upper) |

```
$ PYTHONPATH=src python -m pytest tests/test_retry.py -q
16 passed, 17 warnings in 1.66s
```

## Test plan

- [ ] CI passes
- [ ] All 16 `test_retry.py` tests pass
- [ ] No regression in retry behaviour for first-try-success and retry-then-success paths

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Core].