### PR TITLE
docs(adr): add retroactive ADRs 0017-0025

### DIFF
--- a/docs/adr/0017-merkle-chain-for-audit-tamper-evidence.md
+++ b/docs/adr/0017-merkle-chain-for-audit-tamper-evidence.md
@@ -1,0 +1,49 @@
+# ADR-0017: Merkle Chain for Audit Tamper Evidence
+
+## Status
+
+Accepted
+
+## Context
+
+AGT's audit system needed tamper-evidence guarantees for production deployments
+where audit logs serve as compliance evidence. Traditional append-only file logs
+can be silently modified without detection. Blockchain-based approaches were
+considered but rejected due to operational complexity and latency requirements.
+
+The system needed to:
+- Detect any modification to historical audit entries
+- Provide cryptographic proof that a specific entry existed at a given position
+- Support offline verification without access to the original system
+- Remain fast enough for inline governance decisions (sub-millisecond overhead)
+
+## Decision
+
+We use a SHA-256 hash chain (Merkle chain) where each audit entry's hash
+includes the previous entry's hash, forming an append-only linked structure.
+
+Key design choices:
+- Each `AuditEntry` carries `previous_hash` and `entry_hash` fields
+- Hash computation uses `hashlib.sha256` over the canonical JSON serialization
+- `MerkleAuditChain` manages the chain state and provides `verify_chain()`
+- Proof generation exports a subset of entries sufficient to verify inclusion
+- No external blockchain anchoring -- verification is self-contained
+
+The chain detects:
+- Entry modification (hash mismatch)
+- Entry deletion (chain break)
+- Entry reordering (previous_hash mismatch)
+
+## Consequences
+
+- Any single-entry modification invalidates all subsequent hashes
+- Verification is O(n) for the full chain but O(log n) for inclusion proofs
+- No protection against a complete chain replacement (requires external anchoring for that threat model)
+- Sub-millisecond per-entry overhead suitable for inline use
+- Compatible with CloudEvents export for external archival
+
+## References
+
+- `agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 13
+- PR #1777 (Decision BOM), PR #2177 (hash encoding fix)

--- a/docs/adr/0018-reconstructible-decision-bom-over-prebuilt.md
+++ b/docs/adr/0018-reconstructible-decision-bom-over-prebuilt.md
@@ -1,0 +1,51 @@
+# ADR-0018: Reconstructible Decision BOM Over Pre-built
+
+## Status
+
+Accepted
+
+## Context
+
+Governance decisions involve multiple factors: policy evaluations, trust scores,
+active policies at decision time, and distributed trace context. Two approaches
+were considered for the Decision Bill of Materials (BOM):
+
+1. **Pre-built BOM**: Capture all factors at decision time and store as a single
+   document alongside the decision. Complete but invasive -- requires every
+   action pipeline stage to report into the BOM builder.
+
+2. **Reconstructible BOM**: Query existing observability signals (audit logs,
+   trust scores, policy evaluations, OTel traces) after the fact to reconstruct
+   the decision context on demand.
+
+## Decision
+
+We chose the reconstructible approach. The `DecisionBOMBuilder` queries four
+protocol-based signal sources:
+
+- `AuditSource` -- audit log entries by trace_id or agent_id + time range
+- `TrustSource` -- trust score at a point in time, score history
+- `PolicySource` -- policy evaluation results, active policies at timestamp
+- `TraceSource` -- OTel spans for the decision's trace
+
+Design principles:
+- **Non-invasive**: no agent reporting required, no coupling to action pipeline
+- **Protocol-based**: each source is a `runtime_checkable Protocol`
+- **Completeness levels**: BOM reports how complete the reconstruction is
+  (all sources available vs. partial)
+- **Python-first implementation**
+
+## Consequences
+
+- Slower than pre-built (requires queries at reconstruction time) but complete
+- Zero overhead on the hot path -- no BOM assembly during governance decisions
+- Sources can be swapped (in-memory for tests, real backends for production)
+- Partial reconstruction is explicitly surfaced rather than silently incomplete
+- Agents never need to "cooperate" with BOM building -- fully passive
+
+## References
+
+- `agent-governance-python/agent-mesh/src/agentmesh/governance/decision_bom.py`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 17
+- `docs/tutorials/50-decision-bom.md`
+- PR #1777, PR #1786

--- a/docs/adr/0019-otel-batchspanprocessor-pattern-for-event-sink.md
+++ b/docs/adr/0019-otel-batchspanprocessor-pattern-for-event-sink.md
@@ -1,0 +1,50 @@
+# ADR-0019: OTel BatchSpanProcessor Pattern for Event Sink
+
+## Status
+
+Accepted
+
+## Context
+
+The Governance Event Sink needed to route structured governance events to
+external systems (SIEM, XDR, observability platforms, message buses) without
+blocking the governance decision hot path. Requirements:
+
+- Async delivery to avoid adding latency to policy evaluation
+- Batching to reduce network round-trips
+- Fan-out to multiple sinks simultaneously
+- Resilience to sink failures (one failing sink must not block others)
+- Bounded memory usage under backpressure
+
+The OpenTelemetry SDK's `BatchSpanProcessor` solves an analogous problem for
+trace spans and is battle-tested across thousands of production deployments.
+
+## Decision
+
+We adopted the OTel `BatchSpanProcessor` architecture for `GovernanceEventProcessor`:
+
+- **Bounded queue** (default 1024 events) with drop-on-full semantics
+- **Background thread** drains the queue on a schedule (default 2000ms)
+- **Batch size cap** (default 100 events per export call)
+- **Export timeout** (default 10000ms) per sink call
+- **Fan-out**: each registered `GovernanceEventSink` receives the same batch
+- **Circuit breaker**: after N consecutive failures (default 5), a sink is
+  bypassed for a cooldown period (default 60s)
+
+The `GovernanceEventSink` protocol uses structural typing (Protocol) so external
+packages can implement it without importing agent-os as a dependency.
+
+## Consequences
+
+- Zero-latency impact on governance decisions (events are enqueued, not sent inline)
+- Predictable memory usage via bounded queue
+- Graceful degradation -- circuit breaker prevents cascading failures
+- External sinks are decoupled (structural typing, no import dependency)
+- Events can be dropped under extreme backpressure (acceptable tradeoff for governance where the audit log is the source of truth)
+
+## References
+
+- `agent-governance-python/agent-os/src/agent_os/event_sink.py`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 11
+- PR #2362 (GovernanceEventSink SPI)
+- OpenTelemetry SDK BatchSpanProcessor specification

--- a/docs/adr/0020-circuit-breaker-for-event-sink-delivery.md
+++ b/docs/adr/0020-circuit-breaker-for-event-sink-delivery.md
@@ -1,0 +1,49 @@
+# ADR-0020: Circuit Breaker for Event Sink Delivery
+
+## Status
+
+Accepted
+
+## Context
+
+Governance event sinks connect to external systems (Splunk, Sentinel, Kafka,
+etc.) that may become temporarily unavailable. Without protection, repeated
+failed deliveries would:
+
+- Consume export timeout budget on every batch (10s default)
+- Accumulate retry overhead in the background thread
+- Potentially cause queue overflow as delivery stalls
+
+A circuit breaker pattern was needed to fail-fast when a sink is known to be
+unhealthy, then automatically retry after a cooldown.
+
+## Decision
+
+Each sink tracked by `GovernanceEventProcessor` has an independent circuit
+breaker with:
+
+- **Threshold**: 5 consecutive failures to trip OPEN
+- **Cooldown**: 60 seconds in OPEN state before transitioning to HALF_OPEN
+- **HALF_OPEN**: allows one probe batch through; success resets to CLOSED,
+  failure returns to OPEN
+- **CLOSED**: normal operation, failure counter increments on each failure
+
+The `HALF_OPEN` state is documented as a reserved forward-compatibility surface
+(PR #2192) -- current implementation transitions directly from OPEN to a probe
+attempt, but the state enum is reserved for future use.
+
+## Consequences
+
+- Failing sinks are bypassed within 5 batches (10s at default schedule)
+- Healthy sinks continue receiving events unaffected
+- Automatic recovery when external systems come back online
+- No manual intervention required for transient outages
+- Queue overflow risk is reduced since the background thread is not blocked
+  waiting on timeouts for known-bad sinks
+
+## References
+
+- `agent-governance-python/agent-os/src/agent_os/event_sink.py`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 11
+- PR #2192 (HALF_OPEN reserved surface)
+- PR #2202 (.NET CircuitBreaker OperationCanceledException fix)

--- a/docs/adr/0021-cloudevents-envelope-for-mesh-audit.md
+++ b/docs/adr/0021-cloudevents-envelope-for-mesh-audit.md
@@ -1,0 +1,49 @@
+# ADR-0021: CloudEvents Envelope for Mesh Audit
+
+## Status
+
+Accepted
+
+## Context
+
+AgentMesh audit entries needed a standardized serialization format for export
+to external systems. Options considered:
+
+1. **Custom JSON schema** -- simple but requires consumers to learn a bespoke format
+2. **OpenTelemetry LogRecord** -- good for observability but not designed for
+   event-driven architectures
+3. **CloudEvents** (CNCF specification) -- industry standard for event
+   interoperability, supported by Azure Event Grid, AWS EventBridge, Knative,
+   and most message brokers
+
+## Decision
+
+We adopted CloudEvents v1.0 as the envelope format for mesh audit entry export
+via `AuditEntry.to_cloudevent()`. The mapping:
+
+| CloudEvents attribute | Value |
+|---|---|
+| `specversion` | `"1.0"` |
+| `type` | `"ai.agentmesh.{event_type}"` |
+| `source` | Agent DID URI |
+| `id` | `entry_id` |
+| `time` | Entry timestamp (RFC 3339) |
+| `datacontenttype` | `"application/json"` |
+| `data` | Full audit entry as JSON |
+
+Custom extension attributes use the `ai.agentmesh.*` namespace prefix.
+
+## Consequences
+
+- Audit entries can be routed through any CloudEvents-compatible broker
+- Standard SDKs in multiple languages can parse the events
+- Azure Event Grid native support enables direct SIEM integration
+- The `ai.agentmesh.*` namespace avoids collision with other event producers
+- Slightly larger payload than raw JSON (CloudEvents envelope overhead)
+
+## References
+
+- `agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py` (`to_cloudevent()`)
+- `agent-governance-python/agent-mesh/docs/CLOUDEVENTS_SCHEMA.md`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 14
+- CNCF CloudEvents Specification v1.0

--- a/docs/adr/0022-compliance-framework-auto-mapping.md
+++ b/docs/adr/0022-compliance-framework-auto-mapping.md
@@ -1,0 +1,50 @@
+# ADR-0022: Compliance Framework Auto-Mapping
+
+## Status
+
+Accepted
+
+## Context
+
+Production deployments must demonstrate compliance with regulatory frameworks
+(EU AI Act, SOC 2, HIPAA, GDPR). Two approaches were considered:
+
+1. **Manual compliance tracking** -- operators manually map agent actions to
+   controls and collect evidence. Error-prone and doesn't scale.
+
+2. **Automatic mapping** -- the system maps each action type to applicable
+   controls at runtime, auto-generates evidence where possible, and flags
+   gaps requiring manual evidence.
+
+## Decision
+
+We implemented `ComplianceEngine` with automatic action-to-control mapping:
+
+- `ComplianceFramework` enum: `EU_AI_ACT`, `SOC2`, `HIPAA`, `GDPR`
+- `ComplianceMapping` links action types to control IDs with evidence metadata
+- `ComplianceReport` aggregates findings with severity levels (`critical`, `high`, `medium`, `low`)
+- Evidence is split into `evidence_generated` (automatic) and `evidence_required` (manual)
+
+Action types mapped include:
+- `agent_registration` -- identity and access controls
+- `data_access` -- privacy and data protection controls
+- `automated_decision` -- transparency and explainability controls
+- `supply_chain_audit` -- third-party risk controls
+
+The engine produces `ComplianceViolation` records when required controls lack
+evidence, with severity based on the control's criticality.
+
+## Consequences
+
+- Compliance posture is continuously assessed, not just at audit time
+- New frameworks can be added by extending the enum and adding control mappings
+- Auto-generated evidence reduces manual burden significantly
+- Gaps are surfaced as violations with actionable severity ratings
+- Framework-specific language (article numbers, control IDs) is preserved
+
+## References
+
+- `agent-governance-python/agent-mesh/src/agentmesh/governance/compliance.py`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 16
+- `docs/compliance/` (SOC2, EU AI Act, ISO 42001 guides)
+- PR #2119 (score compliance against per-framework control count)

--- a/docs/adr/0023-append-only-delta-engine-for-hypervisor-audit.md
+++ b/docs/adr/0023-append-only-delta-engine-for-hypervisor-audit.md
@@ -1,0 +1,51 @@
+# ADR-0023: Append-Only Delta Engine for Hypervisor Audit
+
+## Status
+
+Accepted
+
+## Context
+
+The Agent Hypervisor manages sandboxed execution environments where agents can
+modify virtual filesystem state. For forensic analysis and rollback, we needed
+to capture every state change with:
+
+- Tamper-evident history (detect if audit records are modified)
+- Per-turn granularity (attribute changes to specific agent actions)
+- Causal ordering (reconstruct the exact sequence of modifications)
+- Low overhead (cannot significantly impact execution latency)
+
+## Decision
+
+We implemented `DeltaEngine` with a SHA-256 hash-chained append-only log:
+
+- `VFSChange` captures individual file operations (create, modify, delete)
+  with path, operation type, and content hash
+- `SemanticDelta` groups changes into a single atomic unit per agent turn,
+  with fields: `delta_id`, `turn_id`, `session_id`, `agent_did`, `timestamp`,
+  `changes`, `parent_hash`, `delta_hash`
+- Hash computation: `SHA-256(parent_hash || canonical_json(delta))`
+- `CommitmentEngine` stores summary hash commitments for periodic anchoring
+
+Key properties:
+- Deltas are immutable once captured
+- Each delta references its parent hash, forming a chain
+- Chain verification detects any modification or deletion
+- No external dependencies (pure Python, stdlib hashlib)
+
+## Consequences
+
+- Full forensic reconstruction of any agent's filesystem modifications
+- Tamper evidence without blockchain operational overhead
+- Per-turn attribution enables precise rollback to any point
+- In-memory storage by default (CommitmentEngine) -- production deployments
+  can persist to durable storage via the commitment interface
+- Hash chain verification is O(n) but only needed for audit, not hot path
+
+## References
+
+- `agent-governance-python/agent-hypervisor/src/hypervisor/audit/delta.py`
+- `agent-governance-python/agent-hypervisor/src/hypervisor/audit/commitment.py`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 18
+- `docs/specs/AGENT-HYPERVISOR-EXECUTION-CONTROL-1.0.md`
+- PR #2177 (length-prefix encoding fix for Go audit)

--- a/docs/adr/0024-rl-training-governance-with-violation-penalties.md
+++ b/docs/adr/0024-rl-training-governance-with-violation-penalties.md
@@ -1,0 +1,56 @@
+# ADR-0024: RL Training Governance with Violation Penalties
+
+## Status
+
+Accepted
+
+## Context
+
+Agent Lightning provides reinforcement learning infrastructure for agent
+optimization. Without governance integration, RL training could:
+
+- Reward policy-violating behavior (if violations lead to higher task completion)
+- Produce agents that learn to circumvent governance controls
+- Generate training data that includes unsafe action sequences
+
+We needed training-time governance that discourages policy violations through
+the reward signal itself, rather than relying solely on runtime enforcement.
+
+## Decision
+
+`GovernedEnvironment` wraps the RL environment with violation-aware reward
+shaping:
+
+- Each policy violation incurs a **penalty** subtracted from the reward signal
+- Severity levels map to penalty magnitudes:
+  - `critical` -- episode termination (agent is stopped immediately)
+  - `high` -- large negative reward
+  - `medium` -- moderate negative reward
+  - `low` -- small negative reward
+- Violation records include: `policy`, `description`, `severity`, `blocked`,
+  `step`, `timestamp`
+- `FlightRecorderEmitter` exports training spans with full policy evaluation
+  context for audit
+
+Key design choices:
+- Penalties are configurable per deployment (not hardcoded)
+- Critical violations terminate the episode, preventing further unsafe exploration
+- All violations are recorded regardless of severity for audit trail
+- Training audit spans carry `agent_os.*` prefixed attributes for policy
+  name, result, and violation status
+
+## Consequences
+
+- Agents learn that policy violations are costly, shaping behavior toward compliance
+- Critical violations prevent unsafe exploration entirely
+- Training audit trail enables post-hoc analysis of what the agent learned
+- Penalty magnitudes can be tuned without code changes
+- No modification to the underlying RL algorithm required -- works with any
+  algorithm that uses scalar rewards
+
+## References
+
+- `agent-governance-python/agent-lightning/src/agent_lightning_gov/environment.py`
+- `agent-governance-python/agent-lightning/src/agent_lightning_gov/emitter.py`
+- `docs/specs/AGENT-LIGHTNING-FAST-PATH-1.0.md`
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Section 20

--- a/docs/adr/0025-structural-typing-for-sink-and-source-protocols.md
+++ b/docs/adr/0025-structural-typing-for-sink-and-source-protocols.md
@@ -1,0 +1,51 @@
+# ADR-0025: Structural Typing for Sink and Source Protocols
+
+## Status
+
+Accepted
+
+## Context
+
+AGT's audit and event systems define extension points where external packages
+provide implementations (event sinks, audit sources, trust sources, policy
+sources). Two approaches for the interface contract:
+
+1. **Abstract base classes (ABCs)** -- external packages must import and inherit
+   from AGT classes, creating a hard dependency on agent-os.
+
+2. **Protocol classes (structural typing)** -- external packages implement the
+   required methods without importing anything from AGT. Compatibility is
+   verified at runtime via `isinstance()` checks with `runtime_checkable`.
+
+## Decision
+
+We use `typing.Protocol` with `@runtime_checkable` for all extension point
+interfaces:
+
+- `GovernanceEventSink` -- `emit(events: Sequence[GovernanceEvent]) -> SinkExportResult`
+- `AuditBackend` -- `write(entry: AuditEntry) -> None`, `flush() -> None`
+- `AuditSource` -- `query_by_trace(trace_id)`, `query_by_agent(agent_id, start, end)`
+- `TrustSource` -- `get_score_at(agent_id, timestamp)`, `get_score_history(...)`
+- `PolicySource` -- `get_evaluations(trace_id)`, `get_active_policies_at(timestamp)`
+- `TraceSource` -- `get_spans(trace_id)`, `get_span_tree(trace_id)`
+
+All are decorated with `@runtime_checkable` so `isinstance()` works for
+validation without requiring inheritance.
+
+## Consequences
+
+- External sink/source packages have zero dependency on agent-os
+- Any object with the right method signatures satisfies the protocol
+- `isinstance()` checks work at runtime for validation
+- IDE type checking catches protocol mismatches at development time
+- Slightly weaker guarantees than ABCs (no enforcement of method implementation
+  at class definition time -- only at call time or explicit isinstance check)
+- Consistent pattern across all AGT extension points
+
+## References
+
+- `agent-governance-python/agent-os/src/agent_os/event_sink.py` (GovernanceEventSink)
+- `agent-governance-python/agent-os/src/agent_os/audit_logger.py` (AuditBackend)
+- `agent-governance-python/agent-mesh/src/agentmesh/governance/decision_bom.py` (AuditSource, TrustSource, PolicySource, TraceSource)
+- `docs/specs/AUDIT-COMPLIANCE-1.0.md` Sections 10, 17
+- PEP 544 -- Protocols: Structural subtyping

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -19,6 +19,15 @@ Key architectural decisions and their rationale. Each ADR follows the standard f
 | [ADR-0014](0014-parent-deny-rules-immutable-in-merge.md) | Parent deny rules are immutable in policy merge | Policy |
 | [ADR-0015](0015-pluggable-external-policy-backends.md) | Pluggable external policy backends via protocol interface | Policy |
 | [ADR-0016](0016-trust-ceiling-propagation-for-delegation.md) | Trust ceiling propagation for delegated agents | Trust |
+| [ADR-0017](0017-merkle-chain-for-audit-tamper-evidence.md) | Merkle chain for audit tamper evidence | Audit |
+| [ADR-0018](0018-reconstructible-decision-bom-over-prebuilt.md) | Reconstructible Decision BOM over pre-built | Audit |
+| [ADR-0019](0019-otel-batchspanprocessor-pattern-for-event-sink.md) | OTel BatchSpanProcessor pattern for event sink | Events |
+| [ADR-0020](0020-circuit-breaker-for-event-sink-delivery.md) | Circuit breaker for event sink delivery | Events |
+| [ADR-0021](0021-cloudevents-envelope-for-mesh-audit.md) | CloudEvents envelope for mesh audit | Audit |
+| [ADR-0022](0022-compliance-framework-auto-mapping.md) | Compliance framework auto-mapping | Compliance |
+| [ADR-0023](0023-append-only-delta-engine-for-hypervisor-audit.md) | Append-only delta engine for hypervisor audit | Audit |
+| [ADR-0024](0024-rl-training-governance-with-violation-penalties.md) | RL training governance with violation penalties | Lightning |
+| [ADR-0025](0025-structural-typing-for-sink-and-source-protocols.md) | Structural typing for sink and source protocols | Architecture |
 
 ## Proposed
 


### PR DESCRIPTION
## Summary

Adds 9 retroactive Architecture Decision Records (batch 2) capturing design decisions revealed during specification writing.

### New ADRs

| ADR | Decision | Area |
|-----|----------|------|
| 0017 | Merkle chain for audit tamper evidence | Audit |
| 0018 | Reconstructible Decision BOM over pre-built | Audit |
| 0019 | OTel BatchSpanProcessor pattern for event sink | Events |
| 0020 | Circuit breaker for event sink delivery | Events |
| 0021 | CloudEvents envelope for mesh audit | Audit |
| 0022 | Compliance framework auto-mapping | Compliance |
| 0023 | Append-only delta engine for hypervisor audit | Audit |
| 0024 | RL training governance with violation penalties | Lightning |
| 0025 | Structural typing for sink and source protocols | Architecture |

Also updates \docs/adr/index.md\ to include all 9 new entries in the Accepted table.