### PR TITLE
fix(dotnet/policy): consolidate policies and external-backends under one lock

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
@@ -13,9 +13,13 @@ namespace AgentGovernance.Policy;
 public sealed class PolicyEngine
 {
     private readonly List<Policy> _policies = new();
-    private readonly object _policyLock = new();
+    // Single lock protecting both _policies and _externalBackends.
+    // Evaluate() snapshots both, and ClearPolicies() clears both -- they must
+    // be observed atomically, otherwise a concurrent ClearPolicies between the
+    // two snapshots would let Evaluate run with mismatched state (e.g. cleared
+    // internal policies but still-live external backends, or vice versa).
+    private readonly object _snapshotLock = new();
     private readonly object _rateLimitLock = new();
-    private readonly object _externalBackendLock = new();
     private readonly Dictionary<string, RateLimitWindow> _rateLimits = new(StringComparer.Ordinal);
     private readonly List<IExternalPolicyBackend> _externalBackends = new();
 
@@ -33,7 +37,7 @@ public sealed class PolicyEngine
     {
         ArgumentNullException.ThrowIfNull(policy);
 
-        lock (_policyLock)
+        lock (_snapshotLock)
         {
             _policies.Add(policy);
         }
@@ -78,7 +82,7 @@ public sealed class PolicyEngine
     {
         ArgumentNullException.ThrowIfNull(backend);
 
-        lock (_externalBackendLock)
+        lock (_snapshotLock)
         {
             _externalBackends.Add(backend);
         }
@@ -113,7 +117,7 @@ public sealed class PolicyEngine
     /// </summary>
     public IReadOnlyList<string> ListExternalBackends()
     {
-        lock (_externalBackendLock)
+        lock (_snapshotLock)
         {
             return _externalBackends.Select(backend => backend.Name).ToList().AsReadOnly();
         }
@@ -124,7 +128,7 @@ public sealed class PolicyEngine
     /// </summary>
     public IReadOnlyList<Policy> ListPolicies()
     {
-        lock (_policyLock)
+        lock (_snapshotLock)
         {
             return _policies.ToList().AsReadOnly();
         }
@@ -135,13 +139,11 @@ public sealed class PolicyEngine
     /// </summary>
     public void ClearPolicies()
     {
-        lock (_policyLock)
+        // Clear both collections under a single critical section so a
+        // concurrent Evaluate cannot observe one cleared and the other live.
+        lock (_snapshotLock)
         {
             _policies.Clear();
-        }
-
-        lock (_externalBackendLock)
-        {
             _externalBackends.Clear();
         }
 
@@ -163,10 +165,15 @@ public sealed class PolicyEngine
         var evaluatedAt = DateTime.UtcNow;
         var sw = Stopwatch.StartNew();
 
+        // Snapshot both _policies and _externalBackends under a single lock so
+        // a concurrent ClearPolicies (which clears both) cannot land between
+        // the two reads and leave us evaluating with a half-cleared world.
         List<Policy> snapshot;
-        lock (_policyLock)
+        List<IExternalPolicyBackend> externalSnapshot;
+        lock (_snapshotLock)
         {
             snapshot = _policies.ToList();
+            externalSnapshot = _externalBackends.ToList();
         }
 
         var evalContext = new Dictionary<string, object>(context, StringComparer.OrdinalIgnoreCase)
@@ -175,7 +182,6 @@ public sealed class PolicyEngine
         };
 
         var internalEvaluation = EvaluateInternalPolicies(snapshot, evalContext, evaluatedAt, sw);
-        var externalSnapshot = GetExternalBackendsSnapshot();
         sw.Stop();
 
         if (externalSnapshot.Count == 0)
@@ -426,11 +432,4 @@ public sealed class PolicyEngine
         };
     }
 
-    private List<IExternalPolicyBackend> GetExternalBackendsSnapshot()
-    {
-        lock (_externalBackendLock)
-        {
-            return _externalBackends.ToList();
-        }
-    }
 }

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyEngineTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyEngineTests.cs
@@ -193,6 +193,97 @@ rules:
     }
 
     [Fact]
+    public async Task Evaluate_ConcurrentWithClearPolicies_DoesNotThrow_AndDecisionsRemainShaped()
+    {
+        // Regression: Evaluate() previously snapshotted _policies and
+        // _externalBackends under two separate lock acquisitions, and
+        // ClearPolicies() cleared them under two separate acquisitions too --
+        // so a Clear could land between the two snapshots and let Evaluate
+        // run with one collection cleared and the other still populated.
+        // (The two lock objects are now a single _snapshotLock guarding both
+        // collections, and ClearPolicies clears both inside that lock.)
+        //
+        // The torn-read itself is subtle and not directly externally
+        // observable as a "wrong" decision -- the engine still self-
+        // consistently routes through whichever pair of snapshots it got.
+        // What this test pins is the strict load-bearing property of the
+        // single-lock consolidation: under heavy concurrent
+        // ClearPolicies / LoadYaml / AddExternalBackend / Evaluate, no call
+        // throws (the underlying List<T> mutations are safely serialized)
+        // and every returned PolicyDecision is well-shaped (non-null
+        // Action). If the lock consolidation regressed to two locks (or
+        // worse, dropped a lock around mutation), a List<T> resize during
+        // concurrent enumeration would surface as
+        // InvalidOperationException here.
+
+        var engine = new PolicyEngine();
+        engine.LoadYaml(DenyPolicy);
+        var backend = new AllowBackend();
+        engine.AddExternalBackend(backend);
+
+        var ctx = new Dictionary<string, object> { ["tool_name"] = "rm" };
+        var stopAt = DateTime.UtcNow.AddSeconds(2);
+        var exceptions = 0;
+        var malformedDecisions = 0;
+
+        var clearTask = Task.Run(() =>
+        {
+            while (DateTime.UtcNow < stopAt)
+            {
+                try
+                {
+                    engine.ClearPolicies();
+                    engine.LoadYaml(DenyPolicy);
+                    engine.AddExternalBackend(backend);
+                }
+                catch
+                {
+                    Interlocked.Increment(ref exceptions);
+                }
+            }
+        });
+
+        var evalTasks = Enumerable.Range(0, 4).Select(_ => Task.Run(() =>
+        {
+            while (DateTime.UtcNow < stopAt)
+            {
+                try
+                {
+                    var decision = engine.Evaluate("did:mesh:test", ctx);
+                    if (string.IsNullOrEmpty(decision.Action))
+                    {
+                        Interlocked.Increment(ref malformedDecisions);
+                    }
+                }
+                catch
+                {
+                    Interlocked.Increment(ref exceptions);
+                }
+            }
+        })).ToArray();
+
+        await Task.WhenAll(evalTasks.Append(clearTask));
+
+        Assert.Equal(0, exceptions);
+        Assert.Equal(0, malformedDecisions);
+    }
+
+    private sealed class AllowBackend : IExternalPolicyBackend
+    {
+        public string Name => "allow-backend";
+
+        public ExternalPolicyDecision Evaluate(IReadOnlyDictionary<string, object> context)
+        {
+            return new ExternalPolicyDecision
+            {
+                Backend = Name,
+                Allowed = true,
+                Reason = "always-allow"
+            };
+        }
+    }
+
+    [Fact]
     public void Evaluate_RecordsEvaluationMetadata()
     {
         var engine = new PolicyEngine();


### PR DESCRIPTION
## Summary

[`PolicyEngine`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs) holds two separate locks for its two state collections:

- `_policyLock` -> `_policies`
- `_externalBackendLock` -> `_externalBackends`

[`Evaluate()`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs#L174-L242) snapshots `_policies` under one lock, then *later* snapshots `_externalBackends` under the other. [`ClearPolicies()`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs#L136-L152) clears each list under its own lock in sequence. The two operations are each internally serialized, but the combination opens a torn-read window: a concurrent `ClearPolicies` between Evaluate's two snapshot reads (or between Evaluate's snapshot and a follow-on `LoadYaml` + `AddExternalBackend`) can leave Evaluate running with one collection live and the other cleared -- a snapshot that corresponds to no real instant in time.

## Change

Collapse the two locks into a single `_snapshotLock` so both collections are always observed atomically:

- `Evaluate()` snapshots policies and external backends under one lock acquisition.
- `ClearPolicies()` clears both inside one critical section.

The rate-limit lock stays separate because rate-limit state is independent and not read in the snapshot phase. The unused `GetExternalBackendsSnapshot()` helper is removed.

## Tests

The new regression test hammers `Evaluate` against concurrent `ClearPolicies` / `LoadYaml` / `AddExternalBackend` and pins that:
1. No call throws (the lock consolidation must not weaken safety around `List<T>` mutations -- a regression to dropped locking would surface as `InvalidOperationException` during enumeration).
2. Every returned `PolicyDecision` is well-shaped.

The torn-read itself is subtle and not directly externally observable as a "wrong" decision -- the engine still self-consistently routes through whichever pair of snapshots it got -- but the consolidation is still the right shape: snapshot consistency is a foundational invariant for any future audit / replay logic that wants to reason about "what state was the engine in when this request was evaluated."

## Test plan

- [x] `dotnet test` -- 658 / 658 passing (previous baseline 657 + 1 new)
- [x] Existing `ClearPolicies_*` / `Evaluate_*` / `ListExternalBackends_*` tests unchanged

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, .NET].