### PR TITLE
fix: use correct cedarpy API (dict request, Decision.Allow)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/cedar.py
@@ -227,16 +227,16 @@ class CedarEvaluator:
 
         request = self._build_request(action, context)
         response = cedarpy.is_authorized(
-            request=cedarpy.AuthorizationRequest(
-                principal=request["principal"],
-                action=request["action"],
-                resource=request["resource"],
-                context=request["context"],
-            ),
+            request={
+                "principal": request["principal"],
+                "action": request["action"],
+                "resource": request["resource"],
+                "context": request.get("context", {}),
+            },
             policies=self.policy_content or "",
             entities=self.entities,
         )
-        allowed = response.decision == cedarpy.Decision.ALLOW
+        allowed = response.decision == cedarpy.Decision.Allow
         return CedarDecision(
             allowed=allowed,
             raw_result={

--- a/agent-governance-python/agent-os/src/agent_os/policies/backends.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/backends.py
@@ -596,16 +596,16 @@ class CedarBackend:
 
         request = self._build_cedar_request(context)
         response = cedarpy.is_authorized(
-            request=cedarpy.AuthorizationRequest(
-                principal=request["principal"],
-                action=request["action"],
-                resource=request["resource"],
-                context=request["context"],
-            ),
+            request={
+                "principal": request["principal"],
+                "action": request["action"],
+                "resource": request["resource"],
+                "context": request.get("context", {}),
+            },
             policies=self._policy_content or "",
             entities=self._entities,
         )
-        allowed = response.decision == cedarpy.Decision.ALLOW
+        allowed = response.decision == cedarpy.Decision.Allow
         return BackendDecision(
             allowed=allowed,
             action="allow" if allowed else "deny",

--- a/agent-governance-python/agent-os/tests/test_policy_backends.py
+++ b/agent-governance-python/agent-os/tests/test_policy_backends.py
@@ -610,6 +610,7 @@ class TestCedarAutoModeDeniesWithoutEngine:
         from agent_os.policies import backends as backends_mod
 
         monkeypatch.setattr(backends_mod.shutil, "which", lambda _: None)
+        monkeypatch.setattr(CedarBackend, "_check_cedarpy", staticmethod(lambda: False))
         backend = CedarBackend(policy_content=self.POLICY)
         assert backend._mode == "auto"
         decision = backend.evaluate({"tool_name": "read", "agent_id": "a1"})


### PR DESCRIPTION
Fixes docker-compose-test CI failure: \module 'cedarpy' has no attribute 'AuthorizationRequest'\.

**Root cause:** The cedarpy bindings use a plain dict for requests, not \cedarpy.AuthorizationRequest\ (which doesn't exist). Also uses \Decision.Allow\ (capital A) not \Decision.ALLOW\.

**Changes:**
- \gent-mesh/cedar.py\: Use dict request + \Decision.Allow\
- \gent-os/backends.py\: Same fix
- \gent-os/test_policy_backends.py\: Monkeypatch \_check_cedarpy\ in the auto-mode-deny test since cedarpy is now installed in Docker

Follows #2508 which installed cedarpy in the Docker container.