### PR TITLE
fix: make test_tampered_signature_invalidates_cache deterministic

### DIFF
--- a/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
+++ b/agent-governance-python/agent-mesh/tests/test_cards_cache_invalidation.py
@@ -60,9 +60,11 @@ class TestCacheInvalidation:
         registry.register(signed_card)
         assert registry.is_verified(signed_card.agent_did) is True
 
-        # Flip a byte in the signature
+        # Ensure the replacement byte actually differs from the original
         original = signed_card.card_signature
-        signed_card.card_signature = "A" + original[1:]
+        first_char = original[0]
+        replacement = "B" if first_char != "B" else "C"
+        signed_card.card_signature = replacement + original[1:]
         assert registry.is_verified(signed_card.agent_did) is False
 
     def test_unmutated_card_stays_cached(self, signed_card):


### PR DESCRIPTION
Fixes #2255

## Problem

`test_tampered_signature_invalidates_cache` replaces the first character of a base64 signature with `"A"`. ~1/64 chance the signature already starts with `"A"` → no-op → cache returns stale `True` → flaky failure.

## Fix

Conditional replacement that guarantees the byte differs:

```python
replacement = "B" if first_char != "B" else "C"
```

Test-only change, no production code modified.