### PR TITLE
fix(security): prevent command injection in sandbox providers and composite actions

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -126,14 +126,16 @@ runs:
               exit 1
             fi
             echo "📋 Evaluating policy: $POLICY"
-            OUTPUT=$(python -c "
-        import json, sys
+            OUTPUT=$(AGT_POLICY="$POLICY" AGT_CONTEXT="$CONTEXT" python -c "
+        import json, sys, os
+
         from agent_os.policies import PolicyEvaluator
 
         evaluator = PolicyEvaluator()
-        evaluator.load_policies('$POLICY')
+        evaluator.load_policies(os.environ['AGT_POLICY'])
 
-        context = json.loads('$CONTEXT') if '$CONTEXT' else {}
+        ctx_raw = os.environ.get('AGT_CONTEXT', '')
+        context = json.loads(ctx_raw) if ctx_raw else {}
         decision = evaluator.evaluate(context)
 
         result = {
@@ -179,12 +181,13 @@ runs:
             POLICY="${{ inputs.policy-path }}"
             if [ -n "$POLICY" ]; then
               echo "--- Policy Evaluation ---"
-              PE_OUT=$(python -c "
-        import json, sys
+              PE_OUT=$(AGT_POLICY="$POLICY" AGT_CONTEXT='${{ inputs.context-json }}' python -c "
+        import json, sys, os
         from agent_os.policies import PolicyEvaluator
         evaluator = PolicyEvaluator()
-        evaluator.load_policies('$POLICY')
-        context = json.loads('${{ inputs.context-json }}') if '${{ inputs.context-json }}' else {}
+        evaluator.load_policies(os.environ['AGT_POLICY'])
+        ctx_raw = os.environ.get('AGT_CONTEXT', '')
+        context = json.loads(ctx_raw) if ctx_raw else {}
         decision = evaluator.evaluate(context)
         print(json.dumps({'allowed': decision.allowed, 'action': decision.action, 'reason': decision.reason}, indent=2))
         sys.exit(0 if decision.allowed else 1)

--- a/action/security-scan/action.yml
+++ b/action/security-scan/action.yml
@@ -86,18 +86,19 @@ runs:
         fi
         
         # Run the security scanner
-        python -c "
+        AGT_PATHS="$PATHS" AGT_PLUGIN="$PLUGIN_NAME" AGT_VERBOSE="${{ inputs.verbose }}" python -c "
         from pathlib import Path
         from agent_compliance.security import scan_plugin_security
         import json
         import sys
+        import os
 
-        paths = '$PATHS'.split()
-        verbose = '${{ inputs.verbose }}' == 'true'
+        paths = os.environ['AGT_PATHS'].split()
+        verbose = os.environ.get('AGT_VERBOSE', '') == 'true'
 
         # Scan first path (primary plugin directory)
         plugin_dir = Path(paths[0])
-        plugin_name = '$PLUGIN_NAME'
+        plugin_name = os.environ.get('AGT_PLUGIN', '')
 
         exit_code, error_msg = scan_plugin_security(
             plugin_dir=plugin_dir,

--- a/agent-governance-dotnet/src/AgentGovernance/Sandbox/DockerSandboxProvider.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Sandbox/DockerSandboxProvider.cs
@@ -67,10 +67,11 @@ public sealed class DockerSandboxProvider : ISandboxProvider
         args.Append($" --cpus {cfg.CpuLimit:F1}");
         args.Append(" --pids-limit 256");
 
-        // Environment variables
+        // Environment variables — quote values to prevent argument injection
         foreach (var kvp in cfg.EnvVars)
         {
-            args.Append($" -e {kvp.Key}={kvp.Value}");
+            ValidateResourceName(kvp.Key, "EnvVars key");
+            args.Append($" -e \"{kvp.Key}={kvp.Value.Replace("\"", "\\\"")}\"");
         }
 
         // Keep container alive with a blocking process
@@ -118,11 +119,12 @@ public sealed class DockerSandboxProvider : ISandboxProvider
         var timeout = cfg?.TimeoutSeconds ?? 60.0;
 
         var executionId = Guid.NewGuid().ToString("N")[..8];
-        var escapedCode = code.Replace("\"", "\\\"");
 
+        // Avoid shell interpolation: pipe code via stdin instead of python -c.
         var sw = Stopwatch.StartNew();
-        var (exitCode, stdout, stderr) = await RunDockerAsync(
-            $"exec {containerId} python -c \"{escapedCode}\"",
+        var (exitCode, stdout, stderr) = await RunDockerWithStdinAsync(
+            $"exec -i {containerId} python",
+            code,
             timeoutSeconds: timeout).ConfigureAwait(false);
         sw.Stop();
 
@@ -207,6 +209,45 @@ public sealed class DockerSandboxProvider : ISandboxProvider
         };
 
         process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+
+        var timeoutMs = (int)(timeoutSeconds * 1000);
+        var exited = await Task.Run(() => process.WaitForExit(timeoutMs)).ConfigureAwait(false);
+
+        if (!exited)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            var partialStdout = await stdoutTask.ConfigureAwait(false);
+            var partialStderr = await stderrTask.ConfigureAwait(false);
+            return (-1, partialStdout, partialStderr);
+        }
+
+        var stdout = await stdoutTask.ConfigureAwait(false);
+        var stderr = await stderrTask.ConfigureAwait(false);
+        return (process.ExitCode, stdout, stderr);
+    }
+
+    private static async Task<(int ExitCode, string Stdout, string Stderr)> RunDockerWithStdinAsync(
+        string arguments, string stdinContent, double timeoutSeconds = 30.0)
+    {
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "docker",
+            Arguments = arguments,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        process.Start();
+
+        await process.StandardInput.WriteAsync(stdinContent).ConfigureAwait(false);
+        process.StandardInput.Close();
 
         var stdoutTask = process.StandardOutput.ReadToEndAsync();
         var stderrTask = process.StandardError.ReadToEndAsync();

--- a/agent-governance-rust/agentmesh/src/sandbox.rs
+++ b/agent-governance-rust/agentmesh/src/sandbox.rs
@@ -344,9 +344,21 @@ impl SandboxProvider for DockerSandboxProvider {
         let execution_id = generate_id();
         let start = Instant::now();
 
+        // Avoid shell interpolation: pipe code via stdin instead of sh -c.
         let output = Command::new("docker")
-            .args(["exec", &name, "sh", "-c", code])
-            .output()
+            .args(["exec", "-i", &name, "sh"])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .and_then(|mut child| {
+                use std::io::Write;
+                if let Some(ref mut stdin) = child.stdin {
+                    stdin.write_all(code.as_bytes())?;
+                }
+                drop(child.stdin.take());
+                child.wait_with_output()
+            })
             .map_err(|e| format!("Failed to run docker exec: {}", e))?;
 
         let duration = start.elapsed().as_secs_f64();


### PR DESCRIPTION
Eliminate shell interpolation of untrusted input in code execution paths:

- **Rust sandbox**: pipe code via stdin instead of \sh -c\ argument (CWE-78)
- **.NET DockerSandboxProvider**: pipe code via stdin instead of \python -c\ string interpolation; quote env var values to prevent Docker arg injection (CWE-78, CWE-88)
- **action/action.yml**: read inputs from environment variables instead of inline shell interpolation in \python -c\ scripts (CWE-78)
- **action/security-scan/action.yml**: same pattern, use \os.environ\ (CWE-78)

Follows the fix already applied in the Go SDK (\sandbox.go:268-270\).

## Security Impact

All four findings are **critical** severity. An attacker who controls composite action inputs or sandbox code parameters could execute arbitrary commands. The fix eliminates shell metacharacter interpretation by avoiding string interpolation entirely.