### PR TITLE
chore(ci): correct stale upload-artifact version comment

### DIFF
--- a/.github/workflows/weekly-security-audit.yml
+++ b/.github/workflows/weekly-security-audit.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: weekly-security-audit
           path: |


### PR DESCRIPTION
## Summary

[`.github/workflows/weekly-security-audit.yml:74`](https://github.com/microsoft/agent-governance-toolkit/blob/main/.github/workflows/weekly-security-audit.yml#L74) pins `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` but labels the SHA `# v4.6.2`. Every other workflow in the repo pins the same SHA and labels it `# v7.0.1`:

- `benchmarks.yml:51`
- `ci.yml:676`
- `publish.yml:152, 216, 337`
- `scorecard.yml:31`

The SHA does resolve to v7.0.1 — confirmed via the upstream tag:

```
$ curl -s https://api.github.com/repos/actions/upload-artifact/git/refs/tags/v7.0.1 | jq .object.sha
"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
```

So runtime behavior is correct; only the comment is stale, presumably from a copy-paste at an earlier bump.

## Change

Update the comment so Dependabot, reviewers, and future bumps see a consistent `# v7.0.1` label across the workflow set. One-character edit.

## Verification

- Diff is a single comment change.
- `actionlint` parses cleanly (action ref unchanged).

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Infrastructure/CI].