### PR TITLE
fix(py-discovery-inventory): log corrupt-inventory load failures

### DIFF
--- a/agent-governance-python/agent-discovery/src/agent_discovery/inventory.py
+++ b/agent-governance-python/agent-discovery/src/agent_discovery/inventory.py
@@ -10,11 +10,14 @@ the same agent appears in GitHub, as a process, and in config files.
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from .models import AgentStatus, DiscoveredAgent, ScanResult
+
+logger = logging.getLogger(__name__)
 
 
 class AgentInventory:
@@ -136,8 +139,17 @@ class AgentInventory:
             for item in data:
                 agent = DiscoveredAgent.model_validate(item)
                 self._agents[agent.fingerprint] = agent
-        except Exception:  # noqa: S110
-            pass  # start fresh if corrupt
+        except Exception as exc:
+            # Corrupt or unreadable inventory file -- start fresh, but
+            # surface the path and reason so an operator can recover the
+            # data. Previously this silently swallowed every failure,
+            # including transient IO errors and schema mismatches after
+            # a model change.
+            logger.warning(
+                "Failed to load inventory from %s: %s; starting fresh.",
+                self._storage_path,
+                exc,
+            )
 
     def summary(self) -> dict[str, Any]:
         """Generate inventory summary statistics."""

--- a/agent-governance-python/agent-discovery/tests/test_inventory.py
+++ b/agent-governance-python/agent-discovery/tests/test_inventory.py
@@ -123,6 +123,29 @@ class TestAgentInventory:
             assert inv2.get("a") is not None
             assert inv2.get("a").name == "Persistent"
 
+    def test_corrupt_inventory_logs_warning(self, caplog):
+        """When the on-disk inventory is corrupt, _load logs a warning
+        with the offending path instead of silently swallowing the
+        error. Operators need to know why the inventory came up empty.
+        """
+        import logging
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "inventory.json"
+            path.write_text("{not: valid json}", encoding="utf-8")
+
+            with caplog.at_level(logging.WARNING, logger="agent_discovery.inventory"):
+                inv = AgentInventory(storage_path=path)
+
+            assert inv.count == 0  # starts fresh
+            warning_records = [
+                r for r in caplog.records
+                if r.levelno >= logging.WARNING
+                and r.name == "agent_discovery.inventory"
+            ]
+            assert warning_records, "expected a WARNING log for corrupt inventory"
+            assert str(path) in warning_records[0].getMessage()
+
     def test_export_json(self):
         inv = AgentInventory()
         inv.ingest(ScanResult(scanner_name="test", agents=[_make_agent("a", "JSON Agent")]))


### PR DESCRIPTION
## Summary

[`AgentInventory._load()`](agent-governance-python/agent-discovery/src/agent_discovery/inventory.py) caught every exception and silently passed, so any corrupted or schema-mismatched inventory file came up empty with no operator-visible signal. The inventory just "forgets" what it had recorded -- impossible to diagnose unless the operator notices the count drop and goes hunting for log evidence that doesn't exist.

## Change

Replace `except Exception: pass` with a `logger.warning(...)` that includes the offending path and the exception message. The inventory still starts fresh on corruption (preserving the existing contract that a bad file does not crash the caller), but operators now see why:

```
WARNING agent_discovery.inventory: Failed to load inventory from
/var/lib/agentmesh/inventory.json: Expecting value: line 1 column 2
(char 1); starting fresh.
```

## Tests

| Suite | Before | After |
|---|---|---|
| `tests/test_inventory.py` | 13 passed | 14 passed (new caplog test) |
| Full `agent-discovery/tests/` | 53 passed | 54 passed |

New regression test writes invalid JSON to the storage path and asserts that a WARNING record is emitted by `agent_discovery.inventory` containing the path.

Recipe (PowerShell):

```powershell
cd agent-governance-python/agent-discovery
python -m pytest tests/ -q
```

## Test plan

- [x] New caplog regression test passes
- [x] Existing inventory persistence tests still green
- [x] Inventory still starts fresh on corruption (no behavioural break)

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Mesh].