### PR TITLE
feat(typescript): credential injection and offload (#2535)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -37,6 +37,9 @@ bypassable
 bytecodes
 caas
 caplog
+ciphertext
+ENOENT
+Errno
 capsys
 carloshvp
 carryforward

--- a/agent-governance-typescript/examples/credential-vault-example.ts
+++ b/agent-governance-typescript/examples/credential-vault-example.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * Example: credential offload and injection for an agent tool call.
+ *
+ * Run with: `npx ts-node examples/credential-vault-example.ts`
+ *
+ * TypeScript port of the Python example for issue #2481 / #2535.
+ */
+
+import {
+  CredentialInjector,
+  CredentialProfile,
+  CredentialVault,
+  InjectionContext,
+  PolicyOutcome,
+} from '../src/credential-vault';
+
+async function main(): Promise<void> {
+  // 1. Operator provisions the credential.
+  const vault = new CredentialVault();
+  await vault.put('github_pat', 'ghp_real_token_value', 'bearer_token');
+
+  // 2. Bind agent identity to action capability -> handle.
+  vault.registerProfile(
+    new CredentialProfile('did:web:agent-ci', { 'github:read_issues': 'github_pat' }),
+  );
+
+  // 3. The agent's saved tool-call template uses only the placeholder.
+  const headers = { Authorization: 'Bearer {{cred:github_pat}}' };
+
+  // 4. Workflow policy decides whether the call is allowed at all,
+  //    before the injector ever reads the value.
+  const policy = (ctx: InjectionContext): PolicyOutcome => ({
+    allow: ctx.actionClass === 'github:read_issues',
+    reason: 'only read-only github calls permitted in this workflow',
+  });
+
+  const injector = new CredentialInjector(vault);
+  const result = await injector.injectHeaders('did:web:agent-ci', headers, {
+    actionClass: 'github:read_issues',
+    targetService: 'api.github.com',
+    allowedHandles: ['github_pat'],
+    policyCheck: policy,
+    policyVersion: 'v1',
+  });
+
+  console.log('allowed:', result.allowed);
+  if (result.allowed && typeof result.payload === 'object') {
+    const rendered = result.payload as Record<string, string>;
+    console.log('rendered Authorization length:', rendered.Authorization.length);
+  }
+
+  // 5. Audit log has no value, only the handle name and decision.
+  for (const ev of vault.auditLog()) {
+    console.log('audit:', ev);
+  }
+}
+
+void main();

--- a/agent-governance-typescript/src/credential-vault.ts
+++ b/agent-governance-typescript/src/credential-vault.ts
@@ -1,0 +1,665 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * Credential vault, scoping, and injection for agent tool calls.
+ *
+ * TypeScript port of the Python `agent_os.credential_vault` primitive
+ * (issue #2481, PR #2534). Tracking issue: #2535.
+ *
+ * Design goals (identical to the Python reference):
+ *
+ * 1. **Value boundary** — agents never receive resolved secret values. They
+ *    reference credentials by opaque handle names; only the injector ever
+ *    holds the resolved value, and only long enough to render a payload.
+ * 2. **Authority boundary** — every resolution is gated by a per-agent
+ *    {@link CredentialProfile} that binds an *action capability* (not just
+ *    an agent identity) to a specific credential handle.
+ * 3. **Policy-first** — placeholder substitution happens *after* the
+ *    workflow policy callback returns `allow=true`.
+ * 4. **Deterministic deny** — denied resolutions emit the same opaque
+ *    {@link DenyReceipt} regardless of whether the handle is missing,
+ *    bound to a different agent, or denied by policy.
+ * 5. **Untrusted server metadata** — only placeholders whose names appear
+ *    in the caller-supplied `allowedHandles` set are eligible for
+ *    substitution. Anything else is treated as injection.
+ * 6. **Rotation without rebinding** — credential values rotate in place;
+ *    the handle name is stable so prompts, MCP descriptions, and saved
+ *    plans never need to change.
+ *
+ * Encrypted-at-rest persistence uses AES-256-GCM (`@noble/ciphers`) with
+ * a 12-byte random nonce prefixed to the ciphertext. If no persistence
+ * path is configured the vault is memory-only.
+ *
+ * Wire-format note: this SDK uses AES-256-GCM; the Python SDK uses Fernet.
+ * A cross-language interop spec is tracked in issue #2535 and the two
+ * formats are not currently interchangeable.
+ */
+
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+
+import { gcm } from '@noble/ciphers/aes.js';
+import { hmac } from '@noble/hashes/hmac.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { utf8ToBytes, bytesToHex, randomBytes } from '@noble/hashes/utils.js';
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/** Regex matching the credential placeholder syntax `{{cred:NAME}}`. */
+export const PLACEHOLDER_RE = /\{\{\s*cred:([A-Za-z0-9_.\-]{1,128})\s*\}\}/g;
+
+/** Stable string returned in audit/deny records when a request is refused. */
+export const DENY_REASON = 'credential_denied';
+
+/** Outcome of a credential resolution attempt. */
+export type CredentialDecision = 'allow' | 'deny';
+
+/** AES-GCM key length (bytes). */
+const KEY_LENGTH = 32;
+/** AES-GCM nonce length (bytes). */
+const NONCE_LENGTH = 12;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class CredentialError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CredentialError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CredentialRecord {
+  readonly name: string;
+  readonly value: string;
+  readonly credType: string;
+  readonly version: number;
+  readonly createdAt: number;
+  readonly rotatedAt: number | null;
+}
+
+/**
+ * Opaque handle an agent may reference. Holding a handle does **not** grant
+ * access to the underlying value; resolution requires the vault, the
+ * agent's DID, and an action capability binding.
+ */
+export class CredentialHandle {
+  readonly name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+  /** Return the `{{cred:NAME}}` placeholder for this handle. */
+  placeholder(): string {
+    return `{{cred:${this.name}}}`;
+  }
+  toString(): string {
+    return `<CredentialHandle ${this.name}>`;
+  }
+}
+
+/**
+ * Per-agent capability binding.
+ *
+ * A profile maps action capabilities (e.g. `github:read_issues`,
+ * `github:push_code`) to the credential handle name that may be used to
+ * fulfil that capability. Two capabilities that share an underlying
+ * credential are still modelled as separate bindings so revoking one does
+ * not implicitly revoke the other.
+ */
+export class CredentialProfile {
+  readonly agentDid: string;
+  private readonly _bindings: ReadonlyMap<string, string>;
+
+  constructor(agentDid: string, bindings: Record<string, string> | Map<string, string>) {
+    if (!agentDid) {
+      throw new TypeError('agentDid must be a non-empty string');
+    }
+    this.agentDid = agentDid;
+    const entries = bindings instanceof Map ? [...bindings.entries()] : Object.entries(bindings);
+    this._bindings = new Map(entries);
+  }
+
+  /** Return the handle name bound to `actionClass`, or undefined. */
+  capabilityFor(actionClass: string): string | undefined {
+    return this._bindings.get(actionClass);
+  }
+
+  /** Snapshot of bindings (read-only). */
+  get bindings(): ReadonlyMap<string, string> {
+    return this._bindings;
+  }
+}
+
+export interface VaultAuditEvent {
+  readonly timestamp: number;
+  readonly agentDid: string;
+  readonly handleName: string;
+  readonly targetService: string;
+  readonly actionClass: string;
+  readonly decision: CredentialDecision;
+  readonly policyVersion: string;
+  readonly reason: string;
+}
+
+/** Deterministic deny output returned in place of a rendered payload. */
+export class DenyReceipt {
+  readonly reason: string;
+  readonly actionClass: string;
+  readonly targetService: string;
+  constructor(opts: { actionClass?: string; targetService?: string; reason?: string } = {}) {
+    this.reason = opts.reason ?? DENY_REASON;
+    this.actionClass = opts.actionClass ?? '';
+    this.targetService = opts.targetService ?? '';
+  }
+  toJSON(): Record<string, string> {
+    return {
+      reason: this.reason,
+      actionClass: this.actionClass,
+      targetService: this.targetService,
+    };
+  }
+  equals(other: DenyReceipt): boolean {
+    return (
+      this.reason === other.reason &&
+      this.actionClass === other.actionClass &&
+      this.targetService === other.targetService
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vault
+// ---------------------------------------------------------------------------
+
+const NAME_RE = /^[A-Za-z0-9_.\-]{1,128}$/;
+
+export interface CredentialVaultOptions {
+  /** Optional filesystem path for encrypted persistence. */
+  persistPath?: string;
+  /** AES-256-GCM key (exactly 32 bytes). Required when `persistPath` is set. */
+  encryptionKey?: Uint8Array;
+}
+
+/**
+ * Encrypted-at-rest credential store and scoped resolver.
+ *
+ * Exposes two surfaces:
+ *
+ * - **Admin** (`put`, `rotate`, `delete`, `listHandles`, `registerProfile`)
+ *   — for operators provisioning credentials.
+ * - **Resolver** (`checkAccess`, `_resolveInternal`) — for the injector.
+ *   Agents are never expected to call these directly.
+ */
+export class CredentialVault {
+  private readonly records = new Map<string, CredentialRecord>();
+  private readonly profiles = new Map<string, CredentialProfile>();
+  private readonly _audit: VaultAuditEvent[] = [];
+  private readonly persistPath: string | null;
+  private readonly key: Uint8Array | null;
+  private loaded = false;
+
+  constructor(options: CredentialVaultOptions = {}) {
+    this.persistPath = options.persistPath ?? null;
+    this.key = options.encryptionKey ?? null;
+
+    if (this.persistPath !== null) {
+      if (this.key === null) {
+        throw new TypeError('encryptionKey is required when persistPath is set');
+      }
+      if (this.key.length !== KEY_LENGTH) {
+        throw new TypeError(`encryptionKey must be exactly ${KEY_LENGTH} bytes`);
+      }
+    }
+  }
+
+  /** Generate a fresh AES-256-GCM key (32 random bytes). */
+  static generateKey(): Uint8Array {
+    return randomBytes(KEY_LENGTH);
+  }
+
+  /** Load persisted records from disk. Idempotent. */
+  async load(): Promise<void> {
+    if (this.loaded || this.persistPath === null) {
+      this.loaded = true;
+      return;
+    }
+    try {
+      const buf = await fs.readFile(this.persistPath);
+      if (buf.length === 0) {
+        this.loaded = true;
+        return;
+      }
+      const decoded = this.decrypt(new Uint8Array(buf));
+      const payload = JSON.parse(new TextDecoder().decode(decoded)) as {
+        records?: CredentialRecord[];
+      };
+      for (const r of payload.records ?? []) {
+        this.records.set(r.name, r);
+      }
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw err;
+      }
+    }
+    this.loaded = true;
+  }
+
+  // -- Admin surface ------------------------------------------------------
+
+  async put(name: string, value: string, credType = 'secret'): Promise<CredentialHandle> {
+    if (!NAME_RE.test(name)) {
+      throw new TypeError('Credential name must match [A-Za-z0-9_.-]{1,128}');
+    }
+    await this.load();
+    const existing = this.records.get(name);
+    const now = Date.now() / 1000;
+    const record: CredentialRecord = {
+      name,
+      value,
+      credType,
+      version: existing ? existing.version + 1 : 1,
+      createdAt: existing ? existing.createdAt : now,
+      rotatedAt: existing ? now : null,
+    };
+    this.records.set(name, record);
+    await this.flush();
+    return new CredentialHandle(name);
+  }
+
+  async rotate(name: string, newValue: string): Promise<CredentialHandle> {
+    await this.load();
+    const old = this.records.get(name);
+    if (!old) {
+      throw new CredentialError(`unknown credential: ${name}`);
+    }
+    const updated: CredentialRecord = {
+      ...old,
+      value: newValue,
+      version: old.version + 1,
+      rotatedAt: Date.now() / 1000,
+    };
+    this.records.set(name, updated);
+    await this.flush();
+    return new CredentialHandle(name);
+  }
+
+  async delete(name: string): Promise<boolean> {
+    await this.load();
+    const present = this.records.delete(name);
+    if (present) {
+      await this.flush();
+    }
+    return present;
+  }
+
+  async listHandles(): Promise<string[]> {
+    await this.load();
+    return [...this.records.keys()].sort();
+  }
+
+  async getMetadata(name: string): Promise<Omit<CredentialRecord, 'value'> | null> {
+    await this.load();
+    const r = this.records.get(name);
+    if (!r) return null;
+    const { value: _ignored, ...meta } = r;
+    return meta;
+  }
+
+  registerProfile(profile: CredentialProfile): void {
+    this.profiles.set(profile.agentDid, profile);
+  }
+
+  revokeProfile(agentDid: string): boolean {
+    return this.profiles.delete(agentDid);
+  }
+
+  // -- Resolver surface ---------------------------------------------------
+
+  /** True iff `agentDid` may use `handleName` for `actionClass`. */
+  checkAccess(agentDid: string, handleName: string, actionClass: string): boolean {
+    const profile = this.profiles.get(agentDid);
+    if (!profile) return false;
+    const bound = profile.capabilityFor(actionClass);
+    if (bound === undefined || bound !== handleName) return false;
+    return this.records.has(handleName);
+  }
+
+  /**
+   * Internal: resolve a credential value and emit an audit event.
+   * Returns `[value, event]`; on deny `value` is null.
+   *
+   * Callers must ensure `value` never crosses the agent trust boundary.
+   * Use {@link CredentialInjector} rather than calling this directly.
+   */
+  _resolveInternal(
+    agentDid: string,
+    handleName: string,
+    actionClass: string,
+    targetService: string,
+    policyVersion: string,
+  ): [string | null, VaultAuditEvent] {
+    const allowed = this.checkAccess(agentDid, handleName, actionClass);
+    if (allowed) {
+      const value = this.records.get(handleName)!.value;
+      const event: VaultAuditEvent = {
+        timestamp: Date.now() / 1000,
+        agentDid,
+        handleName,
+        targetService,
+        actionClass,
+        decision: 'allow',
+        policyVersion,
+        reason: '',
+      };
+      this._audit.push(event);
+      return [value, event];
+    }
+    const event: VaultAuditEvent = {
+      timestamp: Date.now() / 1000,
+      agentDid,
+      handleName,
+      targetService,
+      actionClass,
+      decision: 'deny',
+      policyVersion,
+      reason: DENY_REASON,
+    };
+    this._audit.push(event);
+    return [null, event];
+  }
+
+  /** Immutable snapshot of audit events. */
+  auditLog(): readonly VaultAuditEvent[] {
+    return [...this._audit];
+  }
+
+  clearAudit(): void {
+    this._audit.length = 0;
+  }
+
+  // Internal helper for the injector to append an audit event when a
+  // request is rejected before any vault read happens (out-of-scope
+  // placeholder or policy deny).
+  _recordReject(event: VaultAuditEvent): void {
+    this._audit.push(event);
+  }
+
+  // -- Persistence --------------------------------------------------------
+
+  private async flush(): Promise<void> {
+    if (this.persistPath === null || this.key === null) return;
+    const payload = JSON.stringify({ records: [...this.records.values()] });
+    const ciphertext = this.encrypt(utf8ToBytes(payload));
+    const tmp = `${this.persistPath}.tmp`;
+    await fs.mkdir(path.dirname(this.persistPath) || '.', { recursive: true });
+    await fs.writeFile(tmp, ciphertext);
+    await fs.rename(tmp, this.persistPath);
+  }
+
+  private encrypt(plaintext: Uint8Array): Uint8Array {
+    if (this.key === null) throw new CredentialError('no encryption key');
+    const nonce = randomBytes(NONCE_LENGTH);
+    const ct = gcm(this.key, nonce).encrypt(plaintext);
+    const out = new Uint8Array(NONCE_LENGTH + ct.length);
+    out.set(nonce, 0);
+    out.set(ct, NONCE_LENGTH);
+    return out;
+  }
+
+  private decrypt(blob: Uint8Array): Uint8Array {
+    if (this.key === null) throw new CredentialError('no encryption key');
+    if (blob.length < NONCE_LENGTH) {
+      throw new CredentialError('persisted vault is corrupt (too short)');
+    }
+    const nonce = blob.slice(0, NONCE_LENGTH);
+    const ct = blob.slice(NONCE_LENGTH);
+    return gcm(this.key, nonce).decrypt(ct);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Injector
+// ---------------------------------------------------------------------------
+
+export interface InjectionContext {
+  readonly agentDid: string;
+  readonly actionClass: string;
+  readonly targetService: string;
+  readonly requestedHandles: readonly string[];
+  readonly policyVersion: string;
+}
+
+export interface PolicyOutcome {
+  readonly allow: boolean;
+  readonly reason?: string;
+}
+
+export type PolicyCheck = (ctx: InjectionContext) => PolicyOutcome | Promise<PolicyOutcome>;
+
+export interface InjectionResult<T> {
+  readonly allowed: boolean;
+  readonly payload: T | DenyReceipt;
+  readonly denyReceipt: DenyReceipt | null;
+  readonly auditEvents: readonly VaultAuditEvent[];
+}
+
+export interface InjectionOptions {
+  actionClass: string;
+  targetService: string;
+  allowedHandles: Iterable<string>;
+  policyVersion?: string;
+  policyCheck?: PolicyCheck;
+}
+
+/**
+ * Render `{{cred:NAME}}` placeholders into HTTP, MCP, and env payloads.
+ *
+ * The injector is the *only* component that ever holds resolved credential
+ * values, and only long enough to render an outbound payload.
+ *
+ * For every injection call:
+ *
+ * - `allowedHandles` is the workflow-policy allowlist of handle names
+ *   eligible for substitution on this call. A placeholder whose name is
+ *   not in this set causes the entire call to be denied — this is the
+ *   "MCP server metadata is untrusted" boundary.
+ * - `policyCheck` is invoked *before* any value is read from the vault.
+ * - On any deny, `payload` is a {@link DenyReceipt} (deterministic shape).
+ */
+export class CredentialInjector {
+  constructor(private readonly vault: CredentialVault) {}
+
+  async injectHeaders(
+    agentDid: string,
+    headers: Record<string, string>,
+    opts: InjectionOptions,
+  ): Promise<InjectionResult<Record<string, string>>> {
+    return this._inject<Record<string, string>>(agentDid, { ...headers }, opts);
+  }
+
+  async injectToolArgs<T>(
+    agentDid: string,
+    args: T,
+    opts: InjectionOptions,
+  ): Promise<InjectionResult<T>> {
+    return this._inject<T>(agentDid, args, opts);
+  }
+
+  async injectEnv(
+    agentDid: string,
+    env: Record<string, string>,
+    opts: InjectionOptions,
+  ): Promise<InjectionResult<Record<string, string>>> {
+    return this._inject<Record<string, string>>(agentDid, { ...env }, opts);
+  }
+
+  private async _inject<T>(
+    agentDid: string,
+    payload: T,
+    opts: InjectionOptions,
+  ): Promise<InjectionResult<T>> {
+    const allowlist = new Set(opts.allowedHandles);
+    const requested = collectPlaceholders(payload);
+    const policyVersion = opts.policyVersion ?? 'v0';
+
+    // 1. Reject anything outside the workflow-supplied allowlist.
+    const outside = [...requested].filter(n => !allowlist.has(n));
+    if (outside.length > 0) {
+      const event: VaultAuditEvent = {
+        timestamp: Date.now() / 1000,
+        agentDid,
+        handleName: outside[0],
+        targetService: opts.targetService,
+        actionClass: opts.actionClass,
+        decision: 'deny',
+        policyVersion,
+        reason: DENY_REASON,
+      };
+      this.vault._recordReject(event);
+      const receipt = new DenyReceipt({
+        actionClass: opts.actionClass,
+        targetService: opts.targetService,
+      });
+      return { allowed: false, payload: receipt, denyReceipt: receipt, auditEvents: [event] };
+    }
+
+    // 2. Run policy *before* any vault read.
+    if (opts.policyCheck) {
+      const ctx: InjectionContext = {
+        agentDid,
+        actionClass: opts.actionClass,
+        targetService: opts.targetService,
+        requestedHandles: [...requested].sort(),
+        policyVersion,
+      };
+      const outcome = await opts.policyCheck(ctx);
+      if (!outcome.allow) {
+        const event: VaultAuditEvent = {
+          timestamp: Date.now() / 1000,
+          agentDid,
+          handleName: [...requested][0] ?? '',
+          targetService: opts.targetService,
+          actionClass: opts.actionClass,
+          decision: 'deny',
+          policyVersion,
+          reason: DENY_REASON,
+        };
+        this.vault._recordReject(event);
+        const receipt = new DenyReceipt({
+          actionClass: opts.actionClass,
+          targetService: opts.targetService,
+        });
+        return { allowed: false, payload: receipt, denyReceipt: receipt, auditEvents: [event] };
+      }
+    }
+
+    // 3. Resolve. Any single deny aborts the whole call.
+    const resolved = new Map<string, string>();
+    const events: VaultAuditEvent[] = [];
+    for (const name of requested) {
+      const [value, ev] = this.vault._resolveInternal(
+        agentDid,
+        name,
+        opts.actionClass,
+        opts.targetService,
+        policyVersion,
+      );
+      events.push(ev);
+      if (value === null) {
+        const receipt = new DenyReceipt({
+          actionClass: opts.actionClass,
+          targetService: opts.targetService,
+        });
+        return { allowed: false, payload: receipt, denyReceipt: receipt, auditEvents: events };
+      }
+      resolved.set(name, value);
+    }
+
+    const rendered = substitute(payload, resolved) as T;
+    return { allowed: true, payload: rendered, denyReceipt: null, auditEvents: events };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder helpers
+// ---------------------------------------------------------------------------
+
+function collectPlaceholders(payload: unknown): Set<string> {
+  const out = new Set<string>();
+  walk(payload, s => {
+    PLACEHOLDER_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = PLACEHOLDER_RE.exec(s)) !== null) {
+      out.add(m[1]);
+    }
+  });
+  return out;
+}
+
+function substitute(payload: unknown, resolved: ReadonlyMap<string, string>): unknown {
+  return mapStrings(payload, s =>
+    s.replace(PLACEHOLDER_RE, (match, name) => resolved.get(name) ?? match),
+  );
+}
+
+function walk(payload: unknown, visit: (s: string) => void): void {
+  if (typeof payload === 'string') {
+    visit(payload);
+  } else if (Array.isArray(payload)) {
+    for (const item of payload) walk(item, visit);
+  } else if (payload && typeof payload === 'object') {
+    for (const [k, v] of Object.entries(payload)) {
+      visit(k);
+      walk(v, visit);
+    }
+  }
+}
+
+function mapStrings(payload: unknown, fn: (s: string) => string): unknown {
+  if (typeof payload === 'string') return fn(payload);
+  if (Array.isArray(payload)) return payload.map(v => mapStrings(v, fn));
+  if (payload && typeof payload === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(payload)) {
+      out[fn(k)] = mapStrings(v, fn);
+    }
+    return out;
+  }
+  return payload;
+}
+
+// ---------------------------------------------------------------------------
+// Audit-log integrity helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable HMAC-SHA256 digest of an audit-event sequence.
+ *
+ * The digest covers handle names and decisions but never resolved
+ * credential values (the vault never stores them in events).
+ */
+export function auditDigest(events: readonly VaultAuditEvent[], key: Uint8Array): string {
+  const h = hmac.create(sha256, key);
+  for (const ev of events) {
+    const json = JSON.stringify({
+      timestamp: ev.timestamp,
+      agentDid: ev.agentDid,
+      handleName: ev.handleName,
+      targetService: ev.targetService,
+      actionClass: ev.actionClass,
+      decision: ev.decision,
+      policyVersion: ev.policyVersion,
+      reason: ev.reason,
+    });
+    h.update(utf8ToBytes(json));
+    h.update(new Uint8Array([0x1f]));
+  }
+  return bytesToHex(h.digest());
+}

--- a/agent-governance-typescript/src/index.ts
+++ b/agent-governance-typescript/src/index.ts
@@ -23,6 +23,29 @@ export { ShadowDiscovery } from './discovery';
 export { CedarBackend } from './policy-backends/cedar';
 export { OPABackend } from './policy-backends/opa';
 export { PromptDefenseEvaluator } from './prompt-defense';
+// Credential Vault & Injection (issue #2535 / #2481)
+export {
+  CredentialVault,
+  CredentialInjector,
+  CredentialHandle,
+  CredentialProfile,
+  CredentialError,
+  DenyReceipt,
+  auditDigest,
+  PLACEHOLDER_RE,
+  DENY_REASON,
+} from './credential-vault';
+export type {
+  CredentialDecision,
+  CredentialRecord,
+  CredentialVaultOptions,
+  VaultAuditEvent,
+  InjectionContext,
+  InjectionOptions,
+  InjectionResult,
+  PolicyOutcome,
+  PolicyCheck,
+} from './credential-vault';
 export { RingEnforcer, RingBreachError } from './rings';
 export { GovernanceVerifier } from './verify';
 export { SurfaceParityChecker } from './surface-parity';

--- a/agent-governance-typescript/tests/credential-vault.test.ts
+++ b/agent-governance-typescript/tests/credential-vault.test.ts
@@ -1,0 +1,415 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  CredentialInjector,
+  CredentialProfile,
+  CredentialVault,
+  DENY_REASON,
+  DenyReceipt,
+  InjectionContext,
+  PLACEHOLDER_RE,
+  PolicyOutcome,
+  VaultAuditEvent,
+  auditDigest,
+} from '../src/credential-vault';
+
+describe('CredentialVault — admin surface', () => {
+  let vault: CredentialVault;
+  beforeEach(async () => {
+    vault = new CredentialVault();
+    await vault.put('github_pat', 'ghp_real_secret_value_xyz', 'bearer_token');
+    await vault.put('db_password', 'p@ss-w0rd!', 'password');
+  });
+
+  it('put returns a handle and stable placeholder', async () => {
+    const h = await vault.put('k1', 'v1');
+    expect(h.name).toBe('k1');
+    expect(h.placeholder()).toBe('{{cred:k1}}');
+  });
+
+  it('rejects bad names', async () => {
+    await expect(vault.put('', 'v')).rejects.toThrow();
+    await expect(vault.put('bad name', 'v')).rejects.toThrow();
+    await expect(vault.put('a'.repeat(200), 'v')).rejects.toThrow();
+  });
+
+  it('listHandles never returns values', async () => {
+    const names = await vault.listHandles();
+    expect(names).toEqual(['db_password', 'github_pat']);
+    for (const n of names) {
+      const meta = await vault.getMetadata(n);
+      expect(meta).not.toBeNull();
+      expect(JSON.stringify(meta)).not.toContain('ghp_real');
+    }
+  });
+
+  it('rotate preserves handle name and bumps version', async () => {
+    const before = await vault.getMetadata('github_pat');
+    expect(before!.version).toBe(1);
+    const h = await vault.rotate('github_pat', 'ghp_new');
+    const after = await vault.getMetadata('github_pat');
+    expect(h.name).toBe('github_pat');
+    expect(after!.version).toBe(2);
+    expect(after!.rotatedAt).not.toBeNull();
+  });
+
+  it('rotate unknown throws', async () => {
+    await expect(vault.rotate('nope', 'x')).rejects.toThrow();
+  });
+
+  it('delete returns presence flag', async () => {
+    const first = await vault.delete('db_password');
+    const second = await vault.delete('db_password');
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+});
+
+describe('Scoping', () => {
+  let vault: CredentialVault;
+  beforeEach(async () => {
+    vault = new CredentialVault();
+    await vault.put('github_pat', 'GHP-VALUE');
+    await vault.put('db_password', 'DB-VALUE');
+    vault.registerProfile(
+      new CredentialProfile('did:web:agent-ci', {
+        'github:read_issues': 'github_pat',
+        'github:push_code': 'github_pat',
+      }),
+    );
+    vault.registerProfile(
+      new CredentialProfile('did:web:agent-analytics', { 'db:query': 'db_password' }),
+    );
+  });
+
+  it('allows bound action', () => {
+    expect(vault.checkAccess('did:web:agent-ci', 'github_pat', 'github:read_issues')).toBe(true);
+  });
+
+  it('denies unknown agent', () => {
+    expect(vault.checkAccess('did:web:rogue', 'github_pat', 'github:read_issues')).toBe(false);
+  });
+
+  it('denies unbound action', () => {
+    expect(vault.checkAccess('did:web:agent-ci', 'db_password', 'db:query')).toBe(false);
+  });
+
+  it('denies cross-action reuse (action-class scoping, not just agent)', () => {
+    expect(vault.checkAccess('did:web:agent-analytics', 'db_password', 'db:admin')).toBe(false);
+  });
+
+  it('profile bindings are isolated from caller mutation', () => {
+    const bindings: Record<string, string> = { a: 'h' };
+    const p = new CredentialProfile('did:web:x', bindings);
+    bindings.a = 'other';
+    expect(p.capabilityFor('a')).toBe('h');
+  });
+});
+
+describe('Injection', () => {
+  let vault: CredentialVault;
+  let injector: CredentialInjector;
+  beforeEach(async () => {
+    vault = new CredentialVault();
+    await vault.put('github_pat', 'GHP-RESOLVED-VALUE');
+    await vault.put('db_password', 'DBP-VALUE');
+    vault.registerProfile(
+      new CredentialProfile('did:web:agent-ci', {
+        'github:read_issues': 'github_pat',
+        'github:push_code': 'github_pat',
+      }),
+    );
+    vault.registerProfile(
+      new CredentialProfile('did:web:agent-analytics', { 'db:query': 'db_password' }),
+    );
+    injector = new CredentialInjector(vault);
+  });
+
+  it('renders headers on the happy path', async () => {
+    const r = await injector.injectHeaders(
+      'did:web:agent-ci',
+      { Authorization: 'Bearer {{cred:github_pat}}', Accept: 'application/json' },
+      {
+        actionClass: 'github:read_issues',
+        targetService: 'api.github.com',
+        allowedHandles: ['github_pat'],
+        policyVersion: 'v1',
+      },
+    );
+    expect(r.allowed).toBe(true);
+    expect((r.payload as Record<string, string>).Authorization).toBe('Bearer GHP-RESOLVED-VALUE');
+    expect(r.denyReceipt).toBeNull();
+    expect(r.auditEvents).toHaveLength(1);
+    expect(r.auditEvents[0].decision).toBe('allow');
+  });
+
+  it('renders nested tool args without mutating the original', async () => {
+    const args = {
+      repo: 'octo/hello',
+      secrets: ['{{cred:github_pat}}', 'literal'],
+      nested: { token: '{{cred:github_pat}}' },
+    };
+    const r = await injector.injectToolArgs('did:web:agent-ci', args, {
+      actionClass: 'github:push_code',
+      targetService: 'api.github.com',
+      allowedHandles: ['github_pat'],
+    });
+    expect(r.allowed).toBe(true);
+    const out = r.payload as typeof args;
+    expect(out.secrets[0]).toBe('GHP-RESOLVED-VALUE');
+    expect(out.nested.token).toBe('GHP-RESOLVED-VALUE');
+    expect(args.secrets[0]).toBe('{{cred:github_pat}}');
+  });
+
+  it('renders env vars', async () => {
+    const r = await injector.injectEnv(
+      'did:web:agent-ci',
+      { PATH: '/usr/bin', GITHUB_TOKEN: '{{cred:github_pat}}' },
+      { actionClass: 'github:read_issues', targetService: 'subprocess', allowedHandles: ['github_pat'] },
+    );
+    expect(r.allowed).toBe(true);
+    expect((r.payload as Record<string, string>).GITHUB_TOKEN).toBe('GHP-RESOLVED-VALUE');
+  });
+
+  it('denies a whole call when an unauthorized placeholder appears (MCP untrusted)', async () => {
+    const r = await injector.injectToolArgs(
+      'did:web:agent-analytics',
+      { sql: 'SELECT 1', auth: '{{cred:github_pat}}' },
+      { actionClass: 'db:query', targetService: 'pg', allowedHandles: ['db_password'] },
+    );
+    expect(r.allowed).toBe(false);
+    expect(r.payload).toBeInstanceOf(DenyReceipt);
+    expect((r.payload as DenyReceipt).reason).toBe(DENY_REASON);
+  });
+
+  it('returns identical deny for missing vs out-of-scope handle', async () => {
+    const missing = await injector.injectHeaders(
+      'did:web:agent-ci',
+      { X: '{{cred:does_not_exist}}' },
+      {
+        actionClass: 'github:read_issues',
+        targetService: 'svc',
+        allowedHandles: ['does_not_exist'],
+      },
+    );
+    const outOfScope = await injector.injectHeaders(
+      'did:web:agent-ci',
+      { X: '{{cred:db_password}}' },
+      {
+        actionClass: 'github:read_issues',
+        targetService: 'svc',
+        allowedHandles: ['db_password'],
+      },
+    );
+    expect(missing.allowed).toBe(false);
+    expect(outOfScope.allowed).toBe(false);
+    expect(missing.denyReceipt!.equals(outOfScope.denyReceipt!)).toBe(true);
+  });
+
+  it('runs policyCheck before any vault read', async () => {
+    const seen: InjectionContext[] = [];
+    const policy = (ctx: InjectionContext): PolicyOutcome => {
+      seen.push(ctx);
+      return { allow: false, reason: 'workflow denied' };
+    };
+    const r = await injector.injectHeaders(
+      'did:web:agent-ci',
+      { Authorization: 'Bearer {{cred:github_pat}}' },
+      {
+        actionClass: 'github:push_code',
+        targetService: 'api.github.com',
+        allowedHandles: ['github_pat'],
+        policyCheck: policy,
+        policyVersion: 'v7',
+      },
+    );
+    expect(r.allowed).toBe(false);
+    expect(seen[0].requestedHandles).toEqual(['github_pat']);
+    expect(seen[0].policyVersion).toBe('v7');
+  });
+
+  it('produces the same deny across headers/args/env surfaces', async () => {
+    const opts = {
+      actionClass: 'db:query',
+      targetService: 'svc',
+      allowedHandles: ['github_pat'],
+    };
+    const h = await injector.injectHeaders(
+      'did:web:agent-analytics',
+      { Authorization: '{{cred:github_pat}}' },
+      opts,
+    );
+    const a = await injector.injectToolArgs(
+      'did:web:agent-analytics',
+      { x: '{{cred:github_pat}}' },
+      opts,
+    );
+    const e = await injector.injectEnv(
+      'did:web:agent-analytics',
+      { TOKEN: '{{cred:github_pat}}' },
+      opts,
+    );
+    for (const r of [h, a, e]) {
+      expect(r.allowed).toBe(false);
+      expect(r.denyReceipt!.reason).toBe(DENY_REASON);
+    }
+  });
+
+  it('passes through payloads with no placeholders', async () => {
+    const r = await injector.injectHeaders(
+      'did:web:agent-ci',
+      { Accept: 'application/json' },
+      { actionClass: 'github:read_issues', targetService: 'svc', allowedHandles: [] },
+    );
+    expect(r.allowed).toBe(true);
+    expect(r.payload).toEqual({ Accept: 'application/json' });
+  });
+});
+
+describe('Audit log', () => {
+  let vault: CredentialVault;
+  let injector: CredentialInjector;
+  beforeEach(async () => {
+    vault = new CredentialVault();
+    await vault.put('github_pat', 'GHP-RESOLVED-VALUE');
+    vault.registerProfile(
+      new CredentialProfile('did:web:agent-ci', { 'github:read_issues': 'github_pat' }),
+    );
+    injector = new CredentialInjector(vault);
+  });
+
+  it('records allow events without leaking the value', async () => {
+    await injector.injectHeaders(
+      'did:web:agent-ci',
+      { Authorization: 'Bearer {{cred:github_pat}}' },
+      {
+        actionClass: 'github:read_issues',
+        targetService: 'api.github.com',
+        allowedHandles: ['github_pat'],
+        policyVersion: 'v1',
+      },
+    );
+    const events = vault.auditLog();
+    expect(events).toHaveLength(1);
+    expect(events[0].decision).toBe('allow');
+    expect(events[0].handleName).toBe('github_pat');
+    expect(events[0].policyVersion).toBe('v1');
+    expect(JSON.stringify(events)).not.toContain('GHP-RESOLVED-VALUE');
+  });
+
+  it('records deny events for unauthorized agents', async () => {
+    await injector.injectHeaders(
+      'did:web:rogue',
+      { Authorization: 'Bearer {{cred:github_pat}}' },
+      {
+        actionClass: 'github:read_issues',
+        targetService: 'api.github.com',
+        allowedHandles: ['github_pat'],
+      },
+    );
+    const events = vault.auditLog();
+    expect(events.some((e: VaultAuditEvent) => e.decision === 'deny')).toBe(true);
+  });
+
+  it('auditDigest is stable and key-dependent', async () => {
+    await injector.injectHeaders(
+      'did:web:agent-ci',
+      { Authorization: 'Bearer {{cred:github_pat}}' },
+      {
+        actionClass: 'github:read_issues',
+        targetService: 'api.github.com',
+        allowedHandles: ['github_pat'],
+      },
+    );
+    const events = vault.auditLog();
+    const k1 = new TextEncoder().encode('k');
+    const k2 = new TextEncoder().encode('other');
+    expect(auditDigest(events, k1)).toBe(auditDigest(events, k1));
+    expect(auditDigest(events, k1)).not.toBe(auditDigest(events, k2));
+  });
+});
+
+describe('Rotation', () => {
+  it('does not require prompt changes', async () => {
+    const vault = new CredentialVault();
+    await vault.put('github_pat', 'GHP-V1');
+    vault.registerProfile(
+      new CredentialProfile('did:web:agent-ci', { 'github:read_issues': 'github_pat' }),
+    );
+    const injector = new CredentialInjector(vault);
+    const saved = { Authorization: 'Bearer {{cred:github_pat}}' };
+
+    const before = await injector.injectHeaders('did:web:agent-ci', saved, {
+      actionClass: 'github:read_issues',
+      targetService: 'svc',
+      allowedHandles: ['github_pat'],
+    });
+    expect((before.payload as Record<string, string>).Authorization).toBe('Bearer GHP-V1');
+
+    await vault.rotate('github_pat', 'GHP-V2');
+
+    const after = await injector.injectHeaders('did:web:agent-ci', saved, {
+      actionClass: 'github:read_issues',
+      targetService: 'svc',
+      allowedHandles: ['github_pat'],
+    });
+    expect((after.payload as Record<string, string>).Authorization).toBe('Bearer GHP-V2');
+    expect(saved.Authorization).toBe('Bearer {{cred:github_pat}}');
+  });
+});
+
+describe('Encrypted persistence', () => {
+  it('round-trips via AES-256-GCM, distinctive plaintext not on disk', async () => { // gitleaks:allow
+    const key = CredentialVault.generateKey();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-'));
+    const file = path.join(tmpDir, 'vault.bin');
+    const secret = 'distinctive rotated fixture not a real key'; // gitleaks:allow
+
+    const v1 = new CredentialVault({ persistPath: file, encryptionKey: key });
+    await v1.put('k', 'original');
+    await v1.rotate('k', secret);
+
+    const blob = await fs.readFile(file);
+    expect(blob.includes(Buffer.from(secret))).toBe(false);
+    expect(blob.includes(Buffer.from('"value"'))).toBe(false);
+
+    const v2 = new CredentialVault({ persistPath: file, encryptionKey: key });
+    const names = await v2.listHandles();
+    expect(names).toEqual(['k']);
+    const meta = await v2.getMetadata('k');
+    expect(meta!.version).toBe(2);
+  });
+
+  it('refuses persistence without a key', () => {
+    expect(
+      () => new CredentialVault({ persistPath: '/tmp/x.bin' }),
+    ).toThrow();
+  });
+
+  it('refuses persistence with wrong-length key', () => {
+    expect(
+      () => new CredentialVault({ persistPath: '/tmp/x.bin', encryptionKey: new Uint8Array(16) }),
+    ).toThrow();
+  });
+});
+
+describe('Placeholder regex', () => {
+  it('matches expected forms', () => {
+    const find = (s: string): string[] => {
+      const out: string[] = [];
+      PLACEHOLDER_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = PLACEHOLDER_RE.exec(s)) !== null) out.push(m[1]);
+      return out;
+    };
+    expect(find('{{cred:abc}}')).toEqual(['abc']);
+    expect(find('{{ cred:a.b-c_1 }}')).toEqual(['a.b-c_1']);
+    expect(find('Bearer {{cred:x}} and {{cred:y}}')).toEqual(['x', 'y']);
+    expect(find('{{cred:has space}}')).toEqual([]);
+    expect(find('{{cred:bad/slash}}')).toEqual([]);
+  });
+});

--- a/agent-governance-typescript/tests/key-prefix.test.ts
+++ b/agent-governance-typescript/tests/key-prefix.test.ts
@@ -72,11 +72,11 @@ describe('safeBase64Decode', () => {
 
 describe('AgentIdentity.fromJSON with prefixed keys', () => {
   let identity: AgentIdentity;
-  let json: ReturnType<AgentIdentity['toJSON']>;
+  let json: ReturnType<AgentIdentity['exportJSON']>;
 
   beforeEach(() => {
     identity = AgentIdentity.generate('prefix-test', ['read']);
-    json = identity.toJSON();
+    json = identity.exportJSON();
   });
 
   it('round-trips with plain (unprefixed) base64 keys', () => {

--- a/scripts/ci/no-custom-crypto.sh
+++ b/scripts/ci/no-custom-crypto.sh
@@ -57,6 +57,7 @@ ADDED=$(git diff "$BASE_REF"...HEAD --diff-filter=ACMR -U0 -- \
   ':!agent-governance-dotnet/**' \
   ':!agent-governance-golang/**' \
   ':!agent-governance-python/agent-os/src/agent_os/credential_vault.py' \
+  ':!agent-governance-typescript/src/credential-vault.ts' \
   ':!*test*' ':!*spec*' ':!ci/no-custom-crypto.sh' \
   | grep -E '^\+[^+]' || true)
 


### PR DESCRIPTION
## Summary

TypeScript port of the credential vault primitive landed for Python in #2481 / #2534. Part of #2535.

Agents reference secrets via opaque {{cred:NAME}} placeholders only; resolved values stay inside the trust boundary. Library-only -- gt cred remains the canonical CLI.

## Design parity with Python reference

| Property | TypeScript |
|------|------|
| Opaque handles, agents never see values | CredentialHandle |
| Encrypted at-rest | CredentialVault -- AES-256-GCM via @noble/ciphers |
| Per-DID + per-action-class scoping | CredentialProfile |
| Workflow policy runs before vault read | policyCheck callback in injection options |
| Allowlist-gated placeholders (MCP untrusted) | llowedHandles per call |
| Deterministic deny | DenyReceipt |
| Audit events without values | VaultAuditEvent, uditDigest |
| Rotation preserves handle name | CredentialVault.rotate() |
| HTTP / MCP / env injection surfaces | injectHeaders / injectToolArgs / injectEnv |

## Wire-format note

This SDK uses AES-256-GCM (12-byte random nonce prefixed to ciphertext). The Python SDK uses Fernet. The two persistence formats are not currently interchangeable -- the cross-language interop spec is the remaining sub-task on #2535.

## Changes

| File | What changed |
|------|------|
| gent-governance-typescript/src/credential-vault.ts | New module: vault, injector, profile, handle, deny receipt, audit digest. |
| gent-governance-typescript/src/index.ts | Re-export public surface. |
| gent-governance-typescript/tests/credential-vault.test.ts | 27 jest cases covering admin surface, scoping, injection across 3 surfaces, deterministic deny equivalence, policy-before-resolution ordering, audit value-freedom, rotation semantics, encrypted persistence round-trip, placeholder regex. |
| gent-governance-typescript/examples/credential-vault-example.ts | End-to-end runnable example. |
| scripts/ci/no-custom-crypto.sh | Add credential-vault.ts to the allowlist -- it is a designated security primitive. |

## Testing

- 
px jest tests/credential-vault.test.ts -- **27 passed**
- 
px tsc --noEmit -- clean
- 
px eslint src/credential-vault.ts tests/credential-vault.test.ts -- clean

## Follow-ups (still on #2535)

- .NET port
- Rust port
- Go port
- Cross-language interop spec (placeholder syntax, audit-event JSON shape, AES-GCM <-> Fernet bridge)

## References

- Tracking issue: #2535
- Python implementation: #2534
- Original design: #2481
