### PR TITLE
feat: implement execution ring enforcement beyond stubs

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/__init__.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/__init__.py
@@ -4,18 +4,34 @@
 
 from hypervisor.rings.breach_detector import BreachEvent, BreachSeverity, RingBreachDetector
 from hypervisor.rings.elevation import (
+    ChildRegistration,
     ElevationDenialReason,
+    ELEVATION_TRUST_THRESHOLDS,
     RingElevation,
     RingElevationError,
     RingElevationManager,
 )
+from hypervisor.rings.enforcer import (
+    ResourceConstraints,
+    ResourceType,
+    RING_CONSTRAINTS,
+    RingCheckResult,
+    RingEnforcer,
+)
 
 __all__ = [
-    "RingElevationManager",
+    "ChildRegistration",
+    "ElevationDenialReason",
+    "ELEVATION_TRUST_THRESHOLDS",
+    "ResourceConstraints",
+    "ResourceType",
+    "RING_CONSTRAINTS",
+    "RingBreachDetector",
+    "RingCheckResult",
     "RingElevation",
     "RingElevationError",
-    "ElevationDenialReason",
-    "RingBreachDetector",
+    "RingElevationManager",
+    "RingEnforcer",
     "BreachEvent",
     "BreachSeverity",
 ]

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/elevation.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/elevation.py
@@ -1,17 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Ring Elevation — privilege escalation stubs.
+Ring Elevation — time-bounded privilege escalation with policy enforcement.
 
-Public Preview: elevation is not supported. All requests are denied.
+Agents can request temporary elevation to a higher-privilege ring.
+Elevations are granted based on trust score thresholds, require attestation
+for sensitive rings, and automatically expire via tick().
 """
 
 from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from typing import Callable, Optional
 
 from hypervisor.models import ExecutionRing
 
@@ -44,6 +46,7 @@ class ElevationDenialReason:
     INSUFFICIENT_TRUST = "insufficient_trust"
     NO_SPONSORSHIP = "no_sponsorship"
     EXPIRED_TTL = "expired_ttl"
+    DUPLICATE = "duplicate_elevation"
 
 
 _RING_LABELS: dict[ExecutionRing, str] = {
@@ -55,10 +58,16 @@ _RING_LABELS: dict[ExecutionRing, str] = {
 
 _DOCS_URL = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/rings.md"
 
+# Trust score thresholds for elevation approval
+ELEVATION_TRUST_THRESHOLDS: dict[ExecutionRing, float] = {
+    ExecutionRing.RING_1_PRIVILEGED: 0.85,
+    ExecutionRing.RING_2_STANDARD: 0.50,
+}
+
 
 @dataclass
 class RingElevation:
-    """A ring elevation grant (stub in Public Preview)."""
+    """A time-bounded ring elevation grant."""
 
     elevation_id: str = field(default_factory=lambda: f"elev:{uuid.uuid4().hex[:8]}")
     agent_did: str = ""
@@ -73,21 +82,50 @@ class RingElevation:
 
     @property
     def is_expired(self) -> bool:
-        return True
+        return datetime.now(UTC) >= self.expires_at
 
     @property
     def remaining_seconds(self) -> float:
-        return 0.0
+        remaining = (self.expires_at - datetime.now(UTC)).total_seconds()
+        return max(0.0, remaining)
+
+
+@dataclass
+class ChildRegistration:
+    """Tracks a parent-child ring relationship."""
+
+    parent_did: str
+    child_did: str
+    parent_ring: ExecutionRing
+    child_ring: ExecutionRing
+    registered_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
 class RingElevationManager:
-    """Manages ring elevations (Public Preview: always denies)."""
+    """Manages time-bounded ring elevations with policy enforcement.
+
+    Elevation requests are evaluated against trust score thresholds.
+    Ring 1 requires attestation. Ring 0 is always forbidden via standard API.
+    Active elevations expire based on TTL and are cleaned up by tick().
+    """
 
     MAX_ELEVATION_TTL = 3600
     DEFAULT_TTL = 300
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        trust_provider: Optional[Callable[[str], float]] = None,
+    ) -> None:
+        """Initialize the elevation manager.
+
+        Args:
+            trust_provider: Callable that returns trust score (0.0-1.0)
+                for a given agent DID. If None, elevation requires explicit
+                trust_score parameter.
+        """
         self._elevations: dict[str, RingElevation] = {}
+        self._children: dict[str, ChildRegistration] = {}
+        self._trust_provider = trust_provider
 
     def request_elevation(
         self,
@@ -98,8 +136,29 @@ class RingElevationManager:
         ttl_seconds: int = 0,
         attestation: str | None = None,
         reason: str = "",
+        trust_score: Optional[float] = None,
     ) -> RingElevation:
-        """Request temporary ring elevation (Public Preview: always denied)."""
+        """Request temporary ring elevation.
+
+        Elevation is granted if the agent's trust score meets the threshold
+        for the target ring. Ring 1 additionally requires an attestation string.
+
+        Args:
+            agent_did: DID of the requesting agent.
+            session_id: Current session identifier.
+            current_ring: Agent's current execution ring.
+            target_ring: Requested elevated ring.
+            ttl_seconds: Duration in seconds (0 = DEFAULT_TTL, capped at MAX).
+            attestation: Required for Ring 1 elevation.
+            reason: Human-readable justification.
+            trust_score: Agent's trust score (0.0-1.0). If None, uses trust_provider.
+
+        Returns:
+            RingElevation grant if approved.
+
+        Raises:
+            RingElevationError: If elevation is denied.
+        """
         # Validate: target must be a higher privilege (lower numeric value)
         if target_ring.value >= current_ring.value:
             denial = ElevationDenialReason.INVALID_TARGET
@@ -132,40 +191,186 @@ class RingElevationManager:
                 agent_did=agent_did,
             )
 
-        # Public Preview: all valid requests are denied
-        denial = ElevationDenialReason.COMMUNITY_EDITION
-        raise RingElevationError(
-            _build_elevation_error_message(
+        # Check for duplicate active elevation
+        existing = self._find_active(agent_did, session_id)
+        if existing is not None:
+            denial = ElevationDenialReason.DUPLICATE
+            raise RingElevationError(
+                _build_elevation_error_message(
+                    current_ring=current_ring,
+                    target_ring=target_ring,
+                    reason=denial,
+                    agent_did=agent_did,
+                ),
                 current_ring=current_ring,
                 target_ring=target_ring,
                 reason=denial,
                 agent_did=agent_did,
-            ),
-            current_ring=current_ring,
-            target_ring=target_ring,
-            reason=denial,
+            )
+
+        # Resolve trust score
+        score = trust_score
+        if score is None and self._trust_provider:
+            score = self._trust_provider(agent_did)
+
+        if score is None:
+            denial = ElevationDenialReason.INSUFFICIENT_TRUST
+            raise RingElevationError(
+                _build_elevation_error_message(
+                    current_ring=current_ring,
+                    target_ring=target_ring,
+                    reason=denial,
+                    agent_did=agent_did,
+                ),
+                current_ring=current_ring,
+                target_ring=target_ring,
+                reason=denial,
+                agent_did=agent_did,
+            )
+
+        # Check trust threshold
+        threshold = ELEVATION_TRUST_THRESHOLDS.get(target_ring, 1.0)
+        if score < threshold:
+            denial = ElevationDenialReason.INSUFFICIENT_TRUST
+            raise RingElevationError(
+                _build_elevation_error_message(
+                    current_ring=current_ring,
+                    target_ring=target_ring,
+                    reason=denial,
+                    agent_did=agent_did,
+                ),
+                current_ring=current_ring,
+                target_ring=target_ring,
+                reason=denial,
+                agent_did=agent_did,
+            )
+
+        # Ring 1 requires attestation
+        if target_ring == ExecutionRing.RING_1_PRIVILEGED and not attestation:
+            denial = ElevationDenialReason.NO_SPONSORSHIP
+            raise RingElevationError(
+                _build_elevation_error_message(
+                    current_ring=current_ring,
+                    target_ring=target_ring,
+                    reason=denial,
+                    agent_did=agent_did,
+                ),
+                current_ring=current_ring,
+                target_ring=target_ring,
+                reason=denial,
+                agent_did=agent_did,
+            )
+
+        # Compute TTL
+        ttl = ttl_seconds if ttl_seconds > 0 else self.DEFAULT_TTL
+        ttl = min(ttl, self.MAX_ELEVATION_TTL)
+
+        # Grant elevation
+        now = datetime.now(UTC)
+        elevation = RingElevation(
             agent_did=agent_did,
+            session_id=session_id,
+            original_ring=current_ring,
+            elevated_ring=target_ring,
+            granted_at=now,
+            expires_at=now + timedelta(seconds=ttl),
+            attestation=attestation,
+            reason=reason,
+            is_active=True,
         )
+        self._elevations[elevation.elevation_id] = elevation
+        return elevation
 
     def get_active_elevation(self, agent_did: str, session_id: str) -> RingElevation | None:
+        """Get the active (non-expired) elevation for an agent in a session."""
+        elev = self._find_active(agent_did, session_id)
+        if elev and not elev.is_expired:
+            return elev
         return None
 
-    def get_effective_ring(self, agent_did: str, session_id: str, base_ring: ExecutionRing) -> ExecutionRing:
+    def get_effective_ring(
+        self, agent_did: str, session_id: str, base_ring: ExecutionRing
+    ) -> ExecutionRing:
+        """Get the effective ring considering active elevations."""
+        elev = self.get_active_elevation(agent_did, session_id)
+        if elev:
+            return elev.elevated_ring
         return base_ring
 
     def revoke_elevation(self, elevation_id: str) -> None:
-        raise RingElevationError(f"Elevation {elevation_id} not found")
+        """Revoke an active elevation by ID.
+
+        Raises:
+            RingElevationError: If elevation not found or already inactive.
+        """
+        elev = self._elevations.get(elevation_id)
+        if elev is None:
+            raise RingElevationError(
+                f"Elevation {elevation_id} not found",
+                reason="not_found",
+            )
+        elev.is_active = False
 
     def tick(self) -> list[RingElevation]:
-        return []
+        """Expire all elevations past their TTL.
 
-    def register_child(self, parent_did: str, child_did: str, parent_ring: ExecutionRing) -> ExecutionRing:
+        Returns:
+            List of elevations that were expired by this tick.
+        """
+        expired: list[RingElevation] = []
+        for elev in self._elevations.values():
+            if elev.is_active and elev.is_expired:
+                elev.is_active = False
+                expired.append(elev)
+        return expired
+
+    def register_child(
+        self, parent_did: str, child_did: str, parent_ring: ExecutionRing
+    ) -> ExecutionRing:
+        """Register a child agent with ring <= parent ring.
+
+        Child agents are assigned one ring level lower privilege than parent
+        (higher numeric value), capped at Ring 3.
+
+        Args:
+            parent_did: DID of the parent agent.
+            child_did: DID of the child agent.
+            parent_ring: Parent's current execution ring.
+
+        Returns:
+            The assigned ring for the child.
+        """
         child_ring_value = min(parent_ring.value + 1, ExecutionRing.RING_3_SANDBOX.value)
-        return ExecutionRing(child_ring_value)
+        child_ring = ExecutionRing(child_ring_value)
+
+        self._children[child_did] = ChildRegistration(
+            parent_did=parent_did,
+            child_did=child_did,
+            parent_ring=parent_ring,
+            child_ring=child_ring,
+        )
+        return child_ring
+
+    def get_child_registration(self, child_did: str) -> ChildRegistration | None:
+        """Get the registration for a child agent."""
+        return self._children.get(child_did)
 
     @property
     def active_elevations(self) -> list[RingElevation]:
-        return []
+        """All currently active (non-expired) elevations."""
+        return [e for e in self._elevations.values() if e.is_active and not e.is_expired]
+
+    def _find_active(self, agent_did: str, session_id: str) -> RingElevation | None:
+        """Find an active elevation for an agent/session pair."""
+        for elev in self._elevations.values():
+            if (
+                elev.agent_did == agent_did
+                and elev.session_id == session_id
+                and elev.is_active
+                and not elev.is_expired
+            ):
+                return elev
+        return None
 
 
 _REMEDIATION: dict[str, str] = {

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/enforcer.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/enforcer.py
@@ -1,19 +1,89 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Ring Enforcer — simple 2-tier access control.
+Ring Enforcer — resource-constrained ring-based access control.
 
-Public Preview: agents get RING_1 (trust > 0.7) or RING_2 (default).
-Ring 0 is reserved for kernel-only operations and always denied.
+Maps execution rings to concrete resource constraints (network, filesystem,
+subprocess) and enforces both ring-level access and resource-level restrictions.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 
 from hypervisor.constants import RING_1_ENFORCER_THRESHOLD
 from hypervisor.models import ActionDescriptor, ExecutionRing
+
+
+class ResourceType(str, Enum):
+    """Types of resources that rings constrain."""
+
+    NETWORK = "network"
+    FILESYSTEM = "filesystem"
+    SUBPROCESS = "subprocess"
+    TOOL_EXECUTION = "tool_execution"
+
+
+@dataclass
+class ResourceConstraints:
+    """Resource constraints for an execution ring.
+
+    Defines what an agent at a given ring level is allowed to do.
+    """
+
+    network_allowed: bool = False
+    network_allowlist: list[str] = field(default_factory=list)
+    filesystem_writable: bool = False
+    filesystem_scope: str = "none"  # none, session, scoped, full
+    subprocess_allowed: bool = False
+    max_concurrent_tools: int = 1
+
+    def allows_resource(self, resource_type: ResourceType) -> bool:
+        """Check if this constraint set allows the given resource type."""
+        if resource_type == ResourceType.NETWORK:
+            return self.network_allowed
+        elif resource_type == ResourceType.FILESYSTEM:
+            return self.filesystem_scope != "none"
+        elif resource_type == ResourceType.SUBPROCESS:
+            return self.subprocess_allowed
+        elif resource_type == ResourceType.TOOL_EXECUTION:
+            return True
+        return False
+
+
+# Ring-to-resource constraint mapping
+RING_CONSTRAINTS: dict[ExecutionRing, ResourceConstraints] = {
+    ExecutionRing.RING_0_ROOT: ResourceConstraints(
+        network_allowed=True,
+        filesystem_writable=True,
+        filesystem_scope="full",
+        subprocess_allowed=True,
+        max_concurrent_tools=32,
+    ),
+    ExecutionRing.RING_1_PRIVILEGED: ResourceConstraints(
+        network_allowed=True,
+        filesystem_writable=True,
+        filesystem_scope="full",
+        subprocess_allowed=True,
+        max_concurrent_tools=16,
+    ),
+    ExecutionRing.RING_2_STANDARD: ResourceConstraints(
+        network_allowed=True,
+        network_allowlist=[],  # empty = all allowed at this ring
+        filesystem_writable=True,
+        filesystem_scope="scoped",
+        subprocess_allowed=True,
+        max_concurrent_tools=8,
+    ),
+    ExecutionRing.RING_3_SANDBOX: ResourceConstraints(
+        network_allowed=False,
+        filesystem_writable=False,
+        filesystem_scope="none",
+        subprocess_allowed=False,
+        max_concurrent_tools=2,
+    ),
+}
 
 
 @dataclass
@@ -27,16 +97,16 @@ class RingCheckResult:
     reason: str
     requires_consensus: bool = False
     requires_sre_witness: bool = False
+    denied_resources: list[ResourceType] = field(default_factory=list)
 
 
 class RingEnforcer:
-    """
-    Simple 2-tier ring enforcer.
+    """Ring enforcer with resource constraint validation.
 
-    Ring 0 (Root): Always denied (kernel-only).
-    Ring 1 (Privileged): Requires trust > 0.7.
-    Ring 2 (Standard): Default for all agents.
-    Ring 3 (Sandbox): Read-only / research.
+    Ring 0 (Root): Always denied for agents (system-only).
+    Ring 1 (Privileged): Full network, full filesystem, subprocess allowed.
+    Ring 2 (Standard): Allowlisted network, scoped filesystem, subprocess allowed.
+    Ring 3 (Sandbox): No network, read-only filesystem, no subprocess.
     """
 
     RING_1_THRESHOLD = RING_1_ENFORCER_THRESHOLD
@@ -52,17 +122,20 @@ class RingEnforcer:
         has_consensus: bool = False,
         has_sre_witness: bool = False,
     ) -> RingCheckResult:
-        """Check if an agent can perform an action given their ring level."""
+        """Check if an agent can perform an action given their ring level.
+
+        Validates both ring-level access and resource constraints.
+        """
         required = action.required_ring
 
-        # Ring 0: always denied in Public Preview
+        # Ring 0: always denied for agents
         if required == ExecutionRing.RING_0_ROOT:
             return RingCheckResult(
                 allowed=False,
                 required_ring=required,
                 agent_ring=agent_ring,
                 eff_score=eff_score,
-                reason="Ring 0 actions are not available in Public Preview",
+                reason="Ring 0 actions require SRE Witness attestation",
                 requires_sre_witness=True,
             )
 
@@ -86,6 +159,51 @@ class RingEnforcer:
             eff_score=eff_score,
             reason="Access granted",
         )
+
+    def check_resource(
+        self,
+        agent_ring: ExecutionRing,
+        resource_type: ResourceType,
+    ) -> RingCheckResult:
+        """Check if an agent's ring allows access to a specific resource type.
+
+        Args:
+            agent_ring: The agent's current execution ring.
+            resource_type: The resource type being requested.
+
+        Returns:
+            RingCheckResult indicating whether access is allowed.
+        """
+        constraints = self.get_constraints(agent_ring)
+
+        if constraints.allows_resource(resource_type):
+            return RingCheckResult(
+                allowed=True,
+                required_ring=agent_ring,
+                agent_ring=agent_ring,
+                eff_score=0.0,
+                reason=f"{resource_type.value} access granted for ring {agent_ring.value}",
+            )
+
+        return RingCheckResult(
+            allowed=False,
+            required_ring=agent_ring,
+            agent_ring=agent_ring,
+            eff_score=0.0,
+            reason=f"{resource_type.value} access denied at ring {agent_ring.value}",
+            denied_resources=[resource_type],
+        )
+
+    def get_constraints(self, ring: ExecutionRing) -> ResourceConstraints:
+        """Get the resource constraints for a given ring.
+
+        Args:
+            ring: The execution ring.
+
+        Returns:
+            ResourceConstraints for the ring.
+        """
+        return RING_CONSTRAINTS.get(ring, RING_CONSTRAINTS[ExecutionRing.RING_3_SANDBOX])
 
     def compute_ring(self, eff_score: float, has_consensus: bool = False) -> ExecutionRing:
         """Compute ring assignment from trust score."""

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/session/isolation.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/session/isolation.py
@@ -1,20 +1,29 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Session Isolation Levels — stub implementation.
+Session Isolation — enforced per-session working directories and data access control.
 
-Public Preview: all access is serialized via a single lock.
-Isolation levels are retained for API compatibility but not enforced.
+Provides isolation levels that control cross-session data access.
+Sessions are assigned scoped working directories, and access to other
+sessions' data requires explicit capability grants.
 """
 
 from __future__ import annotations
 
+import os
+from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import PurePosixPath
+from typing import Optional
 
 
 class IsolationLevel(str, Enum):
-    """Session isolation levels (Public Preview: not enforced)."""
+    """Session isolation levels.
+
+    SNAPSHOT: Read from a point-in-time snapshot, writes go to session scope.
+    READ_COMMITTED: Can read committed data from other sessions (with grants).
+    SERIALIZABLE: Full isolation, no cross-session access.
+    """
 
     SNAPSHOT = "snapshot"
     READ_COMMITTED = "read_committed"
@@ -22,16 +31,162 @@ class IsolationLevel(str, Enum):
 
     @property
     def requires_vector_clocks(self) -> bool:
-        return False
+        return self == IsolationLevel.SERIALIZABLE
 
     @property
     def requires_intent_locks(self) -> bool:
-        return False
+        return self == IsolationLevel.SERIALIZABLE
 
     @property
     def allows_concurrent_writes(self) -> bool:
-        return True
+        return self != IsolationLevel.SERIALIZABLE
 
     @property
     def coordination_cost(self) -> str:
-        return "none"
+        costs = {
+            IsolationLevel.SNAPSHOT: "low",
+            IsolationLevel.READ_COMMITTED: "medium",
+            IsolationLevel.SERIALIZABLE: "high",
+        }
+        return costs.get(self, "none")
+
+
+@dataclass
+class SessionScope:
+    """Defines the isolated scope for a session.
+
+    Each session gets a working directory under the base path.
+    Cross-session access requires explicit grants.
+    """
+
+    session_id: str
+    agent_did: str
+    base_path: str = "/var/agt/sessions"
+    isolation_level: IsolationLevel = IsolationLevel.SNAPSHOT
+    granted_sessions: set[str] = field(default_factory=set)
+
+    @property
+    def working_directory(self) -> str:
+        """Session-scoped working directory."""
+        return str(PurePosixPath(self.base_path) / self.session_id)
+
+    def is_path_allowed(self, path: str) -> bool:
+        """Check if a path is accessible under this session's isolation.
+
+        Args:
+            path: Absolute path to check.
+
+        Returns:
+            True if the path is within the session scope or a granted scope.
+        """
+        normalized = str(PurePosixPath(path))
+        # Always allow access within own working directory
+        if normalized.startswith(self.working_directory):
+            return True
+
+        # Check granted session access (READ_COMMITTED only)
+        if self.isolation_level == IsolationLevel.READ_COMMITTED:
+            for granted_id in self.granted_sessions:
+                granted_dir = str(PurePosixPath(self.base_path) / granted_id)
+                if normalized.startswith(granted_dir):
+                    return True
+
+        return False
+
+    def grant_access(self, other_session_id: str) -> None:
+        """Grant this session read access to another session's data.
+
+        Only effective under READ_COMMITTED isolation.
+
+        Args:
+            other_session_id: Session ID to grant access to.
+        """
+        self.granted_sessions.add(other_session_id)
+
+    def revoke_access(self, other_session_id: str) -> None:
+        """Revoke previously granted cross-session access."""
+        self.granted_sessions.discard(other_session_id)
+
+
+class SessionIsolationManager:
+    """Manages session isolation scopes.
+
+    Creates and tracks per-session scopes with configurable isolation levels.
+    Enforces path-based access control for cross-session data.
+    """
+
+    def __init__(self, base_path: str = "/var/agt/sessions") -> None:
+        self._base_path = base_path
+        self._scopes: dict[str, SessionScope] = {}
+
+    def create_scope(
+        self,
+        session_id: str,
+        agent_did: str,
+        isolation_level: IsolationLevel = IsolationLevel.SNAPSHOT,
+    ) -> SessionScope:
+        """Create an isolated scope for a session.
+
+        Args:
+            session_id: Unique session identifier.
+            agent_did: DID of the agent owning this session.
+            isolation_level: Desired isolation level.
+
+        Returns:
+            SessionScope with the assigned working directory.
+        """
+        scope = SessionScope(
+            session_id=session_id,
+            agent_did=agent_did,
+            base_path=self._base_path,
+            isolation_level=isolation_level,
+        )
+        self._scopes[session_id] = scope
+        return scope
+
+    def get_scope(self, session_id: str) -> Optional[SessionScope]:
+        """Get the isolation scope for a session."""
+        return self._scopes.get(session_id)
+
+    def check_access(self, session_id: str, path: str) -> bool:
+        """Check if a session can access a given path.
+
+        Args:
+            session_id: Session requesting access.
+            path: Path being accessed.
+
+        Returns:
+            True if access is allowed under the session's isolation scope.
+            True if no scope exists (permissive fallback for backward compat).
+        """
+        scope = self._scopes.get(session_id)
+        if scope is None:
+            return True  # No scope = no enforcement (backward compat)
+        return scope.is_path_allowed(path)
+
+    def grant_cross_session_access(
+        self, session_id: str, target_session_id: str
+    ) -> bool:
+        """Grant one session access to another's data.
+
+        Only works for READ_COMMITTED isolation.
+
+        Returns:
+            True if grant was applied, False if session not found or wrong isolation.
+        """
+        scope = self._scopes.get(session_id)
+        if scope is None:
+            return False
+        if scope.isolation_level != IsolationLevel.READ_COMMITTED:
+            return False
+        scope.grant_access(target_session_id)
+        return True
+
+    def remove_scope(self, session_id: str) -> None:
+        """Remove a session's isolation scope (session ended)."""
+        self._scopes.pop(session_id, None)
+
+    @property
+    def active_sessions(self) -> int:
+        """Number of sessions with active isolation scopes."""
+        return len(self._scopes)

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_ring_enforcement.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_ring_enforcement.py
@@ -1,0 +1,533 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for execution ring enforcement: elevation, resource constraints, session isolation."""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from hypervisor.models import ActionDescriptor, ExecutionRing
+from hypervisor.rings.elevation import (
+    ChildRegistration,
+    ElevationDenialReason,
+    ELEVATION_TRUST_THRESHOLDS,
+    RingElevation,
+    RingElevationError,
+    RingElevationManager,
+)
+from hypervisor.rings.enforcer import (
+    ResourceConstraints,
+    ResourceType,
+    RING_CONSTRAINTS,
+    RingCheckResult,
+    RingEnforcer,
+)
+from hypervisor.session.isolation import (
+    IsolationLevel,
+    SessionIsolationManager,
+    SessionScope,
+)
+
+
+# ── Elevation Tests ──────────────────────────────────────────────────
+
+
+class TestElevationGrant:
+    """Test that elevation requests are approved when trust is sufficient."""
+
+    def test_ring3_to_ring2_with_sufficient_trust(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:agent1",
+            session_id="sess-1",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            trust_score=0.6,
+        )
+        assert elev.is_active
+        assert elev.elevated_ring == ExecutionRing.RING_2_STANDARD
+        assert elev.original_ring == ExecutionRing.RING_3_SANDBOX
+
+    def test_ring3_to_ring1_with_attestation(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:agent1",
+            session_id="sess-1",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_1_PRIVILEGED,
+            trust_score=0.90,
+            attestation="sre-witness-token-abc",
+        )
+        assert elev.elevated_ring == ExecutionRing.RING_1_PRIVILEGED
+        assert elev.attestation == "sre-witness-token-abc"
+
+    def test_ring2_to_ring1_with_attestation(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:agent2",
+            session_id="sess-2",
+            current_ring=ExecutionRing.RING_2_STANDARD,
+            target_ring=ExecutionRing.RING_1_PRIVILEGED,
+            trust_score=0.9,
+            attestation="witness",
+        )
+        assert elev.is_active
+
+    def test_default_ttl_applied(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            trust_score=0.6,
+        )
+        assert elev.remaining_seconds > 0
+        assert elev.remaining_seconds <= RingElevationManager.DEFAULT_TTL
+
+    def test_custom_ttl(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            ttl_seconds=60,
+            trust_score=0.6,
+        )
+        assert elev.remaining_seconds <= 60
+
+    def test_ttl_capped_at_max(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            ttl_seconds=99999,
+            trust_score=0.6,
+        )
+        assert elev.remaining_seconds <= RingElevationManager.MAX_ELEVATION_TTL
+
+
+class TestElevationDenial:
+    """Test elevation denial scenarios."""
+
+    def test_insufficient_trust_for_ring2(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:low",
+                session_id="s",
+                current_ring=ExecutionRing.RING_3_SANDBOX,
+                target_ring=ExecutionRing.RING_2_STANDARD,
+                trust_score=0.3,
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.INSUFFICIENT_TRUST
+
+    def test_insufficient_trust_for_ring1(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:med",
+                session_id="s",
+                current_ring=ExecutionRing.RING_3_SANDBOX,
+                target_ring=ExecutionRing.RING_1_PRIVILEGED,
+                trust_score=0.7,
+                attestation="witness",
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.INSUFFICIENT_TRUST
+
+    def test_ring1_without_attestation(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:a",
+                session_id="s",
+                current_ring=ExecutionRing.RING_3_SANDBOX,
+                target_ring=ExecutionRing.RING_1_PRIVILEGED,
+                trust_score=0.95,
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.NO_SPONSORSHIP
+
+    def test_ring0_always_forbidden(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:a",
+                session_id="s",
+                current_ring=ExecutionRing.RING_1_PRIVILEGED,
+                target_ring=ExecutionRing.RING_0_ROOT,
+                trust_score=1.0,
+                attestation="root-witness",
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.RING_0_FORBIDDEN
+
+    def test_invalid_target_same_ring(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:a",
+                session_id="s",
+                current_ring=ExecutionRing.RING_2_STANDARD,
+                target_ring=ExecutionRing.RING_2_STANDARD,
+                trust_score=0.8,
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.INVALID_TARGET
+
+    def test_invalid_target_demotion(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:a",
+                session_id="s",
+                current_ring=ExecutionRing.RING_1_PRIVILEGED,
+                target_ring=ExecutionRing.RING_2_STANDARD,
+                trust_score=0.8,
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.INVALID_TARGET
+
+    def test_duplicate_elevation_rejected(self):
+        mgr = RingElevationManager()
+        mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            trust_score=0.6,
+        )
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:a",
+                session_id="s",
+                current_ring=ExecutionRing.RING_3_SANDBOX,
+                target_ring=ExecutionRing.RING_2_STANDARD,
+                trust_score=0.6,
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.DUPLICATE
+
+    def test_no_trust_score_available(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError) as exc_info:
+            mgr.request_elevation(
+                agent_did="did:mesh:a",
+                session_id="s",
+                current_ring=ExecutionRing.RING_3_SANDBOX,
+                target_ring=ExecutionRing.RING_2_STANDARD,
+            )
+        assert exc_info.value.denial_reason == ElevationDenialReason.INSUFFICIENT_TRUST
+
+
+class TestElevationLifecycle:
+    """Test elevation expiration, revocation, and tick()."""
+
+    def test_active_elevations_list(self):
+        mgr = RingElevationManager()
+        mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            trust_score=0.6,
+        )
+        assert len(mgr.active_elevations) == 1
+
+    def test_revoke_elevation(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            trust_score=0.6,
+        )
+        mgr.revoke_elevation(elev.elevation_id)
+        assert len(mgr.active_elevations) == 0
+
+    def test_revoke_nonexistent_raises(self):
+        mgr = RingElevationManager()
+        with pytest.raises(RingElevationError):
+            mgr.revoke_elevation("elev:doesnotexist")
+
+    def test_get_effective_ring_with_elevation(self):
+        mgr = RingElevationManager()
+        mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            trust_score=0.6,
+        )
+        effective = mgr.get_effective_ring(
+            "did:mesh:a", "s", ExecutionRing.RING_3_SANDBOX
+        )
+        assert effective == ExecutionRing.RING_2_STANDARD
+
+    def test_get_effective_ring_without_elevation(self):
+        mgr = RingElevationManager()
+        effective = mgr.get_effective_ring(
+            "did:mesh:a", "s", ExecutionRing.RING_3_SANDBOX
+        )
+        assert effective == ExecutionRing.RING_3_SANDBOX
+
+    def test_tick_expires_past_ttl(self):
+        mgr = RingElevationManager()
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            ttl_seconds=1,
+            trust_score=0.6,
+        )
+        # Force expiration by setting expires_at in the past
+        elev.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        expired = mgr.tick()
+        assert len(expired) == 1
+        assert expired[0].elevation_id == elev.elevation_id
+        assert not elev.is_active
+
+    def test_tick_does_not_expire_active(self):
+        mgr = RingElevationManager()
+        mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+            ttl_seconds=3600,
+            trust_score=0.6,
+        )
+        expired = mgr.tick()
+        assert len(expired) == 0
+        assert len(mgr.active_elevations) == 1
+
+    def test_trust_provider_callback(self):
+        mgr = RingElevationManager(
+            trust_provider=lambda did: 0.7
+        )
+        elev = mgr.request_elevation(
+            agent_did="did:mesh:a",
+            session_id="s",
+            current_ring=ExecutionRing.RING_3_SANDBOX,
+            target_ring=ExecutionRing.RING_2_STANDARD,
+        )
+        assert elev.is_active
+
+
+class TestChildRegistration:
+    """Test parent-child ring registration."""
+
+    def test_child_inherits_parent_minus_one(self):
+        mgr = RingElevationManager()
+        child_ring = mgr.register_child(
+            "did:mesh:parent", "did:mesh:child", ExecutionRing.RING_1_PRIVILEGED
+        )
+        assert child_ring == ExecutionRing.RING_2_STANDARD
+
+    def test_child_of_sandbox_stays_sandbox(self):
+        mgr = RingElevationManager()
+        child_ring = mgr.register_child(
+            "did:mesh:parent", "did:mesh:child", ExecutionRing.RING_3_SANDBOX
+        )
+        assert child_ring == ExecutionRing.RING_3_SANDBOX
+
+    def test_child_registration_tracked(self):
+        mgr = RingElevationManager()
+        mgr.register_child(
+            "did:mesh:parent", "did:mesh:child", ExecutionRing.RING_2_STANDARD
+        )
+        reg = mgr.get_child_registration("did:mesh:child")
+        assert reg is not None
+        assert reg.parent_did == "did:mesh:parent"
+        assert reg.child_ring == ExecutionRing.RING_3_SANDBOX
+
+    def test_unknown_child_returns_none(self):
+        mgr = RingElevationManager()
+        assert mgr.get_child_registration("did:mesh:unknown") is None
+
+
+# ── Resource Constraint Tests ────────────────────────────────────────
+
+
+class TestResourceConstraints:
+    """Test ring-to-resource constraint mapping."""
+
+    def test_ring3_no_network(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_3_SANDBOX]
+        assert c.network_allowed is False
+
+    def test_ring3_no_filesystem(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_3_SANDBOX]
+        assert c.filesystem_writable is False
+        assert c.filesystem_scope == "none"
+
+    def test_ring3_no_subprocess(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_3_SANDBOX]
+        assert c.subprocess_allowed is False
+
+    def test_ring2_has_network(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_2_STANDARD]
+        assert c.network_allowed is True
+
+    def test_ring2_scoped_filesystem(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_2_STANDARD]
+        assert c.filesystem_scope == "scoped"
+
+    def test_ring2_subprocess_allowed(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_2_STANDARD]
+        assert c.subprocess_allowed is True
+
+    def test_ring1_full_access(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_1_PRIVILEGED]
+        assert c.network_allowed is True
+        assert c.filesystem_scope == "full"
+        assert c.subprocess_allowed is True
+
+    def test_allows_resource_method(self):
+        c = RING_CONSTRAINTS[ExecutionRing.RING_3_SANDBOX]
+        assert c.allows_resource(ResourceType.NETWORK) is False
+        assert c.allows_resource(ResourceType.SUBPROCESS) is False
+        assert c.allows_resource(ResourceType.TOOL_EXECUTION) is True
+
+
+class TestRingEnforcerResources:
+    """Test RingEnforcer resource checks."""
+
+    def test_sandbox_network_denied(self):
+        enforcer = RingEnforcer()
+        result = enforcer.check_resource(
+            ExecutionRing.RING_3_SANDBOX, ResourceType.NETWORK
+        )
+        assert result.allowed is False
+        assert ResourceType.NETWORK in result.denied_resources
+
+    def test_standard_network_allowed(self):
+        enforcer = RingEnforcer()
+        result = enforcer.check_resource(
+            ExecutionRing.RING_2_STANDARD, ResourceType.NETWORK
+        )
+        assert result.allowed is True
+
+    def test_sandbox_subprocess_denied(self):
+        enforcer = RingEnforcer()
+        result = enforcer.check_resource(
+            ExecutionRing.RING_3_SANDBOX, ResourceType.SUBPROCESS
+        )
+        assert result.allowed is False
+
+    def test_get_constraints(self):
+        enforcer = RingEnforcer()
+        c = enforcer.get_constraints(ExecutionRing.RING_3_SANDBOX)
+        assert c.max_concurrent_tools == 2
+
+    def test_get_constraints_defaults_to_sandbox(self):
+        enforcer = RingEnforcer()
+        # Ring 0 has its own constraints
+        c = enforcer.get_constraints(ExecutionRing.RING_0_ROOT)
+        assert c.max_concurrent_tools == 32
+
+
+# ── Session Isolation Tests ──────────────────────────────────────────
+
+
+class TestSessionIsolation:
+    """Test session isolation enforcement."""
+
+    def test_create_scope(self):
+        mgr = SessionIsolationManager()
+        scope = mgr.create_scope("sess-1", "did:mesh:agent1")
+        assert scope.session_id == "sess-1"
+        assert "sess-1" in scope.working_directory
+
+    def test_path_allowed_within_session(self):
+        mgr = SessionIsolationManager()
+        scope = mgr.create_scope("sess-1", "did:mesh:agent1")
+        assert scope.is_path_allowed(scope.working_directory + "/data.json")
+
+    def test_path_denied_outside_session(self):
+        mgr = SessionIsolationManager()
+        scope = mgr.create_scope(
+            "sess-1", "did:mesh:agent1", IsolationLevel.SERIALIZABLE
+        )
+        assert scope.is_path_allowed("/var/agt/sessions/sess-2/data.json") is False
+
+    def test_cross_session_with_grant(self):
+        mgr = SessionIsolationManager()
+        scope = mgr.create_scope(
+            "sess-1", "did:mesh:agent1", IsolationLevel.READ_COMMITTED
+        )
+        scope.grant_access("sess-2")
+        assert scope.is_path_allowed("/var/agt/sessions/sess-2/data.json") is True
+
+    def test_cross_session_without_grant(self):
+        mgr = SessionIsolationManager()
+        scope = mgr.create_scope(
+            "sess-1", "did:mesh:agent1", IsolationLevel.READ_COMMITTED
+        )
+        assert scope.is_path_allowed("/var/agt/sessions/sess-2/data.json") is False
+
+    def test_grant_only_works_for_read_committed(self):
+        mgr = SessionIsolationManager()
+        scope = mgr.create_scope(
+            "sess-1", "did:mesh:agent1", IsolationLevel.SNAPSHOT
+        )
+        scope.grant_access("sess-2")
+        # Snapshot ignores grants
+        assert scope.is_path_allowed("/var/agt/sessions/sess-2/data.json") is False
+
+    def test_manager_check_access(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("sess-1", "did:mesh:agent1")
+        assert mgr.check_access("sess-1", "/var/agt/sessions/sess-1/out.txt") is True
+        assert mgr.check_access("sess-1", "/var/agt/sessions/sess-2/out.txt") is False
+
+    def test_manager_no_scope_is_permissive(self):
+        mgr = SessionIsolationManager()
+        # No scope created = permissive (backward compat)
+        assert mgr.check_access("unknown-sess", "/anything") is True
+
+    def test_manager_grant_cross_session(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("sess-1", "did:mesh:a", IsolationLevel.READ_COMMITTED)
+        mgr.create_scope("sess-2", "did:mesh:b", IsolationLevel.READ_COMMITTED)
+        assert mgr.grant_cross_session_access("sess-1", "sess-2") is True
+        assert mgr.check_access("sess-1", "/var/agt/sessions/sess-2/data.json") is True
+
+    def test_manager_grant_fails_for_snapshot(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("sess-1", "did:mesh:a", IsolationLevel.SNAPSHOT)
+        assert mgr.grant_cross_session_access("sess-1", "sess-2") is False
+
+    def test_remove_scope(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("sess-1", "did:mesh:a")
+        mgr.remove_scope("sess-1")
+        assert mgr.active_sessions == 0
+
+    def test_active_sessions_count(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("sess-1", "did:mesh:a")
+        mgr.create_scope("sess-2", "did:mesh:b")
+        assert mgr.active_sessions == 2
+
+    def test_isolation_level_properties(self):
+        assert IsolationLevel.SERIALIZABLE.requires_vector_clocks is True
+        assert IsolationLevel.SNAPSHOT.requires_vector_clocks is False
+        assert IsolationLevel.SERIALIZABLE.allows_concurrent_writes is False
+        assert IsolationLevel.SNAPSHOT.allows_concurrent_writes is True
+        assert IsolationLevel.SERIALIZABLE.coordination_cost == "high"
+        assert IsolationLevel.SNAPSHOT.coordination_cost == "low"
+
+    def test_revoke_access(self):
+        scope = SessionScope(
+            session_id="sess-1",
+            agent_did="did:mesh:a",
+            isolation_level=IsolationLevel.READ_COMMITTED,
+        )
+        scope.grant_access("sess-2")
+        assert scope.is_path_allowed("/var/agt/sessions/sess-2/file") is True
+        scope.revoke_access("sess-2")
+        assert scope.is_path_allowed("/var/agt/sessions/sess-2/file") is False

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_ring_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_ring_improvements.py
@@ -225,7 +225,7 @@ class TestRingElevationErrorMessages:
                 target_ring=ExecutionRing.RING_2_STANDARD,
             )
         err = exc_info.value
-        assert err.denial_reason == ElevationDenialReason.COMMUNITY_EDITION
+        assert err.denial_reason == ElevationDenialReason.INSUFFICIENT_TRUST
 
     def test_error_includes_remediation(self):
         mgr = RingElevationManager()
@@ -306,4 +306,4 @@ class TestRingElevationErrorMessages:
         assert err.current_ring == ExecutionRing.RING_3_SANDBOX
         assert err.target_ring == ExecutionRing.RING_2_STANDARD
         assert err.agent_did == "did:mesh:test"
-        assert err.denial_reason == ElevationDenialReason.COMMUNITY_EDITION
+        assert err.denial_reason == ElevationDenialReason.INSUFFICIENT_TRUST


### PR DESCRIPTION
## Summary

Replaces stub implementations of ring elevation, resource constraints, and session isolation with functional enforcement. All three phases from issue #2284 are addressed.

## Problem

The execution ring system had the data model but enforcement was mostly stubs:
- RingElevationManager always denied with COMMUNITY_EDITION
- No ring-to-resource constraint mapping
- SessionIsolation explicitly marked "not enforced"

## Changes

### Phase 1: Functional Elevation

| Component | Before | After |
|-----------|--------|-------|
| request_elevation() | Always denied | Trust-based approval with thresholds |
| TTL enforcement | Field existed, never used | tick() expires active elevations |
| register_child() | Returns ring value only | Tracks ChildRegistration with parent |
| Duplicate detection | None | Rejects if active elevation exists |
| Trust provider | None | Callback for dynamic trust resolution |

### Phase 2: Ring-to-Resource Mapping

| Ring | Network | Filesystem | Subprocess | Max Tools |
|------|---------|------------|------------|----------|
| Ring 3 (Sandbox) | Denied | Read-only (none) | Denied | 2 |
| Ring 2 (Standard) | Allowed | Scoped | Allowed | 8 |
| Ring 1 (Privileged) | Full | Full | Allowed | 16 |
| Ring 0 (Root) | Full | Full | Allowed | 32 |

### Phase 3: Session Isolation

| Feature | Detail |
|---------|--------|
| SessionScope | Per-session working directory under /var/agt/sessions/ |
| Path enforcement | is_path_allowed() validates access within scope |
| Cross-session grants | Only under READ_COMMITTED isolation |
| SessionIsolationManager | Lifecycle management for session scopes |
| Backward compat | No scope = permissive (no enforcement) |

## Testing

53 new tests in test_ring_enforcement.py, 80 total ring tests passing:
- 6 elevation grant tests
- 8 elevation denial tests
- 8 lifecycle tests (TTL, revoke, tick, trust provider)
- 4 child registration tests
- 8 resource constraint tests
- 5 enforcer resource check tests
- 14 session isolation tests

Closes #2284