### PR TITLE
ci: add license header enforcement for changed files

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -154,6 +154,7 @@ Printf
 Println
 privatelink
 promptdefense
+pycache
 Pydantic
 pypdf
 pyproject
@@ -170,6 +171,7 @@ requireapproval
 reqwest
 returncode
 rfind
+rglob
 Rootfs
 rrdatas
 rstrip
@@ -222,6 +224,7 @@ urllib
 urlopen
 USERPROFILE
 uvicorn
+venv
 vnet
 westus
 workflow

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+name: License Headers
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**.py"
+      - "**.ts"
+      - "**.cs"
+      - "**.rs"
+      - "**.go"
+
+permissions:
+  contents: read
+
+jobs:
+  check-headers:
+    name: Check license headers (changed files)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - name: Check license headers on changed files
+        run: |
+          # Get list of changed source files in this PR
+          changed=$(git diff --name-only --diff-filter=ACM origin/main...HEAD -- '*.py' '*.ts' '*.cs' '*.rs' '*.go' || true)
+          if [ -z "$changed" ]; then
+            echo "No source files changed."
+            exit 0
+          fi
+          python scripts/check_license_headers.py "$changed"

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+"""Check that source files contain the MIT license header.
+
+Usage:
+    python scripts/check_license_headers.py [--fix]
+
+Checks .py, .ts, .cs, .rs, .go files for the required header.
+With --fix, prepends the header to files that are missing it.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Expected header patterns per language (single-line and two-line variants)
+HEADERS_SINGLE: dict[str, str] = {
+    ".py": "# Copyright (c) Microsoft Corporation. Licensed under the MIT License.",
+    ".ts": "// Copyright (c) Microsoft Corporation. Licensed under the MIT License.",
+    ".cs": "// Copyright (c) Microsoft Corporation. Licensed under the MIT License.",
+    ".rs": "// Copyright (c) Microsoft Corporation. Licensed under the MIT License.",
+    ".go": "// Copyright (c) Microsoft Corporation. Licensed under the MIT License.",
+}
+
+HEADERS_MULTI: dict[str, tuple[str, str]] = {
+    ".py": ("# Copyright (c) Microsoft Corporation.", "# Licensed under the MIT License."),
+    ".ts": ("// Copyright (c) Microsoft Corporation.", "// Licensed under the MIT License."),
+    ".cs": ("// Copyright (c) Microsoft Corporation.", "// Licensed under the MIT License."),
+    ".rs": ("// Copyright (c) Microsoft Corporation.", "// Licensed under the MIT License."),
+    ".go": ("// Copyright (c) Microsoft Corporation.", "// Licensed under the MIT License."),
+}
+
+# Directories to skip
+SKIP_DIRS = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv",
+    "dist", "build", ".eggs", ".tox", ".mypy_cache",
+    "vendor", "third_party",
+}
+
+# Files to skip (generated, vendored, etc.)
+SKIP_FILES = {"__init__.py"}
+
+
+def should_skip(path: Path) -> bool:
+    """Return True if the file should be skipped."""
+    parts = path.parts
+    if any(d in parts for d in SKIP_DIRS):
+        return True
+    if path.name in SKIP_FILES:
+        return True
+    # Skip empty files
+    if path.stat().st_size == 0:
+        return True
+    return False
+
+
+def check_header(path: Path) -> bool:
+    """Return True if the file has the correct license header."""
+    single = HEADERS_SINGLE.get(path.suffix)
+    multi = HEADERS_MULTI.get(path.suffix)
+    if not single:
+        return True
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return True  # skip unreadable files
+
+    # Check first 5 lines for the header (allows shebang, encoding, etc.)
+    lines = content.split("\n", 5)[:5]
+    # Single-line match
+    if any(single in line for line in lines):
+        return True
+    # Two-line match
+    if multi:
+        text = "\n".join(lines)
+        if multi[0] in text and multi[1] in text:
+            return True
+    return False
+
+
+def fix_header(path: Path) -> None:
+    """Prepend the license header to a file."""
+    expected = HEADERS_SINGLE.get(path.suffix)
+    if not expected:
+        return
+    content = path.read_text(encoding="utf-8")
+    # If file starts with shebang, insert after it
+    if content.startswith("#!"):
+        first_newline = content.index("\n")
+        path.write_text(
+            content[: first_newline + 1] + expected + "\n" + content[first_newline + 1 :],
+            encoding="utf-8",
+        )
+    else:
+        path.write_text(expected + "\n" + content, encoding="utf-8")
+
+
+def main() -> int:
+    fix_mode = "--fix" in sys.argv
+    file_args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    root = Path(".")
+    missing: list[Path] = []
+
+    if file_args:
+        # Check only specified files
+        for f in file_args:
+            path = Path(f)
+            if path.exists() and path.suffix in HEADERS_SINGLE and not should_skip(path):
+                if not check_header(path):
+                    missing.append(path)
+    else:
+        # Check all source files
+        for ext in HEADERS_SINGLE:
+            for path in root.rglob(f"*{ext}"):
+                if should_skip(path):
+                    continue
+                if not check_header(path):
+                    missing.append(path)
+
+    if not missing:
+        print(f"All source files have license headers.")
+        return 0
+
+    if fix_mode:
+        for path in missing:
+            fix_header(path)
+            print(f"Fixed: {path}")
+        print(f"\nFixed {len(missing)} file(s).")
+        return 0
+
+    print(f"Missing license header in {len(missing)} file(s):\n")
+    for path in sorted(missing):
+        print(f"  {path}")
+    print(f"\nRun with --fix to add headers automatically.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds automated MIT license header checking for source files changed in PRs.

## Changes

- **\scripts/check_license_headers.py\**: License header checker supporting .py, .ts, .cs, .rs, .go files. Handles both single-line and two-line header variants. Supports \--fix\ flag for auto-remediation.
- **\.github/workflows/license-headers.yml\**: CI workflow that checks only files changed in the PR (not the full repo).

## Design decisions

- **Changed-files only**: ~1978 existing files lack headers. Enforcing on the full repo would be a separate cleanup effort. This ensures new/modified files have headers going forward.
- **Two-line support**: Some existing files use a two-line format. Both are accepted.
- **\--fix\ flag**: Contributors can auto-fix locally before pushing.

Closes #2321