### PR TITLE
feat(cedarling-agentmesh): support injected Cedarling instance

### DIFF
--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/README.md
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/README.md
@@ -13,7 +13,7 @@ to AGT's `ExternalPolicyBackend` contract without modifying AGT core.
 pip install cedarling_agentmesh
 
 # Cedarling Python bindings (optional — fastest evaluation)
-pip install cedarling_python
+pip install cedarling-python
 
 # Or point the backend at an existing Cedarling HTTP service — no extra package.
 ```
@@ -80,7 +80,7 @@ evaluator.add_backend(
 | Mode | Behaviour |
 |------|-----------|
 | `"auto"` (default) | Python bindings → HTTP (if `cedarling_url` set) → safe denial |
-| `"python"` | Requires `cedarling_python` |
+| `"python"` | Requires `cedarling-python` |
 | `"http"` | Requires `cedarling_url`; no Python extras needed |
 
 ## Context Mapping

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/backend.py
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/backend.py
@@ -46,6 +46,12 @@ class CedarlingBackend:
                        else safe denial.
         ``"python"`` — cedarling_python bindings only (ImportError if absent).
         ``"http"``   — HTTP service only (requires ``cedarling_url``).
+
+    When *cedarling_instance* is provided, it is used directly instead of
+    creating a new ``Cedarling`` from *bootstrap_config*. This lets callers
+    control initialization and lifecycle of the Cedarling engine. The mode
+    must still allow Python evaluation (``"auto"`` or ``"python"``) for the
+    instance to be reached.
     """
 
     def __init__(
@@ -59,9 +65,10 @@ class CedarlingBackend:
         cedarling_url: Optional[str] = None,
         mode: Literal["auto", "python", "http"] = "auto",
         timeout_seconds: float = 5.0,
+        cedarling_instance: Any = None,
     ) -> None:
         cfg: dict[str, Any] = dict(bootstrap_config) if bootstrap_config else {}
-        cfg.setdefault("application_name", application_name)
+        cfg.setdefault("CEDARLING_APPLICATION_NAME", application_name)
         self._bootstrap_config = cfg
         self._tokens = tokens or {}
         self._principal_entity_type = principal_entity_type
@@ -70,7 +77,31 @@ class CedarlingBackend:
         self._cedarling_url = cedarling_url.rstrip("/") if cedarling_url else None
         self._mode = mode
         self._timeout = timeout_seconds
-        self._python_available: Optional[bool] = None  # lazily resolved
+        self._cedarling_instance = cedarling_instance
+        self._python_available: bool
+
+        if cedarling_instance is not None:
+            self._python_available = True
+        elif self._mode == "python":
+            try:
+                import cedarling_python  # noqa: F401
+            except ImportError:
+                self._python_available = False
+            else:
+                bootstrap = cedarling_python.BootstrapConfig(self._bootstrap_config)
+                self._cedarling_instance = cedarling_python.Cedarling(bootstrap)
+                self._python_available = True
+        elif self._mode == "auto":
+            try:
+                import cedarling_python
+
+                bootstrap = cedarling_python.BootstrapConfig(self._bootstrap_config)
+                self._cedarling_instance = cedarling_python.Cedarling(bootstrap)
+                self._python_available = True
+            except ImportError:
+                self._python_available = False
+        else:
+            self._python_available = False
 
     @property
     def name(self) -> str:
@@ -80,15 +111,6 @@ class CedarlingBackend:
         """Evaluate *context* and return a normalized ``BackendDecision``."""
         start = datetime.now(timezone.utc)
         try:
-            # Detect cedarling_python availability once, then cache.
-            if self._python_available is None:
-                try:
-                    import cedarling_python  # noqa: F401
-
-                    self._python_available = True
-                except ImportError:
-                    self._python_available = False
-
             use_python = self._mode == "python" or (
                 self._mode == "auto" and self._python_available
             )
@@ -103,12 +125,12 @@ class CedarlingBackend:
             else:
                 msg = (
                     "No Cedarling runtime available. "
-                    "Install cedarling_python or set cedarling_url."
+                    "Install cedarling-python or set cedarling_url."
                 )
                 logger.warning(msg)
                 result = self._deny(
                     msg,
-                    "cedarling_python not installed and cedarling_url not configured",
+                    "cedarling-python not installed and cedarling_url not configured",
                 )
 
             result.evaluation_ms = (
@@ -131,6 +153,26 @@ class CedarlingBackend:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _extract_diagnostics(self, result: Any) -> Optional[dict[str, Any]]:
+        try:
+            raw = getattr(result, "response", None)
+            if raw is None:
+                return None
+            diag = getattr(raw, "diagnostics", None)
+            if diag is None:
+                return None
+            return {
+                "decision": str(raw.decision),
+                "reasons": list(diag.reason),
+            }
+        except Exception:
+            logger.debug(
+                "Failed to extract Cedarling diagnostics from result type %s",
+                type(result).__name__,
+                exc_info=True,
+            )
+            return None
 
     def _deny(self, reason: str, error: str) -> BackendDecision:
         return BackendDecision(
@@ -165,27 +207,50 @@ class CedarlingBackend:
             import cedarling_python
         except ImportError as exc:
             raise ImportError(
-                "cedarling_python is not installed. "
-                "Run `pip install cedarling_python` to use Python-binding mode."
+                "cedarling-python is not installed. "
+                "Run `pip install cedarling-python` to use Python-binding mode."
             ) from exc
 
         req = self._build_request(context)
-        bootstrap = cedarling_python.BootstrapConfig(**self._bootstrap_config)
-        engine = cedarling_python.Cedarling(bootstrap)
-        resource = cedarling_python.ResourceData(
-            resource_type=req["resource"]["type"],
-            id=req["resource"]["id"],
-            payload=req["context"],
-        )
-        request = cedarling_python.Request(
-            tokens=self._tokens,
-            action=req["action"],
-            resource=resource,
-            context=req["context"],
-        )
+
+        engine = self._cedarling_instance
+
+        resource = cedarling_python.EntityData.from_dict({
+            "cedar_entity_mapping": {
+                "entity_type": req["resource"]["type"],
+                "id": req["resource"]["id"],
+            },
+            **req["context"],
+        })
+
         try:
-            result = engine.authorize(request)
-        except cedarling_python.AuthorizeError as exc:
+            if self._tokens:
+                tokens = [
+                    cedarling_python.TokenInput(mapping=k, payload=v)
+                    for k, v in self._tokens.items()
+                ]
+                request = cedarling_python.AuthorizeMultiIssuerRequest(
+                    tokens=tokens,
+                    action=req["action"],
+                    resource=resource,
+                    context=req["context"],
+                )
+                result = engine.authorize_multi_issuer(request)
+            else:
+                principal = cedarling_python.EntityData.from_dict({
+                    "cedar_entity_mapping": {
+                        "entity_type": req["principal"]["type"],
+                        "id": req["principal"]["id"],
+                    },
+                })
+                request = cedarling_python.RequestUnsigned(
+                    principal=principal,
+                    action=req["action"],
+                    resource=resource,
+                    context=req["context"],
+                )
+                result = engine.authorize_unsigned(request)
+        except cedarling_python.authorize_errors.AuthorizeError as exc:
             return BackendDecision(
                 allowed=False,
                 action="deny",
@@ -196,9 +261,7 @@ class CedarlingBackend:
             )
 
         allowed = result.is_allowed()
-        diagnostics: Optional[dict[str, Any]] = None
-        if hasattr(result, "workload") and result.workload is not None:
-            diagnostics = {"workload": str(result.workload)}
+        diagnostics = self._extract_diagnostics(result)
 
         return BackendDecision(
             allowed=allowed,
@@ -206,7 +269,7 @@ class CedarlingBackend:
             reason=f"Cedarling: {'allowed' if allowed else 'denied'} (python)",
             backend="cedarling",
             raw_result={
-                "request_id": getattr(result, "request_id", None),
+                "request_id": result.request_id(),
                 "diagnostics": diagnostics,
             },
         )

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/backend.py
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh/backend.py
@@ -81,6 +81,11 @@ class CedarlingBackend:
         self._python_available: bool
 
         if cedarling_instance is not None:
+            if mode == "http":
+                raise ValueError(
+                    "cedarling_instance is not compatible with mode='http'. "
+                    "Use mode='auto' or mode='python' when providing a Cedarling instance."
+                )
             self._python_available = True
         elif self._mode == "python":
             try:

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-python = ["cedarling_python>=1.0.0"]
+python = ["cedarling-python>=0.0.4"]
 dev = [
     "pytest>=7.0,<8.0",
     "ruff>=0.1.0,<1.0",

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/policy-stores/simple-unsigned/metadata.json
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/policy-stores/simple-unsigned/metadata.json
@@ -1,0 +1,10 @@
+{
+  "cedar_version": "4.4.0",
+  "policy_store": {
+    "id": "2c01a46cc4a168c72196d77afcae13444f19371b",
+    "name": "SimpleUnsigned",
+    "description": "Policy store for unsigned AGT authorization tests",
+    "version": "1.0.0",
+    "created_date": "2025-03-18T17:22:39Z"
+  }
+}

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/policy-stores/simple-unsigned/policies/allow-read.cedar
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/policy-stores/simple-unsigned/policies/allow-read.cedar
@@ -1,0 +1,6 @@
+@id("allow-read")
+permit(
+  principal is Agent,
+  action in [Action::"Read", Action::"ReadData"],
+  resource is Resource
+);

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/policy-stores/simple-unsigned/schema.cedarschema
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/policy-stores/simple-unsigned/schema.cedarschema
@@ -1,0 +1,17 @@
+entity Agent = {};
+entity Resource = {};
+action "ReadData" appliesTo {
+  principal: [Agent],
+  resource: [Resource],
+  context: {}
+};
+action "Read" appliesTo {
+  principal: [Agent],
+  resource: [Resource],
+  context: {}
+};
+action "Write" appliesTo {
+  principal: [Agent],
+  resource: [Resource],
+  context: {}
+};

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/test_cedarling_backend.py
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/test_cedarling_backend.py
@@ -7,8 +7,12 @@ No real cedarling_python installation required — tests mock the module.
 
 from __future__ import annotations
 
+import importlib
 import json
+from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from cedarling_agentmesh import CedarlingBackend
 
@@ -19,24 +23,28 @@ from cedarling_agentmesh import CedarlingBackend
 
 class TestProtocol:
     def test_name(self):
-        assert CedarlingBackend().name == "cedarling"
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            assert CedarlingBackend().name == "cedarling"
 
     def test_evaluate_returns_backend_decision(self):
-        b = CedarlingBackend()
-        d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            b = CedarlingBackend()
+            d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
         assert hasattr(d, "allowed")
         assert hasattr(d, "backend")
         assert d.backend == "cedarling"
 
     def test_denied_safely_when_no_runtime(self):
-        b = CedarlingBackend(mode="auto")
-        d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            b = CedarlingBackend(mode="auto")
+            d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
         assert d.allowed is False
         assert d.error is not None
 
     def test_timing_populated(self):
-        b = CedarlingBackend()
-        d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            b = CedarlingBackend()
+            d = b.evaluate({"tool_name": "read", "agent_id": "a1"})
         assert d.evaluation_ms >= 0
 
 
@@ -123,9 +131,14 @@ def _make_cedarling_python(allowed: bool) -> MagicMock:
     mod = MagicMock()
     result = MagicMock()
     result.is_allowed.return_value = allowed
-    result.workload = None
-    mod.Cedarling.return_value.authorize.return_value = result
-    mod.AuthorizeError = Exception
+    result.request_id.return_value = "mock-req-1"
+    result.response = MagicMock()
+    result.response.decision = "Allow" if allowed else "Deny"
+    result.response.diagnostics = MagicMock()
+    result.response.diagnostics.reason = []
+    result.response.diagnostics.errors = []
+    mod.Cedarling.return_value.authorize_unsigned.return_value = result
+    mod.authorize_errors.AuthorizeError = Exception
     return mod
 
 
@@ -156,7 +169,8 @@ class TestPythonMode:
 
     def test_python_available_cached(self):
         """Once _python_available is set, evaluate must not re-probe."""
-        b = CedarlingBackend(mode="auto")
+        with patch.dict("sys.modules", {"cedarling_python": None}):
+            b = CedarlingBackend(mode="auto")
         b._python_available = False  # pre-set; no cedarling_url → safe denial
         import builtins
 
@@ -279,3 +293,97 @@ class TestAutoMode:
             b = CedarlingBackend(mode="auto")
             d = b.evaluate({"tool_name": "read", "agent_id": "a"})
         assert d.allowed is False
+
+
+def _real_cedarling_instance() -> Any:
+    """Create a real Cedarling instance backed by the test policy store."""
+    from pathlib import Path
+
+    from cedarling_python import BootstrapConfig, Cedarling
+
+    policy_store = (
+        Path(__file__).resolve().parent / "policy-stores" / "simple-unsigned"
+    )
+    config = BootstrapConfig({
+        "CEDARLING_APPLICATION_NAME": "TestIntegration",
+        "CEDARLING_POLICY_STORE_LOCAL_FN": str(policy_store),
+        "CEDARLING_JWT_SIG_VALIDATION": "disabled",
+        "CEDARLING_JWT_STATUS_VALIDATION": "disabled",
+        "CEDARLING_LOG_TYPE": "std_out",
+        "CEDARLING_LOG_LEVEL": "INFO",
+        "CEDARLING_JWT_SIGNATURE_ALGORITHMS_SUPPORTED": ["HS256"],
+    })
+    return Cedarling(config)
+
+
+REAL_CEDARLING = pytest.mark.skipif(
+    importlib.util.find_spec("cedarling_python") is None,
+    reason="cedarling-python is not installed",
+)
+
+
+class TestRealCedarling:
+    """Integration tests using a real Cedarling engine and real policy store.
+
+    Skipped automatically when ``cedarling_python`` is not installed.
+    """
+
+    @staticmethod
+    def _engine() -> Any:
+        return _real_cedarling_instance()
+
+    @REAL_CEDARLING
+    def test_allow_with_unsigned(self):
+        b = CedarlingBackend(cedarling_instance=self._engine(), mode="python")
+        d = b.evaluate({"tool_name": "read_data", "agent_id": "agent-42", "resource": "doc-1"})
+        assert d.allowed is True
+        assert d.backend == "cedarling"
+        assert "(python)" in d.reason
+        assert d.raw_result is not None
+        assert d.raw_result["request_id"] is not None
+
+    @REAL_CEDARLING
+    def test_deny_when_no_policy_matches(self):
+        b = CedarlingBackend(cedarling_instance=self._engine(), mode="python")
+        d = b.evaluate({"tool_name": "write", "agent_id": "agent-42", "resource": "doc-1"})
+        assert d.allowed is False
+
+    @REAL_CEDARLING
+    def test_diagnostics_in_raw_result(self):
+        b = CedarlingBackend(cedarling_instance=self._engine(), mode="python")
+        d = b.evaluate({"tool_name": "read_data", "agent_id": "agent-42", "resource": "doc-1"})
+        diag = d.raw_result.get("diagnostics")
+        assert diag is not None
+        assert diag["decision"] == "ALLOW"
+        assert "allow-read" in diag["reasons"]
+
+    @REAL_CEDARLING
+    def test_injected_instance_used(self):
+        """cedarling_instance is provided → backend must NOT create its own."""
+        engine = self._engine()
+        b = CedarlingBackend(
+            cedarling_instance=engine,
+            bootstrap_config={"CEDARLING_APPLICATION_NAME": "ShouldNotBeUsed"},
+            mode="python",
+        )
+        d = b.evaluate({"tool_name": "read", "agent_id": "agent-42", "resource": "doc-1"})
+        assert d.allowed is True
+
+    @REAL_CEDARLING
+    def test_auto_mode_uses_injected_instance(self):
+        """Auto mode with a cedarling_instance should still work."""
+        b = CedarlingBackend(cedarling_instance=self._engine(), mode="auto")
+        d = b.evaluate({"tool_name": "read", "agent_id": "agent-42", "resource": "doc-1"})
+        assert d.allowed is True
+
+    @REAL_CEDARLING
+    def test_custom_entity_types(self):
+        engine = self._engine()
+        b = CedarlingBackend(
+            cedarling_instance=engine,
+            mode="python",
+            principal_entity_type="Agent",
+            resource_entity_type="Resource",
+        )
+        d = b.evaluate({"tool_name": "read", "agent_id": "agent-42", "resource": "doc-1"})
+        assert d.allowed is True

--- a/examples/cedarling-governed/README.md
+++ b/examples/cedarling-governed/README.md
@@ -15,7 +15,7 @@ python example.py
 Optional — enable in-process Cedarling evaluation:
 
 ```bash
-pip install cedarling_python
+pip install cedarling-python
 python example.py
 ```
 

--- a/examples/cedarling-governed/example.py
+++ b/examples/cedarling-governed/example.py
@@ -10,7 +10,7 @@ Run:
     python example.py
 
 To use real Cedarling evaluation, also install the Python bindings:
-    pip install cedarling_python
+    pip install cedarling-python
 
 Or set CEDARLING_URL to point at an existing Cedarling HTTP service.
 """

--- a/examples/cedarling-governed/requirements.txt
+++ b/examples/cedarling-governed/requirements.txt
@@ -2,4 +2,4 @@ agent-os-kernel>=3.5.0
 cedarling_agentmesh>=3.5.0
 
 # Optional — enables in-process cedarling_python evaluation (fastest)
-# cedarling_python>=1.0.0
+# cedarling-python>=0.0.4


### PR DESCRIPTION
## Description

Adds a cedarling_instance parameter to CedarlingBackend so callers can inject an existing engine (useful when lifecycle is managed externally). Moves cedarling_python detection from lazy (first evaluate()) to eager (__init__()), and migrates to the cedarling-python v0.0.4+ API (EntityData.from_dict, RequestUnsigned, AuthorizeMultiIssuerRequest). Fixes TestProtocol and TestPythonMode.test_python_available_cached to properly mock cedarling_python as absent so tests are environment-independent. Adds integration tests (TestRealCedarling) with a real policy store, skipped when cedarling_python is not installed.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
<!-- REQUIRED for new features, integrations, or architectural patterns -->
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [ ] Any external projects that inspired this design are credited in code comments or documentation
- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
<!-- Example: "Sandboxing approach inspired by https://github.com/example/project (Apache-2.0)" -->
<!-- Leave blank if not applicable -->

## AI Assistance
<!-- See CONTRIBUTING.md "AI-Assisted Contributions" for full policy -->
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
<!-- Example: "GitHub Copilot for boilerplate, Codex for test generation — all output reviewed" -->
<!-- Leave blank if AI was not used or was only used for minor assistance -->

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Related to #2245
