### PR TITLE
fix: replace fake JWT in cedarling README to pass gitleaks

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -36,3 +36,4 @@ bd2e209cd4e1c1fbe49d8383fabd8bb8ba7203cb:packages/agentmesh-integrations/langgra
 2a13c1c56d58a892b018438944db2852c1d6d5c2:packages/agent-os/tests/test_mute_agent.py:stripe-access-token:70
 2a13c1c56d58a892b018438944db2852c1d6d5c2:packages/agent-os/tests/test_mute_agent.py:stripe-access-token:72
 2a13c1c56d58a892b018438944db2852c1d6d5c2:packages/agent-sre/tests/unit/test_capture.py:generic-api-key:60
+2c436227c4b4640ce62c9d61c77a59da412b7ea3:agent-governance-python/agentmesh-integrations/cedarling-agentmesh/README.md:generic-api-key:73

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/README.md
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/README.md
@@ -70,7 +70,7 @@ evaluator.add_backend(
 evaluator.add_backend(
     CedarlingBackend(
         bootstrap_config={"application_name": "my-agent", "policy_store_uri": "..."},
-        tokens={"access_token": "eyJhbGciOiJSUzI1NiJ9..."},
+        tokens={"access_token": "<your-oidc-jwt>"},
     )
 )
 ```


### PR DESCRIPTION
## Summary
Fixes gitleaks CI failure on main caused by a JWT-shaped placeholder in the cedarling-agentmesh README.

## Problem
PR #2399 introduced a fake JWT string (eyJhbGciOiJSUzI1NiJ9...) in a code example that triggered the generic-api-key gitleaks rule.

## Changes
| File | Change |
|------|--------|
| .gitleaksignore | Added fingerprint for the historical commit |
| cedarling-agentmesh/README.md | Replaced fake JWT with \<your-oidc-jwt>\ placeholder |

## Testing
Gitleaks should pass since both the source and the historical fingerprint are addressed.
