### PR TITLE
fix: add UTF-8 stdout encoding for EU AI Act demo on Windows

### DIFF
--- a/agent-governance-python/agent-mesh/examples/06-eu-ai-act-compliance/demo.py
+++ b/agent-governance-python/agent-mesh/examples/06-eu-ai-act-compliance/demo.py
@@ -13,6 +13,11 @@ Demonstrates:
 Runs entirely offline — no API keys required.
 """
 
+import sys
+
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+
 from compliance_checker import (
     AgentProfile,
     EUAIActComplianceChecker,


### PR DESCRIPTION
## Summary

Fixes UnicodeEncodeError when running the EU AI Act compliance demo on Windows terminals with cp1252 encoding.

## Problem

The demo uses Unicode characters (checkmarks, crosses, arrows) that cannot be encoded in Windows default cp1252 codepage, causing a crash at the first emoji output.

## Changes

| File | Change |
|------|--------|
| `examples/06-eu-ai-act-compliance/demo.py` | Added `sys.stdout.reconfigure(encoding="utf-8")` for win32 |

## Testing

Verified demo runs to completion on Windows without UnicodeEncodeError.
