### PR TITLE
fix: resolve SyntaxError in StdoutAuditSink from overlapping merge

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
@@ -487,58 +487,9 @@ class StdoutAuditSink:
     def verify_integrity(self) -> tuple[bool, str | None]:
         """Stdout is a streaming sink; integrity verification is not supported.
 
-        Returns ``(True, None)`` — no integrity violations are known.
+        Returns ``(True, None)`` -- no integrity violations are known.
         Callers that require verifiable audit trails should use
         :class:`FileAuditSink`.
-    """Audit sink that writes JSON lines to stdout.
-
-    Designed for containerized and sidecar deployments where audit logs
-    are collected by a container log driver (Docker, Kubernetes,
-    OpenShell). Each entry is written as a single JSON line and flushed
-    immediately for reliable delivery.
-
-    Args:
-        stream: Output stream. Defaults to ``sys.stdout``.
-        include_context: Whether to include sandbox context fields in
-            the output. Defaults to ``True``.
-    """
-
-    def __init__(
-        self,
-        stream: Any = None,
-        *,
-        include_context: bool = True,
-    ) -> None:
-        import sys
-        self._stream = stream or sys.stdout
-        self._include_context = include_context
-        self._lock = threading.Lock()
-        self._closed = False
-
-    def write(self, entry: AuditEntry) -> None:
-        """Write a single audit entry as one JSON line to stdout."""
-        if self._closed:
-            return
-        line = self._serialize(entry)
-        with self._lock:
-            self._stream.write(line + "\n")
-            self._stream.flush()
-
-    def write_batch(self, entries: list[AuditEntry]) -> None:
-        """Write a batch of audit entries, one JSON line per entry."""
-        if self._closed:
-            return
-        with self._lock:
-            for entry in entries:
-                line = self._serialize(entry)
-                self._stream.write(line + "\n")
-            self._stream.flush()
-
-    def verify_integrity(self) -> tuple[bool, str | None]:
-        """Stdout sink does not support integrity verification.
-
-        Returns:
-            Always returns (True, None) since stdout is write-only.
         """
         return True, None
 
@@ -572,41 +523,3 @@ class StdoutAuditSink:
         do not break downstream parsers with strict schemas.
         """
         return json.dumps(entry.model_dump(mode="json", exclude_none=True), sort_keys=True, ensure_ascii=False)
-        """Mark the sink as closed."""
-        self._closed = True
-
-    def _serialize(self, entry: AuditEntry) -> str:
-        """Serialize an AuditEntry to a JSON line."""
-        data: dict[str, Any] = {
-            "entry_id": entry.entry_id,
-            "timestamp": entry.timestamp.isoformat().replace("+00:00", "Z"),
-            "event_type": entry.event_type,
-            "agent_did": entry.agent_did,
-            "action": entry.action,
-            "outcome": entry.outcome,
-        }
-
-        if entry.resource is not None:
-            data["resource"] = entry.resource
-        if entry.target_did is not None:
-            data["target_did"] = entry.target_did
-        if entry.data:
-            data["data"] = entry.data
-        if entry.policy_decision is not None:
-            data["policy_decision"] = entry.policy_decision
-        if entry.matched_rule is not None:
-            data["matched_rule"] = entry.matched_rule
-        if entry.trace_id is not None:
-            data["trace_id"] = entry.trace_id
-        if entry.session_id is not None:
-            data["session_id"] = entry.session_id
-
-        if self._include_context:
-            if entry.sandbox_id is not None:
-                data["sandbox_id"] = entry.sandbox_id
-            if entry.environment is not None:
-                data["environment"] = entry.environment
-            if entry.compute_driver is not None:
-                data["compute_driver"] = entry.compute_driver
-
-        return json.dumps(data, sort_keys=True, default=str)


### PR DESCRIPTION
## Summary

Fixes a SyntaxError in \udit_backends.py\ caused by two overlapping \StdoutAuditSink\ class bodies merged incorrectly.

## Problem

Commit 36bcdaba0 added \erify_integrity\ and an enhanced \_serialise\ method but left the previous class body (from 2aa7acd90) embedded inside the new docstring. This caused:
- Unterminated string literal on line 558
- Broke all imports of \gentmesh.identity\, \gentmesh.trust\, etc.
- Demo 4 (trust scoring) completely non-functional

## Changes

| File | Change |
|------|--------|
| \udit_backends.py\ | Removed 88 lines of duplicate old-style class body |

Kept the newer class-level \_stdout_lock\ implementation with Pydantic \model_dump\-based \_serialise\ static method. Removed the old instance-level \_lock/_stream/_include_context/_closed\ pattern and manual \_serialize\ method.

## Testing

- \st.parse()\ confirms file is syntactically valid (525 lines)
- All key imports verified: \AgentIdentity\, \TrustHandshake\, \PolicyEvaluator- \StdoutAuditSink.verify_integrity()\ returns \(True, None)\ as expected
