### PR TITLE
fix(scripts): update security_scan.py bootstrap path for repo layout flattening

### DIFF
--- a/scripts/security_scan.py
+++ b/scripts/security_scan.py
@@ -33,7 +33,7 @@ from pathlib import Path
 
 # Allow running from repo root without installing
 REPO_ROOT = Path(__file__).resolve().parent.parent
-AGENT_OS_SRC = REPO_ROOT / "packages" / "agent-os" / "src"
+AGENT_OS_SRC = REPO_ROOT / "agent-governance-python" / "agent-os" / "src"
 if AGENT_OS_SRC.exists():
     sys.path.insert(0, str(AGENT_OS_SRC))
 
@@ -139,7 +139,7 @@ def main() -> int:
                 print(f"Warning: {path_str} not found", file=sys.stderr)
     else:
         # Default: scan all packages
-        pkg_dir = REPO_ROOT / "packages"
+        pkg_dir = REPO_ROOT / "agent-governance-python"
         if pkg_dir.exists():
             all_findings.extend(
                 scan_directory(pkg_dir, exclude_tests=args.exclude_tests)


### PR DESCRIPTION
## Summary

Fixes #2270 — \scripts/security_scan.py\ fails with \ModuleNotFoundError: No module named 'agent_os'\ because it bootstraps from the old \packages/agent-os/src\ path.

## Changes

- \AGENT_OS_SRC\: \packages/agent-os/src\ → \gent-governance-python/agent-os/src\
- Default scan directory: \packages\ → \gent-governance-python\

Verified import resolves correctly after the change.