### PR TITLE
docs: acknowledge cross-session stateful-backdoor variant in LIMITATIONS and OWASP-COMPLIANCE

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -30,8 +30,8 @@ under supply-chain SFT delivery, and demonstrate the attack generalises to
 alternative topologies (branch-and-merge) and alternative persistent components
 (note-tool in place of memory).
 
-*This cross-session variant was identified in external analysis by
-[Dai et al.](https://arxiv.org/abs/2605.06158) (preprint, May 2026).*
+> *This cross-session variant was identified in external analysis by
+> [Dai et al.](https://arxiv.org/abs/2605.06158) (preprint, May 2026).*
 
 **Mitigations available today:**
 - Use **content policies** with blocked patterns (regex) to catch PII in outputs

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -19,6 +19,20 @@ It does **not** govern what agents *think* or *say*.
 an agent could read your customer list and post it to a public channel — both
 actions are individually permitted.
 
+**Cross-session variant.** The same gap extends across session boundaries when
+persistent memory or persistent tools (notes, files, calendar) carry attack state
+between sessions under permission isolation. A backdoored or prompt-injected model
+can write attack state in one session and resume from that state in a later session
+whose tool set permits the next phase — so each session's individual actions remain
+policy-permitted while the full attack chain only resolves across the session
+sequence. Dai et al. report 80–95% attack success rates across four base models
+under supply-chain SFT delivery, and demonstrate the attack generalises to
+alternative topologies (branch-and-merge) and alternative persistent components
+(note-tool in place of memory).
+
+*This cross-session variant was identified in external analysis by
+[Dai et al.](https://arxiv.org/abs/2605.06158) (preprint, May 2026).*
+
 **Mitigations available today:**
 - Use **content policies** with blocked patterns (regex) to catch PII in outputs
 - Use **PromptDefenseEvaluator** to test for prompt injection vulnerabilities
@@ -26,7 +40,8 @@ actions are individually permitted.
 - Use **max_tool_calls** limits to cap action sequences
 
 **What we're building:**
-- **Workflow-level policies** that evaluate action *sequences*, not just individual actions
+- **Workflow-level policies** that evaluate action *sequences*, including cross-session
+  sequences under persistent memory, not just individual actions
 - **Intent declaration** where agents declare what they plan to do before doing it,
   and the policy engine validates the plan
 

--- a/docs/OWASP-COMPLIANCE.md
+++ b/docs/OWASP-COMPLIANCE.md
@@ -162,6 +162,13 @@ ai_bom = {
 
 **Component:** [Agent OS](https://github.com/microsoft/agent-governance-toolkit) — VFS, CMVK verification, MCP proxy sanitizer
 
+> **Scope:** The controls above address content-level memory poisoning — external
+> content corruption of memory the model later reads. See
+> [LIMITATIONS §1](LIMITATIONS.md#1-action-governance-not-reasoning-governance)
+> for the workflow-correlation gap: sequences of individually-allowed actions,
+> including cross-session sequences under persistent memory, are not currently
+> correlated.
+
 ---
 
 ### ASI-07: Insecure Inter-Agent Communication


### PR DESCRIPTION
Closes #2374

## Summary

- **LIMITATIONS §1** — added a cross-session variant paragraph explaining how persistent memory or persistent tools (notes, files, calendar) carry attack state across session boundaries under permission isolation. Each session's individual actions remain policy-permitted; the full attack chain only resolves across the session sequence. Cited Dai et al. (arXiv:2605.06158, May 2026). Updated the "What we're building" bullet to explicitly include cross-session sequences.

- **OWASP-COMPLIANCE ASI-06** — added a scope note clarifying that the existing controls address content-level memory poisoning only, and cross-referencing LIMITATIONS §1 for the workflow-correlation gap so readers of the coverage table get an accurate picture.

## Changes

- `docs/LIMITATIONS.md` — new paragraph + citation after the existing "Example gap", updated roadmap bullet
- `docs/OWASP-COMPLIANCE.md` — scope note blockquote at end of ASI-06 section

## Test plan

- [ ] Verify markdown renders correctly in the docs site (mkdocs-material)
- [ ] Confirm LIMITATIONS §1 anchor link in OWASP-COMPLIANCE resolves correctly
- [ ] No broken links introduced