### PR TITLE
feat: formalize ExternalPolicyBackend interface for pluggable policy evaluators

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
@@ -50,8 +50,9 @@ from .audit_backends import (
     HashChainVerifier,
 )
 from .shadow import ShadowMode, ShadowResult
-from .opa import OPAEvaluator, OPADecision, load_rego_into_engine
-from .cedar import CedarEvaluator, CedarDecision, load_cedar_into_engine
+from .backend import ExternalPolicyBackend, PolicyDecisionResult, BackendRegistry
+from .opa import OPAEvaluator, OPADecision, OPAPolicyBackend, load_rego_into_engine
+from .cedar import CedarEvaluator, CedarDecision, CedarPolicyBackend, load_cedar_into_engine
 from .authority import (
     AuthorityDecision,
     AuthorityRequest,
@@ -155,10 +156,16 @@ __all__ = [
     "ShadowResult",
     "OPAEvaluator",
     "OPADecision",
+    "OPAPolicyBackend",
     "load_rego_into_engine",
     "CedarEvaluator",
     "CedarDecision",
+    "CedarPolicyBackend",
     "load_cedar_into_engine",
+    # External policy backend protocol (issue #2280)
+    "ExternalPolicyBackend",
+    "PolicyDecisionResult",
+    "BackendRegistry",
     "AuthorityDecision",
     "AuthorityRequest",
     "AuthorityResolver",

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/backend.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/backend.py
@@ -1,0 +1,152 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+External Policy Backend Protocol
+
+Defines a unified interface for pluggable policy evaluators (OPA, Cedar, or
+any custom backend). Backends register themselves with BackendRegistry for
+discovery by name.
+
+Usage:
+    from agentmesh.governance.backend import (
+        ExternalPolicyBackend,
+        PolicyDecisionResult,
+        BackendRegistry,
+    )
+
+    # Register a backend
+    BackendRegistry.register(my_opa_evaluator)
+
+    # Retrieve by name
+    backend = BackendRegistry.get("opa")
+    decision = backend.evaluate("export", {"agent": {"role": "analyst"}})
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PolicyDecisionResult:
+    """Unified result from any external policy backend.
+
+    Attributes:
+        allowed: Whether the policy permits the action.
+        reason: Human-readable explanation of the decision.
+        backend: Name of the backend that produced this decision.
+        latency_ms: Evaluation latency in milliseconds.
+        raw_response: Backend-specific response data for debugging.
+    """
+
+    allowed: bool
+    reason: str = ""
+    backend: str = ""
+    latency_ms: float = 0.0
+    raw_response: Any = field(default=None, repr=False)
+
+
+@runtime_checkable
+class ExternalPolicyBackend(Protocol):
+    """Protocol for pluggable policy evaluators.
+
+    Any class implementing these three members can be registered with
+    BackendRegistry and used interchangeably by the governance layer.
+    """
+
+    @property
+    def name(self) -> str:
+        """Unique identifier for this backend (e.g., 'opa', 'cedar')."""
+        ...
+
+    def evaluate(self, action: str, context: dict[str, Any]) -> PolicyDecisionResult:
+        """Evaluate a policy decision.
+
+        Args:
+            action: The action being requested (e.g., 'read', 'export', 'delete').
+            context: Runtime context for evaluation. Typical keys include
+                'agent', 'resource', 'environment', 'trust_score'.
+
+        Returns:
+            PolicyDecisionResult with the evaluation outcome.
+        """
+        ...
+
+    def healthy(self) -> bool:
+        """Check whether this backend is available and operational.
+
+        Returns:
+            True if the backend can accept evaluate() calls.
+        """
+        ...
+
+
+class BackendRegistry:
+    """Registry for discovering and retrieving policy backends by name.
+
+    Backends are stored globally. Use register() to add backends and get()
+    to retrieve them.
+    """
+
+    _backends: dict[str, ExternalPolicyBackend] = {}
+
+    @classmethod
+    def register(cls, backend: ExternalPolicyBackend) -> None:
+        """Register a policy backend.
+
+        Args:
+            backend: An object implementing ExternalPolicyBackend.
+
+        Raises:
+            TypeError: If the backend does not satisfy the protocol.
+        """
+        if not isinstance(backend, ExternalPolicyBackend):
+            raise TypeError(
+                f"{type(backend).__name__} does not implement ExternalPolicyBackend"
+            )
+        cls._backends[backend.name] = backend
+        logger.info("Registered policy backend: %s", backend.name)
+
+    @classmethod
+    def unregister(cls, name: str) -> None:
+        """Remove a backend from the registry.
+
+        Args:
+            name: Backend identifier to remove.
+        """
+        cls._backends.pop(name, None)
+
+    @classmethod
+    def get(cls, name: str) -> ExternalPolicyBackend:
+        """Retrieve a registered backend by name.
+
+        Args:
+            name: Backend identifier.
+
+        Returns:
+            The registered backend.
+
+        Raises:
+            KeyError: If no backend with that name is registered.
+        """
+        if name not in cls._backends:
+            available = list(cls._backends.keys()) or ["(none)"]
+            raise KeyError(
+                f"No backend registered with name '{name}'. "
+                f"Available: {', '.join(available)}"
+            )
+        return cls._backends[name]
+
+    @classmethod
+    def list_backends(cls) -> list[str]:
+        """Return names of all registered backends."""
+        return list(cls._backends.keys())
+
+    @classmethod
+    def clear(cls) -> None:
+        """Remove all registered backends. Primarily for testing."""
+        cls._backends.clear()

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py
@@ -351,6 +351,55 @@ def _parse_cedar_statements(content: str) -> list[dict[str, Any]]:
     return statements
 
 
+class CedarPolicyBackend:
+    """Adapter wrapping CedarEvaluator to satisfy ExternalPolicyBackend protocol.
+
+    Usage:
+        from agentmesh.governance.cedar import CedarPolicyBackend
+        from agentmesh.governance.backend import BackendRegistry
+
+        backend = CedarPolicyBackend(policy_content=MY_CEDAR_POLICY)
+        BackendRegistry.register(backend)
+    """
+
+    def __init__(
+        self,
+        evaluator: Optional["CedarEvaluator"] = None,
+        **kwargs: Any,
+    ):
+        """Initialize the Cedar policy backend.
+
+        Args:
+            evaluator: An existing CedarEvaluator instance. If not provided,
+                one is created from the remaining keyword arguments.
+            **kwargs: Passed to CedarEvaluator constructor if evaluator is None.
+        """
+        self._evaluator = evaluator or CedarEvaluator(**kwargs)
+
+    @property
+    def name(self) -> str:
+        return "cedar"
+
+    def evaluate(self, action: str, context: dict) -> "PolicyDecisionResult":
+        from agentmesh.governance.backend import PolicyDecisionResult
+
+        decision = self._evaluator.evaluate(action, context)
+        return PolicyDecisionResult(
+            allowed=decision.allowed,
+            reason=decision.error or ("allowed" if decision.allowed else "denied by policy"),
+            backend="cedar",
+            latency_ms=decision.evaluation_ms,
+            raw_response=decision.raw_result,
+        )
+
+    def healthy(self) -> bool:
+        return (
+            self._evaluator._cedarpy_available
+            or self._evaluator._cli_available
+            or self._evaluator.policy_content is not None
+        )
+
+
 def load_cedar_into_engine(
     engine: Any,
     cedar_path: str,

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py
@@ -369,6 +369,65 @@ class OPAEvaluator:
 # ── Integration with PolicyEngine ─────────────────────────────────
 
 
+class OPAPolicyBackend:
+    """Adapter wrapping OPAEvaluator to satisfy ExternalPolicyBackend protocol.
+
+    Usage:
+        from agentmesh.governance.opa import OPAPolicyBackend
+        from agentmesh.governance.backend import BackendRegistry
+
+        backend = OPAPolicyBackend(rego_content=MY_REGO)
+        BackendRegistry.register(backend)
+    """
+
+    def __init__(
+        self,
+        evaluator: Optional["OPAEvaluator"] = None,
+        query_prefix: str = "data.agentmesh.allow",
+        **kwargs: Any,
+    ):
+        """Initialize the OPA policy backend.
+
+        Args:
+            evaluator: An existing OPAEvaluator instance. If not provided,
+                one is created from the remaining keyword arguments.
+            query_prefix: Default Rego query path used when evaluate() is called.
+            **kwargs: Passed to OPAEvaluator constructor if evaluator is None.
+        """
+        self._evaluator = evaluator or OPAEvaluator(**kwargs)
+        self._query_prefix = query_prefix
+
+    @property
+    def name(self) -> str:
+        return "opa"
+
+    def evaluate(self, action: str, context: dict) -> "PolicyDecisionResult":
+        from agentmesh.governance.backend import PolicyDecisionResult
+
+        decision = self._evaluator.evaluate(self._query_prefix, context)
+        return PolicyDecisionResult(
+            allowed=decision.allowed,
+            reason=decision.error or ("allowed" if decision.allowed else "denied by policy"),
+            backend="opa",
+            latency_ms=decision.evaluation_ms,
+            raw_response=decision.raw_result,
+        )
+
+    def healthy(self) -> bool:
+        if self._evaluator.mode == "remote":
+            try:
+                import urllib.request
+                req = urllib.request.Request(
+                    f"{self._evaluator.opa_url}/health",
+                    method="GET",
+                )
+                with urllib.request.urlopen(req, timeout=2) as resp:  # noqa: S310
+                    return resp.status == 200
+            except Exception:
+                return False
+        return self._evaluator._opa_available or self._evaluator.rego_content is not None
+
+
 def load_rego_into_engine(engine: Any, rego_path: str, package: str = "agentmesh") -> OPAEvaluator:
     """
     Register a .rego file with the existing PolicyEngine.

--- a/agent-governance-python/agent-mesh/tests/test_backend.py
+++ b/agent-governance-python/agent-mesh/tests/test_backend.py
@@ -1,0 +1,298 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for ExternalPolicyBackend protocol, BackendRegistry, and adapters."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentmesh.governance.backend import (
+    BackendRegistry,
+    ExternalPolicyBackend,
+    PolicyDecisionResult,
+)
+from agentmesh.governance.opa import OPAEvaluator, OPAPolicyBackend
+from agentmesh.governance.cedar import CedarEvaluator, CedarPolicyBackend
+
+
+# ── Sample policies ───────────────────────────────────────────
+
+BASIC_REGO = """
+package agentmesh
+
+default allow = false
+
+allow {
+    input.agent.role == "admin"
+}
+"""
+
+BASIC_CEDAR = """
+permit(
+    principal,
+    action == Action::"ReadData",
+    resource
+);
+
+forbid(
+    principal,
+    action == Action::"DeleteFile",
+    resource
+);
+"""
+
+
+# ── PolicyDecisionResult ──────────────────────────────────────
+
+
+class TestPolicyDecisionResult:
+    """Tests for the unified decision dataclass."""
+
+    def test_defaults(self):
+        result = PolicyDecisionResult(allowed=True)
+        assert result.allowed is True
+        assert result.reason == ""
+        assert result.backend == ""
+        assert result.latency_ms == 0.0
+        assert result.raw_response is None
+
+    def test_full_construction(self):
+        result = PolicyDecisionResult(
+            allowed=False,
+            reason="denied by rule X",
+            backend="opa",
+            latency_ms=1.5,
+            raw_response={"some": "data"},
+        )
+        assert result.allowed is False
+        assert result.reason == "denied by rule X"
+        assert result.backend == "opa"
+        assert result.latency_ms == 1.5
+        assert result.raw_response == {"some": "data"}
+
+
+# ── Protocol conformance ──────────────────────────────────────
+
+
+class TestProtocolConformance:
+    """Verify that adapters satisfy the ExternalPolicyBackend protocol."""
+
+    def test_opa_backend_is_protocol_instance(self):
+        backend = OPAPolicyBackend(rego_content=BASIC_REGO)
+        assert isinstance(backend, ExternalPolicyBackend)
+
+    def test_cedar_backend_is_protocol_instance(self):
+        backend = CedarPolicyBackend(policy_content=BASIC_CEDAR)
+        assert isinstance(backend, ExternalPolicyBackend)
+
+    def test_custom_backend_satisfies_protocol(self):
+        """A plain class with the right methods satisfies the protocol."""
+
+        class MyBackend:
+            @property
+            def name(self) -> str:
+                return "custom"
+
+            def evaluate(self, action: str, context: dict) -> PolicyDecisionResult:
+                return PolicyDecisionResult(allowed=True, backend="custom")
+
+            def healthy(self) -> bool:
+                return True
+
+        backend = MyBackend()
+        assert isinstance(backend, ExternalPolicyBackend)
+
+    def test_incomplete_class_fails_protocol(self):
+        """A class missing methods does not satisfy the protocol."""
+
+        class Incomplete:
+            @property
+            def name(self) -> str:
+                return "bad"
+
+        assert not isinstance(Incomplete(), ExternalPolicyBackend)
+
+
+# ── OPAPolicyBackend ──────────────────────────────────────────
+
+
+class TestOPAPolicyBackend:
+    """Tests for the OPA adapter."""
+
+    def test_name(self):
+        backend = OPAPolicyBackend(rego_content=BASIC_REGO)
+        assert backend.name == "opa"
+
+    def test_evaluate_allowed(self):
+        backend = OPAPolicyBackend(rego_content=BASIC_REGO)
+        result = backend.evaluate("allow", {"agent": {"role": "admin"}})
+        assert isinstance(result, PolicyDecisionResult)
+        assert result.allowed is True
+        assert result.backend == "opa"
+        assert result.latency_ms >= 0
+
+    def test_evaluate_denied(self):
+        backend = OPAPolicyBackend(rego_content=BASIC_REGO)
+        result = backend.evaluate("allow", {"agent": {"role": "guest"}})
+        assert result.allowed is False
+        assert result.backend == "opa"
+
+    def test_healthy_with_content(self):
+        backend = OPAPolicyBackend(rego_content=BASIC_REGO)
+        assert backend.healthy() is True
+
+    def test_healthy_without_anything(self):
+        backend = OPAPolicyBackend(mode="local")
+        # Healthy if opa CLI is available or content exists
+        # Without either, still local mode with no content
+        result = backend.healthy()
+        assert isinstance(result, bool)
+
+    def test_wraps_existing_evaluator(self):
+        evaluator = OPAEvaluator(mode="local", rego_content=BASIC_REGO)
+        backend = OPAPolicyBackend(evaluator=evaluator)
+        result = backend.evaluate("allow", {"agent": {"role": "admin"}})
+        assert result.allowed is True
+
+    def test_custom_query_prefix(self):
+        rego = """
+package custom
+
+default allow = false
+
+allow {
+    input.action == "read"
+}
+"""
+        backend = OPAPolicyBackend(
+            rego_content=rego,
+            query_prefix="data.custom.allow",
+        )
+        result = backend.evaluate("read", {"action": "read"})
+        assert result.allowed is True
+
+
+# ── CedarPolicyBackend ────────────────────────────────────────
+
+
+class TestCedarPolicyBackend:
+    """Tests for the Cedar adapter."""
+
+    def test_name(self):
+        backend = CedarPolicyBackend(policy_content=BASIC_CEDAR)
+        assert backend.name == "cedar"
+
+    def test_evaluate_allowed(self):
+        backend = CedarPolicyBackend(policy_content=BASIC_CEDAR)
+        result = backend.evaluate('Action::"ReadData"', {"agent_did": "did:example:1"})
+        assert isinstance(result, PolicyDecisionResult)
+        assert result.allowed is True
+        assert result.backend == "cedar"
+        assert result.latency_ms >= 0
+
+    def test_evaluate_denied(self):
+        backend = CedarPolicyBackend(policy_content=BASIC_CEDAR)
+        result = backend.evaluate('Action::"DeleteFile"', {"agent_did": "did:example:1"})
+        assert result.allowed is False
+        assert result.backend == "cedar"
+
+    def test_healthy_with_content(self):
+        backend = CedarPolicyBackend(policy_content=BASIC_CEDAR)
+        assert backend.healthy() is True
+
+    def test_wraps_existing_evaluator(self):
+        evaluator = CedarEvaluator(policy_content=BASIC_CEDAR)
+        backend = CedarPolicyBackend(evaluator=evaluator)
+        result = backend.evaluate('Action::"ReadData"', {"agent_did": "did:example:1"})
+        assert result.allowed is True
+
+
+# ── BackendRegistry ───────────────────────────────────────────
+
+
+class TestBackendRegistry:
+    """Tests for backend discovery and registration."""
+
+    def setup_method(self):
+        BackendRegistry.clear()
+
+    def teardown_method(self):
+        BackendRegistry.clear()
+
+    def test_register_and_get(self):
+        backend = OPAPolicyBackend(rego_content=BASIC_REGO)
+        BackendRegistry.register(backend)
+        retrieved = BackendRegistry.get("opa")
+        assert retrieved is backend
+
+    def test_register_cedar(self):
+        backend = CedarPolicyBackend(policy_content=BASIC_CEDAR)
+        BackendRegistry.register(backend)
+        retrieved = BackendRegistry.get("cedar")
+        assert retrieved is backend
+
+    def test_get_missing_raises(self):
+        with pytest.raises(KeyError, match="No backend registered"):
+            BackendRegistry.get("nonexistent")
+
+    def test_list_backends(self):
+        BackendRegistry.register(OPAPolicyBackend(rego_content=BASIC_REGO))
+        BackendRegistry.register(CedarPolicyBackend(policy_content=BASIC_CEDAR))
+        names = BackendRegistry.list_backends()
+        assert "opa" in names
+        assert "cedar" in names
+
+    def test_unregister(self):
+        BackendRegistry.register(OPAPolicyBackend(rego_content=BASIC_REGO))
+        BackendRegistry.unregister("opa")
+        with pytest.raises(KeyError):
+            BackendRegistry.get("opa")
+
+    def test_register_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="does not implement"):
+            BackendRegistry.register("not a backend")  # type: ignore
+
+    def test_register_replaces_existing(self):
+        backend1 = OPAPolicyBackend(rego_content=BASIC_REGO)
+        backend2 = OPAPolicyBackend(rego_content=BASIC_REGO, query_prefix="data.other.allow")
+        BackendRegistry.register(backend1)
+        BackendRegistry.register(backend2)
+        assert BackendRegistry.get("opa") is backend2
+
+    def test_clear(self):
+        BackendRegistry.register(OPAPolicyBackend(rego_content=BASIC_REGO))
+        BackendRegistry.clear()
+        assert BackendRegistry.list_backends() == []
+
+
+# ── Integration: end-to-end via registry ──────────────────────
+
+
+class TestEndToEnd:
+    """Integration test: register, discover, evaluate."""
+
+    def setup_method(self):
+        BackendRegistry.clear()
+
+    def teardown_method(self):
+        BackendRegistry.clear()
+
+    def test_evaluate_through_registry(self):
+        BackendRegistry.register(OPAPolicyBackend(rego_content=BASIC_REGO))
+        BackendRegistry.register(CedarPolicyBackend(policy_content=BASIC_CEDAR))
+
+        opa = BackendRegistry.get("opa")
+        result = opa.evaluate("allow", {"agent": {"role": "admin"}})
+        assert result.allowed is True
+
+        cedar = BackendRegistry.get("cedar")
+        result = cedar.evaluate('Action::"ReadData"', {"agent_did": "did:mesh:abc"})
+        assert result.allowed is True
+
+    def test_all_backends_report_healthy(self):
+        BackendRegistry.register(OPAPolicyBackend(rego_content=BASIC_REGO))
+        BackendRegistry.register(CedarPolicyBackend(policy_content=BASIC_CEDAR))
+
+        for name in BackendRegistry.list_backends():
+            backend = BackendRegistry.get(name)
+            assert backend.healthy() is True


### PR DESCRIPTION
## Summary

Formalizes a unified protocol for external policy backends, enabling any policy evaluator to be plugged in without modifying AGT core code. Previously, OPA and Cedar had completely different interfaces, return types, and method signatures, making it impossible to write backend-agnostic governance code.

## Problem

- OPAEvaluator.evaluate(query, input_data) returns OPADecision
- CedarEvaluator.evaluate(action, context) returns CedarDecision
- No shared interface, no common return type, no discovery mechanism
- Adding a new backend required reverse-engineering existing implementations

## Solution

### New module: agentmesh/governance/backend.py

| Component | Purpose |
|-----------|---------|
| ExternalPolicyBackend | typing.Protocol (runtime-checkable) with evaluate(action, context), name property, healthy() method |
| PolicyDecisionResult | Unified dataclass: allowed, reason, backend, latency_ms, raw_response |
| BackendRegistry | Global registry for discovering backends by name |

### Adapters (non-breaking)

| Adapter | Wraps | Notes |
|---------|-------|-------|
| OPAPolicyBackend | OPAEvaluator | Configurable query prefix, delegates to existing evaluator |
| CedarPolicyBackend | CedarEvaluator | Passes action/context directly to Cedar evaluate |

Existing OPAEvaluator and CedarEvaluator are unchanged. All existing callers continue to work.

## Testing

28 new tests in tests/test_backend.py covering protocol conformance, adapter behavior, registry operations, and end-to-end evaluation. All 47 existing OPA/Cedar tests continue to pass.

## Adding a custom backend

Implement exactly one protocol (name + evaluate + healthy). No other changes required.

Closes #2280
