### PR TITLE
fix(security): use explicit safe YAML schema and stop leaking error details

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
@@ -168,7 +168,7 @@ async def verify_handshake(req: VerifyRequest) -> VerifyResponse:
         )
     except Exception as exc:
         logger.warning("Handshake verification failed: %s", exc)
-        return VerifyResponse(verified=False, rejection_reason=str(exc))
+        return VerifyResponse(verified=False, rejection_reason="Verification failed")
 
 
 @app.post("/api/v1/capabilities/grant", tags=["capabilities"])

--- a/agent-governance-typescript/src/policy.ts
+++ b/agent-governance-typescript/src/policy.ts
@@ -386,7 +386,7 @@ export class PolicyEngine {
   loadYaml(yamlContent: string): Policy {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const yaml = require('js-yaml');
-    const data = yaml.load(yamlContent) as Record<string, unknown>;
+    const data = yaml.load(yamlContent, { schema: yaml.DEFAULT_SCHEMA }) as Record<string, unknown>;
     const policy = dataToPolicy(data);
     this.loadPolicy(policy);
     return policy;
@@ -610,7 +610,7 @@ export class PolicyEngine {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const yaml = require('js-yaml');
     const content = readFileSync(yamlPath, 'utf-8');
-    const doc = yaml.load(content) as { rules?: PolicyRule[] };
+    const doc = yaml.load(content, { schema: yaml.DEFAULT_SCHEMA }) as { rules?: PolicyRule[] };
     if (doc?.rules && Array.isArray(doc.rules)) {
       this._legacyRules.push(...doc.rules);
     }


### PR DESCRIPTION
Two defensive hardening fixes:

- **TypeScript policy.ts** (CWE-502): Pass explicit DEFAULT_SCHEMA to yaml.load() for defense-in-depth. js-yaml v4 is safe by default, but explicit schema prevents regression if the library is ever downgraded.
- **Python trust_engine.py** (CWE-209): Replace raw str(exc) with generic message in rejection_reason to prevent leaking internal error details, file paths, and connection strings to unauthenticated API callers.

## Security Impact

The error leak is **high** severity: raw exception strings can expose internal paths, database connection info, and stack traces. The YAML fix is **defensive** (v4 is already safe).