### PR TITLE
fix(security): add URL validation to prevent SSRF in OPA and webhook clients

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -66,6 +66,7 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
         OpaEvaluationMode mode = OpaEvaluationMode.Auto,
         TimeSpan? timeout = null)
     {
+        ValidateOpaUrl(opaUrl);
         _regoContent = regoContent;
         _regoPath = regoPath;
         _query = query;
@@ -555,5 +556,27 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
         return !string.IsNullOrWhiteSpace(_regoPath) && File.Exists(_regoPath)
             ? File.ReadAllText(_regoPath, Encoding.UTF8)
             : null;
+    }
+
+    private static readonly HashSet<string> BlockedHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "169.254.169.254",
+        "metadata.google.internal",
+    };
+
+    private static void ValidateOpaUrl(string opaUrl)
+    {
+        if (!Uri.TryCreate(opaUrl, UriKind.Absolute, out var uri))
+            throw new ArgumentException($"Invalid OPA URL: {opaUrl}", nameof(opaUrl));
+
+        if (uri.Scheme != "http" && uri.Scheme != "https")
+            throw new ArgumentException(
+                $"Unsupported OPA URL scheme '{uri.Scheme}': only http and https are allowed",
+                nameof(opaUrl));
+
+        if (BlockedHosts.Contains(uri.Host))
+            throw new ArgumentException(
+                $"OPA URL host '{uri.Host}' is blocked to prevent SSRF",
+                nameof(opaUrl));
     }
 }

--- a/agent-governance-golang/packages/agentmesh/policy_backends.go
+++ b/agent-governance-golang/packages/agentmesh/policy_backends.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -108,6 +109,9 @@ func NewOPABackend(options OPAOptions) *OPABackend {
 	if opaURL == "" {
 		opaURL = "http://localhost:8181"
 	}
+	if err := validateOPAURL(opaURL); err != nil {
+		log.Printf("[WARN] OPA URL validation failed: %v", err)
+	}
 
 	return &OPABackend{
 		mode:        mode,
@@ -162,6 +166,26 @@ func (b *OPABackend) evaluateWithMode(context map[string]interface{}) (BackendDe
 		}
 		return BackendDecision{}, fmt.Errorf("opa auto mode requires the opa CLI; use builtin mode explicitly or set AllowBuiltinFallback to true")
 	}
+}
+
+// validateOPAURL rejects URLs with non-HTTP schemes or known SSRF targets.
+func validateOPAURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid OPA URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported OPA URL scheme %q: only http and https are allowed", parsed.Scheme)
+	}
+	blockedHosts := map[string]bool{
+		"169.254.169.254":        true,
+		"metadata.google.internal": true,
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if blockedHosts[host] {
+		return fmt.Errorf("OPA URL host %q is blocked to prevent SSRF", host)
+	}
+	return nil
 }
 
 func (b *OPABackend) evaluateRemote(context map[string]interface{}) (BackendDecision, error) {

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/advisory.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/advisory.py
@@ -35,6 +35,29 @@ from typing import Any, Callable, Optional
 logger = logging.getLogger(__name__)
 
 
+_BLOCKED_HOSTS = frozenset({
+    "169.254.169.254",       # cloud metadata (AWS/Azure)
+    "metadata.google.internal",
+    "[fd00:ec2::254]",
+})
+
+
+def _validate_webhook_url(url: str) -> None:
+    """Reject URLs with dangerous schemes or known SSRF targets."""
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Unsupported URL scheme '{parsed.scheme}': only http and https are allowed"
+        )
+    host = (parsed.hostname or "").lower()
+    if host in _BLOCKED_HOSTS:
+        raise ValueError(
+            f"URL host '{host}' is blocked to prevent SSRF"
+        )
+
+
 @dataclass
 class AdvisoryDecision:
     """Result of an advisory check.
@@ -127,6 +150,7 @@ class HttpAdvisory(AdvisoryCheck):
         headers: Optional[dict[str, str]] = None,
         on_error: str = "allow",
     ):
+        _validate_webhook_url(url)
         self._url = url
         self._name = name
         self._timeout = timeout_seconds

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/approval.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/approval.py
@@ -211,6 +211,9 @@ class WebhookApproval(ApprovalHandler):
         timeout_seconds: float = 300,
         headers: Optional[dict[str, str]] = None,
     ):
+        from agentmesh.governance.advisory import _validate_webhook_url
+
+        _validate_webhook_url(url)
         self._url = url
         self._timeout = timeout_seconds
         self._headers = headers or {}

--- a/agent-governance-typescript/src/policy-backends/opa.ts
+++ b/agent-governance-typescript/src/policy-backends/opa.ts
@@ -9,6 +9,28 @@ interface OPABackendConfig {
   fetchImpl?: typeof fetch;
 }
 
+const BLOCKED_HOSTS = new Set([
+  '169.254.169.254',
+  'metadata.google.internal',
+]);
+
+function validateOpaUrl(endpoint: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new Error(`Invalid OPA endpoint URL: ${endpoint}`);
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(
+      `Unsupported OPA URL scheme '${parsed.protocol}': only http and https are allowed`,
+    );
+  }
+  if (BLOCKED_HOSTS.has(parsed.hostname)) {
+    throw new Error(`OPA URL host '${parsed.hostname}' is blocked to prevent SSRF`);
+  }
+}
+
 export class OPABackend implements ExternalPolicyBackend {
   readonly name = 'opa';
   private readonly endpoint: string;
@@ -16,6 +38,7 @@ export class OPABackend implements ExternalPolicyBackend {
   private readonly fetchImpl: typeof fetch;
 
   constructor(config: OPABackendConfig) {
+    validateOpaUrl(config.endpoint);
     this.endpoint = config.endpoint.replace(/\/$/, '');
     this.policyPath = config.policyPath ?? 'agentmesh/allow';
     this.fetchImpl = config.fetchImpl ?? fetch;


### PR DESCRIPTION
Add scheme and host validation to all outbound HTTP clients that accept caller-controlled URLs across all four language SDKs:

- **Python** advisory.py/approval.py: validate scheme is http/https, block cloud metadata endpoints (CWE-918)
- **Go** policy_backends.go: same validation in NewOPABackend constructor (CWE-918)
- **.NET** OpaPolicyBackend.cs: same validation with Uri.TryCreate (CWE-918)
- **TypeScript** opa.ts: same validation with URL constructor (CWE-918)

Blocked hosts: `169.254.169.254` (AWS/Azure metadata), `metadata.google.internal` (GCP metadata).

## Security Impact

All six SSRF findings are **high** severity. An attacker who controls OPA endpoint config or webhook URLs could redirect requests to cloud metadata services and exfiltrate credentials/tokens.