### PR TITLE
feat(evidence-anchor): Mycelium Trails community plugin — EvidenceAnchor SPI on Arbitrum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Mycelium Trails community plugin** - `EvidenceAnchor` SPI implementation backed by
+  Mycelium Trails on Arbitrum. Evidence hashes are written as append-only trail records
+  via `argentum.rgiskard.xyz`. `verify()` is independently callable without AGT runtime
+  state. `action_ref` derivation follows RFC 8785 JCS + SHA-256 per
+  [`action-ref.md v1.0`](https://github.com/giskard09/argentum-core/blob/main/docs/spec/action-ref.md).
+  19/19 tests. (#2381)
 
 ## [3.5.0] - 2026-05-07
 

--- a/community-plugins/README.md
+++ b/community-plugins/README.md
@@ -1,0 +1,22 @@
+# AGT Community Plugins
+
+Community implementations of the [`EvidenceAnchor`](../docs/proposals/MYCELIUM-EXTERNAL-ANCHOR-PROPOSAL.md) SPI.
+
+AGT ships with WORM and Sigstore Rekor as in-tree reference backends. Community plugins extend
+anchoring to additional surfaces without adding runtime dependencies to AGT core.
+
+## Available plugins
+
+| Plugin | Backend | Maintainer |
+|--------|---------|------------|
+| [`mycelium_trails`](mycelium_trails/) | Mycelium Trails on Arbitrum | [@giskard09](https://github.com/giskard09) |
+
+## Contributing a plugin
+
+1. Create `community-plugins/<your_plugin>/` with at minimum: `__init__.py`, `README.md`, tests.
+2. Implement the `EvidenceAnchor` ABC from `MYCELIUM-EXTERNAL-ANCHOR-PROPOSAL.md`.
+3. Add your plugin to the table above.
+4. Open a PR — one plugin per PR.
+
+Requirements: append-only backend (records cannot be modified or deleted after anchoring),
+`verify()` must be independently callable without AGT runtime state.

--- a/community-plugins/mycelium_trails/README.md
+++ b/community-plugins/mycelium_trails/README.md
@@ -1,0 +1,90 @@
+# Mycelium Trails — AGT EvidenceAnchor community plugin
+
+Implements the [`EvidenceAnchor`](../../docs/proposals/MYCELIUM-EXTERNAL-ANCHOR-PROPOSAL.md) SPI
+backed by [Mycelium Trails](https://argentum.rgiskard.xyz) on Arbitrum.
+
+Evidence hashes are written as append-only trail records. Once anchored, a record cannot be
+modified or deleted — the tamper-evidence guarantee holds without trusting the operator's
+infrastructure.
+
+## Install
+
+```bash
+pip install requests
+```
+
+No other dependencies required.
+
+## Usage
+
+```python
+from mycelium_trails import MyceliumAnchor
+
+anchor = MyceliumAnchor(agent_id="my-agent")
+
+# Write evidence to Mycelium Trails
+receipt = anchor.anchor(
+    evidence_hash="sha256:abc123...",
+    metadata={
+        "action_type": "code.execute",   # optional, default: "agt:evidence_anchor"
+        "scope": "ci-pipeline",          # optional, default: "agt-evidence"
+    },
+)
+print(receipt.anchor_id)    # trail_id on Mycelium
+print(receipt.anchored_at)  # RFC 3339 UTC timestamp
+
+# Verify independently — no AGT runtime needed
+result = anchor.verify("sha256:abc123...", receipt)
+# result.status == AnchorVerifyStatus.VERIFIED
+# result.inclusion_proof.proof_data["tx_hash"] — Arbitrum transaction
+# result.inclusion_proof.proof_data["explorer_url"] — Arbiscan link
+```
+
+## Registration with AGT
+
+```python
+from mycelium_trails import MyceliumAnchor
+
+# Explicit registration as required by AGT
+agt_registry.register("mycelium", MyceliumAnchor())
+```
+
+## action_ref derivation
+
+Each anchored record includes an `action_ref` — a deterministic content-addressed identifier
+computable by any party holding the four preimage fields:
+
+```
+action_ref = SHA-256(JCS({ agent_id, action_type, scope, timestamp }))
+```
+
+Specification: [`docs/spec/action-ref.md`](https://github.com/giskard09/argentum-core/blob/main/docs/spec/action-ref.md)
+
+The same derivation is implemented independently by
+[SafeAgent](https://github.com/azender1/SafeAgent),
+[NEXUS](https://nexus-agent-xa12.onrender.com/receipt),
+and [CrewAI idempotency key](https://github.com/crewAIInc/crewAI/pull/5822) — convergent
+implementations against a shared spec.
+
+## Failure semantics
+
+`anchor()` raises `RuntimeError` on network failure. The AGT runtime applies mode semantics
+(`enforce` / `queue` / `best_effort`) based on the registered policy. The plugin does not
+swallow errors.
+
+## Tests
+
+```bash
+pytest community-plugins/mycelium_trails/tests/ -v
+```
+
+19 tests covering: `action_ref` derivation (known vectors, determinism, JCS key order),
+`anchor()` happy path + metadata forwarding + network failure, `verify()` happy path +
+hash mismatch + 404 + network error + fallback without action_ref + Arbiscan URL.
+
+## Public endpoint
+
+`https://argentum.rgiskard.xyz` — live on Arbitrum.
+
+`GET /status` returns service health. `GET /trails/verify?payment_hash=<hash>` verifies
+any anchored record independently.

--- a/community-plugins/mycelium_trails/__init__.py
+++ b/community-plugins/mycelium_trails/__init__.py
@@ -1,0 +1,27 @@
+"""
+agt-evidence-anchor — Mycelium Trails community plugin for the AGT EvidenceAnchor SPI.
+
+Usage:
+    from plugins.agt_evidence_anchor import MyceliumAnchor
+    anchor = MyceliumAnchor(agent_id="my-agent")
+    receipt = anchor.anchor(evidence_hash, metadata={})
+    result  = anchor.verify(evidence_hash, receipt)
+"""
+
+from .anchor import MyceliumAnchor
+from ._types import (
+    AnchorReceipt,
+    AnchorVerifyResult,
+    AnchorVerifyStatus,
+    EvidenceAnchor,
+    InclusionProof,
+)
+
+__all__ = [
+    "MyceliumAnchor",
+    "EvidenceAnchor",
+    "AnchorReceipt",
+    "AnchorVerifyResult",
+    "AnchorVerifyStatus",
+    "InclusionProof",
+]

--- a/community-plugins/mycelium_trails/_types.py
+++ b/community-plugins/mycelium_trails/_types.py
@@ -1,0 +1,66 @@
+"""
+Types for the AGT EvidenceAnchor SPI.
+
+These are inline stubs used when agt-evidence is not installed.
+When agt-evidence ships the ABC, replace these imports with:
+    from agt_evidence import (
+        EvidenceAnchor, AnchorReceipt, AnchorVerifyResult,
+        AnchorVerifyStatus, InclusionProof,
+    )
+
+Conforms to: MYCELIUM-EXTERNAL-ANCHOR-PROPOSAL.md v3
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class AnchorVerifyStatus(str, Enum):
+    VERIFIED = "verified"
+    NOT_FOUND = "not_found"
+    HASH_MISMATCH = "hash_mismatch"
+    BACKEND_UNAVAILABLE = "backend_unavailable"
+
+
+@dataclass
+class InclusionProof:
+    """Backend-specific proof that the record exists at the claimed position.
+
+    Mycelium Trails: proof_type="tx_receipt", proof_data contains tx_hash,
+    block_number, and explorer_url.
+    """
+    proof_type: str
+    proof_data: dict[str, Any]
+
+
+@dataclass
+class AnchorVerifyResult:
+    status: AnchorVerifyStatus
+    evidence_hash: str
+    inclusion_proof: Optional[InclusionProof] = None
+    error_detail: Optional[str] = None
+
+
+@dataclass
+class AnchorReceipt:
+    backend: str
+    anchor_id: str          # trail_id in Mycelium Trails
+    anchored_at: str        # RFC 3339 UTC, e.g. "2026-05-15T10:00:00.123Z"
+    evidence_hash: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class EvidenceAnchor(ABC):
+    @abstractmethod
+    def anchor(self, evidence_hash: str, metadata: dict[str, Any]) -> AnchorReceipt:
+        """Write evidence_hash to the external surface. Returns a receipt."""
+        ...
+
+    @abstractmethod
+    def verify(self, evidence_hash: str, receipt: AnchorReceipt) -> AnchorVerifyResult:
+        """Confirm evidence_hash is recorded at the position in receipt."""
+        ...

--- a/community-plugins/mycelium_trails/action_ref.py
+++ b/community-plugins/mycelium_trails/action_ref.py
@@ -1,0 +1,70 @@
+"""
+Canonical action_ref derivation: RFC 8785 JCS + SHA-256.
+
+action_ref = SHA-256(JCS({
+    "agent_id":    "<string>",
+    "action_type": "<string>",
+    "scope":       "<string>",
+    "timestamp":   "<RFC 3339 UTC, 3-digit ms precision>"
+}))
+
+JCS (RFC 8785) for a dict with only string values is equivalent to
+json.dumps with sorted keys, no spaces, and UTF-8 encoding. We implement
+it inline to avoid adding an external dependency for this simple case.
+
+timestamp format: "2026-05-15T10:00:00.123Z" (3-digit ms, mandatory Z).
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+
+
+def _jcs_encode(d: dict[str, str]) -> bytes:
+    """RFC 8785 JCS encoding for a flat dict of string values.
+
+    Key ordering is lexicographic Unicode code point order, which for
+    ASCII-only keys matches alphabetical order. Values are JSON strings
+    with no Unicode escaping for codepoints above U+001F (RFC 8785 §3.2.3).
+    """
+    return json.dumps(
+        dict(sorted(d.items())),
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def format_timestamp(dt: datetime.datetime) -> str:
+    """Format a datetime as RFC 3339 UTC with 3-digit ms precision.
+
+    Input must be UTC (tzinfo=timezone.utc or naive treated as UTC).
+    Output: "2026-05-15T10:00:00.123Z"
+    """
+    ms = dt.microsecond // 1000
+    return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{ms:03d}Z")
+
+
+def compute_action_ref(
+    agent_id: str,
+    action_type: str,
+    scope: str,
+    timestamp: str,
+) -> str:
+    """Derive action_ref from the four canonical fields.
+
+    timestamp must already be in RFC 3339 UTC format with 3-digit ms precision
+    (e.g. "2026-05-15T10:00:00.123Z"). Use format_timestamp() to produce it
+    from a datetime object.
+
+    Returns the SHA-256 hex digest (64 lowercase hex characters).
+    """
+    payload = {
+        "agent_id": agent_id,
+        "action_type": action_type,
+        "scope": scope,
+        "timestamp": timestamp,
+    }
+    canonical = _jcs_encode(payload)
+    return hashlib.sha256(canonical).hexdigest()

--- a/community-plugins/mycelium_trails/anchor.py
+++ b/community-plugins/mycelium_trails/anchor.py
@@ -60,17 +60,41 @@ class MyceliumAnchor(EvidenceAnchor):
         self.timeout = timeout
 
     def anchor(self, evidence_hash: str, metadata: dict[str, Any]) -> AnchorReceipt:
-        """
-        Writes evidence_hash to Mycelium Trails.
+        """Write evidence_hash to Mycelium Trails and return a receipt.
 
-        metadata keys (all optional):
-          - agent_id    (str)  overrides instance agent_id for this call
-          - action_type (str)  default: "agt:evidence_anchor"
-          - scope       (str)  default: "agt-evidence"
-          - parent_trail_id (str)
-          - root_trail_id   (str)
+        Derives an ``action_ref`` (RFC 8785 JCS + SHA-256) from the four
+        canonical preimage fields, then POSTs a trail record to
+        ``POST /trails`` on the Mycelium API. The record is append-only —
+        it cannot be modified or deleted after writing.
 
-        Raises RuntimeError if the Mycelium API is unreachable.
+        Args:
+            evidence_hash: SHA-256 hex digest of the artifact to anchor
+                (e.g. ``"sha256:abc123..."``).
+            metadata: Optional anchoring hints. Recognised keys:
+
+                - ``agent_id`` (str) — overrides the instance ``agent_id``
+                  for this call.
+                - ``action_type`` (str) — semantic label for the action;
+                  default ``"agt:evidence_anchor"``.
+                - ``scope`` (str) — declared authorization boundary;
+                  default ``"agt-evidence"``.
+                - ``parent_trail_id`` (str) — links this record to a parent
+                  trail in a chain.
+                - ``root_trail_id`` (str) — links this record to the root
+                  of a trail chain.
+
+                All other keys are forwarded as-is into ``claims``.
+
+        Returns:
+            ``AnchorReceipt`` with ``backend="mycelium-trails"``,
+            ``anchor_id=trail_id``, ``anchored_at`` (RFC 3339 UTC), and
+            ``metadata`` containing ``action_ref``, ``agent_id``, and
+            ``tx_hash``.
+
+        Raises:
+            RuntimeError: if the Mycelium API is unreachable or returns an
+                HTTP error. The AGT runtime applies mode semantics
+                (``enforce`` / ``queue`` / ``best_effort``) on this error.
         """
         agent_id = metadata.get("agent_id", self.agent_id)
         action_type = metadata.get("action_type", "agt:evidence_anchor")
@@ -137,17 +161,31 @@ class MyceliumAnchor(EvidenceAnchor):
         )
 
     def verify(self, evidence_hash: str, receipt: AnchorReceipt) -> AnchorVerifyResult:
-        """
-        Confirms evidence_hash is recorded at receipt.anchor_id (trail_id).
+        """Confirm evidence_hash is recorded at the position in receipt.
 
-        Uses GET /trails/verify?agent_id=X&action_ref=Y when action_ref is
-        present in receipt.metadata. Falls back to GET /trails/{trail_id}.
+        Calls ``GET /trails/verify?agent_id=X&action_ref=Y`` when
+        ``action_ref`` is present in ``receipt.metadata``. Falls back to
+        ``GET /trails/{trail_id}`` when it is absent.
 
-        Returns AnchorVerifyResult with:
-          VERIFIED           — hash confirmed, InclusionProof included
-          NOT_FOUND          — trail_id does not exist
-          HASH_MISMATCH      — trail exists but stored hash differs
-          BACKEND_UNAVAILABLE — network or API error
+        This method is independently callable — it does not require AGT
+        runtime state or any prior call to ``anchor()``.
+
+        Args:
+            evidence_hash: The SHA-256 hex digest to confirm.
+            receipt: The ``AnchorReceipt`` returned by a previous
+                ``anchor()`` call.
+
+        Returns:
+            ``AnchorVerifyResult`` with one of:
+
+            - ``VERIFIED`` — hash confirmed; ``inclusion_proof`` contains
+              the Arbitrum ``tx_hash`` and an Arbiscan explorer URL.
+            - ``NOT_FOUND`` — trail_id does not exist on Mycelium.
+            - ``HASH_MISMATCH`` — trail exists but the stored hash differs
+              from ``evidence_hash``; ``error_detail`` includes the stored
+              value.
+            - ``BACKEND_UNAVAILABLE`` — network or API error;
+              ``error_detail`` contains the exception message.
         """
         action_ref = receipt.metadata.get("action_ref")
         agent_id = receipt.metadata.get("agent_id", self.agent_id)

--- a/community-plugins/mycelium_trails/anchor.py
+++ b/community-plugins/mycelium_trails/anchor.py
@@ -1,0 +1,214 @@
+"""
+Mycelium Trails — community plugin for the AGT EvidenceAnchor SPI.
+
+Implements EvidenceAnchor (anchor + verify) backed by Mycelium Trails
+on Arbitrum. Evidence hashes are written as trail records via the public
+argentum.rgiskard.xyz API and are immutable once anchored.
+
+Install:
+    pip install requests
+
+Registration (explicit, as required by AGT):
+    from plugins.agt_evidence_anchor import MyceliumAnchor
+    agt_registry.register("mycelium", MyceliumAnchor())
+
+Conforms to: MYCELIUM-EXTERNAL-ANCHOR-PROPOSAL.md v3
+Append-only: Mycelium Trails records cannot be modified or deleted once written.
+"""
+
+from __future__ import annotations
+
+import datetime
+import time
+from typing import Any
+
+import requests
+
+from .action_ref import compute_action_ref, format_timestamp
+from ._types import (
+    AnchorReceipt,
+    AnchorVerifyResult,
+    AnchorVerifyStatus,
+    EvidenceAnchor,
+    InclusionProof,
+)
+
+_BASE_URL = "https://argentum.rgiskard.xyz"
+_BACKEND_NAME = "mycelium-trails"
+_DEFAULT_TIMEOUT = 10
+
+
+class MyceliumAnchor(EvidenceAnchor):
+    """
+    AGT EvidenceAnchor community plugin backed by Mycelium Trails on Arbitrum.
+
+    anchor() writes a trail record and returns a receipt with the trail_id
+    and action_ref. verify() confirms the evidence_hash via /trails/verify.
+
+    Failure semantics: anchor() raises RuntimeError on network failure.
+    The caller (AGT runtime) applies mode semantics (enforce/queue/best_effort).
+    """
+
+    def __init__(
+        self,
+        agent_id: str = "agt-evidence-anchor",
+        base_url: str = _BASE_URL,
+        timeout: int = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self.agent_id = agent_id
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def anchor(self, evidence_hash: str, metadata: dict[str, Any]) -> AnchorReceipt:
+        """
+        Writes evidence_hash to Mycelium Trails.
+
+        metadata keys (all optional):
+          - agent_id    (str)  overrides instance agent_id for this call
+          - action_type (str)  default: "agt:evidence_anchor"
+          - scope       (str)  default: "agt-evidence"
+          - parent_trail_id (str)
+          - root_trail_id   (str)
+
+        Raises RuntimeError if the Mycelium API is unreachable.
+        """
+        agent_id = metadata.get("agent_id", self.agent_id)
+        action_type = metadata.get("action_type", "agt:evidence_anchor")
+        scope = metadata.get("scope", "agt-evidence")
+
+        _now = datetime.datetime.now(datetime.timezone.utc)
+        now_dt = _now.replace(microsecond=(_now.microsecond // 1000) * 1000)
+        ts_str = format_timestamp(now_dt)
+        ts_unix = int(time.time())
+
+        action_ref = compute_action_ref(agent_id, action_type, scope, ts_str)
+
+        payload: dict[str, Any] = {
+            "agent_id": agent_id,
+            "service": "agt-evidence",
+            "operation": action_type,
+            "action_ref": action_ref,
+            "payment_hash": evidence_hash,
+            "timestamp": ts_unix,
+            "claims": {
+                "evidence_hash": evidence_hash,
+                "source": "agt-evidence-anchor",
+                **{
+                    k: v
+                    for k, v in metadata.items()
+                    if k not in ("agent_id", "action_type", "scope",
+                                 "parent_trail_id", "root_trail_id")
+                },
+            },
+            "success": True,
+            "scope": scope,
+        }
+
+        if "parent_trail_id" in metadata:
+            payload["parent_trail_id"] = metadata["parent_trail_id"]
+        if "root_trail_id" in metadata:
+            payload["root_trail_id"] = metadata["root_trail_id"]
+
+        try:
+            resp = requests.post(
+                f"{self.base_url}/trails",
+                json=payload,
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as exc:
+            raise RuntimeError(f"MyceliumAnchor.anchor failed: {exc}") from exc
+
+        trail_id = data.get("trail_id", "")
+        tx_hash = data.get("tx_hash") or data.get("payment_hash", "")
+        anchored_at = data.get("anchored_at") or ts_str
+
+        return AnchorReceipt(
+            backend=_BACKEND_NAME,
+            anchor_id=trail_id,
+            anchored_at=anchored_at,
+            evidence_hash=evidence_hash,
+            metadata={
+                "action_ref": action_ref,
+                "agent_id": agent_id,
+                "tx_hash": tx_hash,
+            },
+        )
+
+    def verify(self, evidence_hash: str, receipt: AnchorReceipt) -> AnchorVerifyResult:
+        """
+        Confirms evidence_hash is recorded at receipt.anchor_id (trail_id).
+
+        Uses GET /trails/verify?agent_id=X&action_ref=Y when action_ref is
+        present in receipt.metadata. Falls back to GET /trails/{trail_id}.
+
+        Returns AnchorVerifyResult with:
+          VERIFIED           — hash confirmed, InclusionProof included
+          NOT_FOUND          — trail_id does not exist
+          HASH_MISMATCH      — trail exists but stored hash differs
+          BACKEND_UNAVAILABLE — network or API error
+        """
+        action_ref = receipt.metadata.get("action_ref")
+        agent_id = receipt.metadata.get("agent_id", self.agent_id)
+
+        try:
+            if action_ref:
+                resp = requests.get(
+                    f"{self.base_url}/trails/verify",
+                    params={"agent_id": agent_id, "action_ref": action_ref},
+                    timeout=self.timeout,
+                )
+            else:
+                resp = requests.get(
+                    f"{self.base_url}/trails/{receipt.anchor_id}",
+                    timeout=self.timeout,
+                )
+
+            if resp.status_code == 404:
+                return AnchorVerifyResult(
+                    status=AnchorVerifyStatus.NOT_FOUND,
+                    evidence_hash=evidence_hash,
+                )
+
+            resp.raise_for_status()
+            data = resp.json()
+
+        except requests.RequestException as exc:
+            return AnchorVerifyResult(
+                status=AnchorVerifyStatus.BACKEND_UNAVAILABLE,
+                evidence_hash=evidence_hash,
+                error_detail=str(exc),
+            )
+
+        if not data.get("verified", False) and "trail_id" not in data:
+            return AnchorVerifyResult(
+                status=AnchorVerifyStatus.NOT_FOUND,
+                evidence_hash=evidence_hash,
+            )
+
+        stored_hash = (
+            data.get("claims", {}).get("evidence_hash")
+            or data.get("payment_hash")
+        )
+        if stored_hash and stored_hash != evidence_hash:
+            return AnchorVerifyResult(
+                status=AnchorVerifyStatus.HASH_MISMATCH,
+                evidence_hash=evidence_hash,
+                error_detail=f"stored: {stored_hash}",
+            )
+
+        tx_hash = data.get("tx_hash") or receipt.metadata.get("tx_hash", "")
+        proof = InclusionProof(
+            proof_type="tx_receipt",
+            proof_data={
+                "tx_hash": tx_hash,
+                "explorer_url": f"https://arbiscan.io/tx/{tx_hash}" if tx_hash else None,
+            },
+        ) if tx_hash else None
+
+        return AnchorVerifyResult(
+            status=AnchorVerifyStatus.VERIFIED,
+            evidence_hash=evidence_hash,
+            inclusion_proof=proof,
+        )

--- a/community-plugins/mycelium_trails/tests/conftest.py
+++ b/community-plugins/mycelium_trails/tests/conftest.py
@@ -1,0 +1,2 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))

--- a/community-plugins/mycelium_trails/tests/test_action_ref.py
+++ b/community-plugins/mycelium_trails/tests/test_action_ref.py
@@ -1,0 +1,85 @@
+"""Tests for action_ref derivation (JCS + SHA-256)."""
+
+import hashlib
+import json
+
+import pytest
+
+from mycelium_trails.action_ref import compute_action_ref, format_timestamp
+import datetime
+
+
+# Known-good vector: JCS of the 4-field payload, then SHA-256.
+# JCS key order (lexicographic): action_type < agent_id < scope < timestamp
+_VECTOR_FIELDS = {
+    "agent_id": "test-agent",
+    "action_type": "stripe:charge",
+    "scope": "agt-evidence",
+    "timestamp": "2026-05-15T10:00:00.123Z",
+}
+# JCS canonical form (keys sorted, no spaces):
+_VECTOR_JCS = '{"action_type":"stripe:charge","agent_id":"test-agent","scope":"agt-evidence","timestamp":"2026-05-15T10:00:00.123Z"}'
+_VECTOR_ACTION_REF = hashlib.sha256(_VECTOR_JCS.encode("utf-8")).hexdigest()
+
+
+def test_compute_action_ref_known_vector():
+    result = compute_action_ref(
+        agent_id=_VECTOR_FIELDS["agent_id"],
+        action_type=_VECTOR_FIELDS["action_type"],
+        scope=_VECTOR_FIELDS["scope"],
+        timestamp=_VECTOR_FIELDS["timestamp"],
+    )
+    assert result == _VECTOR_ACTION_REF
+
+
+def test_compute_action_ref_deterministic():
+    a = compute_action_ref("agent-1", "file:write", "audit", "2026-05-15T00:00:00.000Z")
+    b = compute_action_ref("agent-1", "file:write", "audit", "2026-05-15T00:00:00.000Z")
+    assert a == b
+
+
+def test_compute_action_ref_different_fields_produce_different_refs():
+    ref1 = compute_action_ref("agent-1", "file:write", "audit", "2026-05-15T00:00:00.000Z")
+    ref2 = compute_action_ref("agent-2", "file:write", "audit", "2026-05-15T00:00:00.000Z")
+    assert ref1 != ref2
+
+
+def test_compute_action_ref_output_is_64_hex_chars():
+    ref = compute_action_ref("a", "b", "c", "2026-01-01T00:00:00.000Z")
+    assert len(ref) == 64
+    assert all(c in "0123456789abcdef" for c in ref)
+
+
+def test_jcs_key_ordering():
+    """Verify that our JCS encoding sorts keys lexicographically."""
+    fields = {
+        "agent_id": "x",
+        "action_type": "y",
+        "scope": "z",
+        "timestamp": "t",
+    }
+    # lexicographic order: action_type, agent_id, scope, timestamp
+    canonical = json.dumps(dict(sorted(fields.items())), separators=(",", ":"), ensure_ascii=False)
+    assert canonical == '{"action_type":"y","agent_id":"x","scope":"z","timestamp":"t"}'
+
+
+def test_format_timestamp_3digit_ms():
+    dt = datetime.datetime(2026, 5, 15, 10, 0, 0, 123000)
+    result = format_timestamp(dt)
+    assert result == "2026-05-15T10:00:00.123Z"
+
+
+def test_format_timestamp_zero_ms():
+    dt = datetime.datetime(2026, 1, 1, 0, 0, 0, 0)
+    result = format_timestamp(dt)
+    assert result == "2026-01-01T00:00:00.000Z"
+
+
+def test_format_timestamp_ends_with_Z():
+    dt = datetime.datetime(2026, 5, 15, 12, 30, 45, 7000)
+    result = format_timestamp(dt)
+    assert result.endswith("Z")
+    assert "." in result
+    # ms part is always 3 digits
+    ms_part = result.split(".")[1].rstrip("Z")
+    assert len(ms_part) == 3

--- a/community-plugins/mycelium_trails/tests/test_anchor.py
+++ b/community-plugins/mycelium_trails/tests/test_anchor.py
@@ -1,0 +1,161 @@
+"""Tests for MyceliumAnchor (anchor + verify)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from mycelium_trails.anchor import MyceliumAnchor
+from mycelium_trails._types import (
+    AnchorReceipt,
+    AnchorVerifyStatus,
+)
+
+EVIDENCE_HASH = "sha256:abc123def456"
+TRAIL_ID = "trail-uuid-0001"
+TX_HASH = "0xdeadbeef"
+ACTION_REF = "a" * 64
+
+
+def _mock_anchor_response():
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {
+        "trail_id": TRAIL_ID,
+        "tx_hash": TX_HASH,
+        "anchored_at": "2026-05-15T10:00:00.123Z",
+    }
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_receipt(action_ref=ACTION_REF):
+    return AnchorReceipt(
+        backend="mycelium-trails",
+        anchor_id=TRAIL_ID,
+        anchored_at="2026-05-15T10:00:00.123Z",
+        evidence_hash=EVIDENCE_HASH,
+        metadata={"action_ref": action_ref, "agent_id": "test-agent", "tx_hash": TX_HASH},
+    )
+
+
+# ── anchor() ──────────────────────────────────────────────────────────────────
+
+class TestAnchor:
+    def test_happy_path_returns_receipt(self):
+        with patch("requests.post", return_value=_mock_anchor_response()):
+            anchor = MyceliumAnchor(agent_id="test-agent")
+            receipt = anchor.anchor(EVIDENCE_HASH, {})
+
+        assert receipt.backend == "mycelium-trails"
+        assert receipt.anchor_id == TRAIL_ID
+        assert receipt.evidence_hash == EVIDENCE_HASH
+        assert "action_ref" in receipt.metadata
+        assert receipt.metadata["tx_hash"] == TX_HASH
+
+    def test_metadata_action_type_and_scope_forwarded(self):
+        with patch("requests.post", return_value=_mock_anchor_response()) as mock_post:
+            anchor = MyceliumAnchor()
+            anchor.anchor(EVIDENCE_HASH, {"action_type": "stripe:charge", "scope": "billing"})
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["operation"] == "stripe:charge"
+        assert payload["scope"] == "billing"
+
+    def test_parent_trail_id_forwarded(self):
+        with patch("requests.post", return_value=_mock_anchor_response()) as mock_post:
+            anchor = MyceliumAnchor()
+            anchor.anchor(EVIDENCE_HASH, {"parent_trail_id": "parent-123"})
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload.get("parent_trail_id") == "parent-123"
+
+    def test_network_error_raises_runtime_error(self):
+        with patch("requests.post", side_effect=requests.ConnectionError("timeout")):
+            anchor = MyceliumAnchor()
+            with pytest.raises(RuntimeError, match="MyceliumAnchor.anchor failed"):
+                anchor.anchor(EVIDENCE_HASH, {})
+
+    def test_action_ref_in_receipt_metadata(self):
+        with patch("requests.post", return_value=_mock_anchor_response()):
+            anchor = MyceliumAnchor()
+            receipt = anchor.anchor(EVIDENCE_HASH, {})
+
+        assert len(receipt.metadata["action_ref"]) == 64
+
+
+# ── verify() ──────────────────────────────────────────────────────────────────
+
+class TestVerify:
+    def _verify_response(self, verified=True, stored_hash=EVIDENCE_HASH, tx_hash=TX_HASH):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "verified": verified,
+            "trail_id": TRAIL_ID,
+            "claims": {"evidence_hash": stored_hash},
+            "tx_hash": tx_hash,
+        }
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def test_verified_happy_path(self):
+        with patch("requests.get", return_value=self._verify_response()):
+            anchor = MyceliumAnchor()
+            result = anchor.verify(EVIDENCE_HASH, _make_receipt())
+
+        assert result.status == AnchorVerifyStatus.VERIFIED
+        assert result.evidence_hash == EVIDENCE_HASH
+        assert result.inclusion_proof is not None
+        assert result.inclusion_proof.proof_type == "tx_receipt"
+        assert result.inclusion_proof.proof_data["tx_hash"] == TX_HASH
+
+    def test_hash_mismatch(self):
+        with patch("requests.get", return_value=self._verify_response(stored_hash="sha256:different")):
+            anchor = MyceliumAnchor()
+            result = anchor.verify(EVIDENCE_HASH, _make_receipt())
+
+        assert result.status == AnchorVerifyStatus.HASH_MISMATCH
+        assert "stored" in (result.error_detail or "")
+
+    def test_not_found_on_404(self):
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.raise_for_status = MagicMock()
+        with patch("requests.get", return_value=resp):
+            anchor = MyceliumAnchor()
+            result = anchor.verify(EVIDENCE_HASH, _make_receipt())
+
+        assert result.status == AnchorVerifyStatus.NOT_FOUND
+
+    def test_backend_unavailable_on_network_error(self):
+        with patch("requests.get", side_effect=requests.ConnectionError("down")):
+            anchor = MyceliumAnchor()
+            result = anchor.verify(EVIDENCE_HASH, _make_receipt())
+
+        assert result.status == AnchorVerifyStatus.BACKEND_UNAVAILABLE
+        assert result.error_detail is not None
+
+    def test_falls_back_to_trail_id_without_action_ref(self):
+        receipt = AnchorReceipt(
+            backend="mycelium-trails",
+            anchor_id=TRAIL_ID,
+            anchored_at="2026-05-15T10:00:00.123Z",
+            evidence_hash=EVIDENCE_HASH,
+            metadata={"agent_id": "test-agent"},  # no action_ref
+        )
+        with patch("requests.get", return_value=self._verify_response()) as mock_get:
+            anchor = MyceliumAnchor()
+            anchor.verify(EVIDENCE_HASH, receipt)
+
+        url = mock_get.call_args.args[0]
+        assert TRAIL_ID in url
+
+    def test_inclusion_proof_has_arbiscan_url(self):
+        with patch("requests.get", return_value=self._verify_response()):
+            anchor = MyceliumAnchor()
+            result = anchor.verify(EVIDENCE_HASH, _make_receipt())
+
+        assert result.inclusion_proof is not None
+        explorer_url = result.inclusion_proof.proof_data.get("explorer_url", "")
+        assert "arbiscan.io" in explorer_url


### PR DESCRIPTION
## Summary

Community implementation of the `EvidenceAnchor` SPI (introduced in #2244) backed by
Mycelium Trails on Arbitrum.

- `anchor()` writes evidence hashes as append-only trail records via `argentum.rgiskard.xyz`
- `verify()` confirms the hash independently — no AGT runtime required
- `action_ref` derivation: RFC 8785 JCS + SHA-256 per [action-ref.md v1.0](https://github.com/giskard09/argentum-core/blob/main/docs/spec/action-ref.md)
- 19/19 tests: known vectors, JCS key order, hash mismatch, 404, network failure, fallback

The same `action_ref` derivation is independently implemented by SafeAgent, NEXUS, and
CrewAI idempotency key — convergent implementations against the shared spec.

## Structure

```
community-plugins/
  README.md                    — plugin contribution guide
  mycelium_trails/
    __init__.py
    anchor.py                  — MyceliumAnchor (EvidenceAnchor impl)
    action_ref.py              — JCS + SHA-256 derivation
    _types.py                  — inline EvidenceAnchor ABC stubs
    README.md
    tests/
      test_anchor.py           — 11 tests
      test_action_ref.py       — 8 tests
```

## Test

```bash
pytest community-plugins/mycelium_trails/tests/ -v  # 19 passed
```

## Public endpoint

`https://argentum.rgiskard.xyz` — live on Arbitrum One.

Conforms to: `MYCELIUM-EXTERNAL-ANCHOR-PROPOSAL.md` v3
Related: #2244