### PR TITLE
fix(go-policy): make LoadFromYAML replace rules; add MergeFromYAML

### DIFF
--- a/agent-governance-golang/README.md
+++ b/agent-governance-golang/README.md
@@ -88,7 +88,8 @@ Rule-based policy engine with wildcard and condition matching.
 |---|---|
 | `NewPolicyEngine(rules)` | Create a policy engine |
 | `(*PolicyEngine).Evaluate(action, context)` | Evaluate an action |
-| `(*PolicyEngine).LoadFromYAML(path)` | Load rules from YAML file |
+| `(*PolicyEngine).LoadFromYAML(path)` | Replace rules from YAML file |
+| `(*PolicyEngine).MergeFromYAML(path)` | Append rules from a YAML file to the existing rule set |
 | `(*PolicyEngine).AddBackend(backend)` | Register an external policy backend |
 | `(*PolicyEngine).LoadRego(options)` | Register an OPA/Rego backend |
 | `(*PolicyEngine).LoadCedar(options)` | Register a Cedar backend |

--- a/agent-governance-golang/packages/agentmesh/policy.go
+++ b/agent-governance-golang/packages/agentmesh/policy.go
@@ -178,24 +178,53 @@ func (pe *PolicyEngine) checkRateLimit(rule PolicyRule, context map[string]inter
 	return Allow
 }
 
-// LoadFromYAML loads rules from a YAML file, appending to existing rules.
+// LoadFromYAML replaces the engine's rule set with the rules from a YAML
+// file. Existing rules are discarded on success; on parse or I/O error the
+// previous rule set is left intact. This matches the natural semantics of a
+// "load" verb and prevents the rule set from doubling when the same file is
+// re-read (e.g. on config reload).
+//
+// To extend the rule set without replacing it, use MergeFromYAML.
 func (pe *PolicyEngine) LoadFromYAML(path string) error {
-	data, err := os.ReadFile(path)
+	rules, err := readPolicyRulesFromYAML(path)
 	if err != nil {
 		return err
+	}
+
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+	pe.rules = rules
+	return nil
+}
+
+// MergeFromYAML appends rules from a YAML file to the engine's existing rule
+// set. Use this when composing rules from multiple files; use LoadFromYAML
+// when reloading a single canonical rule set.
+func (pe *PolicyEngine) MergeFromYAML(path string) error {
+	rules, err := readPolicyRulesFromYAML(path)
+	if err != nil {
+		return err
+	}
+
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+	pe.rules = append(pe.rules, rules...)
+	return nil
+}
+
+func readPolicyRulesFromYAML(path string) ([]PolicyRule, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
 	}
 
 	var loaded struct {
 		Rules []PolicyRule `yaml:"rules"`
 	}
 	if err := yaml.Unmarshal(data, &loaded); err != nil {
-		return err
+		return nil, err
 	}
-
-	pe.mu.Lock()
-	defer pe.mu.Unlock()
-	pe.rules = append(pe.rules, loaded.Rules...)
-	return nil
+	return loaded.Rules, nil
 }
 
 func matchAction(pattern, action string) bool {

--- a/agent-governance-golang/packages/agentmesh/policy_test.go
+++ b/agent-governance-golang/packages/agentmesh/policy_test.go
@@ -447,7 +447,7 @@ func TestLoadFromYAMLNonexistentFile(t *testing.T) {
 	}
 }
 
-func TestLoadFromYAMLAppendsToExistingRules(t *testing.T) {
+func TestLoadFromYAMLReplacesExistingRules(t *testing.T) {
 	pe := NewPolicyEngine([]PolicyRule{
 		{Action: "existing.action", Effect: Allow},
 	})
@@ -457,13 +457,107 @@ func TestLoadFromYAMLAppendsToExistingRules(t *testing.T) {
   - action: "new.action"
     effect: "deny"
 `
-	path := filepath.Join(dir, "append.yaml")
+	path := filepath.Join(dir, "load.yaml")
 	if err := os.WriteFile(path, []byte(yamlContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := pe.LoadFromYAML(path); err != nil {
 		t.Fatalf("LoadFromYAML: %v", err)
+	}
+
+	// Existing rule is replaced — falls through to default deny
+	if d := pe.Evaluate("existing.action", nil); d != Deny {
+		t.Errorf("existing rule should be replaced: got %q, want deny", d)
+	}
+	// New rule is loaded
+	if d := pe.Evaluate("new.action", nil); d != Deny {
+		t.Errorf("new rule: got %q, want deny", d)
+	}
+}
+
+// Re-loading the same YAML must not double the rule set. Before LoadFromYAML
+// adopted replace semantics, calling it twice appended the rules twice, which
+// was harmless for first-match-wins but quietly doubled memory and evaluation
+// cost on every config reload.
+func TestLoadFromYAMLReloadDoesNotDouble(t *testing.T) {
+	dir := t.TempDir()
+	yamlContent := `rules:
+  - action: "a"
+    effect: "allow"
+  - action: "b"
+    effect: "deny"
+`
+	path := filepath.Join(dir, "reload.yaml")
+	if err := os.WriteFile(path, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pe := NewPolicyEngine(nil)
+	if err := pe.LoadFromYAML(path); err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if err := pe.LoadFromYAML(path); err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if err := pe.LoadFromYAML(path); err != nil {
+		t.Fatalf("third load: %v", err)
+	}
+
+	pe.mu.RLock()
+	count := len(pe.rules)
+	pe.mu.RUnlock()
+	if count != 2 {
+		t.Errorf("rule count after 3 reloads = %d, want 2", count)
+	}
+}
+
+// On read or parse error, LoadFromYAML must leave the existing rule set
+// untouched so a bad reload doesn't strip enforcement.
+func TestLoadFromYAMLPreservesRulesOnError(t *testing.T) {
+	pe := NewPolicyEngine([]PolicyRule{
+		{Action: "existing.action", Effect: Allow},
+	})
+
+	// Nonexistent file: read error
+	if err := pe.LoadFromYAML(filepath.Join(t.TempDir(), "nonexistent.yaml")); err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+	if d := pe.Evaluate("existing.action", nil); d != Allow {
+		t.Errorf("after failed load (missing file), existing rule should remain: got %q, want allow", d)
+	}
+
+	// Invalid YAML: parse error
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte("this is: [not: valid: yaml: {{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := pe.LoadFromYAML(path); err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+	if d := pe.Evaluate("existing.action", nil); d != Allow {
+		t.Errorf("after failed load (bad yaml), existing rule should remain: got %q, want allow", d)
+	}
+}
+
+func TestMergeFromYAMLAppendsToExistingRules(t *testing.T) {
+	pe := NewPolicyEngine([]PolicyRule{
+		{Action: "existing.action", Effect: Allow},
+	})
+
+	dir := t.TempDir()
+	yamlContent := `rules:
+  - action: "new.action"
+    effect: "deny"
+`
+	path := filepath.Join(dir, "merge.yaml")
+	if err := os.WriteFile(path, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pe.MergeFromYAML(path); err != nil {
+		t.Fatalf("MergeFromYAML: %v", err)
 	}
 
 	// Existing rule still works

--- a/docs/tutorials/22-go-sdk.md
+++ b/docs/tutorials/22-go-sdk.md
@@ -313,7 +313,9 @@ if err != nil {
 fmt.Println(engine.Evaluate("data.read", nil))  // allow
 ```
 
-Rules loaded from YAML are appended to any existing rules.
+`LoadFromYAML` replaces the engine's existing rule set; calling it again on a
+config reload won't double the rules. Use `MergeFromYAML` when composing rules
+from multiple files.
 
 ---
 


### PR DESCRIPTION
## Summary

[`PolicyEngine.LoadFromYAML`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-golang/packages/agentmesh/policy.go#L181-L199) appended to ` PolicyEngine.rules` on every call. Reloading the same YAML on a config refresh doubled the rule set each time: harmless for first-match-wins evaluation but quietly inflating memory and per-evaluation cost on long-lived processes.

## Change

- `LoadFromYAML(path)` now **replaces** the engine's existing rules on success. On read or parse error the previous rule set is left intact, so a bad reload doesn't strip enforcement.
- New `MergeFromYAML(path)` retains the previous additive behaviour for callers composing rules from multiple files.
- Internal `readPolicyRulesFromYAML` helper factored out of both paths.
- README and `docs/tutorials/22-go-sdk.md` updated to describe `LoadFromYAML` as a replace and to point callers at `MergeFromYAML` for the additive form.

## Behaviour change

The previous `LoadFromYAML` is now `MergeFromYAML` — callers who relied on the additive behaviour need to switch to the new method. The previous form was undocumented as such outside of one tutorial sentence; the tutorial is updated in this PR.

## Tests

`go test ./...` from `agent-governance-golang/packages/agentmesh/` passes. New / renamed tests:

- `TestLoadFromYAMLReplacesExistingRules` — rename of the previous additive test; now asserts replace semantics.
- `TestLoadFromYAMLReloadDoesNotDouble` — load the same file three times; assert the rule count stays equal to the file's rule count (regression for the double-append bug).
- `TestLoadFromYAMLPreservesRulesOnError` — read error and parse error both leave the existing rule set intact.
- `TestMergeFromYAMLAppendsToExistingRules` — additive Merge variant.

## Test plan

- [x] `go test ./...` passes from `agent-governance-golang/packages/agentmesh/`.
- [x] Three repeated `LoadFromYAML` calls produce the file's rule count (not 3 x).
- [x] Failed `LoadFromYAML` leaves the prior rules in place.
- [x] `MergeFromYAML` continues to append.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Go].