### PR TITLE
docs: add PR hygiene guidance to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,16 @@ When bumping the monorepo version (e.g. `3.2.0` → `3.2.1`):
 - After bumping, verify with: `Select-String -Path package-lock.json -Pattern '"<new-version>"'`
   and confirm only the SDK's own entries appear, not transitive deps.
 
+## PR Hygiene
+
+Before opening a PR:
+
+- fix the PR title so it is semantic and consistently formatted
+- ensure commits satisfy DCO/signoff requirements
+- run the relevant docs link checks for changed docs
+- treat expected 403-prone external links as markdown-link-check exceptions, not flaky failures
+- fix spell-check issues on changed lines before requesting review
+
 ## Validation
 
 - Run the narrowest existing tests for the paths you touched.


### PR DESCRIPTION
## Description
Add a small PR Hygiene section to the root AGENTS.md so agents proactively handle the PR checks that caused friction in PR #2562.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [ ] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [ ] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
GitHub Copilot CLI drafted the wording and PR body for this docs-only update.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
PR hygiene follow-up from #2562.
