### PR TITLE
fix: update security_scan.py bootstrap path for repo layout flattening

### DIFF
--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -33,9 +33,26 @@ from pathlib import Path
 
 # Allow running from repo root without installing
 REPO_ROOT = Path(__file__).resolve().parent.parent
-AGENT_OS_SRC = REPO_ROOT / "packages" / "agent-os" / "src"
-if AGENT_OS_SRC.exists():
-    sys.path.insert(0, str(AGENT_OS_SRC))
+
+# Resolve agent_os source root — try the post-flattening path first,
+# fall back to the legacy path for older checkouts.
+_CANDIDATE_PATHS = [
+    REPO_ROOT / "agent-governance-python" / "agent-os" / "src",
+    REPO_ROOT / "packages" / "agent-os" / "src",
+]
+AGENT_OS_SRC = None
+for _candidate in _CANDIDATE_PATHS:
+    if _candidate.exists():
+        AGENT_OS_SRC = _candidate
+        break
+
+if AGENT_OS_SRC is None:
+    sys.exit(
+        "ERROR: Cannot locate agent_os source tree. "
+        "Tried:\n  " + "\n  ".join(str(p) for p in _CANDIDATE_PATHS)
+    )
+
+sys.path.insert(0, str(AGENT_OS_SRC))
 
 from agent_os.security_skills import (
     SecurityFinding,

--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -155,8 +155,8 @@ def main() -> int:
             else:
                 print(f"Warning: {path_str} not found", file=sys.stderr)
     else:
-        # Default: scan all packages
-        pkg_dir = REPO_ROOT / "packages"
+        # Default: scan all packages under the canonical Python package home
+        pkg_dir = REPO_ROOT / "agent-governance-python"
         if pkg_dir.exists():
             all_findings.extend(
                 scan_directory(pkg_dir, exclude_tests=args.exclude_tests)


### PR DESCRIPTION
## Summary

Fix `scripts/security_scan.py` bootstrap path resolution after the repository layout was flattened. The scanner now correctly locates the `agent_os` source tree in its new location.

## Problem

After the monorepo reorganization from `packages/agent-os/src` to `agent-governance-python/agent-os/src`, running the security scanner from a clean checkout produced:

```
ModuleNotFoundError: No module named agent_os
```

This broke:
- The documented standalone scanner workflow
- The weekly security audit CI pipeline (`.github/workflows/weekly-security-audit.yml`)
- The security hardening tutorial instructions (`docs/tutorials/25-security-hardening.md`)

## Root Cause

`scripts/security_scan.py` line 36 hard-coded the old path:
```python
AGENT_OS_SRC = REPO_ROOT / "packages" / "agent-os" / "src"
```

The `packages/` directory no longer exists in the current repository layout.

## Fix

Updated the bootstrap logic to:
1. Try the post-flattening path first: `agent-governance-python/agent-os/src`
2. Fall back to the legacy path: `packages/agent-os/src` (for older checkouts)
3. Exit with a clear error message if neither path is found

## Verification

```bash
# New path resolves correctly
$ python -c "from pathlib import Path; print((Path(agent-governance-python) / agent-os / src).exists())"
True

# Script compiles without import errors
$ python -c "compile(open(scripts/security_scan.py).read(), scripts/security_scan.py, exec)"
# No errors
```

Closes #2270