### PR TITLE
fix: prevent AI PR Review agents from failing checks on large PRs

### DIFF
--- a/.github/actions/ai-agent-runner/action.yml
+++ b/.github/actions/ai-agent-runner/action.yml
@@ -139,12 +139,15 @@ runs:
                 }
               );
               context.diff = await diffRes.text();
-              // Truncate diffs to stay within GitHub Models token limits
-              // (~4 chars per token, keep under ~6000 tokens for diff)
-              if (context.diff.length > 24000) {
+              // Truncate diffs to stay within GitHub Models token limits.
+              // Budget ~3k tokens for system prompt + PR body, leaving ~5k
+              // tokens (~12k chars) for the diff itself.  The old 24k limit
+              // exceeded model context windows on large PRs.
+              const MAX_DIFF_CHARS = 12000;
+              if (context.diff.length > MAX_DIFF_CHARS) {
                 context.diff =
-                  context.diff.slice(0, 24000) +
-                  "\n\n... [diff truncated — showing first 24k chars of full diff] ...";
+                  context.diff.slice(0, MAX_DIFF_CHARS) +
+                  `\n\n... [diff truncated — showing first ${MAX_DIFF_CHARS / 1000}k of ${(context.diff.length / 1000).toFixed(0)}k chars] ...`;
               }
             }
 
@@ -224,6 +227,16 @@ runs:
               `::warning::Primary model failed (${res.status}), trying fallback: ${env("INPUT_FALLBACK_MODEL")}`
             );
             body.model = env("INPUT_FALLBACK_MODEL");
+
+            // On 413 (payload too large), halve the user message to fit
+            if (res.status === 413) {
+              const userMsg = body.messages[body.messages.length - 1];
+              const half = Math.floor(userMsg.content.length / 2);
+              userMsg.content = userMsg.content.slice(0, half)
+                + "\n\n... [content truncated to fit model context window] ...";
+              console.log(`   Truncated user prompt from ${userMsg.content.length + half} to ${userMsg.content.length} chars for retry`);
+            }
+
             res = await fetch(modelsEndpoint, {
               method: "POST",
               headers: {
@@ -433,11 +446,13 @@ runs:
             setOutput("status", "success");
             setOutput("tokens_used", String(tokensUsed));
           } catch (err) {
-            console.error(`::error::Agent ${agentType} failed: ${err.message}`);
+            // AI agents are informational — log a warning instead of
+            // failing the check so large-diff PRs don't show spurious
+            // red X marks in the checks list.
+            console.log(`::warning::Agent ${agentType} failed: ${err.message}`);
             setOutput("response", "");
             setOutput("status", "failure");
             setOutput("tokens_used", "0");
-            process.exitCode = 1;
           }
         }
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -184,7 +184,7 @@ jobs:
           agent-type: ${{ matrix.agent-type }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           model: gpt-4o
-          fallback-model: gpt-4o-mini
+          fallback-model: gpt-4o
           max-tokens: ${{ matrix.max-tokens }}
           context-mode: pr-diff
           output-mode: pr-comment


### PR DESCRIPTION
## Description
Fixes AI PR Review workflow checks (Code Review, Security Scan, Breaking Changes, Docs Sync, Test Coverage) showing as red X failures on large PRs like #2236.

## Root Cause
1. Diff truncation limit (24k chars) exceeded model context windows, causing HTTP 413 from GitHub Models API
2. Fallback model (gpt-4o-mini) has only 8k token limit, too small for any PR review
3. Catch block set \process.exitCode = 1\, making informational checks appear as CI failures

## Changes
- **Reduce diff truncation** from 24k to 12k chars to stay within model context windows
- **413 retry with truncation**: on payload-too-large, halve the user prompt before retrying
- **Graceful failure**: replace \process.exitCode = 1\ with \::warning::\ annotation so AI agents don't produce red X marks in the checks list
- **Better fallback**: use gpt-4o as fallback instead of gpt-4o-mini

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Package(s) Affected
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] All new and existing tests pass (pytest)
- [x] I have signed the Microsoft CLA

## AI Assistance
- [x] I can explain every meaningful change in this PR
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review

GitHub Copilot assisted with drafting commit messages.