### PR TITLE
fix(py-isolation-circuit-breaker): document HALF_OPEN as reserved forward-compat surface

### DIFF
--- a/agent-governance-python/agent-sre/src/agent_sre/incidents/circuit_breaker.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/incidents/circuit_breaker.py
@@ -16,19 +16,37 @@ from typing import Any
 
 
 class CircuitState(Enum):
-    """Circuit breaker state."""
+    """Circuit breaker state.
+
+    ``HALF_OPEN`` is wired through the enum, the ``CircuitBreakerConfig``
+    knobs (``success_threshold``, ``half_open_max_calls``), the
+    ``CircuitBreaker._half_open_calls`` field, and the
+    ``CircuitBreakerRegistry.summary`` rollup — but **no code path ever
+    transitions to it** in Public Preview. The recovery flow is
+    documented as manual: callers ``force_close()`` or ``reset()`` after
+    deciding the agent is healthy. The HALF_OPEN surface is kept
+    forward-compatible so future versions can flip on auto-recovery
+    without breaking the public type or API shape.
+    """
     CLOSED = "closed"      # Normal operation
     OPEN = "open"          # Failing, reject calls
-    HALF_OPEN = "half_open"  # Testing recovery
+    HALF_OPEN = "half_open"  # Reserved for future auto-recovery; not entered in Public Preview
 
 
 @dataclass
 class CircuitBreakerConfig:
-    """Configuration for a circuit breaker."""
+    """Configuration for a circuit breaker.
+
+    ``success_threshold`` and ``half_open_max_calls`` are part of the
+    forward-compatible HALF_OPEN surface (see ``CircuitState``) and are
+    not read by any code path in Public Preview. They're kept on the
+    config so a future flip to auto-recovery does not break serialised
+    configs in the wild.
+    """
     failure_threshold: int = 5          # Failures before opening
-    success_threshold: int = 3          # Successes in half-open to close
-    timeout_seconds: float = 60.0       # Time in open before half-open
-    half_open_max_calls: int = 3        # Max test calls in half-open
+    success_threshold: int = 3          # Reserved: successes in half-open to close
+    timeout_seconds: float = 60.0       # Reserved: time in open before half-open
+    half_open_max_calls: int = 3        # Reserved: max test calls in half-open
 
     def to_dict(self) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary

[`incidents/circuit_breaker.py`](agent-governance-python/agent-sre/src/agent_sre/incidents/circuit_breaker.py)'s `CircuitState.HALF_OPEN` value, `CircuitBreakerConfig.success_threshold`, `CircuitBreakerConfig.half_open_max_calls`, `CircuitBreakerConfig.timeout_seconds`, and the `CircuitBreaker._half_open_calls` field are all wired into the enum, config, and `CircuitBreakerRegistry.summary` rollup — but **no code path transitions to HALF_OPEN** in Public Preview. The module docstring already notes "Half-open recovery is not available in Public Preview — use `force_close()` or `reset()` to recover", but the un-reached enum value and unused config knobs look like dead code to a fresh reader.

REVIEW.md, Python Isolation: "`circuit_breaker.py:91-94` — `HALF_OPEN` state wired but never reachable; dead code."

## Change

The fields are intentionally forward-compatible — keeping them on the public surface lets a later release flip on auto-recovery without breaking serialised configs in the wild. Two documentation changes make that intent explicit:

1. **`CircuitState` docstring** — added a block explaining HALF_OPEN is reserved for future auto-recovery and naming the surface area kept in support of it (enum value, config knobs, `_half_open_calls` field, registry rollup).
2. **`CircuitBreakerConfig` field comments** — renamed from `# Successes in half-open to close` to `# Reserved: successes in half-open to close` so a reader of the dataclass sees at a glance that these are not currently consumed.

Pure documentation change — no behaviour delta.

## Tests

```
$ PYTHONPATH=src python -m pytest tests/unit/test_circuit_breaker.py -q
15 passed in 0.37s
```

No new tests needed.

## Test plan

- [ ] CI passes
- [ ] No behaviour change in `CircuitBreaker` / `CircuitBreakerConfig` / `CircuitBreakerRegistry`

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Isolation].