### PR TITLE
fix(python): add path traversal guards to SRE capture, signing, and specs

### DIFF
--- a/agent-governance-python/agent-sre/src/agent_sre/replay/capture.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/replay/capture.py
@@ -295,20 +295,30 @@ class TraceStore:
     """
 
     def __init__(self, storage_dir: str | Path = ".agent-governance-python/agent-sre/traces") -> None:
-        self.storage_dir = Path(storage_dir)
+        self.storage_dir = Path(storage_dir).resolve()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def _safe_trace_path(self, trace_id: str) -> Path:
+        """Resolve a trace file path, rejecting traversal attempts."""
+        # Strip path separators and parent-dir components from trace_id
+        safe_id = trace_id.replace("/", "").replace("\\", "").replace("..", "")
+        if not safe_id or safe_id != trace_id:
+            raise ValueError(f"Invalid trace_id: {trace_id!r}")
+        filepath = (self.storage_dir / f"{safe_id}.json").resolve()
+        if not str(filepath).startswith(str(self.storage_dir)):
+            raise ValueError(f"Path traversal detected in trace_id: {trace_id!r}")
+        return filepath
 
     def save(self, trace: Trace, redact: bool = True) -> Path:
         """Save a trace to storage."""
-        filename = f"{trace.trace_id}.json"
-        filepath = self.storage_dir / filename
+        filepath = self._safe_trace_path(trace.trace_id)
         with open(filepath, "w") as f:
             json.dump(trace.to_dict(redact=redact), f, indent=2)
         return filepath
 
     def load(self, trace_id: str) -> Trace | None:
         """Load a trace by ID."""
-        filepath = self.storage_dir / f"{trace_id}.json"
+        filepath = self._safe_trace_path(trace_id)
         if not filepath.exists():
             return None
         with open(filepath) as f:
@@ -337,7 +347,7 @@ class TraceStore:
 
     def delete(self, trace_id: str) -> bool:
         """Delete a trace."""
-        filepath = self.storage_dir / f"{trace_id}.json"
+        filepath = self._safe_trace_path(trace_id)
         if filepath.exists():
             filepath.unlink()
             return True

--- a/agent-governance-python/agent-sre/src/agent_sre/signing.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/signing.py
@@ -82,7 +82,10 @@ class ArtifactSigner:
                 "Install it with: pip install cryptography"
             )
         if private_key_path is not None:
-            pem_bytes = Path(private_key_path).read_bytes()
+            key_path = Path(private_key_path).resolve()
+            if ".." in str(Path(private_key_path).parts):
+                raise ValueError(f"Path traversal detected in private_key_path: {private_key_path!r}")
+            pem_bytes = key_path.read_bytes()
             key = load_pem_private_key(pem_bytes, password=None)
             if not isinstance(key, Ed25519PrivateKey):
                 raise TypeError("Only Ed25519 private keys are supported")

--- a/agent-governance-python/agent-sre/src/agent_sre/specs/__init__.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/specs/__init__.py
@@ -169,7 +169,12 @@ def load_slo_template(
         Dict with keys: name, description, labels, indicators, error_budget
     """
     d = Path(specs_dir) if specs_dir else _SPECS_DIR
+    # Reject path traversal in template name
+    if "/" in name or "\\" in name or ".." in name:
+        raise ValueError(f"Invalid template name: {name!r}")
     path = d / f"{name}.yaml"
+    if not path.resolve().parent == d.resolve():
+        raise ValueError(f"Path traversal detected in template name: {name!r}")
     if not path.exists():
         available = list_templates(specs_dir)
         raise FileNotFoundError(


### PR DESCRIPTION
Adds path traversal validation to three Python agent-sre modules:

- **capture.py**: New \_safe_trace_path()\ method resolves and validates trace file paths stay within \storage_dir\, preventing directory traversal via crafted trace IDs
- **signing.py**: Validates \private_key_path\ rejects path segments containing \..\
- **specs/__init__.py**: Rejects template names containing \/\, \\\\, or \..\

All 1389 agent-sre tests pass.