### PR TITLE
fix: improve openshell-skill code quality for contribution readiness

### DIFF
--- a/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/cli.py
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/cli.py
@@ -2,32 +2,55 @@
 # Licensed under the MIT License.
 """CLI entry point for the OpenShell governance skill."""
 from __future__ import annotations
-import argparse, json, sys
+
+import argparse
+import json
+import sys
 from pathlib import Path
+
 from openshell_agentmesh.skill import GovernanceSkill
 
+
 def main(argv=None):
-    parser = argparse.ArgumentParser(prog="openshell-governance")
+    parser = argparse.ArgumentParser(
+        prog="openshell-governance",
+        description="Policy enforcement CLI for OpenShell sandboxed agents.",
+    )
     sub = parser.add_subparsers(dest="command")
-    cp = sub.add_parser("check-policy")
-    cp.add_argument("--action", required=True)
-    cp.add_argument("--context", default="{}")
-    cp.add_argument("--policy-dir", required=True)
-    ts = sub.add_parser("trust-score")
-    ts.add_argument("--agent-did", required=True)
+
+    cp = sub.add_parser("check-policy", help="Evaluate an action against loaded policies")
+    cp.add_argument("--action", required=True, help="Action string to evaluate (e.g. shell:python)")
+    cp.add_argument("--context", default="{}", help="JSON object with evaluation context")
+    cp.add_argument("--policy-dir", required=True, help="Path to directory containing policy YAML files")
+
+    ts = sub.add_parser("trust-score", help="Query the trust score for an agent DID")
+    ts.add_argument("--agent-did", required=True, help="Agent DID to look up")
+
     args = parser.parse_args(argv)
+
     if args.command == "check-policy":
-        skill = GovernanceSkill(policy_dir=Path(args.policy_dir))
-        ctx = json.loads(args.context) if args.context else {}
+        policy_path = Path(args.policy_dir)
+        if not policy_path.is_dir():
+            print(json.dumps({"error": f"Policy directory not found: {args.policy_dir}"}), file=sys.stderr)
+            return 2
+        try:
+            ctx = json.loads(args.context)
+        except json.JSONDecodeError as exc:
+            print(json.dumps({"error": f"Invalid --context JSON: {exc}"}), file=sys.stderr)
+            return 2
+        skill = GovernanceSkill(policy_dir=policy_path)
         d = skill.check_policy(args.action, ctx)
         print(json.dumps({"allowed": d.allowed, "action": d.action, "reason": d.reason, "policy_name": d.policy_name}))
         return 0 if d.allowed else 1
-    elif args.command == "trust-score":
+
+    if args.command == "trust-score":
         skill = GovernanceSkill()
         print(json.dumps({"agent_did": args.agent_did, "trust_score": skill.get_trust_score(args.agent_did)}))
         return 0
+
     parser.print_help()
     return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/skill.py
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/skill.py
@@ -57,6 +57,11 @@ class GovernanceSkill:
         context = context or {}
         agent_did = context.get("agent_did", "unknown")
         trust = self.get_trust_score(agent_did)
+        if trust < self._trust_threshold:
+            reason = f"Trust score {trust:.2f} below threshold {self._trust_threshold:.2f}"
+            decision = PolicyDecision(allowed=False, action=action, reason=reason, trust_score=trust)
+            self.log_action(action, "deny", agent_did, context)
+            return decision
         for rule in self._rules:
             target = action if rule.field == "action" else context.get(rule.field, "")
             if self._match(rule.operator, target, rule.value):

--- a/examples/openshell-governed/demo.py
+++ b/examples/openshell-governed/demo.py
@@ -1,26 +1,49 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-import sys
+"""Demo: AGT policy enforcement inside an OpenShell sandbox.
+
+Run with:
+    pip install openshell-agentmesh
+    python examples/openshell-governed/demo.py
+"""
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "agent-governance-python" / "agentmesh-integrations" / "openshell-skill"))
+
 from openshell_agentmesh.skill import GovernanceSkill
+
+
+SCENARIOS = [
+    ("file:read:/workspace/main.py", "Read source file"),
+    ("shell:python", "Run Python"),
+    ("shell:git", "Git commit"),
+    ("shell:rm -rf /tmp", "Delete temp data"),
+    ("http:GET:169.254.169.254/metadata", "Cloud metadata"),
+    ("file:write:/etc/shadow", "Write /etc/shadow"),
+]
+
 
 def main():
     print("=" * 60)
     print("   Governed AI Agent in OpenShell Sandbox")
     print("=" * 60)
+
     skill = GovernanceSkill(policy_dir=Path(__file__).parent / "policies")
     agent = "did:mesh:sandbox-agent-001"
+
     print(f"\n  Loaded {len(skill._rules)} rules | Agent: {agent} (trust: {skill.get_trust_score(agent):.2f})")
     print("-" * 60)
-    for action, desc in [("file:read:/workspace/main.py","Read source file"),("shell:python","Run Python"),("shell:git","Git commit"),("shell:rm -rf /tmp","Delete temp data"),("http:GET:169.254.169.254/metadata","Cloud metadata"),("file:write:/etc/shadow","Write /etc/shadow")]:
+
+    for action, desc in SCENARIOS:
         d = skill.check_policy(action, context={"agent_did": agent})
-        if not d.allowed: skill.adjust_trust(agent, -0.15)
+        if not d.allowed:
+            skill.adjust_trust(agent, -0.15)
         icon = "[OK]" if d.allowed else "[XX]"
         print(f"  {icon} {desc:<28} trust={skill.get_trust_score(agent):.2f}  {d.reason}")
+
     log = skill.get_audit_log()
-    a = sum(1 for e in log if e["decision"] == "allow")
-    print(f"\n  Audit: {a} allowed, {len(log)-a} denied | Final trust: {skill.get_trust_score(agent):.2f}")
+    allowed_count = sum(1 for e in log if e["decision"] == "allow")
+    print(f"\n  Audit: {allowed_count} allowed, {len(log) - allowed_count} denied | Final trust: {skill.get_trust_score(agent):.2f}")
     print("=" * 60)
 
-if __name__ == "__main__": main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Improves code quality in the OpenShell governance skill for external contribution readiness.
Part of the OpenShell cleanup effort for NVIDIA contribution readiness.

## Problem

Several code quality issues made the package less approachable for contributors:
- CLI had no error handling for invalid JSON input or missing policy directories
- CLI arguments had no help text
- 	rust_threshold was accepted and stored in the constructor but never enforced during policy evaluation
- Example script used a brittle sys.path.insert hack instead of a proper package import
- Example code was dense single-line formatting, hard to read

## Changes

| File | What changed |
|------|-------------|
| cli.py | Added error handling for invalid JSON and missing policy dir, added help text for all arguments, formatted for readability |
| skill.py | check_policy() now denies actions when the agent trust score falls below 	rust_threshold |
| demo.py | Removed sys.path.insert hack (requires pip install openshell-agentmesh), extracted scenarios to named constant, improved readability |

## Testing

All 9 existing tests pass.
