### PR TITLE
fix(py-isolation-event-bus): rename clear() to _clear() to flag test-only contract

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/observability/event_bus.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/observability/event_bus.py
@@ -259,8 +259,20 @@ class HypervisorEventBus:
         with self._lock:
             return {t.value: len(evts) for t, evts in self._by_type.items()}
 
-    def clear(self) -> None:
-        """Clear all events (for testing)."""
+    def _clear(self) -> None:
+        """Clear all events. **Test-only — do not call in production.**
+
+        The event bus is wired into the hypervisor as a long-lived,
+        process-singleton-shaped collaborator (see
+        ``hypervisor.api.server._event_bus``): production calls would
+        wipe the audit trail of every running session at once.
+
+        The leading underscore makes the test-only contract visible at
+        every call site. The method is kept on the class (rather than
+        moved to a test helper) because some tests construct a fresh
+        bus and then exercise the clear path itself; it just shouldn't
+        be reached from non-test code.
+        """
         with self._lock:
             self._events.clear()
             self._by_type.clear()

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_observability.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_observability.py
@@ -127,7 +127,7 @@ class TestHypervisorEventBus:
         bus = HypervisorEventBus()
         bus.emit(HypervisorEvent(event_type=EventType.SESSION_CREATED))
         assert bus.event_count == 1
-        bus.clear()
+        bus._clear()
         assert bus.event_count == 0
 
     def test_query_with_limit(self):


### PR DESCRIPTION
## Summary

[`event_bus.py`](agent-governance-python/agent-hypervisor/src/hypervisor/observability/event_bus.py)'s `HypervisorEventBus.clear()` was documented as "for testing" but named as a public method:

```python
def clear(self) -> None:
    """Clear all events (for testing)."""
    with self._lock:
        self._events.clear()
        ...
```

The event bus is wired into the hypervisor as a long-lived, process-singleton-shaped collaborator (see `hypervisor.api.server._event_bus`); a production call to `clear()` would wipe the audit trail of every running session at once. The leading-underscore Python convention exists exactly for this contract.

## Change

Two pieces:

1. **Rename `clear` → `_clear`** so the test-only contract is visible at every call site.
2. **Expand the docstring** to name *why* this is test-only and *why* it stays on the class rather than moving to a test helper (some tests exercise the clear path itself on a fresh bus).

Update the one in-tree caller — `test_observability.py::test_clear` — to invoke `bus._clear()`. A repo-wide grep confirmed there are no other callers (a `bus.clear_history()` hit in `agent-os`'s self-evaluating example is a different bus class).

## Tests

```
$ PYTHONPATH=src python -m pytest tests/unit/test_observability.py -q
28 passed in 0.33s
```

## Test plan

- [ ] CI passes
- [ ] All 28 `test_observability.py` tests pass
- [ ] No other callers of the renamed method break (grep confirmed one in-tree caller, now updated)

---

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Isolation].