### PR TITLE
docs(rust-mcp-response): document inspect_text() ordering invariant

### DIFF
--- a/agent-governance-rust/agentmesh-mcp/src/mcp/response.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/response.rs
@@ -193,6 +193,20 @@ impl McpResponseScanner {
                 .replace_all(&sanitized, "[REDACTED_INSTRUCTION]")
                 .into_owned();
         }
+        // Ordering invariant: lowercase the *post-redaction* text so the
+        // exfiltration-context heuristic looks at what the model would still
+        // be saying after the prompt-injection and imperative passes above
+        // have substituted their placeholders. Looking at the original text
+        // here would let an attacker plant exfil verbs ("send", "upload",
+        // "post", ...) inside a `<prompt>...</prompt>` tag or an "ignore
+        // previous instructions" directive that the earlier passes have
+        // already scrubbed, producing a finding for content that no longer
+        // exists in the sanitized output. The placeholders themselves
+        // (`[REDACTED_PROMPT_TAG]`, `[REDACTED_INSTRUCTION]`) deliberately
+        // contain none of the exfil verbs so this snapshot is safe to take
+        // here. `lower` is not used after the URL redaction below, so it
+        // intentionally is not refreshed; the credential-redaction pass
+        // operates on `sanitized` directly.
         let lower = sanitized.to_lowercase();
         if contains_exfiltration_context(&lower) && self.url_pattern.is_match(&sanitized) {
             findings.push(finding(

--- a/agent-governance-rust/agentmesh/src/mcp/response.rs
+++ b/agent-governance-rust/agentmesh/src/mcp/response.rs
@@ -193,6 +193,20 @@ impl McpResponseScanner {
                 .replace_all(&sanitized, "[REDACTED_INSTRUCTION]")
                 .into_owned();
         }
+        // Ordering invariant: lowercase the *post-redaction* text so the
+        // exfiltration-context heuristic looks at what the model would still
+        // be saying after the prompt-injection and imperative passes above
+        // have substituted their placeholders. Looking at the original text
+        // here would let an attacker plant exfil verbs ("send", "upload",
+        // "post", ...) inside a `<prompt>...</prompt>` tag or an "ignore
+        // previous instructions" directive that the earlier passes have
+        // already scrubbed, producing a finding for content that no longer
+        // exists in the sanitized output. The placeholders themselves
+        // (`[REDACTED_PROMPT_TAG]`, `[REDACTED_INSTRUCTION]`) deliberately
+        // contain none of the exfil verbs so this snapshot is safe to take
+        // here. `lower` is not used after the URL redaction below, so it
+        // intentionally is not refreshed; the credential-redaction pass
+        // operates on `sanitized` directly.
         let lower = sanitized.to_lowercase();
         if contains_exfiltration_context(&lower) && self.url_pattern.is_match(&sanitized) {
             findings.push(finding(


### PR DESCRIPTION
## Summary

`McpResponseSanitizer::inspect_text` in [`agent-governance-rust/agentmesh/src/mcp/response.rs`](agent-governance-rust/agentmesh/src/mcp/response.rs) (and its byte-identical copy in `agent-governance-rust/agentmesh-mcp/src/mcp/response.rs`) runs four passes in a specific order: prompt-tag redaction, imperative-phrase redaction, lowercase snapshot, exfiltration-context + URL pass, credential redaction.

The position of `let lower = sanitized.to_lowercase();` between the imperative pass and the URL pass is load-bearing. Taking the snapshot earlier — before the prompt/imperative redactions — would let an attacker plant exfil verbs (`send`, `upload`, `post`, `curl`, `wget`, `exfil`) inside a `<prompt>...</prompt>` tag or an "ignore previous instructions" directive, and the exfil-context check would fire on text that has already been scrubbed from the returned `sanitized` string. A reader who didn't already know that wouldn't see anything in the file warning them off the refactor.

## Change

Add a paragraph comment above the `lower` binding stating:

- Why the snapshot is post-redaction — the prompt-tag / imperative placeholders contain none of the exfil verbs, so they can't smuggle false positives back in.
- That `lower` is intentionally not refreshed after the URL pass, since the credential redactor below operates on `sanitized` directly.

Comment-only change. Applied identically in both copies of `mcp/response.rs`.

## Tests

- `cargo check --workspace --lib` — clean.
- No behavioural change, so no new tests; existing response-sanitizer tests already cover the ordering by example.

## Test plan

- [x] No code paths altered; only documentation added
- [x] Comment names the specific verbs the exfil check looks for so future readers can verify the "placeholders contain none of the exfil verbs" claim by inspection
- [x] Applied to both duplicate crate trees so they remain byte-identical

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Rust].