### PR TITLE
fix: install real OPA CLI and cedarpy in Docker, remove mock fallbacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,13 @@ RUN for i in 1 2 3; do apt-get update && break || sleep 5; done \
     && for i in 1 2 3; do apt-get update && break || sleep 5; done \
     && apt-get install -y --no-install-recommends nodejs \
     && python -m pip install --upgrade pip==24.3.1 setuptools==75.8.0 wheel==0.45.1 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    # OPA CLI — required by OPAEvaluator local mode (opa eval subprocess)
+    && curl -fsSL -o /usr/local/bin/opa \
+        https://openpolicyagent.org/downloads/v1.4.2/opa_linux_amd64_static \
+    && echo "2c0ccdbbe0b8e2a5d12d9c42d92f1f34f494ffb32d1f3c4ddc36101be637d66f  /usr/local/bin/opa" \
+        | sha256sum -c - \
+    && chmod 755 /usr/local/bin/opa
 
 FROM base AS dev
 
@@ -58,6 +64,7 @@ COPY . /workspace
 # Scorecard: editable installs pinned to repo checkout via pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install \
+        "cedarpy>=4.0.0,<5.0" \
         -e "agent-governance-python/agent-primitives[dev]" \
         -e "agent-governance-python/agent-mcp-governance[dev]" \
         -e "agent-governance-python/agent-os[full,dev]" \

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py
@@ -169,8 +169,20 @@ class CedarEvaluator:
             ):
                 result = self._evaluate_cli(action, context)
             else:
-                # builtin or auto fallback: use built-in parser
-                result = self._evaluate_mock(action, context)
+                if self.mode == "builtin":
+                    result = self._evaluate_mock(action, context)
+                else:
+                    elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
+                    return CedarDecision(
+                        allowed=False,
+                        action=action,
+                        evaluation_ms=elapsed,
+                        source="fallback",
+                        error=(
+                            "Cedar auto mode requires cedarpy or the cedar CLI; "
+                            "use mode='builtin' explicitly to opt into the mock evaluator"
+                        ),
+                    )
 
             elapsed = (datetime.now(timezone.utc) - start).total_seconds() * 1000
             result.evaluation_ms = elapsed

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/opa.py
@@ -201,8 +201,15 @@ class OPAEvaluator:
             return self._evaluate_opa_cli(query, input_data)
 
         if self.rego_content or (self.rego_path and Path(self.rego_path).exists()):
-            # Fall back to the built-in mock parser for simple Rego
-            return self._evaluate_mock(query, input_data)
+            return OPADecision(
+                allowed=False,
+                query=query,
+                source="fallback",
+                error=(
+                    "OPA CLI not available; install opa for policy evaluation: "
+                    "https://www.openpolicyagent.org/docs/latest/#running-opa"
+                ),
+            )
 
         return OPADecision(
             allowed=False,

--- a/agent-governance-python/agent-mesh/tests/test_cedar.py
+++ b/agent-governance-python/agent-mesh/tests/test_cedar.py
@@ -58,7 +58,7 @@ forbid(
         evaluator = CedarEvaluator(policy_content=self.SIMPLE_POLICY)
         decision = evaluator.evaluate('Action::"ReadData"', {"agent_did": "did:example:1"})
         assert decision.allowed is True
-        assert decision.source == "builtin"
+        assert decision.source in ("cedarpy", "cli", "builtin")
         assert decision.error is None
 
     def test_forbid_matching_action(self):


### PR DESCRIPTION
Reverts the mock evaluator fallbacks from #2507 and installs real policy engines instead.

**Changes:**
- **Dockerfile**: Install OPA CLI v1.4.2 static binary (SHA-256 verified) and cedarpy Python package
- **opa.py**: Restore strict deny when OPA CLI missing (no mock fallback)
- **cedar.py**: Restore strict deny in auto mode when no real engine available
- **test_cedar.py**: Accept any real evaluator source in assertion

Production code stays strict: missing engines = deny with clear error. The Docker container provides the real tools.