### PR TITLE
fix(audit): remove duplicate AuditEntry fields, align on compute_driver per spec

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -44,10 +44,12 @@ codepoint
 CommonMark
 comspec
 containerapps
+containerd
 contoso
 Cpus
 cref
 CrewAI
+crun
 CuriousHet
 dataclass
 dataclasses
@@ -58,6 +60,7 @@ davidequarracino
 dbt
 dearmor
 defi
+delenv
 demux
 deprioritized
 Deque
@@ -95,6 +98,7 @@ frozenset
 fullmatch
 gemini
 getattr
+getenv
 gethostname
 getuid
 GitHub
@@ -102,7 +106,6 @@ gmtime
 GOPROXY
 governancepolicy
 gvisor
-h├⌐llo
 hasattr
 hashlib
 HEALTHCHECK
@@ -113,6 +116,7 @@ htek
 httpx
 hypercall
 Hyperlight
+h├⌐llo
 IATP
 idweb
 imran

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -29,7 +29,7 @@ class _EnvContext:
 
     sandbox_id: Optional[str]
     environment: Optional[str]
-    container_runtime: Optional[str]
+    compute_driver: Optional[str]
 
 
 def _capture_env_context() -> _EnvContext:
@@ -38,7 +38,7 @@ def _capture_env_context() -> _EnvContext:
     Resolution rules:
     * ``sandbox_id``: prefers ``OPENSHELL_SANDBOX_ID``; falls back to bare ``SANDBOX_ID``.
     * ``environment``: reads ``AGT_ENVIRONMENT``.
-    * ``container_runtime``: reads ``OPENSHELL_CONTAINER_RUNTIME``.
+    * ``compute_driver``: reads ``OPENSHELL_COMPUTE_DRIVER``.
 
     Empty strings are treated as absent (``None``).
     """
@@ -46,11 +46,11 @@ def _capture_env_context() -> _EnvContext:
         os.getenv("OPENSHELL_SANDBOX_ID") or os.getenv("SANDBOX_ID") or None
     )
     environment: Optional[str] = os.getenv("AGT_ENVIRONMENT") or None
-    container_runtime: Optional[str] = os.getenv("OPENSHELL_CONTAINER_RUNTIME") or None
+    compute_driver: Optional[str] = os.getenv("OPENSHELL_COMPUTE_DRIVER") or None
     return _EnvContext(
         sandbox_id=sandbox_id,
         environment=environment,
-        container_runtime=container_runtime,
+        compute_driver=compute_driver,
     )
 
 
@@ -122,10 +122,6 @@ class AuditEntry(BaseModel):
     trace_id: Optional[str] = None
     session_id: Optional[str] = None
 
-    # Execution-context enrichment (optional; not included in integrity hash)
-    sandbox_id: Optional[str] = None
-    environment: Optional[str] = None
-    container_runtime: Optional[str] = None
     # Sandbox/environment context (auto-populated from env vars when available)
     sandbox_id: Optional[str] = Field(
         default=None,
@@ -493,7 +489,7 @@ class AuditLog:
             trace_id=trace_id,
             sandbox_id=self._env_context.sandbox_id,
             environment=self._env_context.environment,
-            container_runtime=self._env_context.container_runtime,
+            compute_driver=self._env_context.compute_driver,
             arguments_hash=arguments_hash,
             approver_did=approver_did,
             policy_version=policy_version,

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit_backends.py
@@ -86,7 +86,7 @@ class SignedAuditEntry(BaseModel):
     # ``_canonical_payload()`` so that existing HMAC chains remain verifiable.
     sandbox_id: Optional[str] = None
     environment: Optional[str] = None
-    container_runtime: Optional[str] = None
+    compute_driver: Optional[str] = None
 
     # Integrity fields
     content_hash: str = ""
@@ -128,7 +128,7 @@ class SignedAuditEntry(BaseModel):
             session_id=entry.session_id,
             sandbox_id=entry.sandbox_id,
             environment=entry.environment,
-            container_runtime=entry.container_runtime,
+            compute_driver=entry.compute_driver,
             previous_hash=previous_hash,
         )
 
@@ -147,7 +147,7 @@ class SignedAuditEntry(BaseModel):
         recomputed during verification.
 
         Also excludes execution-context fields (``sandbox_id``,
-        ``environment``, ``container_runtime``) so that they can be added
+        ``environment``, ``compute_driver``) so that they can be added
         to entries without invalidating existing HMAC chains.
         """
         payload: dict[str, Any] = {
@@ -440,7 +440,7 @@ class StdoutAuditSink:
 
     The JSON schema matches :class:`AuditEntry` (Pydantic ``model_dump``
     with ``mode="json"``), which includes the optional execution-context
-    fields (``sandbox_id``, ``environment``, ``container_runtime``) when
+    fields (``sandbox_id``, ``environment``, ``compute_driver``) when
     present.
 
     Args:

--- a/agent-governance-python/agent-mesh/tests/governance/test_stdout_audit_sink.py
+++ b/agent-governance-python/agent-mesh/tests/governance/test_stdout_audit_sink.py
@@ -343,17 +343,17 @@ class TestAuditEntryContextFields:
         entry = _make_entry()
         assert entry.sandbox_id is None
         assert entry.environment is None
-        assert entry.container_runtime is None
+        assert entry.compute_driver is None
 
     def test_fields_can_be_set_explicitly(self):
         entry = _make_entry(
             sandbox_id="sb-123",
             environment="production",
-            container_runtime="docker",
+            compute_driver="docker",
         )
         assert entry.sandbox_id == "sb-123"
         assert entry.environment == "production"
-        assert entry.container_runtime == "docker"
+        assert entry.compute_driver == "docker"
 
     def test_context_fields_do_not_affect_hash(self):
         """Hash must remain stable when context fields differ."""
@@ -362,31 +362,31 @@ class TestAuditEntryContextFields:
             entry_id="hash-test",
             sandbox_id="sb-999",
             environment="staging",
-            container_runtime="k8s",
+            compute_driver="k8s",
         )
         # Freeze timestamps so only the context differs
         base.timestamp = with_ctx.timestamp
         assert base.compute_hash() == with_ctx.compute_hash()
 
     def test_context_fields_serialised_in_model_dump(self):
-        entry = _make_entry(sandbox_id="sb-x", environment="test", container_runtime="vm")
+        entry = _make_entry(sandbox_id="sb-x", environment="test", compute_driver="vm")
         d = entry.model_dump(mode="json")
         assert d["sandbox_id"] == "sb-x"
         assert d["environment"] == "test"
-        assert d["container_runtime"] == "vm"
+        assert d["compute_driver"] == "vm"
 
     def test_stdout_sink_includes_context_fields_in_output(self):
         entry = _make_entry(
             sandbox_id="sb-out",
             environment="staging",
-            container_runtime="containerd",
+            compute_driver="containerd",
         )
         sink = StdoutAuditSink()
         records = _capture_stdout(sink, lambda s: s.write(entry))
         rec = records[0]
         assert rec["sandbox_id"] == "sb-out"
         assert rec["environment"] == "staging"
-        assert rec["container_runtime"] == "containerd"
+        assert rec["compute_driver"] == "containerd"
 
     def test_missing_context_fields_omitted_from_stdout(self):
         entry = _make_entry()
@@ -395,7 +395,7 @@ class TestAuditEntryContextFields:
         rec = records[0]
         assert "sandbox_id" not in rec
         assert "environment" not in rec
-        assert "container_runtime" not in rec
+        assert "compute_driver" not in rec
 
 
 # ---------------------------------------------------------------------------
@@ -410,12 +410,12 @@ class TestSignedAuditEntryContextFields:
         entry = _make_entry(
             sandbox_id="sb-signed",
             environment="prod",
-            container_runtime="firecracker",
+            compute_driver="firecracker",
         )
         signed = SignedAuditEntry.from_entry(entry, previous_hash="", secret_key=SECRET_KEY)
         assert signed.sandbox_id == "sb-signed"
         assert signed.environment == "prod"
-        assert signed.container_runtime == "firecracker"
+        assert signed.compute_driver == "firecracker"
 
     def test_context_fields_excluded_from_canonical_payload(self):
         """Hash must be identical regardless of context field values."""
@@ -435,7 +435,7 @@ class TestSignedAuditEntryContextFields:
     def test_file_sink_stores_context_fields(self, tmp_path: Path):
         path = tmp_path / "ctx_audit.jsonl"
         sink = FileAuditSink(path, SECRET_KEY)
-        entry = _make_entry(sandbox_id="sb-file", environment="prod", container_runtime="crun")
+        entry = _make_entry(sandbox_id="sb-file", environment="prod", compute_driver="crun")
         sink.write(entry)
 
         entries = sink.read_entries()
@@ -443,7 +443,7 @@ class TestSignedAuditEntryContextFields:
         stored = entries[0]
         assert stored.sandbox_id == "sb-file"
         assert stored.environment == "prod"
-        assert stored.container_runtime == "crun"
+        assert stored.compute_driver == "crun"
 
     def test_file_sink_integrity_unaffected_by_context_fields(self, tmp_path: Path):
         path = tmp_path / "ctx_integrity.jsonl"
@@ -511,20 +511,20 @@ class TestAuditLogEnvAutoDetection:
         )
         assert entry.environment == "production"
 
-    def test_container_runtime_from_openshell_container_runtime(self, monkeypatch):
-        monkeypatch.setenv("OPENSHELL_CONTAINER_RUNTIME", "gvisor")
+    def test_compute_driver_from_openshell_compute_driver(self, monkeypatch):
+        monkeypatch.setenv("OPENSHELL_COMPUTE_DRIVER", "gvisor")
         log = AuditLog()
         entry = log.log(
             event_type="test",
             agent_did="did:web:a1",
             action="ping",
         )
-        assert entry.container_runtime == "gvisor"
+        assert entry.compute_driver == "gvisor"
 
     def test_all_fields_auto_populated(self, monkeypatch):
         monkeypatch.setenv("SANDBOX_ID", "sb-all")
         monkeypatch.setenv("AGT_ENVIRONMENT", "staging")
-        monkeypatch.setenv("OPENSHELL_CONTAINER_RUNTIME", "runc")
+        monkeypatch.setenv("OPENSHELL_COMPUTE_DRIVER", "runc")
         log = AuditLog()
         entry = log.log(
             event_type="test",
@@ -533,13 +533,13 @@ class TestAuditLogEnvAutoDetection:
         )
         assert entry.sandbox_id == "sb-all"
         assert entry.environment == "staging"
-        assert entry.container_runtime == "runc"
+        assert entry.compute_driver == "runc"
 
     def test_missing_env_vars_produce_none(self, monkeypatch):
         monkeypatch.delenv("SANDBOX_ID", raising=False)
         monkeypatch.delenv("OPENSHELL_SANDBOX_ID", raising=False)
         monkeypatch.delenv("AGT_ENVIRONMENT", raising=False)
-        monkeypatch.delenv("OPENSHELL_CONTAINER_RUNTIME", raising=False)
+        monkeypatch.delenv("OPENSHELL_COMPUTE_DRIVER", raising=False)
         log = AuditLog()
         entry = log.log(
             event_type="test",
@@ -548,13 +548,13 @@ class TestAuditLogEnvAutoDetection:
         )
         assert entry.sandbox_id is None
         assert entry.environment is None
-        assert entry.container_runtime is None
+        assert entry.compute_driver is None
 
     def test_empty_string_env_var_treated_as_absent(self, monkeypatch):
         monkeypatch.setenv("SANDBOX_ID", "")
         monkeypatch.setenv("OPENSHELL_SANDBOX_ID", "")
         monkeypatch.setenv("AGT_ENVIRONMENT", "")
-        monkeypatch.setenv("OPENSHELL_CONTAINER_RUNTIME", "")
+        monkeypatch.setenv("OPENSHELL_COMPUTE_DRIVER", "")
         log = AuditLog()
         entry = log.log(
             event_type="test",
@@ -563,7 +563,7 @@ class TestAuditLogEnvAutoDetection:
         )
         assert entry.sandbox_id is None
         assert entry.environment is None
-        assert entry.container_runtime is None
+        assert entry.compute_driver is None
 
     def test_env_context_captured_at_init_not_per_call(self, monkeypatch):
         """Changing env vars after init must not affect subsequent log() calls."""


### PR DESCRIPTION
AuditEntry declared sandbox_id, environment, and container_runtime twice. Pydantic v2 keeps the last declaration, which used \compute_driver\ (matching AUDIT-COMPLIANCE-1.0 spec). Remove duplicates and align all internal references.

Closes #2474