### PR TITLE
fix(ci): remove trailing whitespace in agent-primitives failures.py

### DIFF
--- a/agent-governance-python/agent-primitives/agent_primitives/failures.py
+++ b/agent-governance-python/agent-primitives/agent_primitives/failures.py
@@ -44,13 +44,13 @@ class FailureSeverity(str, Enum):
 
 class FailureTrace(BaseModel):
     """Full trace of an agent failure including reasoning chain."""
-    
+
     user_prompt: str = Field(..., description="Original user prompt that led to failure")
     chain_of_thought: List[str] = Field(default_factory=list, description="Agent's reasoning steps")
     failed_action: Dict[str, Any] = Field(..., description="The action that failed")
     error_details: str = Field(..., description="Detailed error information")
     timestamp: datetime = Field(default_factory=_utcnow)
-    
+
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
@@ -72,7 +72,7 @@ class FailureTrace(BaseModel):
 
 class AgentFailure(BaseModel):
     """Represents a failure detected in an agent."""
-    
+
     agent_id: str = Field(..., description="Unique identifier for the agent")
     failure_type: FailureType = Field(..., description="Type of failure")
     severity: FailureSeverity = Field(default=FailureSeverity.MEDIUM)
@@ -81,7 +81,7 @@ class AgentFailure(BaseModel):
     context: Dict[str, Any] = Field(default_factory=dict, description="Additional context")
     stack_trace: Optional[str] = Field(None, description="Stack trace if available")
     failure_trace: Optional[FailureTrace] = Field(None, description="Full failure trace if available")
-    
+
     model_config = ConfigDict(
         json_schema_extra={
             "example": {


### PR DESCRIPTION
## Summary

Fixes the `lint (agent-primitives)` CI job that has been failing on main since PR #2362.

## Problem

4x W293 (blank line contains whitespace) in `agent_primitives/failures.py` at lines 47, 53, 75, 84.

## Fix

Ran `ruff check --fix --select W293` to remove trailing whitespace from blank lines.