### PR TITLE
fix(security): replace silent exception swallowing with logging

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/security/scanner.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/security/scanner.py
@@ -16,12 +16,15 @@ Integrates with sync-marketplace.py validation flow.
 """
 
 import json
+import logging
 import re
 import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def _glob_to_regex(pattern: str) -> re.Pattern[str]:
@@ -496,8 +499,8 @@ class SecurityScanner:
                 if result.stdout:
                     data = json.loads(result.stdout)
                     self._parse_pip_audit_json(data, req_file.name)
-            except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-                pass
+            except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError) as exc:
+                logger.warning("pip-audit scan failed for %s: %s", req_file, exc)
 
     def _parse_pip_audit_json(self, data: dict, filename: str) -> None:
         """Parse pip-audit JSON output and create findings."""
@@ -558,8 +561,8 @@ class SecurityScanner:
             if result.stdout:
                 data = json.loads(result.stdout)
                 self._parse_npm_audit_json(data)
-        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-            pass
+        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError) as exc:
+            logger.warning("npm audit scan failed: %s", exc)
 
     def _parse_npm_audit_json(self, data: dict) -> None:
         """Parse npm audit JSON output and create findings."""
@@ -620,8 +623,8 @@ class SecurityScanner:
             if result.stdout:
                 data = json.loads(result.stdout)
                 self._parse_bandit_json(data)
-        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-            pass
+        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError) as exc:
+            logger.warning("bandit scan failed: %s", exc)
 
     def _parse_bandit_json(self, data: dict) -> None:
         """Parse bandit JSON output and create findings."""

--- a/agent-governance-python/agent-mesh/src/agentmesh/events/bus.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/events/bus.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 
 import asyncio
 import fnmatch
+import logging
 import threading
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
 
 
 # Standard event types
@@ -128,7 +131,11 @@ class AsyncEventBus(EventBus):
         try:
             self._queue.put_nowait(event)
         except asyncio.QueueFull:
-            pass  # drop events when queue is full
+            logger.warning(
+                "Event bus queue full (max %d); dropping event type=%s",
+                self._queue.maxsize,
+                event.type,
+            )
 
     def subscribe(self, pattern: str, handler: EventHandler) -> None:
         self._subscriptions.append((pattern, handler))

--- a/agent-governance-python/agent-os/src/agent_os/agents_compat.py
+++ b/agent-governance-python/agent-os/src/agent_os/agents_compat.py
@@ -10,6 +10,7 @@ Also provides generation utilities for producing AGENTS.md files
 from AgentMdConfig dataclasses (GitHub Copilot / Cursor / Codex format).
 """
 
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,6 +19,8 @@ from typing import Any, Optional
 import yaml
 
 from agent_os.integrations.base import GovernancePolicy
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -210,7 +213,11 @@ class AgentsParser:
         try:
             return yaml.safe_load(content) or {}
         except yaml.YAMLError:
-            pass
+            logger.warning(
+                "Failed to parse security config as YAML in %s; "
+                "returning empty config",
+                path,
+            )
 
         return {}
 


### PR DESCRIPTION
## Summary

Replaces silent \xcept: pass\ and \xcept: return {}\ patterns with proper logging across three packages. These fail-open patterns silently swallow errors that operators need visibility into.

## Changes

| File | Before | After |
|------|--------|-------|
| \gents_compat.py\ | YAML parse errors silently return \{}\ | Logs warning with file path, returns \{}\ |
| \vents/bus.py\ | Queue overflow silently drops events | Logs warning with queue size and event type |
| \security/scanner.py\ | pip-audit/npm-audit/bandit failures silently pass | Logs warning with tool name and error |

## Why this matters

- **agents_compat.py**: A malformed YAML config silently results in no security policy being applied. Logging surfaces this so operators know governance config failed to load.
- **events/bus.py**: Dropped governance events (trust verification, policy decisions) are invisible without logging. Operators need to know when the event bus is saturated.
- **scanner.py**: A broken security tool (pip-audit, bandit, npm audit) silently produces no findings, which looks identical to a clean scan. Logging distinguishes 'no vulnerabilities' from 'scan tool failed.'

## Testing

- \pytest agent-governance-python/agent-os/tests/test_agents_compat.py\: 22 passed
- \pytest agent-governance-python/agent-mesh/tests/test_event_bus.py\: 17 passed
- \pytest agent-governance-python/agent-compliance/tests/\: 497 passed, 2 skipped