### PR TITLE
fix(dotnet): implement streaming governance for MAF agents

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance.Extensions.Microsoft.Agents/AgentFrameworkGovernanceAdapter.cs
+++ b/agent-governance-dotnet/src/AgentGovernance.Extensions.Microsoft.Agents/AgentFrameworkGovernanceAdapter.cs
@@ -84,6 +84,60 @@ public sealed class AgentFrameworkGovernanceAdapter
     }
 
     /// <summary>
+    /// Applies run-level governance before the inner agent streams a response.
+    /// </summary>
+    public async IAsyncEnumerable<AgentResponseUpdate> RunStreamingAsync(
+        IEnumerable<ChatMessage> messages,
+        AgentSession? session,
+        AgentRunOptions? options,
+        AIAgent innerAgent,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(innerAgent);
+
+        var materializedMessages = messages as IReadOnlyList<ChatMessage> ?? messages.ToList();
+
+        var agentId = ResolveAgentId(innerAgent, session);
+        var agentName = ResolveAgentName(innerAgent);
+        var inputText = ResolveInputText(materializedMessages);
+        var sessionId = ResolveSessionId(session);
+
+        var context = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["message"] = inputText,
+            ["agent_name"] = agentName,
+            ["message_count"] = materializedMessages.Count,
+            ["has_session"] = session is not null
+        };
+
+        var decision = Kernel.PolicyEngine.Evaluate(agentId, context);
+        EmitRunDecision(agentId, sessionId, inputText, decision);
+        Kernel.Metrics?.RecordDecision(
+            decision.Allowed,
+            agentId,
+            "agent_run_streaming",
+            decision.EvaluationMs,
+            decision.RateLimited);
+
+        if (!decision.Allowed)
+        {
+            var blockedResponse = Options.BlockedRunResponseFactory?.Invoke(decision)
+                ?? CreateBlockedRunResponse(decision);
+            foreach (var msg in blockedResponse.Messages)
+            {
+                yield return new AgentResponseUpdate(msg.Role, msg.Text);
+            }
+            yield break;
+        }
+
+        await foreach (var update in innerAgent.RunStreamingAsync(materializedMessages, session, options, cancellationToken).ConfigureAwait(false))
+        {
+            yield return update;
+        }
+    }
+
+    /// <summary>
     /// Applies function-call governance before the inner tool executes.
     /// </summary>
     public async ValueTask<object?> InvokeFunctionAsync(

--- a/agent-governance-dotnet/src/AgentGovernance.Extensions.Microsoft.Agents/AgentFrameworkGovernanceExtensions.cs
+++ b/agent-governance-dotnet/src/AgentGovernance.Extensions.Microsoft.Agents/AgentFrameworkGovernanceExtensions.cs
@@ -20,7 +20,7 @@ public static class AgentFrameworkGovernanceExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(adapter);
 
-        var governedBuilder = builder.Use(runFunc: adapter.RunAsync, runStreamingFunc: null);
+        var governedBuilder = builder.Use(runFunc: adapter.RunAsync, runStreamingFunc: adapter.RunStreamingAsync);
 
         return adapter.Options.EnableFunctionMiddleware
             ? governedBuilder.Use(adapter.InvokeFunctionAsync)

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentFrameworkGovernanceExtensionsTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/AgentFrameworkGovernanceExtensionsTests.cs
@@ -79,4 +79,76 @@ public sealed class AgentFrameworkGovernanceExtensionsTests
         Assert.False(innerAgent.WasRun);
         Assert.Contains("Blocked by governance policy", response.Text, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task WithGovernance_StreamingBlocked_YieldsBlockedResponse()
+    {
+        var kernel = AgentFrameworkGovernanceTestHelpers.CreateKernel(
+            """
+            apiVersion: governance.toolkit/v1
+            version: "1.0"
+            name: deny-stream-policy
+            default_action: allow
+            rules:
+              - name: block-stream-secret
+                condition: "message == 'stream the secret'"
+                action: deny
+                priority: 10
+            """);
+        var innerAgent = new AgentFrameworkGovernanceTestHelpers.TestAgent("stream-agent");
+        var governedAgent = innerAgent.WithGovernance(
+            kernel,
+            new AgentFrameworkGovernanceOptions
+            {
+                EnableFunctionMiddleware = false
+            });
+
+        var updates = new List<AgentResponseUpdate>();
+        await foreach (var update in governedAgent.RunStreamingAsync(
+            [new ChatMessage(ChatRole.User, "stream the secret")],
+            session: null,
+            options: null,
+            cancellationToken: CancellationToken.None))
+        {
+            updates.Add(update);
+        }
+
+        Assert.False(innerAgent.WasRun);
+        Assert.NotEmpty(updates);
+        Assert.Contains("Blocked by governance policy", updates[0].Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WithGovernance_StreamingAllowed_ForwardsToInnerAgent()
+    {
+        var kernel = AgentFrameworkGovernanceTestHelpers.CreateKernel(
+            """
+            apiVersion: governance.toolkit/v1
+            version: "1.0"
+            name: allow-all-policy
+            default_action: allow
+            rules: []
+            """);
+        var innerAgent = new AgentFrameworkGovernanceTestHelpers.TestAgent("stream-allowed-agent");
+        var governedAgent = innerAgent.WithGovernance(
+            kernel,
+            new AgentFrameworkGovernanceOptions
+            {
+                EnableFunctionMiddleware = false
+            });
+
+        var updates = new List<AgentResponseUpdate>();
+        await foreach (var update in governedAgent.RunStreamingAsync(
+            [new ChatMessage(ChatRole.User, "hello")],
+            session: null,
+            options: null,
+            cancellationToken: CancellationToken.None))
+        {
+            updates.Add(update);
+        }
+
+        Assert.True(innerAgent.WasRun);
+        Assert.NotEmpty(updates);
+        Assert.Contains("allowed", updates[0].Text, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a governance bypass where `runStreamingFunc: null` was passed to `AIAgentBuilder.Use()`, causing policy checks to be silently skipped when agents used `RunStreamingAsync()`.

## Changes

| File | Change |
|------|--------|
| `AgentFrameworkGovernanceAdapter.cs` | Added `RunStreamingAsync()` with same policy evaluation, audit emit, and metrics as `RunAsync()` |
| `AgentFrameworkGovernanceExtensions.cs` | Changed `runStreamingFunc: null` to `runStreamingFunc: adapter.RunStreamingAsync` |
| `AgentFrameworkGovernanceExtensionsTests.cs` | Added 2 streaming tests: blocked yields denial, allowed forwards to inner agent |

## Behavior

- **Blocked streaming**: yields a single `AgentResponseUpdate` with the denial reason, then completes
- **Allowed streaming**: forwards all updates from the inner agent unchanged
- Audit events use `agent_run_streaming` action type for distinguishability

Closes #1989