### PR TITLE
fix(py-ext-lightning): log unexpected kernel failures with traceback in step

### DIFF
--- a/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
+++ b/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py
@@ -300,10 +300,14 @@ class GovernedRunner(Generic[T_task]):
                 success = False
                 logger.error(f"Execution blocked by policy: {e.violation.description}")
 
-            except Exception as e:
+            except Exception:
                 result = None
                 success = False
-                logger.error(f"Execution failed: {e}")
+                # logger.exception captures the active traceback so unexpected
+                # kernel failures are diagnosable. ``logger.error(f"...{e}")``
+                # silently dropped the stack frame information that operators
+                # need to localise the failure.
+                logger.exception("Execution failed")
         finally:
             _active_violations_ctx.reset(v_token)
             _active_signals_ctx.reset(s_token)

--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -149,6 +149,44 @@ class TestGovernedRunnerStep:
         with pytest.raises(PolicyViolationError):
             runner._handle_violation("P", "desc", "critical", True)
 
+    def test_step_unexpected_kernel_failure_logs_traceback(self, caplog):
+        """Unexpected exceptions inside the kernel must surface a traceback.
+
+        Regression for an earlier formulation that used
+        ``logger.error(f"...{e}")`` in the bare-except branch: the stack
+        frame information was silently dropped, which made non-policy
+        kernel failures impossible to diagnose from the logs.
+        Switching to ``logger.exception`` preserves ``exc_info`` so the
+        traceback travels with the log record.
+        """
+        kernel = _make_mock_kernel()
+        runner = GovernedRunner(kernel)
+
+        async def _exploding_agent(_: Any) -> Any:
+            raise RuntimeError("kernel boom")
+
+        runner.agent = _exploding_agent  # type: ignore[assignment]
+
+        # Force the "no execute method" branch so ``self.agent`` is invoked
+        # directly. ``hasattr(...) == False`` for both ``execute_async`` and
+        # ``execute`` ensures we hit the fallback in ``step``.
+        kernel = MagicMock(spec=[])
+        runner.kernel = kernel
+
+        with caplog.at_level("ERROR", logger="agent_lightning_gov.runner"):
+            rollout = asyncio.run(runner.step("trigger"))
+
+        assert rollout.success is False
+        # ``logger.exception`` records the active exception in ``exc_info``,
+        # which is the contract that ``logger.error(f"...{e}")`` violated.
+        runner_records = [
+            r for r in caplog.records if r.name == "agent_lightning_gov.runner"
+        ]
+        assert any(
+            "Execution failed" in r.getMessage() and r.exc_info is not None
+            for r in runner_records
+        )
+
 
 class TestGovernedRunnerViolationTracking:
     def test_violation_count_increments(self):


### PR DESCRIPTION
## Summary

[`GovernedRunner.step`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-lightning/src/agent_lightning_gov/runner.py) caught unexpected (non-policy) kernel exceptions in a bare `except Exception as e:` branch and logged them with:

```python
except Exception as e:
    result = None
    success = False
    logger.error(f"Execution failed: {e}")
```

`logger.error(msg)` discards `exc_info` — the operator-visible log record shows only the exception's `str(e)`, dropping the stack frame information needed to localise where the kernel actually failed.

## Change

Switch to `logger.exception("Execution failed")` so the active traceback travels with the record (`exc_info` is automatically set).

The policy-violation branch immediately above is unaffected: it deliberately logs only the violation description because that branch catches an *expected* control-flow exception (`PolicyViolationError`), not an unexpected failure — those are two different log shapes for two different events.

## Tests

New regression test `TestGovernedRunnerStep::test_step_unexpected_kernel_failure_logs_traceback` exercises the fallback `self.agent(input)` path with an agent that raises `RuntimeError("kernel boom")` and asserts the resulting log record carries `exc_info is not None`.

Confirmed the test fails against unfixed source (`exc_info is None` from `logger.error`) and passes with the fix.

```text
$ PYTHONPATH=src python -m pytest tests/ -q
99 passed, 1 skipped in 0.34s
```

## Test plan

- [x] Existing lightning test suite green (98 → 99 with new regression).
- [x] Regression test fails against unfixed source and passes with fix.
- [x] Policy-violation branch behaviour unchanged.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Extensions].