### PR TITLE
fix(py-ext-marketplace): gate seen_names mutation on validate_bundle duplicate path

### DIFF
--- a/agent-governance-python/agent-marketplace/src/agent_marketplace/workflow_bundle.py
+++ b/agent-governance-python/agent-marketplace/src/agent_marketplace/workflow_bundle.py
@@ -89,9 +89,10 @@ class BundleRegistry:
                 errors.append("Component name is required")
             if not comp.version:
                 errors.append(f"Component '{comp.name}' is missing a version")
-            if comp.name in seen_names:
+            if comp.name and comp.name in seen_names:
                 errors.append(f"Duplicate component name: '{comp.name}'")
-            seen_names.add(comp.name)
+            elif comp.name:
+                seen_names.add(comp.name)
         return errors
 
     def search(self, component_type: ComponentType | None = None) -> list[WorkflowBundle]:

--- a/agent-governance-python/agent-marketplace/tests/test_workflow_bundle.py
+++ b/agent-governance-python/agent-marketplace/tests/test_workflow_bundle.py
@@ -149,6 +149,51 @@ class TestValidateBundle:
         errors = reg.validate_bundle(bundle)
         assert any("Duplicate" in e for e in errors)
 
+    def test_three_components_same_name_emit_two_duplicates(self) -> None:
+        """Each repeated occurrence after the first must produce its own error.
+
+        Regression for an earlier formulation that always re-added the name
+        to ``seen_names``: that path was a no-op on a ``set``, so it didn't
+        change the observable error list — but the logic was muddled, and
+        gating the add behind ``name not in seen_names`` keeps the loop's
+        intent (``seen_names`` = canonical/first-seen identifiers) explicit
+        rather than implicit.
+        """
+        reg = BundleRegistry()
+        bundle = WorkflowBundle(
+            "dup3", "1.0.0",
+            components=[
+                BundleComponent(ComponentType.AGENT, "x", "1.0.0"),
+                BundleComponent(ComponentType.TOOL, "x", "1.0.0"),
+                BundleComponent(ComponentType.SKILL, "x", "1.0.0"),
+            ],
+        )
+        errors = reg.validate_bundle(bundle)
+        duplicate_errors = [e for e in errors if "Duplicate" in e]
+        # Two duplicates: the second and the third occurrences of "x".
+        assert len(duplicate_errors) == 2
+
+    def test_unnamed_components_do_not_cross_collide_as_duplicates(self) -> None:
+        """Two components with empty names must each report 'name is required',
+
+        but the second must NOT additionally be reported as a "Duplicate component
+        name: ''" (which would happen if the empty string were recorded in
+        ``seen_names`` after the first unnamed component).
+        """
+        reg = BundleRegistry()
+        bundle = WorkflowBundle(
+            "unnamed", "1.0.0",
+            components=[
+                BundleComponent(ComponentType.AGENT, "", "1.0.0"),
+                BundleComponent(ComponentType.TOOL, "", "1.0.0"),
+            ],
+        )
+        errors = reg.validate_bundle(bundle)
+        name_required = [e for e in errors if e == "Component name is required"]
+        duplicate_errors = [e for e in errors if "Duplicate" in e]
+        assert len(name_required) == 2
+        assert duplicate_errors == []
+
     def test_empty_bundle_rejected(self) -> None:
         reg = BundleRegistry()
         bundle = WorkflowBundle("empty", "1.0.0", components=[])


### PR DESCRIPTION
## Summary

[`BundleRegistry.validate_bundle`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-marketplace/src/agent_marketplace/workflow_bundle.py) recorded every component name in `seen_names` regardless of whether the duplicate check had already fired:

```python
if comp.name in seen_names:
    errors.append(f"Duplicate component name: '{comp.name}'")
seen_names.add(comp.name)         # also runs on duplicates
```

Re-adding an already-present name to a `set` is a no-op, so this didn't change which duplicate errors got emitted — every repeat occurrence still reports correctly. The defect is cosmetic in the strict sense, but two related problems were real:

1. **Empty names polluted `seen_names`.** A `BundleComponent` with `name == ""` had its empty string added to `seen_names`, so the *next* unnamed component would be reported BOTH as `"Component name is required"` AND as `Duplicate component name: ''` — a spurious second finding for the same underlying problem.
2. **Loop intent was implicit.** `seen_names` is meant to mean "canonical / first-seen names". Adding to it on the duplicate branch hid that contract behind a set-semantics quirk.

## Change

Gate `seen_names.add(comp.name)` behind `not in seen_names` and skip the add entirely for empty names. Both adjustments are locally-scoped to the duplicate-tracking branch; the existing "name required" and "version required" findings are unchanged.

## Tests

Two new regression tests in `tests/test_workflow_bundle.py::TestValidateBundle`:

- `test_three_components_same_name_emit_two_duplicates` — three components sharing one name yield two `Duplicate` errors.
- `test_unnamed_components_do_not_cross_collide_as_duplicates` — two unnamed components yield two `"Component name is required"` findings and zero `Duplicate` findings.

```text
$ PYTHONPATH=src python -m pytest tests/ -q
311 passed, 2 skipped in 1.86s
```

## Test plan

- [x] Existing marketplace test suite green (309 → 311 with new regressions).
- [x] Empty-name component no longer produces a spurious duplicate finding.
- [x] Duplicate detection still flags every repeat occurrence.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Extensions].