### PR TITLE
fix: replace deprecated datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
+++ b/agent-governance-python/agent-lightning/tests/test_lightning_comprehensive.py
@@ -414,7 +414,7 @@ class TestPolicyViolation:
         assert v.penalty == 0.0
 
     def test_timestamp_is_timezone_aware(self):
-        """Regression: ``datetime.utcnow()`` produced a naive timestamp
+        """Regression: ``datetime.now(timezone.utc)`` produced a naive timestamp
         that compared-different against ``datetime.now(timezone.utc)``
         used elsewhere in the codebase. The default must be aware."""
         v = PolicyViolation(PolicyViolationType.BLOCKED, "P", "d", "high")

--- a/agent-governance-python/agent-mesh/src/agentmesh/integrations/crewai/agent.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/integrations/crewai/agent.py
@@ -65,7 +65,7 @@ class InMemoryTrustStore:
 
     def record_interaction(self, agent_did: str, *, success: bool) -> None:
         from datetime import datetime as _dt
-        now = _dt.utcnow()
+        now = _dt.now(timezone.utc)
         # V33: Enforce rate limit on score updates
         times = self._update_times.setdefault(agent_did, [])
         cutoff = now.timestamp() - 60

--- a/agent-governance-python/agent-os/examples/customer-service/main.py
+++ b/agent-governance-python/agent-os/examples/customer-service/main.py
@@ -165,7 +165,7 @@ class Ticket:
     category: TicketCategory = TicketCategory.GENERAL
     priority: Priority = Priority.MEDIUM
     status: TicketStatus = TicketStatus.OPEN
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     assigned_to: Optional[str] = None
     tags: list[str] = field(default_factory=list)
     metadata: dict = field(default_factory=dict)

--- a/agent-governance-python/agent-os/examples/ecommerce-support/main.py
+++ b/agent-governance-python/agent-os/examples/ecommerce-support/main.py
@@ -42,7 +42,7 @@ class Customer:
     email: str
     name: str
     verified: bool = False
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     
     # Payment methods (masked)
     payment_methods: list[dict] = field(default_factory=list)
@@ -61,7 +61,7 @@ class Order:
     amount: float
     status: str
     items: list[dict] = field(default_factory=list)
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     
     # Payment info (PCI-DSS: only store masked data)
     card_last_four: str = ""

--- a/agent-governance-python/agent-os/examples/hr-recruiting/main.py
+++ b/agent-governance-python/agent-os/examples/hr-recruiting/main.py
@@ -57,7 +57,7 @@ class Candidate:
     _protected_data: dict = field(default_factory=dict, repr=False)
     
     # Metadata
-    applied_date: datetime = field(default_factory=datetime.utcnow)
+    applied_date: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     data_consent: bool = False
     retention_until: datetime = None
 

--- a/agent-governance-python/agent-os/examples/iot-smart-home/main.py
+++ b/agent-governance-python/agent-os/examples/iot-smart-home/main.py
@@ -54,7 +54,7 @@ class Device:
     room: str
     state: DeviceState = DeviceState.OFF
     value: float = None  # For thermostats, dimmers
-    last_changed: datetime = field(default_factory=datetime.utcnow)
+    last_changed: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     
     # Safety flags
     is_safety_critical: bool = False

--- a/agent-governance-python/agent-os/modules/caas/src/caas/gateway/trust_gateway.py
+++ b/agent-governance-python/agent-os/modules/caas/src/caas/gateway/trust_gateway.py
@@ -24,7 +24,7 @@ it will be the one the Enterprise trusts with the keys to the kingdom.
 
 from enum import Enum
 from typing import Dict, List, Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field
 import uuid
 import json
@@ -57,7 +57,7 @@ class DataRetentionPolicy(BaseModel):
 class AuditLog(BaseModel):
     """Audit log entry for compliance and security monitoring."""
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    timestamp: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    timestamp: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     event_type: str  # e.g., "request_routed", "data_accessed", "policy_changed"
     user_id: Optional[str] = None
     request_id: Optional[str] = None
@@ -159,7 +159,7 @@ class TrustGateway:
             "data_retention_days": self.security_policy.data_retention.retention_days,
             "audit_enabled": self.audit_enabled,
             "compliance_mode": self.security_policy.compliance_mode,
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
     
     def validate_request(
@@ -263,7 +263,7 @@ class TrustGateway:
                 "request_id": request_id,
                 "reason": "Security policy violation",
                 "violations": validation["violations"],
-                "timestamp": datetime.utcnow().isoformat()
+                "timestamp": datetime.now(timezone.utc).isoformat()
             }
         
         # Import here to avoid circular dependency
@@ -287,7 +287,7 @@ class TrustGateway:
                 "audited": self.audit_enabled
             },
             "warnings": validation["warnings"],
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
         
         # Audit the routing decision
@@ -438,7 +438,7 @@ class TrustGateway:
         return {
             "status": "success",
             "message": "Security policy updated",
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
     
     def clear_audit_logs(self, user_id: Optional[str] = None) -> Dict[str, Any]:
@@ -470,5 +470,5 @@ class TrustGateway:
             "status": "success",
             "message": f"Cleared {logs_count} audit log entries",
             "remaining_logs": len(self.audit_logs),
-            "timestamp": datetime.utcnow().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }

--- a/agent-governance-python/agent-os/modules/caas/tests/test_pragmatic_truth.py
+++ b/agent-governance-python/agent-os/modules/caas/tests/test_pragmatic_truth.py
@@ -12,7 +12,7 @@ Tests that the system can:
 """
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 from caas.models import (
     ContentFormat,
@@ -48,7 +48,7 @@ def test_source_detection():
             )
         ],
         metadata={"source_type": "official_docs"},
-        ingestion_timestamp=datetime.utcnow().isoformat()
+        ingestion_timestamp=datetime.now(timezone.utc).isoformat()
     )
     
     doc_id_chat = str(uuid.uuid4())
@@ -65,7 +65,7 @@ def test_source_detection():
             )
         ],
         metadata={"source_type": "team_chat", "url": "slack://channel/engineering/msg123"},
-        ingestion_timestamp=datetime.utcnow().isoformat()
+        ingestion_timestamp=datetime.now(timezone.utc).isoformat()
     )
     
     detector = SourceDetector()
@@ -263,7 +263,7 @@ def test_conflict_detection_in_extraction():
             ),
         ],
         metadata={},
-        ingestion_timestamp=datetime.utcnow().isoformat()
+        ingestion_timestamp=datetime.now(timezone.utc).isoformat()
     )
     
     store.add(doc)

--- a/agent-governance-python/agent-os/modules/cmvk/src/cmvk/benchmarks.py
+++ b/agent-governance-python/agent-os/modules/cmvk/src/cmvk/benchmarks.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -388,7 +388,7 @@ class CMVKBenchmark:
             avg_latency_ms=avg_latency,
             by_category={},
             by_difficulty={},
-            timestamp=datetime.utcnow().isoformat(),
+            timestamp=datetime.now(timezone.utc).isoformat(),
             config=config or {}
         )
     

--- a/agent-governance-python/agent-os/modules/control-plane/src/agent_control_plane/flight_recorder.py
+++ b/agent-governance-python/agent-os/modules/control-plane/src/agent_control_plane/flight_recorder.py
@@ -23,7 +23,7 @@ import hashlib
 import threading
 import atexit
 from typing import Dict, Any, Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from collections import deque
 import json
@@ -116,7 +116,7 @@ class FlightRecorder:
         # Batching state
         self._write_buffer: deque = deque()
         self._buffer_lock = threading.Lock()
-        self._last_flush = datetime.utcnow()
+        self._last_flush = datetime.now(timezone.utc)
         self._last_hash: Optional[str] = None
         
         # Cache immutable trace data for content hash recomputation
@@ -218,7 +218,7 @@ class FlightRecorder:
                     cursor.execute(operation['sql'], operation['params'])
                 
                 conn.commit()
-                self._last_flush = datetime.utcnow()
+                self._last_flush = datetime.now(timezone.utc)
                 self.logger.debug(f"Flushed write buffer")
             except Exception as e:
                 conn.rollback()
@@ -233,7 +233,7 @@ class FlightRecorder:
             
         should_flush = (
             len(self._write_buffer) >= self.batch_size or
-            (datetime.utcnow() - self._last_flush).total_seconds() >= self.flush_interval
+            (datetime.now(timezone.utc) - self._last_flush).total_seconds() >= self.flush_interval
         )
         if should_flush:
             self._flush_buffer()
@@ -365,7 +365,7 @@ class FlightRecorder:
             >>> recorder.log_success(trace_id, result="wrote 5 bytes")
         """
         trace_id = str(uuid.uuid4())
-        timestamp = datetime.utcnow().isoformat()
+        timestamp = datetime.now(timezone.utc).isoformat()
         tool_args_json = json.dumps(tool_args) if tool_args else None
         
         # Compute hash for Merkle chain (immutable after INSERT)

--- a/agent-governance-python/agent-os/modules/nexus/arbiter.py
+++ b/agent-governance-python/agent-os/modules/nexus/arbiter.py
@@ -84,7 +84,7 @@ class DisputeResolution:
     liar_identified: Optional[str] = None  # DID of agent found to be lying
     
     # Timestamps
-    resolved_at: datetime = field(default_factory=datetime.utcnow)
+    resolved_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     
     # Nexus attestation
     arbiter_signature: str = ""

--- a/agent-governance-python/agent-os/modules/nexus/dmz.py
+++ b/agent-governance-python/agent-os/modules/nexus/dmz.py
@@ -114,7 +114,7 @@ class DMZRequest(BaseModel):
     )
     
     # Timestamps
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: Optional[datetime] = Field(
         default=None,
         description="When this request expires"
@@ -130,7 +130,7 @@ class SignedPolicy:
     
     # Signer
     signer_did: str
-    signed_at: datetime = field(default_factory=datetime.utcnow)
+    signed_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     
     # Signature
     signature: str = ""

--- a/agent-governance-python/agent-os/modules/nexus/reputation.py
+++ b/agent-governance-python/agent-os/modules/nexus/reputation.py
@@ -44,7 +44,7 @@ class TrustScore:
     uptime_days: int = 0
     
     # Timestamps
-    calculated_at: datetime = field(default_factory=datetime.utcnow)
+    calculated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     last_activity: Optional[datetime] = None
     
     @classmethod
@@ -127,7 +127,7 @@ class SlashEvent:
     trace_id: Optional[str] = None
     
     # Timestamps
-    occurred_at: datetime = field(default_factory=datetime.utcnow)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     
     # Broadcasting
     broadcast_to_network: bool = True

--- a/agent-governance-python/agent-os/modules/nexus/schemas/compliance.py
+++ b/agent-governance-python/agent-os/modules/nexus/schemas/compliance.py
@@ -7,7 +7,7 @@ Defines data structures for compliance auditing and reporting.
 Supports SOC2, HIPAA, and other regulatory frameworks.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal, Optional, Any
 from pydantic import BaseModel, Field
 import hashlib
@@ -42,7 +42,7 @@ class ComplianceRecord(BaseModel):
         description="Type of compliance event"
     )
     timestamp: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(timezone.utc),
         description="When the event occurred"
     )
     
@@ -174,7 +174,7 @@ class ComplianceAuditReport(BaseModel):
         description="Compliance framework"
     )
     generated_at: datetime = Field(
-        default_factory=datetime.utcnow
+        default_factory=lambda: datetime.now(timezone.utc)
     )
     
     # Scope

--- a/agent-governance-python/agent-os/modules/nexus/schemas/escrow.py
+++ b/agent-governance-python/agent-os/modules/nexus/schemas/escrow.py
@@ -91,7 +91,7 @@ class EscrowReceipt(BaseModel):
     
     # Timestamps
     created_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(timezone.utc),
         description="When escrow was created"
     )
     expires_at: datetime = Field(
@@ -241,7 +241,7 @@ class EscrowResolution(BaseModel):
         description="How resolution was triggered"
     )
     resolved_at: datetime = Field(
-        default_factory=datetime.utcnow
+        default_factory=lambda: datetime.now(timezone.utc)
     )
     
     # Nexus attestation

--- a/agent-governance-python/agent-os/modules/nexus/schemas/receipt.py
+++ b/agent-governance-python/agent-os/modules/nexus/schemas/receipt.py
@@ -6,7 +6,7 @@ Job Receipt Schemas
 Defines receipts for job completion and outcome verification.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal, Optional, Any
 from pydantic import BaseModel, Field
 import hashlib
@@ -37,7 +37,7 @@ class JobReceipt(BaseModel):
         description="SHA-256 hash of the task specification"
     )
     created_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(timezone.utc),
         description="When the receipt was created"
     )
     
@@ -63,7 +63,7 @@ class JobCompletionReceipt(JobReceipt):
         description="Outcome of the job"
     )
     completed_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(timezone.utc),
         description="When the job completed"
     )
     duration_ms: int = Field(
@@ -203,6 +203,6 @@ class DisputeReceipt(BaseModel):
     )
     
     created_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(timezone.utc),
         description="When dispute was raised"
     )

--- a/agent-governance-python/agent-os/modules/scak/agent_kernel/detector.py
+++ b/agent-governance-python/agent-os/modules/scak/agent_kernel/detector.py
@@ -7,7 +7,7 @@ Failure detection and monitoring system.
 
 import logging
 from typing import Optional, Callable, Dict, Any, List
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import deque
 
 from .models import AgentFailure, FailureType, FailureSeverity, FailureTrace
@@ -122,7 +122,7 @@ class FailureDetector:
             context=context or {},
             stack_trace=stack_trace,
             failure_trace=failure_trace,
-            timestamp=datetime.utcnow()
+            timestamp=datetime.now(timezone.utc)
         )
         
         self.failure_history.append(failure)

--- a/agent-governance-python/agent-os/modules/scak/agent_kernel/kernel.py
+++ b/agent-governance-python/agent-os/modules/scak/agent_kernel/kernel.py
@@ -11,7 +11,7 @@ Implements the Dual-Loop Architecture:
 
 import logging
 from typing import Optional, Dict, Any, List
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .models import (
     AgentFailure, FailureAnalysis, SimulationResult, CorrectionPatch, AgentState,
@@ -175,7 +175,7 @@ class SelfCorrectingAgentKernel:
                     "user_prompt": user_prompt,
                     "chain_of_thought": chain_of_thought,
                     "failed_action": failed_action,
-                    "timestamp": datetime.utcnow()
+                    "timestamp": datetime.now(timezone.utc)
                 })
                 
                 return {
@@ -472,7 +472,7 @@ class SelfCorrectingAgentKernel:
         Competence patches teach the agent to avoid giving up too early.
         """
         import uuid
-        from datetime import datetime
+        from datetime import datetime, timezone
         from .models import FailureAnalysis, SimulationResult, AgentFailure, FailureType, FailureSeverity
         
         # Create a synthetic failure for the audit

--- a/agent-governance-python/agent-os/modules/scak/agent_kernel/models.py
+++ b/agent-governance-python/agent-os/modules/scak/agent_kernel/models.py
@@ -8,7 +8,7 @@ are imported from agent-primitives (Layer 1) and re-exported here for backward c
 """
 
 from typing import Dict, List, Optional, Any
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from pydantic import BaseModel, Field, ConfigDict
 
@@ -299,7 +299,7 @@ class AgentOutcome(BaseModel):
     
     agent_id: str
     outcome_type: OutcomeType
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     user_prompt: str
     agent_response: str
     give_up_signal: Optional[GiveUpSignal] = None
@@ -337,7 +337,7 @@ class CompletenessAudit(BaseModel):
     gap_analysis: str = Field(..., description="What the agent missed")
     competence_patch: str = Field(..., description="Lesson to prevent future laziness")
     confidence: float = Field(..., ge=0.0, le=1.0)
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     
     model_config = ConfigDict(
         json_schema_extra={

--- a/agent-governance-python/agent-os/modules/scak/agent_kernel/nudge_mechanism.py
+++ b/agent-governance-python/agent-os/modules/scak/agent_kernel/nudge_mechanism.py
@@ -16,7 +16,7 @@ This implements "The Nudge" pattern from industry best practices:
 import logging
 import uuid
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .models import AgentOutcome, NudgeResult, GiveUpSignal
 
@@ -150,7 +150,7 @@ class NudgeMechanism:
         recent_nudges = [
             n for n in self.nudge_history
             if n.original_outcome.agent_id == outcome.agent_id
-            and (datetime.utcnow() - n.original_outcome.timestamp).total_seconds() < 300  # 5 min
+            and (datetime.now(timezone.utc) - n.original_outcome.timestamp).total_seconds() < 300  # 5 min
         ]
         
         if len(recent_nudges) >= max_nudges:

--- a/agent-governance-python/agent-os/modules/scak/agent_kernel/patcher.py
+++ b/agent-governance-python/agent-os/modules/scak/agent_kernel/patcher.py
@@ -8,7 +8,7 @@ Agent patcher that applies corrections to agents.
 import logging
 import uuid
 from typing import Dict, Any, Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .models import (
     FailureAnalysis, SimulationResult, CorrectionPatch, AgentState,
@@ -116,7 +116,7 @@ class AgentPatcher:
             
             # Mark as applied
             patch.applied = True
-            patch.applied_at = datetime.utcnow()
+            patch.applied_at = datetime.now(timezone.utc)
             
             # Update agent state
             self._update_agent_state(patch.agent_id, patch)
@@ -154,7 +154,7 @@ class AgentPatcher:
         """
         memory = {
             "agent_id": patch.agent_id,
-            "timestamp": datetime.utcnow(),
+            "timestamp": datetime.now(timezone.utc),
             "failure_context": patch.patch_content.get("failure_context", ""),
             "correct_logic": patch.patch_content.get("correct_logic", ""),
             "patch_id": patch.patch_id,
@@ -470,7 +470,7 @@ class AgentPatcher:
             "correct_logic": shadow_result.output if shadow_result else analysis.suggested_fixes[0] if analysis.suggested_fixes else "Unknown",
             "cognitive_glitch": diagnosis.cognitive_glitch.value if diagnosis else "unknown",
             "negative_constraint": negative_constraint,  # New field for hallucinations
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "verified_by_shadow": shadow_result.verified if shadow_result else False
         }
     

--- a/agent-governance-python/agent-os/modules/scak/agent_kernel/semantic_purge.py
+++ b/agent-governance-python/agent-os/modules/scak/agent_kernel/semantic_purge.py
@@ -13,7 +13,7 @@ This allows reducing context usage by 40-60% over the agent's lifetime.
 
 import logging
 from typing import List, Dict, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .models import (
     CorrectionPatch, ClassifiedPatch, PatchDecayType, 
@@ -257,7 +257,7 @@ class SemanticPurge:
         
         # Record purge event
         purge_event = {
-            "timestamp": datetime.utcnow(),
+            "timestamp": datetime.now(timezone.utc),
             "old_version": old_model_version,
             "new_version": new_model_version,
             "purged_count": len(purged_patches),

--- a/agent-governance-python/agent-os/tests/test_layer1_primitives.py
+++ b/agent-governance-python/agent-os/tests/test_layer1_primitives.py
@@ -51,7 +51,7 @@ class TestAgentPrimitives:
     def test_default_timestamps_are_timezone_aware(self):
         """Default-factory timestamps must be tz-aware UTC, not naive.
 
-        Regression guard: ``datetime.utcnow()`` returns a naive datetime that
+        Regression guard: ``datetime.now(timezone.utc)`` returns a naive datetime that
         silently misrepresents UTC. Switching to ``datetime.now(timezone.utc)``
         produces a tz-aware value that survives JSON / ISO-8601 round-trips
         with the correct ``+00:00`` suffix.

--- a/agent-governance-python/agent-primitives/agent_primitives/failures.py
+++ b/agent-governance-python/agent-primitives/agent_primitives/failures.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field, ConfigDict
 def _utcnow() -> datetime:
     """Return the current UTC time as a timezone-aware datetime.
 
-    ``datetime.utcnow()`` was deprecated in Python 3.12; it returns a naive
+    ``datetime.now(timezone.utc)`` was deprecated in Python 3.12; it returns a naive
     datetime that silently misrepresents UTC. This helper returns a proper
     tz-aware UTC datetime, which is what callers expect when they read these
     timestamps back later (e.g. for audit log serialisation).

--- a/agent-governance-python/agent-sre/src/agent_sre/delivery/rollout.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/delivery/rollout.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -117,7 +117,7 @@ class SimulatedAction:
 
     def __post_init__(self) -> None:
         if self.timestamp is None:
-            self.timestamp = datetime.utcnow()
+            self.timestamp = datetime.now(timezone.utc)
 
 
 @dataclass
@@ -170,7 +170,7 @@ class ShadowResult:
     production_rule: str | None = None
     diverged: bool = False
     divergence_reason: str | None = None
-    evaluated_at: datetime = field(default_factory=datetime.utcnow)
+    evaluated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     shadow_latency_ms: float | None = None
     production_latency_ms: float | None = None
 
@@ -252,7 +252,7 @@ class ShadowSession:
     """A governance shadow-mode evaluation session."""
 
     session_id: str = field(default_factory=lambda: f"shadow_{uuid.uuid4().hex[:12]}")
-    started_at: datetime = field(default_factory=datetime.utcnow)
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     agent_dids: list[str] = field(default_factory=list)
     policy_names: list[str] = field(default_factory=list)
     total_evaluated: int = 0
@@ -391,12 +391,12 @@ class ShadowMode:
         if self.policy_engine is None:
             raise RuntimeError("A policy_engine is required for governance shadow evaluation")
 
-        start = datetime.utcnow()
+        start = datetime.now(timezone.utc)
         shadow_decision = self.policy_engine.evaluate(
             agent_did=action.agent_did,
             context=action.context,
         )
-        shadow_latency = (datetime.utcnow() - start).total_seconds() * 1000
+        shadow_latency = (datetime.now(timezone.utc) - start).total_seconds() * 1000
 
         result = ShadowResult(
             action_id=action.action_id,
@@ -459,7 +459,7 @@ class ShadowMode:
 
         session = self._sessions[sid]
         session.active = False
-        session.ended_at = datetime.utcnow()
+        session.ended_at = datetime.now(timezone.utc)
 
         if sid == self._active_session:
             self._active_session = None


### PR DESCRIPTION
Replace all datetime.utcnow() across 25 Python files. Fixes Python 3.12 deprecation and naive/aware comparison bugs. CWE-477.