### PR TITLE
fix: standardize openshell-agentmesh package naming

### DIFF
--- a/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "openshell_agentmesh"
+name = "openshell-agentmesh"
 version = "3.6.0"
 description = "Public Preview - OpenShell + AgentMesh governance skill"
 readme = "README.md"
@@ -21,6 +21,9 @@ Homepage = "https://github.com/microsoft/agent-governance-toolkit"
 
 [tool.hatch.build.targets.wheel]
 packages = ["openshell_agentmesh"]
+
+[project.scripts]
+openshell-governance = "openshell_agentmesh.cli:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -64,7 +64,7 @@ graph TB
 | pydantic-ai-governance | Pydantic AI | `pip install pydantic-ai-governance` |
 | a2a-protocol | A2A Protocol | `pip install a2a-protocol` |
 | mcp-trust-proxy | MCP | `pip install mcp-trust-proxy` |
-| openshell-skill | NVIDIA OpenShell | `pip install openshell-skill` |
+| openshell-skill | NVIDIA OpenShell | `pip install openshell-agentmesh` |
 | agentmesh-avp | Amazon Verified Permissions | `pip install agentmesh-avp` |
 | structural-authz-agentmesh | Structural Authorization | `pip install structural-authz-agentmesh` |
 | nostr-wot | Nostr Web-of-Trust | `pip install nostr-wot` |


### PR DESCRIPTION
## Summary

Standardizes the OpenShell governance skill package naming across all references.
Part of the OpenShell cleanup effort for NVIDIA contribution readiness.

## Problem

The package name was inconsistent across different files:
- pyproject.toml used openshell_agentmesh (underscore, non-conventional)
- README.md install line used openshell-agentmesh (correct)
- docs/packages/index.md used openshell-skill (wrong package name entirely)
- No py.typed marker for PEP 561 typing support
- No [project.scripts] entry point despite having a CLI module

## Changes

| File | What changed |
|------|-------------|
| pyproject.toml | Changed name to openshell-agentmesh (hyphenated, PEP 503 conventional form) |
| pyproject.toml | Added [project.scripts] entry point for openshell-governance CLI |
| docs/packages/index.md | Fixed install command from openshell-skill to openshell-agentmesh |
| openshell_agentmesh/py.typed | Added PEP 561 typing marker |

## Testing

All 9 existing tests pass.
