### PR TITLE
feat: trust ceiling propagation for delegated child agents

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/reward/scoring.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/reward/scoring.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Optional
 from pydantic import BaseModel, Field, field_validator
 from enum import Enum
+import os
 
 from agentmesh.constants import (
     TIER_PROBATIONARY_THRESHOLD,
@@ -126,6 +127,14 @@ class TrustScore(BaseModel):
     previous_score: Optional[int] = None
     score_change: int = 0
 
+    # Trust ceiling for delegated agents (0-1000, None = no ceiling)
+    trust_ceiling: Optional[int] = Field(
+        default=None,
+        ge=0,
+        le=1000,
+        description="Maximum trust score this agent can reach. Set by parent at delegation time.",
+    )
+
     model_config = {"validate_assignment": True}
 
     @field_validator("agent_did")
@@ -141,6 +150,17 @@ class TrustScore(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
+        # Read ceiling from environment if not explicitly set
+        if self.trust_ceiling is None:
+            env_ceiling = os.environ.get("AGT_TRUST_CEILING")
+            if env_ceiling is not None:
+                try:
+                    self.trust_ceiling = max(0, min(TRUST_SCORE_MAX, int(env_ceiling)))
+                except ValueError:
+                    pass
+        # Clamp initial score to ceiling
+        if self.trust_ceiling is not None:
+            self.total_score = min(self.total_score, self.trust_ceiling)
         self._update_tier()
 
     def _update_tier(self) -> None:
@@ -157,9 +177,12 @@ class TrustScore(BaseModel):
             self.tier = "untrusted"
 
     def update(self, new_score: int, dimensions: dict[str, RewardDimension]) -> None:
-        """Update the trust score."""
+        """Update the trust score, respecting ceiling if set."""
         self.previous_score = self.total_score
-        self.total_score = max(0, min(TRUST_SCORE_MAX, new_score))
+        clamped = max(0, min(TRUST_SCORE_MAX, new_score))
+        if self.trust_ceiling is not None:
+            clamped = min(clamped, self.trust_ceiling)
+        self.total_score = clamped
         self.score_change = self.total_score - (self.previous_score or 0)
         self.dimensions = dimensions
         self.calculated_at = datetime.now(timezone.utc)

--- a/agent-governance-python/agent-mesh/tests/test_trust_ceiling.py
+++ b/agent-governance-python/agent-mesh/tests/test_trust_ceiling.py
@@ -1,0 +1,194 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for trust ceiling propagation in TrustScore and DelegationScope."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agentmesh.reward.scoring import TrustScore, RewardDimension
+
+
+# ── TrustScore ceiling ────────────────────────────────────────
+
+
+class TestTrustScoreCeiling:
+    """Tests for trust ceiling enforcement on TrustScore."""
+
+    def test_no_ceiling_by_default(self):
+        score = TrustScore(agent_did="did:mesh:abc")
+        assert score.trust_ceiling is None
+        assert score.total_score == 500  # default
+
+    def test_ceiling_clamps_initial_score(self):
+        score = TrustScore(agent_did="did:mesh:abc", trust_ceiling=300)
+        # Default score is 500, ceiling is 300 -> clamped to 300
+        assert score.total_score == 300
+
+    def test_ceiling_allows_lower_initial_score(self):
+        score = TrustScore(
+            agent_did="did:mesh:abc", total_score=200, trust_ceiling=300
+        )
+        assert score.total_score == 200
+
+    def test_update_respects_ceiling(self):
+        score = TrustScore(
+            agent_did="did:mesh:abc", total_score=200, trust_ceiling=700
+        )
+        score.update(900, {})
+        assert score.total_score == 700  # clamped to ceiling
+
+    def test_update_allows_below_ceiling(self):
+        score = TrustScore(
+            agent_did="did:mesh:abc", total_score=200, trust_ceiling=700
+        )
+        score.update(500, {})
+        assert score.total_score == 500
+
+    def test_update_without_ceiling_uses_max(self):
+        score = TrustScore(agent_did="did:mesh:abc", total_score=200)
+        score.update(999, {})
+        assert score.total_score == 999
+
+    def test_ceiling_from_env_var(self):
+        with patch.dict(os.environ, {"AGT_TRUST_CEILING": "600"}, clear=False):
+            score = TrustScore(agent_did="did:mesh:abc")
+            assert score.trust_ceiling == 600
+            assert score.total_score == 500  # default, below ceiling
+
+    def test_ceiling_from_env_clamps_default_score(self):
+        with patch.dict(os.environ, {"AGT_TRUST_CEILING": "200"}, clear=False):
+            score = TrustScore(agent_did="did:mesh:abc")
+            assert score.trust_ceiling == 200
+            assert score.total_score == 200  # clamped from 500
+
+    def test_explicit_ceiling_overrides_env(self):
+        with patch.dict(os.environ, {"AGT_TRUST_CEILING": "600"}, clear=False):
+            score = TrustScore(
+                agent_did="did:mesh:abc", trust_ceiling=300
+            )
+            assert score.trust_ceiling == 300
+
+    def test_invalid_env_ceiling_ignored(self):
+        with patch.dict(os.environ, {"AGT_TRUST_CEILING": "not_a_number"}, clear=False):
+            score = TrustScore(agent_did="did:mesh:abc")
+            assert score.trust_ceiling is None
+
+    def test_env_ceiling_clamped_to_valid_range(self):
+        with patch.dict(os.environ, {"AGT_TRUST_CEILING": "5000"}, clear=False):
+            score = TrustScore(agent_did="did:mesh:abc")
+            assert score.trust_ceiling == 1000
+
+    def test_negative_env_ceiling_clamped_to_zero(self):
+        with patch.dict(os.environ, {"AGT_TRUST_CEILING": "-100"}, clear=False):
+            score = TrustScore(agent_did="did:mesh:abc")
+            assert score.trust_ceiling == 0
+
+    def test_tier_reflects_clamped_score(self):
+        score = TrustScore(
+            agent_did="did:mesh:abc", total_score=900, trust_ceiling=400
+        )
+        # Score clamped to 400, which is in "probationary" tier (300-499)
+        assert score.total_score == 400
+        assert score.tier == "probationary"
+
+    def test_ceiling_preserved_in_dict(self):
+        score = TrustScore(
+            agent_did="did:mesh:abc", total_score=200, trust_ceiling=700
+        )
+        d = score.to_dict()
+        assert "trust_ceiling" in TrustScore.model_fields
+
+
+# ── DelegationScope ceiling propagation ───────────────────────
+
+try:
+    from adk_agentmesh.governance import DelegationScope
+    _has_adk = True
+except ImportError:
+    _has_adk = False
+
+
+@pytest.mark.skipif(not _has_adk, reason="adk_agentmesh not installed")
+class TestDelegationScopeCeiling:
+    """Tests for trust ceiling propagation through DelegationScope.narrow()."""
+
+    def test_narrow_propagates_parent_ceiling(self):
+        parent = DelegationScope(trust_ceiling=700)
+        child = parent.narrow()
+        assert child.trust_ceiling == 700
+
+    def test_narrow_clamps_requested_ceiling_to_parent(self):
+        parent = DelegationScope(trust_ceiling=700)
+        child = parent.narrow(trust_ceiling=900)
+        assert child.trust_ceiling == 700  # can't exceed parent
+
+    def test_narrow_allows_lower_ceiling(self):
+        parent = DelegationScope(trust_ceiling=700)
+        child = parent.narrow(trust_ceiling=400)
+        assert child.trust_ceiling == 400
+
+    def test_narrow_without_parent_ceiling_passes_through(self):
+        parent = DelegationScope()
+        child = parent.narrow(trust_ceiling=500)
+        assert child.trust_ceiling == 500
+
+    def test_narrow_no_ceiling_stays_none(self):
+        parent = DelegationScope()
+        child = parent.narrow()
+        assert child.trust_ceiling is None
+
+    def test_narrow_chain_monotonically_narrows(self):
+        root = DelegationScope(trust_ceiling=800, max_depth=5)
+        level1 = root.narrow(trust_ceiling=600)
+        level2 = level1.narrow(trust_ceiling=700)  # clamped to 600
+        level3 = level2.narrow(trust_ceiling=300)
+
+        assert level1.trust_ceiling == 600
+        assert level2.trust_ceiling == 600  # can't exceed parent
+        assert level3.trust_ceiling == 300
+
+
+# ── Integration: TrustScore + DelegationScope ─────────────────
+
+
+@pytest.mark.skipif(not _has_adk, reason="adk_agentmesh not installed")
+class TestTrustCeilingIntegration:
+    """End-to-end: parent trust flows through delegation to child score."""
+
+    def test_parent_trust_becomes_child_ceiling(self):
+        parent_score = TrustScore(agent_did="did:mesh:parent", total_score=700)
+
+        scope = DelegationScope(trust_ceiling=parent_score.total_score)
+        child_scope = scope.narrow()
+
+        child_score = TrustScore(
+            agent_did="did:mesh:child",
+            trust_ceiling=child_scope.trust_ceiling,
+        )
+
+        # Child starts at default 500, below ceiling 700
+        assert child_score.total_score == 500
+        # Child cannot exceed parent's score at delegation time
+        child_score.update(900, {})
+        assert child_score.total_score == 700
+
+    def test_low_trust_parent_constrains_child(self):
+        parent_score = TrustScore(agent_did="did:mesh:parent", total_score=250)
+
+        scope = DelegationScope(trust_ceiling=parent_score.total_score)
+        child_scope = scope.narrow()
+
+        child_score = TrustScore(
+            agent_did="did:mesh:child",
+            trust_ceiling=child_scope.trust_ceiling,
+        )
+
+        # Default 500 clamped to ceiling 250
+        assert child_score.total_score == 250
+        # Even perfect behavior can't push past ceiling
+        child_score.update(1000, {})
+        assert child_score.total_score == 250

--- a/agent-governance-python/agentmesh-integrations/adk-agentmesh/src/adk_agentmesh/governance.py
+++ b/agent-governance-python/agentmesh-integrations/adk-agentmesh/src/adk_agentmesh/governance.py
@@ -18,9 +18,23 @@ class DelegationScope:
     max_tool_calls: int = 50
     max_depth: int = 3
     read_only: bool = False
+    trust_ceiling: Optional[int] = None
 
     def narrow(self, **overrides) -> "DelegationScope":
-        """Create a narrower scope for sub-delegation."""
+        """Create a narrower scope for sub-delegation.
+
+        If trust_ceiling is provided in overrides, it is clamped to not
+        exceed the parent's ceiling (monotonic narrowing).
+        """
+        # Compute child ceiling: take the minimum of parent and requested
+        requested_ceiling = overrides.get("trust_ceiling", self.trust_ceiling)
+        if self.trust_ceiling is not None and requested_ceiling is not None:
+            child_ceiling = min(requested_ceiling, self.trust_ceiling)
+        elif self.trust_ceiling is not None:
+            child_ceiling = self.trust_ceiling
+        else:
+            child_ceiling = requested_ceiling
+
         child = DelegationScope(
             allowed_tools=overrides.get("allowed_tools", self.allowed_tools[:]),
             max_tool_calls=min(
@@ -32,6 +46,7 @@ class DelegationScope:
                 self.max_depth - 1,
             ),
             read_only=self.read_only or overrides.get("read_only", False),
+            trust_ceiling=child_ceiling,
         )
         # Monotonic narrowing: child tools must be subset of parent
         if self.allowed_tools:


### PR DESCRIPTION
## Summary

Adds trust ceiling propagation to prevent privilege escalation through delegation. When a parent agent delegates to a child, the parents trust score becomes a hard ceiling on the child. Children can never exceed the parents trust at delegation time, regardless of their own behavior.

## Problem

A parent with trust 300 could spawn a child that starts at 500 (default) and potentially reaches 1000. This breaks the principle that delegated authority should not exceed the delegators own authority.

## Solution

### TrustScore (scoring.py)

| Change | Detail |
|--------|--------|
| New field | trust_ceiling: Optional[int] (0-1000) |
| Init clamp | Initial total_score clamped to min(score, ceiling) |
| Update clamp | update() respects ceiling as hard upper bound |
| Env var | AGT_TRUST_CEILING read at init when no explicit ceiling |

### DelegationScope (adk-agentmesh/governance.py)

| Change | Detail |
|--------|--------|
| New field | trust_ceiling: Optional[int] |
| narrow() | Propagates ceiling, takes min(parent, requested) |
| Chain | Multi-level delegation monotonically narrows ceiling |

## Testing

22 new tests in test_trust_ceiling.py:
- 14 TrustScore ceiling tests (clamp, env var, tier, update)
- 6 DelegationScope narrowing tests (skip if adk_agentmesh not installed)
- 2 integration tests (parent-to-child flow)

All 21 existing trust/reward tests continue to pass.

## Usage

`python
from agentmesh.reward import TrustScore

# Parent with score 700 delegates
parent = TrustScore(agent_did="did:mesh:parent", total_score=700)

# Child constrained by parent ceiling
child = TrustScore(
    agent_did="did:mesh:child",
    trust_ceiling=parent.total_score,
)  # starts at 500, ceiling 700

child.update(900, {})  # clamped to 700
`

Closes #2282