### PR TITLE
feat: add cedarling-agentmesh community integration and runnable example

### DIFF
--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/LICENSE
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/README.md
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/README.md
@@ -1,0 +1,95 @@
+# Cedarling AgentMesh
+
+Community integration package — connects [Cedarling](https://github.com/JanssenProject/jans/tree/main/jans-cedarling)
+to AGT's `ExternalPolicyBackend` contract without modifying AGT core.
+
+> **Community integration.** This package is maintained outside of `agent-os-kernel`
+> so that Cedarling remains a fully optional, zero-impact dependency.
+
+## Installation
+
+```bash
+# AGT integration adapter (required)
+pip install cedarling_agentmesh
+
+# Cedarling Python bindings (optional — fastest evaluation)
+pip install cedarling_python
+
+# Or point the backend at an existing Cedarling HTTP service — no extra package.
+```
+
+## Architecture
+
+```
+Your agent code
+    │
+    ▼
+PolicyEvaluator (agent-os-kernel)
+    │  add_backend()
+    ▼
+CedarlingBackend          ← this package
+    │
+    ├── cedarling_python  (in-process, optional)
+    └── HTTP service      (optional)
+```
+
+`agent-os-kernel` never imports this package. The integration is one-way.
+
+## Quick Start
+
+```python
+from agent_os.policies import PolicyEvaluator
+from cedarling_agentmesh import CedarlingBackend
+
+evaluator = PolicyEvaluator()
+evaluator.add_backend(
+    CedarlingBackend(
+        bootstrap_config={
+            "application_name": "my-agent",
+            "policy_store_uri": "https://example.com/cedarling/policies",
+        }
+    )
+)
+
+decision = evaluator.evaluate({"tool_name": "read_data", "agent_id": "agent-1"})
+print(decision.allowed)   # True / False
+```
+
+HTTP service mode and JWT token forwarding:
+
+```python
+# HTTP service (no cedarling_python required)
+evaluator.add_backend(
+    CedarlingBackend(
+        cedarling_url="http://cedarling.internal:8080",
+        mode="http",
+    )
+)
+
+# OIDC/JWT-aware evaluation
+evaluator.add_backend(
+    CedarlingBackend(
+        bootstrap_config={"application_name": "my-agent", "policy_store_uri": "..."},
+        tokens={"access_token": "eyJhbGciOiJSUzI1NiJ9..."},
+    )
+)
+```
+
+## Evaluation Modes
+
+| Mode | Behaviour |
+|------|-----------|
+| `"auto"` (default) | Python bindings → HTTP (if `cedarling_url` set) → safe denial |
+| `"python"` | Requires `cedarling_python` |
+| `"http"` | Requires `cedarling_url`; no Python extras needed |
+
+## Context Mapping
+
+| AGT context key | Cedarling field |
+|-----------------|-----------------|
+| `agent_id` | `principal` entity id |
+| `tool_name` | `action` (PascalCase, e.g. `"ReadData"`) |
+| `resource` | `resource` entity id |
+| all other keys | Cedar `context` attributes |
+
+`request_id` and `diagnostics` from Cedarling are available in `BackendDecision.raw_result`.

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/SECURITY.md
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/SECURITY.md
@@ -1,0 +1,17 @@
+# Security
+
+This package is part of the [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+## Reporting Vulnerabilities
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting, please follow the guidance at the root repository:
+https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md
+
+Or review Microsoft's security reporting guidance at:
+https://aka.ms/SECURITY.md
+
+## Security Advisories
+
+See the [root SECURITY.md](https://github.com/microsoft/agent-governance-toolkit/blob/main/SECURITY.md#security-advisories) for all published advisories.

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/__init__.py
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""cedarling-agentmesh: Cedarling policy backend for AGT.
+
+Community integration package — connects Cedarling to AGT's
+ExternalPolicyBackend contract without modifying AGT core.
+
+Usage::
+
+    from agent_os.policies import PolicyEvaluator
+    from cedarling_agentmesh import CedarlingBackend
+
+    evaluator = PolicyEvaluator()
+    evaluator.add_backend(CedarlingBackend(
+        bootstrap_config={"policy_store_uri": "https://..."},
+    ))
+    decision = evaluator.evaluate({"tool_name": "read_data", "agent_id": "a1"})
+"""
+
+from cedarling_agentmesh.backend import CedarlingBackend
+
+__all__ = ["CedarlingBackend"]
+
+__version__ = "3.5.0"

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/backend.py
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/backend.py
@@ -1,0 +1,269 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""CedarlingBackend — Cedarling policy adapter for AGT.
+
+Implements the ExternalPolicyBackend protocol (name + evaluate) so that
+Cedarling authorization decisions flow seamlessly into AGT's PolicyEvaluator
+pipeline without modifying AGT core.
+
+``cedarling_python`` is optional. The backend falls back to HTTP when the
+bindings are absent, and fails safe with a denial when neither is configured.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional
+
+from agent_os.policies import BackendDecision
+
+logger = logging.getLogger(__name__)
+
+
+def _tool_to_cedar_action(tool_name: str) -> str:
+    """Convert a snake_case tool name to PascalCase for Cedar action naming.
+
+    Examples::
+
+        "read_data"    -> "ReadData"
+        "send_message" -> "SendMessage"
+        "query"        -> "Query"
+    """
+    return "".join(part.capitalize() for part in tool_name.split("_"))
+
+
+class CedarlingBackend:
+    """AGT policy backend that delegates decisions to Cedarling.
+
+    Implements the ``ExternalPolicyBackend`` protocol — exposes ``name`` and
+    ``evaluate(context) -> BackendDecision`` — so it can be registered with
+    ``PolicyEvaluator.add_backend()`` without any changes to AGT core.
+
+    Modes:
+        ``"auto"``   — cedarling_python if installed, else HTTP if url set,
+                       else safe denial.
+        ``"python"`` — cedarling_python bindings only (ImportError if absent).
+        ``"http"``   — HTTP service only (requires ``cedarling_url``).
+    """
+
+    def __init__(
+        self,
+        bootstrap_config: Optional[dict[str, Any]] = None,
+        application_name: str = "agent-governance-toolkit",
+        tokens: Optional[dict[str, str]] = None,
+        principal_entity_type: str = "Agent",
+        resource_entity_type: str = "Resource",
+        action_namespace: str = "Action",
+        cedarling_url: Optional[str] = None,
+        mode: Literal["auto", "python", "http"] = "auto",
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        cfg: dict[str, Any] = dict(bootstrap_config) if bootstrap_config else {}
+        cfg.setdefault("application_name", application_name)
+        self._bootstrap_config = cfg
+        self._tokens = tokens or {}
+        self._principal_entity_type = principal_entity_type
+        self._resource_entity_type = resource_entity_type
+        self._action_namespace = action_namespace
+        self._cedarling_url = cedarling_url.rstrip("/") if cedarling_url else None
+        self._mode = mode
+        self._timeout = timeout_seconds
+        self._python_available: Optional[bool] = None  # lazily resolved
+
+    @property
+    def name(self) -> str:
+        return "cedarling"
+
+    def evaluate(self, context: dict[str, Any]) -> BackendDecision:
+        """Evaluate *context* and return a normalized ``BackendDecision``."""
+        start = datetime.now(timezone.utc)
+        try:
+            # Detect cedarling_python availability once, then cache.
+            if self._python_available is None:
+                try:
+                    import cedarling_python  # noqa: F401
+
+                    self._python_available = True
+                except ImportError:
+                    self._python_available = False
+
+            use_python = self._mode == "python" or (
+                self._mode == "auto" and self._python_available
+            )
+            use_http = self._mode == "http" or (
+                self._mode == "auto" and not use_python and self._cedarling_url is not None
+            )
+
+            if use_python:
+                result = self._evaluate_python(context)
+            elif use_http:
+                result = self._evaluate_http(context)
+            else:
+                msg = (
+                    "No Cedarling runtime available. "
+                    "Install cedarling_python or set cedarling_url."
+                )
+                logger.warning(msg)
+                result = self._deny(
+                    msg,
+                    "cedarling_python not installed and cedarling_url not configured",
+                )
+
+            result.evaluation_ms = (
+                datetime.now(timezone.utc) - start
+            ).total_seconds() * 1000
+            return result
+
+        except Exception as exc:
+            elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
+            logger.error("Cedarling evaluation failed: %s", exc)
+            return BackendDecision(
+                allowed=False,
+                action="deny",
+                reason=f"Cedarling evaluation error: {exc}",
+                backend="cedarling",
+                evaluation_ms=elapsed,
+                error=str(exc),
+            )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _deny(self, reason: str, error: str) -> BackendDecision:
+        return BackendDecision(
+            allowed=False,
+            action="deny",
+            reason=reason,
+            backend="cedarling",
+            error=error,
+        )
+
+    def _build_request(self, context: dict[str, Any]) -> dict[str, Any]:
+        """Map AGT context keys to a Cedarling authorization request."""
+        agent_id = str(context.get("agent_id", "anonymous"))
+        tool_name = str(context.get("tool_name", "unknown"))
+        resource_id = str(context.get("resource", "default"))
+        action = _tool_to_cedar_action(tool_name)
+        extra = {
+            k: v
+            for k, v in context.items()
+            if k not in ("agent_id", "tool_name", "resource")
+        }
+        return {
+            "principal": {"type": self._principal_entity_type, "id": agent_id},
+            "action": f'{self._action_namespace}::"{action}"',
+            "resource": {"type": self._resource_entity_type, "id": resource_id},
+            "context": extra,
+        }
+
+    def _evaluate_python(self, context: dict[str, Any]) -> BackendDecision:
+        """Delegate to cedarling_python bindings."""
+        try:
+            import cedarling_python
+        except ImportError as exc:
+            raise ImportError(
+                "cedarling_python is not installed. "
+                "Run `pip install cedarling_python` to use Python-binding mode."
+            ) from exc
+
+        req = self._build_request(context)
+        bootstrap = cedarling_python.BootstrapConfig(**self._bootstrap_config)
+        engine = cedarling_python.Cedarling(bootstrap)
+        resource = cedarling_python.ResourceData(
+            resource_type=req["resource"]["type"],
+            id=req["resource"]["id"],
+            payload=req["context"],
+        )
+        request = cedarling_python.Request(
+            tokens=self._tokens,
+            action=req["action"],
+            resource=resource,
+            context=req["context"],
+        )
+        try:
+            result = engine.authorize(request)
+        except cedarling_python.AuthorizeError as exc:
+            return BackendDecision(
+                allowed=False,
+                action="deny",
+                reason=f"Cedarling authorization error: {exc}",
+                backend="cedarling",
+                error=str(exc),
+                raw_result={"request_id": getattr(exc, "request_id", None)},
+            )
+
+        allowed = result.is_allowed()
+        diagnostics: Optional[dict[str, Any]] = None
+        if hasattr(result, "workload") and result.workload is not None:
+            diagnostics = {"workload": str(result.workload)}
+
+        return BackendDecision(
+            allowed=allowed,
+            action="allow" if allowed else "deny",
+            reason=f"Cedarling: {'allowed' if allowed else 'denied'} (python)",
+            backend="cedarling",
+            raw_result={
+                "request_id": getattr(result, "request_id", None),
+                "diagnostics": diagnostics,
+            },
+        )
+
+    def _evaluate_http(self, context: dict[str, Any]) -> BackendDecision:
+        """Delegate to a Cedarling HTTP service (/cedarling/authorize)."""
+        import urllib.error
+        import urllib.parse
+        import urllib.request
+
+        if not self._cedarling_url:
+            return self._deny(
+                "Cedarling HTTP mode requires cedarling_url",
+                "cedarling_url not configured",
+            )
+
+        parsed = urllib.parse.urlparse(self._cedarling_url)
+        if parsed.scheme not in ("http", "https"):
+            return self._deny(
+                f"Invalid cedarling_url: unsupported scheme {parsed.scheme!r}",
+                f"Unsupported scheme: {parsed.scheme!r}",
+            )
+
+        req = self._build_request(context)
+        payload = json.dumps({"tokens": self._tokens, **req}).encode("utf-8")
+        url = f"{self._cedarling_url}/cedarling/authorize"
+        http_req = urllib.request.Request(  # noqa: S310
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(http_req, timeout=self._timeout) as resp:  # noqa: S310
+                body: dict[str, Any] = json.loads(
+                    resp.read().decode("utf-8", errors="replace")
+                )
+                allowed = bool(body.get("allowed", False))
+                return BackendDecision(
+                    allowed=allowed,
+                    action="allow" if allowed else "deny",
+                    reason=f"Cedarling: {'allowed' if allowed else 'denied'} (http)",
+                    backend="cedarling",
+                    raw_result={
+                        "request_id": body.get("request_id"),
+                        "diagnostics": body.get("diagnostics"),
+                        "body": body,
+                    },
+                )
+        except urllib.error.HTTPError as exc:
+            body_text = exc.read().decode("utf-8", errors="replace")
+            return self._deny(
+                f"Cedarling HTTP error {exc.code}: {body_text[:200]}",
+                f"HTTP {exc.code}",
+            )
+        except TimeoutError:
+            return self._deny("Cedarling HTTP request timed out", "timeout")
+        except Exception as exc:
+            return self._deny(f"Cedarling HTTP connection error: {exc}", str(exc))

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cedarling_agentmesh"
+version = "3.5.0"
+description = "Public Preview. Cedarling policy backend for AGT — community integration package"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.9"
+authors = [
+    { name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" }
+]
+keywords = ["cedarling", "cedar", "agents", "policy", "authorization", "agentmesh", "governance"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "agent-os-kernel>=3.5.0",
+]
+
+[project.optional-dependencies]
+python = ["cedarling_python>=1.0.0"]
+dev = [
+    "pytest>=7.0,<8.0",
+    "ruff>=0.1.0,<1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-governance-toolkit"
+Repository = "https://github.com/microsoft/agent-governance-toolkit"
+Issues = "https://github.com/microsoft/agent-governance-toolkit/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["cedarling_agentmesh"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/test_cedarling_backend.py
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/test_cedarling_backend.py
@@ -1,0 +1,281 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for CedarlingBackend.
+
+No real cedarling_python installation required — tests mock the module.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from cedarling_agentmesh import CedarlingBackend
+
+# =============================================================================
+# Protocol surface
+# =============================================================================
+
+
+class TestProtocol:
+    def test_name(self):
+        assert CedarlingBackend().name == "cedarling"
+
+    def test_evaluate_returns_backend_decision(self):
+        b = CedarlingBackend()
+        d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
+        assert hasattr(d, "allowed")
+        assert hasattr(d, "backend")
+        assert d.backend == "cedarling"
+
+    def test_denied_safely_when_no_runtime(self):
+        b = CedarlingBackend(mode="auto")
+        d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
+        assert d.allowed is False
+        assert d.error is not None
+
+    def test_timing_populated(self):
+        b = CedarlingBackend()
+        d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
+        assert d.evaluation_ms >= 0
+
+
+# =============================================================================
+# Request normalization
+# =============================================================================
+
+
+class TestRequestMapping:
+    """Verify AGT context → Cedar request mapping via HTTP round-trip capture."""
+
+    def _capture_http(self, b: CedarlingBackend, context: dict) -> dict:
+        """Evaluate via HTTP mode; return the decoded Cedar request payload."""
+        captured: dict = {}
+
+        def _fake_urlopen(request, timeout):
+            captured["payload"] = json.loads(request.data.decode("utf-8"))
+            return _http_resp(True)
+
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            b.evaluate(context)
+
+        return captured.get("payload", {})
+
+    def test_tool_name_to_pascal_case(self):
+        b = CedarlingBackend(cedarling_url="http://x", mode="http")
+        payload = self._capture_http(b, {"tool_name": "read_data", "agent_id": "a1"})
+        assert '"ReadData"' in payload["action"]
+
+    def test_single_word_tool(self):
+        b = CedarlingBackend(cedarling_url="http://x", mode="http")
+        payload = self._capture_http(b, {"tool_name": "query", "agent_id": "a"})
+        assert '"Query"' in payload["action"]
+
+    def test_agent_id_becomes_principal(self):
+        b = CedarlingBackend(cedarling_url="http://x", mode="http")
+        payload = self._capture_http(b, {"tool_name": "call", "agent_id": "agent-42"})
+        assert payload["principal"]["id"] == "agent-42"
+
+    def test_resource_mapped(self):
+        b = CedarlingBackend(cedarling_url="http://x", mode="http")
+        payload = self._capture_http(
+            b, {"tool_name": "r", "agent_id": "a", "resource": "db-1"}
+        )
+        assert payload["resource"]["id"] == "db-1"
+
+    def test_extra_keys_go_to_context(self):
+        b = CedarlingBackend(cedarling_url="http://x", mode="http")
+        payload = self._capture_http(
+            b, {"tool_name": "read", "agent_id": "a", "env": "prod"}
+        )
+        assert payload["context"]["env"] == "prod"
+
+    def test_defaults_for_missing_keys(self):
+        b = CedarlingBackend(cedarling_url="http://x", mode="http")
+        payload = self._capture_http(b, {})
+        assert payload["principal"]["id"] == "anonymous"
+        assert payload["resource"]["id"] == "default"
+
+    def test_custom_namespace(self):
+        b = CedarlingBackend(cedarling_url="http://x", mode="http", action_namespace="MyNS")
+        payload = self._capture_http(b, {"tool_name": "act", "agent_id": "a"})
+        assert payload["action"].startswith("MyNS::")
+
+    def test_custom_entity_types(self):
+        b = CedarlingBackend(
+            cedarling_url="http://x",
+            mode="http",
+            principal_entity_type="User",
+            resource_entity_type="File",
+        )
+        payload = self._capture_http(b, {"tool_name": "r", "agent_id": "u1"})
+        assert payload["principal"]["type"] == "User"
+        assert payload["resource"]["type"] == "File"
+
+
+# =============================================================================
+# Python binding mode
+# =============================================================================
+
+
+def _make_cedarling_python(allowed: bool) -> MagicMock:
+    """Minimal cedarling_python mock."""
+    mod = MagicMock()
+    result = MagicMock()
+    result.is_allowed.return_value = allowed
+    result.workload = None
+    mod.Cedarling.return_value.authorize.return_value = result
+    mod.AuthorizeError = Exception
+    return mod
+
+
+class TestPythonMode:
+    def test_allow(self):
+        mod = _make_cedarling_python(allowed=True)
+        with patch.dict("sys.modules", {"cedarling_python": mod}):
+            b = CedarlingBackend(mode="python")
+            d = b.evaluate({"tool_name": "read_data", "agent_id": "a1"})
+        assert d.allowed is True
+        assert d.backend == "cedarling"
+        assert "(python)" in d.reason
+
+    def test_deny(self):
+        mod = _make_cedarling_python(allowed=False)
+        with patch.dict("sys.modules", {"cedarling_python": mod}):
+            b = CedarlingBackend(mode="python")
+            d = b.evaluate({"tool_name": "write", "agent_id": "a1"})
+        assert d.allowed is False
+        assert "denied" in d.reason
+
+    def test_timing_nonzero_path(self):
+        mod = _make_cedarling_python(allowed=True)
+        with patch.dict("sys.modules", {"cedarling_python": mod}):
+            b = CedarlingBackend(mode="python")
+            d = b.evaluate({"tool_name": "q", "agent_id": "a"})
+        assert d.evaluation_ms >= 0
+
+    def test_python_available_cached(self):
+        """Once _python_available is set, evaluate must not re-probe."""
+        b = CedarlingBackend(mode="auto")
+        b._python_available = False  # pre-set; no cedarling_url → safe denial
+        import builtins
+
+        original = builtins.__import__
+        calls: list[str] = []
+
+        def tracking_import(name, *args, **kwargs):
+            if name == "cedarling_python":
+                calls.append(name)
+            return original(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=tracking_import):
+            b.evaluate({"tool_name": "x", "agent_id": "a"})
+
+        assert "cedarling_python" not in calls
+
+    def test_missing_package_returns_denial(self):
+        """ImportError from missing cedarling_python is caught; returns denial."""
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            b = CedarlingBackend(mode="python")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.allowed is False
+
+
+# =============================================================================
+# HTTP mode
+# =============================================================================
+
+
+def _http_resp(allowed: bool, request_id: str = "req-1") -> MagicMock:
+    body = json.dumps({"allowed": allowed, "request_id": request_id}).encode()
+    resp = MagicMock()
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    resp.read.return_value = body
+    return resp
+
+
+class TestHTTPMode:
+    def test_allow(self):
+        with patch("urllib.request.urlopen", return_value=_http_resp(True)):
+            b = CedarlingBackend(cedarling_url="http://cedarling.internal:8080", mode="http")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.allowed is True
+        assert "(http)" in d.reason
+
+    def test_deny(self):
+        with patch("urllib.request.urlopen", return_value=_http_resp(False)):
+            b = CedarlingBackend(cedarling_url="http://cedarling.internal:8080", mode="http")
+            d = b.evaluate({"tool_name": "write", "agent_id": "a"})
+        assert d.allowed is False
+
+    def test_request_id_in_raw_result(self):
+        with patch("urllib.request.urlopen", return_value=_http_resp(True, "abc-123")):
+            b = CedarlingBackend(cedarling_url="http://x", mode="http")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.raw_result["request_id"] == "abc-123"
+
+    def test_no_url_returns_denial(self):
+        b = CedarlingBackend(mode="http")
+        d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.allowed is False
+        assert d.error is not None
+
+    def test_bad_scheme_returns_denial(self):
+        b = CedarlingBackend(cedarling_url="ftp://bad.example.com", mode="http")
+        d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.allowed is False
+        assert d.error is not None
+        assert "Unsupported scheme" in d.error
+
+    def test_http_error_returns_denial(self):
+        import urllib.error
+
+        err = urllib.error.HTTPError(
+            url="http://x",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,
+            fp=MagicMock(read=lambda: b"denied"),
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            b = CedarlingBackend(cedarling_url="http://x", mode="http")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.allowed is False
+        assert "403" in d.reason
+
+    def test_timeout_returns_denial(self):
+        with patch("urllib.request.urlopen", side_effect=TimeoutError()):
+            b = CedarlingBackend(cedarling_url="http://x", mode="http")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.allowed is False
+        assert "timeout" in (d.error or "").lower() or "timed out" in d.reason.lower()
+
+
+# =============================================================================
+# Auto mode routing
+# =============================================================================
+
+
+class TestAutoMode:
+    def test_uses_python_when_available(self):
+        mod = _make_cedarling_python(allowed=True)
+        with patch.dict("sys.modules", {"cedarling_python": mod}):
+            b = CedarlingBackend(mode="auto")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert "(python)" in d.reason
+
+    def test_falls_back_to_http_when_python_absent(self):
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            with patch("urllib.request.urlopen", return_value=_http_resp(True)):
+                b = CedarlingBackend(
+                    cedarling_url="http://cedarling.internal:8080", mode="auto"
+                )
+                d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert "(http)" in d.reason
+
+    def test_safe_denial_when_nothing_configured(self):
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            b = CedarlingBackend(mode="auto")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a"})
+        assert d.allowed is False

--- a/examples/cedarling-governed/README.md
+++ b/examples/cedarling-governed/README.md
@@ -1,0 +1,33 @@
+# Cedarling Governed Agent
+
+Demonstrates how to integrate [Cedarling](https://github.com/JanssenProject/jans/tree/main/jans-cedarling)
+with AGT's `PolicyEvaluator` using the `cedarling-agentmesh` community integration package.
+
+AGT core is not modified. The integration is registered as an external backend.
+
+## Run
+
+```bash
+pip install agent-os-kernel cedarling_agentmesh
+python example.py
+```
+
+Optional — enable in-process Cedarling evaluation:
+
+```bash
+pip install cedarling_python
+python example.py
+```
+
+Or point at an existing Cedarling HTTP service:
+
+```bash
+CEDARLING_URL=http://cedarling.internal:8080 python example.py
+```
+
+## What it shows
+
+- `CedarlingBackend` registered with `PolicyEvaluator.add_backend()`
+- Auto-mode runtime selection (Python → HTTP → safe denial)
+- Normalized `BackendDecision` output with timing and diagnostics
+- Zero modifications to `agent-os-kernel`

--- a/examples/cedarling-governed/example.py
+++ b/examples/cedarling-governed/example.py
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Cedarling + AGT policy evaluation example.
+
+Demonstrates how CedarlingBackend integrates with AGT's PolicyEvaluator
+as an external backend — without modifying AGT core.
+
+Run:
+    pip install agent-os-kernel cedarling_agentmesh
+    python example.py
+
+To use real Cedarling evaluation, also install the Python bindings:
+    pip install cedarling_python
+
+Or set CEDARLING_URL to point at an existing Cedarling HTTP service.
+"""
+
+from __future__ import annotations
+
+import os
+
+from agent_os.policies import PolicyEvaluator
+from cedarling_agentmesh import CedarlingBackend
+
+# ---------------------------------------------------------------------------
+# Configure the backend
+# ---------------------------------------------------------------------------
+
+# The backend selects its runtime automatically:
+#   1. cedarling_python bindings (if installed)
+#   2. HTTP service at CEDARLING_URL (if set)
+#   3. Safe denial with a clear error message (if neither is available)
+
+cedarling_url = os.environ.get("CEDARLING_URL")
+
+backend = CedarlingBackend(
+    bootstrap_config={
+        "application_name": "cedarling-governed-example",
+        "policy_store_uri": os.environ.get(
+            "POLICY_STORE_URI",
+            "https://example.com/cedarling/policies",
+        ),
+    },
+    cedarling_url=cedarling_url,
+    mode="auto",
+)
+
+# ---------------------------------------------------------------------------
+# Build the evaluator and register the backend
+# ---------------------------------------------------------------------------
+
+evaluator = PolicyEvaluator()
+evaluator.add_backend(backend)
+
+# ---------------------------------------------------------------------------
+# Evaluate tool calls
+# ---------------------------------------------------------------------------
+
+test_cases = [
+    {"tool_name": "read_data",    "agent_id": "agent-analyst",  "resource": "reports"},
+    {"tool_name": "write_record", "agent_id": "agent-writer",   "resource": "db"},
+    {"tool_name": "delete_file",  "agent_id": "agent-untrusted","resource": "system"},
+]
+
+print(f"Cedarling backend: {backend.name!r}")
+print(f"Runtime: cedarling_url={cedarling_url or '(none)'}")
+print()
+
+for ctx in test_cases:
+    decision = evaluator.evaluate(ctx)
+    status = "ALLOW" if decision.allowed else "DENY "
+    print(f"[{status}] {ctx['agent_id']} → {ctx['tool_name']}")
+    print(f"         reason : {decision.reason}")
+    print(f"         backend: {decision.backend}  timing: {decision.evaluation_ms:.1f}ms")
+    if decision.error:
+        print(f"         error  : {decision.error}")
+    print()

--- a/examples/cedarling-governed/requirements.txt
+++ b/examples/cedarling-governed/requirements.txt
@@ -1,0 +1,5 @@
+agent-os-kernel>=3.5.0
+cedarling_agentmesh>=3.5.0
+
+# Optional — enables in-process cedarling_python evaluation (fastest)
+# cedarling_python>=1.0.0


### PR DESCRIPTION
## Description

Adds `cedarling-agentmesh`, a community integration package connecting the [Janssen Project's Cedarling](https://github.com/JanssenProject/jans/tree/main/jans-cedarling) Cedar policy engine to AGT's `ExternalPolicyBackend` protocol, plus a self-contained runnable example under `examples/cedarling-governed/`.

Scoped as a community integration in `agentmesh-integrations/` — no changes to any AGT core package.

### What's included

| Path | Purpose |
|------|---------|
| `agentmesh-integrations/cedarling-agentmesh/` | `cedarling_agentmesh` v3.5.0 package |
| `cedarling_agentmesh/backend.py` | `CedarlingBackend` — implements `ExternalPolicyBackend` |
| `tests/test_cedarling_backend.py` | 27 tests: protocol, request mapping, python/http/auto modes, timing, safe denial |
| `examples/cedarling-governed/` | Runnable end-to-end governance example |

### Architecture

```
CedarlingBackend.evaluate(context)
  ├── mode="python"  →  cedarling_python bindings (optional extra)
  ├── mode="http"    →  urllib HTTPS call to Cedarling sidecar
  └── mode="auto"    →  python if available, else http, else safe denial
```

`agent-os-kernel` is a required dependency because `CedarlingBackend` returns `BackendDecision` and implements the `ExternalPolicyBackend` protocol defined there. `cedarling_python` is optional: `pip install cedarling_agentmesh[python]`.


## Related Issues

Closes #2245

---

> @imran-siddique — whenever you get a chance, would really appreciate your review. Happy to adjust scope, naming, or architecture based on your feedback. No rush at all!
