### PR TITLE
chore(ci): document docs workflow paths-filter intent

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,17 @@
 name: Deploy docs to GitHub Pages
 
+# This workflow rebuilds the MkDocs site and deploys to GitHub Pages.
+# The `paths:` filter keeps the build cheap by only firing on changes to
+# inputs that affect the rendered output:
+#   - site/**                — extra static assets copied into the build
+#   - mkdocs.yml             — site config (nav, theme, plugins)
+#   - docs/**                — the actual markdown sources
+#   - .github/workflows/docs.yml — this workflow file itself, so changes
+#                                  to the build/deploy logic still trigger
+#                                  a rebuild even when no doc content moved
+# A change anywhere else (e.g. Python source, Dockerfile) will not rebuild
+# the docs site, which is the intended trade-off — docs are derived from
+# this narrow input set, not from the full repository.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

[`.github/workflows/docs.yml`](https://github.com/microsoft/agent-governance-toolkit/blob/main/.github/workflows/docs.yml) triggers on changes to four narrow paths: `site/**`, `mkdocs.yml`, `docs/**`, and the workflow file itself. Why each entry is on the list isn't obvious to a reader trying to extend the doc site — e.g. is `docs/**` for content, derived API docs, or both? Does `mkdocs.yml` belong here or in `site/**`?

The audit asked specifically for `mkdocs.yml`'s presence in the trigger to be documented; while there, every entry deserves a one-liner.

## Change

Add a block comment naming each input and explaining the intentional narrow filter:

- `site/**` — extra static assets copied into the build
- `mkdocs.yml` — site config (nav, theme, plugins)
- `docs/**` — the actual markdown sources
- `.github/workflows/docs.yml` — itself, so changes to the build/deploy logic still trigger a rebuild even when no content moved

Plus a closing line that names the trade-off explicitly: docs are derived from this input set, not from the full repository.

Pure documentation change; no behavior change.

## Verification

- Diff is 12 inserted comment lines, no YAML keys touched.
- `actionlint` parses cleanly.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Infrastructure/CI].