### PR TITLE
docs: add competition law / antitrust policy

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -1,3 +1,4 @@
+AAIF
 abstractmethod
 aenter
 aexit

--- a/ANTITRUST.md
+++ b/ANTITRUST.md
@@ -1,0 +1,43 @@
+# Competition Law / Antitrust Policy
+
+The Agent Governance Toolkit is an open-source project hosted under
+the MIT License. All participants in this project are expected to
+comply with applicable competition (antitrust) laws in their
+respective jurisdictions.
+
+## Guidelines for Participants
+
+When participating in project discussions, meetings, working groups,
+or any other project activities, participants **must not** discuss or
+exchange information about:
+
+- Current or future pricing of products or services
+- Market allocation, customer allocation, or bid rigging
+- Boycotts of suppliers, customers, or competitors
+- Proprietary competitive strategies or confidential business plans
+- Any other topic that could constitute an agreement or coordination
+  among competitors in violation of competition law
+
+## What Is Appropriate
+
+Project discussions should be limited to:
+
+- Technical specifications and implementation details
+- Open-source governance and contribution processes
+- Interoperability standards and protocol design
+- Security, compliance, and policy enforcement patterns
+- Bug reports, feature requests, and code review
+
+## Reporting Concerns
+
+If you believe a discussion or activity within this project may
+violate competition law, please raise the concern with the project
+maintainers at <opencode@microsoft.com> or contact your own
+legal counsel.
+
+## Foundation Transition
+
+If this project moves to a foundation (e.g., AAIF, Linux Foundation),
+this policy will be superseded by the foundation's official
+competition law guidelines. Until then, this policy applies to all
+project activities.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ The project lead sets overall technical direction, resolves disputes when consen
 
 See [MAINTAINERS.md](MAINTAINERS.md) for the full list of current maintainers, their areas of ownership, and affiliation details.
 
-We are actively working to grow the maintainer group to include contributors from other organizations. If you are interested in becoming a maintainer, start by contributing and engaging with the project. Code ownership areas are defined in [CODEOWNERS](CODEOWNERS).
+We are actively working to grow the maintainer group to include contributors from other organizations. If you are interested in becoming a maintainer, start by contributing and engaging with the project. Code ownership areas are defined in [CODEOWNERS](.github/CODEOWNERS).
 
 ## Decision-Making
 
@@ -103,6 +103,10 @@ All participants are expected to follow the [Microsoft Open Source Code of Condu
 ## Security
 
 Security vulnerabilities should be reported via [SECURITY.md](SECURITY.md), not through public issues.
+
+## Competition Law
+
+All participants must comply with applicable competition (antitrust) laws. See [ANTITRUST.md](ANTITRUST.md) for guidelines on appropriate discussion topics.
 
 ## Changes to Governance
 


### PR DESCRIPTION
## Summary

Adds ANTITRUST.md with competition law guidelines for project participants, as required by AAIF and Linux Foundation project standards.

## Changes

- **ANTITRUST.md** (new): Guidelines on appropriate discussion topics, prohibited competitive information exchanges, and reporting process
- **GOVERNANCE.md**: Added reference to ANTITRUST.md in the governance document

## Why

AAIF requires competition law guidelines for all hosted projects. This ensures participants understand what topics are appropriate in project meetings, discussions, and working groups.