### PR TITLE
chore(py-ext-marketplace): drop unused _evaluators init in QualityAssessor

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/quality_assessment.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/quality_assessment.py
@@ -120,9 +120,6 @@ class QualityAssessmentReport:
 class QualityAssessor:
     """Runs multi-dimensional quality assessments."""
 
-    def __init__(self) -> None:
-        self._evaluators: dict[AssessmentDimension, Any] = {}
-
     def assess_security(
         self,
         has_owasp: bool,


### PR DESCRIPTION
## Summary

[`QualityAssessor.__init__`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/quality_assessment.py) only sets:

```python
self._evaluators: dict[AssessmentDimension, Any] = {}
```

…and nothing else on the instance. The attribute is never read, written, or mutated anywhere in the source tree — none of the `assess_*` methods consult it, no caller touches it, and the tests do not reference it.

A repo-wide `grep -rn '_evaluators'` confirms `QualityAssessor` is the only producer; all other `_evaluators` matches belong to unrelated classes in `agent_sandbox` and `agentmesh.governance.policy`.

## Change

Since the only purpose of the constructor was that dead assignment, drop the empty `__init__` entirely. `Any` remains imported because `to_dict` still uses `dict[str, Any]` as its return annotation.

If pluggable evaluators are added later, they should be introduced together with the registration path and the call site that uses them.

## Tests

No behavioural change; the existing suite continues to pass.

```text
$ PYTHONPATH=src python -m pytest tests/ -q
309 passed, 2 skipped in 1.76s
```

## Test plan

- [x] Existing marketplace test suite green.
- [x] `QualityAssessor()` still instantiates (covered by the existing `tests/test_quality_assessment.py::TestQualityAssessor` class).

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Extensions].