### PR TITLE
fix(dotnet/policy): walk nested context before flat dotted-key fallback

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyRule.cs
@@ -298,43 +298,51 @@ public sealed class PolicyRule
     internal static object? ResolveField(string path, IReadOnlyDictionary<string, object> context)
     {
         var segments = path.Split('.');
-        object? current = null;
 
-        // Try the full key first (some contexts use dotted keys directly).
+        // Walk nested dictionaries first — that's the documented dot-notation
+        // behaviour. The flat full-key lookup runs as a fallback only when the
+        // nested walk cannot resolve, so a caller injecting a flat dotted entry
+        // cannot bypass nested-walk semantics.
+        if (context.TryGetValue(segments[0], out object? current))
+        {
+            bool walkComplete = true;
+            for (int i = 1; i < segments.Length; i++)
+            {
+                if (current is IReadOnlyDictionary<string, object> roDict)
+                {
+                    if (!roDict.TryGetValue(segments[i], out current))
+                    {
+                        walkComplete = false;
+                        break;
+                    }
+                }
+                else if (current is IDictionary<string, object> dict)
+                {
+                    if (!dict.TryGetValue(segments[i], out current))
+                    {
+                        walkComplete = false;
+                        break;
+                    }
+                }
+                else
+                {
+                    walkComplete = false;
+                    break;
+                }
+            }
+            if (walkComplete)
+            {
+                return current;
+            }
+        }
+
+        // Fallback: legacy contexts that use the dotted name as a flat key.
         if (context.TryGetValue(path, out var directValue))
         {
             return directValue;
         }
 
-        // Walk nested dictionaries.
-        if (!context.TryGetValue(segments[0], out current))
-        {
-            return null;
-        }
-
-        for (int i = 1; i < segments.Length; i++)
-        {
-            if (current is IReadOnlyDictionary<string, object> roDict)
-            {
-                if (!roDict.TryGetValue(segments[i], out current))
-                {
-                    return null;
-                }
-            }
-            else if (current is IDictionary<string, object> dict)
-            {
-                if (!dict.TryGetValue(segments[i], out current))
-                {
-                    return null;
-                }
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        return current;
+        return null;
     }
 
     /// <summary>

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyRuleTests.cs
@@ -281,4 +281,44 @@ public class PolicyRuleTests
         public override string ToString() =>
             throw new NotSupportedException("simulated rule-data bug");
     }
+
+    [Fact]
+    public void Evaluate_NestedDotNotation_WinsOverFlatDottedKey()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "nested-wins",
+            Condition = "data.classification == 'secret'",
+            Action = PolicyAction.Deny
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["data"] = new Dictionary<string, object>
+            {
+                ["classification"] = "secret",
+            },
+            ["data.classification"] = "public",
+        };
+
+        Assert.True(rule.Evaluate(context));
+    }
+
+    [Fact]
+    public void Evaluate_FallsBackToFlatDottedKey_WhenNoNestedShape()
+    {
+        var rule = new PolicyRule
+        {
+            Name = "flat-fallback",
+            Condition = "data.classification == 'public'",
+            Action = PolicyAction.Allow
+        };
+
+        var context = new Dictionary<string, object>
+        {
+            ["data.classification"] = "public",
+        };
+
+        Assert.True(rule.Evaluate(context));
+    }
 }


### PR DESCRIPTION
Applies finnoybu pattern from PR 2098. Flat dotted-key lookup ran first in ResolveField(), enabling policy bypass via flat key injection. Fix: walk nested dicts first, fall back to flat key only when nested walk fails. Adds two regression tests. Supersedes conflicted PR 2098.