### PR TITLE
fix(governance): export FacetRegistry and extract_protocol_facets from public package

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
@@ -100,6 +100,11 @@ from .federation import (
     FileFederationStore,
     FederationEngine,
 )
+from .protocol_facets import (
+    FacetRegistry,
+    extract_protocol_facets,
+    default_registry,
+)
 
 __all__ = [
     # High-level wrapper (issue #1372)
@@ -206,5 +211,9 @@ __all__ = [
     "AgentRiskProfile",
     "ClassificationResult",
     "EUAIActRiskClassifier",
+    # Wire protocol facets (issue #2483)
+    "FacetRegistry",
+    "extract_protocol_facets",
+    "default_registry",
 ]
 


### PR DESCRIPTION
## What

`FacetRegistry`, `extract_protocol_facets`, and `default_registry` were added in #2487 but never added to `agentmesh/governance/__init__.py`.

Anyone trying to register a custom protocol extractor (as shown in the module docstring example) would hit an `ImportError` when using the public package path:

```python
# fails before this fix
from agentmesh.governance import FacetRegistry, default_registry
```

They had to import from the internal path instead, which is not part of the public API.

## Fix

Added the three symbols to the imports and `__all__` in `agentmesh/governance/__init__.py`, grouped with the other wire protocol facet exports.

## Test

```python
from agentmesh.governance import FacetRegistry, extract_protocol_facets, default_registry

def extract_redis_facets(ctx):
    return {"verb": (ctx.get("command") or "").upper()}

default_registry.register("redis", extract_redis_facets)
ctx = {"redis": {"command": "FLUSHALL"}}
extract_protocol_facets(ctx)
print(ctx["redis"]["verb"])  # FLUSHALL
```