### PR TITLE
fix: correct sys.path in OpenShell governed demo

### DIFF
--- a/examples/openshell-governed/demo.py
+++ b/examples/openshell-governed/demo.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "packages" / "agentmesh-integrations" / "openshell-skill"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "agent-governance-python" / "agentmesh-integrations" / "openshell-skill"))
 from openshell_agentmesh.skill import GovernanceSkill
 
 def main():


### PR DESCRIPTION
The OpenShell governed demo (\xamples/openshell-governed/demo.py\) referenced a nonexistent path \packages/agentmesh-integrations/openshell-skill\. The correct path is \gent-governance-python/agentmesh-integrations/openshell-skill\.

**Before:** \ModuleNotFoundError: No module named 'openshell_agentmesh'\ when running \python examples/openshell-governed/demo.py\

**After:** Demo runs correctly (3 allowed, 3 denied, trust decays 1.00 -> 0.55)

Tests: all 9 tests in \	est_skill.py\ pass.