### PR TITLE
fix(dotnet): remove unused catch variables causing CS0168 build errors

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Hypervisor/SagaOrchestrator.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Hypervisor/SagaOrchestrator.cs
@@ -205,7 +205,7 @@ public sealed class SagaOrchestrator
             {
                 lock (saga.SyncRoot) { step.Error = $"Step '{step.ActionId}' timed out after {step.Timeout.TotalSeconds}s."; }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 lock (saga.SyncRoot) { step.Error = $"Step '{step.ActionId}' failed — see server logs"; }
             }
@@ -253,7 +253,7 @@ public sealed class SagaOrchestrator
                 await step.Compensate(cts.Token).ConfigureAwait(false);
                 lock (saga.SyncRoot) { step.State = StepState.Compensated; }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 lock (saga.SyncRoot)
                 {

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/CedarPolicyBackend.cs
@@ -74,7 +74,7 @@ public sealed class CedarPolicyBackend : IExternalPolicyBackend
                 EvaluationMs = sw.Elapsed.TotalMilliseconds
             };
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             sw.Stop();
             return new ExternalPolicyDecision

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -102,7 +102,7 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
                 EvaluationMs = sw.Elapsed.TotalMilliseconds
             };
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             sw.Stop();
             return new ExternalPolicyDecision
@@ -153,7 +153,7 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
                 EvaluationMs = sw.Elapsed.TotalMilliseconds
             };
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             sw.Stop();
             return new ExternalPolicyDecision

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/SagaOrchestratorAdvancedTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/SagaOrchestratorAdvancedTests.cs
@@ -190,7 +190,7 @@ public class SagaOrchestratorAdvancedTests
         });
         await orchestrator.ExecuteAsync(saga);
         Assert.Equal(StepState.Failed, saga.Steps[0].State);
-        Assert.Contains("Something went wrong", saga.Steps[0].Error!);
+        Assert.Contains("see server logs", saga.Steps[0].Error!);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the .NET build failure (CS0168) that has been breaking CI on all PRs touching dotnet paths, including all open Dependabot PRs.

## Problem

Five catch blocks in SagaOrchestrator, CedarPolicyBackend, and OpaPolicyBackend declared \catch (Exception ex)\ but never used \x\. With \TreatWarningsAsErrors\ enabled, CS0168 promoted these to build errors. A test also asserted the old error message format that included \x.Message\.

## Changes

| File | Change |
|------|--------|
| \SagaOrchestrator.cs\ | \catch (Exception ex)\ to \catch (Exception)\ (2 locations) |
| \CedarPolicyBackend.cs\ | \catch (Exception ex)\ to \catch (Exception)\ (1 location) |
| \OpaPolicyBackend.cs\ | \catch (Exception ex)\ to \catch (Exception)\ (2 locations) |
| \SagaOrchestratorAdvancedTests.cs\ | Assert updated to match current error message format |

## Testing

- \dotnet build AgentGovernance.sln\: 0 warnings, 0 errors
- \dotnet test AgentGovernance.sln\: 666 passed, 0 failed
