### PR TITLE
fix(typescript): use JSON_SCHEMA instead of DEFAULT_SCHEMA in yaml.load

### DIFF
--- a/agent-governance-typescript/src/policy.ts
+++ b/agent-governance-typescript/src/policy.ts
@@ -386,7 +386,7 @@ export class PolicyEngine {
   loadYaml(yamlContent: string): Policy {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const yaml = require('js-yaml');
-    const data = yaml.load(yamlContent, { schema: yaml.DEFAULT_SCHEMA }) as Record<string, unknown>;
+    const data = yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>;
     const policy = dataToPolicy(data);
     this.loadPolicy(policy);
     return policy;
@@ -610,7 +610,7 @@ export class PolicyEngine {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const yaml = require('js-yaml');
     const content = readFileSync(yamlPath, 'utf-8');
-    const doc = yaml.load(content, { schema: yaml.DEFAULT_SCHEMA }) as { rules?: PolicyRule[] };
+    const doc = yaml.load(content, { schema: yaml.JSON_SCHEMA }) as { rules?: PolicyRule[] };
     if (doc?.rules && Array.isArray(doc.rules)) {
       this._legacyRules.push(...doc.rules);
     }


### PR DESCRIPTION
## Summary

Replaces `yaml.DEFAULT_SCHEMA` with `yaml.JSON_SCHEMA` in both YAML loading sites in the TypeScript policy engine.

### Problem

`DEFAULT_SCHEMA` in js-yaml includes JavaScript-specific type constructors (`!!js/undefined`, `!!js/regexp`, `!!js/function`) that can enable code execution when parsing untrusted YAML policy documents. This is CWE-502 (deserialization of untrusted data).

### Fix

`JSON_SCHEMA` only permits standard JSON-compatible types: strings, numbers, booleans, null, arrays, and objects. Policy documents only use these types, so this is a safe drop-in replacement.

### Affected sites

- `PolicyEngine.loadYaml()` (line 389)
- `PolicyEngine.loadFromYAML()` (line 613)

### Testing

All 17 policy tests and 40 policy-parity tests pass with no changes needed.