### PR TITLE
fix(typescript/agent-os-vscode): drop unnecessary double cast on audit details

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/extension.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/extension.ts
@@ -621,7 +621,7 @@ safe_query = "SELECT * FROM users WHERE id = ?"
             const auditEntries = auditLogger.getAll().map(e => ({
                 timestamp: new Date(),
                 type: 'audit',
-                details: e as unknown as Record<string, unknown>
+                details: { ...e } as Record<string, unknown>
             }));
 
             const report = reportGenerator.generate({


### PR DESCRIPTION
## Problem

[`extension.ts:621`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/extension.ts#L618-L622), inside the storage-export command, maps each `AuditEntry` returned from the audit logger into the `ReportGenerator`'s `AuditEntry` shape and assigns the original entry to `details` via:

```typescript
const auditEntries = auditLogger.getAll().map(e => ({
    timestamp: new Date(),
    type: 'audit',
    details: e as unknown as Record<string, unknown>
}));
```

The `as unknown as Record<string, unknown>` is the "I give up" cast: it strips the compiler's view of the value down to `unknown` and then re-asserts it as a record. There's no real structural check in either direction. It's also unnecessary here — [`AuditEntry`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/auditLogger.ts#L11-L20) is a plain interface whose every field is a primitive, string union, or `any`, so a fresh object literal copied from it is naturally assignable to `Record<string, unknown>` with a single narrowing cast.

## Fix

```typescript
details: { ...e } as Record<string, unknown>
```

The cast target is now a fresh object literal rather than the original `AuditEntry` reference. Two side benefits beyond removing the double cast:

- If `AuditEntry` later grows a nested object field that can't satisfy `Record<string, unknown>`, the single cast will surface that as a real type error to investigate, rather than the previous `unknown` shape laundering it silently.
- The `details` field no longer aliases the live `AuditEntry` stored in the logger's internal array, so callers further downstream can't mutate the logger's state through the report payload.

## Test

The agent-os-vscode package's existing `test` script wraps the VS Code integration runner; this is a shape-only change in a `.map` callback and the produced object is structurally identical at runtime. No behavioural change on either path.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, TypeScript].