### PR TITLE
chore(ci): remove unused PYTHON_VERSION ARG from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.7
 
-ARG PYTHON_VERSION=3.11
-
+# Python version is pinned in the FROM line below (tag + digest). The image
+# digest is the single source of truth for reproducibility; do not add an ARG
+# here unless it is actually referenced by the FROM line.
 FROM python:3.11-slim@sha256:9358444059ed78e2975ada2c189f1c1a3144a5dab6f35bff8c981afb38946634 AS base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary

[`Dockerfile:3`](https://github.com/microsoft/agent-governance-toolkit/blob/main/Dockerfile#L3) declares `ARG PYTHON_VERSION=3.11` but the `FROM` line on the next row hardcodes `python:3.11-slim@sha256:9358...` directly. The ARG is never referenced — it is dead syntax that misleads readers into thinking the Python version is parameterized when it is not.

## Change

Replace the dangling `ARG PYTHON_VERSION` with a comment explaining why the version is pinned at the `FROM` line. The image tag + digest is the single source of truth for reproducibility; an ARG without a corresponding `FROM python:${PYTHON_VERSION}` interpolation contributes nothing.

No build-time behavior change — the resulting image is byte-identical.

## Verification

- Diff is a comment swap; no `FROM`/`RUN`/`ENV` lines touched.
- `docker build` against the resulting Dockerfile produces the same image (same `FROM` digest pin, same build stages).

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Infrastructure/CI].