### PR TITLE
fix(security): cap unbounded in-memory collection growth (CWE-770)

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/RateLimiting/RateLimiter.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/RateLimiting/RateLimiter.cs
@@ -10,6 +10,7 @@ namespace AgentGovernance.RateLimiting;
 /// </summary>
 public sealed class RateLimiter
 {
+    private const int MaxTrackedKeys = 50_000;
     private readonly ConcurrentDictionary<string, CallWindow> _windows = new();
 
     /// <summary>
@@ -28,6 +29,13 @@ public sealed class RateLimiter
         if (window <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(window));
 
         var callWindow = _windows.GetOrAdd(key, _ => new CallWindow());
+
+        // Prevent unbounded dictionary growth: prune stale keys when at capacity.
+        if (_windows.Count > MaxTrackedKeys)
+        {
+            PruneStaleKeys(window);
+        }
+
         return callWindow.TryRecord(maxCalls, window);
     }
 
@@ -47,6 +55,17 @@ public sealed class RateLimiter
     /// Removes all tracked state. Useful for testing.
     /// </summary>
     public void Reset() => _windows.Clear();
+
+    private void PruneStaleKeys(TimeSpan window)
+    {
+        foreach (var kvp in _windows)
+        {
+            if (kvp.Value.CountWithin(window) == 0)
+            {
+                _windows.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
 
     /// <summary>
     /// Parses a rate-limit expression like "100/minute", "50/hour", "10/second".

--- a/agent-governance-golang/packages/agentmesh/trust.go
+++ b/agent-governance-golang/packages/agentmesh/trust.go
@@ -38,6 +38,11 @@ type persistedState struct {
 	Interactions int     `json:"interactions"`
 }
 
+// maxTrackedAgents caps the number of unique agent IDs tracked in the
+// scores map to bound memory growth.  When exceeded the least-recently-
+// updated entry is evicted.
+const maxTrackedAgents = 10_000
+
 // TrustManager tracks and updates per-agent trust scores.
 type TrustManager struct {
 	mu     sync.RWMutex
@@ -140,10 +145,28 @@ func (tm *TrustManager) RecordFailure(agentID string, penalty float64) {
 func (tm *TrustManager) getOrCreate(agentID string) *scoreState {
 	s, ok := tm.scores[agentID]
 	if !ok {
+		if len(tm.scores) >= maxTrackedAgents {
+			tm.evictOldest()
+		}
 		s = &scoreState{score: tm.config.InitialScore}
 		tm.scores[agentID] = s
 	}
 	return s
+}
+
+// evictOldest removes the entry with the fewest interactions (least active).
+func (tm *TrustManager) evictOldest() {
+	var evictKey string
+	minInteractions := int(^uint(0) >> 1) // max int
+	for k, v := range tm.scores {
+		if v.interactions < minInteractions {
+			minInteractions = v.interactions
+			evictKey = k
+		}
+	}
+	if evictKey != "" {
+		delete(tm.scores, evictKey)
+	}
 }
 
 func (tm *TrustManager) applyDecay(score float64) float64 {

--- a/agent-governance-rust/Cargo.lock
+++ b/agent-governance-rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "agentmesh"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "base64",
  "cedar-policy",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agentmesh-mcp"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
  "base64",
  "hmac",

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/rate_limit.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/rate_limit.rs
@@ -34,6 +34,9 @@ pub struct InMemoryRateLimitStore {
     windows: Mutex<HashMap<String, Vec<u64>>>,
 }
 
+/// Maximum number of distinct rate-limit keys to track.
+const MAX_RATE_LIMIT_KEYS: usize = 50_000;
+
 impl McpRateLimitStore for InMemoryRateLimitStore {
     fn check_and_record(
         &self,
@@ -46,6 +49,14 @@ impl McpRateLimitStore for InMemoryRateLimitStore {
             .windows
             .lock()
             .map_err(|_| McpError::store("rate_limit", "rate-limit store lock poisoned"))?;
+
+        // Evict stale keys when the map grows too large.
+        if windows.len() >= MAX_RATE_LIMIT_KEYS && !windows.contains_key(key) {
+            windows.retain(|_, events| {
+                events.last().map_or(false, |&t| now_secs.saturating_sub(t) < window_secs)
+            });
+        }
+
         let events = windows.entry(key.to_string()).or_default();
         events.retain(|event_secs| now_secs.saturating_sub(*event_secs) < window_secs);
         if events.len() >= max_requests {

--- a/agent-governance-rust/agentmesh/src/audit.rs
+++ b/agent-governance-rust/agentmesh/src/audit.rs
@@ -23,14 +23,17 @@ struct AuditState {
 }
 
 impl AuditLogger {
-    /// Create an empty audit logger with no entry limit.
+    /// Default maximum entries when no explicit limit is provided.
+    const DEFAULT_MAX_ENTRIES: usize = 100_000;
+
+    /// Create an empty audit logger with a default entry limit.
     pub fn new() -> Self {
         Self {
             state: Mutex::new(AuditState {
                 entries: Vec::new(),
                 seam_hash: None,
             }),
-            max_entries: None,
+            max_entries: Some(Self::DEFAULT_MAX_ENTRIES),
         }
     }
 

--- a/agent-governance-typescript/src/context-poisoning.ts
+++ b/agent-governance-typescript/src/context-poisoning.ts
@@ -89,6 +89,9 @@ export class ContextPoisoningDetector {
   private readonly contextStore = new Map<string, ContextEntry[]>();
   private readonly integrityHashes = new Map<string, string>();
 
+  private static readonly MAX_CONTEXT_KEYS = 10_000;
+  private static readonly MAX_ENTRIES_PER_KEY = 1_000;
+
   constructor(config?: ContextPoisoningConfig) {
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.patterns = [...DEFAULT_PATTERNS, ...(config?.knownPatterns ?? [])];
@@ -108,7 +111,18 @@ export class ContextPoisoningDetector {
   addEntry(entry: ContextEntry): void {
     const key = `${entry.agentId}:${entry.sessionId}`;
     const entries = this.contextStore.get(key) ?? [];
+    if (entries.length >= ContextPoisoningDetector.MAX_ENTRIES_PER_KEY) {
+      entries.shift();
+    }
     entries.push(entry);
+
+    if (!this.contextStore.has(key) && this.contextStore.size >= ContextPoisoningDetector.MAX_CONTEXT_KEYS) {
+      // Evict oldest key (first inserted).
+      const oldest = this.contextStore.keys().next().value;
+      if (oldest !== undefined) {
+        this.contextStore.delete(oldest);
+      }
+    }
     this.contextStore.set(key, entries);
 
     const hash = this.computeHash(entry);

--- a/agent-governance-typescript/src/metrics.ts
+++ b/agent-governance-typescript/src/metrics.ts
@@ -83,6 +83,9 @@ export class GovernanceMetrics {
   private readonly gauges: Record<string, number> = {};
   private readonly events: MetricEvent[] = [];
 
+  private static readonly MAX_HISTOGRAM_SAMPLES = 10_000;
+  private static readonly MAX_EVENTS = 50_000;
+
   constructor(config: boolean | GovernanceMetricsConfig = false) {
     if (typeof config === 'boolean') {
       this.enabled = config;
@@ -178,7 +181,14 @@ export class GovernanceMetrics {
   }
 
   private recordHistogram(name: string, value: number): void {
-    this.histograms[name] = [...(this.histograms[name] ?? []), value];
+    const samples = this.histograms[name] ?? [];
+    if (samples.length < GovernanceMetrics.MAX_HISTOGRAM_SAMPLES) {
+      samples.push(value);
+    } else {
+      // Reservoir-style: overwrite a random older sample to bound memory.
+      samples[Math.floor(Math.random() * samples.length)] = value;
+    }
+    this.histograms[name] = samples;
   }
 
   private emit(event: MetricEvent): void {
@@ -186,6 +196,9 @@ export class GovernanceMetrics {
       return;
     }
 
+    if (this.events.length >= GovernanceMetrics.MAX_EVENTS) {
+      this.events.splice(0, Math.floor(GovernanceMetrics.MAX_EVENTS / 4));
+    }
     this.events.push(event);
     for (const sink of this.sinks) {
       sink.record(event);


### PR DESCRIPTION
Cap unbounded in-memory collections across all SDKs to prevent memory exhaustion DoS in long-running processes.

**Changes:**
| SDK | File | Fix |
|-----|------|-----|
| Go | trust.go | Cap scores map at 10K, evict least-active |
| Rust | audit.rs | Default max_entries=100K instead of None |
| Rust | rate_limit.rs | Evict stale keys at 50K threshold |
| TS | metrics.ts | Cap histograms (10K) and events (50K) |
| TS | context-poisoning.ts | Cap context keys (10K), entries/key (1K) |
| .NET | RateLimiter.cs | Prune stale keys at 50K threshold |

**Testing:** Go all pass, Rust 342 pass, TS 32/32 pass (metrics + context-poisoning).