### PR TITLE
fix(py-core-deploy): validate agent_id before docker / kubectl interpolation

### DIFF
--- a/agent-governance-python/agent-runtime/src/agent_runtime/deploy.py
+++ b/agent-governance-python/agent-runtime/src/agent_runtime/deploy.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
@@ -20,6 +21,47 @@ from pathlib import Path
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
+
+
+# Conservative identifier shape that survives every downstream consumer this
+# module hands `agent_id` to:
+#
+#   - Docker container names accept `[a-zA-Z0-9][a-zA-Z0-9_.-]+`. Combined
+#     with the `agt-` prefix the deployer prepends, a leading dash or dot in
+#     `agent_id` cannot trigger Docker's "invalid name" path, but `agent_id`
+#     is also embedded raw into `--label agt.agent-id=<id>`, where a value
+#     starting with `-` would be reinterpreted as a CLI flag if the order
+#     ever changes.
+#   - Kubernetes pod/label names follow RFC-1123: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`,
+#     63 chars max. We allow uppercase here because the runtime lowercases
+#     when constructing the actual pod name (`agt-<id>`); upstream of that
+#     point the value is just an opaque tag.
+#
+# 63 chars matches Kubernetes' label-value length cap; the `agt-` prefix uses
+# the remaining 4 chars.
+_AGENT_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$")
+
+
+def _validate_agent_id(agent_id: str) -> str:
+    """Reject ``agent_id`` values that would be unsafe to interpolate into
+    Docker / kubectl command-lines and label values.
+
+    Returns the validated id unchanged so call sites can write
+    ``agent_id = _validate_agent_id(agent_id)`` as a single guard.
+
+    Raises:
+        ValueError: if ``agent_id`` is empty, starts with a dash (would be
+            reparsed as a CLI flag), exceeds 63 characters, or contains any
+            character outside ``[a-zA-Z0-9_-]``.
+    """
+    if not isinstance(agent_id, str) or not _AGENT_ID_PATTERN.match(agent_id):
+        raise ValueError(
+            f"invalid agent_id {agent_id!r}: must match "
+            f"^[a-zA-Z0-9][a-zA-Z0-9_-]{{0,62}}$ "
+            "(alphanumeric start, then alphanumerics/underscores/dashes, "
+            "max 63 chars)"
+        )
+    return agent_id
 
 
 class DeploymentStatus(str, Enum):
@@ -91,6 +133,7 @@ class DockerDeployer:
 
     def deploy(self, agent_id: str, image: str, config: GovernanceConfig,
                port: int = 0, env: dict[str, str] | None = None, **kwargs: Any) -> DeploymentResult:
+        agent_id = _validate_agent_id(agent_id)
         container_name = f"agt-{agent_id}"
         cmd = [
             "run", "-d",
@@ -141,6 +184,7 @@ class DockerDeployer:
             )
 
     def stop(self, agent_id: str) -> DeploymentResult:
+        agent_id = _validate_agent_id(agent_id)
         container_name = f"agt-{agent_id}"
         try:
             self._run(["stop", container_name])
@@ -159,6 +203,7 @@ class DockerDeployer:
             )
 
     def status(self, agent_id: str) -> DeploymentResult:
+        agent_id = _validate_agent_id(agent_id)
         container_name = f"agt-{agent_id}"
         try:
             result = self._run(["inspect", container_name, "--format", "{{.State.Status}}"])
@@ -178,6 +223,7 @@ class DockerDeployer:
             )
 
     def logs(self, agent_id: str, tail: int = 100) -> str:
+        agent_id = _validate_agent_id(agent_id)
         try:
             result = self._run(["logs", f"agt-{agent_id}", "--tail", str(tail)])
             return result.stdout
@@ -270,6 +316,7 @@ class KubernetesDeployer:
         }
 
     def deploy(self, agent_id: str, image: str, config: GovernanceConfig, **kwargs: Any) -> DeploymentResult:
+        agent_id = _validate_agent_id(agent_id)
         manifest = self._build_pod_manifest(agent_id, image, config)
         manifest_json = json.dumps(manifest)
         try:
@@ -297,6 +344,7 @@ class KubernetesDeployer:
             )
 
     def stop(self, agent_id: str) -> DeploymentResult:
+        agent_id = _validate_agent_id(agent_id)
         try:
             self._run(["delete", "pod", f"agt-{agent_id}", "-n", self._namespace])
             return DeploymentResult(
@@ -313,6 +361,7 @@ class KubernetesDeployer:
             )
 
     def status(self, agent_id: str) -> DeploymentResult:
+        agent_id = _validate_agent_id(agent_id)
         try:
             result = self._run([
                 "get", "pod", f"agt-{agent_id}",
@@ -339,6 +388,7 @@ class KubernetesDeployer:
             )
 
     def logs(self, agent_id: str, tail: int = 100) -> str:
+        agent_id = _validate_agent_id(agent_id)
         try:
             result = self._run([
                 "logs", f"agt-{agent_id}",

--- a/agent-governance-python/agent-runtime/tests/test_deploy.py
+++ b/agent-governance-python/agent-runtime/tests/test_deploy.py
@@ -14,6 +14,7 @@ from agent_runtime.deploy import (
     DockerDeployer,
     GovernanceConfig,
     KubernetesDeployer,
+    _validate_agent_id,
 )
 
 
@@ -355,3 +356,111 @@ class TestKubernetesDeployer:
         mock_run.return_value = MagicMock(stdout="k8s log line\n", stderr="", returncode=0)
         deployer = KubernetesDeployer()
         assert "k8s log line" in deployer.logs("agent-1")
+
+
+# ---------------------------------------------------------------------------
+# agent_id validation
+# ---------------------------------------------------------------------------
+
+class TestValidateAgentId:
+    """`_validate_agent_id` is the single guard for any string interpolated
+    into a Docker container name, kubectl pod name, or label value. The
+    regex pins the conservative shape that survives every downstream
+    consumer: alphanumeric start, alphanumerics + ``_-`` thereafter,
+    63 chars max.
+    """
+
+    @pytest.mark.parametrize("agent_id", [
+        "a",
+        "analyst-001",
+        "agent_42",
+        "A",
+        "9-already-leading-digit",
+        "x" * 63,  # max length
+    ])
+    def test_accepts_well_formed_ids(self, agent_id: str) -> None:
+        assert _validate_agent_id(agent_id) == agent_id
+
+    @pytest.mark.parametrize("agent_id,reason", [
+        ("", "empty"),
+        ("-rm", "leading dash would reparse as docker CLI flag"),
+        ("--privileged", "leading dash, looks like a flag"),
+        ("a b", "whitespace"),
+        ("a;rm -rf /", "shell metachars"),
+        ("a$(id)", "command substitution"),
+        ("a`id`", "backtick substitution"),
+        ("a.b", "dot — RFC-1123 allows but conservative regex does not"),
+        ("a/b", "path separator"),
+        ("a:b", "colon — would break docker label syntax"),
+        ("agent\nname", "newline injection"),
+        ("agent\x00name", "NUL byte"),
+        ("_leading_underscore", "underscore start — keep alphanumeric-only first char"),
+        ("x" * 64, "one over the 63-char cap"),
+    ])
+    def test_rejects_malformed_ids(self, agent_id: str, reason: str) -> None:
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            _validate_agent_id(agent_id)
+
+    def test_rejects_non_str(self) -> None:
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            _validate_agent_id(None)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            _validate_agent_id(42)  # type: ignore[arg-type]
+
+
+class TestDockerDeployerAgentIdValidation:
+    """Every `DockerDeployer` public entry point must validate `agent_id`
+    before interpolating it into a docker command-line. The previous
+    behaviour silently forwarded `agent_id="-rm"` etc., where the leading
+    dash would be reparsed as a CLI flag depending on Docker version.
+    """
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_deploy_rejects_leading_dash(self, mock_which: MagicMock) -> None:
+        deployer = DockerDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.deploy("-rm", "img:latest", GovernanceConfig())
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_stop_rejects_leading_dash(self, mock_which: MagicMock) -> None:
+        deployer = DockerDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.stop("-rm")
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_status_rejects_shell_metachars(self, mock_which: MagicMock) -> None:
+        deployer = DockerDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.status("a;rm -rf /")
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/docker")
+    def test_logs_rejects_empty(self, mock_which: MagicMock) -> None:
+        deployer = DockerDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.logs("")
+
+
+class TestKubernetesDeployerAgentIdValidation:
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_deploy_rejects_overlong(self, mock_which: MagicMock) -> None:
+        deployer = KubernetesDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.deploy("x" * 64, "img:latest", GovernanceConfig())
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_stop_rejects_leading_dash(self, mock_which: MagicMock) -> None:
+        deployer = KubernetesDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.stop("-rm")
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_status_rejects_dot(self, mock_which: MagicMock) -> None:
+        deployer = KubernetesDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.status("a.b")
+
+    @patch("agent_runtime.deploy.shutil.which", return_value="/usr/bin/kubectl")
+    def test_logs_rejects_newline(self, mock_which: MagicMock) -> None:
+        deployer = KubernetesDeployer()
+        with pytest.raises(ValueError, match="invalid agent_id"):
+            deployer.logs("agent\nname")


### PR DESCRIPTION
## Summary

[`agent-runtime/deploy.py`](agent-governance-python/agent-runtime/src/agent_runtime/deploy.py)'s `DockerDeployer` and `KubernetesDeployer` interpolated the caller-supplied `agent_id` raw into f-strings that drive container names, pod names, Docker label values, and kubectl positional arguments:

```python
container_name = f"agt-{agent_id}"
cmd = ["--label", f"agt.agent-id={agent_id}", ...]
self._run(["delete", "pod", f"agt-{agent_id}", "-n", ns])
```

With no validation, problem values reach downstream tooling in surprising ways:

| `agent_id` | Trap |
|---|---|
| `"-rm"` / `"--privileged"` | leading dash collides with docker/kubectl flag parser if argv order ever shifts |
| `"a;rm -rf /"` | shell metachars survive into docker label value |
| `"a.b"` / `"a/b"` / `"a:b"` | breaks docker's name validator and Kubernetes RFC-1123 label rules |
| `"agent\nname"` / `"agent\x00name"` | injection-style values |
| `"x" * 200` | exceeds Kubernetes 63-char label-value cap (silent truncation downstream) |

## Change

A module-level `_validate_agent_id` guard pins the regex

```
^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$
```

(alphanumeric start, then `[a-zA-Z0-9_-]`, max 63 chars — the Kubernetes label-value cap minus the `agt-` prefix the deployer prepends). The guard is called at the head of every public entry point on both deployers: `deploy`, `stop`, `status`, `logs`. Malformed input raises `ValueError` immediately — hard fail-fast, since the downstream docker/kubectl error messages are unhelpful for debugging a malformed `agent_id`.

The private `_build_pod_manifest` is *not* re-validated since it's only called from `KubernetesDeployer.deploy`, which already validates.

## Tests

- `TestValidateAgentId` parametrises 6 well-formed and 14 malformed inputs (leading-dash CLI-flag trap, shell metachars, NUL byte, newline injection, dot, 64-char overflow, non-str types).
- `TestDockerDeployerAgentIdValidation` and `TestKubernetesDeployerAgentIdValidation` confirm each of the eight public entry points routes through the validator.

```
$ PYTHONPATH=src python -m pytest tests/test_deploy.py -q
53 passed in 0.58s
```

Pre-existing tests use only well-formed ids (`"analyst-001"`, `"a1"`, `"agent-1"`); no fixtures needed updating.

## Test plan

- [ ] CI passes
- [ ] All 53 `test_deploy.py` tests pass
- [ ] No regression — existing well-formed `agent_id` values still flow through

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Core].