### PR TITLE
fix: implement VectorClock causal ordering and fail-close SessionIsolation

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/session/isolation.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/session/isolation.py
@@ -157,11 +157,11 @@ class SessionIsolationManager:
 
         Returns:
             True if access is allowed under the session's isolation scope.
-            True if no scope exists (permissive fallback for backward compat).
+            False if no scope exists (fail-closed: unscoped sessions are denied).
         """
         scope = self._scopes.get(session_id)
         if scope is None:
-            return True  # No scope = no enforcement (backward compat)
+            return False  # Fail-closed: no scope = no access
         return scope.is_path_allowed(path)
 
     def grant_cross_session_access(

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/session/vector_clock.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/session/vector_clock.py
@@ -2,10 +2,10 @@
 # Licensed under the MIT License.
 # Public Preview — basic implementation
 """
-Version Counters — stub implementation.
+Vector Clocks -- causal ordering for multi-agent writes.
 
-Public Preview: no causal consistency enforcement.
-VectorClock and VectorClockManager are retained for API compatibility.
+Implements standard component-wise vector clock comparison for
+detecting causal ordering and concurrency between agent operations.
 """
 
 from __future__ import annotations
@@ -53,10 +53,32 @@ class VectorClock:
         return VectorClock(clocks=merged_clocks)
 
     def happens_before(self, other: VectorClock) -> bool:
-        return False
+        """Return True if self causally precedes other.
+
+        Clock A happens-before clock B iff every component of A is <=
+        the corresponding component of B, and at least one is strictly <.
+        """
+        first, second = sorted([self, other], key=id)
+        with first._lock:
+            with second._lock:
+                all_agents = set(self.clocks.keys()) | set(other.clocks.keys())
+                at_least_one_less = False
+                for agent in all_agents:
+                    self_val = self.clocks.get(agent, 0)
+                    other_val = other.clocks.get(agent, 0)
+                    if self_val > other_val:
+                        return False
+                    if self_val < other_val:
+                        at_least_one_less = True
+                return at_least_one_less
 
     def is_concurrent(self, other: VectorClock) -> bool:
-        return False
+        """Return True if neither clock causally precedes the other."""
+        return (
+            not self.happens_before(other)
+            and not other.happens_before(self)
+            and self != other
+        )
 
     def copy(self) -> VectorClock:
         with self._lock:

--- a/agent-governance-python/agent-hypervisor/tests/test_session_isolation.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_session_isolation.py
@@ -1,0 +1,95 @@
+# Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+"""Tests for VectorClock and SessionIsolationManager fixes."""
+
+from hypervisor.session.vector_clock import VectorClock, VectorClockManager, CausalViolationError
+from hypervisor.session.isolation import SessionIsolationManager, IsolationLevel
+
+
+class TestVectorClockHappensBefore:
+    """Verify happens_before implements standard vector clock comparison."""
+
+    def test_empty_clocks_not_happens_before(self):
+        a = VectorClock()
+        b = VectorClock()
+        assert not a.happens_before(b)
+
+    def test_strictly_less_happens_before(self):
+        a = VectorClock(clocks={"agent1": 1})
+        b = VectorClock(clocks={"agent1": 2})
+        assert a.happens_before(b)
+
+    def test_equal_clocks_not_happens_before(self):
+        a = VectorClock(clocks={"agent1": 2})
+        b = VectorClock(clocks={"agent1": 2})
+        assert not a.happens_before(b)
+
+    def test_greater_not_happens_before(self):
+        a = VectorClock(clocks={"agent1": 3})
+        b = VectorClock(clocks={"agent1": 2})
+        assert not a.happens_before(b)
+
+    def test_multi_agent_happens_before(self):
+        a = VectorClock(clocks={"agent1": 1, "agent2": 2})
+        b = VectorClock(clocks={"agent1": 2, "agent2": 3})
+        assert a.happens_before(b)
+
+    def test_multi_agent_not_happens_before_when_any_greater(self):
+        a = VectorClock(clocks={"agent1": 3, "agent2": 1})
+        b = VectorClock(clocks={"agent1": 2, "agent2": 2})
+        assert not a.happens_before(b)
+
+    def test_missing_agent_treated_as_zero(self):
+        a = VectorClock(clocks={"agent1": 1})
+        b = VectorClock(clocks={"agent1": 1, "agent2": 1})
+        assert a.happens_before(b)
+
+
+class TestVectorClockIsConcurrent:
+    """Verify is_concurrent detects when neither clock precedes the other."""
+
+    def test_concurrent_when_diverged(self):
+        a = VectorClock(clocks={"agent1": 2, "agent2": 1})
+        b = VectorClock(clocks={"agent1": 1, "agent2": 2})
+        assert a.is_concurrent(b)
+
+    def test_not_concurrent_when_ordered(self):
+        a = VectorClock(clocks={"agent1": 1})
+        b = VectorClock(clocks={"agent1": 2})
+        assert not a.is_concurrent(b)
+
+    def test_not_concurrent_when_equal(self):
+        a = VectorClock(clocks={"agent1": 1})
+        b = VectorClock(clocks={"agent1": 1})
+        assert not a.is_concurrent(b)
+
+    def test_tick_then_concurrent(self):
+        """Two agents ticking independently should produce concurrent clocks."""
+        a = VectorClock()
+        b = VectorClock()
+        a.tick("agent1")
+        b.tick("agent2")
+        assert a.is_concurrent(b)
+
+
+class TestSessionIsolationFailClosed:
+    """Verify check_access returns False for unscoped sessions."""
+
+    def test_unscoped_session_denied(self):
+        mgr = SessionIsolationManager()
+        assert mgr.check_access("unknown-session", "/var/agt/sessions/unknown-session/data") is False
+
+    def test_scoped_session_allowed_own_path(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("session-1", "did:mesh:agent-1")
+        assert mgr.check_access("session-1", "/var/agt/sessions/session-1/output.json") is True
+
+    def test_scoped_session_denied_other_path(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("session-1", "did:mesh:agent-1")
+        assert mgr.check_access("session-1", "/var/agt/sessions/session-2/secret.json") is False
+
+    def test_removed_scope_denied(self):
+        mgr = SessionIsolationManager()
+        mgr.create_scope("session-1", "did:mesh:agent-1")
+        mgr.remove_scope("session-1")
+        assert mgr.check_access("session-1", "/var/agt/sessions/session-1/data") is False


### PR DESCRIPTION
## Summary

Fixes two security/correctness bugs in the hypervisor session module.

### VectorClock stubs (#2335)
\happens_before()\ and \is_concurrent()\ were hardcoded to \eturn False\, making causal ordering detection non-functional.

**Fix:** Standard component-wise vector clock comparison:
- \happens_before\: all self[a] <= other[a] and at least one strictly <
- \is_concurrent\: neither clock precedes the other (and they are not equal)
- Thread-safe using deterministic lock ordering (same pattern as \merge\/\__eq__\)

### SessionIsolation fail-open (#2336)
\check_access()\ returned \True\ when no scope existed, granting unrestricted access to unscoped sessions.

**Fix:** Return \False\ (fail-closed). A governance framework must deny by default.

### Tests
15 regression tests covering:
- Causal ordering (empty, equal, strictly-less, multi-agent, missing-agent-as-zero)
- Concurrency detection (diverged clocks, ordered clocks, equal clocks, independent ticks)
- Fail-closed isolation (unscoped denied, scoped allowed/denied, removed scope denied)

Fixes #2335
Fixes #2336