### PR TITLE
docs: use agent-governance-toolkit[full] consistently in install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Prompt-based safety ("please follow the rules") has a [26.67% policy violation r
 **Prerequisites:** Python 3.10+
 
 ```bash
-pip install agent-governance-toolkit
+pip install agent-governance-toolkit[full]
 ```
 
 Govern any tool function in two lines:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hide:
 Policy enforcement, identity, sandboxing, and SRE for autonomous AI agents. One `pip install`, any framework.
 
 ```
-pip install agent-governance-toolkit
+pip install agent-governance-toolkit[full]
 ```
 
 <div class="agt-hero-badges">
@@ -163,7 +163,7 @@ Every layer is optional. Start with `govern()` and add layers as your risk profi
 
 | SDK | Install |
 |-----|---------|
-| 🐍 [Python](packages/agent-compliance.md) | `pip install agent-governance-toolkit` |
+| 🐍 [Python](packages/agent-compliance.md) | `pip install agent-governance-toolkit[full]` |
 | 📘 TypeScript | `npm install @microsoft/agent-governance-sdk` |
 | 🔷 [.NET](packages/dotnet-sdk.md) | `dotnet add package Microsoft.AgentGovernance` |
 | 🦀 Rust | `cargo add agent-governance` |

--- a/docs/integrations/citadel-integration.md
+++ b/docs/integrations/citadel-integration.md
@@ -212,7 +212,7 @@ for the fragment XML, sample product policy, and deployment instructions.
 ## Getting Started
 
 1. **Deploy Citadel Governance Hub**: Follow the [Citadel quickstart](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/tree/citadel-v1)
-2. **Install AGT**: `pip install agent-governance-toolkit`
+2. **Install AGT**: `pip install agent-governance-toolkit[full]`
 3. **Configure the exporter**: Set `CITADEL_EVENTHUB_CONNECTION_STRING` and `CITADEL_APPINSIGHTS_CONNECTION_STRING`
 4. **Deploy the APIM fragment**: See [`apim-policies/README.md`](../../examples/citadel-governed-agent/apim-policies/README.md)
 5. **See the example**: [`examples/citadel-governed-agent/`](../../examples/citadel-governed-agent/)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Get from zero to governed AI agents in under 5 minutes.
 ## Install
 
 ```bash
-pip install agent-governance-toolkit
+pip install agent-governance-toolkit[full]
 ```
 
 !!! info "Other languages"

--- a/docs/tutorials/36-govern-quickstart.md
+++ b/docs/tutorials/36-govern-quickstart.md
@@ -1,6 +1,6 @@
 # Tutorial 36: 2-Line Governance with govern()
 
-> **Time**: 10 minutes · **Level**: Beginner · **Prerequisites**: `pip install agent-governance-toolkit`
+> **Time**: 10 minutes · **Level**: Beginner · **Prerequisites**: `pip install agent-governance-toolkit[full]`
 
 ## What You'll Build
 

--- a/docs/tutorials/44-a2a-conversation-policy.md
+++ b/docs/tutorials/44-a2a-conversation-policy.md
@@ -16,7 +16,7 @@ A multi-agent system where:
 ## Prerequisites
 
 ```bash
-pip install agent-governance-toolkit
+pip install agent-governance-toolkit[full]
 ```
 
 ## Step 1 — Define A2A Governance Policy

--- a/examples/citadel-governed-agent/README.md
+++ b/examples/citadel-governed-agent/README.md
@@ -43,7 +43,7 @@ governance) and **AGT** (agent-level governance) working together.
 ## Prerequisites
 
 ```bash
-pip install agent-governance-toolkit
+pip install agent-governance-toolkit[full]
 ```
 
 For Azure integration (optional, not needed for local mock mode):


### PR DESCRIPTION
## Summary

Standardizes install commands to `pip install agent-governance-toolkit[full]` across all hero/getting-started locations.

## Problem

The bare `pip install agent-governance-toolkit` (without `[full]`) appeared in the homepage, README quick start, quickstart guide, and several tutorials. This gives users an incomplete install missing runtime, SRE, and framework adapter packages. Our own docs, examples, and CHANGELOG consistently use `[full]`, but the most visible entry points did not.

## Changes

| File | What changed |
|------|-------------|
| `docs/index.md` | Homepage hero install + Language SDKs table |
| `README.md` | Quick Start install command |
| `docs/quickstart.md` | Install section |
| `docs/tutorials/36-govern-quickstart.md` | Prerequisites line |
| `docs/tutorials/44-a2a-conversation-policy.md` | Prerequisites install |
| `examples/citadel-governed-agent/README.md` | Prerequisites install |
| `docs/integrations/citadel-integration.md` | Getting Started step 2 |

Intentionally left bare installs in: package consolidation proposal (showing extras structure), compliance-only install docs, and extras comparison tables where the base package is being contrasted with `[full]`.

## Testing

Docs-only change. No code modified.
