### PR TITLE
test(rust-audit): cover iso8601 civil-date conversion with fixed-time cases

### DIFF
--- a/agent-governance-rust/agentmesh/src/audit.rs
+++ b/agent-governance-rust/agentmesh/src/audit.rs
@@ -188,10 +188,19 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 fn iso8601_now() -> String {
-    let d = SystemTime::now()
+    let secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap_or_default();
-    let secs = d.as_secs();
+        .unwrap_or_default()
+        .as_secs();
+    iso8601_from_unix_secs(secs)
+}
+
+/// Format `secs` (seconds since the Unix epoch) as an ISO-8601 UTC timestamp
+/// (`YYYY-MM-DDTHH:MM:SSZ`).
+///
+/// Split out from [`iso8601_now`] so the civil-date conversion can be tested
+/// with fixed inputs.
+fn iso8601_from_unix_secs(secs: u64) -> String {
     let days = secs / 86400;
     let time_of_day = secs % 86400;
     let hours = time_of_day / 3600;
@@ -502,6 +511,41 @@ mod tests {
         assert_eq!(&ts[13..14], ":");
         assert_eq!(&ts[16..17], ":");
         assert_eq!(&ts[19..20], "Z");
+    }
+
+    #[test]
+    fn test_iso8601_from_unix_secs_known_values() {
+        // Unix epoch.
+        assert_eq!(iso8601_from_unix_secs(0), "1970-01-01T00:00:00Z");
+        // 2000-01-01T00:00:00Z — century start, divisible-by-400 leap year.
+        assert_eq!(iso8601_from_unix_secs(946_684_800), "2000-01-01T00:00:00Z");
+        // 2000-02-29T00:00:00Z — leap day in a divisible-by-400 century year.
+        assert_eq!(iso8601_from_unix_secs(951_782_400), "2000-02-29T00:00:00Z");
+        // 2001-09-09T01:46:40Z — common reference timestamp (1e9 seconds).
+        assert_eq!(
+            iso8601_from_unix_secs(1_000_000_000),
+            "2001-09-09T01:46:40Z"
+        );
+        // 2023-11-14T22:13:20Z (1.7e9 seconds) — sanity check in current era.
+        assert_eq!(
+            iso8601_from_unix_secs(1_700_000_000),
+            "2023-11-14T22:13:20Z"
+        );
+        // 2024-02-29T00:00:00Z — leap day in an ordinary (divisible-by-4) leap year.
+        assert_eq!(
+            iso8601_from_unix_secs(1_709_164_800),
+            "2024-02-29T00:00:00Z"
+        );
+        // 2024-03-01T00:00:00Z — day after the leap day, guards off-by-one.
+        assert_eq!(
+            iso8601_from_unix_secs(1_709_251_200),
+            "2024-03-01T00:00:00Z"
+        );
+        // 2024-12-31T23:59:59Z — last second of a leap year.
+        assert_eq!(
+            iso8601_from_unix_secs(1_735_689_599),
+            "2024-12-31T23:59:59Z"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

[`agent-governance-rust/agentmesh/src/audit.rs`](agent-governance-rust/agentmesh/src/audit.rs) re-implements the Howard Hinnant civil-from-days algorithm inside `iso8601_now` to avoid pulling in chrono. The only existing test for it asserted shape (length and delimiter positions) — the actual era / day-of-era arithmetic was unverified, so a regression in the date math would silently produce wrong timestamps in every audit entry.

## Change

- Factor the formatting body into a pure `iso8601_from_unix_secs(secs: u64) -> String` helper. `iso8601_now()` still reads `SystemTime::now()` and produces identical output.
- Add `test_iso8601_from_unix_secs_known_values` asserting eight reference points:
  - Unix epoch (1970-01-01T00:00:00Z)
  - 2000-01-01 (divisible-by-400 century year)
  - 2000-02-29 and 2024-02-29 (both kinds of leap year)
  - 2024-03-01 (day after leap day — guards off-by-one in `mp`)
  - 2024-12-31T23:59:59 (last second of a leap year)
  - 1e9 seconds (2001-09-09T01:46:40Z)
  - 1.7e9 seconds (2023-11-14T22:13:20Z)

Reference timestamps cross-checked against `DateTimeOffset.FromUnixTimeSeconds`.

## Tests

- `cargo test -p agentmesh --lib audit::` — 27 passed, 0 failed.

## Test plan

- [x] New test fails if any constant in the civil-date arithmetic (719_468, 146_097, 36524, 1460, the `mp` formula) is perturbed
- [x] Existing `test_iso8601_now_format` shape check still passes
- [x] No behavioural change to `iso8601_now()`

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Rust].