### PR TITLE
fix(py-mesh-cards): require registry lookup for card signature verification

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 import json
 
-from agentmesh.identity.agent_id import AgentIdentity
+from agentmesh.identity.agent_id import AgentIdentity, IdentityRegistry
 from agentmesh.identity.revocation import RevocationList
 
 
@@ -73,13 +73,35 @@ class TrustedAgentCard(BaseModel):
         self.card_signature = identity.sign(signable.encode())
         self.signature_timestamp = datetime.now(timezone.utc)
 
-    def verify_signature(self, identity: Optional[AgentIdentity] = None) -> bool:
+    def verify_signature(
+        self,
+        identity: Optional[AgentIdentity] = None,
+        identity_registry: Optional["IdentityRegistry"] = None,
+    ) -> bool:
         """
         Verify the card's signature is valid.
 
+        Verification authority precedence (highest first):
+
+        1. Explicit ``identity`` -- authoritative; signature checked
+           against the supplied identity's public key.
+        2. ``identity_registry`` -- looked up by ``agent_did``; the
+           registry's stored public key is authoritative. If the DID
+           is not registered, verification fails (the embedded key is
+           NOT consulted -- a registered lookup is required).
+        3. Embedded ``public_key`` on the card itself -- self-attesting
+           and trust-on-first-use only. An attacker can mint a card
+           that carries their own key and a matching signature, so this
+           path proves only that the bearer signed the card, not that
+           the bearer owns the claimed agent identity. Callers that
+           need authoritative verification should always pass either
+           ``identity`` or ``identity_registry``.
+
         Args:
-            identity: Optional identity to verify against. If not provided,
-                     uses the public key embedded in the card.
+            identity: Optional authoritative identity to verify against.
+            identity_registry: Optional registry; when provided and
+                the card's ``agent_did`` is registered, the registry's
+                public key is used and the embedded key is ignored.
 
         Returns:
             True if signature is valid, False otherwise
@@ -92,8 +114,18 @@ class TrustedAgentCard(BaseModel):
         if identity:
             return identity.verify_signature(signable.encode(), self.card_signature)
 
-        # Verify using embedded public key
-        # This requires reconstructing a minimal identity for verification
+        if identity_registry is not None and self.agent_did:
+            registered = identity_registry.get(self.agent_did)
+            if registered is None:
+                # Registry is authoritative: an unregistered DID cannot
+                # be verified by falling back to the card's own key.
+                return False
+            return registered.verify_signature(
+                signable.encode(), self.card_signature
+            )
+
+        # Self-attesting fallback: verify using the embedded public key.
+        # Trust-on-first-use only -- see method docstring.
         from cryptography.hazmat.primitives.asymmetric import ed25519
         import base64
 
@@ -195,6 +227,7 @@ class CardRegistry:
         self,
         cache_ttl_seconds: int = 900,
         revocation_list: Optional["RevocationList"] = None,
+        identity_registry: Optional["IdentityRegistry"] = None,
     ):
         """Initialise the card registry.
 
@@ -204,11 +237,19 @@ class CardRegistry:
             revocation_list: Optional revocation list to check during
                 verification. When set, revoked agent DIDs fail
                 ``is_verified()`` even if their signatures are valid.
+            identity_registry: Optional authoritative identity registry.
+                When set, card verification looks up the agent's
+                registered identity by DID and verifies against that
+                key rather than the card's self-attested embedded key.
+                Recommended in production -- without it, a tampered
+                card that re-signs its own content with an attacker's
+                key still passes ``verify_signature()``.
         """
         self._cards: Dict[str, TrustedAgentCard] = {}
         self._verified_cache: Dict[str, tuple[bool, datetime]] = {}
         self._cache_ttl = timedelta(seconds=cache_ttl_seconds)
         self._revocation_list = revocation_list
+        self._identity_registry = identity_registry
 
     def register(self, card: TrustedAgentCard) -> bool:
         """
@@ -220,7 +261,7 @@ class CardRegistry:
         Returns:
             True if registered successfully, False if verification failed
         """
-        if not card.verify_signature():
+        if not card.verify_signature(identity_registry=self._identity_registry):
             return False
 
         if card.agent_did:
@@ -272,7 +313,9 @@ class CardRegistry:
         if not card:
             return False
 
-        verified = card.verify_signature()
+        verified = card.verify_signature(
+            identity_registry=self._identity_registry
+        )
         self._verified_cache[agent_did] = (verified, datetime.now(timezone.utc))
         return verified
 

--- a/agent-governance-python/agent-mesh/tests/test_cards_registry_authority.py
+++ b/agent-governance-python/agent-mesh/tests/test_cards_registry_authority.py
@@ -1,0 +1,127 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for authoritative-registry verification on TrustedAgentCard.
+
+These tests pin the verification-authority precedence documented on
+``TrustedAgentCard.verify_signature``:
+
+1. Explicit ``identity`` is authoritative.
+2. ``identity_registry`` is consulted by ``agent_did``; the embedded
+   key must NOT be used as a fallback when the registry is provided.
+3. Bare verification with neither argument is self-attesting only.
+"""
+
+import pytest
+
+from agentmesh.identity.agent_id import AgentIdentity, IdentityRegistry
+from agentmesh.trust.cards import TrustedAgentCard, CardRegistry
+
+
+@pytest.fixture
+def authoritative_identity():
+    return AgentIdentity.create("alice", sponsor="alice@example.com")
+
+
+@pytest.fixture
+def authoritative_card(authoritative_identity):
+    return TrustedAgentCard.from_identity(authoritative_identity)
+
+
+class TestRegistryLookupPrecedence:
+    def test_card_verified_against_registered_identity(
+        self, authoritative_identity, authoritative_card
+    ):
+        registry = IdentityRegistry()
+        registry.register(authoritative_identity)
+        assert (
+            authoritative_card.verify_signature(identity_registry=registry)
+            is True
+        )
+
+    def test_unregistered_did_fails_when_registry_supplied(
+        self, authoritative_card
+    ):
+        """The embedded public key must NOT be a fallback when a
+        registry is provided -- if the DID is not registered,
+        verification fails."""
+        empty_registry = IdentityRegistry()
+        assert (
+            authoritative_card.verify_signature(
+                identity_registry=empty_registry
+            )
+            is False
+        )
+
+    def test_tampered_card_with_self_signed_key_fails_registry_check(
+        self, authoritative_identity
+    ):
+        """An attacker mints a card claiming alice's DID but signs it
+        with their own key. Registry lookup rejects it because the
+        registry holds alice's real public key."""
+        attacker = AgentIdentity.create(
+            "attacker", sponsor="evil@example.com"
+        )
+        registry = IdentityRegistry()
+        registry.register(authoritative_identity)
+
+        forged = TrustedAgentCard(
+            name="alice",
+            description="impersonator",
+            capabilities=["read:everything"],
+        )
+        # Sign with attacker's key but claim alice's DID
+        forged.sign(attacker)
+        forged.agent_did = str(authoritative_identity.did)
+        # Re-sign so the card is internally consistent with the new DID
+        forged.card_signature = attacker.sign(
+            forged._get_signable_content().encode()
+        )
+        forged.public_key = attacker.public_key
+
+        # Self-attestation path: passes (the card is internally
+        # consistent with the attacker's embedded key).
+        assert forged.verify_signature() is True
+        # Registry path: fails because alice's authoritative key does
+        # not match the attacker's signature.
+        assert (
+            forged.verify_signature(identity_registry=registry) is False
+        )
+
+    def test_explicit_identity_overrides_registry(
+        self, authoritative_identity, authoritative_card
+    ):
+        empty_registry = IdentityRegistry()
+        # Even though registry doesn't know this DID, the explicit
+        # identity argument is authoritative.
+        assert (
+            authoritative_card.verify_signature(
+                identity=authoritative_identity,
+                identity_registry=empty_registry,
+            )
+            is True
+        )
+
+
+class TestCardRegistryUsesIdentityRegistry:
+    def test_register_uses_identity_registry_when_supplied(
+        self, authoritative_identity, authoritative_card
+    ):
+        id_registry = IdentityRegistry()
+        id_registry.register(authoritative_identity)
+        card_registry = CardRegistry(identity_registry=id_registry)
+        assert card_registry.register(authoritative_card) is True
+
+    def test_register_rejects_unregistered_did(self, authoritative_card):
+        """If a CardRegistry is configured with an identity registry,
+        cards whose DIDs are not registered fail to register."""
+        id_registry = IdentityRegistry()
+        card_registry = CardRegistry(identity_registry=id_registry)
+        assert card_registry.register(authoritative_card) is False
+
+    def test_register_without_identity_registry_falls_back_to_self_attestation(
+        self, authoritative_card
+    ):
+        """Backward-compatible path: when no identity registry is
+        configured, the embedded key is honoured (self-attestation)."""
+        card_registry = CardRegistry()
+        assert card_registry.register(authoritative_card) is True


### PR DESCRIPTION
## Summary

[`TrustedAgentCard.verify_signature()`](agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py) previously verified against the public key embedded in the card itself when no explicit identity was supplied. This is a self-attesting check that proves only that the bearer signed the card, not that the bearer owns the claimed agent identity.

An attacker who knows a victim's DID can mint a card with their own Ed25519 keypair, set ``agent_did`` to the victim's DID, sign it with the attacker key, and the signature will verify because the card is internally consistent with the attacker's embedded key. ``CardRegistry.register()`` called the bare verification path with no identity argument, so a poisoned card would register successfully.

## Change

- Add optional ``identity_registry: IdentityRegistry`` parameter to ``TrustedAgentCard.verify_signature()``.
- Add optional ``identity_registry`` to ``CardRegistry.__init__()`` and propagate it through ``register()`` and ``is_verified()``.
- Verification authority precedence (highest first):
  1. Explicit ``identity`` argument
  2. ``identity_registry`` lookup by ``agent_did`` -- registry is authoritative, unregistered DIDs fail verification (the embedded key is NOT a fallback)
  3. Bare call: self-attesting fallback only, documented as trust-on-first-use

The self-attestation path remains for backward compatibility but is now clearly scoped in the docstring. ``CardRegistry`` users opt into authoritative verification with a single argument:

```python
CardRegistry(identity_registry=mesh_registry)
```

## Tests

| Suite | Before | After |
|---|---|---|
| `tests/test_cards_registry_authority.py` (new) | n/a | 7 passed |
| `tests/test_revocation_rotation.py` | 16 passed | 16 passed |
| Full `tests/` | 11 pre-existing failures | 11 pre-existing failures |

New regression tests pin:

- Registry-lookup succeeds for registered DIDs
- Unregistered DID fails when registry is supplied (no embedded-key fallback)
- Tampered card with attacker-key passes self-attestation path but fails registry path
- Explicit identity argument overrides registry lookup
- ``CardRegistry`` honours ``identity_registry`` in ``register()``

Recipe (PowerShell):

```powershell
cd agent-governance-python/agent-mesh
$env:PYTHONPATH = \"src\"
python -m pytest tests/test_cards_registry_authority.py tests/test_revocation_rotation.py -q
```

## Test plan

- [x] New regression suite passes (7/7)
- [x] Existing ``CardRegistry`` revocation tests still green
- [x] Full suite shows no new failures (same 11 pre-existing 3.14 deprecation failures)

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Mesh].