### PR TITLE
chore(security): add registration auth guardrails (CI + tests + policy)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -47,6 +47,19 @@ jobs:
           chmod +x scripts/ci/security-audit-required.sh
           scripts/ci/security-audit-required.sh "origin/$BASE_REF"
 
+  no-unauthed-registration:
+    name: No Unauthenticated Registration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          chmod +x scripts/ci/no-unauthed-registration.sh
+          scripts/ci/no-unauthed-registration.sh "origin/$BASE_REF"
+
   vendored-patch-audit:
     name: Dependency Audit Trail
     runs-on: ubuntu-latest

--- a/agent-governance-python/agent-mesh/AGENTS.md
+++ b/agent-governance-python/agent-mesh/AGENTS.md
@@ -70,6 +70,7 @@ black --check .
 - **Never serialize** private keys in JSON/YAML output
 - **Never commit** secrets, API keys, or credentials
 - **Never weaken** trust thresholds — only tighten
+- **Never accept public keys without proof-of-possession** — any HTTP endpoint that accepts a `public_key` or `verification_key` MUST verify the caller controls the corresponding private key via Ed25519 signature over `(key || timestamp)`. DIDs MUST be derived from `SHA-256(public_key)`, never client-supplied. See `registry/app.py` for the reference implementation. CI enforces this via `scripts/ci/no-unauthed-registration.sh`.
 - Keep backward compatibility with existing protocol messages
 - the repo root are standalone — changes there need their own test suite
 

--- a/agent-governance-python/agent-mesh/tests/test_registration_auth.py
+++ b/agent-governance-python/agent-mesh/tests/test_registration_auth.py
@@ -1,0 +1,224 @@
+"""Negative auth tests for registration endpoints.
+
+Every endpoint that accepts a public key MUST reject requests without
+valid proof-of-possession. These tests serve as a regression gate:
+if someone adds a new registration endpoint and forgets auth, these
+fail and CI blocks the merge.
+"""
+import base64
+
+import pytest
+
+from nacl.signing import SigningKey
+
+
+def _b64(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode().rstrip("=")
+
+
+# ── Registry /v1/agents ──────────────────────────────────────────────
+
+
+class TestRegistryRejectsUnauthenticated:
+    """POST /v1/agents must reject registration without valid proof."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from agentmesh.registry.app import RegistryServer
+        from fastapi.testclient import TestClient
+
+        server = RegistryServer()
+        self.client = TestClient(server.app)
+
+    def test_rejects_no_proof_fields(self):
+        sk = SigningKey.generate()
+        pub = sk.verify_key.encode()
+        resp = self.client.post("/v1/agents", json={
+            "public_key": _b64(pub),
+        })
+        assert resp.status_code == 422, "Must reject when proof fields are missing"
+
+    def test_rejects_wrong_signature(self):
+        sk = SigningKey.generate()
+        wrong_sk = SigningKey.generate()
+        pub = sk.verify_key.encode()
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).isoformat()
+        message = _b64(pub).encode() + ts.encode()
+        bad_sig = wrong_sk.sign(message).signature
+        resp = self.client.post("/v1/agents", json={
+            "public_key": _b64(pub),
+            "proof": _b64(bad_sig),
+            "proof_timestamp": ts,
+        })
+        assert resp.status_code == 401, "Must reject proof signed by wrong key"
+
+    def test_rejects_expired_proof(self):
+        sk = SigningKey.generate()
+        pub = sk.verify_key.encode()
+        pub_b64 = _b64(pub)
+        from datetime import datetime, timezone, timedelta
+        old_ts = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+        message = pub_b64.encode() + old_ts.encode()
+        sig = sk.sign(message).signature
+        resp = self.client.post("/v1/agents", json={
+            "public_key": pub_b64,
+            "proof": _b64(sig),
+            "proof_timestamp": old_ts,
+        })
+        assert resp.status_code == 401, "Must reject expired proof timestamp"
+
+    def test_rejects_client_supplied_did(self):
+        """Clients cannot choose their own DID; it must be server-derived."""
+        sk = SigningKey.generate()
+        pub = sk.verify_key.encode()
+        pub_b64 = _b64(pub)
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).isoformat()
+        message = pub_b64.encode() + ts.encode()
+        sig = sk.sign(message).signature
+        resp = self.client.post("/v1/agents", json={
+            "did": "did:mesh:attacker-chosen-did",
+            "public_key": pub_b64,
+            "proof": _b64(sig),
+            "proof_timestamp": ts,
+        })
+        if resp.status_code == 201:
+            data = resp.json()
+            assert data["did"] != "did:mesh:attacker-chosen-did", \
+                "Server must derive DID from key hash, not accept client-supplied DID"
+
+
+# ── Trust Engine /api/v1/agents/register ─────────────────────────────
+
+
+class TestTrustEngineRejectsUnauthenticated:
+    """POST /api/v1/agents/register must reject registration without proof."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from agentmesh.server.trust_engine import app, registry, _pending_challenges
+        from fastapi.testclient import TestClient
+
+        _pending_challenges.clear()
+        registry._identities.clear()
+        registry._by_sponsor.clear()
+        self.client = TestClient(app)
+
+    def test_rejects_no_proof_fields(self):
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        key = Ed25519PrivateKey.generate()
+        pub_b64 = base64.b64encode(key.public_key().public_bytes_raw()).decode()
+        resp = self.client.post("/api/v1/agents/register", json={
+            "name": "test-agent",
+            "public_key": pub_b64,
+            "sponsor_email": "test@example.com",
+        })
+        assert resp.status_code == 422, "Must reject when proof fields are missing"
+
+    def test_rejects_wrong_signature(self):
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        key = Ed25519PrivateKey.generate()
+        wrong_key = Ed25519PrivateKey.generate()
+        pub_b64 = base64.b64encode(key.public_key().public_bytes_raw()).decode()
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).isoformat()
+        message = pub_b64.encode() + ts.encode()
+        bad_sig = wrong_key.sign(message)
+        resp = self.client.post("/api/v1/agents/register", json={
+            "name": "test-agent",
+            "public_key": pub_b64,
+            "proof": base64.b64encode(bad_sig).decode(),
+            "proof_timestamp": ts,
+            "sponsor_email": "test@example.com",
+        })
+        assert resp.status_code == 401, "Must reject proof signed by wrong key"
+
+    def test_rejects_name_squatting(self):
+        """DID must be derived from key hash, not from the name field."""
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        key = Ed25519PrivateKey.generate()
+        pub_b64 = base64.b64encode(key.public_key().public_bytes_raw()).decode()
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).isoformat()
+        message = pub_b64.encode() + ts.encode()
+        sig = key.sign(message)
+        resp = self.client.post("/api/v1/agents/register", json={
+            "name": "microsoft-payments",
+            "public_key": pub_b64,
+            "proof": base64.b64encode(sig).decode(),
+            "proof_timestamp": ts,
+            "sponsor_email": "attacker@example.com",
+        })
+        if resp.status_code == 200:
+            import hashlib
+            expected_hash = hashlib.sha256(key.public_key().public_bytes_raw()).hexdigest()[:32]
+            data = resp.json()
+            assert expected_hash in data["agent_did"], \
+                "DID must be derived from public key hash, not from name"
+
+
+# ── Prekey Upload Auth ───────────────────────────────────────────────
+
+
+class TestPrekeyUploadRejectsUnauthenticated:
+    """PUT /v1/agents/{did}/prekeys must reject unauthenticated uploads."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from agentmesh.registry.app import RegistryServer
+        from fastapi.testclient import TestClient
+
+        server = RegistryServer()
+        self.client = TestClient(server.app)
+
+    def _register_agent(self):
+        import hashlib
+        from datetime import datetime, timezone
+        sk = SigningKey.generate()
+        pub = sk.verify_key.encode()
+        pub_b64 = _b64(pub)
+        ts = datetime.now(timezone.utc).isoformat()
+        message = pub_b64.encode() + ts.encode()
+        sig = sk.sign(message).signature
+        resp = self.client.post("/v1/agents", json={
+            "public_key": pub_b64,
+            "proof": _b64(sig),
+            "proof_timestamp": ts,
+        })
+        assert resp.status_code == 201
+        did = resp.json()["did"]
+        return sk, did
+
+    def test_rejects_no_auth_header(self):
+        _, did = self._register_agent()
+        resp = self.client.put(f"/v1/agents/{did}/prekeys", json={
+            "identity_key": _b64(b"\x11" * 32),
+            "signed_pre_key": {
+                "key_id": 1,
+                "public_key": _b64(b"\x22" * 32),
+                "signature": _b64(b"\x33" * 64),
+            },
+        })
+        assert resp.status_code == 422, "Must reject prekey upload without auth header"
+
+    def test_rejects_wrong_key_auth(self):
+        sk, did = self._register_agent()
+        wrong_sk = SigningKey.generate()
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).isoformat()
+        sig = wrong_sk.sign(ts.encode()).signature
+        auth = f"Ed25519-Timestamp {did} {ts} {_b64(sig)}"
+        resp = self.client.put(
+            f"/v1/agents/{did}/prekeys",
+            json={
+                "identity_key": _b64(b"\x11" * 32),
+                "signed_pre_key": {
+                    "key_id": 1,
+                    "public_key": _b64(b"\x22" * 32),
+                    "signature": _b64(b"\x33" * 64),
+                },
+            },
+            headers={"Authorization": auth},
+        )
+        assert resp.status_code == 401, "Must reject prekey upload with wrong key"

--- a/scripts/ci/no-unauthed-registration.sh
+++ b/scripts/ci/no-unauthed-registration.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ci/no-unauthed-registration.sh — Block registration endpoints without auth.
+#
+# Scans Python files touched by a PR for HTTP endpoints that accept
+# public_key or verification_key without corresponding proof-of-possession
+# verification (VerifyKey, BadSignatureError, proof). Catches CWE-306
+# regressions: unauthenticated key registration.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+
+CHANGED_PY=$(git diff --name-only "$BASE_REF"...HEAD -- '*.py' || true)
+
+if [ -z "$CHANGED_PY" ]; then
+  echo "✅ no-unauthed-registration: no Python files changed"
+  exit 0
+fi
+
+FAIL=false
+
+# Pattern 1: Pydantic model with public_key/verification_key field in a file
+# that also defines an HTTP route (app.post, app.put, router.post, router.put)
+# but does NOT import or call VerifyKey anywhere.
+for f in $CHANGED_PY; do
+  [ -f "$f" ] || continue
+
+  # Only check files that define HTTP endpoints
+  if ! grep -qE '@(app|router)\.(post|put)' "$f" 2>/dev/null; then
+    continue
+  fi
+
+  # Only check files that accept a public key field
+  if ! grep -qE 'public_key|verification_key' "$f" 2>/dev/null; then
+    continue
+  fi
+
+  # Check if the file has proof-of-possession verification
+  HAS_VERIFY=$(grep -cE 'VerifyKey|BadSignatureError|proof_of_possession|verify.*proof' "$f" 2>/dev/null || echo 0)
+
+  if [ "$HAS_VERIFY" -eq 0 ]; then
+    echo "❌ $f: defines HTTP endpoint accepting public_key/verification_key but has no proof-of-possession verification"
+    echo "   Every registration endpoint that accepts a public key MUST verify"
+    echo "   the caller controls the corresponding private key (Ed25519 PoP)."
+    echo "   See: agentmesh/registry/app.py for the reference implementation."
+    FAIL=true
+  fi
+done
+
+if [ "$FAIL" = true ]; then
+  echo ""
+  echo "❌ no-unauthed-registration: FAILED — unauthenticated key registration detected"
+  echo "   All endpoints accepting public keys must require proof-of-possession."
+  echo "   Reference: CWE-306 (Missing Authentication for Critical Function)"
+  exit 1
+fi
+
+echo "✅ no-unauthed-registration: all key-accepting endpoints have auth verification"


### PR DESCRIPTION
## Summary

Adds three layers of defense to prevent CWE-306 (unauthenticated key registration) from recurring. Follow-up to the fixes in #2533 and #2542.

## Problem

The vulnerability fixed in #2533/#2542 existed because nothing prevented new endpoints from accepting public keys without proof-of-possession. No CI check, no policy doc, no regression tests.

## Changes

| File | Change |
|------|--------|
| `scripts/ci/no-unauthed-registration.sh` | CI script that scans changed Python files for HTTP endpoints accepting `public_key`/`verification_key` without `VerifyKey`/`BadSignatureError` verification. Blocks PRs that introduce unauthenticated registration. |
| `.github/workflows/quality-gates.yml` | Added `no-unauthed-registration` job to the existing quality gates. |
| `agent-mesh/AGENTS.md` | Added explicit boundary rule: never accept public keys without proof-of-possession. References the CI script and reference implementation. |
| `agent-mesh/tests/test_registration_auth.py` | 9 negative auth tests covering: missing proof fields, wrong key signature, expired timestamp, client-supplied DID rejection, name squatting prevention, unauthenticated prekey upload, wrong-key prekey auth. |

## Testing

9/9 new tests pass. Full suite: 61 pass, 2 pre-existing failures (subprocess timeout in `TestMainModule` on Windows, unrelated).
