### PR TITLE
fix(ci): drop continue-on-error from CodeQL analyze job

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,6 @@ jobs:
       security-events: write
       actions: read
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

[`.github/workflows/codeql.yml:29`](https://github.com/microsoft/agent-governance-toolkit/blob/main/.github/workflows/codeql.yml#L29) sets `continue-on-error: true` on the `analyze` job. That means CodeQL failures (autobuild crashes, analyze step errors, SARIF upload failures, init action problems) are recorded as passing checks. The intent on a code-scanning workflow is the opposite: the analysis must succeed or the check should fail, so the team can fix the analyzer and not silently drift away from SAST coverage.

`strategy.fail-fast: false` already keeps the matrix legs independent — a Python failure doesn't block JavaScript/TypeScript analysis and vice versa. Dropping `continue-on-error` only changes the outcome reported for a leg that genuinely failed; the other leg still runs to completion.

(Note: `scorecard.yml` does not have `continue-on-error: true` on its `analyze` job, so this PR is scoped to `codeql.yml`. If the reviewer noticed the same shape elsewhere, it's not present today.)

## Change

Single-line deletion of `continue-on-error: true` from the `analyze` job header.

## Effect — these previously-silent failures will now mark the check as failed

- CodeQL `init` action failure (e.g. ref/SHA pin breakage)
- CodeQL `autobuild` action failure (e.g. missing build deps)
- CodeQL `analyze` step failure (e.g. queries running out of memory)
- SARIF upload failure to GitHub Security

None of these should be considered passing states; the previous configuration hid real coverage gaps.

## Verification

- Diff is a single deletion; nothing else touched.
- `actionlint` parses cleanly.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Infrastructure/CI].