### PR TITLE
fix(python): verify HMAC before committing nonce in MCP message signer

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_message_signer.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_message_signer.py
@@ -203,11 +203,9 @@ class MCPMessageSigner:
                 if self._nonce_store.has(envelope.nonce):
                     logger.warning("Duplicate MCP nonce detected: %s", envelope.nonce)
                     return MCPVerificationResult.failed("Duplicate nonce (replay detected).")
-                self._nonce_store.add(
-                    envelope.nonce,
-                    envelope.timestamp + self.replay_window,
-                )
 
+            # Verify HMAC before committing the nonce to prevent an
+            # attacker from burning valid nonces with forged signatures.
             expected_signature = self._compute_signature(
                 nonce=envelope.nonce,
                 timestamp=envelope.timestamp,
@@ -216,6 +214,12 @@ class MCPMessageSigner:
             )
             if not hmac.compare_digest(expected_signature, envelope.signature):
                 return MCPVerificationResult.failed("Invalid signature.")
+
+            with self._lock:
+                self._nonce_store.add(
+                    envelope.nonce,
+                    envelope.timestamp + self.replay_window,
+                )
 
             return MCPVerificationResult.success(envelope.payload, envelope.sender_id)
         except Exception as exc:


### PR DESCRIPTION
Fixes a nonce-burning vulnerability in MCP message verification.

**Bug:** The nonce was committed to the replay-detection store *before* HMAC verification. An attacker could send messages with valid nonces but forged signatures, burning the nonce and causing the legitimate message to be rejected as a replay.

**Fix:** Move \
once_store.add()\ after \hmac.compare_digest()\ so only authenticated messages consume nonces.

All 8 MCP message signer tests pass.