### PR TITLE
fix(py-gov-compliance): log optional-dep ImportError fallbacks at DEBUG

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/__init__.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/__init__.py
@@ -18,25 +18,44 @@ Components:
     - agent-lightning: RL training governance
 """
 
+import logging
+
 __version__ = "3.2.2"
 
-# Re-export core components for convenience
+_logger = logging.getLogger(__name__)
+
+# Re-export optional companion packages. The legacy ``try: import; except
+# ImportError: pass`` form silenced every failure with no breadcrumb,
+# which made "why isn't ``StatelessKernel`` resolvable?" much harder to
+# diagnose than it needed to be (typo'd extras install, broken venv,
+# half-uninstalled agent-os). A DEBUG-level log line records the missing
+# symbol and the original exception message so opt-in debugging
+# (``logging.getLogger("agent_compliance").setLevel(logging.DEBUG)``)
+# surfaces the cause without spamming default-config callers.
 try:
     from agent_os import StatelessKernel, ExecutionContext  # noqa: F401
-except ImportError:
-    pass
+except ImportError as exc:
+    _logger.debug(
+        "agent_compliance: optional dependency 'agent_os' not importable "
+        "(StatelessKernel, ExecutionContext unavailable): %s",
+        exc,
+    )
 
 try:
     from agentmesh import TrustManager  # noqa: F401
-except ImportError:
-    pass
+except ImportError as exc:
+    _logger.debug(
+        "agent_compliance: optional dependency 'agentmesh' not importable "
+        "(TrustManager unavailable): %s",
+        exc,
+    )
 
-from agent_compliance.supply_chain import (  # noqa: F401
+from agent_compliance.supply_chain import (  # noqa: F401,E402
     SupplyChainGuard,
     SupplyChainFinding,
     SupplyChainConfig,
 )
-from agent_compliance.prompt_defense import (  # noqa: F401
+from agent_compliance.prompt_defense import (  # noqa: F401,E402
     PromptDefenseEvaluator,
     PromptDefenseConfig,
     PromptDefenseFinding,

--- a/agent-governance-python/agent-compliance/tests/test_init_imports.py
+++ b/agent-governance-python/agent-compliance/tests/test_init_imports.py
@@ -1,0 +1,109 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests that optional-dependency ImportError fallbacks log at DEBUG.
+
+The package supports being imported without ``agent_os`` or
+``agentmesh`` installed. The previous code swallowed the resulting
+``ImportError`` with ``pass``, leaving no breadcrumb when callers
+later wondered why ``StatelessKernel`` was missing. The current code
+records each fallback at DEBUG level — these tests pin that contract
+without requiring the optional deps to be absent (and without
+unloading them where they happen to be installed).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def reimport_agent_compliance(monkeypatch):
+    """Force a fresh import of agent_compliance with controllable state."""
+    # Drop any already-loaded entries so the import side effects run again.
+    for mod in list(sys.modules):
+        if mod == "agent_compliance" or mod.startswith("agent_compliance."):
+            sys.modules.pop(mod, None)
+    yield
+    for mod in list(sys.modules):
+        if mod == "agent_compliance" or mod.startswith("agent_compliance."):
+            sys.modules.pop(mod, None)
+
+
+def _force_import_error(monkeypatch, blocked_top_level: set[str]) -> None:
+    """Make ``import <name>`` raise ImportError for selected modules."""
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        top = name.split(".", 1)[0]
+        if top in blocked_top_level:
+            raise ImportError(f"forced absence of {top}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+
+def test_missing_agent_os_logs_at_debug(
+    monkeypatch, caplog, reimport_agent_compliance
+):
+    _force_import_error(monkeypatch, {"agent_os"})
+    with caplog.at_level(logging.DEBUG, logger="agent_compliance"):
+        importlib.import_module("agent_compliance")
+
+    matches = [
+        record for record in caplog.records
+        if record.name == "agent_compliance"
+        and record.levelno == logging.DEBUG
+        and "agent_os" in record.getMessage()
+    ]
+    assert matches, "expected a DEBUG log mentioning agent_os"
+    # The breadcrumb must carry the original ImportError text so the
+    # operator can distinguish "not installed" from "broken install".
+    assert any("forced absence of agent_os" in m.getMessage() for m in matches)
+
+
+def test_missing_agentmesh_logs_at_debug(
+    monkeypatch, caplog, reimport_agent_compliance
+):
+    _force_import_error(monkeypatch, {"agentmesh"})
+    with caplog.at_level(logging.DEBUG, logger="agent_compliance"):
+        importlib.import_module("agent_compliance")
+
+    matches = [
+        record for record in caplog.records
+        if record.name == "agent_compliance"
+        and record.levelno == logging.DEBUG
+        and "agentmesh" in record.getMessage()
+    ]
+    assert matches, "expected a DEBUG log mentioning agentmesh"
+
+
+def test_default_log_level_stays_quiet(
+    monkeypatch, caplog, reimport_agent_compliance
+):
+    # At WARNING (default for most apps) the fallback should not surface
+    # — DEBUG is the explicit opt-in for diagnostics.
+    _force_import_error(monkeypatch, {"agent_os", "agentmesh"})
+    with caplog.at_level(logging.WARNING, logger="agent_compliance"):
+        importlib.import_module("agent_compliance")
+
+    noisy = [
+        record for record in caplog.records
+        if record.name == "agent_compliance"
+        and record.levelno >= logging.WARNING
+    ]
+    assert not noisy, f"unexpected warning/error logs: {noisy!r}"
+
+
+def test_import_still_succeeds_without_optional_deps(
+    monkeypatch, reimport_agent_compliance
+):
+    _force_import_error(monkeypatch, {"agent_os", "agentmesh"})
+    mod = importlib.import_module("agent_compliance")
+    # Core exports remain available even when both companion packages
+    # are missing.
+    assert hasattr(mod, "PromptDefenseEvaluator")
+    assert hasattr(mod, "SupplyChainGuard")


### PR DESCRIPTION
## Summary

[`agent_compliance/__init__.py`](agent-governance-python/agent-compliance/src/agent_compliance/__init__.py) wrapped the `agent_os` and `agentmesh` re-exports in:

```python
try:
    from agent_os import StatelessKernel, ExecutionContext
except ImportError:
    pass

try:
    from agentmesh import TrustManager
except ImportError:
    pass
```

The intent — letting the package import without companion packages installed — is correct. But the bare `pass` left no breadcrumb: operators wondering why `StatelessKernel` was missing at runtime had to grep the source to find that an import had been silently swallowed. "Not installed," "broken install," and "wrong extras" all looked identical from outside.

## Change

Replaces each `pass` with a `_logger.debug(...)` line that records the missing symbol and the original `ImportError` message:

```python
_logger.debug(
    "agent_compliance: optional dependency 'agent_os' not importable "
    "(StatelessKernel, ExecutionContext unavailable): %s",
    exc,
)
```

Default logging stays quiet (`WARNING` and above are silent). Opting in via `logging.getLogger("agent_compliance").setLevel(logging.DEBUG)` surfaces the cause without touching default-config callers — exactly the failure mode the bullet flagged.

## Tests

New `tests/test_init_imports.py` uses a `__builtins__.__import__` monkeypatch to force ImportError on either or both optional deps and reimports `agent_compliance` from scratch:

| Test | Pins |
|---|---|
| `test_missing_agent_os_logs_at_debug` | DEBUG line emitted, includes the original ImportError text |
| `test_missing_agentmesh_logs_at_debug` | Same contract for the second optional dep |
| `test_default_log_level_stays_quiet` | No WARNING+ records — fallback isn't noisy by default |
| `test_import_still_succeeds_without_optional_deps` | `PromptDefenseEvaluator`, `SupplyChainGuard` still importable |

```
$ PYTHONPATH=src python -m pytest tests/test_init_imports.py -q
4 passed in 0.47s
```

Full agent-compliance suite (excluding a pre-existing unrelated `test_red_team_cli` failure): 452 passed, 2 skipped.

## Test plan

- [ ] CI passes
- [ ] All four `test_init_imports.py` cases pass
- [ ] Existing `agent_compliance` import works when both `agent_os` and `agentmesh` are absent (the original behaviour)
- [ ] `logging.getLogger("agent_compliance").setLevel(logging.DEBUG)` surfaces the new breadcrumbs

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Governance].