### PR TITLE
fix(py-isolation-sso): correct misleading 'deep copy' comment in create_snapshot

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/session/sso.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/session/sso.py
@@ -109,7 +109,21 @@ class SessionVFS:
         return self._permissions.get(self._resolve(path))
 
     def create_snapshot(self, snapshot_id: str | None = None) -> str:
-        """Snapshot current state (simple deep copy)."""
+        """Snapshot current state.
+
+        This is **not** a ``copy.deepcopy`` — it's a one-level copy that
+        relies on the value types being either immutable (``str`` file
+        contents) or explicitly rebuilt below (``set`` permission
+        entries). The two containers are independent of the live
+        ``_files`` / ``_permissions`` dicts, so subsequent writes don't
+        mutate the snapshot.
+
+        If either value shape ever changes to a mutable nested type
+        (e.g. ``dict[str, list[...]]`` for files, or sets-of-mutable
+        values for permissions), the snapshot would stop being
+        effectively-independent and this would need an actual
+        ``copy.deepcopy``.
+        """
         sid = snapshot_id or f"snap:{uuid.uuid4()}"
         self._snapshots[sid] = {
             "files": dict(self._files),


### PR DESCRIPTION
## Summary

[`session/sso.py`](agent-governance-python/agent-hypervisor/src/hypervisor/session/sso.py)'s `SessionVFS.create_snapshot` was documented as "simple deep copy", but the body is a one-level copy:

```python
self._snapshots[sid] = {
    "files": dict(self._files),
    "permissions": {k: set(v) for k, v in self._permissions.items()},
}
```

Neither line is a `copy.deepcopy`. The implementation is *sufficient* today because the value types are either immutable (`str` file contents) or explicitly rebuilt (the inner `set` per path), but the docstring sets the wrong mental model and would mislead anyone extending the value shape.

## Change

Replace the docstring with one that names what the operation actually does, and flags the future-fragility: if either value shape grows a mutable nested type (e.g. `dict[str, list[...]]` for files, or sets-of-mutable values for permissions), the snapshot would stop being effectively-independent and a real `copy.deepcopy` would be required.

## Tests

Pure comment change — no behaviour delta, no new tests. Existing `SessionVFS` snapshot/restore tests continue to pass.

```
$ PYTHONPATH=src python -m pytest tests/unit/test_session.py -q
... passed
```

## Test plan

- [ ] CI passes
- [ ] No behaviour change in `SessionVFS.create_snapshot` / `restore_snapshot`

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Isolation].