### PR TITLE
fix(go-audit): break backing-array reference chain and use RLock for reads

### DIFF
--- a/agent-governance-golang/packages/agentmesh/audit.go
+++ b/agent-governance-golang/packages/agentmesh/audit.go
@@ -38,7 +38,7 @@ func (ae *AuditEntry) Clone() *AuditEntry {
 
 // AuditLogger maintains an append-only hash-chained audit log.
 type AuditLogger struct {
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	entries    []*AuditEntry
 	seamHash   string
 	MaxEntries int
@@ -60,7 +60,12 @@ func (al *AuditLogger) Log(agentID, action string, decision PolicyDecision) *Aud
 	if al.MaxEntries > 0 && len(al.entries) >= al.MaxEntries {
 		sliceFrom := len(al.entries) - al.MaxEntries + 1
 		al.seamHash = al.entries[sliceFrom-1].Hash
-		al.entries = al.entries[sliceFrom:]
+		// Allocate a fresh slice so the original backing array (and
+		// evicted *AuditEntry pointers in the dropped prefix) can be
+		// garbage-collected. A plain reslice keeps the old array alive.
+		retained := make([]*AuditEntry, len(al.entries)-sliceFrom)
+		copy(retained, al.entries[sliceFrom:])
+		al.entries = retained
 	}
 
 	prevHash := al.seamHash
@@ -86,8 +91,8 @@ func (al *AuditLogger) Log(agentID, action string, decision PolicyDecision) *Aud
 // eviction, the surviving head's PreviousHash is checked against the seam
 // hash recorded at eviction time, so tampering with it is still detected.
 func (al *AuditLogger) Verify() bool {
-	al.mu.Lock()
-	defer al.mu.Unlock()
+	al.mu.RLock()
+	defer al.mu.RUnlock()
 
 	for i, entry := range al.entries {
 		expected := computeHash(entry)
@@ -109,8 +114,8 @@ func (al *AuditLogger) Verify() bool {
 
 // GetEntries returns entries matching the given filter.
 func (al *AuditLogger) GetEntries(filter AuditFilter) []*AuditEntry {
-	al.mu.Lock()
-	defer al.mu.Unlock()
+	al.mu.RLock()
+	defer al.mu.RUnlock()
 
 	var result []*AuditEntry
 	for _, e := range al.entries {

--- a/agent-governance-golang/packages/agentmesh/audit_test.go
+++ b/agent-governance-golang/packages/agentmesh/audit_test.go
@@ -547,3 +547,20 @@ func TestComputeHashDistinguishesFieldBoundaries(t *testing.T) {
 		})
 	}
 }
+
+// Regression: eviction via plain reslice kept the original backing array
+// alive; cap() grew proportional to total-logged count. After the fix,
+// cap() stays bounded close to MaxEntries.
+func TestMaxEntriesNoBackingArrayLeak(t *testing.T) {
+	al := NewAuditLogger()
+	al.MaxEntries = 5
+	for i := 0; i < 1000; i++ {
+		al.Log("agent", fmt.Sprintf("action-%d", i), Allow)
+	}
+	if got := len(al.entries); got != al.MaxEntries {
+		t.Fatalf("len(entries) = %d, want %d", got, al.MaxEntries)
+	}
+	if got := cap(al.entries); got > al.MaxEntries*4 {
+		t.Errorf("cap(entries) = %d, want close to %d (backing array leak)", got, al.MaxEntries)
+	}
+}


### PR DESCRIPTION
Applies finnoybu patterns #2017 and #2019 (audit portion):

- Eviction via plain reslice kept the original backing array alive, leaking memory proportional to total entries ever logged. Fix: make()+copy() on each eviction.
- Verify() and GetEntries() are read-only but held an exclusive lock, serializing all readers. Fix: upgrade to sync.RWMutex, use RLock for reads.

Supersedes conflicted PR #2017.