### PR TITLE
docs: align OWASP ASI risk names in README and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,10 +269,10 @@ AGT covers all 10 risks identified in the [OWASP Agentic Security Top 10](docs/O
 | ASI-01 Agent Goal Hijack | Policy engine blocks unauthorized goal changes |
 | ASI-02 Tool Misuse & Exploitation | Capability model enforces least-privilege |
 | ASI-03 Identity & Privilege Abuse | Zero-trust identity with Ed25519 + ML-DSA-65 |
-| ASI-04 Agentic Supply Chain Compromise | Dependency-confusion scanning + tool verification |
+| ASI-04 Agentic Supply Chain Vulnerabilities | Dependency-confusion scanning + tool verification |
 | ASI-05 Unexpected Code Execution | 4-tier execution rings + sandboxing |
 | ASI-06 Memory & Context Poisoning | Episodic memory with integrity checks |
-| ASI-07 Unsafe Inter-Agent Comms | Encrypted channels + trust gates |
+| ASI-07 Insecure Inter-Agent Communication | Encrypted channels + trust gates |
 | ASI-08 Cascading Agent Failures | Circuit breakers + SLO enforcement |
 | ASI-09 Human-Agent Trust Exploitation | Full audit trails + flight recorder |
 | ASI-10 Rogue Agents | Kill switch + ring isolation + anomaly detection |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -119,9 +119,9 @@ agt verify
 ```
 Agent Governance Toolkit — OWASP ASI 2026 Compliance
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  ASI-01 Agentic Prompt Injection      ✅ Covered
-  ASI-02 Unsafe Tool/Function Calling  ✅ Covered
-  ASI-03 Tool Poisoning Attacks        ✅ Covered
+  ASI-01 Agent Goal Hijack             ✅ Covered
+  ASI-02 Tool Misuse & Exploitation    ✅ Covered
+  ASI-03 Identity & Privilege Abuse    ✅ Covered
   ...
   10/10 risks covered
 ```


### PR DESCRIPTION
While reading through the OWASP standardization changes that landed in #2506, I noticed a few residual call-sites that still use the pre-standard ASI risk names. The PR description for #2506 stated:

> Verified with grep that zero instances of the old names remain across the entire repo.

These five locations appear to have been missed, so this PR completes that alignment against `docs/OWASP-COMPLIANCE.md` (the canonical names declared in #2506).

## Changes

**`README.md` — Top 10 coverage table:**
- `ASI-04 Agentic Supply Chain Compromise` → `ASI-04 Agentic Supply Chain Vulnerabilities`
- `ASI-07 Unsafe Inter-Agent Comms` → `ASI-07 Insecure Inter-Agent Communication`

**`docs/quickstart.md` — `agt verify` sample output:**
- `ASI-01 Agentic Prompt Injection` → `ASI-01 Agent Goal Hijack`
- `ASI-02 Unsafe Tool/Function Calling` → `ASI-02 Tool Misuse & Exploitation`
- `ASI-03 Tool Poisoning Attacks` → `ASI-03 Identity & Privilege Abuse`

Column spacing preserved in the quickstart sample output.

## Verification

```
$ git grep -E 'Agentic Prompt Injection|Unsafe Tool/Function Calling|Tool Poisoning Attacks|Agentic Supply Chain Compromise|Unsafe Inter-Agent Comms'
(no output)
```

All five renames match `docs/OWASP-COMPLIANCE.md` exactly.
