### PR TITLE
chore(python): package consolidation audit, proposal, and migration plan

### DIFF
--- a/agent-governance-python/README.md
+++ b/agent-governance-python/README.md
@@ -7,24 +7,38 @@ It exists to give Python the same contributor-facing repository shape as other s
 surfaces such as `agent-governance-dotnet/` and `agent-governance-golang/`, while still allowing
 Python to publish multiple focused distributions instead of a single monolithic SDK package.
 
+## Installing
+
+The recommended install for most users is the meta-package, which pulls in the core runtime and lets you add framework integrations as extras:
+
+```
+pip install agent-governance-toolkit
+pip install agent-governance-toolkit[langchain]
+pip install agent-governance-toolkit[crewai]
+pip install agent-governance-toolkit[openai-agents]
+pip install agent-governance-toolkit[full]
+```
+
+If you only need a specific component, each package can also be installed on its own. See the package listing below for names.
+
 ## Scope
 
-This directory is for:
+This directory is for published Python SDK and package surfaces, reusable foundational Python packages, and package-specific tests, metadata, and documentation.
 
-- published Python SDK/package surfaces
-- reusable foundational Python packages
-- package-specific tests, metadata, and documentation
+It is not for applications or dashboards, demos or examples, monorepo-only product composition code, or framework-specific integration packages that are not part of the core first-party Python package story. Those surfaces belong in the repo root, `examples/`, `examples/demos/`, or other existing homes.
 
-This directory is **not** for:
+## Package Overview
 
-- applications or dashboards
-- demos or examples
-- monorepo-only product composition code
-- framework-specific integration packages that are not part of the core first-party Python package story
+**Core packages** are the runtime kernel, execution supervisor, sandbox, SRE layer, and shared primitives. Most users need only the meta-package or `agent-governance-toolkit-core` once the consolidation in issue #2482 lands.
 
-Those surfaces should stay in the repo root, `examples/`, `examples/demos/`, or other existing homes.
+**Framework integrations** live under `agentmesh-integrations/` and each wraps a specific framework like LangChain, CrewAI, LlamaIndex, or Haystack with AGT governance middleware.
+
+**Agent OS modules** under `agent-os/modules/` are internal kernel primitives. They are not published to PyPI and are not intended for direct external consumption at this time.
 
 ## Current Packages
 
-- `agent-primitives/`
-- `agent-mcp-governance/`
+`agent-compliance/`, `agent-discovery/`, `agent-hypervisor/`, `agent-lightning/`, `agent-marketplace/`, `agent-mcp-governance/`, `agent-mesh/`, `agent-os/`, `agent-primitives/`, `agent-rag-governance/`, `agent-runtime/`, `agent-sandbox/`, `agent-sre/`, `agentmesh-integrations/`
+
+## Package Consolidation
+
+We are working to reduce the number of separately published packages from 45 down to 5 top-level distributions. This is tracked in [issue #2482](https://github.com/microsoft/agent-governance-toolkit/issues/2482). The consolidation plan, audit data, and migration guide are in `docs/package-consolidation/`. Existing package names will remain installable via stub packages throughout the transition so nothing breaks for current users.

--- a/docs/package-consolidation/AUDIT.md
+++ b/docs/package-consolidation/AUDIT.md
@@ -1,0 +1,130 @@
+# Python Package Audit: Agent Governance Toolkit
+
+Tracks issue [#2482](https://github.com/microsoft/agent-governance-toolkit/issues/2482)
+Audit date: 2026-05-23
+
+## Summary
+
+The repository contains 45 Python packages spread across two top-level groupings. Of these, 11 are confirmed on PyPI with meaningful download traffic. The remaining 34 exist in the repo but are either unpublished or receive negligible traffic. All packages are versioned at 3.7.0 except `cedarling-agentmesh` which sits at 3.5.0, already showing the version-skew problem this consolidation effort is trying to solve.
+
+## PyPI-Published Packages
+
+Download numbers are from pypistats.org (last 30 days).
+
+| PyPI name | Downloads/month | Tier | Internal deps |
+|-----------|----------------|------|---------------|
+| `agent-governance-toolkit` | ~63,555 | meta installer | `agent-os-kernel`, `agentmesh-platform`, `agentmesh-runtime`, `agent-sre` as optional extras |
+| `agent-os-kernel` | ~59,220 | core kernel | none |
+| `agent-sandbox` | ~87,213 | core runtime | none |
+| `agent-sre` | ~46,636 | core SRE | none |
+| `agentmesh-runtime` | ~37,686 | core runtime | `agent-hypervisor` |
+| `agentmesh-primitives` | ~19,944 | shared primitives | none |
+| `agentmesh-mcp-trust` | ~774 | MCP governance | none |
+| `agent-mcp-governance` | ~772 | MCP governance | `agent-os-kernel` |
+| `agentmesh-marketplace` | ~1,442 | tooling | none |
+| `agentmesh-drift` | ~750 | observability | none |
+| `agentmesh-openai-agents-trust` | ~564 | integration | none |
+
+## All Packages by Directory Group
+
+### Core packages under `agent-governance-python/`
+
+| Directory | PyPI name | Version | Description | On PyPI |
+|-----------|-----------|---------|-------------|---------|
+| `agent-compliance` | `agent-governance-toolkit` | 3.7.0 | Meta-package and unified installer | yes |
+| `agent-primitives` | `agentmesh-primitives` | 3.7.0 | Shared primitive data models | yes |
+| `agent-mesh` | `agentmesh-platform` | 3.7.0 | Secure nervous system for agent ecosystems | no |
+| `agent-mesh/packages/mcp-trust-server` | `agentmesh-mcp-trust` | 3.7.0 | MCP trust server | yes |
+| `agent-os` | `agent-os-kernel` | 3.7.0 | OS kernel for governing autonomous agents | yes |
+| `agent-runtime` | `agentmesh-runtime` | 3.7.0 | Multi-agent session execution supervisor | yes |
+| `agent-hypervisor` | `agent-hypervisor` | 3.7.0 | Runtime supervisor for Shared Sessions | no |
+| `agent-sre` | `agent-sre` | 3.7.0 | Reliability engineering for AI agent systems | yes |
+| `agent-sandbox` | `agent-sandbox` | 3.7.0 | Docker-based execution isolation for agents | yes |
+| `agent-discovery` | `agentmesh-discovery` | 3.7.0 | Shadow AI agent discovery and inventory | no |
+| `agent-lightning` | `agentmesh-lightning` | 3.7.0 | RL integration for governed training | no |
+| `agent-marketplace` | `agentmesh-marketplace` | 3.7.0 | Plugin marketplace | yes |
+| `agent-mcp-governance` | `agent-mcp-governance` | 3.7.0 | MCP governance primitives | yes |
+| `agent-rag-governance` | `agent-rag-governance` | 3.7.0 | RAG pipeline policy enforcement | no |
+
+### Agent OS Modules under `agent-governance-python/agent-os/modules/`
+
+None of these 10 modules are published to PyPI. They appear to be internal kernel primitives not yet ready for external consumption.
+
+| Module | PyPI name | Description |
+|--------|-----------|-------------|
+| `amb` | `agentmesh-message-bus` | Broker-agnostic message bus for agents |
+| `atr` | `agentmesh-tool-registry` | Decentralized agent capability marketplace |
+| `caas` | `agentmesh-context` | Context routing and RAG window management |
+| `cmvk` | `agentmesh-drift` | Drift and hallucination score detection |
+| `control-plane` | `agentmesh-control-plane` | Deterministic governance kernel with POSIX signals |
+| `emk` | `agentmesh-memory` | Episodic Memory Kernel |
+| `iatp` | `agentmesh-trust-protocol` | Inter-Agent Trust Protocol sidecar |
+| `mcp-kernel-server` | `agentmesh-mcp-server` | MCP Server for Claude Desktop kernel primitives |
+| `nexus` | `agentmesh-nexus` | Agent Trust Exchange (research prototype) |
+| `observability` | `agentmesh-observability` | OTel traces, Prometheus metrics, Grafana dashboards |
+
+### Framework Integrations under `agent-governance-python/agentmesh-integrations/`
+
+| Package directory | PyPI name | Downloads/month | On PyPI |
+|-------------------|-----------|----------------|---------|
+| `a2a-protocol` | `a2a-agentmesh` | not tracked | no |
+| `adk-agentmesh` | `adk-agentmesh` | not tracked | no |
+| `agentmesh-avp` | `avp-agentmesh` | not tracked | no |
+| `audit-accountability-export` | `agentmesh-audit-export` | not tracked | no |
+| `cedarling-agentmesh` | `cedarling-agentmesh` | not tracked | no, v3.5.0 (behind core) |
+| `crewai-agentmesh` | `crewai-agentmesh` | not tracked | no |
+| `flowise-agentmesh` | `flowise-agentmesh` | not tracked | no |
+| `haystack-agentmesh` | `haystack-agentmesh` | ~698 | yes |
+| `langchain-agentmesh` | `agentmesh-langchain` | not tracked | no |
+| `langflow-agentmesh` | `langflow-agentmesh` | not tracked | no |
+| `langgraph-trust` | `langgraph-agentmesh` | ~752 | yes |
+| `llamaindex-agentmesh` | `llamaindex-agentmesh` | not tracked | no |
+| `mcp-receipt-governed` | `agentmesh-mcp-receipts` | not tracked | no |
+| `mcp-trust-proxy` | `agentmesh-mcp-proxy` | not tracked | no |
+| `nostr-wot` | `nostr-wot-agentmesh` | ~753 | yes |
+| `openai-agents-agentmesh` | `openai-agents-agentmesh` | ~764 | yes |
+| `openai-agents-trust` | `agentmesh-openai-agents-trust` | ~564 | yes |
+| `openshell-skill` | `openshell-agentmesh` | ~713 | yes |
+| `pydantic-ai-governance` | `pydantic-ai-agentmesh` | ~527 | yes |
+| `structural-authz-agentmesh` | `structural-authz-agentmesh` | ~511 | yes |
+| `template-agentmesh` | `template-agentmesh` | not tracked | no |
+
+## Internal Dependency Graph
+
+```
+agent-governance-toolkit (meta)
+    [extra: kernel]   agent-os-kernel
+    [extra: mesh]     agentmesh-platform
+    [extra: runtime]  agentmesh-runtime
+                          agent-hypervisor
+    [extra: sre]      agent-sre
+    [extra: cedar]    cedarpy (external)
+
+agent-mcp-governance
+    agent-os-kernel
+
+cedarling-agentmesh
+    agent-os-kernel
+
+agentmesh-nexus
+    agentmesh-trust-protocol
+        agentmesh-primitives
+```
+
+All framework integrations are leaf packages. They depend on external frameworks like langchain and crewai but declare no internal AGT dependencies in their `pyproject.toml`. They consume AGT APIs at runtime via optional imports.
+
+## Version Skew
+
+Every package is at 3.7.0 except `cedarling-agentmesh` which is at 3.5.0. That 0.2 version lag is exactly the kind of cross-package drift the issue warns about. Right now it is just one package. With 45 `pyproject.toml` files to bump manually on every release, this will happen again.
+
+## Key Findings
+
+**34 packages have no measurable PyPI presence.** They are either unpublished or receive traffic too low for pypistats to register. Folding them into consolidated distributions is straightforward since there are no existing consumers to break.
+
+**Five packages drive almost all downloads.** `agent-sandbox` at 87K, `agent-governance-toolkit` at 63K, `agent-os-kernel` at 59K, `agent-sre` at 46K, and `agentmesh-runtime` at 37K together account for the vast majority of monthly installs. Any consolidation must preserve these package names or provide clear aliases.
+
+**Framework integrations are small but uniform.** Each integration gets 500 to 760 downloads per month and all follow the same structural pattern. Shipping them as extras on a single distribution rather than 21 separate packages cuts the release overhead significantly with no real downside for users.
+
+**Agent OS modules are entirely unpublished.** All 10 modules under `agent-os/modules/` have no PyPI presence and are likely not ready for external use. They should stay internal and not be part of the first consolidation pass.
+
+**Naming is inconsistent.** Packages use `agent_*`, `agentmesh_*`, `a2a_*`, `avp_*`, `cedarling_*`, and `nostr_*` prefixes with no shared namespace. The consolidation is a good time to fix this by moving everything under the `agent-governance-toolkit-*` prefix.

--- a/docs/package-consolidation/MIGRATION.md
+++ b/docs/package-consolidation/MIGRATION.md
@@ -1,0 +1,110 @@
+# Migration Plan: Package Consolidation
+
+Tracks issue [#2482](https://github.com/microsoft/agent-governance-toolkit/issues/2482)
+Date: 2026-05-23
+
+## Guiding Principle
+
+No existing install command should break. Users who have `agent-os-kernel` or `agentmesh-runtime` in their requirements files today must still get a working install after consolidation. This is handled through stub packages that redirect pip installs to the new distributions.
+
+## Phase 1: Stub Packages
+
+Before the new distributions are published, a stub package is published under each old name that declares the new package as its only dependency. This means someone pinned to `agentmesh-runtime==3.7.0` will install the stub, which pulls in `agent-governance-toolkit-core`, and their code continues to work.
+
+Example stub `pyproject.toml` for `agentmesh-runtime`:
+
+```toml
+[project]
+name = "agentmesh-runtime"
+version = "4.0.0"
+description = "Deprecated. Replaced by agent-governance-toolkit-core."
+dependencies = ["agent-governance-toolkit-core>=4.0.0"]
+```
+
+The stub packages are published at the same time as the first release of the consolidated distributions so there is no window where one exists and the other does not.
+
+## Phase 2: Deprecation Warnings
+
+Once stubs are live, any import of a deprecated package name at runtime emits a `DeprecationWarning` pointing to the replacement. This gives developers who install via stubs a clear signal to update their requirements files without breaking their builds.
+
+```python
+import warnings
+warnings.warn(
+    "agentmesh-runtime is deprecated. Use agent-governance-toolkit-core instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+```
+
+The warning ships in the first consolidated release and stays present for at least two minor versions before the stub is marked unsupported.
+
+## Phase 3: Stub Removal
+
+After two minor release cycles, roughly 6 months at the normal AGT release cadence, the stub packages are yanked from PyPI. The deprecation warnings make the removal unsurprising for anyone who has run their tests recently.
+
+## Package Mapping
+
+The table below lists every package being consolidated and its replacement.
+
+| Old package name | Replacement | Stub needed |
+|-----------------|-------------|-------------|
+| `agent-os-kernel` | `agent-governance-toolkit-core` | yes |
+| `agentmesh-platform` | `agent-governance-toolkit-core` | yes |
+| `agentmesh-runtime` | `agent-governance-toolkit-core` | yes |
+| `agent-hypervisor` | `agent-governance-toolkit-core` | yes |
+| `agentmesh-primitives` | `agent-governance-toolkit-core` | yes |
+| `agentmesh-langchain` | `agent-governance-toolkit-integrations[langchain]` | yes |
+| `crewai-agentmesh` | `agent-governance-toolkit-integrations[crewai]` | yes |
+| `openai-agents-agentmesh` | `agent-governance-toolkit-integrations[openai-agents]` | yes |
+| `agentmesh-openai-agents-trust` | `agent-governance-toolkit-integrations[openai-agents]` | yes |
+| `langgraph-agentmesh` | `agent-governance-toolkit-integrations[langgraph]` | yes |
+| `llamaindex-agentmesh` | `agent-governance-toolkit-integrations[llamaindex]` | yes |
+| `haystack-agentmesh` | `agent-governance-toolkit-integrations[haystack]` | yes |
+| `pydantic-ai-agentmesh` | `agent-governance-toolkit-integrations[pydantic-ai]` | yes |
+| `flowise-agentmesh` | `agent-governance-toolkit-integrations[flowise]` | yes |
+| `langflow-agentmesh` | `agent-governance-toolkit-integrations[langflow]` | yes |
+| `adk-agentmesh` | `agent-governance-toolkit-integrations[adk]` | yes |
+| `avp-agentmesh` | `agent-governance-toolkit-integrations[avp]` | yes |
+| `cedarling-agentmesh` | `agent-governance-toolkit-integrations[cedarling]` | yes |
+| `nostr-wot-agentmesh` | `agent-governance-toolkit-integrations[nostr-wot]` | yes |
+| `structural-authz-agentmesh` | `agent-governance-toolkit-integrations[structural-authz]` | yes |
+| `openshell-agentmesh` | `agent-governance-toolkit-integrations[openshell]` | yes |
+| `agentmesh-audit-export` | `agent-governance-toolkit-integrations[audit-export]` | no (unpublished) |
+| `agent-sre` | `agent-governance-toolkit-cli` | yes |
+| `agent-sandbox` | `agent-governance-toolkit-cli` | yes |
+| `agentmesh-mcp-proxy` | `agent-governance-toolkit-cli` | no (unpublished) |
+| `agentmesh-mcp-server` | `agent-governance-toolkit-cli` | no (unpublished) |
+| `agentmesh-mcp-trust` | `agent-governance-toolkit-cli` | yes |
+| `agent-mcp-governance` | `agent-governance-toolkit-protocols` | yes |
+| `agentmesh-trust-protocol` | `agent-governance-toolkit-protocols` | no (unpublished) |
+| `a2a-agentmesh` | `agent-governance-toolkit-protocols` | no (unpublished) |
+| `agentmesh-mcp-receipts` | `agent-governance-toolkit-protocols` | no (unpublished) |
+
+Packages in the standalone category (`agent-discovery`, `agentmesh-lightning`, `agent-rag-governance`, `agentmesh-drift`, `agentmesh-observability`, `agentmesh-marketplace`) are not being consolidated and do not appear in this table.
+
+## Import Compatibility
+
+Where two old packages merge into one distribution, the public Python module names and class names must not change. Users import classes directly, not package metadata names. Moving code between distributions is fine as long as existing import paths keep working.
+
+If a module path must change, add a compatibility shim at the old location:
+
+```python
+# agentmesh/openai_agents_trust/__init__.py  (compatibility shim)
+import warnings
+from agentmesh.integrations.openai_agents import *  # noqa: F401, F403
+
+warnings.warn(
+    "agentmesh.openai_agents_trust is deprecated. Import from agentmesh.integrations.openai_agents.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+```
+
+## Version Numbering
+
+The consolidated packages start at version 4.0.0. The major bump signals the restructuring and gives dependency management tools a clear signal to review the update. Stub packages that redirect old names also publish at 4.0.0 for consistency.
+
+## Rollout Order
+
+Implement `agent-governance-toolkit-core` first since it covers the packages with the highest download counts and the clearest scope. Publish stubs for all packages absorbed into core at the same time. Once core is stable, implement `agent-governance-toolkit-integrations` and publish its stubs simultaneously. Follow with `agent-governance-toolkit-cli` and `agent-governance-toolkit-protocols`. After two minor releases, yank the stubs for core and integrations.

--- a/docs/package-consolidation/PROPOSAL.md
+++ b/docs/package-consolidation/PROPOSAL.md
@@ -1,0 +1,60 @@
+# Package Consolidation Proposal
+
+Tracks issue [#2482](https://github.com/microsoft/agent-governance-toolkit/issues/2482)
+Date: 2026-05-23
+
+## Problem
+
+The repo ships 45 Python packages, 11 of which have any PyPI presence. Maintaining 45 separate `pyproject.toml` files, version pins, and CI jobs for packages that get under 1000 downloads a month creates overhead without proportional value. The `cedarling-agentmesh` version lag (3.5.0 vs core 3.7.0) is an early warning of what happens as the package count grows.
+
+See [AUDIT.md](AUDIT.md) for the full data behind this proposal.
+
+## Proposed Structure
+
+The goal is to go from 45 packages to 5 top-level distributions, with framework integrations as optional extras on a single integrations package rather than 21 separate ones.
+
+### Package 1: `agent-governance-toolkit`
+
+This package already exists and already uses optional extras. It stays as-is and becomes the single recommended install entry point. The extras list expands to cover all integrations that today ship as standalone packages.
+
+```
+pip install agent-governance-toolkit
+pip install agent-governance-toolkit[langchain]
+pip install agent-governance-toolkit[crewai]
+pip install agent-governance-toolkit[openai-agents]
+pip install agent-governance-toolkit[full]
+```
+
+### Package 2: `agent-governance-toolkit-core`
+
+Consolidates the runtime kernel packages that currently require separate installs. Absorbs `agent-os-kernel`, `agentmesh-primitives`, `agentmesh-runtime`, `agent-hypervisor`, and `agentmesh-platform`. This is the policy engine, trust scoring, audit, identity, and execution ring layer. Everything needed to govern an agent programmatically without a CLI or framework adapter.
+
+### Package 3: `agent-governance-toolkit-integrations`
+
+A single distribution for all framework adapters. Each adapter ships as an optional extra so users only pull in what they need. Absorbs all 21 packages under `agentmesh-integrations/` including langchain, crewai, openai-agents, langgraph, llamaindex, haystack, pydantic-ai, flowise, langflow, and adk. Adapters with independent community adoption above 5000 downloads per month are evaluated individually before folding in.
+
+### Package 4: `agent-governance-toolkit-cli`
+
+CLI tools and proxy servers that operators install on infrastructure rather than in application code. Absorbs `agent-sre`, `agent-sandbox`, `agentmesh-mcp-proxy`, `agentmesh-mcp-server`, and `agentmesh-mcp-trust`.
+
+### Package 5: `agent-governance-toolkit-protocols`
+
+Protocol implementations that may have consumers outside of AGT. Absorbs `agent-mcp-governance`, `agentmesh-trust-protocol`, `a2a-agentmesh`, and `agentmesh-mcp-receipts`. These are kept separate because protocol packages sometimes get pinned independently by downstream consumers who do not want the full governance stack.
+
+### Packages that stay standalone
+
+`agent-discovery`, `agentmesh-lightning`, `agent-rag-governance`, `agentmesh-drift`, `agentmesh-observability`, and `agentmesh-marketplace` stay as standalone packages for now. Their scope is focused enough that pulling them into a larger distribution adds confusion without meaningfully reducing maintenance burden.
+
+The 10 Agent OS kernel modules (`agentmesh-message-bus`, `agentmesh-tool-registry`, `agentmesh-context`, `agentmesh-control-plane`, `agentmesh-memory`, `agentmesh-nexus`, and others) are not published today and should remain internal until they have a clearer external use case.
+
+## Naming
+
+All new package names use the `agent-governance-toolkit-*` prefix. This resolves the inconsistency where packages currently span `agent_*`, `agentmesh_*`, `avp_*`, `cedarling_*`, and `nostr_*` with no shared namespace.
+
+## What Does Not Change
+
+Source code does not move. The directory layout under `agent-governance-python/` stays the same. Only packaging metadata changes: `pyproject.toml` files in absorbed packages are updated to declare their content as part of the parent distribution, and old package names become thin aliases via the migration plan in [MIGRATION.md](MIGRATION.md).
+
+## Before Implementing
+
+This proposal requires a community feedback period per the [RFC process](../RFC_PROCESS.md). Open a discussion on the issue before merging any code changes. The minimum review window is 7 days.


### PR DESCRIPTION
Closes #2482

## What this PR does

Adds the research and planning deliverables required by issue #2482 before any code consolidation can begin.

**docs/package-consolidation/AUDIT.md** — Full audit of all 45 Python packages in the repo. Includes PyPI download numbers from pypistats.org, on/off PyPI status for each package, and the internal dependency graph between packages. Key finding: five packages account for the vast majority of installs while 34 have no measurable PyPI presence.

**docs/package-consolidation/PROPOSAL.md** — Recommended structure: collapse from 45 packages to 5 top-level distributions (`agent-governance-toolkit`, `agent-governance-toolkit-core`, `agent-governance-toolkit-integrations`, `agent-governance-toolkit-cli`, `agent-governance-toolkit-protocols`). Framework integrations become optional extras rather than 21 separate packages. No source code moves in this PR.

**docs/package-consolidation/MIGRATION.md** — Phased migration plan. Old package names stay installable via stub packages published simultaneously with the new distributions. Runtime `DeprecationWarning` in stubs tells users to update their requirements files. Stubs yanked after two minor release cycles. Includes full package-to-replacement mapping table and a note on import path compatibility shims.

**agent-governance-python/README.md** — Added install instructions for the meta-package with extras, a plain-language scope description, and a note pointing to the consolidation docs.

## What this PR does not do

No packages are merged, renamed, or restructured here. This PR satisfies the audit and proposal acceptance criteria so the community feedback period can begin. Implementation work tracked in the follow-up referenced in PROPOSAL.md.

## Test plan

Read through each document and verify the data matches the repo. The download numbers can be spot-checked at pypistats.org for any of the package names in the audit table.