### PR TITLE
fix(py-gov-compliance): pin grade-threshold scan order with list of tuples

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py
@@ -30,12 +30,31 @@ from typing import Optional
 # Grade scale
 # ---------------------------------------------------------------------------
 
-GRADE_THRESHOLDS: dict[str, int] = {"A": 90, "B": 70, "C": 50, "D": 30, "F": 0}
+# Ordered descending by threshold. A list of tuples encodes the scan
+# order explicitly so the mapping survives ``dict(...)`` round-trips,
+# external mutation, and accidental re-ordering — all of which the
+# previous insertion-ordered dict relied on Python 3.7+ semantics to
+# guarantee silently. ``GRADE_THRESHOLDS`` (the historical dict) is
+# kept as a public re-export for backwards compatibility, but the
+# scoring function reads from the canonical tuple list below.
+GRADE_THRESHOLD_LIST: tuple[tuple[str, int], ...] = (
+    ("A", 90),
+    ("B", 70),
+    ("C", 50),
+    ("D", 30),
+    ("F", 0),
+)
+
+GRADE_THRESHOLDS: dict[str, int] = dict(GRADE_THRESHOLD_LIST)
 
 
 def _score_to_grade(score: int) -> str:
-    """Map a 0-100 score to a letter grade."""
-    for grade, threshold in GRADE_THRESHOLDS.items():
+    """Map a 0-100 score to a letter grade.
+
+    Scans ``GRADE_THRESHOLD_LIST`` top-down (highest threshold first)
+    and returns the first letter whose threshold the score meets.
+    """
+    for grade, threshold in GRADE_THRESHOLD_LIST:
         if score >= threshold:
             return grade
     return "F"

--- a/agent-governance-python/agent-compliance/tests/test_prompt_defense.py
+++ b/agent-governance-python/agent-compliance/tests/test_prompt_defense.py
@@ -9,6 +9,8 @@ import hashlib
 
 
 from agent_compliance.prompt_defense import (
+    GRADE_THRESHOLD_LIST,
+    GRADE_THRESHOLDS,
     PromptDefenseConfig,
     PromptDefenseEvaluator,
     PromptDefenseFinding,
@@ -77,6 +79,24 @@ class TestScoreToGrade:
     def test_grade_f(self) -> None:
         assert _score_to_grade(29) == "F"
         assert _score_to_grade(0) == "F"
+
+    def test_threshold_list_is_descending(self) -> None:
+        # The list-of-tuples encoding pins scan order independently of
+        # Python's insertion-ordered-dict semantics. Each successive
+        # threshold must be strictly lower than the previous one for
+        # the top-down "first match wins" loop to be correct.
+        thresholds = [t for _, t in GRADE_THRESHOLD_LIST]
+        assert thresholds == sorted(thresholds, reverse=True)
+
+    def test_threshold_list_matches_legacy_dict(self) -> None:
+        # The public re-export stays in sync with the canonical tuple
+        # list so downstream callers reading ``GRADE_THRESHOLDS`` see
+        # the same numbers.
+        assert dict(GRADE_THRESHOLD_LIST) == GRADE_THRESHOLDS
+
+    def test_threshold_list_covers_all_grades(self) -> None:
+        grades = [g for g, _ in GRADE_THRESHOLD_LIST]
+        assert grades == ["A", "B", "C", "D", "F"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

[`prompt_defense.py`](agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py)'s `GRADE_THRESHOLDS` was a dict literal:

```python
GRADE_THRESHOLDS: dict[str, int] = {"A": 90, "B": 70, "C": 50, "D": 30, "F": 0}
```

and `_score_to_grade` iterated via `.items()`, relying on Python 3.7+ insertion-ordered dict semantics to scan from highest threshold to lowest. A future caller that rebuilt the mapping via a `dict(...)` round-trip, `sorted(...)`, a set operation, or a config-driven merge could silently shuffle the order — at which point a score of 95 might be returned as `"B"` because `"B": 70` was visited before `"A": 90`.

The brittleness was load-bearing: the scoring contract holds only as long as nothing ever reorders the dict.

## Change

Adds `GRADE_THRESHOLD_LIST: tuple[tuple[str, int], ...]` as the canonical sequence with the descending order baked into the data type itself:

```python
GRADE_THRESHOLD_LIST = (
    ("A", 90),
    ("B", 70),
    ("C", 50),
    ("D", 30),
    ("F", 0),
)

GRADE_THRESHOLDS: dict[str, int] = dict(GRADE_THRESHOLD_LIST)
```

`_score_to_grade` now reads from the tuple list. `GRADE_THRESHOLDS` is preserved as a public re-export so any downstream caller that imports the dict continues to see identical data.

## Tests

Three new cases in `TestScoreToGrade` pin the contract:

| Test | Pins |
|---|---|
| `test_threshold_list_is_descending` | Scan order is strictly decreasing |
| `test_threshold_list_matches_legacy_dict` | `dict(GRADE_THRESHOLD_LIST) == GRADE_THRESHOLDS` |
| `test_threshold_list_covers_all_grades` | All five grades present, in order |

The existing boundary cases (`test_grade_a` through `test_grade_f`) continue to assert the score-to-grade mapping is byte-equivalent to the prior behaviour.

```
$ PYTHONPATH=src python -m pytest tests/test_prompt_defense.py -q
75 passed in 1.03s
```

## Test plan

- [ ] CI passes
- [ ] All 75 `test_prompt_defense.py` cases pass
- [ ] Score boundaries (100, 90, 89, 70, 69, 50, 49, 30, 29, 0) map to the same letter grades as before
- [ ] `GRADE_THRESHOLDS` dict still importable for any external consumers

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Governance].