### PR TITLE
fix(ci): scope per-job permissions in marketplace-governance example

### DIFF
--- a/examples/marketplace-governance/.github/workflows/plugin-governance.yml
+++ b/examples/marketplace-governance/.github/workflows/plugin-governance.yml
@@ -16,9 +16,13 @@ on:
       - 'plugins/**'
       - 'policies/**'
 
+# Workflow-level permissions are read-only. Each job below sets the
+# narrowest write scope it actually needs (principle of least privilege —
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).
+# Downstream consumers copy this file as a starting point, so per-job
+# scoping is important even though the example itself doesn't run here.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   # ------------------------------------------------------------------
@@ -27,6 +31,8 @@ jobs:
   validate-manifest:
     name: Validate Plugin Manifests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -61,6 +67,8 @@ jobs:
     name: Evaluate Marketplace Policy
     runs-on: ubuntu-latest
     needs: validate-manifest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -104,6 +112,8 @@ jobs:
     name: Governance Verification
     runs-on: ubuntu-latest
     needs: evaluate-policy
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

[`examples/marketplace-governance/.github/workflows/plugin-governance.yml`](https://github.com/microsoft/agent-governance-toolkit/blob/main/examples/marketplace-governance/.github/workflows/plugin-governance.yml) is a downstream-facing example — consumers copy it into their own repos as a starting point — so its permission hygiene shapes the default behavior in many production CI pipelines that adopt the toolkit.

Two issues:

1. **Workflow-level `pull-requests: write` is unused.** None of the three jobs (`validate-manifest`, `evaluate-policy`, `governance-verify`) comments on or modifies a PR. They run policy validation, evaluate plugins, upload an artifact, and write to `GITHUB_STEP_SUMMARY` (which needs no extra scope).
2. **No per-job `permissions:` blocks.** Every job inherits the workflow-level grants, which means a future copy-paste consumer that adds a write-scoped job inherits the over-broad grant by default.

Both apply to lines 33, 65, and 108 (the three job headers).

This is in the same spirit as [#2138](https://github.com/microsoft/agent-governance-toolkit/pull/2138) (workflow shell-injection hardening) and [#2141](https://github.com/microsoft/agent-governance-toolkit/pull/2141) (Gitleaks fork-PR skip) — example workflows are templates as much as they are code.

## Change

- Drop workflow-level `pull-requests: write` (no job uses it).
- Keep workflow-level `contents: read`.
- Add explicit `permissions: { contents: read }` to each of the three jobs.
- Add a comment block at the top explaining the per-job scoping rationale for downstream readers — the whole point of an example workflow is to be learned from.

## Verification

- Diff is local to the example workflow file; nothing else in the repo touches this file.
- `actionlint` parses cleanly (the workflow does not actually run on this repo's CI, since it triggers on `plugins/**` which doesn't exist here).
- No job in this workflow needs any write scope to function — verified by reading every step.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Infrastructure/CI].