### PR TITLE
fix(py-mesh-identity): downgrade verify_signature failure log to DEBUG

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/agent_id.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/agent_id.py
@@ -210,7 +210,14 @@ class AgentIdentity(BaseModel):
         return base64.b64encode(signature).decode()
 
     def verify_signature(self, data: bytes, signature: str) -> bool:
-        """Verify a signature against this agent's public key."""
+        """Verify a signature against this agent's public key.
+
+        All verification failures are logged at DEBUG. Bad signatures are
+        an expected, attacker-controllable signal -- logging them at
+        WARNING enables log flooding by any peer that can send messages.
+        Operators chasing forensic detail can enable DEBUG on this
+        logger explicitly.
+        """
         try:
             public_key_bytes = base64.b64decode(self.public_key)
             public_key = ed25519.Ed25519PublicKey.from_public_bytes(public_key_bytes)
@@ -221,7 +228,7 @@ class AgentIdentity(BaseModel):
             logger.debug("Malformed key or signature data: %s", exc)
             return False
         except Exception as exc:
-            logger.warning("Signature verification failed: %s", exc)
+            logger.debug("Signature verification failed: %s", exc)
             return False
 
     # Maximum delegation depth to prevent Sybil attacks via infinite chains.

--- a/agent-governance-python/agent-mesh/tests/test_identity.py
+++ b/agent-governance-python/agent-mesh/tests/test_identity.py
@@ -97,12 +97,35 @@ class TestAgentIdentity:
     def test_sign_and_verify(self):
         """Test signing and verification."""
         identity = AgentIdentity.create("signer", "s@e.com")
-        
+
         message = b"Hello, AgentMesh!"
         signature = identity.sign(message)
-        
+
         assert identity.verify_signature(message, signature)
         assert not identity.verify_signature(b"Modified message", signature)
+
+    def test_bad_signature_does_not_log_at_warning(self, caplog):
+        """Verifying a bad signature must NOT log at WARNING.
+
+        Attacker-controllable failures at WARNING enable log flooding;
+        all verification failures are routed to DEBUG instead.
+        """
+        import logging
+        identity = AgentIdentity.create("signer", "s@e.com")
+        message = b"Hello, AgentMesh!"
+        signature = identity.sign(message)
+
+        with caplog.at_level(logging.DEBUG, logger="agentmesh.identity.agent_id"):
+            assert not identity.verify_signature(b"Modified message", signature)
+
+        warning_records = [
+            r for r in caplog.records
+            if r.levelno >= logging.WARNING
+            and r.name == "agentmesh.identity.agent_id"
+        ]
+        assert warning_records == [], (
+            f"verify_signature must not log at WARNING; got: {warning_records}"
+        )
     
     def test_delegate_creates_child(self):
         """Test delegating to create sub-agent."""


### PR DESCRIPTION
## Summary

[`AgentIdentity.verify_signature`](agent-governance-python/agent-mesh/src/agentmesh/identity/agent_id.py) caught all exceptions and logged ``Signature verification failed`` at WARNING. Signature failures are attacker-controllable -- any peer that can send messages can trigger this path repeatedly -- so logging at WARNING enables log flooding: disk-space exhaustion, alert fatigue, increased SIEM cost-of-noise.

## Change

Downgrade the catch-all `except Exception` branch from `logger.warning` to `logger.debug`. The already-debug `(ValueError, TypeError)` branch for malformed input is unchanged. Operators chasing forensic detail can enable DEBUG on `agentmesh.identity.agent_id` explicitly; nothing else changes.

## Tests

| Suite | Before | After |
|---|---|---|
| `tests/test_identity.py::TestAgentIdentity` | 8 passed | 9 passed (new caplog test) |

The new test asserts no WARNING records are emitted by `agentmesh.identity.agent_id` when verifying a bad signature.

Recipe (PowerShell):

```powershell
cd agent-governance-python/agent-mesh
$env:PYTHONPATH = \"src\"
python -m pytest tests/test_identity.py::TestAgentIdentity -q
```

## Test plan

- [x] New caplog regression test passes
- [x] Existing `TestAgentIdentity` suite still green

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Mesh].