### PR TITLE
fix(py-isolation-kill-switch): document registration invariant on failed kills

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/security/kill_switch.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/security/kill_switch.py
@@ -134,7 +134,20 @@ class KillSwitch:
         in_flight_steps: list[dict] | None = None,
         details: str = "",
     ) -> KillResult:
-        """Kill an agent, handing off in-flight steps to a substitute if available."""
+        """Kill an agent, handing off in-flight steps to a substitute if available.
+
+        Registration invariant: the agent is unregistered from the
+        process registry **unconditionally** at the end of this method,
+        regardless of whether the termination callback succeeded
+        (``terminated=True``) or failed/timed out (``terminated=False``).
+        This is intentional. The kill *intent* is durably recorded in
+        ``_kill_history`` and surfaced via the returned ``KillResult``;
+        leaving the callback registered would falsely advertise the
+        agent as live and re-callable when its process state is
+        actually unknown. Callers who detect ``terminated=False`` and
+        want to retry must re-register the agent (presumably with a
+        new, working callback) before issuing the second ``kill()``.
+        """
         in_flight = in_flight_steps or []
 
         with self._lock:


### PR DESCRIPTION
## Summary

[`kill_switch.py`](agent-governance-python/agent-hypervisor/src/hypervisor/security/kill_switch.py)'s `KillSwitch.kill` calls `unregister_agent(agent_did)` unconditionally at the end of the method (line 197), regardless of whether the termination callback succeeded (`terminated=True`) or failed/timed out (`terminated=False`).

The behaviour was correct but undocumented; the audit flagged it as ambiguous because two reasonable interpretations existed:

- **A) Always unregister** (the current code): kill *intent* is recorded, retries must re-register first.
- **B) Preserve registration on failure**: failed kill means process state is unknown; retries find the callback still there.

Picking between A and B is a real product call, not just style.

## Change

Document the intentional answer in the `kill` docstring: A.

Rationale:
- The kill *intent* is durably recorded in `_kill_history` and surfaced via the returned `KillResult.terminated` field.
- Leaving a registration in place when the callback failed would falsely advertise the agent as live and re-callable, which is worse than no registration at all.
- Callers who detect `terminated=False` and want to retry must re-register the agent (presumably with a new, working callback) before issuing the second `kill()`.

Pure docstring change — no behaviour delta.

## Tests

```
$ PYTHONPATH=src python -m pytest tests/test_kill_switch.py -q
32 passed in 0.63s
```

No new tests needed (documentation change). Existing 32 kill-switch tests cover the registration-removal path on both success and failure cases.

## Test plan

- [ ] CI passes
- [ ] No behaviour change in `KillSwitch.kill`

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Isolation].