### PR TITLE
fix(go): add nil guard to ExecuteWithGovernance

### DIFF
--- a/agent-governance-golang/packages/agentmesh/client.go
+++ b/agent-governance-golang/packages/agentmesh/client.go
@@ -42,6 +42,10 @@ func NewClient(agentID string, opts ...Option) (*AgentMeshClient, error) {
 
 // ExecuteWithGovernance evaluates the action through the governance pipeline.
 func (c *AgentMeshClient) ExecuteWithGovernance(action string, params map[string]interface{}) (*GovernanceResult, error) {
+	if c.Policy == nil || c.Audit == nil || c.Identity == nil || c.Trust == nil {
+		return nil, fmt.Errorf("AgentMeshClient is not fully initialised: ensure NewClient was used")
+	}
+
 	decision := c.Policy.Evaluate(action, params)
 	entry := c.Audit.Log(c.Identity.DID, action, decision)
 	score := c.Trust.GetTrustScore(c.Identity.DID)

--- a/agent-governance-golang/packages/agentmesh/client_test.go
+++ b/agent-governance-golang/packages/agentmesh/client_test.go
@@ -377,3 +377,14 @@ func TestGovernanceAuditChainIntegrityAfterMixedActions(t *testing.T) {
 		t.Errorf("audit entries = %d, want 5", len(entries))
 	}
 }
+
+func TestExecuteWithGovernanceNilFieldsReturnsError(t *testing.T) {
+	// Manually construct a client with nil fields to simulate
+	// struct-literal construction bypassing NewClient.
+	client := &AgentMeshClient{}
+
+	_, err := client.ExecuteWithGovernance("any.action", nil)
+	if err == nil {
+		t.Fatal("expected error when client fields are nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a nil guard at the top of \ExecuteWithGovernance()\ to prevent nil pointer dereference when \AgentMeshClient\ is constructed via struct literal instead of \NewClient()\.

## Changes

| File | Change |
|------|--------|
| \client.go\ | Check Policy, Audit, Identity, Trust for nil before use |
| \client_test.go\ | Add test for struct-literal client returning error |

## Why

\NewClient()\ always initializes all fields, but nothing prevents users from writing \&AgentMeshClient{}\ directly. Without the guard, this panics with a nil pointer dereference. Now it returns a descriptive error.

## Testing

\go test ./... -count=1\: all tests pass