### PR TITLE
fix(typescript/encryption): cap aggregate skippedKeys across DH ratchet steps

### DIFF
--- a/agent-governance-typescript/src/encryption/ratchet.ts
+++ b/agent-governance-typescript/src/encryption/ratchet.ts
@@ -25,6 +25,16 @@ const KDF_INFO_RATCHET = new TextEncoder().encode("AgentMesh_Ratchet_v1");
 const NONCE_LEN = 12;
 const KEY_LEN = 32;
 const MAX_SKIP = 100;
+/**
+ * Aggregate cap on cached skipped keys across all DH rotations.
+ *
+ * The per-call cap (`maxSkip`) bounds a single skip burst within one
+ * receive chain; this cap bounds the lifetime accumulation. Without it,
+ * a session that survives many DH ratchet steps with persistent out-of-
+ * order tails grows `skippedKeys` without limit. Mirrors the Python
+ * core implementation (`_MAX_SKIPPED_KEYS_TOTAL`).
+ */
+const MAX_SKIPPED_KEYS_TOTAL = 2000;
 
 export interface MessageHeader {
   dhPublicKey: Uint8Array;
@@ -256,6 +266,15 @@ export class DoubleRatchet {
       s.skippedKeys.set(skippedKeyId(s.dhRemotePublic!, s.recvMessageNumber), mk);
       s.chainKeyRecv = next;
       s.recvMessageNumber++;
+      // Evict the oldest skipped key once the aggregate cap is exceeded.
+      // ES2015+ `Map` iteration order is insertion order, so the first
+      // key returned is the oldest insertion that survived all prior
+      // evictions. Mirrors the Python core implementation.
+      while (s.skippedKeys.size > MAX_SKIPPED_KEYS_TOTAL) {
+        const oldest = s.skippedKeys.keys().next();
+        if (oldest.done) break;
+        s.skippedKeys.delete(oldest.value);
+      }
     }
   }
 

--- a/agent-governance-typescript/tests/encryption.test.ts
+++ b/agent-governance-typescript/tests/encryption.test.ts
@@ -282,6 +282,49 @@ describe("DoubleRatchet", () => {
 
     expect(() => bLimited.decrypt(e4)).toThrow("Too many skipped");
   });
+
+  test("skippedKeys cache is bounded by the aggregate cap", () => {
+    // The per-chain cap (maxSkip) bounds a single burst; the global cap
+    // bounds the lifetime accumulation across DH ratchet steps. This
+    // test forces a single oversized burst within one chain by raising
+    // maxSkip well above the global cap and confirms the resulting
+    // skippedKeys map never exceeds it (oldest entries are evicted FIFO).
+    const MAX_TOTAL = 2000;
+    const OVERFLOW = 50;
+    const SKIP = MAX_TOTAL + OVERFLOW;
+
+    const alice = makeManager();
+    const bob = makeManager();
+    bob.generateSignedPreKey();
+    bob.generateOneTimePreKeys(1);
+    const bundle = bob.getPublicBundle(0);
+    const ar = alice.initiate(bundle);
+    const br = bob.respond(alice.identityKey.publicKey, ar.ephemeralPublicKey, 0);
+
+    const aRatchet = DoubleRatchet.initSender(ar.sharedSecret, bundle.signedPreKey);
+    const bRatchetRaw = DoubleRatchet.initReceiver(br.sharedSecret, {
+      privateKey: bob.signedPreKey!.keyPair.privateKey,
+      publicKey: bob.signedPreKey!.keyPair.publicKey,
+    });
+
+    // Rebuild bob with a generous per-chain cap so the burst itself is
+    // not rejected, leaving the global cap as the only thing protecting
+    // memory.
+    const bRatchet = DoubleRatchet.fromState(bRatchetRaw.getState(), SKIP + 1);
+
+    // Alice sends SKIP messages that bob will skip, then one we deliver.
+    for (let i = 0; i < SKIP; i++) {
+      aRatchet.encrypt(enc.encode(`skipped-${i}`));
+    }
+    const final = aRatchet.encrypt(enc.encode("delivered"));
+
+    expect(dec.decode(bRatchet.decrypt(final))).toBe("delivered");
+
+    // After processing the final message, exactly MAX_TOTAL skipped keys
+    // remain cached; the oldest OVERFLOW were evicted.
+    const cachedAfter = bRatchet.getState().skippedKeys.size;
+    expect(cachedAfter).toBe(MAX_TOTAL);
+  });
 });
 
 // ── SecureChannel ──


### PR DESCRIPTION
## Problem

[`DoubleRatchet.skipMessages`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/src/encryption/ratchet.ts#L246-L260) enforced a per-call cap (`maxSkip`, default `MAX_SKIP = 100`) on the size of a single burst of skipped messages within one receive chain:

```typescript
if (until - s.recvMessageNumber > this.maxSkip) {
    throw new Error(`Too many skipped messages (${until - s.recvMessageNumber} > ${this.maxSkip})`);
}
while (s.recvMessageNumber < until) {
    const [mk, next] = kdfChain(s.chainKeyRecv);
    s.skippedKeys.set(skippedKeyId(s.dhRemotePublic!, s.recvMessageNumber), mk);
    s.chainKeyRecv = next;
    s.recvMessageNumber++;
}
```

But the `skippedKeys` map is *not* reset on a DH ratchet step (it is intentionally kept so out-of-order messages from old chains can still be decrypted). A long-lived session whose peer repeatedly forces fresh DH rotations while leaving small out-of-order tails behind in each chain accumulates skipped message keys indefinitely — memory grows in O(total skipped across the lifetime of the ratchet) rather than O(per-chain burst).

The Python core implementation already pins this: [`agent-governance-python/agent-mesh/src/agentmesh/encryption/ratchet.py`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-mesh/src/agentmesh/encryption/ratchet.py#L300-L327) defines `_MAX_SKIPPED_KEYS_TOTAL: int = 2000` and FIFO-evicts the oldest entries. The TypeScript implementation had no equivalent.

## Fix

Add a module-level `MAX_SKIPPED_KEYS_TOTAL = 2000` and FIFO-evict the oldest entries from `state.skippedKeys` whenever it exceeds the cap. `Map` iteration order is insertion order in ES2015+, so `s.skippedKeys.keys().next().value` returns the oldest surviving insertion — the same pattern Python's `next(iter(d))` uses. The cap is intentionally kept identical to Python (2000) so the two SDKs have matching memory bounds for the same wire protocol.

## Test

Added a regression test in [`tests/encryption.test.ts`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/tests/encryption.test.ts) that:

1. Raises `maxSkip` to 2051 via `DoubleRatchet.fromState`, so the per-chain cap does not gate the burst.
2. Has Alice encrypt 2050 messages that Bob will skip, then a final one we deliver.
3. Asserts the final decrypts correctly AND that `bRatchet.getState().skippedKeys.size === 2000` after delivery (the oldest 50 were evicted FIFO).

```
PASS  tests/encryption.test.ts
  ...
  Tests:       26 passed, 26 total
```

Recipe: `cd agent-governance-typescript && npx jest tests/encryption.test.ts --no-coverage`.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, TypeScript].