### PR TITLE
fix(py-mesh-delegation): collapse verify_capability_narrowing to all()

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/delegation.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/delegation.py
@@ -105,12 +105,20 @@ class DelegationLink(BaseModel):
     previous_link_hash: Optional[str] = Field(None, description="Hash of previous link in chain")
 
     def verify_capability_narrowing(self) -> bool:
-        """Verify that delegated capabilities are a subset of parent's."""
-        for cap in self.delegated_capabilities:
-            if cap not in self.parent_capabilities:
-                if not self._is_narrower_capability(cap, self.parent_capabilities):
-                    return False
-        return True
+        """Verify that every delegated capability is a subset of the parent's.
+
+        A capability is considered narrowed when it appears literally
+        in the parent set or matches a parent wildcard via
+        ``_is_narrower_capability``. The previous early-return form
+        fanned the same predicate across two nested ``if`` blocks; the
+        ``all(...)`` form is shorter, has one predicate, and short-
+        circuits identically.
+        """
+        return all(
+            cap in self.parent_capabilities
+            or self._is_narrower_capability(cap, self.parent_capabilities)
+            for cap in self.delegated_capabilities
+        )
 
     def _is_narrower_capability(self, cap: str, parent_caps: list[str]) -> bool:
         """Check if a capability is a narrowed version of a parent capability."""


### PR DESCRIPTION
## Summary

[`DelegationLink.verify_capability_narrowing`](agent-governance-python/agent-mesh/src/agentmesh/identity/delegation.py) was a nested-if loop that returned False on the first non-narrowed capability and True at the end. The early-return form is brittle for the same reason early returns usually are: the predicate is split across two `if` branches plus an implicit "everything passed" fall-through. A future maintainer who adds an early `return True` in the wrong place silently widens delegation -- a soundness regression that lints won't catch.

## Change

Collapse to a single `all(...)` comprehension over the same predicate:

```python
return all(
    cap in self.parent_capabilities
    or self._is_narrower_capability(cap, self.parent_capabilities)
    for cap in self.delegated_capabilities
)
```

Short-circuit semantics are identical; the predicate is now explicit and unsplit. Behaviour is unchanged.

## Tests

Existing coverage in [`test_coverage_boost.py::TestDelegationLink`](agent-governance-python/agent-mesh/tests/test_coverage_boost.py) exercises every branch:

- `test_verify_capability_narrowing_valid`
- `test_verify_capability_narrowing_invalid`
- `test_verify_capability_wildcard_narrowing`
- `test_verify_capability_star_parent`

Plus `test_credential_lifecycle.py` exercises the False path on widening attempts.

| Suite | Before | After |
|---|---|---|
| `test_identity.py + test_credential_lifecycle.py + test_validation.py + test_fuzzing.py + test_delegation_depth.py + test_coverage_boost.py` | 630 passed | 630 passed |

Pure refactor; no new tests added because existing coverage is comprehensive.

Recipe (PowerShell):

```powershell
cd agent-governance-python/agent-mesh
$env:PYTHONPATH = \"src\"
python -m pytest tests/test_coverage_boost.py::TestDelegationLink tests/test_identity.py -q
```

## Test plan

- [x] All four `verify_capability_narrowing` branches still pass
- [x] No new failures across delegation-touching tests

Surfaced during independent audit conducted by @finnoybu (Ken Tannenbaum, AEGIS Initiative); [LOW, Python Mesh].