### PR TITLE
docs: add ANTITRUST.md and TRADEMARKS.md to README governance table

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ See [Known Limitations](docs/LIMITATIONS.md) for honest design boundaries and re
 | [MAINTAINERS.md](MAINTAINERS.md) | Maintainers and organizations |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting and response SLAs |
 | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Microsoft Open Source Code of Conduct |
+| [ANTITRUST.md](ANTITRUST.md) | Competition law guidelines for participants |
+| [TRADEMARKS.md](TRADEMARKS.md) | Trademark usage policy |
 
 ## Important Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,9 +163,9 @@ Every layer is optional. Start with `govern()` and add layers as your risk profi
 
 | SDK | Install |
 |-----|---------|
-| 🐍 [Python](packages/agent-compliance/) | `pip install agent-governance-toolkit` |
+| 🐍 [Python](packages/agent-compliance.md) | `pip install agent-governance-toolkit` |
 | 📘 TypeScript | `npm install @microsoft/agent-governance-sdk` |
-| 🔷 [.NET](packages/dotnet-sdk/) | `dotnet add package Microsoft.AgentGovernance` |
+| 🔷 [.NET](packages/dotnet-sdk.md) | `dotnet add package Microsoft.AgentGovernance` |
 | 🦀 Rust | `cargo add agent-governance` |
 | 🐹 Go | `go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang` |
 


### PR DESCRIPTION
Links the recently-added ANTITRUST.md and TRADEMARKS.md governance files from the README table so they're discoverable.