### PR TITLE
fix(test): align hypervisor isolation tests with fail-closed implementation

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/session/isolation.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/session/isolation.py
@@ -10,7 +10,6 @@ sessions' data requires explicit capability grants.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import PurePosixPath

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_ring_enforcement.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_ring_enforcement.py
@@ -484,10 +484,10 @@ class TestSessionIsolation:
         assert mgr.check_access("sess-1", "/var/agt/sessions/sess-1/out.txt") is True
         assert mgr.check_access("sess-1", "/var/agt/sessions/sess-2/out.txt") is False
 
-    def test_manager_no_scope_is_permissive(self):
+    def test_manager_no_scope_is_denied(self):
         mgr = SessionIsolationManager()
-        # No scope created = permissive (backward compat)
-        assert mgr.check_access("unknown-sess", "/anything") is True
+        # No scope created = fail-closed (unscoped sessions are denied)
+        assert mgr.check_access("unknown-sess", "/anything") is False
 
     def test_manager_grant_cross_session(self):
         mgr = SessionIsolationManager()

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_session_security.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_session_security.py
@@ -178,27 +178,24 @@ class TestIntentLocks:
 class TestIsolationLevels:
     def test_snapshot_properties(self):
         level = IsolationLevel.SNAPSHOT
-        # Public Preview: all isolation levels have same properties
         assert not level.requires_vector_clocks
         assert not level.requires_intent_locks
         assert level.allows_concurrent_writes
-        assert level.coordination_cost == "none"
+        assert level.coordination_cost == "low"
 
     def test_read_committed_properties(self):
         level = IsolationLevel.READ_COMMITTED
-        # Public Preview: no enforcement, same as snapshot
         assert not level.requires_vector_clocks
         assert not level.requires_intent_locks
         assert level.allows_concurrent_writes
-        assert level.coordination_cost == "none"
+        assert level.coordination_cost == "medium"
 
     def test_serializable_properties(self):
         level = IsolationLevel.SERIALIZABLE
-        # Public Preview: no enforcement, same as snapshot
-        assert not level.requires_vector_clocks
-        assert not level.requires_intent_locks
-        assert level.allows_concurrent_writes
-        assert level.coordination_cost == "none"
+        assert level.requires_vector_clocks
+        assert level.requires_intent_locks
+        assert not level.allows_concurrent_writes
+        assert level.coordination_cost == "high"
 
 
 # ── Rate Limiter Tests ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fix 4 test failures in docker-compose-test CI and 1 lint error in agent-hypervisor.

## Problem

1. **docker-compose-test**: 4 assertion failures where tests expected "Public Preview" stub behavior (no enforcement, all isolation levels identical), but the implementation now has real isolation semantics
2. **lint (agent-hypervisor)**: Unused `os` import in `isolation.py`

## Changes

| File | Change |
|------|--------|
| isolation.py | Remove unused `os` import |
| test_ring_enforcement.py | Update `test_manager_no_scope_is_permissive` to expect fail-closed behavior |
| test_session_security.py | Update 3 isolation level property tests to match real costs (low/medium/high) and SERIALIZABLE constraints |

## Testing

Test assertions now match the actual implementation: SNAPSHOT=low cost, READ_COMMITTED=medium, SERIALIZABLE=high with vector clocks and intent locks.
