### PR TITLE
fix(rust): fsync atomic write parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Rust prompt guard** - added custom configuration and audit interpretation examples, tuned escaped-sequence detection to reduce benign `\x` / `\u` false positives, and switched file-backed audit/federation persistence to compact atomic writes.
+- **Rust file durability** - file-backed audit and federation stores now sync parent directories after successful atomic renames on Unix-like platforms, surfacing directory-sync failures instead of silently claiming durability.
 
 
 ## [3.6.0] - 2026-05-12

--- a/agent-governance-rust/Cargo.lock
+++ b/agent-governance-rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "agentmesh"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "agentmesh-mcp",
  "base64",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "agentmesh-mcp"
-version = "3.6.0"
+version = "3.7.0"
 dependencies = [
  "base64",
  "hmac",

--- a/agent-governance-rust/README.md
+++ b/agent-governance-rust/README.md
@@ -65,6 +65,11 @@ policy evaluation, trust scoring, audit logging, Ed25519 identity, execution rin
 lifecycle management, governance/compliance helpers, reward primitives, and
 control-plane utilities such as kill-switch and SLO helpers.
 
+File-backed audit and federation stores write compact JSON through temp-file
+replacement. On Unix-like platforms, successful renames also sync the parent
+directory and return any sync error instead of claiming durability when the
+directory entry was not persisted.
+
 The crate also exposes `agentmesh::prompt_injection` for deterministic prompt
 guarding in Rust agents. The detector reports typed `InjectionType` and
 `ThreatLevel` values, supports optional canary tokens plus allow/block/custom

--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -34,7 +34,19 @@ fn unix_secs_now() -> u64 {
 
 /// Replaces a file through a synced temp-file write and rename so readers do not observe partial JSON.
 fn write_file_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    write_file_atomic_with_parent_sync(path, contents, sync_parent_directory)
+}
+
+fn write_file_atomic_with_parent_sync<F>(
+    path: &Path,
+    contents: &[u8],
+    sync_parent: F,
+) -> std::io::Result<()>
+where
+    F: FnOnce(&Path) -> std::io::Result<()>,
+{
     let temp_path = atomic_temp_path(path)?;
+    let parent = atomic_parent_path(path);
     let write_result = (|| {
         let mut temp = fs::OpenOptions::new()
             .write(true)
@@ -54,6 +66,25 @@ fn write_file_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> {
         return Err(error);
     }
 
+    sync_parent(parent)
+}
+
+fn atomic_parent_path(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(parent: &Path) -> std::io::Result<()> {
+    fs::File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_parent: &Path) -> std::io::Result<()> {
+    // The Rust standard library does not expose a portable way to open and
+    // fsync a directory on non-Unix targets. Keep those platforms conservative
+    // and portable while Unix gets the stronger directory-entry durability.
     Ok(())
 }
 
@@ -64,10 +95,7 @@ fn atomic_temp_path(path: &Path) -> std::io::Result<PathBuf> {
             "atomic write target must include a file name",
         )
     })?;
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
+    let parent = atomic_parent_path(path);
     let counter = ATOMIC_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
     let process_id = std::process::id();
     let temp_name = format!(
@@ -2223,6 +2251,51 @@ mod tests {
         assert!(
             leaked_temp_files.is_empty(),
             "atomic write leaked temp files after rename failure: {leaked_temp_files:?}"
+        );
+    }
+
+    #[test]
+    fn write_file_atomic_calls_parent_directory_sync_after_rename() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("audit.json");
+        let synced_parents = std::cell::RefCell::new(Vec::new());
+        let target_for_sync = target.clone();
+
+        write_file_atomic_with_parent_sync(&target, br#"{"ok":true}"#, |parent| {
+            assert_eq!(fs::read(&target_for_sync).unwrap(), br#"{"ok":true}"#);
+            synced_parents.borrow_mut().push(parent.to_path_buf());
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(synced_parents.into_inner(), vec![root.path().to_path_buf()]);
+    }
+
+    #[test]
+    fn write_file_atomic_surfaces_parent_directory_sync_error() {
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("audit.json");
+
+        let result = write_file_atomic_with_parent_sync(&target, b"durable", |_parent| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "directory sync failed",
+            ))
+        });
+
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert_eq!(error.to_string(), "directory sync failed");
+        assert_eq!(fs::read(&target).unwrap(), b"durable");
+
+        let leaked_temp_files = fs::read_dir(root.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(".audit.json.") && name.ends_with(".tmp"))
+            .collect::<Vec<_>>();
+        assert!(
+            leaked_temp_files.is_empty(),
+            "atomic write leaked temp files after parent sync failure: {leaked_temp_files:?}"
         );
     }
 

--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -37,6 +37,7 @@ fn write_file_atomic(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     write_file_atomic_with_parent_sync(path, contents, sync_parent_directory)
 }
 
+/// Runs the atomic file replacement with an injectable parent-directory sync hook.
 fn write_file_atomic_with_parent_sync<F>(
     path: &Path,
     contents: &[u8],
@@ -69,17 +70,20 @@ where
     sync_parent(parent)
 }
 
+/// Returns the directory entry that must be synced after an atomic rename.
 fn atomic_parent_path(path: &Path) -> &Path {
     path.parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .unwrap_or_else(|| Path::new("."))
 }
 
+/// Syncs the parent directory so the renamed entry is durable on Unix filesystems.
 #[cfg(unix)]
 fn sync_parent_directory(parent: &Path) -> std::io::Result<()> {
     fs::File::open(parent)?.sync_all()
 }
 
+/// No-ops parent-directory sync where Rust does not expose portable directory fsync.
 #[cfg(not(unix))]
 fn sync_parent_directory(_parent: &Path) -> std::io::Result<()> {
     // The Rust standard library does not expose a portable way to open and
@@ -2219,6 +2223,43 @@ mod tests {
 
         assert_ne!(first, second);
         assert_eq!(first.parent(), Some(Path::new(".")));
+    }
+
+    #[test]
+    fn atomic_parent_path_handles_plain_file_names() {
+        assert_eq!(atomic_parent_path(Path::new("audit.json")), Path::new("."));
+        assert_eq!(
+            atomic_parent_path(Path::new("logs/audit.json")),
+            Path::new("logs")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_parent_path_handles_unix_root_directory() {
+        assert_eq!(atomic_parent_path(Path::new("/")), Path::new("."));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_parent_directory_surfaces_missing_unix_parent() {
+        let root = tempfile::tempdir().unwrap();
+        let missing_parent = root.path().join("missing");
+
+        let result = sync_parent_directory(&missing_parent);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn sync_parent_directory_noops_on_non_unix_targets() {
+        let missing_parent = Path::new("agentmesh-missing-parent-for-non-unix-test");
+
+        let result = sync_parent_directory(missing_parent);
+
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -512,7 +512,7 @@ Key controls:
 
 **Short answer:** Any agent type. AGT is framework-agnostic and vendor-independent by design — the core packages (`agent-os-kernel`, `agentmesh-platform`, etc.) have zero vendor dependencies.
 
-It works with Azure AI Foundry, AWS Bedrock, Google ADK, LangChain, CrewAI, AutoGen, OpenAI Agents, OpenClaw, and 20+ other frameworks. See the full list in the [README](../README.md#works-with-your-stack).
+It works with Azure AI Foundry, AWS Bedrock, Google ADK, LangChain, CrewAI, AutoGen, OpenAI Agents, OpenClaw, and 20+ other frameworks. See the full list in the [README](../README.md#framework-support).
 
 ### How It Works
 

--- a/docs/dependency-audits/2026-05-20-rust-cargo-lock-version-metadata.md
+++ b/docs/dependency-audits/2026-05-20-rust-cargo-lock-version-metadata.md
@@ -1,0 +1,29 @@
+---
+title: Rust Cargo Lockfile Version Metadata Refresh
+last_reviewed: 2026-05-20
+owner: rust-maintainers
+---
+
+# Rust Cargo Lockfile Version Metadata Refresh
+
+## Which Dependencies Changed And Why
+
+- `agent-governance-rust/Cargo.lock` updates the workspace package metadata for
+  `agentmesh` and `agentmesh-mcp` from `3.6.0` to `3.7.0`.
+- No third-party crate dependency was added, removed, or version-bumped by this
+  lockfile change.
+- The refresh keeps the lockfile aligned with the Rust workspace package version
+  while the PR strengthens file-backed audit and federation store durability.
+
+## Security Advisory Relevance
+
+- No CVE, RustSec advisory, or dependency-review finding applies because this
+  change does not alter third-party crate selections.
+- The changed lockfile entries are first-party workspace crates only.
+
+## Breaking Change Risk Assessment
+
+- Risk is low: this is lockfile metadata for first-party workspace package
+  versions, not a dependency graph change.
+- Public Rust APIs and serialized JSON formats are unchanged by the lockfile
+  refresh.


### PR DESCRIPTION
## Summary

Closes #2385.

This strengthens Rust file-backed audit and federation store durability by syncing the parent directory after successful atomic renames on Unix-like platforms.

The change keeps the helper private, preserves existing public APIs and JSON formats, and keeps non-Unix behavior conservative and portable. Parent sync errors are surfaced instead of silently claiming durability when the directory entry sync fails.

## Validation

Rust formatting passed.

Diff whitespace hygiene passed.

Focused governance-support tests passed with 26 tests.

Release Rust workspace build passed.

Clippy passed with warnings denied.

Full release Rust workspace tests passed.

Changed-line spell check and local quality gates passed.

## CLA

I am contributing on behalf of myself and will complete the Microsoft CLA bot flow if requested.