### PR TITLE
docs: align README with homepage narrative and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Agent Governance Toolkit
 
+### Ship agents to production without losing sleep
+
 <p align="center">
   <a href="https://microsoft.github.io/agent-governance-toolkit">
     <img src="https://img.shields.io/badge/%F0%9F%93%96_Full_Documentation-microsoft.github.io%2Fagent--governance--toolkit-0078D4?style=for-the-badge&logoColor=white" alt="Full Documentation" height="40">
@@ -31,34 +33,27 @@
 > [!IMPORTANT]
 > **Public Preview** -- production-quality, Microsoft-signed releases. May have breaking changes before GA.
 
-Runtime governance for AI agents. Every tool call, resource access, and inter-agent message is evaluated against policy *before* execution -- deterministic, sub-millisecond, and auditable.
-
-```
-Agent Action ──► Policy Check ──► Allow / Deny ──► Audit Log    (< 0.1 ms)
-```
-
-Prompt-based safety ("please follow the rules") has a [26.67% policy violation rate](docs/BENCHMARKS.md) in red-team testing. AGT's application-layer enforcement: **0.00%**.
-
-Python · TypeScript · .NET · Rust · Go. Works with LangChain, CrewAI, AutoGen, OpenAI Agents, Google ADK, Semantic Kernel, AWS Bedrock, and [20+ more](#framework-support).
+Policy enforcement, identity, sandboxing, and SRE for autonomous AI agents. One `pip install`, any framework.
 
 ---
 
-## Prerequisites
+## The Problem
 
-- **Python**: `pip install agent-governance-toolkit[full]` requires Python 3.10+
-- **Node.js**: For TypeScript SDK, Node.js 18+ and npm 9+
-- **.NET**: .NET 8+ for the .NET SDK
-- **Go**: Go 1.25+ for the Go SDK
-- **Rust**: Rust 1.70+ for the Rust SDK
+Your AI agents call tools, browse the web, query databases, and delegate to other agents. Once deployed, they make decisions autonomously. You need answers to three questions:
 
-### Optional dependencies
+**1. Is this action allowed?** An agent with access to `send_email` and `query_database` should not be able to `drop_table`. OAuth scopes and IAM roles control which services an agent can reach, not what it does once connected.
 
-- **Azure credentials**: Set `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` for Azure-integrated features
-- **MCP SDK**: For Model Context Protocol integrations
+**2. Which agent did this?** In a multi-agent system, five agents might share a single API key. When something goes wrong, "an agent did it" is not an incident response.
+
+**3. Can you prove what happened?** Auditors and regulators need tamper-evident records of every decision: what policy was active, what the agent requested, and why it was allowed or denied.
+
+Prompt-based safety ("please follow the rules") has a [26.67% policy violation rate](docs/BENCHMARKS.md) in red-team testing. AGT's application-layer enforcement: **0.00%**.
+
+---
 
 ## Quick Start
 
-**Prerequisites:** Python 3.10+ required.
+**Prerequisites:** Python 3.10+
 
 ```bash
 pip install agent-governance-toolkit
@@ -72,7 +67,38 @@ from agentmesh.governance import govern
 safe_tool = govern(my_tool, policy="policy.yaml")   # every call checked, logged, enforced
 ```
 
+That's it. `safe_tool` evaluates your YAML policy on every call, logs the decision, and raises `GovernanceDenied` if the action is blocked.
+
+```yaml
+# policy.yaml
+apiVersion: governance.toolkit/v1
+name: production-policy
+default_action: allow
+rules:
+  - name: block-destructive
+    condition: "action.type in ['drop', 'delete', 'truncate']"
+    action: deny
+    description: "Destructive operations require human approval"
+
+  - name: require-approval-for-send
+    condition: "action.type == 'send_email'"
+    action: require_approval
+    approvers: ["security-team"]
+```
+
+```python
+>>> safe_tool(action="read", table="users")
+{'table': 'users', 'rows': 42}
+
+>>> safe_tool(action="drop", table="users")
+GovernanceDenied: Action denied by policy rule 'block-destructive':
+  Destructive operations require human approval
+```
+
 Or use the full `PolicyEvaluator` API for programmatic control:
+
+<details>
+<summary><b>PolicyEvaluator example</b></summary>
 
 ```python
 from agent_os.policies import (
@@ -94,9 +120,11 @@ evaluator = PolicyEvaluator(policies=[PolicyDocument(
     )],
 )])
 
-result = evaluator.evaluate({"tool_name": "web_search"})    # ✅ Allowed
-result = evaluator.evaluate({"tool_name": "delete_file"})   # ❌ Blocked
+result = evaluator.evaluate({"tool_name": "web_search"})    # Allowed
+result = evaluator.evaluate({"tool_name": "delete_file"})   # Blocked
 ```
+
+</details>
 
 <details>
 <summary><b>TypeScript / .NET / Rust / Go examples</b></summary>
@@ -170,114 +198,44 @@ Full walkthrough: [quickstart.md](docs/quickstart.md) -- zero to governed agents
 
 ---
 
-## Core Capabilities
+## How It Works
 
-### Policy Engine
-Deterministic allow/deny evaluation for every agent action. Sub-millisecond latency (0.012ms p50 for single rule, 35K ops/sec concurrent). Supports YAML, OPA/Rego, and Cedar policy languages. Fail-closed by default -- if the engine errors, the action is denied.
+```
+Agent ──► Policy Engine ──► Identity ──► Audit Log
+            (YAML/OPA/Cedar)  (SPIFFE/DID/mTLS)  (Tamper-evident)
+                 │                                      │
+                 ├── Allowed ──► Tool executes           │
+                 └── Denied  ──► GovernanceDenied        │
+                                                        ▼
+                                                 Decision Record
+```
 
-[Agent OS](agent-governance-python/agent-os/) · [Benchmarks](docs/BENCHMARKS.md) · [Spec](docs/specs/AGENT-OS-POLICY-ENGINE-1.0.md)
+Every layer is optional. Start with `govern()` and add layers as your risk profile grows. Most teams run policy enforcement + audit logging and never need the full stack.
 
-### Zero-Trust Identity
-Ed25519 + quantum-safe ML-DSA-65 agent credentials. Behavioral trust scoring (0--1000) that decays when agents act outside expected patterns. SPIFFE/SVID compatible. Trust ceilings propagate through delegation chains -- a delegated agent can never exceed its parent's trust level.
+---
 
-[AgentMesh](agent-governance-python/agent-mesh/) · [Spec](docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md)
+## Packages
 
-### Execution Sandboxing
-Four privilege rings (kernel, supervisor, user, untrusted) with hardware-style isolation semantics. Saga orchestration for multi-step workflows with automatic compensation on failure. Kill switch for immediate agent termination.
-
-[Runtime](agent-governance-python/agent-runtime/) · [Hypervisor](agent-governance-python/agent-hypervisor/) · [Spec](docs/specs/AGENT-HYPERVISOR-EXECUTION-CONTROL-1.0.md)
-
-### Agent SRE
-SLOs, error budgets, replay debugging, chaos engineering, and circuit breakers for agent fleets. OTel-native observability with structured governance events.
-
-[Agent SRE](agent-governance-python/agent-sre/) · [Spec](docs/specs/AGENT-SRE-GOVERNANCE-1.0.md)
-
-### Audit and Compliance
-Tamper-evident Merkle-chained audit logs. Reconstructible Decision BOMs from observability signals. Automated compliance mapping for EU AI Act, SOC 2, HIPAA, and GDPR. CloudEvents export for SIEM integration.
-
-[Compliance](agent-governance-python/agent-mesh/src/agentmesh/governance/) · [Spec](docs/specs/AUDIT-COMPLIANCE-1.0.md)
-
-### MCP Security Gateway
-Tool poisoning detection, description drift monitoring, typosquatting checks, and hidden instruction scanning for MCP tool definitions.
-
-[MCP Scanner](agent-governance-python/agent-os/src/agent_os/mcp_security.py) · [Spec](docs/specs/MCP-SECURITY-GATEWAY-1.0.md)
+| Package | Description |
+|---------|-------------|
+| [**Agent OS**](agent-governance-python/agent-os/) | Policy engine, agent lifecycle, governance gate |
+| [**Agent Mesh**](agent-governance-python/agent-mesh/) | Agent discovery, routing, and trust mesh |
+| [**Agent Runtime**](agent-governance-python/agent-runtime/) | Execution sandboxing with four privilege rings |
+| [**Agent SRE**](agent-governance-python/agent-sre/) | Kill switch, SLO monitoring, chaos testing |
+| [**Agent Compliance**](agent-governance-python/agent-compliance/) | OWASP verification, policy linting, integrity checks |
+| [**Agent Marketplace**](agent-governance-python/agent-marketplace/) | Plugin governance and trust scoring |
+| [**Agent Lightning**](agent-governance-python/agent-lightning/) | RL training governance with violation penalties |
+| [**Agent Hypervisor**](agent-governance-python/agent-hypervisor/) | Execution audit, delta engine, commitment anchoring |
 
 ### Additional Capabilities
 
 | Capability | Description |
 |---|---|
-| **Inter-Agent Trust** | Mesh-wide trust negotiation, peer signature verification, coordinated policy enforcement ([Spec](docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md)) |
-| **RL Training Governance** | Violation penalties in reward signals, episode termination on critical violations ([Spec](docs/specs/AGENT-LIGHTNING-FAST-PATH-1.0.md)) |
-| **Framework Adapters** | 10 adapters with unified governance interceptor chain ([Spec](docs/specs/FRAMEWORK-ADAPTER-CONTRACT-1.0.md)) |
+| **MCP Security Gateway** | Tool poisoning detection, drift monitoring, typosquatting, hidden instruction scanning ([Spec](docs/specs/MCP-SECURITY-GATEWAY-1.0.md)) |
 | **Shadow AI Discovery** | Find unregistered agents across processes, configs, and repos ([Discovery](agent-governance-python/agent-discovery/)) |
-| **Agent Lifecycle** | Provisioning, credential rotation, orphan detection, decommissioning ([Lifecycle](agent-governance-python/agent-mesh/src/agentmesh/lifecycle/)) |
 | **Governance Dashboard** | Real-time fleet visibility for health, trust, and compliance ([Dashboard](examples/demos/governance-dashboard/)) |
 | **PromptDefense Evaluator** | 12-vector prompt injection audit ([Evaluator](agent-governance-python/agent-compliance/src/agent_compliance/prompt_defense.py)) |
 | **Contributor Reputation** | PR/issue author screening for social engineering. Reusable GitHub Action ([Action](.github/actions/contributor-check/)) |
-
----
-
-## Specifications
-
-Every major component has a formal RFC 2119 specification with conformance tests. These specs define the behavioral contract -- what implementations MUST, SHOULD, and MAY do.
-
-| Specification | Scope | Tests |
-|---|---|---|
-| [Agent OS Policy Engine](docs/specs/AGENT-OS-POLICY-ENGINE-1.0.md) | Policy evaluation, rule merging, fail-closed semantics | 68 |
-| [AgentMesh Identity and Trust](docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md) | Credentials, trust scoring, delegation chains | 135 |
-| [Agent Hypervisor Execution Control](docs/specs/AGENT-HYPERVISOR-EXECUTION-CONTROL-1.0.md) | Privilege rings, saga orchestration, kill switch | 80 |
-| [AgentMesh Trust and Coordination](docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md) | Peer trust negotiation, mesh-wide policy | 62 |
-| [Agent SRE Governance](docs/specs/AGENT-SRE-GOVERNANCE-1.0.md) | SLOs, error budgets, chaos, circuit breakers | 111 |
-| [MCP Security Gateway](docs/specs/MCP-SECURITY-GATEWAY-1.0.md) | Tool poisoning, drift detection, hidden instructions | 127 |
-| [Agent Lightning Fast-Path](docs/specs/AGENT-LIGHTNING-FAST-PATH-1.0.md) | RL training governance, violation penalties | 100 |
-| [Framework Adapter Contract](docs/specs/FRAMEWORK-ADAPTER-CONTRACT-1.0.md) | 10 adapter integrations, interceptor chain | 152 |
-| [Audit and Compliance](docs/specs/AUDIT-COMPLIANCE-1.0.md) | Merkle audit, compliance mapping, Decision BOM | 157 |
-| [AgentMesh Wire Protocol](docs/specs/AGENTMESH-WIRE-1.0.md) | Message format, routing, serialization | -- |
-
-**992 conformance tests** ensure code stays aligned to specs. [25 Architecture Decision Records](docs/adr/) document why.
-
----
-
-## Framework Support
-
-| Framework | Integration |
-|-----------|-------------|
-| [**Microsoft Agent Framework**](https://github.com/microsoft/agent-framework) | Native Middleware |
-| [**Semantic Kernel**](https://github.com/microsoft/semantic-kernel) | Native (.NET + Python) |
-| [AutoGen](https://github.com/microsoft/autogen) | Adapter |
-| [LangGraph](https://github.com/langchain-ai/langgraph) / [LangChain](https://github.com/langchain-ai/langchain) | Adapter |
-| [CrewAI](https://github.com/crewAIInc/crewAI) | Adapter |
-| [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | Middleware |
-| Claude Code | Governance plugin package |
-| [Google ADK](https://github.com/google/adk-python) | Adapter |
-| [LlamaIndex](https://github.com/run-llama/llama_index) | Middleware |
-| [Haystack](https://github.com/deepset-ai/haystack) | Pipeline |
-| [Dify](https://github.com/langgenius/dify) | Plugin |
-| [Azure AI Foundry](https://learn.microsoft.com/azure/ai-studio/) | Deployment Guide |
-| GitHub Copilot CLI | Governance installer |
-
-Full list: [Framework Integrations](agent-governance-python/agentmesh-integrations/) · [Quickstart Examples](examples/quickstart/)
-
----
-
-## OWASP Agentic Top 10
-
-AGT covers all 10 risks identified in the [OWASP Agentic Security Top 10](docs/OWASP-COMPLIANCE.md):
-
-| Risk | AGT Control |
-|------|-------------|
-| ASI-01 Agent Goal Hijack | Policy engine blocks unauthorized goal changes |
-| ASI-02 Tool Misuse & Exploitation | Capability model enforces least-privilege |
-| ASI-03 Identity & Privilege Abuse | Zero-trust identity with Ed25519 + ML-DSA-65 |
-| ASI-04 Agentic Supply Chain Vulnerabilities | Dependency-confusion scanning + tool verification |
-| ASI-05 Unexpected Code Execution | 4-tier execution rings + sandboxing |
-| ASI-06 Memory & Context Poisoning | Episodic memory with integrity checks |
-| ASI-07 Insecure Inter-Agent Communication | Encrypted channels + trust gates |
-| ASI-08 Cascading Agent Failures | Circuit breakers + SLO enforcement |
-| ASI-09 Human-Agent Trust Exploitation | Full audit trails + flight recorder |
-| ASI-10 Rogue Agents | Kill switch + ring isolation + anomaly detection |
-
-Regulatory alignment: [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [SOC 2](docs/compliance/soc2-mapping.md)
 
 ---
 
@@ -294,7 +252,7 @@ Regulatory alignment: [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compli
 | **Rust** | [`agent-governance`](https://crates.io/crates/agent-governance) | `cargo add agent-governance` |
 | **Go** | [`agent-governance-toolkit`](agent-governance-golang/) | `go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang` |
 
-All five language packages implement core governance (policy, identity, trust, audit). Python has the full stack, and the Copilot CLI and Claude Code packages are first-party local developer surfaces built on the TypeScript SDK.
+All five language SDKs implement core governance (policy, identity, trust, audit). Python has the full stack. Copilot CLI and Claude Code are first-party developer surfaces built on the TypeScript SDK.
 See **[Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md)** for detailed per-language coverage.
 
 <details>
@@ -314,13 +272,91 @@ See **[Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md)** for detailed p
 
 </details>
 
+### Prerequisites
+
+- **Python**: 3.10+
+- **Node.js**: 18+ / npm 9+ (TypeScript SDK)
+- **.NET**: 8+
+- **Go**: 1.25+
+- **Rust**: 1.70+
+- **Optional**: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` for Azure-integrated features
+
+---
+
+## Framework Support
+
+| Framework | Integration |
+|-----------|-------------|
+| [**Microsoft Agent Framework**](https://github.com/microsoft/agent-framework) | Native Middleware |
+| [**Semantic Kernel**](https://github.com/microsoft/semantic-kernel) | Native (.NET + Python) |
+| [AutoGen](https://github.com/microsoft/autogen) | Adapter |
+| [LangGraph](https://github.com/langchain-ai/langgraph) / [LangChain](https://github.com/langchain-ai/langchain) | Adapter |
+| [CrewAI](https://github.com/crewAIInc/crewAI) | Adapter |
+| [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) | Middleware |
+| Claude Code | Governance plugin package |
+| [Google ADK](https://github.com/google/adk-python) | Adapter |
+| [LlamaIndex](https://github.com/run-llama/llama_index) | Middleware |
+| [Haystack](https://github.com/deepset-ai/haystack) | Pipeline |
+| [Mastra](https://github.com/mastra-ai/mastra) | Adapter |
+| [Dify](https://github.com/langgenius/dify) | Plugin |
+| [Azure AI Foundry](https://learn.microsoft.com/azure/ai-studio/) | Deployment Guide |
+| GitHub Copilot CLI | Governance installer |
+
+Full list: [Framework Integrations](agent-governance-python/agentmesh-integrations/) · [Quickstart Examples](examples/quickstart/)
+
+---
+
+## Examples
+
+| Example | Framework | What it demonstrates |
+|---------|-----------|----------------------|
+| [openai-agents-governed](examples/openai-agents-governed) | OpenAI Agents SDK | Policy-gated tool calls with trust tiers |
+| [crewai-governed](examples/crewai-governed) | CrewAI | Multi-agent governance with role-based policies |
+| [smolagents-governed](examples/smolagents-governed) | HuggingFace smolagents | Lightweight agent governance |
+| [maf-integration](examples/maf-integration) | MAF | Microsoft Agent Framework integration |
+| [mcp-trust-verified-server](examples/mcp-trust-verified-server) | MCP | Trust-verified MCP server implementation |
+| [cedarling-governed](examples/cedarling-governed) | Cedar/Cedarling | Janssen Cedarling policy engine integration |
+| [governance-dashboard](examples/demos/governance-dashboard) | Streamlit | Real-time fleet visibility dashboard |
+
+---
+
+## Specifications
+
+Every major component has a formal RFC 2119 specification with conformance tests. These specs define the behavioral contract: what implementations MUST, SHOULD, and MAY do.
+
+| Specification | Scope | Tests |
+|---|---|---|
+| [Agent OS Policy Engine](docs/specs/AGENT-OS-POLICY-ENGINE-1.0.md) | Policy evaluation, rule merging, fail-closed semantics | 68 |
+| [AgentMesh Identity and Trust](docs/specs/AGENTMESH-IDENTITY-TRUST-1.0.md) | Credentials, trust scoring, delegation chains | 135 |
+| [Agent Hypervisor Execution Control](docs/specs/AGENT-HYPERVISOR-EXECUTION-CONTROL-1.0.md) | Privilege rings, saga orchestration, kill switch | 80 |
+| [AgentMesh Trust and Coordination](docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md) | Peer trust negotiation, mesh-wide policy | 62 |
+| [Agent SRE Governance](docs/specs/AGENT-SRE-GOVERNANCE-1.0.md) | SLOs, error budgets, chaos, circuit breakers | 111 |
+| [MCP Security Gateway](docs/specs/MCP-SECURITY-GATEWAY-1.0.md) | Tool poisoning, drift detection, hidden instructions | 127 |
+| [Agent Lightning Fast-Path](docs/specs/AGENT-LIGHTNING-FAST-PATH-1.0.md) | RL training governance, violation penalties | 100 |
+| [Framework Adapter Contract](docs/specs/FRAMEWORK-ADAPTER-CONTRACT-1.0.md) | 10 adapter integrations, interceptor chain | 152 |
+| [Audit and Compliance](docs/specs/AUDIT-COMPLIANCE-1.0.md) | Merkle audit, compliance mapping, Decision BOM | 157 |
+| [AgentMesh Wire Protocol](docs/specs/AGENTMESH-WIRE-1.0.md) | Message format, routing, serialization | -- |
+
+**992 conformance tests** ensure code stays aligned to specs. [25 Architecture Decision Records](docs/adr/) document why.
+
+---
+
+## Standards Compliance
+
+| Standard | Coverage |
+|----------|----------|
+| [OWASP Agentic AI Top 10](docs/OWASP-COMPLIANCE.md) | All 10 risks covered with deterministic controls |
+| [NIST AI RMF 1.0](docs/compliance/nist-ai-rmf-alignment.md) | Full GOVERN, MAP, MEASURE, MANAGE alignment |
+| [EU AI Act](docs/compliance/) | Compliance mapping with automated evidence |
+| [SOC 2](docs/compliance/soc2-mapping.md) | Control mapping with audit trail export |
+
 ---
 
 ## Security
 
-AGT enforces governance at the Python middleware layer, not at the OS kernel level. The policy engine and agents share the same process boundary.
+AGT enforces governance at the application middleware layer, not at the OS kernel level. The policy engine and agents share the same process boundary.
 
-**Production recommendation:** Run each agent in a separate container for OS-level isolation. See [Architecture -- Security Boundaries](docs/ARCHITECTURE.md).
+**Production recommendation:** Run each agent in a separate container for OS-level isolation. See [Architecture: Security Boundaries](docs/ARCHITECTURE.md).
 
 | Tool | Coverage |
 |------|----------|
@@ -339,7 +375,7 @@ See [Known Limitations](docs/LIMITATIONS.md) for honest design boundaries and re
 | Category | Links |
 |----------|-------|
 | **Getting Started** | [Quick Start](docs/quickstart.md) · [Tutorials](docs/tutorials/) (60+) · [FAQ](docs/FAQ.md) |
-| **Architecture** | [System Design](docs/ARCHITECTURE.md) · [Threat Model](docs/security/threat-model.md) · [ADRs](docs/adr/) (25) |
+| **Architecture** | [System Design](docs/ARCHITECTURE.md) · [Threat Model](docs/THREAT_MODEL.md) · [ADRs](docs/adr/) (25) |
 | **Specifications** | [All Specs](docs/specs/) (10 formal specs, 992 conformance tests) |
 | **API Reference** | [Agent OS](agent-governance-python/agent-os/README.md) · [AgentMesh](agent-governance-python/agent-mesh/README.md) · [Agent SRE](agent-governance-python/agent-sre/README.md) |
 | **Compliance** | [OWASP](docs/OWASP-COMPLIANCE.md) · [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [SOC 2](docs/compliance/soc2-mapping.md) |


### PR DESCRIPTION
## Summary

Aligns README.md with the homepage at microsoft.github.io/agent-governance-toolkit.

## Problem

The README and homepage told different stories. The homepage leads with a clear problem statement and a 2-line quick start with a policy.yaml example. The README jumped straight into prerequisites and a longer PolicyEvaluator code block. Visitors who land on the repo should get the same narrative arc as the docs site.

## Changes

| Area | What changed |
|------|-------------|
| Hero | Added homepage tagline: "Ship agents to production without losing sleep" |
| Problem framing | Added "The Problem" section with three questions (action allowed? which agent? prove it?) |
| Quick Start | Show `govern()` + policy.yaml + deny/allow output before the longer PolicyEvaluator example |
| Architecture | Added "How It Works" ASCII diagram showing the governance pipeline |
| Packages | Replaced prose Core Capabilities sections with a table matching homepage layout |
| Examples | Added table of 7 featured examples (previously missing from README) |
| Standards | Added Standards Compliance table (OWASP, NIST, EU AI Act, SOC 2) |
| Framework Support | Added Mastra to the integrations table |
| Install | Moved Prerequisites under Install section to reduce friction before quick start |
| Cleanup | Collapsed PolicyEvaluator into a details block, removed per-risk OWASP table (redundant with Standards Compliance link) |

## Testing

Docs-only change. No code modified.
