### PR TITLE
fix(py-isolation-saga): document wait_for cancel semantics on timeout

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
@@ -90,6 +90,18 @@ class SagaOrchestrator:
         """
         Execute a single saga step with timeout and retry support.
 
+        Cancellation semantics on timeout:
+            ``asyncio.wait_for`` cancels the wrapped coroutine on timeout
+            *and* awaits the cancellation before raising ``TimeoutError``,
+            so a cooperative executor (one with ``await`` points)
+            receives ``CancelledError`` and has a chance to release
+            resources before this method moves on to FAILED. An executor
+            with no ``await`` points (synchronous CPU work inside an
+            ``async def``) is not cancellable by Python — the timeout
+            will only fire once the executor yields control.
+            Callers needing hard-kill semantics must run such executors
+            in a process or thread pool and arrange external termination.
+
         Args:
             saga_id: Saga identifier
             step_id: Step identifier
@@ -157,6 +169,9 @@ class SagaOrchestrator:
     ) -> list[SagaStep]:
         """
         Run compensation (rollback) for all committed steps in reverse order.
+
+        Cancellation semantics on timeout match ``execute_step``: see that
+        method's docstring for the cooperative-cancel contract.
 
         Args:
             saga_id: Saga identifier


### PR DESCRIPTION
## Summary

[`saga/orchestrator.py`](agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py)'s `SagaOrchestrator.execute_step` and `.compensate` both wrap their callable in `asyncio.wait_for(callable, timeout=step.timeout_seconds)`. The standing audit question was whether `wait_for` *awaits* the cancellation it issues, or just signals it and moves on.

CPython's `asyncio.wait_for` does wait for the cancellation to complete before raising `TimeoutError` (see [Python docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait_for)). Cooperative executors with `await` points get a chance to release resources. But:

- Executors with **no `await` points** (synchronous CPU work inside an `async def`) are not cancellable by Python at all — the timeout only fires once the executor next yields control.
- Callers needing **hard-kill semantics** must run such executors in a process or thread pool and arrange external termination.

The behaviour is correct as-is; what's missing is the contract being documented for callers writing executors.

## Change

Add a `Cancellation semantics on timeout:` block to `execute_step`'s docstring naming the cooperative-cancel contract and the two failure modes. Cross-reference from `compensate`'s docstring.

Pure documentation change — no behaviour delta.

## Tests

```
$ PYTHONPATH=src python -m pytest tests/unit/test_saga.py tests/unit/test_saga_improvements.py -q
32 passed, 12 skipped in 0.35s
```

No new tests needed (documentation change).

## Test plan

- [ ] CI passes
- [ ] No behaviour change in saga step / compensation paths

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Isolation].