### PR TITLE
fix(dotnet): expand OPA SSRF blocklist with cloud metadata endpoints

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/OpaPolicyBackend.cs
@@ -560,8 +560,12 @@ public sealed class OpaPolicyBackend : IExternalPolicyBackend
 
     private static readonly HashSet<string> BlockedHosts = new(StringComparer.OrdinalIgnoreCase)
     {
-        "169.254.169.254",
+        "169.254.169.254",        // AWS/Azure IMDS
+        "169.254.170.2",          // ECS task metadata
+        "168.63.129.16",          // Azure Wire Server
         "metadata.google.internal",
+        "metadata.google",
+        "100.100.100.200",        // Alibaba Cloud IMDS
     };
 
     private static void ValidateOpaUrl(string opaUrl)


### PR DESCRIPTION
Add AWS ECS metadata (169.254.170.2), Azure Wire Server (168.63.129.16), GCP alternate (metadata.google), and Alibaba Cloud IMDS (100.100.100.200) to the OPA backend SSRF blocklist. All 13 OPA tests pass.