### PR TITLE
fix(ci): pin marshmallow<3.22 for safety==3.2.1 compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Install safety
         run: |
           pip install --no-cache-dir --require-hashes --no-deps -r "$GITHUB_WORKSPACE/agent-governance-python/requirements/ci-safety.txt"
-          pip install --no-cache-dir 'typer>=0.9.0,<0.15.0'
+          pip install --no-cache-dir 'typer>=0.9.0,<0.15.0' 'marshmallow>=3.15.0,<3.22.0'
           pip install --no-cache-dir safety==3.2.1
       - name: Check dependencies
         env:


### PR DESCRIPTION
safety==3.2.1 uses marshmallow's deprecated pass_many kwarg in post_dump(), removed in marshmallow>=3.22.0. Pin marshmallow>=3.15.0,<3.22.0 alongside existing typer pin.