### PR TITLE
fix(rust): harden trust persistence and sandbox input validation

### DIFF
--- a/agent-governance-python/agent-discovery/src/agent_discovery/cli/main.py
+++ b/agent-governance-python/agent-discovery/src/agent_discovery/cli/main.py
@@ -185,7 +185,7 @@ def inventory(storage: str, output: str) -> None:
         click.echo(inv.export_json())
     elif output == "summary":
         summary = inv.summary()
-        console.print(f"\n[bold]Agent Inventory Summary[/bold]")
+        console.print("\n[bold]Agent Inventory Summary[/bold]")
         console.print(f"  Total agents: {summary['total_agents']}")
         console.print(f"  By type: {json.dumps(summary['by_type'], indent=2)}")
         console.print(f"  By status: {json.dumps(summary['by_status'], indent=2)}")
@@ -254,7 +254,7 @@ def reconcile(storage: str, registry_file: str | None, output: str) -> None:
             )
         )
     elif shadow_agents:
-        console.print(f"\n[bold red]⚠ Shadow Agents Detected[/bold red]\n")
+        console.print("\n[bold red]⚠ Shadow Agents Detected[/bold red]\n")
         table = Table(show_header=True, header_style="bold red")
         table.add_column("Name", style="white", max_width=40)
         table.add_column("Type", style="cyan")

--- a/agent-governance-rust/agentmesh/src/sandbox.rs
+++ b/agent-governance-rust/agentmesh/src/sandbox.rs
@@ -15,6 +15,16 @@ use std::fmt;
 use std::process::Command;
 use std::time::Instant;
 
+/// Validate that an environment variable name contains only safe characters.
+fn validate_env_key(key: &str) -> Result<(), String> {
+    if key.is_empty()
+        || !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Err(format!("Invalid environment variable name: {:?}", key));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Enums
 // ---------------------------------------------------------------------------
@@ -217,8 +227,19 @@ fn generate_id() -> String {
 }
 
 /// Format a Docker-safe container name from agent and session IDs.
+/// Strips non-alphanumeric characters to prevent injection via agent_id.
 fn container_name(agent_id: &str, session_id: &str) -> String {
-    format!("{}-{}-{}", CONTAINER_PREFIX, agent_id, session_id)
+    let safe_agent: String = agent_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(64)
+        .collect();
+    let safe_session: String = session_id
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(64)
+        .collect();
+    format!("{}-{}-{}", CONTAINER_PREFIX, safe_agent, safe_session)
 }
 
 /// `SandboxProvider` backed by hardened Docker containers.
@@ -294,6 +315,7 @@ impl SandboxProvider for DockerSandboxProvider {
         }
 
         for (k, v) in &cfg.env_vars {
+            validate_env_key(k)?;
             args.push("-e".to_string());
             args.push(format!("{}={}", k, v));
         }
@@ -439,6 +461,14 @@ impl SandboxProvider for DockerSandboxProvider {
             args.push("--network=none".to_string());
         }
         for (k, v) in &cfg.env_vars {
+            if let Err(e) = validate_env_key(k) {
+                return SandboxResult {
+                    success: false,
+                    exit_code: -1,
+                    stderr: e,
+                    ..Default::default()
+                };
+            }
             args.push("-e".to_string());
             args.push(format!("{}={}", k, v));
         }

--- a/agent-governance-rust/agentmesh/src/trust.rs
+++ b/agent-governance-rust/agentmesh/src/trust.rs
@@ -212,10 +212,15 @@ impl TrustManager {
     /// Best-effort load from persistence file.
     fn load_from_disk(&self) {
         if let Some(path) = &self.config.persist_path {
+            let path = std::path::Path::new(path);
+            if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+                return;
+            }
             if let Ok(data) = std::fs::read_to_string(path) {
                 if let Ok(states) = serde_json::from_str::<Vec<AgentState>>(&data) {
                     let mut agents = self.agents.write().unwrap_or_else(|e| e.into_inner());
-                    for state in states {
+                    for mut state in states {
+                        state.score = state.score.min(1000);
                         agents.insert(state.agent_id.clone(), state);
                     }
                 }
@@ -226,6 +231,10 @@ impl TrustManager {
     /// Best-effort save to persistence file.
     fn save_to_disk(&self) {
         if let Some(path) = &self.config.persist_path {
+            let path = std::path::Path::new(path);
+            if path.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+                return;
+            }
             let agents = self.agents.read().unwrap_or_else(|e| e.into_inner());
             let states: Vec<&AgentState> = agents.values().collect();
             if let Ok(json) = serde_json::to_string(&states) {


### PR DESCRIPTION
## Summary

Hardens the Rust SDK trust persistence and Docker sandbox against path traversal and injection attacks.

### Trust persistence (trust.rs)

- **Path traversal guard**: `load_from_disk()` and `save_to_disk()` now reject `persist_path` values containing `..` components (CWE-22)
- **Score clamping on load**: Deserialized trust scores are clamped to 0-1000 range, preventing tampered persistence files from injecting out-of-bounds scores

### Docker sandbox (sandbox.rs)

- **Container name sanitization**: `container_name()` now strips all characters except ASCII alphanumeric, hyphens, and underscores, with a 64-char truncation limit. Prevents injection via crafted `agent_id` values
- **Env var key validation**: New `validate_env_key()` rejects empty keys and keys containing non-alphanumeric/underscore characters before passing to Docker CLI (CWE-78)

### Testing

`cargo check --workspace` passes. Only pre-existing deprecation warnings on the MCP gateway shim.