### PR TITLE
fix: add MCP specific re-exports to agent_mcp_governance package

### DIFF
--- a/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
+++ b/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
@@ -2,9 +2,24 @@
 # Licensed under the MIT License.
 """agent_mcp_governance — MCP governance primitives for the Agent Governance Toolkit.
 
-Re-exports the core governance, audit, trust, and monitoring classes from
-``agent-os-kernel`` so that downstream consumers can depend on a single,
-focused package.
+This package provides a focused surface for governing agents that communicate
+over the Model Context Protocol (MCP). It re-exports:
+
+General governance primitives (from ``agent-os``):
+    - GovernanceMiddleware: policy enforcement for agent actions
+    - AuditMiddleware: structured audit logging
+    - TrustGate: inter-agent trust verification
+    - BehaviorMonitor: runtime behavioral anomaly detection
+
+MCP-specific security primitives (from ``agent_os.mcp_security``):
+    - MCPSecurityScanner: scans MCP tool definitions for poisoning, rug pulls,
+      cross-server attacks, and hidden instructions
+    - MCPSecurityConfig: configuration for scanner sensitivity and thresholds
+    - ToolFingerprint: immutable fingerprint of a registered tool definition
+    - ScanResult: result of a single tool scan, including any detected threats
+    - MCPThreat: individual threat record with type, severity, and evidence
+    - MCPThreatType: enumeration of MCP threat categories
+    - MCPSeverity: enumeration of threat severity levels
 """
 
 from __future__ import annotations
@@ -16,10 +31,29 @@ from agent_os.audit.middleware import AuditMiddleware
 from agent_os.trust.gate import TrustGate
 from agent_os.services.behavior_monitor import BehaviorMonitor
 
+from agent_os.mcp_security import (
+    MCPSecurityScanner,
+    MCPSecurityConfig,
+    ToolFingerprint,
+    ScanResult,
+    MCPThreat,
+    MCPThreatType,
+    MCPSeverity,
+)
+
 __all__ = [
     "__version__",
+    # General governance primitives
     "GovernanceMiddleware",
     "AuditMiddleware",
     "TrustGate",
     "BehaviorMonitor",
+    # MCP-specific security primitives
+    "MCPSecurityScanner",
+    "MCPSecurityConfig",
+    "ToolFingerprint",
+    "ScanResult",
+    "MCPThreat",
+    "MCPThreatType",
+    "MCPSeverity",
 ]


### PR DESCRIPTION
Closes #2187

## Summary

The `agent-mcp-governance` package only exposed general governance primitives while the genuinely MCP-specific classes (`MCPSecurityScanner`, `ToolFingerprint`, `ScanResult`, `MCPThreat`, etc.) lived in `agent_os.mcp_security` and were not accessible via this package at all.

This PR implements option 1 from the issue as confirmed by the maintainer (@miyannishar). Added re-exports for all MCP-specific security primitives from `agent_os.mcp_security`, updated the module docstring to clearly describe both groups of exports, and extended `__all__` to include the new symbols.

## Changes

`agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py`
Added MCP security re-exports and updated the docstring.

## Test plan

- [ ] `python -c "from agent_mcp_governance import MCPSecurityScanner, ToolFingerprint, ScanResult, MCPThreat, MCPThreatType, MCPSeverity, MCPSecurityConfig; print('OK')"` passes
- [ ] `python -c "import agent_mcp_governance; print([n for n in dir(agent_mcp_governance) if not n.startswith('_')])"` shows all 11 exported names
- [ ] Existing imports of `GovernanceMiddleware`, `AuditMiddleware`, `TrustGate`, `BehaviorMonitor` remain unaffected