### PR TITLE
fix(py-core-policy): parse Cedar CLI decision from first-line token

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/backends.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/backends.py
@@ -377,6 +377,55 @@ class OPABackend:
 # ── Cedar Backend ─────────────────────────────────────────────
 
 
+def _cedar_decision_from_cli_output(stdout: str) -> tuple[bool, bool]:
+    """Parse the decision token from a ``cedar authorize`` invocation.
+
+    Returns ``(allowed, parsed)``:
+
+      - ``(True, True)`` if the first non-empty line is ALLOW (any case)
+      - ``(False, True)`` if the first non-empty line is DENY (any case)
+      - ``(False, False)`` if the first non-empty line is anything else
+        (caller should treat as fail-closed)
+
+    Why not "allow" in stdout?
+        The previous parser was ``"allow" in output and "deny" not in output``
+        on the lowercased stdout. That is a substring sniff, not a token
+        match: it misclassifies adjective phrases that future Cedar CLI
+        versions may plausibly emit as diagnostic context, e.g.
+        ``"DENY (request disallowed by policy)"`` classifies as DENY only by
+        coincidence (both substrings present), and
+        ``"ALLOW: caveats reference the deny-list scoping"`` flips to DENY
+        for the same reason. A single character difference between the
+        decision token and the rest of the diagnostic output flips the
+        verdict.
+
+    Why not ``--json``?
+        REVIEW.md proposed switching to ``cedar authorize --json``. Cedar
+        CLI 4.x supports structured output, but this project does not pin
+        a minimum Cedar CLI version, and older releases reject the flag
+        with ``unknown argument``. The first-line token parse keeps
+        backward compatibility with every Cedar CLI version while
+        eliminating the substring trap; a future PR can switch to JSON
+        once a minimum is pinned.
+
+        The Go sibling (`agent-governance-golang/.../policy_backends.go`)
+        took the same first-line-token approach in
+        microsoft/agent-governance-toolkit#2127.
+    """
+    for line in stdout.split("\n"):
+        token = line.strip().lower()
+        if not token:
+            continue
+        if token == "allow":
+            return True, True
+        if token == "deny":
+            return False, True
+        # First non-empty line was neither bare ALLOW nor bare DENY; refuse
+        # to guess. The caller's fail-closed path takes over.
+        return False, False
+    return False, False
+
+
 class CedarBackend:
     """Evaluate Cedar policies for Agent-OS.
 
@@ -574,8 +623,25 @@ class CedarBackend:
                     text=True,
                     timeout=self._timeout,
                 )
-                output = proc.stdout.strip().lower()
-                allowed = "allow" in output and "deny" not in output
+                allowed, parsed = _cedar_decision_from_cli_output(proc.stdout)
+                if not parsed:
+                    # Cedar CLI emitted something other than a clean
+                    # ALLOW/DENY token on the first non-empty line. Fail
+                    # closed rather than guessing.
+                    return BackendDecision(
+                        allowed=False,
+                        action="deny",
+                        reason=(
+                            f"Cedar CLI: unrecognised output "
+                            f"{proc.stdout.strip()!r}"
+                        ),
+                        backend="cedar",
+                        raw_result={
+                            "stdout": proc.stdout,
+                            "stderr": proc.stderr,
+                        },
+                        error="unrecognised cedar CLI output",
+                    )
                 return BackendDecision(
                     allowed=allowed,
                     action="allow" if allowed else "deny",

--- a/agent-governance-python/agent-os/tests/test_policy_backends.py
+++ b/agent-governance-python/agent-os/tests/test_policy_backends.py
@@ -289,6 +289,128 @@ permit(
         assert stmts[2]["action_constraint"] == 'Action::"DeleteFile"'
 
 
+class TestCedarDecisionFromCliOutput:
+    """Regression tests for the Cedar CLI decision parser.
+
+    The previous parser used ``"allow" in stdout and "deny" not in stdout``
+    on the lowercased output — a substring sniff that gets fooled by
+    diagnostic phrases like ``DENY (request disallowed by policy)`` or
+    ``ALLOW: caveats reference the deny-list scoping``. The new parser only
+    accepts the first non-empty line being a bare ``ALLOW`` or ``DENY``
+    token (case-insensitive); anything else returns ``parsed=False`` so the
+    caller can fail closed.
+    """
+
+    @pytest.mark.parametrize("stdout", [
+        "ALLOW\n",
+        "ALLOW",
+        "allow",
+        "  ALLOW  \n",
+        "\n\nALLOW\n",  # leading blank lines tolerated
+    ])
+    def test_recognises_bare_allow_token(self, stdout: str) -> None:
+        from agent_os.policies.backends import _cedar_decision_from_cli_output
+
+        allowed, parsed = _cedar_decision_from_cli_output(stdout)
+        assert parsed is True
+        assert allowed is True
+
+    @pytest.mark.parametrize("stdout", [
+        "DENY\n",
+        "DENY",
+        "deny",
+        "  DENY  \n",
+        "\n\nDENY\n",
+    ])
+    def test_recognises_bare_deny_token(self, stdout: str) -> None:
+        from agent_os.policies.backends import _cedar_decision_from_cli_output
+
+        allowed, parsed = _cedar_decision_from_cli_output(stdout)
+        assert parsed is True
+        assert allowed is False
+
+    @pytest.mark.parametrize("stdout,description", [
+        ("DENY (request disallowed by policy)\n",
+         "first-line adjective phrase: contains 'allow' as substring of 'disallowed'"),
+        ("ALLOW: caveats reference the deny-list scoping\n",
+         "first-line adjective phrase: contains 'deny' as substring of 'deny-list'"),
+        ("", "empty stdout"),
+        ("\n\n  \n", "whitespace-only stdout"),
+        ("Decision: allow\n", "labelled decision, not a bare token"),
+        ("authorization failed\n", "garbage output"),
+        ("garbage line 1\nALLOW\n", "first line is garbage; second is ALLOW"),
+    ])
+    def test_rejects_ambiguous_output(self, stdout: str, description: str) -> None:
+        from agent_os.policies.backends import _cedar_decision_from_cli_output
+
+        allowed, parsed = _cedar_decision_from_cli_output(stdout)
+        assert parsed is False, description
+        assert allowed is False, description
+
+
+class TestCedarBackendCliPath:
+    """End-to-end test that `_evaluate_cli` routes through the new parser
+    and fails closed on ambiguous output.
+    """
+
+    SIMPLE_POLICY = 'permit(principal, action == Action::"ReadData", resource);'
+
+    def test_cli_allow_decision(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from agent_os.policies import backends as backends_mod
+
+        class _FakeProc:
+            stdout = "ALLOW\n"
+            stderr = ""
+
+        monkeypatch.setattr(
+            backends_mod.subprocess, "run",
+            lambda *_a, **_kw: _FakeProc(),
+        )
+        backend = CedarBackend(policy_content=self.SIMPLE_POLICY)
+        decision = backend._evaluate_cli({"tool_name": "read_data", "agent_id": "a1"})
+        assert decision.allowed is True
+        assert decision.error is None
+
+    def test_cli_deny_decision(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from agent_os.policies import backends as backends_mod
+
+        class _FakeProc:
+            stdout = "DENY\n"
+            stderr = ""
+
+        monkeypatch.setattr(
+            backends_mod.subprocess, "run",
+            lambda *_a, **_kw: _FakeProc(),
+        )
+        backend = CedarBackend(policy_content=self.SIMPLE_POLICY)
+        decision = backend._evaluate_cli({"tool_name": "read_data", "agent_id": "a1"})
+        assert decision.allowed is False
+
+    def test_cli_fails_closed_on_ambiguous_output(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The old parser flipped the verdict on adjective phrases. The new
+        parser refuses to interpret them and fails closed with an explicit
+        error.
+        """
+        from agent_os.policies import backends as backends_mod
+
+        class _FakeProc:
+            # Would have classified as ALLOW under the old "allow in output"
+            # check because of "disallowed". New behaviour: deny + error.
+            stdout = "DENY (request disallowed by policy)\n"
+            stderr = ""
+
+        monkeypatch.setattr(
+            backends_mod.subprocess, "run",
+            lambda *_a, **_kw: _FakeProc(),
+        )
+        backend = CedarBackend(policy_content=self.SIMPLE_POLICY)
+        decision = backend._evaluate_cli({"tool_name": "read_data", "agent_id": "a1"})
+        assert decision.allowed is False
+        assert decision.error == "unrecognised cedar CLI output"
+
+
 # ── PolicyEvaluator Integration Tests ─────────────────────────
 
 


### PR DESCRIPTION
## Summary

[`policies/backends.py`](agent-governance-python/agent-os/src/agent_os/policies/backends.py)'s `CedarBackend._evaluate_cli` decided ALLOW/DENY by sniffing substrings inside the entire ``cedar authorize`` stdout:

```python
output = proc.stdout.strip().lower()
allowed = "allow" in output and "deny" not in output
```

That mis-classifies adjective phrases that future Cedar CLI versions may plausibly emit as diagnostic context:

| Output | Substring check | Correct |
|---|---|---|
| ``DENY (request disallowed by policy)`` | classified DENY (`"allow" in output and not "deny"` — false because "deny" present) | DENY (by coincidence) |
| ``ALLOW: caveats reference the deny-list scoping`` | classified **DENY** (contains "deny" in "deny-list") | **ALLOW** |
| ``ALLOW`` | classified ALLOW | ALLOW |
| ``DENY`` | classified DENY | DENY |

The trap is a coincidence: "allow" and "disallow" share a stem, "deny" appears in compound nouns like "deny-list". A single-character difference between the decision token and the rest of the diagnostic flips the verdict.

## Change

Extract `_cedar_decision_from_cli_output` returning `(allowed, parsed)`. `parsed=False` means the first non-empty line was not a bare `ALLOW`/`DENY` token (case-insensitive). The caller treats `parsed=False` as a hard fail-closed:

```python
return BackendDecision(
    allowed=False,
    action="deny",
    reason=f"Cedar CLI: unrecognised output {proc.stdout.strip()!r}",
    backend="cedar",
    raw_result={"stdout": proc.stdout, "stderr": proc.stderr},
    error="unrecognised cedar CLI output",
)
```

### Why not ``--json``?

REVIEW.md suggested ``cedar authorize --json``. Cedar CLI 4.x supports structured output, but this project does not pin a minimum Cedar CLI version, and older releases reject the flag with ``unknown argument``. The first-line parse keeps backward compatibility with every Cedar CLI version while eliminating the substring trap; a future PR can switch to JSON once the project pins a minimum Cedar CLI version.

This matches the Go sibling's approach in #2127 — same anti-pattern, same fix shape.

## Tests

20 new sub-tests pin the contract:

- `TestCedarDecisionFromCliOutput` — 5 bare-ALLOW, 5 bare-DENY, 7 ambiguous cases (including the two "old parser flipped the verdict" phrases as explicit regression guards).
- `TestCedarBackendCliPath` — patches `subprocess.run` and asserts the full `_evaluate_cli` path: ALLOW → `allowed=True`, DENY → `allowed=False`, ambiguous → `allowed=False` with `error="unrecognised cedar CLI output"`.

```
$ PYTHONPATH=src python -m pytest tests/test_policy_backends.py::TestCedarDecisionFromCliOutput tests/test_policy_backends.py::TestCedarBackendCliPath -q
20 passed, 1 warning in 1.32s
```

Three pre-existing `TestCedarBackend` failures in this test file (`cedarpy.AuthorizationRequest` attribute missing) are unrelated to this change and pre-date it on `upstream/main`.

## Test plan

- [ ] CI passes
- [ ] All `TestCedarDecisionFromCliOutput` and `TestCedarBackendCliPath` tests pass
- [ ] No regression in CedarBackend external behaviour for callers that already supplied a working Cedar CLI

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Core].