### PR TITLE
fix: stop leaking internal error details in API responses

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Hypervisor/SagaOrchestrator.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Hypervisor/SagaOrchestrator.cs
@@ -207,7 +207,7 @@ public sealed class SagaOrchestrator
             }
             catch (Exception ex)
             {
-                lock (saga.SyncRoot) { step.Error = $"Step '{step.ActionId}' failed: {ex.Message}"; }
+                lock (saga.SyncRoot) { step.Error = $"Step '{step.ActionId}' failed — see server logs"; }
             }
 
             // Stop retrying if the caller cancelled the operation
@@ -258,7 +258,7 @@ public sealed class SagaOrchestrator
                 lock (saga.SyncRoot)
                 {
                     step.State = StepState.CompensationFailed;
-                    step.Error = $"Compensation for '{step.ActionId}' failed: {ex.Message}";
+                    step.Error = $"Compensation for '{step.ActionId}' failed — see server logs";
                     saga.FailedCompensations.Add(step.ActionId);
                 }
             }

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
@@ -81,8 +81,8 @@ public sealed class CedarPolicyBackend : IExternalPolicyBackend
             {
                 Backend = Name,
                 Allowed = false,
-                Reason = $"Cedar evaluation failed: {ex.Message}",
-                Error = ex.Message,
+                Reason = "Cedar evaluation failed — see server logs for details",
+                Error = "INTERNAL_ERROR",
                 EvaluationMs = sw.Elapsed.TotalMilliseconds
             };
         }

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -108,8 +108,8 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
             {
                 Backend = Name,
                 Allowed = false,
-                Reason = $"OPA evaluation failed: {ex.Message}",
-                Error = ex.Message,
+                Reason = "OPA evaluation failed — see server logs for details",
+                Error = "INTERNAL_ERROR",
                 EvaluationMs = sw.Elapsed.TotalMilliseconds
             };
         }
@@ -159,8 +159,8 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
             {
                 Backend = Name,
                 Allowed = false,
-                Reason = $"OPA evaluation failed: {ex.Message}",
-                Error = ex.Message,
+                Reason = "OPA evaluation failed — see server logs for details",
+                Error = "INTERNAL_ERROR",
                 EvaluationMs = sw.Elapsed.TotalMilliseconds
             };
         }

--- a/agent-governance-python/agent-os/extensions/mcp-server/src/server.ts
+++ b/agent-governance-python/agent-os/extensions/mcp-server/src/server.ts
@@ -216,7 +216,7 @@ export class AgentOSMCPServer {
           content: [
             {
               type: 'text',
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              text: 'An internal error occurred while executing the tool.',
             },
           ],
           isError: true,


### PR DESCRIPTION
Redact ex.Message from client-facing policy decisions and MCP tool responses. Server-side audit logs retain details. CWE-209.