### PR TITLE
docs: update AAIF proposal with current governance files and tiers

### DIFF
--- a/docs/proposals/AAIF-PROPOSAL.md
+++ b/docs/proposals/AAIF-PROPOSAL.md
@@ -3,10 +3,10 @@
 ## Agent Governance Toolkit — Runtime Governance for Agentic AI
 
 **Proposed by:** Microsoft (microsoft/agent-governance-toolkit)
-**Requested Level:** Sandbox → Incubation
+**Requested Level:** Member Project
 **License:** MIT
 **Primary Contact:** Agent Governance Toolkit Team (agentgovtoolkit@microsoft.com)
-**Status:** 🟢 Ready for submission -- Public Preview shipped (v3.2.0). 5 SDK languages. 19 framework integrations. Microsoft-signed releases via ESRP.
+**Status:** 🟢 Ready for submission -- Public Preview shipped (v3.7.0). 5 SDK languages. 19 framework integrations. Microsoft-signed releases via ESRP.
 
 ---
 
@@ -134,26 +134,32 @@ The toolkit is unique in providing **external, runtime, mandatory** governance:
 ## 9. Project Governance
 
 - **License:** MIT
-- **Code of Conduct:** Microsoft Open Source Code of Conduct (Contributor Covenant)
-- **Contributing Guide:** CONTRIBUTING.md with DCO sign-off
-- **CI/CD:** GitHub Actions, branch protection, automated testing
-- **Security:** SECURITY.md with vulnerability reporting process
+- **Code of Conduct:** Contributor Covenant v2.1 ([CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md))
+- **Contributing Guide:** [CONTRIBUTING.md](../../CONTRIBUTING.md) with CLA + DCO sign-off
+- **Governance:** [GOVERNANCE.md](../../GOVERNANCE.md) with decision-making matrix, succession planning, dispute resolution
+- **Technical Charter:** [CHARTER.md](../../CHARTER.md) covering TSC structure, IP policy, and foundation transition
+- **Security:** [SECURITY.md](../../SECURITY.md) with vulnerability reporting and threat model
+- **Maintainers:** [MAINTAINERS.md](../../MAINTAINERS.md) with 5 core maintainers (3 non-Microsoft)
+- **CODEOWNERS:** [.github/CODEOWNERS](../../.github/CODEOWNERS) with per-SDK maintainer ownership
+- **Competition Law:** [ANTITRUST.md](../../ANTITRUST.md) with participant guidelines
+- **Trademarks:** [TRADEMARKS.md](../../TRADEMARKS.md) with usage guidelines
+- **CI/CD:** GitHub Actions, branch protection, automated testing, CodeQL, OpenSSF Scorecard
 
 ## 10. Proposed Roadmap Under AAIF
 
-### Phase 1: Sandbox
-- Public release under microsoft/ org
+### Phase 1: Member Project Onboarding
+- Transfer repository or establish mirror under AAIF org
 - Complete ASI-04 (Supply Chain) coverage with Agent-SBOM
 - Formalize governance policy schema as an open specification
 - Publish integration guides for all major agent frameworks
 
-### Phase 2: Incubation
-- Multi-language support (Python + TypeScript + .NET)
+### Phase 2: Supported Project
+- Multi-language support maturity (Python + TypeScript + .NET + Rust + Go)
 - Formal verification of policy engine
 - Cross-framework governance policy portability standard
 - Reference implementations for AAIF member organizations
 
-### Phase 3: Graduated
+### Phase 3: Managed Project
 - Industry-standard governance policy format (like OPA/Rego for agents)
 - Certification program for governance-compliant agent frameworks
 - Integration with cloud-native security tooling (Falco, OPA, SPIFFE)


### PR DESCRIPTION
## Summary

Updates the AAIF project proposal to reflect current project state and correct AAIF terminology.

## Changes

- Fix project tier names: Sandbox/Incubation/Graduated to Member/Supported/Managed (AAIF terminology)
- Update version reference from v3.2.0 to v3.7.0
- Expand Section 9 (Project Governance) to reference all governance files added this session: CHARTER.md, ANTITRUST.md, TRADEMARKS.md, per-SDK CODEOWNERS, threat model in SECURITY.md
- Note 3/5 non-Microsoft core maintainers