### PR TITLE
fix(py-isolation-rate-limiter): use tuple bucket key to prevent DID collision

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/security/rate_limiter.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/security/rate_limiter.py
@@ -102,10 +102,25 @@ class AgentRateLimiter:
         ring_limits: dict[ExecutionRing, tuple[float, float]] | None = None,
     ) -> None:
         self._limits = ring_limits or dict(DEFAULT_RING_LIMITS)
-        # (agent_did, session_id) -> TokenBucket
-        self._buckets: dict[str, TokenBucket] = {}
-        self._stats: dict[str, RateLimitStats] = {}
+        # (agent_did, session_id) -> TokenBucket. A tuple is used so that
+        # identifiers containing ``:`` cannot collide across distinct
+        # (agent, session) pairs — see ``_bucket_key`` for the rationale.
+        self._buckets: dict[tuple[str, str], TokenBucket] = {}
+        self._stats: dict[tuple[str, str], RateLimitStats] = {}
         self._lock = threading.Lock()
+
+    @staticmethod
+    def _bucket_key(agent_did: str, session_id: str) -> tuple[str, str]:
+        """Build the per-(agent, session) bucket key.
+
+        Using ``(agent_did, session_id)`` rather than the joined string
+        ``f"{agent_did}:{session_id}"`` keeps the identifiers
+        unambiguous: ``("a:b", "c")`` and ``("a", "b:c")`` would
+        otherwise hash to the same bucket and quietly share a rate
+        limit. ``agent_did`` is a DID (e.g. ``did:key:z6Mk...``) so the
+        colon collision is the realistic case, not the contrived one.
+        """
+        return (agent_did, session_id)
 
     def check(
         self,
@@ -119,7 +134,7 @@ class AgentRateLimiter:
 
         Returns True if allowed, raises RateLimitExceeded if not.
         """
-        key = f"{agent_did}:{session_id}"
+        key = self._bucket_key(agent_did, session_id)
         with self._lock:
             bucket = self._get_or_create_bucket_locked(key, ring)
             stats = self._stats.setdefault(
@@ -157,7 +172,7 @@ class AgentRateLimiter:
         new_ring: ExecutionRing,
     ) -> None:
         """Update an agent's rate limit when their ring changes."""
-        key = f"{agent_did}:{session_id}"
+        key = self._bucket_key(agent_did, session_id)
         rate, capacity = self._limits.get(
             new_ring, RATE_LIMIT_FALLBACK
         )
@@ -172,7 +187,7 @@ class AgentRateLimiter:
 
     def get_stats(self, agent_did: str, session_id: str) -> RateLimitStats | None:
         """Get rate limit stats for an agent."""
-        key = f"{agent_did}:{session_id}"
+        key = self._bucket_key(agent_did, session_id)
         with self._lock:
             stats = self._stats.get(key)
             if stats:
@@ -183,7 +198,7 @@ class AgentRateLimiter:
             return stats
 
     def _get_or_create_bucket_locked(
-        self, key: str, ring: ExecutionRing
+        self, key: tuple[str, str], ring: ExecutionRing
     ) -> TokenBucket:
         """Caller must hold ``self._lock``."""
         if key not in self._buckets:

--- a/agent-governance-python/agent-hypervisor/tests/test_rate_limiter.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_rate_limiter.py
@@ -158,6 +158,57 @@ class TestAgentRateLimiter:
         assert ExecutionRing.RING_2_STANDARD in DEFAULT_RING_LIMITS
         assert ExecutionRing.RING_3_SANDBOX in DEFAULT_RING_LIMITS
 
+    def test_colon_in_agent_did_does_not_collide_with_other_session(self):
+        """A previous implementation used ``f"{agent_did}:{session_id}"`` as
+        the bucket key. Because ``agent_did`` is a DID (``did:key:z6Mk...``),
+        a colon in the agent identifier could collide with a different
+        ``(agent_did, session_id)`` pair — e.g. ``("did:key:abc", "s")``
+        and ``("did:key", "abc:s")`` both flattened to
+        ``"did:key:abc:s"`` and shared a single bucket and stats slot.
+
+        With a tuple key the two pairs are tracked independently.
+        """
+        limiter = AgentRateLimiter(
+            ring_limits={ExecutionRing.RING_3_SANDBOX: (0.0, 1.0)}
+        )
+        # Drain the bucket for the first pair.
+        limiter.check("did:key:abc", "s", ExecutionRing.RING_3_SANDBOX)
+        # The colliding-on-string pair must still have its own token.
+        assert (
+            limiter.try_check("did:key", "abc:s", ExecutionRing.RING_3_SANDBOX)
+            is True
+        )
+        # And tracked-agents reflects two distinct buckets, not one.
+        assert limiter.tracked_agents == 2
+
+    def test_colon_in_session_id_does_not_collide_with_other_agent(self):
+        """Mirror of the agent-side test: colon in ``session_id`` must not
+        leak into a different ``(agent_did, session_id)`` pair.
+        """
+        limiter = AgentRateLimiter(
+            ring_limits={ExecutionRing.RING_3_SANDBOX: (0.0, 1.0)}
+        )
+        limiter.check("a", "1:sess", ExecutionRing.RING_3_SANDBOX)
+        assert (
+            limiter.try_check("a:1", "sess", ExecutionRing.RING_3_SANDBOX)
+            is True
+        )
+        assert limiter.tracked_agents == 2
+
+    def test_get_stats_isolation_under_colon_collision(self):
+        """``get_stats`` must return distinct ``RateLimitStats`` instances
+        for two pairs that previously flattened to the same string key.
+        """
+        limiter = AgentRateLimiter()
+        limiter.check("did:key:abc", "s", ExecutionRing.RING_2_STANDARD)
+        limiter.check("did:key", "abc:s", ExecutionRing.RING_2_STANDARD)
+        a = limiter.get_stats("did:key:abc", "s")
+        b = limiter.get_stats("did:key", "abc:s")
+        assert a is not None and b is not None
+        assert a is not b
+        assert a.agent_did == "did:key:abc"
+        assert b.agent_did == "did:key"
+
 
 class TestConcurrency:
     def test_concurrent_check_does_not_overspend_tokens(self):


### PR DESCRIPTION
## Summary

[`rate_limiter.py`](agent-governance-python/agent-hypervisor/src/hypervisor/security/rate_limiter.py)'s `AgentRateLimiter` keyed its per-(agent, session) token buckets and stats slots on the joined string `f"{agent_did}:{session_id}"`. Because `agent_did` is a DID (e.g. `did:key:z6Mk...`), distinct `(agent_did, session_id)` pairs could collapse to the same flattened string and silently share a bucket:

| Pair | Flattened key |
|---|---|
| `("did:key:abc", "s")` | `"did:key:abc:s"` |
| `("did:key", "abc:s")` | `"did:key:abc:s"` |

The two pairs then shared both a `TokenBucket` and a `RateLimitStats` record — one agent could drain the other's quota, and `get_stats` returned the same object for both. DIDs always contain at least one colon, so this isn't a contrived case.

## Change

Switch the bucket-key type to `tuple[str, str]` via a new `_bucket_key` helper. Tuples preserve component boundaries unambiguously, so no string-shape of identifier can produce a collision. `_buckets`, `_stats`, and the `_get_or_create_bucket_locked` annotation updated accordingly. No behaviour change for the non-colliding case — same `dict[..., TokenBucket]` lookups, same locking.

## Tests

| Test | Pins |
|---|---|
| `test_colon_in_agent_did_does_not_collide_with_other_session` | Two pairs that flattened to the same string get independent buckets; `tracked_agents == 2` |
| `test_colon_in_session_id_does_not_collide_with_other_agent` | Mirror of the agent-side test on the session field |
| `test_get_stats_isolation_under_colon_collision` | `get_stats` returns distinct `RateLimitStats` objects for the two pairs |

```
$ PYTHONPATH=src python -m pytest tests/test_rate_limiter.py -q
26 passed in 0.87s
```

(23 pre-existing + 3 new.)

## Test plan

- [ ] CI passes
- [ ] All 26 `test_rate_limiter.py` tests pass
- [ ] No regression for the common non-colliding case (covered by the pre-existing 23 tests)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Isolation].