### PR TITLE
docs: rewrite README for clarity and completeness

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 
 <p align="center">
   <strong>
-    📖 <a href="https://microsoft.github.io/agent-governance-toolkit">Documentation Site</a> ·
-    🚀 <a href="#get-started-in-90-seconds">Quick Start</a> ·
+    📖 <a href="https://microsoft.github.io/agent-governance-toolkit">Docs</a> ·
+    🚀 <a href="#quick-start">Quick Start</a> ·
+    📋 <a href="#specifications">Specifications</a> ·
     📦 <a href="https://pypi.org/project/agent-governance-toolkit/">PyPI</a> ·
     📝 <a href="CHANGELOG.md">Changelog</a>
   </strong>
@@ -18,84 +19,59 @@
 [![PyPI version](https://img.shields.io/pypi/v/agent-governance-toolkit?label=PyPI)](https://pypi.org/project/agent-governance-toolkit/)
 [![npm](https://img.shields.io/npm/v/%40microsoft/agent-governance-sdk?label=npm)](https://www.npmjs.com/package/@microsoft/agent-governance-sdk)
 [![NuGet](https://img.shields.io/nuget/v/Microsoft.AgentGovernance?label=NuGet)](https://www.nuget.org/packages/Microsoft.AgentGovernance)
-[![GitHub stars](https://img.shields.io/github/stars/microsoft/agent-governance-toolkit?style=flat&label=Stars)](https://github.com/microsoft/agent-governance-toolkit)
-[![Contributors](https://img.shields.io/github/contributors/microsoft/agent-governance-toolkit?label=Contributors)](https://github.com/microsoft/agent-governance-toolkit/graphs/contributors)
-[![OWASP Agentic Top 10](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10_Covered-blue)](docs/OWASP-COMPLIANCE.md)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/microsoft/agent-governance-toolkit/badge)](https://scorecard.dev/viewer/?uri=github.com/microsoft/agent-governance-toolkit)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12085/badge)](https://www.bestpractices.dev/projects/12085)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/microsoft/agent-governance-toolkit)
+[![OWASP Agentic Top 10](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10_Covered-blue)](docs/OWASP-COMPLIANCE.md)
 
 > [!IMPORTANT]
-> **Public Preview** — Microsoft-signed, production-quality releases. May have breaking changes before GA.
-> [Open a GitHub issue](https://github.com/microsoft/agent-governance-toolkit/issues) for feedback.
+> **Public Preview** -- production-quality, Microsoft-signed releases. May have breaking changes before GA.
 
-> [!TIP]
-> **v3.7.0 is out!** Latest release with formal RFC 2119 specifications, 25 ADRs, Tool Usage Policies for agent-spec, and governance hardening. [Changelog →](CHANGELOG.md)
-
-**Runtime governance for AI agents** -- deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous agents. Covers all **10 OWASP Agentic risks** with **13,000+ tests**.
-
-**Works with any stack** — AWS Bedrock, Google ADK, Azure AI, LangChain, CrewAI, AutoGen, OpenAI Agents, and 20+ more. Python · TypeScript · .NET · Rust · Go.
-
----
-
-## What This Is (and Isn't)
-
-**What it does:** Sits between your agent framework and the actions agents take. Every tool call, resource access, and inter-agent message is evaluated against policy *before* execution. Deterministic — not probabilistic.
-
-**What it doesn't do:** This is not a prompt guardrail or content moderation tool. It governs agent *actions*, not LLM inputs/outputs. For model-level safety, see [Azure AI Content Safety](https://learn.microsoft.com/azure/ai-services/content-safety/).
+Runtime governance for AI agents. Every tool call, resource access, and inter-agent message is evaluated against policy *before* execution -- deterministic, sub-millisecond, and auditable.
 
 ```
 Agent Action ──► Policy Check ──► Allow / Deny ──► Audit Log    (< 0.1 ms)
 ```
 
-**Why it matters:** Prompt-based safety ("please follow the rules") has a [26.67% policy violation rate](docs/BENCHMARKS.md) in red-team testing. AGT's deterministic application-layer enforcement: **0.00%**.
+Prompt-based safety ("please follow the rules") has a [26.67% policy violation rate](docs/BENCHMARKS.md) in red-team testing. AGT's application-layer enforcement: **0.00%**.
+
+Python · TypeScript · .NET · Rust · Go. Works with LangChain, CrewAI, AutoGen, OpenAI Agents, Google ADK, Semantic Kernel, AWS Bedrock, and [20+ more](#framework-support).
 
 ---
 
-## Get Started in 90 Seconds
+## Quick Start
 
 ```bash
-# 1. Install
 pip install agent-governance-toolkit[full]
-
-# 2. Check your installation
-agt doctor
-
-# 3. Verify OWASP compliance
-agt verify
-
-# 4. Verify runtime evidence, when available
-agt verify --evidence ./agt-evidence.json
-
-# 5. Fail CI on weak runtime evidence
-agt verify --evidence ./agt-evidence.json --strict
-
-# 6. Red-team your agent's security posture
-agt red-team scan ./prompts/ --min-grade B --strict
 ```
 
-Then govern your first action:
-
 ```python
-from agent_os.policies import PolicyEvaluator, PolicyDocument, PolicyRule, PolicyCondition, PolicyAction, PolicyOperator, PolicyDefaults
+from agent_os.policies import (
+    PolicyEvaluator, PolicyDocument, PolicyRule,
+    PolicyCondition, PolicyAction, PolicyOperator, PolicyDefaults
+)
 
 evaluator = PolicyEvaluator(policies=[PolicyDocument(
     name="my-policy", version="1.0",
     defaults=PolicyDefaults(action=PolicyAction.ALLOW),
     rules=[PolicyRule(
         name="block-dangerous-tools",
-        condition=PolicyCondition(field="tool_name", operator=PolicyOperator.IN, value=["execute_code", "delete_file"]),
+        condition=PolicyCondition(
+            field="tool_name",
+            operator=PolicyOperator.IN,
+            value=["execute_code", "delete_file"]
+        ),
         action=PolicyAction.DENY, priority=100,
     )],
 )])
 
 result = evaluator.evaluate({"tool_name": "web_search"})    # ✅ Allowed
-result = evaluator.evaluate({"tool_name": "delete_file"})   # ❌ Blocked deterministically
+result = evaluator.evaluate({"tool_name": "delete_file"})   # ❌ Blocked
 ```
 
 <details>
-<summary><b>TypeScript</b></summary>
+<summary><b>TypeScript / .NET / Rust / Go examples</b></summary>
 
+**TypeScript**
 ```typescript
 import { PolicyEngine } from "@microsoft/agent-governance-sdk";
 
@@ -107,11 +83,7 @@ engine.evaluate("web_search"); // "allow"
 engine.evaluate("shell_exec"); // "deny"
 ```
 
-</details>
-
-<details>
-<summary><b>.NET</b></summary>
-
+**.NET**
 ```csharp
 using AgentGovernance;
 using AgentGovernance.Extensions.ModelContextProtocol;
@@ -121,21 +93,15 @@ var kernel = new GovernanceKernel(new GovernanceOptions
 {
     PolicyPaths = new() { "policies/default.yaml" },
 });
-
 var result = kernel.EvaluateToolCall("did:mesh:agent-1", "web_search",
     new() { ["query"] = "latest AI news" });
-// result.Allowed == true
 
-builder.Services
-    .AddMcpServer()
+// MCP server integration
+builder.Services.AddMcpServer()
     .WithGovernance(options => options.PolicyPaths.Add("policies/mcp.yaml"));
 ```
 
-</details>
-
-<details>
-<summary><b>Rust</b></summary>
-
+**Rust**
 ```rust
 use agent_governance::{AgentMeshClient, ClientOptions};
 
@@ -144,11 +110,7 @@ let result = client.execute_with_governance("data.read", None);
 assert!(result.allowed);
 ```
 
-</details>
-
-<details>
-<summary><b>Go</b></summary>
-
+**Go**
 ```go
 import agentmesh "github.com/microsoft/agent-governance-toolkit/agent-governance-golang"
 
@@ -159,108 +121,148 @@ client, _ := agentmesh.NewClient("my-agent",
     }),
 )
 result := client.ExecuteWithGovernance("data.read", nil)
-// result.Allowed == true
 ```
 
 </details>
 
-> **Full walkthrough:** [quickstart.md](docs/quickstart.md) — zero to governed agents in 10 minutes with YAML policies, OPA/Rego, and Cedar support.
-> 🌍 Also available in: [日本語](docs/i18n/quickstart.ja.md) | [简体中文](docs/i18n/quickstart.zh-CN.md) | [한국어](docs/i18n/quickstart.ko.md)]
+CLI tools:
+
+```bash
+agt doctor                                        # check installation
+agt verify                                        # OWASP compliance check
+agt verify --evidence ./agt-evidence.json --strict # fail CI on weak evidence
+agt red-team scan ./prompts/ --min-grade B         # prompt injection audit
+agt lint-policy policies/                          # validate policy files
+```
+
+Full walkthrough: [quickstart.md](docs/quickstart.md) -- zero to governed agents in 10 minutes with YAML, OPA/Rego, and Cedar policies.
+🌍 Also in: [日本語](docs/i18n/quickstart.ja.md) | [简体中文](docs/i18n/quickstart.zh-CN.md) | [한국어](docs/i18n/quickstart.ko.md)
 
 ---
 
-## What You Get
+## Core Capabilities
 
-| Capability | What It Does | Links |
+### Policy Engine
+Deterministic allow/deny evaluation for every agent action. Sub-millisecond latency (0.012ms p50 for single rule, 35K ops/sec concurrent). Supports YAML, OPA/Rego, and Cedar policy languages. Fail-closed by default -- if the engine errors, the action is denied.
+
+[Agent OS](agent-governance-python/agent-os/) · [Benchmarks](docs/BENCHMARKS.md) · [Spec](docs/specs/AGENT-OS-POLICY-ENGINE-1.0.md)
+
+### Zero-Trust Identity
+Ed25519 + quantum-safe ML-DSA-65 agent credentials. Behavioral trust scoring (0--1000) that decays when agents act outside expected patterns. SPIFFE/SVID compatible. Trust ceilings propagate through delegation chains -- a delegated agent can never exceed its parent's trust level.
+
+[AgentMesh](agent-governance-python/agent-mesh/) · [Spec](docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md)
+
+### Execution Sandboxing
+Four privilege rings (kernel, supervisor, user, untrusted) with hardware-style isolation semantics. Saga orchestration for multi-step workflows with automatic compensation on failure. Kill switch for immediate agent termination.
+
+[Runtime](agent-governance-python/agent-runtime/) · [Hypervisor](agent-governance-python/agent-hypervisor/) · [Spec](docs/specs/AGENT-HYPERVISOR-EXECUTION-CONTROL-1.0.md)
+
+### Agent SRE
+SLOs, error budgets, replay debugging, chaos engineering, and circuit breakers for agent fleets. OTel-native observability with structured governance events.
+
+[Agent SRE](agent-governance-python/agent-sre/) · [Spec](docs/specs/AGENT-SRE-GOVERNANCE-1.0.md)
+
+### Audit and Compliance
+Tamper-evident Merkle-chained audit logs. Reconstructible Decision BOMs from observability signals. Automated compliance mapping for EU AI Act, SOC 2, HIPAA, and GDPR. CloudEvents export for SIEM integration.
+
+[Compliance](agent-governance-python/agent-mesh/src/agentmesh/governance/) · [Spec](docs/specs/AUDIT-COMPLIANCE-1.0.md)
+
+### MCP Security Gateway
+Tool poisoning detection, description drift monitoring, typosquatting checks, and hidden instruction scanning for MCP tool definitions.
+
+[MCP Scanner](agent-governance-python/agent-os/src/agent_os/mcp_security.py) · [Spec](docs/specs/MCP-SECURITY-GATEWAY-1.0.md)
+
+### Additional Capabilities
+
+| Capability | Description |
+|---|---|
+| **Inter-Agent Trust** | Mesh-wide trust negotiation, peer signature verification, coordinated policy enforcement ([Spec](docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md)) |
+| **RL Training Governance** | Violation penalties in reward signals, episode termination on critical violations ([Spec](docs/specs/AGENT-LIGHTNING-FAST-PATH-1.0.md)) |
+| **Framework Adapters** | 10 adapters with unified governance interceptor chain ([Spec](docs/specs/FRAMEWORK-ADAPTER-CONTRACT-1.0.md)) |
+| **Shadow AI Discovery** | Find unregistered agents across processes, configs, and repos ([Discovery](agent-governance-python/agent-discovery/)) |
+| **Agent Lifecycle** | Provisioning, credential rotation, orphan detection, decommissioning ([Lifecycle](agent-governance-python/agent-mesh/src/agentmesh/lifecycle/)) |
+| **Governance Dashboard** | Real-time fleet visibility for health, trust, and compliance ([Dashboard](examples/demos/governance-dashboard/)) |
+| **PromptDefense Evaluator** | 12-vector prompt injection audit ([Evaluator](agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py)) |
+| **Contributor Reputation** | PR/issue author screening for social engineering. Reusable GitHub Action ([Action](.github/actions/contributor-check/)) |
+
+---
+
+## Specifications
+
+Every major component has a formal RFC 2119 specification with conformance tests. These specs define the behavioral contract -- what implementations MUST, SHOULD, and MAY do.
+
+| Specification | Scope | Tests |
 |---|---|---|
-| **Policy Engine** | Every action evaluated before execution — sub-millisecond, deterministic. Supports YAML, OPA/Rego, and Cedar policies | [Agent OS](agent-governance-python/agent-os/) · [Benchmarks](docs/BENCHMARKS.md) |
-| **Contributor Reputation** | Screens PR/issue authors for social engineering: credential laundering, spray patterns, network coordination. Reusable GitHub Action for any repo | [Action](.github/actions/contributor-check/) · [Scripts](scripts/) |
-| **Zero-Trust Identity** | Ed25519 + quantum-safe ML-DSA-65 credentials, trust scoring (0–1000), SPIFFE/SVID | [AgentMesh](agent-governance-python/agent-mesh/) |
-| **Execution Sandboxing** | 4-tier privilege rings, saga orchestration, kill switch | [Runtime](agent-governance-python/agent-runtime/) · [Hypervisor](agent-governance-python/agent-hypervisor/) |
-| **Agent SRE** | SLOs, error budgets, replay debugging, chaos engineering, circuit breakers | [Agent SRE](agent-governance-python/agent-sre/) |
-| **MCP Security Scanner** | Detect tool poisoning, typosquatting, hidden instructions in MCP definitions | [MCP Scanner](agent-governance-python/agent-os/src/agent_os/mcp_security.py) |
-| **Shadow AI Discovery** | Find unregistered agents across processes, configs, and repos | [Agent Discovery](agent-governance-python/agent-discovery/) |
-| **Agent Lifecycle** | Provisioning → credential rotation → orphan detection → decommissioning | [Lifecycle](agent-governance-python/agent-mesh/src/agentmesh/lifecycle/) |
-| **Governance Dashboard** | Real-time fleet visibility — health, trust, compliance, audit events | [Dashboard](examples/demos/governance-dashboard/) |
-| **Unified CLI** | `agt verify`, `agt red-team`, `agt doctor`, `agt lint-policy` — one command for everything | [CLI](agent-governance-python/agent-compliance/src/agent_compliance/cli/agt.py) |
-| **PromptDefense Evaluator** | 12-vector prompt injection audit for compliance testing | [Evaluator](agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py) |
+| [Agent OS Policy Engine](docs/specs/AGENT-OS-POLICY-ENGINE-1.0.md) | Policy evaluation, rule merging, fail-closed semantics | 68 |
+| [AgentMesh Identity and Trust](docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md) | Credentials, trust scoring, delegation chains | 135 |
+| [Agent Hypervisor Execution Control](docs/specs/AGENT-HYPERVISOR-EXECUTION-CONTROL-1.0.md) | Privilege rings, saga orchestration, kill switch | 80 |
+| [AgentMesh Trust and Coordination](docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md) | Peer trust negotiation, mesh-wide policy | 62 |
+| [Agent SRE Governance](docs/specs/AGENT-SRE-GOVERNANCE-1.0.md) | SLOs, error budgets, chaos, circuit breakers | 111 |
+| [MCP Security Gateway](docs/specs/MCP-SECURITY-GATEWAY-1.0.md) | Tool poisoning, drift detection, hidden instructions | 127 |
+| [Agent Lightning Fast-Path](docs/specs/AGENT-LIGHTNING-FAST-PATH-1.0.md) | RL training governance, violation penalties | 100 |
+| [Framework Adapter Contract](docs/specs/FRAMEWORK-ADAPTER-CONTRACT-1.0.md) | 10 adapter integrations, interceptor chain | 152 |
+| [Audit and Compliance](docs/specs/AUDIT-COMPLIANCE-1.0.md) | Merkle audit, compliance mapping, Decision BOM | 157 |
+| [AgentMesh Wire Protocol](docs/specs/AGENTMESH-WIRE-1.0.md) | Message format, routing, serialization | -- |
+
+**992 conformance tests** ensure code stays aligned to specs. [25 Architecture Decision Records](docs/adr/) document why.
 
 ---
 
-## Works With Your Stack
+## Framework Support
 
 | Framework | Integration |
 |-----------|-------------|
 | [**Microsoft Agent Framework**](https://github.com/microsoft/agent-framework) | Native Middleware |
 | [**Semantic Kernel**](https://github.com/microsoft/semantic-kernel) | Native (.NET + Python) |
-| [Microsoft AutoGen](https://github.com/microsoft/autogen) | Adapter |
+| [AutoGen](https://github.com/microsoft/autogen) | Adapter |
 | [LangGraph](https://github.com/langchain-ai/langgraph) / [LangChain](https://github.com/langchain-ai/langchain) | Adapter |
 | [CrewAI](https://github.com/crewAIInc/crewAI) | Adapter |
 | [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | Middleware |
-| GitHub Copilot CLI | Governance installer package |
-| [pi-mono](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | TypeScript SDK Integration |
 | [Google ADK](https://github.com/google/adk-python) | Adapter |
 | [LlamaIndex](https://github.com/run-llama/llama_index) | Middleware |
 | [Haystack](https://github.com/deepset-ai/haystack) | Pipeline |
 | [Dify](https://github.com/langgenius/dify) | Plugin |
 | [Azure AI Foundry](https://learn.microsoft.com/azure/ai-studio/) | Deployment Guide |
+| GitHub Copilot CLI | Governance installer |
 
 Full list: [Framework Integrations](agent-governance-python/agentmesh-integrations/) · [Quickstart Examples](examples/quickstart/)
 
 ---
 
-## OWASP Agentic Top 10 — 10/10 Covered
+## OWASP Agentic Top 10
 
-| Risk | ID | AGT Control |
-|------|----|-------------|
-| Agent Goal Hijacking | ASI-01 | Policy engine blocks unauthorized goal changes |
-| Excessive Capabilities | ASI-02 | Capability model enforces least-privilege |
-| Identity & Privilege Abuse | ASI-03 | Zero-trust identity with Ed25519 + ML-DSA-65 |
-| Uncontrolled Code Execution | ASI-04 | Execution rings + sandboxing |
-| Insecure Output Handling | ASI-05 | Content policies validate all outputs |
-| Memory Poisoning | ASI-06 | Episodic memory with integrity checks |
-| Unsafe Inter-Agent Comms | ASI-07 | Encrypted channels + trust gates |
-| Cascading Failures | ASI-08 | Circuit breakers + SLO enforcement |
-| Human-Agent Trust Deficit | ASI-09 | Full audit trails + flight recorder |
-| Rogue Agents | ASI-10 | Kill switch + ring isolation + anomaly detection |
+AGT covers all 10 risks identified in the [OWASP Agentic Security Top 10](docs/OWASP-COMPLIANCE.md):
 
-Full mapping: [OWASP-COMPLIANCE.md](docs/OWASP-COMPLIANCE.md) · Regulatory alignment: [EU AI Act](docs/compliance/), [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md), [Colorado AI Act](docs/compliance/)
+| Risk | AGT Control |
+|------|-------------|
+| ASI-01 Agent Goal Hijacking | Policy engine blocks unauthorized goal changes |
+| ASI-02 Excessive Capabilities | Capability model enforces least-privilege |
+| ASI-03 Identity & Privilege Abuse | Zero-trust identity with Ed25519 + ML-DSA-65 |
+| ASI-04 Uncontrolled Code Execution | Execution rings + sandboxing |
+| ASI-05 Insecure Output Handling | Content policies validate all outputs |
+| ASI-06 Memory Poisoning | Episodic memory with integrity checks |
+| ASI-07 Unsafe Inter-Agent Comms | Encrypted channels + trust gates |
+| ASI-08 Cascading Failures | Circuit breakers + SLO enforcement |
+| ASI-09 Human-Agent Trust Deficit | Full audit trails + flight recorder |
+| ASI-10 Rogue Agents | Kill switch + ring isolation + anomaly detection |
 
----
-
-## Performance
-
-Governance adds **< 0.1 ms per action** — roughly 10,000× faster than an LLM API call.
-
-| Metric | Latency (p50) | Throughput |
-|---|---|---|
-| Policy evaluation (1 rule) | 0.012 ms | 72K ops/sec |
-| Policy evaluation (100 rules) | 0.029 ms | 31K ops/sec |
-| Policy enforcement | 0.091 ms | 9.3K ops/sec |
-| Concurrent (50 agents) | — | 35,481 ops/sec |
-
-> **Note:** These numbers measure policy evaluation only. In distributed multi-agent
-> deployments, add ~5–50ms for cryptographic verification and mesh handshake on
-> inter-agent messages. See [Limitations — Performance](docs/LIMITATIONS.md#3-performance-policy-eval-vs-end-to-end) for full breakdown.
-
-Full methodology: [BENCHMARKS.md](docs/BENCHMARKS.md)
+Regulatory alignment: [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [SOC 2](docs/compliance/soc2-mapping.md)
 
 ---
 
 ## Install
 
-| Language | Package | Command |
-|----------|---------|---------|
-| **Python** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@microsoft/agent-governance-sdk`](agent-governance-typescript/) | `npm install @microsoft/agent-governance-sdk` |
-| **Copilot CLI** | [`@microsoft/agent-governance-copilot-cli`](agent-governance-copilot-cli/) | `npx @microsoft/agent-governance-copilot-cli install` |
-| **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
-| **.NET MCP** | `Microsoft.AgentGovernance.Extensions.ModelContextProtocol` | `dotnet add package Microsoft.AgentGovernance.Extensions.ModelContextProtocol` |
-| **Rust** | [`agent-governance`](https://crates.io/crates/agent-governance) | `cargo add agent-governance` |
-| **Go** | [`agent-governance-toolkit`](agent-governance-golang/) | `go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang` |
+| Language | Command |
+|----------|---------|
+| **Python** | `pip install agent-governance-toolkit[full]` |
+| **TypeScript** | `npm install @microsoft/agent-governance-sdk` |
+| **Copilot CLI** | `npx @microsoft/agent-governance-copilot-cli install` |
+| **.NET** | `dotnet add package Microsoft.AgentGovernance` |
+| **Rust** | `cargo add agent-governance` |
+| **Go** | `go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang` |
 
-All five language packages implement core governance (policy, identity, trust, audit). Python has the full stack, and the Copilot CLI package is a first-party install surface built on the TypeScript SDK.
-See **[Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md)** for detailed per-language coverage.
+All five languages implement core governance (policy, identity, trust, audit). Python has the full stack.
+See [Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md) for per-language coverage.
 
 <details>
 <summary><b>Individual Python packages</b></summary>
@@ -273,7 +275,7 @@ See **[Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md)** for detailed p
 | Agent SRE | [`agent-sre`](https://pypi.org/project/agent-sre/) | SLOs, error budgets, chaos engineering, circuit breakers |
 | Agent Compliance | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | OWASP verification, integrity checks, policy linting |
 | Agent Discovery | [`agent-discovery`](agent-governance-python/agent-discovery/) | Shadow AI discovery, inventory, risk scoring |
-| Agent Hypervisor | [`agent-hypervisor`](agent-governance-python/agent-hypervisor/) | Reversibility verification, execution plan validation |
+| Agent Hypervisor | [`agent-hypervisor`](agent-governance-python/agent-hypervisor/) | Execution plan validation, reversibility verification |
 | Agent Marketplace | [`agentmesh-marketplace`](agent-governance-python/agent-marketplace/) | Plugin lifecycle management |
 | Agent Lightning | [`agentmesh-lightning`](agent-governance-python/agent-lightning/) | RL training governance |
 
@@ -281,56 +283,11 @@ See **[Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md)** for detailed p
 
 ---
 
-## Documentation
+## Security
 
-**Getting Started**
-- [Quick Start](docs/quickstart.md) — Zero to governed agents in 10 minutes
-- [Tutorials](docs/tutorials/) — 40+ numbered tutorials + 7-chapter Policy-as-Code deep dive
-- [FAQ](docs/FAQ.md) — Technical Q&A for customers, partners, and evaluators
+AGT enforces governance at the Python middleware layer, not at the OS kernel level. The policy engine and agents share the same process boundary.
 
-**Architecture & Reference**
-- [Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md) — Per-language capability comparison
-- [Architecture](docs/ARCHITECTURE.md) — System design, security model, trust scoring
-- [Architecture Decisions](docs/adr/README.md) — ADR log
-- [Threat Model](docs/THREAT_MODEL.md) — Trust boundaries and STRIDE analysis
-- [API: Agent OS](agent-governance-python/agent-os/README.md) · [AgentMesh](agent-governance-python/agent-mesh/README.md) · [Agent SRE](agent-governance-python/agent-sre/README.md)
-
-**Compliance & Deployment**
-- [Known Limitations](docs/LIMITATIONS.md) — Honest design boundaries and recommended layered defense
-- [OWASP Compliance](docs/OWASP-COMPLIANCE.md) — Full ASI-01 through ASI-10 mapping
-- [Deployment Guides](docs/deployment/README.md) — Azure (AKS, Foundry, Container Apps), AWS (ECS/Fargate), GCP (GKE), Docker Compose
-- [NIST AI RMF Alignment](docs/compliance/nist-ai-rmf-alignment.md) · [EU AI Act](docs/compliance/) · [SOC 2 Mapping](docs/compliance/soc2-mapping.md)
-
-**Extensions**
-- [VS Code Extension](agent-governance-typescript/agent-os-vscode/) · [Framework Integrations](agent-governance-python/agentmesh-integrations/)
-
----
-
-## Repository Layout
-
-```
-agent-governance-toolkit/
-├── agent-governance-python/     # Python SDK (14 packages: agent-os, agent-mesh, etc.)
-├── agent-governance-dotnet/     # .NET SDK (NuGet packages)
-├── agent-governance-typescript/ # TypeScript SDK (npm packages)
-├── agent-governance-rust/       # Rust SDK (crate)
-├── agent-governance-golang/     # Go SDK (module)
-├── agent-governance-copilot-cli/# Copilot CLI governance installer
-├── docs/                        # Documentation site (mkdocs-material)
-├── examples/                    # Runnable examples and policy templates
-├── action/                      # GitHub Actions (governance-attestation, security-scan)
-├── scripts/                     # CI/CD and build tooling
-├── tests/                       # Cross-package smoke and integration tests
-└── [standard files]             # README, LICENSE, CONTRIBUTING, SECURITY, etc.
-```
-
----
-
-## Security (Python middleware), not OS kernel-level isolation. The policy engine and agents run in the same process — the same trust boundary as every Python agent framework.
-
-**Production recommendation:** Run each agent in a separate container for OS-level isolation. See [Architecture — Security Boundaries](docs/ARCHITECTURE.md).
-
-> **📖 [Known Limitations & Design Boundaries](docs/LIMITATIONS.md)** — what AGT does *not* do, honest performance numbers for distributed deployments, and the recommended layered defense architecture.
+**Production recommendation:** Run each agent in a separate container for OS-level isolation. See [Architecture -- Security Boundaries](docs/ARCHITECTURE.md).
 
 | Tool | Coverage |
 |------|----------|
@@ -340,30 +297,39 @@ agent-governance-toolkit/
 | Dependabot | 13 ecosystems |
 | OpenSSF Scorecard | Weekly scoring + SARIF upload |
 
+See [Known Limitations](docs/LIMITATIONS.md) for honest design boundaries and recommended layered defense.
+
+---
+
+## Documentation
+
+| Category | Links |
+|----------|-------|
+| **Getting Started** | [Quick Start](docs/quickstart.md) · [Tutorials](docs/tutorials/) (40+) · [FAQ](docs/FAQ.md) |
+| **Architecture** | [System Design](docs/ARCHITECTURE.md) · [Threat Model](docs/THREAT_MODEL.md) · [ADRs](docs/adr/) (25) |
+| **Specifications** | [All Specs](docs/specs/) (10 formal specs, 992 conformance tests) |
+| **API Reference** | [Agent OS](agent-governance-python/agent-os/README.md) · [AgentMesh](agent-governance-python/agent-mesh/README.md) · [Agent SRE](agent-governance-python/agent-sre/README.md) |
+| **Compliance** | [OWASP](docs/OWASP-COMPLIANCE.md) · [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [SOC 2](docs/compliance/soc2-mapping.md) |
+| **Deployment** | [Azure](docs/deployment/README.md) · [AWS](docs/deployment/README.md) · [GCP](docs/deployment/README.md) · [Docker Compose](docs/deployment/README.md) |
+| **Extensions** | [VS Code](agent-governance-typescript/agent-os-vscode/) · [Framework Integrations](agent-governance-python/agentmesh-integrations/) |
+
 ---
 
 ## Contributing
 
-- [Contributing Guide](CONTRIBUTING.md) · [Community](docs/COMMUNITY.md) · [Security Policy](SECURITY.md) · [Changelog](CHANGELOG.md)
+[Contributing Guide](CONTRIBUTING.md) · [Community](docs/COMMUNITY.md) · [Security Policy](SECURITY.md) · [Changelog](CHANGELOG.md)
 
-**Using AGT?** Add your organization to [ADOPTERS.md](docs/ADOPTERS.md), it helps the project gain momentum and helps others discover real-world use cases.
+**Using AGT?** Add your organization to [ADOPTERS.md](docs/ADOPTERS.md).
 
-## Governance & Standards
-
-AGT follows open governance practices aligned with foundation incubation requirements:
+## Governance
 
 | Document | Purpose |
 |----------|---------|
 | [GOVERNANCE.md](GOVERNANCE.md) | Decision-making, roles, contributor ladder |
 | [CHARTER.md](docs/CHARTER.md) | Technical charter (LF Projects format) |
-| [MAINTAINERS.md](MAINTAINERS.md) | 6 maintainers from 4 organizations |
-| [RELEASE.md](docs/RELEASE.md) | Release process, versioning, registries |
+| [MAINTAINERS.md](MAINTAINERS.md) | Maintainers and organizations |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting and response SLAs |
 | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Microsoft Open Source Code of Conduct |
-| [CONTRIBUTING.md](CONTRIBUTING.md) | DCO, attribution policy, AI-assisted contribution rules |
-| [ADOPTERS.md](docs/ADOPTERS.md) | 9 adopters across production, pilot, and research |
-
-**Standards alignment:** [OWASP Agentic Top 10](docs/OWASP-COMPLIANCE.md) (10/10) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [EU AI Act](docs/compliance/) · [OpenSSF Best Practices](https://www.bestpractices.dev/projects/12085) (100%)
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary

Complete README rewrite. Major changes:

- **Fixed broken Security section** -- was a garbled mid-sentence header
- **New Specifications section** -- showcases all 10 formal specs with 992 conformance tests
- **Reorganized capabilities** -- descriptive sections with spec links instead of a flat table
- **Code-first quick start** -- Python example front and center, other languages collapsed
- **Cleaner structure** -- scannable docs table, streamlined install, trimmed governance boilerplate
- **Removed clutter** -- redundant badges (stars, contributors, DeepWiki), duplicate content