### PR TITLE
docs: add AgentMesh Identity and Trust specification v1.0

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -48,6 +48,7 @@ demux
 deprioritized
 Deserialise
 Diffable
+dids
 Dify
 Dockerfiles
 Docstrings
@@ -92,9 +93,11 @@ imran
 IPFS
 isinstance
 isort
+jwkjwks
 kanish
 kata
 kevinkaylie
+keypair
 keyrings
 kwarg
 kwargs
@@ -166,6 +169,7 @@ pyupgrade
 Ravande
 Rego
 relativedelta
+removeprefix
 repudiable
 requireapproval
 reqwest
@@ -196,6 +200,8 @@ skipif
 Slidev
 SLSA
 spacy
+SPIFFE
+spiffe
 spellcheck
 spellchecking
 splitlines
@@ -206,6 +212,7 @@ streamlit
 strftime
 structlog
 subpro
+SVID
 sybil
 syscall
 syscalls
@@ -219,6 +226,7 @@ uncallable
 unconfigured
 Ungated
 Unregisters
+unrevoke
 unsets
 urllib
 urlopen

--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -47,8 +47,8 @@ dearmor
 demux
 deprioritized
 Deserialise
-Diffable
 dids
+Diffable
 Dify
 Dockerfiles
 Docstrings
@@ -200,10 +200,10 @@ skipif
 Slidev
 SLSA
 spacy
-SPIFFE
-spiffe
 spellcheck
 spellchecking
+SPIFFE
+spiffesvid
 splitlines
 startswith
 staticmethod
@@ -226,10 +226,12 @@ uncallable
 unconfigured
 Ungated
 Unregisters
+unrevocation
 unrevoke
 unsets
 urllib
 urlopen
+urlsafe
 USERPROFILE
 uvicorn
 venv

--- a/agent-governance-python/agent-mesh/tests/test_spec_identity_trust_conformance.py
+++ b/agent-governance-python/agent-mesh/tests/test_spec_identity_trust_conformance.py
@@ -1,0 +1,1293 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Conformance tests for AGENTMESH-IDENTITY-TRUST-1.0.
+
+Every test references a specific section of the specification.
+Tests marked [Pure Specification] verify normative requirements.
+Tests marked [Default Implementation] verify reference defaults.
+"""
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import re
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Imports under test
+# ---------------------------------------------------------------------------
+
+from agentmesh.identity.agent_id import AgentDID, AgentIdentity, IdentityRegistry
+from agentmesh.identity.credentials import Credential
+from agentmesh.identity.revocation import RevocationEntry, RevocationList
+from agentmesh.identity.rotation import KeyRotationManager
+from agentmesh.identity.jwk import to_jwk, from_jwk, to_jwks, from_jwks
+from agentmesh.identity.spiffe import SVID, SPIFFEIdentity, SPIFFERegistry
+from agentmesh.identity.delegation import (
+    DelegationLink,
+    ScopeChain,
+    UserContext,
+)
+from agentmesh.trust.handshake import (
+    HandshakeChallenge,
+    HandshakeResponse,
+    HandshakeResult,
+    TrustHandshake,
+)
+from agentmesh.reward.scoring import (
+    DimensionType,
+    RewardDimension,
+    RewardSignal,
+    ScoreThresholds,
+    TrustScore,
+)
+from agentmesh.reward.trust_decay import (
+    InteractionEdge,
+    NetworkTrustEngine,
+    RegimeChangeAlert,
+    TrustEvent,
+)
+from agentmesh.trust_types import (
+    AgentProfile,
+    TrustRecord,
+    TrustScore as IntegrationTrustScore,
+    TrustTracker,
+)
+from agentmesh.constants import (
+    CREDENTIAL_ROTATION_THRESHOLD_SECONDS,
+    DEFAULT_DELEGATION_MAX_DEPTH,
+    TIER_PROBATIONARY_THRESHOLD,
+    TIER_STANDARD_THRESHOLD,
+    TIER_TRUSTED_THRESHOLD,
+    TIER_VERIFIED_PARTNER_THRESHOLD,
+    TRUST_REVOCATION_THRESHOLD,
+    TRUST_SCORE_DEFAULT,
+    TRUST_SCORE_MAX,
+    TRUST_SCORE_MIN,
+    WEIGHT_COLLABORATION_HEALTH,
+    WEIGHT_OUTPUT_QUALITY,
+    WEIGHT_POLICY_COMPLIANCE,
+    WEIGHT_RESOURCE_EFFICIENCY,
+    WEIGHT_SECURITY_POSTURE,
+)
+from agentmesh.exceptions import (
+    DelegationDepthError,
+    DelegationError,
+    HandshakeError,
+    HandshakeTimeoutError,
+    IdentityError,
+    TrustError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_identity(
+    name: str = "test-agent",
+    sponsor: str = "sponsor@contoso.com",
+    capabilities: list[str] | None = None,
+) -> AgentIdentity:
+    return AgentIdentity.create(
+        name=name,
+        sponsor=sponsor,
+        capabilities=capabilities or ["read:data", "write:data"],
+    )
+
+
+def _make_credential(
+    agent_did: str = "did:mesh:abc123",
+    capabilities: list[str] | None = None,
+    ttl_seconds: int = 900,
+) -> Credential:
+    return Credential.issue(
+        agent_did=agent_did,
+        capabilities=capabilities or ["read:data"],
+        ttl_seconds=ttl_seconds,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 3: Agent DID Schema
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAgentDIDSchema:
+    """Spec §3 — Agent DID Schema."""
+
+    def test_did_format_matches_spec(self):
+        """§3.1 — DID MUST be did:mesh:<unique-id>."""
+        did = AgentDID.generate("test")
+        assert str(did).startswith("did:mesh:")
+
+    def test_did_unique_id_128_bits(self):
+        """§3.2 — unique-id MUST use >= 128 bits of randomness."""
+        did = AgentDID.generate("test")
+        unique_id = str(did).removeprefix("did:mesh:")
+        # 128 bits = 32 hex chars
+        assert len(unique_id) >= 32
+        assert re.match(r"^[0-9a-f]+$", unique_id)
+
+    def test_did_generation_unique(self):
+        """§3.2 — successive DIDs MUST be distinct."""
+        dids = {str(AgentDID.generate("x")) for _ in range(100)}
+        assert len(dids) == 100
+
+    def test_did_parsing_valid(self):
+        """§3.3 — valid did:mesh: strings MUST be accepted."""
+        did = AgentDID.from_string("did:mesh:abcdef1234567890abcdef1234567890")
+        assert did.unique_id == "abcdef1234567890abcdef1234567890"
+
+    def test_did_parsing_invalid_prefix(self):
+        """§3.3 — non-did:mesh: strings MUST be rejected."""
+        with pytest.raises(ValueError):
+            AgentDID.from_string("did:web:example.com")
+
+    def test_did_equality(self):
+        """§3.4 — equality MUST be byte-identical string comparison."""
+        did1 = AgentDID.from_string("did:mesh:abc")
+        did2 = AgentDID.from_string("did:mesh:abc")
+        assert str(did1) == str(did2)
+
+    def test_did_hashing(self):
+        """§3.4 — hashing MUST be deterministic and consistent with equality."""
+        did1 = AgentDID.from_string("did:mesh:abc")
+        did2 = AgentDID.from_string("did:mesh:abc")
+        assert hash(did1) == hash(did2)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 4: Agent Identity Model
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAgentIdentityModel:
+    """Spec §4 — Agent Identity Model."""
+
+    def test_factory_creates_valid_identity(self):
+        """§4.5 — factory method MUST produce valid identity."""
+        identity = _make_identity()
+        assert str(identity.did).startswith("did:mesh:")
+        assert identity.public_key  # non-empty base64
+        assert identity.verification_key_id.startswith("key-")
+        assert identity.sponsor_email == "sponsor@contoso.com"
+        assert identity.status == "active"
+        assert identity.delegation_depth == 0
+
+    def test_verification_key_id_format(self):
+        """§4.4 — key ID MUST be key-<first-16-hex-of-SHA256>."""
+        identity = _make_identity()
+        assert re.match(r"^key-[0-9a-f]{16}$", identity.verification_key_id)
+
+    def test_private_key_not_serialized(self):
+        """§4.5 — private key MUST NOT appear in serialized output."""
+        identity = _make_identity()
+        data = identity.model_dump()
+        assert "_private_key" not in data
+        assert "private_key" not in str(data).lower()
+
+    def test_name_empty_rejected(self):
+        """§4.3 — name MUST NOT be empty."""
+        with pytest.raises((IdentityError, ValueError)):
+            AgentIdentity.create(name="", sponsor="s@contoso.com")
+
+    def test_name_whitespace_rejected(self):
+        """§4.3 — name MUST NOT be whitespace-only."""
+        with pytest.raises((IdentityError, ValueError)):
+            AgentIdentity.create(name="   ", sponsor="s@contoso.com")
+
+    def test_sponsor_email_missing_at(self):
+        """§4.3 — sponsor_email MUST contain @."""
+        with pytest.raises((IdentityError, ValueError)):
+            AgentIdentity.create(name="agent", sponsor="invalid")
+
+    def test_sponsor_email_empty(self):
+        """§4.3 — sponsor_email MUST NOT be empty."""
+        with pytest.raises((IdentityError, ValueError)):
+            AgentIdentity.create(name="agent", sponsor="")
+
+    def test_parent_did_must_match_prefix(self):
+        """§4.3 — parent_did MUST match did:mesh: prefix."""
+        with pytest.raises((IdentityError, ValueError)):
+            AgentIdentity(
+                did=AgentDID.generate("x"),
+                name="x",
+                public_key="dGVzdA==",
+                verification_key_id="key-abc",
+                sponsor_email="s@contoso.com",
+                parent_did="did:web:nope",
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 5: Identity Lifecycle
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestIdentityLifecycle:
+    """Spec §5 — Identity Lifecycle."""
+
+    def test_suspend(self):
+        """§5.2.1 — suspend MUST set status to suspended."""
+        identity = _make_identity()
+        identity.suspend("routine")
+        assert identity.status == "suspended"
+        assert identity.revocation_reason == "routine"
+
+    def test_revoke(self):
+        """§5.2.2 — revoke MUST set status to revoked."""
+        identity = _make_identity()
+        identity.revoke("policy violation")
+        assert identity.status == "revoked"
+
+    def test_reactivate_suspended(self):
+        """§5.2.3 — reactivate MUST restore active status."""
+        identity = _make_identity()
+        identity.suspend("temporary")
+        identity.reactivate()
+        assert identity.status == "active"
+
+    def test_reactivate_security_suspension_requires_override(self):
+        """§5.2.3 — security suspension MUST require override_reason=True."""
+        identity = _make_identity()
+        identity.suspend("security breach detected")
+        with pytest.raises(ValueError, match="security"):
+            identity.reactivate()
+        # With override, it works
+        identity.reactivate(override_reason=True)
+        assert identity.status == "active"
+
+    def test_revoked_cannot_reactivate(self):
+        """§5.2.4 — revoked identity MUST NOT be reactivated."""
+        identity = _make_identity()
+        identity.revoke("permanent")
+        with pytest.raises(ValueError, match="revoked"):
+            identity.reactivate()
+
+    def test_is_active_checks_expiry(self):
+        """§5.3 — is_active MUST check expires_at."""
+        identity = _make_identity()
+        identity.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        assert not identity.is_active()
+
+    def test_is_active_when_active_and_not_expired(self):
+        """§5.3 — active + not expired = is_active True."""
+        identity = _make_identity()
+        assert identity.is_active()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 6: Cryptographic Primitives
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCryptographicPrimitives:
+    """Spec §6 — Cryptographic Primitives."""
+
+    def test_sign_and_verify(self):
+        """§6.2/6.3 — sign+verify round-trip MUST succeed."""
+        identity = _make_identity()
+        data = b"test payload"
+        sig = identity.sign(data)
+        assert identity.verify_signature(data, sig)
+
+    def test_verify_wrong_data(self):
+        """§6.3 — wrong data MUST return false, not raise."""
+        identity = _make_identity()
+        sig = identity.sign(b"original")
+        assert not identity.verify_signature(b"tampered", sig)
+
+    def test_verify_bad_signature(self):
+        """§6.3 — invalid signature MUST return false, not raise."""
+        identity = _make_identity()
+        assert not identity.verify_signature(b"data", "bm90YXNpZw==")
+
+    def test_sign_without_private_key_raises(self):
+        """§6.2 — signing without private key MUST raise error."""
+        identity = _make_identity()
+        identity._private_key = None
+        with pytest.raises(ValueError):
+            identity.sign(b"data")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 7: Human Sponsor Binding
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestHumanSponsorBinding:
+    """Spec §7 — Human Sponsor Binding."""
+
+    def test_sponsor_required(self):
+        """§7.1 — every identity MUST have a sponsor."""
+        identity = _make_identity()
+        assert identity.sponsor_email
+        assert "@" in identity.sponsor_email
+
+    def test_delegation_inherits_sponsor(self):
+        """§7.4 — delegated child MUST inherit sponsor_email."""
+        parent = _make_identity(capabilities=["read:data"])
+        child = parent.delegate("child", ["read:data"])
+        assert child.sponsor_email == parent.sponsor_email
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 8: Credential Lifecycle
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCredentialLifecycle:
+    """Spec §8 — Credential Lifecycle."""
+
+    def test_issue_creates_active_credential(self):
+        """§8.3 — issued credential MUST be active with correct TTL."""
+        cred = _make_credential()
+        assert cred.status == "active"
+        assert cred.is_valid()
+        assert cred.credential_id.startswith("cred_")
+
+    def test_token_hash_is_sha256(self):
+        """§8.3 — token_hash MUST be SHA-256 of token."""
+        cred = _make_credential()
+        expected = hashlib.sha256(cred.token.encode()).hexdigest()
+        assert cred.token_hash == expected
+
+    def test_token_verification_constant_time(self):
+        """§8.5 — token verification MUST use constant-time comparison."""
+        cred = _make_credential()
+        assert cred.verify_token(cred.token)
+        assert not cred.verify_token("wrong-token")
+
+    def test_expired_credential_invalid(self):
+        """§8.4 — expired credential MUST fail validation."""
+        cred = _make_credential(ttl_seconds=0)
+        # Force expiry
+        cred.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        assert not cred.is_valid()
+
+    def test_rotation(self):
+        """§8.7 — rotation MUST create new credential with correct chain."""
+        c1 = _make_credential()
+        c2 = c1.rotate()
+        assert c1.status == "rotated"
+        assert c2.status == "active"
+        assert c2.previous_credential_id == c1.credential_id
+        assert c2.rotation_count == c1.rotation_count + 1
+        assert c2.agent_did == c1.agent_did
+        assert c2.capabilities == c1.capabilities
+
+    def test_revocation(self):
+        """§8.8 — revocation MUST invalidate credential."""
+        cred = _make_credential()
+        cred.revoke("compromised")
+        assert cred.status == "revoked"
+        assert not cred.is_valid()
+        assert cred.revocation_reason == "compromised"
+        assert cred.revoked_at is not None
+
+    def test_capability_exact_match(self):
+        """§8.9 — exact capability match."""
+        cred = _make_credential(capabilities=["read:data"])
+        assert cred.has_capability("read:data")
+        assert not cred.has_capability("write:data")
+
+    def test_capability_wildcard(self):
+        """§8.9 — wildcard capability matches all."""
+        cred = _make_credential(capabilities=["*"])
+        assert cred.has_capability("anything")
+
+    def test_capability_prefix_wildcard(self):
+        """§8.9 — prefix wildcard matches sub-capabilities."""
+        cred = _make_credential(capabilities=["read:*"])
+        assert cred.has_capability("read:data")
+        assert not cred.has_capability("write:data")
+
+    def test_resource_access_open_scope(self):
+        """§8.10 — empty resources = open access."""
+        cred = _make_credential()
+        assert cred.can_access_resource("any-resource")
+
+    def test_default_ttl(self):
+        """§8.3 — default TTL is 900 seconds."""
+        cred = _make_credential()
+        assert cred.ttl_seconds == 900
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 9: Trust Score Model
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTrustScoreModel:
+    """Spec §9 — Trust Score Model."""
+
+    def test_default_score(self):
+        """§9.2 — default trust score MUST be 500."""
+        assert TRUST_SCORE_DEFAULT == 500
+        ts = TrustScore(agent_did="did:mesh:abc")
+        assert ts.total_score == TRUST_SCORE_DEFAULT
+
+    def test_score_clamped_to_range(self):
+        """§9.1 — scores MUST be clamped to [0, 1000]."""
+        ts = TrustScore(agent_did="did:mesh:abc", total_score=500)
+        ts.update(1500, {})
+        assert ts.total_score == 1000
+        ts.update(-100, {})
+        assert ts.total_score == 0
+
+    def test_trust_ceiling_enforcement(self):
+        """§9.5 — trust ceiling MUST be enforced on updates."""
+        ts = TrustScore(agent_did="did:mesh:abc", trust_ceiling=600)
+        assert ts.total_score <= 600
+        ts.update(800, {})
+        assert ts.total_score == 600
+
+    def test_trust_ceiling_on_init(self):
+        """§9.5 — ceiling MUST clamp initial score."""
+        ts = TrustScore(
+            agent_did="did:mesh:abc",
+            total_score=700,
+            trust_ceiling=500,
+        )
+        assert ts.total_score == 500
+
+    def test_agent_did_validation(self):
+        """§9.3 — agent_did MUST match did:mesh: prefix."""
+        with pytest.raises(TrustError):
+            TrustScore(agent_did="did:web:nope")
+
+    def test_dual_trust_systems(self):
+        """§9.6 — two trust score systems MUST coexist."""
+        # Integration TrustScore: 0.0-1.0 float
+        its = IntegrationTrustScore(score=0.7)
+        assert its.is_trusted  # >= 0.5
+        its_low = IntegrationTrustScore(score=0.3)
+        assert not its_low.is_trusted
+
+        # Reward TrustScore: 0-1000 int
+        rts = TrustScore(agent_did="did:mesh:abc", total_score=700)
+        assert rts.tier == "trusted"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 10: Trust Tiers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTrustTiers:
+    """Spec §10 — Trust Tiers."""
+
+    @pytest.mark.parametrize(
+        "score,expected_tier",
+        [
+            (1000, "verified_partner"),
+            (900, "verified_partner"),
+            (899, "trusted"),
+            (700, "trusted"),
+            (699, "standard"),
+            (500, "standard"),
+            (499, "probationary"),
+            (300, "probationary"),
+            (299, "untrusted"),
+            (0, "untrusted"),
+        ],
+    )
+    def test_tier_thresholds(self, score: int, expected_tier: str):
+        """§10.1/10.2 — tier MUST match threshold boundaries exactly."""
+        ts = TrustScore(agent_did="did:mesh:abc", total_score=score)
+        assert ts.tier == expected_tier
+
+    def test_tier_constants(self):
+        """§10.1 — tier threshold constants MUST match spec."""
+        assert TIER_VERIFIED_PARTNER_THRESHOLD == 900
+        assert TIER_TRUSTED_THRESHOLD == 700
+        assert TIER_STANDARD_THRESHOLD == 500
+        assert TIER_PROBATIONARY_THRESHOLD == 300
+
+    def test_action_thresholds(self):
+        """§10.3 — action thresholds MUST match defaults."""
+        st = ScoreThresholds()
+        assert st.allow_threshold == 500
+        assert st.warn_threshold == 400
+        assert st.revocation_threshold == 300
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 11: Reward Dimensions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRewardDimensions:
+    """Spec §11 — Reward Dimensions."""
+
+    def test_five_dimensions_exist(self):
+        """§11.1 — exactly 5 dimensions MUST exist."""
+        assert len(DimensionType) == 5
+        expected = {
+            "policy_compliance",
+            "resource_efficiency",
+            "output_quality",
+            "security_posture",
+            "collaboration_health",
+        }
+        assert {d.value for d in DimensionType} == expected
+
+    def test_weights_sum_to_one(self):
+        """§11.1 — dimension weights MUST sum to 1.0."""
+        total = (
+            WEIGHT_POLICY_COMPLIANCE
+            + WEIGHT_RESOURCE_EFFICIENCY
+            + WEIGHT_OUTPUT_QUALITY
+            + WEIGHT_SECURITY_POSTURE
+            + WEIGHT_COLLABORATION_HEALTH
+        )
+        assert abs(total - 1.0) < 1e-9
+
+    def test_ema_score_update(self):
+        """§11.3 — EMA update with alpha=0.1."""
+        dim = RewardDimension(name="test", score=50.0)
+        signal = RewardSignal(
+            dimension=DimensionType.POLICY_COMPLIANCE,
+            value=1.0,
+            source="test",
+        )
+        dim.add_signal(signal)
+        # new = 50 * 0.9 + 100 * 0.1 = 55.0
+        assert abs(dim.score - 55.0) < 0.01
+
+    def test_positive_signal_counter(self):
+        """§11.3 — value >= 0.5 increments positive_signals."""
+        dim = RewardDimension(name="test")
+        sig = RewardSignal(
+            dimension=DimensionType.OUTPUT_QUALITY, value=0.8, source="test"
+        )
+        dim.add_signal(sig)
+        assert dim.positive_signals == 1
+        assert dim.negative_signals == 0
+
+    def test_negative_signal_counter(self):
+        """§11.3 — value < 0.5 increments negative_signals."""
+        dim = RewardDimension(name="test")
+        sig = RewardSignal(
+            dimension=DimensionType.OUTPUT_QUALITY, value=0.3, source="test"
+        )
+        dim.add_signal(sig)
+        assert dim.negative_signals == 1
+        assert dim.positive_signals == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 12: Trust Decay and Network Propagation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTrustDecay:
+    """Spec §12 — Trust Decay and Network Propagation."""
+
+    def test_temporal_decay_no_positive(self):
+        """§12.1 — scores decay when no positive signals received."""
+        engine = NetworkTrustEngine(decay_rate=10.0)
+        engine.set_score("did:mesh:a", 500)
+        # Simulate 1 hour without positive signal
+        past = time.time() - 3600
+        engine._last_positive["did:mesh:a"] = past
+        deltas = engine.apply_temporal_decay()
+        assert deltas.get("did:mesh:a", 0) < 0
+
+    def test_decay_floor_at_100(self):
+        """§12.1 — decay MUST NOT reduce score below 100."""
+        engine = NetworkTrustEngine(decay_rate=1000.0)
+        engine.set_score("did:mesh:a", 150)
+        engine._last_positive["did:mesh:a"] = time.time() - 7200
+        engine.apply_temporal_decay()
+        assert engine.get_score("did:mesh:a") >= 100
+
+    def test_network_propagation(self):
+        """§12.2 — trust events MUST propagate to neighbors."""
+        engine = NetworkTrustEngine(propagation_factor=0.3, propagation_depth=2)
+        engine.set_score("did:mesh:a", 500)
+        engine.set_score("did:mesh:b", 500)
+        engine.record_interaction("did:mesh:a", "did:mesh:b")
+        event = TrustEvent(
+            agent_did="did:mesh:a",
+            event_type="policy_violation",
+            severity_weight=0.5,
+        )
+        deltas = engine.process_trust_event(event)
+        assert "did:mesh:a" in deltas  # direct impact
+        assert "did:mesh:b" in deltas  # propagated
+
+    def test_interaction_weight_saturates(self):
+        """§12.3 — interaction weight saturates at 100 interactions."""
+        edge = InteractionEdge(from_did="a", to_did="b", interaction_count=200)
+        assert edge.weight == 1.0
+
+    def test_positive_signal_bonus(self):
+        """§12.4 — positive signal adds bonus and updates timestamp."""
+        engine = NetworkTrustEngine()
+        engine.set_score("did:mesh:a", 500)
+        engine.record_positive_signal("did:mesh:a", bonus=10)
+        assert engine.get_score("did:mesh:a") == 510
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 13: Regime Detection
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRegimeDetection:
+    """Spec §13 — Regime Detection."""
+
+    def test_insufficient_data_returns_none(self):
+        """§13.2 — < 10 total actions returns None."""
+        engine = NetworkTrustEngine()
+        result = engine.detect_regime_change("did:mesh:a")
+        assert result is None
+
+    def test_regime_change_detected(self):
+        """§13.2 — divergent distributions trigger alert."""
+        engine = NetworkTrustEngine(
+            regime_threshold=0.1,
+            history_window_hours=1,
+            baseline_days=30,
+        )
+        now = time.time()
+        # Historical baseline: all "read" actions
+        for i in range(20):
+            engine._action_history["did:mesh:a"].append(
+                (now - 86400 * 15 + i, "read")
+            )
+        # Recent: all "delete" actions (regime change)
+        for i in range(10):
+            engine._action_history["did:mesh:a"].append(
+                (now - 60 + i, "delete")
+            )
+        alert = engine.detect_regime_change("did:mesh:a", now=now)
+        assert alert is not None
+        assert alert.kl_divergence > engine.regime_threshold
+
+    def test_callback_failure_silent(self):
+        """§13.4 — callback failures MUST be silently caught."""
+        engine = NetworkTrustEngine(regime_threshold=0.01)
+
+        def bad_callback(alert):
+            raise RuntimeError("boom")
+
+        engine.on_regime_change(bad_callback)
+        now = time.time()
+        for i in range(20):
+            engine._action_history["did:mesh:x"].append(
+                (now - 86400 * 15 + i, "read")
+            )
+        for i in range(10):
+            engine._action_history["did:mesh:x"].append(
+                (now - 60 + i, "delete")
+            )
+        # Should not raise
+        engine.detect_regime_change("did:mesh:x", now=now)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 14: Trust Handshake Protocol (IATP)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTrustHandshake:
+    """Spec §14 — Trust Handshake Protocol (IATP)."""
+
+    def test_challenge_format(self):
+        """§14.2 — challenge MUST have correct fields."""
+        ch = HandshakeChallenge.generate()
+        assert ch.challenge_id.startswith("challenge_")
+        assert len(ch.nonce) == 64  # 256 bits = 32 bytes hex = 64 chars
+        assert ch.expires_in_seconds == 30
+
+    def test_challenge_expiry(self):
+        """§14.2 — expired challenges MUST be detected."""
+        ch = HandshakeChallenge.generate()
+        ch.timestamp = datetime.now(timezone.utc) - timedelta(seconds=60)
+        assert ch.is_expired()
+
+    def test_challenge_freshness_nonce(self):
+        """§14.2 — freshness nonce for RFC 9334."""
+        ch = HandshakeChallenge.generate(require_freshness=True)
+        assert ch.freshness_nonce is not None
+        assert len(ch.freshness_nonce) == 32  # 128 bits = 16 bytes hex
+
+    def test_result_success_trust_levels(self):
+        """§14.7 — HandshakeResult trust levels MUST match thresholds."""
+        r900 = HandshakeResult.success("did:mesh:a", 900, [])
+        assert r900.trust_level == "verified_partner"
+
+        r700 = HandshakeResult.success("did:mesh:a", 700, [])
+        assert r700.trust_level == "trusted"
+
+        r400 = HandshakeResult.success("did:mesh:a", 400, [])
+        assert r400.trust_level == "standard"
+
+        r300 = HandshakeResult.success("did:mesh:a", 300, [])
+        assert r300.trust_level == "untrusted"
+
+    def test_result_failure(self):
+        """§14.5 — failed handshake MUST have verified=false."""
+        r = HandshakeResult.failure("did:mesh:a", "bad signature")
+        assert not r.verified
+        assert r.rejection_reason == "bad signature"
+
+    def test_handshake_empty_did_rejected(self):
+        """§14 — empty agent_did MUST be rejected."""
+        with pytest.raises(HandshakeError):
+            TrustHandshake(agent_did="")
+
+    def test_handshake_invalid_did_rejected(self):
+        """§14 — non-did:mesh: MUST be rejected."""
+        with pytest.raises(HandshakeError):
+            TrustHandshake(agent_did="did:web:example")
+
+    def test_handshake_negative_cache_ttl_rejected(self):
+        """§14 — negative cache TTL MUST be rejected."""
+        with pytest.raises(HandshakeError):
+            TrustHandshake(agent_did="did:mesh:abc", cache_ttl_seconds=-1)
+
+    def test_respond_to_expired_challenge_rejected(self):
+        """§14.2 — responding to expired challenge MUST fail."""
+        hs = TrustHandshake(
+            agent_did="did:mesh:abc",
+            identity=_make_identity(),
+        )
+        ch = HandshakeChallenge.generate()
+        ch.timestamp = datetime.now(timezone.utc) - timedelta(seconds=60)
+        with pytest.raises(ValueError, match="expired"):
+            asyncio.get_event_loop().run_until_complete(
+                hs.respond(ch, ["read"], 500)
+            )
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 15: Delegation and Scope Chains
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDelegation:
+    """Spec §15 — Delegation and Scope Chains."""
+
+    def test_delegation_narrows_capabilities(self):
+        """§15.1 — child capabilities MUST be subset of parent."""
+        parent = _make_identity(capabilities=["read:data", "write:data"])
+        child = parent.delegate("child", ["read:data"])
+        assert child.capabilities == ["read:data"]
+
+    def test_delegation_rejects_unknown_capability(self):
+        """§15.1 — delegating non-existent capability MUST raise."""
+        parent = _make_identity(capabilities=["read:data"])
+        with pytest.raises(ValueError):
+            parent.delegate("child", ["write:data"])
+
+    def test_delegation_rejects_wildcard(self):
+        """§15.1 — wildcard MUST NOT be delegated."""
+        parent = _make_identity(capabilities=["*"])
+        with pytest.raises(ValueError, match="wildcard"):
+            parent.delegate("child", ["*"])
+
+    def test_delegation_depth_increment(self):
+        """§15.1 — child depth MUST be parent depth + 1."""
+        parent = _make_identity(capabilities=["read:data"])
+        child = parent.delegate("child", ["read:data"])
+        assert child.delegation_depth == parent.delegation_depth + 1
+
+    def test_delegation_depth_limit(self):
+        """§15.1 — exceeding MAX_DELEGATION_DEPTH MUST raise."""
+        parent = _make_identity(capabilities=["read:data"])
+        parent.delegation_depth = AgentIdentity.MAX_DELEGATION_DEPTH
+        with pytest.raises(ValueError, match="depth"):
+            parent.delegate("child", ["read:data"])
+
+    def test_scope_chain_create_root(self):
+        """§15.2 — root chain creation."""
+        chain, link = ScopeChain.create_root(
+            sponsor_email="alice@contoso.com",
+            root_agent_did="did:mesh:root123",
+            capabilities=["read:*", "write:data"],
+        )
+        assert chain.root_sponsor_email == "alice@contoso.com"
+        assert chain.leaf_did == "did:mesh:root123"
+
+    def test_scope_chain_capability_narrowing(self):
+        """§15.4 — monotonic narrowing invariant."""
+        link = DelegationLink(
+            link_id="link1",
+            depth=0,
+            parent_did="did:mesh:sponsor:s@contoso.com",
+            child_did="did:mesh:child1",
+            parent_capabilities=["read:*"],
+            delegated_capabilities=["read:data"],
+            parent_signature="",
+            link_hash="",
+        )
+        assert link.verify_capability_narrowing()
+
+    def test_scope_chain_capability_escalation_rejected(self):
+        """§15.4 — capability escalation MUST fail narrowing check."""
+        link = DelegationLink(
+            link_id="link1",
+            depth=0,
+            parent_did="did:mesh:sponsor:s@contoso.com",
+            child_did="did:mesh:child1",
+            parent_capabilities=["read:data"],
+            delegated_capabilities=["write:data"],
+            parent_signature="",
+            link_hash="",
+        )
+        assert not link.verify_capability_narrowing()
+
+    def test_scope_chain_max_depth(self):
+        """§15.4 — chain MUST NOT exceed max_depth."""
+        assert DEFAULT_DELEGATION_MAX_DEPTH == 5
+
+
+class TestUserContext:
+    """Spec §15.6 — OBO Context."""
+
+    def test_user_context_validity(self):
+        """§15.6 — expired context MUST be invalid."""
+        ctx = UserContext.create(
+            user_id="user1",
+            user_email="u@contoso.com",
+            ttl_seconds=0,
+        )
+        ctx.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        assert not ctx.is_valid()
+
+    def test_user_context_permission_wildcard(self):
+        """§15.6 — wildcard permission matches everything."""
+        ctx = UserContext(
+            user_id="user1",
+            permissions=["*"],
+        )
+        assert ctx.has_permission("anything")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 16: Trust Ceiling Propagation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTrustCeiling:
+    """Spec §16 — Trust Ceiling Propagation."""
+
+    def test_ceiling_on_delegation(self):
+        """§16.1 — delegated child respects max_initial_trust_score."""
+        parent = _make_identity(capabilities=["read:data"])
+        child = parent.delegate(
+            "child",
+            ["read:data"],
+            max_initial_trust_score=600,
+        )
+        assert child.max_initial_trust_score == 600
+
+    def test_ceiling_enforced_in_trust_score(self):
+        """§16.3 — TrustScore ceiling clamped on every update."""
+        ts = TrustScore(
+            agent_did="did:mesh:abc",
+            total_score=400,
+            trust_ceiling=500,
+        )
+        ts.update(900, {})
+        assert ts.total_score == 500
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 17: Key Rotation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestKeyRotation:
+    """Spec §17 — Key Rotation."""
+
+    def test_rotation_preserves_did(self):
+        """§17.2 — DID MUST remain unchanged after rotation."""
+        identity = _make_identity()
+        original_did = str(identity.did)
+        mgr = KeyRotationManager(identity)
+        mgr.rotate()
+        assert str(identity.did) == original_did
+
+    def test_rotation_changes_key(self):
+        """§17.2 — public key MUST change after rotation."""
+        identity = _make_identity()
+        old_key = identity.public_key
+        mgr = KeyRotationManager(identity)
+        mgr.rotate()
+        assert identity.public_key != old_key
+
+    def test_rotation_proof_verifiable(self):
+        """§17.4 — rotation proof MUST be verifiable."""
+        identity = _make_identity()
+        old_key = identity.public_key
+        mgr = KeyRotationManager(identity)
+        mgr.rotate()
+        new_key = identity.public_key
+        proof = mgr.get_rotation_proof()
+        assert KeyRotationManager.verify_rotation(old_key, new_key, proof)
+
+    def test_key_history_retained(self):
+        """§17.5 — old keys MUST be stored in history."""
+        identity = _make_identity()
+        mgr = KeyRotationManager(identity, max_history=5)
+        mgr.rotate()
+        assert len(mgr.get_key_history()) == 1
+
+    def test_key_history_max_limit(self):
+        """§17.5 — history MUST be trimmed to max_history."""
+        identity = _make_identity()
+        mgr = KeyRotationManager(identity, max_history=3)
+        for _ in range(5):
+            mgr.rotate()
+        assert len(mgr.get_key_history()) == 3
+
+    def test_needs_rotation_ttl(self):
+        """§17.6 — needs_rotation MUST respect TTL."""
+        identity = _make_identity()
+        mgr = KeyRotationManager(identity, rotation_ttl_seconds=0)
+        # TTL=0 means immediate rotation needed
+        assert mgr.needs_rotation()
+
+    def test_no_private_key_rejected(self):
+        """§17.7 — rotation without private key MUST be rejected."""
+        identity = _make_identity()
+        identity._private_key = None
+        with pytest.raises(IdentityError):
+            KeyRotationManager(identity)
+
+    def test_no_rotation_proof_before_first_rotation(self):
+        """§17.2 — get_rotation_proof before rotation MUST raise."""
+        identity = _make_identity()
+        mgr = KeyRotationManager(identity)
+        with pytest.raises(IdentityError):
+            mgr.get_rotation_proof()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 18: Identity Revocation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestIdentityRevocation:
+    """Spec §18 — Identity Revocation."""
+
+    def test_permanent_revocation(self):
+        """§18.2 — no expires_at = permanent."""
+        rl = RevocationList()
+        rl.revoke("did:mesh:bad", "malicious")
+        assert rl.is_revoked("did:mesh:bad")
+
+    def test_temporary_revocation_expires(self):
+        """§18.2 — temporary revocation auto-expires."""
+        rl = RevocationList()
+        rl.revoke("did:mesh:temp", "timeout", ttl_seconds=0)
+        # Force expiry
+        entry = rl._entries["did:mesh:temp"]
+        entry.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        assert not rl.is_revoked("did:mesh:temp")
+
+    def test_is_revoked_missing_entry(self):
+        """§18.3 — missing entry returns false."""
+        rl = RevocationList()
+        assert not rl.is_revoked("did:mesh:unknown")
+
+    def test_unrevoke(self):
+        """§18.4 — unrevoke MUST remove entry."""
+        rl = RevocationList()
+        rl.revoke("did:mesh:x", "mistake")
+        assert rl.unrevoke("did:mesh:x")
+        assert not rl.is_revoked("did:mesh:x")
+
+    def test_unrevoke_missing(self):
+        """§18.4 — unrevoke non-existent returns false."""
+        rl = RevocationList()
+        assert not rl.unrevoke("did:mesh:nope")
+
+    def test_cleanup_expired(self):
+        """§18.6 — cleanup removes expired entries."""
+        rl = RevocationList()
+        rl.revoke("did:mesh:a", "temp", ttl_seconds=0)
+        rl._entries["did:mesh:a"].expires_at = (
+            datetime.now(timezone.utc) - timedelta(seconds=1)
+        )
+        removed = rl.cleanup_expired()
+        assert removed == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 19: SPIFFE/SVID Integration
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSPIFFE:
+    """Spec §19 — SPIFFE/SVID Integration."""
+
+    def test_spiffe_id_format(self):
+        """§19.2 — SPIFFE ID format."""
+        si = SPIFFEIdentity.create(
+            agent_did="did:mesh:abc",
+            agent_name="analyzer",
+            trust_domain="agentmesh.local",
+            organization="research",
+        )
+        assert si.spiffe_id == "spiffe://agentmesh.local/agentmesh/research/analyzer"
+
+    def test_default_trust_domain(self):
+        """§19.2 — default trust domain is agentmesh.local."""
+        registry = SPIFFERegistry()
+        assert registry.trust_domain == "agentmesh.local"
+
+    def test_svid_validity(self):
+        """§19.4 — SVID is valid when issued_at <= now < expires_at."""
+        si = SPIFFEIdentity.create("did:mesh:abc", "agent")
+        svid = si.issue_svid(ttl_hours=1)
+        assert svid.is_valid()
+
+    def test_svid_expired(self):
+        """§19.4 — expired SVID is invalid."""
+        svid = SVID(
+            spiffe_id="spiffe://test/agent",
+            trust_domain="test",
+            issued_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            agent_did="did:mesh:abc",
+        )
+        assert not svid.is_valid()
+
+    def test_svid_rotation_threshold(self):
+        """§19.5 — rotation needed when time remaining < threshold."""
+        si = SPIFFEIdentity.create("did:mesh:abc", "agent")
+        assert si.needs_rotation()  # No SVID = needs rotation
+        si.issue_svid(ttl_hours=1)
+        assert not si.needs_rotation()  # Fresh SVID
+
+    def test_svid_validation(self):
+        """§19.6 — validation checks domain and registration."""
+        registry = SPIFFERegistry(trust_domain="agentmesh.local")
+        si = registry.register("did:mesh:abc", "agent")
+        svid = si.issue_svid()
+        assert registry.validate_svid(svid)
+
+    def test_svid_wrong_domain_rejected(self):
+        """§19.6 — wrong trust domain fails validation."""
+        registry = SPIFFERegistry(trust_domain="good.local")
+        si = registry.register("did:mesh:abc", "agent")
+        svid = si.issue_svid()
+        svid.trust_domain = "evil.local"
+        assert not registry.validate_svid(svid)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 20: JWK/JWKS Serialization
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestJWK:
+    """Spec §20 — JWK/JWKS Serialization."""
+
+    def test_jwk_format(self):
+        """§20.1 — JWK MUST have correct parameters."""
+        identity = _make_identity()
+        jwk = to_jwk(identity)
+        assert jwk["kty"] == "OKP"
+        assert jwk["crv"] == "Ed25519"
+        assert jwk["use"] == "sig"
+        assert jwk["kid"] == str(identity.did)
+        assert "x" in jwk
+        assert "d" not in jwk  # private not included by default
+
+    def test_jwk_private_key_only_when_requested(self):
+        """§20.2 — private key only with include_private=True."""
+        identity = _make_identity()
+        jwk_pub = to_jwk(identity, include_private=False)
+        assert "d" not in jwk_pub
+        jwk_priv = to_jwk(identity, include_private=True)
+        assert "d" in jwk_priv
+
+    def test_jwk_round_trip(self):
+        """§20.4 — export+import round-trip preserves key material."""
+        original = _make_identity()
+        jwk = to_jwk(original, include_private=True)
+        restored = from_jwk(jwk)
+        assert restored.public_key == original.public_key
+
+    def test_jwk_wrong_kty_rejected(self):
+        """§20.4 — kty != OKP MUST be rejected."""
+        with pytest.raises(IdentityError, match="key type"):
+            from_jwk({"kty": "RSA", "crv": "Ed25519", "x": "abc"})
+
+    def test_jwk_wrong_crv_rejected(self):
+        """§20.4 — crv != Ed25519 MUST be rejected."""
+        with pytest.raises(IdentityError, match="curve"):
+            from_jwk({"kty": "OKP", "crv": "X25519", "x": "abc"})
+
+    def test_jwk_missing_x_rejected(self):
+        """§20.4 — missing x parameter MUST be rejected."""
+        with pytest.raises(IdentityError, match="x"):
+            from_jwk({"kty": "OKP", "crv": "Ed25519"})
+
+    def test_jwks_format(self):
+        """§20.5 — JWKS wraps JWK in keys array."""
+        identity = _make_identity()
+        jwks = to_jwks(identity)
+        assert "keys" in jwks
+        assert len(jwks["keys"]) == 1
+
+    def test_jwks_empty_rejected(self):
+        """§20.5 — empty keys array MUST be rejected."""
+        with pytest.raises(IdentityError):
+            from_jwks({"keys": []})
+
+    def test_jwks_kid_filter(self):
+        """§20.5 — JWKS import with kid filter."""
+        identity = _make_identity()
+        jwks = to_jwks(identity)
+        kid = str(identity.did)
+        restored = from_jwks(jwks, kid=kid)
+        assert restored.public_key == identity.public_key
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 21: DID Document Export
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDIDDocument:
+    """Spec §21 — DID Document Export."""
+
+    def test_did_document_structure(self):
+        """§21.1 — DID Document MUST have W3C structure."""
+        identity = _make_identity()
+        doc = identity.to_did_document()
+        assert doc["@context"] == ["https://www.w3.org/ns/did/v1"]
+        assert doc["id"] == str(identity.did)
+        assert len(doc["verificationMethod"]) == 1
+        vm = doc["verificationMethod"][0]
+        assert vm["type"] == "Ed25519VerificationKey2020"
+        assert vm["controller"] == str(identity.did)
+        assert "publicKeyBase64" in vm
+        assert len(doc["authentication"]) == 1
+        assert len(doc["service"]) == 1
+        assert doc["service"][0]["type"] == "AgentMeshIdentity"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 22: Identity Registry
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestIdentityRegistry:
+    """Spec §22 — Identity Registry."""
+
+    def test_register_and_get(self):
+        """§22.2 — register + get round-trip."""
+        registry = IdentityRegistry()
+        identity = _make_identity()
+        registry.register(identity)
+        retrieved = registry.get(str(identity.did))
+        assert retrieved is not None
+        assert retrieved.name == identity.name
+
+    def test_duplicate_did_rejected(self):
+        """§22.3 — duplicate DID MUST be rejected."""
+        registry = IdentityRegistry()
+        identity = _make_identity()
+        registry.register(identity)
+        with pytest.raises((ValueError, IdentityError)):
+            registry.register(identity)
+
+    def test_delegation_chain_verification(self):
+        """§22.4 — verify_delegation_chain walks parent links."""
+        registry = IdentityRegistry()
+        parent = _make_identity(capabilities=["read:data"])
+        registry.register(parent)
+        child = parent.delegate("child", ["read:data"])
+        registry.register(child)
+        assert AgentIdentity.verify_delegation_chain(child, registry)
+
+    def test_delegation_chain_circular_reference_detected(self):
+        """§22.4 — circular references MUST be detected."""
+        identity = _make_identity()
+        identity.parent_did = str(identity.did)
+        identity.delegation_depth = 1
+        registry = IdentityRegistry()
+        registry.register(identity)
+        assert not AgentIdentity.verify_delegation_chain(identity, registry)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 23: Failure Semantics
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestFailureSemantics:
+    """Spec §23 — Failure Semantics."""
+
+    def test_signature_verify_returns_false_not_raise(self):
+        """§23.1 — signature verification returns false on failure."""
+        identity = _make_identity()
+        result = identity.verify_signature(b"x", "invalid-base64!!")
+        assert result is False
+
+    def test_handshake_failure_returns_result(self):
+        """§23.1 — handshake failure returns HandshakeResult."""
+        r = HandshakeResult.failure("did:mesh:x", "test error")
+        assert r.verified is False
+        assert r.trust_score == 0
+
+    def test_default_trust_score_for_unknown(self):
+        """§23.1 — unknown agent gets default score (500)."""
+        engine = NetworkTrustEngine()
+        assert engine.get_score("did:mesh:unknown") == TRUST_SCORE_DEFAULT
+
+    def test_revocation_check_missing_entry(self):
+        """§23.1 — missing revocation entry returns false."""
+        rl = RevocationList()
+        assert rl.is_revoked("did:mesh:nope") is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Section 24: Security Considerations
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSecurityConsiderations:
+    """Spec §24 — Security Considerations."""
+
+    def test_private_key_not_in_model_dump(self):
+        """§24.1 — private key MUST NOT appear in serialized output."""
+        identity = _make_identity()
+        dump = identity.model_dump()
+        dump_str = str(dump)
+        assert "_private_key" not in dump_str
+
+    def test_token_constant_time_comparison(self):
+        """§24.2 — token verification uses hmac.compare_digest."""
+        cred = _make_credential()
+        # The implementation uses hmac.compare_digest internally;
+        # we verify correct behavior (matching token passes, wrong fails)
+        assert cred.verify_token(cred.token)
+        assert not cred.verify_token("wrong")
+
+    def test_nonce_entropy(self):
+        """§24.4 — challenge nonce >= 256 bits, response nonce >= 128 bits."""
+        ch = HandshakeChallenge.generate()
+        # 256 bits = 32 bytes = 64 hex chars
+        assert len(ch.nonce) >= 64
+
+    def test_sybil_resistance_wildcard_blocked(self):
+        """§24.6 — wildcard delegation blocked."""
+        parent = _make_identity(capabilities=["*"])
+        with pytest.raises(ValueError, match="wildcard"):
+            parent.delegate("child", ["*"])

--- a/docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md
+++ b/docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md
@@ -1,0 +1,1546 @@
+<!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
+
+# AgentMesh Identity and Trust -- Version 1.0
+
+> **Status:** Draft · **Date:** 2026-05-17 · **Authors:** Agent Governance Toolkit team
+>
+> This specification defines the identity model, trust scoring, credential
+> lifecycle, key management, delegation chains, and trust handshake protocol
+> for AgentMesh. All SDK implementations (Python, TypeScript, Rust, .NET, Go)
+> MUST conform to this specification.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+"SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in
+[RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) and
+[RFC 8174](https://datatracker.ietf.org/doc/html/rfc8174).
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Terminology](#2-terminology)
+3. [Agent DID Schema](#3-agent-did-schema)
+4. [Agent Identity Model](#4-agent-identity-model)
+5. [Identity Lifecycle](#5-identity-lifecycle)
+6. [Cryptographic Primitives](#6-cryptographic-primitives)
+7. [Human Sponsor Binding](#7-human-sponsor-binding)
+8. [Credential Lifecycle](#8-credential-lifecycle)
+9. [Trust Score Model](#9-trust-score-model)
+10. [Trust Tiers](#10-trust-tiers)
+11. [Reward Dimensions](#11-reward-dimensions)
+12. [Trust Decay and Network Propagation](#12-trust-decay-and-network-propagation)
+13. [Regime Detection](#13-regime-detection)
+14. [Trust Handshake Protocol (IATP)](#14-trust-handshake-protocol-iatp)
+15. [Delegation and Scope Chains](#15-delegation-and-scope-chains)
+16. [Trust Ceiling Propagation](#16-trust-ceiling-propagation)
+17. [Key Rotation](#17-key-rotation)
+18. [Identity Revocation](#18-identity-revocation)
+19. [SPIFFE/SVID Integration](#19-spiffesvid-integration)
+20. [JWK/JWKS Serialization](#20-jwkjwks-serialization)
+21. [DID Document Export](#21-did-document-export)
+22. [Identity Registry](#22-identity-registry)
+23. [Failure Semantics](#23-failure-semantics)
+24. [Security Considerations](#24-security-considerations)
+25. [Conformance Requirements](#25-conformance-requirements)
+26. [Worked Examples](#26-worked-examples)
+27. [References](#27-references)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This specification defines how AI agents are identified, authenticated,
+and trust-scored within AgentMesh. Every agent operating in a governed
+mesh MUST possess a cryptographically bound identity tied to a human
+sponsor. Trust is not binary: it is a continuously computed score that
+reflects behavioral history across five dimensions, decays over time
+without positive signals, and propagates through interaction networks.
+
+### 1.2 Scope
+
+This specification covers:
+
+- **Identity:** DID generation, Ed25519 keypair binding, sponsor
+  accountability, status lifecycle.
+- **Credentials:** Short-lived bearer tokens scoped to capabilities and
+  resources, with rotation and revocation.
+- **Trust scoring:** 0-1000 integer scale, five reward dimensions,
+  tier classification, ceiling propagation.
+- **Trust dynamics:** Temporal decay, network contagion, behavioral
+  regime detection via KL divergence.
+- **Authentication:** Challenge-response handshake protocol (IATP) with
+  Ed25519 signatures, RFC 9334 freshness support.
+- **Delegation:** Scope chains with monotonic capability narrowing, hash
+  chain integrity, depth limits.
+- **Key management:** Rotation with cryptographic proofs, history
+  retention, SPIFFE/SVID integration, JWK export.
+
+### 1.3 Relationship to Other Specifications
+
+| Specification | Relationship |
+| --- | --- |
+| Agent OS Policy Engine 1.0 | Trust scores feed policy conditions; policy violations generate negative trust signals |
+| Agent Hypervisor (planned) | Execution rings enforce trust-tier access boundaries |
+| Agent SRE (planned) | SLO breaches generate trust events; circuit breakers use trust scores |
+
+### 1.4 Design Principles
+
+1. **Every agent has a human sponsor.** No orphan agents. Accountability
+   traces to a verified person.
+2. **Trust is earned, not declared.** Initial scores are defaults; only
+   behavioral signals move them.
+3. **Scope chains only narrow.** Delegation can never grant more
+   capabilities than the parent holds.
+4. **Fail closed.** Any identity or trust verification failure MUST
+   result in denial, not fallback to a permissive default.
+5. **Cryptographic binding.** Identity claims are backed by Ed25519
+   signatures; no unsigned assertions are trusted.
+
+---
+
+## 2. Terminology
+
+| Term | Definition |
+| --- | --- |
+| **AgentDID** | Decentralized Identifier in the format `did:mesh:<unique-id>`, uniquely identifying an agent within the mesh. |
+| **AgentIdentity** | The full identity record binding a DID, Ed25519 keypair, human sponsor, capabilities, and status. |
+| **Credential** | A short-lived bearer token scoped to a subset of an agent's capabilities and resources. |
+| **Trust Score** | An integer from 0 to 1000 representing an agent's aggregate behavioral trustworthiness. |
+| **Trust Tier** | A named classification derived from the trust score: verified_partner, trusted, standard, probationary, untrusted. |
+| **Reward Dimension** | One of five behavioral categories that feed the aggregate trust score. |
+| **Trust Decay** | Automatic reduction of trust scores when no positive signals are received. |
+| **Trust Contagion** | Propagation of trust impact through the interaction graph when a connected agent fails. |
+| **Regime Change** | A sudden behavioral shift detected via KL divergence between recent and historical action distributions. |
+| **IATP** | Inter-Agent Trust Protocol: the Ed25519 challenge-response handshake used for mutual authentication. |
+| **Scope Chain** | An ordered sequence of delegation links from a root sponsor to a leaf agent, each narrowing capabilities. |
+| **Trust Ceiling** | Maximum trust score a delegated agent can reach, set by its parent at delegation time. |
+| **Rotation Proof** | A cryptographic proof linking an old key to a new key during key rotation, signed by the old key. |
+| **SVID** | SPIFFE Verifiable Identity Document, used for workload identity in mTLS contexts. |
+| **OBO** | On-Behalf-Of: a delegation pattern where an agent acts with end-user context propagated through the chain. |
+
+---
+
+## 3. Agent DID Schema
+
+### 3.1 Format
+
+An Agent DID MUST conform to the following format:
+
+```
+did:mesh:<unique-id>
+```
+
+Where `<unique-id>` is a hex-encoded string. **[Pure Specification]**
+
+### 3.2 Generation
+
+Implementations MUST generate the `unique-id` using at least 128 bits
+of cryptographically secure randomness. **[Pure Specification]**
+
+**[Default Implementation]** The reference implementation uses
+`secrets.token_hex(16)` producing 32 hex characters (128 bits).
+
+### 3.3 Parsing
+
+Implementations MUST accept any string matching the pattern
+`did:mesh:<hex-string>`. A DID string that does not start with
+`did:mesh:` MUST be rejected with an error. **[Pure Specification]**
+
+### 3.4 Equality and Hashing
+
+Two AgentDID values are equal if and only if their string
+representations are byte-identical. Implementations MUST provide
+deterministic hashing consistent with equality. **[Pure Specification]**
+
+### 3.5 Migration Path
+
+> **Note:** The canonical wire format for DIDs is planned to migrate to
+> `did:agentmesh:<fingerprint>` in a future version. Implementations
+> SHOULD be prepared to accept both `did:mesh:` and `did:agentmesh:`
+> prefixes in DID parsing, but MUST generate `did:mesh:` format in
+> version 1.0.
+
+---
+
+## 4. Agent Identity Model
+
+### 4.1 Required Fields
+
+An AgentIdentity record MUST contain the following fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `did` | AgentDID | The agent's decentralized identifier |
+| `name` | string | Human-readable name; MUST NOT be empty or whitespace-only |
+| `public_key` | string | Base64-encoded Ed25519 public key |
+| `verification_key_id` | string | Key identifier derived from the public key |
+| `sponsor_email` | string | Email of the human sponsor; MUST contain `@` |
+| `status` | enum | One of: `active`, `suspended`, `revoked` |
+
+### 4.2 Optional Fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `description` | string | null | Free-text description |
+| `organization` | string | null | Organization name |
+| `organization_id` | string | null | Organization identifier |
+| `capabilities` | list\[string\] | \[\] | Granted capabilities |
+| `sponsor_verified` | bool | false | Whether sponsor identity is verified |
+| `created_at` | datetime | now(UTC) | Creation timestamp |
+| `updated_at` | datetime | now(UTC) | Last modification timestamp |
+| `expires_at` | datetime | null | Identity expiration (null = no expiry) |
+| `revocation_reason` | string | null | Reason for revocation or suspension |
+| `parent_did` | string | null | Parent agent DID if this is a delegated identity |
+| `delegation_depth` | int | 0 | Depth in the delegation chain (0 = root) |
+| `max_initial_trust_score` | int | null | Trust ceiling for Sybil resistance |
+
+### 4.3 Validation Rules
+
+1. `name` MUST NOT be empty or whitespace-only. **[Pure Specification]**
+2. `public_key` MUST NOT be empty or whitespace-only. **[Pure Specification]**
+3. `sponsor_email` MUST NOT be empty and MUST contain `@`. **[Pure Specification]**
+4. If `parent_did` is not null, it MUST match the `did:mesh:` prefix. **[Pure Specification]**
+5. `delegation_depth` MUST be >= 0. **[Pure Specification]**
+
+### 4.4 Verification Key ID
+
+The `verification_key_id` MUST be derived from the SHA-256 hash of the
+raw public key bytes. **[Pure Specification]**
+
+**[Default Implementation]** Format: `key-<first-16-hex-chars-of-SHA256>`.
+
+### 4.5 Factory Method
+
+Implementations MUST provide a factory method that:
+
+1. Generates an Ed25519 keypair.
+2. Encodes the public key as base64 (standard, not URL-safe).
+3. Generates a DID via `AgentDID.generate()`.
+4. Derives the verification key ID from the public key hash.
+5. Stores the private key in a non-serialized field.
+
+The private key MUST NOT appear in any serialized representation of the
+identity (JSON, dict export, logging). **[Pure Specification]**
+
+---
+
+## 5. Identity Lifecycle
+
+### 5.1 Status Transitions
+
+```
+                 ┌──────────┐
+   create() ────►│  active   │
+                 └─────┬─────┘
+                       │
+              ┌────────┼────────┐
+              ▼        ▼        │
+        ┌──────────┐  ┌────────────┐
+        │suspended │  │  revoked   │
+        └─────┬────┘  └────────────┘
+              │              ▲
+              │ reactivate() │
+              └──────────────┤
+                             │
+              (if security   │
+               suspension:   │
+               requires      │
+               override)     │
+```
+
+### 5.2 Transition Rules
+
+1. **active -> suspended:** The `suspend(reason)` method MUST set
+   `status` to `"suspended"` and record the reason. **[Pure Specification]**
+
+2. **active -> revoked:** The `revoke(reason)` method MUST set `status`
+   to `"revoked"` and record the reason. **[Pure Specification]**
+
+3. **suspended -> active:** The `reactivate()` method MUST restore
+   `status` to `"active"`. If the `revocation_reason` contains the
+   substring `"security"` (case-insensitive), reactivation MUST require
+   an explicit `override_reason=True` flag; without it, reactivation
+   MUST be rejected. **[Pure Specification]**
+
+4. **revoked -> any:** A revoked identity MUST NOT be reactivated.
+   Attempts MUST raise an error. **[Pure Specification]**
+
+5. **suspended -> revoked:** A suspended identity MAY be revoked.
+   **[Pure Specification]**
+
+### 5.3 Activity Check
+
+An identity is considered active if and only if:
+
+1. `status` equals `"active"`, AND
+2. `expires_at` is null OR `expires_at` is in the future.
+
+**[Pure Specification]**
+
+---
+
+## 6. Cryptographic Primitives
+
+### 6.1 Signature Algorithm
+
+All agent identity signatures MUST use Ed25519
+(Edwards-curve Digital Signature Algorithm, EdDSA on Curve25519).
+**[Pure Specification]**
+
+### 6.2 Signing
+
+The `sign(data: bytes)` method MUST:
+
+1. Verify that a private key is available; if not, raise an error.
+2. Sign the data using the Ed25519 private key.
+3. Return the signature as a base64-encoded string.
+
+**[Pure Specification]**
+
+### 6.3 Verification
+
+The `verify_signature(data: bytes, signature: string)` method MUST:
+
+1. Decode the base64-encoded public key to raw bytes.
+2. Reconstruct the Ed25519 public key object.
+3. Decode the base64-encoded signature.
+4. Verify the signature against the data.
+5. Return `true` on success, `false` on any failure.
+
+Verification failures MUST NOT raise exceptions. They MUST be logged at
+DEBUG level only. Logging verification failures at WARNING or higher
+enables log-flooding attacks by any peer that can send messages.
+**[Pure Specification]**
+
+---
+
+## 7. Human Sponsor Binding
+
+### 7.1 Requirement
+
+Every AgentIdentity MUST be bound to a human sponsor via
+`sponsor_email`. **[Pure Specification]**
+
+### 7.2 Rationale
+
+AI agents cannot be held legally or organizationally accountable.
+The sponsor binding ensures that every agent action traces to a
+responsible person. This is the foundational accountability mechanism.
+
+### 7.3 Verification
+
+The `sponsor_verified` flag indicates whether the sponsor's identity
+has been independently verified (e.g., via email confirmation, SSO,
+or organizational directory). Implementations SHOULD verify sponsors
+before granting trust scores above the `standard` tier.
+
+### 7.4 Delegation Inheritance
+
+When an agent delegates to a child, the child MUST inherit the parent's
+`sponsor_email`. This ensures the accountability chain is unbroken
+from root sponsor to leaf agent. **[Pure Specification]**
+
+---
+
+## 8. Credential Lifecycle
+
+### 8.1 Credential Schema
+
+A Credential MUST contain the following fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `credential_id` | string | Unique identifier (format: `cred_<hex>`) |
+| `agent_did` | string | DID of the owning agent |
+| `token` | string | Bearer token (URL-safe base64, 32 bytes) |
+| `token_hash` | string | SHA-256 hex digest of the token |
+| `capabilities` | list\[string\] | Scoped capabilities |
+| `resources` | list\[string\] | Scoped resource identifiers |
+| `status` | enum | One of: `active`, `rotated`, `revoked`, `expired` |
+| `issued_at` | datetime | Issuance timestamp (UTC) |
+| `expires_at` | datetime | Expiration timestamp (UTC) |
+| `ttl_seconds` | int | Time-to-live used at issuance |
+
+### 8.2 Optional Credential Fields
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `issued_for` | string | null | Purpose or context |
+| `revoked_at` | datetime | null | Revocation timestamp |
+| `revocation_reason` | string | null | Reason for revocation |
+| `previous_credential_id` | string | null | ID of predecessor (rotation chain) |
+| `rotation_count` | int | 0 | Number of rotations from original |
+
+### 8.3 Issuance
+
+The `issue()` factory method MUST:
+
+1. Generate a token using `secrets.token_urlsafe(32)`.
+2. Compute `token_hash` as `SHA-256(token).hexdigest()`.
+3. Generate a unique `credential_id`.
+4. Set `expires_at` to `issued_at + ttl_seconds`.
+5. Set `status` to `"active"`.
+
+**[Default Implementation]** Default `ttl_seconds` is 900 (15 minutes).
+
+### 8.4 Validation
+
+A credential is valid if and only if:
+
+1. `status` equals `"active"`, AND
+2. The current UTC time is before `expires_at`.
+
+**[Pure Specification]**
+
+### 8.5 Token Verification
+
+Token verification MUST use constant-time comparison of SHA-256 hashes
+to prevent timing side-channel attacks. Implementations MUST use
+`hmac.compare_digest` or equivalent. **[Pure Specification]**
+
+The raw token MUST NOT be stored after issuance. Only the `token_hash`
+is retained for verification. The token is returned to the caller at
+issuance time and MUST be treated as a secret.
+
+### 8.6 Expiring Soon Check
+
+Implementations MUST provide a method to check whether a credential
+expires within a configurable threshold. **[Pure Specification]**
+
+**[Default Implementation]** The threshold defaults to 60 seconds
+(`CREDENTIAL_ROTATION_THRESHOLD_SECONDS`).
+
+### 8.7 Rotation
+
+Credential rotation MUST:
+
+1. Set the old credential's status to `"rotated"`.
+2. Issue a new credential with the same `agent_did`, `capabilities`,
+   `resources`, `ttl_seconds`, and `issued_for`.
+3. Set `previous_credential_id` on the new credential to the old
+   credential's `credential_id`.
+4. Increment `rotation_count` by 1.
+
+The old credential remains valid (status `"rotated"`, not `"revoked"`)
+to allow a brief overlap period for zero-downtime rotation.
+**[Pure Specification]**
+
+### 8.8 Revocation
+
+Credential revocation MUST:
+
+1. Set `status` to `"revoked"`.
+2. Record `revoked_at` as the current UTC time.
+3. Record the `revocation_reason`.
+
+A revoked credential MUST fail all subsequent validity checks.
+**[Pure Specification]**
+
+### 8.9 Capability Matching
+
+Capability checks on credentials MUST support three matching modes:
+
+1. **Exact match:** `capability == requested_capability`.
+2. **Wildcard:** If any capability is `"*"`, all requests match.
+3. **Prefix wildcard:** A capability `"prefix:*"` matches any
+   `"prefix:<suffix>"` request.
+
+**[Pure Specification]**
+
+### 8.10 Resource Access
+
+If a credential has an empty `resources` list, all resource access
+requests MUST be allowed (open scope). If `resources` is non-empty,
+only listed resources are accessible. **[Pure Specification]**
+
+---
+
+## 9. Trust Score Model
+
+### 9.1 Scale
+
+Trust scores operate on an integer scale from 0 to 1000 inclusive.
+Implementations MUST clamp scores to this range on every update.
+**[Pure Specification]**
+
+### 9.2 Default Score
+
+New agents MUST receive an initial trust score of 500
+(`TRUST_SCORE_DEFAULT`). **[Pure Specification]**
+
+### 9.3 Trust Score Record
+
+A TrustScore record MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `agent_did` | string | The agent's DID (MUST match `did:mesh:` prefix) |
+| `total_score` | int | Aggregate score (0-1000) |
+| `tier` | string | Current trust tier |
+| `dimensions` | map | Per-dimension breakdown |
+| `calculated_at` | datetime | Last calculation timestamp |
+
+### 9.4 Score Updates
+
+When updating a trust score, implementations MUST:
+
+1. Clamp the new score to `[0, 1000]`.
+2. If a `trust_ceiling` is set, clamp to `min(score, ceiling)`.
+3. Record `previous_score` and compute `score_change`.
+4. Recalculate the trust tier (see Section 10).
+
+**[Pure Specification]**
+
+### 9.5 Trust Ceiling
+
+A trust ceiling is an upper bound on an agent's trust score, typically
+set at delegation time. **[Pure Specification]**
+
+1. If `trust_ceiling` is not null, the effective score is
+   `min(computed_score, trust_ceiling)`.
+2. Trust ceilings MUST be respected on every score update, including
+   initial score assignment.
+3. Trust ceilings MAY be read from the environment variable
+   `AGT_TRUST_CEILING` if not explicitly set. **[Default Implementation]**
+
+### 9.6 Dual Trust Score Systems
+
+AgentMesh maintains two trust score systems for different contexts:
+
+| System | Scale | Location | Purpose |
+| --- | --- | --- | --- |
+| Integration TrustScore | 0.0 - 1.0 (float) | `trust_types.py` | Lightweight tracking for integration plugins |
+| Reward TrustScore | 0 - 1000 (int) | `reward/scoring.py` | Full multi-dimensional scoring for mesh operations |
+
+The integration TrustScore uses a `score >= 0.5` threshold for
+`is_trusted`. The reward TrustScore uses tier thresholds defined in
+Section 10. Implementations MUST NOT conflate these two systems.
+**[Pure Specification]**
+
+---
+
+## 10. Trust Tiers
+
+### 10.1 Tier Thresholds
+
+Trust tiers MUST be computed from the total score using the following
+thresholds:
+
+| Tier | Minimum Score | Description |
+| --- | --- | --- |
+| `verified_partner` | 900 | Highest trust, verified partner agent |
+| `trusted` | 700 | Trusted agent with good track record |
+| `standard` | 500 | Default tier for new agents |
+| `probationary` | 300 | Below-normal trust, under observation |
+| `untrusted` | 0 | No trust, should be restricted or quarantined |
+
+**[Pure Specification]**
+
+### 10.2 Tier Computation
+
+Tier assignment MUST use a descending threshold check: the first
+threshold met (highest score first) determines the tier. An agent with
+score exactly equal to a threshold MUST be assigned the corresponding
+tier. **[Pure Specification]**
+
+### 10.3 Action Thresholds
+
+Implementations SHOULD define action thresholds for operational
+decisions:
+
+| Action | Threshold | Description |
+| --- | --- | --- |
+| Allow | >= 500 | Actions generally permitted |
+| Warn | < 400 | Trigger warnings and enhanced monitoring |
+| Revoke | < 300 | Trigger automatic credential revocation |
+
+**[Default Implementation]**
+
+### 10.4 Risk Score Thresholds
+
+Complementary to trust tiers, risk thresholds provide an inverse scale:
+
+| Risk Level | Threshold | Description |
+| --- | --- | --- |
+| Minimal | >= 800 | Very low risk |
+| Alert | >= 600 | Elevated monitoring |
+| High | >= 400 | Significant risk |
+| Critical | < 200 | Immediate intervention required |
+
+**[Default Implementation]**
+
+---
+
+## 11. Reward Dimensions
+
+### 11.1 Dimensions
+
+Trust scores are composed from five reward dimensions:
+
+| Dimension | Weight | Description |
+| --- | --- | --- |
+| `policy_compliance` | 0.25 | Adherence to governance policies |
+| `resource_efficiency` | 0.15 | Efficient use of compute, memory, API calls |
+| `output_quality` | 0.20 | Quality of agent outputs and results |
+| `security_posture` | 0.25 | Security behavior, credential handling, input validation |
+| `collaboration_health` | 0.15 | Quality of interactions with other agents |
+
+Dimension weights MUST sum to 1.0. **[Pure Specification]**
+
+### 11.2 Reward Signals
+
+A reward signal MUST contain:
+
+| Field | Type | Constraint | Description |
+| --- | --- | --- | --- |
+| `dimension` | DimensionType | required | Which dimension this signal affects |
+| `value` | float | [0.0, 1.0] | Signal value (0 = bad, 1 = good) |
+| `source` | string | required | Origin of the signal |
+| `weight` | float | >= 0.0, default 1.0 | Importance weight |
+
+### 11.3 Dimension Score Update
+
+When a signal is received for a dimension, the dimension score MUST
+be updated using an exponential moving average:
+
+```
+new_score = current_score * (1 - alpha) + (signal_value * 100) * alpha
+```
+
+**[Default Implementation]** `alpha = 0.1` (smoothing factor).
+
+A signal with `value >= 0.5` MUST increment `positive_signals`.
+A signal with `value < 0.5` MUST increment `negative_signals`.
+**[Pure Specification]**
+
+### 11.4 Trend Detection
+
+After each score update, the trend MUST be classified:
+
+- `"improving"` if `score - previous_score > 5`
+- `"degrading"` if `score - previous_score < -5`
+- `"stable"` otherwise
+
+**[Default Implementation]**
+
+---
+
+## 12. Trust Decay and Network Propagation
+
+### 12.1 Temporal Decay
+
+Trust scores MUST decay over time when no positive signals are
+received. **[Pure Specification]**
+
+**[Default Implementation]** Linear decay at `decay_rate` points per
+hour since the last positive signal. Decay MUST NOT reduce a score
+below 100.
+
+```
+effective_decay = min(decay_rate * hours_since_positive, max(0, score - 100))
+```
+
+Default `decay_rate` is 2.0 points per hour.
+
+### 12.2 Network Propagation (Trust Contagion)
+
+When a trust event occurs for agent A, the impact MUST propagate to
+agents that have interacted with A. **[Pure Specification]**
+
+**[Default Implementation]** Propagation parameters:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `propagation_factor` | 0.3 | Fraction of impact transmitted to neighbors |
+| `propagation_depth` | 2 | Maximum hops for propagation |
+| Hop diminishing | `0.5^depth` | Impact halves at each hop |
+
+The propagation algorithm MUST:
+
+1. Apply direct impact: `score -= severity_weight * 100`.
+2. For each neighbor within `propagation_depth` hops:
+   a. Compute neighbor impact:
+      `severity * interaction_weight * propagation_factor * 100 * (0.5^depth)`.
+   b. Reduce the neighbor's score by the computed impact.
+3. Track visited agents to prevent cycles.
+
+### 12.3 Interaction Weight
+
+Interaction weight between two agents is computed as:
+
+```
+weight = min(1.0, interaction_count / 100)
+```
+
+This saturates at 100 interactions to prevent unbounded influence.
+**[Default Implementation]**
+
+### 12.4 Positive Signals
+
+Recording a positive signal MUST:
+
+1. Update the last-positive-signal timestamp for the agent.
+2. Add a configurable bonus to the agent's score (default: 5.0).
+
+**[Default Implementation]**
+
+---
+
+## 13. Regime Detection
+
+### 13.1 Purpose
+
+Regime detection identifies sudden behavioral shifts that may indicate
+compromise, misconfiguration, or adversarial takeover.
+
+### 13.2 Algorithm
+
+Implementations MUST provide behavioral regime detection using
+KL divergence between recent and historical action distributions.
+**[Pure Specification]**
+
+**[Default Implementation]**
+
+1. Collect all recorded actions for the agent.
+2. Partition into "recent" (last `history_window_hours` hours, default 1)
+   and "baseline" (last `baseline_days` days, default 30).
+3. Require at least 10 total actions, 5 recent, and 5 baseline to proceed.
+4. Compute the action frequency distribution for each partition.
+5. Compute `KL(recent || baseline)` with Laplace smoothing (`eps = 1e-10`).
+6. If `KL > regime_threshold` (default 0.5), emit a `RegimeChangeAlert`.
+
+### 13.3 Regime Change Alert
+
+A RegimeChangeAlert MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `agent_did` | string | Agent whose behavior shifted |
+| `kl_divergence` | float | Computed KL divergence value |
+| `threshold` | float | Threshold that was exceeded |
+| `recent_distribution` | map | Action frequencies in the recent window |
+| `historical_distribution` | map | Action frequencies in the baseline window |
+| `detected_at` | float | Unix timestamp of detection |
+
+### 13.4 Callbacks
+
+Implementations MUST support registering callbacks for regime change
+events and score change events. Callback failures MUST be caught and
+silently ignored to prevent cascade failures. **[Pure Specification]**
+
+---
+
+## 14. Trust Handshake Protocol (IATP)
+
+### 14.1 Overview
+
+The Inter-Agent Trust Protocol (IATP) is a challenge-response
+handshake that establishes mutual authentication and trust level
+between two agents.
+
+### 14.2 Challenge
+
+A HandshakeChallenge MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `challenge_id` | string | Unique identifier (format: `challenge_<hex>`) |
+| `nonce` | string | Hex-encoded random nonce (256 bits) |
+| `freshness_nonce` | string or null | RFC 9334 freshness nonce for Evidence liveness |
+| `timestamp` | datetime | Challenge creation time (UTC) |
+| `expires_in_seconds` | int | TTL for the challenge (default: 30) |
+
+A challenge is expired when `elapsed_seconds > expires_in_seconds`.
+Expired challenges MUST be rejected. **[Pure Specification]**
+
+### 14.3 Response
+
+A HandshakeResponse MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `challenge_id` | string | Must match the challenge |
+| `response_nonce` | string | Responder's own nonce |
+| `agent_did` | string | Responder's DID |
+| `capabilities` | list\[string\] | Attested capabilities |
+| `trust_score` | int | Self-reported trust score (0-1000) |
+| `signature` | string | Ed25519 signature over the payload |
+| `public_key` | string | Responder's base64 public key |
+| `freshness_nonce` | string or null | Echoed freshness nonce |
+| `user_context` | dict or null | OBO user context if applicable |
+
+### 14.4 Signature Payload
+
+The signed payload MUST be constructed as:
+
+```
+{challenge_id}:{challenge_nonce}:{response_nonce}:{agent_did}
+```
+
+If a freshness nonce is present, it MUST be appended:
+
+```
+{challenge_id}:{challenge_nonce}:{response_nonce}:{agent_did}:{freshness_nonce}
+```
+
+The signature MUST be produced using the responder's Ed25519 private
+key. **[Pure Specification]**
+
+### 14.5 Verification
+
+The initiator MUST verify:
+
+1. The `challenge_id` matches a pending challenge.
+2. The challenge has not expired.
+3. The `response_nonce` matches the original challenge nonce.
+4. The `agent_did` in the response matches the expected peer DID.
+5. The Ed25519 signature is valid over the constructed payload.
+6. If a registry is available: the peer is registered and active.
+7. If a registry is available: the peer's registered public key matches.
+8. If `freshness_nonce` was required: it is present and matches.
+9. The peer's trust score meets the `required_trust_score` threshold.
+10. The peer has all `required_capabilities` (if specified).
+
+Any verification failure MUST result in a `HandshakeResult` with
+`verified = false` and a `rejection_reason`. **[Pure Specification]**
+
+### 14.6 Result
+
+A HandshakeResult MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `verified` | bool | Whether the handshake succeeded |
+| `peer_did` | string | Peer's DID |
+| `peer_name` | string or null | Peer's human-readable name |
+| `trust_score` | int | Verified trust score (0-1000) |
+| `trust_level` | string | One of: verified_partner, trusted, standard, untrusted |
+| `capabilities` | list\[string\] | Verified capabilities |
+| `user_context` | UserContext or null | OBO context if present |
+| `handshake_started` | datetime | Start timestamp |
+| `handshake_completed` | datetime or null | Completion timestamp |
+| `latency_ms` | int or null | Round-trip latency |
+| `rejection_reason` | string or null | Reason for failure |
+
+### 14.7 Trust Level Assignment in Results
+
+The trust level in the HandshakeResult MUST be assigned as:
+
+| Score Range | Trust Level |
+| --- | --- |
+| >= 900 | `verified_partner` |
+| >= 700 | `trusted` |
+| >= 400 | `standard` |
+| < 400 | `untrusted` |
+
+Note: the `standard` threshold in HandshakeResult (400) differs from
+the tier threshold (500) in TrustScore. This is intentional: handshake
+results use a lower bar because the peer has already passed
+cryptographic verification. **[Pure Specification]**
+
+### 14.8 Caching
+
+Implementations SHOULD cache successful handshake results. Cached
+results MUST be invalidated after a configurable TTL. **[Pure Specification]**
+
+**[Default Implementation]** Cache TTL is 900 seconds (15 minutes).
+
+When `require_freshness` is true, the cache MUST be bypassed entirely:
+every call produces a fresh verification. **[Pure Specification]**
+
+### 14.9 Timeout
+
+Implementations MUST enforce a timeout on the handshake. If the peer
+does not respond within the timeout, the handshake MUST fail with a
+`HandshakeTimeoutError`. **[Pure Specification]**
+
+**[Default Implementation]** Default timeout is 30 seconds.
+Performance target: handshakes SHOULD complete within 200ms
+(`MAX_HANDSHAKE_MS`).
+
+### 14.10 DoS Protection
+
+Implementations MUST limit the number of pending (unanswered)
+challenges to prevent memory exhaustion. When the limit is reached,
+new challenges MUST be rejected. Expired challenges MUST be purged
+before checking the limit. **[Pure Specification]**
+
+**[Default Implementation]** Maximum pending challenges: 1000.
+
+### 14.11 Concurrency
+
+Challenge creation, lookup, and cleanup MUST be serialized to prevent
+race conditions where concurrent handshakes bypass the pending
+challenge limit. **[Pure Specification]**
+
+Peer cache reads and writes MUST be serialized to prevent TTL-delete
+races. **[Pure Specification]**
+
+---
+
+## 15. Delegation and Scope Chains
+
+### 15.1 Delegation from Identity
+
+An AgentIdentity MUST support delegating to a child agent via a
+`delegate()` method. **[Pure Specification]**
+
+Delegation MUST enforce:
+
+1. **Depth limit:** `delegation_depth` MUST NOT exceed
+   `MAX_DELEGATION_DEPTH`. **[Default Implementation]**
+   Default: 10.
+2. **No wildcard propagation:** Delegating the `"*"` capability MUST be
+   rejected. Capabilities MUST be explicitly listed.
+3. **Subset enforcement:** Every delegated capability MUST exist in the
+   parent's capability set.
+4. **Sponsor inheritance:** The child MUST inherit `sponsor_email` from
+   the parent.
+5. **Depth increment:** The child's `delegation_depth` MUST equal
+   `parent.delegation_depth + 1`.
+
+### 15.2 Scope Chain Model
+
+A ScopeChain represents the full delegation path from a root sponsor
+to a leaf agent. It MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `chain_id` | string | Unique chain identifier |
+| `max_depth` | int | Maximum allowed depth (default: 5) |
+| `root_sponsor_email` | string | Human sponsor at the root |
+| `root_capabilities` | list\[string\] | Capabilities granted by sponsor |
+| `links` | list\[DelegationLink\] | Ordered delegation links |
+| `leaf_did` | string | DID of the terminal agent |
+| `leaf_capabilities` | list\[string\] | Effective capabilities at the leaf |
+| `chain_hash` | string | SHA-256 hash of the entire chain |
+
+### 15.3 Delegation Link
+
+Each link in the chain MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `link_id` | string | Unique link identifier |
+| `depth` | int | Position in chain (0-indexed) |
+| `parent_did` | string | Delegating agent's DID |
+| `child_did` | string | Receiving agent's DID |
+| `parent_capabilities` | list\[string\] | Parent's capabilities at delegation time |
+| `delegated_capabilities` | list\[string\] | Capabilities granted to child |
+| `parent_signature` | string | Parent's Ed25519 signature |
+| `link_hash` | string | SHA-256 hash of this link |
+| `previous_link_hash` | string or null | Hash of the preceding link |
+
+### 15.4 Chain Invariants
+
+The following invariants MUST hold for a valid scope chain:
+
+1. **Monotonic narrowing:** At each link, `delegated_capabilities` MUST
+   be a subset of `parent_capabilities`. Subset includes exact match
+   and prefix-wildcard narrowing (e.g., `read:data` is a subset of
+   `read:*`). **[Pure Specification]**
+
+2. **Hash chain integrity:** Each link's `previous_link_hash` MUST
+   equal the preceding link's `link_hash`. The first link's
+   `previous_link_hash` MUST be null. **[Pure Specification]**
+
+3. **Depth consistency:** Link at index `i` MUST have `depth == i`.
+   **[Pure Specification]**
+
+4. **Connectivity:** Each link's `parent_did` MUST equal the previous
+   link's `child_did`. **[Pure Specification]**
+
+5. **Depth limit:** `len(links)` MUST NOT exceed `max_depth`.
+   Attempts to exceed MUST raise `DelegationDepthError`.
+   **[Pure Specification]**
+
+### 15.5 Chain Verification
+
+The `verify()` method MUST check all invariants in Section 15.4.
+Signature checks are compatibility-mode and best-effort: if the parent
+identity is not available in `known_identities`, the signature check
+MUST be skipped (not failed). **[Pure Specification]**
+
+### 15.6 OBO (On-Behalf-Of) Context
+
+A `UserContext` MAY be attached to delegation links to propagate
+end-user identity through the chain. **[Pure Specification]**
+
+UserContext MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `user_id` | string | Unique user identifier |
+| `user_email` | string or null | User email for audit |
+| `roles` | list\[string\] | User roles for RBAC |
+| `permissions` | list\[string\] | Fine-grained permissions |
+| `issued_at` | datetime | Context creation time |
+| `expires_at` | datetime or null | Context expiration |
+
+UserContext is valid if `expires_at` is null or in the future.
+Permission check MUST support wildcard `"*"`. **[Pure Specification]**
+
+### 15.7 Capability Tracing
+
+Implementations MUST provide a method to trace how a specific
+capability was granted through the chain, producing an audit trail from
+root sponsor to leaf agent. **[Pure Specification]**
+
+---
+
+## 16. Trust Ceiling Propagation
+
+### 16.1 Invariant
+
+When a parent delegates to a child and sets `max_initial_trust_score`,
+the child's effective trust score MUST NOT exceed
+`min(parent_ceiling, requested_ceiling)`. This provides monotonic
+narrowing of trust through the delegation chain.
+**[Pure Specification]**
+
+### 16.2 Sybil Resistance
+
+Trust ceilings prevent trust washing: an attacker cannot spawn
+sub-agents to obtain higher trust scores than the parent. The child's
+initial trust score is capped by the parent's ceiling.
+**[Pure Specification]**
+
+### 16.3 Enforcement
+
+Trust ceilings MUST be enforced:
+
+1. At identity creation time (initial score clamped to ceiling).
+2. On every trust score update.
+3. Across delegation chains (child ceiling <= parent ceiling).
+
+**[Pure Specification]**
+
+---
+
+## 17. Key Rotation
+
+### 17.1 Purpose
+
+Long-lived agents MUST support key rotation to limit the impact of key
+compromise. Key rotation replaces the Ed25519 keypair while preserving
+the agent's DID. **[Pure Specification]**
+
+### 17.2 Rotation Process
+
+The rotation MUST:
+
+1. Generate a new Ed25519 keypair.
+2. Create a rotation proof: the old private key signs a message
+   containing both the old and new public keys.
+3. Store the old public key, old verification key ID, rotation timestamp,
+   and rotation proof in the key history.
+4. Update the identity's `public_key`, `verification_key_id`, and
+   `_private_key` to the new values.
+5. Preserve the agent's DID unchanged.
+
+**[Pure Specification]**
+
+### 17.3 Rotation Proof Format
+
+The rotation proof MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `old_public_key` | string | Base64 old public key |
+| `new_public_key` | string | Base64 new public key |
+| `message` | string | `"rotate:{old_key_b64}:{new_key_b64}"` |
+| `signature` | string | Base64 Ed25519 signature of the message by the old key |
+| `timestamp` | string | ISO 8601 timestamp |
+
+### 17.4 Rotation Proof Verification
+
+To verify a rotation proof:
+
+1. Confirm `old_public_key` and `new_public_key` match the proof fields.
+2. Reconstruct the Ed25519 public key from `old_public_key`.
+3. Verify the `signature` over `message` using the old public key.
+4. Return `true` if valid, `false` on any failure.
+
+**[Pure Specification]**
+
+### 17.5 Key History
+
+Implementations MUST retain a configurable number of previous keys
+for backward verification of signatures made with old keys.
+**[Pure Specification]**
+
+**[Default Implementation]** Maximum history: 5 entries.
+
+### 17.6 TTL-Based Auto-Rotation
+
+Implementations MUST provide a method to check whether rotation is
+needed based on elapsed time since last rotation. **[Pure Specification]**
+
+**[Default Implementation]** Rotation TTL: 86400 seconds (24 hours).
+
+### 17.7 Prerequisites
+
+Key rotation MUST require access to the current private key. Attempts
+to manage rotation without a private key MUST be rejected.
+**[Pure Specification]**
+
+---
+
+## 18. Identity Revocation
+
+### 18.1 Revocation Entry
+
+A revocation entry MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `agent_did` | string | DID of the revoked agent |
+| `revoked_at` | datetime | Revocation timestamp (UTC) |
+| `reason` | string | Human-readable reason |
+| `revoked_by` | string or null | DID of the revoking entity |
+| `expires_at` | datetime or null | Expiry for temporary revocations |
+
+### 18.2 Permanent vs Temporary Revocation
+
+If `expires_at` is null, the revocation is permanent. If `expires_at`
+is set and the current time exceeds it, the revocation is automatically
+lifted and the entry is removed. **[Pure Specification]**
+
+### 18.3 Revocation Check
+
+The `is_revoked(agent_did)` method MUST:
+
+1. If no entry exists for the DID, return `false`.
+2. If an entry exists with `expires_at` in the past, delete the entry
+   and return `false`.
+3. Otherwise, return `true`.
+
+**[Pure Specification]**
+
+### 18.4 Unrevocation
+
+An explicit `unrevoke(agent_did)` method MUST be provided to manually
+remove a revocation entry. It MUST return `true` if the entry existed,
+`false` otherwise. **[Pure Specification]**
+
+### 18.5 Persistence
+
+Implementations MUST support both in-memory and file-backed storage
+for the revocation list. File-backed storage MUST auto-persist on
+every mutation. **[Pure Specification]**
+
+### 18.6 Cleanup
+
+Implementations MUST provide a method to remove all expired temporary
+revocations. **[Pure Specification]**
+
+---
+
+## 19. SPIFFE/SVID Integration
+
+### 19.1 Purpose
+
+SPIFFE (Secure Production Identity Framework for Everyone) integration
+enables AgentMesh identities to participate in standard workload
+identity ecosystems. This provides mutual TLS (mTLS) for agent-to-agent
+transport.
+
+### 19.2 SPIFFE ID Format
+
+SPIFFE IDs MUST follow the format:
+
+```
+spiffe://{trust_domain}/agentmesh[/{organization}]/{agent_name}
+```
+
+**[Default Implementation]** Default trust domain: `agentmesh.local`.
+
+### 19.3 SVID Model
+
+An SVID (SPIFFE Verifiable Identity Document) MUST contain:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `spiffe_id` | string | Full SPIFFE ID |
+| `svid_type` | string | `"x509"` or `"jwt"` |
+| `trust_domain` | string | SPIFFE trust domain |
+| `issued_at` | datetime | Issuance timestamp |
+| `expires_at` | datetime | Expiration timestamp |
+| `agent_did` | string | Bound AgentMesh DID |
+
+### 19.4 SVID Validity
+
+An SVID is valid when `issued_at <= now < expires_at`.
+**[Pure Specification]**
+
+### 19.5 SVID Rotation
+
+SVID rotation SHOULD be triggered when the time remaining until expiry
+falls below a configurable threshold. **[Default Implementation]**
+Default threshold: 10 minutes. Default SVID TTL: 1 hour.
+
+### 19.6 SVID Validation
+
+SVID validation MUST check:
+
+1. Temporal validity (`is_valid()`).
+2. Trust domain matches the registry's trust domain.
+3. The agent is registered in the SPIFFE registry.
+
+**[Pure Specification]**
+
+---
+
+## 20. JWK/JWKS Serialization
+
+### 20.1 JWK Format
+
+Agent identities MUST support export as JWK
+([RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)) with the
+following parameters:
+
+| Parameter | Value | Description |
+| --- | --- | --- |
+| `kty` | `"OKP"` | Key type: Octet Key Pair |
+| `crv` | `"Ed25519"` | Curve: Ed25519 |
+| `x` | base64url | Public key (no padding) |
+| `kid` | string | DID string as key identifier |
+| `use` | `"sig"` | Key use: signature |
+
+### 20.2 Private Key Export
+
+The private key parameter `d` MUST only be included when explicitly
+requested via `include_private=True`. Implementations MUST NOT include
+private keys by default. **[Pure Specification]**
+
+### 20.3 Base64url Encoding
+
+JWK key material MUST use base64url encoding without padding, per
+[RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515).
+**[Pure Specification]**
+
+### 20.4 JWK Import
+
+When importing from JWK:
+
+1. `kty` MUST be `"OKP"`. Other values MUST be rejected.
+2. `crv` MUST be `"Ed25519"`. Other values MUST be rejected.
+3. `x` (public key) MUST be present and valid base64url.
+4. If `kid` starts with `did:mesh:`, it MUST be used as the identity DID.
+5. If `kid` is absent or does not match, a new DID MUST be generated.
+6. If `d` (private key) is present, it MUST be restored as the
+   identity's private key.
+
+**[Pure Specification]**
+
+### 20.5 JWKS (JWK Set)
+
+The JWKS format wraps one or more JWKs in a `{"keys": [...]}` object.
+Import from JWKS MUST support filtering by `kid`. If no `kid` is
+specified, the first key MUST be used. An empty `keys` array MUST be
+rejected. **[Pure Specification]**
+
+---
+
+## 21. DID Document Export
+
+### 21.1 W3C DID Document
+
+Implementations MUST support exporting an AgentIdentity as a
+W3C DID Document with the following structure:
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/did/v1"],
+  "id": "did:mesh:<unique-id>",
+  "verificationMethod": [{
+    "id": "did:mesh:<unique-id>#<key-id>",
+    "type": "Ed25519VerificationKey2020",
+    "controller": "did:mesh:<unique-id>",
+    "publicKeyBase64": "<base64-public-key>"
+  }],
+  "authentication": ["did:mesh:<unique-id>#<key-id>"],
+  "service": [{
+    "id": "did:mesh:<unique-id>#agentmesh",
+    "type": "AgentMeshIdentity",
+    "serviceEndpoint": "https://mesh.agentmesh.dev/v1"
+  }]
+}
+```
+
+**[Pure Specification]**
+
+---
+
+## 22. Identity Registry
+
+### 22.1 Purpose
+
+The Identity Registry provides centralized lookup and management of
+agent identities within a mesh.
+
+### 22.2 Operations
+
+Implementations MUST support the following operations:
+
+| Operation | Description |
+| --- | --- |
+| `register(identity)` | Add an identity to the registry |
+| `get(did)` | Retrieve an identity by DID string |
+| `get_by_sponsor(email)` | List identities by sponsor email |
+| `list_active()` | List all active identities |
+| `unregister(did)` | Remove an identity |
+| `revoke(did, reason)` | Revoke an identity |
+
+### 22.3 Registration Rules
+
+1. An identity with a duplicate DID MUST be rejected.
+   **[Pure Specification]**
+2. The registry MAY require attestation before registration
+   (configurable via `require_attestation`).
+3. Registration MUST index by both DID and sponsor email.
+
+### 22.4 Delegation Chain Verification
+
+The registry MUST support verifying delegation chains by walking
+`parent_did` links, checking at each level:
+
+1. The parent exists in the registry.
+2. The parent is active.
+3. The child's capabilities are a subset of the parent's.
+4. Delegation depth is consistent (`child.depth == parent.depth + 1`).
+5. No circular references exist.
+
+**[Pure Specification]**
+
+---
+
+## 23. Failure Semantics
+
+### 23.1 Fail Closed
+
+All identity and trust operations MUST fail closed:
+
+| Operation | Failure Behavior |
+| --- | --- |
+| DID parsing | Reject with error |
+| Identity validation | Reject with error |
+| Signature verification | Return `false` (never raise) |
+| Handshake | Return `HandshakeResult(verified=false)` |
+| Credential validation | Return `false` |
+| Delegation | Raise error |
+| Revocation check | Return `false` (not revoked) on missing entry |
+| Trust score lookup | Return default score (500) |
+
+### 23.2 Error Types
+
+Implementations MUST define the following error types:
+
+| Error | Context |
+| --- | --- |
+| `IdentityError` | DID parsing, key operations, JWK errors |
+| `HandshakeError` | Handshake protocol errors |
+| `HandshakeTimeoutError` | Handshake timeout (extends HandshakeError) |
+| `DelegationError` | Scope chain and delegation errors |
+| `DelegationDepthError` | Depth limit exceeded (extends DelegationError) |
+| `TrustError` | Trust score computation errors |
+
+---
+
+## 24. Security Considerations
+
+### 24.1 Private Key Protection
+
+Private keys MUST NOT appear in:
+
+- Serialized identity records (JSON, dict, model dump).
+- Log output at any level.
+- API responses.
+- Error messages.
+
+### 24.2 Timing Side Channels
+
+Token verification MUST use constant-time comparison (e.g.,
+`hmac.compare_digest`). Implementations MUST NOT use standard
+string equality for token comparison.
+
+### 24.3 Log Flooding
+
+Signature verification failures MUST be logged at DEBUG level only.
+WARNING-level logging of verification failures enables log-flooding
+attacks by any peer that can submit messages.
+
+### 24.4 Nonce Entropy
+
+Challenge nonces MUST use at least 256 bits of cryptographically
+secure randomness. Response nonces MUST use at least 128 bits.
+**[Pure Specification]**
+
+### 24.5 DoS Resistance
+
+- Pending challenge count MUST be bounded.
+- Expired challenges MUST be purged before admitting new ones.
+- Challenge creation, lookup, and cleanup MUST be atomic to prevent
+  race conditions that bypass limits.
+
+### 24.6 Sybil Resistance
+
+- Trust ceilings on delegated agents prevent trust washing.
+- Wildcard capability `"*"` MUST NOT be delegated.
+- Maximum delegation depth limits chain length.
+- Initial trust scores for delegated agents are capped by parent
+  ceilings.
+
+### 24.7 Replay Protection
+
+Challenge nonces are single-use: each challenge MUST be removed from
+the pending set after use (success or failure). The combination of
+`challenge_id`, `nonce`, and `response_nonce` ensures uniqueness.
+
+### 24.8 Credential Security
+
+- Tokens are generated with `secrets.token_urlsafe(32)` (256 bits).
+- Only the SHA-256 hash is stored; the raw token is returned once.
+- Credentials have short TTLs (default 15 minutes).
+- Rotation provides zero-downtime credential refresh.
+
+---
+
+## 25. Conformance Requirements
+
+### 25.1 MUST Requirements
+
+An implementation is conformant if it satisfies all MUST and MUST NOT
+requirements in this specification. The following is a summary of
+critical conformance points:
+
+1. DID format MUST be `did:mesh:<unique-id>` with >= 128 bits of
+   randomness.
+2. Ed25519 MUST be the signature algorithm.
+3. Private keys MUST NOT appear in serialized output.
+4. Every identity MUST have a human sponsor.
+5. Trust scores MUST be clamped to [0, 1000].
+6. Trust ceilings MUST be enforced on every score update.
+7. Scope chain capabilities MUST only narrow, never widen.
+8. Wildcard `"*"` MUST NOT be delegated.
+9. Handshake challenges MUST expire and be cleaned up.
+10. Token verification MUST use constant-time comparison.
+11. Signature verification failures MUST NOT raise exceptions.
+12. Revoked identities MUST NOT be reactivated.
+13. Key rotation MUST produce verifiable proofs.
+14. JWK export MUST NOT include private keys by default.
+
+### 25.2 Test Coverage
+
+Conformance tests MUST cover:
+
+- DID generation and parsing.
+- Identity creation, validation, and lifecycle transitions.
+- Credential issuance, validation, rotation, and revocation.
+- Trust score computation, tier assignment, and ceiling enforcement.
+- Trust decay and network propagation.
+- Handshake challenge-response flow.
+- Delegation chain construction and verification.
+- Key rotation with proof verification.
+- JWK round-trip (export/import).
+- Revocation list operations.
+
+---
+
+## 26. Worked Examples
+
+### 26.1 Agent Identity Creation
+
+```
+Given: name="data-analyst", sponsor="alice@contoso.com"
+When:  AgentIdentity.create(name, sponsor) is called
+Then:
+  - did matches /did:mesh:[0-9a-f]{32}/
+  - public_key is non-empty base64
+  - verification_key_id matches /key-[0-9a-f]{16}/
+  - sponsor_email == "alice@contoso.com"
+  - status == "active"
+  - delegation_depth == 0
+  - Private key is available for signing
+  - Private key does NOT appear in model_dump()
+```
+
+### 26.2 Credential Rotation
+
+```
+Given: An active credential C1 for did:mesh:abc with capabilities=["read:data"]
+When:  C1.rotate() is called
+Then:
+  - C1.status == "rotated" (not "revoked" -- zero-downtime overlap)
+  - New credential C2 is returned
+  - C2.agent_did == C1.agent_did
+  - C2.capabilities == C1.capabilities
+  - C2.previous_credential_id == C1.credential_id
+  - C2.rotation_count == C1.rotation_count + 1
+  - C2.status == "active"
+```
+
+### 26.3 Trust Score with Ceiling
+
+```
+Given: Agent with trust_ceiling = 600, current score = 500
+When:  update(new_score=800, dimensions={...}) is called
+Then:
+  - total_score == 600 (clamped to ceiling)
+  - tier == "standard" (600 >= 500 but < 700)
+```
+
+### 26.4 Delegation Chain Narrowing
+
+```
+Given: Parent agent with capabilities=["read:*", "write:data"]
+When:  Parent delegates ["read:data"] to child
+Then:
+  - Child receives capabilities=["read:data"]
+  - "read:data" is a valid narrowing of "read:*"
+  - Child cannot access "write:data"
+  - Child cannot delegate "write:data" further
+```
+
+### 26.5 Key Rotation Proof
+
+```
+Given: Agent with keypair (old_priv, old_pub)
+When:  KeyRotationManager.rotate() is called
+Then:
+  - New keypair (new_priv, new_pub) is generated
+  - Rotation proof: old_priv signs "rotate:{old_pub_b64}:{new_pub_b64}"
+  - verify_rotation(old_pub, new_pub, proof) returns true
+  - Agent DID is unchanged
+  - Old key is in key_history
+```
+
+### 26.6 Handshake with Freshness
+
+```
+Given: Two agents A and B with registered identities
+When:  A initiates handshake with B, require_freshness=true
+Then:
+  - Challenge includes freshness_nonce
+  - B signs payload including freshness_nonce
+  - A verifies freshness_nonce matches
+  - Result is NOT cached (freshness bypasses cache)
+```
+
+---
+
+## 27. References
+
+- [RFC 2119: Key words for use in RFCs](https://datatracker.ietf.org/doc/html/rfc2119)
+- [RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119](https://datatracker.ietf.org/doc/html/rfc8174)
+- [RFC 7517: JSON Web Key (JWK)](https://datatracker.ietf.org/doc/html/rfc7517)
+- [RFC 7515: JSON Web Signature (JWS)](https://datatracker.ietf.org/doc/html/rfc7515)
+- [RFC 9334: Remote ATtestation procedureS (RATS)](https://datatracker.ietf.org/doc/html/rfc9334)
+- [RFC 8032: Edwards-Curve Digital Signature Algorithm (EdDSA)](https://datatracker.ietf.org/doc/html/rfc8032)
+- [W3C DID Core 1.0](https://www.w3.org/TR/did-core/)
+- [SPIFFE: Secure Production Identity Framework for Everyone](https://spiffe.io/)
+- [Agent OS Policy Engine Specification v1.0](./AGENT-OS-POLICY-ENGINE-1.0.md)


### PR DESCRIPTION
## Summary

Adds the second formal specification for AGT: **AgentMesh Identity and Trust v1.0**.

### Specification (54KB, 27 sections)
Covers the complete identity and trust model with RFC 2119/8174 normative language:

- **Agent DID** (did:mesh: format, 128-bit randomness, parsing rules)
- **Agent Identity** (Ed25519 keypair, sponsor binding, status lifecycle)
- **Credential Lifecycle** (issue, validate, rotate, revoke, TTL, constant-time verification)
- **Trust Score Model** (0-1000 scale, 5 reward dimensions, trust ceiling enforcement)
- **Trust Tiers** (verified_partner/trusted/standard/probationary/untrusted)
- **Trust Decay** (temporal decay, network propagation, interaction-weighted contagion)
- **Regime Detection** (KL divergence behavioral shift detection)
- **IATP Handshake** (Ed25519 challenge-response, RFC 9334 freshness, DoS protection)
- **Delegation/Scope Chains** (monotonic capability narrowing, hash chain integrity, OBO context)
- **Trust Ceiling Propagation** (Sybil resistance via ceiling clamping)
- **Key Rotation** (rotation proofs, history, TTL-based auto-rotation)
- **Identity Revocation** (permanent/temporary, auto-expiry, file-backed persistence)
- **SPIFFE/SVID** (workload identity, mTLS integration)
- **JWK/JWKS** (RFC 7517 serialization, round-trip import/export)
- **DID Document** (W3C format export)
- **Security Considerations** (private key protection, timing channels, nonce entropy, replay protection)

### Conformance Tests (135 tests, all passing)
Tests reference specific spec sections and validate both [Pure Specification] requirements and [Default Implementation] behaviors.

### Files Changed
- \docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md\ (new)
- \gent-governance-python/agent-mesh/tests/test_spec_identity_trust_conformance.py\ (new)