### PR TITLE
fix(typescript): add SSRF blocklist to Cedar policy backend

### DIFF
--- a/agent-governance-typescript/src/policy-backends/cedar.ts
+++ b/agent-governance-typescript/src/policy-backends/cedar.ts
@@ -3,6 +3,48 @@
 
 import { BackendDecision, ExternalPolicyBackend } from '../types';
 
+/** Hostnames and IP prefixes that must never be used as Cedar endpoints. */
+const SSRF_BLOCKLIST = [
+  '169.254.169.254',    // AWS/Azure IMDS
+  '169.254.170.2',      // ECS task metadata
+  '168.63.129.16',      // Azure Wire Server
+  'metadata.google.internal',
+  'metadata.google',
+  '100.100.100.200',    // Alibaba Cloud IMDS
+  'fd00::',             // IPv6 unique-local prefix
+  '::1',                // IPv6 loopback
+];
+
+const SSRF_PRIVATE_RANGES = [
+  /^127\./,             // IPv4 loopback
+  /^10\./,              // RFC 1918
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,        // RFC 1918
+  /^0\./,               // "this" network
+];
+
+function isBlockedEndpoint(endpoint: string): boolean {
+  let hostname: string;
+  try {
+    const url = new URL(endpoint);
+    hostname = url.hostname.replace(/^\[|\]$/g, '');
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return true;
+    }
+  } catch {
+    return true;
+  }
+
+  const lower = hostname.toLowerCase();
+  if (lower === 'localhost' || SSRF_BLOCKLIST.some(b => lower === b || lower.endsWith('.' + b))) {
+    return true;
+  }
+  if (SSRF_PRIVATE_RANGES.some(re => re.test(hostname))) {
+    return true;
+  }
+  return false;
+}
+
 interface CedarBackendConfig {
   endpoint: string;
   fetchImpl?: typeof fetch;
@@ -14,7 +56,11 @@ export class CedarBackend implements ExternalPolicyBackend {
   private readonly fetchImpl: typeof fetch;
 
   constructor(config: CedarBackendConfig) {
-    this.endpoint = config.endpoint.replace(/\/$/, '');
+    const cleaned = config.endpoint.replace(/\/$/, '');
+    if (isBlockedEndpoint(cleaned)) {
+      throw new Error('Cedar endpoint blocked: URL points to a reserved or private address');
+    }
+    this.endpoint = cleaned;
     this.fetchImpl = config.fetchImpl ?? fetch;
   }
 


### PR DESCRIPTION
## Summary

Adds SSRF protection to the TypeScript Cedar policy backend by validating endpoint URLs at construction time.

### Problem

`CedarBackend` accepted any URL as its endpoint, including cloud metadata services (169.254.169.254), private networks (10.x, 172.16-31.x, 192.168.x), and loopback addresses. An attacker who controls the Cedar endpoint configuration could exfiltrate cloud credentials or access internal services (CWE-918).

### Fix

New `isBlockedEndpoint()` function validates the URL at construction time, rejecting:
- Cloud IMDS endpoints (AWS, Azure, GCP, Alibaba)
- Azure Wire Server (168.63.129.16)
- RFC 1918 private ranges
- IPv4/IPv6 loopback
- Non-HTTP protocols
- Unparseable URLs

### Testing

All 8 policy-backends tests pass.