### PR TITLE
fix(ci): add missing packages to dep-confusion allowlist

### DIFF
--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -107,6 +107,12 @@ REGISTERED_PACKAGES = {
     # Microsoft Agent Framework (MAF) — not yet on PyPI, used in examples
     "agent-framework", "agent_framework",
     "agent-framework-openai", "agent_framework_openai",
+    # SpendGuard SDK (real PyPI package, used in examples)
+    "spendguard-sdk", "spendguard_sdk",
+    # Cedarling Python bindings (real PyPI package, optional dep)
+    "cedarling-python", "cedarling_python",
+    # Cedarling-AgentMesh integration (internal cross-package, local-only)
+    "cedarling-agentmesh", "cedarling_agentmesh",
     # Internal cross-package references (local-only, NOT on PyPI)
     # These are flagged as HIGH RISK if found in requirements.txt with version pins
     # instead of path references. See dependency confusion attack vector.


### PR DESCRIPTION
## Summary

Fixes failing CI on main. The \dep-confusion-scan\ job rejects packages not in the allowlist.

## Problem

Three packages were missing from \REGISTERED_PACKAGES\ in \scripts/check_dependency_confusion.py\, causing the dep-confusion-scan to fail on every push to main:

- \spendguard-sdk\: real PyPI package (v0.3.0), used in \xamples/spendguard-composite/- \cedarling_python\: real PyPI package (v0.0.4), optional dep in cedarling-agentmesh
- \cedarling_agentmesh\: internal integration package, referenced in \xamples/cedarling-governed/
## Changes

| File | Change |
|------|--------|
| \scripts/check_dependency_confusion.py\ | Add 3 packages (6 entries with underscore variants) to REGISTERED_PACKAGES |

## Testing

Ran \python scripts/check_dependency_confusion.py\ locally: exit code 0 (clean).
