### PR TITLE
docs: rewrite homepage with narrative structure and add learning paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **AgentMesh Wire Protocol v1.0** specification (`docs/specs/AGENTMESH-WIRE-1.0.md`)
-- **TypeScript E2E Encryption** — X3DH + Double Ratchet + SecureChannel ported to `@microsoft/agentmesh-sdk`
+- **TypeScript E2E Encryption** — X3DH + Double Ratchet + SecureChannel ported to `@microsoft/agent-governance-sdk`
 - **MeshClient** — high-level relay transport with plaintext peers, KNOCK pending queue, wsFactory hook
 - **Registry Service** — first-party agent registry with pre-key bundles, discovery, presence, reputation
 - **Relay Service** — store-and-forward WebSocket relay with 72h TTL offline inbox
@@ -482,7 +482,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **TypeScript SDK full parity** (— PolicyEngine + AgentIdentity) — rich policy evaluation with 4 conflict resolution strategies, expression evaluator, rate limiting, YAML/JSON policy documents, Ed25519 identity with lifecycle/delegation/JWK/JWKS/DID export, IdentityRegistry with cascade revocation. 136 tests passing. (#269)
-- **@microsoft/agentmesh-sdk 1.0.0** — TypeScript package now publish-ready with `exports` field, `prepublishOnly` build hook, correct `repository.directory`, MIT license.
+- **@microsoft/agent-governance-sdk 1.0.0** — TypeScript package now publish-ready with `exports` field, `prepublishOnly` build hook, correct `repository.directory`, MIT license.
 - **Multi-language README** — root README now surfaces Python (PyPI), TypeScript (npm), and .NET (NuGet) install sections, badges, quickstart code, and a multi-SDK packages table.
 - **Multi-language QUICKSTART** — getting started guide now covers all three SDKs with code examples.
 - **Semantic Kernel + Azure AI Foundry** added to framework integration table.
@@ -540,7 +540,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 pip install agent-governance-toolkit[full]
 
 # TypeScript
-npm install @microsoft/agentmesh-sdk
+npm install @microsoft/agent-governance-sdk
 
 # .NET
 dotnet add package Microsoft.AgentGovernance

--- a/agent-governance-python/agent-mesh/docs/trust-model-guide.md
+++ b/agent-governance-python/agent-mesh/docs/trust-model-guide.md
@@ -532,7 +532,7 @@ print(f"At risk: {report['at_risk_agents']}")
 ### Example 6: Using the TypeScript SDK
 
 ```typescript
-import { TrustManager } from '@microsoft/agentmesh-sdk';
+import { TrustManager } from '@microsoft/agent-governance-sdk';
 
 const manager = new TrustManager({
   initialScore: 0.5,

--- a/agent-governance-python/agent-mesh/docs/trust-scoring-api.md
+++ b/agent-governance-python/agent-mesh/docs/trust-scoring-api.md
@@ -584,7 +584,7 @@ metrics = score.to_dict()
 The TypeScript SDK provides a simpler trust model suitable for client-side use.
 
 ```typescript
-import { TrustManager } from '@microsoft/agentmesh-sdk';
+import { TrustManager } from '@microsoft/agent-governance-sdk';
 
 const manager = new TrustManager({
   initialScore: 0.5,

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -160,7 +160,7 @@ All types deliver the same governance capabilities — policy enforcement, ident
 | Language | Package | Status |
 |----------|---------|--------|
 | Python | `agent-governance-toolkit[full]` | ✅ Full-featured, primary package |
-| TypeScript | `@microsoft/agentmesh-sdk` | ✅ Published on npm |
+| TypeScript | `@microsoft/agent-governance-sdk` | ✅ Published on npm |
 | .NET | `Microsoft.AgentGovernance` | ✅ Published on NuGet |
 | Rust | `agentmesh` crate | ✅ Published on crates.io |
 | Go | `github.com/microsoft/agent-governance-toolkit/agent-governance-golang` | ✅ Module available |
@@ -347,7 +347,7 @@ In sidecar deployments, the governance sidecar can be updated independently of t
 | Ecosystem | Package | Status |
 |-----------|---------|--------|
 | PyPI | `agent-governance-toolkit[full]`, `agent-os-kernel`, `agentmesh-platform`, `agentmesh-runtime`, `agent-sre`, `agentmesh-marketplace`, `agentmesh-lightning`, `agentmesh-openai-agents-trust`, `langgraph-trust` | ✅ Published |
-| npm | `@microsoft/agentmesh-sdk` | ✅ Published |
+| npm | `@microsoft/agent-governance-sdk` | ✅ Published |
 | NuGet | `Microsoft.AgentGovernance` | ✅ Published |
 | crates.io | `agentmesh` | ✅ Published |
 | Dify Marketplace | Trust verification plugin | ✅ Merged |
@@ -696,7 +696,7 @@ See [Tutorial 40 — OTel Observability](tutorials/40-otel-observability.md) for
 | GitHub Repository | https://github.com/microsoft/agent-governance-toolkit |
 | Launch Blog Post | https://opensource.microsoft.com/blog/2026/04/02/introducing-the-agent-governance-toolkit-open-source-runtime-security-for-ai-agents/ |
 | PyPI (Full Stack) | https://pypi.org/project/agent-governance-toolkit/ |
-| npm (TypeScript) | `@microsoft/agentmesh-sdk` |
+| npm (TypeScript) | `@microsoft/agent-governance-sdk` |
 | NuGet (.NET) | `Microsoft.AgentGovernance` |
 | DeepWiki | https://deepwiki.com/microsoft/agent-governance-toolkit |
 | OWASP Agentic Top 10 | https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/ |

--- a/docs/INDEPENDENCE.md
+++ b/docs/INDEPENDENCE.md
@@ -24,7 +24,7 @@ Core paths (`agent_os/`, `agentmesh/`, `agent_hypervisor/`, `agent_sre/`) must f
 | **agentmesh** (Rust) | None — pure crypto + serde | ✅ Independent |
 | **agentmesh-mcp** (Rust) | None — pure crypto + serde | ✅ Independent |
 | **agentmesh** (Go) | None — yaml.v3 only | ✅ Independent |
-| **@microsoft/agentmesh-sdk** (TypeScript) | None — zero runtime deps | ✅ Independent |
+| **@microsoft/agent-governance-sdk** (TypeScript) | None — zero runtime deps | ✅ Independent |
 | **Microsoft.AgentGovernance** (.NET) | None — YamlDotNet only | ✅ Independent |
 
 ## Adapter Pattern

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -112,7 +112,7 @@ See the full list of Microsoft-controlled scopes: `@microsoft`, `@azure`,
 | AgentMesh Mastra | `@microsoft/agentmesh-mastra` | `agent-governance-python/agentmesh-integrations/mastra-agentmesh` |
 | AgentMesh API | `@microsoft/agentmesh-api` | `agent-governance-python/agent-mesh/services/api` |
 | AgentMesh MCP Proxy | `@microsoft/agentmesh-mcp-proxy` | `agent-governance-python/agent-mesh/packages/mcp-proxy` |
-| AgentMesh SDK | `@microsoft/agentmesh-sdk` | `agent-governance-typescript` |
+| AgentMesh SDK | `@microsoft/agent-governance-sdk` | `agent-governance-typescript` |
 | Agent OS Copilot Extension | `@microsoft/agent-os-copilot-extension` | `agent-governance-python/agent-os/extensions/copilot` |
 | AgentOS MCP Server | `@microsoft/agentos-mcp-server` | `agent-governance-python/agent-os/extensions/mcp-server` |
 

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -49,7 +49,7 @@ pip install agent-governance-toolkit[full]
 
 **TypeScript / Node.js** (npm)
 ```bash
-npm install @microsoft/agentmesh-sdk
+npm install @microsoft/agent-governance-sdk
 ```
 
 **.NET** (NuGet)
@@ -153,7 +153,7 @@ if decision.allowed:
 ### ポリシーの適用 — TypeScript
 
 ```typescript
-import { PolicyEngine } from "@microsoft/agentmesh-sdk";
+import { PolicyEngine } from "@microsoft/agent-governance-sdk";
 
 const engine = new PolicyEngine([
   { action: "web_search", effect: "allow" },
@@ -285,7 +285,7 @@ decision = engine.evaluate("did:mesh:agent-1", {"tool_name": "analyze"})
 | 言語 | パッケージ | インストール |
 |----------|---------|---------|
 | **Python** | [`agent-governance-toolkit[full]`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@microsoft/agentmesh-sdk`](../../agent-governance-typescript/) | `npm install @microsoft/agentmesh-sdk` |
+| **TypeScript** | [`@microsoft/agent-governance-sdk`](../../agent-governance-typescript/) | `npm install @microsoft/agent-governance-sdk` |
 | **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
 | **Rust** | [`agentmesh`](https://crates.io/crates/agentmesh) | `cargo add agentmesh` |
 | **Rust MCP** | [`agentmesh-mcp`](https://crates.io/crates/agentmesh-mcp) | `cargo add agentmesh-mcp` |

--- a/docs/i18n/README.zh-CN.md
+++ b/docs/i18n/README.zh-CN.md
@@ -42,7 +42,7 @@ pip install agent-governance-toolkit[full]
 
 **TypeScript / Node.js** (npm)
 ```bash
-npm install @microsoft/agentmesh-sdk
+npm install @microsoft/agent-governance-sdk
 ```
 
 **.NET** (NuGet)
@@ -135,7 +135,7 @@ if decision.allowed:
 ### 执行策略 — TypeScript
 
 ```typescript
-import { PolicyEngine } from "@microsoft/agentmesh-sdk";
+import { PolicyEngine } from "@microsoft/agent-governance-sdk";
 
 const engine = new PolicyEngine([
   { action: "web_search", effect: "allow" },
@@ -267,7 +267,7 @@ decision = engine.evaluate("did:mesh:agent-1", {"tool_name": "analyze"})
 | 语言 | Package | Install |
 |----------|---------|---------|
 | **Python** | [`agent-governance-toolkit[full]`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
-| **TypeScript** | [`@microsoft/agentmesh-sdk`](../../agent-governance-typescript/) | `npm install @microsoft/agentmesh-sdk` |
+| **TypeScript** | [`@microsoft/agent-governance-sdk`](../../agent-governance-typescript/) | `npm install @microsoft/agent-governance-sdk` |
 | **.NET** | [`Microsoft.AgentGovernance`](https://www.nuget.org/packages/Microsoft.AgentGovernance) | `dotnet add package Microsoft.AgentGovernance` |
 | **Rust** | [`agentmesh`](https://crates.io/crates/agentmesh) | `cargo add agentmesh` |
 | **Go** | [`agentmesh`](../../agent-governance-golang/) | `go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang` |

--- a/docs/i18n/quickstart.ja.md
+++ b/docs/i18n/quickstart.ja.md
@@ -42,7 +42,7 @@ pip install agentmesh-lightning        # RL training governance
 ### TypeScript / Node.js
 
 ```bash
-npm install @microsoft/agentmesh-sdk
+npm install @microsoft/agent-governance-sdk
 ```
 
 ### .NET
@@ -119,7 +119,7 @@ python governed_agent.py
 `governed_agent.ts` というファイルを作成します。
 
 ```typescript
-import { PolicyEngine, AgentIdentity, AuditLogger } from "@microsoft/agentmesh-sdk";
+import { PolicyEngine, AgentIdentity, AuditLogger } from "@microsoft/agent-governance-sdk";
 
 const identity = AgentIdentity.generate("my-agent", ["web_search", "read_file"]);
 

--- a/docs/i18n/quickstart.zh-CN.md
+++ b/docs/i18n/quickstart.zh-CN.md
@@ -42,7 +42,7 @@ pip install agentmesh-lightning        # 强化学习训练治理
 ### TypeScript / Node.js
 
 ```bash
-npm install @microsoft/agentmesh-sdk
+npm install @microsoft/agent-governance-sdk
 ```
 
 ### .NET

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,9 +78,13 @@ hide:
 
 <div class="agt-hero" markdown>
 
-# Agent Governance Toolkit
+# Ship agents to production without losing sleep
 
-Runtime governance for AI agents: deterministic policy enforcement, zero-trust identity, execution sandboxing, and SRE for autonomous agents.
+Policy enforcement, identity, sandboxing, and SRE for autonomous AI agents. One `pip install`, any framework.
+
+```
+pip install agent-governance-toolkit
+```
 
 <div class="agt-hero-badges">
   <a href="quickstart/">🚀 Quick Start</a>
@@ -95,6 +99,88 @@ Runtime governance for AI agents: deterministic policy enforcement, zero-trust i
   <div class="agt-stat"><span class="agt-stat-value">5</span><span class="agt-stat-label">Languages</span></div>
   <div class="agt-stat"><span class="agt-stat-value">20+</span><span class="agt-stat-label">Integrations</span></div>
 </div>
+
+</div>
+
+<div class="agt-section" markdown>
+
+## The problem
+
+Your AI agents call tools, browse the web, query databases, and delegate to other agents. Once deployed, they make decisions autonomously. You need answers to three questions:
+
+**1. Is this action allowed?** An agent with access to `send_email` and `query_database` should not be able to `drop_table`. OAuth scopes and IAM roles control which services an agent can reach, not what it does once connected.
+
+**2. Which agent did this?** In a multi-agent system, five agents might share a single API key. When something goes wrong, "an agent did it" is not an incident response.
+
+**3. Can you prove what happened?** Auditors and regulators need tamper-evident records of every decision: what policy was active, what the agent requested, and why it was allowed or denied.
+
+</div>
+
+<div class="agt-section" markdown>
+
+## Govern any agent in 2 lines
+
+Wrap any tool function with `govern()`. Policy enforcement, audit logging, and denial handling are automatic.
+
+```python
+from agentmesh.governance import govern
+
+safe_tool = govern(my_tool, policy="policy.yaml")
+```
+
+That's it. `safe_tool` evaluates your YAML policy on every call, logs the decision, and raises `GovernanceDenied` if the action is blocked. Works with LangChain, CrewAI, OpenAI Agents, AutoGen, Google ADK, and any other framework.
+
+```yaml
+# policy.yaml
+apiVersion: governance.toolkit/v1
+name: production-policy
+default_action: allow
+rules:
+  - name: block-destructive
+    condition: "action.type in ['drop', 'delete', 'truncate']"
+    action: deny
+    description: "Destructive operations require human approval"
+
+  - name: require-approval-for-send
+    condition: "action.type == 'send_email'"
+    action: require_approval
+    approvers: ["security-team"]
+```
+
+```
+>>> safe_tool(action="read", table="users")
+{'table': 'users', 'rows': 42}
+
+>>> safe_tool(action="drop", table="users")
+GovernanceDenied: Action denied by policy rule 'block-destructive':
+  Destructive operations require human approval
+```
+
+</div>
+
+<div class="agt-section" markdown>
+
+## How it works
+
+```
+                       ┌─────────────────────────────────────────────┐
+                       │            Agent Governance Toolkit          │
+                       │                                             │
+Agent ──→ govern() ──→ │  Policy Engine ──→ Identity ──→ Audit Log   │ ──→ Tool
+                       │       │                │            │       │
+                       │   YAML/OPA/Cedar   SPIFFE SVID   Tamper-   │
+                       │                                  evident    │
+                       └─────────────────────────────────────────────┘
+
+  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
+  │ Agent OS  │    │   Mesh   │    │   SRE    │    │ Sandbox  │
+  │ policies  │    │ identity │    │  SLOs    │    │  rings   │
+  │ lifecycle │    │  routing │    │  chaos   │    │ isolation│
+  │ approval  │    │   trust  │    │  costs   │    │ kill sw  │
+  └──────────┘    └──────────┘    └──────────┘    └──────────┘
+```
+
+Every layer is optional. Start with `govern()` and add layers as your risk profile grows. Most teams run policy enforcement + audit logging and never need the full stack.
 
 </div>
 

--- a/docs/modern-agent-architecture-overview.md
+++ b/docs/modern-agent-architecture-overview.md
@@ -218,7 +218,7 @@ Catches: tool poisoning, typosquatting, hidden instructions, rug-pull attacks.
 pip install agent-governance-toolkit[full]
 ```
 
-Also available for: **TypeScript** (`npm install @microsoft/agentmesh-sdk`), **.NET** (`dotnet add package Microsoft.AgentGovernance`), **Rust** (`cargo add agentmesh`), **Go**
+Also available for: **TypeScript** (`npm install @microsoft/agent-governance-sdk`), **.NET** (`dotnet add package Microsoft.AgentGovernance`), **Rust** (`cargo add agentmesh`), **Go**
 
 ### Step 2: Your First Governed Agent
 

--- a/docs/tutorials/08-opa-rego-cedar-policies.md
+++ b/docs/tutorials/08-opa-rego-cedar-policies.md
@@ -33,7 +33,7 @@ start to production multi-backend deployments.
 | [OPA/Rego Backend](#oparego-backend) | Loading Rego files, package configuration, evaluation |
 | [Three Evaluation Modes](#three-evaluation-modes) | Embedded engine, remote OPA server, built-in fallback |
 | [Cedar Backend](#cedar-backend) | Cedar policy syntax, schema validation, compilation |
-| [Cedar with AgentMesh](#cedar-with-agentmesh) | Trust-aware Cedar policies via `CedarEvaluator` |
+| [Cedar with AgentMesh](#cedar-with-agentmesh) | Trust-aware Cedar policies via `CedarBackend` |
 | [BackendDecision](#backenddecision) | Normalized output format from any backend |
 | [Combining Backends](#combining-backends) | Using OPA + Cedar + YAML together |
 | [Migration Guide](#migration-guide) | Moving from YAML-only to OPA/Cedar |
@@ -581,12 +581,12 @@ The AgentMesh package provides its own Cedar evaluator at
 `agentmesh.governance.cedar` with additional features for trust-aware,
 multi-agent governance.
 
-### CedarEvaluator
+### CedarBackend
 
 ```python
-from agentmesh.governance.cedar import CedarEvaluator, CedarDecision
+from agentmesh.governance.cedar import CedarBackend, CedarDecision
 
-evaluator = CedarEvaluator(
+evaluator = CedarBackend(
     mode="auto",                           # "auto", "cedarpy", "cli", "builtin"
     policy_path="./policies/mesh.cedar",   # path to .cedar file
     policy_content=None,                   # or inline Cedar string
@@ -597,7 +597,7 @@ evaluator = CedarEvaluator(
 )
 ```
 
-Unlike the Agent-OS `CedarBackend`, `CedarEvaluator.evaluate()` takes an
+Unlike the Agent-OS `CedarBackend`, `CedarBackend.evaluate()` takes an
 explicit `action` string and a `context` dict:
 
 ```python
@@ -634,7 +634,7 @@ Combine Cedar with AgentMesh trust scoring to create policies that adapt based
 on agent reputation:
 
 ```python
-from agentmesh.governance.cedar import CedarEvaluator
+from agentmesh.governance.cedar import CedarBackend
 from agentmesh.governance.policy import PolicyEngine
 
 engine = PolicyEngine()
@@ -682,12 +682,12 @@ cedar_eval = load_cedar_into_engine(
 The AgentMesh package provides its own OPA evaluator at
 `agentmesh.governance.opa` with the same trust-aware integration pattern.
 
-### OPAEvaluator
+### OPABackend
 
 ```python
-from agentmesh.governance.opa import OPAEvaluator, OPADecision
+from agentmesh.governance.opa import OPABackend, OPADecision
 
-evaluator = OPAEvaluator(
+evaluator = OPABackend(
     mode="local",                          # "remote" or "local"
     opa_url="http://localhost:8181",        # remote OPA server URL
     rego_path="./policies/mesh.rego",      # path to .rego file
@@ -696,7 +696,7 @@ evaluator = OPAEvaluator(
 )
 ```
 
-Unlike the Agent-OS `OPABackend`, `OPAEvaluator.evaluate()` takes an explicit
+Unlike the Agent-OS `OPABackend`, `OPABackend.evaluate()` takes an explicit
 `query` string and an `input_data` dict:
 
 ```python
@@ -841,8 +841,8 @@ The toolkit has three decision types at different layers:
 | Type | Package | Used by | Key differences |
 |------|---------|---------|-----------------|
 | `BackendDecision` | `agent_os.policies.backends` | `OPABackend`, `CedarBackend` | Normalized; feeds into `PolicyEvaluator` |
-| `OPADecision` | `agentmesh.governance.opa` | `OPAEvaluator` | Includes `query` and `source` fields |
-| `CedarDecision` | `agentmesh.governance.cedar` | `CedarEvaluator` | Includes `action` and `source` fields |
+| `OPADecision` | `agentmesh.governance.opa` | `OPABackend` | Includes `query` and `source` fields |
+| `CedarDecision` | `agentmesh.governance.cedar` | `CedarBackend` | Includes `action` and `source` fields |
 
 All three share the `allowed`, `raw_result`, `evaluation_ms`, and `error`
 fields. The Agent-OS `BackendDecision` adds `action`, `reason`, and `backend`
@@ -1269,7 +1269,7 @@ print(f"Reason: {decision.reason}")
 - **OPA Playground:** Test Rego policies at [play.openpolicyagent.org](https://play.openpolicyagent.org/)
 - **Cedar Playground:** Test Cedar policies at [cedarpolicy.com/playground](https://www.cedarpolicy.com/en/playground)
 - **Custom backends:** Implement `ExternalPolicyBackend` to integrate any policy engine
-- **AgentMesh multi-backend:** Combine `PolicyEngine` with `OPAEvaluator` and `CedarEvaluator` for trust-aware governance
+- **AgentMesh multi-backend:** Combine `PolicyEngine` with `OPABackend` and `CedarBackend` for trust-aware governance
 
 ---
 
@@ -1283,9 +1283,9 @@ print(f"Reason: {decision.reason}")
 | `BackendDecision` | `agent-governance-python/agent-os/src/agent_os/policies/backends.py` |
 | `PolicyEvaluator` | `agent-governance-python/agent-os/src/agent_os/policies/evaluator.py` |
 | `PolicyDecision` | `agent-governance-python/agent-os/src/agent_os/policies/evaluator.py` |
-| `OPAEvaluator` | `agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py` |
+| `OPABackend` | `agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py` |
 | `OPADecision` | `agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py` |
-| `CedarEvaluator` | `agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py` |
+| `CedarBackend` | `agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py` |
 | `CedarDecision` | `agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py` |
 | `PolicyEngine` | `agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py` |
 | OPA tests | `agent-governance-python/agent-mesh/tests/test_opa.py` |

--- a/docs/tutorials/14-kill-switch-and-rate-limiting.md
+++ b/docs/tutorials/14-kill-switch-and-rate-limiting.md
@@ -75,7 +75,7 @@ Governance Toolkit:
 
 - Python ≥ 3.11
 - `pip install agent-hypervisor` (kill switch, agent rate limiter, rings)
-- `pip install agent-mesh` (service-level rate limiter, HTTP middleware)
+- `pip install agentmesh-platform` (service-level rate limiter, HTTP middleware)
 
 ---
 

--- a/docs/tutorials/20-typescript-sdk.md
+++ b/docs/tutorials/20-typescript-sdk.md
@@ -1,6 +1,6 @@
-# Tutorial 20 — TypeScript package (@microsoft/agentmesh-sdk)
+# Tutorial 20 — TypeScript package (@microsoft/agent-governance-sdk)
 
-> **Package:** `@microsoft/agentmesh-sdk` · **Time:** 30 minutes · **Prerequisites:** Node.js 18+
+> **Package:** `@microsoft/agent-governance-sdk` · **Time:** 30 minutes · **Prerequisites:** Node.js 18+
 
 ---
 
@@ -14,12 +14,12 @@
 ---
 
 Build governance-aware AI agents in TypeScript and Node.js.
-The `@microsoft/agentmesh-sdk` package provides cryptographic identity (Ed25519 DIDs),
+The `@microsoft/agent-governance-sdk` package provides cryptographic identity (Ed25519 DIDs),
 trust scoring, declarative policy evaluation, and hash-chain audit logging — all in
 a single npm install.
 
 **Prerequisites:** Node.js ≥ 18 · TypeScript ≥ 5.4
-**Package:** `@microsoft/agentmesh-sdk` v1.0.0
+**Package:** `@microsoft/agent-governance-sdk` v3.7.0
 **Modules:** `AgentIdentity`, `TrustManager`, `PolicyEngine`, `AuditLogger`, `AgentMeshClient`
 
 ---
@@ -44,7 +44,7 @@ a single npm install.
 ## Installation
 
 ```bash
-npm install @microsoft/agentmesh-sdk
+npm install @microsoft/agent-governance-sdk
 ```
 
 The package has two runtime dependencies — `@noble/ed25519` for cryptography and
@@ -55,7 +55,7 @@ needed.
 
 ```bash
 # Verify the install
-node -e "const sdk = require('@microsoft/agentmesh-sdk'); console.log(Object.keys(sdk))"
+node -e "const sdk = require('@microsoft/agent-governance-sdk'); console.log(Object.keys(sdk))"
 ```
 
 ---
@@ -65,7 +65,7 @@ node -e "const sdk = require('@microsoft/agentmesh-sdk'); console.log(Object.key
 Five lines to evaluate your first policy:
 
 ```typescript
-import { PolicyEngine } from '@microsoft/agentmesh-sdk';
+import { PolicyEngine } from '@microsoft/agent-governance-sdk';
 
 const engine = new PolicyEngine([
   { action: 'data.read',  effect: 'allow' },
@@ -83,7 +83,7 @@ console.log(engine.evaluate('data.delete')); // 'deny'  ← default when no rule
 Or use the unified `AgentMeshClient` for the full governance pipeline:
 
 ```typescript
-import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
 
 const client = AgentMeshClient.create('my-agent', {
   capabilities: ['data.read', 'data.write'],
@@ -110,7 +110,7 @@ trust, policy, and audit into a single governance-aware pipeline.
 ### Creating a Client
 
 ```typescript
-import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
 
 // Quick creation with defaults
 const client = AgentMeshClient.create('sales-agent', {
@@ -127,7 +127,7 @@ console.log(client.audit);           // AuditLogger instance
 ### Full Configuration
 
 ```typescript
-import { AgentMeshClient, AgentMeshConfig } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient, AgentMeshConfig } from '@microsoft/agent-governance-sdk';
 
 const config: AgentMeshConfig = {
   agentId: 'analytics-agent',
@@ -201,7 +201,7 @@ conflict resolution).
 Flat rules match an `action` string and return an `effect`:
 
 ```typescript
-import { PolicyEngine, PolicyRule } from '@microsoft/agentmesh-sdk';
+import { PolicyEngine, PolicyRule } from '@microsoft/agent-governance-sdk';
 
 const rules: PolicyRule[] = [
   { action: 'data.read',   effect: 'allow' },
@@ -238,7 +238,7 @@ Rich policies add expressions, rate limits, approval workflows, and conflict
 resolution:
 
 ```typescript
-import { PolicyEngine } from '@microsoft/agentmesh-sdk';
+import { PolicyEngine } from '@microsoft/agent-governance-sdk';
 
 const engine = new PolicyEngine();
 
@@ -368,7 +368,7 @@ import {
   PolicyEngine,
   PolicyConflictResolver,
   ConflictResolutionStrategy,
-} from '@microsoft/agentmesh-sdk';
+} from '@microsoft/agent-governance-sdk';
 
 const engine = new PolicyEngine([], ConflictResolutionStrategy.DenyOverrides);
 ```
@@ -452,7 +452,7 @@ delegation, and lifecycle management.
 ### §5.1 Generating an Identity
 
 ```typescript
-import { AgentIdentity } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity } from '@microsoft/agent-governance-sdk';
 
 const agent = AgentIdentity.generate('sales-assistant', ['crm.read', 'email.send'], {
   name: 'Sales Assistant',
@@ -645,7 +645,7 @@ const didDoc = agent.toDIDDocument();
 Manage multiple identities with the `IdentityRegistry`:
 
 ```typescript
-import { AgentIdentity, IdentityRegistry } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity, IdentityRegistry } from '@microsoft/agent-governance-sdk';
 
 const registry = new IdentityRegistry();
 
@@ -691,7 +691,7 @@ Scores decay over time and update based on interaction outcomes.
 ### §6.1 Creating a Trust Manager
 
 ```typescript
-import { TrustManager, TrustConfig } from '@microsoft/agentmesh-sdk';
+import { TrustManager, TrustConfig } from '@microsoft/agent-governance-sdk';
 
 // Default configuration
 const tm = new TrustManager();
@@ -785,7 +785,7 @@ Verified       █████████████████████�
 Verify another agent's identity and establish initial trust:
 
 ```typescript
-import { AgentIdentity, TrustManager } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity, TrustManager } from '@microsoft/agent-governance-sdk';
 
 const tm = new TrustManager();
 const peer = AgentIdentity.generate('remote-agent', ['data.read']);
@@ -831,7 +831,7 @@ chain similar to a blockchain.
 ### §7.1 Logging Events
 
 ```typescript
-import { AuditLogger } from '@microsoft/agentmesh-sdk';
+import { AuditLogger } from '@microsoft/agent-governance-sdk';
 
 const logger = new AuditLogger();
 
@@ -941,7 +941,7 @@ const logger = new AuditLogger({ maxEntries: 50_000 });
 Wrap LangChain tool calls with governance checks:
 
 ```typescript
-import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
 import { ChatOpenAI } from '@langchain/openai';
 import { DynamicTool } from '@langchain/core/tools';
 
@@ -981,7 +981,7 @@ const searchTool = governedTool('search', async (query) => {
 Add governance to OpenAI function calls:
 
 ```typescript
-import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
 import OpenAI from 'openai';
 
 const client = AgentMeshClient.create('openai-agent', {
@@ -1061,7 +1061,7 @@ The package itself is configuration-object driven, but you can wire environment 
 into your configuration:
 
 ```typescript
-import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
 
 const client = AgentMeshClient.create(
   process.env.AGENT_ID ?? 'default-agent',
@@ -1114,7 +1114,7 @@ includes:
 ### §10.1 Identity Errors
 
 ```typescript
-import { AgentIdentity } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity } from '@microsoft/agent-governance-sdk';
 
 // Revoked identity cannot be reactivated
 const agent = AgentIdentity.generate('temp', ['read']);
@@ -1140,7 +1140,7 @@ try {
 ### §10.2 Policy Errors
 
 ```typescript
-import { PolicyEngine } from '@microsoft/agentmesh-sdk';
+import { PolicyEngine } from '@microsoft/agent-governance-sdk';
 
 const engine = new PolicyEngine();
 
@@ -1162,7 +1162,7 @@ try {
 ### §10.3 Governance Pipeline Errors
 
 ```typescript
-import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
 
 const client = AgentMeshClient.create('agent', {
   policyRules: [{ action: '*', effect: 'deny' }],
@@ -1191,7 +1191,7 @@ import type {
   PolicyDecisionResult,
   GovernanceResult,
   TrustTier,
-} from '@microsoft/agentmesh-sdk';
+} from '@microsoft/agent-governance-sdk';
 
 // Type guard for trust tiers
 function requiresTrust(tier: TrustTier, minimum: TrustTier): boolean {
@@ -1234,7 +1234,7 @@ equivalent Python tutorial for each topic:
 | `AuditLogger` | `agent_os.audit` | [Tutorial 04 — Audit & Compliance](./04-audit-and-compliance.md) |
 
 > **Note:** The TypeScript package wraps all governance features into a single
-> `@microsoft/agentmesh-sdk` package, while the Python implementation splits
+> `@microsoft/agent-governance-sdk` package, while the Python implementation splits
 > them across separate `agent_os.*` modules. The APIs are designed for
 > cross-language parity — policy YAML files work identically in both.
 

--- a/docs/tutorials/22-go-sdk.md
+++ b/docs/tutorials/22-go-sdk.md
@@ -6,7 +6,7 @@ Build governance-aware AI agents in Go. The `agentmesh` module provides
 Ed25519 cryptographic identity, trust scoring, declarative policy evaluation,
 and hash-chain audit logging — all in a single `go get`.
 
-> **Target runtime:** Go 1.21+
+> **Target runtime:** Go 1.25+
 > **Module:** `github.com/microsoft/agent-governance-toolkit/agent-governance-golang`
 > **Package:** `agentmesh`
 
@@ -31,7 +31,7 @@ and hash-chain audit logging — all in a single `go get`.
 
 ## Prerequisites
 
-- **Go 1.21+**
+- **Go 1.25+**
 - Familiarity with Go modules (`go.mod`)
 - Recommended: read [Tutorial 01 — Policy Engine](01-policy-engine.md) for
   governance concepts

--- a/docs/tutorials/23-delegation-chains.md
+++ b/docs/tutorials/23-delegation-chains.md
@@ -7,7 +7,7 @@ narrowing** — child agents can only receive a subset of their parent's
 capabilities, never more. This tutorial shows how to build delegation chains
 that enforce the principle of least privilege across multi-agent systems.
 
-> **Package:** `@microsoft/agentmesh-sdk` (TypeScript) · `agentmesh` (Rust/Go)
+> **Package:** `@microsoft/agent-governance-sdk` (TypeScript) · `agentmesh` (Rust/Go)
 > **Key class:** `AgentIdentity.delegate()`
 > **Concept:** Authority can only decrease through a delegation chain
 
@@ -32,7 +32,7 @@ that enforce the principle of least privilege across multi-agent systems.
 ## Prerequisites
 
 - **Node.js 18+** with TypeScript 5.4+
-- `npm install @microsoft/agentmesh-sdk`
+- `npm install @microsoft/agent-governance-sdk`
 - Recommended: read [Tutorial 02 — Trust & Identity](02-trust-and-identity.md)
   and [Tutorial 20 — TypeScript package](20-typescript-sdk.md)
 
@@ -107,7 +107,7 @@ const bad = parent.delegate('bad', ['admin']);  // throws Error
 ### §3.1 Basic Delegation
 
 ```typescript
-import { AgentIdentity } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity } from '@microsoft/agent-governance-sdk';
 
 // 1. Create the root identity (manager)
 const manager = AgentIdentity.generate('manager', [
@@ -240,7 +240,7 @@ function getDelegationChain(
 }
 
 // Usage
-import { IdentityRegistry } from '@microsoft/agentmesh-sdk';
+import { IdentityRegistry } from '@microsoft/agent-governance-sdk';
 
 const registry = new IdentityRegistry();
 registry.register(manager);
@@ -305,7 +305,7 @@ console.log(manager.verify(attestation, signature));  // true
 Combine delegation with trust scoring to propagate trust through the chain:
 
 ```typescript
-import { AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentMeshClient } from '@microsoft/agent-governance-sdk';
 
 // Create a governed manager
 const managerClient = AgentMeshClient.create('manager', {
@@ -349,7 +349,7 @@ console.log(result.trustScore);
 ## Full Example: Manager → Researcher → Reader
 
 ```typescript
-import { AgentIdentity, IdentityRegistry, AgentMeshClient } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity, IdentityRegistry, AgentMeshClient } from '@microsoft/agent-governance-sdk';
 
 // ── Step 1: Create the root manager ──
 const manager = AgentIdentity.generate('manager', [
@@ -451,7 +451,7 @@ The `IdentityRegistry` manages all agent identities and supports cascade
 revocation:
 
 ```typescript
-import { IdentityRegistry, AgentIdentity } from '@microsoft/agentmesh-sdk';
+import { IdentityRegistry, AgentIdentity } from '@microsoft/agent-governance-sdk';
 
 const registry = new IdentityRegistry();
 

--- a/docs/tutorials/26-sbom-and-signing.md
+++ b/docs/tutorials/26-sbom-and-signing.md
@@ -167,7 +167,7 @@ binaries, SBOMs, policy files, or audit logs.
 ### §3.1 Signing with the TypeScript package
 
 ```typescript
-import { AgentIdentity } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity } from '@microsoft/agent-governance-sdk';
 import { readFileSync, writeFileSync } from 'fs';
 
 // 1. Generate (or load) a signing identity
@@ -277,7 +277,7 @@ func main() {
 ### §4.1 Verification with the TypeScript package
 
 ```typescript
-import { AgentIdentity } from '@microsoft/agentmesh-sdk';
+import { AgentIdentity } from '@microsoft/agent-governance-sdk';
 import { readFileSync } from 'fs';
 
 // 1. Load the signer's public identity
@@ -411,7 +411,7 @@ Add a verification step to your deployment pipeline:
 - name: Verify artifact signature
   run: |
     node -e "
-      const { AgentIdentity } = require('@microsoft/agentmesh-sdk');
+      const { AgentIdentity } = require('@microsoft/agent-governance-sdk');
       const fs = require('fs');
       const signer = AgentIdentity.fromJSON(
         JSON.parse(fs.readFileSync('signing-identity.json', 'utf-8'))

--- a/docs/tutorials/29-agent-discovery.md
+++ b/docs/tutorials/29-agent-discovery.md
@@ -34,12 +34,12 @@ Discover → Inventory → Reconcile → Govern
 ## Step 1: Install
 
 ```bash
-pip install agentmesh-discovery
+pip install agentmesh_discovery
 ```
 
 For GitHub scanning:
 ```bash
-pip install agentmesh-discovery[github]
+pip install agentmesh_discovery[github]
 ```
 
 ---
@@ -251,7 +251,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Install agent-discovery
-        run: pip install agentmesh-discovery[github]
+        run: pip install agentmesh_discovery[github]
       
       - name: Scan repository
         run: |

--- a/docs/tutorials/45-shift-left-governance.md
+++ b/docs/tutorials/45-shift-left-governance.md
@@ -436,7 +436,7 @@ properties in `Directory.Build.props` and `Directory.Build.targets`:
 These are enforced automatically for any project in the `agent-governance-dotnet/`
 directory tree.
 
-### §4.2 TypeScript (@microsoft/agentmesh-sdk)
+### §4.2 TypeScript (@microsoft/agent-governance-sdk)
 
 The TypeScript SDK uses strict compiler settings in `tsconfig.json`:
 
@@ -542,7 +542,7 @@ enforcing that nothing that ran has failed.
 | SBOM and artifact signing | [Tutorial 26 -- SBOM & Signing](26-sbom-and-signing.md) |
 | MCP tool scanning | [Tutorial 27 -- MCP Scan CLI](27-mcp-scan-cli.md) |
 | Multi-stage policy pipeline | [Tutorial 37 -- Multi-Stage Pipeline](37-multi-stage-pipeline.md) |
-| Contributor reputation deep dive | [Tutorial 46 -- Contributor Governance](46-contributor-governance.md) |
+| Contributor reputation deep dive | [Tutorial 46 -- Contributor Governance](53-contributor-governance.md) |
 | .NET SDK | [Tutorial 19 -- .NET package](19-dotnet-sdk.md) |
 | TypeScript SDK | [Tutorial 20 -- TypeScript package](20-typescript-sdk.md) |
 | Plugin marketplace | [Tutorial 10 -- Plugin Marketplace](10-plugin-marketplace.md) |

--- a/docs/tutorials/47-red-team-testing.md
+++ b/docs/tutorials/47-red-team-testing.md
@@ -306,6 +306,6 @@ If playbooks report "BYPASSED" results, your governance policies need strengthen
 ## Next Steps
 
 - [Tutorial 09: Prompt Injection Detection](09-prompt-injection-detection.md) - Runtime detection
-- [Tutorial 32: Chaos Testing Agents](32-chaos-testing-agents.md) - Resilience under failure
+- [Tutorial 32: Chaos Testing Agents](52-chaos-testing-agents.md) - Resilience under failure
 - [Tutorial 45: Shift-Left Governance](45-shift-left-governance.md) - Pre-commit governance gates
 - [Tutorial 25: Security Hardening](25-security-hardening.md) - Production security checklist

--- a/docs/tutorials/52-chaos-testing-agents.md
+++ b/docs/tutorials/52-chaos-testing-agents.md
@@ -1,4 +1,4 @@
-# Tutorial 32: Chaos Testing Your AI Agents
+# Tutorial 52: Chaos Testing Your AI Agents
 
 > **Package:** `agent-sre` · **Time:** 20 minutes · **Level:** Intermediate
 

--- a/docs/tutorials/53-contributor-governance.md
+++ b/docs/tutorials/53-contributor-governance.md
@@ -1,6 +1,6 @@
 <!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
 
-# Tutorial 46: Contributor Governance
+# Tutorial 53: Contributor Governance
 
 > **Time**: 30 minutes · **Level**: Intermediate · **Prerequisites**: Tutorial 45 (Shift-Left Governance)
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -74,7 +74,7 @@ guides.
 |---|----------|-------------------|---------|
 | 19 | [.NET package](19-dotnet-sdk.md) | GovernanceKernel, policy, rings, saga, SLO, OpenTelemetry in C# | `Microsoft.AgentGovernance` |
 | 42 | [C# MCP extension](42-csharp-mcp-extension.md) | Add governed tool execution, startup scanning, and response sanitization to MCP servers | `Microsoft.AgentGovernance.Extensions.ModelContextProtocol` |
-| 20 | [TypeScript package](20-typescript-sdk.md) | Identity, trust, policy, audit in TypeScript/Node.js | `@microsoft/agentmesh-sdk` |
+| 20 | [TypeScript package](20-typescript-sdk.md) | Identity, trust, policy, audit in TypeScript/Node.js | `@microsoft/agent-governance-sdk` |
 | 21 | [Rust crate](21-rust-sdk.md) | Policy, trust, audit, identity with `agentmesh` crate | `agentmesh` |
 | 22 | [Go module](22-go-sdk.md) | Policy, trust, audit, identity with Go module | `agentmesh` |
 
@@ -82,7 +82,7 @@ guides.
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 23 | [Delegation Chains](23-delegation-chains.md) | Monotonic scope narrowing, multi-agent delegation, cascade revocation | `@microsoft/agentmesh-sdk` |
+| 23 | [Delegation Chains](23-delegation-chains.md) | Monotonic scope narrowing, multi-agent delegation, cascade revocation | `@microsoft/agent-governance-sdk` |
 | 24 | [Cost & Token Budgets](24-cost-and-token-budgets.md) | Per-session token limits, context scheduling, budget signals | `agent-os-kernel` |
 | 49 | [Multi-Agent Collective Policies](49-multi-agent-policies.md) | Aggregate constraints across agents: rate limits, concurrent caps, alert-only monitoring | `agentmesh-platform` |
 
@@ -220,7 +220,7 @@ Install the full toolkit:
 ```bash
 pip install agent-governance-toolkit[full]    # Python
 dotnet add package Microsoft.AgentGovernance  # .NET
-npm install @microsoft/agentmesh-sdk                    # TypeScript
+npm install @microsoft/agent-governance-sdk                    # TypeScript
 cargo add agentmesh                           # Rust
 go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang  # Go
 ```

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -99,7 +99,7 @@ Monitoring, alerting, and operational management of governed agents.
 | [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) | Emergency controls, throttling |
 | [Agent Discovery](29-agent-discovery.md) | Finding shadow AI in your organization |
 | [Agent Lifecycle](30-agent-lifecycle.md) | Birth-to-retirement management |
-| [Chaos Testing](32-chaos-testing-agents.md) | Chaos engineering for agent reliability |
+| [Chaos Testing](52-chaos-testing-agents.md) | Chaos engineering for agent reliability |
 | [Agent Reliability](05-agent-reliability.md) | SLOs, monitoring, graceful degradation |
 
 ---
@@ -121,7 +121,7 @@ Deep dives into specialized governance patterns.
 | [Decision BOM](50-decision-bom.md) | Decision bill of materials, audit artifacts |
 | [Offline Verifiable Receipts](33-offline-verifiable-receipts.md) | Offline-verifiable decision receipts |
 | [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridging AGT identity with Microsoft Entra |
-| [Contributor Governance](46-contributor-governance.md) | Contributor reputation, spam detection |
+| [Contributor Governance](53-contributor-governance.md) | Contributor reputation, spam detection |
 
 ---
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -7,6 +7,57 @@ Step-by-step guides organized by what you're trying to accomplish.
 
 ---
 
+## Learning Paths
+
+Pick a path based on your role. Each path is a curated sequence of tutorials, not a flat list.
+
+### :material-rocket-launch: **Path 1: First governed agent** (30 min)
+
+For developers adding governance to their first agent.
+
+1. [2-Line Quickstart](36-govern-quickstart.md) — `govern()` in 2 lines
+2. [Policy Engine Basics](01-policy-engine.md) — write your first policy
+3. [Framework Integrations](03-framework-integrations.md) — connect to LangChain, CrewAI, OpenAI, etc.
+4. [Govern an AI Agent](04-audit-and-compliance.md) — full audit trail
+
+### :material-shield-lock: **Path 2: Secure an agent fleet** (60 min)
+
+For platform teams deploying agents in production.
+
+1. [Trust & Identity](02-trust-and-identity.md) — agent identity with SPIFFE
+2. [MCP Security Gateway](07-mcp-security-gateway.md) — govern MCP tool servers
+3. [Execution Sandboxing](06-execution-sandboxing.md) — privilege rings
+4. [Prompt Injection Detection](09-prompt-injection-detection.md) — detect and block attacks
+5. [Security Hardening](25-security-hardening.md) — production best practices
+6. [Multi-Agent Fleet Policies](49-multi-agent-policies.md) — collective enforcement
+
+### :material-clipboard-check: **Path 3: Compliance and audit** (45 min)
+
+For teams that need to prove what happened to auditors or regulators.
+
+1. [OPA / Rego / Cedar](08-opa-rego-cedar-policies.md) — policy engine options
+2. [Delegation Chains](23-delegation-chains.md) — who authorized what
+3. [Compliance Verification](18-compliance-verification.md) — OWASP, NIST mapping
+4. [SBOM & Signing](26-sbom-and-signing.md) — artifact integrity
+5. [Decision BOM](50-decision-bom.md) — audit artifacts
+
+### :material-chart-line: **Path 4: SRE for agents** (45 min)
+
+For SRE teams operating agents at scale.
+
+1. [Agent Reliability](05-agent-reliability.md) — SLOs and error budgets
+2. [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) — emergency controls
+3. [Cost Governance](51-cost-governance.md) — budget enforcement
+4. [Chaos Testing](52-chaos-testing-agents.md) — fault injection
+5. [Observability & Tracing](13-observability-and-tracing.md) — distributed tracing
+6. [OpenTelemetry Integration](40-otel-observability.md) — OTel for governance events
+
+---
+
+## All Tutorials by Category
+
+---
+
 ## Getting Started
 
 The essentials to get your first governed agent running in minutes.

--- a/docs/tutorials/policy-as-code/07-policy-versioning.md
+++ b/docs/tutorials/policy-as-code/07-policy-versioning.md
@@ -95,12 +95,15 @@ def classify(decision):
 tools = ["search_documents", "write_file", "send_email",
          "delete_database", "transfer_funds"]
 
+results = []
 for tool in tools:
     ctx = {"tool_name": tool}
     t1 = classify(eval_v1.evaluate(ctx))
     t2 = classify(eval_v2.evaluate(ctx))
-    changed = "⚠️" if t1 != t2 else ""
-    print(f"{tool:<22s} {t1:<12s} {t2:<12s} {changed}")
+    changed = t1 != t2
+    results.append((tool, t1, t2, changed))
+    flag = "⚠️" if changed else ""
+    print(f"{tool:<22s} {t1:<12s} {t2:<12s} {flag}")
 ```
 
 ### Example output

--- a/docs/tutorials/progressive-governance.md
+++ b/docs/tutorials/progressive-governance.md
@@ -22,15 +22,18 @@
 and you need something running today.
 
 ```python
-from agent_os.policies import PolicyEvaluator
+from agent_os.policies import PolicyEvaluator, PolicyDocument
 
-evaluator = PolicyEvaluator()
-evaluator.add_rules([
-    {"action": "web_search", "effect": "allow"},
-    {"action": "read_file", "effect": "allow"},
-    {"action": "*", "effect": "deny"},
-])
+doc = PolicyDocument.from_dict({
+    "version": "1.0",
+    "rules": [
+        {"action": "web_search", "effect": "allow"},
+        {"action": "read_file", "effect": "allow"},
+        {"action": "*", "effect": "deny"},
+    ],
+})
 
+evaluator = PolicyEvaluator(policies=[doc])
 decision = evaluator.evaluate({"action": "delete_file"})
 assert not decision.allowed  # blocked by default-deny
 ```
@@ -81,16 +84,15 @@ decision = evaluator.evaluate({"action": "read_file", "path": "/data/public/repo
 did what, or you need trust scoring between agents.
 
 ```python
-from agent_os.mesh import AgentIdentity, TrustScorer
+from agentmesh.identity import AgentIdentity
 
 identity = AgentIdentity.create(
     name="research-agent",
     capabilities=["web_search", "read_file"],
 )
 
-scorer = TrustScorer()
-score = scorer.evaluate(identity, action="web_search")
-# score.trust_level → 0.95 (high — action matches declared capabilities)
+# Identity gives each agent a verifiable SPIFFE SVID
+# Use with policy evaluation: evaluator.evaluate({"agent_id": identity.id, "action": "web_search"})
 ```
 
 > 💡 **Add this when you move to multi-agent systems.** Single-agent setups
@@ -104,19 +106,19 @@ score = scorer.evaluate(identity, action="web_search")
 rotation, or you need to detect orphaned/shadow agents.
 
 ```python
-from agent_os.lifecycle import AgentProvisioner, OrphanDetector
+from agentmesh.lifecycle import LifecycleManager, OrphanDetector
 
-provisioner = AgentProvisioner()
-agent = provisioner.create(
+manager = LifecycleManager()
+agent = manager.request_provisioning(
     name="data-analyst",
-    ttl_hours=24,
+    owner="platform-team",
     capabilities=["read_file", "web_search"],
 )
 
 detector = OrphanDetector()
 orphans = detector.scan()  # finds agents with no active owner
 for orphan in orphans:
-    provisioner.decommission(orphan.id)
+    manager.decommission(orphan.id)
 ```
 
 > 💡 **Add this when you're running agents in production at scale.** Credential
@@ -130,24 +132,24 @@ for orphan in orphans:
 or you need a complete governance dashboard with SRE capabilities.
 
 ```python
-from agent_os import GovernanceStack
+from agentmesh.governance import govern, GovernanceConfig
+from agent_os.policies import PolicyEvaluator
 
-stack = GovernanceStack(
-    policies="policies/",
-    identity=True,
-    lifecycle=True,
-    execution_rings=True,      # sandboxed execution tiers
-    sre=True,                  # circuit breakers, rate limiting
-    compliance=True,           # audit trail, NIST/OWASP mapping
-    dashboard=True,            # real-time governance dashboard
+# Wrap any agent with full governance: policies, identity, audit, SRE
+config = GovernanceConfig(
+    policy="policies/",
+    agent_id="enterprise-agent",
+    audit=True,
+    audit_file="audit/governance.jsonl",
 )
 
+safe_agent = govern(agent.run, config=config)
+
 # Everything from Levels 1–4, plus:
-# - Execution rings (sandbox → staging → production)
-# - Circuit breakers and rate limiting
-# - Compliance verification and audit export
-# - Real-time governance dashboard
-stack.start()
+# - Policy enforcement with conflict resolution
+# - Full audit trail with compliance mapping
+# - Approval workflows for high-risk actions
+result = safe_agent(action="transfer_funds", amount=10000)
 ```
 
 > 💡 **Most teams never need Level 5.** It exists for regulated industries

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,7 +151,7 @@ nav:
       - Kill Switch & Rate Limiting: tutorials/14-kill-switch-and-rate-limiting.md
       - Agent Discovery: tutorials/29-agent-discovery.md
       - Agent Lifecycle: tutorials/30-agent-lifecycle.md
-      - Chaos Testing: tutorials/32-chaos-testing-agents.md
+      - Chaos Testing: tutorials/52-chaos-testing-agents.md
       - Agent Reliability: tutorials/05-agent-reliability.md
     - Advanced Topics:
       - Trust & Identity Deep Dive: tutorials/02-trust-and-identity.md
@@ -165,7 +165,7 @@ nav:
       - Decision BOM: tutorials/50-decision-bom.md
       - Offline Verifiable Receipts: tutorials/33-offline-verifiable-receipts.md
       - Entra Agent ID Bridge: tutorials/31-entra-agent-id-bridge.md
-      - Contributor Governance: tutorials/46-contributor-governance.md
+      - Contributor Governance: tutorials/53-contributor-governance.md
     - Language & Platform Guides:
       - .NET SDK: tutorials/19-dotnet-sdk.md
       - C# MCP Extension: tutorials/42-csharp-mcp-extension.md


### PR DESCRIPTION
## Motivation

Compared our docs site to [clawpatrol.dev](https://clawpatrol.dev/) and identified key UX gaps. Their site leads with a clear problem statement, shows runnable code with real output on the landing page, and includes an architecture diagram. Our homepage was a feature grid with no narrative hook.

## Changes

### Homepage (\docs/index.md\)
- **Problem statement** - 3 concrete questions every agent team faces (action control, identity, audit proof)
- **2-line quickstart** - \govern()\ code + YAML policy + terminal output, right on the landing page
- **Architecture diagram** - ASCII flow showing Agent -> govern() -> Policy/Identity/Audit -> Tool
- **Install command** - \pip install agent-governance-toolkit\ in the hero section
- All existing content (packages, SDKs, specs, compliance) preserved below

### Tutorial index (\docs/tutorials/index.md\)
- **4 learning paths** at the top, each with a role, time estimate, and numbered sequence:
  1. First governed agent (30 min) - developers
  2. Secure an agent fleet (60 min) - platform teams
  3. Compliance and audit (45 min) - regulated industries
  4. SRE for agents (45 min) - SRE teams
- Existing categorized table preserved as 'All Tutorials by Category'

### Validation
- \check_links.py\: 0 new broken links