### PR TITLE
feat(identity): add attestation collector and verifier interfaces

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/exceptions.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/exceptions.py
@@ -17,6 +17,18 @@ class IdentityError(AgentMeshError):
     """Errors related to agent identity (DID, keys, credentials)."""
 
 
+class AttestationError(IdentityError):
+    """Errors related to confidential-computing attestation."""
+
+
+class AttestationCollectionError(AttestationError):
+    """Attestation evidence could not be collected from the runtime."""
+
+
+class AttestationVerificationError(AttestationError):
+    """Attestation evidence failed verification against reference values."""
+
+
 class TrustError(AgentMeshError):
     """Errors related to trust scoring and verification."""
 
@@ -60,6 +72,9 @@ class MarketplaceError(AgentMeshError):
 __all__ = [
     "AgentMeshError",
     "IdentityError",
+    "AttestationError",
+    "AttestationCollectionError",
+    "AttestationVerificationError",
     "TrustError",
     "TrustVerificationError",
     "TrustViolationError",

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/__init__.py
@@ -16,6 +16,7 @@ from .attestation import (
     AttestationClaims,
     AttestationEvidence,
     ConfidentialLevel,
+    ImageMatchPolicy,
     KeyOrigin,
     ReferenceValues,
     compute_report_data_hash,
@@ -23,6 +24,12 @@ from .attestation import (
     matches_report_data_binding,
     public_key_hash_hex,
 )
+from .attestation_collector import (
+    AttestationCollector,
+    MockAttestationCollector,
+    NoopAttestationCollector,
+)
+from .attestation_verifier import AttestationVerifier, MockAttestationVerifier
 from .credentials import Credential, CredentialManager
 from .delegation import DelegationLink, ScopeChain, UserContext
 from .entra import EntraAgentBlueprint, EntraAgentIdentity, EntraAgentRegistry
@@ -75,8 +82,14 @@ __all__ = [
     "AttestationClaims",
     "AttestationEvidence",
     "ConfidentialLevel",
+    "ImageMatchPolicy",
     "KeyOrigin",
     "ReferenceValues",
+    "AttestationCollector",
+    "MockAttestationCollector",
+    "NoopAttestationCollector",
+    "AttestationVerifier",
+    "MockAttestationVerifier",
     "compute_report_data_hash",
     "compute_report_data_hash_hex",
     "matches_report_data_binding",

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/attestation.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/attestation.py
@@ -42,6 +42,14 @@ class KeyOrigin(StrEnum):
         return self in {KeyOrigin.SKR, KeyOrigin.TEE_GENERATED}
 
 
+class ImageMatchPolicy(StrEnum):
+    """How verifier reference values match measured agent images."""
+
+    EXACT_HASH = "exact_hash"
+    SIGNING_IDENTITY = "signing_identity"
+    STABLE_CLAIMS = "stable_claims"
+
+
 def public_key_hash_hex(public_key: bytes) -> str:
     """Return the SHA-256 hash of a raw Ed25519 public key as lowercase hex."""
     if len(public_key) != ED25519_PUBLIC_KEY_SIZE:
@@ -237,6 +245,8 @@ class ReferenceValues(BaseModel):
     required_claims: dict[str, str] = Field(default_factory=dict)
     allowed_tcb_statuses: list[str] = Field(default_factory=lambda: ["up_to_date"])
     require_debug_disabled: bool = True
+    image_match_policy: ImageMatchPolicy = ImageMatchPolicy.EXACT_HASH
+    allowed_image_signers: list[str] = Field(default_factory=list)
 
 
 def _length_prefixed_utf8(value: str, *, field_name: str) -> bytes:

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/attestation_collector.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/attestation_collector.py
@@ -1,0 +1,128 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Provider-neutral attestation evidence collection interfaces and mocks."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+
+from agentmesh.exceptions import AttestationCollectionError
+
+from .attestation import (
+    DEFAULT_EVIDENCE_TTL_SECONDS,
+    AttestationEvidence,
+    KeyOrigin,
+    compute_report_data_hash_hex,
+)
+
+
+class AttestationCollector(ABC):
+    """Collects attestation evidence from the current runtime environment."""
+
+    @abstractmethod
+    async def collect(
+        self,
+        agent_did: str,
+        challenge_id: str,
+        nonce: str,
+        public_key_hash: str,
+    ) -> AttestationEvidence | None:
+        """Gather platform evidence bound to the agent identity and challenge."""
+
+    @abstractmethod
+    def platform(self) -> str:
+        """Return the attestation platform identifier."""
+
+
+class NoopAttestationCollector(AttestationCollector):
+    """Collector used when attestation is disabled."""
+
+    async def collect(
+        self,
+        agent_did: str,
+        challenge_id: str,
+        nonce: str,
+        public_key_hash: str,
+    ) -> None:
+        """Return no evidence without touching a platform attestation provider."""
+        return None
+
+    def platform(self) -> str:
+        """Return the no-op platform identifier."""
+        return "none"
+
+
+class MockAttestationCollector(AttestationCollector):
+    """CI-safe collector that synthesizes valid attestation evidence."""
+
+    def __init__(
+        self,
+        *,
+        platform: str = "mock",
+        evidence: str = "mock-attestation-evidence",
+        key_origin: KeyOrigin = KeyOrigin.LOCAL,
+        runtime_measurements: Mapping[str, str] | None = None,
+        secure_boot_verified: bool = False,
+        ttl_seconds: int = DEFAULT_EVIDENCE_TTL_SECONDS,
+        latency_seconds: float = 0.0,
+        error: Exception | None = None,
+    ) -> None:
+        if not platform:
+            raise ValueError("platform must not be empty")
+        if not evidence:
+            raise ValueError("evidence must not be empty")
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if latency_seconds < 0:
+            raise ValueError("latency_seconds must not be negative")
+
+        self._platform = platform
+        self._evidence = evidence
+        self._key_origin = key_origin
+        self._runtime_measurements = dict(runtime_measurements or {})
+        self._secure_boot_verified = secure_boot_verified
+        self._ttl_seconds = ttl_seconds
+        self._latency_seconds = latency_seconds
+        self._error = error
+
+    async def collect(
+        self,
+        agent_did: str,
+        challenge_id: str,
+        nonce: str,
+        public_key_hash: str,
+    ) -> AttestationEvidence:
+        """Return synthetic evidence with a deterministic ADR 0010 binding."""
+        if self._latency_seconds:
+            await asyncio.sleep(self._latency_seconds)
+        if self._error is not None:
+            raise AttestationCollectionError(str(self._error)) from self._error
+
+        timestamp = datetime.now(UTC)
+        return AttestationEvidence(
+            platform=self._platform,
+            evidence=self._evidence,
+            agent_did=agent_did,
+            challenge_id=challenge_id,
+            nonce=nonce,
+            public_key_hash=public_key_hash,
+            report_data_hash=compute_report_data_hash_hex(
+                agent_did=agent_did,
+                challenge_id=challenge_id,
+                nonce=nonce,
+                public_key_hash=public_key_hash,
+            ),
+            key_origin=self._key_origin,
+            runtime_measurements=self._runtime_measurements,
+            secure_boot_verified=self._secure_boot_verified,
+            timestamp=timestamp,
+            expires_at=timestamp + timedelta(seconds=self._ttl_seconds),
+        )
+
+    def platform(self) -> str:
+        """Return the configured mock platform identifier."""
+        return self._platform
+

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/attestation_verifier.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/attestation_verifier.py
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Provider-neutral attestation verification interfaces and mocks."""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+
+from agentmesh.exceptions import AttestationVerificationError
+
+from .attestation import (
+    DEFAULT_EVIDENCE_TTL_SECONDS,
+    AttestationClaims,
+    AttestationEvidence,
+    ConfidentialLevel,
+    ImageMatchPolicy,
+    ReferenceValues,
+)
+
+DEBUGGABLE_CLAIM = "x-ms-sevsnpvm-is-debuggable"
+IMAGE_SIGNER_CLAIMS = ("image_signer", "x-ms-image-signer")
+
+
+class AttestationVerifier(ABC):
+    """Verifies attestation evidence against expected reference values."""
+
+    @abstractmethod
+    async def verify(
+        self,
+        evidence: AttestationEvidence,
+        reference_values: ReferenceValues,
+    ) -> AttestationClaims:
+        """Validate evidence against reference values. Raise on failure."""
+
+
+class MockAttestationVerifier(AttestationVerifier):
+    """CI-safe verifier with configurable success and failure modes."""
+
+    def __init__(
+        self,
+        *,
+        platform_verified: bool = True,
+        report_data_match: bool = True,
+        confidential_level: ConfidentialLevel = ConfidentialLevel.TEE_CONTAINER,
+        tcb_status: str = "up_to_date",
+        runtime_measurements: Mapping[str, str] | None = None,
+        claims: Mapping[str, str] | None = None,
+        ttl_seconds: int = DEFAULT_EVIDENCE_TTL_SECONDS,
+        latency_seconds: float = 0.0,
+        error: Exception | None = None,
+    ) -> None:
+        if not tcb_status:
+            raise ValueError("tcb_status must not be empty")
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if latency_seconds < 0:
+            raise ValueError("latency_seconds must not be negative")
+
+        self._platform_verified = platform_verified
+        self._report_data_match = report_data_match
+        self._confidential_level = confidential_level
+        self._tcb_status = tcb_status
+        self._runtime_measurements = dict(runtime_measurements or {})
+        self._claims = dict(claims or {})
+        self._ttl_seconds = ttl_seconds
+        self._latency_seconds = latency_seconds
+        self._error = error
+
+    async def verify(
+        self,
+        evidence: AttestationEvidence,
+        reference_values: ReferenceValues,
+    ) -> AttestationClaims:
+        """Validate synthetic evidence and return normalized attestation claims."""
+        if self._latency_seconds:
+            await asyncio.sleep(self._latency_seconds)
+        if self._error is not None:
+            raise AttestationVerificationError(str(self._error)) from self._error
+        if evidence.is_expired():
+            raise AttestationVerificationError("attestation evidence is expired")
+        if not self._platform_verified:
+            raise AttestationVerificationError("attestation platform was not verified")
+        if not self._report_data_match:
+            raise AttestationVerificationError("attestation report data did not match")
+
+        runtime_measurements = {**evidence.runtime_measurements, **self._runtime_measurements}
+        claims = dict(self._claims)
+
+        self._verify_reference_values(
+            evidence=evidence,
+            reference_values=reference_values,
+            runtime_measurements=runtime_measurements,
+            claims=claims,
+        )
+
+        verified_at = datetime.now(UTC)
+        return AttestationClaims(
+            platform=evidence.platform,
+            confidential_level=self._confidential_level,
+            key_origin=evidence.key_origin,
+            platform_verified=True,
+            report_data_match=True,
+            tcb_status=self._tcb_status,
+            runtime_measurements=runtime_measurements,
+            verified_at=verified_at,
+            expires_at=verified_at + timedelta(seconds=self._ttl_seconds),
+            claims=claims,
+        )
+
+    def _verify_reference_values(
+        self,
+        *,
+        evidence: AttestationEvidence,
+        reference_values: ReferenceValues,
+        runtime_measurements: Mapping[str, str],
+        claims: Mapping[str, str],
+    ) -> None:
+        if reference_values.required_platform is not None:
+            if evidence.platform != reference_values.required_platform:
+                raise AttestationVerificationError(
+                    "attestation platform mismatch: "
+                    f"expected {reference_values.required_platform!r}, got {evidence.platform!r}"
+                )
+
+        if self._tcb_status not in reference_values.allowed_tcb_statuses:
+            raise AttestationVerificationError(
+                f"attestation TCB status {self._tcb_status!r} is not allowed"
+            )
+
+        if reference_values.require_debug_disabled:
+            debuggable = claims.get(DEBUGGABLE_CLAIM, "false")
+            if debuggable.lower() == "true":
+                raise AttestationVerificationError("attestation debug mode is enabled")
+
+        for name, expected in reference_values.expected_measurements.items():
+            actual = runtime_measurements.get(name)
+            if actual != expected:
+                raise AttestationVerificationError(
+                    f"attestation measurement mismatch for {name!r}: "
+                    f"expected {expected!r}, got {actual!r}"
+                )
+
+        for name, expected in reference_values.required_claims.items():
+            actual = claims.get(name)
+            if actual != expected:
+                raise AttestationVerificationError(
+                    f"attestation claim mismatch for {name!r}: "
+                    f"expected {expected!r}, got {actual!r}"
+                )
+
+        if reference_values.image_match_policy is ImageMatchPolicy.SIGNING_IDENTITY:
+            self._verify_signing_identity(reference_values, claims)
+
+    def _verify_signing_identity(
+        self,
+        reference_values: ReferenceValues,
+        claims: Mapping[str, str],
+    ) -> None:
+        if not reference_values.allowed_image_signers:
+            return
+
+        signer = next((claims.get(name) for name in IMAGE_SIGNER_CLAIMS if claims.get(name)), None)
+        if signer not in reference_values.allowed_image_signers:
+            raise AttestationVerificationError(
+                "attestation image signer mismatch: "
+                f"expected one of {reference_values.allowed_image_signers!r}, got {signer!r}"
+            )
+

--- a/agent-governance-python/agent-mesh/tests/test_attestation_collector.py
+++ b/agent-governance-python/agent-mesh/tests/test_attestation_collector.py
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for attestation evidence collectors."""
+
+from collections.abc import Callable
+
+import pytest
+
+from agentmesh.exceptions import AttestationCollectionError
+from agentmesh.identity.attestation import KeyOrigin, public_key_hash_hex
+from agentmesh.identity.attestation_collector import (
+    AttestationCollector,
+    MockAttestationCollector,
+    NoopAttestationCollector,
+)
+
+
+@pytest.mark.asyncio
+async def test_noop_attestation_collector_returns_no_evidence() -> None:
+    collector: AttestationCollector = NoopAttestationCollector()
+
+    evidence = await collector.collect(
+        agent_did="did:mesh:agent-1",
+        challenge_id="challenge_123",
+        nonce="nonce-abc",
+        public_key_hash=public_key_hash_hex(b"\x01" * 32),
+    )
+
+    assert evidence is None
+    assert collector.platform() == "none"
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_collector_returns_bound_evidence() -> None:
+    public_key_hash = public_key_hash_hex(b"\x02" * 32)
+    collector = MockAttestationCollector(
+        platform="azure-caci",
+        key_origin=KeyOrigin.SKR,
+        runtime_measurements={"cce_policy_hash": "policy-v1"},
+        secure_boot_verified=True,
+    )
+
+    evidence = await collector.collect(
+        agent_did="did:mesh:agent-1",
+        challenge_id="challenge_123",
+        nonce="nonce-abc",
+        public_key_hash=public_key_hash,
+    )
+
+    assert evidence.platform == "azure-caci"
+    assert evidence.key_origin is KeyOrigin.SKR
+    assert evidence.key_bound_to_tee is True
+    assert evidence.runtime_measurements["cce_policy_hash"] == "policy-v1"
+    assert evidence.secure_boot_verified is True
+    assert evidence.matches_binding(
+        agent_did="did:mesh:agent-1",
+        challenge_id="challenge_123",
+        nonce="nonce-abc",
+        public_key_hash=public_key_hash,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_collector_wraps_configured_error() -> None:
+    collector = MockAttestationCollector(error=RuntimeError("sidecar unavailable"))
+
+    with pytest.raises(AttestationCollectionError, match="sidecar unavailable"):
+        await collector.collect(
+            agent_did="did:mesh:agent-1",
+            challenge_id="challenge_123",
+            nonce="nonce-abc",
+            public_key_hash=public_key_hash_hex(b"\x03" * 32),
+        )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: MockAttestationCollector(platform=""),
+        lambda: MockAttestationCollector(evidence=""),
+        lambda: MockAttestationCollector(ttl_seconds=0),
+        lambda: MockAttestationCollector(latency_seconds=-1.0),
+    ],
+)
+def test_mock_attestation_collector_rejects_invalid_configuration(
+    factory: Callable[[], MockAttestationCollector],
+) -> None:
+    with pytest.raises(ValueError):
+        factory()
+

--- a/agent-governance-python/agent-mesh/tests/test_attestation_verifier.py
+++ b/agent-governance-python/agent-mesh/tests/test_attestation_verifier.py
@@ -1,0 +1,181 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for attestation evidence verifiers."""
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from agentmesh.exceptions import AttestationVerificationError
+from agentmesh.identity.attestation import (
+    AttestationEvidence,
+    ImageMatchPolicy,
+    KeyOrigin,
+    ReferenceValues,
+    compute_report_data_hash_hex,
+    public_key_hash_hex,
+)
+from agentmesh.identity.attestation_verifier import MockAttestationVerifier
+
+
+def _valid_evidence(**overrides: object) -> AttestationEvidence:
+    public_key_hash = public_key_hash_hex(b"\x01" * 32)
+    values: dict[str, Any] = {
+        "platform": "azure-caci",
+        "evidence": "base64-attestation-report",
+        "agent_did": "did:mesh:agent-1",
+        "challenge_id": "challenge_123",
+        "nonce": "nonce-abc",
+        "public_key_hash": public_key_hash,
+        "report_data_hash": compute_report_data_hash_hex(
+            "did:mesh:agent-1",
+            "challenge_123",
+            "nonce-abc",
+            public_key_hash,
+        ),
+        "key_origin": KeyOrigin.SKR,
+        "runtime_measurements": {"cce_policy_hash": "policy-v1"},
+        "secure_boot_verified": True,
+    }
+    values.update(overrides)
+    return AttestationEvidence(**values)
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_returns_claims() -> None:
+    verifier = MockAttestationVerifier(
+        claims={"x-ms-sevsnpvm-is-debuggable": "false"},
+    )
+
+    claims = await verifier.verify(
+        _valid_evidence(),
+        ReferenceValues(
+            required_platform="azure-caci",
+            expected_measurements={"cce_policy_hash": "policy-v1"},
+        ),
+    )
+
+    assert claims.platform == "azure-caci"
+    assert claims.platform_verified is True
+    assert claims.report_data_match is True
+    assert claims.key_origin is KeyOrigin.SKR
+    assert claims.runtime_measurements["cce_policy_hash"] == "policy-v1"
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_rejects_platform_mismatch() -> None:
+    verifier = MockAttestationVerifier()
+
+    with pytest.raises(AttestationVerificationError, match="platform mismatch"):
+        await verifier.verify(
+            _valid_evidence(),
+            ReferenceValues(required_platform="azure-cvm"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_rejects_cce_policy_hash_mismatch() -> None:
+    verifier = MockAttestationVerifier()
+
+    with pytest.raises(AttestationVerificationError, match="measurement mismatch"):
+        await verifier.verify(
+            _valid_evidence(),
+            ReferenceValues(expected_measurements={"cce_policy_hash": "policy-v2"}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_rejects_required_claim_mismatch() -> None:
+    verifier = MockAttestationVerifier(claims={"x-ms-compliance-status": "non-compliant"})
+
+    with pytest.raises(AttestationVerificationError, match="claim mismatch"):
+        await verifier.verify(
+            _valid_evidence(),
+            ReferenceValues(required_claims={"x-ms-compliance-status": "compliant"}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_rejects_disallowed_tcb_status() -> None:
+    verifier = MockAttestationVerifier(tcb_status="out_of_date")
+
+    with pytest.raises(AttestationVerificationError, match="TCB status"):
+        await verifier.verify(
+            _valid_evidence(),
+            ReferenceValues(allowed_tcb_statuses=["up_to_date"]),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_rejects_debug_mode() -> None:
+    verifier = MockAttestationVerifier(claims={"x-ms-sevsnpvm-is-debuggable": "true"})
+
+    with pytest.raises(AttestationVerificationError, match="debug mode"):
+        await verifier.verify(_valid_evidence(), ReferenceValues())
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_supports_signing_identity_policy() -> None:
+    verifier = MockAttestationVerifier(claims={"image_signer": "trusted-ci"})
+
+    claims = await verifier.verify(
+        _valid_evidence(),
+        ReferenceValues(
+            image_match_policy=ImageMatchPolicy.SIGNING_IDENTITY,
+            allowed_image_signers=["trusted-ci"],
+        ),
+    )
+
+    assert claims.claims["image_signer"] == "trusted-ci"
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_rejects_signing_identity_mismatch() -> None:
+    verifier = MockAttestationVerifier(claims={"image_signer": "untrusted-ci"})
+
+    with pytest.raises(AttestationVerificationError, match="image signer mismatch"):
+        await verifier.verify(
+            _valid_evidence(),
+            ReferenceValues(
+                image_match_policy=ImageMatchPolicy.SIGNING_IDENTITY,
+                allowed_image_signers=["trusted-ci"],
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_rejects_expired_evidence() -> None:
+    timestamp = datetime.now(UTC) - timedelta(minutes=10)
+    evidence = _valid_evidence(
+        timestamp=timestamp,
+        expires_at=timestamp + timedelta(minutes=5),
+    )
+
+    with pytest.raises(AttestationVerificationError, match="expired"):
+        await MockAttestationVerifier().verify(evidence, ReferenceValues())
+
+
+@pytest.mark.asyncio
+async def test_mock_attestation_verifier_wraps_configured_error() -> None:
+    verifier = MockAttestationVerifier(error=RuntimeError("MAA unavailable"))
+
+    with pytest.raises(AttestationVerificationError, match="MAA unavailable"):
+        await verifier.verify(_valid_evidence(), ReferenceValues())
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: MockAttestationVerifier(tcb_status=""),
+        lambda: MockAttestationVerifier(ttl_seconds=0),
+        lambda: MockAttestationVerifier(latency_seconds=-1.0),
+    ],
+)
+def test_mock_attestation_verifier_rejects_invalid_configuration(
+    factory: Callable[[], MockAttestationVerifier],
+) -> None:
+    with pytest.raises(ValueError):
+        factory()
+


### PR DESCRIPTION
## Summary

Follow-up to ADR 0010 / PR #1763. This adds provider-neutral extension points for collecting and verifying confidential-computing attestation evidence without introducing Azure or hardware dependencies yet.

Adds:
- `AttestationCollector` ABC with `NoopAttestationCollector` and `MockAttestationCollector`
- `AttestationVerifier` ABC with `MockAttestationVerifier`
- Attestation-specific exceptions
- `ImageMatchPolicy` on `ReferenceValues` for exact-hash, signing-identity, and stable-claims strategies
- CI-safe tests for platform mismatch, stale evidence, TCB status, debug mode, required claims, CCE policy hash mismatch, and image signer checks

## Validation

- `python -m pytest tests\test_attestation.py tests\test_attestation_binding.py tests\test_attestation_collector.py tests\test_attestation_verifier.py -q`
- `python -m ruff check src\agentmesh\identity\attestation.py src\agentmesh\identity\attestation_collector.py src\agentmesh\identity\attestation_verifier.py src\agentmesh\identity\__init__.py tests\test_attestation.py tests\test_attestation_collector.py tests\test_attestation_verifier.py`
- `python -m mypy src\agentmesh\identity\attestation.py src\agentmesh\identity\attestation_collector.py src\agentmesh\identity\attestation_verifier.py src\agentmesh\identity\__init__.py tests\test_attestation_collector.py tests\test_attestation_verifier.py`
