### PR TITLE
perf(dotnet/policy): cache YamlDotNet IDeserializer in Policy.FromYaml

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/Policy.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/Policy.cs
@@ -25,6 +25,15 @@ public sealed class Policy
         AllowTrailingCommas = true
     };
 
+    // YamlDotNet's IDeserializer is documented as thread-safe once built, and
+    // constructing one is non-trivial (it resolves type inspectors, converters,
+    // and naming conventions). Cache a single instance so policy loading does
+    // not pay that cost on every FromYaml / FromYamlFile call.
+    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
     /// <summary>
     /// The API version of the policy schema (e.g., "governance.toolkit/v1").
     /// </summary>
@@ -67,12 +76,7 @@ public sealed class Policy
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
 
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(UnderscoredNamingConvention.Instance)
-            .IgnoreUnmatchedProperties()
-            .Build();
-
-        var raw = deserializer.Deserialize<PolicyDocument>(yaml)
+        var raw = YamlDeserializer.Deserialize<PolicyDocument>(yaml)
             ?? throw new ArgumentException("Failed to parse YAML policy document.");
         return FromDocument(raw);
     }

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyTests.cs
@@ -145,6 +145,50 @@ rules: []
     }
 
     [Fact]
+    public void FromYaml_CachedDeserializer_ProducesStableResultsAcrossCalls()
+    {
+        // FromYaml caches a single IDeserializer at type-init time. This test
+        // pins the contract that repeated calls (including concurrent calls
+        // across different inputs) parse independently and return equivalent
+        // results to a one-shot call.
+        var yamls = new[]
+        {
+            ValidYaml,
+            @"
+apiVersion: governance.toolkit/v1
+name: tenant-policy
+scope: tenant
+default_action: allow
+rules: []
+",
+            @"
+apiVersion: governance.toolkit/v1
+name: agent-policy
+scope: agent
+default_action: deny
+rules: []
+"
+        };
+
+        var first = yamls.Select(GovernancePolicy.FromYaml).ToList();
+
+        // Re-parse repeatedly, including in parallel, and confirm results
+        // match field-for-field. If the cached deserializer leaked state
+        // between calls, fields would drift.
+        for (var iter = 0; iter < 5; iter++)
+        {
+            var again = yamls.AsParallel().Select(GovernancePolicy.FromYaml).ToList();
+            for (var i = 0; i < first.Count; i++)
+            {
+                Assert.Equal(first[i].Name, again[i].Name);
+                Assert.Equal(first[i].Scope, again[i].Scope);
+                Assert.Equal(first[i].DefaultAction, again[i].DefaultAction);
+                Assert.Equal(first[i].Rules.Count, again[i].Rules.Count);
+            }
+        }
+    }
+
+    [Fact]
     public void FromYaml_DefaultsWhenFieldsMissing()
     {
         var yaml = @"


### PR DESCRIPTION
## Summary

[`Policy.FromYaml`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/Policy.cs#L66-L78) rebuilds a fresh `IDeserializer` on every call:

```csharp
var deserializer = new DeserializerBuilder()
    .WithNamingConvention(UnderscoredNamingConvention.Instance)
    .IgnoreUnmatchedProperties()
    .Build();
```

`DeserializerBuilder.Build()` walks every public property on the target type (`Policy.PolicyDocument` and `Policy.RuleDocument`), resolves the naming convention, and wires up type inspectors and converters. That cost is identical on every call, and YamlDotNet documents the resulting `IDeserializer` as thread-safe once built -- so building it per call is pure waste. Loading a handful of policies at startup, or hot-reloading them from disk, pays the construction cost N times for no benefit.

## Change

Promote the builder result to a `static readonly IDeserializer` field so every `FromYaml` / `FromYamlFile` call reuses the same configured deserializer. This mirrors the existing `JsonSerializerOptions` caching right above it -- the JSON path already does the equivalent.

## Tests

Added `FromYaml_CachedDeserializer_ProducesStableResultsAcrossCalls`: parses three different policy documents sequentially and in parallel across multiple iterations, and asserts that field-for-field results stay stable across calls. Guards against future refactors that would accidentally introduce per-call state on the shared instance.

## Test plan

- [x] `dotnet test` -- 658 / 658 passing (previous baseline 657 + 1 new)
- [x] Existing `FromYaml_*` tests unchanged

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, .NET].