### PR TITLE
fix(ci): diagnose and repair main CI failures

### DIFF
--- a/agent-governance-python/agent-os/extensions/jetbrains/.gitignore
+++ b/agent-governance-python/agent-os/extensions/jetbrains/.gitignore
@@ -1,0 +1,11 @@
+# Gradle build cache and IntelliJ IDEA generated files
+.gradle/
+build/
+local.properties
+
+# IntelliJ IDEA project files
+.idea/
+*.iml
+*.ipr
+*.iws
+out/


### PR DESCRIPTION

The `.gradle/` directory under `agent-governance-python/agent-os/extensions/jetbrains/` is auto-generated by IntelliJ IDEA when it opens the Gradle project. These files (gc.properties, checksum lockfiles, binary caches) are local build state and should not be tracked. The missing `.gitignore` caused them to show as untracked changes on any dev machine running JetBrains IDEs.

---

## Changes so far

- `agent-governance-python/agent-os/extensions/jetbrains/.gitignore` — new file, ignores `.gradle/`, `build/`, `local.properties`, `.idea/`, `*.iml`
