### PR TITLE
chore(py-ext-marketplace): drop unused ComplianceResult import, scope PluginManifest hint to TYPE_CHECKING

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/cli_commands.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/cli_commands.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
@@ -33,7 +34,6 @@ from agent_marketplace import (
     load_manifest,
 )
 from agent_marketplace.marketplace_policy import (
-    ComplianceResult,
     MarketplacePolicy,
     MCPServerPolicy,
     evaluate_plugin_compliance,
@@ -45,6 +45,9 @@ from agent_marketplace.schema_adapters import (
     extract_capabilities,
     extract_mcp_servers,
 )
+
+if TYPE_CHECKING:
+    from agent_marketplace.manifest import PluginManifest
 
 console = Console()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

Two unused-symbol cleanups in [`agent_marketplace/cli_commands.py`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/cli_commands.py):

- **Unused import.** `ComplianceResult` was imported from `agent_marketplace.marketplace_policy` but never referenced anywhere in the module.
- **Unresolved forward-reference.** `_print_verify_result(manifest: "PluginManifest")` used a forward-reference string for `PluginManifest`, but the name was never brought into module scope. The annotation only happens to "work" because `from __future__ import annotations` makes all annotations lazy strings; any caller of `typing.get_type_hints` on this function would have raised `NameError`.

## Change

- Remove `ComplianceResult` from the runtime import list.
- Add a `TYPE_CHECKING`-only import of `PluginManifest` from `agent_marketplace.manifest` so type-checkers and IDEs can resolve the hint without runtime cost.

## Tests

No behavioural change; the existing suite continues to pass.

```text
$ PYTHONPATH=src python -m pytest tests/ -q
309 passed, 2 skipped in 2.39s
```

A smoke import of `agent_marketplace.cli_commands` succeeds.

## Test plan

- [x] Existing marketplace test suite green.
- [x] Module imports cleanly.
- [x] Static-analysis tools can resolve `PluginManifest` via the `TYPE_CHECKING` block.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Extensions].