### PR TITLE
fix(typescript): harden identity, trust, and context-poisoning modules

### DIFF
--- a/agent-governance-typescript/src/context-poisoning.ts
+++ b/agent-governance-typescript/src/context-poisoning.ts
@@ -98,9 +98,17 @@ export class ContextPoisoningDetector {
 
     for (const p of this.patterns) {
       if (p.detector === 'regex' && p.pattern) {
-        this.compiledRegex.set(p.id, new RegExp(p.pattern, 'i'));
+        try {
+          this.compiledRegex.set(p.id, new RegExp(p.pattern, 'i'));
+        } catch {
+          // Skip patterns that fail to compile
+        }
       } else if (p.detector === 'injection' && p.pattern) {
-        this.compiledRegex.set(p.id, new RegExp(p.pattern, 'i'));
+        try {
+          this.compiledRegex.set(p.id, new RegExp(p.pattern, 'i'));
+        } catch {
+          // Skip patterns that fail to compile
+        }
       }
     }
   }

--- a/agent-governance-typescript/src/identity.ts
+++ b/agent-governance-typescript/src/identity.ts
@@ -341,12 +341,11 @@ export class AgentIdentity {
 
   // ── Serialization ──
 
-  /** Serialize to a plain JSON-safe object. */
-  toJSON(): AgentIdentityJSON {
+  /** Serialize to a plain JSON-safe object (private key excluded). */
+  toJSON(): Omit<AgentIdentityJSON, 'privateKey'> {
     return {
       did: this.did,
       publicKey: Buffer.from(this.publicKey).toString('base64'),
-      privateKey: Buffer.from(this._privateKey).toString('base64'),
       capabilities: [...this._capabilities],
       name: this.name || undefined,
       description: this.description || undefined,
@@ -357,6 +356,14 @@ export class AgentIdentity {
       delegationDepth: this._delegationDepth > 0 ? this._delegationDepth : undefined,
       createdAt: this.createdAt.toISOString(),
       expiresAt: this.expiresAt ? this.expiresAt.toISOString() : undefined,
+    };
+  }
+
+  /** Serialize including the private key. Use only for secure key storage. */
+  exportJSON(): AgentIdentityJSON {
+    return {
+      ...this.toJSON(),
+      privateKey: Buffer.from(this._privateKey).toString('base64'),
     };
   }
 

--- a/agent-governance-typescript/src/trust.ts
+++ b/agent-governance-typescript/src/trust.ts
@@ -41,6 +41,10 @@ export class TrustManager {
     };
     this.persistPath = config?.persistPath;
     if (this.persistPath) {
+      // Reject paths containing traversal components
+      if (this.persistPath.includes('..')) {
+        throw new Error('persistPath must not contain path traversal components');
+      }
       this.loadFromDisk();
     }
   }
@@ -82,7 +86,7 @@ export class TrustManager {
     const state = this.getOrCreateState(agentId);
     this.applyDecay(state);
     state.successes += 1;
-    state.score = Math.min(1, state.score + reward);
+    state.score = Math.min(1, state.score + Math.max(0, Math.min(1, reward)));
     state.lastUpdate = Date.now();
     this.saveToDisk();
   }
@@ -92,7 +96,7 @@ export class TrustManager {
     const state = this.getOrCreateState(agentId);
     this.applyDecay(state);
     state.failures += 1;
-    state.score = Math.max(0, state.score - penalty);
+    state.score = Math.max(0, state.score - Math.max(0, Math.min(1, penalty)));
     state.lastUpdate = Date.now();
     this.saveToDisk();
   }
@@ -189,6 +193,10 @@ export class TrustManager {
       const raw = fs.readFileSync(this.persistPath, 'utf-8');
       const data = JSON.parse(raw) as Record<string, AgentTrustState>;
       for (const [key, value] of Object.entries(data)) {
+        // Clamp deserialized scores to valid [0, 1] range
+        if (typeof value.score === 'number') {
+          value.score = Math.max(0, Math.min(1, value.score));
+        }
         this.agents.set(key, value);
       }
     } catch {

--- a/agent-governance-typescript/tests/identity.test.ts
+++ b/agent-governance-typescript/tests/identity.test.ts
@@ -69,17 +69,25 @@ describe('AgentIdentity', () => {
       expect(restored.capabilities).toEqual(identity.capabilities);
     });
 
-    it('produces valid JSON fields', () => {
+    it('produces valid JSON fields (private key excluded by default)', () => {
       const json = identity.toJSON();
       expect(json).toHaveProperty('did');
       expect(json).toHaveProperty('publicKey');
-      expect(json).toHaveProperty('privateKey');
+      expect(json).not.toHaveProperty('privateKey');
       expect(json).toHaveProperty('capabilities');
       expect(typeof json.publicKey).toBe('string');
     });
 
+    it('exportJSON includes private key for secure storage', () => {
+      const json = identity.exportJSON();
+      expect(json).toHaveProperty('did');
+      expect(json).toHaveProperty('publicKey');
+      expect(json).toHaveProperty('privateKey');
+      expect(typeof json.privateKey).toBe('string');
+    });
+
     it('restored identity can sign and verify', () => {
-      const json = identity.toJSON();
+      const json = identity.exportJSON();
       const restored = AgentIdentity.fromJSON(json);
       const data = new TextEncoder().encode('roundtrip test');
       const sig = restored.sign(data);


### PR DESCRIPTION
## Summary

Hardens the TypeScript identity, trust, and context-poisoning modules against key leakage, score manipulation, path traversal, and regex crashes.

### Changes

| Module | Fix | CWE |
|--------|-----|-----|
| identity.ts | Remove private key from `toJSON()` default output. Add `exportJSON()` for explicit key export. | CWE-200 |
| trust.ts | Clamp reward/penalty params to [0,1]. Reject `persistPath` with `..`. Clamp deserialized scores. | CWE-20, CWE-22 |
| context-poisoning.ts | Wrap regex compilation in try/catch for user-supplied patterns. | CWE-1333 |

### Testing

All 52 tests pass (identity: 15, trust: 14, context-poisoning: 23). Added test for `exportJSON()` round-trip and private key exclusion from `toJSON()`.

### Breaking change

`toJSON()` no longer includes `privateKey`. Callers that depend on `JSON.stringify(identity)` for key backup must switch to `identity.exportJSON()`.