### PR TITLE
feat(agent_os.policies): add optional proof_artefact and verification_pointers to BackendDecision

### DIFF
--- a/agent-governance-python/agent-os/CHANGELOG.md
+++ b/agent-governance-python/agent-os/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of running with a caller-supplied identity.
 
 ### Added
+- **`BackendDecision` assurance fields**: optional `proof_artefact: str | None`
+  (content-address of an underlying proof, e.g. `sha256:…`) and
+  `verification_pointers: dict[str, str]` (named URLs for offline re-verification)
+  on `agent_os.policies.backends.BackendDecision`. High-assurance external
+  backends (SMT-verified gates, mechanised-proof PDPs, TEE-attested PDPs) can
+  populate them; `PolicyEvaluator._evaluate_flat` propagates non-empty values
+  into `PolicyDecision.audit_entry`. Fully additive — existing `OPABackend` and
+  `CedarBackend` are unaffected and audit consumers see no new keys until a
+  backend supplies them.
 - `AGENT_OS_EXECUTION_TOKENS="agent-id=token"` for packaged-server bootstrap
   credentials. These tokens remain valid for the life of the process unless
   revoked explicitly.

--- a/agent-governance-python/agent-os/src/agent_os/policies/backends.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/backends.py
@@ -32,7 +32,7 @@ import re
 import shutil
 import subprocess
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, Optional, Protocol, runtime_checkable
@@ -72,7 +72,16 @@ class ExternalPolicyBackend(Protocol):
 
 @dataclass
 class BackendDecision:
-    """Normalized result from an external policy backend."""
+    """Normalized result from an external policy backend.
+
+    The optional ``proof_artefact`` and ``verification_pointers`` fields
+    let high-assurance backends (SMT-verified gates, mechanised-proof
+    PDPs, TEE-attested PDPs) attach offline-verifiable evidence to a
+    decision. They flow verbatim through ``PolicyEvaluator`` into the
+    resulting ``PolicyDecision.audit_entry`` so downstream audit
+    consumers can record and re-check them. Backends without proofs
+    leave both empty; existing OPA/Cedar backends are unaffected.
+    """
 
     allowed: bool
     action: str = "allow"
@@ -81,6 +90,8 @@ class BackendDecision:
     raw_result: Any = None
     evaluation_ms: float = 0.0
     error: Optional[str] = None
+    proof_artefact: Optional[str] = None
+    verification_pointers: dict[str, str] = field(default_factory=dict)
 
 
 # ── OPA/Rego Backend ─────────────────────────────────────────

--- a/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
@@ -219,6 +219,18 @@ class PolicyEvaluator:
                             "evaluation_ms": result.evaluation_ms,
                             "context_snapshot": context,
                             "timestamp": datetime.now(timezone.utc).isoformat(),
+                            # High-assurance backends may carry offline-
+                            # verifiable evidence; propagate when present.
+                            **(
+                                {"proof_artefact": result.proof_artefact}
+                                if result.proof_artefact
+                                else {}
+                            ),
+                            **(
+                                {"verification_pointers": dict(result.verification_pointers)}
+                                if result.verification_pointers
+                                else {}
+                            ),
                         },
                     )
 

--- a/agent-governance-python/agent-os/tests/test_backend_decision_assurance_fields.py
+++ b/agent-governance-python/agent-os/tests/test_backend_decision_assurance_fields.py
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for high-assurance fields on ``BackendDecision``.
+
+Verifies that ``proof_artefact`` and ``verification_pointers`` round-trip
+through an in-test ``ExternalPolicyBackend`` and land in the resulting
+``PolicyDecision.audit_entry`` emitted by ``PolicyEvaluator``.
+
+The new fields are optional and default to empty, so existing
+``OPABackend`` and ``CedarBackend`` are unaffected — those backends
+construct ``BackendDecision`` instances without them and the audit
+entry omits both keys, as today.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agent_os.policies.backends import BackendDecision
+from agent_os.policies.evaluator import PolicyEvaluator
+
+
+class _StubAssuranceBackend:
+    """Minimal ``ExternalPolicyBackend`` carrying assurance evidence."""
+
+    name = "stub-smt"
+
+    def evaluate(self, context: dict[str, Any]) -> BackendDecision:
+        return BackendDecision(
+            allowed=True,
+            action="allow",
+            reason="constraints discharged",
+            backend=self.name,
+            proof_artefact="sha256:" + "0" * 64,
+            verification_pointers={
+                "issuer_pubkey": "https://example.test/.well-known/issuer.pub",
+                "policy_registry": "https://example.test/.well-known/policies/",
+            },
+        )
+
+
+def test_backend_decision_defaults_are_empty():
+    """Existing backends construct without the new fields; defaults must
+    be empty so audit consumers see no change."""
+    d = BackendDecision(allowed=True, action="allow", reason="ok", backend="x")
+    assert d.proof_artefact is None
+    assert d.verification_pointers == {}
+
+
+def test_backend_decision_carries_assurance_fields():
+    """When set, the fields round-trip without coercion."""
+    d = BackendDecision(
+        allowed=True,
+        action="allow",
+        reason="proven",
+        backend="smt",
+        proof_artefact="sha256:abcd",
+        verification_pointers={"issuer_pubkey": "https://x/"},
+    )
+    assert d.proof_artefact == "sha256:abcd"
+    assert d.verification_pointers["issuer_pubkey"].startswith("https://")
+
+
+def test_assurance_fields_propagate_into_policy_decision_audit_entry():
+    """The evaluator must forward proof_artefact and verification_pointers
+    into ``PolicyDecision.audit_entry`` when a backend provides them.
+
+    Without YAML rules loaded, the evaluator falls through to registered
+    external backends; this exercises that path end-to-end.
+    """
+    ev = PolicyEvaluator()
+    ev.add_backend(_StubAssuranceBackend())
+
+    decision = ev.evaluate({"tool_name": "lookup_customer", "agent_id": "agent:test"})
+
+    assert decision.allowed is True
+    assert decision.action == "allow"
+    audit = decision.audit_entry
+    assert audit["backend"] == "stub-smt"
+    assert audit["proof_artefact"] == "sha256:" + "0" * 64
+    assert audit["verification_pointers"]["issuer_pubkey"].startswith("https://")
+    assert audit["verification_pointers"]["policy_registry"].endswith("/")
+
+
+def test_audit_entry_omits_assurance_keys_when_backend_does_not_supply_them():
+    """Backends that don't supply the new fields must not introduce
+    empty keys into the audit entry — keeps audit records compact and
+    backwards-compatible with consumers that key on presence."""
+
+    class _LegacyBackend:
+        name = "legacy"
+
+        def evaluate(self, context: dict[str, Any]) -> BackendDecision:
+            return BackendDecision(
+                allowed=False,
+                action="deny",
+                reason="legacy denial",
+                backend=self.name,
+            )
+
+    ev = PolicyEvaluator()
+    ev.add_backend(_LegacyBackend())
+
+    decision = ev.evaluate({"tool_name": "x"})
+
+    assert decision.allowed is False
+    assert "proof_artefact" not in decision.audit_entry
+    assert "verification_pointers" not in decision.audit_entry


### PR DESCRIPTION
## Summary

Adds two optional fields to `agent_os.policies.backends.BackendDecision`:

- `proof_artefact: Optional[str]` — content-address (e.g. `sha256:…`) of an underlying proof, if the backend's decision is derived from one.
- `verification_pointers: dict[str, str]` — named URLs at which a third-party verifier can fetch the deployer's published material (issuer public key, policy registry, theorem development, attestation chain) to re-check the decision offline.

`PolicyEvaluator._evaluate_flat` propagates them into the resulting `PolicyDecision.audit_entry` when present, so downstream audit consumers can record and verify them. The change is fully additive: existing `OPABackend` and `CedarBackend` are untouched, the new fields default to empty, and the audit entry omits both keys when a backend does not supply them.

## Motivation

`ExternalPolicyBackend` is the right seam for adding new policy substrates alongside YAML / OPA / Cedar — OPA and Cedar already implement it. A class of deployments — particularly in regulated finance, healthcare, and government — needs backends whose soundness is established by methods that produce **content-addressable evidence** beyond a simple allow/deny:

- **SMT-verified gates** that prove a policy holds over every string a tool's JSON Schema admits, producing a proof artefact the audit chain can cite.
- **Mechanically verified theorems** (e.g. Lean 4) backing the gate's soundness claim, where the audit record needs to name the theorem so an external verifier can re-check the proof offline.
- **Hardware-attested decision substrates** (TEE-rooted backends) whose attestation document is required in the audit record.

Today, such backends can implement `ExternalPolicyBackend` and return a `BackendDecision` — but the evidence has nowhere to live; the receiver only sees `(allowed, action, reason, backend, evaluation_ms)`. This PR adds two optional carry-through fields so a deployment that wants externally-verifiable policy decisions can have them, without changing anything for deployments that don't.

## Goals

1. **Minimal surface.** Two optional fields on an existing dataclass. No new module, no new ABC.
2. **Self-describing decisions.** When present, the proof artefact and verification pointers travel with the decision into the audit entry, so a verifier reading the audit log can re-check offline without contacting the operator.
3. **No new dependencies.** Standard library only.
4. **Additive.** Existing backends are unchanged. Existing audit consumers see no new keys until a backend supplies them.

## Non-goals

- **Not a new provider abstraction.** `ExternalPolicyBackend` already exists and is the right seam; this PR strengthens it rather than duplicating it.
- **Not an audit-record schema change for `PolicyCheckResult`.** Those fields would belong in `audit_entry` of the integration-layer result; this PR only touches the policy-engine path (`evaluator.py`). The integration-layer wiring is a smaller follow-up if maintainers want it.
- **Not opinionated about proof format.** `proof_artefact` is a free-form string (convention: `sha256:…` content-address); resolution to a real artefact is the backend's and verifier's concern.

## Detailed design

```python
# agent_os/policies/backends.py
@dataclass
class BackendDecision:
    allowed: bool
    action: str = "allow"
    reason: str = ""
    backend: str = ""
    raw_result: Any = None
    evaluation_ms: float = 0.0
    error: Optional[str] = None
    proof_artefact: Optional[str] = None                                  # new
    verification_pointers: dict[str, str] = field(default_factory=dict)   # new
```

```python
# agent_os/policies/evaluator.py — inside _evaluate_flat's backend loop
audit_entry={
    "policy": f"external:{backend.name}",
    "rule": None,
    "action": result.action,
    "backend": backend.name,
    "evaluation_ms": result.evaluation_ms,
    "context_snapshot": context,
    "timestamp": datetime.now(timezone.utc).isoformat(),
    # High-assurance backends may carry offline-verifiable evidence;
    # propagate when present.
    **({"proof_artefact": result.proof_artefact}
       if result.proof_artefact else {}),
    **({"verification_pointers": dict(result.verification_pointers)}
       if result.verification_pointers else {}),
},
```

### Tests

`tests/test_backend_decision_assurance_fields.py` adds four tests:

1. `BackendDecision` defaults: new fields default to `None` / empty dict (unchanged audit shape for existing backends).
2. `BackendDecision` round-trip: when set, the fields are preserved.
3. End-to-end: a stub backend supplying both fields produces a `PolicyDecision` whose `audit_entry` contains them.
4. Compactness: a backend that does **not** supply them produces an `audit_entry` with neither key present (no empty values).

All passing locally (Python 3.14, pytest 8.4). Existing `tests/test_policy_backends.py`, `tests/test_async_evaluator.py`, `tests/test_policy_decisions.py` continue to pass (107 tests, no regressions).

## Backwards compatibility

Fully additive:

- `BackendDecision`'s new fields default to `None` / empty.
- `OPABackend` and `CedarBackend` construct `BackendDecision` without the new fields; behaviour unchanged.
- `PolicyEvaluator` only inserts the new keys into `audit_entry` when the backend supplies non-empty values — audit consumers keying on presence are unaffected.

## Drawbacks

1. **One more concept in `BackendDecision`'s surface.** Mitigation: docstring explicitly notes the fields are optional and intended for high-assurance backends.
2. **The audit chain gains externally-verifiable structure.** We see this as a feature, but it does couple the audit-entry shape to the new optional keys going forward.

## Alternatives considered

1. **A new top-level `IPolicyProvider` ABC** alongside `ExternalPolicyBackend`. Rejected — duplicates an existing seam.
2. **Embed the proof artefact in `raw_result`.** Possible today, but leaves discovery to convention; audit consumers wouldn't know where to look across backends.
3. **An OPA/Rego external-data callback.** Ties high-assurance substrates to OPA's lifecycle and offers no native audit-chain integration.

## Note on the folder-scoped evaluator path

`_evaluate_rules` (the folder-scoped path) has a backend loop at lines ~287–296 that returns a `PolicyDecision` without constructing an `audit_entry` at all — a pre-existing asymmetry with `_evaluate_flat`. I have **not** touched that path in this PR to keep the change minimal; happy to follow up if maintainers would like the folder-scoped path harmonised (which would naturally also carry the new fields).

## Reference implementation / future consumer

[raucle](https://github.com/craigamcw/raucle) is a Verified Capability Discipline implementation — Z3-verified policy gates with Ed25519-signed capability tokens and a Lean 4 soundness theorem development. Its AGT integration will be reworked to implement `ExternalPolicyBackend` directly once this PR lands, populating both new fields. Linked here as evidence that the contract change is implementable and that at least one external project intends to consume it; raucle is **not** part of this PR.

## Acknowledgements

Thanks to the AGT team for the layered policy architecture — having both YAML rules and a registered-backend chain made this a one-page change rather than a redesign.