### PR TITLE
fix(agent-mesh): harden AsyncTrustPolicyEvaluator RW lock for #2447

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/async_policy_evaluator.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/async_policy_evaluator.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 # Concurrency statistics
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ConcurrencyStats:
     """Tracks concurrency-related metrics for the async trust evaluator.
@@ -73,40 +74,68 @@ class ConcurrencyStats:
 # Read-write lock helpers
 # ---------------------------------------------------------------------------
 
+
 class _ReadWriteLock:
-    """Simple readers-writer lock built on :class:`threading.RLock`.
+    """Simple readers-writer lock built on :class:`threading.Condition`.
 
     Multiple readers can hold the lock concurrently; a writer gets
     exclusive access (no readers **and** no other writers).
+
+    Fairness policy: writer-preference. Once a writer is waiting,
+    admission of new readers is blocked until the writer acquires.
+    This prevents writer starvation under sustained read pressure, with
+    the tradeoff that readers may starve under extreme continuous write
+    pressure.
+
+    Implemented with a condition variable so acquire/release ownership
+    for reader activity is tracked by counters rather than by a thread-
+    owned primitive. This avoids cross-thread release failures that can
+    happen with an ``RLock`` when the first reader and last reader are
+    different threads.
     """
 
     def __init__(self) -> None:
+        self._cond = threading.Condition()
         self._readers: int = 0
-        self._lock = threading.RLock()
-        self._write_lock = threading.RLock()
+        self._writers: int = 0
+        self._waiting_writers: int = 0
 
     def acquire_read(self) -> None:
-        with self._lock:
+        with self._cond:
+            while self._writers > 0 or self._waiting_writers > 0:
+                self._cond.wait()
             self._readers += 1
-            if self._readers == 1:
-                self._write_lock.acquire()
 
     def release_read(self) -> None:
-        with self._lock:
+        with self._cond:
+            if self._readers <= 0:
+                raise RuntimeError("release_read called without matching acquire_read")
             self._readers -= 1
             if self._readers == 0:
-                self._write_lock.release()
+                self._cond.notify_all()
 
     def acquire_write(self) -> None:
-        self._write_lock.acquire()
+        with self._cond:
+            self._waiting_writers += 1
+            try:
+                while self._readers > 0 or self._writers > 0:
+                    self._cond.wait()
+                self._writers += 1
+            finally:
+                self._waiting_writers -= 1
 
     def release_write(self) -> None:
-        self._write_lock.release()
+        with self._cond:
+            if self._writers <= 0:
+                raise RuntimeError("release_write called without matching acquire_write")
+            self._writers -= 1
+            self._cond.notify_all()
 
 
 # ---------------------------------------------------------------------------
 # Async-safe trust policy evaluator
 # ---------------------------------------------------------------------------
+
 
 class AsyncTrustPolicyEvaluator:
     """Thread-safe and asyncio-safe trust policy evaluator.
@@ -147,10 +176,11 @@ class AsyncTrustPolicyEvaluator:
     async def evaluate(self, context: dict[str, Any]) -> TrustPolicyDecision:
         """Evaluate trust policies against *context* with async + thread safety.
 
-        Acquires the async lock (coroutine safety) and the read side of
-        the RW lock (thread safety) so that concurrent evaluations can
-        proceed but a policy reload will block until all in-flight
-        evaluations complete.
+        Async ``evaluate`` calls are intentionally serialised with an
+        ``asyncio.Lock`` in this implementation to preserve existing
+        event-loop semantics. The executor work still acquires the read
+        side of the RW lock, so thread-level safety and writer
+        exclusivity remain enforced.
 
         Thread-safety: YES — safe to call from multiple threads via
         ``asyncio.run_coroutine_threadsafe``.
@@ -160,6 +190,10 @@ class AsyncTrustPolicyEvaluator:
         TrustPolicyDecision
             The result of evaluating the loaded trust policies.
         """
+        # Keep coroutine-level serialization here intentionally to
+        # preserve existing event-loop semantics. Thread-level safety and
+        # writer exclusivity are still enforced by _ReadWriteLock inside
+        # the executor work item.
         async with self._async_lock:
             return await asyncio.get_running_loop().run_in_executor(
                 None, self._evaluate_with_read_lock, context
@@ -180,9 +214,7 @@ class AsyncTrustPolicyEvaluator:
         """
         return self._evaluate_with_read_lock(context)
 
-    async def evaluate_batch(
-        self, contexts: list[dict[str, Any]]
-    ) -> list[TrustPolicyDecision]:
+    async def evaluate_batch(self, contexts: list[dict[str, Any]]) -> list[TrustPolicyDecision]:
         """Evaluate multiple contexts concurrently.
 
         Each context is evaluated in its own asyncio task.  All tasks
@@ -196,9 +228,7 @@ class AsyncTrustPolicyEvaluator:
         list[TrustPolicyDecision]
             One decision per input context, in the same order.
         """
-        tasks = [
-            asyncio.ensure_future(self.evaluate(ctx)) for ctx in contexts
-        ]
+        tasks = [asyncio.ensure_future(self.evaluate(ctx)) for ctx in contexts]
         return list(await asyncio.gather(*tasks))
 
     async def reload_policies(self, policies: list[TrustPolicy]) -> None:
@@ -229,9 +259,7 @@ class AsyncTrustPolicyEvaluator:
 
     # -- internal helpers --------------------------------------------------
 
-    def _evaluate_with_read_lock(
-        self, context: dict[str, Any]
-    ) -> TrustPolicyDecision:
+    def _evaluate_with_read_lock(self, context: dict[str, Any]) -> TrustPolicyDecision:
         """Run the trust evaluator under the read side of the RW lock."""
         self._rw_lock.acquire_read()
         try:
@@ -258,9 +286,7 @@ class AsyncTrustPolicyEvaluator:
         finally:
             self._rw_lock.release_read()
 
-    def _reload_with_write_lock(
-        self, policies: list[TrustPolicy]
-    ) -> None:
+    def _reload_with_write_lock(self, policies: list[TrustPolicy]) -> None:
         """Replace policies under the exclusive write lock."""
         self._rw_lock.acquire_write()
         try:

--- a/agent-governance-python/agent-mesh/tests/test_async_policy_evaluator.py
+++ b/agent-governance-python/agent-mesh/tests/test_async_policy_evaluator.py
@@ -1,0 +1,296 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Concurrency tests for AsyncTrustPolicyEvaluator and its RW lock."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from agentmesh.governance.async_policy_evaluator import (
+    AsyncTrustPolicyEvaluator,
+    _ReadWriteLock,
+)
+from agentmesh.governance.policy_evaluator import PolicyEvaluator
+from agentmesh.governance.trust_policy import (
+    TrustCondition,
+    TrustDefaults,
+    TrustPolicy,
+    TrustRule,
+)
+
+
+def _make_policy(default_action: str = "allow") -> TrustPolicy:
+    """Create a minimal trust policy for evaluator tests."""
+    return TrustPolicy(
+        name="async-evaluator-test",
+        version="1.0",
+        rules=[
+            TrustRule(
+                name="deny_high_risk",
+                condition=TrustCondition(
+                    field="risk_score",
+                    operator="gt",
+                    value=75,
+                ),
+                action="deny",
+                priority=10,
+            )
+        ],
+        defaults=TrustDefaults(
+            min_trust_score=0,
+            max_delegation_depth=20,
+            allowed_namespaces=["*"],
+            require_handshake=False,
+        ),
+    )
+
+
+class TestReadWriteLock:
+    def test_multiple_concurrent_readers(self):
+        """Multiple readers should hold the lock at the same time."""
+        rw = _ReadWriteLock()
+        start = threading.Barrier(4)
+        all_reading = threading.Barrier(4)
+        counter_lock = threading.Lock()
+        active = 0
+        peak = 0
+
+        def reader():
+            nonlocal active, peak
+            start.wait(timeout=2.0)
+            rw.acquire_read()
+            try:
+                with counter_lock:
+                    active += 1
+                    peak = max(peak, active)
+                all_reading.wait(timeout=2.0)
+            finally:
+                with counter_lock:
+                    active -= 1
+                rw.release_read()
+
+        threads = [threading.Thread(target=reader) for _ in range(3)]
+        for thread in threads:
+            thread.start()
+
+        start.wait(timeout=2.0)
+        all_reading.wait(timeout=2.0)
+
+        for thread in threads:
+            thread.join(timeout=2.0)
+            assert not thread.is_alive()
+
+        assert peak == 3
+
+    def test_writer_blocks_reader_until_release(self):
+        rw = _ReadWriteLock()
+        rw.acquire_write()
+
+        attempt_started = threading.Event()
+        acquired = threading.Event()
+
+        def reader():
+            attempt_started.set()
+            rw.acquire_read()
+            try:
+                acquired.set()
+            finally:
+                rw.release_read()
+
+        thread = threading.Thread(target=reader)
+        thread.start()
+
+        assert attempt_started.wait(timeout=2.0)
+        assert not acquired.wait(timeout=0.5)
+        rw.release_write()
+
+        assert acquired.wait(timeout=2.0)
+        thread.join(timeout=2.0)
+        assert not thread.is_alive()
+
+    def test_reader_blocks_writer_until_release(self):
+        rw = _ReadWriteLock()
+        rw.acquire_read()
+
+        attempt_started = threading.Event()
+        acquired = threading.Event()
+
+        def writer():
+            attempt_started.set()
+            rw.acquire_write()
+            try:
+                acquired.set()
+            finally:
+                rw.release_write()
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+
+        assert attempt_started.wait(timeout=2.0)
+        assert not acquired.wait(timeout=0.5)
+        rw.release_read()
+
+        assert acquired.wait(timeout=2.0)
+        thread.join(timeout=2.0)
+        assert not thread.is_alive()
+
+    def test_waiting_writer_blocks_new_reader(self):
+        rw = _ReadWriteLock()
+        rw.acquire_read()
+
+        writer_attempt_started = threading.Event()
+        writer_acquired = threading.Event()
+        second_reader_attempt_started = threading.Event()
+        second_reader_acquired = threading.Event()
+
+        def writer():
+            writer_attempt_started.set()
+            rw.acquire_write()
+            try:
+                writer_acquired.set()
+            finally:
+                rw.release_write()
+
+        def second_reader():
+            second_reader_attempt_started.set()
+            rw.acquire_read()
+            try:
+                second_reader_acquired.set()
+            finally:
+                rw.release_read()
+
+        writer_thread = threading.Thread(target=writer)
+        writer_thread.start()
+        assert writer_attempt_started.wait(timeout=2.0)
+
+        second_reader_thread = threading.Thread(target=second_reader)
+        second_reader_thread.start()
+        assert second_reader_attempt_started.wait(timeout=2.0)
+
+        # Reader should be blocked while a writer is waiting.
+        assert not second_reader_acquired.wait(timeout=0.5)
+
+        rw.release_read()
+
+        assert writer_acquired.wait(timeout=2.0)
+        writer_thread.join(timeout=2.0)
+        second_reader_thread.join(timeout=2.0)
+        assert not writer_thread.is_alive()
+        assert not second_reader_thread.is_alive()
+
+    def test_release_read_without_acquire_raises(self):
+        rw = _ReadWriteLock()
+        try:
+            rw.release_read()
+        except RuntimeError as exc:
+            assert "release_read called without matching acquire_read" in str(exc)
+        else:  # pragma: no cover - defensive assertion
+            raise AssertionError("Expected RuntimeError from release_read without acquire")
+
+    def test_release_write_without_acquire_raises(self):
+        rw = _ReadWriteLock()
+        try:
+            rw.release_write()
+        except RuntimeError as exc:
+            assert "release_write called without matching acquire_write" in str(exc)
+        else:  # pragma: no cover - defensive assertion
+            raise AssertionError("Expected RuntimeError from release_write without acquire")
+
+    def test_cross_thread_final_reader_release_does_not_raise(self):
+        """Regression: first and final readers can be different threads."""
+        rw = _ReadWriteLock()
+        a_has_lock = threading.Event()
+        b_has_lock = threading.Event()
+        a_can_release = threading.Event()
+        errors: queue.Queue[Exception] = queue.Queue()
+
+        def reader_a():
+            try:
+                rw.acquire_read()
+                a_has_lock.set()
+                a_can_release.wait(timeout=2.0)
+                rw.release_read()
+            except Exception as exc:  # pragma: no cover - only for diagnostics
+                errors.put(exc)
+
+        def reader_b():
+            try:
+                a_has_lock.wait(timeout=2.0)
+                rw.acquire_read()
+                b_has_lock.set()
+                a_can_release.set()
+                rw.release_read()
+            except Exception as exc:  # pragma: no cover - only for diagnostics
+                errors.put(exc)
+
+        ta = threading.Thread(target=reader_a)
+        tb = threading.Thread(target=reader_b)
+        ta.start()
+        tb.start()
+
+        ta.join(timeout=2.0)
+        tb.join(timeout=2.0)
+
+        assert not ta.is_alive()
+        assert not tb.is_alive()
+        assert a_has_lock.is_set()
+        assert b_has_lock.is_set()
+        assert errors.empty()
+
+
+class TestAsyncTrustPolicyEvaluatorConcurrency:
+    def test_repeated_concurrent_evaluate_sync_is_stable(self):
+        evaluator = PolicyEvaluator([_make_policy()])
+        async_eval = AsyncTrustPolicyEvaluator(evaluator)
+
+        contexts = [
+            {"risk_score": 50},
+            {"risk_score": 99},
+            {"risk_score": 10},
+            {"risk_score": 80},
+        ]
+
+        for _ in range(60):
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                futures = [
+                    pool.submit(async_eval.evaluate_sync, contexts[i % len(contexts)])
+                    for i in range(24)
+                ]
+                results = [future.result(timeout=5.0) for future in futures]
+
+            assert len(results) == 24
+            assert all(result.action in {"allow", "deny"} for result in results)
+
+        stats = async_eval.get_stats()
+        assert stats["evaluation_count"] == 60 * 24
+        assert stats["error_count"] == 0
+
+    def test_reload_and_reads_concurrent_no_runtime_error(self):
+        async def _run() -> list[object]:
+            evaluator = PolicyEvaluator([_make_policy(default_action="allow")])
+            async_eval = AsyncTrustPolicyEvaluator(evaluator)
+
+            deny_by_default = _make_policy(default_action="deny")
+            allow_by_default = _make_policy(default_action="allow")
+
+            tasks: list[asyncio.Future] = []
+            for i in range(30):
+                tasks.append(asyncio.ensure_future(async_eval.evaluate({"risk_score": i})))
+                if i % 5 == 0:
+                    policies = [deny_by_default] if (i // 5) % 2 else [allow_by_default]
+                    tasks.append(asyncio.ensure_future(async_eval.reload_policies(policies)))
+
+            return await asyncio.gather(*tasks, return_exceptions=True)
+
+        results = asyncio.run(_run())
+        runtime_errors = [
+            item
+            for item in results
+            if isinstance(item, RuntimeError) and "cannot release un-acquired lock" in str(item)
+        ]
+
+        assert not runtime_errors
+        assert all(not isinstance(item, Exception) for item in results)


### PR DESCRIPTION
﻿## Summary
Harden AsyncTrustPolicyEvaluator lock handling to prevent unsafe concurrent access patterns and improve reliability under contention.

## Problem
Closes #2447 reported RW lock behavior in agent-mesh evaluation paths that could lead to race conditions or inconsistent read/write coordination.

## Changes
- Tightened RW lock usage around AsyncTrustPolicyEvaluator critical sections.
- Ensured lock acquisition/release flow is consistent for async execution paths.
- Kept behavior aligned with existing public interfaces while improving safety.

| File | Change Type | Notes |
|---|---|---|
| $file1 | Modified | Locking and/or evaluator flow updates. |
| $file2 | Modified | Supporting updates for correctness/tests. |

## Testing
- Verified local commit and branch state.
- Confirmed PR body content updates.
- gh PR edit/view commands executed for fork and upstream checks.

---

@imran-siddique can you please review when available?  Thank you.

