### PR TITLE
feat: governance sidecar container image and deployment packaging

### DIFF
--- a/agent-governance-python/agent-mesh/docker/Dockerfile.sidecar
+++ b/agent-governance-python/agent-mesh/docker/Dockerfile.sidecar
@@ -1,0 +1,68 @@
+# AGT Governance Sidecar Dockerfile
+#
+# Unified governance sidecar for deployment alongside agent containers.
+# Provides policy evaluation, trust verification, and Prometheus metrics
+# in a single lightweight container.
+#
+# Build (from repo root):
+#   docker build -t ghcr.io/microsoft/agentmesh/governance-sidecar:0.3.0 \
+#     -f agent-governance-python/agent-mesh/docker/Dockerfile.sidecar .
+#
+# Run:
+#   docker run -p 8081:8081 \
+#     -v /path/to/policies:/etc/agt/policies:ro \
+#     ghcr.io/microsoft/agentmesh/governance-sidecar:0.3.0
+#
+# Environment variables:
+#   AGT_POLICY_DIR   — Path to YAML policy files (default: /etc/agt/policies)
+#   AGT_PORT         — Server port (default: 8081)
+#   AGT_HOST         — Bind address (default: 0.0.0.0)
+#   AGT_LOG_LEVEL    — Logging level (default: info)
+#   AGT_SERVICE_NAME — OTEL service name (default: agt-sidecar)
+
+ARG PYTHON_VERSION=3.11
+
+FROM python:${PYTHON_VERSION}-slim AS base
+
+LABEL maintainer="Microsoft Corporation"
+LABEL org.opencontainers.image.source="https://github.com/microsoft/agent-governance-toolkit"
+LABEL org.opencontainers.image.description="AGT Governance Sidecar - policy enforcement and trust verification"
+LABEL org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+
+# Install tini for proper signal handling
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy package source from repo root context
+COPY agent-governance-python/agent-mesh/pyproject.toml ./
+COPY agent-governance-python/agent-mesh/README.md ./
+COPY agent-governance-python/agent-mesh/src/ ./src/
+
+# Install with server extras
+RUN pip install --no-cache-dir ".[server]" && \
+    pip cache purge 2>/dev/null; true
+
+# Create non-root user and policy directory
+RUN useradd -m -s /bin/bash -u 1000 agt && \
+    mkdir -p /etc/agt/policies && \
+    chown agt:agt /etc/agt/policies
+
+USER agt
+
+# Environment defaults
+ENV PYTHONUNBUFFERED=1
+ENV AGT_PORT=8081
+ENV AGT_HOST=0.0.0.0
+ENV AGT_LOG_LEVEL=info
+ENV AGT_POLICY_DIR=/etc/agt/policies
+
+EXPOSE 8081
+
+ENTRYPOINT ["tini", "--"]
+CMD ["python", "-m", "agentmesh.server.sidecar"]
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8081/health')" || exit 1

--- a/agent-governance-python/agent-mesh/docker/examples/docker-compose.sidecar.yaml
+++ b/agent-governance-python/agent-mesh/docker/examples/docker-compose.sidecar.yaml
@@ -1,0 +1,56 @@
+# AGT Governance Sidecar — Docker Compose Example
+#
+# Demonstrates an agent container governed by an AGT sidecar.
+# The sidecar evaluates policies for every tool call the agent makes.
+#
+# Usage:
+#   docker compose up
+#
+# Test policy evaluation:
+#   curl -X POST http://localhost:8081/api/v1/policy/evaluate \
+#     -H "Content-Type: application/json" \
+#     -d '{"agent_did":"did:mesh:agent-1","action":"shell.execute","resource":"/bin/bash"}'
+
+services:
+  # The governance sidecar — evaluates policies, serves metrics
+  governance-sidecar:
+    build:
+      context: ../../../..
+      dockerfile: agent-governance-python/agent-mesh/docker/Dockerfile.sidecar
+    ports:
+      - "8081:8081"
+      - "9090:8081"  # Prometheus scrape alias
+    volumes:
+      - ./policies:/etc/agt/policies:ro
+    environment:
+      AGT_LOG_LEVEL: info
+      AGT_PORT: "8081"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8081/health')"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+
+  # Example agent container — uses the sidecar for policy checks
+  agent:
+    image: python:3.11-slim
+    depends_on:
+      governance-sidecar:
+        condition: service_healthy
+    environment:
+      AGT_SIDECAR_URL: http://governance-sidecar:8081
+    command: >
+      python -c "
+      import json, urllib.request;
+      req = urllib.request.Request(
+          'http://governance-sidecar:8081/api/v1/policy/evaluate',
+          data=json.dumps({
+              'agent_did': 'did:mesh:demo-agent',
+              'action': 'file.read',
+              'resource': '/data/report.csv',
+          }).encode(),
+          headers={'Content-Type': 'application/json'},
+      );
+      resp = urllib.request.urlopen(req);
+      print('Policy decision:', json.loads(resp.read()));
+      "

--- a/agent-governance-python/agent-mesh/docker/examples/k8s-sidecar.yaml
+++ b/agent-governance-python/agent-mesh/docker/examples/k8s-sidecar.yaml
@@ -1,0 +1,93 @@
+# AGT Governance Sidecar — Kubernetes Sidecar Container Spec
+#
+# Add this container to your agent Pod spec to enforce governance
+# policies on tool calls. The agent container communicates with
+# the sidecar over localhost:8081.
+#
+# Usage: Include the sidecar container in your Pod spec alongside
+# your agent container. Mount policies via ConfigMap or volume.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: governed-agent
+  labels:
+    app: governed-agent
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8081"
+    prometheus.io/path: "/metrics"
+spec:
+  containers:
+    # Your agent container
+    - name: agent
+      image: your-agent-image:latest
+      env:
+        - name: AGT_SIDECAR_URL
+          value: "http://localhost:8081"
+      ports:
+        - containerPort: 8080
+
+    # AGT governance sidecar
+    - name: governance-sidecar
+      image: ghcr.io/microsoft/agentmesh/governance-sidecar:0.3.0
+      ports:
+        - containerPort: 8081
+          name: governance
+      env:
+        - name: AGT_POLICY_DIR
+          value: /etc/agt/policies
+        - name: AGT_LOG_LEVEL
+          value: info
+        - name: AGT_SERVICE_NAME
+          value: agt-sidecar
+        # Optional: OTEL collector endpoint
+        # - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        #   value: http://otel-collector:4317
+      volumeMounts:
+        - name: policies
+          mountPath: /etc/agt/policies
+          readOnly: true
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8081
+        initialDelaySeconds: 5
+        periodSeconds: 15
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: 8081
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "50m"
+        limits:
+          memory: "128Mi"
+          cpu: "200m"
+
+  volumes:
+    - name: policies
+      configMap:
+        name: agt-policies  # Create from your policy YAML files
+
+---
+# Create the ConfigMap from policy files:
+#   kubectl create configmap agt-policies --from-file=policies/
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agt-policies
+data:
+  sandbox-policy.yaml: |
+    name: sandbox-policy
+    version: "1.0"
+    rules:
+      - name: allow-file-read
+        condition: "action == 'file.read'"
+        action: allow
+      - name: deny-shell-execute
+        condition: "action == 'shell.execute'"
+        action: deny

--- a/agent-governance-python/agent-mesh/docker/examples/policies/sandbox-policy.yaml
+++ b/agent-governance-python/agent-mesh/docker/examples/policies/sandbox-policy.yaml
@@ -1,0 +1,20 @@
+# Example AGT governance policy for sidecar demo.
+# Allows file reads but denies shell execution and network access
+# for sandbox-level agents.
+name: demo-sandbox-policy
+version: "1.0"
+rules:
+  - name: allow-file-read
+    description: Allow reading files in /data
+    condition: "action == 'file.read'"
+    action: allow
+
+  - name: deny-shell-execute
+    description: Deny shell execution for sandboxed agents
+    condition: "action == 'shell.execute'"
+    action: deny
+
+  - name: deny-network-egress
+    description: Deny outbound network access
+    condition: "action == 'network.egress'"
+    action: deny

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/sidecar.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/sidecar.py
@@ -1,0 +1,243 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Governance Sidecar — unified FastAPI application.
+
+Composes the policy server, trust engine, and metrics into a single
+application for sidecar deployment alongside agent containers.
+
+Environment variables:
+    AGT_POLICY_DIR: Path to policy YAML files (default: /etc/agt/policies)
+    AGT_LOG_LEVEL: Logging level (default: info)
+    AGT_PORT: Server port (default: 8081)
+    AGT_HOST: Server bind address (default: 0.0.0.0)
+    AGT_SERVICE_NAME: OTEL service name (default: agt-sidecar)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import PlainTextResponse
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+VERSION = "0.3.0"
+_start_time: float = 0.0
+
+
+def create_sidecar_app() -> FastAPI:
+    """Create the governance sidecar FastAPI application."""
+    global _start_time
+    _start_time = time.monotonic()
+
+    app = FastAPI(
+        title="AGT Governance Sidecar",
+        description=(
+            "Policy enforcement, trust verification, and observability sidecar "
+            "for AI agent containers."
+        ),
+        version=VERSION,
+        docs_url="/docs",
+        redoc_url=None,
+    )
+
+    # ── Health probes ────────────────────────────────────────────────
+
+    @app.get("/health", tags=["health"])
+    async def health() -> dict[str, str]:
+        """Liveness probe."""
+        return {"status": "ok", "component": "governance-sidecar"}
+
+    @app.get("/ready", tags=["health"])
+    async def ready() -> dict[str, Any]:
+        """Readiness probe. Reports loaded policy count."""
+        return {
+            "status": "ready",
+            "component": "governance-sidecar",
+            "policies_loaded": _loaded_count,
+        }
+
+    @app.get("/healthz", tags=["health"])
+    async def healthz() -> dict[str, str]:
+        """Kubernetes-style liveness probe."""
+        return {"status": "ok", "component": "governance-sidecar"}
+
+    @app.get("/readyz", tags=["health"])
+    async def readyz() -> dict[str, str]:
+        """Kubernetes-style readiness probe."""
+        return {"status": "ready", "component": "governance-sidecar"}
+
+    # ── Metrics endpoint ─────────────────────────────────────────────
+
+    @app.get("/metrics", tags=["observability"])
+    async def metrics_endpoint() -> PlainTextResponse:
+        """Prometheus exposition format metrics."""
+        try:
+            from prometheus_client import generate_latest, REGISTRY
+
+            output = generate_latest(REGISTRY).decode("utf-8")
+            uptime = time.monotonic() - _start_time
+            output += (
+                f"# HELP agt_sidecar_uptime_seconds Sidecar uptime in seconds\n"
+                f"# TYPE agt_sidecar_uptime_seconds gauge\n"
+                f"agt_sidecar_uptime_seconds {uptime:.2f}\n"
+            )
+            return PlainTextResponse(
+                content=output,
+                media_type="text/plain; version=0.0.4; charset=utf-8",
+            )
+        except ImportError:
+            uptime = time.monotonic() - _start_time
+            return PlainTextResponse(
+                content=(
+                    f"# HELP agt_sidecar_uptime_seconds Sidecar uptime\n"
+                    f"# TYPE agt_sidecar_uptime_seconds gauge\n"
+                    f"agt_sidecar_uptime_seconds {uptime:.2f}\n"
+                ),
+                media_type="text/plain; version=0.0.4; charset=utf-8",
+            )
+
+    # ── Policy evaluation ────────────────────────────────────────────
+
+    @app.on_event("startup")
+    async def startup() -> None:
+        _load_policies()
+        _bootstrap_telemetry()
+
+    @app.post("/api/v1/policy/evaluate", tags=["policy"])
+    async def evaluate_policy(req: EvaluateRequest) -> EvaluateResponse:
+        """Evaluate governance policies against an agent action."""
+        from agentmesh.governance.policy import PolicyDecision
+
+        ctx = {
+            "action": req.action,
+            "resource": req.resource,
+            **req.context,
+        }
+        result: PolicyDecision = _engine.evaluate(agent_did=req.agent_did, context=ctx)
+        return EvaluateResponse(
+            decision=result.action,
+            matched_rule=result.matched_rule,
+            reason=result.reason,
+            policy_name=result.policy_name,
+        )
+
+    @app.get("/api/v1/policies", tags=["policy"])
+    async def list_policies() -> dict[str, Any]:
+        """List loaded policies."""
+        return {
+            "total_loaded": _loaded_count,
+            "policy_dir": _policy_dir,
+            "version": VERSION,
+        }
+
+    @app.post("/api/v1/policy/reload", tags=["policy"])
+    async def reload_policies() -> dict[str, Any]:
+        """Hot-reload policies from disk."""
+        _load_policies()
+        return {"status": "reloaded", "total_loaded": _loaded_count}
+
+    return app
+
+
+# ── Request / Response models ────────────────────────────────────────
+
+
+class EvaluateRequest(BaseModel):
+    agent_did: str = Field(..., description="DID of the acting agent")
+    action: str = Field(..., description="Action being performed")
+    resource: str | None = Field(None, description="Target resource")
+    context: dict[str, Any] = Field(default_factory=dict, description="Additional context")
+
+
+class EvaluateResponse(BaseModel):
+    decision: str = Field(..., description="allow, deny, warn, or require_approval")
+    matched_rule: str | None = None
+    reason: str = ""
+    policy_name: str | None = None
+
+
+# ── Internal state ───────────────────────────────────────────────────
+
+_policy_dir = os.getenv("AGT_POLICY_DIR", "/etc/agt/policies")
+_loaded_count = 0
+
+# Initialize engine eagerly so tests work without startup event
+from agentmesh.governance.policy import PolicyEngine as _PolicyEngine
+_engine = _PolicyEngine()
+
+
+def _load_policies() -> None:
+    """Load policies from AGT_POLICY_DIR."""
+    global _engine, _loaded_count, _policy_dir
+
+    from agentmesh.governance.policy import PolicyEngine
+
+    _policy_dir = os.getenv("AGT_POLICY_DIR", "/etc/agt/policies")
+    _engine = PolicyEngine()
+
+    policy_path = Path(_policy_dir)
+    if not policy_path.exists():
+        logger.warning("Policy directory %s does not exist", _policy_dir)
+        _loaded_count = 0
+        return
+
+    count = 0
+    for f in sorted(policy_path.glob("*.yaml")):
+        try:
+            _engine.load_yaml(f.read_text())
+            count += 1
+            logger.info("Loaded policy: %s", f.name)
+        except Exception as exc:
+            logger.warning("Skipped %s: %s", f.name, exc)
+
+    for f in sorted(policy_path.glob("*.json")):
+        try:
+            _engine.load_json(f.read_text())
+            count += 1
+        except Exception as exc:
+            logger.warning("Skipped %s: %s", f.name, exc)
+
+    _loaded_count = count
+    logger.info("Loaded %d policies from %s", count, _policy_dir)
+
+
+def _bootstrap_telemetry() -> None:
+    """Bootstrap OTEL if configured."""
+    try:
+        from agentmesh.telemetry import bootstrap_otel
+
+        service_name = os.getenv("AGT_SERVICE_NAME", "agt-sidecar")
+        bootstrap_otel(service_name=service_name)
+    except ImportError:
+        pass
+
+
+# ── Application instance ─────────────────────────────────────────────
+
+app = create_sidecar_app()
+
+
+def main() -> None:
+    """Run the governance sidecar server."""
+    import uvicorn
+
+    host = os.getenv("AGT_HOST", "0.0.0.0")  # noqa: S104 — intentional bind-all for container
+    port = int(os.getenv("AGT_PORT", "8081"))
+    log_level = os.getenv("AGT_LOG_LEVEL", "info").lower()
+
+    logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
+    logger.info("Starting AGT Governance Sidecar on %s:%d", host, port)
+
+    uvicorn.run(app, host=host, port=port, log_level=log_level)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent-governance-python/agent-mesh/tests/test_sidecar.py
+++ b/agent-governance-python/agent-mesh/tests/test_sidecar.py
@@ -1,0 +1,172 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for governance sidecar application."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the sidecar app."""
+    from agentmesh.server.sidecar import create_sidecar_app
+    app = create_sidecar_app()
+    return TestClient(app)
+
+
+class TestHealthProbes:
+    """Test sidecar health and readiness endpoints."""
+
+    def test_health(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["component"] == "governance-sidecar"
+
+    def test_ready(self, client):
+        resp = client.get("/ready")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ready"
+        assert "policies_loaded" in data
+
+    def test_healthz(self, client):
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_readyz(self, client):
+        resp = client.get("/readyz")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"
+
+
+class TestMetricsEndpoint:
+    """Test sidecar Prometheus metrics endpoint."""
+
+    def test_metrics_returns_200(self, client):
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+
+    def test_metrics_content_type(self, client):
+        resp = client.get("/metrics")
+        assert "text/plain" in resp.headers["content-type"]
+
+    def test_metrics_contains_uptime(self, client):
+        resp = client.get("/metrics")
+        assert "agt_sidecar_uptime_seconds" in resp.text
+
+    def test_metrics_has_help_lines(self, client):
+        resp = client.get("/metrics")
+        assert "# HELP" in resp.text
+        assert "# TYPE" in resp.text
+
+
+class TestPolicyEvaluation:
+    """Test sidecar policy evaluation endpoint."""
+
+    def test_evaluate_returns_decision(self, client):
+        resp = client.post(
+            "/api/v1/policy/evaluate",
+            json={
+                "agent_did": "did:mesh:test-agent",
+                "action": "file.read",
+                "resource": "/data/file.txt",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "decision" in data
+
+    def test_evaluate_with_context(self, client):
+        resp = client.post(
+            "/api/v1/policy/evaluate",
+            json={
+                "agent_did": "did:mesh:test-agent",
+                "action": "shell.execute",
+                "resource": "/bin/bash",
+                "context": {"ring": 3, "trust_score": 400},
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_evaluate_missing_required_fields(self, client):
+        resp = client.post(
+            "/api/v1/policy/evaluate",
+            json={"action": "file.read"},
+        )
+        assert resp.status_code == 422  # Validation error
+
+    def test_list_policies(self, client):
+        resp = client.get("/api/v1/policies")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total_loaded" in data
+        assert "policy_dir" in data
+
+    def test_reload_policies(self, client):
+        resp = client.post("/api/v1/policy/reload")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "reloaded"
+
+
+class TestPolicyWithFiles:
+    """Test sidecar with actual policy files loaded."""
+
+    @pytest.fixture
+    def policy_client(self, tmp_path):
+        """Create a client with policies loaded from a temp directory."""
+        policy_file = tmp_path / "test-policy.yaml"
+        policy_file.write_text(
+            "name: test-policy\n"
+            "version: '1.0'\n"
+            "rules:\n"
+            "  - name: deny-shell\n"
+            "    condition: \"action == 'shell.execute'\"\n"
+            "    action: deny\n"
+            "    reason: 'Shell execution blocked'\n"
+        )
+        with patch.dict(os.environ, {"AGT_POLICY_DIR": str(tmp_path)}):
+            from agentmesh.server.sidecar import create_sidecar_app, _load_policies
+            app = create_sidecar_app()
+            _load_policies()
+            return TestClient(app)
+
+    def test_policy_loaded(self, policy_client):
+        resp = policy_client.get("/api/v1/policies")
+        data = resp.json()
+        assert data["total_loaded"] >= 1
+
+    def test_evaluate_with_loaded_policy(self, policy_client):
+        resp = policy_client.post(
+            "/api/v1/policy/evaluate",
+            json={
+                "agent_did": "did:mesh:test-agent",
+                "action": "shell.execute",
+                "resource": "/bin/bash",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["decision"] == "deny"
+
+
+class TestOpenAPIDocs:
+    """Test sidecar OpenAPI docs endpoint."""
+
+    def test_docs_available(self, client):
+        resp = client.get("/docs")
+        assert resp.status_code == 200
+
+    def test_openapi_json(self, client):
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "AGT Governance Sidecar" in data["info"]["title"]


### PR DESCRIPTION
## Summary

Adds a standalone governance sidecar container image for deploying AGT alongside agent containers in Kubernetes, Docker Compose, or ACA. Single container provides policy evaluation, health probes, and metrics.

## Problem

AGT has multiple HTTP servers but no packaged container for sidecar deployment. Operators must assemble their own Dockerfile and wire health probes manually.

## Solution

### Unified Sidecar App (sidecar.py)

| Endpoint | Method | Purpose |
|----------|--------|--------|
| /health | GET | Liveness probe |
| /ready | GET | Readiness probe (reports policy count) |
| /metrics | GET | Prometheus exposition format |
| /api/v1/policy/evaluate | POST | Evaluate governance policy |
| /api/v1/policies | GET | List loaded policies |
| /api/v1/policy/reload | POST | Hot-reload policies from disk |
| /docs | GET | OpenAPI interactive docs |

### Dockerfile.sidecar

- Python 3.11 slim base
- tini for signal handling
- Non-root user (uid 1000)
- Exposes port 8081
- HEALTHCHECK configured
- Estimated image size: ~150MB

### Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| AGT_POLICY_DIR | /etc/agt/policies | Policy YAML directory |
| AGT_PORT | 8081 | Server port |
| AGT_HOST | 0.0.0.0 | Bind address |
| AGT_LOG_LEVEL | info | Logging level |
| AGT_SERVICE_NAME | agt-sidecar | OTEL service name |

### Deployment Examples

- Docker Compose: agent + sidecar with shared policy volume
- Kubernetes: Pod spec with sidecar container, ConfigMap for policies, Prometheus annotations

## Testing

17 tests in test_sidecar.py:
- 4 health probe tests
- 4 metrics endpoint tests
- 5 policy evaluation tests
- 2 policy file loading tests
- 2 OpenAPI docs tests

Closes #2285