### PR TITLE
fix(py-mesh-cards): invalidate verification cache on card mutation

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py
@@ -206,9 +206,29 @@ class CardRegistry:
                 ``is_verified()`` even if their signatures are valid.
         """
         self._cards: Dict[str, TrustedAgentCard] = {}
-        self._verified_cache: Dict[str, tuple[bool, datetime]] = {}
+        # Cache entry: (verified, timestamp, signed_content_hash). The
+        # hash pins the cached verdict to the exact signable content
+        # that was verified, so any in-place mutation of the stored
+        # card (capabilities, trust score, etc.) invalidates the entry
+        # on the next read.
+        self._verified_cache: Dict[str, tuple[bool, datetime, str]] = {}
         self._cache_ttl = timedelta(seconds=cache_ttl_seconds)
         self._revocation_list = revocation_list
+
+    @staticmethod
+    def _card_content_hash(card: TrustedAgentCard) -> str:
+        """Stable hash of the card's signable content + signature.
+
+        Used as a cache key suffix so any mutation of the signed fields
+        or the signature itself produces a new hash and the cached
+        verdict is discarded.
+        """
+        import hashlib
+
+        signable = card._get_signable_content()
+        signature = card.card_signature or ""
+        material = f"{signable}|{signature}".encode()
+        return hashlib.sha256(material).hexdigest()
 
     def register(self, card: TrustedAgentCard) -> bool:
         """
@@ -225,7 +245,11 @@ class CardRegistry:
 
         if card.agent_did:
             self._cards[card.agent_did] = card
-            self._verified_cache[card.agent_did] = (True, datetime.now(timezone.utc))
+            self._verified_cache[card.agent_did] = (
+                True,
+                datetime.now(timezone.utc),
+                self._card_content_hash(card),
+            )
 
         return True
 
@@ -263,17 +287,29 @@ class CardRegistry:
             self._verified_cache.pop(agent_did, None)
             return False
 
-        if agent_did in self._verified_cache:
-            verified, timestamp = self._verified_cache[agent_did]
-            if datetime.now(timezone.utc) - timestamp < self._cache_ttl:
-                return verified
-
         card = self._cards.get(agent_did)
         if not card:
             return False
 
+        current_hash = self._card_content_hash(card)
+
+        if agent_did in self._verified_cache:
+            verified, timestamp, cached_hash = self._verified_cache[agent_did]
+            if (
+                cached_hash == current_hash
+                and datetime.now(timezone.utc) - timestamp < self._cache_ttl
+            ):
+                return verified
+            # Mutation detected (or TTL expired) -- drop the entry and
+            # re-verify from scratch below.
+            self._verified_cache.pop(agent_did, None)
+
         verified = card.verify_signature()
-        self._verified_cache[agent_did] = (verified, datetime.now(timezone.utc))
+        self._verified_cache[agent_did] = (
+            verified,
+            datetime.now(timezone.utc),
+            current_hash,
+        )
         return verified
 
     def clear_cache(self) -> None:

--- a/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
+++ b/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for cache invalidation on TrustedAgentCard mutation.
+
+``CardRegistry.is_verified`` previously returned a cached ``True`` for
+the full TTL after a successful ``register()`` call, even if the card
+was mutated in place afterwards. These tests pin the new behaviour:
+the verification verdict is bound to the card's signed content via a
+content hash, so any mutation invalidates the cache on the next read.
+"""
+
+import pytest
+
+from agentmesh.identity.agent_id import AgentIdentity
+from agentmesh.trust.cards import TrustedAgentCard, CardRegistry
+
+
+@pytest.fixture
+def identity():
+    return AgentIdentity.create("alice", sponsor="alice@example.com")
+
+
+@pytest.fixture
+def signed_card(identity):
+    return TrustedAgentCard.from_identity(identity)
+
+
+class TestCacheInvalidation:
+    def test_register_caches_only_for_matching_content(self, signed_card):
+        registry = CardRegistry()
+        assert registry.register(signed_card) is True
+        # First read hits cache and matches stored hash
+        assert registry.is_verified(signed_card.agent_did) is True
+
+    def test_mutating_capabilities_invalidates_cache(self, signed_card):
+        """A tampered card whose capabilities list grows after
+        registration must NOT remain ``is_verified == True``."""
+        registry = CardRegistry()
+        assert registry.register(signed_card) is True
+        # Cached as True
+        assert registry.is_verified(signed_card.agent_did) is True
+
+        # Mutate the registered card in place
+        signed_card.capabilities.append("admin:everything")
+
+        # is_verified must re-check and find the signature no longer
+        # matches the mutated content
+        assert registry.is_verified(signed_card.agent_did) is False
+
+    def test_mutating_trust_score_invalidates_cache(self, signed_card):
+        registry = CardRegistry()
+        registry.register(signed_card)
+        assert registry.is_verified(signed_card.agent_did) is True
+
+        signed_card.trust_score = 0.01  # different signed field
+        assert registry.is_verified(signed_card.agent_did) is False
+
+    def test_tampered_signature_invalidates_cache(self, signed_card):
+        registry = CardRegistry()
+        registry.register(signed_card)
+        assert registry.is_verified(signed_card.agent_did) is True
+
+        # Flip a byte in the signature
+        original = signed_card.card_signature
+        signed_card.card_signature = "A" + original[1:]
+        assert registry.is_verified(signed_card.agent_did) is False
+
+    def test_unmutated_card_stays_cached(self, signed_card):
+        """Sanity: an unchanged card keeps using the cache."""
+        registry = CardRegistry()
+        registry.register(signed_card)
+        # Multiple reads stay True
+        for _ in range(5):
+            assert registry.is_verified(signed_card.agent_did) is True


### PR DESCRIPTION
## Summary

[`CardRegistry.register()`](agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py) cached `(True, timestamp)` immediately after a successful verify, keyed only by `agent_did`. Within the TTL window (default 15 minutes), `is_verified()` returned the cached `True` without re-checking. Because cards are mutable Pydantic models held by the caller, any in-place mutation -- adding a capability, lowering a trust score, flipping a signature byte -- went undetected until the cache expired.

## Change

Pin the cached verdict to the card's actual signed content. Cache entries become `(verified, timestamp, content_hash)`, where `content_hash` is sha256 over `_get_signable_content() | card_signature`. On every `is_verified()` call:

- hash matches and TTL not expired -> return cached verdict
- hash mismatch (mutation) or TTL expired -> drop entry, re-verify from scratch

A tampered card is rejected on the very next `is_verified()` call instead of staying authoritative for up to 15 minutes.

## Tests

| Suite | Before | After |
|---|---|---|
| `tests/test_cards_cache_invalidation.py` (new) | n/a | 5 passed |
| `tests/test_revocation_rotation.py` | 16 passed | 16 passed |
| Full `tests/` | 11 pre-existing failures | 11 pre-existing failures |

New regression tests pin:

- Mutating `capabilities` after register flips `is_verified` False on the next read
- Mutating `trust_score` invalidates cache
- Tampered `card_signature` invalidates cache
- Unmutated cards keep using the cache (sanity)

Recipe (PowerShell):

```powershell
cd agent-governance-python/agent-mesh
$env:PYTHONPATH = \"src\"
python -m pytest tests/test_cards_cache_invalidation.py -q
```

## Test plan

- [x] New regression suite passes (5/5)
- [x] Existing ``CardRegistry`` revocation tests still green
- [x] Full suite shows no new failures (same 11 pre-existing 3.14 deprecation failures)

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Mesh].