### PR TITLE
fix(ci): drop runtime UID on dev and dashboard compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     init: true
     stdin_open: true
     tty: true
+    # Match the host UID/GID so files created inside the bind-mounted
+    # workspace land with host ownership (not root). Override on the host
+    # with `HOST_UID=$(id -u) HOST_GID=$(id -g)` if your IDs differ.
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     working_dir: /workspace
     volumes:
       - .:/workspace
@@ -36,6 +40,9 @@ services:
       - --server.address=0.0.0.0
       - --server.port=8501
     init: true
+    # Match the host UID/GID so any files Streamlit writes back to the
+    # bind-mounted workspace are owned by the host user, not root.
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     ports:
       - "8501:8501"
     working_dir: /workspace


### PR DESCRIPTION
## Summary

The [`test` service](https://github.com/microsoft/agent-governance-toolkit/blob/main/docker-compose.yml#L15-L25) in `docker-compose.yml` already runs as `${HOST_UID:-1000}:${HOST_GID:-1000}`, but `dev` and `dashboard` did not. All three services bind-mount the repo at `/workspace`, and the `dev` Docker stage does not declare a `USER` — so any file the `dev` or `dashboard` container wrote back to the bind mount (a new file from `pip install -e`, a dashboard artifact, a `git` operation inside the container) landed on the host as root.

## Change

Apply the same `${HOST_UID:-1000}:${HOST_GID:-1000}` pattern to both services so file ownership stays consistent with the `test` service and with the host user.

- `docker-compose.yml`:11 — `dev` service gets `user:`
- `docker-compose.yml`:42 — `dashboard` service gets `user:`

The default of `1000:1000` matches the typical first-created Linux user; hosts with different IDs can override via `HOST_UID` / `HOST_GID` env vars before `docker compose up`.

## Verification

- Diff is two added blocks, no other compose keys touched.
- `docker compose config` parses cleanly.
- After this change, `docker compose run dev touch /workspace/foo && ls -l foo` on the host shows host-user ownership (was: root).

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Infrastructure/CI].