### PR TITLE
fix(security): scan .sh files for dependency confusion in pre-commit …

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -152,3 +152,6 @@ Nanvix
 reqwest
 requireapproval
 uncallable
+endswith
+rfind
+lstrip

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -46,6 +46,7 @@ REGISTERED_PACKAGES = {
     "opentelemetry-sdk", "fhir.resources", "hl7apy", "zenpy", "freshdesk",
     "google-adk", "safety", "jupyter", "vitest", "tsup", "typescript",
     "requests",
+    "twine",
     # Dashboard / visualization (used in examples)
     "streamlit", "plotly", "pandas", "networkx", "matplotlib", "pyvis",
     # Async / caching (used in examples)
@@ -211,8 +212,24 @@ def check_file(filepath: str) -> list[str]:
     except (OSError, UnicodeDecodeError):
         return findings
 
+    is_shell = filepath.endswith((".sh", ".bash"))
+
     for match in PIP_INSTALL_RE.finditer(content):
         line_num = content[:match.start()].count("\n") + 1
+        # For shell scripts, filter out matches that are inside a comment
+        # or an echo/printf invocation. Only the current shell command
+        # segment (split on ;, &&, ||, |) is examined so that
+        # `echo done; pip install foo` is still flagged.
+        if is_shell:
+            line_start = content.rfind("\n", 0, match.start()) + 1
+            before_pip = content[line_start:match.start()]
+            # Take the last command segment on this line.
+            segment = re.split(r';|&&|\|\||(?<!\|)\|(?!\|)', before_pip)[-1]
+            if "#" in segment:
+                continue
+            stripped = segment.lstrip()
+            if re.match(r'(?:sudo\s+)?(?:echo|printf)\b', stripped):
+                continue
         packages = extract_package_names(match.group(1))
         for pkg in packages:
             if pkg.lower() not in {p.lower() for p in REGISTERED_PACKAGES}:
@@ -412,7 +429,7 @@ def main() -> int:
         )
         files = [
             f for f in result.stdout.strip().split("\n")
-            if f.endswith((".md", ".py", ".ts", ".txt", ".yaml", ".yml", ".ipynb", ".svg"))
+            if f.endswith((".md", ".py", ".ts", ".txt", ".yaml", ".yml", ".ipynb", ".svg", ".sh", ".bash"))
         ]
 
     all_findings = []

--- a/tests/ci/test_check_dependency_confusion.py
+++ b/tests/ci/test_check_dependency_confusion.py
@@ -1,0 +1,144 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Regression tests for scripts/check_dependency_confusion.py.
+
+Covers the fix for issue #2207: shell-script (.sh/.bash) scanning in
+pre-commit mode and false-positive avoidance for echoed/commented
+``pip install`` lines.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "check_dependency_confusion.py"
+)
+SPEC = importlib.util.spec_from_file_location("check_dep_conf", SCRIPT_PATH)
+assert SPEC is not None
+check_dep_conf = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(check_dep_conf)
+
+
+def _write(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return str(p)
+
+
+def test_sh_real_pip_install_unregistered_is_flagged(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "build.sh",
+        "#!/usr/bin/env bash\nset -e\npip install totally-not-a-real-package-xyz\n",
+    )
+    findings = check_dep_conf.check_file(path)
+    assert any("totally-not-a-real-package-xyz" in f for f in findings), findings
+
+
+def test_sh_echoed_pip_install_is_not_flagged(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "build.sh",
+        '#!/usr/bin/env bash\necho "pip install totally-not-a-real-package-xyz"\n',
+    )
+    assert check_dep_conf.check_file(path) == []
+
+
+def test_sh_printf_pip_install_is_not_flagged(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "build.sh",
+        '#!/usr/bin/env bash\nprintf "run: pip install totally-not-a-real-package-xyz\\n"\n',
+    )
+    assert check_dep_conf.check_file(path) == []
+
+
+def test_sh_commented_pip_install_is_not_flagged(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "build.sh",
+        "#!/usr/bin/env bash\n# pip install totally-not-a-real-package-xyz\n",
+    )
+    assert check_dep_conf.check_file(path) == []
+
+
+def test_sh_inline_comment_pip_install_is_not_flagged(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "build.sh",
+        "#!/usr/bin/env bash\ntrue  # pip install totally-not-a-real-package-xyz\n",
+    )
+    assert check_dep_conf.check_file(path) == []
+
+
+def test_sh_known_package_is_not_flagged(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "build.sh",
+        "#!/usr/bin/env bash\npip install pydantic\n",
+    )
+    assert check_dep_conf.check_file(path) == []
+
+
+def test_sh_real_install_after_echo_separator_is_flagged(tmp_path: Path) -> None:
+    # Regression: `echo ...; pip install <unregistered>` is a real install.
+    path = _write(
+        tmp_path,
+        "build.sh",
+        '#!/usr/bin/env bash\necho preparing; pip install totally-not-a-real-package-xyz\n',
+    )
+    findings = check_dep_conf.check_file(path)
+    assert any("totally-not-a-real-package-xyz" in f for f in findings), findings
+
+
+def test_md_pip_install_after_hash_still_flagged(tmp_path: Path) -> None:
+    # Suppression must not affect non-shell files: a markdown heading like
+    # `# Install: pip install <unregistered>` should still be flagged.
+    path = _write(
+        tmp_path,
+        "guide.md",
+        "# Install: pip install totally-not-a-real-package-xyz\n",
+    )
+    findings = check_dep_conf.check_file(path)
+    assert any("totally-not-a-real-package-xyz" in f for f in findings), findings
+
+
+def test_txt_existing_behavior_unchanged_flags_unregistered(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "install.txt",
+        "Run: pip install totally-not-a-real-package-xyz\n",
+    )
+    findings = check_dep_conf.check_file(path)
+    assert any("totally-not-a-real-package-xyz" in f for f in findings), findings
+
+
+def test_md_existing_behavior_unchanged_known_package_ok(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "README.md",
+        "# Install\n\n```bash\npip install pydantic\n```\n",
+    )
+    assert check_dep_conf.check_file(path) == []
+
+
+def test_pre_commit_extension_filter_includes_shell() -> None:
+    # Sanity check on the extensions we want to be picked up by pre-commit.
+    src = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert '".sh"' in src
+    assert '".bash"' in src
+
+
+@pytest.mark.parametrize("ext", [".py", ".md", ".txt", ".ipynb"])
+def test_pre_commit_extension_filter_keeps_existing(ext: str) -> None:
+    src = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert f'"{ext}"' in src


### PR DESCRIPTION
Closes #2207

## Description

Pre-commit mode of `scripts/check_dependency_confusion.py` previously filtered staged files by extension and excluded `.sh`/`.bash`, so real `pip install` commands inside shell scripts (e.g. `agent-governance-python/agent-os/modules/control-plane/build_and_publish.sh`, `.../scak/build_and_publish.sh`) were never scanned for dependency-confusion risks.

This PR closes that gap:

- **Includes shell scripts in pre-commit scanning.** Adds `.sh` and `.bash` to the staged-file extension filter in `main()`.
- **Avoids false positives in shell scripts.** In `check_file()`, `pip install` matches that fall inside a shell comment (`#`) or an `echo`/`printf` invocation are skipped. The check is scoped to the **current shell command segment** (split on `;`, `&&`, `||`, `|`), so a real install after a separator (e.g. `echo done; pip install foo`) is still flagged.
- **Preserves existing behavior for other file types.** The new suppression is gated to `.sh`/`.bash`, so `.md`, `.py`, `.txt`, `.ipynb` scanning is unchanged (e.g. `# Install: pip install <unregistered>` in markdown is still flagged).
- **Adds `twine` to `REGISTERED_PACKAGES`** since the now-scanned existing `build_and_publish.sh` scripts use it and it is a legitimate PyPI package.
- **Regression tests** under `tests/ci/test_check_dependency_confusion.py` cover: real `pip install <unregistered>` in `.sh` is flagged; `echo "pip install <unregistered>"` is not; `printf "... pip install <unregistered>"` is not; full-line and inline `#` comments are not; known package (`pydantic`) in `.sh` is not; `echo done; pip install <unregistered>` (segment edge case) is flagged; markdown `#` lines still flagged; `.txt` behavior unchanged; pre-commit extension filter sanity checks for `.sh`/`.bash` and existing `.py`/`.md`/`.txt`/`.ipynb`.

**Out of scope (intentional, per issue):** Dockerfile support, heredoc bodies, and multi-line `pip install \` continuations. These are tracked as follow-ups.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Maintenance
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root  *(scripts/ + tests/)*

## Checklist
- [x] My code follows the project style guidelines (`ruff check` passes)
- [x] I have added tests that prove my fix works (15 regression tests)
- [x] All new and existing tests pass (`pytest tests/ci/test_check_dependency_confusion.py` — 15/15)
- [x] I have updated documentation as needed *(no doc changes required; behavior of documented usage unchanged)*
- [x] I have signed the Microsoft CLA

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] N/A — this is a bug fix to an existing script

**Prior art / related projects:** None.

## AI Assistance
- [x] I can explain every meaningful change in this PR
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot was used to scaffold the regression tests and the segment-based suppression logic; all output was reviewed, tested, and validated against the issue requirements.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
Closes #2207

## Follow-ups
- Dockerfile (`FROM`/`RUN pip install`) scanning in pre-commit mode
- Shell heredoc body suppression (`<<EOF ... EOF`)
- Multi-line `pip install \` continuation parsing