### PR TITLE
fix: correct v3.6.0 release date to 2026-05-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [3.6.0] - 2026-05-18
+## [3.6.0] - 2026-05-12
 
 ### Highlights
 

--- a/docs/releases/RELEASE_NOTES_v3.6.0.md
+++ b/docs/releases/RELEASE_NOTES_v3.6.0.md
@@ -1,6 +1,6 @@
 # Agent Governance Toolkit v3.6.0
 
-**Release Date:** 2026-05-18
+**Release Date:** 2026-05-12
 
 > [!IMPORTANT]
 > **Public Preview** - All packages published from this repository are


### PR DESCRIPTION
Fixes the release date in CHANGELOG.md from 2026-05-18 to 2026-05-12 (when the version bump actually landed).