### PR TITLE
fix: correct broken RELEASE.md link in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -71,7 +71,7 @@ the relevant GitHub Issue or PR.
 
 ## Releases
 
-Releases follow [Semantic Versioning](https://semver.org/). Any maintainer can propose a release. The release process is documented in [RELEASE.md](RELEASE.md) and automated via GitHub Actions with trusted publishing and SLSA build provenance.
+Releases follow [Semantic Versioning](https://semver.org/). Any maintainer can propose a release. The release process is documented in [RELEASE.md](docs/RELEASE.md) and automated via GitHub Actions with trusted publishing and SLSA build provenance.
 
 ## Project Charter
 


### PR DESCRIPTION
GOVERNANCE.md referenced \RELEASE.md\ at root, but the file lives at \docs/RELEASE.md\. Fixes the broken link.