### PR TITLE
docs: fix Go version, tutorial count, and quickstart timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Python · TypeScript · .NET · Rust · Go. Works with LangChain, CrewAI, AutoGe
 - **Python**: `pip install agent-governance-toolkit[full]` requires Python 3.10+
 - **Node.js**: For TypeScript SDK, Node.js 18+ and npm 9+
 - **.NET**: .NET 8+ for the .NET SDK
-- **Go**: Go 1.21+ for the Go SDK
+- **Go**: Go 1.25+ for the Go SDK
 - **Rust**: Rust 1.70+ for the Rust SDK
 
 ### Optional dependencies
@@ -328,7 +328,7 @@ See [Known Limitations](docs/LIMITATIONS.md) for honest design boundaries and re
 
 | Category | Links |
 |----------|-------|
-| **Getting Started** | [Quick Start](docs/quickstart.md) · [Tutorials](docs/tutorials/) (40+) · [FAQ](docs/FAQ.md) |
+| **Getting Started** | [Quick Start](docs/quickstart.md) · [Tutorials](docs/tutorials/) (60+) · [FAQ](docs/FAQ.md) |
 | **Architecture** | [System Design](docs/ARCHITECTURE.md) · [Threat Model](docs/THREAT_MODEL.md) · [ADRs](docs/adr/) (25) |
 | **Specifications** | [All Specs](docs/specs/) (10 formal specs, 992 conformance tests) |
 | **API Reference** | [Agent OS](agent-governance-python/agent-os/README.md) · [AgentMesh](agent-governance-python/agent-mesh/README.md) · [Agent SRE](agent-governance-python/agent-sre/README.md) |

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -150,7 +150,7 @@ A self-contained sub-series progressing from basic allow/deny rules to productio
 
 ## Learning Paths
 
-### 🚀 "I want to govern my agent in 10 minutes"
+### 🚀 "I want to govern my agent in 5 minutes"
 
 1. [01 — Policy Engine](01-policy-engine.md) → define allow/deny rules
 2. [03 — Framework Integrations](03-framework-integrations.md) → wrap your framework
@@ -227,7 +227,7 @@ go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang  # 
 
 ## More Resources
 
-- **[Quick Start](../../quickstart.md)** — Zero to governed agents in 10 minutes
+- **[Quick Start](../../quickstart.md)** — Zero to governed agents in 5 minutes
 - **[Architecture](../ARCHITECTURE.md)** — System design and security model
 - **[OWASP Compliance](../OWASP-COMPLIANCE.md)** — ASI-01 through ASI-10 mapping
 - **[Benchmarks](../../BENCHMARKS.md)** — Performance data


### PR DESCRIPTION
Fixes Go prerequisite from 1.21 to 1.25 (matches go.mod). Updates tutorial count from 40+ to 60+ (64 tutorials exist). Updates quickstart timing from 10 min to 5 min to match rewritten quickstart page.