### PR TITLE
perf(dotnet/audit): compute SHA-256 hash outside the entries lock

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Audit/AuditLogger.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Audit/AuditLogger.cs
@@ -63,7 +63,16 @@ public sealed class AuditEntry
 public sealed class AuditLogger
 {
     private readonly List<AuditEntry> _entries = new();
-    private readonly object _lock = new();
+    // Two-level locking:
+    //   _appendLock  serializes writers (the hash chain is sequential, so
+    //                appends must happen one at a time), held for the
+    //                duration of a single Log call.
+    //   _entriesLock guards reads and writes of _entries; held very briefly
+    //                so reader operations (Count, Verify, GetEntries,
+    //                ExportJson) are not blocked while a writer is busy
+    //                computing the SHA-256 hash for its new entry.
+    private readonly object _appendLock = new();
+    private readonly object _entriesLock = new();
 
     /// <summary>
     /// Returns the number of entries in the audit log.
@@ -72,7 +81,7 @@ public sealed class AuditLogger
     {
         get
         {
-            lock (_lock)
+            lock (_entriesLock)
             {
                 return _entries.Count;
             }
@@ -93,12 +102,27 @@ public sealed class AuditLogger
         ArgumentException.ThrowIfNullOrWhiteSpace(action);
         ArgumentException.ThrowIfNullOrWhiteSpace(decision);
 
-        lock (_lock)
+        // The hash chain is sequential -- each entry hashes the previous
+        // entry's hash, so appends must serialize. _appendLock provides that
+        // serialization for the entire Log call.
+        //
+        // Within _appendLock we still need a separate, very brief
+        // _entriesLock around _entries reads/writes so concurrent reader
+        // operations (Count, Verify, GetEntries, ExportJson) are not blocked
+        // by this writer while it spends ~all of its wall-clock time inside
+        // SHA-256. Pre-fix, readers were blocked on the same lock that held
+        // through ComputeHash + string allocations.
+        lock (_appendLock)
         {
-            var seq = _entries.Count;
-            var timestamp = DateTimeOffset.UtcNow;
-            var previousHash = seq == 0 ? string.Empty : _entries[seq - 1].Hash;
+            int seq;
+            string previousHash;
+            lock (_entriesLock)
+            {
+                seq = _entries.Count;
+                previousHash = seq == 0 ? string.Empty : _entries[seq - 1].Hash;
+            }
 
+            var timestamp = DateTimeOffset.UtcNow;
             var hash = ComputeHash(seq, timestamp, agentId, action, decision, previousHash);
 
             var entry = new AuditEntry
@@ -112,7 +136,10 @@ public sealed class AuditLogger
                 Hash = hash
             };
 
-            _entries.Add(entry);
+            lock (_entriesLock)
+            {
+                _entries.Add(entry);
+            }
             return entry;
         }
     }
@@ -125,7 +152,7 @@ public sealed class AuditLogger
     /// <returns><c>true</c> if the chain is intact; otherwise <c>false</c>.</returns>
     public bool Verify()
     {
-        lock (_lock)
+        lock (_entriesLock)
         {
             for (var i = 0; i < _entries.Count; i++)
             {
@@ -161,7 +188,7 @@ public sealed class AuditLogger
     /// <returns>A read-only list of matching entries.</returns>
     public IReadOnlyList<AuditEntry> GetEntries(string? agentId = null, string? action = null)
     {
-        lock (_lock)
+        lock (_entriesLock)
         {
             IEnumerable<AuditEntry> query = _entries;
 
@@ -185,7 +212,7 @@ public sealed class AuditLogger
     /// <returns>A JSON array of all audit entries.</returns>
     public string ExportJson()
     {
-        lock (_lock)
+        lock (_entriesLock)
         {
             return JsonSerializer.Serialize(_entries, JsonOptions);
         }

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/AuditLoggerTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/AuditLoggerTests.cs
@@ -221,4 +221,63 @@ public class AuditLoggerTests
         Assert.True(logger.Verify());
         Assert.True(logger.Verify());
     }
+
+    [Fact]
+    public async Task Log_ConcurrentWritersWithConcurrentReaders_ProducesIntactChain()
+    {
+        // Regression for the hash-out-of-lock refactor. Log now performs
+        // SHA-256 outside the brief lock that guards _entries, but appends
+        // are still serialized via a separate _appendLock so each entry's
+        // hash deterministically chains off the previous entry's hash.
+        //
+        // Hammer with multiple concurrent writers plus concurrent readers
+        // (Count / Verify) and pin three invariants:
+        //   1) Every entry's Seq matches its position in the chain.
+        //   2) PreviousHash links form an unbroken chain (each entry's
+        //      PreviousHash equals the prior entry's Hash).
+        //   3) Verify() returns true at the end -- every recomputed hash
+        //      still matches the stored hash.
+        // A regression that dropped the writer serialization, or that
+        // captured Seq/PreviousHash inconsistently relative to the actual
+        // append order, would break (1) or (2) immediately.
+
+        const int writersCount = 4;
+        const int entriesPerWriter = 100;
+        var logger = new AuditLogger();
+        var stopReaders = new CancellationTokenSource();
+
+        var readers = Enumerable.Range(0, 2).Select(_ => Task.Run(() =>
+        {
+            while (!stopReaders.IsCancellationRequested)
+            {
+                var unusedCount = logger.Count;
+                var unusedVerify = logger.Verify();
+                GC.KeepAlive((unusedCount, unusedVerify));
+            }
+        })).ToArray();
+
+        var writers = Enumerable.Range(0, writersCount).Select(w => Task.Run(() =>
+        {
+            for (var i = 0; i < entriesPerWriter; i++)
+            {
+                logger.Log($"did:agentmesh:w{w}", $"action{i}", i % 2 == 0 ? "allow" : "deny");
+            }
+        })).ToArray();
+
+        await Task.WhenAll(writers);
+        stopReaders.Cancel();
+        await Task.WhenAll(readers);
+
+        var entries = logger.GetEntries();
+        Assert.Equal(writersCount * entriesPerWriter, entries.Count);
+
+        for (var i = 0; i < entries.Count; i++)
+        {
+            Assert.Equal(i, entries[i].Seq);
+            var expectedPrev = i == 0 ? string.Empty : entries[i - 1].Hash;
+            Assert.Equal(expectedPrev, entries[i].PreviousHash);
+        }
+
+        Assert.True(logger.Verify());
+    }
 }


### PR DESCRIPTION
## Summary

[`AuditLogger.Log()`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Audit/AuditLogger.cs#L90-L118) held a single `_lock` through the SHA-256 hash computation and `AuditEntry` allocation. The SHA-256 (plus timestamp formatting and entry construction) dominate per-call wall time -- the actual `List<T>.Add` at the end is microseconds. Holding the lock through the hash blocked every reader (`Count`, `Verify`, `GetEntries`, `ExportJson`) for the full duration of each append. That's exactly backwards for an audit log: writes are sporadic but verification / export tends to scan the whole chain, so reader contention is the dominant cost.

## Change

Split into two locks:

- `_appendLock` serializes writers. The hash chain is sequential -- each entry hashes off the previous entry's hash, so appends must be one-at-a-time. Held for the entire `Log` call.
- `_entriesLock` guards reads and writes of `_entries`. Held only for the cheap parts: capturing `seq` + `previousHash` at the start of an append, the final `List<T>.Add`, and every reader path.

The SHA-256 hash and entry construction now run **between** the two `_entriesLock` acquisitions inside the writer's `_appendLock` critical section -- concurrent readers no longer wait on hash computation, but writers remain strictly serialized so the chain stays sound.

## Tests

The new regression test runs 4 concurrent writers (100 entries each) plus concurrent `Count` / `Verify` readers, and at the end pins:

- chain length is exactly `writers * entries-per-writer`,
- every `Seq` matches its position in the list,
- every `PreviousHash` links to the prior entry's `Hash`, and
- `Verify()` returns `true` (recomputed hashes still match the stored hashes).

A regression that dropped writer serialization, or that captured `Seq` / `PreviousHash` inconsistently relative to append order, would break one of those immediately.

## Test plan

- [x] `dotnet test` -- 658 / 658 passing (previous baseline 657 + 1 new). One pre-existing flaky test (`GovernanceMetricsTagPolicyTests::ToolNameBucket_AppliedBeforeEmission`) failed once under parallel execution and passed on rerun and in isolation; reproduces against bare `main` too, unrelated to this change.
- [x] Existing `Log_*` / `Verify_*` / `GetEntries_*` / `ExportJson_*` tests unchanged.

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, .NET].