### PR TITLE
feat(golang): credential injection and offload (#2535)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -37,6 +37,12 @@ bypassable
 bytecodes
 caas
 caplog
+ciphertext
+Errorf
+Fatalf
+omitempty
+Submatch
+Unmarshal
 capsys
 carloshvp
 carryforward

--- a/agent-governance-golang/packages/agentmesh/credential_vault.go
+++ b/agent-governance-golang/packages/agentmesh/credential_vault.go
@@ -1,0 +1,812 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package agentmesh credential_vault.go — Credential vault, scoping, and
+// injection for agent tool calls.
+//
+// Go port of the Python `agent_os.credential_vault` primitive (issue
+// #2481, PR #2534). Tracking issue: #2535.
+//
+// Agents reference secrets via opaque {{cred:NAME}} placeholders only;
+// resolved values stay inside the trust boundary.
+//
+// Wire-format note: this SDK uses AES-256-GCM (crypto/aes + crypto/cipher)
+// with a 12-byte random nonce prefixed to the ciphertext. The Python SDK
+// uses Fernet. The two persistence formats are not currently interoperable
+// — the cross-language interop spec is tracked in #2535.
+package agentmesh
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+)
+
+// CredentialDenyReason is the stable string returned in audit/deny records when a request is refused.
+const CredentialDenyReason = "credential_denied"
+
+const (
+	credKeyLength   = 32
+	credNonceLength = 12
+)
+
+// CredentialPlaceholderRegex matches the credential placeholder syntax {{cred:NAME}}.
+var CredentialPlaceholderRegex = regexp.MustCompile(`\{\{\s*cred:([A-Za-z0-9_.\-]{1,128})\s*\}\}`)
+
+var credNameRegex = regexp.MustCompile(`^[A-Za-z0-9_.\-]{1,128}$`)
+
+// CredentialDecision is the outcome of a credential resolution attempt.
+type CredentialDecision string
+
+const (
+	// CredentialAllow means the request was allowed.
+	CredentialAllow CredentialDecision = "allow"
+	// CredentialDeny means the request was denied.
+	CredentialDeny CredentialDecision = "deny"
+)
+
+// Errors returned by the credential vault.
+var (
+	// ErrCredentialInvalidName is returned when a credential name fails validation.
+	ErrCredentialInvalidName = errors.New("invalid credential name: must match [A-Za-z0-9_.-]{1,128}")
+	// ErrCredentialUnknown is returned when the named credential does not exist.
+	ErrCredentialUnknown = errors.New("unknown credential")
+	// ErrCredentialKeyRequired is returned when a persistent vault is created without an encryption key.
+	ErrCredentialKeyRequired = errors.New("encryption key required when persistence is configured")
+	// ErrCredentialBadKeyLength is returned when the encryption key is not 32 bytes.
+	ErrCredentialBadKeyLength = fmt.Errorf("encryption key must be exactly %d bytes", credKeyLength)
+)
+
+// CredentialRecord is an internal credential entry. Never exposed to agents.
+type CredentialRecord struct {
+	Name      string   `json:"name"`
+	Value     string   `json:"value"`
+	CredType  string   `json:"credType"`
+	Version   int      `json:"version"`
+	CreatedAt float64  `json:"createdAt"`
+	RotatedAt *float64 `json:"rotatedAt,omitempty"`
+}
+
+// CredentialMetadata is the non-secret view of a credential.
+type CredentialMetadata struct {
+	Name      string   `json:"name"`
+	CredType  string   `json:"credType"`
+	Version   int      `json:"version"`
+	CreatedAt float64  `json:"createdAt"`
+	RotatedAt *float64 `json:"rotatedAt,omitempty"`
+}
+
+// CredentialHandle is the opaque handle an agent may reference.
+type CredentialHandle struct {
+	Name string
+}
+
+// Placeholder returns the {{cred:NAME}} placeholder for this handle.
+func (h CredentialHandle) Placeholder() string {
+	return "{{cred:" + h.Name + "}}"
+}
+
+// CredentialProfile binds action capabilities to credential handle names for one agent DID.
+type CredentialProfile struct {
+	AgentDID string
+	bindings map[string]string
+}
+
+// NewCredentialProfile creates a profile mapping action classes to handle names.
+func NewCredentialProfile(agentDID string, bindings map[string]string) *CredentialProfile {
+	copied := make(map[string]string, len(bindings))
+	for k, v := range bindings {
+		copied[k] = v
+	}
+	return &CredentialProfile{AgentDID: agentDID, bindings: copied}
+}
+
+// CapabilityFor returns the handle name bound to the action class, or "" if absent.
+func (p *CredentialProfile) CapabilityFor(actionClass string) string {
+	return p.bindings[actionClass]
+}
+
+// Bindings returns a copy of the capability bindings.
+func (p *CredentialProfile) Bindings() map[string]string {
+	out := make(map[string]string, len(p.bindings))
+	for k, v := range p.bindings {
+		out[k] = v
+	}
+	return out
+}
+
+// VaultAuditEvent is a single audit record. Contains agent identity, handle
+// name, target service, action class, decision, and policy version — but
+// never the resolved credential value.
+type VaultAuditEvent struct {
+	Timestamp     float64            `json:"timestamp"`
+	AgentDID      string             `json:"agentDid"`
+	HandleName    string             `json:"handleName"`
+	TargetService string             `json:"targetService"`
+	ActionClass   string             `json:"actionClass"`
+	Decision      CredentialDecision `json:"decision"`
+	PolicyVersion string             `json:"policyVersion"`
+	Reason        string             `json:"reason"`
+}
+
+// DenyReceipt is the deterministic deny output returned in place of a rendered payload.
+type DenyReceipt struct {
+	Reason        string `json:"reason"`
+	ActionClass   string `json:"actionClass"`
+	TargetService string `json:"targetService"`
+}
+
+func newDenyReceipt(actionClass, targetService string) DenyReceipt {
+	return DenyReceipt{
+		Reason:        CredentialDenyReason,
+		ActionClass:   actionClass,
+		TargetService: targetService,
+	}
+}
+
+// Equals reports whether two deny receipts have identical fields.
+func (d DenyReceipt) Equals(other DenyReceipt) bool {
+	return d.Reason == other.Reason &&
+		d.ActionClass == other.ActionClass &&
+		d.TargetService == other.TargetService
+}
+
+type credPersistPayload struct {
+	Records []CredentialRecord `json:"records"`
+}
+
+// CredentialVault is an encrypted-at-rest credential store and scoped resolver.
+type CredentialVault struct {
+	mu          sync.Mutex
+	records     map[string]CredentialRecord
+	profiles    map[string]*CredentialProfile
+	audit       []VaultAuditEvent
+	persistPath string
+	key         []byte
+	loaded      bool
+}
+
+// NewCredentialVault creates an in-memory vault.
+func NewCredentialVault() *CredentialVault {
+	return &CredentialVault{
+		records:  make(map[string]CredentialRecord),
+		profiles: make(map[string]*CredentialProfile),
+		loaded:   true,
+	}
+}
+
+// NewPersistentCredentialVault creates a vault with encrypted-at-rest persistence.
+func NewPersistentCredentialVault(persistPath string, encryptionKey []byte) (*CredentialVault, error) {
+	if persistPath == "" {
+		return nil, errors.New("persistPath must be non-empty")
+	}
+	if len(encryptionKey) != credKeyLength {
+		return nil, ErrCredentialBadKeyLength
+	}
+	keyCopy := make([]byte, credKeyLength)
+	copy(keyCopy, encryptionKey)
+	v := &CredentialVault{
+		records:     make(map[string]CredentialRecord),
+		profiles:    make(map[string]*CredentialProfile),
+		persistPath: persistPath,
+		key:         keyCopy,
+	}
+	if err := v.ensureLoaded(); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// GenerateCredentialKey generates a fresh AES-256-GCM key (32 random bytes).
+func GenerateCredentialKey() ([]byte, error) {
+	k := make([]byte, credKeyLength)
+	if _, err := io.ReadFull(rand.Reader, k); err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+// -- Admin surface ----------------------------------------------------------
+
+// Put stores or replaces a credential.
+func (v *CredentialVault) Put(name, value, credType string) (CredentialHandle, error) {
+	if !credNameRegex.MatchString(name) {
+		return CredentialHandle{}, ErrCredentialInvalidName
+	}
+	if err := v.ensureLoaded(); err != nil {
+		return CredentialHandle{}, err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	now := nowSeconds()
+	rec := CredentialRecord{
+		Name:     name,
+		Value:    value,
+		CredType: credType,
+		Version:  1,
+	}
+	if existing, ok := v.records[name]; ok {
+		rec.Version = existing.Version + 1
+		rec.CreatedAt = existing.CreatedAt
+		rotatedAt := now
+		rec.RotatedAt = &rotatedAt
+	} else {
+		rec.CreatedAt = now
+	}
+	v.records[name] = rec
+	if err := v.flushLocked(); err != nil {
+		return CredentialHandle{}, err
+	}
+	return CredentialHandle{Name: name}, nil
+}
+
+// Rotate rotates a credential's value while preserving the handle name.
+func (v *CredentialVault) Rotate(name, newValue string) (CredentialHandle, error) {
+	if err := v.ensureLoaded(); err != nil {
+		return CredentialHandle{}, err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	old, ok := v.records[name]
+	if !ok {
+		return CredentialHandle{}, fmt.Errorf("%w: %s", ErrCredentialUnknown, name)
+	}
+	rotatedAt := nowSeconds()
+	old.Value = newValue
+	old.Version++
+	old.RotatedAt = &rotatedAt
+	v.records[name] = old
+	if err := v.flushLocked(); err != nil {
+		return CredentialHandle{}, err
+	}
+	return CredentialHandle{Name: name}, nil
+}
+
+// Delete removes a credential. Returns true if it existed.
+func (v *CredentialVault) Delete(name string) (bool, error) {
+	if err := v.ensureLoaded(); err != nil {
+		return false, err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if _, ok := v.records[name]; !ok {
+		return false, nil
+	}
+	delete(v.records, name)
+	if err := v.flushLocked(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ListHandles returns all credential handle names.
+func (v *CredentialVault) ListHandles() ([]string, error) {
+	if err := v.ensureLoaded(); err != nil {
+		return nil, err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	names := make([]string, 0, len(v.records))
+	for k := range v.records {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Metadata returns non-secret metadata for a credential, or (nil, nil) if absent.
+func (v *CredentialVault) Metadata(name string) (*CredentialMetadata, error) {
+	if err := v.ensureLoaded(); err != nil {
+		return nil, err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	r, ok := v.records[name]
+	if !ok {
+		return nil, nil
+	}
+	return &CredentialMetadata{
+		Name:      r.Name,
+		CredType:  r.CredType,
+		Version:   r.Version,
+		CreatedAt: r.CreatedAt,
+		RotatedAt: r.RotatedAt,
+	}, nil
+}
+
+// RegisterProfile registers or replaces a per-agent profile.
+func (v *CredentialVault) RegisterProfile(p *CredentialProfile) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.profiles[p.AgentDID] = p
+}
+
+// RevokeProfile revokes a profile by agent DID. Returns true if it existed.
+func (v *CredentialVault) RevokeProfile(agentDID string) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if _, ok := v.profiles[agentDID]; ok {
+		delete(v.profiles, agentDID)
+		return true
+	}
+	return false
+}
+
+// -- Resolver surface -------------------------------------------------------
+
+// CheckAccess returns true iff agentDID may use handleName for actionClass.
+func (v *CredentialVault) CheckAccess(agentDID, handleName, actionClass string) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.checkAccessLocked(agentDID, handleName, actionClass)
+}
+
+func (v *CredentialVault) checkAccessLocked(agentDID, handleName, actionClass string) bool {
+	profile, ok := v.profiles[agentDID]
+	if !ok {
+		return false
+	}
+	bound := profile.CapabilityFor(actionClass)
+	if bound == "" || bound != handleName {
+		return false
+	}
+	_, present := v.records[handleName]
+	return present
+}
+
+// AuditLog returns a snapshot of audit events.
+func (v *CredentialVault) AuditLog() []VaultAuditEvent {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make([]VaultAuditEvent, len(v.audit))
+	copy(out, v.audit)
+	return out
+}
+
+// ClearAudit removes all audit events.
+func (v *CredentialVault) ClearAudit() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.audit = nil
+}
+
+func (v *CredentialVault) resolveInternal(
+	agentDID, handleName, actionClass, targetService, policyVersion string,
+) (string, bool, VaultAuditEvent) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	allowed := v.checkAccessLocked(agentDID, handleName, actionClass)
+	if allowed {
+		value := v.records[handleName].Value
+		ev := VaultAuditEvent{
+			Timestamp:     nowSeconds(),
+			AgentDID:      agentDID,
+			HandleName:    handleName,
+			TargetService: targetService,
+			ActionClass:   actionClass,
+			Decision:      CredentialAllow,
+			PolicyVersion: policyVersion,
+		}
+		v.audit = append(v.audit, ev)
+		return value, true, ev
+	}
+	ev := VaultAuditEvent{
+		Timestamp:     nowSeconds(),
+		AgentDID:      agentDID,
+		HandleName:    handleName,
+		TargetService: targetService,
+		ActionClass:   actionClass,
+		Decision:      CredentialDeny,
+		PolicyVersion: policyVersion,
+		Reason:        CredentialDenyReason,
+	}
+	v.audit = append(v.audit, ev)
+	return "", false, ev
+}
+
+func (v *CredentialVault) recordReject(ev VaultAuditEvent) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.audit = append(v.audit, ev)
+}
+
+// -- Persistence ------------------------------------------------------------
+
+func (v *CredentialVault) ensureLoaded() error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.loaded {
+		return nil
+	}
+	v.loaded = true
+	if v.persistPath == "" || v.key == nil {
+		return nil
+	}
+	blob, err := os.ReadFile(v.persistPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(blob) == 0 {
+		return nil
+	}
+	plaintext, err := credDecrypt(v.key, blob)
+	if err != nil {
+		return err
+	}
+	var payload credPersistPayload
+	if err := json.Unmarshal(plaintext, &payload); err != nil {
+		return err
+	}
+	for _, r := range payload.Records {
+		v.records[r.Name] = r
+	}
+	return nil
+}
+
+func (v *CredentialVault) flushLocked() error {
+	if v.persistPath == "" || v.key == nil {
+		return nil
+	}
+	records := make([]CredentialRecord, 0, len(v.records))
+	for _, r := range v.records {
+		records = append(records, r)
+	}
+	plaintext, err := json.Marshal(credPersistPayload{Records: records})
+	if err != nil {
+		return err
+	}
+	blob, err := credEncrypt(v.key, plaintext)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(v.persistPath)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	tmp := v.persistPath + ".tmp"
+	if err := os.WriteFile(tmp, blob, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, v.persistPath)
+}
+
+func credEncrypt(key, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, credNonceLength)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	ct := gcm.Seal(nil, nonce, plaintext, nil)
+	out := make([]byte, 0, len(nonce)+len(ct))
+	out = append(out, nonce...)
+	out = append(out, ct...)
+	return out, nil
+}
+
+func credDecrypt(key, blob []byte) ([]byte, error) {
+	if len(blob) < credNonceLength {
+		return nil, errors.New("persisted vault is corrupt (too short)")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce, ct := blob[:credNonceLength], blob[credNonceLength:]
+	return gcm.Open(nil, nonce, ct, nil)
+}
+
+func nowSeconds() float64 {
+	return float64(time.Now().UnixNano()) / 1e9
+}
+
+// -- Injector ---------------------------------------------------------------
+
+// InjectionContext is information presented to the workflow policy before resolution.
+type InjectionContext struct {
+	AgentDID         string
+	ActionClass      string
+	TargetService    string
+	RequestedHandles []string
+	PolicyVersion    string
+}
+
+// PolicyOutcome is the result returned by the workflow policy callback.
+type PolicyOutcome struct {
+	Allow  bool
+	Reason string
+}
+
+// PolicyCheck is the workflow-policy callback type.
+type PolicyCheck func(ctx InjectionContext) PolicyOutcome
+
+// InjectionResult is the outcome of an injection call.
+type InjectionResult struct {
+	Allowed     bool
+	Payload     interface{}
+	DenyReceipt *DenyReceipt
+	AuditEvents []VaultAuditEvent
+}
+
+// InjectionOptions are options for an injection call.
+type InjectionOptions struct {
+	ActionClass    string
+	TargetService  string
+	AllowedHandles []string
+	PolicyVersion  string
+	PolicyCheck    PolicyCheck
+}
+
+// CredentialInjector renders {{cred:NAME}} placeholders into HTTP, MCP, and env payloads.
+//
+// The injector is the only component that ever holds resolved credential
+// values, and only long enough to render an outbound payload.
+type CredentialInjector struct {
+	vault *CredentialVault
+}
+
+// NewCredentialInjector constructs an injector backed by the given vault.
+func NewCredentialInjector(v *CredentialVault) *CredentialInjector {
+	return &CredentialInjector{vault: v}
+}
+
+// InjectHeaders renders placeholders in an HTTP header map.
+func (i *CredentialInjector) InjectHeaders(
+	agentDID string, headers map[string]string, opts InjectionOptions,
+) InjectionResult {
+	clone := make(map[string]string, len(headers))
+	for k, v := range headers {
+		clone[k] = v
+	}
+	return i.inject(agentDID, clone, opts)
+}
+
+// InjectToolArgs renders placeholders in MCP tool arguments (nested map/slice/string).
+func (i *CredentialInjector) InjectToolArgs(
+	agentDID string, args interface{}, opts InjectionOptions,
+) InjectionResult {
+	return i.inject(agentDID, args, opts)
+}
+
+// InjectEnv renders placeholders in a subprocess environment map.
+func (i *CredentialInjector) InjectEnv(
+	agentDID string, env map[string]string, opts InjectionOptions,
+) InjectionResult {
+	clone := make(map[string]string, len(env))
+	for k, v := range env {
+		clone[k] = v
+	}
+	return i.inject(agentDID, clone, opts)
+}
+
+func (i *CredentialInjector) inject(
+	agentDID string, payload interface{}, opts InjectionOptions,
+) InjectionResult {
+	if opts.PolicyVersion == "" {
+		opts.PolicyVersion = "v0"
+	}
+	allowlist := make(map[string]struct{}, len(opts.AllowedHandles))
+	for _, h := range opts.AllowedHandles {
+		allowlist[h] = struct{}{}
+	}
+	requested := credCollectPlaceholders(payload)
+
+	// 1. Reject anything outside the allowlist.
+	var outside []string
+	for _, n := range requested {
+		if _, ok := allowlist[n]; !ok {
+			outside = append(outside, n)
+		}
+	}
+	if len(outside) > 0 {
+		ev := VaultAuditEvent{
+			Timestamp:     nowSeconds(),
+			AgentDID:      agentDID,
+			HandleName:    outside[0],
+			TargetService: opts.TargetService,
+			ActionClass:   opts.ActionClass,
+			Decision:      CredentialDeny,
+			PolicyVersion: opts.PolicyVersion,
+			Reason:        CredentialDenyReason,
+		}
+		i.vault.recordReject(ev)
+		deny := newDenyReceipt(opts.ActionClass, opts.TargetService)
+		return InjectionResult{
+			Allowed:     false,
+			Payload:     deny,
+			DenyReceipt: &deny,
+			AuditEvents: []VaultAuditEvent{ev},
+		}
+	}
+
+	// 2. Run policy BEFORE any vault read.
+	if opts.PolicyCheck != nil {
+		ctx := InjectionContext{
+			AgentDID:         agentDID,
+			ActionClass:      opts.ActionClass,
+			TargetService:    opts.TargetService,
+			RequestedHandles: append([]string(nil), requested...),
+			PolicyVersion:    opts.PolicyVersion,
+		}
+		outcome := opts.PolicyCheck(ctx)
+		if !outcome.Allow {
+			handleName := ""
+			if len(requested) > 0 {
+				handleName = requested[0]
+			}
+			ev := VaultAuditEvent{
+				Timestamp:     nowSeconds(),
+				AgentDID:      agentDID,
+				HandleName:    handleName,
+				TargetService: opts.TargetService,
+				ActionClass:   opts.ActionClass,
+				Decision:      CredentialDeny,
+				PolicyVersion: opts.PolicyVersion,
+				Reason:        CredentialDenyReason,
+			}
+			i.vault.recordReject(ev)
+			deny := newDenyReceipt(opts.ActionClass, opts.TargetService)
+			return InjectionResult{
+				Allowed:     false,
+				Payload:     deny,
+				DenyReceipt: &deny,
+				AuditEvents: []VaultAuditEvent{ev},
+			}
+		}
+	}
+
+	// 3. Resolve. Any single deny aborts the whole call.
+	resolved := make(map[string]string)
+	var events []VaultAuditEvent
+	for _, name := range requested {
+		value, ok, ev := i.vault.resolveInternal(
+			agentDID, name, opts.ActionClass, opts.TargetService, opts.PolicyVersion)
+		events = append(events, ev)
+		if !ok {
+			deny := newDenyReceipt(opts.ActionClass, opts.TargetService)
+			return InjectionResult{
+				Allowed:     false,
+				Payload:     deny,
+				DenyReceipt: &deny,
+				AuditEvents: events,
+			}
+		}
+		resolved[name] = value
+	}
+
+	rendered := credSubstitute(payload, resolved)
+	return InjectionResult{
+		Allowed:     true,
+		Payload:     rendered,
+		AuditEvents: events,
+	}
+}
+
+// credCollectPlaceholders walks a nested structure and returns the sorted set of placeholder names found.
+func credCollectPlaceholders(payload interface{}) []string {
+	seen := make(map[string]struct{})
+	credWalk(payload, func(s string) {
+		for _, m := range CredentialPlaceholderRegex.FindAllStringSubmatch(s, -1) {
+			seen[m[1]] = struct{}{}
+		}
+	})
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func credWalk(payload interface{}, visit func(string)) {
+	switch p := payload.(type) {
+	case nil:
+		return
+	case string:
+		visit(p)
+	case map[string]string:
+		for k, v := range p {
+			visit(k)
+			visit(v)
+		}
+	case map[string]interface{}:
+		for k, v := range p {
+			visit(k)
+			credWalk(v, visit)
+		}
+	case []interface{}:
+		for _, item := range p {
+			credWalk(item, visit)
+		}
+	case []string:
+		for _, item := range p {
+			visit(item)
+		}
+	}
+}
+
+func credSubstitute(payload interface{}, resolved map[string]string) interface{} {
+	return credMapStrings(payload, func(s string) string {
+		return CredentialPlaceholderRegex.ReplaceAllStringFunc(s, func(m string) string {
+			caps := CredentialPlaceholderRegex.FindStringSubmatch(m)
+			if v, ok := resolved[caps[1]]; ok {
+				return v
+			}
+			return m
+		})
+	})
+}
+
+func credMapStrings(payload interface{}, fn func(string) string) interface{} {
+	switch p := payload.(type) {
+	case string:
+		return fn(p)
+	case map[string]string:
+		out := make(map[string]string, len(p))
+		for k, v := range p {
+			out[fn(k)] = fn(v)
+		}
+		return out
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(p))
+		for k, v := range p {
+			out[fn(k)] = credMapStrings(v, fn)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(p))
+		for i, item := range p {
+			out[i] = credMapStrings(item, fn)
+		}
+		return out
+	case []string:
+		out := make([]string, len(p))
+		for i, item := range p {
+			out[i] = fn(item)
+		}
+		return out
+	default:
+		return payload
+	}
+}
+
+// CredentialAuditDigest computes a stable HMAC-SHA256 digest of an audit-event
+// sequence. The digest covers handle names and decisions but never references
+// resolved credential values.
+func CredentialAuditDigest(events []VaultAuditEvent, key []byte) string {
+	h := hmac.New(sha256.New, key)
+	for _, ev := range events {
+		js, _ := json.Marshal(ev)
+		h.Write(js)
+		h.Write([]byte{0x1f})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/agent-governance-golang/packages/agentmesh/credential_vault_test.go
+++ b/agent-governance-golang/packages/agentmesh/credential_vault_test.go
@@ -1,0 +1,415 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func makeCredStack(t *testing.T) (*CredentialVault, *CredentialInjector) {
+	t.Helper()
+	v := NewCredentialVault()
+	if _, err := v.Put("github_pat", "GHP-RESOLVED-VALUE", "bearer_token"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if _, err := v.Put("db_password", "DBP-VALUE", "password"); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	v.RegisterProfile(NewCredentialProfile("did:web:agent-ci", map[string]string{
+		"github:read_issues": "github_pat",
+		"github:push_code":   "github_pat",
+	}))
+	v.RegisterProfile(NewCredentialProfile("did:web:agent-analytics", map[string]string{
+		"db:query": "db_password",
+	}))
+	return v, NewCredentialInjector(v)
+}
+
+func TestCredentialPut_ReturnsHandle(t *testing.T) {
+	v := NewCredentialVault()
+	h, err := v.Put("k1", "v1", "secret")
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if h.Name != "k1" {
+		t.Fatalf("got %q", h.Name)
+	}
+	if h.Placeholder() != "{{cred:k1}}" {
+		t.Fatalf("got %q", h.Placeholder())
+	}
+}
+
+func TestCredentialPut_RejectsBadNames(t *testing.T) {
+	v := NewCredentialVault()
+	for _, name := range []string{"", "bad name", strings.Repeat("a", 200)} {
+		if _, err := v.Put(name, "v", "s"); err == nil {
+			t.Errorf("expected error for name %q", name)
+		}
+	}
+}
+
+func TestCredentialList_NoValueLeak(t *testing.T) {
+	v, _ := makeCredStack(t)
+	names, _ := v.ListHandles()
+	wantA, wantB := "db_password", "github_pat"
+	if len(names) != 2 || names[0] != wantA || names[1] != wantB {
+		t.Fatalf("got %v", names)
+	}
+	for _, n := range names {
+		meta, _ := v.Metadata(n)
+		js, _ := json.Marshal(meta)
+		if strings.Contains(string(js), "GHP-RESOLVED-VALUE") {
+			t.Fatalf("metadata leaked value: %s", js)
+		}
+	}
+}
+
+func TestCredentialRotate_PreservesHandle_BumpsVersion(t *testing.T) {
+	v, _ := makeCredStack(t)
+	before, _ := v.Metadata("github_pat")
+	if before.Version != 1 {
+		t.Fatalf("expected v1, got %d", before.Version)
+	}
+	h, err := v.Rotate("github_pat", "ghp_new")
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if h.Name != "github_pat" {
+		t.Fatalf("rotate changed name: %q", h.Name)
+	}
+	after, _ := v.Metadata("github_pat")
+	if after.Version != 2 {
+		t.Fatalf("expected v2, got %d", after.Version)
+	}
+	if after.RotatedAt == nil {
+		t.Fatalf("expected rotatedAt to be set")
+	}
+}
+
+func TestCredentialRotate_Unknown_Errors(t *testing.T) {
+	v, _ := makeCredStack(t)
+	if _, err := v.Rotate("nope", "x"); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestCredentialDelete_PresenceFlag(t *testing.T) {
+	v, _ := makeCredStack(t)
+	first, _ := v.Delete("db_password")
+	second, _ := v.Delete("db_password")
+	if !first || second {
+		t.Fatalf("got first=%v second=%v", first, second)
+	}
+}
+
+func TestCredentialCheckAccess(t *testing.T) {
+	v, _ := makeCredStack(t)
+	if !v.CheckAccess("did:web:agent-ci", "github_pat", "github:read_issues") {
+		t.Fatalf("expected allow")
+	}
+	if v.CheckAccess("did:web:rogue", "github_pat", "github:read_issues") {
+		t.Fatalf("expected deny for unknown agent")
+	}
+	if v.CheckAccess("did:web:agent-ci", "db_password", "db:query") {
+		t.Fatalf("expected deny for unbound action")
+	}
+	if v.CheckAccess("did:web:agent-analytics", "db_password", "db:admin") {
+		t.Fatalf("expected deny for cross-action reuse")
+	}
+}
+
+func TestCredentialInjectHeaders_HappyPath(t *testing.T) {
+	v, i := makeCredStack(t)
+	r := i.InjectHeaders("did:web:agent-ci",
+		map[string]string{
+			"Authorization": "Bearer {{cred:github_pat}}",
+			"Accept":        "application/json",
+		},
+		InjectionOptions{
+			ActionClass:    "github:read_issues",
+			TargetService:  "api.github.com",
+			AllowedHandles: []string{"github_pat"},
+			PolicyVersion:  "v1",
+		})
+	if !r.Allowed {
+		t.Fatalf("expected allow, got %+v", r)
+	}
+	got := r.Payload.(map[string]string)
+	if got["Authorization"] != "Bearer GHP-RESOLVED-VALUE" {
+		t.Fatalf("got %q", got["Authorization"])
+	}
+	events := v.AuditLog()
+	if len(events) != 1 || events[0].Decision != CredentialAllow {
+		t.Fatalf("unexpected audit %+v", events)
+	}
+}
+
+func TestCredentialInjectToolArgs_Nested(t *testing.T) {
+	_, i := makeCredStack(t)
+	args := map[string]interface{}{
+		"repo":    "octo/hello",
+		"secrets": []interface{}{"{{cred:github_pat}}", "literal"},
+		"nested":  map[string]interface{}{"token": "{{cred:github_pat}}"},
+	}
+	r := i.InjectToolArgs("did:web:agent-ci", args, InjectionOptions{
+		ActionClass:    "github:push_code",
+		TargetService:  "api.github.com",
+		AllowedHandles: []string{"github_pat"},
+	})
+	if !r.Allowed {
+		t.Fatalf("expected allow, got %+v", r)
+	}
+	out := r.Payload.(map[string]interface{})
+	if out["secrets"].([]interface{})[0].(string) != "GHP-RESOLVED-VALUE" {
+		t.Fatalf("secrets[0] not rendered: %v", out["secrets"])
+	}
+	if out["nested"].(map[string]interface{})["token"].(string) != "GHP-RESOLVED-VALUE" {
+		t.Fatalf("nested.token not rendered: %v", out["nested"])
+	}
+}
+
+func TestCredentialInjectEnv(t *testing.T) {
+	_, i := makeCredStack(t)
+	r := i.InjectEnv("did:web:agent-ci",
+		map[string]string{"PATH": "/usr/bin", "GITHUB_TOKEN": "{{cred:github_pat}}"},
+		InjectionOptions{
+			ActionClass:    "github:read_issues",
+			TargetService:  "subprocess",
+			AllowedHandles: []string{"github_pat"},
+		})
+	if !r.Allowed {
+		t.Fatalf("expected allow")
+	}
+	if r.Payload.(map[string]string)["GITHUB_TOKEN"] != "GHP-RESOLVED-VALUE" {
+		t.Fatalf("not rendered")
+	}
+}
+
+func TestCredentialUnauthorizedPlaceholder_DeniesWholeCall(t *testing.T) {
+	_, i := makeCredStack(t)
+	r := i.InjectToolArgs("did:web:agent-analytics",
+		map[string]interface{}{"sql": "SELECT 1", "auth": "{{cred:github_pat}}"},
+		InjectionOptions{
+			ActionClass:    "db:query",
+			TargetService:  "pg",
+			AllowedHandles: []string{"db_password"},
+		})
+	if r.Allowed {
+		t.Fatalf("expected deny")
+	}
+	if r.DenyReceipt.Reason != CredentialDenyReason {
+		t.Fatalf("expected DENY_REASON, got %q", r.DenyReceipt.Reason)
+	}
+}
+
+func TestCredentialMissing_And_OutOfScope_IdenticalDeny(t *testing.T) {
+	_, i := makeCredStack(t)
+	missing := i.InjectHeaders("did:web:agent-ci",
+		map[string]string{"X": "{{cred:does_not_exist}}"},
+		InjectionOptions{
+			ActionClass:    "github:read_issues",
+			TargetService:  "svc",
+			AllowedHandles: []string{"does_not_exist"},
+		})
+	outOfScope := i.InjectHeaders("did:web:agent-ci",
+		map[string]string{"X": "{{cred:db_password}}"},
+		InjectionOptions{
+			ActionClass:    "github:read_issues",
+			TargetService:  "svc",
+			AllowedHandles: []string{"db_password"},
+		})
+	if missing.Allowed || outOfScope.Allowed {
+		t.Fatalf("expected both denied")
+	}
+	if !missing.DenyReceipt.Equals(*outOfScope.DenyReceipt) {
+		t.Fatalf("deny receipts differ")
+	}
+}
+
+func TestCredentialPolicy_RunsBeforeVaultRead(t *testing.T) {
+	_, i := makeCredStack(t)
+	var seen []string
+	var mu sync.Mutex
+	r := i.InjectHeaders("did:web:agent-ci",
+		map[string]string{"Authorization": "Bearer {{cred:github_pat}}"},
+		InjectionOptions{
+			ActionClass:    "github:push_code",
+			TargetService:  "api.github.com",
+			AllowedHandles: []string{"github_pat"},
+			PolicyVersion:  "v7",
+			PolicyCheck: func(ctx InjectionContext) PolicyOutcome {
+				mu.Lock()
+				seen = append(seen, ctx.RequestedHandles...)
+				mu.Unlock()
+				return PolicyOutcome{Allow: false, Reason: "no"}
+			},
+		})
+	if r.Allowed {
+		t.Fatalf("expected deny")
+	}
+	if len(seen) != 1 || seen[0] != "github_pat" {
+		t.Fatalf("policy didn't see requested handles: %v", seen)
+	}
+}
+
+func TestCredentialSameDenyAcrossSurfaces(t *testing.T) {
+	_, i := makeCredStack(t)
+	opts := InjectionOptions{
+		ActionClass:    "db:query",
+		TargetService:  "svc",
+		AllowedHandles: []string{"github_pat"},
+	}
+	h := i.InjectHeaders("did:web:agent-analytics",
+		map[string]string{"Authorization": "{{cred:github_pat}}"}, opts)
+	a := i.InjectToolArgs("did:web:agent-analytics",
+		map[string]interface{}{"x": "{{cred:github_pat}}"}, opts)
+	e := i.InjectEnv("did:web:agent-analytics",
+		map[string]string{"TOKEN": "{{cred:github_pat}}"}, opts)
+	for _, r := range []InjectionResult{h, a, e} {
+		if r.Allowed || r.DenyReceipt.Reason != CredentialDenyReason {
+			t.Fatalf("expected deny: %+v", r)
+		}
+	}
+}
+
+func TestCredentialPayloadWithoutPlaceholders(t *testing.T) {
+	_, i := makeCredStack(t)
+	r := i.InjectHeaders("did:web:agent-ci",
+		map[string]string{"Accept": "application/json"},
+		InjectionOptions{
+			ActionClass:    "github:read_issues",
+			TargetService:  "svc",
+			AllowedHandles: nil,
+		})
+	if !r.Allowed {
+		t.Fatalf("expected allow")
+	}
+}
+
+func TestCredentialAudit_NoValueLeak(t *testing.T) {
+	v, i := makeCredStack(t)
+	i.InjectHeaders("did:web:agent-ci",
+		map[string]string{"Authorization": "Bearer {{cred:github_pat}}"},
+		InjectionOptions{
+			ActionClass:    "github:read_issues",
+			TargetService:  "svc",
+			AllowedHandles: []string{"github_pat"},
+			PolicyVersion:  "v1",
+		})
+	events := v.AuditLog()
+	js, _ := json.Marshal(events)
+	if strings.Contains(string(js), "GHP-RESOLVED-VALUE") {
+		t.Fatalf("audit leaked value")
+	}
+}
+
+func TestCredentialAuditDigest_StableAndKeyDependent(t *testing.T) {
+	v, i := makeCredStack(t)
+	i.InjectHeaders("did:web:agent-ci",
+		map[string]string{"Authorization": "Bearer {{cred:github_pat}}"},
+		InjectionOptions{
+			ActionClass:    "github:read_issues",
+			TargetService:  "svc",
+			AllowedHandles: []string{"github_pat"},
+		})
+	events := v.AuditLog()
+	a := CredentialAuditDigest(events, []byte("k"))
+	b := CredentialAuditDigest(events, []byte("k"))
+	c := CredentialAuditDigest(events, []byte("other"))
+	if a != b {
+		t.Fatalf("digest not stable")
+	}
+	if a == c {
+		t.Fatalf("digest not key-dependent")
+	}
+}
+
+func TestCredentialRotation_DoesNotRequirePromptChanges(t *testing.T) {
+	v := NewCredentialVault()
+	if _, err := v.Put("github_pat", "GHP-V1", "secret"); err != nil {
+		t.Fatal(err)
+	}
+	v.RegisterProfile(NewCredentialProfile("did:web:agent-ci", map[string]string{
+		"github:read_issues": "github_pat",
+	}))
+	i := NewCredentialInjector(v)
+	saved := map[string]string{"Authorization": "Bearer {{cred:github_pat}}"}
+	opts := InjectionOptions{
+		ActionClass: "github:read_issues", TargetService: "svc",
+		AllowedHandles: []string{"github_pat"},
+	}
+	before := i.InjectHeaders("did:web:agent-ci", saved, opts)
+	if before.Payload.(map[string]string)["Authorization"] != "Bearer GHP-V1" {
+		t.Fatalf("before: %v", before.Payload)
+	}
+	if _, err := v.Rotate("github_pat", "GHP-V2"); err != nil {
+		t.Fatal(err)
+	}
+	after := i.InjectHeaders("did:web:agent-ci", saved, opts)
+	if after.Payload.(map[string]string)["Authorization"] != "Bearer GHP-V2" {
+		t.Fatalf("after: %v", after.Payload)
+	}
+	if saved["Authorization"] != "Bearer {{cred:github_pat}}" {
+		t.Fatalf("saved was mutated")
+	}
+}
+
+func TestCredentialEncryptedPersistence_RoundTrip(t *testing.T) {
+	key, err := GenerateCredentialKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.bin")
+	secret := "distinctive rotated fixture not a real key" // gitleaks:allow
+
+	v1, err := NewPersistentCredentialVault(path, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := v1.Put("k", "original", "secret"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := v1.Rotate("k", secret); err != nil {
+		t.Fatal(err)
+	}
+
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(blob, []byte(secret)) {
+		t.Fatal("secret appeared in encrypted blob")
+	}
+	if bytes.Contains(blob, []byte(`"value"`)) {
+		t.Fatal("value key appeared in encrypted blob")
+	}
+
+	v2, err := NewPersistentCredentialVault(path, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, _ := v2.ListHandles()
+	if len(names) != 1 || names[0] != "k" {
+		t.Fatalf("got %v", names)
+	}
+	meta, _ := v2.Metadata("k")
+	if meta.Version != 2 {
+		t.Fatalf("got version %d", meta.Version)
+	}
+}
+
+func TestCredentialPersistence_RequiresCorrectKeyLength(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vault.bin")
+	if _, err := NewPersistentCredentialVault(path, make([]byte, 16)); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Summary

Go port of the credential vault primitive landed for Python in #2534. Part of #2535.

Agents reference secrets via opaque `{{cred:NAME}}` placeholders only; resolved values stay inside the trust boundary. Library-only — `agt cred` remains the canonical CLI.

## Design parity with the Python reference

| Property | Go surface |
|------|------|
| Opaque handles, agents never see values | `CredentialHandle` |
| Encrypted at-rest | `CredentialVault` — AES-256-GCM via stdlib `crypto/aes` + `crypto/cipher` |
| Per-DID + per-action-class scoping | `CredentialProfile` |
| Workflow policy runs before vault read | `InjectionOptions.PolicyCheck` |
| Allowlist-gated placeholders (MCP untrusted) | `InjectionOptions.AllowedHandles` |
| Deterministic deny | `DenyReceipt` |
| Audit events without values | `VaultAuditEvent`, `CredentialAuditDigest` |
| Rotation preserves handle name | `CredentialVault.Rotate` |
| HTTP / MCP / env injection surfaces | `InjectHeaders` / `InjectToolArgs` / `InjectEnv` |

## Changes

| File | What changed |
|------|------|
| `agent-governance-golang/packages/agentmesh/credential_vault.go` | New module: vault, injector, profile, handle, deny receipt, audit digest. |
| `agent-governance-golang/packages/agentmesh/credential_vault_test.go` | 19 Go test cases. |

## Testing

To be validated by CI via `go test ./packages/agentmesh/... -run Credential`. Go toolchain was not available on the author's machine, so local `go test` could not be executed before opening this PR.

## Wire format

AES-256-GCM with a 12-byte random nonce prefixed to the ciphertext. Not currently interoperable with the Python SDK's Fernet format — cross-language interop spec is the remaining sub-task on #2535.

## References

- Tracking issue: #2535
- Python reference implementation: #2534
- Original design: #2481
- Sibling port: #2570 (TypeScript). Parallel PRs for .NET and Rust in flight.
