### PR TITLE
fix(ci): add sarif and autobuild to cspell dictionary

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -278,3 +278,5 @@ uvicorn
 setext
 linkified
 CommonMark
+autobuild
+sarif


### PR DESCRIPTION
Adds \sarif\ and \utobuild\ to \.cspell-repo-terms.txt\. These are standard CI terms that appear in codeql-action workflow YAML and were causing spell-check failures on dependabot PRs.