### PR TITLE
fix(ci): resolve four CI failures across Go, Python, and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,7 @@ jobs:
       - name: Install safety
         run: |
           pip install --no-cache-dir --require-hashes --no-deps -r "$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-safety.txt"
+          pip install --no-cache-dir 'typer>=0.9.0,<0.15.0'
           pip install --no-cache-dir safety==3.2.1
       - name: Check dependencies
         env:

--- a/agent-governance-golang/packages/agentmesh/sandbox.go
+++ b/agent-governance-golang/packages/agentmesh/sandbox.go
@@ -228,6 +228,9 @@ func (p *DockerSandboxProvider) CreateSession(agentID string, config *SandboxCon
 	}
 
 	p.mu.Lock()
+	if p.containers == nil {
+		p.containers = make(map[string]string)
+	}
 	p.containers[containerKey(agentID, sessionID)] = name
 	p.mu.Unlock()
 

--- a/agent-governance-golang/packages/agentmesh/sandbox_test.go
+++ b/agent-governance-golang/packages/agentmesh/sandbox_test.go
@@ -137,15 +137,16 @@ func TestCreateSessionRejectsInvalidAgentID(t *testing.T) {
 
 func TestCreateSessionAcceptsValidAgentID(t *testing.T) {
 	// Confirms the regex is not over-restrictive on legitimate IDs.
-	// We don't actually call docker — IsAvailable=false short-circuits.
-	p := &DockerSandboxProvider{available: false, image: "alpine"}
-	_, err := p.CreateSession("agent-123_test.local", nil)
-	// Expect a `docker is not available` error, not an `invalid agentID` error.
-	if err == nil {
-		t.Fatal("expected docker-unavailable error, got nil")
-	}
-	if strings.Contains(err.Error(), "invalid agentID") {
+	// If Docker is available the call may succeed; we only assert the
+	// regex did not reject the agent ID.
+	p := NewDockerSandboxProvider("alpine")
+	session, err := p.CreateSession("agent-123_test.local", nil)
+	if err != nil && strings.Contains(err.Error(), "invalid agentID") {
 		t.Fatalf("regex rejected a valid agentID: %v", err)
+	}
+	// Clean up if a container was actually created.
+	if err == nil && session != nil {
+		_ = p.DestroySession(session.AgentID, session.SessionID)
 	}
 }
 

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_ring_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_ring_improvements.py
@@ -4,6 +4,7 @@
 
 
 import pytest
+from unittest.mock import patch
 
 from hypervisor.models import ExecutionRing
 from hypervisor.rings.breach_detector import (
@@ -119,12 +120,19 @@ class TestRingInheritance:
 class TestBreachDetector:
     def test_no_breach_with_normal_pattern(self):
         detector = RingBreachDetector()
-        for _ in range(10):
-            result = detector.record_call(
-                "a1", "s1",
-                ExecutionRing.RING_2_STANDARD,
-                ExecutionRing.RING_2_STANDARD,
-            )
+        # Space calls at 200ms intervals (5/s), well under the default
+        # baseline of 10/s. Without mocking, back-to-back calls appear
+        # as a 10000/s burst and trigger a false breach.
+        times = iter([i * 0.2 for i in range(10)])
+        with patch("hypervisor.rings.breach_detector.time") as mock_time:
+            mock_time.monotonic = lambda: next(times)
+            for _ in range(10):
+                result = detector.record_call(
+                    "a1", "s1",
+                    ExecutionRing.RING_2_STANDARD,
+                    ExecutionRing.RING_2_STANDARD,
+                )
+        assert result is None
         assert result is None
 
     @pytest.mark.skip("Feature not available in Public Preview")
@@ -137,12 +145,15 @@ class TestBreachDetector:
 
     def test_breaker_not_tripped_for_normal(self):
         detector = RingBreachDetector()
-        for _ in range(10):
-            detector.record_call(
-                "a1", "s1",
-                ExecutionRing.RING_2_STANDARD,
-                ExecutionRing.RING_2_STANDARD,
-            )
+        times = iter([i * 0.2 for i in range(10)])
+        with patch("hypervisor.rings.breach_detector.time") as mock_time:
+            mock_time.monotonic = lambda: next(times)
+            for _ in range(10):
+                detector.record_call(
+                    "a1", "s1",
+                    ExecutionRing.RING_2_STANDARD,
+                    ExecutionRing.RING_2_STANDARD,
+                )
         assert not detector.is_breaker_tripped("a1", "s1")
 
     def test_reset_breaker(self):

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -156,6 +156,8 @@ SAFE_PATTERNS = {
     "-e", "--editable", "-r", "--requirement", "--upgrade", "--no-cache-dir",
     "--quiet", "--require-hashes", "--hash", ".", "..", "../..",
     "pip", "install", "%pip",
+    # Dockerfile / shell tokens that appear alongside pip install
+    "RUN", "run", "if", "then", "fi", "&&", "||", ";",
 }
 
 PIP_INSTALL_RE = re.compile(
@@ -182,7 +184,7 @@ def extract_package_names(install_args: str) -> list[str]:
         if token.startswith((".", "/", "\\", "http", "git+")):
             continue
         # Skip tokens that look like code, not package names
-        if any(c in token for c in ('(', ')', '=', '"', "'", ":")):
+        if any(c in token for c in ('(', ')', '=', '"', "'", ":", "[", "]")):
             continue
         # Skip tokens that look like filenames or shell keywords
         if any(token.rstrip(";") == kw for kw in ("if", "then", "else", "fi", "do", "done")):
@@ -259,6 +261,8 @@ def check_notebook(filepath: str) -> list[str]:
 
     registered_lower = {p.lower() for p in REGISTERED_PACKAGES}
     for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
         for line in cell.get("source", []):
             if "pip install" in line and not line.strip().startswith("#"):
                 packages = extract_package_names(line)


### PR DESCRIPTION
Fixes four independent CI failures on main:

1. **Go sandbox nil map panic** - \TestCreateSessionAcceptsValidAgentID\ used struct literal without initializing \containers\ map. Added nil-guard in \CreateSession\ and fixed test to use \NewDockerSandboxProvider\.

2. **Hypervisor breach detector false positives** - \	est_no_breach_with_normal_pattern\ and \	est_breaker_not_tripped_for_normal\ called \ecord_call()\ 10 times instantly, producing 10000/s rate vs 10/s baseline. Fixed by mocking \	ime.monotonic\ with 200ms spacing (5/s).

3. **dep-confusion-scan notebook false positives** - Scanner parsed markdown cells and Dockerfile \RUN\ commands as pip install args. Fixed: skip non-code cells, add brackets/Dockerfile tokens to safe patterns.

4. **safety typer crash** - \safety==3.2.1\ pulls incompatible \	yper\ that removed \ich_utils\. Fixed: pin \	yper<0.15\ before safety install.