### PR TITLE
Deprecate agentmesh::mcp; canonical home is agentmesh-mcp crate

### DIFF
--- a/agent-governance-rust/README.md
+++ b/agent-governance-rust/README.md
@@ -71,6 +71,14 @@ Use `agentmesh-mcp` when you only need the MCP-specific surface:
 message signing, session authentication, credential redaction, rate limiting,
 gateway decisions, and related MCP security helpers.
 
+`agentmesh-mcp` is the **canonical home** for MCP types. The `agentmesh::mcp`
+module is a verbatim copy that is now `#[deprecated]` and scheduled for removal
+in the next major release. New code should import from `agentmesh_mcp::mcp::...`
+directly — see
+[#2013](https://github.com/microsoft/agent-governance-toolkit/issues/2013)
+and
+[#2088](https://github.com/microsoft/agent-governance-toolkit/issues/2088).
+
 ## MCP gateway migration note
 
 The Rust MCP gateway now fails closed unless requests are processed through a

--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -25,6 +25,21 @@ pub mod identity;
 pub mod identity_support;
 pub mod integration_support;
 pub mod lifecycle;
+/// Deprecated: use the [`agentmesh-mcp`](https://crates.io/crates/agentmesh-mcp) crate directly.
+///
+/// `agentmesh::mcp` is a verbatim copy of `agentmesh_mcp::mcp` and will be
+/// removed in the next major release. The two paths resolve to *distinct*
+/// types in the Rust type system, so consumers that mix imports from
+/// `agentmesh::mcp::...` and `agentmesh_mcp::mcp::...` will hit confusing
+/// type-mismatch errors. Standardize on the `agentmesh-mcp` crate.
+///
+/// Tracking issues:
+/// <https://github.com/microsoft/agent-governance-toolkit/issues/2013> and
+/// <https://github.com/microsoft/agent-governance-toolkit/issues/2088>.
+#[deprecated(
+    since = "3.5.0",
+    note = "use the `agentmesh-mcp` crate directly; `agentmesh::mcp` will be removed in the next major release (see issue #2013)"
+)]
 pub mod mcp;
 pub mod policy;
 pub(crate) mod regex_cache;
@@ -76,6 +91,7 @@ pub use integration_support::{
     ShadowAgent,
 };
 pub use lifecycle::{LifecycleEvent, LifecycleManager, LifecycleState};
+#[allow(deprecated)]
 pub use mcp::*;
 pub use policy::{PolicyEngine, PolicyError};
 pub use reward_support::{


### PR DESCRIPTION
closes https://github.com/microsoft/agent-governance-toolkit/issues/2088

## Description

`agentmesh/src/mcp/` is a verbatim copy of `agentmesh-mcp/src/mcp/` (12 files, ~5,500 lines, identical file hashes). Externally this is a cross-namespace type-mismatch hazard: `agentmesh::mcp::T` and `agentmesh_mcp::mcp::T` are distinct types to the compiler despite identical source.

This change is the smallest non-breaking step from issue #2013 option (b):
- Marks `pub mod mcp;` in `agentmesh/src/lib.rs` with `#[deprecated]` pointing consumers at the `agentmesh-mcp` crate.
- Wraps the crate-root `pub use mcp::*;` with `#[allow(deprecated)]` to preserve the existing flattened public surface without emitting a warning at the re-export site.
- Updates README to call out `agentmesh-mcp` as the canonical home for MCP types and links the tracking issues.

Duplicate files are intentionally left in tree; their removal is tracked separately in #2088 for the next major release.

Diff: 2 files changed, +24 / −0.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [x] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

(Affects the Rust workspace: `agent-governance-rust/agentmesh`.)

## Checklist
- [x] My code follows the project style guidelines (ruff check)  *(N/A — Rust-only change; `cargo build` clean.)*
- [x] I have added tests that prove my fix/feature works  *(No new tests — deprecation is a compile-time annotation; existing `cargo test --all` continues to pass: 285 + 26 + 1 doc tests.)*
- [x] All new and existing tests pass (pytest)  *(Rust: `cargo test --all` → all green.)*
- [x] I have updated documentation as needed  *(README updated; `#[deprecated]` doc comment links #2013 and #2088.)*
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**: None — purely an in-tree deprecation annotation.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot was used to draft the `#[deprecated]` doc comment and this PR description. All output was reviewed locally and verified with `cargo build --all-targets` and `cargo test --all` before commit.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Refs #2013 (intermediate step — deprecation now, no breaking change). Follow-up removal of the duplicate files tracked in #2088 for the next major release.