### PR TITLE
fix(ci): validate sanitized title is non-empty in spec drafter

### DIFF
--- a/.github/workflows/ai-spec-drafter.yml
+++ b/.github/workflows/ai-spec-drafter.yml
@@ -82,7 +82,17 @@ jobs:
           # prevent interpretation of backslash escapes and special chars
           # (CWE-77: ISSUE_TITLE is untrusted user input)
           SAFE_TITLE=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' \
-            | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | head -c 50)
+            | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | head -c 50)
+
+          # If the title contained no [a-z0-9] characters, SAFE_TITLE is now
+          # empty and would produce malformed paths like `docs/spec-123-`
+          # (trailing dash) or even a directory traversal in pathological
+          # cases. Abort cleanly with a workflow warning instead.
+          if [ -z "$SAFE_TITLE" ]; then
+            echo "::warning::Issue title contains no usable characters after sanitization; cannot derive branch/filename"
+            exit 0
+          fi
+
           BRANCH="docs/spec-${ISSUE_NUMBER}-${SAFE_TITLE}"
           SPEC_FILE="docs/specs/issue-${ISSUE_NUMBER}-${SAFE_TITLE}.md"
 


### PR DESCRIPTION
## Summary

[`.github/workflows/ai-spec-drafter.yml:84-87`](https://github.com/microsoft/agent-governance-toolkit/blob/main/.github/workflows/ai-spec-drafter.yml#L84-L87) sanitizes a user-supplied issue title down to `[a-z0-9-]` and uses it in both a git branch name and a file path:

```bash
SAFE_TITLE=$(printf '%s' "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' \
  | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | head -c 50)
BRANCH="docs/spec-${ISSUE_NUMBER}-${SAFE_TITLE}"
SPEC_FILE="docs/specs/issue-${ISSUE_NUMBER}-${SAFE_TITLE}.md"
```

If the title contains no `[a-z0-9]` characters at all (e.g. an issue titled `"✨🚀✨"`), the sed pipeline collapses to a single `-` which `head -c 50` keeps. The resulting branch (`docs/spec-123--`) and filename (`docs/specs/issue-123--.md`) are malformed; a fully-empty result would produce dangling-dash paths.

This builds on the shell-injection hardening from [#2138](https://github.com/microsoft/agent-governance-toolkit/pull/2138) — same workflow, related defensive layer.

## Change

- Strip leading/trailing dashes after the collapse.
- Abort cleanly with a `::warning::` if the sanitized result is empty.

The workflow exits 0 so the broader CI run isn't marked failed for a content issue on the source issue.

## Verification

- Diff is local to a single `run:` block.
- Manual shell test on a few title shapes:
  - `"Add new feature"` -> `add-new-feature` (unchanged)
  - `"✨🚀✨"` -> empty -> workflow exits with warning (was: `docs/spec-N--`)
  - `"---fix---"` -> `fix` after the new strip (was: `-fix-`)

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Infrastructure/CI].