### PR TITLE
docs: fix broken demo paths and update OpenShell/OpenClaw status labels

### DIFF
--- a/docs/compliance/nist-rfi-2026-00206.md
+++ b/docs/compliance/nist-rfi-2026-00206.md
@@ -67,7 +67,7 @@ The Agent Governance Toolkit provides an application-level governance stack that
 - **Evidence:**
   - Coverage table: [README.md](../../README.md#L133-L142)
   - Risk mapping and mitigation examples: [agent-governance-python/agent-compliance/docs/analyst/owasp-agentic-mapping.md](../../agent-governance-python/agent-compliance/docs/analyst/owasp-agentic-mapping.md#L134-L136)
-  - Demo showing rogue detection/quarantine: [examples/demos/maf_governance_demo.py](../../demo/maf_governance_demo.py#L287-L296)
+  - Demo showing rogue detection/quarantine: [examples/demos/maf_governance_demo.py](../../examples/demos/maf_governance_demo.py#L287-L296)
 
 ### 1(b) Variation by model capability, scaffold, deployment, hosting, use case
 - **Status:** Partial
@@ -104,7 +104,7 @@ The Agent Governance Toolkit provides an application-level governance stack that
 - **Rationale:** The repo includes model/agent controls, system-level policies, and human-oversight primitives with CI/test tooling.
 - **Evidence:**
   - Model/agent capability model & `PolicyEngine`: [README.md](../../README.md#L86-L96)
-  - Middleware & system-level controls: [examples/demos/maf_governance_demo.py](../../demo/maf_governance_demo.py#L49-L60), [examples/demos/README.md](../../demo/README.md#L11-L14)
+  - Middleware & system-level controls: [examples/demos/maf_governance_demo.py](../../examples/demos/maf_governance_demo.py#L49-L60), [examples/demos/README.md](../../examples/demos/README.md#L11-L14)
   - Human-in-the-loop policies: [agent-governance-python/agent-compliance/docs/analyst/owasp-agentic-mapping.md](../../agent-governance-python/agent-compliance/docs/analyst/owasp-agentic-mapping.md#L169-L172)
   - Sandboxing / hypervisor: [agent-governance-python/agent-compliance/docs/analyst/owasp-agentic-mapping.md](../../agent-governance-python/agent-compliance/docs/analyst/owasp-agentic-mapping.md#L139-L150)
 
@@ -148,7 +148,7 @@ The Agent Governance Toolkit provides an application-level governance stack that
 
 #### 3(a)(i) Post-deploy detection
 - **Status:** Yes
-- **Evidence:** Auto-quarantine demo and audit logs — [examples/demos/maf_governance_demo.py](../../demo/maf_governance_demo.py#L299-L313)
+- **Evidence:** Auto-quarantine demo and audit logs — [examples/demos/maf_governance_demo.py](../../examples/demos/maf_governance_demo.py#L299-L313)
 
 #### 3(a)(ii–iv) Alignment, maturity, resources
 - **Status:** Partial
@@ -166,7 +166,7 @@ The Agent Governance Toolkit provides an application-level governance stack that
 
 ### 3(d) State of practice for user-facing secure-deployment docs
 - **Status:** Yes
-- **Evidence:** Deployment patterns, demo scenarios, and policy examples: [examples/demos/README.md](../../demo/README.md#L121-L124), `examples/demos/policies/research_policy.yaml` (examples/demos/policies)
+- **Evidence:** Deployment patterns, demo scenarios, and policy examples: [examples/demos/README.md](../../examples/demos/README.md#L121-L124), `examples/demos/policies/research_policy.yaml` (examples/demos/policies)
 
 ---
 
@@ -187,7 +187,7 @@ The Agent Governance Toolkit provides an application-level governance stack that
 ### 4(c) Managing risks with counterparties
 - **Status:** Partial
 - **Rationale:** Demo scenarios illustrate interaction controls and audit; a formal counterparty risk playbook is not present.
-- **Evidence:** [examples/demos/maf_governance_demo.py](../../demo/maf_governance_demo.py#L11-L14), [README.md](../../README.md#L73)
+- **Evidence:** [examples/demos/maf_governance_demo.py](../../examples/demos/maf_governance_demo.py#L11-L14), [README.md](../../README.md#L73)
 
 ### 4(d) Monitoring deployment environments
 - **Status:** Yes

--- a/docs/deployment/openclaw-sidecar.md
+++ b/docs/deployment/openclaw-sidecar.md
@@ -5,10 +5,10 @@ Deploy OpenClaw as an autonomous agent with the Agent Governance Toolkit as a si
 > [!WARNING]
 > **Known limitations — read before deploying:**
 > - OpenClaw does **not** natively call the governance sidecar. Your orchestration layer must call the sidecar HTTP API explicitly before executing tools.
-> - The docker-compose example in this doc is for illustration. For a working local demo, use [`examples/demos/openclaw-governed/`](../../demo/openclaw-governed/).
+> - The docker-compose example in this doc is for illustration. For a working local demo, use [`examples/demos/openclaw-governed/`](../../examples/demos/openclaw-governed/).
 > - See [Roadmap](#roadmap) for the full list of unimplemented features.
 
-> **Container images** are published to `ghcr.io/microsoft/agentmesh/`. See [Container Images](../../agent-governance-python/agent-mesh/docs/deployment/azure.md#container-images) for the full list.
+> **Container images** are not yet published to a public registry. Build from source and push to your own registry (see [Build the Sidecar Image](#1-build-the-governance-sidecar-image)).
 
 > **See also:** [Deployment Overview](README.md) | [AKS Deployment](../../agent-governance-python/agent-mesh/docs/deployment/azure.md) | [OpenShell Integration](../integrations/openshell.md)
 
@@ -79,7 +79,7 @@ OpenClaw is a powerful autonomous agent capable of executing code, calling APIs,
 
 ## Quick Start with Docker Compose
 
-A working local demo is available at [`examples/demos/openclaw-governed/`](../../demo/openclaw-governed/):
+A working local demo is available at [`examples/demos/openclaw-governed/`](../../examples/demos/openclaw-governed/):
 
 ```bash
 cd examples/demos/openclaw-governed
@@ -383,7 +383,7 @@ pip install agent-os-kernel
 python -m agent_os.server --host 127.0.0.1 --port 8081
 ```
 
-A smoke test script is available at [`examples/demos/openclaw-governed/test-sidecar.sh`](../../demo/openclaw-governed/test-sidecar.sh) — it tests all 8 API endpoints.
+A smoke test script is available at [`examples/demos/openclaw-governed/test-sidecar.sh`](../../examples/demos/openclaw-governed/test-sidecar.sh) — it tests all 8 API endpoints.
 
 ---
 
@@ -412,7 +412,7 @@ Features we're actively working on:
 - [ ] **Transparent tool-call proxy** — Intercept agent → tool calls without agent modification
 - [ ] **YAML policy loading from mounted volume** — Load `PolicyDocument` files from `/policies`
 - [ ] **Prometheus `/metrics` endpoint** — Standard Prometheus format alongside the JSON API
-- [ ] **Published container images** — Pre-built images on GHCR (currently build-from-source)
+- [ ] **Published container images** — Pre-built images on a public registry (currently build-from-source)
 - [ ] **Helm chart sidecar injection** — First-class sidecar support in the AgentMesh Helm chart
 - [ ] **Trust score persistence** — Shared trust state across sidecar restarts
 - [ ] **OpenClaw native integration** — `GOVERNANCE_PROXY` env var support in OpenClaw upstream

--- a/docs/integrations/openshell.md
+++ b/docs/integrations/openshell.md
@@ -86,11 +86,10 @@ if not decision.allowed:
 
 See the [runnable example](../../examples/openshell-governed/) for a complete demo.
 
-### Option B: Governance Sidecar (Planned)
+### Option B: Governance Sidecar
 
-> **Status:** The sidecar deployment pattern is documented as a reference architecture.
-> The governance HTTP API is not yet packaged as a standalone server.
-> See the [OpenClaw sidecar deployment guide](../deployment/openclaw-sidecar.md) for progress and known limitations.
+> **Status:** The sidecar deployment pattern is available as a reference architecture with a working HTTP API.
+> See the [OpenClaw sidecar deployment guide](../deployment/openclaw-sidecar.md) for Docker Compose and AKS deployment instructions.
 
 Run the governance API server as a sidecar container. Your agent (or orchestration layer) calls the sidecar's HTTP API before executing actions:
 
@@ -164,13 +163,13 @@ Result: Action blocked before reaching OpenShell
 
 When running both layers, you get two complementary telemetry streams:
 
-**Governance Toolkit metrics** (planned, reference schema):
+**Governance Toolkit metrics** (JSON API available, Prometheus format planned):
 - `policy_decisions_total{result="allow|deny"}`
 - `trust_score_current{agent="did:mesh:..."}`
 - `audit_chain_entries_total`
 - `authority_resolutions_total{decision="allow|deny|narrowed"}`
 
-> These metric names are a reference design. The OpenShell governance skill currently provides in-memory audit logs via `get_audit_log()`. Prometheus/OpenTelemetry export is planned.
+> The sidecar exposes governance metrics via the JSON API at `/api/v1/metrics`. Prometheus/OpenTelemetry export format is planned. The OpenShell governance skill provides in-memory audit logs via `get_audit_log()`.
 
 **OpenShell metrics**:
 - Sandbox network egress logs

--- a/docs/tutorials/34-maf-integration.md
+++ b/docs/tutorials/34-maf-integration.md
@@ -204,7 +204,7 @@ tier1_agent = Agent(name="tier1-support", kernel=tier1_kernel, ...)
 admin_agent = Agent(name="admin-support", kernel=admin_kernel, ...)
 ```
 
-See the full demo: [`examples/demos/maf-integration/02_helpdesk_it.py`](../../demo/maf-integration/02_helpdesk_it.py)
+See the full demo: [`examples/demos/maf-integration/02_helpdesk_it.py`](../../examples/demos/maf-integration/02_helpdesk_it.py)
 
 ## Step 6 — Prompt Injection Detection
 
@@ -236,7 +236,7 @@ kernel.add_agent_middleware(
 support_agent = Agent(name="support", kernel=kernel, ...)
 ```
 
-See the full demo: [`examples/demos/maf-integration/03_contoso_support.py`](../../demo/maf-integration/03_contoso_support.py)
+See the full demo: [`examples/demos/maf-integration/03_contoso_support.py`](../../examples/demos/maf-integration/03_contoso_support.py)
 
 ## Step 7 — Folder-Level Policies for Multi-Agent Systems
 
@@ -266,9 +266,9 @@ result = evaluator.evaluate({
 
 | Demo | Scenario | Key Governance Features |
 |---|---|---|
-| [`01_contoso_bank.py`](../../demo/maf-integration/01_contoso_bank.py) | Banking | PII blocking, fund transfer denial, SOC2 audit trail |
-| [`02_helpdesk_it.py`](../../demo/maf-integration/02_helpdesk_it.py) | IT Support | Role-based tool access, privilege escalation prevention |
-| [`03_contoso_support.py`](../../demo/maf-integration/03_contoso_support.py) | Customer Chat | Jailbreak detection, system prompt extraction defense |
+| [`01_contoso_bank.py`](../../examples/demos/maf-integration/01_contoso_bank.py) | Banking | PII blocking, fund transfer denial, SOC2 audit trail |
+| [`02_helpdesk_it.py`](../../examples/demos/maf-integration/02_helpdesk_it.py) | IT Support | Role-based tool access, privilege escalation prevention |
+| [`03_contoso_support.py`](../../examples/demos/maf-integration/03_contoso_support.py) | Customer Chat | Jailbreak detection, system prompt extraction defense |
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Fix all broken relative links to demo files across docs and update stale status labels for OpenShell/OpenClaw integrations.

## Problem

- 11 links across 4 docs files used `../../demo/` paths that should be `../../examples/demos/`
- `openclaw-sidecar.md` contradicted itself on GHCR image availability (line 11 said published, line 160 said not published)
- `openshell.md` labeled the sidecar deployment as "Planned" despite a full deployment guide existing

## Changes

| File | Change |
|------|--------|
| `docs/deployment/openclaw-sidecar.md` | Fix 3 broken paths, remove GHCR contradiction, update roadmap wording |
| `docs/integrations/openshell.md` | Update sidecar status from Planned to available, update metrics section |
| `docs/compliance/nist-rfi-2026-00206.md` | Fix 5 broken demo paths |
| `docs/tutorials/34-maf-integration.md` | Fix 5 broken demo paths |

## Testing

Verified all target files exist at `examples/demos/`. Confirmed zero remaining `../../demo/` references in docs.
