### PR TITLE
fix(py-mesh-datetime): replace deprecated utcnow with tz-aware UTC

### DIFF
--- a/agent-governance-python/agent-mesh/README.md
+++ b/agent-governance-python/agent-mesh/README.md
@@ -576,11 +576,11 @@ violations = compliance.check_compliance(
 )
 
 # Generate compliance report
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 report = compliance.generate_report(
     framework=ComplianceFramework.SOC2,
-    period_start=datetime.utcnow() - timedelta(days=30),
-    period_end=datetime.utcnow(),
+    period_start=datetime.now(timezone.utc) - timedelta(days=30),
+    period_end=datetime.now(timezone.utc),
 )
 ```
 

--- a/agent-governance-python/agent-mesh/docs/identity.md
+++ b/agent-governance-python/agent-mesh/docs/identity.md
@@ -77,7 +77,7 @@ identity_document = {
     "public_key": base64.b64encode(public_bytes).decode(),
     "sponsor": "alice@company.com",
     "capabilities": ["read:customer-data"],
-    "created_at": datetime.utcnow().isoformat(),
+    "created_at": datetime.now(timezone.utc).isoformat(),
 }
 
 # 4. Sign the identity document

--- a/agent-governance-python/agent-mesh/docs/zero-trust.md
+++ b/agent-governance-python/agent-mesh/docs/zero-trust.md
@@ -22,7 +22,7 @@ message = Message(
     to_agent="did:agentmesh:bob",
     payload={"request": "read_data"},
     signature=sign(payload, alice_private_key),
-    timestamp=datetime.utcnow(),
+    timestamp=datetime.now(timezone.utc),
 )
 
 # Recipient verifies before processing

--- a/agent-governance-python/agent-mesh/examples/00-registration-hello-world/README.md
+++ b/agent-governance-python/agent-mesh/examples/00-registration-hello-world/README.md
@@ -262,7 +262,7 @@ Certificates are short-lived (15 minutes). Rotate before expiry:
 
 ```python
 # Check expiry
-time_remaining = (expires_at - datetime.utcnow()).total_seconds()
+time_remaining = (expires_at - datetime.now(timezone.utc)).total_seconds()
 if time_remaining < 300:  # Less than 5 minutes
     rotate_credentials()
 ```

--- a/agent-governance-python/agent-mesh/examples/00-registration-hello-world/simulated_registration.py
+++ b/agent-governance-python/agent-mesh/examples/00-registration-hello-world/simulated_registration.py
@@ -13,7 +13,7 @@ Run: python simulated_registration.py
 
 import asyncio
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives import serialization
 from rich.console import Console
@@ -132,7 +132,7 @@ async def simulate_registration():
         "sponsor_signature": sponsor_signature_b64,
         "capabilities": capabilities,
         "supported_protocols": ["a2a", "mcp", "iatp"],
-        "requested_at": datetime.utcnow().isoformat() + "Z",
+        "requested_at": datetime.now(timezone.utc).isoformat() + "Z",
     }
     
     print_success("Built RegistrationRequest")
@@ -162,7 +162,7 @@ async def simulate_registration():
     print_success(f"Generated DID: {did}")
     
     # Issue SVID certificate (simulated)
-    svid_expires_at = datetime.utcnow() + timedelta(minutes=15)
+    svid_expires_at = datetime.now(timezone.utc) + timedelta(minutes=15)
     print_success(f"Issued SVID certificate (expires in 15 minutes)")
     
     # Calculate initial trust score
@@ -202,7 +202,7 @@ async def simulate_registration():
         "token_ttl_seconds": 900,  # 15 minutes
         "registry_endpoint": "https://registry.agentmesh.io",
         "status": "success",
-        "registered_at": datetime.utcnow().isoformat() + "Z",
+        "registered_at": datetime.now(timezone.utc).isoformat() + "Z",
         "next_rotation_at": svid_expires_at.isoformat() + "Z",
     }
     

--- a/agent-governance-python/agent-mesh/examples/01-mcp-tool-server/main.py
+++ b/agent-governance-python/agent-mesh/examples/01-mcp-tool-server/main.py
@@ -11,7 +11,7 @@ MCP is Anthropic's protocol for connecting AI models to tools and data sources.
 
 import asyncio
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 
@@ -250,7 +250,7 @@ class GovernedMCPServer:
     def _audit_log_event(self, action: str, params: Dict[str, Any], result: str):
         """Log event to audit trail."""
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
             "agent": self.identity.did,
             "action": action,
             "params": params,

--- a/agent-governance-python/agent-mesh/examples/02-customer-service/main.py
+++ b/agent-governance-python/agent-mesh/examples/02-customer-service/main.py
@@ -12,7 +12,7 @@ Demonstrates:
 
 import asyncio
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 from enum import Enum
 
@@ -75,7 +75,7 @@ class GovernedAgent:
     def log_action(self, action: str, details: dict):
         """Log action to audit trail."""
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
             "agent": self.identity.did,
             "action": action,
             "details": details,

--- a/agent-governance-python/agent-mesh/examples/03-healthcare-hipaa/main.py
+++ b/agent-governance-python/agent-mesh/examples/03-healthcare-hipaa/main.py
@@ -12,7 +12,7 @@ Demonstrates:
 
 import asyncio
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Any
 
 from agentmesh import (
@@ -154,7 +154,7 @@ class HealthcareAgent:
     def _audit_phi_access(self, patient_id: str, result: str, reason: str):
         """Log PHI access to audit chain."""
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
             "agent": self.identity.did,
             "action": "phi_access",
             "patient_id": f"[ENCRYPTED:{patient_id}]",  # Never log actual patient ID
@@ -170,7 +170,7 @@ class HealthcareAgent:
     def _audit_analysis(self, analysis_type: str, results: Dict[str, Any]):
         """Log data analysis to audit chain."""
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
             "agent": self.identity.did,
             "action": "data_analysis",
             "analysis_type": analysis_type,

--- a/agent-governance-python/agent-mesh/src/agentmesh/cli/proxy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/cli/proxy.py
@@ -17,7 +17,7 @@ import asyncio
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, List
 import subprocess
 
@@ -388,7 +388,7 @@ rules: []
     ):
         """Log tool call to audit trail."""
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat() + "Z",
             "agent": str(self.identity.did),
             "action": "mcp_tool_call",
             "tool": tool_name,

--- a/agent-governance-python/agent-mesh/src/agentmesh/cli/trust_cli.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/cli/trust_cli.py
@@ -13,7 +13,7 @@ Commands for inspecting and managing the trust network:
 """
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import click
@@ -54,7 +54,7 @@ def _format_datetime(dt: Optional[datetime]) -> str:
 
 def _get_demo_peers() -> dict[str, PeerInfo]:
     """Return demo peer data for display when no live data is available."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return {
         "did:mesh:agent-alpha-001": PeerInfo(
             peer_did="did:mesh:agent-alpha-001",
@@ -105,7 +105,7 @@ def _get_demo_peers() -> dict[str, PeerInfo]:
 
 def _get_demo_history(agent_id: str) -> list[dict]:
     """Return demo trust score history for an agent."""
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     base_scores = {
         "did:mesh:agent-alpha-001": [800, 820, 850, 870, 900, 920],
         "did:mesh:agent-beta-002": [600, 650, 700, 720, 740, 750],
@@ -486,7 +486,7 @@ def revoke(agent_id: str, reason: str, force: bool, fmt: str, json_flag: bool):
         "reason": reason,
         "previous_score": peer.trust_score,
         "new_score": 0,
-        "revoked_at": _format_datetime(datetime.utcnow()),
+        "revoked_at": _format_datetime(datetime.now(timezone.utc)),
     }
 
     if fmt in ("json", "yaml"):
@@ -542,7 +542,7 @@ def attest(agent_id: str, note: str, score_boost: int, fmt: str, json_flag: bool
         "score_boost": score_boost,
         "new_score": new_score,
         "new_level": _trust_level_label(new_score),
-        "attested_at": _format_datetime(datetime.utcnow()),
+        "attested_at": _format_datetime(datetime.now(timezone.utc)),
     }
 
     if fmt in ("json", "yaml"):

--- a/agent-governance-python/agent-mesh/src/agentmesh/core/identity/ca.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/core/identity/ca.py
@@ -83,7 +83,7 @@ class RegistrationRequest(BaseModel):
 
     # Metadata
     metadata: dict[str, str] = Field(default_factory=dict)
-    requested_at: datetime = Field(default_factory=datetime.utcnow)
+    requested_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class RegistrationResponse(BaseModel):
@@ -112,7 +112,7 @@ class RegistrationResponse(BaseModel):
 
     # Status
     status: str = "success"
-    registered_at: datetime = Field(default_factory=datetime.utcnow)
+    registered_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     next_rotation_at: datetime
 
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -495,7 +495,7 @@ class AuditLog:
         entries = self.query(start_time=start_time, end_time=end_time, limit=10000)
 
         return {
-            "exported_at": datetime.utcnow().isoformat(),
+            "exported_at": datetime.now(timezone.utc).isoformat(),
             "merkle_root": self._chain.get_root_hash(),
             "chain_root": self._chain.get_root_hash(),
             "entry_count": len(entries),

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
@@ -14,7 +14,7 @@ import hmac
 import json
 import os
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, Protocol, runtime_checkable
 
@@ -292,7 +292,7 @@ class FileAuditSink:
             return
         if self._path.stat().st_size >= self._max_file_size:
             rotated = self._path.with_suffix(
-                f".{datetime.utcnow().strftime('%Y%m%d%H%M%S')}.jsonl"
+                f".{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}.jsonl"
             )
             os.replace(self._path, rotated)
             # Reset chain for the new file

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/compliance.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/compliance.py
@@ -12,7 +12,7 @@ Automated compliance mapping for:
 Every action is mapped to relevant controls automatically.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Literal
 from pydantic import BaseModel, Field
 from enum import Enum
@@ -95,7 +95,7 @@ class ComplianceViolation(BaseModel):
     """
 
     violation_id: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # What happened
     agent_did: str
@@ -140,7 +140,7 @@ class ComplianceReport(BaseModel):
     """
 
     report_id: str
-    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # Scope
     framework: ComplianceFramework
@@ -526,7 +526,7 @@ class ComplianceEngine:
         for v in self._violations:
             if v.violation_id == violation_id:
                 v.remediated = True
-                v.remediated_at = datetime.utcnow()
+                v.remediated_at = datetime.now(timezone.utc)
                 v.remediation_notes = notes
                 return True
         return False

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
@@ -11,7 +11,7 @@ Supports schema versioning via ``apiVersion`` (e.g.,
 warnings; unknown versions raise ``ValueError``.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Literal, Any
 from pydantic import BaseModel, Field
 import logging
@@ -238,8 +238,8 @@ class Policy(BaseModel):
     default_action: Literal["allow", "deny"] = Field(default="deny")
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     @classmethod
     def from_yaml(cls, yaml_content: str, base_dir: str = "") -> "Policy":
@@ -456,7 +456,7 @@ class PolicyDecision(BaseModel):
     rate_limit_reset: Optional[datetime] = None
 
     # Timing
-    evaluated_at: datetime = Field(default_factory=datetime.utcnow)
+    evaluated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     evaluation_ms: Optional[float] = None
 
     # Extension metadata (e.g., authority resolver details)
@@ -648,7 +648,7 @@ class PolicyEngine:
             return False
 
         # Check if reset time passed
-        if datetime.utcnow() > limit_data["reset_at"]:
+        if datetime.now(timezone.utc) > limit_data["reset_at"]:
             self._rate_limits[limit_key] = None
             return False
 
@@ -669,7 +669,7 @@ class PolicyEngine:
             from datetime import timedelta
             self._rate_limits[limit_key] = {
                 "count": 0,
-                "reset_at": datetime.utcnow() + timedelta(seconds=period),
+                "reset_at": datetime.now(timezone.utc) + timedelta(seconds=period),
             }
 
         self._rate_limits[limit_key]["count"] += 1
@@ -813,7 +813,7 @@ class PolicyEngine:
             PolicyScope,
         )
 
-        start = datetime.utcnow()
+        start = datetime.now(timezone.utc)
 
         # 1. Check YAML/JSON policies first
         applicable = [p for p in self._policies.values() if p.applies_to(agent_did)]
@@ -844,7 +844,7 @@ class PolicyEngine:
             if candidates:
                 result = self._resolver.resolve(candidates)
                 winner = result.winning_decision
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+                elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
 
                 # Apply rate limiting for the winning rule
                 matched_rule = None
@@ -911,7 +911,7 @@ class PolicyEngine:
             )
             authority_decision = self._authority_resolver.resolve(authority_req)
             if authority_decision.decision == "deny":
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+                elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
                 return PolicyDecision(
                     allowed=False,
                     action="deny",
@@ -920,7 +920,7 @@ class PolicyEngine:
                     evaluation_ms=elapsed,
                 )
             if authority_decision.decision == "allow_narrowed":
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+                elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
                 return PolicyDecision(
                     allowed=True,
                     action="allow",
@@ -939,7 +939,7 @@ class PolicyEngine:
             query = f"data.{package}.allow"
             opa_result = evaluator.evaluate(query, context)
             if opa_result.error is None:
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+                elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
                 return PolicyDecision(
                     allowed=opa_result.allowed,
                     action="allow" if opa_result.allowed else "deny",
@@ -955,7 +955,7 @@ class PolicyEngine:
             cedar_action = f'Action::"{action_name}"' if "::" not in action_name else action_name
             cedar_result = cedar_eval.evaluate(cedar_action, context)
             if cedar_result.error is None:
-                elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+                elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
                 return PolicyDecision(
                     allowed=cedar_result.allowed,
                     action="allow" if cedar_result.allowed else "deny",
@@ -972,7 +972,7 @@ class PolicyEngine:
             # Operators must explicitly load an allow policy.
             default = "deny"
 
-        elapsed = (datetime.utcnow() - start).total_seconds() * 1000
+        elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
         return PolicyDecision(
             allowed=(default == "allow"),
             action=default,

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/agent_id.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/agent_id.py
@@ -7,7 +7,7 @@ Every agent gets a unique, cryptographically bound identity issued by AgentMesh 
 Identity persists across restarts; revocation propagates in ≤5s.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import ClassVar, Optional, Literal
 from pydantic import BaseModel, Field, field_validator
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -93,8 +93,8 @@ class AgentIdentity(BaseModel):
     capabilities: list[str] = Field(default_factory=list)
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: Optional[datetime] = Field(None, description="Identity expiration")
 
     # Status
@@ -298,13 +298,13 @@ class AgentIdentity(BaseModel):
         """Revoke this identity."""
         self.status = "revoked"
         self.revocation_reason = reason
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def suspend(self, reason: str) -> None:
         """Temporarily suspend this identity."""
         self.status = "suspended"
         self.revocation_reason = reason
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def reactivate(self, *, override_reason: bool = False) -> None:
         """Reactivate a suspended identity.
@@ -327,13 +327,13 @@ class AgentIdentity(BaseModel):
                 )
         self.status = "active"
         self.revocation_reason = None
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def is_active(self) -> bool:
         """Check if identity is active and not expired."""
         if self.status != "active":
             return False
-        if self.expires_at and datetime.utcnow() > self.expires_at:
+        if self.expires_at and datetime.now(timezone.utc) > self.expires_at:
             return False
         return True
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/credentials.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/credentials.py
@@ -7,7 +7,7 @@ Credentials with configurable TTL (default 15 min).
 Expired credentials are rejected; rotation is automatic and zero-downtime.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional, Literal
 from pydantic import BaseModel, Field
 import hashlib
@@ -44,7 +44,7 @@ class Credential(BaseModel):
     resources: list[str] = Field(default_factory=list, description="Accessible resources")
 
     # Timing
-    issued_at: datetime = Field(default_factory=datetime.utcnow)
+    issued_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime = Field(..., description="When credential expires")
     ttl_seconds: int = Field(default=900, description="TTL in seconds (default 15 min)")
 
@@ -89,7 +89,7 @@ class Credential(BaseModel):
         # Generate credential ID
         credential_id = f"cred_{uuid.uuid4().hex[:16]}"
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         return cls(
             credential_id=credential_id,
@@ -112,7 +112,7 @@ class Credential(BaseModel):
         """
         if self.status != "active":
             return False
-        return datetime.utcnow() < self.expires_at
+        return datetime.now(timezone.utc) < self.expires_at
 
     def is_expiring_soon(self, threshold_seconds: int = CREDENTIAL_ROTATION_THRESHOLD_SECONDS) -> bool:
         """Check if credential is about to expire.
@@ -124,7 +124,7 @@ class Credential(BaseModel):
         Returns:
             True if the credential expires within the threshold window.
         """
-        return datetime.utcnow() > (self.expires_at - timedelta(seconds=threshold_seconds))
+        return datetime.now(timezone.utc) > (self.expires_at - timedelta(seconds=threshold_seconds))
 
     def verify_token(self, token: str) -> bool:
         """Verify a token matches this credential.
@@ -144,7 +144,7 @@ class Credential(BaseModel):
             reason: Human-readable reason for revocation.
         """
         self.status = "revoked"
-        self.revoked_at = datetime.utcnow()
+        self.revoked_at = datetime.now(timezone.utc)
         self.revocation_reason = reason
 
     def rotate(self) -> "Credential":
@@ -223,7 +223,7 @@ class Credential(BaseModel):
         Returns:
             A non-negative timedelta; zero if already expired.
         """
-        return max(timedelta(0), self.expires_at - datetime.utcnow())
+        return max(timedelta(0), self.expires_at - datetime.now(timezone.utc))
 
     def to_bearer_token(self) -> str:
         """Get the bearer token for Authorization header.

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/delegation.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/delegation.py
@@ -6,7 +6,7 @@ Scope Chains
 Simple scope passing: sub-agent gets parent's scopes minus any denied ones.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import ClassVar, Optional
 from pydantic import BaseModel, Field, field_validator
 import hashlib
@@ -30,13 +30,13 @@ class UserContext(BaseModel):
     user_email: Optional[str] = Field(None, description="User email for audit trails")
     roles: list[str] = Field(default_factory=list, description="User roles for RBAC")
     permissions: list[str] = Field(default_factory=list, description="Fine-grained permissions")
-    issued_at: datetime = Field(default_factory=datetime.utcnow)
+    issued_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: Optional[datetime] = Field(None, description="OBO context expiration")
     metadata: dict = Field(default_factory=dict, description="Additional user attributes")
 
     def is_valid(self) -> bool:
         """Check if the user context is still valid."""
-        if self.expires_at and datetime.utcnow() > self.expires_at:
+        if self.expires_at and datetime.now(timezone.utc) > self.expires_at:
             return False
         return True
 
@@ -60,7 +60,7 @@ class UserContext(BaseModel):
         ttl_seconds: int = 3600,
     ) -> "UserContext":
         """Create a new user context with TTL."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         return cls(
             user_id=user_id,
             user_email=user_email,
@@ -93,7 +93,7 @@ class DelegationLink(BaseModel):
     delegated_capabilities: list[str] = Field(..., description="Capabilities granted to child")
 
     # Timestamps
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: Optional[datetime] = Field(None)
 
     # User context for OBO flows
@@ -140,7 +140,7 @@ class DelegationLink(BaseModel):
 
     def is_valid(self) -> bool:
         """Check if this link is valid (expiration and capability narrowing only)."""
-        if self.expires_at and datetime.utcnow() > self.expires_at:
+        if self.expires_at and datetime.now(timezone.utc) > self.expires_at:
             return False
 
         if not self.verify_capability_narrowing():
@@ -215,7 +215,7 @@ class ScopeChain(BaseModel):
         return v
 
     # Chain metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     total_depth: int = Field(default=0)
 
     # Verification

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/namespace.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/namespace.py
@@ -8,7 +8,7 @@ communicate freely; cross-namespace interaction requires explicit rules.
 Supports nested namespaces (e.g. "finance.trading" is a child of "finance").
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -37,7 +37,7 @@ class AgentNamespace(BaseModel):
         None, description="Optional trust policy governing this namespace"
     )
     members: set[str] = Field(default_factory=set, description="Agent DIDs in this namespace")
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class NamespaceRule(BaseModel):

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/risk.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/risk.py
@@ -7,7 +7,7 @@ Updates trust score every ≤30s based on agent behavior.
 Score visible in dashboard; configurable alert thresholds.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Optional, Literal
 from pydantic import BaseModel, Field
 from dataclasses import dataclass, field
@@ -43,7 +43,7 @@ class RiskSignal:
     signal_type: str
     severity: Literal["critical", "high", "medium", "low", "info"]
     value: float  # 0.0 to 1.0
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     source: Optional[str] = None
     details: Optional[str] = None
 
@@ -85,8 +85,8 @@ class RiskScore(BaseModel):
     critical_signals: int = Field(default=0)
 
     # Timestamps
-    calculated_at: datetime = Field(default_factory=datetime.utcnow)
-    next_update_at: datetime = Field(default_factory=datetime.utcnow)
+    calculated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    next_update_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     @classmethod
     def get_risk_level(cls, score: int) -> str:
@@ -144,8 +144,8 @@ class RiskScore(BaseModel):
         self.risk_level = self.get_risk_level(self.total_score)
         self.active_signals = active_signals
         self.critical_signals = critical_signals
-        self.calculated_at = datetime.utcnow()
-        self.next_update_at = datetime.utcnow() + timedelta(seconds=RISK_UPDATE_INTERVAL_SECONDS)
+        self.calculated_at = datetime.now(timezone.utc)
+        self.next_update_at = datetime.now(timezone.utc) + timedelta(seconds=RISK_UPDATE_INTERVAL_SECONDS)
 
 
 class RiskScorer:
@@ -220,7 +220,7 @@ class RiskScorer:
         signals = self._signals.get(agent_did, [])
 
         # Filter to recent signals (last 24 hours)
-        cutoff = datetime.utcnow() - timedelta(hours=24)
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
         recent_signals = [s for s in signals if s.timestamp > cutoff]
 
         # Calculate component scores

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/rotation.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/rotation.py
@@ -11,7 +11,7 @@ the agent's DID identity.
 import base64
 import hashlib
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.hazmat.primitives import serialization
@@ -87,7 +87,7 @@ class KeyRotationManager:
             {
                 "public_key": old_public_key_b64,
                 "verification_key_id": self._identity.verification_key_id,
-                "rotated_at": datetime.utcnow().isoformat(),
+                "rotated_at": datetime.now(timezone.utc).isoformat(),
                 "rotation_proof": proof,
             }
         )
@@ -101,7 +101,7 @@ class KeyRotationManager:
         self._identity.public_key = new_public_key_b64
         self._identity.verification_key_id = new_key_id
         self._identity._private_key = new_private_key
-        self._identity.updated_at = datetime.utcnow()
+        self._identity.updated_at = datetime.now(timezone.utc)
 
         self._last_rotation_time = time.monotonic()
 
@@ -193,5 +193,5 @@ class KeyRotationManager:
             "new_public_key": new_public_key_b64,
             "message": message,
             "signature": base64.b64encode(signature).decode(),
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/spiffe.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/spiffe.py
@@ -12,7 +12,7 @@ SPIFFE/SVID provides:
 - Standard workload identity
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Literal
 from pydantic import BaseModel, Field
 
@@ -37,7 +37,7 @@ class SVID(BaseModel):
 
     # Metadata
     trust_domain: str = Field(..., description="SPIFFE trust domain")
-    issued_at: datetime = Field(default_factory=datetime.utcnow)
+    issued_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime = Field(...)
 
     # Agent binding
@@ -73,7 +73,7 @@ class SVID(BaseModel):
         Returns:
             True if the current time is within the issued/expiry window.
         """
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         return self.issued_at <= now < self.expires_at
 
     def time_remaining(self) -> timedelta:
@@ -82,7 +82,7 @@ class SVID(BaseModel):
         Returns:
             A non-negative timedelta; zero if already expired.
         """
-        return max(timedelta(0), self.expires_at - datetime.utcnow())
+        return max(timedelta(0), self.expires_at - datetime.now(timezone.utc))
 
 
 class SPIFFEIdentity(BaseModel):
@@ -106,7 +106,7 @@ class SPIFFEIdentity(BaseModel):
     current_svid: Optional[SVID] = Field(None)
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     @classmethod
     def create(
@@ -159,7 +159,7 @@ class SPIFFEIdentity(BaseModel):
         Returns:
             The newly issued SVID, also stored as ``current_svid``.
         """
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         svid = SVID(
             spiffe_id=self.spiffe_id,

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/sponsor.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/sponsor.py
@@ -7,7 +7,7 @@ Every agent identity is linked to a human sponsor who is accountable.
 The sponsor's credentials are cryptographically linked to the scope chain.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from pydantic import BaseModel, Field, EmailStr
 import uuid
@@ -49,7 +49,7 @@ class HumanSponsor(BaseModel):
     agent_dids: list[str] = Field(default_factory=list, description="DIDs of sponsored agents")
 
     # Timestamps
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_activity_at: Optional[datetime] = Field(None)
 
     @classmethod
@@ -89,7 +89,7 @@ class HumanSponsor(BaseModel):
             method: Verification method used (e.g. "email", "sso", "manual").
         """
         self.verified = True
-        self.verified_at = datetime.utcnow()
+        self.verified_at = datetime.now(timezone.utc)
         self.verification_method = method
 
     def can_sponsor_agent(self) -> bool:
@@ -138,7 +138,7 @@ class HumanSponsor(BaseModel):
         """
         if agent_did not in self.agent_dids:
             self.agent_dids.append(agent_did)
-            self.last_activity_at = datetime.utcnow()
+            self.last_activity_at = datetime.now(timezone.utc)
 
     def remove_agent(self, agent_did: str) -> None:
         """Remove an agent from sponsorship.

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/langgraph/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/langgraph/__init__.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Generic
 from enum import Enum
 
@@ -249,7 +249,7 @@ class TrustCheckpoint:
             trust_score=self.identity.trust_score if hasattr(self.identity, "trust_score") else 500,
             trust_level=TrustLevel.STANDARD,
             capabilities=list(self.identity.capabilities) if hasattr(self.identity, "capabilities") else [],
-            verified_at=datetime.utcnow(),
+            verified_at=datetime.now(timezone.utc),
             sponsor_id=self.identity.sponsor_id if hasattr(self.identity, "sponsor_id") else "",
         )
 
@@ -265,7 +265,7 @@ class TrustCheckpoint:
         self._checkpoints[checkpoint_id] = {
             "state": state,
             "trust_context": context.to_dict() if context else None,
-            "saved_at": datetime.utcnow().isoformat(),
+            "saved_at": datetime.now(timezone.utc).isoformat(),
         }
         logger.info(f"Saved trust checkpoint: {checkpoint_id}")
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/mcp/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/mcp/__init__.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Optional, Awaitable
 from enum import Enum
 
@@ -81,7 +81,7 @@ class MCPToolCall:
     capabilities_checked: List[str] = field(default_factory=list)
 
     # Timing
-    started_at: datetime = field(default_factory=datetime.utcnow)
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: Optional[datetime] = None
 
     # Result
@@ -180,7 +180,7 @@ class TrustGatedMCPServer:
         # Check cache
         if client_did in self._verified_clients:
             cached_time = self._verified_clients[client_did]
-            if datetime.utcnow() - cached_time < self._verification_ttl:
+            if datetime.now(timezone.utc) - cached_time < self._verification_ttl:
                 return True
             # Expired — remove stale entry
             del self._verified_clients[client_did]
@@ -194,7 +194,7 @@ class TrustGatedMCPServer:
             try:
                 result = await self.trust_bridge.verify_peer(client_did)
                 if result:
-                    self._verified_clients[client_did] = datetime.utcnow()
+                    self._verified_clients[client_did] = datetime.now(timezone.utc)
                     return True
             except Exception as e:
                 logger.error(f"Trust verification failed: {e}")
@@ -204,7 +204,7 @@ class TrustGatedMCPServer:
         if client_card:
             if hasattr(client_card, "trust_score"):
                 if client_card.trust_score >= self.min_trust_score:
-                    self._verified_clients[client_did] = datetime.utcnow()
+                    self._verified_clients[client_did] = datetime.now(timezone.utc)
                     return True
 
         logger.warning(f"Client {client_did} failed trust verification")
@@ -212,7 +212,7 @@ class TrustGatedMCPServer:
 
     def _evict_expired_clients(self) -> None:
         """Remove expired entries from the verified clients cache."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         expired = [
             did for did, ts in self._verified_clients.items()
             if now - ts >= self._verification_ttl
@@ -281,14 +281,14 @@ class TrustGatedMCPServer:
             args_size = 0
         if args_size > self._MAX_ARGUMENTS_SIZE:
             call.error = f"Arguments too large: {args_size} bytes exceeds {self._MAX_ARGUMENTS_SIZE} limit"
-            call.completed_at = datetime.utcnow()
+            call.completed_at = datetime.now(timezone.utc)
             self._record_call(call)
             return call
 
         # Check tool exists
         if tool_name not in self._tools:
             call.error = f"Unknown tool: {tool_name}"
-            call.completed_at = datetime.utcnow()
+            call.completed_at = datetime.now(timezone.utc)
             self._record_call(call)
             return call
 
@@ -299,7 +299,7 @@ class TrustGatedMCPServer:
             call.error = (
                 f"Insufficient trust score: {caller_trust_score} < {tool.min_trust_score}"
             )
-            call.completed_at = datetime.utcnow()
+            call.completed_at = datetime.now(timezone.utc)
             tool.failed_calls += 1
             self._record_call(call)
             logger.warning(f"Trust check failed for {caller_did} on {tool_name}")
@@ -309,7 +309,7 @@ class TrustGatedMCPServer:
         if tool.required_capability:
             if not self._check_capability(caller_capabilities or [], tool.required_capability):
                 call.error = f"Missing capability: {tool.required_capability}"
-                call.completed_at = datetime.utcnow()
+                call.completed_at = datetime.now(timezone.utc)
                 tool.failed_calls += 1
                 self._record_call(call)
                 logger.warning(f"Capability check failed for {caller_did} on {tool_name}")
@@ -322,7 +322,7 @@ class TrustGatedMCPServer:
         fail_count = self._tool_failures.get(tool_name, 0)
         if fail_count >= self._circuit_breaker_threshold:
             call.error = f"Circuit breaker open: {tool_name} has {fail_count} consecutive failures"
-            call.completed_at = datetime.utcnow()
+            call.completed_at = datetime.now(timezone.utc)
             self._record_call(call)
             return call
 
@@ -343,7 +343,7 @@ class TrustGatedMCPServer:
             call.success = True
             call.result = result
             tool.total_calls += 1
-            tool.last_called = datetime.utcnow()
+            tool.last_called = datetime.now(timezone.utc)
             self._tool_failures.pop(tool_name, None)  # reset on success
             logger.info(f"Tool {tool_name} invoked successfully by {caller_did}")
         except Exception as e:
@@ -354,7 +354,7 @@ class TrustGatedMCPServer:
             self._tool_failures[tool_name] = self._tool_failures.get(tool_name, 0) + 1
             logger.error("Tool %s failed with %s (caller: %s)", tool_name, error_type, caller_did)
 
-        call.completed_at = datetime.utcnow()
+        call.completed_at = datetime.now(timezone.utc)
         self._record_call(call)
         return call
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/reward/engine.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/reward/engine.py
@@ -6,7 +6,7 @@ Reward Engine
 Single-dimension trust scoring with per-agent reward signals.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Callable
 from pydantic import BaseModel, Field
 import asyncio
@@ -69,7 +69,7 @@ class AgentRewardState(BaseModel):
     max_history: int = Field(default=100)
 
     # Status
-    last_updated: datetime = Field(default_factory=datetime.utcnow)
+    last_updated: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     revoked: bool = False
     revoked_at: Optional[datetime] = None
     revocation_reason: Optional[str] = None
@@ -84,7 +84,7 @@ class AgentRewardState(BaseModel):
 
     def record_score(self, score: int) -> None:
         """Record score in history."""
-        self.score_history.append((datetime.utcnow(), score))
+        self.score_history.append((datetime.now(timezone.utc), score))
 
         if len(self.score_history) > self.max_history:
             self.score_history = self.score_history[-self.max_history:]
@@ -295,7 +295,7 @@ class RewardEngine:
             dimensions=state.dimensions,
         )
         state.record_score(total_score)
-        state.last_updated = datetime.utcnow()
+        state.last_updated = datetime.now(timezone.utc)
 
         # Check for revocation
         if total_score < self.config.revocation_threshold and not state.revoked:
@@ -310,7 +310,7 @@ class RewardEngine:
             return
 
         state.revoked = True
-        state.revoked_at = datetime.utcnow()
+        state.revoked_at = datetime.now(timezone.utc)
         state.revocation_reason = reason
 
         # Notify callbacks
@@ -435,7 +435,7 @@ class RewardEngine:
 
     def get_health_report(self, days: int = 7) -> dict[str, Any]:
         """Get longitudinal health report."""
-        cutoff = datetime.utcnow() - timedelta(days=days)
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
         report = {
             "period_days": days,

--- a/agent-governance-python/agent-mesh/src/agentmesh/reward/scoring.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/reward/scoring.py
@@ -6,7 +6,7 @@ Reward Scoring
 Multi-dimensional scoring with trust scores and reward signals.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from pydantic import BaseModel, Field, field_validator
 from enum import Enum
@@ -50,7 +50,7 @@ class RewardSignal(BaseModel):
     trace_id: Optional[str] = None
 
     # Timing
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # Weight (for importance)
     weight: float = Field(default=1.0, ge=0.0)
@@ -72,7 +72,7 @@ class RewardDimension(BaseModel):
     trend: str = "stable"  # improving, degrading, stable
 
     # Last update
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     def add_signal(self, signal: RewardSignal) -> None:
         """Add a signal and update score."""
@@ -98,7 +98,7 @@ class RewardDimension(BaseModel):
             else:
                 self.trend = "stable"
 
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
 
 class TrustScore(BaseModel):
@@ -120,7 +120,7 @@ class TrustScore(BaseModel):
     dimensions: dict[str, RewardDimension] = Field(default_factory=dict)
 
     # Timestamps
-    calculated_at: datetime = Field(default_factory=datetime.utcnow)
+    calculated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # History
     previous_score: Optional[int] = None
@@ -162,7 +162,7 @@ class TrustScore(BaseModel):
         self.total_score = max(0, min(TRUST_SCORE_MAX, new_score))
         self.score_change = self.total_score - (self.previous_score or 0)
         self.dimensions = dimensions
-        self.calculated_at = datetime.utcnow()
+        self.calculated_at = datetime.now(timezone.utc)
         self._update_tier()
 
     def meets_threshold(self, threshold: int) -> bool:

--- a/agent-governance-python/agent-mesh/src/agentmesh/services/behavior_monitor.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/services/behavior_monitor.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class AgentBehaviorMonitor:
     ) -> None:
         """Record a tool invocation and check for anomalies."""
         m = self._get_metrics(agent_did)
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         m.total_calls += 1
         m.last_activity = now
 
@@ -146,7 +146,7 @@ class AgentBehaviorMonitor:
             return  # already quarantined
         m.quarantined = True
         m.quarantine_reason = reason
-        m.quarantined_at = datetime.utcnow()
+        m.quarantined_at = datetime.now(timezone.utc)
         logger.warning("QUARANTINE agent %s: %s", agent_did, reason)
 
     def is_quarantined(self, agent_did: str) -> bool:
@@ -155,7 +155,7 @@ class AgentBehaviorMonitor:
         if not m or not m.quarantined:
             return False
         # Auto-release after quarantine duration
-        if m.quarantined_at and datetime.utcnow() - m.quarantined_at > self._quarantine_duration:
+        if m.quarantined_at and datetime.now(timezone.utc) - m.quarantined_at > self._quarantine_duration:
             self.release_quarantine(agent_did)
             return False
         return True

--- a/agent-governance-python/agent-mesh/src/agentmesh/services/registry/agent_registry.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/services/registry/agent_registry.py
@@ -56,9 +56,9 @@ class AgentRegistryEntry(BaseModel):
     current_credential_expires_at: datetime
 
     # Timestamps
-    registered_at: datetime = Field(default_factory=datetime.utcnow)
+    registered_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     last_seen_at: datetime | None = None
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # Delegation
     parent_did: str | None = None

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/bridge.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/bridge.py
@@ -7,7 +7,7 @@ Direct passthrough bridge.
 Maintains the same API surface for compatibility.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Any
 from pydantic import BaseModel, Field
 import hashlib
@@ -172,7 +172,7 @@ class TrustBridge(BaseModel):
                 protocol=protocol,
                 trust_score=result.trust_score,
                 trust_verified=True,
-                last_verified=datetime.utcnow(),
+                last_verified=datetime.now(timezone.utc),
                 capabilities=result.capabilities,
             )
             self.peers[peer_did] = peer
@@ -394,7 +394,7 @@ class A2AAdapter:
             raise PermissionError("Peer not trusted")
 
         return {
-            "task_id": f"task_{peer_did}_{datetime.utcnow().timestamp()}",
+            "task_id": f"task_{peer_did}_{datetime.now(timezone.utc).timestamp()}",
             "status": "created",
             "type": task_type,
         }

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
@@ -6,7 +6,7 @@ Capability Scoping
 Simple string-based capability scope checking.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from pydantic import BaseModel, Field
 import uuid
@@ -47,7 +47,7 @@ class CapabilityGrant(BaseModel):
     )
 
     # Timing
-    granted_at: datetime = Field(default_factory=datetime.utcnow)
+    granted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: Optional[datetime] = Field(None)
 
     # Status
@@ -94,7 +94,7 @@ class CapabilityGrant(BaseModel):
         """Check if the grant is currently active and not expired."""
         if not self.active:
             return False
-        if self.expires_at and datetime.utcnow() > self.expires_at:
+        if self.expires_at and datetime.now(timezone.utc) > self.expires_at:
             return False
         return True
 
@@ -148,7 +148,7 @@ class CapabilityGrant(BaseModel):
     def revoke(self) -> None:
         """Revoke this grant immediately."""
         self.active = False
-        self.revoked_at = datetime.utcnow()
+        self.revoked_at = datetime.now(timezone.utc)
 
 
 class CapabilityScope(BaseModel):

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/endorsement.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/endorsement.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone, UTC
 from enum import Enum
 from typing import Any
 
@@ -96,7 +96,7 @@ class Endorsement:
         try:
             expiry = datetime.fromisoformat(self.expires_at)
             if expiry.tzinfo is None:
-                now = datetime.utcnow()
+                now = datetime.now(timezone.utc)
             else:
                 now = datetime.now(UTC)
             return now > expiry

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/handshake.py
@@ -6,7 +6,7 @@ Trust Handshake
 Ed25519 challenge/response handshake with registry-backed identity verification.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Literal
 from pydantic import BaseModel, Field
 import logging
@@ -33,7 +33,7 @@ class HandshakeChallenge(BaseModel):
         None,
         description="RFC 9334 freshness nonce for Evidence liveness proof",
     )
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_in_seconds: int = 30
 
     @classmethod
@@ -53,7 +53,7 @@ class HandshakeChallenge(BaseModel):
 
     def is_expired(self) -> bool:
         """Check if the challenge has exceeded its time-to-live."""
-        elapsed = (datetime.utcnow() - self.timestamp).total_seconds()
+        elapsed = (datetime.now(timezone.utc) - self.timestamp).total_seconds()
         return elapsed > self.expires_in_seconds
 
 
@@ -79,7 +79,7 @@ class HandshakeResponse(BaseModel):
     user_context: Optional[dict] = Field(None, description="End-user context for OBO flows")
 
     # Metadata
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 class HandshakeResult(BaseModel):
@@ -100,7 +100,7 @@ class HandshakeResult(BaseModel):
     user_context: Optional[UserContext] = Field(None, description="End-user context if acting on behalf of a user")
 
     # Timing
-    handshake_started: datetime = Field(default_factory=datetime.utcnow)
+    handshake_started: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     handshake_completed: Optional[datetime] = None
     latency_ms: Optional[int] = None
 
@@ -118,7 +118,7 @@ class HandshakeResult(BaseModel):
         user_context: Optional[UserContext] = None,
     ) -> "HandshakeResult":
         """Create a successful handshake result."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         start = started or now
         latency = int((now - start).total_seconds() * 1000)
 
@@ -152,7 +152,7 @@ class HandshakeResult(BaseModel):
         started: Optional[datetime] = None,
     ) -> "HandshakeResult":
         """Create a failed handshake result."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         start = started or now
         latency = int((now - start).total_seconds() * 1000)
 
@@ -238,7 +238,7 @@ class TrustHandshake:
         async with self._peers_lock:
             if peer_did in self._verified_peers:
                 result, timestamp = self._verified_peers[peer_did]
-                if datetime.utcnow() - timestamp < self._cache_ttl:
+                if datetime.now(timezone.utc) - timestamp < self._cache_ttl:
                     return result
                 del self._verified_peers[peer_did]
         return None
@@ -246,7 +246,7 @@ class TrustHandshake:
     async def _cache_result(self, peer_did: str, result: HandshakeResult) -> None:
         """Cache a verification result with timestamp."""
         async with self._peers_lock:
-            self._verified_peers[peer_did] = (result, datetime.utcnow())
+            self._verified_peers[peer_did] = (result, datetime.now(timezone.utc))
 
     def _purge_expired_challenges(self) -> None:
         """Remove expired challenges to prevent unbounded growth.
@@ -293,7 +293,7 @@ class TrustHandshake:
             if cached:
                 return cached
 
-        start = datetime.utcnow()
+        start = datetime.now(timezone.utc)
 
         try:
             result = await asyncio.wait_for(

--- a/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
+++ b/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
@@ -212,7 +212,7 @@ class TestSVID:
             SVID.parse_spiffe_id("http://not-spiffe")
 
     def test_is_valid_true(self):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         svid = SVID(
             spiffe_id="spiffe://d/p",
             trust_domain="d",
@@ -223,7 +223,7 @@ class TestSVID:
         assert svid.is_valid() is True
 
     def test_is_valid_expired(self):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         svid = SVID(
             spiffe_id="spiffe://d/p",
             trust_domain="d",
@@ -234,7 +234,7 @@ class TestSVID:
         assert svid.is_valid() is False
 
     def test_time_remaining_positive(self):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         svid = SVID(
             spiffe_id="spiffe://d/p",
             trust_domain="d",
@@ -245,7 +245,7 @@ class TestSVID:
         assert svid.time_remaining() > timedelta(0)
 
     def test_time_remaining_expired(self):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         svid = SVID(
             spiffe_id="spiffe://d/p",
             trust_domain="d",
@@ -391,7 +391,7 @@ class TestSPIFFERegistry:
 
     def test_validate_svid_unregistered_agent(self):
         reg = SPIFFERegistry()
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         svid = SVID(
             spiffe_id="spiffe://agentmesh.local/agentmesh/unknown",
             trust_domain="agentmesh.local",
@@ -1116,7 +1116,7 @@ class TestCapabilityGrant:
     def test_is_valid_expired(self):
         g = CapabilityGrant.create(
             "read:data", "did:mesh:1", "did:mesh:0",
-            expires_at=datetime.utcnow() - timedelta(hours=1),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
         )
         assert g.is_valid() is False
 
@@ -1288,7 +1288,7 @@ class TestHandshakeChallenge:
 
     def test_is_expired_old(self):
         c = HandshakeChallenge.generate()
-        c.timestamp = datetime.utcnow() - timedelta(seconds=60)
+        c.timestamp = datetime.now(timezone.utc) - timedelta(seconds=60)
         c.expires_in_seconds = 30
         assert c.is_expired() is True
 
@@ -1401,7 +1401,7 @@ class TestTrustHandshake:
         me = AgentIdentity.create(name="me-re", sponsor="me@test.com", capabilities=["read:data"])
         th = TrustHandshake(agent_did=str(me.did), identity=me)
         challenge = HandshakeChallenge.generate()
-        challenge.timestamp = datetime.utcnow() - timedelta(seconds=60)
+        challenge.timestamp = datetime.now(timezone.utc) - timedelta(seconds=60)
         with pytest.raises(ValueError, match="expired"):
             await th.respond(challenge, ["read:data"], 750, identity=me)
 
@@ -1418,14 +1418,14 @@ class TestTrustHandshake:
 
     def test_clear_cache(self):
         th = TrustHandshake(agent_did="did:mesh:me")
-        th._verified_peers["did:mesh:peer"] = (MagicMock(), datetime.utcnow())
+        th._verified_peers["did:mesh:peer"] = (MagicMock(), datetime.now(timezone.utc))
         th.clear_cache()
         assert len(th._verified_peers) == 0
 
     @pytest.mark.asyncio
     async def test_get_cached_result_expired(self):
         th = TrustHandshake(agent_did="did:mesh:me", cache_ttl_seconds=0)
-        th._verified_peers["did:mesh:peer"] = (MagicMock(), datetime.utcnow() - timedelta(seconds=1))
+        th._verified_peers["did:mesh:peer"] = (MagicMock(), datetime.now(timezone.utc) - timedelta(seconds=1))
         assert await th._get_cached_result("did:mesh:peer") is None
         assert "did:mesh:peer" not in th._verified_peers
 
@@ -1447,7 +1447,7 @@ class TestCredential:
         c = Credential.issue("did:mesh:1", ttl_seconds=0)
         # Might still be valid since issued_at == expires_at edge
         # Force expiration
-        c.expires_at = datetime.utcnow() - timedelta(seconds=1)
+        c.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
         assert c.is_valid() is False
 
     def test_is_valid_revoked(self):
@@ -1663,7 +1663,7 @@ class TestDelegationLink:
 
     def test_is_valid_expired(self):
         link = self._make_link()
-        link.expires_at = datetime.utcnow() - timedelta(hours=1)
+        link.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
         assert link.is_valid() is False
 
     def test_is_valid_bad_hash(self):

--- a/agent-governance-python/agent-mesh/tests/test_credential_lifecycle.py
+++ b/agent-governance-python/agent-mesh/tests/test_credential_lifecycle.py
@@ -14,7 +14,7 @@ import hashlib
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -258,7 +258,7 @@ class TestCredentialRenewal:
         mgr = CredentialManager(default_ttl=5)
         cred = mgr.issue(agent_did="did:mesh:renew", capabilities=["read"])
         # Force near-expiry
-        cred.expires_at = datetime.utcnow() + timedelta(seconds=2)
+        cred.expires_at = datetime.now(timezone.utc) + timedelta(seconds=2)
         new_cred = mgr.rotate_if_needed(cred.credential_id)
         assert new_cred is not None
         assert new_cred.credential_id != cred.credential_id

--- a/agent-governance-python/agent-mesh/tests/test_expired_certs.py
+++ b/agent-governance-python/agent-mesh/tests/test_expired_certs.py
@@ -7,7 +7,7 @@ correctly rejected, including edge cases around clock skew and boundary times.
 """
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -74,7 +74,7 @@ class TestCredentialExpiry:
     def test_far_expired_one_year_ago(self):
         """Credential expired 1 year ago is invalid."""
         cred = Credential.issue(agent_did="did:mesh:test", ttl_seconds=1)
-        cred.expires_at = datetime.utcnow() - timedelta(days=400)
+        cred.expires_at = datetime.now(timezone.utc) - timedelta(days=400)
         assert not cred.is_valid()
 
     def test_valid_credential(self):
@@ -93,7 +93,7 @@ class TestCredentialExpiry:
         by is_valid (which only checks status + expires_at). The issued_at field
         is informational; applications should check it separately if needed."""
         cred = Credential.issue(agent_did="did:mesh:test", ttl_seconds=7200)
-        cred.issued_at = datetime.utcnow() + timedelta(hours=1)
+        cred.issued_at = datetime.now(timezone.utc) + timedelta(hours=1)
         # is_valid only checks status + expires_at
         assert cred.is_valid()
 
@@ -112,14 +112,14 @@ class TestCredentialManagerExpiry:
         mgr = CredentialManager()
         cred = mgr.issue("did:mesh:test", ttl_seconds=1)
         # Force expiry
-        cred.expires_at = datetime.utcnow() - timedelta(seconds=10)
+        cred.expires_at = datetime.now(timezone.utc) - timedelta(seconds=10)
         assert mgr.validate(cred.token) is None
 
     def test_cleanup_removes_expired(self):
         """cleanup_expired removes non-active expired credentials."""
         mgr = CredentialManager()
         cred = mgr.issue("did:mesh:test", ttl_seconds=1)
-        cred.expires_at = datetime.utcnow() - timedelta(seconds=10)
+        cred.expires_at = datetime.now(timezone.utc) - timedelta(seconds=10)
         cred.status = "expired"
         removed = mgr.cleanup_expired()
         assert removed >= 1
@@ -135,21 +135,21 @@ class TestDelegationLinkExpiry:
     def test_expired_link_invalid(self):
         """Link with past expires_at is invalid."""
         _, link = _chain_with_expiring_link(
-            expires_at=datetime.utcnow() - timedelta(seconds=1),
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
         )
         assert not link.is_valid()
 
     def test_far_expired_link(self):
         """Link expired 1 year ago is invalid."""
         _, link = _chain_with_expiring_link(
-            expires_at=datetime.utcnow() - timedelta(days=400),
+            expires_at=datetime.now(timezone.utc) - timedelta(days=400),
         )
         assert not link.is_valid()
 
     def test_valid_link_future_expiry(self):
         """Link with future expiry is valid."""
         _, link = _chain_with_expiring_link(
-            expires_at=datetime.utcnow() + timedelta(hours=1),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
         )
         assert link.is_valid()
 
@@ -162,7 +162,7 @@ class TestDelegationLinkExpiry:
         """Link whose expires_at just passed is invalid."""
         # Set expiry to just barely in the past
         _, link = _chain_with_expiring_link(
-            expires_at=datetime.utcnow() - timedelta(milliseconds=100),
+            expires_at=datetime.now(timezone.utc) - timedelta(milliseconds=100),
         )
         assert not link.is_valid()
 
@@ -176,7 +176,7 @@ class TestScopeChainWithExpiredLinks:
         This test documents current behaviour: verify() does NOT reject
         expired links automatically."""
         chain, link = _chain_with_expiring_link(
-            expires_at=datetime.utcnow() - timedelta(days=1),
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
         )
         # Structural verification still passes
         is_valid, error = chain.verify()
@@ -188,7 +188,7 @@ class TestScopeChainWithExpiredLinks:
     def test_application_checks_link_validity(self):
         """Applications should iterate links and check is_valid for expiry."""
         chain, _ = _chain_with_expiring_link(
-            expires_at=datetime.utcnow() - timedelta(seconds=30),
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=30),
         )
         expired_links = [lnk for lnk in chain.links if not lnk.is_valid()]
         assert len(expired_links) >= 1
@@ -229,13 +229,13 @@ class TestAgentIdentityExpiry:
     def test_expired_identity_not_active(self):
         """Identity with past expires_at is not active."""
         identity = _make_identity()
-        identity.expires_at = datetime.utcnow() - timedelta(seconds=1)
+        identity.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
         assert not identity.is_active()
 
     def test_identity_not_yet_expired(self):
         """Identity with future expires_at is active."""
         identity = _make_identity()
-        identity.expires_at = datetime.utcnow() + timedelta(hours=1)
+        identity.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         assert identity.is_active()
 
     def test_identity_no_expiry_active(self):
@@ -247,6 +247,6 @@ class TestAgentIdentityExpiry:
     def test_revoked_identity_not_active(self):
         """Revoked identity is not active even if not expired."""
         identity = _make_identity()
-        identity.expires_at = datetime.utcnow() + timedelta(hours=1)
+        identity.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
         identity.revoke("test")
         assert not identity.is_active()

--- a/agent-governance-python/agent-mesh/tests/test_governance.py
+++ b/agent-governance-python/agent-mesh/tests/test_governance.py
@@ -3,7 +3,7 @@
 """Tests for AgentMesh Governance module."""
 
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import tempfile
 import json
 
@@ -138,7 +138,7 @@ class TestCompliance:
         """Test generating compliance report."""
         engine = ComplianceEngine([ComplianceFramework.SOC2])
         
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         report = engine.generate_report(
             framework=ComplianceFramework.SOC2,
             period_start=now - timedelta(days=30),

--- a/agent-governance-python/agent-mesh/tests/test_identity.py
+++ b/agent-governance-python/agent-mesh/tests/test_identity.py
@@ -3,7 +3,7 @@
 """Tests for AgentMesh Identity module."""
 
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlparse
 
 from agentmesh.identity import (
@@ -154,7 +154,7 @@ class TestCredentials:
         cred = Credential.issue(agent_did="did:mesh:test")
         
         # Should expire in approximately 15 minutes
-        time_diff = cred.expires_at - datetime.utcnow()
+        time_diff = cred.expires_at - datetime.now(timezone.utc)
         assert 14 * 60 < time_diff.total_seconds() < 16 * 60
     
     def test_credential_expiry(self):

--- a/agent-governance-python/agent-mesh/tests/test_mcp_integration.py
+++ b/agent-governance-python/agent-mesh/tests/test_mcp_integration.py
@@ -9,7 +9,7 @@ credentials).
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -510,14 +510,14 @@ class TestVerifyClient:
     @pytest.mark.asyncio
     async def test_cache_hit_within_ttl(self, server: TrustGatedMCPServer) -> None:
         """A recently verified client should be served from cache."""
-        server._verified_clients["did:mesh:cached"] = datetime.utcnow()
+        server._verified_clients["did:mesh:cached"] = datetime.now(timezone.utc)
         result = await server.verify_client("did:mesh:cached")
         assert result is True
 
     @pytest.mark.asyncio
     async def test_cache_miss_expired_ttl(self, server: TrustGatedMCPServer) -> None:
         """An expired cache entry should not pass without bridge or card."""
-        expired_time = datetime.utcnow() - timedelta(minutes=15)
+        expired_time = datetime.now(timezone.utc) - timedelta(minutes=15)
         server._verified_clients["did:mesh:old"] = expired_time
         result = await server.verify_client("did:mesh:old")
         assert result is False
@@ -601,7 +601,7 @@ class TestVerifyClient:
         bridge = AsyncMock()
         bridge.verify_peer = AsyncMock(return_value=True)
         server = TrustGatedMCPServer(server_identity, trust_bridge=bridge)
-        server._verified_clients["did:mesh:cached"] = datetime.utcnow()
+        server._verified_clients["did:mesh:cached"] = datetime.now(timezone.utc)
 
         result = await server.verify_client("did:mesh:cached")
         assert result is True

--- a/agent-governance-python/agent-mesh/tests/test_negative_security.py
+++ b/agent-governance-python/agent-mesh/tests/test_negative_security.py
@@ -360,7 +360,7 @@ class TestIdentityLifecycleAttacks:
 
     def test_expired_identity_not_active(self):
         agent = _create_agent("test")
-        agent.expires_at = datetime.utcnow() - timedelta(hours=1)
+        agent.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
         assert agent.is_active() is False
 
     def test_revoked_identity_cannot_sign(self):
@@ -487,7 +487,7 @@ class TestHandshakeChallengeDoS:
             public_key=agent_b.public_key,
         )
         # Now expire the challenge
-        challenge.timestamp = datetime.utcnow() - timedelta(seconds=60)
+        challenge.timestamp = datetime.now(timezone.utc) - timedelta(seconds=60)
         assert challenge.is_expired() is True
         # Verify with expired challenge should fail
         result = await handshake._verify_response(


### PR DESCRIPTION
## Summary

`datetime.utcnow()` is deprecated in Python 3.12+ and returns a naive datetime, which silently mixes with timezone-aware datetimes elsewhere in the codebase. The result is `TypeError: can't subtract offset-naive and offset-aware datetimes` at runtime in handshake/expiry/scoring paths.

This sweep replaces every `utcnow()` site across [`agent-governance-python/agent-mesh/`](agent-governance-python/agent-mesh/) with `datetime.now(timezone.utc)`, and the structurally-equivalent pydantic `default_factory=datetime.utcnow` with `default_factory=lambda: datetime.now(timezone.utc)`.

## Change

| Pattern | Replacement |
|---|---|
| `datetime.utcnow()` | `datetime.now(timezone.utc)` |
| `default_factory=datetime.utcnow` | `default_factory=lambda: datetime.now(timezone.utc)` |
| `from datetime import datetime[, ...]` (missing `timezone`) | adds `timezone` |

The `default_factory` case was load-bearing: models such as `HandshakeChallenge.timestamp`, `AgentIdentity.created_at`, `Credential.issued_at`, and `RewardScore.calculated_at` stored naive timestamps that were then subtracted from a `now(timezone.utc)` in `is_expired()` / `is_valid()` / continuous-trust accumulators, producing the TypeError under registered-identity handshakes, signature tampering tests, capability inflation tests, expired-cert checks, and similar paths.

Scope covers `src/agentmesh/**`, `tests/**`, and `examples/**`, plus four doc files (`README.md`, `docs/zero-trust.md`, `docs/identity.md`, `examples/00-registration-hello-world/README.md`) that showed the deprecated pattern in user-facing snippets.

## Tests

| Before | After |
|---|---|
| 11 failed, 2593 passed, 37 skipped, 32707 warnings | 11 failed, 2593 passed, 37 skipped, 34 warnings |

Identical failure set (pre-existing Python 3.14 deprecations in `test_cedar.py`, `test_policy_provider.py`, `test_websocket_transport.py` -- unrelated to this change). Pydantic deprecation warning count drops to 34, all of which are pydantic's own internal `utcnow()` usage in `pydantic/main.py:250`, not in this codebase.

Recipe (PowerShell):

```powershell
cd agent-governance-python/agent-mesh
$env:PYTHONPATH = \"src\"
python -m pytest tests/ -q
```

## Test plan

- [x] Existing test suite still passes (same 11 pre-existing failures, no new regressions)
- [x] No remaining `datetime.utcnow` references in `agent-governance-python/agent-mesh/` Python sources
- [x] All modified files have `timezone` imported

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Mesh].