### PR TITLE
docs: add package SVG icons, color-coded cards, and refined hero gradient

### DIFF
--- a/docs/assets/icons/agent-compliance.svg
+++ b/docs/assets/icons/agent-compliance.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#16A34A;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#15803D;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Clipboard -->
+  <rect x="20" y="20" width="24" height="28" rx="3" fill="none" stroke="white" stroke-width="2"/>
+  <rect x="27" y="16" width="10" height="6" rx="2" fill="white"/>
+  <!-- Checkmarks -->
+  <polyline points="25,30 28,33 34,27" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="25,38 28,41 34,35" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Line placeholder -->
+  <line x1="37" y1="30" x2="42" y2="30" stroke="white" stroke-width="1.5" opacity="0.5"/>
+  <line x1="37" y1="38" x2="42" y2="38" stroke="white" stroke-width="1.5" opacity="0.5"/>
+</svg>

--- a/docs/assets/icons/agent-hypervisor.svg
+++ b/docs/assets/icons/agent-hypervisor.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1E40AF;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#1E3A8A;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Stacked layers -->
+  <ellipse cx="32" cy="24" rx="16" ry="6" fill="none" stroke="white" stroke-width="2"/>
+  <path d="M16 24 L16 32 C16 35.3 22.3 38 32 38 C41.7 38 48 35.3 48 32 L48 24"
+        fill="none" stroke="white" stroke-width="2"/>
+  <path d="M16 32 L16 40 C16 43.3 22.3 46 32 46 C41.7 46 48 43.3 48 40 L48 32"
+        fill="none" stroke="white" stroke-width="2"/>
+  <!-- Lock icon on front layer -->
+  <rect x="28" y="37" width="8" height="6" rx="1.5" fill="white"/>
+  <path d="M30 37 L30 35 C30 33 31 32 32 32 C33 32 34 33 34 35 L34 37"
+        fill="none" stroke="white" stroke-width="1.5"/>
+  <circle cx="32" cy="40" r="1" fill="#1E40AF"/>
+</svg>

--- a/docs/assets/icons/agent-lightning.svg
+++ b/docs/assets/icons/agent-lightning.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#D97706;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B45309;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Lightning bolt -->
+  <polygon points="36,14 24,34 30,34 28,50 40,30 34,30"
+           fill="white"/>
+  <!-- Small sparks -->
+  <line x1="18" y1="24" x2="14" y2="22" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
+  <line x1="16" y1="32" x2="12" y2="32" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4"/>
+  <line x1="46" y1="24" x2="50" y2="22" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
+  <line x1="48" y1="32" x2="52" y2="32" stroke="white" stroke-width="1.5" stroke-linecap="round" opacity="0.4"/>
+</svg>

--- a/docs/assets/icons/agent-marketplace.svg
+++ b/docs/assets/icons/agent-marketplace.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4F46E5;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#3730A3;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Grid of items (marketplace) -->
+  <rect x="16" y="18" width="12" height="12" rx="3" fill="white" opacity="0.9"/>
+  <rect x="36" y="18" width="12" height="12" rx="3" fill="white" opacity="0.7"/>
+  <rect x="16" y="36" width="12" height="12" rx="3" fill="white" opacity="0.7"/>
+  <rect x="36" y="36" width="12" height="12" rx="3" fill="white" opacity="0.5"/>
+  <!-- Trust badge on first item -->
+  <circle cx="25" cy="27" r="2" fill="#4F46E5"/>
+  <polyline points="23.5,27 24.5,28 27,25.5" fill="none" stroke="white" stroke-width="1" stroke-linecap="round"/>
+</svg>

--- a/docs/assets/icons/agent-mesh.svg
+++ b/docs/assets/icons/agent-mesh.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7C3AED;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#5B21B6;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Mesh network nodes -->
+  <circle cx="32" cy="22" r="4" fill="white"/>
+  <circle cx="20" cy="38" r="4" fill="white"/>
+  <circle cx="44" cy="38" r="4" fill="white"/>
+  <circle cx="32" cy="48" r="3" fill="white" opacity="0.7"/>
+  <!-- Mesh connections -->
+  <line x1="32" y1="26" x2="20" y2="34" stroke="white" stroke-width="1.5" opacity="0.6"/>
+  <line x1="32" y1="26" x2="44" y2="34" stroke="white" stroke-width="1.5" opacity="0.6"/>
+  <line x1="20" y1="42" x2="44" y2="42" stroke="white" stroke-width="1.5" opacity="0.6"/>
+  <line x1="20" y1="42" x2="32" y2="48" stroke="white" stroke-width="1.5" opacity="0.4"/>
+  <line x1="44" y1="42" x2="32" y2="48" stroke="white" stroke-width="1.5" opacity="0.4"/>
+  <!-- Identity lock in center node -->
+  <rect x="28" y="30" width="8" height="6" rx="1" fill="white" opacity="0.3"/>
+  <circle cx="32" cy="29" r="3" fill="none" stroke="white" stroke-width="1.5" opacity="0.3"/>
+</svg>

--- a/docs/assets/icons/agent-os.svg
+++ b/docs/assets/icons/agent-os.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0E9AA7;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#0B7A85;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <!-- Rounded square base -->
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Gear outline -->
+  <path d="M32 18 l2.5 0 l1 3.5 l3-1 l1.5 2 l-2 3 l2.5 2 l-0.5 2.5 l-3.5 0.5 l-0.5 3 l-2.5 0.5 l-1.5-3 l-3 1 l-1.5-2 l2-2.5 l-2.5-2 l0.5-2.5 l3.5-0.5 l0.5-3z"
+        fill="none" stroke="white" stroke-width="1.5" opacity="0.3"/>
+  <!-- Simplified gear -->
+  <circle cx="32" cy="32" r="10" fill="none" stroke="white" stroke-width="2.5"/>
+  <circle cx="32" cy="32" r="4.5" fill="white"/>
+  <!-- Gear teeth -->
+  <rect x="30" y="18" width="4" height="5" rx="1" fill="white"/>
+  <rect x="30" y="41" width="4" height="5" rx="1" fill="white"/>
+  <rect x="18" y="30" width="5" height="4" rx="1" fill="white"/>
+  <rect x="41" y="30" width="5" height="4" rx="1" fill="white"/>
+  <rect x="21.5" y="21.5" width="4" height="4" rx="1" fill="white" transform="rotate(45 23.5 23.5)"/>
+  <rect x="38.5" y="38.5" width="4" height="4" rx="1" fill="white" transform="rotate(45 40.5 40.5)"/>
+  <rect x="38.5" y="21.5" width="4" height="4" rx="1" fill="white" transform="rotate(45 40.5 23.5)"/>
+  <rect x="21.5" y="38.5" width="4" height="4" rx="1" fill="white" transform="rotate(45 23.5 40.5)"/>
+</svg>

--- a/docs/assets/icons/agent-runtime.svg
+++ b/docs/assets/icons/agent-runtime.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#EA580C;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#C2410C;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Shield shape -->
+  <path d="M32 16 L46 23 L46 35 C46 43 40 49 32 52 C24 49 18 43 18 35 L18 23 Z"
+        fill="none" stroke="white" stroke-width="2.5"/>
+  <!-- Concentric rings inside shield -->
+  <circle cx="32" cy="34" r="10" fill="none" stroke="white" stroke-width="1.5" opacity="0.4"/>
+  <circle cx="32" cy="34" r="6" fill="none" stroke="white" stroke-width="1.5" opacity="0.6"/>
+  <circle cx="32" cy="34" r="2.5" fill="white"/>
+</svg>

--- a/docs/assets/icons/agent-sre.svg
+++ b/docs/assets/icons/agent-sre.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#DC2626;stop-opacity:1"/>
+      <stop offset="100%" style="stop-color:#B91C1C;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="url(#g)"/>
+  <!-- Heartbeat / monitoring line -->
+  <polyline points="14,36 22,36 26,26 30,42 34,30 38,36 42,36 44,32 46,36 50,36"
+            fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Small graph bars at bottom -->
+  <rect x="18" y="44" width="4" height="4" rx="1" fill="white" opacity="0.5"/>
+  <rect x="24" y="42" width="4" height="6" rx="1" fill="white" opacity="0.6"/>
+  <rect x="30" y="40" width="4" height="8" rx="1" fill="white" opacity="0.7"/>
+  <rect x="36" y="43" width="4" height="5" rx="1" fill="white" opacity="0.6"/>
+  <rect x="42" y="44" width="4" height="4" rx="1" fill="white" opacity="0.5"/>
+  <!-- Alert dot -->
+  <circle cx="46" cy="20" r="4" fill="white" opacity="0.9"/>
+  <circle cx="46" cy="20" r="2" fill="#DC2626"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -118,37 +118,45 @@ Every layer is optional. Start with `govern()` and add layers as your risk profi
 ## Packages
 
 <div class="agt-cards">
-<a class="agt-card" href="packages/agent-os.md">
-<span class="agt-card-title">⚙️ Agent OS</span>
-<span class="agt-card-desc">Policy engine, agent lifecycle, governance gate</span>
+<a class="agt-card" data-pkg="os" href="packages/agent-os.md">
+<img class="agt-card-icon" src="assets/icons/agent-os.svg" alt="Agent OS">
+<span class="agt-card-body"><span class="agt-card-title">Agent OS</span>
+<span class="agt-card-desc">Policy engine, agent lifecycle, governance gate</span></span>
 </a>
-<a class="agt-card" href="packages/agent-mesh.md">
-<span class="agt-card-title">🔗 Agent Mesh</span>
-<span class="agt-card-desc">Agent discovery, routing, and trust mesh</span>
+<a class="agt-card" data-pkg="mesh" href="packages/agent-mesh.md">
+<img class="agt-card-icon" src="assets/icons/agent-mesh.svg" alt="Agent Mesh">
+<span class="agt-card-body"><span class="agt-card-title">Agent Mesh</span>
+<span class="agt-card-desc">Agent discovery, routing, and trust mesh</span></span>
 </a>
-<a class="agt-card" href="packages/agent-runtime.md">
-<span class="agt-card-title">🛡️ Agent Runtime</span>
-<span class="agt-card-desc">Execution sandboxing with four privilege rings</span>
+<a class="agt-card" data-pkg="runtime" href="packages/agent-runtime.md">
+<img class="agt-card-icon" src="assets/icons/agent-runtime.svg" alt="Agent Runtime">
+<span class="agt-card-body"><span class="agt-card-title">Agent Runtime</span>
+<span class="agt-card-desc">Execution sandboxing with four privilege rings</span></span>
 </a>
-<a class="agt-card" href="packages/agent-sre.md">
-<span class="agt-card-title">📊 Agent SRE</span>
-<span class="agt-card-desc">Kill switch, SLO monitoring, chaos testing</span>
+<a class="agt-card" data-pkg="sre" href="packages/agent-sre.md">
+<img class="agt-card-icon" src="assets/icons/agent-sre.svg" alt="Agent SRE">
+<span class="agt-card-body"><span class="agt-card-title">Agent SRE</span>
+<span class="agt-card-desc">Kill switch, SLO monitoring, chaos testing</span></span>
 </a>
-<a class="agt-card" href="packages/agent-compliance.md">
-<span class="agt-card-title">✅ Agent Compliance</span>
-<span class="agt-card-desc">OWASP verification, policy linting, integrity checks</span>
+<a class="agt-card" data-pkg="compliance" href="packages/agent-compliance.md">
+<img class="agt-card-icon" src="assets/icons/agent-compliance.svg" alt="Agent Compliance">
+<span class="agt-card-body"><span class="agt-card-title">Agent Compliance</span>
+<span class="agt-card-desc">OWASP verification, policy linting, integrity checks</span></span>
 </a>
-<a class="agt-card" href="packages/agent-marketplace.md">
-<span class="agt-card-title">🏪 Agent Marketplace</span>
-<span class="agt-card-desc">Plugin governance and trust scoring</span>
+<a class="agt-card" data-pkg="marketplace" href="packages/agent-marketplace.md">
+<img class="agt-card-icon" src="assets/icons/agent-marketplace.svg" alt="Agent Marketplace">
+<span class="agt-card-body"><span class="agt-card-title">Agent Marketplace</span>
+<span class="agt-card-desc">Plugin governance and trust scoring</span></span>
 </a>
-<a class="agt-card" href="packages/agent-lightning.md">
-<span class="agt-card-title">⚡ Agent Lightning</span>
-<span class="agt-card-desc">RL training governance with violation penalties</span>
+<a class="agt-card" data-pkg="lightning" href="packages/agent-lightning.md">
+<img class="agt-card-icon" src="assets/icons/agent-lightning.svg" alt="Agent Lightning">
+<span class="agt-card-body"><span class="agt-card-title">Agent Lightning</span>
+<span class="agt-card-desc">RL training governance with violation penalties</span></span>
 </a>
-<a class="agt-card" href="packages/agent-hypervisor.md">
-<span class="agt-card-title">🔒 Agent Hypervisor</span>
-<span class="agt-card-desc">Execution audit, delta engine, commitment anchoring</span>
+<a class="agt-card" data-pkg="hypervisor" href="packages/agent-hypervisor.md">
+<img class="agt-card-icon" src="assets/icons/agent-hypervisor.svg" alt="Agent Hypervisor">
+<span class="agt-card-body"><span class="agt-card-title">Agent Hypervisor</span>
+<span class="agt-card-desc">Execution audit, delta engine, commitment anchoring</span></span>
 </a>
 </div>
 </div>

--- a/docs/stylesheets/mslearn.css
+++ b/docs/stylesheets/mslearn.css
@@ -398,11 +398,12 @@ html {
   transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
   text-decoration: none;
   color: inherit;
-  display: block;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
 }
 
 .agt-card:hover {
-  border-color: var(--md-primary-fg-color);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   transform: translateY(-2px);
 }
@@ -411,11 +412,23 @@ html {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
+.agt-card-icon {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border-radius: 8px;
+}
+
+.agt-card-body {
+  flex: 1;
+  min-width: 0;
+}
+
 .agt-card-title {
   font-size: 1rem;
   font-weight: 600;
-  margin: 0 0 0.5rem;
-  color: var(--md-primary-fg-color);
+  margin: 0 0 0.35rem;
+  display: block;
 }
 
 .agt-card-desc {
@@ -423,7 +436,45 @@ html {
   color: var(--mslearn-text-muted);
   margin: 0;
   line-height: 1.5;
+  display: block;
 }
+
+/* ── Per-package card accent colors ── */
+.agt-card[data-pkg="os"]          { border-left: 3px solid #0E9AA7; }
+.agt-card[data-pkg="mesh"]        { border-left: 3px solid #7C3AED; }
+.agt-card[data-pkg="runtime"]     { border-left: 3px solid #EA580C; }
+.agt-card[data-pkg="sre"]         { border-left: 3px solid #DC2626; }
+.agt-card[data-pkg="compliance"]  { border-left: 3px solid #16A34A; }
+.agt-card[data-pkg="marketplace"] { border-left: 3px solid #4F46E5; }
+.agt-card[data-pkg="lightning"]   { border-left: 3px solid #D97706; }
+.agt-card[data-pkg="hypervisor"]  { border-left: 3px solid #1E40AF; }
+
+.agt-card[data-pkg="os"]:hover          { border-color: #0E9AA7; }
+.agt-card[data-pkg="mesh"]:hover        { border-color: #7C3AED; }
+.agt-card[data-pkg="runtime"]:hover     { border-color: #EA580C; }
+.agt-card[data-pkg="sre"]:hover         { border-color: #DC2626; }
+.agt-card[data-pkg="compliance"]:hover  { border-color: #16A34A; }
+.agt-card[data-pkg="marketplace"]:hover { border-color: #4F46E5; }
+.agt-card[data-pkg="lightning"]:hover   { border-color: #D97706; }
+.agt-card[data-pkg="hypervisor"]:hover  { border-color: #1E40AF; }
+
+.agt-card[data-pkg="os"]          .agt-card-title { color: #0E9AA7; }
+.agt-card[data-pkg="mesh"]        .agt-card-title { color: #7C3AED; }
+.agt-card[data-pkg="runtime"]     .agt-card-title { color: #EA580C; }
+.agt-card[data-pkg="sre"]         .agt-card-title { color: #DC2626; }
+.agt-card[data-pkg="compliance"]  .agt-card-title { color: #16A34A; }
+.agt-card[data-pkg="marketplace"] .agt-card-title { color: #4F46E5; }
+.agt-card[data-pkg="lightning"]   .agt-card-title { color: #D97706; }
+.agt-card[data-pkg="hypervisor"]  .agt-card-title { color: #1E40AF; }
+
+[data-md-color-scheme="slate"] .agt-card[data-pkg="os"]          .agt-card-title { color: #2DD4BF; }
+[data-md-color-scheme="slate"] .agt-card[data-pkg="mesh"]        .agt-card-title { color: #A78BFA; }
+[data-md-color-scheme="slate"] .agt-card[data-pkg="runtime"]     .agt-card-title { color: #FB923C; }
+[data-md-color-scheme="slate"] .agt-card[data-pkg="sre"]         .agt-card-title { color: #F87171; }
+[data-md-color-scheme="slate"] .agt-card[data-pkg="compliance"]  .agt-card-title { color: #4ADE80; }
+[data-md-color-scheme="slate"] .agt-card[data-pkg="marketplace"] .agt-card-title { color: #818CF8; }
+[data-md-color-scheme="slate"] .agt-card[data-pkg="lightning"]   .agt-card-title { color: #FBBF24; }
+[data-md-color-scheme="slate"] .agt-card[data-pkg="hypervisor"]  .agt-card-title { color: #60A5FA; }
 
 
 /* ==========================================================================
@@ -431,7 +482,7 @@ html {
    ========================================================================== */
 
 .agt-hero {
-  background: linear-gradient(135deg, #0078D4, #005A9E);
+  background: linear-gradient(135deg, #1B2838 0%, #0D3B66 40%, #1E3A5F 70%, #2A1B3D 100%);
   color: #FFFFFF;
   padding: 3rem 2rem;
   border-radius: 8px;
@@ -440,7 +491,7 @@ html {
 }
 
 [data-md-color-scheme="slate"] .agt-hero {
-  background: linear-gradient(135deg, #003D6B, #002244);
+  background: linear-gradient(135deg, #0F1923 0%, #0A2847 40%, #15293F 70%, #1A1128 100%);
 }
 
 .agt-hero h1,


### PR DESCRIPTION
Replaces generic emoji with custom SVG icons for all 8 packages. Each package gets a distinct color accent (border + title). Hero gradient updated from solid blue to a dark multi-tone palette.

**Icons:** agent-os (teal), agent-mesh (purple), agent-runtime (orange), agent-sre (red), agent-compliance (green), agent-marketplace (indigo), agent-lightning (amber), agent-hypervisor (dark blue)

**CSS:** Per-package card accent classes via \data-pkg\ attribute, dark mode color variants, card layout updated to icon+body flex.