### PR TITLE
fix(py-core-mcp): index tool_registry by name for O(1) cross-server check

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_security.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_security.py
@@ -366,6 +366,14 @@ class MCPSecurityScanner:
                 stacklevel=2,
             )
         self._tool_registry: dict[str, ToolFingerprint] = {}
+        # Secondary index from `tool_name` to the list of `ToolFingerprint`
+        # records registered under that name (one per server). Used by
+        # `_check_cross_server` so exact-name impersonation detection is
+        # O(1) on registry size instead of O(N): the previous code scanned
+        # the entire `_tool_registry` for every `scan_tool` call, so a
+        # deployment registering K tools across S servers paid O(K*S) on
+        # each scan.
+        self._tool_by_name: dict[str, list[ToolFingerprint]] = {}
         # Bounded ring buffer — unbounded list grew without limit on
         # long-running deployments.
         self._audit_log: deque[dict[str, Any]] = deque(maxlen=10_000)
@@ -562,6 +570,11 @@ class MCPSecurityScanner:
             version=1,
         )
         self._tool_registry[key] = fp
+        # Mirror the new fingerprint into the by-name index for O(1)
+        # cross-server lookups. Append since multiple servers may register
+        # the same tool name (which is precisely what cross-server attack
+        # detection cares about).
+        self._tool_by_name.setdefault(tool_name, []).append(fp)
         return fp
 
     def check_rug_pull(
@@ -875,46 +888,70 @@ class MCPSecurityScanner:
         tool_name: str,
         server_name: str,
     ) -> list[MCPThreat]:
-        """Check for cross-server attack patterns."""
+        """Check for cross-server attack patterns.
+
+        Two patterns are detected:
+
+          1. **Impersonation** — same `tool_name` registered from a
+             different `server_name`. The `_tool_by_name` secondary index
+             gives O(1) lookup of all fingerprints sharing `tool_name`,
+             replacing the previous O(N) full-registry scan.
+
+          2. **Typosquatting** — a name that differs by ≤ 2 edits from an
+             already-registered tool name on a different server. This
+             still requires iterating over distinct tool names (since
+             edit distance has no general index), but we iterate the
+             keys of `_tool_by_name` rather than every fingerprint,
+             which collapses S registrations of the same tool name into
+             a single comparison.
+        """
         threats: list[MCPThreat] = []
 
-        for _key, fp in self._tool_registry.items():
-            # Same tool name from a different server
-            if fp.tool_name == tool_name and fp.server_name != server_name:
+        # 1. Exact-name impersonation — O(1) lookup via secondary index.
+        for fp in self._tool_by_name.get(tool_name, ()):
+            if fp.server_name == server_name:
+                continue
+            threats.append(
+                MCPThreat(
+                    threat_type=MCPThreatType.CROSS_SERVER_ATTACK,
+                    severity=MCPSeverity.CRITICAL,
+                    tool_name=tool_name,
+                    server_name=server_name,
+                    message=(
+                        f"Tool '{tool_name}' already registered from server "
+                        f"'{fp.server_name}' — potential impersonation"
+                    ),
+                    details={"original_server": fp.server_name},
+                )
+            )
+
+        # 2. Typosquatting — iterate distinct names from the by-name index,
+        #    skipping the exact match (handled above) and same-server hits.
+        for other_name, fps in self._tool_by_name.items():
+            if other_name == tool_name:
+                continue
+            if not self._is_typosquat(tool_name, other_name):
+                continue
+            for fp in fps:
+                if fp.server_name == server_name:
+                    continue
                 threats.append(
                     MCPThreat(
                         threat_type=MCPThreatType.CROSS_SERVER_ATTACK,
-                        severity=MCPSeverity.CRITICAL,
+                        severity=MCPSeverity.WARNING,
                         tool_name=tool_name,
                         server_name=server_name,
                         message=(
-                            f"Tool '{tool_name}' already registered from server "
-                            f"'{fp.server_name}' — potential impersonation"
+                            f"Tool name '{tool_name}' resembles "
+                            f"'{fp.tool_name}' from server '{fp.server_name}' "
+                            f"— potential typosquatting"
                         ),
-                        details={"original_server": fp.server_name},
+                        details={
+                            "similar_tool": fp.tool_name,
+                            "similar_server": fp.server_name,
+                        },
                     )
                 )
-
-            # Typosquatting: similar name from a different server
-            if fp.server_name != server_name and fp.tool_name != tool_name:
-                if self._is_typosquat(tool_name, fp.tool_name):
-                    threats.append(
-                        MCPThreat(
-                            threat_type=MCPThreatType.CROSS_SERVER_ATTACK,
-                            severity=MCPSeverity.WARNING,
-                            tool_name=tool_name,
-                            server_name=server_name,
-                            message=(
-                                f"Tool name '{tool_name}' resembles "
-                                f"'{fp.tool_name}' from server '{fp.server_name}' "
-                                f"— potential typosquatting"
-                            ),
-                            details={
-                                "similar_tool": fp.tool_name,
-                                "similar_server": fp.server_name,
-                            },
-                        )
-                    )
 
         return threats
 

--- a/agent-governance-python/agent-os/tests/test_mcp_security.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_security.py
@@ -359,6 +359,145 @@ class TestCrossServerAttacks:
         threats = self.scanner._check_cross_server("search", "server-a")
         assert len(threats) == 0
 
+    def test_by_name_index_populated_on_register(self):
+        """Registration must mirror into the secondary `_tool_by_name`
+        index so `_check_cross_server` can hit O(1) on exact-name match.
+        """
+        self.scanner.register_tool("search", "Search A", None, "server-a")
+        self.scanner.register_tool("search", "Search B", None, "server-b")
+        self.scanner.register_tool("other", "Other tool", None, "server-a")
+
+        # Same tool name → both fingerprints share an index entry.
+        assert len(self.scanner._tool_by_name["search"]) == 2
+        servers = {fp.server_name for fp in self.scanner._tool_by_name["search"]}
+        assert servers == {"server-a", "server-b"}
+
+        # Unrelated name → separate entry.
+        assert len(self.scanner._tool_by_name["other"]) == 1
+
+    def test_exact_match_lookup_does_not_iterate_unrelated_entries(self):
+        """Regression: previously `_check_cross_server` iterated every
+        entry in `_tool_registry` on every call, so adding K unrelated
+        tools to the registry made every subsequent scan K-times slower.
+
+        We pin the new behaviour by spying on `_is_typosquat` (the only
+        per-name work the new loop does) and asserting that registering
+        unrelated tools does not increase the comparison count for an
+        exact-name lookup beyond what's needed for typosquat checks
+        against the *distinct* tool names.
+        """
+        from unittest.mock import patch
+
+        # Register an exact-name impersonation case plus 50 distinct
+        # other tool names. The exact-match path should not call
+        # `_is_typosquat` for the impersonation hit itself.
+        self.scanner.register_tool("search", "Search A", None, "server-a")
+        for i in range(50):
+            self.scanner.register_tool(f"unrelated_tool_{i}", "x", None, "server-x")
+
+        with patch.object(
+            self.scanner, "_is_typosquat", wraps=self.scanner._is_typosquat,
+        ) as spy:
+            threats = self.scanner._check_cross_server("search", "server-b")
+
+        # The CRITICAL impersonation threat is found via the by-name
+        # index — no `_is_typosquat` call needed for that case.
+        crit = [t for t in threats if t.severity == MCPSeverity.CRITICAL]
+        assert len(crit) == 1
+        assert crit[0].details["original_server"] == "server-a"
+
+        # `_is_typosquat` was called only for the *distinct* other tool
+        # names, not once per fingerprint. With 50 unrelated names + the
+        # one matched name (which is skipped via `other_name == tool_name`),
+        # we expect exactly 50 typosquat comparisons.
+        assert spy.call_count == 50
+
+    def test_typosquat_index_iterates_distinct_names_only(self):
+        """When multiple servers register the same tool name, the typosquat
+        loop should compare against that name *once*, not once per server.
+        """
+        from unittest.mock import patch
+
+        # 5 servers each register the same `legitimate-tool` name.
+        for i in range(5):
+            self.scanner.register_tool(
+                "legitimate-tool", "Legit", None, f"server-{i}",
+            )
+
+        with patch.object(
+            self.scanner, "_is_typosquat", wraps=self.scanner._is_typosquat,
+        ) as spy:
+            # `legitimate-tooll` differs by 1 edit; should match all 5
+            # different-server fingerprints as typosquat warnings.
+            threats = self.scanner._check_cross_server(
+                "legitimate-tooll", "server-attacker",
+            )
+
+        # Five typosquat warnings (one per server), but only ONE call to
+        # `_is_typosquat` (one distinct name in `_tool_by_name`).
+        warnings_emitted = [
+            t for t in threats if t.severity == MCPSeverity.WARNING
+        ]
+        assert len(warnings_emitted) == 5
+        assert spy.call_count == 1
+
+    def test_index_equivalence_with_legacy_scan(self):
+        """The new index-based `_check_cross_server` must return the same
+        threat set as a linear-scan reference implementation for arbitrary
+        registry shapes.
+        """
+        # Populate a non-trivial registry shape.
+        registrations = [
+            ("search", "Search v1", "server-a"),
+            ("search", "Search v2", "server-b"),
+            ("seaarch", "Almost search", "server-c"),  # typosquat
+            ("calculator", "Math", "server-a"),
+            ("calc", "Math short", "server-b"),
+            ("totally-unrelated", "x", "server-d"),
+        ]
+        for name, desc, srv in registrations:
+            self.scanner.register_tool(name, desc, None, srv)
+
+        def linear_scan(tool_name: str, server_name: str):
+            """Mirror of the pre-PR linear-scan logic."""
+            out = []
+            for fp in self.scanner._tool_registry.values():
+                if fp.tool_name == tool_name and fp.server_name != server_name:
+                    out.append(("impersonation", fp.server_name, fp.tool_name))
+                if fp.server_name != server_name and fp.tool_name != tool_name:
+                    if self.scanner._is_typosquat(tool_name, fp.tool_name):
+                        out.append(("typosquat", fp.server_name, fp.tool_name))
+            return sorted(out)
+
+        def index_scan(tool_name: str, server_name: str):
+            """Same shape, drawn from the new index-based output."""
+            out = []
+            for t in self.scanner._check_cross_server(tool_name, server_name):
+                if t.severity == MCPSeverity.CRITICAL:
+                    out.append((
+                        "impersonation",
+                        t.details["original_server"],
+                        t.tool_name,
+                    ))
+                else:
+                    out.append((
+                        "typosquat",
+                        t.details["similar_server"],
+                        t.details["similar_tool"],
+                    ))
+            return sorted(out)
+
+        for (probe_name, probe_srv) in [
+            ("search", "server-z"),
+            ("search", "server-a"),  # same server: should suppress impersonation
+            ("seaarch", "server-z"),
+            ("calculator", "server-z"),
+            ("unknown", "server-z"),
+        ]:
+            assert linear_scan(probe_name, probe_srv) == index_scan(probe_name, probe_srv), (
+                f"linear vs index scan diverged for {probe_name!r} from {probe_srv!r}"
+            )
+
 
 # ============================================================================
 # TestScanTool — full scan of clean and poisoned tools


### PR DESCRIPTION
## Summary

[`mcp_security.py`](agent-governance-python/agent-os/src/agent_os/mcp_security.py)'s `MCPSecurityScanner._check_cross_server` runs on every `scan_tool` call and iterates the entire `_tool_registry` looking for two distinct patterns:

1. **Impersonation** — exact `tool_name` match from a different `server_name`.
2. **Typosquatting** — names within edit-distance 2 from a different server.

The exact-name case is a dictionary lookup, but the previous code iterated all K*S fingerprints (K tool names across S servers) on every scan. Deployments registering many tools — the common case in mature MCP fleets — paid quadratic-in-fleet-size cost on every scan.

## Change

Adds a secondary index `_tool_by_name: dict[str, list[ToolFingerprint]]`, mirrored from `register_tool`. Splits `_check_cross_server` into two phases:

1. **Impersonation** — O(1) lookup via `_tool_by_name.get(tool_name)`.
2. **Typosquatting** — iterate `_tool_by_name.items()` (distinct names). Five servers registering the same `legitimate-tool` collapse from five edit-distance comparisons to one. Edit distance has no general index, so the typosquat phase remains linear in *distinct-name-count*, but that's typically much smaller than total registrations.

The threat-set output is byte-for-byte equivalent to the previous linear scan — pinned by `test_index_equivalence_with_legacy_scan`.

## Tests

| Test | Pins |
|---|---|
| `test_by_name_index_populated_on_register` | `register_tool` mirrors into the secondary index |
| `test_exact_match_lookup_does_not_iterate_unrelated_entries` | 50 unrelated tools don't add 50 `_is_typosquat` calls; impersonation hit comes from the index |
| `test_typosquat_index_iterates_distinct_names_only` | 5 servers × same tool name → 1 `_is_typosquat` call, not 5 |
| `test_index_equivalence_with_legacy_scan` | Reference linear-scan implementation matches index-based output for 5 probe shapes |

```
$ PYTHONPATH=src python -m pytest tests/test_mcp_security.py -q
61 passed, 113 warnings in 1.33s
```

(57 pre-existing + 4 new.)

## Test plan

- [ ] CI passes
- [ ] All 61 `test_mcp_security.py` tests pass
- [ ] No regression in `_check_cross_server` output for existing fixtures
- [ ] `register_tool` continues to handle re-registration without doubling index entries (covered by `test_register_updates_version` + the new index test)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Core].