### PR TITLE
feat(dotnet): credential injection and offload (#2535)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -37,9 +37,6 @@ bypassable
 bytecodes
 caas
 caplog
-ciphertext
-ENOENT
-Errno
 capsys
 carloshvp
 carryforward
@@ -51,6 +48,7 @@ checkpointed
 checkpointing
 cibuild
 cicd
+ciphertext
 classmethod
 cmdshell
 CMVK
@@ -75,8 +73,8 @@ dateutil
 davidequarracino
 dbt
 dearmor
-deidentified
 defi
+deidentified
 delenv
 deletecollection
 demux
@@ -98,20 +96,19 @@ EigenTrust
 elif
 embedders
 endswith
+ENOENT
 ensurepip
 Entra
+Errno
 esrp
 EUAI
 evilpypi
 exfiltration
 expanduser
 fastapi
-<<<<<<< HEAD
-finalizer
-=======
 fernet
 Fernet
->>>>>>> origin/main
+finalizer
 findall
 finditer
 FIPS
@@ -145,6 +142,7 @@ healthz
 helpdesk
 hexdigest
 HMAC
+HMACSHA
 htek
 HTTPMCP
 httpx
@@ -156,6 +154,7 @@ idweb
 IGNORECASE
 importorskip
 imran
+inheritdoc
 inspectable
 IPFS
 isinstance
@@ -166,11 +165,11 @@ jwkjwks
 kanish
 kata
 kayalopez
-kubeconfigs
 kevinkaylie
 keypair
 keypairs
 keyrings
+kubeconfigs
 kwarg
 kwargs
 Landlock
@@ -181,6 +180,7 @@ lawcontinue
 levelname
 linkcheck
 linkified
+Linq
 LlamaIndex
 lockdown
 lockfiles
@@ -223,15 +223,12 @@ noqa
 nostr
 npmjs
 numpy
-<<<<<<< HEAD
-oxycodone
-=======
 octo
 OpenAI
 OpenClaw
->>>>>>> origin/main
 openshell
 ospo
+oxycodone
 parseability
 parseable
 pathext

--- a/agent-governance-dotnet/src/AgentGovernance/Security/CredentialVault.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Security/CredentialVault.cs
@@ -196,26 +196,20 @@ public sealed class CredentialVault
         {
             EnsureLoaded();
             var now = NowSeconds();
-            CredentialRecord rec;
-            if (_records.TryGetValue(name!, out var existing))
-            {
-                rec = existing with
+            var rec = _records.TryGetValue(name!, out var existing)
+                ? existing with
                 {
                     Value = value,
                     Version = existing.Version + 1,
                     RotatedAt = now,
-                };
-            }
-            else
-            {
-                rec = new CredentialRecord(
+                }
+                : new CredentialRecord(
                     Name: name!,
                     Value: value,
                     CredType: credType,
                     Version: 1,
                     CreatedAt: now,
                     RotatedAt: null);
-            }
             _records[name!] = rec;
             Flush();
         }
@@ -713,20 +707,19 @@ public static class CredentialAudit
     public static string Digest(IEnumerable<VaultAuditEvent> events, byte[] key)
     {
         using var hmac = new HMACSHA256(key);
-        var buf = new MemoryStream();
-        foreach (var ev in events)
+        using var buf = new MemoryStream();
+        foreach (var json in events.Select(ev => JsonSerializer.SerializeToUtf8Bytes(new
         {
-            var json = JsonSerializer.SerializeToUtf8Bytes(new
-            {
-                timestamp = ev.Timestamp,
-                agentDid = ev.AgentDid,
-                handleName = ev.HandleName,
-                targetService = ev.TargetService,
-                actionClass = ev.ActionClass,
-                decision = ev.Decision.ToString().ToLowerInvariant(),
-                policyVersion = ev.PolicyVersion,
-                reason = ev.Reason,
-            });
+            timestamp = ev.Timestamp,
+            agentDid = ev.AgentDid,
+            handleName = ev.HandleName,
+            targetService = ev.TargetService,
+            actionClass = ev.ActionClass,
+            decision = ev.Decision.ToString().ToLowerInvariant(),
+            policyVersion = ev.PolicyVersion,
+            reason = ev.Reason,
+        })))
+        {
             buf.Write(json, 0, json.Length);
             buf.WriteByte(0x1f);
         }

--- a/agent-governance-dotnet/src/AgentGovernance/Security/CredentialVault.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Security/CredentialVault.cs
@@ -1,0 +1,738 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AgentGovernance.Security;
+
+/// <summary>
+/// Outcome of a credential resolution attempt.
+/// </summary>
+public enum CredentialDecision
+{
+    /// <summary>Allowed.</summary>
+    Allow,
+
+    /// <summary>Denied.</summary>
+    Deny,
+}
+
+/// <summary>
+/// Base error for credential vault operations.
+/// </summary>
+public class CredentialException : Exception
+{
+    /// <summary>Create a new <see cref="CredentialException"/>.</summary>
+    public CredentialException(string message) : base(message) { }
+}
+
+/// <summary>
+/// An internal credential entry. Never exposed to agents.
+/// </summary>
+public sealed record CredentialRecord(
+    string Name,
+    string Value,
+    string CredType,
+    int Version,
+    double CreatedAt,
+    double? RotatedAt
+);
+
+/// <summary>
+/// Opaque handle an agent may reference. Holding a handle does NOT grant
+/// access to the underlying value; resolution requires the vault, the
+/// agent's DID, and an action capability binding.
+/// </summary>
+public sealed class CredentialHandle
+{
+    /// <summary>The handle's name.</summary>
+    public string Name { get; }
+
+    /// <summary>Create a new handle.</summary>
+    public CredentialHandle(string name) { Name = name; }
+
+    /// <summary>Return the <c>{{cred:NAME}}</c> placeholder for this handle.</summary>
+    public string Placeholder() => $"{{{{cred:{Name}}}}}";
+
+    /// <inheritdoc/>
+    public override string ToString() => $"<CredentialHandle {Name}>";
+}
+
+/// <summary>
+/// Per-agent capability binding. Maps action capabilities (e.g.
+/// <c>github:read_issues</c>) to credential handle names.
+/// </summary>
+public sealed class CredentialProfile
+{
+    /// <summary>The agent's DID.</summary>
+    public string AgentDid { get; }
+
+    private readonly ReadOnlyDictionary<string, string> _bindings;
+
+    /// <summary>The capability -&gt; handle bindings (read-only).</summary>
+    public IReadOnlyDictionary<string, string> Bindings => _bindings;
+
+    /// <summary>Create a profile.</summary>
+    public CredentialProfile(string agentDid, IDictionary<string, string> bindings)
+    {
+        if (string.IsNullOrEmpty(agentDid))
+        {
+            throw new ArgumentException("agentDid must be non-empty", nameof(agentDid));
+        }
+        AgentDid = agentDid;
+        _bindings = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(bindings));
+    }
+
+    /// <summary>Return the handle name bound to the action class, or null.</summary>
+    public string? CapabilityFor(string actionClass)
+    {
+        return _bindings.TryGetValue(actionClass, out var v) ? v : null;
+    }
+}
+
+/// <summary>
+/// A single audit record. Contains the agent identity, handle name,
+/// target service, action class, decision, and policy version. Does NOT
+/// contain the resolved credential value.
+/// </summary>
+public sealed record VaultAuditEvent(
+    double Timestamp,
+    string AgentDid,
+    string HandleName,
+    string TargetService,
+    string ActionClass,
+    CredentialDecision Decision,
+    string PolicyVersion,
+    string Reason
+);
+
+/// <summary>
+/// Deterministic deny output returned in place of a rendered payload.
+/// Identical for missing / out-of-scope / policy-denied handles so agents
+/// cannot probe vault contents via deny shape.
+/// </summary>
+public sealed record DenyReceipt(
+    string Reason = CredentialVault.DenyReason,
+    string ActionClass = "",
+    string TargetService = "");
+
+/// <summary>
+/// Encrypted-at-rest credential store and scoped resolver.
+/// </summary>
+/// <remarks>
+/// Persistence uses AES-256-GCM with a 12-byte random nonce prefixed to
+/// the ciphertext. The wire format is not currently interoperable with
+/// the Python SDK's Fernet format -- see tracking issue #2535.
+/// </remarks>
+public sealed class CredentialVault
+{
+    /// <summary>Stable string returned in audit/deny records when a request is refused.</summary>
+    public const string DenyReason = "credential_denied";
+
+    private const int KeyLength = 32;
+    private const int NonceLength = 12;
+    private const int TagLength = 16;
+
+    private static readonly Regex NameRegex = new(
+        "^[A-Za-z0-9_.\\-]{1,128}$", RegexOptions.Compiled);
+
+    private readonly object _lock = new();
+    private readonly Dictionary<string, CredentialRecord> _records = new();
+    private readonly Dictionary<string, CredentialProfile> _profiles = new();
+    private readonly List<VaultAuditEvent> _audit = new();
+    private readonly string? _persistPath;
+    private readonly byte[]? _key;
+    private bool _loaded;
+
+    /// <summary>Create an in-memory vault.</summary>
+    public CredentialVault() { }
+
+    /// <summary>Create a vault with encrypted-at-rest persistence.</summary>
+    /// <param name="persistPath">Path to the encrypted vault file.</param>
+    /// <param name="encryptionKey">32-byte AES-256-GCM key. Use <see cref="GenerateKey"/>.</param>
+    public CredentialVault(string persistPath, byte[] encryptionKey)
+    {
+        if (string.IsNullOrEmpty(persistPath))
+        {
+            throw new ArgumentException("persistPath must be non-empty", nameof(persistPath));
+        }
+        if (encryptionKey is null || encryptionKey.Length != KeyLength)
+        {
+            throw new ArgumentException(
+                $"encryptionKey must be exactly {KeyLength} bytes", nameof(encryptionKey));
+        }
+        _persistPath = persistPath;
+        _key = (byte[])encryptionKey.Clone();
+    }
+
+    /// <summary>Generate a fresh AES-256-GCM key (32 random bytes).</summary>
+    public static byte[] GenerateKey()
+    {
+        var k = new byte[KeyLength];
+        RandomNumberGenerator.Fill(k);
+        return k;
+    }
+
+    // -- Admin surface ------------------------------------------------------
+
+    /// <summary>Store or replace a credential.</summary>
+    public CredentialHandle Put(string name, string value, string credType = "secret")
+    {
+        if (!NameRegex.IsMatch(name ?? string.Empty))
+        {
+            throw new ArgumentException(
+                "Credential name must match [A-Za-z0-9_.-]{1,128}", nameof(name));
+        }
+        lock (_lock)
+        {
+            EnsureLoaded();
+            var now = NowSeconds();
+            CredentialRecord rec;
+            if (_records.TryGetValue(name!, out var existing))
+            {
+                rec = existing with
+                {
+                    Value = value,
+                    Version = existing.Version + 1,
+                    RotatedAt = now,
+                };
+            }
+            else
+            {
+                rec = new CredentialRecord(
+                    Name: name!,
+                    Value: value,
+                    CredType: credType,
+                    Version: 1,
+                    CreatedAt: now,
+                    RotatedAt: null);
+            }
+            _records[name!] = rec;
+            Flush();
+        }
+        return new CredentialHandle(name!);
+    }
+
+    /// <summary>Rotate a credential's value, preserving the handle name.</summary>
+    public CredentialHandle Rotate(string name, string newValue)
+    {
+        lock (_lock)
+        {
+            EnsureLoaded();
+            if (!_records.TryGetValue(name, out var old))
+            {
+                throw new KeyNotFoundException($"unknown credential: {name}");
+            }
+            _records[name] = old with
+            {
+                Value = newValue,
+                Version = old.Version + 1,
+                RotatedAt = NowSeconds(),
+            };
+            Flush();
+        }
+        return new CredentialHandle(name);
+    }
+
+    /// <summary>Delete a credential. Returns true if it existed.</summary>
+    public bool Delete(string name)
+    {
+        lock (_lock)
+        {
+            EnsureLoaded();
+            var present = _records.Remove(name);
+            if (present) { Flush(); }
+            return present;
+        }
+    }
+
+    /// <summary>List all credential handle names.</summary>
+    public IReadOnlyList<string> ListHandles()
+    {
+        lock (_lock)
+        {
+            EnsureLoaded();
+            var names = _records.Keys.ToList();
+            names.Sort(StringComparer.Ordinal);
+            return names;
+        }
+    }
+
+    /// <summary>Return non-secret metadata for a credential, or null.</summary>
+    public IReadOnlyDictionary<string, object?>? GetMetadata(string name)
+    {
+        lock (_lock)
+        {
+            EnsureLoaded();
+            if (!_records.TryGetValue(name, out var r)) return null;
+            return new Dictionary<string, object?>
+            {
+                ["name"] = r.Name,
+                ["credType"] = r.CredType,
+                ["version"] = r.Version,
+                ["createdAt"] = r.CreatedAt,
+                ["rotatedAt"] = r.RotatedAt,
+            };
+        }
+    }
+
+    /// <summary>Register or replace a per-agent profile.</summary>
+    public void RegisterProfile(CredentialProfile profile)
+    {
+        lock (_lock) { _profiles[profile.AgentDid] = profile; }
+    }
+
+    /// <summary>Revoke a profile by agent DID. Returns true if it existed.</summary>
+    public bool RevokeProfile(string agentDid)
+    {
+        lock (_lock) { return _profiles.Remove(agentDid); }
+    }
+
+    // -- Resolver surface ---------------------------------------------------
+
+    /// <summary>True iff the agent may use the handle for the action class.</summary>
+    public bool CheckAccess(string agentDid, string handleName, string actionClass)
+    {
+        lock (_lock)
+        {
+            if (!_profiles.TryGetValue(agentDid, out var profile)) return false;
+            var bound = profile.CapabilityFor(actionClass);
+            if (bound is null || bound != handleName) return false;
+            return _records.ContainsKey(handleName);
+        }
+    }
+
+    /// <summary>
+    /// Internal: resolve a credential value and emit an audit event.
+    /// Use <see cref="CredentialInjector"/> rather than calling directly.
+    /// </summary>
+    internal (string? Value, VaultAuditEvent Event) ResolveInternal(
+        string agentDid,
+        string handleName,
+        string actionClass,
+        string targetService,
+        string policyVersion)
+    {
+        lock (_lock)
+        {
+            var allowed = CheckAccessNoLock(agentDid, handleName, actionClass);
+            if (allowed)
+            {
+                var value = _records[handleName].Value;
+                var ev = new VaultAuditEvent(
+                    Timestamp: NowSeconds(),
+                    AgentDid: agentDid,
+                    HandleName: handleName,
+                    TargetService: targetService,
+                    ActionClass: actionClass,
+                    Decision: CredentialDecision.Allow,
+                    PolicyVersion: policyVersion,
+                    Reason: string.Empty);
+                _audit.Add(ev);
+                return (value, ev);
+            }
+            var denyEv = new VaultAuditEvent(
+                Timestamp: NowSeconds(),
+                AgentDid: agentDid,
+                HandleName: handleName,
+                TargetService: targetService,
+                ActionClass: actionClass,
+                Decision: CredentialDecision.Deny,
+                PolicyVersion: policyVersion,
+                Reason: DenyReason);
+            _audit.Add(denyEv);
+            return (null, denyEv);
+        }
+    }
+
+    internal void RecordReject(VaultAuditEvent ev)
+    {
+        lock (_lock) { _audit.Add(ev); }
+    }
+
+    /// <summary>Immutable snapshot of audit events.</summary>
+    public IReadOnlyList<VaultAuditEvent> AuditLog()
+    {
+        lock (_lock) { return _audit.ToList(); }
+    }
+
+    /// <summary>Clear all audit events.</summary>
+    public void ClearAudit()
+    {
+        lock (_lock) { _audit.Clear(); }
+    }
+
+    // -- Internal helpers ---------------------------------------------------
+
+    private bool CheckAccessNoLock(string agentDid, string handleName, string actionClass)
+    {
+        if (!_profiles.TryGetValue(agentDid, out var profile)) return false;
+        var bound = profile.CapabilityFor(actionClass);
+        if (bound is null || bound != handleName) return false;
+        return _records.ContainsKey(handleName);
+    }
+
+    private static double NowSeconds() =>
+        (DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).TotalSeconds;
+
+    private void EnsureLoaded()
+    {
+        if (_loaded) return;
+        _loaded = true;
+        if (_persistPath is null || _key is null) return;
+        if (!File.Exists(_persistPath)) return;
+        var blob = File.ReadAllBytes(_persistPath);
+        if (blob.Length == 0) return;
+        var plaintext = Decrypt(blob);
+        var payload = JsonSerializer.Deserialize<PersistPayload>(plaintext);
+        if (payload?.Records is null) return;
+        foreach (var r in payload.Records)
+        {
+            _records[r.Name] = r;
+        }
+    }
+
+    private void Flush()
+    {
+        if (_persistPath is null || _key is null) return;
+        var payload = new PersistPayload(_records.Values.ToList());
+        var json = JsonSerializer.SerializeToUtf8Bytes(payload);
+        var blob = Encrypt(json);
+        var tmp = _persistPath + ".tmp";
+        var dir = Path.GetDirectoryName(_persistPath);
+        if (!string.IsNullOrEmpty(dir)) { Directory.CreateDirectory(dir); }
+        File.WriteAllBytes(tmp, blob);
+        File.Move(tmp, _persistPath, overwrite: true);
+    }
+
+    private byte[] Encrypt(byte[] plaintext)
+    {
+        if (_key is null) throw new InvalidOperationException("no key");
+        var nonce = new byte[NonceLength];
+        RandomNumberGenerator.Fill(nonce);
+        var ct = new byte[plaintext.Length];
+        var tag = new byte[TagLength];
+        using (var gcm = new AesGcm(_key, TagLength))
+        {
+            gcm.Encrypt(nonce, plaintext, ct, tag);
+        }
+        var output = new byte[NonceLength + ct.Length + TagLength];
+        Buffer.BlockCopy(nonce, 0, output, 0, NonceLength);
+        Buffer.BlockCopy(ct, 0, output, NonceLength, ct.Length);
+        Buffer.BlockCopy(tag, 0, output, NonceLength + ct.Length, TagLength);
+        return output;
+    }
+
+    private byte[] Decrypt(byte[] blob)
+    {
+        if (_key is null) throw new InvalidOperationException("no key");
+        if (blob.Length < NonceLength + TagLength)
+        {
+            throw new CredentialException("persisted vault is corrupt (too short)");
+        }
+        var nonce = new byte[NonceLength];
+        var tag = new byte[TagLength];
+        var ct = new byte[blob.Length - NonceLength - TagLength];
+        Buffer.BlockCopy(blob, 0, nonce, 0, NonceLength);
+        Buffer.BlockCopy(blob, NonceLength, ct, 0, ct.Length);
+        Buffer.BlockCopy(blob, NonceLength + ct.Length, tag, 0, TagLength);
+        var pt = new byte[ct.Length];
+        using (var gcm = new AesGcm(_key, TagLength))
+        {
+            gcm.Decrypt(nonce, ct, tag, pt);
+        }
+        return pt;
+    }
+
+    private sealed record PersistPayload(List<CredentialRecord> Records);
+}
+
+/// <summary>Context passed to the workflow policy callback.</summary>
+public sealed record InjectionContext(
+    string AgentDid,
+    string ActionClass,
+    string TargetService,
+    IReadOnlyList<string> RequestedHandles,
+    string PolicyVersion);
+
+/// <summary>Result returned by the workflow policy callback.</summary>
+public sealed record PolicyOutcome(bool Allow, string Reason = "");
+
+/// <summary>Outcome of an injection call.</summary>
+public sealed record InjectionResult(
+    bool Allowed,
+    object Payload,
+    DenyReceipt? DenyReceipt,
+    IReadOnlyList<VaultAuditEvent> AuditEvents);
+
+/// <summary>Options for an injection call.</summary>
+public sealed class InjectionOptions
+{
+    /// <summary>The action class this call represents (e.g. <c>github:read_issues</c>).</summary>
+    public required string ActionClass { get; init; }
+
+    /// <summary>The downstream service this credential will be sent to.</summary>
+    public required string TargetService { get; init; }
+
+    /// <summary>
+    /// Workflow-policy allowlist of handle names eligible for substitution
+    /// on this call. Placeholders outside this set deny the whole call.
+    /// </summary>
+    public required IEnumerable<string> AllowedHandles { get; init; }
+
+    /// <summary>Recorded in the audit log.</summary>
+    public string PolicyVersion { get; init; } = "v0";
+
+    /// <summary>
+    /// Optional workflow-policy callback. Invoked BEFORE any vault read.
+    /// </summary>
+    public Func<InjectionContext, PolicyOutcome>? PolicyCheck { get; init; }
+}
+
+/// <summary>
+/// Renders <c>{{cred:NAME}}</c> placeholders into HTTP headers, MCP tool
+/// arguments, and environment variable payloads.
+/// </summary>
+/// <remarks>
+/// The injector is the only component that ever holds resolved credential
+/// values, and only long enough to render an outbound payload.
+/// </remarks>
+public sealed class CredentialInjector
+{
+    /// <summary>Regex matching the credential placeholder syntax <c>{{cred:NAME}}</c>.</summary>
+    public static readonly Regex PlaceholderRegex = new(
+        "\\{\\{\\s*cred:([A-Za-z0-9_.\\-]{1,128})\\s*\\}\\}", RegexOptions.Compiled);
+
+    private readonly CredentialVault _vault;
+
+    /// <summary>Create an injector backed by the given vault.</summary>
+    public CredentialInjector(CredentialVault vault) { _vault = vault; }
+
+    /// <summary>Inject placeholders in an HTTP header dictionary.</summary>
+    public InjectionResult InjectHeaders(
+        string agentDid,
+        IDictionary<string, string> headers,
+        InjectionOptions options) =>
+        Inject(agentDid, new Dictionary<string, string>(headers), options);
+
+    /// <summary>Inject placeholders in MCP tool arguments (nested dict/list/string).</summary>
+    public InjectionResult InjectToolArgs(
+        string agentDid,
+        object args,
+        InjectionOptions options) =>
+        Inject(agentDid, args, options);
+
+    /// <summary>Inject placeholders in a subprocess environment dictionary.</summary>
+    public InjectionResult InjectEnv(
+        string agentDid,
+        IDictionary<string, string> env,
+        InjectionOptions options) =>
+        Inject(agentDid, new Dictionary<string, string>(env), options);
+
+    private InjectionResult Inject(string agentDid, object payload, InjectionOptions options)
+    {
+        var allowlist = new HashSet<string>(options.AllowedHandles);
+        var requested = CollectPlaceholders(payload);
+
+        // 1. Reject anything outside the workflow-supplied allowlist.
+        var outside = requested.Where(n => !allowlist.Contains(n)).ToList();
+        if (outside.Count > 0)
+        {
+            var ev = new VaultAuditEvent(
+                Timestamp: (DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).TotalSeconds,
+                AgentDid: agentDid,
+                HandleName: outside[0],
+                TargetService: options.TargetService,
+                ActionClass: options.ActionClass,
+                Decision: CredentialDecision.Deny,
+                PolicyVersion: options.PolicyVersion,
+                Reason: CredentialVault.DenyReason);
+            _vault.RecordReject(ev);
+            var deny = new DenyReceipt(
+                Reason: CredentialVault.DenyReason,
+                ActionClass: options.ActionClass,
+                TargetService: options.TargetService);
+            return new InjectionResult(false, deny, deny, new[] { ev });
+        }
+
+        // 2. Run policy BEFORE any vault read.
+        if (options.PolicyCheck is not null)
+        {
+            var ctx = new InjectionContext(
+                AgentDid: agentDid,
+                ActionClass: options.ActionClass,
+                TargetService: options.TargetService,
+                RequestedHandles: requested.OrderBy(s => s, StringComparer.Ordinal).ToList(),
+                PolicyVersion: options.PolicyVersion);
+            var outcome = options.PolicyCheck(ctx);
+            if (!outcome.Allow)
+            {
+                var ev = new VaultAuditEvent(
+                    Timestamp: (DateTimeOffset.UtcNow - DateTimeOffset.UnixEpoch).TotalSeconds,
+                    AgentDid: agentDid,
+                    HandleName: requested.FirstOrDefault() ?? string.Empty,
+                    TargetService: options.TargetService,
+                    ActionClass: options.ActionClass,
+                    Decision: CredentialDecision.Deny,
+                    PolicyVersion: options.PolicyVersion,
+                    Reason: CredentialVault.DenyReason);
+                _vault.RecordReject(ev);
+                var deny = new DenyReceipt(
+                    Reason: CredentialVault.DenyReason,
+                    ActionClass: options.ActionClass,
+                    TargetService: options.TargetService);
+                return new InjectionResult(false, deny, deny, new[] { ev });
+            }
+        }
+
+        // 3. Resolve. Any single deny aborts the whole call.
+        var resolved = new Dictionary<string, string>();
+        var events = new List<VaultAuditEvent>();
+        foreach (var name in requested)
+        {
+            var (value, ev) = _vault.ResolveInternal(
+                agentDid, name, options.ActionClass, options.TargetService, options.PolicyVersion);
+            events.Add(ev);
+            if (value is null)
+            {
+                var deny = new DenyReceipt(
+                    Reason: CredentialVault.DenyReason,
+                    ActionClass: options.ActionClass,
+                    TargetService: options.TargetService);
+                return new InjectionResult(false, deny, deny, events);
+            }
+            resolved[name] = value;
+        }
+
+        var rendered = Substitute(payload, resolved);
+        return new InjectionResult(true, rendered, null, events);
+    }
+
+    private static HashSet<string> CollectPlaceholders(object payload)
+    {
+        var found = new HashSet<string>();
+        Walk(payload, s =>
+        {
+            foreach (Match m in PlaceholderRegex.Matches(s))
+            {
+                found.Add(m.Groups[1].Value);
+            }
+        });
+        return found;
+    }
+
+    private static object Substitute(object payload, IReadOnlyDictionary<string, string> resolved)
+    {
+        return MapStrings(payload, s => PlaceholderRegex.Replace(s, m =>
+            resolved.TryGetValue(m.Groups[1].Value, out var v) ? v : m.Value));
+    }
+
+    private static void Walk(object? payload, Action<string> visit)
+    {
+        switch (payload)
+        {
+            case null:
+                return;
+            case string s:
+                visit(s);
+                return;
+            case IDictionary<string, string> ds:
+                foreach (var kv in ds)
+                {
+                    visit(kv.Key);
+                    visit(kv.Value);
+                }
+                return;
+            case IDictionary<string, object?> d:
+                foreach (var kv in d)
+                {
+                    visit(kv.Key);
+                    Walk(kv.Value, visit);
+                }
+                return;
+            case IEnumerable<object?> list:
+                foreach (var item in list) Walk(item, visit);
+                return;
+        }
+    }
+
+    private static object MapStrings(object payload, Func<string, string> fn)
+    {
+        switch (payload)
+        {
+            case string s:
+                return fn(s);
+            case IDictionary<string, string> ds:
+                {
+                    var o = new Dictionary<string, string>(ds.Count);
+                    foreach (var kv in ds) o[fn(kv.Key)] = fn(kv.Value);
+                    return o;
+                }
+            case IDictionary<string, object?> d:
+                {
+                    var o = new Dictionary<string, object?>(d.Count);
+                    foreach (var kv in d)
+                    {
+                        o[fn(kv.Key)] = kv.Value is null ? null : MapStrings(kv.Value, fn);
+                    }
+                    return o;
+                }
+            case IList<object?> list:
+                {
+                    var o = new List<object?>(list.Count);
+                    foreach (var item in list)
+                    {
+                        o.Add(item is null ? null : MapStrings(item, fn));
+                    }
+                    return o;
+                }
+            default:
+                return payload;
+        }
+    }
+}
+
+/// <summary>
+/// Audit-log integrity helper.
+/// </summary>
+public static class CredentialAudit
+{
+    /// <summary>
+    /// Stable HMAC-SHA256 digest of an audit-event sequence. Covers handle
+    /// names and decisions but never references resolved credential values.
+    /// </summary>
+    public static string Digest(IEnumerable<VaultAuditEvent> events, byte[] key)
+    {
+        using var hmac = new HMACSHA256(key);
+        var buf = new MemoryStream();
+        foreach (var ev in events)
+        {
+            var json = JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                timestamp = ev.Timestamp,
+                agentDid = ev.AgentDid,
+                handleName = ev.HandleName,
+                targetService = ev.TargetService,
+                actionClass = ev.ActionClass,
+                decision = ev.Decision.ToString().ToLowerInvariant(),
+                policyVersion = ev.PolicyVersion,
+                reason = ev.Reason,
+            });
+            buf.Write(json, 0, json.Length);
+            buf.WriteByte(0x1f);
+        }
+        var digest = hmac.ComputeHash(buf.ToArray());
+        var sb = new StringBuilder(digest.Length * 2);
+        foreach (var b in digest) sb.Append(b.ToString("x2"));
+        return sb.ToString();
+    }
+}

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/CredentialVaultTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/CredentialVaultTests.cs
@@ -45,9 +45,8 @@ public class CredentialVaultAdminTests
         var v = MakeVault();
         var names = v.ListHandles();
         Assert.Equal(new[] { "db_password", "github_pat" }, names);
-        foreach (var n in names)
+        foreach (var meta in names.Select(n => v.GetMetadata(n)))
         {
-            var meta = v.GetMetadata(n);
             Assert.NotNull(meta);
             Assert.False(meta!.ContainsKey("value"));
             Assert.DoesNotContain("ghp_real", JsonSerializer.Serialize(meta));
@@ -396,7 +395,7 @@ public class CredentialVaultPersistenceTests
     public void RoundTrip_DistinctivePlaintextNotOnDisk() // gitleaks:allow
     {
         var key = CredentialVault.GenerateKey();
-        var tmp = Path.Combine(Path.GetTempPath(), $"vault-{Guid.NewGuid():N}.bin");
+        var tmp = Path.Join(Path.GetTempPath(), $"vault-{Guid.NewGuid():N}.bin");
         try
         {
             var secret = "distinctive rotated fixture not a real key"; // gitleaks:allow

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/CredentialVaultTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/CredentialVaultTests.cs
@@ -1,0 +1,468 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using AgentGovernance.Security;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class CredentialVaultAdminTests
+{
+    private static CredentialVault MakeVault()
+    {
+        var v = new CredentialVault();
+        v.Put("github_pat", "ghp_real_secret_value", "bearer_token");
+        v.Put("db_password", "p@ss-w0rd!", "password");
+        return v;
+    }
+
+    [Fact]
+    public void Put_ReturnsHandle_WithPlaceholder()
+    {
+        var v = new CredentialVault();
+        var h = v.Put("k1", "v1");
+        Assert.Equal("k1", h.Name);
+        Assert.Equal("{{cred:k1}}", h.Placeholder());
+    }
+
+    [Fact]
+    public void Put_RejectsBadNames()
+    {
+        var v = new CredentialVault();
+        Assert.Throws<ArgumentException>(() => v.Put("", "v"));
+        Assert.Throws<ArgumentException>(() => v.Put("bad name", "v"));
+        Assert.Throws<ArgumentException>(() => v.Put(new string('a', 200), "v"));
+    }
+
+    [Fact]
+    public void ListHandles_NeverLeaksValues()
+    {
+        var v = MakeVault();
+        var names = v.ListHandles();
+        Assert.Equal(new[] { "db_password", "github_pat" }, names);
+        foreach (var n in names)
+        {
+            var meta = v.GetMetadata(n);
+            Assert.NotNull(meta);
+            Assert.False(meta!.ContainsKey("value"));
+            Assert.DoesNotContain("ghp_real", JsonSerializer.Serialize(meta));
+        }
+    }
+
+    [Fact]
+    public void Rotate_PreservesHandleName_BumpsVersion()
+    {
+        var v = MakeVault();
+        var before = v.GetMetadata("github_pat")!;
+        Assert.Equal(1, (int)before["version"]!);
+        var h = v.Rotate("github_pat", "ghp_new");
+        var after = v.GetMetadata("github_pat")!;
+        Assert.Equal("github_pat", h.Name);
+        Assert.Equal(2, (int)after["version"]!);
+        Assert.NotNull(after["rotatedAt"]);
+    }
+
+    [Fact]
+    public void Rotate_Unknown_Throws()
+    {
+        var v = MakeVault();
+        Assert.Throws<KeyNotFoundException>(() => v.Rotate("nope", "x"));
+    }
+
+    [Fact]
+    public void Delete_ReturnsPresenceFlag()
+    {
+        var v = MakeVault();
+        var first = v.Delete("db_password");
+        var second = v.Delete("db_password");
+        Assert.True(first);
+        Assert.False(second);
+    }
+}
+
+public class CredentialVaultScopingTests
+{
+    private static CredentialVault MakeVault()
+    {
+        var v = new CredentialVault();
+        v.Put("github_pat", "GHP-VALUE");
+        v.Put("db_password", "DB-VALUE");
+        v.RegisterProfile(new CredentialProfile("did:web:agent-ci",
+            new Dictionary<string, string>
+            {
+                ["github:read_issues"] = "github_pat",
+                ["github:push_code"] = "github_pat",
+            }));
+        v.RegisterProfile(new CredentialProfile("did:web:agent-analytics",
+            new Dictionary<string, string> { ["db:query"] = "db_password" }));
+        return v;
+    }
+
+    [Fact]
+    public void CheckAccess_AllowsBoundAction()
+    {
+        var v = MakeVault();
+        Assert.True(v.CheckAccess("did:web:agent-ci", "github_pat", "github:read_issues"));
+    }
+
+    [Fact]
+    public void CheckAccess_DeniesUnknownAgent()
+    {
+        var v = MakeVault();
+        Assert.False(v.CheckAccess("did:web:rogue", "github_pat", "github:read_issues"));
+    }
+
+    [Fact]
+    public void CheckAccess_DeniesUnboundAction()
+    {
+        var v = MakeVault();
+        Assert.False(v.CheckAccess("did:web:agent-ci", "db_password", "db:query"));
+    }
+
+    [Fact]
+    public void CheckAccess_DeniesCrossActionReuse()
+    {
+        var v = MakeVault();
+        Assert.False(v.CheckAccess("did:web:agent-analytics", "db_password", "db:admin"));
+    }
+
+    [Fact]
+    public void ProfileBindings_IsolatedFromCallerMutation()
+    {
+        var bindings = new Dictionary<string, string> { ["a"] = "h" };
+        var p = new CredentialProfile("did:web:x", bindings);
+        bindings["a"] = "other";
+        Assert.Equal("h", p.CapabilityFor("a"));
+    }
+}
+
+public class CredentialInjectorTests
+{
+    private static (CredentialVault v, CredentialInjector i) MakeStack()
+    {
+        var v = new CredentialVault();
+        v.Put("github_pat", "GHP-RESOLVED-VALUE");
+        v.Put("db_password", "DBP-VALUE");
+        v.RegisterProfile(new CredentialProfile("did:web:agent-ci",
+            new Dictionary<string, string>
+            {
+                ["github:read_issues"] = "github_pat",
+                ["github:push_code"] = "github_pat",
+            }));
+        v.RegisterProfile(new CredentialProfile("did:web:agent-analytics",
+            new Dictionary<string, string> { ["db:query"] = "db_password" }));
+        return (v, new CredentialInjector(v));
+    }
+
+    [Fact]
+    public void InjectHeaders_HappyPath()
+    {
+        var (_, i) = MakeStack();
+        var r = i.InjectHeaders("did:web:agent-ci",
+            new Dictionary<string, string>
+            {
+                ["Authorization"] = "Bearer {{cred:github_pat}}",
+                ["Accept"] = "application/json",
+            },
+            new InjectionOptions
+            {
+                ActionClass = "github:read_issues",
+                TargetService = "api.github.com",
+                AllowedHandles = new[] { "github_pat" },
+                PolicyVersion = "v1",
+            });
+        Assert.True(r.Allowed);
+        var headers = (Dictionary<string, string>)r.Payload;
+        Assert.Equal("Bearer GHP-RESOLVED-VALUE", headers["Authorization"]);
+        Assert.Null(r.DenyReceipt);
+        Assert.Single(r.AuditEvents);
+        Assert.Equal(CredentialDecision.Allow, r.AuditEvents[0].Decision);
+    }
+
+    [Fact]
+    public void InjectEnv_RendersValues()
+    {
+        var (_, i) = MakeStack();
+        var r = i.InjectEnv("did:web:agent-ci",
+            new Dictionary<string, string>
+            {
+                ["PATH"] = "/usr/bin",
+                ["GITHUB_TOKEN"] = "{{cred:github_pat}}",
+            },
+            new InjectionOptions
+            {
+                ActionClass = "github:read_issues",
+                TargetService = "subprocess",
+                AllowedHandles = new[] { "github_pat" },
+            });
+        Assert.True(r.Allowed);
+        var env = (Dictionary<string, string>)r.Payload;
+        Assert.Equal("GHP-RESOLVED-VALUE", env["GITHUB_TOKEN"]);
+    }
+
+    [Fact]
+    public void UnauthorizedPlaceholder_DeniesWholeCall_McpUntrusted()
+    {
+        var (_, i) = MakeStack();
+        var r = i.InjectToolArgs("did:web:agent-analytics",
+            new Dictionary<string, string> { ["sql"] = "SELECT 1", ["auth"] = "{{cred:github_pat}}" },
+            new InjectionOptions
+            {
+                ActionClass = "db:query",
+                TargetService = "pg",
+                AllowedHandles = new[] { "db_password" },
+            });
+        Assert.False(r.Allowed);
+        Assert.IsType<DenyReceipt>(r.Payload);
+        Assert.Equal(CredentialVault.DenyReason, ((DenyReceipt)r.Payload).Reason);
+    }
+
+    [Fact]
+    public void Missing_And_OutOfScope_ReturnIdenticalDeny()
+    {
+        var (_, i) = MakeStack();
+        var missing = i.InjectHeaders("did:web:agent-ci",
+            new Dictionary<string, string> { ["X"] = "{{cred:does_not_exist}}" },
+            new InjectionOptions
+            {
+                ActionClass = "github:read_issues",
+                TargetService = "svc",
+                AllowedHandles = new[] { "does_not_exist" },
+            });
+        var outOfScope = i.InjectHeaders("did:web:agent-ci",
+            new Dictionary<string, string> { ["X"] = "{{cred:db_password}}" },
+            new InjectionOptions
+            {
+                ActionClass = "github:read_issues",
+                TargetService = "svc",
+                AllowedHandles = new[] { "db_password" },
+            });
+        Assert.False(missing.Allowed);
+        Assert.False(outOfScope.Allowed);
+        Assert.Equal(missing.DenyReceipt, outOfScope.DenyReceipt);
+    }
+
+    [Fact]
+    public void PolicyCheck_RunsBeforeVaultRead()
+    {
+        var (_, i) = MakeStack();
+        var seen = new List<InjectionContext>();
+        var r = i.InjectHeaders("did:web:agent-ci",
+            new Dictionary<string, string> { ["Authorization"] = "Bearer {{cred:github_pat}}" },
+            new InjectionOptions
+            {
+                ActionClass = "github:push_code",
+                TargetService = "api.github.com",
+                AllowedHandles = new[] { "github_pat" },
+                PolicyVersion = "v7",
+                PolicyCheck = ctx => { seen.Add(ctx); return new PolicyOutcome(false, "no"); },
+            });
+        Assert.False(r.Allowed);
+        Assert.Single(seen);
+        Assert.Equal(new[] { "github_pat" }, seen[0].RequestedHandles);
+        Assert.Equal("v7", seen[0].PolicyVersion);
+    }
+
+    [Fact]
+    public void SameDenyAcrossSurfaces()
+    {
+        var (_, i) = MakeStack();
+        var opts = new InjectionOptions
+        {
+            ActionClass = "db:query",
+            TargetService = "svc",
+            AllowedHandles = new[] { "github_pat" },
+        };
+        var h = i.InjectHeaders("did:web:agent-analytics",
+            new Dictionary<string, string> { ["Authorization"] = "{{cred:github_pat}}" }, opts);
+        var a = i.InjectToolArgs("did:web:agent-analytics",
+            new Dictionary<string, string> { ["x"] = "{{cred:github_pat}}" }, opts);
+        var e = i.InjectEnv("did:web:agent-analytics",
+            new Dictionary<string, string> { ["TOKEN"] = "{{cred:github_pat}}" }, opts);
+        foreach (var r in new[] { h, a, e })
+        {
+            Assert.False(r.Allowed);
+            Assert.Equal(CredentialVault.DenyReason, r.DenyReceipt!.Reason);
+        }
+    }
+
+    [Fact]
+    public void PayloadWithoutPlaceholders_PassesThrough()
+    {
+        var (_, i) = MakeStack();
+        var r = i.InjectHeaders("did:web:agent-ci",
+            new Dictionary<string, string> { ["Accept"] = "application/json" },
+            new InjectionOptions
+            {
+                ActionClass = "github:read_issues",
+                TargetService = "svc",
+                AllowedHandles = Array.Empty<string>(),
+            });
+        Assert.True(r.Allowed);
+        Assert.Equal("application/json", ((Dictionary<string, string>)r.Payload)["Accept"]);
+    }
+}
+
+public class CredentialAuditTests
+{
+    [Fact]
+    public void AuditRecords_NoValueLeakage()
+    {
+        var v = new CredentialVault();
+        v.Put("github_pat", "GHP-RESOLVED-VALUE");
+        v.RegisterProfile(new CredentialProfile("did:web:agent-ci",
+            new Dictionary<string, string> { ["github:read_issues"] = "github_pat" }));
+        var i = new CredentialInjector(v);
+        i.InjectHeaders("did:web:agent-ci",
+            new Dictionary<string, string> { ["Authorization"] = "Bearer {{cred:github_pat}}" },
+            new InjectionOptions
+            {
+                ActionClass = "github:read_issues",
+                TargetService = "svc",
+                AllowedHandles = new[] { "github_pat" },
+                PolicyVersion = "v1",
+            });
+        var events = v.AuditLog();
+        Assert.Single(events);
+        Assert.Equal(CredentialDecision.Allow, events[0].Decision);
+        Assert.DoesNotContain("GHP-RESOLVED-VALUE", JsonSerializer.Serialize(events));
+    }
+
+    [Fact]
+    public void Digest_StableAndKeyDependent()
+    {
+        var v = new CredentialVault();
+        v.Put("k", "x");
+        v.RegisterProfile(new CredentialProfile("did:web:a",
+            new Dictionary<string, string> { ["act"] = "k" }));
+        var i = new CredentialInjector(v);
+        i.InjectHeaders("did:web:a",
+            new Dictionary<string, string> { ["A"] = "{{cred:k}}" },
+            new InjectionOptions
+            {
+                ActionClass = "act",
+                TargetService = "svc",
+                AllowedHandles = new[] { "k" },
+            });
+        var events = v.AuditLog();
+        var k1 = Encoding.UTF8.GetBytes("k");
+        var k2 = Encoding.UTF8.GetBytes("other");
+        Assert.Equal(CredentialAudit.Digest(events, k1), CredentialAudit.Digest(events, k1));
+        Assert.NotEqual(CredentialAudit.Digest(events, k1), CredentialAudit.Digest(events, k2));
+    }
+}
+
+public class CredentialVaultRotationTests
+{
+    [Fact]
+    public void Rotation_DoesNotRequirePromptChanges()
+    {
+        var v = new CredentialVault();
+        v.Put("github_pat", "GHP-V1");
+        v.RegisterProfile(new CredentialProfile("did:web:agent-ci",
+            new Dictionary<string, string> { ["github:read_issues"] = "github_pat" }));
+        var i = new CredentialInjector(v);
+        var saved = new Dictionary<string, string> { ["Authorization"] = "Bearer {{cred:github_pat}}" };
+
+        var before = i.InjectHeaders("did:web:agent-ci", saved, new InjectionOptions
+        {
+            ActionClass = "github:read_issues",
+            TargetService = "svc",
+            AllowedHandles = new[] { "github_pat" },
+        });
+        Assert.Equal("Bearer GHP-V1", ((Dictionary<string, string>)before.Payload)["Authorization"]);
+
+        v.Rotate("github_pat", "GHP-V2");
+
+        var after = i.InjectHeaders("did:web:agent-ci", saved, new InjectionOptions
+        {
+            ActionClass = "github:read_issues",
+            TargetService = "svc",
+            AllowedHandles = new[] { "github_pat" },
+        });
+        Assert.Equal("Bearer GHP-V2", ((Dictionary<string, string>)after.Payload)["Authorization"]);
+        Assert.Equal("Bearer {{cred:github_pat}}", saved["Authorization"]);
+    }
+}
+
+public class CredentialVaultPersistenceTests
+{
+    [Fact]
+    public void RoundTrip_DistinctivePlaintextNotOnDisk() // gitleaks:allow
+    {
+        var key = CredentialVault.GenerateKey();
+        var tmp = Path.Combine(Path.GetTempPath(), $"vault-{Guid.NewGuid():N}.bin");
+        try
+        {
+            var secret = "distinctive rotated fixture not a real key"; // gitleaks:allow
+            var v1 = new CredentialVault(tmp, key);
+            v1.Put("k", "original");
+            v1.Rotate("k", secret);
+
+            var blob = File.ReadAllBytes(tmp);
+            // secret bytes not present anywhere in blob
+            var secretBytes = Encoding.UTF8.GetBytes(secret);
+            Assert.False(BytesContain(blob, secretBytes));
+            Assert.False(BytesContain(blob, Encoding.UTF8.GetBytes("\"value\"")));
+
+            var v2 = new CredentialVault(tmp, key);
+            Assert.Equal(new[] { "k" }, v2.ListHandles());
+            var meta = v2.GetMetadata("k")!;
+            Assert.Equal(2, (int)meta["version"]!);
+        }
+        finally
+        {
+            if (File.Exists(tmp)) File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void Persistence_RequiresKey()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new CredentialVault("/tmp/x.bin", null!));
+        Assert.Throws<ArgumentException>(() =>
+            new CredentialVault("/tmp/x.bin", new byte[16]));
+    }
+
+    private static bool BytesContain(byte[] haystack, byte[] needle)
+    {
+        if (needle.Length == 0) return true;
+        for (int i = 0; i <= haystack.Length - needle.Length; i++)
+        {
+            bool match = true;
+            for (int j = 0; j < needle.Length; j++)
+            {
+                if (haystack[i + j] != needle[j]) { match = false; break; }
+            }
+            if (match) return true;
+        }
+        return false;
+    }
+}
+
+public class CredentialPlaceholderRegexTests
+{
+    [Theory]
+    [InlineData("{{cred:abc}}", "abc")]
+    [InlineData("{{ cred:a.b-c_1 }}", "a.b-c_1")]
+    public void MatchesValid(string input, string expected)
+    {
+        var matches = CredentialInjector.PlaceholderRegex.Matches(input);
+        Assert.Single(matches);
+        Assert.Equal(expected, matches[0].Groups[1].Value);
+    }
+
+    [Theory]
+    [InlineData("{{cred:has space}}")]
+    [InlineData("{{cred:bad/slash}}")]
+    public void RejectsInvalid(string input)
+    {
+        Assert.Empty(CredentialInjector.PlaceholderRegex.Matches(input).Cast<object>());
+    }
+}


### PR DESCRIPTION
Rebased version of #2574 by Ricky-G. cspell conflict resolved.

Adds CredentialVault to .NET SDK with AES-256-GCM encryption, policy-first injection, allowlist filtering, and deterministic deny. 25 tests.

Co-authored-by: Ricky Gummadi <ricky.gummadi@outlook.com>