### PR TITLE
fix(installer): vendor SDK even when its exports field omits package.json in agent-governance-copilot-cli installation

### DIFF
--- a/agent-governance-copilot-cli/lib/cli.mjs
+++ b/agent-governance-copilot-cli/lib/cli.mjs
@@ -476,10 +476,33 @@ async function vendorSdkDependencyTree({ destinationExtensionPath, packageRoot }
   try {
     sdkPackageManifestPath = packageRequire.resolve("@microsoft/agent-governance-sdk/package.json");
   } catch {
-    const cliRequire = createRequire(import.meta.url);
-    sdkPackageManifestPath = cliRequire.resolve("@microsoft/agent-governance-sdk/package.json", {
-      paths: [packageRoot],
-    });
+    try {
+      const cliRequire = createRequire(import.meta.url);
+      sdkPackageManifestPath = cliRequire.resolve(
+        "@microsoft/agent-governance-sdk/package.json",
+        { paths: [packageRoot] },
+      );
+    } catch {
+      // Fallback for SDKs whose package.json is not exported via the
+      // `exports` field (older releases / strict resolution). Walk the
+      // standard node_modules layout instead of going through resolve.
+      const candidate = join(
+        packageRoot,
+        "node_modules",
+        "@microsoft",
+        "agent-governance-sdk",
+        "package.json",
+      );
+      if (!existsSync(candidate)) {
+        throw new Error(
+          `Cannot locate @microsoft/agent-governance-sdk/package.json. ` +
+            `Tried require.resolve (both contexts) and filesystem fallback at ${candidate}. ` +
+            `Ensure @microsoft/agent-governance-sdk is installed and that its package.json ` +
+            `exports field includes "./package.json".`,
+        );
+      }
+      sdkPackageManifestPath = candidate;
+    }
   }
   const sdkPackageRoot = dirname(sdkPackageManifestPath);
   const sourceNodeModulesRoot = resolve(sdkPackageRoot, "..", "..");

--- a/agent-governance-typescript/package.json
+++ b/agent-governance-typescript/package.json
@@ -56,7 +56,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "homepage": "https://github.com/microsoft/agent-governance-toolkit/tree/main/agent-governance-typescript"
 }


### PR DESCRIPTION
## Problem

`npx @microsoft/agent-governance-copilot-cli install` fails on Node 18+
with:

> Package subpath './package.json' is not defined by "exports" in
> .../@microsoft/agent-governance-sdk/package.json

The installer (`vendorSdkDependencyTree` in `cli.mjs`) calls
`require.resolve('@microsoft/agent-governance-sdk/package.json')` to
discover the SDK's manifest, but the SDK's `exports` field only exposes
`.`, so Node's strict module resolution rejects the request.

The existing `try/catch` does not help because the catch branch retries
the same resolve, which fails identically.

## Fix

Two complementary changes:

1. **`agent-governance-typescript/package.json`** — add `./package.json`
    to the `exports` field. This is the standard Node idiom (React, Vite,
    Next.js, ESLint all do it) and unblocks every consumer that needs to
    read the SDK manifest.

2. **`agent-governance-copilot-cli/lib/cli.mjs`** — add a filesystem
    fallback so the installer keeps working against older SDK versions
    that still have the restrictive `exports` field (e.g. 3.6.0 which is
    what `npx` resolves on a fresh cache today).

## Repro

     npm cache clean --force
     npx @microsoft/agent-governance-copilot-cli@3.7.0 install

<img width="800" height="183" alt="image" src="https://github.com/user-attachments/assets/7036b970-7f43-4608-8f72-c3fcd234945c" />

Fails before the patch, succeeds after.
## Tested on

- Windows 11, Node 24.13.0, npm 11.6.2
- Tested both the SDK-only fix and the installer-only fix in isolation;
   each independently resolves the failure on fresh `npx` cache.

