### PR TITLE
fix(ci): add missing Cargo crates to allowlist and fix cross-platform path validation

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/cli/mcp_scan.py
+++ b/agent-governance-python/agent-os/src/agent_os/cli/mcp_scan.py
@@ -80,7 +80,8 @@ def _validate_command(command: str) -> None:
     """Raise if command is not on the allowlist and policy is enforced."""
     if _ALLOW_ALL_COMMANDS:
         return
-    basename = os.path.basename(command).lower()
+    # Handle both Unix and Windows path separators regardless of host OS
+    basename = command.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
     for ext in (".exe", ".cmd", ".bat"):
         if basename.endswith(ext):
             basename = basename[: -len(ext)]

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -167,6 +167,9 @@ REGISTERED_NPM_PACKAGES = {
 REGISTERED_CARGO_PACKAGES = {
     "serde", "serde_json", "serde_yaml", "sha2", "ed25519-dalek",
     "rand", "thiserror", "tempfile", "agentmesh",
+    "agentmesh-mcp", "base64", "cedar-policy", "clap", "hmac",
+    "opentelemetry", "regex", "regorus",
+    "assert_cmd", "predicates",
 }
 
 # Patterns that are always safe (not package names)


### PR DESCRIPTION
## Summary

Fixes two CI failures on main: dep-confusion-scan and docker-compose-test.

## Problem

1. **dep-confusion-scan**: Rust workspace crates (clap, opentelemetry, base64, cedar-policy, hmac, regex, regorus, agentmesh-mcp, assert_cmd, predicates) were not in the REGISTERED_CARGO_PACKAGES allowlist, causing false positives.
2. **docker-compose-test**: \_validate_command\ used \os.path.basename()\ which does not split Windows-style backslash paths on Linux. The test \	est_full_path_to_allowed_command_passes\ passes a Windows path that fails in the Linux container.

## Changes

| File | Change |
|------|--------|
| \scripts/check_dependency_confusion.py\ | Add 10 missing Cargo crates to allowlist |
| \gent-governance-python/agent-os/src/agent_os/cli/mcp_scan.py\ | Replace \os.path.basename()\ with manual split on both \/\ and \\\ for cross-platform support |

## Testing

- \python scripts/check_dependency_confusion.py --strict\ exits clean
- All 22 TestCommandAllowlist tests pass, including the previously failing \	est_full_path_to_allowed_command_passes