### PR TITLE
docs: add RFC process and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,112 @@
+name: "RFC: Major Feature Proposal"
+description: Propose a significant architectural change or new capability
+title: "RFC: "
+labels: ["rfc", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## RFC Process
+
+        RFCs are required for changes that affect public API surfaces, introduce
+        new packages, change the security model, or add framework integrations.
+        Small bug fixes and documentation updates do not need an RFC.
+
+        **Lifecycle:** Draft → Under Review → Accepted / Rejected → Implemented
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-paragraph explanation of the proposal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this change needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Detailed Design
+      description: |
+        Explain the design in enough detail for someone familiar with AGT to
+        understand and implement it. Include API signatures, data models, and
+        interaction diagrams where relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches were considered and why were they rejected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: security
+    attributes:
+      label: Security Implications
+      description: |
+        How does this change affect the trust model, cryptographic boundaries,
+        or attack surface? For governance framework changes this section is
+        mandatory.
+    validations:
+      required: true
+
+  - type: textarea
+    id: migration
+    attributes:
+      label: Migration / Backward Compatibility
+      description: |
+        Does this break existing APIs? If so, what is the deprecation and
+        migration path?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: How large is this change?
+      options:
+        - Single package
+        - Cross-package (2-3 packages)
+        - Architecture-wide
+    validations:
+      required: true
+
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target Placement
+      description: Where should this land?
+      options:
+        - Core (agent-os, agent-mesh, agent-hypervisor)
+        - Integration (integrations/ directory)
+        - Community / Examples
+        - New package
+    validations:
+      required: true
+
+  - type: textarea
+    id: prior_art
+    attributes:
+      label: Prior Art
+      description: |
+        Are there similar features in other governance/security frameworks?
+        Link to relevant specs, papers, or implementations.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched existing issues and RFCs for duplicates
+          required: true
+        - label: I have read the ADR index (adr/index.md) for related decisions
+        - label: I am willing to implement this RFC or help review an implementation

--- a/docs/RFC_PROCESS.md
+++ b/docs/RFC_PROCESS.md
@@ -1,0 +1,64 @@
+# Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+# RFC Process
+
+This document describes how major changes to the Agent Governance Toolkit
+are proposed, reviewed, and accepted.
+
+## When is an RFC required?
+
+An RFC is required for any change that:
+
+- Adds or removes a public API surface (new classes, method signatures)
+- Introduces a new package or framework integration
+- Changes the security model, trust boundaries, or cryptographic choices
+- Modifies the policy engine, privilege rings, or delegation chains
+- Affects backward compatibility or requires a migration path
+
+An RFC is **not** required for:
+
+- Bug fixes
+- Documentation improvements
+- Test additions
+- Dependency updates
+- Internal refactoring that preserves the public API
+
+## Lifecycle
+
+```
+Draft → Under Review → Accepted / Rejected → Implemented → Closed
+```
+
+| Stage | Description |
+|-------|-------------|
+| **Draft** | Author opens an RFC issue using the template. |
+| **Under Review** | Maintainers add the `rfc:review` label. Community discussion happens on the issue. Minimum review period is 7 days. |
+| **Accepted** | Maintainers add `rfc:accepted`. An ADR is created to record the decision. Implementation work begins. |
+| **Rejected** | Maintainers add `rfc:rejected` with a rationale comment. Issue is closed. |
+| **Implemented** | Implementation PRs reference the RFC. Once merged, the RFC issue is closed. |
+
+## How to write a good RFC
+
+1. **Start with the problem.** Explain what is broken or missing today.
+2. **Show the API.** Include concrete code examples, type signatures, and
+   data models.
+3. **Address security.** AGT is a governance framework. Every RFC must
+   consider how it affects the trust model and attack surface.
+4. **Consider alternatives.** Show what else you evaluated and why you
+   chose this approach.
+5. **Plan the migration.** If this is a breaking change, describe the
+   deprecation path.
+
+## Relationship to ADRs
+
+RFCs capture the proposal and discussion. Once accepted, the decision is
+recorded as an [Architecture Decision Record](../adr/index.md) (ADR) for
+long-term reference. The ADR links back to the RFC issue.
+
+## Review expectations
+
+- Maintainers aim to provide initial feedback within 5 business days.
+- RFCs with security implications require sign-off from at least two
+  maintainers.
+- Community members are encouraged to comment, ask questions, and
+  propose amendments.


### PR DESCRIPTION
## Summary

Adds a TFC-style RFC process for major feature proposals.

### Changes
- \.github/ISSUE_TEMPLATE/rfc.yml\: Structured RFC issue template with sections for summary, motivation, detailed design, security implications, migration path, and scope/target placement
- \docs/RFC_PROCESS.md\: Documents the RFC lifecycle (Draft -> Under Review -> Accepted/Rejected -> Implemented -> Closed), when an RFC is required, and how it relates to ADRs

### RFC lifecycle
| Stage | Description |
|-------|-------------|
| Draft | Author opens issue using template |
| Under Review | 7-day minimum review period |
| Accepted | ADR created, implementation begins |
| Rejected | Rationale posted, issue closed |

Closes #2243