### PR TITLE
docs: add retroactive ADRs for core policy engine decisions

### DIFF
--- a/docs/adr/0013-fail-closed-on-policy-evaluation-errors.md
+++ b/docs/adr/0013-fail-closed-on-policy-evaluation-errors.md
@@ -1,0 +1,41 @@
+# ADR 0013: Fail closed on policy evaluation errors
+
+- Status: accepted
+- Date: 2026-04-10
+
+## Context
+
+The policy engine evaluates governance rules against agent actions at runtime.
+When evaluation encounters an unexpected error (malformed context, backend
+timeout, regex compilation failure, or any unhandled exception), the engine
+must choose between two failure modes: fail-open (allow the action) or
+fail-closed (deny the action).
+
+Fail-open is simpler and avoids false-positive denials, but it creates an
+exploitable attack surface. An adversary who can trigger evaluation errors
+(e.g., by injecting malformed context fields or causing resource exhaustion)
+could bypass all governance controls. In enterprise and multi-tenant
+deployments, a single fail-open path can undermine the entire trust model.
+
+## Decision
+
+The policy engine fails closed on all evaluation errors. Any unhandled
+exception during rule matching, backend consultation, or condition evaluation
+results in an immediate deny with action `"deny"`, a reason indicating policy
+evaluation error, and an audit entry with `error: true`. The exception is
+logged at ERROR level with full stack trace and context snapshot.
+
+This applies uniformly to flat evaluation, folder-scoped evaluation, and
+external backend consultation. There are no configuration flags to switch to
+fail-open behavior.
+
+## Consequences
+
+Governance guarantees are maintained even during partial system failures.
+Operators can trust that a passing policy check genuinely means the rules were
+evaluated, not that evaluation was skipped due to an error. The tradeoff is
+that bugs in policy configuration (e.g., invalid regex patterns, misconfigured
+backends) will cause legitimate actions to be denied until the configuration is
+fixed. This is acceptable because it creates immediate, visible feedback that
+drives rapid correction, whereas fail-open errors are silent and may go
+undetected.

--- a/docs/adr/0014-parent-deny-rules-immutable-in-merge.md
+++ b/docs/adr/0014-parent-deny-rules-immutable-in-merge.md
@@ -1,0 +1,42 @@
+# ADR 0014: Parent deny rules are immutable in policy merge
+
+- Status: accepted
+- Date: 2026-04-10
+
+## Context
+
+AGT supports folder-level governance policies where child directories can
+refine or specialize parent policies. During merge, a child rule with
+`override: true` and the same name as a parent rule replaces the parent.
+This raises a security question: should a child policy be able to override a
+parent deny rule with an allow?
+
+In Azure Policy, deny assignments are immutable at a given scope. XACML
+deny-overrides is a standard combining algorithm that prevents lower-priority
+allow rules from defeating higher-scoped denies. The principle is the same:
+security-critical restrictions set at a higher organizational level should
+not be circumventable by more specific policies.
+
+Without this invariant, a team-level `governance.yaml` could neutralize an
+org-level deny by declaring `override: true` with a higher priority, defeating
+the purpose of centralized security governance.
+
+## Decision
+
+Parent deny rules cannot be overridden by child rules during folder-level
+policy merge. When a child rule declares `override: true` with the same name
+as a parent deny rule, the child rule is silently dropped and a warning is
+logged. The parent deny remains in effect regardless of the child's priority
+value.
+
+This invariant is enforced in the `merge_policies()` function and is tested by
+the spec conformance suite.
+
+## Consequences
+
+Organizations can set security boundaries at the root level with confidence
+that no subdirectory policy can weaken them. The tradeoff is reduced
+flexibility: if a team legitimately needs an exception to an org-level deny,
+the exception must be granted at the org level itself (by modifying the parent
+policy), not worked around at the team level. This is intentional and follows
+the principle of least surprise for security-critical governance.

--- a/docs/adr/0015-pluggable-external-policy-backends.md
+++ b/docs/adr/0015-pluggable-external-policy-backends.md
@@ -1,0 +1,40 @@
+# ADR 0015: Pluggable external policy backends via protocol interface
+
+- Status: accepted
+- Date: 2026-05-16
+
+## Context
+
+AGT's policy engine originally supported only native YAML/JSON rules. As
+adoption grew, users needed to integrate existing policy investments written
+in OPA/Rego and Cedar. The initial OPA and Cedar integrations used completely
+different interfaces, return types, and method signatures, making it
+impossible to write backend-agnostic governance code or add new backends
+without reverse-engineering existing implementations.
+
+A unified interface was needed so that: (1) YAML rules and external backends
+compose cleanly in a single evaluation pipeline, (2) new backends can be added
+without modifying the evaluator, and (3) backend results are normalized to a
+common decision type with consistent audit metadata.
+
+## Decision
+
+Define `ExternalPolicyBackend` as a runtime-checkable Protocol with two
+requirements: a `name` property returning a human-readable identifier, and an
+`evaluate(context)` method accepting an execution context dict and returning a
+`BackendDecision` dataclass. Backend results carry `allowed`, `action`,
+`reason`, `backend` name, `evaluation_ms`, and an `error` field.
+
+Backends are consulted only when no YAML rule matches. They are evaluated in
+registration order and the first non-error result determines the decision.
+Convenience methods (`load_rego()`, `load_cedar()`) simplify common setups.
+
+## Consequences
+
+Adding a new policy backend (e.g., Sentinel, custom gRPC service) requires
+implementing a two-method protocol and registering it with the evaluator. No
+core evaluator code changes are needed. The evaluation pipeline has a clear
+priority order: YAML rules first, then external backends, then defaults. The
+tradeoff is that all backends must normalize their native decision formats to
+`BackendDecision`, which may lose backend-specific metadata unless it is
+stashed in the audit entry.

--- a/docs/adr/0016-trust-ceiling-propagation-for-delegation.md
+++ b/docs/adr/0016-trust-ceiling-propagation-for-delegation.md
@@ -1,0 +1,43 @@
+# ADR 0016: Trust ceiling propagation for delegated agents
+
+- Status: accepted
+- Date: 2026-05-16
+
+## Context
+
+AgentMesh uses numeric trust scores (0-1000) to gate agent capabilities.
+When a parent agent delegates work to a child agent, the child previously
+started at the default score (500) and could potentially reach 1000 through
+good behavior. This broke the principle that delegated authority should never
+exceed the delegator's own authority: a parent with trust 300 could spawn a
+child that accumulates higher trust than the parent itself.
+
+This is analogous to capability-based security systems where a process cannot
+grant more capabilities than it holds. Without ceiling propagation, the
+delegation chain becomes a privilege escalation vector.
+
+## Decision
+
+Trust ceiling propagation is enforced on all delegation paths. When a parent
+agent delegates to a child, the parent's current trust score becomes a hard
+ceiling on the child's trust. The child's initial score is clamped to
+`min(initial_score, ceiling)`, and all subsequent score updates respect the
+ceiling as an upper bound.
+
+For multi-level delegation, ceilings propagate monotonically: each level takes
+`min(parent_ceiling, requested_ceiling)`, ensuring trust can only narrow as
+delegation depth increases.
+
+The ceiling can also be set via the `AGT_TRUST_CEILING` environment variable
+for containerized deployments where the orchestrator sets trust boundaries at
+the infrastructure level.
+
+## Consequences
+
+Delegation chains cannot be used for privilege escalation. A child agent's
+trust is always bounded by its parent's trust at delegation time. The tradeoff
+is that child agents in trusted environments may be artificially constrained
+if their parent happens to have a low score. This is acceptable because the
+alternative (unbounded child trust) is a security violation, and operators can
+adjust parent scores or set explicit ceilings when higher child trust is
+genuinely needed.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -15,6 +15,10 @@ Key architectural decisions and their rationale. Each ADR follows the standard f
 | [ADR-0004](0004-keep-policy-evaluation-deterministic.md) | Keep policy evaluation deterministic | Policy |
 | [ADR-0009](0009-rfc-9334-rats-architecture-alignment.md) | RFC 9334 (RATS) architecture alignment | Standards |
 | [ADR-0012](0012-cost-governance-observability-policies.md) | Cost governance via observability policies | SRE |
+| [ADR-0013](0013-fail-closed-on-policy-evaluation-errors.md) | Fail closed on policy evaluation errors | Policy |
+| [ADR-0014](0014-parent-deny-rules-immutable-in-merge.md) | Parent deny rules are immutable in policy merge | Policy |
+| [ADR-0015](0015-pluggable-external-policy-backends.md) | Pluggable external policy backends via protocol interface | Policy |
+| [ADR-0016](0016-trust-ceiling-propagation-for-delegation.md) | Trust ceiling propagation for delegated agents | Trust |
 
 ## Proposed
 


### PR DESCRIPTION
Adds four architecture decision records documenting design decisions that were previously implicit in the codebase. These ADRs complement the new Policy Engine Specification (#2328) by explaining the *why* behind key behavioral requirements.

**New ADRs:**

| ADR | Decision | Area |
|-----|----------|------|
| 0013 | Fail closed on policy evaluation errors | Policy |
| 0014 | Parent deny rules are immutable in policy merge | Policy |
| 0015 | Pluggable external policy backends via protocol interface | Policy |
| 0016 | Trust ceiling propagation for delegated agents | Trust |

Each ADR follows the existing Context/Decision/Consequences format. ADR index updated.