### PR TITLE
fix(audit): remove duplicate AuditEntry fields, align on compute_driver per spec

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -44,10 +44,12 @@ codepoint
 CommonMark
 comspec
 containerapps
+containerd
 contoso
 Cpus
 cref
 CrewAI
+crun
 CuriousHet
 dataclass
 dataclasses
@@ -58,6 +60,7 @@ davidequarracino
 dbt
 dearmor
 defi
+delenv
 demux
 deprioritized
 Deque
@@ -95,6 +98,7 @@ frozenset
 fullmatch
 gemini
 getattr
+getenv
 gethostname
 getuid
 GitHub
@@ -102,7 +106,6 @@ gmtime
 GOPROXY
 governancepolicy
 gvisor
-h├⌐llo
 hasattr
 hashlib
 HEALTHCHECK
@@ -113,6 +116,7 @@ htek
 httpx
 hypercall
 Hyperlight
+h├⌐llo
 IATP
 idweb
 imran

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,23 +91,48 @@ GovernanceDenied: Action denied by policy rule 'block-destructive':
 
 ## How it works
 
-```
-                       ┌─────────────────────────────────────────────┐
-                       │            Agent Governance Toolkit          │
-                       │                                             │
-Agent ──→ govern() ──→ │  Policy Engine ──→ Identity ──→ Audit Log   │ ──→ Tool
-                       │       │                │            │       │
-                       │   YAML/OPA/Cedar   SPIFFE SVID   Tamper-   │
-                       │                                  evident    │
-                       └─────────────────────────────────────────────┘
+```mermaid
+flowchart LR
+    A[🤖 Agent] -->|"govern()"| GK
 
-  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐
-  │ Agent OS  │    │   Mesh   │    │   SRE    │    │ Sandbox  │
-  │ policies  │    │ identity │    │  SLOs    │    │  rings   │
-  │ lifecycle │    │  routing │    │  chaos   │    │ isolation│
-  │ approval  │    │   trust  │    │  costs   │    │ kill sw  │
-  └──────────┘    └──────────┘    └──────────┘    └──────────┘
+    subgraph GK ["Agent Governance Toolkit"]
+        direction LR
+        PE["⚙️ Policy Engine\nYAML · OPA · Cedar"]
+        ID["🔑 Identity\nSPIFFE · DID · mTLS"]
+        AL["📋 Audit Log\nTamper-evident"]
+        PE --> ID --> AL
+    end
+
+    GK -->|"✅ Allowed"| T[🔧 Tool]
+    GK -->|"🚫 Denied"| D[GovernanceDenied]
+
+    style GK fill:#0078D4,stroke:#005A9E,color:#fff
+    style PE fill:#1a5276,stroke:#0078D4,color:#fff
+    style ID fill:#1a5276,stroke:#0078D4,color:#fff
+    style AL fill:#1a5276,stroke:#0078D4,color:#fff
+    style A fill:#2C3E50,stroke:#566573,color:#fff
+    style T fill:#1E8449,stroke:#196F3D,color:#fff
+    style D fill:#922B21,stroke:#7B241C,color:#fff
 ```
+
+<div class="agt-cards" style="margin-top: 1.5rem;">
+<div class="agt-card" style="cursor:default;">
+<span class="agt-card-title">⚙️ Agent OS</span>
+<span class="agt-card-desc">Policies · Lifecycle · Approval workflows</span>
+</div>
+<div class="agt-card" style="cursor:default;">
+<span class="agt-card-title">🔗 Agent Mesh</span>
+<span class="agt-card-desc">Identity · Routing · Trust scoring</span>
+</div>
+<div class="agt-card" style="cursor:default;">
+<span class="agt-card-title">📊 Agent SRE</span>
+<span class="agt-card-desc">SLOs · Chaos testing · Cost budgets</span>
+</div>
+<div class="agt-card" style="cursor:default;">
+<span class="agt-card-title">🛡️ Sandbox</span>
+<span class="agt-card-desc">Execution rings · Isolation · Kill switch</span>
+</div>
+</div>
 
 Every layer is optional. Start with `govern()` and add layers as your risk profile grows. Most teams run policy enforcement + audit logging and never need the full stack.
 


### PR DESCRIPTION
AuditEntry declared sandbox_id, environment, and container_runtime twice. Pydantic v2 keeps the last declaration, which used compute_driver (matching the AUDIT-COMPLIANCE-1.0 spec). The first set and all remaining container_runtime references are removed.

Closes #2474