### PR TITLE
ci: add semantic PR title enforcement

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -14,6 +14,7 @@ aioredis
 AKIA
 AKIA
 alnum
+amannn
 Amol
 Amol
 appsettings

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            test
+            refactor
+            chore
+            ci
+            perf
+            security
+            examples
+            build
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The PR title subject "{subject}" must not start with an uppercase letter.
+            Use lowercase: "feat: add foo" not "feat: Add foo".


### PR DESCRIPTION
## Summary

Adds a CI workflow that validates PR titles follow conventional commit format, enabling automated changelog generation and consistent git history.

## Changes

- **\.github/workflows/pr-title-check.yml\**: New workflow using \mannn/action-semantic-pull-request\ (SHA-pinned to v5.5.3)
- Allowed types: feat, fix, docs, test, refactor, chore, ci, perf, security, examples, build, revert
- Enforces lowercase subject start
- Scope is optional

## Why

Envoy AI Gateway enforces semantic PR titles with 20+ type prefixes. Consistent titles enable automated changelog generation and make git history scannable.

Closes #2322