### PR TITLE
fix(py-gov-compliance): retry _api on URLError and 5xx with exponential backoff

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/contributor_check.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/contributor_check.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
@@ -64,6 +66,25 @@ def _get_token() -> str:
     return token
 
 
+# Retry configuration. Three attempts plus the original request was
+# already the contract; the previous code retried only on HTTP 403 and
+# let every URLError (DNS hiccups, TLS resets, connection refused)
+# propagate immediately even though those failure modes are the most
+# common transient errors in a long-running scan. Exponential backoff
+# with full jitter spreads concurrent CLI invocations across the wake
+# window and prevents the thundering-herd retry pattern.
+_RETRY_MAX_ATTEMPTS = 3
+_RETRY_BASE_SECONDS = 1.0
+_RETRY_MAX_SLEEP_SECONDS = 60.0
+
+
+def _retry_sleep_seconds(attempt: int) -> float:
+    """Full-jitter exponential backoff: random in [0, base * 2**attempt)."""
+    upper = _RETRY_BASE_SECONDS * (2 ** attempt)
+    upper = min(upper, _RETRY_MAX_SLEEP_SECONDS)
+    return random.uniform(0, upper)
+
+
 def _api(path: str, params: dict[str, str] | None = None) -> Any:
     """Call the GitHub REST API and return parsed JSON."""
     url = f"https://api.github.com{path}"
@@ -76,21 +97,58 @@ def _api(path: str, params: dict[str, str] | None = None) -> Any:
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
 
-    for attempt in range(3):
+    last_exc: Exception | None = None
+    for attempt in range(_RETRY_MAX_ATTEMPTS):
         try:
             with urlopen(req, timeout=15) as resp:
                 return json.loads(resp.read())
         except HTTPError as exc:
-            if exc.code == 403 and attempt < 2:
+            last_exc = exc
+            # GitHub's documented rate-limit envelope: 403 with a
+            # Retry-After header. Honour it verbatim (clamped to a
+            # sane band) when present.
+            if exc.code == 403 and attempt < _RETRY_MAX_ATTEMPTS - 1:
                 wait = int(exc.headers.get("Retry-After", "10"))
                 wait = min(max(wait, 5), 60)
                 print(f"  Rate limited, waiting {wait}s...", file=sys.stderr)
-                import time
+                time.sleep(wait)
+                continue
+            # 5xx is transient on GitHub's side — also worth retrying
+            # with backoff rather than crashing the whole check.
+            if 500 <= exc.code < 600 and attempt < _RETRY_MAX_ATTEMPTS - 1:
+                wait = _retry_sleep_seconds(attempt)
+                print(
+                    f"  Server error {exc.code}, retrying in {wait:.1f}s...",
+                    file=sys.stderr,
+                )
                 time.sleep(wait)
                 continue
             if exc.code == 404:
                 return None
             raise
+        except URLError as exc:
+            # Network-layer failures: DNS resolution, TCP reset, TLS
+            # handshake aborts, socket timeout. The previous code let
+            # these propagate on the first occurrence even though
+            # they're typically the most retryable failure shape.
+            last_exc = exc
+            if attempt < _RETRY_MAX_ATTEMPTS - 1:
+                wait = _retry_sleep_seconds(attempt)
+                print(
+                    f"  Network error ({exc.reason}), retrying in "
+                    f"{wait:.1f}s...",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+                continue
+            raise
+
+    # Defensive: the loop exits via return/raise; this only fires if
+    # the retry counter ran out without a final raise (shouldn't
+    # happen, but better than returning None silently).
+    if last_exc is not None:
+        raise last_exc
+    return None
 
 
 def _search_issues(query: str, per_page: int = 30) -> list[dict]:

--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py
@@ -18,13 +18,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import re
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
@@ -59,6 +61,25 @@ def _get_token() -> str:
     return token
 
 
+# Retry configuration. Three attempts plus the original request was
+# already the contract; the previous code retried only on HTTP 403 and
+# let every URLError (DNS hiccups, TLS resets, connection refused)
+# propagate immediately even though those failure modes are the most
+# common transient errors in a long-running scan. Exponential backoff
+# with full jitter spreads concurrent CLI invocations across the wake
+# window and prevents the thundering-herd retry pattern.
+_RETRY_MAX_ATTEMPTS = 3
+_RETRY_BASE_SECONDS = 1.0
+_RETRY_MAX_SLEEP_SECONDS = 60.0
+
+
+def _retry_sleep_seconds(attempt: int) -> float:
+    """Full-jitter exponential backoff: random in [0, base * 2**attempt)."""
+    upper = _RETRY_BASE_SECONDS * (2 ** attempt)
+    upper = min(upper, _RETRY_MAX_SLEEP_SECONDS)
+    return random.uniform(0, upper)
+
+
 def _api(path: str, params: dict[str, str] | None = None) -> Any:
     url = f"https://api.github.com{path}"
     if params:
@@ -70,21 +91,58 @@ def _api(path: str, params: dict[str, str] | None = None) -> Any:
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
 
-    for attempt in range(3):
+    last_exc: Exception | None = None
+    for attempt in range(_RETRY_MAX_ATTEMPTS):
         try:
             with urlopen(req, timeout=15) as resp:
                 return json.loads(resp.read())
         except HTTPError as exc:
-            if exc.code == 403 and attempt < 2:
+            last_exc = exc
+            # GitHub's documented rate-limit envelope: 403 with a
+            # Retry-After header. Honour it verbatim (clamped to a
+            # sane band) when present.
+            if exc.code == 403 and attempt < _RETRY_MAX_ATTEMPTS - 1:
                 wait = int(exc.headers.get("Retry-After", "10"))
                 wait = min(max(wait, 5), 60)
                 print(f"  Rate limited, waiting {wait}s...", file=sys.stderr)
-                import time
+                time.sleep(wait)
+                continue
+            # 5xx is transient on GitHub's side — also worth retrying
+            # with backoff rather than crashing the whole audit.
+            if 500 <= exc.code < 600 and attempt < _RETRY_MAX_ATTEMPTS - 1:
+                wait = _retry_sleep_seconds(attempt)
+                print(
+                    f"  Server error {exc.code}, retrying in {wait:.1f}s...",
+                    file=sys.stderr,
+                )
                 time.sleep(wait)
                 continue
             if exc.code in (404, 422):
                 return None
             raise
+        except URLError as exc:
+            # Network-layer failures: DNS resolution, TCP reset, TLS
+            # handshake aborts, socket timeout. The previous code let
+            # these propagate on the first occurrence even though
+            # they're typically the most retryable failure shape.
+            last_exc = exc
+            if attempt < _RETRY_MAX_ATTEMPTS - 1:
+                wait = _retry_sleep_seconds(attempt)
+                print(
+                    f"  Network error ({exc.reason}), retrying in "
+                    f"{wait:.1f}s...",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+                continue
+            raise
+
+    # Defensive: the loop exits via return/raise; this only fires if
+    # the retry counter ran out without a final raise (shouldn't
+    # happen, but better than returning None silently).
+    if last_exc is not None:
+        raise last_exc
+    return None
 
 
 def _search(endpoint: str, query: str, per_page: int = 100) -> list[dict]:

--- a/agent-governance-python/agent-compliance/tests/test_cli_api_retry.py
+++ b/agent-governance-python/agent-compliance/tests/test_cli_api_retry.py
@@ -1,0 +1,184 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests that the GitHub `_api` helpers retry on transient failures.
+
+Both `credential_audit._api` and `contributor_check._api` previously
+retried HTTP 403 with Retry-After but let every other failure
+propagate immediately — including URLError (DNS hiccups, TLS resets,
+connection refused) and 5xx responses, which are the most common
+transient errors in a long-running scan. These tests pin the new
+retry envelope:
+
+  * URLError -> exponential-backoff retry (up to 3 attempts total)
+  * 5xx HTTPError -> exponential-backoff retry
+  * 403 with Retry-After -> honoured (existing behaviour)
+  * 404 -> returns None (existing behaviour)
+  * Non-retryable HTTPError on the final attempt -> re-raised
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from agent_compliance.cli import contributor_check, credential_audit
+
+
+@pytest.fixture(autouse=True)
+def _silence_token(monkeypatch):
+    """Bypass token resolution so _api doesn't fail trying to read
+    GITHUB_TOKEN or shell out to `gh`."""
+    monkeypatch.setattr(contributor_check, "_get_token", lambda: "test-token")
+    monkeypatch.setattr(credential_audit, "_get_token", lambda: "test-token")
+    # Reset module-level cache too.
+    monkeypatch.setattr(contributor_check, "_TOKEN", None)
+    monkeypatch.setattr(credential_audit, "_TOKEN", None)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Retries shouldn't actually wait during tests."""
+    monkeypatch.setattr(contributor_check.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(credential_audit.time, "sleep", lambda _s: None)
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _make_urlopen(side_effects: list):
+    """Return a fake urlopen that walks through `side_effects` on each call.
+
+    Each side effect is either an Exception (raised) or a dict (wrapped
+    into a _FakeResponse).
+    """
+    calls = {"count": 0}
+
+    def _fake(*_args, **_kwargs):
+        idx = calls["count"]
+        calls["count"] += 1
+        if idx >= len(side_effects):
+            raise AssertionError(f"unexpected urlopen call #{idx + 1}")
+        effect = side_effects[idx]
+        if isinstance(effect, Exception):
+            raise effect
+        return _FakeResponse(effect)
+
+    return _fake, calls
+
+
+@pytest.mark.parametrize(
+    "module", [contributor_check, credential_audit],
+    ids=["contributor_check", "credential_audit"],
+)
+class TestApiRetry:
+    """Both CLI modules share the same retry shape — assert against both."""
+
+    def test_url_error_retried_then_succeeds(self, monkeypatch, module):
+        fake, calls = _make_urlopen([
+            URLError("temporary DNS failure"),
+            {"ok": True, "items": []},
+        ])
+        monkeypatch.setattr(module, "urlopen", fake)
+        result = module._api("/users/x")
+        assert result == {"ok": True, "items": []}
+        assert calls["count"] == 2
+
+    def test_url_error_persists_then_raises(self, monkeypatch, module):
+        fake, calls = _make_urlopen([
+            URLError("connection refused"),
+            URLError("connection refused"),
+            URLError("connection refused"),
+        ])
+        monkeypatch.setattr(module, "urlopen", fake)
+        with pytest.raises(URLError):
+            module._api("/users/x")
+        # _RETRY_MAX_ATTEMPTS == 3
+        assert calls["count"] == 3
+
+    def test_server_error_retried_then_succeeds(self, monkeypatch, module):
+        fake, calls = _make_urlopen([
+            HTTPError(
+                "https://api.github.com/x", 503, "Service Unavailable",
+                {}, io.BytesIO(b""),
+            ),
+            {"ok": True},
+        ])
+        monkeypatch.setattr(module, "urlopen", fake)
+        result = module._api("/users/x")
+        assert result == {"ok": True}
+        assert calls["count"] == 2
+
+    def test_403_with_retry_after_honoured(self, monkeypatch, module):
+        import email.message
+        headers = email.message.Message()
+        headers["Retry-After"] = "5"
+        fake, calls = _make_urlopen([
+            HTTPError(
+                "https://api.github.com/x", 403, "Rate Limited",
+                headers, io.BytesIO(b""),
+            ),
+            {"ok": True},
+        ])
+        monkeypatch.setattr(module, "urlopen", fake)
+        result = module._api("/users/x")
+        assert result == {"ok": True}
+        assert calls["count"] == 2
+
+    def test_404_returns_none_without_retry(self, monkeypatch, module):
+        fake, calls = _make_urlopen([
+            HTTPError(
+                "https://api.github.com/x", 404, "Not Found",
+                {}, io.BytesIO(b""),
+            ),
+        ])
+        monkeypatch.setattr(module, "urlopen", fake)
+        result = module._api("/users/x")
+        assert result is None
+        assert calls["count"] == 1
+
+    def test_401_unauthorized_raised_immediately(self, monkeypatch, module):
+        # Non-retryable status: a bad token won't fix itself.
+        fake, calls = _make_urlopen([
+            HTTPError(
+                "https://api.github.com/x", 401, "Unauthorized",
+                {}, io.BytesIO(b""),
+            ),
+        ])
+        monkeypatch.setattr(module, "urlopen", fake)
+        with pytest.raises(HTTPError) as exc:
+            module._api("/users/x")
+        assert exc.value.code == 401
+        assert calls["count"] == 1
+
+
+class TestCredentialAudit422:
+    """credential_audit._api treats 422 as a missing-resource sentinel
+    (consistent with /search endpoints returning 422 on stale results).
+    contributor_check._api does NOT (it only suppresses 404)."""
+
+    def test_422_returns_none(self, monkeypatch):
+        fake, calls = _make_urlopen([
+            HTTPError(
+                "https://api.github.com/x", 422, "Unprocessable",
+                {}, io.BytesIO(b""),
+            ),
+        ])
+        monkeypatch.setattr(credential_audit, "urlopen", fake)
+        result = credential_audit._api("/x")
+        assert result is None
+        assert calls["count"] == 1


### PR DESCRIPTION
## Summary

Both [`credential_audit.py`](agent-governance-python/agent-compliance/src/agent_compliance/cli/credential_audit.py) and [`contributor_check.py`](agent-governance-python/agent-compliance/src/agent_compliance/cli/contributor_check.py) ship a `_api` helper that calls `urlopen` against GitHub's REST API. The previous retry envelope only handled HTTP 403 with a `Retry-After` header and let every other failure propagate immediately:

| Failure | Previous behaviour | New behaviour |
|---|---|---|
| `urllib.error.URLError` (DNS, TCP reset, TLS abort, socket timeout) | Raised on the first attempt | Retry with full-jitter exponential backoff |
| 5xx `HTTPError` | Raised on the first attempt | Retry with same backoff |
| 403 with `Retry-After` | Honoured, retried | Unchanged |
| 404 (`/users/{login}` miss, `/repos/...` miss) | Returns `None` | Unchanged |
| 422 (only `credential_audit`, for stale `/search` results) | Returns `None` | Unchanged |
| Other non-retryable HTTPError (401, 410, ...) | Raised | Raised on final attempt |

The URLError class was the most painful gap — a single DNS hiccup mid-scan would kill a multi-minute `contributor-check` run before any of the gathered signals could be reported.

## Change

Adds `_RETRY_MAX_ATTEMPTS`, `_RETRY_BASE_SECONDS`, `_RETRY_MAX_SLEEP_SECONDS`, and a `_retry_sleep_seconds(attempt)` helper to each module (full jitter: `random.uniform(0, base * 2**attempt)`, clamped to 60s). The `_api` body now wraps the `urlopen` call in:

- `except HTTPError as exc:` — 403 honours `Retry-After`; 5xx triggers backoff; 404/422 return `None`; everything else falls through to `raise`.
- `except URLError as exc:` — backoff and retry until the attempt counter exhausts, then re-raise.

Full-jitter exponential backoff (the same pattern shipped in [#2144](https://github.com/microsoft/agent-governance-toolkit/pull/2144) for `agent_os.retry`) spreads concurrent CLI invocations across the wake window so back-to-back audits sharing an incident don't all reawake at the same instant.

Both files take the identical fix shape, so per the one-logical-change convention this lands as a single PR.

## Tests

New `tests/test_cli_api_retry.py` parametrises the contract across both modules:

| Test | Pins |
|---|---|
| `test_url_error_retried_then_succeeds` | Single URLError -> second attempt returns the payload |
| `test_url_error_persists_then_raises` | Three URLErrors -> final raise after 3 attempts |
| `test_server_error_retried_then_succeeds` | 503 then 200 -> payload returned |
| `test_403_with_retry_after_honoured` | Existing rate-limit behaviour intact |
| `test_404_returns_none_without_retry` | No retry, no raise |
| `test_401_unauthorized_raised_immediately` | Non-retryable -> single attempt, raise |
| `test_422_returns_none` | `credential_audit`-only behaviour preserved |

```
$ PYTHONPATH=src python -m pytest tests/test_cli_api_retry.py -q
13 passed in 0.55s
```

Full agent-compliance suite (excluding a pre-existing unrelated `test_red_team_cli` failure): 461 passed, 2 skipped.

## Test plan

- [ ] CI passes
- [ ] All 13 `test_cli_api_retry.py` cases pass for both modules
- [ ] Existing `test_contributor_check.py` cases still pass
- [ ] Running `agent-compliance contributor-check --username <user>` survives a single DNS / TLS / 5xx blip without aborting the whole report

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Governance].