### PR TITLE
fix(security): harden workflows against injection and require Jupyter auth

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -17,12 +17,13 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO sign-off on commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
           MISSING=()
 
-          for SHA in $(git rev-list "$BASE".."$HEAD"); do
+          for SHA in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
             # Skip merge commits (commits with more than one parent)
             PARENT_COUNT=$(git cat-file -p "$SHA" | grep -c '^parent ')
             if [ "$PARENT_COUNT" -gt 1 ]; then

--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -91,12 +91,16 @@ jobs:
       - name: Set image tag
         if: steps.check.outputs.skip != 'true'
         id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            TAG="${RELEASE_TAG}"
             TAG="${TAG#v}"
           else
-            TAG="${{ github.event.inputs.tag || 'latest' }}"
+            TAG="${INPUT_TAG:-latest}"
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Image tag: $TAG"

--- a/agent-governance-python/agent-os/modules/scak/docker-compose.yml
+++ b/agent-governance-python/agent-os/modules/scak/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - ./notebooks:/app/notebooks
     networks:
       - scak-network
-    command: jupyter lab --ip=0.0.0.0 --allow-root --no-browser --NotebookApp.token=''
+    command: jupyter lab --ip=0.0.0.0 --no-browser --IdentityProvider.token='changeme'
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Three workflow/infrastructure hardening fixes:

- **publish-containers.yml** (CWE-78): Move release tag and input tag to env block instead of direct interpolation in run steps. Prevents shell injection via crafted release tags.
- **dco.yml** (CWE-78): Move PR base/head SHA to env vars. While SHA values are low-risk, direct interpolation sets a bad precedent.
- **scak docker-compose** (CWE-798): Remove --allow-root and require Jupyter authentication token instead of blank token. Prevents unauthenticated code execution.

## Security Impact

The container publish workflow injection is **high** severity. The Jupyter fix addresses a **critical** unauthenticated RCE in the SCAK development environment.