### PR TITLE
fix: align __version__ with pyproject.toml across packages

### DIFF
--- a/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
+++ b/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
@@ -9,7 +9,7 @@ focused package.
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "3.6.0"
 
 from agent_os.governance.middleware import GovernanceMiddleware
 from agent_os.audit.middleware import AuditMiddleware

--- a/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
@@ -8,10 +8,10 @@ Identity · Trust · Reward · Governance
 AgentMesh is the platform built for the Governed Agent Mesh - the cloud-native,
 multi-vendor network of AI agents that will define enterprise operations.
 
-Version: 1.0.0-alpha
+Version: 3.6.0
 """
 
-__version__ = "3.2.2"
+__version__ = "3.6.0"
 
 # Layer 1: Identity & Zero-Trust Core
 from .identity import (


### PR DESCRIPTION
## Summary
Production readiness audit found version mismatches between \__init__.py\ and \pyproject.toml\ in two packages.

## Changes
| Package | \__init__.py\ before | \pyproject.toml\ | \__init__.py\ after |
|---------|----------------------|-------------------|----------------------|
| agent-mcp-governance | \