### PR TITLE
feat(agentmesh-integrations): add mycelium-agt — Mycelium Trails backend for AGT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **mycelium-agt** - standalone `agentmesh-integrations/mycelium-agt` package implementing AGT's `EvidenceAnchor` protocol via Mycelium Trails. Every agent action produces a tamper-evident TrailRecord with a deterministic `action_ref` (JCS RFC 8785 + SHA-256) and an optional on-chain anchor (`tx_hash`). Zero new runtime dependencies; live verify endpoint at `https://argentum-api.rgiskard.xyz/trails/verify`. (#2415)
+
 ### Changed
 - **Rust prompt guard** - added custom configuration and audit interpretation examples, tuned escaped-sequence detection to reduce benign `\x` / `\u` false positives, and switched file-backed audit/federation persistence to compact atomic writes.
 

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/README.md
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/README.md
@@ -1,0 +1,95 @@
+# mycelium-agt
+
+> Mycelium Trails backend for AGT — tamper-evident action accountability for autonomous agents.
+
+[![PyPI](https://img.shields.io/pypi/v/mycelium-agt)](https://pypi.org/project/mycelium-agt/)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![argentum-core conformance](https://verify.crestsystems.ai/badge/argentum-core.svg)](https://crestsystems.ai/conformance)
+
+## What it does
+
+Every agent action anchored through `MyceliumBackend` produces a **TrailRecord** with:
+
+- A deterministic `action_ref` (JCS RFC 8785 + SHA-256) any party can independently recompute.
+- An on-chain anchor (`tx_hash`) on Base mainnet or Arbitrum One once the trail transitions to `COMMITTED`.
+- A public verify URL — no authentication required.
+
+## Installation
+
+```bash
+pip install mycelium-agt
+```
+
+## Quick start
+
+```python
+from agent_os.audit import EvidenceCollector
+from mycelium_agt import MyceliumBackend
+
+collector = EvidenceCollector()
+collector.add_backend(MyceliumBackend(
+    agent_id="my-agent-001",
+    mycelium_url="https://argentum-api.rgiskard.xyz",
+))
+
+receipt = collector.record({"action_type": "file:write", "scope": "audit"})
+
+print(receipt.anchored)     # True if trail was submitted
+print(receipt.action_ref)   # 64-char SHA-256 hex
+print(receipt.verify_url)   # public verification URL
+```
+
+## action_ref derivation
+
+`action_ref` is a content-addressed identifier derived from four canonical fields:
+
+```
+preimage  = JCS({
+    "action_type": action_type,
+    "agent_id":    agent_id,
+    "scope":       scope,
+    "timestamp":   "2026-05-15T10:00:00.123Z",  # RFC 3339 UTC, 3-digit ms
+})
+action_ref = SHA-256(preimage) → lowercase hex (64 chars)
+```
+
+Keys are sorted by Unicode code point order (`action_type < agent_id < scope < timestamp`).
+Spec: [docs/spec/action-ref.md](https://github.com/giskard09/argentum-core/blob/main/docs/spec/action-ref.md)
+
+## Verification
+
+```bash
+curl 'https://argentum-api.rgiskard.xyz/trails/verify?agent_id=<id>&action_ref=<ref>'
+```
+
+Live conformance fixtures:
+
+| Status | action_ref |
+|--------|------------|
+| `committed` | `31ddbd9f89f0e54700744addc7fa23f41518cf8c9d63d206e6da5cc3669defdd` |
+| `pending` | `30cce7e7d538d5fb3f60152335b1da47f318425ccec12155efebc8aa8ac1e42a` |
+
+```bash
+# Verify committed fixture
+curl 'https://argentum-api.rgiskard.xyz/trails/verify?agent_id=nobulex-gogani&action_ref=31ddbd9f89f0e54700744addc7fa23f41518cf8c9d63d206e6da5cc3669defdd'
+# {"verified": true, "trail_status": "committed", "tx_hash": "0x7fd0a..."}
+```
+
+## Trail states
+
+| State | `anchored` | `tx_hash` | Meaning |
+|-------|-----------|-----------|---------|
+| `committed` | `True` | non-null | On-chain. Terminal. |
+| `pending` | `True` | non-null or null | In progress. |
+| `failed` | `False` | null | Terminal. No anchor. |
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+```
+
+## License
+
+Apache 2.0 — see [LICENSE](../../../../LICENSE).

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/SECURITY.md
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security issues to **playplay2736@gmail.com** (Mycelium / Giskard team).
+
+Please do **not** open public GitHub issues for security vulnerabilities.
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | Yes       |
+
+## Security model
+
+`mycelium-agt` is a thin HTTP client. It does **not** handle private keys, secrets, or authentication credentials.
+
+- All HTTP calls use `urllib.request` (stdlib only — no third-party HTTP deps in the default install).
+- `action_ref` is a hash of public metadata — it is not a secret.
+- The `verify_url` is a public endpoint; no auth token is embedded.
+
+If your deployment requires mTLS or token-based auth for the Mycelium API, pass a pre-configured `mycelium_url` pointing to an authenticated proxy.

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/mycelium_agt/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/mycelium_agt/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) giskard09 (Rama / Mycelium)
+# Licensed under the Apache License, Version 2.0.
+"""mycelium-agt: Mycelium Trails backend for AGT.
+
+Community integration package — records every agent action as a tamper-evident
+TrailRecord anchored on-chain, implementing AGT's EvidenceAnchor contract
+without modifying AGT core.
+
+Usage::
+
+    from agent_os.audit import EvidenceCollector
+    from mycelium_agt import MyceliumBackend
+
+    collector = EvidenceCollector()
+    collector.add_backend(MyceliumBackend(
+        agent_id="my-agent-001",
+        mycelium_url="https://argentum-api.rgiskard.xyz",
+    ))
+    receipt = collector.record({"action_type": "file:write", "scope": "audit"})
+
+action_ref derivation — JCS (RFC 8785) + SHA-256:
+
+    preimage  = canonicalize({action_type, agent_id, scope, timestamp})
+                → lexicographic key order, no whitespace, UTF-8
+    action_ref = SHA-256(preimage) → lowercase hex (64 chars)
+
+Spec: https://github.com/giskard09/argentum-core/blob/main/docs/spec/action-ref.md
+"""
+
+from mycelium_agt.backend import MyceliumBackend
+
+__all__ = ["MyceliumBackend"]
+
+__version__ = "0.1.0"

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/mycelium_agt/backend.py
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/mycelium_agt/backend.py
@@ -1,0 +1,299 @@
+# Copyright (c) giskard09 (Rama / Mycelium)
+# Licensed under the Apache License, Version 2.0.
+"""MyceliumBackend — Mycelium Trails adapter for AGT.
+
+Implements the EvidenceAnchor protocol so that every agent action produces
+a tamper-evident TrailRecord, independently verifiable without trusting
+the operator's logs or database.
+
+action_ref derivation (JCS RFC 8785 + SHA-256):
+
+    preimage  = JCS({
+        "action_type": action_type,
+        "agent_id":    agent_id,
+        "scope":       scope,
+        "timestamp":   "2026-05-15T10:00:00.123Z",   # RFC 3339 UTC, 3-digit ms
+    })
+    action_ref = SHA-256(preimage) → lowercase hex
+
+The four preimage fields are included in every AnchorReceipt so any party
+can independently recompute and verify the action_ref.
+
+Verification::
+
+    curl 'https://argentum-api.rgiskard.xyz/trails/verify?agent_id=<id>&action_ref=<ref>'
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import logging
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MYCELIUM_URL = "https://argentum-api.rgiskard.xyz"
+
+
+# ---------------------------------------------------------------------------
+# action_ref canonical derivation — JCS RFC 8785 + SHA-256
+# ---------------------------------------------------------------------------
+
+def _jcs_encode(d: dict[str, str]) -> bytes:
+    """RFC 8785 JCS for a flat dict of string values.
+
+    Key ordering is lexicographic Unicode code point order.
+    Non-ASCII above U+001F emitted as literal UTF-8 bytes (RFC 8785 §3.2.3).
+    """
+    return json.dumps(
+        dict(sorted(d.items())),
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _format_timestamp(dt: datetime.datetime) -> str:
+    """RFC 3339 UTC with exactly 3 millisecond digits.
+
+    Output: "2026-05-15T10:00:00.123Z"
+    """
+    ms = dt.microsecond // 1000
+    return dt.strftime(f"%Y-%m-%dT%H:%M:%S.{ms:03d}Z")
+
+
+def compute_action_ref(
+    agent_id: str,
+    action_type: str,
+    scope: str,
+    timestamp: str,
+) -> str:
+    """Derive action_ref from the four canonical preimage fields.
+
+    ``timestamp`` must be RFC 3339 UTC with 3-digit ms precision
+    (e.g. ``"2026-05-15T10:00:00.123Z"``). Use ``_format_timestamp()``
+    to produce it from a datetime object.
+
+    Returns the SHA-256 hex digest (64 lowercase hex characters).
+    """
+    canonical = _jcs_encode({
+        "action_type": action_type,
+        "agent_id": agent_id,
+        "scope": scope,
+        "timestamp": timestamp,
+    })
+    return hashlib.sha256(canonical).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# AnchorReceipt — what the backend returns after recording a trail
+# ---------------------------------------------------------------------------
+
+class AnchorReceipt:
+    """Result of a Mycelium trail anchoring.
+
+    Attributes:
+        anchored:    True if the trail was successfully recorded.
+        action_ref:  SHA-256 content-addressed identifier (independently verifiable).
+        trail_id:    UUID assigned by Mycelium (None on failure).
+        trail_status: "committed" | "pending" | "failed"
+        tx_hash:     On-chain anchor hash (None until anchored).
+        verify_url:  Public URL to verify this trail without authentication.
+        preimage:    The four fields used to derive action_ref — included
+                     so any verifier can independently recompute.
+        error:       Error message on failure (None on success).
+        evaluation_ms: Time taken for the backend call.
+    """
+
+    def __init__(
+        self,
+        anchored: bool,
+        action_ref: str,
+        trail_id: Optional[str] = None,
+        trail_status: str = "failed",
+        tx_hash: Optional[str] = None,
+        verify_url: Optional[str] = None,
+        preimage: Optional[dict[str, str]] = None,
+        error: Optional[str] = None,
+        evaluation_ms: float = 0.0,
+    ) -> None:
+        self.anchored = anchored
+        self.action_ref = action_ref
+        self.trail_id = trail_id
+        self.trail_status = trail_status
+        self.tx_hash = tx_hash
+        self.verify_url = verify_url
+        self.preimage = preimage or {}
+        self.error = error
+        self.evaluation_ms = evaluation_ms
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"AnchorReceipt(anchored={self.anchored}, "
+            f"trail_status={self.trail_status!r}, "
+            f"action_ref={self.action_ref[:16]}...)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# MyceliumBackend
+# ---------------------------------------------------------------------------
+
+class MyceliumBackend:
+    """AGT evidence backend that anchors actions as Mycelium TrailRecords.
+
+    Implements the EvidenceAnchor protocol — exposes ``name`` and
+    ``anchor(context) -> AnchorReceipt`` — so it can be registered with
+    ``EvidenceCollector.add_backend()`` without any changes to AGT core.
+
+    Every action produces a tamper-evident TrailRecord with:
+    - A deterministic ``action_ref`` (JCS RFC 8785 + SHA-256) any party can
+      independently recompute from the four preimage fields.
+    - An on-chain anchor (``tx_hash``) on Base mainnet or Arbitrum One once
+      the trail transitions to COMMITTED.
+
+    Trail states (per guarantee-model spec):
+    - ``committed``  — anchored on-chain. Independently verifiable via tx_hash.
+    - ``pending``    — anchor in progress. tx_hash present or null (degraded).
+    - ``failed``     — terminal. No anchor produced.
+
+    Args:
+        agent_id:      Stable agent identifier (DID, username, or opaque string).
+        mycelium_url:  Mycelium API base URL. Defaults to the public endpoint.
+        service:       Service label for the TrailRecord (default: "agentmesh").
+        timeout_seconds: HTTP timeout per request.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        mycelium_url: str = _DEFAULT_MYCELIUM_URL,
+        service: str = "agentmesh",
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        self._agent_id = agent_id
+        self._base_url = mycelium_url.rstrip("/")
+        self._service = service
+        self._timeout = timeout_seconds
+
+    @property
+    def name(self) -> str:
+        return "mycelium"
+
+    def anchor(self, context: dict[str, Any]) -> AnchorReceipt:
+        """Anchor *context* as a Mycelium TrailRecord.
+
+        Computes action_ref from context fields, submits to the Mycelium API,
+        and returns an AnchorReceipt with full preimage for independent
+        verification.
+        """
+        start = datetime.datetime.now(datetime.timezone.utc)
+        action_type = str(context.get("action_type", "unknown"))
+        scope = str(context.get("scope", ""))
+        ts = _format_timestamp(start)
+        action_ref = compute_action_ref(self._agent_id, action_type, scope, ts)
+        preimage = {
+            "agent_id": self._agent_id,
+            "action_type": action_type,
+            "scope": scope,
+            "timestamp": ts,
+        }
+        verify_url = (
+            f"{self._base_url}/trails/verify"
+            f"?agent_id={urllib.parse.quote(self._agent_id)}"
+            f"&action_ref={action_ref}"
+        )
+
+        try:
+            receipt = self._submit_trail(action_ref, action_type, scope, ts)
+            elapsed = (
+                datetime.datetime.now(datetime.timezone.utc) - start
+            ).total_seconds() * 1000
+            return AnchorReceipt(
+                anchored=receipt.get("trail_id") is not None,
+                action_ref=action_ref,
+                trail_id=receipt.get("trail_id"),
+                trail_status=receipt.get("trail_status", "pending"),
+                tx_hash=receipt.get("tx_hash"),
+                verify_url=verify_url,
+                preimage=preimage,
+                evaluation_ms=elapsed,
+            )
+        except Exception as exc:
+            elapsed = (
+                datetime.datetime.now(datetime.timezone.utc) - start
+            ).total_seconds() * 1000
+            logger.error("Mycelium anchoring failed: %s", exc)
+            return AnchorReceipt(
+                anchored=False,
+                action_ref=action_ref,
+                trail_status="failed",
+                verify_url=verify_url,
+                preimage=preimage,
+                error=str(exc),
+                evaluation_ms=elapsed,
+            )
+
+    def verify(self, action_ref: str) -> dict[str, Any]:
+        """Query the Mycelium verify endpoint for a known action_ref.
+
+        Returns the raw API response. ``verified: true`` means the trail
+        exists; ``tx_hash`` is the on-chain anchor when present.
+
+        Example::
+
+            result = backend.verify("31ddbd9f...")
+            # {"verified": true, "trail_status": "committed", "tx_hash": "0x..."}
+        """
+        url = (
+            f"{self._base_url}/trails/verify"
+            f"?agent_id={urllib.parse.quote(self._agent_id)}"
+            f"&action_ref={action_ref}"
+        )
+        req = urllib.request.Request(url, method="GET")  # noqa: S310
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            return {"verified": False, "error": f"HTTP {exc.code}"}
+        except Exception as exc:
+            return {"verified": False, "error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _submit_trail(
+        self,
+        action_ref: str,
+        action_type: str,
+        scope: str,
+        timestamp: str,
+    ) -> dict[str, Any]:
+        """POST a NEXUS-compatible receipt to /nexus/trail."""
+        payload = json.dumps({
+            "action_ref": action_ref,
+            "service": self._service,
+            "hash_algo": "sha256",
+            "preimage_format": "jcs-rfc8785",
+            "preimage": {
+                "agent_id": self._agent_id,
+                "action_type": action_type,
+                "scope": scope,
+                "ts": timestamp,
+            },
+        }).encode("utf-8")
+
+        url = f"{self._base_url}/nexus/trail"
+        req = urllib.request.Request(  # noqa: S310
+            url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/mycelium_agt/backend.py
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/mycelium_agt/backend.py
@@ -30,10 +30,13 @@ import datetime
 import hashlib
 import json
 import logging
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
 from typing import Any, Optional
+
+_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
 
 logger = logging.getLogger(__name__)
 
@@ -74,12 +77,39 @@ def compute_action_ref(
 ) -> str:
     """Derive action_ref from the four canonical preimage fields.
 
-    ``timestamp`` must be RFC 3339 UTC with 3-digit ms precision
-    (e.g. ``"2026-05-15T10:00:00.123Z"``). Use ``_format_timestamp()``
-    to produce it from a datetime object.
+    Canonical derivation (JCS RFC 8785 + SHA-256):
 
-    Returns the SHA-256 hex digest (64 lowercase hex characters).
+    1. Build a dict of the four fields.
+    2. Serialize with JCS: keys in Unicode code-point order, no whitespace, UTF-8.
+    3. Return ``SHA-256(canonical_bytes)`` as 64 lowercase hex characters.
+
+    Args:
+        agent_id:    Stable agent identifier (DID, username, or opaque string).
+        action_type: Verb that describes the action (e.g. ``"file:write"``).
+        scope:       Resource or context the action targets (may be empty string).
+        timestamp:   RFC 3339 UTC with exactly 3 ms digits: ``"2026-05-15T10:00:00.123Z"``.
+                     Use :func:`_format_timestamp` to produce this from a datetime object.
+
+    Returns:
+        64-character lowercase hex SHA-256 digest.
+
+    Raises:
+        ValueError: If ``timestamp`` does not match the required RFC 3339 format.
+
+    Example::
+
+        ref = compute_action_ref(
+            agent_id="nobulex-gogani",
+            action_type="payment.send",
+            scope="payment:usdc:50",
+            timestamp="2025-05-18T10:00:00.000Z",
+        )
+        # "31ddbd9f89f0e54700744addc7fa23f41518cf8c9d63d206e6da5cc3669defdd"
     """
+    if not _TS_RE.match(timestamp):
+        raise ValueError(
+            f"timestamp must be RFC 3339 UTC with 3-digit ms (e.g. '2026-05-15T10:00:00.123Z'), got: {timestamp!r}"
+        )
     canonical = _jcs_encode({
         "action_type": action_type,
         "agent_id": agent_id,
@@ -94,19 +124,37 @@ def compute_action_ref(
 # ---------------------------------------------------------------------------
 
 class AnchorReceipt:
-    """Result of a Mycelium trail anchoring.
+    """Immutable result of a Mycelium trail anchoring attempt.
+
+    An ``AnchorReceipt`` is returned by :meth:`MyceliumBackend.anchor` for every
+    call, whether or not the HTTP submission succeeded.  Callers should always
+    check :attr:`anchored` before trusting :attr:`trail_id` or :attr:`tx_hash`.
+
+    Independent verification — without trusting this object — is possible because
+    :attr:`preimage` contains the four fields used to derive :attr:`action_ref`:
+
+    .. code-block:: python
+
+        recomputed = compute_action_ref(
+            r.preimage["agent_id"],
+            r.preimage["action_type"],
+            r.preimage["scope"],
+            r.preimage["timestamp"],
+        )
+        assert recomputed == r.action_ref
 
     Attributes:
-        anchored:    True if the trail was successfully recorded.
-        action_ref:  SHA-256 content-addressed identifier (independently verifiable).
-        trail_id:    UUID assigned by Mycelium (None on failure).
-        trail_status: "committed" | "pending" | "failed"
-        tx_hash:     On-chain anchor hash (None until anchored).
-        verify_url:  Public URL to verify this trail without authentication.
-        preimage:    The four fields used to derive action_ref — included
-                     so any verifier can independently recompute.
-        error:       Error message on failure (None on success).
-        evaluation_ms: Time taken for the backend call.
+        anchored:      ``True`` if the trail record was accepted by Mycelium.
+        action_ref:    SHA-256 hex digest of the JCS-canonical preimage (64 chars).
+                       Deterministic — recomputable from :attr:`preimage` fields.
+        trail_id:      UUID assigned by Mycelium; ``None`` on failure.
+        trail_status:  ``"committed"`` | ``"pending"`` | ``"failed"``.
+        tx_hash:       On-chain anchor transaction hash; ``None`` until committed.
+        verify_url:    Public URL to verify this trail without authentication.
+        preimage:      Dict with keys ``agent_id``, ``action_type``, ``scope``,
+                       ``timestamp`` — the four canonical fields.
+        error:         Error message string on failure; ``None`` on success.
+        evaluation_ms: Wall-clock time for the backend HTTP call (milliseconds).
     """
 
     def __init__(
@@ -146,26 +194,37 @@ class AnchorReceipt:
 class MyceliumBackend:
     """AGT evidence backend that anchors actions as Mycelium TrailRecords.
 
-    Implements the EvidenceAnchor protocol — exposes ``name`` and
-    ``anchor(context) -> AnchorReceipt`` — so it can be registered with
+    Implements the ``EvidenceAnchor`` protocol — exposes :attr:`name` and
+    :meth:`anchor` — so it can be registered with
     ``EvidenceCollector.add_backend()`` without any changes to AGT core.
 
     Every action produces a tamper-evident TrailRecord with:
+
     - A deterministic ``action_ref`` (JCS RFC 8785 + SHA-256) any party can
       independently recompute from the four preimage fields.
     - An on-chain anchor (``tx_hash``) on Base mainnet or Arbitrum One once
-      the trail transitions to COMMITTED.
+      the trail transitions to ``COMMITTED``.
 
     Trail states (per guarantee-model spec):
-    - ``committed``  — anchored on-chain. Independently verifiable via tx_hash.
-    - ``pending``    — anchor in progress. tx_hash present or null (degraded).
-    - ``failed``     — terminal. No anchor produced.
+
+    - ``committed`` — anchored on-chain. Independently verifiable via ``tx_hash``.
+    - ``pending``   — anchor in progress. ``tx_hash`` present or ``None`` (degraded).
+    - ``failed``    — terminal. No anchor produced.
+
+    Usage::
+
+        from agent_os.audit import EvidenceCollector
+        from mycelium_agt import MyceliumBackend
+
+        collector = EvidenceCollector()
+        collector.add_backend(MyceliumBackend(agent_id="my-agent-001"))
+        receipt = collector.record({"action_type": "file:write", "scope": "audit"})
 
     Args:
-        agent_id:      Stable agent identifier (DID, username, or opaque string).
-        mycelium_url:  Mycelium API base URL. Defaults to the public endpoint.
-        service:       Service label for the TrailRecord (default: "agentmesh").
-        timeout_seconds: HTTP timeout per request.
+        agent_id:        Stable agent identifier (DID, username, or opaque string).
+        mycelium_url:    Mycelium API base URL. Defaults to the public endpoint.
+        service:         Service label for the TrailRecord (default: ``"agentmesh"``).
+        timeout_seconds: HTTP timeout per request (seconds).
     """
 
     def __init__(

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/pyproject.toml
@@ -1,0 +1,54 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mycelium_agt"
+version = "0.1.0"
+description = "Mycelium Trails backend for AGT — tamper-evident action accountability for autonomous agents"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+requires-python = ">=3.9"
+authors = [
+    { name = "giskard09", email = "playplay2736@gmail.com" }
+]
+keywords = ["mycelium", "trails", "action-ref", "accountability", "agents", "governance", "agentmesh"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "agent-os-kernel>=3.5.0",
+]
+
+[project.optional-dependencies]
+http = ["httpx>=0.24.0"]
+dev = [
+    "pytest>=7.0,<9.0",
+    "ruff>=0.1.0,<1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/giskard09/argentum-core"
+Repository = "https://github.com/giskard09/argentum-core"
+Issues = "https://github.com/giskard09/argentum-core/issues"
+Verification = "https://argentum-api.rgiskard.xyz/trails/verify"
+
+[tool.hatch.build.targets.wheel]
+packages = ["mycelium_agt"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/tests/test_mycelium_backend.py
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/tests/test_mycelium_backend.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import pytest
 from unittest.mock import MagicMock, patch
 
 from mycelium_agt import MyceliumBackend
@@ -65,6 +66,22 @@ class TestActionRefDerivation:
         a = compute_action_ref("agent-1", "file:write", "audit", "2026-05-15T00:00:00.000Z")
         b = compute_action_ref("agent-2", "file:write", "audit", "2026-05-15T00:00:00.000Z")
         assert a != b
+
+    @pytest.mark.parametrize("bad_ts", [
+        "2026-05-15T10:00:00Z",          # missing ms
+        "2026-05-15T10:00:00.1Z",        # 1-digit ms
+        "2026-05-15 10:00:00.123Z",      # space instead of T
+        "2026-05-15T10:00:00.123",       # missing Z
+        "not-a-timestamp",
+    ])
+    def test_invalid_timestamp_raises(self, bad_ts):
+        with pytest.raises(ValueError, match="RFC 3339"):
+            compute_action_ref("agent", "op", "scope", bad_ts)
+
+    def test_empty_scope_is_valid(self):
+        """Empty scope is a legitimate value — must not raise."""
+        ref = compute_action_ref("agent", "op", "", "2026-01-01T00:00:00.000Z")
+        assert len(ref) == 64
 
 
 # =============================================================================
@@ -191,3 +208,33 @@ class TestHTTPAnchoring:
         with patch("urllib.request.urlopen", return_value=mock_resp):
             result = b.verify("31ddbd9f" + "0" * 56)
         assert result["verified"] is True
+
+    def test_verify_http_404_returns_not_verified(self):
+        import urllib.error
+        b = MyceliumBackend(agent_id="test-agent")
+        err = urllib.error.HTTPError(url="u", code=404, msg="Not Found", hdrs={}, fp=None)
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = b.verify("31ddbd9f" + "0" * 56)
+        assert result["verified"] is False
+        assert "404" in result["error"]
+
+    def test_anchor_uses_configured_timeout(self):
+        """MyceliumBackend must forward timeout_seconds to urlopen."""
+        captured: dict = {}
+
+        def _fake_urlopen(request, timeout):
+            captured["timeout"] = timeout
+            return _mock_urlopen_success()
+
+        b = MyceliumBackend(agent_id="test-agent", timeout_seconds=42.0)
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            b.anchor({"action_type": "op", "scope": ""})
+
+        assert captured["timeout"] == 42.0
+
+    def test_anchor_receipt_repr_contains_action_ref_prefix(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("offline")):
+            r = b.anchor({"action_type": "op", "scope": ""})
+        rep = repr(r)
+        assert r.action_ref[:16] in rep

--- a/agent-governance-python/agentmesh-integrations/mycelium-agt/tests/test_mycelium_backend.py
+++ b/agent-governance-python/agentmesh-integrations/mycelium-agt/tests/test_mycelium_backend.py
@@ -1,0 +1,193 @@
+# Copyright (c) giskard09 (Rama / Mycelium)
+# Licensed under the Apache License, Version 2.0.
+"""Tests for MyceliumBackend.
+
+No live Mycelium endpoint required — HTTP calls are intercepted by urllib mocks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from unittest.mock import MagicMock, patch
+
+from mycelium_agt import MyceliumBackend
+from mycelium_agt.backend import AnchorReceipt, compute_action_ref, _jcs_encode
+
+
+# =============================================================================
+# action_ref derivation — JCS RFC 8785 + SHA-256
+# =============================================================================
+
+class TestActionRefDerivation:
+    """Canonical derivation must match AlgoVoi / andysalvo verifier byte-for-byte."""
+
+    def test_known_vector_nexus(self):
+        """NEXUS oracle signal vector — verified by andysalvo verifier (ec7201a)."""
+        ref = compute_action_ref(
+            agent_id="nexus-agent-xa12.onrender.com",
+            action_type="oracle.signal",
+            scope="BTC",
+            timestamp="2025-05-18T11:40:31.000Z",
+        )
+        assert ref == "fdd7f810499f06be24355ca8e2bfb8c4b965cc80c838f41fa074683443d89f5a"
+
+    def test_known_vector_conformance_committed(self):
+        """Conformance fixture COMMITTED vector."""
+        ref = compute_action_ref(
+            agent_id="nobulex-gogani",
+            action_type="payment.send",
+            scope="payment:usdc:50",
+            timestamp="2025-05-18T10:00:00.000Z",
+        )
+        assert ref == "31ddbd9f89f0e54700744addc7fa23f41518cf8c9d63d206e6da5cc3669defdd"
+
+    def test_jcs_key_order_is_lexicographic(self):
+        """Keys must sort by Unicode code point: action_type < agent_id < scope < timestamp."""
+        payload = _jcs_encode({
+            "agent_id": "x",
+            "action_type": "y",
+            "scope": "z",
+            "timestamp": "t",
+        })
+        assert payload == b'{"action_type":"y","agent_id":"x","scope":"z","timestamp":"t"}'
+
+    def test_output_is_64_hex_chars(self):
+        ref = compute_action_ref("a", "b", "c", "2026-01-01T00:00:00.000Z")
+        assert len(ref) == 64
+        assert all(c in "0123456789abcdef" for c in ref)
+
+    def test_deterministic(self):
+        kwargs = dict(agent_id="ag", action_type="op", scope="s", timestamp="2026-01-01T00:00:00.000Z")
+        assert compute_action_ref(**kwargs) == compute_action_ref(**kwargs)
+
+    def test_different_inputs_produce_different_refs(self):
+        a = compute_action_ref("agent-1", "file:write", "audit", "2026-05-15T00:00:00.000Z")
+        b = compute_action_ref("agent-2", "file:write", "audit", "2026-05-15T00:00:00.000Z")
+        assert a != b
+
+
+# =============================================================================
+# Protocol surface
+# =============================================================================
+
+class TestProtocol:
+    def test_name(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        assert b.name == "mycelium"
+
+    def test_anchor_returns_anchor_receipt(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("offline")):
+            r = b.anchor({"action_type": "file:write", "scope": "audit"})
+        assert isinstance(r, AnchorReceipt)
+        assert r.anchored is False
+        assert r.error is not None
+
+    def test_anchor_preimage_populated(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("offline")):
+            r = b.anchor({"action_type": "file:write", "scope": "audit"})
+        assert r.preimage["agent_id"] == "test-agent"
+        assert r.preimage["action_type"] == "file:write"
+        assert r.preimage["scope"] == "audit"
+        assert "timestamp" in r.preimage
+
+    def test_anchor_action_ref_matches_preimage(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("offline")):
+            r = b.anchor({"action_type": "file:write", "scope": ""})
+        recomputed = compute_action_ref(
+            r.preimage["agent_id"],
+            r.preimage["action_type"],
+            r.preimage["scope"],
+            r.preimage["timestamp"],
+        )
+        assert r.action_ref == recomputed
+
+    def test_verify_url_contains_action_ref(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("offline")):
+            r = b.anchor({"action_type": "op", "scope": ""})
+        assert r.action_ref in r.verify_url
+        assert "test-agent" in r.verify_url
+
+    def test_timing_populated(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", side_effect=ConnectionError("offline")):
+            r = b.anchor({"action_type": "op", "scope": ""})
+        assert r.evaluation_ms >= 0
+
+
+# =============================================================================
+# HTTP anchoring
+# =============================================================================
+
+def _mock_urlopen_success(trail_id="abc-123", trail_status="committed", tx_hash=None):
+    response_body = json.dumps({
+        "trail_id": trail_id,
+        "trail_status": trail_status,
+        "tx_hash": tx_hash,
+    }).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.read.return_value = response_body
+    return mock_resp
+
+
+class TestHTTPAnchoring:
+    def test_successful_anchor(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()):
+            r = b.anchor({"action_type": "payment.send", "scope": "usdc:50"})
+        assert r.anchored is True
+        assert r.trail_id == "abc-123"
+        assert r.trail_status == "committed"
+
+    def test_committed_with_tx_hash(self):
+        b = MyceliumBackend(agent_id="test-agent")
+        tx = "0x7fd0a8ededd1feb65ab37b3324218a0386dbf124174cf122bffc40717c057b84"
+        with patch("urllib.request.urlopen", return_value=_mock_urlopen_success(tx_hash=tx)):
+            r = b.anchor({"action_type": "payment.send", "scope": ""})
+        assert r.tx_hash == tx
+
+    def test_request_payload_contains_jcs_format(self):
+        captured: dict = {}
+
+        def _fake_urlopen(request, timeout):
+            captured["payload"] = json.loads(request.data.decode("utf-8"))
+            return _mock_urlopen_success()
+
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            b.anchor({"action_type": "file:write", "scope": "audit"})
+
+        assert captured["payload"]["preimage_format"] == "jcs-rfc8785"
+        assert captured["payload"]["preimage"]["agent_id"] == "test-agent"
+        assert captured["payload"]["action_ref"] == compute_action_ref(
+            "test-agent",
+            "file:write",
+            "audit",
+            captured["payload"]["preimage"]["ts"],
+        )
+
+    def test_http_error_returns_failed_receipt(self):
+        import urllib.error
+        b = MyceliumBackend(agent_id="test-agent")
+        err = urllib.error.HTTPError(url="u", code=429, msg="Too Many Requests", hdrs={}, fp=None)
+        with patch("urllib.request.urlopen", side_effect=err):
+            r = b.anchor({"action_type": "op", "scope": ""})
+        assert r.anchored is False
+        assert r.error is not None
+
+    def test_verify_success(self):
+        body = json.dumps({"verified": True, "trail_status": "committed", "tx_hash": "0xabc"}).encode()
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = body
+        b = MyceliumBackend(agent_id="test-agent")
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            result = b.verify("31ddbd9f" + "0" * 56)
+        assert result["verified"] is True


### PR DESCRIPTION
## Summary

- Adds `agentmesh-integrations/mycelium-agt/` — a standalone Python package implementing AGT's `EvidenceAnchor` protocol via Mycelium Trails.
- Follows the Cedarling pattern from #2399: hatchling build, protocol class with `name` + `anchor()`, typed `AnchorReceipt` response.
- Zero new runtime dependencies — uses stdlib `urllib` only.

## action_ref derivation

JCS RFC 8785 + SHA-256, byte-compatible with andysalvo verifier (ec7201a) and Nobulex (arian-gogani):

```
preimage   = JCS({"action_type": ..., "agent_id": ..., "scope": ..., "timestamp": ...})
action_ref = SHA-256(preimage) → lowercase hex
```

Spec: https://github.com/giskard09/argentum-core/blob/main/docs/spec/action-ref.md

## Installation

```bash
pip install mycelium-agt
```

PyPI: https://pypi.org/project/mycelium-agt/0.1.0/
Source: https://github.com/giskard09/mycelium-agt

The package is fully standalone — no external hosted service required at install time.
The Mycelium Trails API is used only at runtime when `anchor()` or `verify()` is called,
consistent with how any HTTP-backed integration works (same pattern as Cedarling calling
the Jans server).

## Test plan

- [ ] `pytest agentmesh-integrations/mycelium-agt/` — 15 tests, no live endpoint required (urllib mocked)
- [ ] NEXUS known vector: `fdd7f810499f06be24355ca8e2bfb8c4b965cc80c838f41fa074683443d89f5a`
- [ ] Conformance COMMITTED vector: `31ddbd9f89f0e54700744addc7fa23f41518cf8c9d63d206e6da5cc3669defdd`