### PR TITLE
fix(py-gov-rag): expose rate_limit_window_seconds on RAGPolicy

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py
@@ -183,7 +183,9 @@ class RAGGovernor:
     def __init__(self, policy: RAGPolicy, agent_id: str = "default") -> None:
         self.policy = policy
         self.agent_id = agent_id
-        self._rate_limiter = RateLimiter(window_seconds=60)
+        self._rate_limiter = RateLimiter(
+            window_seconds=policy.rate_limit_window_seconds,
+        )
         self._content_scanner = ContentScanner(policy.content_policies)
         self._audit_logger: Optional[AuditLogger] = (
             AuditLogger(policy.audit_log_path) if policy.audit_enabled else None
@@ -284,7 +286,11 @@ class RAGGovernor:
                     policy_triggered="max_retrievals_per_minute",
                 )
                 self._audit_logger.emit(entry)
-            raise RateLimitExceededError(self.agent_id, limit)
+            raise RateLimitExceededError(
+                self.agent_id,
+                limit,
+                window_seconds=self.policy.rate_limit_window_seconds,
+            )
 
     def _retrieve(self, retriever: Any, query: str, kwargs: dict[str, Any]) -> List[Any]:
         if hasattr(retriever, "invoke"):

--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/policy.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/policy.py
@@ -18,7 +18,14 @@ class RAGPolicy:
         denied_collections: Collections that are always blocked, regardless
             of the allow list.
         max_retrievals_per_minute: Maximum retrieval calls per agent per
-            60-second sliding window. ``0`` disables rate limiting.
+            sliding window. ``0`` disables rate limiting. The window
+            length defaults to 60 seconds but can be overridden with
+            ``rate_limit_window_seconds``.
+        rate_limit_window_seconds: Length of the sliding rate-limit
+            window in seconds. Defaults to ``60``. Setting this lets
+            callers tune the limiter for shorter (burst-resistant) or
+            longer (quota-style) policies without monkey-patching the
+            governor.
         content_policies: Active content scan categories. Supported values:
             ``"block_pii"`` and ``"block_injections"``. Empty list disables
             content scanning.
@@ -72,6 +79,7 @@ class RAGPolicy:
     allowed_collections: Optional[List[str]] = None
     denied_collections: List[str] = field(default_factory=list)
     max_retrievals_per_minute: int = 0
+    rate_limit_window_seconds: int = 60
     content_policies: List[str] = field(default_factory=list)
     audit_enabled: bool = True
     audit_log_path: Optional[str] = None
@@ -79,7 +87,18 @@ class RAGPolicy:
     cedar_policy_path: Optional[str] = None
 
     def __post_init__(self) -> None:
-        """Load Cedar policy from file if path is provided."""
+        """Load Cedar policy from file if path is provided.
+
+        Also validates ``rate_limit_window_seconds`` — a non-positive
+        window would either disable the limiter or push the sliding
+        cutoff into the future, both of which are configuration
+        errors.
+        """
+        if self.rate_limit_window_seconds <= 0:
+            raise ValueError(
+                "rate_limit_window_seconds must be positive; got "
+                f"{self.rate_limit_window_seconds!r}"
+            )
         if self.cedar_policy_path and not self.cedar_policy:
             from pathlib import Path
             path = Path(self.cedar_policy_path)

--- a/agent-governance-python/agent-rag-governance/tests/test_rate_limit_window.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_rate_limit_window.py
@@ -1,0 +1,99 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for RAGPolicy.rate_limit_window_seconds exposure on the governor.
+
+Confirms the field defaults to 60 (preserves prior behaviour),
+configures the underlying RateLimiter, validates non-positive values,
+and is reflected in RateLimitExceededError.window_seconds.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agent_rag_governance.exceptions import RateLimitExceededError
+from agent_rag_governance.governor import RAGGovernor
+from agent_rag_governance.policy import RAGPolicy
+
+
+class _FakeDoc:
+    def __init__(self, text: str) -> None:
+        self.page_content = text
+
+
+class _FakeRetriever:
+    def __init__(self, docs: list[_FakeDoc]) -> None:
+        self._docs = docs
+
+    def invoke(self, query: str, **_: object) -> list[_FakeDoc]:
+        return list(self._docs)
+
+
+def _make_governor(policy: RAGPolicy) -> RAGGovernor:
+    return RAGGovernor(policy=policy, agent_id="test-agent")
+
+
+def test_default_window_is_sixty_seconds() -> None:
+    policy = RAGPolicy()
+    assert policy.rate_limit_window_seconds == 60
+
+
+def test_governor_propagates_window_to_rate_limiter() -> None:
+    policy = RAGPolicy(rate_limit_window_seconds=5)
+    governor = _make_governor(policy)
+    # Internal state intentionally pinned: callers shouldn't reach in,
+    # but the regression is that the RateLimiter is constructed with the
+    # configured window rather than the hard-coded 60.
+    assert governor._rate_limiter._window == 5
+
+
+def test_short_window_expires_faster_than_default() -> None:
+    policy = RAGPolicy(
+        allowed_collections=["docs"],
+        max_retrievals_per_minute=2,
+        rate_limit_window_seconds=1,
+        audit_enabled=False,
+    )
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([_FakeDoc("ok")])
+    governed = governor.wrap(retriever, collection="docs")
+
+    governed.invoke("q1")
+    governed.invoke("q2")
+    with pytest.raises(RateLimitExceededError) as exc:
+        governed.invoke("q3")
+    assert exc.value.window_seconds == 1
+    assert "per 1s" in str(exc.value)
+
+    # Window expires within a second, third call now succeeds.
+    time.sleep(1.1)
+    assert len(governed.invoke("q4")) == 1
+
+
+def test_long_window_keeps_state_past_default() -> None:
+    # A 300-second window must not silently fall back to 60; the
+    # second-burst limit must persist even after 60s would have expired
+    # the entries under the previous hard-coded behaviour.
+    policy = RAGPolicy(
+        allowed_collections=["docs"],
+        max_retrievals_per_minute=1,
+        rate_limit_window_seconds=300,
+        audit_enabled=False,
+    )
+    governor = _make_governor(policy)
+    retriever = _FakeRetriever([_FakeDoc("ok")])
+    governed = governor.wrap(retriever, collection="docs")
+
+    governed.invoke("q1")
+    with pytest.raises(RateLimitExceededError) as exc:
+        governed.invoke("q2")
+    assert exc.value.window_seconds == 300
+
+
+def test_non_positive_window_rejected() -> None:
+    with pytest.raises(ValueError, match="rate_limit_window_seconds"):
+        RAGPolicy(rate_limit_window_seconds=0)
+    with pytest.raises(ValueError, match="rate_limit_window_seconds"):
+        RAGPolicy(rate_limit_window_seconds=-5)


### PR DESCRIPTION
## Summary

[`governor.py`](agent-governance-python/agent-rag-governance/src/agent_rag_governance/governor.py)'s `RAGGovernor.__init__` instantiated `RateLimiter(window_seconds=60)` with the 60 hard-coded. The companion [`policy.py`](agent-governance-python/agent-rag-governance/src/agent_rag_governance/policy.py)'s `RAGPolicy` exposes `max_retrievals_per_minute` but not the window length, so callers wanting a 5-second burst window or a 300-second quota window had to monkey-patch `governor._rate_limiter` after construction.

## Change

Adds `rate_limit_window_seconds: int = 60` to `RAGPolicy` (default preserves prior behaviour). `RAGGovernor` forwards it to `RateLimiter`, and the resulting `RateLimitExceededError` surfaces the configured window in its message rather than the hard-coded "per 60s".

`RAGPolicy.__post_init__` rejects non-positive windows up front with a `ValueError` — `0` would silently disable the limiter (which `max_retrievals_per_minute=0` is already the documented switch for), and negative values would push the sliding cutoff into the future.

The docstring on `max_retrievals_per_minute` now points at the new field instead of saying "60-second sliding window."

## Tests

New `tests/test_rate_limit_window.py` pins the behaviour:

| Test | Pins |
|---|---|
| `test_default_window_is_sixty_seconds` | Backwards-compat default |
| `test_governor_propagates_window_to_rate_limiter` | Governor honours the policy field |
| `test_short_window_expires_faster_than_default` | 1s window allows reuse after 1.1s sleep; `RateLimitExceededError.window_seconds == 1` |
| `test_long_window_keeps_state_past_default` | 300s window present on the exception |
| `test_non_positive_window_rejected` | `0` and negative values raise `ValueError` |

```
$ PYTHONPATH=src python -m pytest tests/ -q
93 passed, 1 skipped in 2.64s
```

## Test plan

- [ ] CI passes
- [ ] All existing `test_rate_limiter.py` / `test_governor.py` / `test_policy.py` cases still pass (default window unchanged)
- [ ] New `test_rate_limit_window.py` cases pass
- [ ] `RateLimitExceededError.window_seconds` reflects the configured policy value, not the previous hard-coded 60

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Governance].