### PR TITLE
fix(py-mesh-cards): require registry lookup for card signature verification

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/cards.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 import json
 
-from agentmesh.identity.agent_id import AgentIdentity
+from agentmesh.identity.agent_id import AgentIdentity, IdentityRegistry
 from agentmesh.identity.revocation import RevocationList
 
 
@@ -73,13 +73,33 @@ class TrustedAgentCard(BaseModel):
         self.card_signature = identity.sign(signable.encode())
         self.signature_timestamp = datetime.now(timezone.utc)
 
-    def verify_signature(self, identity: Optional[AgentIdentity] = None) -> bool:
+    def verify_signature(
+        self,
+        identity: Optional[AgentIdentity] = None,
+        identity_registry: Optional["IdentityRegistry"] = None,
+    ) -> bool:
         """
         Verify the card's signature is valid.
 
+        Verification authority precedence (highest first):
+
+        1. Explicit ``identity`` -- authoritative; signature checked
+           against the supplied identity's public key.
+        2. ``identity_registry`` -- looked up by ``agent_did``; the
+           registry's stored public key is authoritative. If the DID
+           is not registered, verification fails (the embedded key is
+           NOT consulted).
+        3. Embedded ``public_key`` on the card -- self-attesting and
+           trust-on-first-use only. An attacker can mint a card with
+           their own key and a matching signature, so this path proves
+           only that the bearer signed the card, not ownership of the
+           claimed identity.
+
         Args:
-            identity: Optional identity to verify against. If not provided,
-                     uses the public key embedded in the card.
+            identity: Optional authoritative identity to verify against.
+            identity_registry: Optional registry; when provided and
+                the card's ``agent_did`` is registered, the registry's
+                public key is used and the embedded key is ignored.
 
         Returns:
             True if signature is valid, False otherwise
@@ -92,8 +112,18 @@ class TrustedAgentCard(BaseModel):
         if identity:
             return identity.verify_signature(signable.encode(), self.card_signature)
 
-        # Verify using embedded public key
-        # This requires reconstructing a minimal identity for verification
+        if identity_registry is not None and self.agent_did:
+            registered = identity_registry.get(self.agent_did)
+            if registered is None:
+                # Registry is authoritative: an unregistered DID cannot
+                # be verified by falling back to the card's own key.
+                return False
+            return registered.verify_signature(
+                signable.encode(), self.card_signature
+            )
+
+        # Self-attesting fallback: verify using the embedded public key.
+        # Trust-on-first-use only -- see method docstring.
         from cryptography.hazmat.primitives.asymmetric import ed25519
         import base64
 
@@ -195,6 +225,7 @@ class CardRegistry:
         self,
         cache_ttl_seconds: int = 900,
         revocation_list: Optional["RevocationList"] = None,
+        identity_registry: Optional["IdentityRegistry"] = None,
     ):
         """Initialise the card registry.
 
@@ -204,6 +235,10 @@ class CardRegistry:
             revocation_list: Optional revocation list to check during
                 verification. When set, revoked agent DIDs fail
                 ``is_verified()`` even if their signatures are valid.
+            identity_registry: Optional authoritative identity registry.
+                When set, card verification looks up the agent's
+                registered identity by DID and verifies against that
+                key rather than the card's self-attested embedded key.
         """
         self._cards: Dict[str, TrustedAgentCard] = {}
         # Cache entry: (verified, timestamp, signed_content_hash). The
@@ -214,6 +249,7 @@ class CardRegistry:
         self._verified_cache: Dict[str, tuple[bool, datetime, str]] = {}
         self._cache_ttl = timedelta(seconds=cache_ttl_seconds)
         self._revocation_list = revocation_list
+        self._identity_registry = identity_registry
 
     @staticmethod
     def _card_content_hash(card: TrustedAgentCard) -> str:
@@ -240,7 +276,7 @@ class CardRegistry:
         Returns:
             True if registered successfully, False if verification failed
         """
-        if not card.verify_signature():
+        if not card.verify_signature(identity_registry=self._identity_registry):
             return False
 
         if card.agent_did:
@@ -304,7 +340,7 @@ class CardRegistry:
             # re-verify from scratch below.
             self._verified_cache.pop(agent_did, None)
 
-        verified = card.verify_signature()
+        verified = card.verify_signature(identity_registry=self._identity_registry)
         self._verified_cache[agent_did] = (
             verified,
             datetime.now(timezone.utc),


### PR DESCRIPTION
Applies finnoybu pattern from PR 2189. When an identity_registry is provided, card verification uses the registered public key (authoritative) rather than the embedded key (self-attesting). Unregistered DIDs fail verification outright. Closes the attack where a tampered card carries an attacker key with a matching signature. Supersedes conflicted PR 2189.