### PR TITLE
fix(runtime): use unique tempfile for deploy manifests

### DIFF
--- a/agent-governance-python/agent-runtime/src/agent_runtime/deploy.py
+++ b/agent-governance-python/agent-runtime/src/agent_runtime/deploy.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -322,9 +323,10 @@ class KubernetesDeployer:
         try:
             # Ensure namespace
             self._run(["create", "namespace", self._namespace], check=False)
-            tmp_dir = Path(tempfile.gettempdir())
-            manifest_path = tmp_dir / f"agt-{agent_id}-manifest.json"
+            fd, tmp_path = tempfile.mkstemp(prefix=f"agt-{agent_id}-", suffix=".json")
+            manifest_path = Path(tmp_path)
             try:
+                os.close(fd)
                 manifest_path.write_text(manifest_json, encoding="utf-8")
                 self._run(["apply", "-f", str(manifest_path)])
             finally:


### PR DESCRIPTION
## Summary

Fixes a race condition in \KubernetesDeployer.deploy()\ where concurrent deployments of the same agent_id would overwrite each other's manifest file.

## Change

\deploy.py\: Replace deterministic path \{tmpdir}/agt-{agent_id}-manifest.json\ with \	empfile.mkstemp()\ which generates a unique file per call.

## Why

Two concurrent \deploy()\ calls for the same agent_id would write to the same temp file path. The second write could overwrite the first manifest before \kubectl apply\ reads it, causing a silent deployment of the wrong manifest.

## Testing

\pytest agent-governance-python/agent-runtime/tests/test_deploy.py\: 53 passed