### PR TITLE
fix(agentmesh): export FacetRegistry and extract_protocol_facets from agentmesh.governance

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
@@ -100,6 +100,11 @@ from .federation import (
     FileFederationStore,
     FederationEngine,
 )
+from .protocol_facets import (
+    FacetRegistry,
+    extract_protocol_facets,
+    default_registry,
+)
 
 __all__ = [
     # High-level wrapper (issue #1372)
@@ -206,5 +211,9 @@ __all__ = [
     "AgentRiskProfile",
     "ClassificationResult",
     "EUAIActRiskClassifier",
+    # Wire protocol facets (issue #2483)
+    "FacetRegistry",
+    "extract_protocol_facets",
+    "default_registry",
 ]
 


### PR DESCRIPTION
## Summary

`FacetRegistry`, `extract_protocol_facets`, and `default_registry` were defined in `agentmesh/governance/protocol_facets.py` but not exported from the `agentmesh.governance` package. Any consumer importing these directly from the submodule path worked, but the public package surface was incomplete and would cause `ImportError` for code doing `from agentmesh.governance import FacetRegistry`.

This adds the missing imports to `__init__.py` and adds all three names to `__all__`.

## Changes

- `agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py`: added imports and `__all__` entries for `FacetRegistry`, `extract_protocol_facets`, and `default_registry`

## Testing

No logic changes. Verified the names are importable from `agentmesh.governance` after this fix.

Closes #2483