### PR TITLE
fix(ci): add safety CLI v3 policy file

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,19 @@
+# Safety CLI v3 policy file
+# https://docs.safetycli.com/safety-docs/safety-3/configuration/policy-file
+version: "3.0"
+
+scan:
+  max-depth: 10
+  exclude: []
+
+report:
+  auto-ignore-in-report:
+    python:
+      unpinned-specifications: "warn"
+
+fail-scan-with-exit-code:
+  dependency-vulnerabilities:
+    enabled: true
+    fail-on-any-of:
+      cvss-severity:
+        - critical


### PR DESCRIPTION
## Summary

Fix the `security` CI job failure caused by missing `.safety-policy.yml`.

## Problem

`safety check` (v3) auto-discovers `.safety-policy.yml` in the repo root. When the file is missing, it exits with code 2 and the error: `Invalid value for '--policy-file': Policy file YAML is not valid. HINT: [Errno 2] No such file or directory: '.safety-policy.yml'`

This has been failing on every PR's `security` check.

## Changes

| File | Change |
|------|--------|
| `.safety-policy.yml` (new) | Minimal safety v3 policy: fail on critical CVEs only, matching existing CI logic |

## Testing

Policy file follows the [Safety v3 policy file spec](https://docs.safetycli.com/safety-docs/safety-3/configuration/policy-file). The `fail-on-any-of` critical-only rule matches the existing `jq` logic in `ci.yml` that counts critical CVEs.
