### PR TITLE
chore(go-identity): document ToJSON public-only semantics and asymmetry

### DIFF
--- a/agent-governance-golang/packages/agentmesh/identity.go
+++ b/agent-governance-golang/packages/agentmesh/identity.go
@@ -49,7 +49,16 @@ type identityJSON struct {
 	Capabilities []string `json:"capabilities,omitempty"`
 }
 
-// ToJSON serialises the public portion of the identity.
+// ToJSON serialises the public portion of the identity (DID, public key,
+// capabilities). The private key is deliberately excluded so the output is
+// safe to share with peers, store in registries, or transmit over untrusted
+// channels.
+//
+// There is intentionally no symmetric ToPrivateJSON: private keys live only
+// in-process and should be persisted via a key management system, not by
+// round-tripping through this package. An identity rehydrated via FromJSON
+// can Verify peer signatures but cannot Sign — calling Sign on such an
+// identity returns an error.
 func (a *AgentIdentity) ToJSON() ([]byte, error) {
 	return json.Marshal(identityJSON{
 		DID:          a.DID,
@@ -58,7 +67,11 @@ func (a *AgentIdentity) ToJSON() ([]byte, error) {
 	})
 }
 
-// FromJSON deserialises an identity from JSON (public fields only).
+// FromJSON deserialises an identity from the public-only JSON format produced
+// by ToJSON. The resulting identity has no private key, so it can Verify
+// signatures from the original agent but cannot Sign new data. To obtain a
+// signing-capable identity, call GenerateIdentity or load the private key
+// from a key management system separately.
 func FromJSON(data []byte) (*AgentIdentity, error) {
 	var j identityJSON
 	if err := json.Unmarshal(data, &j); err != nil {


### PR DESCRIPTION
## Summary

Documentation-only change for [`agent-governance-golang/packages/agentmesh/identity.go`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-golang/packages/agentmesh/identity.go).

`AgentIdentity.ToJSON` serialises only the public part of the identity (DID, public key, capabilities) and there is no symmetric `ToPrivateJSON`. The previous doc comment mentioned the public-only behaviour but didn't motivate the asymmetry or spell out what a round-tripped identity can still do.

## Change

Expand the doc comments on `ToJSON` and `FromJSON` to make three things explicit:

- `ToJSON` output is safe to share with peers / store in registries; private keys are deliberately never written by this package.
- There is no `ToPrivateJSON` by design — private keys belong in a key management system, not in JSON round-trips through this package.
- An identity rehydrated via `FromJSON` can `Verify` peer signatures but cannot `Sign`; calling `Sign` on it returns an error (matching existing behaviour).

No behaviour change. No new API surface.

## Tests

`go test ./...` from `agent-governance-golang/packages/agentmesh/` passes (existing identity tests already cover the round-trip).

## Test plan

- [x] `go test ./...` from `agent-governance-golang/packages/agentmesh/` passes.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Go].