### PR TITLE
chore(py-ext-marketplace): remove never-read additional_blocked_plugins field

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/marketplace_policy.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/marketplace_policy.py
@@ -66,7 +66,6 @@ class OrgMarketplacePolicy:
 
     organization: str
     additional_allowed_plugin_types: list[str] = field(default_factory=list)
-    additional_blocked_plugins: list[str] = field(default_factory=list)
     mcp_server_overrides: MCPServerPolicy | None = None
 
 

--- a/agent-governance-python/agent-marketplace/tests/test_org_marketplace.py
+++ b/agent-governance-python/agent-marketplace/tests/test_org_marketplace.py
@@ -132,7 +132,6 @@ class TestOrgMarketplacePolicy:
         org = OrgMarketplacePolicy(organization="contoso")
         assert org.organization == "contoso"
         assert org.additional_allowed_plugin_types == []
-        assert org.additional_blocked_plugins == []
         assert org.mcp_server_overrides is None
 
     def test_get_effective_policy_no_org(self) -> None:


### PR DESCRIPTION
## Summary

[`agent_marketplace/marketplace_policy.py`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/marketplace_policy.py): `OrgMarketplacePolicy.additional_blocked_plugins` is declared on the dataclass but never consulted by any caller.

The companion `additional_allowed_plugin_types` field IS consumed by [`MarketplacePolicy.get_effective_policy`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/marketplace_policy.py) to merge org overrides into the base policy. The blocklist counterpart was clearly planned but the corresponding merge logic was never wired up — leaving an attribute on the public surface that silently does nothing.

A repo-wide `grep -rn 'additional_blocked_plugins'` finds only:

- The field declaration itself.
- A single test assertion (`assert org.additional_blocked_plugins == []`) checking the default-empty value.

## Change

- Remove the field from `OrgMarketplacePolicy`.
- Drop the test assertion that references it.

If org-scoped plugin blocklisting becomes a feature later, the field should be re-introduced together with the merge logic that reads it, ideally as part of the PR that lands the feature.

## Tests

No behavioural change; the existing suite continues to pass.

```text
$ PYTHONPATH=src python -m pytest tests/ -q
309 passed, 2 skipped in 2.15s
```

## Test plan

- [x] Existing marketplace test suite green.
- [x] `grep -rn additional_blocked_plugins` is empty after the change.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Extensions].