### PR TITLE
fix: fail-close workflow designer exports

### DIFF
--- a/agent-governance-typescript/agent-os-vscode/src/test/webviews/workflowDesignerPanel.test.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/test/webviews/workflowDesignerPanel.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+
+const Module = require('module') as {
+    _load: (request: string, parent: NodeModule | undefined, isMain: boolean) => unknown;
+};
+const originalLoad = Module._load;
+const workflowDesignerModulePath = '../../webviews/workflowDesigner/WorkflowDesignerPanel';
+let WorkflowDesignerPanel: typeof import('../../webviews/workflowDesigner/WorkflowDesignerPanel').WorkflowDesignerPanel;
+
+type WorkflowShape = {
+    id: string;
+    name: string;
+    description: string;
+    nodes: Array<{
+        id: string;
+        type: 'start' | 'end' | 'action' | 'condition' | 'loop' | 'parallel';
+        label: string;
+        position: { x: number; y: number };
+        config: Record<string, unknown>;
+        policy?: string;
+    }>;
+    edges: Array<{ id: string; source: string; target: string; label?: string }>;
+    policies: string[];
+};
+
+function makeWorkflow(overrides?: Partial<WorkflowShape>): WorkflowShape {
+    return {
+        id: 'workflow-1',
+        name: 'Generated Workflow',
+        description: 'Generated workflow description',
+        nodes: [
+            { id: 'start', type: 'start', label: 'Start', position: { x: 0, y: 0 }, config: {} },
+            { id: 'end', type: 'end', label: 'End', position: { x: 200, y: 0 }, config: {} },
+        ],
+        edges: [],
+        policies: [],
+        ...overrides,
+    };
+}
+
+function createPanel(workflow: WorkflowShape): any {
+    const panel = Object.create(WorkflowDesignerPanel.prototype) as any;
+    panel._workflow = workflow;
+    return panel;
+}
+
+suite('WorkflowDesignerPanel code generation', () => {
+    setup(() => {
+        Module._load = ((request: string, parent: NodeModule | undefined, isMain: boolean) => {
+            if (request === 'vscode') {
+                return {
+                    window: {},
+                    workspace: {},
+                    Uri: { file: (fsPath: string) => ({ fsPath }) },
+                    ProgressLocation: { Notification: 15 },
+                    ViewColumn: { One: 1 },
+                };
+            }
+            return originalLoad(request, parent, isMain);
+        }) as typeof Module._load;
+        delete require.cache[require.resolve(workflowDesignerModulePath)];
+        WorkflowDesignerPanel = require(workflowDesignerModulePath).WorkflowDesignerPanel;
+    });
+
+    teardown(() => {
+        Module._load = originalLoad;
+        delete require.cache[require.resolve(workflowDesignerModulePath)];
+    });
+
+    test('empty exports fail closed without TODO placeholders', () => {
+        const panel = createPanel(makeWorkflow());
+
+        const python = panel._generatePythonCode() as string;
+        const typescript = panel._generateTypeScriptCode() as string;
+        const go = panel._generateGoCode() as string;
+
+        for (const code of [python, typescript, go]) {
+            assert.ok(!code.includes('TODO'), 'generated scaffold should not contain TODO placeholders');
+            assert.ok(code.includes('blocked'), 'generated scaffold should fail closed');
+            assert.ok(
+                code.includes('Add at least one Action node in the Workflow Designer before exporting runnable code.'),
+                'empty export should explain how to unblock execution',
+            );
+        }
+    });
+
+    test('action exports generate blocked scaffolds with step metadata', () => {
+        const panel = createPanel(makeWorkflow({
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start', position: { x: 0, y: 0 }, config: {} },
+                {
+                    id: 'action-1',
+                    type: 'action',
+                    label: '1 Review Input',
+                    position: { x: 120, y: 0 },
+                    config: {
+                        action: 'file_read',
+                        description: 'Read the input payload before validation.',
+                    },
+                    policy: 'restricted',
+                },
+                { id: 'end', type: 'end', label: 'End', position: { x: 240, y: 0 }, config: {} },
+            ],
+        }));
+
+        const python = panel._generatePythonCode() as string;
+        const typescript = panel._generateTypeScriptCode() as string;
+        const go = panel._generateGoCode() as string;
+
+        for (const code of [python, typescript, go]) {
+            assert.ok(!code.includes('TODO'), 'generated scaffold should not contain TODO placeholders');
+            assert.ok(
+                code.includes('Replace this scaffold with a governed implementation before executing the workflow.'),
+                'action scaffold should explain why execution is blocked',
+            );
+            assert.ok(code.includes('file_read'), 'configured action should be preserved in the scaffold');
+            assert.ok(code.includes('restricted'), 'attached policy should be preserved in the scaffold');
+        }
+
+        assert.ok(python.includes('step_1_review_input'), 'python export should fall back to a safe identifier');
+        assert.ok(typescript.includes('step1ReviewInput'), 'typescript export should fall back to a safe identifier');
+        assert.ok(go.includes('step_1_review_input'), 'go export should fall back to a safe identifier');
+        assert.ok(typescript.includes('type WorkflowStepResult = {'), 'typescript export should expose structured step results');
+        assert.ok(go.includes('type StepResult struct {'), 'go export should expose structured step results');
+    });
+});

--- a/agent-governance-typescript/agent-os-vscode/src/webviews/workflowDesigner/WorkflowDesignerPanel.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/webviews/workflowDesigner/WorkflowDesignerPanel.ts
@@ -9,7 +9,6 @@
 
 import * as vscode from 'vscode';
 import * as crypto from 'crypto';
-import { escapeHtml } from '../../utils/escapeHtml';
 
 interface WorkflowNode {
     id: string;
@@ -243,14 +242,37 @@ export class WorkflowDesignerPanel {
         await vscode.window.showTextDocument(doc);
     }
 
+    private _quoteGeneratedString(value: string): string {
+        return JSON.stringify(value);
+    }
+
+    private _getNodeAction(node: WorkflowNode): string {
+        const configuredAction = typeof node.config.action === 'string' ? node.config.action.trim() : '';
+        return configuredAction || 'custom_action';
+    }
+
+    private _getNodeDescription(node: WorkflowNode): string {
+        const configuredDescription = typeof node.config.description === 'string' ? node.config.description.trim() : '';
+        return configuredDescription || `Execute ${node.label}`;
+    }
+
     private _generatePythonCode(): string {
-        const nodes = this._workflow.nodes.filter(n => n.type === 'action');
+        const actionNodes = this._workflow.nodes
+            .filter(n => n.type === 'action')
+            .map((node, index) => ({
+                node,
+                action: this._getNodeAction(node),
+                description: this._getNodeDescription(node),
+                functionName: this._toSnakeCase(node.label, `step_${index + 1}`),
+            }));
         const imports = [
-            'from agent_os import KernelSpace, Policy',
+            'from agent_os import KernelSpace',
             'from agent_os.tools import create_safe_toolkit'
         ];
+        const scaffoldReason = 'Replace this scaffold with a governed implementation before executing the workflow.';
+        const emptyWorkflowReason = 'Add at least one Action node in the Workflow Designer before exporting runnable code.';
 
-        if (nodes.length === 0) {
+        if (actionNodes.length === 0) {
             return `"""
 ${this._workflow.name || 'New Workflow'}
 
@@ -265,10 +287,13 @@ toolkit = create_safe_toolkit("standard")
 
 @kernel.register
 async def run_workflow(task: str):
-    """Add action nodes to your workflow to generate code"""
-    context = {"task": task}
-    # TODO: Add workflow steps
-    return {"status": "success"}
+    """Exported workflow requires at least one action node before it can run."""
+    return {
+        "status": "blocked",
+        "reason": ${this._quoteGeneratedString(emptyWorkflowReason)},
+        "steps": [],
+        "input": {"task": task},
+    }
 
 if __name__ == "__main__":
     import asyncio
@@ -277,30 +302,26 @@ if __name__ == "__main__":
 `;
         }
 
-        const functions = nodes.map(node => {
-            const action = node.config.action || 'execute_task';
-            return `
-async def ${this._toSnakeCase(node.label)}(context):
-    """${node.config.description || 'Execute ' + node.label}"""
-    ${node.policy ? `# Policy: ${node.policy}` : '# No policy attached'}
-    # TODO: Implement ${action}
-    return {"status": "success"}
-`;
-        });
+        const functions = actionNodes.map(({ node, action, description, functionName }) => `
+async def ${functionName}(context):
+    """Generated scaffold for ${node.label}."""
+    _ = context
+    step = {
+        "step": ${this._quoteGeneratedString(node.label)},
+        "action": ${this._quoteGeneratedString(action)},
+        "status": "blocked",
+        "reason": ${this._quoteGeneratedString(scaffoldReason)},
+        "details": {
+            "description": ${this._quoteGeneratedString(description)}
+        }
+    }
+    ${node.policy ? `step["policy"] = ${this._quoteGeneratedString(node.policy)}` : ''}
+    return step
+`).join('\n');
 
-        const workflowSteps = nodes.length > 0 
-            ? nodes.map(n => `result = await ${this._toSnakeCase(n.label)}(context)`).join('\n    ')
-            : '# No action nodes defined';
-
-        const workflow = `
-async def run_workflow(task: str):
-    """${this._workflow.description || 'Agent workflow'}"""
-    context = {"task": task}
-    
-    ${workflowSteps}
-    
-    return result if 'result' in dir() else {"status": "success"}
-`;
+        const workflowSteps = actionNodes
+            .map(({ functionName }) => `steps.append(await ${functionName}(context))`)
+            .join('\n    ');
 
         return `"""
 ${this._workflow.name || 'New Workflow'}
@@ -314,10 +335,26 @@ ${imports.join('\n')}
 kernel = KernelSpace(policy="strict")
 toolkit = create_safe_toolkit("standard")
 
-${functions.join('\n')}
+${functions}
 
 @kernel.register
-${workflow}
+async def run_workflow(task: str):
+    """${this._workflow.description || 'Agent workflow'}"""
+    context = {"task": task, "toolkit": toolkit}
+    steps = []
+    
+    ${workflowSteps}
+
+    blocked_step = next((step for step in steps if step.get("status") != "completed"), None)
+    if blocked_step:
+        return {
+            "status": "blocked",
+            "reason": "Workflow contains scaffolded steps that must be implemented before execution.",
+            "blocked_step": blocked_step,
+            "steps": steps,
+        }
+
+    return {"status": "completed", "steps": steps}
 
 if __name__ == "__main__":
     import asyncio
@@ -327,10 +364,43 @@ if __name__ == "__main__":
     }
 
     private _generateTypeScriptCode(): string {
-        const nodes = this._workflow.nodes.filter(n => n.type === 'action');
+        const actionNodes = this._workflow.nodes
+            .filter(n => n.type === 'action')
+            .map((node, index) => ({
+                node,
+                action: this._getNodeAction(node),
+                description: this._getNodeDescription(node),
+                functionName: this._toCamelCase(node.label, `step${index + 1}`),
+            }));
         const workflowName = this._workflow.name || 'New Workflow';
+        const scaffoldReason = 'Replace this scaffold with a governed implementation before executing the workflow.';
+        const emptyWorkflowReason = 'Add at least one Action node in the Workflow Designer before exporting runnable code.';
+        const stepResultType = `type WorkflowStepResult = {
+  step: string;
+  action: string;
+  status: 'blocked' | 'completed';
+  reason?: string;
+  policy?: string;
+  details?: Record<string, unknown>;
+};`;
+        const blockedStepHelper = `function blockedStep(
+  step: string,
+  action: string,
+  reason: string,
+  policy?: string,
+  details?: Record<string, unknown>,
+): WorkflowStepResult {
+  return {
+    step,
+    action,
+    status: 'blocked',
+    reason,
+    ...(policy ? { policy } : {}),
+    ...(details ? { details } : {}),
+  };
+}`;
 
-        if (nodes.length === 0) {
+        if (actionNodes.length === 0) {
             return `/**
  * ${workflowName}
  * 
@@ -339,33 +409,40 @@ if __name__ == "__main__":
 
 import { AgentOS } from '@agent-governance-python/agent-os/sdk';
 
+${stepResultType}
+
 const agentOS = new AgentOS({
   policy: 'strict',
   apiKey: process.env.AGENT_OS_KEY
 });
 
-export async function runWorkflow(task: string) {
-  return agentOS.execute(async () => {
-    const context = { task };
-    // TODO: Add workflow steps by adding Action nodes in the designer
-    return { success: true };
-  });
+export async function runWorkflow(task: string): Promise<Record<string, unknown>> {
+  return agentOS.execute(async () => ({
+    status: 'blocked',
+    reason: ${this._quoteGeneratedString(emptyWorkflowReason)},
+    steps: [] as WorkflowStepResult[],
+    input: { task },
+  }));
 }
 `;
         }
 
-        const functionDefs = nodes.map(node => `
-async function ${this._toCamelCase(node.label)}(context: Record<string, unknown>): Promise<Record<string, unknown>> {
-  // ${node.config.description || 'Execute ' + node.label}
-  ${node.policy ? `// Policy: ${node.policy}` : '// No policy attached'}
-  // TODO: Implement ${node.config.action || 'action'}
-  return { status: 'success' };
+        const functionDefs = actionNodes.map(({ node, action, description, functionName }) => `
+async function ${functionName}(context: Record<string, unknown>): Promise<WorkflowStepResult> {
+  void context;
+  return blockedStep(
+    ${this._quoteGeneratedString(node.label)},
+    ${this._quoteGeneratedString(action)},
+    ${this._quoteGeneratedString(scaffoldReason)},
+    ${node.policy ? this._quoteGeneratedString(node.policy) : 'undefined'},
+    { description: ${this._quoteGeneratedString(description)} },
+  );
 }
 `).join('');
 
-        const workflowSteps = nodes.map(n => 
-            `const ${this._toCamelCase(n.label)}Result = await ${this._toCamelCase(n.label)}(context);`
-        ).join('\n    ');
+        const workflowSteps = actionNodes
+            .map(({ functionName }) => `steps.push(await ${functionName}(context));`)
+            .join('\n    ');
 
         return `/**
  * ${workflowName}
@@ -375,29 +452,72 @@ async function ${this._toCamelCase(node.label)}(context: Record<string, unknown>
 
 import { AgentOS } from '@agent-governance-python/agent-os/sdk';
 
+${stepResultType}
+
 const agentOS = new AgentOS({
   policy: 'strict',
   apiKey: process.env.AGENT_OS_KEY
 });
+
+${blockedStepHelper}
 ${functionDefs}
 
 export async function runWorkflow(task: string): Promise<Record<string, unknown>> {
   return agentOS.execute(async () => {
     const context: Record<string, unknown> = { task };
+    const steps: WorkflowStepResult[] = [];
     
     ${workflowSteps}
-    
-    return { success: true };
+
+    const blockedStepResult = steps.find(step => step.status !== 'completed');
+    if (blockedStepResult) {
+      return {
+        status: 'blocked',
+        reason: 'Workflow contains scaffolded steps that must be implemented before execution.',
+        blockedStep: blockedStepResult,
+        steps,
+      };
+    }
+
+    return { status: 'completed', steps };
   });
 }
 `;
     }
 
     private _generateGoCode(): string {
-        const nodes = this._workflow.nodes.filter(n => n.type === 'action');
+        const actionNodes = this._workflow.nodes
+            .filter(n => n.type === 'action')
+            .map((node, index) => ({
+                node,
+                action: this._getNodeAction(node),
+                description: this._getNodeDescription(node),
+                functionName: this._toSnakeCase(node.label, `step_${index + 1}`),
+            }));
         const workflowName = this._workflow.name || 'New Workflow';
+        const scaffoldReason = 'Replace this scaffold with a governed implementation before executing the workflow.';
+        const emptyWorkflowReason = 'Add at least one Action node in the Workflow Designer before exporting runnable code.';
+        const stepResultType = `type StepResult struct {
+\tStep    string                 \`json:"step"\`
+\tAction  string                 \`json:"action"\`
+\tStatus  string                 \`json:"status"\`
+\tReason  string                 \`json:"reason,omitempty"\`
+\tPolicy  string                 \`json:"policy,omitempty"\`
+\tDetails map[string]interface{} \`json:"details,omitempty"\`
+}
 
-        if (nodes.length === 0) {
+func blockedStep(step string, action string, reason string, policy string, details map[string]interface{}) StepResult {
+\treturn StepResult{
+\t\tStep:    step,
+\t\tAction:  action,
+\t\tStatus:  "blocked",
+\t\tReason:  reason,
+\t\tPolicy:  policy,
+\t\tDetails: details,
+\t}
+}`;
+
+        if (actionNodes.length === 0) {
             return `// ${workflowName}
 //
 // Auto-generated by Agent OS Workflow Designer
@@ -405,49 +525,60 @@ export async function runWorkflow(task: string): Promise<Record<string, unknown>
 package main
 
 import (
-	"context"
-	"fmt"
-	
-	agentos "github.com/microsoft/agent-governance-toolkit/sdk/go"
+\t"context"
+\t"fmt"
+\t
+\tagentos "github.com/microsoft/agent-governance-toolkit/sdk/go"
 )
 
-func main() {
-	kernel, err := agentos.NewKernel(agentos.WithPolicy("strict"))
-	if err != nil {
-		panic(err)
-	}
+${stepResultType}
 
-	result, err := kernel.Execute(context.Background(), runWorkflow, "example task")
-	if err != nil {
-		panic(err)
-	}
-	
-	fmt.Printf("Result: %v\\n", result)
+func main() {
+\tkernel, err := agentos.NewKernel(agentos.WithPolicy("strict"))
+\tif err != nil {
+\t\tpanic(err)
+\t}
+
+\tresult, err := kernel.Execute(context.Background(), runWorkflow, "example task")
+\tif err != nil {
+\t\tpanic(err)
+\t}
+\t
+\tfmt.Printf("Result: %v\\n", result)
 }
 
 func runWorkflow(ctx context.Context, task string) (map[string]interface{}, error) {
-	_ = ctx  // TODO: Use context
-	_ = task // TODO: Use task
-	// Add Action nodes in the designer to generate workflow steps
-	return map[string]interface{}{"status": "success"}, nil
+\t_ = ctx
+\treturn map[string]interface{}{
+\t\t"status": "blocked",
+\t\t"reason": ${this._quoteGeneratedString(emptyWorkflowReason)},
+\t\t"steps":  []StepResult{},
+\t\t"input": map[string]interface{}{
+\t\t\t"task": task,
+\t\t},
+\t}, nil
 }
 `;
         }
 
-        const workflowSteps = nodes.map(n => `
-	// ${n.config.description || 'Execute ' + n.label}
-	${this._toSnakeCase(n.label)}Result, err := ${this._toSnakeCase(n.label)}(ctx, workflowCtx)
-	if err != nil {
-		return nil, err
-	}
-	_ = ${this._toSnakeCase(n.label)}Result`).join('\n');
+        const workflowSteps = actionNodes.map(({ functionName }) => `
+\tstepResult, err := ${functionName}(ctx, workflowCtx)
+\tif err != nil {
+\t\treturn nil, err
+\t}
+\tsteps = append(steps, stepResult)`).join('\n');
 
-        const functionDefs = nodes.map(node => `
-func ${this._toSnakeCase(node.label)}(ctx context.Context, workflowCtx map[string]interface{}) (map[string]interface{}, error) {
-	_ = ctx         // TODO: Use context
-	_ = workflowCtx // TODO: Use workflow context
-	// TODO: Implement ${node.config.action || 'action'}
-	return map[string]interface{}{"status": "success"}, nil
+        const functionDefs = actionNodes.map(({ node, action, description, functionName }) => `
+func ${functionName}(ctx context.Context, workflowCtx map[string]interface{}) (StepResult, error) {
+\t_ = ctx
+\t_ = workflowCtx
+\treturn blockedStep(
+\t\t${this._quoteGeneratedString(node.label)},
+\t\t${this._quoteGeneratedString(action)},
+\t\t${this._quoteGeneratedString(scaffoldReason)},
+\t\t${node.policy ? this._quoteGeneratedString(node.policy) : '""'},
+\t\tmap[string]interface{}{"description": ${this._quoteGeneratedString(description)}},
+\t), nil
 }
 `).join('');
 
@@ -458,43 +589,71 @@ func ${this._toSnakeCase(node.label)}(ctx context.Context, workflowCtx map[strin
 package main
 
 import (
-	"context"
-	"fmt"
-	
-	agentos "github.com/microsoft/agent-governance-toolkit/sdk/go"
+\t"context"
+\t"fmt"
+\t
+\tagentos "github.com/microsoft/agent-governance-toolkit/sdk/go"
 )
 
-func main() {
-	kernel, err := agentos.NewKernel(agentos.WithPolicy("strict"))
-	if err != nil {
-		panic(err)
-	}
+${stepResultType}
 
-	result, err := kernel.Execute(context.Background(), runWorkflow, "example task")
-	if err != nil {
-		panic(err)
-	}
-	
-	fmt.Printf("Result: %v\\n", result)
+func main() {
+\tkernel, err := agentos.NewKernel(agentos.WithPolicy("strict"))
+\tif err != nil {
+\t\tpanic(err)
+\t}
+
+\tresult, err := kernel.Execute(context.Background(), runWorkflow, "example task")
+\tif err != nil {
+\t\tpanic(err)
+\t}
+\t
+\tfmt.Printf("Result: %v\\n", result)
 }
 
 func runWorkflow(ctx context.Context, task string) (map[string]interface{}, error) {
-	workflowCtx := map[string]interface{}{"task": task}
-	${workflowSteps}
-	
-	return map[string]interface{}{"status": "success"}, nil
+\tworkflowCtx := map[string]interface{}{"task": task}
+\tsteps := []StepResult{}
+\t${workflowSteps}
+
+\tfor _, step := range steps {
+\t\tif step.Status != "completed" {
+\t\t\treturn map[string]interface{}{
+\t\t\t\t"status": "blocked",
+\t\t\t\t"reason": "Workflow contains scaffolded steps that must be implemented before execution.",
+\t\t\t\t"blockedStep": step,
+\t\t\t\t"steps": steps,
+\t\t\t}, nil
+\t\t}
+\t}
+
+\treturn map[string]interface{}{"status": "completed", "steps": steps}, nil
 }
 ${functionDefs}
 `;
     }
 
-    private _toSnakeCase(str: string): string {
-        return str.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '');
+    private _toSnakeCase(str: string, fallback = 'step'): string {
+        const normalized = str
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '_')
+            .replace(/^_+|_+$/g, '');
+        const safe = normalized || fallback;
+        return /^[a-z_]/.test(safe) ? safe : `step_${safe}`;
     }
 
-    private _toCamelCase(str: string): string {
-        return str.toLowerCase()
-            .replace(/[^a-zA-Z0-9]+(.)/g, (m, chr) => chr.toUpperCase());
+    private _toCamelCase(str: string, fallback = 'step'): string {
+        const segments = str
+            .trim()
+            .split(/[^a-zA-Z0-9]+/)
+            .filter(Boolean)
+            .map(segment => segment.toLowerCase());
+        if (segments.length === 0) {
+            return fallback;
+        }
+        const [first, ...rest] = segments;
+        const safe = first + rest.map(segment => segment.charAt(0).toUpperCase() + segment.slice(1)).join('');
+        return /^[a-zA-Z_$]/.test(safe) ? safe : `step${safe.charAt(0).toUpperCase()}${safe.slice(1)}`;
     }
 
     private async _saveWorkflow(): Promise<void> {
@@ -1407,9 +1566,9 @@ ${functionDefs}
             }
         });
 
-        // Toolbar buttons use ``data-action`` rather than inline ``onclick=``
+        // Toolbar buttons use "data-action" rather than inline "onclick="
         // attributes so the page is CSP-compliant under
-        // ``script-src 'nonce-...'`` (which blocks inline event handlers).
+        // "script-src 'nonce-...'" (which blocks inline event handlers).
         // A single delegated click listener bound from this nonce-gated
         // script dispatches to the appropriate function.
         const __toolbarActions = {


### PR DESCRIPTION
## Summary

Fail-close workflow-designer exports so generated Python, TypeScript, and Go code no longer ships `TODO` placeholders with success-shaped defaults.

## Problem

Exported workflow code looked runnable even when action implementations were missing. Empty workflows and scaffolded steps returned success-shaped results, which is misleading and creates a sharp edge for anyone trying to use the generated output as-is.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-typescript/agent-os-vscode/src/webviews/workflowDesigner/WorkflowDesignerPanel.ts` | Reworked Python, TypeScript, and Go code generation to emit blocked scaffolds for empty workflows and scaffolded action steps, preserve configured action/policy/description metadata, add safe generated identifier fallbacks, and fix local verification issues in the file. |
| `agent-governance-typescript/agent-os-vscode/src/test/webviews/workflowDesignerPanel.test.ts` | Added focused regression tests for empty exports, action-step scaffolds, and identifier fallback behavior. |

## Testing

- `npx tsc --noEmit --module commonjs --target ES2022 --lib ES2022 --strict --esModuleInterop --skipLibCheck --resolveJsonModule src\webviews\workflowDesigner\WorkflowDesignerPanel.ts src\test\webviews\workflowDesignerPanel.test.ts`
- `npx mocha --ui tdd .tmp-workflow-designer-verify\test\webviews\workflowDesignerPanel.test.js` (**2 passing**)
- `npx eslint src\webviews\workflowDesigner\WorkflowDesignerPanel.ts src\test\webviews\workflowDesignerPanel.test.ts`
- `npm run compile` still fails on a pre-existing unrelated error in `agent-governance-typescript/agent-os-vscode/src/server/browserScripts.ts:204`

## Description
<!-- Briefly describe the changes in this PR -->

Fail-close generated workflow-designer exports and add focused regression coverage for the generated output.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
<!-- REQUIRED for new features, integrations, or architectural patterns -->
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
<!-- Example: "Sandboxing approach inspired by https://github.com/example/project (Apache-2.0)" -->
<!-- Leave blank if not applicable -->

## AI Assistance
<!-- See CONTRIBUTING.md "AI-Assisted Contributions" for full policy -->
- [ ] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [ ] No part of this PR was autonomously submitted by an AI agent without my review
- [ ] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
<!-- Example: "GitHub Copilot for boilerplate, Codex for test generation — all output reviewed" -->
<!-- Leave blank if AI was not used or was only used for minor assistance -->
GitHub Copilot CLI drafted the code and test changes and ran the focused validation listed above. Human author review is still required before merge.

## IP, Patents, and Licensing
- [ ] This contribution does not implement patent-pending or patent-encumbered techniques
- [ ] This contribution does not require an NDA or licensing agreement to understand or use
- [ ] Any AI tools used have terms compatible with the MIT License

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
