### PR TITLE
fix(ci): add bot-blocked domains to markdown-link-check ignore list

### DIFF
--- a/.github/linters/markdown-link-check.json
+++ b/.github/linters/markdown-link-check.json
@@ -46,7 +46,11 @@
     { "pattern": "marketplace\\.visualstudio\\.com/manage" },
     { "pattern": "huggingface\\.co/datasets/microsoft" },
     { "pattern": "datatracker\\.ietf\\.org" },
-    { "pattern": "ExternalPlatform\\.dev" }
+    { "pattern": "ExternalPlatform\\.dev" },
+    { "pattern": "arxiv\\.org" },
+    { "pattern": "genai\\.owasp\\.org" },
+    { "pattern": "learn\\.microsoft\\.com" },
+    { "pattern": "microsoft\\.com/en-us/security/blog" }
   ],
   "timeout": "30s",
   "retryOn429": true,


### PR DESCRIPTION
## Problem

The `ci-complete` gate on `main` is failing because `markdown-link-check` reports broken links for external citation URLs added in PR #2586.

Closes #2593

**Evidence from CI run [#4601](https://github.com/microsoft/agent-governance-toolkit/actions/runs/26429023651):**

```
Failed jobs: markdown-link-check
```

The failing URLs are legitimate academic and vendor references that return **403 to automated link checkers** from GitHub Actions runners:

| Domain | Why it blocks bots |
|--------|-------------------|
| `arxiv.org` | Rate-limits/blocks automated crawlers |
| `genai.owasp.org` | CloudFlare bot protection |
| `learn.microsoft.com` | Bot detection on docs platform |
| `microsoft.com/en-us/security/blog` | WAF bot filtering |

All URLs are valid and accessible from browsers.

## Fix

Add ignore patterns to `.github/linters/markdown-link-check.json` matching the existing pattern for similar bot-blocking domains already in the list (`nist.gov`, `owaspai.org`, `cedarpolicy.com`, `eur-lex.europa.eu`, etc.).

## Verification

- The `ci_complete_check.py` gate logic is correct — it properly treats `skipped` as passing
- Only `markdown-link-check` was genuinely failing (not a skipped-job issue)
- This follows the repo's established convention per `AGENTS.md`: *"treat expected 403-prone external links as markdown-link-check exceptions, not flaky failures"*

## Changes

- `.github/linters/markdown-link-check.json` — 4 new ignore patterns added