### PR TITLE
fix(ci): handle flat package layout in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,12 @@ jobs:
       - if: steps.gate.outputs.run == 'true'
         name: Lint ${{ matrix.package }}
         working-directory: agent-governance-python/${{ matrix.package }}
-        run: ruff check src/ --select E,F,W --ignore E501
+        run: |
+          if [ -d src ]; then
+            ruff check src/ --select E,F,W --ignore E501
+          else
+            ruff check . --select E,F,W --ignore E501 --exclude '*.egg-info'
+          fi
 
   # ── Python test (only when Python files change) ───────────────────────
   test:


### PR DESCRIPTION
## Summary

Fix lint (agent-primitives) CI failure caused by hardcoded `src/` path assumption.

## Problem

The ruff lint step runs `ruff check src/` for all packages, but agent-primitives uses a flat layout (`agent_primitives/` directory, no `src/`). This causes E902 "No such file or directory" error.

## Changes

| File | Change |
|------|--------|
| ci.yml | Check for `src/` directory, fall back to `.` with egg-info exclusion for flat layouts |

## Testing

All other packages have `src/` and are unaffected. Only agent-primitives hits the fallback path.
