### PR TITLE
fix: constant-time comparisons for all security-sensitive hash checks

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Audit/AuditLogger.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Audit/AuditLogger.cs
@@ -170,7 +170,9 @@ public sealed class AuditLogger
                     entry.Seq, entry.Timestamp, entry.AgentId,
                     entry.Action, entry.Decision, entry.PreviousHash);
 
-                if (entry.Hash != recomputed)
+                if (!CryptographicOperations.FixedTimeEquals(
+                        Encoding.UTF8.GetBytes(entry.Hash),
+                        Encoding.UTF8.GetBytes(recomputed)))
                 {
                     return false;
                 }

--- a/agent-governance-golang/packages/agentmesh/audit.go
+++ b/agent-governance-golang/packages/agentmesh/audit.go
@@ -5,6 +5,7 @@ package agentmesh
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -96,7 +97,7 @@ func (al *AuditLogger) Verify() bool {
 
 	for i, entry := range al.entries {
 		expected := computeHash(entry)
-		if entry.Hash != expected {
+		if subtle.ConstantTimeCompare([]byte(entry.Hash), []byte(expected)) != 1 {
 			return false
 		}
 		if i == 0 {

--- a/agent-governance-golang/packages/agentmesh/sandbox.go
+++ b/agent-governance-golang/packages/agentmesh/sandbox.go
@@ -257,7 +257,9 @@ func (p *DockerSandboxProvider) ExecuteCode(agentID, sessionID, code string) (*E
 
 	ctx, cancel := context.WithTimeout(context.Background(), dockerExecTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "docker", "exec", name, "sh", "-c", code)
+	// Avoid shell interpolation: pipe code via stdin instead of sh -c.
+	cmd := exec.CommandContext(ctx, "docker", "exec", "-i", name, "sh")
+	cmd.Stdin = strings.NewReader(code)
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Optional, Any
 from pydantic import BaseModel, Field
 import hashlib
+import hmac
 import json
 import uuid
 
@@ -85,7 +86,7 @@ class AuditEntry(BaseModel):
         Returns:
             ``True`` if ``entry_hash`` equals ``compute_hash()``.
         """
-        return self.entry_hash == self.compute_hash()
+        return hmac.compare_digest(self.entry_hash, self.compute_hash())
 
     # ── CloudEvents v1.0 ──────────────────────────────────
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
@@ -385,7 +385,7 @@ class HashChainVerifier:
 
             # Content hash
             expected_hash = entry._compute_content_hash()
-            if entry.content_hash != expected_hash:
+            if not hmac.compare_digest(entry.content_hash, expected_hash):
                 errors.append(
                     f"Entry {idx} ({entry.entry_id}): content hash mismatch"
                 )

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/credentials.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/credentials.py
@@ -304,7 +304,7 @@ class CredentialManager:
         token_hash = hashlib.sha256(token.encode()).hexdigest()
 
         for cred in self._credentials.values():
-            if cred.token_hash == token_hash:
+            if hmac.compare_digest(cred.token_hash, token_hash):
                 if cred.is_valid():
                     return cred
                 return None  # Found but invalid

--- a/agent-governance-python/agent-mesh/src/agentmesh/marketplace/sigstore_provenance.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/marketplace/sigstore_provenance.py
@@ -47,6 +47,7 @@ References:
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
 import subprocess
@@ -349,7 +350,7 @@ def verify_provenance(
 
     attestation = ProvenanceAttestation.load(attestation_path)
     actual_digest = _sha256_file(artifact_path)
-    digest_match = actual_digest == attestation.subject_digest
+    digest_match = hmac.compare_digest(actual_digest, attestation.subject_digest)
 
     if not digest_match:
         return VerificationResult(

--- a/agent-governance-python/agent-os/extensions/copilot/src/index.ts
+++ b/agent-governance-python/agent-os/extensions/copilot/src/index.ts
@@ -251,7 +251,9 @@ app.post('/api/webhook', async (req: Request, res: Response) => {
                 .update(rawBody)
                 .digest('hex');
             
-            if (signature !== expectedSignature) {
+            const expected = Buffer.from(expectedSignature, 'utf8');
+            const actual = Buffer.from(signature, 'utf8');
+            if (expected.length !== actual.length || !crypto.timingSafeEqual(expected, actual)) {
                 logger.warn('Invalid webhook signature');
                 return res.status(401).json({ error: 'Invalid signature' });
             }

--- a/agent-governance-python/agent-sre/src/agent_sre/anomaly/rogue_detector.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/anomaly/rogue_detector.py
@@ -11,6 +11,7 @@ assessment with optional auto-quarantine recommendations.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
 import math
@@ -429,7 +430,7 @@ class RogueAgentDetector:
                     f"previous_hash mismatch",
                 )
             expected = assessment.compute_hash(prev_hash)
-            if assessment.entry_hash != expected:
+            if not hmac.compare_digest(assessment.entry_hash, expected):
                 return (
                     False,
                     f"Assessment {idx} (agent={assessment.agent_id}): "

--- a/agent-governance-rust/agentmesh/src/identity_support.rs
+++ b/agent-governance-rust/agentmesh/src/identity_support.rs
@@ -33,6 +33,17 @@ fn hex_sha256(input: &str) -> String {
         .collect()
 }
 
+/// Constant-time byte comparison to prevent timing side-channels.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter()
+        .zip(b.iter())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
 fn parse_agent_name_from_did(did: &str) -> Result<&str, IdentityError> {
     did.strip_prefix("did:agentmesh:")
         .filter(|name| !name.is_empty())
@@ -190,7 +201,7 @@ impl Credential {
     }
 
     pub fn verify_token(&self, token: &str) -> bool {
-        self.token_hash == hex_sha256(token)
+        constant_time_eq(self.token_hash.as_bytes(), hex_sha256(token).as_bytes())
     }
 
     pub fn revoke(&mut self, reason: &str) {
@@ -564,7 +575,7 @@ impl ScopeChain {
             }
             previous_hash = Some(link.link_hash.as_str());
         }
-        self.chain_hash == self.compute_hash()
+        constant_time_eq(self.chain_hash.as_bytes(), self.compute_hash().as_bytes())
     }
 }
 

--- a/agent-governance-typescript/src/audit.ts
+++ b/agent-governance-typescript/src/audit.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { createHash } from 'crypto';
+import { createHash, timingSafeEqual } from 'crypto';
 import { AuditConfig, AuditEntry, LegacyPolicyDecision } from './types';
 
 type PolicyDecision = LegacyPolicyDecision;
@@ -81,7 +81,7 @@ export class AuditLogger {
       });
 
       const expectedHash = createHash('sha256').update(payload).digest('hex');
-      if (entry.hash !== expectedHash) return false;
+      if (!timingSafeEqual(Buffer.from(entry.hash, 'utf8'), Buffer.from(expectedHash, 'utf8'))) return false;
     }
     return true;
   }


### PR DESCRIPTION
Replace timing-vulnerable == / !== with constant-time alternatives across all 5 SDKs. Also fixes Go sandbox shell injection by piping code via stdin instead of sh -c. CWE-208, CWE-78.