### PR TITLE
fix(go-audit): hash entries with length-prefix encoding, not | delimiter

### DIFF
--- a/agent-governance-golang/packages/agentmesh/audit.go
+++ b/agent-governance-golang/packages/agentmesh/audit.go
@@ -5,6 +5,7 @@ package agentmesh
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -133,14 +134,41 @@ func (al *AuditLogger) GetEntries(filter AuditFilter) []*AuditEntry {
 	return result
 }
 
+// auditHashVersion identifies the wire format of the hash input. Bumping
+// this invalidates any persisted hashes and is required when the field
+// layout below changes.
+const auditHashVersion byte = 1
+
+// computeHash returns the SHA-256 hash of a length-prefixed encoding of the
+// entry's fields. Each variable-length field is encoded as a 4-byte
+// big-endian length followed by the raw bytes, with a fixed-position
+// version byte at the start. The encoding is unambiguous regardless of the
+// field contents, which closes the forgery seam in the previous
+// "|"-separated format (where e.g. AgentID="a", Action="b|c" hashed
+// identically to AgentID="a|b", Action="c").
 func computeHash(e *AuditEntry) string {
-	data := e.Timestamp.Format(time.RFC3339Nano) + "|" +
-		e.AgentID + "|" +
-		e.Action + "|" +
-		string(e.Decision) + "|" +
-		e.PreviousHash
-	h := sha256.Sum256([]byte(data))
+	timestamp := e.Timestamp.Format(time.RFC3339Nano)
+
+	// 1 byte version + 5 fields, each prefixed by a 4-byte length.
+	size := 1 + 5*4 + len(timestamp) + len(e.AgentID) + len(e.Action) + len(e.Decision) + len(e.PreviousHash)
+	buf := make([]byte, 0, size)
+	buf = append(buf, auditHashVersion)
+	buf = appendLengthPrefixed(buf, timestamp)
+	buf = appendLengthPrefixed(buf, e.AgentID)
+	buf = appendLengthPrefixed(buf, e.Action)
+	buf = appendLengthPrefixed(buf, string(e.Decision))
+	buf = appendLengthPrefixed(buf, e.PreviousHash)
+
+	h := sha256.Sum256(buf)
 	return hex.EncodeToString(h[:])
+}
+
+func appendLengthPrefixed(buf []byte, s string) []byte {
+	var lenBytes [4]byte
+	binary.BigEndian.PutUint32(lenBytes[:], uint32(len(s)))
+	buf = append(buf, lenBytes[:]...)
+	buf = append(buf, s...)
+	return buf
 }
 
 // ExportJSON serialises all audit entries to a JSON string.

--- a/agent-governance-golang/packages/agentmesh/audit_test.go
+++ b/agent-governance-golang/packages/agentmesh/audit_test.go
@@ -487,3 +487,63 @@ func TestGetEntriesReturnsClones(t *testing.T) {
 		t.Error("chain verify should still pass after caller mutates a GetEntries result")
 	}
 }
+
+// Regression: under the previous "|"-separated hash format, two field-sets
+// that differed only in where the "|" sat hashed identically — e.g.
+// AgentID="a", Action="b|c" vs AgentID="a|b", Action="c". The length-prefix
+// encoding closes that seam: the lengths are committed to the digest, so
+// the two layouts produce distinct hashes.
+func TestComputeHashSeparatorForgery(t *testing.T) {
+	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	a := &AuditEntry{
+		Timestamp:    ts,
+		AgentID:      "a",
+		Action:       "b|c",
+		Decision:     Allow,
+		PreviousHash: "",
+	}
+	b := &AuditEntry{
+		Timestamp:    ts,
+		AgentID:      "a|b",
+		Action:       "c",
+		Decision:     Allow,
+		PreviousHash: "",
+	}
+
+	hashA := computeHash(a)
+	hashB := computeHash(b)
+	if hashA == hashB {
+		t.Fatalf("hash collision across separator boundary: AgentID=%q,Action=%q == AgentID=%q,Action=%q (%s)",
+			a.AgentID, a.Action, b.AgentID, b.Action, hashA)
+	}
+}
+
+// Length-prefixed encoding also rejects collisions across other field
+// boundaries — action vs decision, decision vs previous_hash.
+func TestComputeHashDistinguishesFieldBoundaries(t *testing.T) {
+	ts := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		a, b *AuditEntry
+	}{
+		{
+			name: "action_vs_decision",
+			a: &AuditEntry{Timestamp: ts, AgentID: "x", Action: "do", Decision: PolicyDecision("|allow"), PreviousHash: ""},
+			b: &AuditEntry{Timestamp: ts, AgentID: "x", Action: "do|", Decision: PolicyDecision("allow"), PreviousHash: ""},
+		},
+		{
+			name: "decision_vs_previous_hash",
+			a: &AuditEntry{Timestamp: ts, AgentID: "x", Action: "do", Decision: PolicyDecision("allow|deadbeef"), PreviousHash: ""},
+			b: &AuditEntry{Timestamp: ts, AgentID: "x", Action: "do", Decision: PolicyDecision("allow"), PreviousHash: "deadbeef"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if h1, h2 := computeHash(tc.a), computeHash(tc.b); h1 == h2 {
+				t.Errorf("hash collision across %s: %s == %s", tc.name, h1, h2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

[`computeHash`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-golang/packages/agentmesh/audit.go#L121-L129) in `audit.go` joined `AuditEntry` fields with a literal `|` separator before hashing. The separator was forgeable across field boundaries when any user-controlled field contained a `|`.

For example, with the previous format:

| AgentID | Action | Pre-hash bytes |
|---|---|---|
| `a` | `b\|c` | `...\|a\|b\|c\|...` |
| `a\|b` | `c` | `...\|a\|b\|c\|...` |

Both fields are caller-supplied via `AuditLogger.Log`, so an attacker who controls one of them can fabricate an entry that hashes identically to a legitimate one with the field boundary shifted — undermining the tamper-detection guarantee the hash chain is meant to provide.

## Change

Replace the `|`-concatenated pre-hash with **length-prefixed encoding**:

```
[1 byte version] [4-byte BE length | UTF-8 bytes] x 5 fields
```

Each field's length is committed to the digest, so no value can impersonate a different field-boundary layout. A 1-byte version prefix is reserved at the head so the encoding can be evolved later without ambiguity. Length-prefix is more principled here than JSON-encoding the hash input: no schema dependency, deterministic byte layout, and no allocator surprises.

## Compatibility

The audit log is in-memory only and there is no `ImportJSON` / load-and-verify path in this package — `Verify()` always recomputes hashes from in-store fields using the current format. So changing the hash input does not break any persisted-and-re-verified state.

## Tests

`go test ./...` from `agent-governance-golang/packages/agentmesh/` passes. New regression tests:

- `TestComputeHashSeparatorForgery` — the canonical `AgentID=\"a\", Action=\"b|c\"` vs `AgentID=\"a|b\", Action=\"c\"` pair, which collided under the old format, now hashes differently.
- `TestComputeHashDistinguishesFieldBoundaries` — exercises the action/decision and decision/previous_hash boundaries as well.

All existing audit tests continue to pass (`TestAuditLogAndVerify`, `TestAuditHashDeterministic`, the retention/seam tests, etc.).

## Test plan

- [x] `go test ./...` passes from `agent-governance-golang/packages/agentmesh/`.
- [x] Two field-sets that previously hashed identically across the `|` boundary now produce different hashes.
- [x] Hash chain Verify() continues to pass for normal sequences.
- [x] Tamper-detection tests continue to reject mutated entries.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Go].