### PR TITLE
docs: add prerequisites section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Python · TypeScript · .NET · Rust · Go. Works with LangChain, CrewAI, AutoGe
 
 ---
 
+## Prerequisites
+
+- **Python**: `pip install agent-governance-toolkit[full]` requires Python 3.10+
+- **Node.js**: For TypeScript SDK, Node.js 18+ and npm 9+
+- **.NET**: .NET 8+ for the .NET SDK
+- **Go**: Go 1.21+ for the Go SDK
+- **Rust**: Rust 1.70+ for the Rust SDK
+
+### Optional dependencies
+
+- **Azure credentials**: Set `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` for Azure-integrated features
+- **MCP SDK**: For Model Context Protocol integrations
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- Added a **Prerequisites** section to the README, positioned before the Quick Start section

## Problem
- New users lacked clear guidance on required runtimes (Python, Node.js, .NET, Go, Rust) and version requirements
- No documentation on optional Azure credentials needed for cloud integrations

## Solution
- Added Prerequisites section with:
  - Python 3.10+ for pip install
  - Node.js 18+ / npm 9+ for TypeScript SDK
  - .NET 8+ for .NET SDK
  - Go 1.21+ for Go SDK
  - Rust 1.70+ for Rust SDK
  - Optional Azure credential environment variables

## Tests
- N/A (documentation only)

## Risk / Compatibility
- Risk: LOW
- Affects: docs only