### PR TITLE
fix(dotnet/policy): extract CommandExists into shared backend helper

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
@@ -95,7 +95,7 @@ public sealed class CedarPolicyBackend : IExternalPolicyBackend
             return _mode;
         }
 
-        return CommandExists(OperatingSystem.IsWindows() ? "cedar.exe" : "cedar")
+        return ExternalBackendUtilities.CommandExists(OperatingSystem.IsWindows() ? "cedar.exe" : "cedar")
             ? CedarEvaluationMode.Cli
             : CedarEvaluationMode.Builtin;
     }
@@ -355,25 +355,6 @@ public sealed class CedarPolicyBackend : IExternalPolicyBackend
         startInfo.ArgumentList.Add("--request-json");
         startInfo.ArgumentList.Add(requestPath);
         return startInfo;
-    }
-
-    private static bool CommandExists(string executable)
-    {
-        var path = Environment.GetEnvironmentVariable("PATH");
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            if (File.Exists(Path.Combine(directory, executable)))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private sealed record CedarStatement(string Effect, string? ActionConstraint);

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/ExternalPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/ExternalPolicyBackend.cs
@@ -77,3 +77,34 @@ public interface IExternalPolicyBackend
         CancellationToken cancellationToken = default)
         => Task.FromResult(Evaluate(context));
 }
+
+/// <summary>
+/// Internal helpers shared by external policy backends.
+/// </summary>
+internal static class ExternalBackendUtilities
+{
+    /// <summary>
+    /// Checks whether <paramref name="executable"/> resolves to an existing file
+    /// on any directory of the PATH environment variable. Used by external
+    /// backends in Auto mode to decide between the CLI and the built-in
+    /// evaluator. Returns <c>false</c> when PATH is unset or empty.
+    /// </summary>
+    public static bool CommandExists(string executable)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (File.Exists(Path.Combine(directory, executable)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -318,7 +318,7 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
     private ExternalPolicyDecision? TryEvaluateWithCli(IReadOnlyDictionary<string, object> context)
     {
         var opaExecutable = OperatingSystem.IsWindows() ? "opa.exe" : "opa";
-        if (!CommandExists(opaExecutable))
+        if (!ExternalBackendUtilities.CommandExists(opaExecutable))
         {
             return null;
         }
@@ -543,26 +543,6 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
         startInfo.ArgumentList.Add(regoPath);
         startInfo.ArgumentList.Add(query);
         return startInfo;
-    }
-
-    private static bool CommandExists(string executable)
-    {
-        var path = Environment.GetEnvironmentVariable("PATH");
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return false;
-        }
-
-        foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            var candidate = Path.Combine(directory, executable);
-            if (File.Exists(candidate))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private string? ResolveRegoContent()


### PR DESCRIPTION
## Summary

[`CedarPolicyBackend`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs#L322-L339) and [`OpaPolicyBackend`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs#L404-L422) each carry a private `static CommandExists(string)` that walks `PATH` looking for an executable on disk. The two implementations differ only in one local: OPA assigns `Path.Combine(...)` to a `candidate` variable before `File.Exists`; Cedar inlines it. Otherwise byte-identical.

## Change

Promote a single `ExternalBackendUtilities.CommandExists` helper into [`ExternalPolicyBackend.cs`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Policy/ExternalPolicyBackend.cs) -- the file that already hosts the `IExternalPolicyBackend` interface both backends implement -- and route both callers through it. Future external backends added to the same namespace pick up the same PATH resolution for free, instead of growing a third copy.

## Tests

Pure refactor, no behaviour change. Existing `PolicyBackendTests` cover the Auto-mode resolution path that calls this helper on both backends.

## Test plan

- [x] `dotnet test` -- 657 / 657 passing (no test count change since this is a refactor)
- [x] Existing OPA / Cedar `Evaluate_*` and `ResolveMode_*` tests unchanged

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, .NET].