### PR TITLE
fix(go-policy): use RLock for rule scan and check threshold before incrementing

### DIFF
--- a/agent-governance-golang/packages/agentmesh/policy.go
+++ b/agent-governance-golang/packages/agentmesh/policy.go
@@ -81,27 +81,32 @@ func (pe *PolicyEngine) LoadCedar(options CedarOptions) {
 
 // Evaluate returns the decision for the given action and context.
 // Rules are evaluated in order; first match wins. Default is Deny.
+//
+// Concurrency: the rule scan runs under RLock so concurrent evaluations
+// don't serialize. Only checkRateLimit acquires the write lock.
 func (pe *PolicyEngine) Evaluate(action string, context map[string]interface{}) PolicyDecision {
-	pe.mu.Lock()
+	pe.mu.RLock()
 
-	for _, rule := range pe.rules {
-		if matchAction(rule.Action, action) && matchConditions(rule.Conditions, context) {
-			if rule.MaxCalls > 0 {
-				decision := pe.checkRateLimit(rule, context)
-				pe.mu.Unlock()
-				return decision
-			}
-			if rule.MinApprovals > 0 {
-				pe.mu.Unlock()
-				return RequiresApproval
-			}
-			pe.mu.Unlock()
-			return rule.Effect
+	var matched *PolicyRule
+	for i := range pe.rules {
+		r := &pe.rules[i]
+		if matchAction(r.Action, action) && matchConditions(r.Conditions, context) {
+			matched = r
+			break
 		}
 	}
-
 	backends := append([]ExternalPolicyBackend(nil), pe.backends...)
-	pe.mu.Unlock()
+	pe.mu.RUnlock()
+
+	if matched != nil {
+		if matched.MaxCalls > 0 {
+			return pe.checkRateLimit(*matched, context)
+		}
+		if matched.MinApprovals > 0 {
+			return RequiresApproval
+		}
+		return matched.Effect
+	}
 
 	backendContext := clonePolicyContext(context)
 	if _, ok := backendContext["action"]; !ok {
@@ -148,7 +153,12 @@ func rateLimitContextString(v interface{}) string {
 // noisy caller does not exhaust the budget for all other agents or tenants.
 // Missing context keys collapse to an empty segment — callers that don't
 // supply agent_id / tenant retain the previous globally-scoped behavior.
+//
+// Acquires the write lock internally; callers must NOT hold any lock.
 func (pe *PolicyEngine) checkRateLimit(rule PolicyRule, context map[string]interface{}) PolicyDecision {
+	pe.mu.Lock()
+	defer pe.mu.Unlock()
+
 	agentID := rateLimitContextString(context["agent_id"])
 	tenant := rateLimitContextString(context["tenant"])
 	key := rule.Action + "\x1f" + agentID + "\x1f" + tenant
@@ -171,10 +181,11 @@ func (pe *PolicyEngine) checkRateLimit(rule PolicyRule, context map[string]inter
 		return Allow
 	}
 
-	state.count++
-	if state.count > rule.MaxCalls {
+	// Check BEFORE incrementing so the counter never grows past MaxCalls.
+	if state.count >= rule.MaxCalls {
 		return RateLimit
 	}
+	state.count++
 	return Allow
 }
 

--- a/agent-governance-golang/packages/agentmesh/policy_test.go
+++ b/agent-governance-golang/packages/agentmesh/policy_test.go
@@ -720,3 +720,33 @@ func TestRateLimitNilContextRetainsGlobalBehavior(t *testing.T) {
 		t.Fatalf("call 3: got %q, want rate-limit", d)
 	}
 }
+
+// Regression: checkRateLimit used to increment count then compare,
+// so once over the limit the counter grew unboundedly. After the fix,
+// the counter stays pinned at MaxCalls.
+func TestRateLimitCounterDoesNotGrowAfterDeny(t *testing.T) {
+	pe := NewPolicyEngine([]PolicyRule{
+		{Action: "api.call", Effect: Allow, MaxCalls: 3, Window: "60s"},
+	})
+	const key = "api.call\x1f\x1f"
+
+	for i := 0; i < 3; i++ {
+		if d := pe.Evaluate("api.call", nil); d != Allow {
+			t.Fatalf("call %d: decision = %q, want allow", i+1, d)
+		}
+	}
+
+	if d := pe.Evaluate("api.call", nil); d != RateLimit {
+		t.Fatalf("call 4: decision = %q, want rate-limit", d)
+	}
+	if got := pe.rateLimits[key].count; got != 3 {
+		t.Errorf("after first deny, count = %d, want 3", got)
+	}
+
+	for i := 4; i < 6; i++ {
+		_ = pe.Evaluate("api.call", nil)
+	}
+	if got := pe.rateLimits[key].count; got != 3 {
+		t.Errorf("after multiple denies, count = %d, want 3", got)
+	}
+}


### PR DESCRIPTION
Applies finnoybu patterns #2019 and #2021:

- Evaluate() held an exclusive lock for the entire rule scan, serializing all concurrent callers. Fix: RLock for the read-only scan, write lock only in checkRateLimit().
- checkRateLimit incremented count then compared, so once over the limit the counter grew unboundedly. Fix: check >= MaxCalls before incrementing.

Supersedes conflicted PRs #2019 and #2021.