### PR TITLE
fix: make test_tampered_signature_invalidates_cache deterministic

### DIFF
--- a/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
+++ b/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
@@ -60,9 +60,14 @@ class TestCacheInvalidation:
         registry.register(signed_card)
         assert registry.is_verified(signed_card.agent_did) is True
 
-        # Flip a byte in the signature
+        # Flip the first byte to a character guaranteed to differ.
+        # The old code used "A" + original[1:] which is a no-op ~1/64
+        # of the time when the signature already starts with "A",
+        # causing intermittent failures.  See #2255.
         original = signed_card.card_signature
-        signed_card.card_signature = "A" + original[1:]
+        first_char = original[0]
+        replacement = "B" if first_char != "B" else "C"
+        signed_card.card_signature = replacement + original[1:]
         assert registry.is_verified(signed_card.agent_did) is False
 
     def test_unmutated_card_stays_cached(self, signed_card):

--- a/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
+++ b/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
@@ -60,10 +60,7 @@ class TestCacheInvalidation:
         registry.register(signed_card)
         assert registry.is_verified(signed_card.agent_did) is True
 
-        # Flip the first byte to a character guaranteed to differ.
-        # The old code used "A" + original[1:] which is a no-op ~1/64
-        # of the time when the signature already starts with "A",
-        # causing intermittent failures.  See #2255.
+        # Ensure the replacement byte actually differs from the original
         original = signed_card.card_signature
         first_char = original[0]
         replacement = "B" if first_char != "B" else "C"


### PR DESCRIPTION
Fixes #2255

## Problem

`test_tampered_signature_invalidates_cache` fails intermittently (~1.5% of runs). The test tampers a base64-encoded Ed25519 signature by replacing the first character with `"A"`:

```python
signed_card.card_signature = "A" + original[1:]
```

When the signature already starts with `"A"` (1-in-64 chance with base64), this is a no-op — the content hash doesn't change, the cache returns the old `True` verdict, and the assertion fails.

## Fix

Use a conditional replacement that guarantees the byte actually differs:

```python
first_char = original[0]
replacement = "B" if first_char != "B" else "C"
signed_card.card_signature = replacement + original[1:]
```

No changes to production code — the `CardRegistry` cache logic is correct, only the test was non-deterministic.