### PR TITLE
fix(ci): replace gitleaks-action with free CLI to fix expired license

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -31,21 +31,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Gitleaks requires the `GITLEAKS_LICENSE` secret to run with its
-      # full ruleset. Secrets are not exposed to workflows triggered by
-      # fork PRs, so the step is skipped cleanly in that case (the
-      # upstream maintainer will see the run on the rebased branch or
-      # on the post-merge push event). For every other trigger
-      # (in-tree PR, push to main, schedule, manual dispatch) the step
-      # MUST succeed — the previous `continue-on-error: true` made a
-      # licensed-but-failing scan indistinguishable from a successful
-      # one, undermining the gate the workflow is supposed to provide.
+      # The gitleaks *action* requires a paid GITLEAKS_LICENSE for org
+      # repos. The gitleaks *CLI* is MIT-licensed and free. We install
+      # the CLI directly to avoid license-key management overhead.
+      - name: Install Gitleaks
+        run: |
+          GITLEAKS_VERSION="8.24.3"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+
       - name: Run Gitleaks
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            gitleaks detect --source . --log-opts "${BASE_SHA}..${HEAD_SHA}" --verbose
+          else
+            gitleaks detect --source . --verbose
+          fi
 
       - name: Scan for high-entropy strings
         run: |


### PR DESCRIPTION
The gitleaks GitHub Action requires a paid GITLEAKS_LICENSE secret for org repos. The secret expired, breaking Secret Scanning on all PRs.

**Fix:** Replace the gitleaks-action with a direct install of the gitleaks CLI (MIT-licensed, free). Also moves PR SHA interpolation into env vars to stay consistent with prior workflow injection hardening.

Unblocks PR #2240 and all other PRs currently failing on Secret Scanning.