### PR TITLE
feat(rust): wire-protocol-aware policy evaluation for SQL and Kubernetes (#2537)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -386,3 +386,9 @@ workflow
 workflows
 xfail
 xunit
+dedup
+dedupe
+eprintln
+peekable
+recognising
+subresources

--- a/agent-governance-rust/agentmesh/examples/wire-protocol-rules.yaml
+++ b/agent-governance-rust/agentmesh/examples/wire-protocol-rules.yaml
@@ -1,0 +1,44 @@
+# Wire-protocol-aware policy rules (Rust SDK)
+#
+# Mirrors examples/policy-templates/wire-protocol-rules.yaml from the Python
+# SDK. Load with PolicyEngine::load_from_yaml(yaml_str).
+version: "1"
+agent: "did:example:agent1"
+policies:
+  # ── SQL ─────────────────────────────────────────────────────────────────
+  - name: deny-destructive-sql
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      sql.verb: [DROP, TRUNCATE, DELETE]
+
+  - name: deny-schema-changes
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      sql.verb: [ALTER, GRANT, REVOKE]
+
+  - name: deny-writes-to-protected
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      sql.target: protected
+
+  # ── Kubernetes ──────────────────────────────────────────────────────────
+  - name: deny-k8s-production-namespace
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      k8s.namespace: production
+
+  - name: deny-k8s-exec
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      k8s.subresource: exec
+
+  - name: deny-k8s-deletecollection
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      k8s.verb: deletecollection

--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -100,8 +100,8 @@ pub use integration_support::{
 pub use lifecycle::{LifecycleEvent, LifecycleManager, LifecycleState};
 pub use policy::{PolicyEngine, PolicyError};
 pub use protocol_facets::{
-    default_registry, extract_k8s_facets, extract_protocol_facets, extract_sql_facets,
-    FacetRegistry,
+    default_registry, extract_k8s_facets, extract_protocol_facets, extract_protocol_facets_with,
+    extract_sql_facets, FacetRegistry,
 };
 pub use prompt_injection::{
     AuditRecord as PromptInjectionAuditRecord, DetectionConfig as PromptInjectionDetectionConfig,

--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -45,6 +45,7 @@ pub mod mcp {
 }
 pub mod policy;
 pub mod prompt_injection;
+pub mod protocol_facets;
 pub(crate) mod regex_cache;
 pub mod reward_support;
 pub mod rings;
@@ -98,6 +99,10 @@ pub use integration_support::{
 };
 pub use lifecycle::{LifecycleEvent, LifecycleManager, LifecycleState};
 pub use policy::{PolicyEngine, PolicyError};
+pub use protocol_facets::{
+    default_registry, extract_k8s_facets, extract_protocol_facets, extract_sql_facets,
+    FacetRegistry,
+};
 pub use prompt_injection::{
     AuditRecord as PromptInjectionAuditRecord, DetectionConfig as PromptInjectionDetectionConfig,
     DetectionOptions as PromptInjectionDetectionOptions, DetectionResult as PromptInjectionResult,

--- a/agent-governance-rust/agentmesh/src/policy.rs
+++ b/agent-governance-rust/agentmesh/src/policy.rs
@@ -375,6 +375,17 @@ fn conditions_match(
     conditions: &HashMap<String, serde_yaml::Value>,
     context: Option<&HashMap<String, serde_yaml::Value>>,
 ) -> bool {
+    // Condition matching is **case-sensitive** for both keys and values.
+    // Wire-protocol extractors (`protocol_facets`) emit canonical casing:
+    // SQL verbs are uppercase (`SELECT`, `DROP`, ...) while Kubernetes
+    // verbs are lowercase (`get`, `list`, `watch`, ...). Policy authors
+    // must match that casing exactly — e.g.
+    //     sql.verb: DROP            # matches
+    //     sql.verb: drop            # does NOT match
+    //     k8s.verb: get             # matches
+    //     k8s.verb: GET             # does NOT match
+    // If the rule expresses the expected value as a YAML sequence the same
+    // case-sensitive comparison is applied to each element.
     if conditions.is_empty() {
         return true;
     }

--- a/agent-governance-rust/agentmesh/src/policy.rs
+++ b/agent-governance-rust/agentmesh/src/policy.rs
@@ -4,6 +4,7 @@
 //! YAML-based policy evaluation engine with four-way decisions:
 //! allow, deny, requires-approval, and rate-limit.
 
+use crate::protocol_facets::extract_protocol_facets;
 use crate::types::{
     CandidateDecision, ConflictResolutionStrategy, PolicyDecision, PolicyScope, ResolutionResult,
 };
@@ -218,6 +219,16 @@ impl PolicyEngine {
         action: &str,
         context: Option<&HashMap<String, serde_yaml::Value>>,
     ) -> PolicyDecision {
+        // Enrich a copy of the context with wire-protocol facets (sql.*, k8s.*)
+        // so existing condition matching can reference protocol-level fields
+        // without any rule-schema changes. We never mutate the caller's map.
+        let enriched: Option<HashMap<String, serde_yaml::Value>> = context.map(|c| {
+            let mut owned = c.clone();
+            extract_protocol_facets(&mut owned);
+            owned
+        });
+        let effective_ctx = enriched.as_ref().or(context);
+
         let guard = self.profile.read().unwrap_or_else(|e| e.into_inner());
         let profile = match guard.as_ref() {
             Some(p) => p,
@@ -225,7 +236,7 @@ impl PolicyEngine {
         };
 
         for rule in &profile.policies {
-            if !conditions_match(&rule.conditions, context) {
+            if !conditions_match(&rule.conditions, effective_ctx) {
                 continue;
             }
 
@@ -372,9 +383,22 @@ fn conditions_match(
         None => return false,
     };
     for (key, expected) in conditions {
-        match ctx.get(key) {
-            Some(actual) if actual == expected => {}
-            _ => return false,
+        let actual = match ctx.get(key) {
+            Some(v) => v,
+            None => return false,
+        };
+        // If the rule expresses the expected value as a sequence (YAML list),
+        // treat the comparison as set membership (`actual in expected`).
+        // Otherwise fall back to strict equality. This is the minimal
+        // surface needed for wire-protocol rules like
+        //   sql.verb: [DROP, TRUNCATE, DELETE]
+        // while preserving existing exact-match semantics.
+        if let serde_yaml::Value::Sequence(seq) = expected {
+            if !seq.iter().any(|v| v == actual) {
+                return false;
+            }
+        } else if actual != expected {
+            return false;
         }
     }
     true

--- a/agent-governance-rust/agentmesh/src/protocol_facets.rs
+++ b/agent-governance-rust/agentmesh/src/protocol_facets.rs
@@ -1,0 +1,1109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Protocol-aware facet extraction for policy evaluation.
+//!
+//! Populates `sql.*` and `k8s.*` keys in the evaluation context so YAML
+//! policy rules can reference wire-level semantics (e.g. `sql.verb`,
+//! `k8s.namespace`) alongside HTTP metadata.
+//!
+//! This is the Rust port of `protocol_facets.py` and mirrors its public
+//! contract: [`FacetRegistry`], [`default_registry`], and
+//! [`extract_protocol_facets`].
+//!
+//! # Custom protocols
+//!
+//! ```
+//! use agentmesh::protocol_facets::default_registry;
+//! use serde_yaml::Value;
+//!
+//! default_registry().register("redis", |sub| {
+//!     let mut out = std::collections::HashMap::new();
+//!     if let Some(Value::String(cmd)) = sub.get("command") {
+//!         out.insert("verb".to_string(), Value::String(cmd.to_uppercase()));
+//!     }
+//!     out
+//! });
+//! ```
+
+use regex::Regex;
+use serde_yaml::Value;
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+
+/// Function signature for a protocol facet extractor.
+///
+/// Receives the sub-mapping stored at the registered context key and
+/// returns the facet fields to merge back into that sub-mapping. The
+/// returned keys are inserted as `<context_key>.<field>` flat entries on
+/// the top-level context so they can be referenced by policy rules.
+pub type ExtractorFn =
+    Box<dyn Fn(&serde_yaml::Mapping) -> HashMap<String, Value> + Send + Sync + 'static>;
+
+/// Holds protocol facet extractors keyed by context field name.
+///
+/// Each extractor receives the sub-mapping at its registered key and
+/// returns fields to merge back. Errors inside an extractor are isolated:
+/// because Rust functions cannot throw, extractors that cannot classify
+/// input return UNKNOWN/empty values rather than propagating failure.
+pub struct FacetRegistry {
+    extractors: RwLock<Vec<(String, ExtractorFn)>>,
+}
+
+impl FacetRegistry {
+    /// Create an empty registry with no built-in extractors.
+    pub fn new() -> Self {
+        Self {
+            extractors: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Register an extractor for sub-mappings stored at `context_key`.
+    pub fn register<F>(&self, context_key: impl Into<String>, extractor: F)
+    where
+        F: Fn(&serde_yaml::Mapping) -> HashMap<String, Value> + Send + Sync + 'static,
+    {
+        let mut guard = self
+            .extractors
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        guard.push((context_key.into(), Box::new(extractor)));
+    }
+
+    /// Number of registered extractors. Primarily for tests.
+    pub fn len(&self) -> usize {
+        self.extractors
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
+    }
+
+    /// Returns true if no extractors are registered.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Remove all registered extractors. Primarily for tests.
+    pub fn clear(&self) {
+        self.extractors
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+    }
+
+    /// Run all registered extractors against `context` in place.
+    ///
+    /// For each registered key whose value is a mapping, the extractor is
+    /// called and the returned fields are:
+    /// 1. Merged back into the sub-mapping (so callers inspecting the raw
+    ///    context see them), and
+    /// 2. Inserted as flat `<key>.<field>` entries on the top-level
+    ///    context so dot-keyed policy rules match.
+    pub fn extract(&self, context: &mut HashMap<String, Value>) {
+        let extractors = self
+            .extractors
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+
+        // Snapshot the (key, facets) pairs first so we don't hold a mutable
+        // borrow on `context` while iterating extractors.
+        let mut updates: Vec<(String, HashMap<String, Value>)> = Vec::new();
+        for (key, extractor) in extractors.iter() {
+            let sub_map = match context.get(key) {
+                Some(Value::Mapping(m)) => m.clone(),
+                _ => continue,
+            };
+            // Per-extractor panic isolation: a buggy parser must never block
+            // policy evaluation.
+            let facets = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                extractor(&sub_map)
+            })) {
+                Ok(facets) => facets,
+                Err(_) => {
+                    eprintln!(
+                        "[protocol_facets] extractor for '{}' panicked; skipping",
+                        key
+                    );
+                    continue;
+                }
+            };
+            updates.push((key.clone(), facets));
+        }
+
+        for (key, facets) in updates {
+            // Merge facets back into the sub-mapping so consumers can read
+            // them via `context["sql"]["verb"]`.
+            if let Some(Value::Mapping(m)) = context.get_mut(&key) {
+                for (fk, fv) in &facets {
+                    m.insert(Value::String(fk.clone()), fv.clone());
+                }
+            }
+            // Also flatten to `key.field` at the top level so the existing
+            // condition matcher (which is keyed by string) hits them
+            // without needing dot-path traversal.
+            for (fk, fv) in facets {
+                context.insert(format!("{}.{}", key, fk), fv);
+            }
+        }
+    }
+}
+
+impl Default for FacetRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── SQL facets ──────────────────────────────────────────────────────────────
+
+const SQL_KNOWN_VERBS: &[&str] = &[
+    "SELECT", "INSERT", "UPDATE", "DELETE", "DROP", "TRUNCATE", "ALTER", "CREATE", "GRANT",
+    "REVOKE", "MERGE", "CALL", "EXECUTE", "EXPLAIN", "WITH", "REPLACE", "RENAME", "COMMENT",
+];
+
+fn known_verb(s: &str) -> bool {
+    SQL_KNOWN_VERBS.contains(&s)
+}
+
+fn empty_sql_facets() -> HashMap<String, Value> {
+    let mut m = HashMap::new();
+    m.insert("verb".to_string(), Value::String(String::new()));
+    m.insert("target".to_string(), Value::String(String::new()));
+    m.insert("tables".to_string(), Value::String(String::new()));
+    m.insert("functions".to_string(), Value::String(String::new()));
+    m
+}
+
+fn unknown_sql_facets() -> HashMap<String, Value> {
+    let mut m = empty_sql_facets();
+    m.insert("verb".to_string(), Value::String("UNKNOWN".to_string()));
+    m
+}
+
+/// Strip `/* ... */` and `-- ...` style SQL comments.
+fn strip_sql_comments(sql: &str) -> String {
+    static BLOCK: OnceLock<Regex> = OnceLock::new();
+    static LINE: OnceLock<Regex> = OnceLock::new();
+    let block = BLOCK.get_or_init(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
+    let line = LINE.get_or_init(|| Regex::new(r"--[^\n\r]*").unwrap());
+    let s = block.replace_all(sql, " ").to_string();
+    line.replace_all(&s, " ").to_string()
+}
+
+/// Split on top-level semicolons (outside quoted strings).
+fn split_sql_statements(sql: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut buf = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = sql.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if let Some(q) = quote {
+            buf.push(ch);
+            if ch == q {
+                // Escaped doubled quote
+                if chars.peek().copied() == Some(q) {
+                    if let Some(next) = chars.next() {
+                        buf.push(next);
+                    }
+                } else {
+                    quote = None;
+                }
+            }
+            continue;
+        }
+        if ch == '\'' || ch == '"' || ch == '`' {
+            quote = Some(ch);
+            buf.push(ch);
+            continue;
+        }
+        if ch == ';' {
+            let t = buf.trim().to_string();
+            if !t.is_empty() {
+                out.push(t);
+            }
+            buf.clear();
+            continue;
+        }
+        buf.push(ch);
+    }
+    let tail = buf.trim().to_string();
+    if !tail.is_empty() {
+        out.push(tail);
+    }
+    out
+}
+
+/// For a CTE-prefixed query, find the first DML keyword at top-level
+/// paren depth. Falls back to SELECT.
+fn detect_cte_inner_verb(query: &str) -> &'static str {
+    let mut depth: i32 = 0;
+    let mut quote: Option<char> = None;
+    let mut token = String::new();
+    let mut saw_with = false;
+    let bytes: Vec<char> = query.chars().collect();
+    for &ch in bytes.iter().chain(std::iter::once(&' ')) {
+        if let Some(q) = quote {
+            if ch == q {
+                quote = None;
+            }
+            continue;
+        }
+        if ch == '\'' || ch == '"' || ch == '`' {
+            quote = Some(ch);
+            continue;
+        }
+        if ch == '(' {
+            depth += 1;
+            token.clear();
+            continue;
+        }
+        if ch == ')' {
+            depth = (depth - 1).max(0);
+            token.clear();
+            continue;
+        }
+        if ch.is_ascii_alphabetic() || ch == '_' {
+            token.push(ch);
+            continue;
+        }
+        if !token.is_empty() {
+            if depth == 0 {
+                let up = token.to_ascii_uppercase();
+                if !saw_with && up == "WITH" {
+                    saw_with = true;
+                } else {
+                    match up.as_str() {
+                        "SELECT" => return "SELECT",
+                        "INSERT" => return "INSERT",
+                        "UPDATE" => return "UPDATE",
+                        "DELETE" => return "DELETE",
+                        "MERGE" => return "MERGE",
+                        _ => {}
+                    }
+                }
+            }
+            token.clear();
+        }
+    }
+    "SELECT"
+}
+
+const IDENT_PART: &str = r#"(?:[A-Za-z_][A-Za-z0-9_]*|"[^"]+"|`[^`]+`|\[[^\]]+\])"#;
+
+fn ident_pattern() -> String {
+    format!(r"({0}(?:\.{0})*)", IDENT_PART)
+}
+
+/// Normalize an identifier capture: take last dotted segment and strip
+/// surrounding quoting/brackets to match Python sqlglot `Table.name`.
+fn normalize_ident(ident: &str) -> String {
+    let s = ident.trim();
+    let mut parts: Vec<String> = Vec::new();
+    let mut buf = String::new();
+    let mut depth: Option<char> = None;
+    for ch in s.chars() {
+        if let Some(open) = depth {
+            buf.push(ch);
+            let close = match open {
+                '"' => '"',
+                '`' => '`',
+                '[' => ']',
+                _ => '\0',
+            };
+            if ch == close {
+                depth = None;
+            }
+            continue;
+        }
+        match ch {
+            '"' | '`' | '[' => {
+                depth = Some(ch);
+                buf.push(ch);
+            }
+            '.' => {
+                parts.push(std::mem::take(&mut buf));
+            }
+            _ => buf.push(ch),
+        }
+    }
+    parts.push(buf);
+    let mut last = parts.pop().unwrap_or_default().trim().to_string();
+    if (last.starts_with('"') && last.ends_with('"'))
+        || (last.starts_with('`') && last.ends_with('`'))
+        || (last.starts_with('[') && last.ends_with(']'))
+    {
+        last = last[1..last.len() - 1].to_string();
+    }
+    last
+}
+
+fn extract_tables(query: &str, verb: &str) -> Vec<String> {
+    let ident = ident_pattern();
+    let mut patterns: Vec<Regex> = Vec::new();
+    patterns.push(Regex::new(&format!(r"(?i)\bFROM\s+{}", ident)).unwrap());
+    patterns.push(Regex::new(&format!(r"(?i)\bJOIN\s+{}", ident)).unwrap());
+    patterns.push(Regex::new(&format!(r"(?i)\bINTO\s+{}", ident)).unwrap());
+    patterns.push(Regex::new(&format!(r"(?i)\bUPDATE\s+{}", ident)).unwrap());
+
+    if matches!(verb, "DROP" | "TRUNCATE" | "ALTER" | "CREATE" | "RENAME") {
+        let p = format!(
+            r"(?i)\b{}\s+(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?{}",
+            verb, ident
+        );
+        patterns.push(Regex::new(&p).unwrap());
+        patterns.push(Regex::new(&format!(r"(?i)\bON\s+{}", ident)).unwrap());
+    }
+    if matches!(verb, "GRANT" | "REVOKE") {
+        patterns.push(Regex::new(&format!(r"(?i)\bON\s+(?:TABLE\s+)?{}", ident)).unwrap());
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut found = Vec::new();
+    for re in &patterns {
+        for caps in re.captures_iter(query) {
+            if let Some(m) = caps.get(1) {
+                let name = normalize_ident(m.as_str());
+                if !name.is_empty() && seen.insert(name.clone()) {
+                    found.push(name);
+                }
+            }
+        }
+    }
+    found
+}
+
+const FUNC_DENYLIST: &[&str] = &[
+    "VALUES", "IN", "EXISTS", "ANY", "ALL", "SOME", "CAST", "CASE", "IF", "DISTINCT", "ON",
+    "USING", "WHEN", "THEN", "ELSE", "AND", "OR", "NOT",
+];
+
+fn extract_functions(query: &str) -> Vec<String> {
+    static FUNC_RE: OnceLock<Regex> = OnceLock::new();
+    let re = FUNC_RE.get_or_init(|| Regex::new(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(").unwrap());
+    let mut seen = std::collections::HashSet::new();
+    let mut found = Vec::new();
+    for caps in re.captures_iter(query) {
+        if let Some(m) = caps.get(1) {
+            let up = m.as_str().to_ascii_uppercase();
+            if FUNC_DENYLIST.contains(&up.as_str()) {
+                continue;
+            }
+            if seen.insert(up.clone()) {
+                found.push(up);
+            }
+        }
+    }
+    found
+}
+
+fn pick_target(query: &str, verb: &str, tables: &[String]) -> String {
+    let ident = ident_pattern();
+    let pat = match verb {
+        "INSERT" | "MERGE" => Some(format!(r"(?i)\bINTO\s+{}", ident)),
+        "UPDATE" => Some(format!(r"(?i)\bUPDATE\s+{}", ident)),
+        "DELETE" => Some(format!(r"(?i)\bDELETE\s+FROM\s+{}", ident)),
+        "DROP" | "TRUNCATE" | "ALTER" | "CREATE" | "RENAME" => Some(format!(
+            r"(?i)\b{}\s+(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?{}",
+            verb, ident
+        )),
+        "GRANT" | "REVOKE" => Some(format!(r"(?i)\bON\s+(?:TABLE\s+)?{}", ident)),
+        _ => Some(format!(r"(?i)\bFROM\s+{}", ident)),
+    };
+    if let Some(p) = pat {
+        let re = Regex::new(&p).unwrap();
+        if let Some(caps) = re.captures(query) {
+            if let Some(m) = caps.get(1) {
+                return normalize_ident(m.as_str());
+            }
+        }
+    }
+    // DELETE without FROM (rare dialects): fall back to first FROM
+    if verb == "DELETE" {
+        let re = Regex::new(&format!(r"(?i)\bFROM\s+{}", ident)).unwrap();
+        if let Some(caps) = re.captures(query) {
+            if let Some(m) = caps.get(1) {
+                return normalize_ident(m.as_str());
+            }
+        }
+    }
+    tables.first().cloned().unwrap_or_default()
+}
+
+/// Built-in SQL facet extractor. Reads `sql_ctx["query"]` and returns
+/// `{verb, target, tables, functions}` (as flat-string fields).
+pub fn extract_sql_facets(sql_ctx: &serde_yaml::Mapping) -> HashMap<String, Value> {
+    let raw = match sql_ctx.get(Value::String("query".to_string())) {
+        Some(Value::String(s)) => s.clone(),
+        _ => return empty_sql_facets(),
+    };
+    let stripped = strip_sql_comments(&raw);
+    let trimmed = stripped.trim();
+    if trimmed.is_empty() {
+        return empty_sql_facets();
+    }
+
+    let statements = split_sql_statements(trimmed);
+    if statements.len() > 1 {
+        return unknown_sql_facets();
+    }
+    let query = statements.first().cloned().unwrap_or_else(|| trimmed.to_string());
+
+    let verb_match = match Regex::new(r"^\s*([A-Za-z]+)").unwrap().captures(&query) {
+        Some(c) => c.get(1).unwrap().as_str().to_ascii_uppercase(),
+        None => return unknown_sql_facets(),
+    };
+
+    let verb: String = if verb_match == "WITH" {
+        detect_cte_inner_verb(&query).to_string()
+    } else if known_verb(&verb_match) {
+        verb_match
+    } else {
+        "UNKNOWN".to_string()
+    };
+
+    let tables = extract_tables(&query, &verb);
+    let functions = extract_functions(&query);
+    let target = pick_target(&query, &verb, &tables);
+
+    let mut out = HashMap::new();
+    out.insert("verb".to_string(), Value::String(verb));
+    out.insert("target".to_string(), Value::String(target));
+    out.insert("tables".to_string(), Value::String(tables.join(",")));
+    out.insert("functions".to_string(), Value::String(functions.join(",")));
+    out
+}
+
+// ── Kubernetes facets ───────────────────────────────────────────────────────
+
+struct K8sPattern {
+    re: Regex,
+    groups: &'static [&'static str],
+}
+
+fn k8s_patterns() -> &'static Vec<K8sPattern> {
+    static P: OnceLock<Vec<K8sPattern>> = OnceLock::new();
+    P.get_or_init(|| {
+        let mk = |p: &str, g: &'static [&'static str]| K8sPattern {
+            re: Regex::new(p).unwrap(),
+            groups: g,
+        };
+        vec![
+            // Watch — namespaced collection
+            mk(
+                r"^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource"],
+            ),
+            mk(
+                r"^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource"],
+            ),
+            // Watch — namespaced named
+            mk(
+                r"^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource", "name"],
+            ),
+            mk(
+                r"^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource", "name"],
+            ),
+            // Watch — cluster
+            mk(r"^/api/[^/]+/watch/([^/]+)/?$", &["resource"]),
+            mk(r"^/apis/[^/]+/[^/]+/watch/([^/]+)/?$", &["resource"]),
+            // Proxy tail
+            mk(
+                r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
+                &["namespace", "resource", "name", "subresource"],
+            ),
+            mk(
+                r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
+                &["namespace", "resource", "name", "subresource"],
+            ),
+            // Generic — most specific first
+            mk(
+                r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource", "name", "subresource"],
+            ),
+            mk(
+                r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource", "name", "subresource"],
+            ),
+            mk(
+                r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource", "name"],
+            ),
+            mk(
+                r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource", "name"],
+            ),
+            mk(
+                r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource"],
+            ),
+            mk(
+                r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/?$",
+                &["namespace", "resource"],
+            ),
+            mk(r"^/api/[^/]+/([^/]+)/([^/]+)/?$", &["resource", "name"]),
+            mk(r"^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/?$", &["resource", "name"]),
+            mk(r"^/api/[^/]+/([^/]+)/?$", &["resource"]),
+            mk(r"^/apis/[^/]+/[^/]+/([^/]+)/?$", &["resource"]),
+        ]
+    })
+}
+
+fn method_to_verb_named(m: &str) -> Option<&'static str> {
+    Some(match m {
+        "GET" => "get",
+        "DELETE" => "delete",
+        "PUT" => "update",
+        "PATCH" => "patch",
+        "POST" => "create",
+        "HEAD" => "get",
+        _ => return None,
+    })
+}
+
+fn method_to_verb_collection(m: &str) -> Option<&'static str> {
+    Some(match m {
+        "GET" => "list",
+        "POST" => "create",
+        "DELETE" => "deletecollection",
+        "PUT" => "update",
+        "PATCH" => "patch",
+        "HEAD" => "list",
+        _ => return None,
+    })
+}
+
+/// Built-in Kubernetes facet extractor. Reads `k8s_ctx["method"]` and
+/// `k8s_ctx["path"]` and returns `{verb, resource, namespace, name, subresource}`.
+pub fn extract_k8s_facets(k8s_ctx: &serde_yaml::Mapping) -> HashMap<String, Value> {
+    let method = match k8s_ctx.get(Value::String("method".to_string())) {
+        Some(Value::String(s)) => s.to_ascii_uppercase(),
+        _ => String::new(),
+    };
+    let path = match k8s_ctx.get(Value::String("path".to_string())) {
+        Some(Value::String(s)) => s.clone(),
+        _ => String::new(),
+    };
+
+    let mut out: HashMap<String, Value> = HashMap::new();
+    for k in ["verb", "resource", "namespace", "name", "subresource"] {
+        out.insert(k.to_string(), Value::String(String::new()));
+    }
+    if path.is_empty() {
+        return out;
+    }
+
+    let mut matched: HashMap<&'static str, String> = HashMap::new();
+    for pat in k8s_patterns() {
+        if let Some(caps) = pat.re.captures(&path) {
+            for (i, g) in pat.groups.iter().enumerate() {
+                if let Some(m) = caps.get(i + 1) {
+                    matched.insert(*g, m.as_str().to_string());
+                }
+            }
+            break;
+        }
+    }
+
+    let resource = matched.get("resource").cloned().unwrap_or_default();
+    let namespace = matched.get("namespace").cloned().unwrap_or_default();
+    let name = matched.get("name").cloned().unwrap_or_default();
+    let subresource = matched.get("subresource").cloned().unwrap_or_default();
+
+    let is_watch = path.contains("/watch/");
+    let verb: String = if is_watch {
+        "watch".to_string()
+    } else if !method.is_empty() {
+        let tbl = if !name.is_empty() {
+            method_to_verb_named(&method)
+        } else {
+            method_to_verb_collection(&method)
+        };
+        tbl.map(|s| s.to_string())
+            .unwrap_or_else(|| method.to_ascii_lowercase())
+    } else {
+        String::new()
+    };
+
+    out.insert("verb".to_string(), Value::String(verb));
+    out.insert("resource".to_string(), Value::String(resource));
+    out.insert("namespace".to_string(), Value::String(namespace));
+    out.insert("name".to_string(), Value::String(name));
+    out.insert("subresource".to_string(), Value::String(subresource));
+    out
+}
+
+// ── Default registry & top-level API ───────────────────────────────────────
+
+/// Returns the process-wide default [`FacetRegistry`], pre-loaded with SQL
+/// and Kubernetes extractors. Call `.register(..)` on it to add support
+/// for new protocols.
+pub fn default_registry() -> &'static FacetRegistry {
+    static R: OnceLock<FacetRegistry> = OnceLock::new();
+    R.get_or_init(|| {
+        let r = FacetRegistry::new();
+        r.register("sql", extract_sql_facets);
+        r.register("k8s", extract_k8s_facets);
+        r
+    })
+}
+
+/// Enrich a policy evaluation context with wire-protocol facets.
+///
+/// Mutates `context` in place. Inserts flat `sql.verb`, `k8s.namespace`,
+/// etc. keys so existing condition-matching code can match without
+/// dot-path traversal.
+pub fn extract_protocol_facets(context: &mut HashMap<String, Value>) {
+    default_registry().extract(context);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map_of(pairs: &[(&str, Value)]) -> serde_yaml::Mapping {
+        let mut m = serde_yaml::Mapping::new();
+        for (k, v) in pairs {
+            m.insert(Value::String((*k).to_string()), v.clone());
+        }
+        m
+    }
+
+    // ── FacetRegistry ────────────────────────────────────────────────────
+
+    #[test]
+    fn registry_runs_custom_extractor_and_flattens_keys() {
+        let r = FacetRegistry::new();
+        r.register("redis", |sub| {
+            let mut out = HashMap::new();
+            let cmd = sub
+                .get(Value::String("command".to_string()))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_ascii_uppercase();
+            out.insert("verb".to_string(), Value::String(cmd));
+            out
+        });
+
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert(
+            "redis".to_string(),
+            Value::Mapping(map_of(&[(
+                "command",
+                Value::String("flushall".to_string()),
+            )])),
+        );
+
+        r.extract(&mut ctx);
+
+        // Flat key inserted at top level
+        assert_eq!(
+            ctx.get("redis.verb").and_then(|v| v.as_str()),
+            Some("FLUSHALL")
+        );
+        // And merged into sub-mapping
+        if let Some(Value::Mapping(m)) = ctx.get("redis") {
+            assert_eq!(
+                m.get(Value::String("verb".to_string()))
+                    .and_then(|v| v.as_str()),
+                Some("FLUSHALL")
+            );
+        } else {
+            panic!("redis sub-context missing or not a mapping");
+        }
+    }
+
+    #[test]
+    fn registry_skips_missing_or_non_mapping_sub_contexts() {
+        let r = FacetRegistry::new();
+        r.register("sql", extract_sql_facets);
+
+        let mut empty: HashMap<String, Value> = HashMap::new();
+        r.extract(&mut empty);
+        assert!(empty.is_empty());
+
+        let mut wrong_type: HashMap<String, Value> = HashMap::new();
+        wrong_type.insert("sql".to_string(), Value::String("not a mapping".into()));
+        r.extract(&mut wrong_type);
+        assert_eq!(wrong_type.len(), 1);
+        assert!(!wrong_type.contains_key("sql.verb"));
+    }
+
+    #[test]
+    fn registry_isolates_panicking_extractors() {
+        let r = FacetRegistry::new();
+        r.register("bad", |_| panic!("boom"));
+        r.register("good", |_| {
+            let mut m = HashMap::new();
+            m.insert("ok".to_string(), Value::Bool(true));
+            m
+        });
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert("bad".to_string(), Value::Mapping(serde_yaml::Mapping::new()));
+        ctx.insert(
+            "good".to_string(),
+            Value::Mapping(serde_yaml::Mapping::new()),
+        );
+        r.extract(&mut ctx);
+        assert_eq!(ctx.get("good.ok"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn default_registry_has_sql_and_k8s() {
+        let r = default_registry();
+        assert!(r.len() >= 2);
+    }
+
+    // ── SQL ──────────────────────────────────────────────────────────────
+
+    fn sql_facets(q: &str) -> HashMap<String, Value> {
+        extract_sql_facets(&map_of(&[("query", Value::String(q.to_string()))]))
+    }
+
+    fn fv(m: &HashMap<String, Value>, k: &str) -> String {
+        m.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    }
+
+    #[test]
+    fn sql_empty_query_returns_empty_fields() {
+        let f = extract_sql_facets(&serde_yaml::Mapping::new());
+        assert_eq!(fv(&f, "verb"), "");
+        let f = sql_facets("");
+        assert_eq!(fv(&f, "verb"), "");
+        let f = sql_facets("    ");
+        assert_eq!(fv(&f, "verb"), "");
+    }
+
+    #[test]
+    fn sql_basic_verbs_and_targets() {
+        let cases = [
+            ("SELECT * FROM users", "SELECT", "users"),
+            ("select id from users", "SELECT", "users"),
+            ("INSERT INTO orders (id) VALUES (1)", "INSERT", "orders"),
+            (
+                "UPDATE accounts SET balance = 0 WHERE id = 1",
+                "UPDATE",
+                "accounts",
+            ),
+            (
+                "DELETE FROM sessions WHERE expired = true",
+                "DELETE",
+                "sessions",
+            ),
+            ("DROP TABLE production", "DROP", "production"),
+            (
+                "DROP TABLE IF EXISTS staging.payments",
+                "DROP",
+                "payments",
+            ),
+            ("TRUNCATE TABLE audit_log", "TRUNCATE", "audit_log"),
+            (
+                "ALTER TABLE users ADD COLUMN age INT",
+                "ALTER",
+                "users",
+            ),
+            ("CREATE TABLE foo (id INT)", "CREATE", "foo"),
+            ("GRANT SELECT ON users TO bob", "GRANT", "users"),
+            (
+                "MERGE INTO dst USING src ON dst.id = src.id",
+                "MERGE",
+                "dst",
+            ),
+        ];
+        for (q, verb, target) in cases {
+            let f = sql_facets(q);
+            assert_eq!(fv(&f, "verb"), verb, "query={}", q);
+            assert_eq!(fv(&f, "target"), target, "query={}", q);
+        }
+    }
+
+    #[test]
+    fn sql_unknown_verb_for_garbage() {
+        let f = sql_facets("WAT IS THIS");
+        assert_eq!(fv(&f, "verb"), "UNKNOWN");
+    }
+
+    #[test]
+    fn sql_multi_statement_fails_closed() {
+        let f = sql_facets("SELECT 1; DROP TABLE production");
+        assert_eq!(fv(&f, "verb"), "UNKNOWN");
+        assert_eq!(fv(&f, "target"), "");
+    }
+
+    #[test]
+    fn sql_trailing_semicolon_ok() {
+        let f = sql_facets("SELECT * FROM users;");
+        assert_eq!(fv(&f, "verb"), "SELECT");
+        assert_eq!(fv(&f, "target"), "users");
+    }
+
+    #[test]
+    fn sql_semicolon_in_string_is_not_boundary() {
+        let f = sql_facets("SELECT * FROM users WHERE name = 'a;b'");
+        assert_eq!(fv(&f, "verb"), "SELECT");
+    }
+
+    #[test]
+    fn sql_cte_classifies_inner_verb() {
+        assert_eq!(
+            fv(
+                &sql_facets(
+                    "WITH stale AS (SELECT id FROM users WHERE inactive) DELETE FROM users WHERE id IN (SELECT id FROM stale)"
+                ),
+                "verb"
+            ),
+            "DELETE"
+        );
+        assert_eq!(
+            fv(
+                &sql_facets(
+                    "WITH new_rows AS (SELECT 1 AS id) INSERT INTO audit (id) SELECT id FROM new_rows"
+                ),
+                "verb"
+            ),
+            "INSERT"
+        );
+        assert_eq!(
+            fv(&sql_facets("WITH x AS (SELECT 1) SELECT * FROM x"), "verb"),
+            "SELECT"
+        );
+    }
+
+    #[test]
+    fn sql_insert_target_is_written_object() {
+        let f = sql_facets("INSERT INTO protected SELECT * FROM source");
+        assert_eq!(fv(&f, "verb"), "INSERT");
+        assert_eq!(fv(&f, "target"), "protected");
+        let raw = fv(&f, "tables");
+        let tables: Vec<&str> = raw.split(',').collect();
+        assert!(tables.contains(&"protected"));
+        assert!(tables.contains(&"source"));
+    }
+
+    #[test]
+    fn sql_update_with_from_target_is_written_object() {
+        let f = sql_facets(
+            "UPDATE protected SET val = src.val FROM source AS src WHERE protected.id = src.id",
+        );
+        assert_eq!(fv(&f, "target"), "protected");
+    }
+
+    #[test]
+    fn sql_delete_from_target() {
+        let f = sql_facets("DELETE FROM protected WHERE id IN (SELECT id FROM staging)");
+        assert_eq!(fv(&f, "verb"), "DELETE");
+        assert_eq!(fv(&f, "target"), "protected");
+    }
+
+    #[test]
+    fn sql_function_extraction_dedup_and_denylist() {
+        let f = sql_facets("SELECT COUNT(id), Count(name), NOW() FROM users");
+        let raw = fv(&f, "functions");
+        let fns: Vec<&str> = raw.split(',').collect();
+        assert!(fns.contains(&"COUNT"));
+        assert!(fns.contains(&"NOW"));
+        // dedupe
+        assert_eq!(fns.iter().filter(|x| **x == "COUNT").count(), 1);
+
+        let f = sql_facets("INSERT INTO t VALUES (CAST('1' AS INT))");
+        let raw = fv(&f, "functions");
+        let fns: Vec<&str> = raw.split(',').filter(|s| !s.is_empty()).collect();
+        assert!(!fns.contains(&"VALUES"));
+        assert!(!fns.contains(&"CAST"));
+    }
+
+    #[test]
+    fn sql_strips_comments() {
+        let f = sql_facets("/* hi */ -- comment\n SELECT id FROM users -- tail");
+        assert_eq!(fv(&f, "verb"), "SELECT");
+        assert_eq!(fv(&f, "target"), "users");
+    }
+
+    #[test]
+    fn sql_strips_quoting() {
+        let cases = [
+            (r#"SELECT * FROM "public"."users""#, "users"),
+            ("SELECT * FROM `db`.`orders`", "orders"),
+            ("SELECT * FROM [dbo].[items]", "items"),
+        ];
+        for (q, expected) in cases {
+            let f = sql_facets(q);
+            let raw = fv(&f, "tables");
+            let tables: Vec<&str> = raw.split(',').collect();
+            assert!(tables.contains(&expected), "query={}, tables={:?}", q, tables);
+        }
+    }
+
+    // ── K8s ──────────────────────────────────────────────────────────────
+
+    fn k8s(method: &str, path: &str) -> HashMap<String, Value> {
+        extract_k8s_facets(&map_of(&[
+            ("method", Value::String(method.to_string())),
+            ("path", Value::String(path.to_string())),
+        ]))
+    }
+
+    #[test]
+    fn k8s_empty_path() {
+        let f = extract_k8s_facets(&serde_yaml::Mapping::new());
+        assert_eq!(fv(&f, "verb"), "");
+        assert_eq!(fv(&f, "resource"), "");
+    }
+
+    #[test]
+    fn k8s_cluster_list() {
+        let f = k8s("GET", "/api/v1/nodes");
+        assert_eq!(fv(&f, "verb"), "list");
+        assert_eq!(fv(&f, "resource"), "nodes");
+        assert_eq!(fv(&f, "namespace"), "");
+    }
+
+    #[test]
+    fn k8s_namespaced_collection_list() {
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods");
+        assert_eq!(fv(&f, "verb"), "list");
+        assert_eq!(fv(&f, "namespace"), "prod");
+        assert_eq!(fv(&f, "resource"), "pods");
+        assert_eq!(fv(&f, "name"), "");
+    }
+
+    #[test]
+    fn k8s_named_object_get() {
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods/mypod");
+        assert_eq!(fv(&f, "verb"), "get");
+        assert_eq!(fv(&f, "name"), "mypod");
+    }
+
+    #[test]
+    fn k8s_exec_subresource() {
+        let f = k8s("POST", "/api/v1/namespaces/prod/pods/mypod/exec");
+        assert_eq!(fv(&f, "subresource"), "exec");
+        assert_eq!(fv(&f, "verb"), "create");
+    }
+
+    #[test]
+    fn k8s_delete_collection_vs_named() {
+        let coll = k8s("DELETE", "/api/v1/namespaces/prod/pods");
+        assert_eq!(fv(&coll, "verb"), "deletecollection");
+
+        let named = k8s("DELETE", "/api/v1/namespaces/prod/pods/p1");
+        assert_eq!(fv(&named, "verb"), "delete");
+    }
+
+    #[test]
+    fn k8s_apis_group() {
+        let f = k8s("GET", "/apis/apps/v1/namespaces/prod/deployments/web");
+        assert_eq!(fv(&f, "resource"), "deployments");
+        assert_eq!(fv(&f, "name"), "web");
+        assert_eq!(fv(&f, "namespace"), "prod");
+        assert_eq!(fv(&f, "verb"), "get");
+    }
+
+    #[test]
+    fn k8s_trailing_slash() {
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods/");
+        assert_eq!(fv(&f, "resource"), "pods");
+        assert_eq!(fv(&f, "namespace"), "prod");
+    }
+
+    #[test]
+    fn k8s_unknown_method_lowercased() {
+        let f = k8s("OPTIONS", "/api/v1/namespaces/prod/pods");
+        assert_eq!(fv(&f, "verb"), "options");
+    }
+
+    #[test]
+    fn k8s_missing_method_yields_empty_verb() {
+        let f = extract_k8s_facets(&map_of(&[(
+            "path",
+            Value::String("/api/v1/namespaces/prod/pods".to_string()),
+        )]));
+        assert_eq!(fv(&f, "verb"), "");
+        assert_eq!(fv(&f, "resource"), "pods");
+    }
+
+    #[test]
+    fn k8s_watch_paths() {
+        let f = k8s("GET", "/api/v1/watch/pods");
+        assert_eq!(fv(&f, "verb"), "watch");
+        assert_eq!(fv(&f, "resource"), "pods");
+
+        let f = k8s("GET", "/api/v1/watch/namespaces/prod/pods");
+        assert_eq!(fv(&f, "verb"), "watch");
+        assert_eq!(fv(&f, "namespace"), "prod");
+
+        let f = k8s("GET", "/api/v1/watch/namespaces/prod/pods/web");
+        assert_eq!(fv(&f, "verb"), "watch");
+        assert_eq!(fv(&f, "name"), "web");
+    }
+
+    #[test]
+    fn k8s_proxy_tail() {
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods/web/proxy/healthz");
+        assert_eq!(fv(&f, "subresource"), "proxy");
+        assert_eq!(fv(&f, "name"), "web");
+        assert_eq!(fv(&f, "resource"), "pods");
+    }
+
+    #[test]
+    fn k8s_log_and_status_subresources() {
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods/web/log");
+        assert_eq!(fv(&f, "subresource"), "log");
+
+        let f = k8s("PATCH", "/apis/apps/v1/namespaces/prod/deployments/web/status");
+        assert_eq!(fv(&f, "subresource"), "status");
+        assert_eq!(fv(&f, "verb"), "patch");
+    }
+
+    // ── extract_protocol_facets default flow ─────────────────────────────
+
+    #[test]
+    fn default_extract_flattens_sql_into_context() {
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert(
+            "sql".to_string(),
+            Value::Mapping(map_of(&[(
+                "query",
+                Value::String("DROP TABLE production".to_string()),
+            )])),
+        );
+        extract_protocol_facets(&mut ctx);
+        assert_eq!(
+            ctx.get("sql.verb").and_then(|v| v.as_str()),
+            Some("DROP")
+        );
+        assert_eq!(
+            ctx.get("sql.target").and_then(|v| v.as_str()),
+            Some("production")
+        );
+    }
+
+    #[test]
+    fn default_extract_flattens_k8s_into_context() {
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert(
+            "k8s".to_string(),
+            Value::Mapping(map_of(&[
+                ("method", Value::String("DELETE".to_string())),
+                (
+                    "path",
+                    Value::String("/api/v1/namespaces/prod/pods/p1".to_string()),
+                ),
+            ])),
+        );
+        extract_protocol_facets(&mut ctx);
+        assert_eq!(
+            ctx.get("k8s.verb").and_then(|v| v.as_str()),
+            Some("delete")
+        );
+        assert_eq!(
+            ctx.get("k8s.namespace").and_then(|v| v.as_str()),
+            Some("prod")
+        );
+    }
+}

--- a/agent-governance-rust/agentmesh/src/protocol_facets.rs
+++ b/agent-governance-rust/agentmesh/src/protocol_facets.rs
@@ -29,7 +29,30 @@
 use regex::Regex;
 use serde_yaml::Value;
 use std::collections::HashMap;
-use std::sync::{OnceLock, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+/// Process-wide cache of compiled regexes. The set of patterns is fully
+/// determined by the verb dispatch in [`pick_target`] / [`extract_tables`],
+/// so the cache is bounded by a small constant and cannot grow unbounded.
+fn cached_regex(pattern: &str) -> Arc<Regex> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Arc<Regex>>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    // Fast path: lock briefly to look up; compile outside the lock if absent
+    // so a slow regex compile doesn't serialise other lookups behind us.
+    {
+        let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(re) = guard.get(pattern) {
+            return Arc::clone(re);
+        }
+    }
+    let compiled = Arc::new(Regex::new(pattern).expect("static pattern must compile"));
+    let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+    // Another thread may have inserted in the meantime; prefer the existing.
+    guard
+        .entry(pattern.to_string())
+        .or_insert_with(|| Arc::clone(&compiled))
+        .clone()
+}
 
 /// Function signature for a protocol facet extractor.
 ///
@@ -99,6 +122,16 @@ impl FacetRegistry {
     ///    context see them), and
     /// 2. Inserted as flat `<key>.<field>` entries on the top-level
     ///    context so dot-keyed policy rules match.
+    ///
+    /// # Performance
+    ///
+    /// Each registered sub-mapping is `.clone()`d once so the extractor
+    /// receives an owned snapshot without holding any borrow on `context`.
+    /// For typical wire-protocol sub-maps (a handful of small string keys
+    /// per protocol) this is sub-microsecond. Hot paths that need to push
+    /// large structured payloads into the protocol context should keep
+    /// them out of the sub-mapping (e.g. by stashing them at the top level
+    /// where they bypass extractor cloning).
     pub fn extract(&self, context: &mut HashMap<String, Value>) {
         let extractors = self
             .extractors
@@ -390,22 +423,22 @@ fn normalize_ident(ident: &str) -> String {
 
 fn extract_tables(query: &str, verb: &str) -> Vec<String> {
     let ident = ident_pattern();
-    let mut patterns: Vec<Regex> = Vec::new();
-    patterns.push(Regex::new(&format!(r"(?i)\bFROM\s+{}", ident)).unwrap());
-    patterns.push(Regex::new(&format!(r"(?i)\bJOIN\s+{}", ident)).unwrap());
-    patterns.push(Regex::new(&format!(r"(?i)\bINTO\s+{}", ident)).unwrap());
-    patterns.push(Regex::new(&format!(r"(?i)\bUPDATE\s+{}", ident)).unwrap());
+    let mut patterns: Vec<Arc<Regex>> = Vec::new();
+    patterns.push(cached_regex(&format!(r"(?i)\bFROM\s+{}", ident)));
+    patterns.push(cached_regex(&format!(r"(?i)\bJOIN\s+{}", ident)));
+    patterns.push(cached_regex(&format!(r"(?i)\bINTO\s+{}", ident)));
+    patterns.push(cached_regex(&format!(r"(?i)\bUPDATE\s+{}", ident)));
 
     if matches!(verb, "DROP" | "TRUNCATE" | "ALTER" | "CREATE" | "RENAME") {
         let p = format!(
             r"(?i)\b{}\s+(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?{}",
             verb, ident
         );
-        patterns.push(Regex::new(&p).unwrap());
-        patterns.push(Regex::new(&format!(r"(?i)\bON\s+{}", ident)).unwrap());
+        patterns.push(cached_regex(&p));
+        patterns.push(cached_regex(&format!(r"(?i)\bON\s+{}", ident)));
     }
     if matches!(verb, "GRANT" | "REVOKE") {
-        patterns.push(Regex::new(&format!(r"(?i)\bON\s+(?:TABLE\s+)?{}", ident)).unwrap());
+        patterns.push(cached_regex(&format!(r"(?i)\bON\s+(?:TABLE\s+)?{}", ident)));
     }
 
     let mut seen = std::collections::HashSet::new();
@@ -461,7 +494,7 @@ fn pick_target(query: &str, verb: &str, tables: &[String]) -> String {
         _ => Some(format!(r"(?i)\bFROM\s+{}", ident)),
     };
     if let Some(p) = pat {
-        let re = Regex::new(&p).unwrap();
+        let re = cached_regex(&p);
         if let Some(caps) = re.captures(query) {
             if let Some(m) = caps.get(1) {
                 return normalize_ident(m.as_str());
@@ -470,7 +503,7 @@ fn pick_target(query: &str, verb: &str, tables: &[String]) -> String {
     }
     // DELETE without FROM (rare dialects): fall back to first FROM
     if verb == "DELETE" {
-        let re = Regex::new(&format!(r"(?i)\bFROM\s+{}", ident)).unwrap();
+        let re = cached_regex(&format!(r"(?i)\bFROM\s+{}", ident));
         if let Some(caps) = re.captures(query) {
             if let Some(m) = caps.get(1) {
                 return normalize_ident(m.as_str());
@@ -499,9 +532,13 @@ pub fn extract_sql_facets(sql_ctx: &serde_yaml::Mapping) -> HashMap<String, Valu
     }
     let query = statements.first().cloned().unwrap_or_else(|| trimmed.to_string());
 
-    let verb_match = match Regex::new(r"^\s*([A-Za-z]+)").unwrap().captures(&query) {
-        Some(c) => c.get(1).unwrap().as_str().to_ascii_uppercase(),
-        None => return unknown_sql_facets(),
+    let verb_match = {
+        static FIRST_WORD: OnceLock<Regex> = OnceLock::new();
+        let re = FIRST_WORD.get_or_init(|| Regex::new(r"^\s*([A-Za-z]+)").unwrap());
+        match re.captures(&query) {
+            Some(c) => c.get(1).unwrap().as_str().to_ascii_uppercase(),
+            None => return unknown_sql_facets(),
+        }
     };
 
     let verb: String = if verb_match == "WITH" {

--- a/agent-governance-rust/agentmesh/src/protocol_facets.rs
+++ b/agent-governance-rust/agentmesh/src/protocol_facets.rs
@@ -180,14 +180,65 @@ fn unknown_sql_facets() -> HashMap<String, Value> {
     m
 }
 
-/// Strip `/* ... */` and `-- ...` style SQL comments.
+/// Strip `/* ... */` and `-- ...` style SQL comments in a quote-aware way.
+///
+/// A naive regex strip would corrupt inputs like `SELECT '--'; DROP TABLE x`
+/// (the `--` inside the string literal would be treated as a line comment
+/// and the trailing `DROP` would be silently consumed). This walker
+/// respects single, double and backtick quoting (with SQL doubled-quote
+/// escapes) before recognising comment markers.
 fn strip_sql_comments(sql: &str) -> String {
-    static BLOCK: OnceLock<Regex> = OnceLock::new();
-    static LINE: OnceLock<Regex> = OnceLock::new();
-    let block = BLOCK.get_or_init(|| Regex::new(r"(?s)/\*.*?\*/").unwrap());
-    let line = LINE.get_or_init(|| Regex::new(r"--[^\n\r]*").unwrap());
-    let s = block.replace_all(sql, " ").to_string();
-    line.replace_all(&s, " ").to_string()
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.chars().peekable();
+    let mut quote: Option<char> = None;
+    while let Some(ch) = chars.next() {
+        if let Some(q) = quote {
+            out.push(ch);
+            if ch == q {
+                if chars.peek().copied() == Some(q) {
+                    // Escaped doubled quote
+                    if let Some(next) = chars.next() {
+                        out.push(next);
+                    }
+                } else {
+                    quote = None;
+                }
+            }
+            continue;
+        }
+        if ch == '\'' || ch == '"' || ch == '`' {
+            quote = Some(ch);
+            out.push(ch);
+            continue;
+        }
+        // -- line comment
+        if ch == '-' && chars.peek().copied() == Some('-') {
+            chars.next(); // consume second '-'
+            while let Some(&c) = chars.peek() {
+                if c == '\n' || c == '\r' {
+                    break;
+                }
+                chars.next();
+            }
+            out.push(' ');
+            continue;
+        }
+        // /* block comment */
+        if ch == '/' && chars.peek().copied() == Some('*') {
+            chars.next(); // consume '*'
+            let mut prev = '\0';
+            for c in chars.by_ref() {
+                if prev == '*' && c == '/' {
+                    break;
+                }
+                prev = c;
+            }
+            out.push(' ');
+            continue;
+        }
+        out.push(ch);
+    }
+    out
 }
 
 /// Split on top-level semicolons (outside quoted strings).
@@ -478,75 +529,89 @@ pub fn extract_sql_facets(sql_ctx: &serde_yaml::Mapping) -> HashMap<String, Valu
 struct K8sPattern {
     re: Regex,
     groups: &'static [&'static str],
+    is_watch: bool,
 }
 
 fn k8s_patterns() -> &'static Vec<K8sPattern> {
     static P: OnceLock<Vec<K8sPattern>> = OnceLock::new();
     P.get_or_init(|| {
-        let mk = |p: &str, g: &'static [&'static str]| K8sPattern {
+        let mk = |p: &str, g: &'static [&'static str], is_watch: bool| K8sPattern {
             re: Regex::new(p).unwrap(),
             groups: g,
+            is_watch,
         };
         vec![
             // Watch — namespaced collection
             mk(
                 r"^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource"],
+                true,
             ),
             mk(
                 r"^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource"],
+                true,
             ),
             // Watch — namespaced named
             mk(
                 r"^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource", "name"],
+                true,
             ),
             mk(
                 r"^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource", "name"],
+                true,
             ),
             // Watch — cluster
-            mk(r"^/api/[^/]+/watch/([^/]+)/?$", &["resource"]),
-            mk(r"^/apis/[^/]+/[^/]+/watch/([^/]+)/?$", &["resource"]),
+            mk(r"^/api/[^/]+/watch/([^/]+)/?$", &["resource"], true),
+            mk(r"^/apis/[^/]+/[^/]+/watch/([^/]+)/?$", &["resource"], true),
             // Proxy tail
             mk(
                 r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
                 &["namespace", "resource", "name", "subresource"],
+                false,
             ),
             mk(
                 r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
                 &["namespace", "resource", "name", "subresource"],
+                false,
             ),
             // Generic — most specific first
             mk(
                 r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource", "name", "subresource"],
+                false,
             ),
             mk(
                 r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource", "name", "subresource"],
+                false,
             ),
             mk(
                 r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource", "name"],
+                false,
             ),
             mk(
                 r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource", "name"],
+                false,
             ),
             mk(
                 r"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource"],
+                false,
             ),
             mk(
                 r"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/?$",
                 &["namespace", "resource"],
+                false,
             ),
-            mk(r"^/api/[^/]+/([^/]+)/([^/]+)/?$", &["resource", "name"]),
-            mk(r"^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/?$", &["resource", "name"]),
-            mk(r"^/api/[^/]+/([^/]+)/?$", &["resource"]),
-            mk(r"^/apis/[^/]+/[^/]+/([^/]+)/?$", &["resource"]),
+            mk(r"^/api/[^/]+/([^/]+)/([^/]+)/?$", &["resource", "name"], false),
+            mk(r"^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/?$", &["resource", "name"], false),
+            mk(r"^/api/[^/]+/([^/]+)/?$", &["resource"], false),
+            mk(r"^/apis/[^/]+/[^/]+/([^/]+)/?$", &["resource"], false),
         ]
     })
 }
@@ -582,7 +647,7 @@ pub fn extract_k8s_facets(k8s_ctx: &serde_yaml::Mapping) -> HashMap<String, Valu
         Some(Value::String(s)) => s.to_ascii_uppercase(),
         _ => String::new(),
     };
-    let path = match k8s_ctx.get(Value::String("path".to_string())) {
+    let raw_path = match k8s_ctx.get(Value::String("path".to_string())) {
         Some(Value::String(s)) => s.clone(),
         _ => String::new(),
     };
@@ -591,18 +656,32 @@ pub fn extract_k8s_facets(k8s_ctx: &serde_yaml::Mapping) -> HashMap<String, Valu
     for k in ["verb", "resource", "namespace", "name", "subresource"] {
         out.insert(k.to_string(), Value::String(String::new()));
     }
-    if path.is_empty() {
+    if raw_path.is_empty() {
         return out;
     }
 
+    // Strip query and fragment before path-pattern matching so resources
+    // named "watch" cannot be spoofed and `?watch=true` can be detected
+    // independently of the path.
+    let (path_only, query) = match raw_path.split_once('?') {
+        Some((p, q)) => (p.to_string(), q.to_string()),
+        None => (raw_path.clone(), String::new()),
+    };
+    let path_only = match path_only.split_once('#') {
+        Some((p, _)) => p.to_string(),
+        None => path_only,
+    };
+
     let mut matched: HashMap<&'static str, String> = HashMap::new();
+    let mut matched_is_watch = false;
     for pat in k8s_patterns() {
-        if let Some(caps) = pat.re.captures(&path) {
+        if let Some(caps) = pat.re.captures(&path_only) {
             for (i, g) in pat.groups.iter().enumerate() {
                 if let Some(m) = caps.get(i + 1) {
                     matched.insert(*g, m.as_str().to_string());
                 }
             }
+            matched_is_watch = pat.is_watch;
             break;
         }
     }
@@ -612,7 +691,13 @@ pub fn extract_k8s_facets(k8s_ctx: &serde_yaml::Mapping) -> HashMap<String, Valu
     let name = matched.get("name").cloned().unwrap_or_default();
     let subresource = matched.get("subresource").cloned().unwrap_or_default();
 
-    let is_watch = path.contains("/watch/");
+    // Honor `?watch=true` query parameter as an alternate way to signal a
+    // watch request. Only treat as watch when explicitly set to true/1.
+    let query_signals_watch = query
+        .split('&')
+        .any(|kv| matches!(kv.split_once('='), Some(("watch", v)) if matches!(v, "true" | "1" | "True")));
+
+    let is_watch = matched_is_watch || query_signals_watch;
     let verb: String = if is_watch {
         "watch".to_string()
     } else if !method.is_empty() {
@@ -657,6 +742,18 @@ pub fn default_registry() -> &'static FacetRegistry {
 /// dot-path traversal.
 pub fn extract_protocol_facets(context: &mut HashMap<String, Value>) {
     default_registry().extract(context);
+}
+
+/// Like [`extract_protocol_facets`] but using a caller-supplied registry.
+///
+/// Mirrors the Python `extract_protocol_facets(context, registry=...)` form
+/// for callers that need an isolated or test-local registry rather than the
+/// process-wide default.
+pub fn extract_protocol_facets_with(
+    context: &mut HashMap<String, Value>,
+    registry: &FacetRegistry,
+) {
+    registry.extract(context);
 }
 
 #[cfg(test)]
@@ -1104,6 +1201,84 @@ mod tests {
         assert_eq!(
             ctx.get("k8s.namespace").and_then(|v| v.as_str()),
             Some("prod")
+        );
+    }
+
+    // ── Regression: comment-stripping must be quote-aware ────────────────
+
+    #[test]
+    fn sql_double_dash_inside_string_literal_does_not_hide_injection() {
+        // Naive `--[^\n\r]*` regex stripping would eat from `--';` through
+        // to end-of-line and silently turn this into a single SELECT. The
+        // quote-aware stripper preserves the semicolon so the multi-
+        // statement guard fires.
+        let f = sql_facets("SELECT '--'; DROP TABLE production");
+        assert_eq!(fv(&f, "verb"), "UNKNOWN");
+    }
+
+    #[test]
+    fn sql_block_comment_inside_string_literal_preserved() {
+        let f = sql_facets("SELECT '/* not a comment */' FROM users");
+        assert_eq!(fv(&f, "verb"), "SELECT");
+        assert_eq!(fv(&f, "target"), "users");
+    }
+
+    // ── Regression: K8s query-string / fragment / spoofed names ──────────
+
+    #[test]
+    fn k8s_query_string_is_stripped_before_path_match() {
+        // Resource `pods` must still parse with a trailing ?fieldManager=...
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods?fieldManager=test");
+        assert_eq!(fv(&f, "resource"), "pods");
+        assert_eq!(fv(&f, "namespace"), "prod");
+        assert_eq!(fv(&f, "verb"), "list");
+    }
+
+    #[test]
+    fn k8s_watch_query_param_signals_watch_verb() {
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods?watch=true");
+        assert_eq!(fv(&f, "verb"), "watch");
+        assert_eq!(fv(&f, "resource"), "pods");
+    }
+
+    #[test]
+    fn k8s_resource_named_watch_does_not_falsely_trigger_watch_verb() {
+        // Namespace name `watch-test` contains the substring `/watch` after
+        // /namespaces/ — the previous `path.contains("/watch/")` substring
+        // check would have spuriously emitted verb=watch.
+        let f = k8s("GET", "/api/v1/namespaces/watch-test/pods");
+        assert_eq!(fv(&f, "verb"), "list");
+        assert_eq!(fv(&f, "namespace"), "watch-test");
+    }
+
+    #[test]
+    fn k8s_fragment_is_stripped() {
+        let f = k8s("GET", "/api/v1/namespaces/prod/pods#anchor");
+        assert_eq!(fv(&f, "resource"), "pods");
+    }
+
+    // ── extract_protocol_facets_with custom registry ─────────────────────
+
+    #[test]
+    fn extract_with_custom_registry_does_not_touch_default() {
+        let r = FacetRegistry::new();
+        r.register("sql", |_| {
+            let mut m = HashMap::new();
+            m.insert("verb".to_string(), Value::String("CUSTOM".to_string()));
+            m
+        });
+        let mut ctx: HashMap<String, Value> = HashMap::new();
+        ctx.insert(
+            "sql".to_string(),
+            Value::Mapping(map_of(&[(
+                "query",
+                Value::String("SELECT 1".to_string()),
+            )])),
+        );
+        extract_protocol_facets_with(&mut ctx, &r);
+        assert_eq!(
+            ctx.get("sql.verb").and_then(|v| v.as_str()),
+            Some("CUSTOM")
         );
     }
 }

--- a/agent-governance-rust/agentmesh/tests/protocol_facets_integration.rs
+++ b/agent-governance-rust/agentmesh/tests/protocol_facets_integration.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//! Integration tests for wire-protocol-aware policy evaluation.
+
+use agentmesh::PolicyEngine;
+use serde_yaml::Value;
+use std::collections::HashMap;
+
+fn ctx_with_sql(query: &str) -> HashMap<String, Value> {
+    let mut sub = serde_yaml::Mapping::new();
+    sub.insert(Value::String("query".into()), Value::String(query.into()));
+    let mut ctx = HashMap::new();
+    ctx.insert("sql".to_string(), Value::Mapping(sub));
+    ctx
+}
+
+fn ctx_with_k8s(method: &str, path: &str) -> HashMap<String, Value> {
+    let mut sub = serde_yaml::Mapping::new();
+    sub.insert(Value::String("method".into()), Value::String(method.into()));
+    sub.insert(Value::String("path".into()), Value::String(path.into()));
+    let mut ctx = HashMap::new();
+    ctx.insert("k8s".to_string(), Value::Mapping(sub));
+    ctx
+}
+
+#[test]
+fn denies_destructive_sql_via_sql_verb_list() {
+    let yaml = r#"
+version: "1"
+agent: "did:example:agent1"
+policies:
+  - name: deny-destructive-sql
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      sql.verb: [DROP, TRUNCATE, DELETE]
+"#;
+    let engine = PolicyEngine::new();
+    engine.load_from_yaml(yaml).expect("load");
+    let decision = engine.evaluate("db.exec", Some(&ctx_with_sql("DROP TABLE production")));
+    assert!(
+        matches!(decision, agentmesh::PolicyDecision::Deny(_)),
+        "expected deny, got {:?}",
+        decision
+    );
+}
+
+#[test]
+fn allows_select_when_not_in_destructive_set() {
+    let yaml = r#"
+version: "1"
+agent: "did:example:agent1"
+policies:
+  - name: deny-destructive-sql
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      sql.verb: [DROP, TRUNCATE, DELETE]
+"#;
+    let engine = PolicyEngine::new();
+    engine.load_from_yaml(yaml).expect("load");
+    let decision = engine.evaluate("db.exec", Some(&ctx_with_sql("SELECT * FROM users")));
+    assert!(
+        matches!(decision, agentmesh::PolicyDecision::Allow),
+        "expected allow, got {:?}",
+        decision
+    );
+}
+
+#[test]
+fn denies_pod_exec_via_k8s_subresource() {
+    let yaml = r#"
+version: "1"
+agent: "did:example:agent1"
+policies:
+  - name: deny-k8s-exec
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      k8s.subresource: exec
+"#;
+    let engine = PolicyEngine::new();
+    engine.load_from_yaml(yaml).expect("load");
+    let decision = engine.evaluate(
+        "k8s.request",
+        Some(&ctx_with_k8s("POST", "/api/v1/namespaces/prod/pods/web/exec")),
+    );
+    assert!(
+        matches!(decision, agentmesh::PolicyDecision::Deny(_)),
+        "expected deny, got {:?}",
+        decision
+    );
+}
+
+#[test]
+fn denies_production_namespace_writes() {
+    let yaml = r#"
+version: "1"
+agent: "did:example:agent1"
+policies:
+  - name: deny-k8s-prod
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      k8s.namespace: production
+"#;
+    let engine = PolicyEngine::new();
+    engine.load_from_yaml(yaml).expect("load");
+    let decision = engine.evaluate(
+        "k8s.request",
+        Some(&ctx_with_k8s("DELETE", "/api/v1/namespaces/production/pods/web")),
+    );
+    assert!(matches!(
+        decision,
+        agentmesh::PolicyDecision::Deny(_)
+    ));
+}
+
+#[test]
+fn sql_target_can_be_referenced_directly() {
+    let yaml = r#"
+version: "1"
+agent: "did:example:agent1"
+policies:
+  - name: deny-writes-to-protected
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      sql.target: protected
+"#;
+    let engine = PolicyEngine::new();
+    engine.load_from_yaml(yaml).expect("load");
+    let decision = engine.evaluate(
+        "db.exec",
+        Some(&ctx_with_sql("INSERT INTO protected SELECT * FROM staging")),
+    );
+    assert!(matches!(
+        decision,
+        agentmesh::PolicyDecision::Deny(_)
+    ));
+}
+
+#[test]
+fn empty_context_does_not_break_evaluation() {
+    let yaml = r#"
+version: "1"
+agent: "did:example:agent1"
+policies: []
+"#;
+    let engine = PolicyEngine::new();
+    engine.load_from_yaml(yaml).expect("load");
+    let decision = engine.evaluate("anything", None);
+    assert!(matches!(
+        decision,
+        agentmesh::PolicyDecision::Allow
+    ));
+}
+
+#[test]
+fn caller_context_is_not_mutated_by_evaluation() {
+    let yaml = r#"
+version: "1"
+agent: "did:example:agent1"
+policies: []
+"#;
+    let engine = PolicyEngine::new();
+    engine.load_from_yaml(yaml).expect("load");
+    let ctx = ctx_with_sql("SELECT 1");
+    let snapshot = ctx.clone();
+    let _ = engine.evaluate("x", Some(&ctx));
+    assert_eq!(ctx, snapshot, "PolicyEngine.evaluate must not mutate caller context");
+}
+

--- a/docs/WIRE-PROTOCOL-FACETS.md
+++ b/docs/WIRE-PROTOCOL-FACETS.md
@@ -159,3 +159,56 @@ write rules like:
 
 See [`examples/policy-templates/wire-protocol-rules.yaml`](../examples/policy-templates/wire-protocol-rules.yaml)
 for a full set of example rules.
+
+## Language parity — Rust
+
+The Rust SDK exposes the same facet model under the
+[`agentmesh::protocol_facets`](https://docs.rs/agentmesh) module:
+`FacetRegistry`, `default_registry()`, `extract_protocol_facets`,
+`extract_sql_facets`, `extract_k8s_facets`. The same `sql.*` and `k8s.*`
+fields are surfaced, and `PolicyEngine::evaluate` invokes the registry on a
+defensive copy of the caller's context before matching rules.
+
+```rust
+use agentmesh::{PolicyEngine, default_registry};
+use serde_yaml::Value;
+use std::collections::HashMap;
+
+let engine = PolicyEngine::new();
+engine.load_from_yaml(r#"
+version: "1"
+agent: "did:example:agent1"
+policies:
+  - name: deny-destructive-sql
+    type: capability
+    denied_actions: ["*"]
+    conditions:
+      sql.verb: [DROP, TRUNCATE, DELETE]
+"#).unwrap();
+
+let mut sub = serde_yaml::Mapping::new();
+sub.insert(Value::String("query".into()), Value::String("DROP TABLE production".into()));
+let mut ctx = HashMap::new();
+ctx.insert("sql".to_string(), Value::Mapping(sub));
+
+let decision = engine.evaluate("db.exec", Some(&ctx));
+// decision == PolicyDecision::Deny(...)
+
+// Register a custom protocol extractor:
+default_registry().register("redis", |sub| {
+    let mut m = std::collections::HashMap::new();
+    if let Some(cmd) = sub.get(Value::String("command".into())).and_then(|v| v.as_str()) {
+        m.insert("verb".to_string(), Value::String(cmd.to_uppercase()));
+    }
+    m
+});
+```
+
+Rule conditions in the Rust SDK use the existing YAML mapping shape
+(`key: value` or `key: [v1, v2]` for `in`-style membership). Field names
+and decision outcomes are identical to the Python implementation.
+
+> **SQL parser note.** The Rust extractor uses a built-in regex tokenizer
+> that handles the common verb / target / function cases used by policy
+> rules. For complex dialect-specific SQL, register a custom extractor via
+> `default_registry().register("sql", ...)`.


### PR DESCRIPTION
## Summary

Brings the wire-protocol facet model from the Python SDK (#2553) to the Rust SDK so policy rules can reference `sql.*` and `k8s.*` fields alongside action and HTTP metadata. Implements the Rust leg of #2537.

## Problem

#2553 added `protocol_facets.py` to the Python SDK, but the Rust `PolicyEngine` only matched conditions against the raw context map. Rules could not express "deny any SQL that drops a table" or "deny pod exec" without callers manually pre-computing those fields.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-rust/agentmesh/src/protocol_facets.rs` | New. `FacetRegistry`, `default_registry()`, `extract_protocol_facets`, `extract_protocol_facets_with`, `extract_sql_facets`, `extract_k8s_facets`. SQL parsing uses a built-in regex tokenizer with quote-aware comment stripping, multi-statement fail-closed, and CTE-aware verb classification. Kubernetes extracts verb, resource, namespace, name and subresource from API paths, including watch and proxy tails plus `?watch=true` query parameter handling. Per-extractor `catch_unwind` panic isolation so a buggy parser cannot block policy evaluation. |
| `agent-governance-rust/agentmesh/src/policy.rs` | `PolicyEngine::evaluate` now runs the facet extractor on a defensive copy of the caller context, then flat-keyed `sql.verb`, `k8s.namespace`, … become matchable. The condition matcher was extended to treat YAML sequences as `in`-membership so rules like `sql.verb: [DROP, TRUNCATE, DELETE]` work. |
| `agent-governance-rust/agentmesh/src/lib.rs` | Re-exports `FacetRegistry`, `default_registry`, `extract_protocol_facets`, `extract_protocol_facets_with`, `extract_sql_facets`, `extract_k8s_facets`. |
| `agent-governance-rust/agentmesh/examples/wire-protocol-rules.yaml` | New. Example SQL and Kubernetes rules mirroring the Python template. |
| `agent-governance-rust/agentmesh/tests/protocol_facets_integration.rs` | New. 7 `PolicyEngine` integration tests covering SQL verb-list deny, `sql.target`, `k8s.exec`, `k8s.namespace`, and the no-mutation contract on caller context. |
| `docs/WIRE-PROTOCOL-FACETS.md` | Adds a language-parity section for Rust with usage example and the SQL parser note. |

## Testing

- `cargo build -p agentmesh` clean.
- `cargo clippy -p agentmesh --all-targets -- -D warnings` clean.
- `cargo test -p agentmesh`: **347 lib tests + 7 integration tests pass**, plus the other agentmesh-* targets (23, 1, 6, 44, 7) — 0 failures.

## Closes

Closes #2537 for the Rust SDK leg.
