### PR TITLE
feat(policy): wire-protocol-aware policy evaluation for SQL and Kubernetes

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -61,6 +61,7 @@ dbt
 dearmor
 defi
 delenv
+deletecollection
 demux
 deprioritized
 Deque
@@ -90,6 +91,8 @@ findall
 finditer
 FIPS
 flatbuffer
+FLUSHALL
+FLUSHDB
 fnmatch
 fromisoformat
 fromtimestamp
@@ -106,6 +109,7 @@ gmtime
 GOPROXY
 governancepolicy
 gvisor
+h├⌐llo
 hasattr
 hashlib
 HEALTHCHECK
@@ -116,7 +120,6 @@ htek
 httpx
 hypercall
 Hyperlight
-h├⌐llo
 IATP
 idweb
 imran
@@ -162,6 +165,9 @@ monkeypatching
 MSHV
 msinternal
 mTLS
+myapp
+mynamespace
+mypod
 mypy
 nameof
 Nanvix
@@ -251,6 +257,7 @@ spellchecking
 SPIFFE
 spiffesvid
 splitlines
+SQLGLOT
 startswith
 staticmethod
 stepreceipt
@@ -259,6 +266,7 @@ streamlit
 strftime
 structlog
 subpro
+Subresource
 SVID
 sybil
 syscall

--- a/agent-governance-python/agent-mesh/src/agentmesh/cli/proxy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/cli/proxy.py
@@ -300,12 +300,22 @@ rules: []
         arguments = params.get("arguments", {})
 
         # Build policy context
-        context = {
+        context: Dict[str, Any] = {
             "action": {
                 "tool": tool_name,
                 "path": arguments.get("path", ""),
             }
         }
+
+        # Wire protocol context so sql.* and k8s.* policy rules can match
+        sql_query = arguments.get("query") or arguments.get("sql")
+        if sql_query and isinstance(sql_query, str):
+            context["sql"] = {"query": sql_query}
+
+        k8s_method = arguments.get("method") or arguments.get("http_method")
+        k8s_path = arguments.get("path") or arguments.get("api_path")
+        if k8s_method and k8s_path and isinstance(k8s_path, str) and k8s_path.startswith(("/api/", "/apis/")):
+            context["k8s"] = {"method": str(k8s_method).upper(), "path": k8s_path}
 
         # Check policy
         decision = self.policy_engine.evaluate(self.identity.did, context)

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/policy.py
@@ -825,6 +825,10 @@ class PolicyEngine:
 
         start = datetime.now(timezone.utc)
 
+        # Populate sql.* and k8s.* fields before rules run
+        from agentmesh.governance.protocol_facets import extract_protocol_facets
+        extract_protocol_facets(context)
+
         # 1. Check YAML/JSON policies first
         applicable = [p for p in self._policies.values() if p.applies_to(agent_did)]
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/protocol_facets.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/protocol_facets.py
@@ -1,0 +1,277 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Protocol-aware facet extraction for policy evaluation.
+
+Populates sql.* and k8s.* fields in the evaluation context so YAML rules
+can reference wire-level semantics like sql.verb or k8s.namespace.
+
+To add support for a new protocol, register an extractor on default_registry:
+
+    from agentmesh.governance.protocol_facets import default_registry
+
+    def extract_redis_facets(redis_ctx):
+        cmd = (redis_ctx.get("command") or "").upper()
+        return {"verb": cmd, "key": redis_ctx.get("key", "")}
+
+    default_registry.register("redis", extract_redis_facets)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class FacetRegistry:
+    """Holds protocol facet extractors keyed by context field name.
+
+    Each extractor receives the sub-dict at its registered key and returns
+    fields to merge back in. Errors inside an extractor are caught and
+    logged so a broken parser never blocks policy evaluation.
+    """
+
+    def __init__(self) -> None:
+        self._extractors: list[tuple[str, Callable[[dict[str, Any]], dict[str, Any]]]] = []
+
+    def register(
+        self,
+        context_key: str,
+        extractor: Callable[[dict[str, Any]], dict[str, Any]],
+    ) -> None:
+        """Register extractor for sub-dicts stored at context_key."""
+        self._extractors.append((context_key, extractor))
+
+    def extract(self, context: dict[str, Any]) -> dict[str, Any]:
+        """Run all registered extractors against context in place."""
+        for key, extractor in self._extractors:
+            sub = context.get(key)
+            if not isinstance(sub, dict):
+                continue
+            try:
+                facets = extractor(sub)
+                sub.update(facets)
+            except Exception:
+                logger.exception("Facet extraction failed for context key '%s'", key)
+        return context
+
+
+# SQL verb lookup keyed by sqlglot AST class name (lowercased)
+_SQL_VERB_MAP: dict[str, str] = {
+    "select": "SELECT",
+    "insert": "INSERT",
+    "update": "UPDATE",
+    "delete": "DELETE",
+    "drop": "DROP",
+    "truncate": "TRUNCATE",
+    "alter": "ALTER",
+    "create": "CREATE",
+    "grant": "GRANT",
+    "revoke": "REVOKE",
+    "merge": "MERGE",
+    "call": "CALL",
+    "execute": "EXECUTE",
+    "explain": "EXPLAIN",
+    "with": "WITH",
+}
+
+
+def _extract_sql_facets(sql_ctx: dict[str, Any]) -> dict[str, Any]:
+    """Parse sql_ctx["query"] and return verb, target, tables and functions.
+
+    Uses sqlglot for AST level parsing. Falls back to UNKNOWN if sqlglot
+    is not installed or parsing fails.
+    """
+    query: str = sql_ctx.get("query", "")
+    if not query or not query.strip():
+        return {"verb": "", "target": "", "tables": "", "functions": ""}
+
+    try:
+        import sqlglot
+        from sqlglot import exp
+
+        try:
+            statements = sqlglot.parse(query)
+        except Exception:
+            logger.warning("SQL parsing failed, defaulting to UNKNOWN verb")
+            return {"verb": "UNKNOWN", "target": "", "tables": "", "functions": ""}
+
+        if not statements or statements[0] is None:
+            return {"verb": "UNKNOWN", "target": "", "tables": "", "functions": ""}
+
+        stmt = statements[0]
+
+        verb = "UNKNOWN"
+        if isinstance(stmt, exp.Select):
+            verb = "SELECT"
+        elif isinstance(stmt, exp.Insert):
+            verb = "INSERT"
+        elif isinstance(stmt, exp.Update):
+            verb = "UPDATE"
+        elif isinstance(stmt, exp.Delete):
+            verb = "DELETE"
+        elif isinstance(stmt, exp.Drop):
+            verb = "DROP"
+        elif isinstance(stmt, exp.Create):
+            verb = "CREATE"
+        elif isinstance(stmt, exp.AlterTable):
+            verb = "ALTER"
+        elif isinstance(stmt, exp.Grant):
+            verb = "GRANT"
+        elif isinstance(stmt, exp.Merge):
+            verb = "MERGE"
+        elif isinstance(stmt, exp.Command):
+            cmd = (stmt.this or "").upper()
+            verb = _SQL_VERB_MAP.get(cmd.lower(), cmd) if cmd else "UNKNOWN"
+        else:
+            class_name = type(stmt).__name__.upper()
+            verb = _SQL_VERB_MAP.get(class_name.lower(), class_name)
+
+        tables = [t.name for t in stmt.find_all(exp.Table) if t.name]
+        functions = [f.name.upper() for f in stmt.find_all(exp.Func) if f.name]
+
+        # target is the first (primary) table the statement operates on
+        target = tables[0] if tables else ""
+
+        return {
+            "verb": verb,
+            "target": target,
+            "tables": ",".join(tables),
+            "functions": ",".join(functions),
+        }
+
+    except ImportError:
+        logger.warning(
+            "sqlglot is not installed so SQL facets are unavailable. "
+            "Run: pip install sqlglot"
+        )
+        return {"verb": "UNKNOWN", "target": "", "tables": "", "functions": ""}
+
+
+# Maps HTTP method to a Kubernetes verb when the URL targets a named object
+_METHOD_TO_VERB_NAMED: dict[str, str] = {
+    "GET": "get",
+    "DELETE": "delete",
+    "PUT": "update",
+    "PATCH": "patch",
+    "POST": "create",
+    "HEAD": "get",
+}
+
+# Maps HTTP method to a Kubernetes verb when the URL targets a collection
+_METHOD_TO_VERB_COLLECTION: dict[str, str] = {
+    "GET": "list",
+    "POST": "create",
+    "DELETE": "deletecollection",
+    "PUT": "update",
+    "PATCH": "patch",
+    "HEAD": "list",
+}
+
+# Path patterns ordered most specific first; captured groups named by the
+# tuple that follows each compiled regex
+_K8S_PATH_PATTERNS: list[tuple[re.Pattern[str], tuple[str, ...]]] = [
+    (
+        re.compile(r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$"),
+        ("namespace", "resource", "name", "subresource"),
+    ),
+    (
+        re.compile(r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$"),
+        ("namespace", "resource", "name", "subresource"),
+    ),
+    (
+        re.compile(r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$"),
+        ("namespace", "resource", "name"),
+    ),
+    (
+        re.compile(r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$"),
+        ("namespace", "resource", "name"),
+    ),
+    (
+        re.compile(r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/?$"),
+        ("namespace", "resource"),
+    ),
+    (
+        re.compile(r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/?$"),
+        ("namespace", "resource"),
+    ),
+    (
+        re.compile(r"^/api/[^/]+/([^/]+)/([^/]+)/?$"),
+        ("resource", "name"),
+    ),
+    (
+        re.compile(r"^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/?$"),
+        ("resource", "name"),
+    ),
+    (
+        re.compile(r"^/api/[^/]+/([^/]+)/?$"),
+        ("resource",),
+    ),
+    (
+        re.compile(r"^/apis/[^/]+/[^/]+/([^/]+)/?$"),
+        ("resource",),
+    ),
+]
+
+
+def _extract_k8s_facets(k8s_ctx: dict[str, Any]) -> dict[str, Any]:
+    """Parse a Kubernetes API request into policy-evaluable fields.
+
+    Reads k8s_ctx["method"] and k8s_ctx["path"] and returns verb, resource,
+    namespace, name and subresource.
+    """
+    method: str = (k8s_ctx.get("method") or "").upper()
+    path: str = k8s_ctx.get("path") or ""
+
+    result: dict[str, str] = {
+        "verb": "",
+        "resource": "",
+        "namespace": "",
+        "name": "",
+        "subresource": "",
+    }
+
+    if not path:
+        return result
+
+    matched_groups: dict[str, str] = {}
+    for pattern, group_names in _K8S_PATH_PATTERNS:
+        m = pattern.match(path)
+        if m:
+            matched_groups = dict(zip(group_names, m.groups()))
+            break
+
+    result["resource"] = matched_groups.get("resource", "")
+    result["namespace"] = matched_groups.get("namespace", "")
+    result["name"] = matched_groups.get("name", "")
+    result["subresource"] = matched_groups.get("subresource", "")
+
+    has_name = bool(result["name"])
+    if method:
+        if has_name:
+            result["verb"] = _METHOD_TO_VERB_NAMED.get(method, method.lower())
+        else:
+            result["verb"] = _METHOD_TO_VERB_COLLECTION.get(method, method.lower())
+
+    return result
+
+
+# Module-level registry pre-loaded with SQL and Kubernetes parsers.
+# Import this and call register() to add support for new protocols.
+default_registry = FacetRegistry()
+default_registry.register("sql", _extract_sql_facets)
+default_registry.register("k8s", _extract_k8s_facets)
+
+
+def extract_protocol_facets(
+    context: dict[str, Any],
+    registry: FacetRegistry | None = None,
+) -> dict[str, Any]:
+    """Enrich a policy evaluation context with wire-protocol facets.
+
+    Uses the supplied registry or default_registry if none is given.
+    Modifies context in place and returns it.
+    """
+    return (registry or default_registry).extract(context)

--- a/agent-governance-python/agent-mesh/tests/test_protocol_facets.py
+++ b/agent-governance-python/agent-mesh/tests/test_protocol_facets.py
@@ -1,0 +1,494 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for wire-protocol facet extraction (issue #2483)."""
+
+import pytest
+
+from agentmesh.governance.protocol_facets import (
+    FacetRegistry,
+    default_registry,
+    extract_protocol_facets,
+    _extract_sql_facets,
+    _extract_k8s_facets,
+)
+
+try:
+    import sqlglot  # noqa: F401
+    SQLGLOT_AVAILABLE = True
+except ImportError:
+    SQLGLOT_AVAILABLE = False
+
+needs_sqlglot = pytest.mark.skipif(not SQLGLOT_AVAILABLE, reason="sqlglot not installed")
+
+
+class TestSqlVerbExtraction:
+
+    @needs_sqlglot
+    def test_select(self):
+        assert _extract_sql_facets({"query": "SELECT * FROM users"})["verb"] == "SELECT"
+
+    @needs_sqlglot
+    def test_insert(self):
+        assert _extract_sql_facets({"query": "INSERT INTO logs (msg) VALUES ('hi')"})["verb"] == "INSERT"
+
+    @needs_sqlglot
+    def test_update(self):
+        assert _extract_sql_facets({"query": "UPDATE users SET active=0 WHERE id=1"})["verb"] == "UPDATE"
+
+    @needs_sqlglot
+    def test_delete(self):
+        assert _extract_sql_facets({"query": "DELETE FROM users WHERE id=1"})["verb"] == "DELETE"
+
+    @needs_sqlglot
+    def test_drop(self):
+        assert _extract_sql_facets({"query": "DROP TABLE users"})["verb"] == "DROP"
+
+    @needs_sqlglot
+    def test_truncate(self):
+        verb = _extract_sql_facets({"query": "TRUNCATE TABLE users"})["verb"]
+        assert verb in ("TRUNCATE", "UNKNOWN")
+
+    @needs_sqlglot
+    def test_alter(self):
+        assert _extract_sql_facets({"query": "ALTER TABLE users ADD COLUMN x INT"})["verb"] == "ALTER"
+
+    @needs_sqlglot
+    def test_grant(self):
+        assert _extract_sql_facets({"query": "GRANT SELECT ON users TO readonly"})["verb"] == "GRANT"
+
+    @needs_sqlglot
+    def test_merge(self):
+        q = "MERGE INTO target USING source ON target.id = source.id WHEN MATCHED THEN UPDATE SET target.val = source.val"
+        assert _extract_sql_facets({"query": q})["verb"] == "MERGE"
+
+    @needs_sqlglot
+    def test_create_table(self):
+        assert _extract_sql_facets({"query": "CREATE TABLE logs (id INT)"})["verb"] == "CREATE"
+
+    def test_empty_query(self):
+        assert _extract_sql_facets({"query": ""})["verb"] == ""
+
+    def test_whitespace_only(self):
+        assert _extract_sql_facets({"query": "   "})["verb"] == ""
+
+    def test_missing_query_key(self):
+        assert _extract_sql_facets({})["verb"] == ""
+
+    def test_no_sqlglot_returns_unknown(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "sqlglot":
+                raise ImportError("mocked")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        assert _extract_sql_facets({"query": "SELECT 1"})["verb"] == "UNKNOWN"
+
+
+class TestSqlTableAndFunctionExtraction:
+
+    @needs_sqlglot
+    def test_single_table(self):
+        assert "users" in _extract_sql_facets({"query": "SELECT * FROM users"})["tables"]
+
+    @needs_sqlglot
+    def test_multiple_tables(self):
+        result = _extract_sql_facets({"query": "SELECT * FROM orders JOIN users ON orders.user_id = users.id"})
+        assert "orders" in result["tables"]
+        assert "users" in result["tables"]
+
+    @needs_sqlglot
+    def test_drop_table_name_extracted(self):
+        assert "production_data" in _extract_sql_facets({"query": "DROP TABLE production_data"})["tables"]
+
+    @needs_sqlglot
+    def test_function_extraction(self):
+        assert "COUNT" in _extract_sql_facets({"query": "SELECT COUNT(*) FROM users"})["functions"]
+
+    @needs_sqlglot
+    def test_no_functions(self):
+        assert _extract_sql_facets({"query": "SELECT id FROM users"})["functions"] == ""
+
+
+class TestSqlFailClosed:
+
+    @needs_sqlglot
+    def test_invalid_sql_returns_string_verb(self):
+        result = _extract_sql_facets({"query": "NOT VALID SQL @@##"})
+        assert isinstance(result["verb"], str)
+
+    @needs_sqlglot
+    def test_all_fields_are_strings(self):
+        result = _extract_sql_facets({"query": "SELECT 1"})
+        for field in ("verb", "target", "tables", "functions"):
+            assert isinstance(result[field], str)
+
+
+class TestSqlTargetExtraction:
+
+    @needs_sqlglot
+    def test_select_target_is_first_table(self):
+        assert _extract_sql_facets({"query": "SELECT * FROM users"})["target"] == "users"
+
+    @needs_sqlglot
+    def test_drop_target_is_table_name(self):
+        assert _extract_sql_facets({"query": "DROP TABLE production_data"})["target"] == "production_data"
+
+    @needs_sqlglot
+    def test_delete_target_is_table_name(self):
+        assert _extract_sql_facets({"query": "DELETE FROM orders WHERE id=1"})["target"] == "orders"
+
+    @needs_sqlglot
+    def test_update_target_is_table_name(self):
+        assert _extract_sql_facets({"query": "UPDATE users SET active=0 WHERE id=1"})["target"] == "users"
+
+    @needs_sqlglot
+    def test_join_target_is_first_table(self):
+        q = "SELECT * FROM orders JOIN users ON orders.user_id = users.id"
+        assert _extract_sql_facets({"query": q})["target"] == "orders"
+
+    @needs_sqlglot
+    def test_no_table_gives_empty_target(self):
+        assert _extract_sql_facets({"query": "SELECT 1"})["target"] == ""
+
+    def test_empty_query_gives_empty_target(self):
+        assert _extract_sql_facets({"query": ""})["target"] == ""
+
+    @needs_sqlglot
+    def test_target_works_in_policy_condition(self):
+        from agentmesh.governance.policy import Policy, PolicyEngine
+
+        policy = Policy.model_validate({
+            "name": "test-target-policy",
+            "agents": ["*"],
+            "rules": [{
+                "name": "deny-drop-production",
+                "condition": "sql.verb in ['DROP', 'TRUNCATE', 'DELETE'] and sql.target == 'production'",
+                "action": "deny",
+                "stage": "pre_tool",
+            }],
+            "default_action": "allow",
+        })
+        engine = PolicyEngine()
+        engine.load_policy(policy)
+
+        denied = engine.evaluate(
+            agent_did="did:example:agent1",
+            context={"sql": {"query": "DROP TABLE production"}},
+            stage="pre_tool",
+        )
+        assert not denied.allowed
+
+        allowed = engine.evaluate(
+            agent_did="did:example:agent1",
+            context={"sql": {"query": "DROP TABLE staging"}},
+            stage="pre_tool",
+        )
+        assert allowed.allowed
+
+
+class TestFacetRegistry:
+
+    def test_register_and_extract_custom_protocol(self):
+        registry = FacetRegistry()
+        registry.register("redis", lambda ctx: {"verb": (ctx.get("command") or "").upper()})
+        ctx = {"redis": {"command": "flushall"}}
+        registry.extract(ctx)
+        assert ctx["redis"]["verb"] == "FLUSHALL"
+
+    def test_non_dict_context_key_skipped(self):
+        registry = FacetRegistry()
+        called = []
+        registry.register("sql", lambda ctx: called.append(True) or {})
+        registry.extract({"sql": "not-a-dict"})
+        assert not called
+
+    def test_extractor_exception_is_swallowed(self):
+        registry = FacetRegistry()
+
+        def bad_extractor(ctx):
+            raise RuntimeError("boom")
+
+        registry.register("sql", bad_extractor)
+        ctx = {"sql": {"query": "SELECT 1"}}
+        registry.extract(ctx)
+        assert ctx["sql"]["query"] == "SELECT 1"
+
+    def test_multiple_extractors_all_run_in_order(self):
+        registry = FacetRegistry()
+        order = []
+        registry.register("a", lambda ctx: order.append("a") or {})
+        registry.register("b", lambda ctx: order.append("b") or {})
+        registry.extract({"a": {}, "b": {}})
+        assert order == ["a", "b"]
+
+    def test_default_registry_has_sql_and_k8s(self):
+        keys = [key for key, _ in default_registry._extractors]
+        assert "sql" in keys
+        assert "k8s" in keys
+
+    def test_custom_registry_passed_to_extract_protocol_facets(self):
+        registry = FacetRegistry()
+        registry.register("redis", lambda ctx: {"verb": "CUSTOM"})
+        ctx = {"redis": {"command": "get"}}
+        extract_protocol_facets(ctx, registry=registry)
+        assert ctx["redis"]["verb"] == "CUSTOM"
+
+
+class TestK8sVerbMapping:
+
+    def test_get_named_resource(self):
+        result = _extract_k8s_facets({"method": "GET", "path": "/api/v1/namespaces/default/pods/mypod"})
+        assert result["verb"] == "get"
+
+    def test_get_collection(self):
+        result = _extract_k8s_facets({"method": "GET", "path": "/api/v1/namespaces/default/pods"})
+        assert result["verb"] == "list"
+
+    def test_delete_named(self):
+        result = _extract_k8s_facets({"method": "DELETE", "path": "/api/v1/namespaces/production/pods/mypod"})
+        assert result["verb"] == "delete"
+
+    def test_post_collection(self):
+        result = _extract_k8s_facets({"method": "POST", "path": "/api/v1/namespaces/default/pods"})
+        assert result["verb"] == "create"
+
+    def test_put_named(self):
+        result = _extract_k8s_facets({"method": "PUT", "path": "/api/v1/namespaces/default/deployments/myapp"})
+        assert result["verb"] == "update"
+
+    def test_patch_named(self):
+        result = _extract_k8s_facets({"method": "PATCH", "path": "/api/v1/namespaces/default/deployments/myapp"})
+        assert result["verb"] == "patch"
+
+    def test_delete_collection(self):
+        result = _extract_k8s_facets({"method": "DELETE", "path": "/api/v1/namespaces/default/pods"})
+        assert result["verb"] == "deletecollection"
+
+
+class TestK8sPathParsing:
+
+    def test_namespaced_named_resource(self):
+        result = _extract_k8s_facets({"method": "GET", "path": "/api/v1/namespaces/production/pods/mypod"})
+        assert result["namespace"] == "production"
+        assert result["resource"] == "pods"
+        assert result["name"] == "mypod"
+        assert result["subresource"] == ""
+
+    def test_namespaced_collection(self):
+        result = _extract_k8s_facets({"method": "GET", "path": "/api/v1/namespaces/staging/deployments"})
+        assert result["namespace"] == "staging"
+        assert result["resource"] == "deployments"
+        assert result["name"] == ""
+
+    def test_subresource_exec(self):
+        result = _extract_k8s_facets({"method": "POST", "path": "/api/v1/namespaces/default/pods/mypod/exec"})
+        assert result["resource"] == "pods"
+        assert result["name"] == "mypod"
+        assert result["subresource"] == "exec"
+
+    def test_subresource_log(self):
+        result = _extract_k8s_facets({"method": "GET", "path": "/api/v1/namespaces/default/pods/mypod/log"})
+        assert result["subresource"] == "log"
+
+    def test_cluster_scoped_named(self):
+        result = _extract_k8s_facets({"method": "DELETE", "path": "/api/v1/namespaces/mynamespace"})
+        assert result["resource"] == "namespaces"
+        assert result["name"] == "mynamespace"
+        assert result["namespace"] == ""
+
+    def test_cluster_scoped_collection(self):
+        result = _extract_k8s_facets({"method": "GET", "path": "/api/v1/nodes"})
+        assert result["resource"] == "nodes"
+        assert result["namespace"] == ""
+        assert result["name"] == ""
+
+    def test_apis_group_namespaced(self):
+        result = _extract_k8s_facets({"method": "DELETE", "path": "/apis/apps/v1/namespaces/production/deployments/myapp"})
+        assert result["namespace"] == "production"
+        assert result["resource"] == "deployments"
+        assert result["name"] == "myapp"
+        assert result["verb"] == "delete"
+
+    def test_empty_path(self):
+        result = _extract_k8s_facets({"method": "GET", "path": ""})
+        assert result["verb"] == ""
+        assert result["resource"] == ""
+
+    def test_missing_method(self):
+        result = _extract_k8s_facets({"path": "/api/v1/namespaces/default/pods"})
+        assert result["resource"] == "pods"
+        assert result["verb"] == ""
+
+
+class TestExtractProtocolFacets:
+
+    @needs_sqlglot
+    def test_sql_context_enriched(self):
+        ctx = {"sql": {"query": "DROP TABLE users"}}
+        assert extract_protocol_facets(ctx)["sql"]["verb"] == "DROP"
+
+    def test_k8s_context_enriched(self):
+        ctx = {"k8s": {"method": "DELETE", "path": "/api/v1/namespaces/production/pods/mypod"}}
+        result = extract_protocol_facets(ctx)
+        assert result["k8s"]["verb"] == "delete"
+        assert result["k8s"]["namespace"] == "production"
+
+    @needs_sqlglot
+    def test_both_contexts_enriched(self):
+        ctx = {
+            "sql": {"query": "SELECT * FROM users"},
+            "k8s": {"method": "GET", "path": "/api/v1/namespaces/default/pods"},
+        }
+        result = extract_protocol_facets(ctx)
+        assert result["sql"]["verb"] == "SELECT"
+        assert result["k8s"]["verb"] == "list"
+
+    def test_unrelated_context_untouched(self):
+        ctx = {"action": {"type": "http", "method": "POST"}}
+        result = extract_protocol_facets(ctx)
+        assert "sql" not in result
+        assert "k8s" not in result
+
+    def test_sql_without_query_key_returns_empty_facets(self):
+        ctx = {"sql": {"dialect": "postgres"}}
+        extract_protocol_facets(ctx)
+        assert ctx["sql"].get("verb", "") == ""
+
+    def test_k8s_without_path_returns_empty_facets(self):
+        ctx = {"k8s": {"method": "GET"}}
+        extract_protocol_facets(ctx)
+        assert ctx["k8s"].get("verb", "") == ""
+
+    def test_returns_same_dict(self):
+        ctx = {"sql": {"query": "SELECT 1"}}
+        assert extract_protocol_facets(ctx) is ctx
+
+    def test_non_dict_sql_value_ignored(self):
+        ctx = {"sql": "not-a-dict"}
+        extract_protocol_facets(ctx)
+        assert ctx["sql"] == "not-a-dict"
+
+
+class TestPolicyEngineIntegration:
+
+    @needs_sqlglot
+    def test_sql_drop_denied_by_rule(self):
+        from agentmesh.governance.policy import Policy, PolicyEngine
+
+        policy = Policy.model_validate({
+            "name": "test-sql-policy",
+            "agents": ["*"],
+            "rules": [{
+                "name": "deny-drop",
+                "condition": "sql.verb in ['DROP', 'TRUNCATE']",
+                "action": "deny",
+                "stage": "pre_tool",
+            }],
+        })
+        engine = PolicyEngine()
+        engine.load_policy(policy)
+
+        decision = engine.evaluate(
+            agent_did="did:example:agent1",
+            context={"sql": {"query": "DROP TABLE users"}},
+            stage="pre_tool",
+        )
+        assert not decision.allowed
+        assert decision.matched_rule == "deny-drop"
+
+    @needs_sqlglot
+    def test_sql_select_not_matched_by_drop_rule(self):
+        from agentmesh.governance.policy import Policy, PolicyEngine
+
+        policy = Policy.model_validate({
+            "name": "test-sql-policy",
+            "agents": ["*"],
+            "rules": [{
+                "name": "deny-drop",
+                "condition": "sql.verb in ['DROP', 'TRUNCATE']",
+                "action": "deny",
+                "stage": "pre_tool",
+            }],
+            "default_action": "allow",
+        })
+        engine = PolicyEngine()
+        engine.load_policy(policy)
+
+        assert engine.evaluate(
+            agent_did="did:example:agent1",
+            context={"sql": {"query": "SELECT * FROM users"}},
+            stage="pre_tool",
+        ).allowed
+
+    def test_k8s_delete_prod_denied(self):
+        from agentmesh.governance.policy import Policy, PolicyEngine
+
+        policy = Policy.model_validate({
+            "name": "test-k8s-policy",
+            "agents": ["*"],
+            "rules": [{
+                "name": "deny-k8s-delete-prod",
+                "condition": "k8s.verb == 'delete' and k8s.namespace == 'production'",
+                "action": "deny",
+                "stage": "pre_tool",
+            }],
+        })
+        engine = PolicyEngine()
+        engine.load_policy(policy)
+
+        decision = engine.evaluate(
+            agent_did="did:example:agent1",
+            context={"k8s": {"method": "DELETE", "path": "/api/v1/namespaces/production/pods/mypod"}},
+            stage="pre_tool",
+        )
+        assert not decision.allowed
+        assert decision.matched_rule == "deny-k8s-delete-prod"
+
+    def test_k8s_delete_staging_allowed(self):
+        from agentmesh.governance.policy import Policy, PolicyEngine
+
+        policy = Policy.model_validate({
+            "name": "test-k8s-policy",
+            "agents": ["*"],
+            "rules": [{
+                "name": "deny-k8s-delete-prod",
+                "condition": "k8s.verb == 'delete' and k8s.namespace == 'production'",
+                "action": "deny",
+                "stage": "pre_tool",
+            }],
+            "default_action": "allow",
+        })
+        engine = PolicyEngine()
+        engine.load_policy(policy)
+
+        assert engine.evaluate(
+            agent_did="did:example:agent1",
+            context={"k8s": {"method": "DELETE", "path": "/api/v1/namespaces/staging/pods/mypod"}},
+            stage="pre_tool",
+        ).allowed
+
+    def test_k8s_exec_denied(self):
+        from agentmesh.governance.policy import Policy, PolicyEngine
+
+        policy = Policy.model_validate({
+            "name": "test-k8s-exec-policy",
+            "agents": ["*"],
+            "rules": [{
+                "name": "deny-exec",
+                "condition": "k8s.subresource == 'exec'",
+                "action": "deny",
+                "stage": "pre_tool",
+            }],
+        })
+        engine = PolicyEngine()
+        engine.load_policy(policy)
+
+        decision = engine.evaluate(
+            agent_did="did:example:agent1",
+            context={"k8s": {"method": "POST", "path": "/api/v1/namespaces/default/pods/mypod/exec"}},
+            stage="pre_tool",
+        )
+        assert not decision.allowed

--- a/agent-governance-python/agent-mesh/tests/test_proxy.py
+++ b/agent-governance-python/agent-mesh/tests/test_proxy.py
@@ -241,6 +241,132 @@ class TestProxyPolicyEngine:
             target_command=["test"],
             policy="permissive",
         )
-        
+
         policies = proxy.policy_engine.list_policies()
         assert "permissive-mcp-policy" in policies
+
+
+class TestMCPProxyWireProtocolContext:
+    """Verify _handle_tool_call populates sql.* and k8s.* context for policy evaluation."""
+
+    def _make_proxy(self):
+        return MCPProxy(target_command=["test"], policy="permissive")
+
+    def _make_tool_call_message(self, tool_name: str, arguments: dict) -> dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        }
+
+    def test_sql_query_argument_populates_sql_context(self):
+        """Tool call with 'query' argument injects sql.query into policy context."""
+        proxy = self._make_proxy()
+        captured = {}
+
+        original_evaluate = proxy.policy_engine.evaluate
+
+        def capture_evaluate(agent_did, context, stage="pre_tool"):
+            captured["context"] = context
+            return original_evaluate(agent_did, context, stage)
+
+        proxy.policy_engine.evaluate = capture_evaluate
+
+        import asyncio
+        message = self._make_tool_call_message(
+            "db_query", {"query": "SELECT * FROM users"}
+        )
+        asyncio.run(proxy._handle_tool_call(message))
+
+        assert "sql" in captured["context"]
+        assert captured["context"]["sql"]["query"] == "SELECT * FROM users"
+
+    def test_sql_sql_argument_also_works(self):
+        """Tool call with 'sql' argument (alternate key) injects sql.query."""
+        proxy = self._make_proxy()
+        captured = {}
+
+        original_evaluate = proxy.policy_engine.evaluate
+
+        def capture_evaluate(agent_did, context, stage="pre_tool"):
+            captured["context"] = context
+            return original_evaluate(agent_did, context, stage)
+
+        proxy.policy_engine.evaluate = capture_evaluate
+
+        import asyncio
+        message = self._make_tool_call_message(
+            "execute_sql", {"sql": "DROP TABLE users"}
+        )
+        asyncio.run(proxy._handle_tool_call(message))
+
+        assert "sql" in captured["context"]
+        assert captured["context"]["sql"]["query"] == "DROP TABLE users"
+
+    def test_no_sql_argument_no_sql_context(self):
+        """Tool call without query argument does not inject sql context."""
+        proxy = self._make_proxy()
+        captured = {}
+
+        original_evaluate = proxy.policy_engine.evaluate
+
+        def capture_evaluate(agent_did, context, stage="pre_tool"):
+            captured["context"] = context
+            return original_evaluate(agent_did, context, stage)
+
+        proxy.policy_engine.evaluate = capture_evaluate
+
+        import asyncio
+        message = self._make_tool_call_message(
+            "filesystem_read", {"path": "/tmp/test.txt"}
+        )
+        asyncio.run(proxy._handle_tool_call(message))
+
+        assert "sql" not in captured["context"]
+
+    def test_k8s_api_path_populates_k8s_context(self):
+        """Tool call with method + /api/ path injects k8s context."""
+        proxy = self._make_proxy()
+        captured = {}
+
+        original_evaluate = proxy.policy_engine.evaluate
+
+        def capture_evaluate(agent_did, context, stage="pre_tool"):
+            captured["context"] = context
+            return original_evaluate(agent_did, context, stage)
+
+        proxy.policy_engine.evaluate = capture_evaluate
+
+        import asyncio
+        message = self._make_tool_call_message(
+            "kubectl_api",
+            {"method": "DELETE", "path": "/api/v1/namespaces/production/pods/mypod"},
+        )
+        asyncio.run(proxy._handle_tool_call(message))
+
+        assert "k8s" in captured["context"]
+        assert captured["context"]["k8s"]["method"] == "DELETE"
+        assert captured["context"]["k8s"]["path"] == "/api/v1/namespaces/production/pods/mypod"
+
+    def test_non_k8s_path_does_not_inject_k8s_context(self):
+        """Tool call with method + non-K8s path does not inject k8s context."""
+        proxy = self._make_proxy()
+        captured = {}
+
+        original_evaluate = proxy.policy_engine.evaluate
+
+        def capture_evaluate(agent_did, context, stage="pre_tool"):
+            captured["context"] = context
+            return original_evaluate(agent_did, context, stage)
+
+        proxy.policy_engine.evaluate = capture_evaluate
+
+        import asyncio
+        message = self._make_tool_call_message(
+            "http_request",
+            {"method": "GET", "path": "/health"},
+        )
+        asyncio.run(proxy._handle_tool_call(message))
+
+        assert "k8s" not in captured["context"]

--- a/docs/WIRE-PROTOCOL-FACETS.md
+++ b/docs/WIRE-PROTOCOL-FACETS.md
@@ -1,0 +1,161 @@
+# Wire-Protocol-Aware Policy Evaluation
+
+AGT policy rules can now reference wire-level protocol semantics — not just HTTP
+metadata — through **protocol facets**.  Facets are structured fields extracted
+from raw protocol context (SQL queries, Kubernetes API paths, etc.) and merged
+into the policy evaluation context before rules are evaluated.
+
+## How it works
+
+When `PolicyEngine.evaluate()` is called, it runs
+`extract_protocol_facets(context)` before evaluating rules.  If the context
+contains a `sql` or `k8s` sub-dict, the relevant parser populates structured
+fields that YAML rules can reference with dot-notation conditions.
+
+## SQL facets
+
+Populate `context["sql"]["query"]` with a SQL statement.  The following fields
+are extracted and available in policy conditions:
+
+| Field | Example value | Description |
+|---|---|---|
+| `sql.verb` | `SELECT`, `DROP`, `DELETE` | Uppercase SQL verb |
+| `sql.target` | `users` | Primary table/object being operated on |
+| `sql.tables` | `orders,users` | Comma-joined list of all tables referenced |
+| `sql.functions` | `COUNT,NOW` | Comma-joined list of SQL functions used |
+
+**Requires `sqlglot`** (`pip install sqlglot`).  Without it, `sql.verb` is set
+to `UNKNOWN` (fail-closed).
+
+### Example rules
+
+Each rule matches a single extracted field via `{field, operator, value}`.
+Compound checks (e.g. verb + target) should be expressed as separate rules
+with appropriate priorities.
+
+```yaml
+rules:
+  - name: deny-destructive-sql
+    condition: {field: "sql.verb", operator: in, value: ["DROP", "TRUNCATE", "DELETE"]}
+    action: deny
+    priority: 100
+
+  - name: deny-schema-changes
+    condition: {field: "sql.verb", operator: in, value: ["ALTER", "GRANT", "REVOKE"]}
+    action: deny
+    priority: 100
+
+  - name: allow-read-only-sql
+    condition: {field: "sql.verb", operator: eq, value: "SELECT"}
+    action: allow
+    priority: 5
+```
+
+### Example evaluation context
+
+```python
+engine.evaluate(
+    agent_did="did:example:agent1",
+    context={"sql": {"query": "DROP TABLE production"}},
+)
+```
+
+## Kubernetes facets
+
+Populate `context["k8s"]["method"]` (HTTP method) and `context["k8s"]["path"]`
+(API server path).  The following fields are extracted:
+
+| Field | Example value | Description |
+|---|---|---|
+| `k8s.verb` | `get`, `list`, `delete`, `create` | Kubernetes API verb |
+| `k8s.resource` | `pods`, `deployments` | Resource type |
+| `k8s.namespace` | `production` | Namespace (empty for cluster-scoped) |
+| `k8s.name` | `mypod` | Resource name (empty for collection requests) |
+| `k8s.subresource` | `exec`, `log` | Subresource (empty if none) |
+
+HTTP methods are mapped to Kubernetes verbs:
+
+| HTTP | Named resource | Collection |
+|---|---|---|
+| GET | `get` | `list` |
+| DELETE | `delete` | `deletecollection` |
+| POST | `create` | `create` |
+| PUT | `update` | `update` |
+| PATCH | `patch` | `patch` |
+
+### Example rules
+
+```yaml
+rules:
+  - name: deny-k8s-production-namespace
+    condition: {field: "k8s.namespace", operator: eq, value: "production"}
+    action: deny
+    priority: 110
+
+  - name: deny-k8s-exec
+    condition: {field: "k8s.subresource", operator: eq, value: "exec"}
+    action: deny
+    priority: 100
+
+  - name: deny-k8s-deletecollection
+    condition: {field: "k8s.verb", operator: eq, value: "deletecollection"}
+    action: deny
+    priority: 100
+
+  - name: allow-k8s-readonly
+    condition: {field: "k8s.verb", operator: in, value: ["get", "list", "watch"]}
+    action: allow
+    priority: 5
+```
+
+### Example evaluation context
+
+```python
+engine.evaluate(
+    agent_did="did:example:agent1",
+    context={
+        "k8s": {
+            "method": "DELETE",
+            "path": "/api/v1/namespaces/production/pods/mypod",
+        }
+    },
+)
+```
+
+## Transparent proxy integration
+
+The MCP proxy (`agentmesh proxy`) automatically populates wire-protocol context
+from tool call arguments:
+
+- Tool arguments named `query` or `sql` → `context["sql"]["query"]`
+- Tool arguments named `method`/`http_method` + `path`/`api_path` starting with
+  `/api/` or `/apis/` → `context["k8s"]`
+
+No application changes are required.  Define SQL or K8s rules in your policy
+file and they apply automatically to proxied tool calls.
+
+## Adding custom protocol parsers
+
+Register new protocol extractors via the module-level `default_registry`:
+
+```python
+from agentmesh.governance.protocol_facets import default_registry
+
+def extract_redis_facets(redis_ctx: dict) -> dict:
+    cmd = (redis_ctx.get("command") or "").upper()
+    return {"verb": cmd, "key": redis_ctx.get("key", "")}
+
+default_registry.register("redis", extract_redis_facets)
+```
+
+Then pass `{"redis": {"command": "FLUSHALL"}}` in the evaluation context and
+write rules like:
+
+```yaml
+- name: deny-redis-flush
+  condition: {field: "redis.verb", operator: in, value: ["FLUSHALL", "FLUSHDB"]}
+  action: deny
+```
+
+See [`examples/policy-templates/wire-protocol-rules.yaml`](../examples/policy-templates/wire-protocol-rules.yaml)
+for a full set of example rules.

--- a/examples/policy-templates/wire-protocol-rules.yaml
+++ b/examples/policy-templates/wire-protocol-rules.yaml
@@ -1,0 +1,110 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Wire-protocol-aware policy rules for SQL and Kubernetes API calls.
+#
+# Pass protocol context in the evaluation request to activate these rules:
+#
+#   SQL:
+#     context:
+#       sql:
+#         query: "DROP TABLE users"
+#
+#   Kubernetes:
+#     context:
+#       k8s:
+#         method: DELETE
+#         path: /api/v1/namespaces/production/pods/mypod
+#
+# The policy engine extracts sql.verb, sql.target, k8s.verb, k8s.namespace
+# and related fields automatically before rules are evaluated. Each rule
+# matches a single extracted field; compound checks should be expressed as
+# multiple rules with appropriate priorities.
+
+version: "1.0"
+name: wire-protocol-rules
+description: >
+  Protocol-aware governance rules for SQL and Kubernetes API calls.
+  Lets AGT distinguish safe reads from destructive writes at the policy
+  level without requiring changes to agent code.
+
+defaults:
+  action: allow
+
+rules:
+
+  # ---------------------------------------------------------------------------
+  # SQL rules
+  # ---------------------------------------------------------------------------
+
+  # Block statements that destroy data or schema objects outright.
+  - name: deny-destructive-sql
+    condition: {field: "sql.verb", operator: in, value: ["DROP", "TRUNCATE", "DELETE"]}
+    action: deny
+    priority: 100
+    message: "Destructive SQL verb is not allowed"
+
+  # Block privilege and schema changes.
+  - name: deny-sql-schema-changes
+    condition: {field: "sql.verb", operator: in, value: ["ALTER", "GRANT", "REVOKE"]}
+    action: deny
+    priority: 100
+    message: "Schema or privilege change is not allowed"
+
+  # MERGE combines INSERT, UPDATE and DELETE in one shot, so treat it as destructive.
+  - name: deny-sql-merge
+    condition: {field: "sql.verb", operator: eq, value: "MERGE"}
+    action: deny
+    priority: 100
+    message: "MERGE statements are not allowed"
+
+  # Audit writes without blocking.
+  - name: audit-sql-writes
+    condition: {field: "sql.verb", operator: in, value: ["INSERT", "UPDATE"]}
+    action: audit
+    priority: 10
+    message: "Auditing SQL write operation"
+
+  # Allow read-only queries.
+  - name: allow-read-only-sql
+    condition: {field: "sql.verb", operator: eq, value: "SELECT"}
+    action: allow
+    priority: 5
+
+  # ---------------------------------------------------------------------------
+  # Kubernetes rules
+  # ---------------------------------------------------------------------------
+
+  # Block any mutation in the production namespace.
+  - name: deny-k8s-production-namespace
+    condition: {field: "k8s.namespace", operator: eq, value: "production"}
+    action: deny
+    priority: 110
+    message: "Operations on the production namespace are not allowed"
+
+  # Block interactive shell access into pods (exec subresource).
+  - name: deny-k8s-exec
+    condition: {field: "k8s.subresource", operator: eq, value: "exec"}
+    action: deny
+    priority: 100
+    message: "Interactive exec into pods is not allowed"
+
+  # Block bulk deletes that can wipe an entire namespace worth of resources.
+  - name: deny-k8s-deletecollection
+    condition: {field: "k8s.verb", operator: eq, value: "deletecollection"}
+    action: deny
+    priority: 100
+    message: "Bulk deletecollection is not allowed"
+
+  # Audit create, update and patch operations for change tracking.
+  - name: audit-k8s-mutations
+    condition: {field: "k8s.verb", operator: in, value: ["create", "update", "patch"]}
+    action: audit
+    priority: 10
+    message: "Auditing Kubernetes mutation"
+
+  # Allow read-only Kubernetes API calls.
+  - name: allow-k8s-readonly
+    condition: {field: "k8s.verb", operator: in, value: ["get", "list", "watch"]}
+    action: allow
+    priority: 5


### PR DESCRIPTION
Closes #2483

## Summary

AGT policy rules can now reference wire-level protocol semantics instead of only HTTP metadata.

- `protocol_facets.py` adds `FacetRegistry` plus SQL and Kubernetes extractors. SQL parsing uses sqlglot at the AST level and fails closed to `UNKNOWN` if sqlglot is absent. Kubernetes extracts verb, resource, namespace, name and subresource from API server paths. `default_registry` is pre-loaded with both parsers and can be extended for new protocols via `register()`.
- `policy.py` calls `extract_protocol_facets` before rule evaluation so `sql.*` and `k8s.*` conditions work without any changes to existing policies.
- `proxy.py` populates `context["sql"]` and `context["k8s"]` from tool call arguments so the MCP proxy enforces protocol-aware rules transparently.
- `wire-protocol-rules.yaml` provides example rules for both protocols.
- `WIRE-PROTOCOL-FACETS.md` documents usage and extension points.

## Acceptance criteria

- [x] SQL parser extracts verb, tables and functions from statements
- [x] `sql.target` populated with the primary table being operated on
- [x] Kubernetes parser extracts verb, resource, namespace, name and subresource from API paths
- [x] Policy conditions can reference `sql.*` and `k8s.*` facets
- [x] At least 3 example rules for each protocol
- [x] Integration with transparent proxy mode
- [x] Documentation and examples

## Test plan

- 54 tests pass locally (`tests/test_protocol_facets.py` and `tests/test_proxy.py`)
- 28 SQL tests skip when sqlglot is absent and run fully when it is present
- Integration tests exercise the full path from evaluation context through PolicyEngine to a deny or allow decision