### PR TITLE
fix(dotnet/sre): let OperationCanceledException flow through CircuitBreaker

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Sre/CircuitBreaker.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Sre/CircuitBreaker.cs
@@ -112,6 +112,14 @@ public sealed class CircuitBreaker
             RecordSuccess();
             return result;
         }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is the caller backing out, not a failure of the
+            // underlying service -- recording it as a failure would let a
+            // burst of cancelled requests trip the breaker open against a
+            // perfectly healthy dependency. Let it flow through untouched.
+            throw;
+        }
         catch (Exception)
         {
             RecordFailure();
@@ -130,6 +138,12 @@ public sealed class CircuitBreaker
         {
             await action().ConfigureAwait(false);
             RecordSuccess();
+        }
+        catch (OperationCanceledException)
+        {
+            // See ExecuteAsync<T>: cancellation isn't a failure of the
+            // protected operation; never record it against the breaker.
+            throw;
         }
         catch (Exception)
         {

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/SreTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/SreTests.cs
@@ -91,6 +91,89 @@ public class CircuitBreakerTests
         Assert.Equal(30, ex.RetryAfter.TotalSeconds);
         Assert.Contains("30", ex.Message);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_OperationCanceledException_DoesNotRecordFailure()
+    {
+        // Regression: ExecuteAsync<T> previously caught all exceptions and
+        // recorded them as failures before re-throwing. That treated caller
+        // cancellation as a service failure -- a burst of cancelled requests
+        // (e.g. a downstream request timeout, a shutdown signal, an upstream
+        // client disconnect) would trip the breaker open against a perfectly
+        // healthy dependency. Cancellation should propagate without touching
+        // the failure counter.
+
+        var cb = new CircuitBreaker(new CircuitBreakerConfig { FailureThreshold = 3 });
+
+        for (var i = 0; i < 5; i++)
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await cb.ExecuteAsync<int>(() => throw new OperationCanceledException());
+            });
+        }
+
+        Assert.Equal(CircuitState.Closed, cb.State);
+        Assert.Equal(0, cb.FailureCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Void_OperationCanceledException_DoesNotRecordFailure()
+    {
+        // Same property as the generic overload, exercising the void Task path.
+        var cb = new CircuitBreaker(new CircuitBreakerConfig { FailureThreshold = 3 });
+
+        for (var i = 0; i < 5; i++)
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            {
+                await cb.ExecuteAsync(() => throw new OperationCanceledException());
+            });
+        }
+
+        Assert.Equal(CircuitState.Closed, cb.State);
+        Assert.Equal(0, cb.FailureCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TaskCanceledException_DoesNotRecordFailure()
+    {
+        // TaskCanceledException inherits from OperationCanceledException -- the
+        // same flow-through must apply (it's what HttpClient + CancellationToken
+        // throw when an HTTP call is cancelled).
+        var cb = new CircuitBreaker(new CircuitBreakerConfig { FailureThreshold = 3 });
+
+        for (var i = 0; i < 5; i++)
+        {
+            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            {
+                await cb.ExecuteAsync<int>(() => throw new TaskCanceledException());
+            });
+        }
+
+        Assert.Equal(CircuitState.Closed, cb.State);
+        Assert.Equal(0, cb.FailureCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonCancellationException_StillRecordsFailure()
+    {
+        // Sanity check: the OperationCanceledException carve-out must not
+        // swallow real exceptions. InvalidOperationException etc. should still
+        // count against the breaker.
+        var cb = new CircuitBreaker(new CircuitBreakerConfig { FailureThreshold = 3 });
+
+        for (var i = 0; i < 3; i++)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await cb.ExecuteAsync<int>(() => throw new InvalidOperationException("downstream failure"));
+            });
+        }
+
+        Assert.Equal(CircuitState.Open, cb.State);
+        Assert.Equal(3, cb.FailureCount);
+    }
 }
 
 public class SloEngineTests


### PR DESCRIPTION
## Summary

Both [`CircuitBreaker.ExecuteAsync<T>`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Sre/CircuitBreaker.cs#L105-L120) and [`CircuitBreaker.ExecuteAsync`](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-dotnet/src/AgentGovernance/Sre/CircuitBreaker.cs#L125-L139) catch `Exception` and call `RecordFailure()` before re-throwing:

```csharp
catch (Exception)
{
    RecordFailure();
    throw;
}
```

`Exception` includes `OperationCanceledException` (and its derived `TaskCanceledException`), so caller cancellation is counted as a service failure. A burst of cancelled requests -- e.g. a downstream request timeout, a shutdown signal, an upstream client disconnect -- would trip the breaker open against a perfectly healthy dependency. That's the opposite of what a circuit breaker is for: the breaker exists to back off failing dependencies, and cancellation is the *caller* backing out -- the dependency may not even have started work.

## Change

Add a dedicated `catch (OperationCanceledException)` ahead of the generic `Exception` handler in both overloads that simply re-throws. `TaskCanceledException` is covered transitively (it derives from `OperationCanceledException`). Real failures still hit `RecordFailure` as before.

## Tests

Four new tests pin the behaviour:

- Generic `ExecuteAsync<T>`: 5 `OperationCanceledException` throws leave the breaker `Closed` and `FailureCount` at 0.
- Void `ExecuteAsync`: same property for the `Task`-returning overload.
- `TaskCanceledException`: covered transitively (what `HttpClient` + `CancellationToken` throws on a cancelled HTTP call).
- Sanity check: `InvalidOperationException` is still counted (FailureCount = 3, state `Open` at threshold). The OCE carve-out must not swallow real exceptions.

## Test plan

- [x] `dotnet test` -- 661 / 661 passing (previous baseline 657 + 4 new)
- [x] Existing `RecordFailure_*` / `Reset_*` / `CircuitBreakerOpenException_*` tests unchanged

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, .NET].