### PR TITLE
chore: add cspell terms for package consolidation docs

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -32,6 +32,8 @@ capsys
 carloshvp
 carryforward
 carveout
+cedarling
+cedarpy
 cheatsheet
 checkpointed
 checkpointing
@@ -90,6 +92,7 @@ findall
 finditer
 FIPS
 flatbuffer
+flowise
 fnmatch
 fromisoformat
 fromtimestamp
@@ -135,6 +138,7 @@ kwarg
 kwargs
 Landlock
 LangChain
+langflow
 LangGraph
 lawcontinue
 levelname
@@ -173,6 +177,7 @@ networkx
 newpartner
 NNNN
 noqa
+nostr
 npmjs
 numpy
 OpenAI
@@ -200,6 +205,7 @@ promptdefense
 pycache
 Pydantic
 pypdf
+pypistats
 pyproject
 pytest
 pytestmark
@@ -251,6 +257,7 @@ spellchecking
 SPIFFE
 spiffesvid
 splitlines
+stacklevel
 startswith
 staticmethod
 stepreceipt


### PR DESCRIPTION
Adds cedarling, cedarpy, flowise, langflow, nostr, pypistats, stacklevel to .cspell-repo-terms.txt. Unblocks spell check for PR #2543.