### PR TITLE
fix: resolve direct URL policy bypass in resource validation

### DIFF
--- a/agent-governance-claude-code/lib/policy.mjs
+++ b/agent-governance-claude-code/lib/policy.mjs
@@ -987,7 +987,7 @@ function collectDirectResourceCandidates({ toolArgs, toolName, cwd }) {
     }
 
     const lastKey = String(keyPath.at(-1) ?? "");
-    if (looksLikeUrlField(lastKey) && looksLikeUrlValue(value)) {
+    if (looksLikeUrlValue(value)) {
       urls.push({
         normalizedUrl: normalizeUrlValue(value),
       });

--- a/agent-governance-claude-code/test/policy.test.mjs
+++ b/agent-governance-claude-code/test/policy.test.mjs
@@ -111,6 +111,38 @@ test("evaluatePreToolUse denies Windows-style secret reads", async () => {
   await rm(root, { recursive: true, force: true });
 });
 
+test("evaluatePreToolUse denies direct URL metadata access regardless of parameter key name", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-claude-url-denypath-"));
+  const auditPath = join(root, "audit.json");
+  const state = await loadPolicy({ auditPath });
+
+  // Parameter named "link" (instead of standard "url")
+  const linkResult = await evaluatePreToolUse(state, {
+    tool_name: "WebFetch",
+    tool_input: {
+      link: "http://169.254.169.254/latest/meta-data/",
+    },
+    session_id: "url-session-1",
+    cwd: root,
+  });
+
+  assert.equal(linkResult.hookSpecificOutput.permissionDecision, "deny");
+
+  // Parameter named "target"
+  const targetResult = await evaluatePreToolUse(state, {
+    tool_name: "WebFetch",
+    tool_input: {
+      target: "http://169.254.169.254/latest/meta-data/",
+    },
+    session_id: "url-session-2",
+    cwd: root,
+  });
+
+  assert.equal(targetResult.hookSpecificOutput.permissionDecision, "deny");
+
+  await rm(root, { recursive: true, force: true });
+});
+
 test("checkArbitraryText surfaces poisoning and MCP scan findings", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-claude-check-"));
   const state = await loadPolicy({ auditPath: join(root, "audit.json") });

--- a/agent-governance-copilot-cli/assets/extensions/agt-global-policy/lib/policy.mjs
+++ b/agent-governance-copilot-cli/assets/extensions/agt-global-policy/lib/policy.mjs
@@ -1105,7 +1105,7 @@ function collectDirectResourceCandidates({ commandText, toolArgs, toolName, cwd 
     }
 
     const lastKey = String(keyPath.at(-1) ?? "");
-    if (looksLikeUrlField(lastKey) && looksLikeUrlValue(value)) {
+    if (looksLikeUrlValue(value)) {
       urls.push({
         normalizedUrl: normalizeUrlValue(value),
       });

--- a/agent-governance-copilot-cli/test/policy-engine.test.mjs
+++ b/agent-governance-copilot-cli/test/policy-engine.test.mjs
@@ -374,6 +374,24 @@ test("evaluateDirectResourceAccess denies secret reads, allows env templates, re
 
   assert.equal(
     evaluateDirectResourceAccess(policy, {
+      toolName: "web_fetch",
+      cwd: "C:\\repo",
+      rawToolArgs: { link: "http://169.254.169.254/latest/meta-data/" },
+    })?.effect,
+    "deny",
+  );
+
+  assert.equal(
+    evaluateDirectResourceAccess(policy, {
+      toolName: "web_fetch",
+      cwd: "C:\\repo",
+      rawToolArgs: { target: "http://169.254.169.254/latest/meta-data/" },
+    })?.effect,
+    "deny",
+  );
+
+  assert.equal(
+    evaluateDirectResourceAccess(policy, {
       toolName: "powershell",
       commandText: "Get-Content '.env'",
       cwd: "C:\\repo",


### PR DESCRIPTION
## Description
This PR fixes a critical security bypass vulnerability in the Direct URL Policy evaluation logic (`collectDirectResourceCandidates`).

### The Vulnerability & Fix
Previously, tool argument values starting with `http://` or `https://` were only recognized as URL candidates if their parameter key matched the narrow regex `/^(url|uri|href|endpoint)$/i`. In cases where tool schemas defined parameters with other common names like `link`, `target`, `site`, `webhook`, `host`, or `origin` (e.g. `{ link: "http://169.254.169.254" }`), the URL completely bypassed metadata endpoint blocking rules and direct resource URL checks.

We resolved this bypass in both the Claude Code and Copilot CLI governance packages by unconditionally parsing any string argument starting with `http://` or `https://` as a URL candidate.

### Co-Author Attribution
This code was co-authored and verified alongside @Renish-Patel (<renishpatel2482001@gmail.com>), who assisted in diagnosing, hardening, and testing this security logic.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
N/A

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
N/A — 100% human-developed and reviewed alongside co-author Renish Patel.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
Closes security gateway bypass vector.
