### PR TITLE
docs: add Python version prerequisites to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Python · TypeScript · .NET · Rust · Go. Works with LangChain, CrewAI, AutoGe
 
 ## Quick Start
 
+**Prerequisites:** Python 3.10+ required.
+
 ```bash
 pip install agent-governance-toolkit[full]
 ```


### PR DESCRIPTION
Adds Python 3.10+ prerequisite notice to the Quick Start section in README.