### PR TITLE
fix(py-gov-compliance): resolve lint line numbers via YAML AST

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/lint_policy.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/lint_policy.py
@@ -105,16 +105,146 @@ class LintResult:
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# AST-based line lookup
 # ---------------------------------------------------------------------------
 
 
-def _find_line(lines: list[str], needle: str, start: int = 0) -> int:
-    """Return the 1-based line number where *needle* first appears."""
-    for i, raw in enumerate(lines[start:], start=start + 1):
-        if needle in raw:
-            return i
-    return 1
+class _LineMap:
+    """Resolve `(rule_index, key)` -> source line number from a yaml AST.
+
+    The previous implementation called `_find_line(lines, needle)` and
+    grep-walked the raw text. That worked for unambiguous needles but
+    blew up on benign collisions: searching for the literal substring
+    `"op:"` (deprecated key) inside a file that also contains an
+    unrelated comment, value, or anchor name containing `op:` returned
+    the wrong line. More broadly, value-based searches (e.g., locating
+    the line for `operator: nope` by searching for `"nope"`) match the
+    first textual occurrence rather than the structural one.
+
+    pyyaml's `compose` produces a node tree with `start_mark.line` on
+    every node, which is the correct source for line numbers. We walk
+    the tree once at construction time and cache the key positions we
+    care about. `pyyaml` is already a required dependency so no new
+    library is introduced; the resulting line numbers are exact rather
+    than best-effort.
+    """
+
+    def __init__(self, root_node: Any) -> None:
+        # Top-level mapping: key -> 1-based line of the key token.
+        self._top: dict[str, int] = {}
+        # Per-rule: idx -> {key -> line}
+        self._rule_keys: dict[int, dict[str, int]] = {}
+        # Per-rule: idx -> rule_line (the `- name:` / dash line)
+        self._rule_lines: dict[int, int] = {}
+        # Per-rule, per-condition-branch ("condition" or "conditions"):
+        # idx -> [{key -> line}, ...] indexed by condition position
+        # (single-condition branches still occupy slot 0).
+        self._rule_cond_keys: dict[int, dict[str, list[dict[str, int]]]] = {}
+        if root_node is None:
+            return
+        self._index(root_node)
+
+    @staticmethod
+    def _line(node: Any) -> int:
+        # pyyaml uses 0-based line numbers; the linter and human eyes
+        # want 1-based.
+        return node.start_mark.line + 1
+
+    def _index(self, root: Any) -> None:
+        import yaml
+
+        if not isinstance(root, yaml.MappingNode):
+            return
+
+        for key_node, value_node in root.value:
+            if not isinstance(key_node, yaml.ScalarNode):
+                continue
+            key = key_node.value
+            self._top[key] = self._line(key_node)
+
+            if key == "rules" and isinstance(value_node, yaml.SequenceNode):
+                self._index_rules(value_node)
+
+    def _index_rules(self, rules_node: Any) -> None:
+        import yaml
+
+        for idx, rule_node in enumerate(rules_node.value):
+            self._rule_lines[idx] = self._line(rule_node)
+            if not isinstance(rule_node, yaml.MappingNode):
+                continue
+
+            keys: dict[str, int] = {}
+            cond_branches: dict[str, list[dict[str, int]]] = {
+                "condition": [],
+                "conditions": [],
+            }
+
+            for key_node, value_node in rule_node.value:
+                if not isinstance(key_node, yaml.ScalarNode):
+                    continue
+                key = key_node.value
+                keys[key] = self._line(key_node)
+
+                if key == "condition" and isinstance(value_node, yaml.MappingNode):
+                    cond_branches["condition"].append(
+                        self._index_condition(value_node)
+                    )
+                elif key == "conditions" and isinstance(value_node, yaml.SequenceNode):
+                    for cond_node in value_node.value:
+                        if isinstance(cond_node, yaml.MappingNode):
+                            cond_branches["conditions"].append(
+                                self._index_condition(cond_node)
+                            )
+
+            self._rule_keys[idx] = keys
+            self._rule_cond_keys[idx] = cond_branches
+
+    def _index_condition(self, cond_node: Any) -> dict[str, int]:
+        import yaml
+
+        out: dict[str, int] = {}
+        for key_node, _value_node in cond_node.value:
+            if isinstance(key_node, yaml.ScalarNode):
+                out[key_node.value] = self._line(key_node)
+        return out
+
+    # ── Public accessors ──────────────────────────────────────────
+
+    def top_key_line(self, key: str) -> int:
+        """Return the source line of a top-level key, or 1 if missing."""
+        return self._top.get(key, 1)
+
+    def rule_line(self, idx: int) -> int:
+        """Return the dash/start line of the *idx*-th rule, or 1."""
+        return self._rule_lines.get(idx, 1)
+
+    def rule_key_line(self, idx: int, key: str) -> int:
+        """Return the source line of a key inside the *idx*-th rule.
+
+        Falls back to the rule's own line if the key is not in the AST
+        (e.g., when the rule isn't a mapping). Never returns 0.
+        """
+        rule = self._rule_keys.get(idx, {})
+        if key in rule:
+            return rule[key]
+        return self._rule_lines.get(idx, 1)
+
+    def condition_key_line(
+        self, idx: int, branch: str, cond_idx: int, key: str
+    ) -> int:
+        """Return the source line of a key inside a condition.
+
+        *branch* is either ``"condition"`` or ``"conditions"``. *cond_idx*
+        is the position within that branch (single-condition rules use
+        slot 0). Falls back to the rule's own line on any lookup miss.
+        """
+        rule_branches = self._rule_cond_keys.get(idx, {})
+        branch_list = rule_branches.get(branch, [])
+        if 0 <= cond_idx < len(branch_list):
+            cond_keys = branch_list[cond_idx]
+            if key in cond_keys:
+                return cond_keys[key]
+        return self.rule_key_line(idx, branch)
 
 
 # ---------------------------------------------------------------------------
@@ -140,11 +270,15 @@ def lint_file(path: str | Path) -> LintResult:
         )
         return result
 
-    lines = raw.splitlines()
-
-    # ── YAML parsing ──────────────────────────────────────────
+    # ── YAML parsing (data + AST) ─────────────────────────────
     try:
         data = yaml.safe_load(raw)
+        # compose() rebuilds the tree from scratch for line info; we
+        # need both the Python data structure (for fast key lookups
+        # and value-shape checks) and the AST (for source line
+        # numbers). The cost is one extra parse pass — negligible for
+        # policy-file scale.
+        root_node = yaml.compose(raw)
     except yaml.YAMLError as exc:
         line = 1
         if hasattr(exc, "problem_mark") and exc.problem_mark is not None:
@@ -159,6 +293,8 @@ def lint_file(path: str | Path) -> LintResult:
             LintMessage("error", "Policy file must be a YAML mapping", str(path), 1)
         )
         return result
+
+    line_map = _LineMap(root_node)
 
     # ── Required top-level fields ─────────────────────────────
     for field_name in REQUIRED_FIELDS:
@@ -175,33 +311,36 @@ def lint_file(path: str | Path) -> LintResult:
     # ── Deprecated top-level fields ───────────────────────────
     for old, new in DEPRECATED_FIELDS.items():
         if old in data:
-            line = _find_line(lines, old + ":")
             result.messages.append(
                 LintMessage(
                     "warning",
                     f"Deprecated field '{old}'; use '{new}' instead",
                     str(path),
-                    line,
+                    line_map.top_key_line(old),
                 )
             )
 
     # ── Rules validation ──────────────────────────────────────
     rules = data.get("rules")
     if isinstance(rules, list) and len(rules) == 0:
-        line = _find_line(lines, "rules:")
         result.messages.append(
-            LintMessage("warning", "Rules list is empty", str(path), line)
+            LintMessage(
+                "warning",
+                "Rules list is empty",
+                str(path),
+                line_map.top_key_line("rules"),
+            )
         )
 
     if isinstance(rules, list):
-        _lint_rules(rules, lines, str(path), result)
+        _lint_rules(rules, line_map, str(path), result)
 
     return result
 
 
 def _lint_rules(
     rules: list[Any],
-    lines: list[str],
+    line_map: _LineMap,
     filepath: str,
     result: LintResult,
 ) -> None:
@@ -217,93 +356,103 @@ def _lint_rules(
     for idx, rule in enumerate(rules):
         if not isinstance(rule, dict):
             result.messages.append(
-                LintMessage("error", f"Rule {idx} is not a mapping", filepath, 1)
+                LintMessage(
+                    "error",
+                    f"Rule {idx} is not a mapping",
+                    filepath,
+                    line_map.rule_line(idx),
+                )
             )
             continue
 
         rule_name = rule.get("name", f"rule[{idx}]")
-        search_hint = rule_name if rule_name != f"rule[{idx}]" else "- name:"
-        rule_line = _find_line(lines, search_hint)
+        rule_line = line_map.rule_line(idx)
 
         # ── Deprecated fields inside rules ────────────────────
         for old, new in DEPRECATED_FIELDS.items():
             if old in rule:
-                line = _find_line(lines, old + ":", max(rule_line - 1, 0))
                 result.messages.append(
                     LintMessage(
                         "warning",
                         f"Rule '{rule_name}': deprecated field '{old}'; "
                         f"use '{new}' instead",
                         filepath,
-                        line,
+                        line_map.rule_key_line(idx, old),
                     )
                 )
 
         # ── Action validation ─────────────────────────────────
         action = rule.get("action")
         if action is not None and action not in KNOWN_ACTIONS:
-            line = _find_line(lines, str(action), max(rule_line - 1, 0))
             result.messages.append(
                 LintMessage(
                     "error",
                     f"Rule '{rule_name}': unknown action '{action}'",
                     filepath,
-                    line,
+                    line_map.rule_key_line(idx, "action"),
                 )
             )
 
         # ── Condition / conditions validation ─────────────────
         condition = rule.get("condition")
         conditions = rule.get("conditions", [])
-        all_conditions: list[dict[str, Any]] = []
+        # Pair each condition dict with the branch + position it came
+        # from so we can resolve the structural line for every key
+        # rather than scanning the raw text.
+        all_conditions: list[tuple[dict[str, Any], str, int]] = []
         if isinstance(condition, dict):
-            all_conditions.append(condition)
+            all_conditions.append((condition, "condition", 0))
         if isinstance(conditions, list):
-            all_conditions.extend(c for c in conditions if isinstance(c, dict))
+            cond_idx = 0
+            for c in conditions:
+                if isinstance(c, dict):
+                    all_conditions.append((c, "conditions", cond_idx))
+                    cond_idx += 1
 
-        for cond in all_conditions:
+        for cond, branch, cond_idx in all_conditions:
             operator = cond.get("operator")
             if operator is not None and operator not in KNOWN_OPERATORS:
-                line = _find_line(lines, str(operator), max(rule_line - 1, 0))
                 result.messages.append(
                     LintMessage(
                         "error",
                         f"Rule '{rule_name}': unknown operator '{operator}'",
                         filepath,
-                        line,
+                        line_map.condition_key_line(
+                            idx, branch, cond_idx, "operator"
+                        ),
                     )
                 )
 
             for old, new in DEPRECATED_FIELDS.items():
                 if old in cond:
-                    line = _find_line(lines, old + ":", max(rule_line - 1, 0))
                     result.messages.append(
                         LintMessage(
                             "warning",
                             f"Rule '{rule_name}': deprecated field '{old}' "
                             f"in condition; use '{new}' instead",
                             filepath,
-                            line,
+                            line_map.condition_key_line(
+                                idx, branch, cond_idx, old
+                            ),
                         )
                     )
 
         # ── Priority validation ───────────────────────────────
         priority = rule.get("priority")
         if priority is not None and not isinstance(priority, int):
-            line = _find_line(lines, "priority:", max(rule_line - 1, 0))
             result.messages.append(
                 LintMessage(
                     "error",
                     f"Rule '{rule_name}': priority must be an integer, "
                     f"got {type(priority).__name__}",
                     filepath,
-                    line,
+                    line_map.rule_key_line(idx, "priority"),
                 )
             )
 
         # ── Conflict detection ────────────────────────────────
         if action in ("allow", "deny") and all_conditions:
-            for cond in all_conditions:
+            for cond, _branch, _cond_idx in all_conditions:
                 # JSON-canonical form for the value key — collapses
                 # equivalent dicts/lists with reordered members and
                 # preserves int-vs-string distinctions that str()

--- a/agent-governance-python/agent-compliance/tests/test_lint_policy.py
+++ b/agent-governance-python/agent-compliance/tests/test_lint_policy.py
@@ -550,3 +550,184 @@ class TestLintPolicyCLI:
     def test_lint_nonexistent_path(self, tmp_path, capsys):
         rc = run_cli("lint-policy", str(tmp_path / "nope.yaml"))
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# AST-based line resolution
+# ---------------------------------------------------------------------------
+
+
+class TestAstLineResolution:
+    """Pin that line numbers come from the YAML parse tree, not substring
+    grep. Each case exercises a layout where the substring approach
+    would have returned the wrong line, and confirms the AST resolver
+    points at the structural occurrence.
+    """
+
+    def test_deprecated_op_in_condition_points_at_op_not_operator(
+        self, tmp_path
+    ):
+        # Both keys appear in the condition; the line for the deprecated
+        # 'op:' must point at the 'op:' line, not the 'operator:' line.
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: t
+            rules:
+              - name: r1
+                action: allow
+                condition:
+                  field: tool_name
+                  op: eq
+                  operator: eq
+                  value: foo
+        """)
+        result = lint_file(p)
+        op_warnings = [
+            m for m in result.warnings
+            if "'op'" in m.message and "deprecated" in m.message.lower()
+        ]
+        assert op_warnings, "expected a deprecated-op warning"
+        # The op: key sits on line 8 (after `version`, `name`, `rules:`,
+        # `- name`, `action`, `condition:`, `field`).
+        assert op_warnings[0].line == 8
+
+    def test_unknown_operator_points_at_operator_value_line(self, tmp_path):
+        # An unrelated rule earlier in the file mentions 'nope' as a
+        # value. The substring approach would target that line instead
+        # of the actual unknown-operator line.
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: t
+            rules:
+              - name: distraction
+                action: allow
+                condition:
+                  field: nope
+                  operator: eq
+                  value: nope
+              - name: real-bad
+                action: allow
+                condition:
+                  field: tool_name
+                  operator: nope
+                  value: foo
+        """)
+        result = lint_file(p)
+        op_errors = [
+            m for m in result.errors
+            if "unknown operator" in m.message.lower() and "nope" in m.message
+        ]
+        assert op_errors, "expected a single unknown-operator error"
+        # The bad `operator: nope` token sits on line 14 (after the
+        # 7-line distraction rule).
+        assert op_errors[0].line == 14
+
+    def test_deprecated_type_in_rule_targets_correct_rule(self, tmp_path):
+        # Two rules each have a `type:` deprecated key. The previous
+        # approach used `_find_line(lines, "type:")` and would only
+        # ever return the first occurrence; the AST resolver gives
+        # distinct lines for each rule.
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: t
+            rules:
+              - name: first
+                type: allow
+                action: allow
+                condition: {field: a, operator: eq, value: x}
+              - name: second
+                type: deny
+                action: deny
+                condition: {field: b, operator: eq, value: y}
+        """)
+        result = lint_file(p)
+        type_warnings = [
+            m for m in result.warnings
+            if "'type'" in m.message and "deprecated" in m.message.lower()
+        ]
+        assert len(type_warnings) == 2
+        # First rule's `type:` is line 5, second rule's is line 9.
+        lines = sorted(m.line for m in type_warnings)
+        assert lines == [5, 9]
+
+    def test_unknown_action_points_at_action_key(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: t
+            rules:
+              - name: r1
+                condition:
+                  field: x
+                  operator: eq
+                  value: y
+                action: zap
+        """)
+        result = lint_file(p)
+        action_errors = [
+            m for m in result.errors
+            if "unknown action" in m.message.lower()
+        ]
+        assert action_errors
+        # The `action: zap` key sits on line 9.
+        assert action_errors[0].line == 9
+
+    def test_invalid_priority_targets_priority_key(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: t
+            rules:
+              - name: r1
+                action: allow
+                condition:
+                  field: x
+                  operator: eq
+                  value: y
+                priority: "high"
+        """)
+        result = lint_file(p)
+        prio_errors = [
+            m for m in result.errors
+            if "priority must be an integer" in m.message.lower()
+        ]
+        assert prio_errors
+        # `priority:` sits on line 10.
+        assert prio_errors[0].line == 10
+
+    def test_empty_rules_warning_points_at_rules_key(self, tmp_path):
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: t
+            rules: []
+        """)
+        result = lint_file(p)
+        empty = [m for m in result.warnings if "empty" in m.message.lower()]
+        assert empty
+        # `rules:` is on line 3.
+        assert empty[0].line == 3
+
+    def test_substring_collision_in_comment_ignored(self, tmp_path):
+        # The earlier comment line contains the literal text `op: eq`,
+        # which a substring search for "op:" would match before
+        # reaching the real deprecated key two lines below.
+        p = _write_policy(tmp_path, """\
+            version: "1.0"
+            name: t
+            rules:
+              - name: r1
+                action: allow
+                # legacy stub: op: eq
+                condition:
+                  field: x
+                  op: eq
+                  operator: eq
+                  value: y
+        """)
+        result = lint_file(p)
+        op_warnings = [
+            m for m in result.warnings
+            if "'op'" in m.message and "deprecated" in m.message.lower()
+        ]
+        assert op_warnings
+        # The structural `op:` key lives on line 9, not line 6 where
+        # the comment mentions it.
+        assert op_warnings[0].line == 9


### PR DESCRIPTION
## Summary

[`lint_policy.py`](agent-governance-python/agent-compliance/src/agent_compliance/lint_policy.py)'s `_find_line()` walked the raw text looking for a needle substring (`old + ":"`, `str(operator)`, `rule_name`). That returned a best-effort approximation that broke in predictable ways:

| Scenario | Wrong behaviour |
|---|---|
| Condition has both deprecated `op:` and canonical `operator:` | Value-based searches (e.g. `_find_line(lines, "nope")`) hit earlier mentions of the literal needle in other fields, strings, or YAML anchors |
| Two rules each carry a deprecated `type:` key | `_find_line` returns the FIRST occurrence, so the second rule's warning points at the first rule's line |
| A comment contains the literal key text (`# legacy stub: op: eq`) | Substring search matches the comment line before reaching the structural key |

The bullet calls this out as "`op:` collides with `operator:`" — the collision is more general (any value-based substring search collides with strings/comments/anchors that happen to contain the needle), and the AST-based fix resolves the whole class.

## Change

Adds a `_LineMap` helper in [`lint_policy.py`](agent-governance-python/agent-compliance/src/agent_compliance/lint_policy.py) that walks pyyaml's `compose()` AST once at lint-file entry and caches per-key source lines:

- `top_key_line(key)` — top-level keys (e.g. `rules:`)
- `rule_line(idx)` — start of the *idx*-th rule
- `rule_key_line(idx, key)` — keys inside a rule (`action:`, `priority:`, deprecated `type:` / `op:`)
- `condition_key_line(idx, branch, cond_idx, key)` — keys inside conditions (per branch: `condition` vs `conditions[i]`)

Every line-resolution call site in `lint_file` and `_lint_rules` now consults the AST instead of grepping raw text. `_find_line` is removed.

No new dependency — `pyyaml` is already required, and its `compose()` returns nodes carrying `start_mark.line` (1-based after the off-by-one fix). The bullet originally suggested `ruamel.yaml`; that would have added a heavyweight transitive dep for a YAML feature `pyyaml` already supports. Documented the choice in the `_LineMap` docstring.

## Tests

`tests/test_lint_policy.py` gains a `TestAstLineResolution` class with seven cases:

| Test | Pins |
|---|---|
| `test_deprecated_op_in_condition_points_at_op_not_operator` | `op:` on line 8 reported, not the adjacent `operator:` line |
| `test_unknown_operator_points_at_operator_value_line` | "nope" used as a value earlier doesn't poison the `operator: nope` lookup |
| `test_deprecated_type_in_rule_targets_correct_rule` | Two `type:` keys produce two distinct line numbers, not two copies of the first |
| `test_unknown_action_points_at_action_key` | `action: zap` line is reported |
| `test_invalid_priority_targets_priority_key` | `priority:` key line, not a value-side match |
| `test_empty_rules_warning_points_at_rules_key` | `rules:` key line |
| `test_substring_collision_in_comment_ignored` | A `# legacy stub: op: eq` comment doesn't capture the lookup |

All 37 pre-existing `test_lint_policy.py` cases continue to pass.

```
$ PYTHONPATH=src python -m pytest tests/test_lint_policy.py -q
44 passed in 0.68s
```

Full agent-compliance suite: 476 passed, 1 pre-existing failure in `test_red_team_cli` unrelated to this change.

## Test plan

- [ ] CI passes
- [ ] All 44 `test_lint_policy.py` cases pass
- [ ] No regression in existing `TestLintFileDeprecatedFields` / `TestLintFileInvalidAction` / `TestLintFileInvalidPriority` cases
- [ ] CLI output (`agent-compliance lint-policy`) still surfaces `<file>:<line>:` headers in the human format

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Governance].