### PR TITLE
fix(policies): prevent same-name child rules from bypassing parent deny without override

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/merge.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/merge.py
@@ -73,10 +73,20 @@ def merge_policies(policy_chain: list[PolicyDocument]) -> list[PolicyRule]:
                         rule.name,
                         level,
                     )
+            elif existing is not None:
+                # Same-name rule without override=True — drop it.
+                # The parent version stays; appending a duplicate would let
+                # the child's priority defeat the parent at evaluation time.
+                logger.debug(
+                    "Rule '%s' at level %d duplicates parent rule without "
+                    "override=True — dropped",
+                    rule.name,
+                    level,
+                )
             else:
+                # New rule name — append normally
                 merged.append(rule)
-                if rule.name not in rules_by_name:
-                    rules_by_name[rule.name] = (rule, level)
+                rules_by_name[rule.name] = (rule, level)
 
     merged.sort(key=lambda r: r.priority, reverse=True)
     return merged

--- a/agent-governance-python/agent-os/tests/test_folder_governance.py
+++ b/agent-governance-python/agent-os/tests/test_folder_governance.py
@@ -256,6 +256,35 @@ class TestMergePolicies:
         assert result[0].action == PolicyAction.DENY
         assert all(r.action != PolicyAction.ALLOW for r in result)
 
+    def test_same_name_without_override_does_not_accumulate(self):
+        """Regression for #2276: same-name child rule without override=True
+        should NOT be appended — otherwise its higher priority defeats the
+        parent deny at evaluation time."""
+        root = PolicyDocument(name="root", rules=[
+            PolicyRule(name="block-exec", condition=PolicyCondition(field="tool", operator=PolicyOperator.EQ, value="shell"), action=PolicyAction.DENY, priority=100),
+        ])
+        child = PolicyDocument(name="child", rules=[
+            PolicyRule(name="block-exec", condition=PolicyCondition(field="tool", operator=PolicyOperator.EQ, value="shell"), action=PolicyAction.ALLOW, priority=9999, override=False),
+        ])
+        result = merge_policies([root, child])
+        # Child is dropped — only the parent deny remains.
+        assert len(result) == 1
+        assert result[0].action == PolicyAction.DENY
+        assert result[0].name == "block-exec"
+
+    def test_same_name_without_override_non_deny_parent_keeps_parent(self):
+        """When parent is non-deny, same-name child without override still
+        keeps only the parent version (no accumulation)."""
+        root = PolicyDocument(name="root", rules=[
+            PolicyRule(name="audit-rule", condition=PolicyCondition(field="x", operator=PolicyOperator.EQ, value=1), action=PolicyAction.AUDIT, priority=50),
+        ])
+        child = PolicyDocument(name="child", rules=[
+            PolicyRule(name="audit-rule", condition=PolicyCondition(field="x", operator=PolicyOperator.EQ, value=1), action=PolicyAction.ALLOW, priority=200, override=False),
+        ])
+        result = merge_policies([root, child])
+        assert len(result) == 1
+        assert result[0].action == PolicyAction.AUDIT
+
     def test_empty_chain(self):
         assert merge_policies([]) == []
 


### PR DESCRIPTION
## Summary

Fixes #2276 — security bug where \merge_policies()\ accumulates same-name child rules without \override=True\, allowing priority-based bypass of parent deny rules.

## Problem

When a child rule shares a name with a parent deny rule but does not set \override=True\, it was unconditionally appended to the merged list. After priority-descending sort, the higher-priority child ALLOW evaluates first and wins, defeating the parent DENY.

## Fix

Split the \lse\ branch into two cases:
- **New rule name:** append normally
- **Existing name, no override:** drop the child (parent version stays)

This preserves the security invariant: parent deny rules cannot be bypassed regardless of child priority or override flag.

## Tests

Added 2 regression tests:
- \	est_same_name_without_override_does_not_accumulate\ — deny parent, high-priority child without override
- \	est_same_name_without_override_non_deny_parent_keeps_parent\ — non-deny parent, same-name child without override

All 8 \TestMergePolicies\ tests pass.