### PR TITLE
docs(tutorials): reorganize into collapsible customer-centric categories

### DIFF
--- a/agent-governance-python/agent-mesh/examples/06-eu-ai-act-compliance/demo.py
+++ b/agent-governance-python/agent-mesh/examples/06-eu-ai-act-compliance/demo.py
@@ -13,6 +13,11 @@ Demonstrates:
 Runs entirely offline — no API keys required.
 """
 
+import sys
+
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+
 from compliance_checker import (
     AgentProfile,
     EUAIActComplianceChecker,

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,88 +1,77 @@
 # Tutorials
 
-50+ step-by-step guides covering every aspect of AI agent governance.
+Step-by-step guides organized by what you're trying to accomplish.
 
 !!! tip "Where to start?"
-    **New here?** Start with [Tutorial 01: Policy Engine](01-policy-engine.md), then work through the Foundations section. For a quick taste, try [Tutorial 36: 2-Line Governance](36-govern-quickstart.md).
+    **New here?** Start with [2-Line Quickstart](36-govern-quickstart.md) to see AGT in action, then follow [Policy Engine Basics](01-policy-engine.md) for a full walkthrough.
 
-## Foundations
+---
 
-| #  | Tutorial  | What you'll learn   |
-|----|-----------|---------------------|
-| 01 | [Policy Engine](01-policy-engine.md) | Core policy evaluation, rule authoring |
-| 02 | [Trust & Identity](02-trust-and-identity.md) | Agent identity, trust tiers, verification |
-| 03 | [Framework Integrations](03-framework-integrations.md) | Connect AGT to LangChain, CrewAI, OpenAI, etc. |
-| 04 | [Audit & Compliance](04-audit-and-compliance.md) | Logging, evidence collection, compliance mapping |
-| 05 | [Agent Reliability](05-agent-reliability.md) | SLOs, monitoring, graceful degradation |
-| 36 | [2-Line Governance Quickstart](36-govern-quickstart.md) | Fastest path to governed agents |
+## Getting Started
+
+The essentials to get your first governed agent running in minutes.
+
+| Tutorial | What you'll accomplish |
+|----------|----------------------|
+| [2-Line Quickstart](36-govern-quickstart.md) | Add governance to any agent in 2 lines of code |
+| [Policy Engine Basics](01-policy-engine.md) | Write and evaluate your first policy rules |
+| [Framework Integrations](03-framework-integrations.md) | Connect AGT to LangChain, CrewAI, OpenAI, etc. |
+| [Progressive Governance](progressive-governance.md) | Start simple, add layers incrementally |
+
+---
+
+## End-to-End Scenarios
+
+Complete workflows from a customer perspective: pick the scenario closest to your use case.
+
+| Scenario | Description |
+|----------|-------------|
+| [Govern an AI Agent (Python)](04-audit-and-compliance.md) | Full audit trail with compliance mapping for a Python agent |
+| [Govern MCP Tool Servers](07-mcp-security-gateway.md) | Per-tool policy enforcement for MCP servers |
+| [.NET MAF Integration](34-maf-integration.md) | Govern agents built with Microsoft Agent Framework |
+| [.NET MAF Hook](43-dotnet-maf-hook-integration.md) | Add governance hooks to .NET MAF agents |
+| [Multi-Agent Fleet Policies](49-multi-agent-policies.md) | Collective policy enforcement across agent fleets |
+| [Multi-Stage Pipeline](37-multi-stage-pipeline.md) | Chained policy evaluation for complex workflows |
+| [Retrofit Existing Agents](retrofit-governance.md) | Add governance to agents already in production |
+| [Shift-Left CI/CD Gates](45-shift-left-governance.md) | Pre-commit hooks, CI gates, build-time enforcement |
+| [A2A Conversation Policy](44-a2a-conversation-policy.md) | Govern agent-to-agent conversations |
+| [Copilot CLI Governance](46-copilot-cli-governance.md) | Install governance policies for GitHub Copilot CLI |
+
+---
 
 ## Security
 
-| #  | Tutorial   | What you'll learn   |
-|----|------------|---------------------|
-| 06 | [Execution Sandboxing](06-execution-sandboxing.md) | Privilege rings, runtime isolation |
-| 07 | [MCP Security Gateway](07-mcp-security-gateway.md) | Per-tool policy enforcement for MCP servers |
-| 08 | [OPA / Rego / Cedar Policies](08-opa-rego-cedar-policies.md) | Policy engines comparison and integration |
-| 09 | [Prompt Injection Detection](09-prompt-injection-detection.md) | Detecting and preventing prompt injection |
-| 25 | [Security Hardening](25-security-hardening.md) | Production security best practices |
-| 26 | [SBOM & Signing](26-sbom-and-signing.md) | Software bill of materials, artifact signing |
-| 27 | [MCP Scan CLI](27-mcp-scan-cli.md) | Static analysis for MCP server security |
-| 39 | [DLP with Attribute Ratchets](39-dlp-attribute-ratchets.md) | Data loss prevention, sensitivity escalation |
-| 41 | [Defense-in-Depth](41-advisory-defense-in-depth.md) | Advisory classifiers, layered security |
-| 45 | [Shift-Left Governance](45-shift-left-governance.md) | Pre-commit hooks, CI gates, build-time enforcement |
-| 46 | [Contributor Governance](46-contributor-governance.md) | Contributor reputation, spam detection, cross-project scanning |
-| 47 | [Red-Team Testing](47-red-team-testing.md) | Adversarial security testing with `agt red-team` |
+Hardening, threat mitigation, and data protection.
 
-## Advanced Patterns
+| Tutorial | What you'll learn |
+|----------|-------------------|
+| [Execution Sandboxing](06-execution-sandboxing.md) | Privilege rings, runtime isolation |
+| [Prompt Injection Detection](09-prompt-injection-detection.md) | Detect and block prompt injection attacks |
+| [Security Hardening](25-security-hardening.md) | Production security best practices |
+| [DLP & Attribute Ratchets](39-dlp-attribute-ratchets.md) | Data loss prevention, sensitivity escalation |
+| [Defense-in-Depth](41-advisory-defense-in-depth.md) | Advisory classifiers, layered security |
+| [SBOM & Signing](26-sbom-and-signing.md) | Software bill of materials, artifact signing |
+| [MCP Scan CLI](27-mcp-scan-cli.md) | Static analysis for MCP server security |
+| [E2E Encrypted Messaging](32-e2e-encrypted-messaging.md) | End-to-end encrypted agent communication |
+| [Red-Team Testing](47-red-team-testing.md) | Adversarial security testing |
 
-| #  | Tutorial     | What you'll learn    |
-|----|--------------|----------------------|
-| 10 | [Plugin Marketplace](10-plugin-marketplace.md) | Marketplace governance, trust scoring |
-| 11 | [Saga Orchestration](11-saga-orchestration.md) | Multi-step agent workflows with rollback |
-| 12 | [Liability & Attribution](12-liability-and-attribution.md) | Decision tracing, blame assignment |
-| 13 | [Observability & Tracing](13-observability-and-tracing.md) | Distributed tracing for agent systems |
-| 14 | [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) | Emergency controls, throttling |
-| 15 | [RL Training Governance](15-rl-training-governance.md) | Governing reinforcement learning agents |
-| 16 | [Protocol Bridges](16-protocol-bridges.md)     | Cross-protocol agent communication |
-| 17 | [Advanced Trust](17-advanced-trust-and-behavior.md) | Behavioral analysis, reputation systems |
-| 18 | [Compliance Verification](18-compliance-verification.md) | Automated compliance checks |
-| 23 | [Delegation Chains](23-delegation-chains.md)   | Agent-to-agent authorization |
-| 24 | [Cost & Token Budgets](24-cost-and-token-budgets.md) | Resource governance |
-| 35 | [Policy Composition](35-policy-composition.md) | Enterprise governance layers, policy merging |
-| 37 | [Multi-Stage Pipeline](37-multi-stage-pipeline.md) | Chained policy evaluation pipelines |
-| 38 | [Approval Workflows](38-approval-workflows.md) | Human-in-the-loop approval gates |
-| 40 | [OpenTelemetry Observability](40-otel-observability.md) | OTel integration for governance events |
-| 44 | [A2A Conversation Policy](44-a2a-conversation-policy.md) | Agent-to-agent conversation governance |
-| 48 | [Intent-Based Authorization](48-intent-based-authorization.md) | Authorize actions by declared intent |
-| 49 | [Multi-Agent Policies](49-multi-agent-policies.md) | Collective policy enforcement across agent fleets |
-| 50 | [Decision BOM](50-decision-bom.md) | Decision bill of materials, audit artifacts |
-| 51 | [Cost Governance](51-cost-governance.md) | Budget enforcement, cost attribution |
+---
 
-## Language Package Guides
+## Policy & Authorization
 
-| #  | Tutorial | What you'll learn |
-|----|----------|-------------------|
-| 19 | [.NET package](19-dotnet-sdk.md) | Agent governance in C# / .NET |
-| 42 | [C# MCP extension](42-csharp-mcp-extension.md) | Govern MCP servers built with the official C# SDK |
-| 43 | [.NET MAF Hook](43-dotnet-maf-hook-integration.md) | Integrate AGT with Microsoft Agent Framework in .NET |
-| 20 | [TypeScript package](20-typescript-sdk.md) | Agent governance in TypeScript |
-| 21 | [Rust crate](21-rust-sdk.md) | Agent governance in Rust |
-| 22 | [Go module](22-go-sdk.md) | Agent governance in Go |
+Writing, composing, and enforcing governance policies.
 
-## Enterprise & Operations
+| Tutorial | What you'll learn |
+|----------|-------------------|
+| [OPA / Rego / Cedar](08-opa-rego-cedar-policies.md) | Policy engines comparison and integration |
+| [Policy Composition](35-policy-composition.md) | Enterprise governance layers, policy merging |
+| [Approval Workflows](38-approval-workflows.md) | Human-in-the-loop approval gates |
+| [Intent-Based Authorization](48-intent-based-authorization.md) | Authorize actions by declared intent |
+| [Delegation Chains](23-delegation-chains.md) | Agent-to-agent authorization |
+| [Cost & Token Budgets](24-cost-and-token-budgets.md) | Resource governance and budget enforcement |
+| [Cost Governance](51-cost-governance.md) | Budget enforcement, cost attribution |
 
-| #  | Tutorial | What you'll learn |
-|----|----------|-------------------|
-| 28 | [Build Custom Integration](28-build-custom-integration.md) | Create your own governance adapter |
-| 29 | [Agent Discovery](29-agent-discovery.md) | Finding shadow AI in your organization |
-| 30 | [Agent Lifecycle](30-agent-lifecycle.md) | Agent lifecycle management, birth to retirement |
-| 31 | [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridging AGT identity with Microsoft Entra |
-| 32 | [Chaos Testing](32-chaos-testing-agents.md) | Chaos engineering for agent reliability |
-| 32b | [E2E Encrypted Messaging](32-e2e-encrypted-messaging.md) | End-to-end encrypted agent communication |
-| 33 | [Offline Verifiable Receipts](33-offline-verifiable-receipts.md) | Offline-verifiable decision receipts |
-| 34 | [MAF Integration](34-maf-integration.md) | Governing agents with Microsoft Agent Framework |
-
-## Policy-as-Code Series
+### Policy-as-Code Series
 
 A focused series on writing, testing, and versioning governance policies.
 
@@ -97,9 +86,54 @@ A focused series on writing, testing, and versioning governance policies.
 | 7 | [Policy Versioning](policy-as-code/07-policy-versioning.md) | Version control for policies |
 | - | [MCP Governance](policy-as-code/mcp-governance.md) | MCP-specific policy patterns |
 
-## Guides
+---
 
-| Guide | What you'll learn |
-|-------|-------------------|
-| [Progressive Governance](progressive-governance.md) | Start simple, add governance layers incrementally |
-| [Retrofit Governance](retrofit-governance.md) | Add governance to an existing agent |
+## Observability & Operations
+
+Monitoring, alerting, and operational management of governed agents.
+
+| Tutorial | What you'll learn |
+|----------|-------------------|
+| [Observability & Tracing](13-observability-and-tracing.md) | Distributed tracing for agent systems |
+| [OpenTelemetry Integration](40-otel-observability.md) | OTel integration for governance events |
+| [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) | Emergency controls, throttling |
+| [Agent Discovery](29-agent-discovery.md) | Finding shadow AI in your organization |
+| [Agent Lifecycle](30-agent-lifecycle.md) | Birth-to-retirement management |
+| [Chaos Testing](32-chaos-testing-agents.md) | Chaos engineering for agent reliability |
+| [Agent Reliability](05-agent-reliability.md) | SLOs, monitoring, graceful degradation |
+
+---
+
+## Advanced Topics
+
+Deep dives into specialized governance patterns.
+
+| Tutorial | What you'll learn |
+|----------|-------------------|
+| [Trust & Identity Deep Dive](02-trust-and-identity.md) | Agent identity, trust tiers, verification |
+| [Advanced Trust & Behavior](17-advanced-trust-and-behavior.md) | Behavioral analysis, reputation systems |
+| [Compliance Verification](18-compliance-verification.md) | Automated compliance checks |
+| [Saga Orchestration](11-saga-orchestration.md) | Multi-step workflows with rollback |
+| [Liability & Attribution](12-liability-and-attribution.md) | Decision tracing, blame assignment |
+| [Protocol Bridges](16-protocol-bridges.md) | Cross-protocol agent communication |
+| [Plugin Marketplace](10-plugin-marketplace.md) | Marketplace governance, trust scoring |
+| [RL Training Governance](15-rl-training-governance.md) | Governing reinforcement learning agents |
+| [Decision BOM](50-decision-bom.md) | Decision bill of materials, audit artifacts |
+| [Offline Verifiable Receipts](33-offline-verifiable-receipts.md) | Offline-verifiable decision receipts |
+| [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridging AGT identity with Microsoft Entra |
+| [Contributor Governance](46-contributor-governance.md) | Contributor reputation, spam detection |
+
+---
+
+## Language & Platform Guides
+
+SDK-specific guides for each supported language.
+
+| Tutorial | Language |
+|----------|----------|
+| [.NET SDK](19-dotnet-sdk.md) | C# / .NET |
+| [C# MCP Extension](42-csharp-mcp-extension.md) | C# (MCP servers) |
+| [TypeScript SDK](20-typescript-sdk.md) | TypeScript / Node.js |
+| [Rust Crate](21-rust-sdk.md) | Rust |
+| [Go Module](22-go-sdk.md) | Go |
+| [Build Custom Integration](28-build-custom-integration.md) | Any language |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,6 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.sections
-    - navigation.expand
     - navigation.top
     - navigation.path
     - search.suggest
@@ -103,46 +102,77 @@ nav:
     - VS Code Extension: packages/agent-os-vscode.md
   - Tutorials:
     - Overview: tutorials/index.md
-    - Policy Engine: tutorials/01-policy-engine.md
-    - Trust & Identity: tutorials/02-trust-and-identity.md
-    - Framework Integrations: tutorials/03-framework-integrations.md
-    - Audit & Compliance: tutorials/04-audit-and-compliance.md
-    - Agent Reliability: tutorials/05-agent-reliability.md
-    - Execution Sandboxing: tutorials/06-execution-sandboxing.md
-    - MCP Security Gateway: tutorials/07-mcp-security-gateway.md
-    - OPA / Rego / Cedar Policies: tutorials/08-opa-rego-cedar-policies.md
-    - Prompt Injection Detection: tutorials/09-prompt-injection-detection.md
-    - Plugin Marketplace: tutorials/10-plugin-marketplace.md
-    - Saga Orchestration: tutorials/11-saga-orchestration.md
-    - Liability & Attribution: tutorials/12-liability-and-attribution.md
-    - Observability & Tracing: tutorials/13-observability-and-tracing.md
-    - Kill Switch & Rate Limiting: tutorials/14-kill-switch-and-rate-limiting.md
-    - RL Training Governance: tutorials/15-rl-training-governance.md
-    - Protocol Bridges: tutorials/16-protocol-bridges.md
-    - Advanced Trust: tutorials/17-advanced-trust-and-behavior.md
-    - Compliance Verification: tutorials/18-compliance-verification.md
-    - .NET package: tutorials/19-dotnet-sdk.md
-    - C# MCP extension: tutorials/42-csharp-mcp-extension.md
-    - TypeScript package: tutorials/20-typescript-sdk.md
-    - Rust crate: tutorials/21-rust-sdk.md
-    - Go module: tutorials/22-go-sdk.md
-    - Delegation Chains: tutorials/23-delegation-chains.md
-    - Cost & Token Budgets: tutorials/24-cost-and-token-budgets.md
-    - Security Hardening: tutorials/25-security-hardening.md
-    - SBOM & Signing: tutorials/26-sbom-and-signing.md
-    - MCP Scan CLI: tutorials/27-mcp-scan-cli.md
-    - Build Custom Integration: tutorials/28-build-custom-integration.md
-    - Agent Discovery: tutorials/29-agent-discovery.md
-    - Agent Lifecycle: tutorials/30-agent-lifecycle.md
-    - Entra Agent ID Bridge: tutorials/31-entra-agent-id-bridge.md
-    - Chaos Testing Agents: tutorials/32-chaos-testing-agents.md
-    - E2E Encrypted Messaging: tutorials/32-e2e-encrypted-messaging.md
-    - Offline Verifiable Receipts: tutorials/33-offline-verifiable-receipts.md
-    - MAF Integration: tutorials/34-maf-integration.md
-    - .NET MAF Hook Integration: tutorials/43-dotnet-maf-hook-integration.md
-    - A2A Conversation Policy: tutorials/44-a2a-conversation-policy.md
-    - Shift-Left Governance: tutorials/45-shift-left-governance.md
-    - Copilot CLI governance installer: tutorials/46-copilot-cli-governance.md
+    - Getting Started:
+      - 2-Line Quickstart: tutorials/36-govern-quickstart.md
+      - Policy Engine Basics: tutorials/01-policy-engine.md
+      - Framework Integrations: tutorials/03-framework-integrations.md
+      - Progressive Governance: tutorials/progressive-governance.md
+    - End-to-End Scenarios:
+      - Govern an AI Agent (Python): tutorials/04-audit-and-compliance.md
+      - Govern MCP Tool Servers: tutorials/07-mcp-security-gateway.md
+      - .NET MAF Integration: tutorials/34-maf-integration.md
+      - .NET MAF Hook: tutorials/43-dotnet-maf-hook-integration.md
+      - Multi-Agent Fleet Policies: tutorials/49-multi-agent-policies.md
+      - Multi-Stage Pipeline: tutorials/37-multi-stage-pipeline.md
+      - Retrofit Existing Agents: tutorials/retrofit-governance.md
+      - Shift-Left CI/CD Gates: tutorials/45-shift-left-governance.md
+      - A2A Conversation Policy: tutorials/44-a2a-conversation-policy.md
+      - Copilot CLI Governance: tutorials/46-copilot-cli-governance.md
+    - Security:
+      - Execution Sandboxing: tutorials/06-execution-sandboxing.md
+      - Prompt Injection Detection: tutorials/09-prompt-injection-detection.md
+      - Security Hardening: tutorials/25-security-hardening.md
+      - DLP & Attribute Ratchets: tutorials/39-dlp-attribute-ratchets.md
+      - Defense-in-Depth: tutorials/41-advisory-defense-in-depth.md
+      - SBOM & Signing: tutorials/26-sbom-and-signing.md
+      - MCP Scan CLI: tutorials/27-mcp-scan-cli.md
+      - E2E Encrypted Messaging: tutorials/32-e2e-encrypted-messaging.md
+      - Red-Team Testing: tutorials/47-red-team-testing.md
+    - Policy & Authorization:
+      - OPA / Rego / Cedar: tutorials/08-opa-rego-cedar-policies.md
+      - Policy Composition: tutorials/35-policy-composition.md
+      - Approval Workflows: tutorials/38-approval-workflows.md
+      - Intent-Based Authorization: tutorials/48-intent-based-authorization.md
+      - Delegation Chains: tutorials/23-delegation-chains.md
+      - Cost & Token Budgets: tutorials/24-cost-and-token-budgets.md
+      - Cost Governance: tutorials/51-cost-governance.md
+      - Policy-as-Code Series:
+        - Your First Policy: tutorials/policy-as-code/01-your-first-policy.md
+        - Capability Scoping: tutorials/policy-as-code/02-capability-scoping.md
+        - Rate Limiting: tutorials/policy-as-code/03-rate-limiting.md
+        - Conditional Policies: tutorials/policy-as-code/04-conditional-policies.md
+        - Approval Workflows: tutorials/policy-as-code/05-approval-workflows.md
+        - Policy Testing: tutorials/policy-as-code/06-policy-testing.md
+        - Policy Versioning: tutorials/policy-as-code/07-policy-versioning.md
+        - MCP Governance: tutorials/policy-as-code/mcp-governance.md
+    - Observability & Operations:
+      - Observability & Tracing: tutorials/13-observability-and-tracing.md
+      - OpenTelemetry Integration: tutorials/40-otel-observability.md
+      - Kill Switch & Rate Limiting: tutorials/14-kill-switch-and-rate-limiting.md
+      - Agent Discovery: tutorials/29-agent-discovery.md
+      - Agent Lifecycle: tutorials/30-agent-lifecycle.md
+      - Chaos Testing: tutorials/32-chaos-testing-agents.md
+      - Agent Reliability: tutorials/05-agent-reliability.md
+    - Advanced Topics:
+      - Trust & Identity Deep Dive: tutorials/02-trust-and-identity.md
+      - Advanced Trust & Behavior: tutorials/17-advanced-trust-and-behavior.md
+      - Compliance Verification: tutorials/18-compliance-verification.md
+      - Saga Orchestration: tutorials/11-saga-orchestration.md
+      - Liability & Attribution: tutorials/12-liability-and-attribution.md
+      - Protocol Bridges: tutorials/16-protocol-bridges.md
+      - Plugin Marketplace: tutorials/10-plugin-marketplace.md
+      - RL Training Governance: tutorials/15-rl-training-governance.md
+      - Decision BOM: tutorials/50-decision-bom.md
+      - Offline Verifiable Receipts: tutorials/33-offline-verifiable-receipts.md
+      - Entra Agent ID Bridge: tutorials/31-entra-agent-id-bridge.md
+      - Contributor Governance: tutorials/46-contributor-governance.md
+    - Language & Platform Guides:
+      - .NET SDK: tutorials/19-dotnet-sdk.md
+      - C# MCP Extension: tutorials/42-csharp-mcp-extension.md
+      - TypeScript SDK: tutorials/20-typescript-sdk.md
+      - Rust Crate: tutorials/21-rust-sdk.md
+      - Go Module: tutorials/22-go-sdk.md
+      - Build Custom Integration: tutorials/28-build-custom-integration.md
   - Deployment:
     - Overview: deployment/index.md
     - Azure Container Apps: deployment/azure-container-apps.md


### PR DESCRIPTION
## Problem

The tutorials sidebar shows 50+ items in a flat list, overwhelming new users. There's no clear guidance on where to start or which tutorials solve their specific use case.

## Solution

Reorganize tutorials into **7 collapsible categories** in the sidebar nav:

| Category | Count | Purpose |
|----------|-------|---------|
| Getting Started | 4 | Immediate onboarding in minutes |
| End-to-End Scenarios | 10 | Customer-journey workflows (pick your use case) |
| Security | 9 | Hardening, threat mitigation, DLP |
| Policy & Authorization | 7+8 | Policy engines, composition, Policy-as-Code series |
| Observability & Operations | 7 | Monitoring, discovery, chaos testing |
| Advanced Topics | 12 | Deep dives for power users |
| Language & Platform Guides | 6 | SDK-specific (.NET, TS, Rust, Go) |

### Key changes

1. **Removed \
avigation.expand\** from mkdocs theme so sections start collapsed
2. **Restructured \mkdocs.yml\ nav** with nested subsections under Tutorials
3. **Rewrote \	utorials/index.md\** with customer-centric framing (scenario-based tables)
4. **Getting Started leads with quickstart**, not the full policy engine walkthrough
5. **End-to-End Scenarios** category answers 'how do I govern X?' directly

No tutorial files were moved or renamed, only the navigation structure and index page changed.