### PR TITLE
fix(typescript/agent-os-vscode): whitelist policy-row badge class to the four defined variants

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/server/browserScripts.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/server/browserScripts.ts
@@ -198,7 +198,17 @@ export function buildClientScript(wsPort: number, sessionToken: string): string 
             return;
         }
         list.innerHTML = filtered.map(function(r) {
-            var cls = 'badge-' + r.action.toLowerCase().replace(/[^a-z0-9-]/g, '');
+            // Whitelist the four badge variants defined in browserStyles.ts
+            // (badge-allow / badge-deny / badge-block / badge-audit). Any
+            // other r.action (corrupt data, a future enum addition, or a
+            // typo) falls back to a generic `badge-unknown` class — that
+            // gives an unstyled but visible chip instead of silently
+            // collapsing the action token to a class that doesn't exist.
+            // The displayed label is still esc(r.action) so the raw value
+            // is observable and consistent with the surrounding cells.
+            var BADGE_ACTIONS = { allow: 1, deny: 1, block: 1, audit: 1 };
+            var normalized = String(r.action || '').toLowerCase().replace(/[^a-z0-9-]/g, '');
+            var cls = Object.prototype.hasOwnProperty.call(BADGE_ACTIONS, normalized) ? 'badge-' + normalized : 'badge-unknown';
             return '<div class="policy-row">' +
                 '<span class="action-badge ' + cls + '">' + esc(r.action) + '</span>' +
                 '<span style="flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-bright);">' + esc(r.name) + '</span>' +

--- a/agent-governance-typescript/agent-os-vscode/src/server/browserStyles.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/server/browserStyles.ts
@@ -342,6 +342,9 @@ export function buildBrowserStyles(): string {
     .badge-block { background: rgba(239,68,68,0.15); color: var(--error); }
     .badge-allow { background: rgba(34,197,94,0.15); color: var(--success); }
     .badge-audit { background: rgba(0,102,255,0.15); color: var(--accent); }
+    /* Fallback for any action that isn't in the whitelist (corrupt data
+       or a future enum addition that hasn't been styled yet). */
+    .badge-unknown { background: rgba(127,127,127,0.15); color: var(--text-muted); }
 
     /* === Audit list === */
     .audit-row {


### PR DESCRIPTION
## Problem

[`renderPoliciesFiltered`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/server/browserScripts.ts#L200-L203) derived the policy-row badge class from `r.action` via:

```javascript
var cls = 'badge-' + r.action.toLowerCase().replace(/[^a-z0-9-]/g, '');
return '<div class=\"policy-row\">' +
    '<span class=\"action-badge ' + cls + '\">' + esc(r.action) + '</span>' +
    ...
```

The non-alphanumeric strip used to build the class is asymmetric with the `esc(r.action)` two characters later: the displayed label keeps the original mixed-case text (just HTML-escaped), but the class collapses anything outside `[a-z0-9-]` to nothing. For the current `PolicyAction = 'ALLOW' | 'DENY' | 'AUDIT' | 'BLOCK'` enum that produces the right four classes by accident, but the moment any drift appears the display and class diverge silently:

- `'BLOCK_WRITE'` (a plausible future enum extension) → class `badge-blockwrite` (no such class exists in [`browserStyles.ts`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-typescript/agent-os-vscode/src/server/browserStyles.ts#L341-L344)); text `BLOCK_WRITE` (uppercase via the existing CSS).
- `'block-read'` → class `badge-block-read` (also not defined); text `block-read`.
- `''` (empty / corrupt) → class `badge-` (matches nothing); text empty.
- Any non-ASCII action token → class `badge-` (everything stripped).

In every case the chip renders unstyled in the same row as a normal-coloured chip, with no signal to the user that the row's action is unrecognised.

## Fix

Whitelist the four classes that actually exist in `browserStyles.ts` and fall back to `badge-unknown` for anything else. Add a corresponding muted-grey `.badge-unknown` style so the chip is still visible — that's the signal that something unexpected showed up in the policy feed, rather than a silently misclassified row.

```javascript
var BADGE_ACTIONS = { allow: 1, deny: 1, block: 1, audit: 1 };
var normalized = String(r.action || '').toLowerCase().replace(/[^a-z0-9-]/g, '');
var cls = Object.prototype.hasOwnProperty.call(BADGE_ACTIONS, normalized) ? 'badge-' + normalized : 'badge-unknown';
```

The displayed label is unchanged — `esc(r.action)` still shows the raw action string with the existing HTML escaping — so the inconsistency between display and class is now an intentional, observable fallback (badge-unknown is grey) rather than silent drift to a class that doesn't exist.

## Test

`browserScripts.ts` exports the script as a template-literal string; there is no unit-test harness covering the in-browser rendering today. The change is purely class-name-derivation, and:

- All four current `PolicyAction` enum values still resolve to the same class names they did before (`badge-allow` / `badge-deny` / `badge-block` / `badge-audit`).
- The displayed text is unchanged (still `esc(r.action)`).
- A new `.badge-unknown` style is added to `browserStyles.ts` so the fallback is visibly muted-grey rather than unstyled.

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, TypeScript].