### PR TITLE
fix(typescript/agent-os-vscode): release sreServer exit listeners on whichever event fires first

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/services/sreServer.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/services/sreServer.ts
@@ -110,6 +110,39 @@ function runPipInstall(pythonPath: string): Promise<boolean> {
     });
 }
 
+/** Minimal contract on the spawned ChildProcess that we exercise from {@link wireExitListeners}. */
+export interface ProcessExitTarget {
+    once(event: 'error' | 'exit', listener: (...args: unknown[]) => void): unknown;
+    removeListener(event: 'error' | 'exit', listener: (...args: unknown[]) => void): unknown;
+}
+
+/**
+ * Wire mutually-removing one-shot `'error'` and `'exit'` handlers on a child
+ * process and invoke `onTerminated` exactly once when either fires.
+ *
+ * Node's child_process may emit `'error'` then `'exit'`, or `'exit'` alone.
+ * Registering both with plain `.on()` leaks the orphan handler on the dead
+ * ChildProcess, which pins the closure (and anything it captures) until the
+ * ChildProcess itself is garbage-collected. Using `.once()` removes the
+ * fired handler but leaves the sibling waiting forever. Mutually removing
+ * one another guarantees the listener set is empty after the first event,
+ * regardless of which one fires.
+ */
+export function wireExitListeners(proc: ProcessExitTarget, onTerminated: () => void): void {
+    let terminated = false;
+    const fire = (): void => {
+        if (terminated) { return; }
+        terminated = true;
+        proc.removeListener('error', onError);
+        proc.removeListener('exit', onExit);
+        onTerminated();
+    };
+    const onError = (): void => { fire(); };
+    const onExit = (): void => { fire(); };
+    proc.once('error', onError);
+    proc.once('exit', onExit);
+}
+
 /**
  * Manages the lifecycle of a local agent-failsafe REST server.
  *
@@ -149,8 +182,7 @@ export class SREServerManager {
             detached: false,
         });
 
-        this._proc.on('error', () => { this._proc = undefined; });
-        this._proc.on('exit', () => { this._proc = undefined; });
+        wireExitListeners(this._proc, () => { this._proc = undefined; });
 
         // Wait for health check
         for (let i = 0; i < HEALTH_RETRIES; i++) {

--- a/agent-governance-typescript/agent-os-vscode/src/test/services/sreServer.test.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/test/services/sreServer.test.ts
@@ -8,7 +8,8 @@
  */
 
 import * as assert from 'assert';
-import { isAgentFailsafeAvailable, isValidPythonPath, SREServerManager } from '../../services/sreServer';
+import { EventEmitter } from 'events';
+import { isAgentFailsafeAvailable, isValidPythonPath, SREServerManager, wireExitListeners } from '../../services/sreServer';
 
 suite('isValidPythonPath', () => {
     test('rejects empty string', () => { assert.strictEqual(isValidPythonPath(''), false); });
@@ -72,5 +73,47 @@ suite('SREServerManager', () => {
         // Don't actually start — just verify the default port
         assert.strictEqual(mgr.getEndpoint(), '');
         mgr.stop();
+    });
+});
+
+suite('wireExitListeners', () => {
+    test('error before exit fires callback once and removes both listeners', () => {
+        const emitter = new EventEmitter();
+        let calls = 0;
+        wireExitListeners(emitter as unknown as Parameters<typeof wireExitListeners>[0], () => { calls += 1; });
+        assert.strictEqual(emitter.listenerCount('error'), 1);
+        assert.strictEqual(emitter.listenerCount('exit'), 1);
+
+        emitter.emit('error', new Error('spawn ENOENT'));
+        assert.strictEqual(calls, 1);
+        assert.strictEqual(emitter.listenerCount('error'), 0);
+        assert.strictEqual(emitter.listenerCount('exit'), 0);
+
+        // Subsequent 'exit' must not double-fire the callback.
+        emitter.emit('exit', 1);
+        assert.strictEqual(calls, 1);
+    });
+
+    test('exit alone fires callback once and removes both listeners', () => {
+        const emitter = new EventEmitter();
+        let calls = 0;
+        wireExitListeners(emitter as unknown as Parameters<typeof wireExitListeners>[0], () => { calls += 1; });
+
+        emitter.emit('exit', 0);
+        assert.strictEqual(calls, 1);
+        assert.strictEqual(emitter.listenerCount('error'), 0);
+        assert.strictEqual(emitter.listenerCount('exit'), 0);
+    });
+
+    test('error then exit (Node\'s common ordering on spawn failure) fires callback once', () => {
+        const emitter = new EventEmitter();
+        let calls = 0;
+        wireExitListeners(emitter as unknown as Parameters<typeof wireExitListeners>[0], () => { calls += 1; });
+
+        emitter.emit('error', new Error('spawn ENOENT'));
+        emitter.emit('exit', null, 'SIGTERM');
+        assert.strictEqual(calls, 1, 'callback must not double-fire when both events arrive');
+        assert.strictEqual(emitter.listenerCount('error'), 0);
+        assert.strictEqual(emitter.listenerCount('exit'), 0);
     });
 });


### PR DESCRIPTION
## Problem

[`SREServerManager.start`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/services/sreServer.ts#L152-L153) registered plain (long-lived) listeners on the spawned `python -m agent_failsafe.rest_server` subprocess:

```typescript
this._proc.on('error', () => { this._proc = undefined; });
this._proc.on('exit',  () => { this._proc = undefined; });
```

Node's [`child_process`](https://nodejs.org/api/child_process.html#event-error) can drive this pair two ways:

- **`'error'` then `'exit'`** — the spawn itself failed (ENOENT, EACCES, etc.) and Node emits the error and then synthesises an exit. Both handlers fire and `_proc = undefined` is set twice; that's harmless on its own, but the handlers stay registered on the dead `ChildProcess`.
- **`'exit'` alone** — the subprocess started and then died cleanly or via signal. The `'error'` listener never fires and is leaked on the dead `ChildProcess`.

The orphan handler pins its closure (and the arrow's captured `this`) until the `ChildProcess` itself is garbage-collected. Switching naively to `.once()` would auto-remove the fired handler but leaves the sibling waiting forever for an event that may never come.

## Fix

Extract a `wireExitListeners(proc, onTerminated)` helper that:

- Registers both with `.once()` (the fired handler removes itself).
- AND, on first fire, the handler proactively removes the sibling via `removeListener`, so the listener set drops to zero after the first event regardless of which one arrived.
- Debounces `onTerminated` so that the legitimate ENOENT case (`error` followed by `exit`) still only clears `_proc` once.

The helper accepts a narrow `ProcessExitTarget` contract (just `.once` and `.removeListener`) so the cleanup behaviour is observable against a plain `EventEmitter` from the unit test bed — no real subprocess needed.

## Test

New unit tests in [`src/test/services/sreServer.test.ts`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/test/services/sreServer.test.ts) cover three firing orders:

1. `'error'` only — callback fires once, both listener counts drop to zero.
2. `'exit'` only — callback fires once, both listener counts drop to zero.
3. `'error'` then `'exit'` (Node's common ordering on spawn failure) — callback fires exactly once, both listener counts drop to zero.

Existing tests (`start with invalid python returns not ok`, etc.) still cover the live-spawn integration path.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, TypeScript].