### PR TITLE
fix(py-gov-rag): render CollectionDeniedError reasons as human phrases

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/exceptions.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/exceptions.py
@@ -9,22 +9,36 @@ class RAGGovernanceError(Exception):
     """Base class for all agent-rag-governance errors."""
 
 
+# Maps the machine-readable ``reason`` codes returned by
+# ``RAGPolicy.is_collection_allowed`` to the human-readable phrase used
+# in the exception message. The ``reason`` codes themselves are kept on
+# the attribute (and forwarded to ``policy_triggered`` in audit entries)
+# so callers can still pattern-match on them.
+_REASON_PHRASES: dict[str, str] = {
+    "denied": "explicitly denied",
+    "not_allowed": "not in the allow list",
+    "cedar_denied": "denied by Cedar policy",
+}
+
+
 class CollectionDeniedError(RAGGovernanceError):
     """Raised when an agent attempts to query a denied or unlisted collection.
 
     Attributes:
         collection: The collection name that was blocked.
         agent_id: The agent that attempted the retrieval.
-        reason: Either ``"denied"`` (explicit deny list) or ``"not_allowed"``
-            (allow list is set and collection is absent).
+        reason: One of ``"denied"`` (explicit deny list), ``"not_allowed"``
+            (allow list is set and collection is absent), or
+            ``"cedar_denied"`` (rejected by the Cedar policy engine).
     """
 
     def __init__(self, collection: str, agent_id: str, reason: str = "denied") -> None:
         self.collection = collection
         self.agent_id = agent_id
         self.reason = reason
+        phrase = _REASON_PHRASES.get(reason, reason)
         super().__init__(
-            f"Collection '{collection}' access {reason} for agent '{agent_id}'"
+            f"Collection '{collection}' is {phrase} for agent '{agent_id}'"
         )
 
 

--- a/agent-governance-python/agent-rag-governance/tests/test_exceptions.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_exceptions.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for human-readable phrasing of CollectionDeniedError messages.
+
+The ``reason`` attribute remains a machine-readable code (``"denied"`` /
+``"not_allowed"`` / ``"cedar_denied"``) so callers and audit entries can
+still pattern-match on it. The exception *message* uses a human phrase
+that reads naturally when interpolated by logs or surfaced to users.
+"""
+
+from __future__ import annotations
+
+from agent_rag_governance.exceptions import (
+    CollectionDeniedError,
+    ContentScanError,
+    RateLimitExceededError,
+)
+
+
+def test_denied_reason_renders_explicit_phrase() -> None:
+    exc = CollectionDeniedError("hr_records", "agent-1", reason="denied")
+    assert exc.reason == "denied"
+    assert (
+        str(exc)
+        == "Collection 'hr_records' is explicitly denied for agent 'agent-1'"
+    )
+
+
+def test_not_allowed_reason_renders_allow_list_phrase() -> None:
+    exc = CollectionDeniedError("internal_wiki", "agent-1", reason="not_allowed")
+    assert exc.reason == "not_allowed"
+    assert (
+        str(exc)
+        == "Collection 'internal_wiki' is not in the allow list for agent 'agent-1'"
+    )
+
+
+def test_cedar_denied_reason_renders_cedar_phrase() -> None:
+    exc = CollectionDeniedError("financials", "agent-1", reason="cedar_denied")
+    assert exc.reason == "cedar_denied"
+    assert (
+        str(exc)
+        == "Collection 'financials' is denied by Cedar policy for agent 'agent-1'"
+    )
+
+
+def test_unknown_reason_falls_back_to_raw_code() -> None:
+    # Defensive: any future or unmapped reason code is interpolated
+    # verbatim rather than crashing.
+    exc = CollectionDeniedError("col", "agent-1", reason="custom_code")
+    assert exc.reason == "custom_code"
+    assert str(exc) == "Collection 'col' is custom_code for agent 'agent-1'"
+
+
+def test_rate_limit_message_unchanged() -> None:
+    exc = RateLimitExceededError("agent-1", limit=10, window_seconds=60)
+    assert exc.agent_id == "agent-1"
+    assert exc.limit == 10
+    assert exc.window_seconds == 60
+    assert str(exc) == "Agent 'agent-1' exceeded retrieval limit of 10 per 60s"
+
+
+def test_content_scan_message_unchanged() -> None:
+    exc = ContentScanError(2, "SSN pattern", category="pii")
+    assert exc.chunk_index == 2
+    assert exc.pattern_matched == "SSN pattern"
+    assert exc.category == "pii"
+    assert str(exc) == "Chunk 2 blocked by content scan [pii]: SSN pattern"


### PR DESCRIPTION
## Summary

[`exceptions.py`](agent-governance-python/agent-rag-governance/src/agent_rag_governance/exceptions.py)'s `CollectionDeniedError` interpolates the raw reason code from `RAGPolicy.is_collection_allowed` directly into its message:

```
Collection 'X' access not_allowed for agent 'Y'
Collection 'X' access cedar_denied for agent 'Y'
```

The codes are correct as machine-readable tags — they're carried on `.reason` (pattern-matched by callers) and forwarded to `policy_triggered` in audit entries — but they read poorly when surfaced in logs, error responses, or test failure output.

## Change

Adds a small `_REASON_PHRASES` mapping in [`exceptions.py`](agent-governance-python/agent-rag-governance/src/agent_rag_governance/exceptions.py) and rewires the constructor to render the human phrase in the exception message:

| reason code | message phrase |
|---|---|
| `denied` | `is explicitly denied` |
| `not_allowed` | `is not in the allow list` |
| `cedar_denied` | `is denied by Cedar policy` |

`.reason` keeps the original code so callers that catch the exception and branch on it (and the audit pipeline's `collection_<reason>` `policy_triggered` value) are unaffected. Unknown codes fall back to the raw value rather than crashing.

## Tests

New `tests/test_exceptions.py` pins the phrase mapping and the unchanged behaviour of the sibling exceptions:

| Test | Pins |
|---|---|
| `test_denied_reason_renders_explicit_phrase` | `denied` -> `is explicitly denied` |
| `test_not_allowed_reason_renders_allow_list_phrase` | `not_allowed` -> `is not in the allow list` |
| `test_cedar_denied_reason_renders_cedar_phrase` | `cedar_denied` -> `is denied by Cedar policy` |
| `test_unknown_reason_falls_back_to_raw_code` | Unknown code -> raw interpolation, no crash |
| `test_rate_limit_message_unchanged` | `RateLimitExceededError` message untouched |
| `test_content_scan_message_unchanged` | `ContentScanError` message untouched |

```
$ PYTHONPATH=src python -m pytest tests/test_exceptions.py tests/test_policy.py tests/test_governor.py -q
32 passed in 1.05s
```

## Test plan

- [ ] CI passes
- [ ] All `test_exceptions.py` cases pass
- [ ] Existing `test_governor.py` / `test_policy.py` cases still assert `.reason` codes (`"denied"`, `"not_allowed"`) unchanged
- [ ] Audit entries continue to emit `policy_triggered=collection_denied` / `collection_not_allowed` / `collection_cedar_denied`

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Governance].