### PR TITLE
docs: fix accuracy in openshell integration docs

### DIFF
--- a/docs/integrations/openshell.md
+++ b/docs/integrations/openshell.md
@@ -86,7 +86,11 @@ if not decision.allowed:
 
 See the [runnable example](../../examples/openshell-governed/) for a complete demo.
 
-### Option B: Governance Sidecar (Production)
+### Option B: Governance Sidecar (Planned)
+
+> **Status:** The sidecar deployment pattern is documented as a reference architecture.
+> The governance HTTP API is not yet packaged as a standalone server.
+> See the [OpenClaw sidecar deployment guide](../deployment/openclaw-sidecar.md) for progress and known limitations.
 
 Run the governance API server as a sidecar container. Your agent (or orchestration layer) calls the sidecar's HTTP API before executing actions:
 
@@ -104,19 +108,7 @@ network:
     - action: deny           # Block everything else
 ```
 
-```bash
-# Start the governance sidecar (Agent OS server)
-python -m agent_os.server --host 127.0.0.1 --port 8081 &
-
-# Create the sandbox with the policy
-openshell sandbox create \
-  --policy openshell-governance-policy.yaml \
-  -- claude
-```
-
-> **Note:** The sidecar does not yet transparently intercept tool calls — your agent must call `http://localhost:8081/api/v1/detect/injection` or `/api/v1/execute` explicitly. See the [sidecar API docs](../deployment/openclaw-sidecar.md#sidecar-api-endpoints).
-
-See the full [OpenClaw sidecar deployment guide](../deployment/openclaw-sidecar.md) for Docker Compose and AKS configurations.
+> **Note:** The sidecar does not yet transparently intercept tool calls. See the [sidecar deployment guide](../deployment/openclaw-sidecar.md) for the current state of this integration.
 
 ---
 
@@ -172,11 +164,13 @@ Result: Action blocked before reaching OpenShell
 
 When running both layers, you get two complementary telemetry streams:
 
-**Governance Toolkit metrics** (Prometheus / OpenTelemetry):
+**Governance Toolkit metrics** (planned, reference schema):
 - `policy_decisions_total{result="allow|deny"}`
 - `trust_score_current{agent="did:mesh:..."}`
 - `audit_chain_entries_total`
 - `authority_resolutions_total{decision="allow|deny|narrowed"}`
+
+> These metric names are a reference design. The OpenShell governance skill currently provides in-memory audit logs via `get_audit_log()`. Prometheus/OpenTelemetry export is planned.
 
 **OpenShell metrics**:
 - Sandbox network egress logs

--- a/examples/openshell-governed/README.md
+++ b/examples/openshell-governed/README.md
@@ -8,7 +8,7 @@ Demonstrates AGT policy enforcement, trust scoring, and audit inside an OpenShel
 - No API keys required
 
 ```bash
-pip install agent-governance-toolkit[full]
+pip install openshell-agentmesh
 ```
 
 ## How to Run


### PR DESCRIPTION
## Summary

Fixes overclaims and inaccurate references in OpenShell integration documentation.
Part of the OpenShell cleanup effort for NVIDIA contribution readiness.

## Problem

The integration doc at docs/integrations/openshell.md contained several inaccuracies:

- **Option B (Sidecar)** described CLI commands for gent_os.server which does not exist
- Monitoring section listed Prometheus/OTel metrics as shipped when they are not yet implemented
- Example README pointed users to pip install agent-governance-toolkit[full] instead of the actual package name

## Changes

| File | What changed |
|------|-------------|
| docs/integrations/openshell.md | Marked sidecar deployment as planned reference architecture, removed non-existent CLI commands, added status callout for metrics |
| xamples/openshell-governed/README.md | Fixed install command to pip install openshell-agentmesh |

## Testing

Documentation-only change. Verified all relative links resolve correctly.
