### PR TITLE
fix(ci): resolve shellcheck warnings in license-check workflow

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -31,28 +31,28 @@ jobs:
         run: |
           # Check all source files for copyright header
           # If no @microsoft/license-header tool exists, use grep as fallback
-          MISSING=0
+          LH_MISSING=0
           for ext in ts js py cs rs go; do
             for file in $(git diff --name-only origin/main...HEAD -- "*.${ext}" 2>/dev/null || echo ""); do
               if ! grep -q "Copyright (c) Microsoft Corporation" "$file" 2>/dev/null; then
                 echo "MISSING license header: $file"
-                MISSING=$((MISSING + 1))
+                LH_MISSING=$((LH_MISSING + 1))
               fi
             done
           done
-          
+
           # Also check untracked/new files
           for ext in ts js py cs rs go; do
             for file in $(git ls-files --others --exclude-standard "*.${ext}" 2>/dev/null | head -20); do
               if [ -f "$file" ] && ! grep -q "Copyright (c) Microsoft Corporation" "$file" 2>/dev/null; then
                 echo "MISSING license header: $file"
-                MISSING=$((MISSING + 1))
+                LH_MISSING=$((LH_MISSING + 1))
               fi
             done
           done
-          
-          if [ $MISSING -gt 0 ]; then
-            echo "Found $MISSING file(s) without license headers"
+
+          if [ "$LH_MISSING" -gt 0 ]; then
+            echo "Found $LH_MISSING file(s) without license headers"
             exit 1
           fi
           echo "All source files have valid license headers."


### PR DESCRIPTION
## Summary
Fix shellcheck SC2178/SC2128/SC2086 warnings in license-check.yml that are failing workflow-lint on main.

## Problem
The workflow-lint CI step extracts all workflow shell blocks into a single file for shellcheck analysis. `dco.yml` uses `MISSING` as an array (`MISSING=()`), while `license-check.yml` used it as a scalar (`MISSING=0`). shellcheck sees the name collision and reports SC2178 (variable used as array but assigned string) and SC2128 (expanding array without index).

## Fix
- Renamed `MISSING` to `LH_MISSING` in license-check.yml to avoid the name collision
- Added proper quoting on the `-gt` comparison (SC2086)