### PR TITLE
docs: add guidance for bulk/automated audit issue filings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,19 @@ ruff check --fix .
 - Use the provided issue templates when available
 - Include reproduction steps, expected behavior, and actual behavior
 
+**Automated and AI-assisted audit findings:**
+
+If you are filing issues from an automated scanner, LLM-assisted code review, or bulk audit
+(e.g. running a tool across the whole repo), please consolidate low-severity findings into a
+single tracking issue with a summary table. One well-prioritized issue is more useful to
+maintainers than a dozen separate filings that each need individual triage.
+
+For high-severity findings (security bugs, data loss risks, correctness issues), individual
+issues are fine and encouraged.
+
+This helps maintainers focus review time on the findings that actually matter and avoids
+burying genuine bugs under a pile of style nits.
+
 ### Pull Requests
 
 1. Fork the repository and create a feature branch from `main`


### PR DESCRIPTION
Adds a short section under "Reporting Issues" in CONTRIBUTING.md asking contributors who run bulk/automated audits (LLM-assisted scanners, SAST sweeps, etc.) to consolidate low-severity findings into a single tracking issue instead of filing each one individually.

High-severity findings (security, correctness, data loss) still get their own issues.

**Why:** We recently triaged 13 issues from a single automated audit run. The high-impact ones were genuinely useful (#2013, #2185, #2187), but the low-severity style/naming nits created a lot of triage overhead for little value. Consolidated them into #2259.

This sets clear expectations for future audit contributors without being hostile to the practice itself.