### PR TITLE
fix(test): remove eager event loop access in websocket transport fixture

### DIFF
--- a/agent-governance-python/agent-mesh/tests/test_websocket_transport.py
+++ b/agent-governance-python/agent-mesh/tests/test_websocket_transport.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 """Tests for the WebSocket transport implementation."""
 
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,14 +24,17 @@ def config() -> TransportConfig:
 
 @pytest.fixture
 def mock_ws_connection() -> AsyncMock:
-    """Mock websockets ClientConnection."""
+    """Mock websockets ClientConnection.
+
+    Avoids calling ``asyncio.get_event_loop()`` at collection time,
+    which raises on Python 3.12+ when no loop is running.  The ping
+    mock returns a coroutine that resolves to ``None`` instead.
+    """
     ws = AsyncMock()
     ws.close = AsyncMock()
     ws.send = AsyncMock()
     ws.recv = AsyncMock(return_value=json.dumps({"topic": "test", "payload": {"ok": True}}))
-    pong_future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
-    pong_future.set_result(None)
-    ws.ping = AsyncMock(return_value=pong_future)
+    ws.ping = AsyncMock(return_value=None)
     return ws
 
 


### PR DESCRIPTION
## Summary

Fix 5 test errors in docker-compose-test CI caused by eager event loop access at fixture collection time.

## Problem

The `mock_ws_connection` fixture in `test_websocket_transport.py` calls `asyncio.get_event_loop().create_future()` at collection time. On Python 3.12+, there is no default event loop in the main thread, causing `RuntimeError: There is no current event loop in thread 'MainThread'` for all 5 tests that use this fixture.

## Changes

| File | Change |
|------|--------|
| test_websocket_transport.py | Replace `asyncio.get_event_loop().create_future()` with `AsyncMock(return_value=None)` for ping mock; remove unused asyncio import |

## Testing

The ping mock only needs to be awaitable and return None. AsyncMock handles this natively without needing a real event loop.
