### PR TITLE
fix(security): reject alg-none JWTs and prevent path traversal in policy loaders

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
@@ -333,6 +333,16 @@ class Policy(BaseModel):
                 if os.path.isabs(parent_ref)
                 else os.path.join(base_dir, parent_ref)
             )
+
+            # Prevent path traversal: resolved path must stay within base_dir
+            real_parent = os.path.realpath(parent_path)
+            real_base = os.path.realpath(base_dir)
+            if not real_parent.startswith(real_base + os.sep) and real_parent != real_base:
+                raise ValueError(
+                    f"Policy extends '{parent_ref}' resolves to '{real_parent}' "
+                    f"which is outside the policy directory '{real_base}'"
+                )
+
             if not os.path.exists(parent_path):
                 raise FileNotFoundError(
                     f"Policy extends '{parent_ref}' not found at {parent_path}"

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/entra_agent_id.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/entra_agent_id.py
@@ -103,12 +103,34 @@ class EntraAgentID:
     def validate_token(self, token: str) -> dict:
         """Validate a JWT token issued by Entra ID for this agent.
 
+        .. warning::
+
+            This method does **not** verify the cryptographic signature.
+            Call :meth:`validate_token_with_signature` or verify the
+            signature yourself via JWKS before trusting the claims.
+
         Performs structural and claim-level validation (expiry, issuer,
         audience).  Cryptographic signature verification requires the
         Entra JWKS and is intentionally left to callers with
         ``azure-identity`` or equivalent.
         """
+        import warnings
+
+        warnings.warn(
+            "validate_token() does not verify the JWT signature. "
+            "Use validate_token_with_signature() or verify the signature "
+            "via JWKS before trusting these claims.",
+            stacklevel=2,
+        )
         claims = self._decode_jwt_claims(token)
+
+        # Reject unsigned tokens (alg: none)
+        header = self._decode_jwt_header(token)
+        alg = header.get("alg", "")
+        if not alg or alg.lower() == "none":
+            raise ValueError(
+                "Token uses algorithm 'none' — unsigned tokens are not accepted"
+            )
 
         # Expiry
         exp = claims.get("exp")
@@ -196,6 +218,19 @@ class EntraAgentID:
         if padding != 4:
             payload += "=" * padding
         decoded = base64.urlsafe_b64decode(payload)
+        return json.loads(decoded)
+
+    @staticmethod
+    def _decode_jwt_header(token: str) -> dict:
+        """Decode the header section of a JWT."""
+        parts = token.split(".")
+        if len(parts) != 3:
+            raise ValueError("Invalid JWT: expected 3 dot-separated parts")
+        header = parts[0]
+        padding = 4 - len(header) % 4
+        if padding != 4:
+            header += "=" * padding
+        decoded = base64.urlsafe_b64decode(header)
         return json.loads(decoded)
 
     def __repr__(self) -> str:

--- a/agent-governance-rust/agentmesh/src/policy.rs
+++ b/agent-governance-rust/agentmesh/src/policy.rs
@@ -187,8 +187,25 @@ impl PolicyEngine {
     }
 
     /// Load a policy profile from a YAML file on disk.
+    ///
+    /// The path is canonicalized to prevent directory-traversal via
+    /// `..` segments. Relative paths are resolved against the current
+    /// working directory.
     pub fn load_from_file(&self, path: &str) -> Result<(), PolicyError> {
-        let yaml = std::fs::read_to_string(path).map_err(PolicyError::Io)?;
+        let requested = std::path::Path::new(path);
+
+        // Reject paths that contain traversal components before resolution
+        for component in requested.components() {
+            if matches!(component, std::path::Component::ParentDir) {
+                return Err(PolicyError::Validation(format!(
+                    "Policy path '{}' contains directory traversal",
+                    path
+                )));
+            }
+        }
+
+        let canonical = std::fs::canonicalize(requested).map_err(PolicyError::Io)?;
+        let yaml = std::fs::read_to_string(&canonical).map_err(PolicyError::Io)?;
         self.load_from_yaml(&yaml)
     }
 
@@ -328,6 +345,8 @@ pub enum PolicyError {
     InvalidYaml(serde_yaml::Error),
     #[error("I/O error: {0}")]
     Io(std::io::Error),
+    #[error("validation error: {0}")]
+    Validation(String),
     #[error("rule '{rule}' has invalid duration '{window}': {reason}")]
     InvalidDuration {
         rule: String,


### PR DESCRIPTION
Three security hardening fixes:

- **Python entra_agent_id** (CWE-287): Reject tokens with \lg: none\ header to prevent unsigned JWT acceptance. Add deprecation warning that \alidate_token()\ does not verify cryptographic signatures.
- **Python policy.py** (CWE-22): Add \ealpath\ containment check on \xtends\ field to prevent reads outside the policy directory via \../../\ traversal or absolute paths.
- **Rust policy.rs** (CWE-22): Reject paths containing \..\ traversal components in \load_from_file()\. Add \PolicyError::Validation\ variant.

## Security Impact

The JWT fix prevents a **critical** bypass where an attacker crafts a token with \lg: none\ that passes all claim checks without cryptographic verification. The path traversal fixes prevent **critical** (Python) and **medium** (Rust) arbitrary file reads.