### PR TITLE
fix(py-isolation-api-server): use public accessors in get_stats

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/api/server.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/api/server.py
@@ -180,19 +180,16 @@ async def get_stats() -> StatsResponse:
     """Get overall hypervisor statistics."""
     hv = _hv()
     bus = _bus()
-    total_participants = sum(
-        m.sso.participant_count for m in hv._sessions.values()
-    )
-    active_sagas = sum(
-        len(m.saga.active_sagas) for m in hv._sessions.values()
-    )
+    sessions = hv.sessions
+    total_participants = sum(m.sso.participant_count for m in sessions)
+    active_sagas = sum(len(m.saga.active_sagas) for m in sessions)
     return StatsResponse(
         version=__version__,
-        total_sessions=len(hv._sessions),
+        total_sessions=hv.session_count,
         active_sessions=len(hv.active_sessions),
         total_participants=total_participants,
         active_sagas=active_sagas,
-        total_vouches=len(hv.vouching._vouches),
+        total_vouches=hv.vouching.vouch_count,
         event_count=bus.event_count,
     )
 

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/core.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/core.py
@@ -306,6 +306,23 @@ class Hypervisor:
         return [self._sessions[sid] for sid in self._active_ids
                 if sid in self._sessions]
 
+    @property
+    def sessions(self) -> list[ManagedSession]:
+        """All managed sessions, including archived/terminating ones.
+
+        ``active_sessions`` filters via ``_active_ids``; this property
+        exposes the full registry for callers (admin APIs, monitoring,
+        stats) that need a count or iterator over every session the
+        Hypervisor is still tracking. Returns a snapshot list so callers
+        can iterate without holding any internal reference.
+        """
+        return list(self._sessions.values())
+
+    @property
+    def session_count(self) -> int:
+        """Total number of managed sessions, including archived/terminating."""
+        return len(self._sessions)
+
     def _get_session(self, session_id: str) -> ManagedSession:
         managed = self._sessions.get(session_id)
         if not managed:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/vouching.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/vouching.py
@@ -57,6 +57,11 @@ class VouchingEngine:
         self._vouches: dict[str, VouchRecord] = {}
         self.max_exposure = max_exposure or self.DEFAULT_MAX_EXPOSURE
 
+    @property
+    def vouch_count(self) -> int:
+        """Total number of sponsorship records (active + released)."""
+        return len(self._vouches)
+
     def vouch(
         self,
         voucher_did: str,

--- a/agent-governance-python/agent-hypervisor/tests/test_agent_manager.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_agent_manager.py
@@ -335,6 +335,44 @@ class TestActiveSessions:
 
 
 # ---------------------------------------------------------------------------
+# sessions / session_count accessors
+# ---------------------------------------------------------------------------
+
+class TestSessionsAccessor:
+    """``sessions`` and ``session_count`` expose the full session registry
+    without callers having to reach into ``_sessions``. ``active_sessions``
+    is filtered by the active index; these accessors include archived /
+    terminating ones too.
+    """
+
+    async def test_session_count_empty(self, hypervisor):
+        assert hypervisor.session_count == 0
+        assert hypervisor.sessions == []
+
+    async def test_session_count_includes_terminated(self, hypervisor, config):
+        s1 = await hypervisor.create_session(config, creator_did=CREATOR)
+        s2 = await hypervisor.create_session(config, creator_did=CREATOR)
+        await hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
+        await hypervisor.activate_session(s1.sso.session_id)
+        await hypervisor.terminate_session(s1.sso.session_id)
+        # active_sessions drops s1; session_count keeps it.
+        assert len(hypervisor.active_sessions) == 1
+        assert hypervisor.session_count == 2
+        assert {m.sso.session_id for m in hypervisor.sessions} == {
+            s1.sso.session_id,
+            s2.sso.session_id,
+        }
+
+    async def test_sessions_returns_snapshot_not_live_view(self, hypervisor, config):
+        await hypervisor.create_session(config, creator_did=CREATOR)
+        snapshot = hypervisor.sessions
+        await hypervisor.create_session(config, creator_did=CREATOR)
+        # Snapshot taken before second create must not grow.
+        assert len(snapshot) == 1
+        assert hypervisor.session_count == 2
+
+
+# ---------------------------------------------------------------------------
 # verify_behavior
 # ---------------------------------------------------------------------------
 

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_liability.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_liability.py
@@ -13,6 +13,21 @@ class TestVouchingEngine:
         self.engine = VouchingEngine()
         self.session = "session:test-1"
 
+    def test_vouch_count_accessor(self):
+        """``vouch_count`` is the public alternative to ``len(_vouches)`` —
+        callers (notably the stats API) should not reach into the
+        private dict.
+        """
+        assert self.engine.vouch_count == 0
+        self.engine.vouch("did:mesh:a", "did:mesh:b", self.session, 0.8)
+        assert self.engine.vouch_count == 1
+        self.engine.vouch("did:mesh:c", "did:mesh:d", self.session, 0.8)
+        assert self.engine.vouch_count == 2
+        # Releasing a bond does not remove the record — count includes released.
+        records = list(self.engine._vouches.values())
+        self.engine.release_bond(records[0].vouch_id)
+        assert self.engine.vouch_count == 2
+
     def test_basic_vouch(self):
         record = self.engine.vouch(
             voucher_did="did:mesh:high",


### PR DESCRIPTION
## Summary

[`api/server.py`](agent-governance-python/agent-hypervisor/src/hypervisor/api/server.py)'s `/api/v1/stats` handler reached into three private attributes on the Hypervisor and VouchingEngine:

```python
total_participants = sum(m.sso.participant_count for m in hv._sessions.values())
active_sagas       = sum(len(m.saga.active_sagas) for m in hv._sessions.values())
total_sessions     = len(hv._sessions)
total_vouches      = len(hv.vouching._vouches)
```

Reaching into another module's underscored containers makes any internal refactor (locking, indexing, storage backend) a breaking API change rather than an internal one. The fields are underscored on purpose.

## Change

Adds three public accessors and switches `get_stats` to use them:

| Accessor | Returns |
|---|---|
| `Hypervisor.sessions` | snapshot `list[ManagedSession]` of every managed session |
| `Hypervisor.session_count` | total session count incl. archived/terminating |
| `VouchingEngine.vouch_count` | total sponsorship-record count incl. released |

`Hypervisor.active_sessions` already existed but filters via `_active_ids`, so it isn't equivalent to `len(hv._sessions)`. The new accessors give the *full* registry, which is what `get_stats` needed. The snapshot form (`list(self._sessions.values())`) lets callers iterate without holding internal references.

Behaviour of `get_stats` is unchanged — same fields, same values, same ordering — and the iteration is now done once over `hv.sessions` rather than twice over `hv._sessions.values()`.

## Tests

| Test | Pins |
|---|---|
| `test_session_count_empty` | Empty Hypervisor: `session_count == 0`, `sessions == []` |
| `test_session_count_includes_terminated` | After terminate, `active_sessions == 1` but `session_count == 2` |
| `test_sessions_returns_snapshot_not_live_view` | A list captured before a later `create_session` does not grow |
| `test_vouch_count_accessor` | Count tracks creation and survives `release_bond` (records aren't deleted) |

```
$ PYTHONPATH=src python -m pytest tests/test_agent_manager.py tests/unit/test_liability.py -q
65 passed, 3 skipped in 0.70s
```

Full suite: 617 passed, 2 pre-existing failures in `tests/unit/test_ring_improvements.py::TestBreachDetector` confirmed unrelated to this change (verified by stashing and re-running on upstream/main).

## Test plan

- [ ] CI passes
- [ ] All 65 `test_agent_manager.py` + `test_liability.py` tests pass
- [ ] No regression in `/api/v1/stats` response shape or values
- [ ] `Hypervisor.sessions` / `session_count` / `VouchingEngine.vouch_count` available to other internal callers that previously reached into `_sessions` / `_vouches`

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Isolation].