### PR TITLE
feat(audit): add issued_at, completed_at to AuditEntry (#2449)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -65,6 +65,28 @@ class AuditEntry(BaseModel):
 
     entry_id: str = Field(default_factory=lambda: f"audit_{uuid.uuid4().hex[:16]}")
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    issued_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Optional UTC datetime marking when the action was authorized or "
+            "issued for execution (e.g., approval granted, tool call decided). "
+            "When paired with ``completed_at``, enables third-party verifiers to "
+            "compute action latency and distinguish decision time from outcome "
+            "time. NOT part of the canonical entry hash in spec v1.0; v1.1 will "
+            "extend MerkleAuditChain coverage. See spec §4.3.1."
+        ),
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        description=(
+            "Optional UTC datetime marking when the action's outcome was "
+            "recorded. When ``issued_at`` and ``completed_at`` are both set, "
+            "their difference is the verifiable execution latency. The existing "
+            "``timestamp`` field continues to mark entry creation time and is "
+            "unaffected. NOT part of the canonical entry hash in spec v1.0; "
+            "v1.1 will extend MerkleAuditChain coverage. See spec §4.3.1."
+        ),
+    )
 
     # Event details
     event_type: str
@@ -210,6 +232,8 @@ class AuditEntry(BaseModel):
                 **({"policy_version": self.policy_version} if self.policy_version else {}),
                 **({"arguments_hash": self.arguments_hash} if self.arguments_hash else {}),
                 **({"approver_did": self.approver_did} if self.approver_did else {}),
+                **({"issued_at": self.issued_at.isoformat()} if self.issued_at else {}),
+                **({"completed_at": self.completed_at.isoformat()} if self.completed_at else {}),
                 **self.data,
             },
             "agentmeshentryhash": self.entry_hash,
@@ -470,13 +494,16 @@ class AuditLog:
         arguments_hash: str | None = None,
         approver_did: str | None = None,
         policy_version: str | None = None,
+        issued_at: datetime | None = None,
+        completed_at: datetime | None = None,
     ) -> AuditEntry:
         """Log an audit event.
 
-        The ``arguments_hash``, ``approver_did``, and ``policy_version`` parameters
-        are accepted as keyword-only arguments to preserve the positional signature
-        for existing callers. See spec §4.3.1 for semantics and the v1.0/v1.1 hash
-        coverage caveat.
+        The ``arguments_hash``, ``approver_did``, ``policy_version``,
+        ``issued_at``, and ``completed_at`` parameters are accepted as
+        keyword-only arguments to preserve the positional signature for
+        existing callers. See spec §4.3.1 for semantics and the v1.0/v1.1
+        hash coverage caveat.
         """
         entry = AuditEntry(
             event_type=event_type,
@@ -493,6 +520,8 @@ class AuditLog:
             arguments_hash=arguments_hash,
             approver_did=approver_did,
             policy_version=policy_version,
+            issued_at=issued_at,
+            completed_at=completed_at,
         )
 
         self._chain.add_entry(entry)

--- a/agent-governance-python/agent-mesh/tests/test_governance.py
+++ b/agent-governance-python/agent-mesh/tests/test_governance.py
@@ -423,6 +423,175 @@ class TestAuditEntryExtensions:
         assert error is None
 
 
+class TestAuditEntryTemporalExtensions:
+    """Tests for v1.0 additive temporal fields: issued_at, completed_at.
+
+    These fields split the single ``timestamp`` into authorization-time
+    (``issued_at``) and outcome-time (``completed_at``), enabling third-party
+    verifiers to compute execution latency. They are recorded but are NOT yet
+    part of the canonical hash computed by ``AuditEntry.compute_hash()``;
+    spec v1.1 will extend ``MerkleAuditChain`` coverage. See
+    ``docs/specs/AUDIT-COMPLIANCE-1.0.md`` §4.3.1.
+    """
+
+    def test_audit_entry_accepts_issued_at(self):
+        from agentmesh.governance.audit import AuditEntry
+
+        issued = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+        entry = AuditEntry(
+            event_type="tool_invocation",
+            agent_did="did:agentmesh:caller",
+            action="wire_transfer",
+            issued_at=issued,
+        )
+
+        assert entry.issued_at == issued
+
+    def test_audit_entry_accepts_completed_at(self):
+        from agentmesh.governance.audit import AuditEntry
+
+        completed = datetime(2026, 5, 22, 12, 0, 5, tzinfo=timezone.utc)
+        entry = AuditEntry(
+            event_type="tool_invocation",
+            agent_did="did:agentmesh:caller",
+            action="wire_transfer",
+            completed_at=completed,
+        )
+
+        assert entry.completed_at == completed
+
+    def test_temporal_fields_default_to_none(self):
+        from agentmesh.governance.audit import AuditEntry
+
+        entry = AuditEntry(
+            event_type="action",
+            agent_did="did:agentmesh:test",
+            action="read",
+        )
+
+        assert entry.issued_at is None
+        assert entry.completed_at is None
+
+    def test_timestamp_unaffected_by_temporal_fields(self):
+        """``timestamp`` continues to auto-populate; the new fields are additive."""
+        from agentmesh.governance.audit import AuditEntry
+
+        entry = AuditEntry(
+            event_type="action",
+            agent_did="did:agentmesh:test",
+            action="read",
+        )
+
+        assert entry.timestamp is not None
+        assert entry.timestamp.tzinfo is timezone.utc
+
+    def test_audit_log_log_passes_through_temporal_fields(self):
+        audit_log = AuditLog()
+
+        issued = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+        completed = datetime(2026, 5, 22, 12, 0, 5, tzinfo=timezone.utc)
+        entry = audit_log.log(
+            event_type="tool_invocation",
+            agent_did="did:agentmesh:caller",
+            action="wire_transfer",
+            issued_at=issued,
+            completed_at=completed,
+        )
+
+        assert entry.issued_at == issued
+        assert entry.completed_at == completed
+
+    def test_canonical_hash_unchanged_by_temporal_fields(self):
+        """Backward compat: temporal fields MUST NOT affect ``compute_hash()`` in v1.0.
+
+        Spec §4.4 fixes the canonical hash field set. The v1.0 canonical form is
+        intentionally unchanged so that previously-persisted entries continue to
+        verify. Spec v1.1 will introduce hash coverage under an explicit
+        schema-version selector. See §4.3.1.
+        """
+        from agentmesh.governance.audit import AuditEntry
+
+        fixed_ts = datetime(2026, 5, 22, 0, 0, 0, tzinfo=timezone.utc)
+
+        baseline = AuditEntry(
+            entry_id="audit_fixed_id_0002",
+            timestamp=fixed_ts,
+            event_type="action",
+            agent_did="did:agentmesh:test",
+            action="read",
+        )
+
+        extended = AuditEntry(
+            entry_id="audit_fixed_id_0002",
+            timestamp=fixed_ts,
+            event_type="action",
+            agent_did="did:agentmesh:test",
+            action="read",
+            issued_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 5, 22, 12, 0, 5, tzinfo=timezone.utc),
+        )
+
+        assert extended.compute_hash() == baseline.compute_hash(), (
+            "v1.0 canonical hash form must not depend on additive fields; "
+            "see spec §4.3.1. Schema v1.1 will introduce hash coverage."
+        )
+
+    def test_cloudevent_serialization_includes_temporal_fields_when_set(self):
+        from agentmesh.governance.audit import AuditEntry
+
+        issued = datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc)
+        completed = datetime(2026, 5, 22, 12, 0, 5, tzinfo=timezone.utc)
+        entry = AuditEntry(
+            event_type="tool_invocation",
+            agent_did="did:agentmesh:caller",
+            action="wire_transfer",
+            issued_at=issued,
+            completed_at=completed,
+        )
+
+        envelope = entry.to_cloudevent()
+
+        assert envelope["data"]["issued_at"] == issued.isoformat()
+        assert envelope["data"]["completed_at"] == completed.isoformat()
+
+    def test_cloudevent_serialization_omits_temporal_fields_when_unset(self):
+        from agentmesh.governance.audit import AuditEntry
+
+        entry = AuditEntry(
+            event_type="action",
+            agent_did="did:agentmesh:test",
+            action="read",
+        )
+
+        envelope = entry.to_cloudevent()
+
+        assert "issued_at" not in envelope["data"]
+        assert "completed_at" not in envelope["data"]
+
+    def test_chain_verification_with_temporal_fields(self):
+        """Chain still verifies when temporal fields are populated."""
+        audit_log = AuditLog()
+
+        audit_log.log(
+            event_type="tool_invocation",
+            agent_did="did:agentmesh:agent-1",
+            action="read",
+            issued_at=datetime(2026, 5, 22, 12, 0, 0, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 5, 22, 12, 0, 1, tzinfo=timezone.utc),
+        )
+        audit_log.log(
+            event_type="tool_invocation",
+            agent_did="did:agentmesh:agent-1",
+            action="write",
+            issued_at=datetime(2026, 5, 22, 12, 0, 2, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 5, 22, 12, 0, 3, tzinfo=timezone.utc),
+        )
+
+        is_valid, error = audit_log.verify_integrity()
+        assert is_valid is True
+        assert error is None
+
+
 class TestShadowMode:
     """Tests for ShadowMode."""
     

--- a/docs/specs/AUDIT-COMPLIANCE-1.0.md
+++ b/docs/specs/AUDIT-COMPLIANCE-1.0.md
@@ -215,7 +215,9 @@ The Agent Mesh audit entry extends the base schema with mesh-specific fields:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `entry_id` | string | REQUIRED | Unique identifier. Format: `audit_{uuid4_hex[:16]}`. |
-| `timestamp` | datetime (UTC) | REQUIRED | When the event occurred. |
+| `timestamp` | datetime (UTC) | REQUIRED | When the event occurred (entry creation time). |
+| `issued_at` | datetime (UTC) | OPTIONAL | When the action was authorized or issued for execution. Pairs with `completed_at` to expose execution latency. See §4.3.1. |
+| `completed_at` | datetime (UTC) | OPTIONAL | When the action's outcome was recorded. See §4.3.1. |
 | `event_type` | string | REQUIRED | Category of the audit event. |
 | `agent_did` | string | REQUIRED | DID of the agent. |
 | `action` | string | REQUIRED | The action being audited. |
@@ -238,9 +240,9 @@ The Agent Mesh audit entry extends the base schema with mesh-specific fields:
 
 ### 4.3.1 Additive Tamper-Evidence Fields [Pure Specification]
 
-The fields `arguments_hash`, `approver_did`, and `policy_version` are OPTIONAL
-in spec v1.0 and serve verifiability purposes that are not yet covered by the
-canonical entry hash defined in §4.4. In spec v1.0:
+The fields `arguments_hash`, `approver_did`, `policy_version`, `issued_at`, and
+`completed_at` are OPTIONAL in spec v1.0 and serve verifiability purposes that
+are not yet covered by the canonical entry hash defined in §4.4. In spec v1.0:
 
 - Implementations MAY populate these fields. Verifiers MUST NOT treat their
   presence or absence as a conformance signal.


### PR DESCRIPTION
## Summary

Adds optional `issued_at` and `completed_at` datetime fields to `AuditEntry`. When both are set, third-party verifiers can compute action execution latency directly from the audit row, distinguishing the moment an action was decided/authorized from the moment its outcome was recorded.

The existing `timestamp` field is unchanged — it continues to mark entry-creation time. Both new fields default to `None`; no caller behaviour changes unless they opt in.

This is the second of two PRs from the AgentBoundary v0.1 conformance evaluation in #2449 (the first, #2473, added `arguments_hash`, `approver_did`, `policy_version`). Closes the *"single timestamp per entry (no issued-vs-completed split)"* gap noted in that issue.

> The third item from the original issue — adding an `environment` field — was already addressed by #2527 (`environment` is now a first-class `AuditEntry` field). No further work needed on that axis from this PR.

## Changes

- `AuditEntry`: two new optional `datetime | None` fields with spec-§4.3.1 docstrings
- `AuditLog.log()`: two new keyword-only parameters mirroring the additive-fields pattern from #2473
- `to_cloudevent()`: includes ISO-8601 `issued_at` / `completed_at` in the data block when set; omits them otherwise
- `docs/specs/AUDIT-COMPLIANCE-1.0.md`: §4.3 field table updated; §4.3.1 additive-fields list updated
- `tests/test_governance.py`: new `TestAuditEntryTemporalExtensions` class with 9 tests mirroring the existing `TestAuditEntryExtensions` shape

## v1.0 hash semantics

Following the precedent set in #2473, these fields are **not** included in `compute_hash()` — the v1.0 canonical hash field set in §4.4 is intentionally unchanged so previously-persisted entries continue to verify. Spec v1.1 will extend MerkleAuditChain coverage under an explicit schema-version selector. The included `test_canonical_hash_unchanged_by_temporal_fields` test pins this invariant.

## Test plan

- [x] `pytest tests/test_governance.py tests/test_stdout_audit.py tests/governance/test_audit_backends.py tests/governance/test_stdout_audit_sink.py` — 129 passed, no regressions
- [x] `TestAuditEntryTemporalExtensions` — 9/9 passed
- [x] `ruff check src/ --select E,F,W --ignore E501` — clean (matches CI gate)
- [x] CloudEvent envelope inclusion/omission verified
- [x] Chain verification holds when temporal fields are populated

Refs #2449