### PR TITLE
fix(py-mesh-transport): accept ssl.SSLContext in TransportConfig

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/transport/base.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/transport/base.py
@@ -8,6 +8,7 @@ Defines the contract that all transport backends (WebSocket, gRPC, etc.)
 must implement to exchange trust data between agents.
 """
 
+import ssl
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
@@ -35,6 +36,14 @@ class TransportConfig:
         max_retries: Maximum reconnection attempts.
         retry_delay_seconds: Base delay between reconnection attempts.
         metadata: Additional transport-specific configuration.
+        ssl_context: Optional ``ssl.SSLContext`` used when ``use_tls`` is
+            true. When ``None``, the underlying transport falls back to
+            its default context (``ssl.create_default_context()`` or the
+            equivalent for that backend). Supply a custom context to
+            pin a private CA bundle, require client certificates for
+            mTLS, or restrict cipher suites. Required for any
+            production deployment where the server certificate is not
+            chained to a public root.
     """
 
     host: str = "localhost"
@@ -44,6 +53,7 @@ class TransportConfig:
     max_retries: int = 5
     retry_delay_seconds: float = 1.0
     metadata: dict[str, str] = field(default_factory=dict)
+    ssl_context: Optional[ssl.SSLContext] = None
 
     @property
     def uri(self) -> str:

--- a/agent-governance-python/agent-mesh/src/agentmesh/transport/websocket.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/transport/websocket.py
@@ -75,12 +75,25 @@ class WebSocketTransport(Transport):
     # -- Connection lifecycle --------------------------------------------------
 
     async def connect(self) -> None:
-        """Open a WebSocket connection to the server."""
+        """Open a WebSocket connection to the server.
+
+        When ``config.use_tls`` is true, ``config.ssl_context`` is
+        threaded through to the ``websockets`` client. If the caller
+        leaves ``ssl_context`` as ``None`` the library uses its default
+        context (system trust store, hostname verification on). Supply
+        a custom context when pinning a private CA, requiring client
+        certificates, or restricting cipher suites.
+        """
         self._state = TransportState.CONNECTING
         scheme = "wss" if self.config.use_tls else "ws"
         uri = f"{scheme}://{self.config.uri}"
+        connect_kwargs: dict[str, Any] = {
+            "open_timeout": self.config.timeout_seconds,
+        }
+        if self.config.use_tls and self.config.ssl_context is not None:
+            connect_kwargs["ssl"] = self.config.ssl_context
         try:
-            self._ws = await connect(uri, open_timeout=self.config.timeout_seconds)
+            self._ws = await connect(uri, **connect_kwargs)
             self._state = TransportState.CONNECTED
             self._should_reconnect = True
             self._last_pong = time.monotonic()

--- a/agent-governance-python/agent-mesh/tests/test_websocket_transport.py
+++ b/agent-governance-python/agent-mesh/tests/test_websocket_transport.py
@@ -62,6 +62,113 @@ class TestTransportBase:
         cfg = TransportConfig(host="example.com", port=443)
         assert cfg.uri == "example.com:443"
 
+    def test_transport_config_ssl_context_default_none(self) -> None:
+        """TransportConfig.ssl_context defaults to None (use library default)."""
+        cfg = TransportConfig()
+        assert cfg.ssl_context is None
+
+    def test_transport_config_accepts_ssl_context(self) -> None:
+        """TransportConfig stores a caller-supplied ssl.SSLContext."""
+        import ssl
+
+        ctx = ssl.create_default_context()
+        cfg = TransportConfig(use_tls=True, ssl_context=ctx)
+        assert cfg.ssl_context is ctx
+
+
+class TestWebSocketTLSContext:
+    """Tests for TLS context plumbing on WebSocketTransport.connect().
+
+    Uses a local AsyncMock ws instead of the shared ``mock_ws_connection``
+    fixture, because that fixture calls ``asyncio.get_event_loop()``
+    eagerly at collection time, which is unreliable on Python 3.14.
+    """
+
+    @staticmethod
+    def _local_ws_mock() -> AsyncMock:
+        ws = AsyncMock()
+        ws.close = AsyncMock()
+        return ws
+
+    @pytest.mark.asyncio
+    async def test_connect_passes_ssl_context_when_tls(self) -> None:
+        """When use_tls=True and an ssl_context is set, it is forwarded
+        to the websockets `connect()` call as the `ssl` kwarg."""
+        import ssl
+
+        ctx = ssl.create_default_context()
+        cfg = TransportConfig(
+            host="mesh.example.com",
+            port=443,
+            use_tls=True,
+            ssl_context=ctx,
+        )
+        transport = WebSocketTransport(cfg, heartbeat_interval=0)
+        ws = self._local_ws_mock()
+
+        mock_connect = AsyncMock(return_value=ws)
+        with patch("agentmesh.transport.websocket.connect", mock_connect):
+            with patch.object(transport, "_listen", return_value=None):
+                await transport.connect()
+            await transport.disconnect()
+
+        mock_connect.assert_awaited_once()
+        _, kwargs = mock_connect.call_args
+        assert kwargs.get("ssl") is ctx, (
+            "ssl_context must be forwarded to the websockets connect()"
+        )
+
+    @pytest.mark.asyncio
+    async def test_connect_omits_ssl_kwarg_when_no_context(self) -> None:
+        """When ssl_context is None, the `ssl` kwarg is not passed --
+        the websockets library uses its own default context."""
+        cfg = TransportConfig(
+            host="mesh.example.com",
+            port=443,
+            use_tls=True,
+            ssl_context=None,
+        )
+        transport = WebSocketTransport(cfg, heartbeat_interval=0)
+        ws = self._local_ws_mock()
+
+        mock_connect = AsyncMock(return_value=ws)
+        with patch("agentmesh.transport.websocket.connect", mock_connect):
+            with patch.object(transport, "_listen", return_value=None):
+                await transport.connect()
+            await transport.disconnect()
+
+        mock_connect.assert_awaited_once()
+        _, kwargs = mock_connect.call_args
+        assert "ssl" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_connect_omits_ssl_kwarg_when_tls_disabled(self) -> None:
+        """When use_tls=False, the ssl kwarg is not forwarded even if a
+        context is set (plain ws:// URI)."""
+        import ssl
+
+        ctx = ssl.create_default_context()
+        cfg = TransportConfig(
+            host="mesh.example.com",
+            port=8080,
+            use_tls=False,
+            ssl_context=ctx,
+        )
+        transport = WebSocketTransport(cfg, heartbeat_interval=0)
+        ws = self._local_ws_mock()
+
+        mock_connect = AsyncMock(return_value=ws)
+        with patch("agentmesh.transport.websocket.connect", mock_connect):
+            with patch.object(transport, "_listen", return_value=None):
+                await transport.connect()
+            await transport.disconnect()
+
+        mock_connect.assert_awaited_once()
+        args, kwargs = mock_connect.call_args
+        # ws:// scheme is used because use_tls is False
+        assert args[0].startswith("ws://"), args[0]
+        assert "ssl" not in kwargs
+
 
 # ---------------------------------------------------------------------------
 # Test: WebSocketTransport


### PR DESCRIPTION
## Summary

[`WebSocketTransport.connect()`](agent-governance-python/agent-mesh/src/agentmesh/transport/websocket.py) called `connect(uri, ...)` without passing an `ssl` argument, forcing the `websockets` library to build a default `ssl.SSLContext` from the system trust store. There was no way for a caller to:

- pin a private CA bundle (private/self-signed root)
- require a client certificate (mTLS to AgentMesh services)
- restrict cipher suites for compliance

In effect any deployment whose server cert is not chained to a public root could not use TLS verification, leaving operators to disable hostname checking via library-level monkeypatch.

## Change

- Add `ssl_context: Optional[ssl.SSLContext] = None` to [`TransportConfig`](agent-governance-python/agent-mesh/src/agentmesh/transport/base.py).
- `WebSocketTransport.connect()` forwards the context as the `ssl` kwarg when `use_tls=True` and `ssl_context is not None`.
- When `ssl_context is None`, the kwarg is omitted and the library default is used (backward compatible).
- When `use_tls=False`, the kwarg is always omitted (plain `ws://` URI).

Typical use:

```python
import ssl
ctx = ssl.create_default_context(cafile=\"/etc/agentmesh/private-ca.pem\")
ctx.load_cert_chain(\"/etc/agentmesh/agent.crt\", \"/etc/agentmesh/agent.key\")
cfg = TransportConfig(host=\"mesh.internal\", port=443, use_tls=True, ssl_context=ctx)
```

## Tests

| Suite | Before | After |
|---|---|---|
| `tests/test_websocket_transport.py::TestTransportBase` | 3 passed | 5 passed (2 new) |
| `tests/test_websocket_transport.py::TestWebSocketTLSContext` (new) | n/a | 3 passed |
| Full `tests/` | 11 pre-existing failures | 11 pre-existing failures |

New regression tests pin:

- `ssl_context=ctx` and `use_tls=True` -> context forwarded as `ssl` kwarg
- `ssl_context=None` -> no `ssl` kwarg passed
- `use_tls=False` (with ssl_context set) -> no `ssl` kwarg, `ws://` scheme

The new tests use a local `AsyncMock` rather than the shared `mock_ws_connection` fixture because that fixture calls `asyncio.get_event_loop()` at collection time, which is unreliable on Python 3.14 -- the same root cause as the 5 pre-existing `TestWebSocketTransport` ERRORs in the baseline.

Recipe (PowerShell):

```powershell
cd agent-governance-python/agent-mesh
$env:PYTHONPATH = \"src\"
python -m pytest tests/test_websocket_transport.py::TestTransportBase tests/test_websocket_transport.py::TestWebSocketTLSContext -q
```

## Test plan

- [x] New regression tests pass (8/8)
- [x] No new failures in full suite (same 11 pre-existing 3.14 deprecation failures)
- [x] Default `ssl_context=None` keeps existing call sites working unchanged

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Mesh].