### PR TITLE
feat(dotnet): wire-protocol-aware policy evaluation for SQL and Kubernetes

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -20,6 +20,7 @@ amannn
 Amol
 antigravity
 APIM
+apiserver
 appsettings
 argparse
 asctime
@@ -33,6 +34,7 @@ axios
 aymenhmaidiwastaken
 backpressure
 baselined
+behaviour
 bursty
 bypassable
 bytecodes
@@ -77,6 +79,8 @@ dateutil
 davidequarracino
 dbt
 dearmor
+Dedup
+dedupe
 defi
 deidentified
 delenv
@@ -103,6 +107,7 @@ endswith
 ENOENT
 ensurepip
 Entra
+eprintln
 Errno
 Errorf
 esrp
@@ -112,7 +117,6 @@ exfiltration
 expanduser
 fastapi
 Fatalf
-fernet
 Fernet
 finalizer
 findall
@@ -124,7 +128,6 @@ FLUSHALL
 FLUSHDB
 fmean
 fnmatch
-FRIA
 fria
 fromisoformat
 fromtimestamp
@@ -137,12 +140,14 @@ getattr
 getenv
 gethostname
 getuid
+gfns
 GitHub
 gmtime
 gomod
 GOPROXY
 governancepolicy
 gvisor
+h├⌐llo
 hasattr
 hashlib
 HEALTHCHECK
@@ -156,7 +161,6 @@ HTTPMCP
 httpx
 hypercall
 Hyperlight
-h├⌐llo
 IATP
 idweb
 IGNORECASE
@@ -200,6 +204,7 @@ markdown
 Marp
 masquerade
 mastra
+materialised
 maxlen
 mgmt
 microkernel
@@ -229,6 +234,7 @@ newpartner
 NNNN
 nonlocal
 noqa
+normalises
 nostr
 npmjs
 numpy
@@ -239,11 +245,14 @@ OpenClaw
 openshell
 ospo
 oxycodone
+paramref
 parseability
 parseable
+pathed
 pathext
 pathlib
 PCRE
+peekable
 Permissioned
 pharma
 pids
@@ -276,6 +285,7 @@ quickstarts
 Ravande
 readouterr
 recognised
+recognising
 Rego
 relativedelta
 removeprefix
@@ -330,7 +340,6 @@ stacklevel
 startswith
 staticmethod
 stepreceipt
-streamable
 Streamable
 streamablehttp
 streamlit
@@ -340,6 +349,7 @@ Submatch
 subparsers
 subpro
 Subresource
+subresources
 SVID
 sybil
 syscall
@@ -364,6 +374,7 @@ Unregisters
 unrevocation
 unrevoke
 unsets
+uppercased
 urandom
 urljoin
 urllib
@@ -388,10 +399,3 @@ workflows
 XACML
 xfail
 xunit
-dedup
-dedupe
-eprintln
-peekable
-uppercased
-recognising
-subresources

--- a/agent-governance-dotnet/examples/Quickstart/wire-protocol-rules.yaml
+++ b/agent-governance-dotnet/examples/Quickstart/wire-protocol-rules.yaml
@@ -1,0 +1,47 @@
+# Wire-protocol-aware policy rules (.NET SDK)
+#
+# Mirrors examples/policy-templates/wire-protocol-rules.yaml from the Python
+# SDK. Load with engine.LoadYaml(File.ReadAllText(path)).
+apiVersion: governance.toolkit/v1
+name: wire-protocol-rules
+scope: global
+default_action: allow
+
+rules:
+  # ── SQL ──────────────────────────────────────────────────────────────────
+  - name: deny-destructive-sql-drop
+    description: Block DROP statements outright.
+    condition: "sql.verb == 'DROP'"
+    action: deny
+    priority: 100
+
+  - name: deny-destructive-sql-truncate
+    condition: "sql.verb == 'TRUNCATE'"
+    action: deny
+    priority: 100
+
+  - name: deny-destructive-sql-delete
+    condition: "sql.verb == 'DELETE'"
+    action: deny
+    priority: 100
+
+  - name: deny-writes-to-protected
+    condition: "sql.target == 'protected'"
+    action: deny
+    priority: 100
+
+  # ── Kubernetes ───────────────────────────────────────────────────────────
+  - name: deny-k8s-production-namespace
+    condition: "k8s.namespace == 'production'"
+    action: deny
+    priority: 110
+
+  - name: deny-k8s-exec
+    condition: "k8s.subresource == 'exec'"
+    action: deny
+    priority: 100
+
+  - name: deny-k8s-deletecollection
+    condition: "k8s.verb == 'deletecollection'"
+    action: deny
+    priority: 100

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
@@ -181,6 +181,13 @@ public sealed class PolicyEngine
             ["agent_did"] = normalizedDid
         };
 
+        // Enrich the evaluation context with wire-protocol facets (sql.*,
+        // k8s.*, plus any caller-registered protocols) before rules run, so
+        // policy authors can reference protocol-level fields without any
+        // extra wiring. We mutate evalContext (an internal copy), never
+        // the caller's dictionary.
+        ProtocolFacets.ExtractProtocolFacets(evalContext);
+
         var internalEvaluation = EvaluateInternalPolicies(snapshot, evalContext, evaluatedAt, sw);
         sw.Stop();
 

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/ProtocolFacets.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/ProtocolFacets.cs
@@ -1,0 +1,703 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AgentGovernance.Policy;
+
+/// <summary>
+/// Function signature for a protocol facet extractor. Receives the
+/// sub-dictionary stored at the registered context key and returns the
+/// facet fields to merge back into that sub-dictionary.
+/// </summary>
+public delegate IReadOnlyDictionary<string, object> FacetExtractor(
+    IReadOnlyDictionary<string, object> sub);
+
+/// <summary>
+/// Holds protocol facet extractors keyed by context field name.
+/// </summary>
+/// <remarks>
+/// Each extractor receives the sub-dictionary at its registered key and
+/// returns fields to merge back. Exceptions thrown inside an extractor are
+/// caught and logged so a broken parser can never block policy evaluation.
+/// </remarks>
+public sealed class FacetRegistry
+{
+    private readonly object _gate = new();
+    private readonly List<(string Key, FacetExtractor Extractor)> _extractors = new();
+
+    /// <summary>Number of registered extractors (primarily for tests).</summary>
+    public int Count
+    {
+        get
+        {
+            lock (_gate) { return _extractors.Count; }
+        }
+    }
+
+    /// <summary>Register an extractor for sub-dictionaries at <paramref name="contextKey"/>.</summary>
+    public void Register(string contextKey, FacetExtractor extractor)
+    {
+        if (string.IsNullOrEmpty(contextKey)) throw new ArgumentException("key required", nameof(contextKey));
+        ArgumentNullException.ThrowIfNull(extractor);
+        lock (_gate)
+        {
+            _extractors.Add((contextKey, extractor));
+        }
+    }
+
+    /// <summary>Remove all registered extractors. Primarily for tests.</summary>
+    public void Clear()
+    {
+        lock (_gate) { _extractors.Clear(); }
+    }
+
+    /// <summary>
+    /// Run all registered extractors against <paramref name="context"/> in place.
+    /// </summary>
+    /// <remarks>
+    /// For each registered key whose value is a string-keyed dictionary, the
+    /// extractor is called and the returned fields are merged back into that
+    /// sub-dictionary. Existing dot-path field resolution in
+    /// <see cref="PolicyRule"/> already navigates nested dictionaries, so no
+    /// top-level flattening is required.
+    /// </remarks>
+    public void Extract(IDictionary<string, object> context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Snapshot under the gate; do extractor work without holding the lock
+        // so a buggy or slow extractor cannot block registration.
+        List<(string Key, FacetExtractor Extractor)> snapshot;
+        lock (_gate) { snapshot = new(_extractors); }
+
+        foreach (var (key, extractor) in snapshot)
+        {
+            if (!context.TryGetValue(key, out var sub) || sub is null) continue;
+            if (sub is not IDictionary<string, object> subDict) continue;
+
+            IReadOnlyDictionary<string, object> facets;
+            try
+            {
+                facets = extractor(new Dictionary<string, object>(subDict));
+            }
+            catch (ArgumentException ex)
+            {
+                Console.Error.WriteLine(
+                    $"[protocol-facets] extractor for '{key}' threw: {ex.Message}");
+                continue;
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.Error.WriteLine(
+                    $"[protocol-facets] extractor for '{key}' threw: {ex.Message}");
+                continue;
+            }
+            catch (Exception ex) when (!IsFatal(ex))
+            {
+                Console.Error.WriteLine(
+                    $"[protocol-facets] extractor for '{key}' threw: {ex.Message}");
+                continue;
+            }
+            if (facets is null) continue;
+
+            // Replace the sub-dictionary slot with a fresh copy that contains
+            // the original entries plus the extracted facets. Mutating
+            // `subDict` in place would mutate any caller dictionary aliased
+            // into the context, which the PolicyEngine relies on NOT
+            // happening (Evaluate must not modify caller state).
+            var merged = new Dictionary<string, object>(subDict, StringComparer.Ordinal);
+            foreach (var kvp in facets)
+            {
+                merged[kvp.Key] = kvp.Value;
+            }
+            context[key] = merged;
+        }
+    }
+
+    private static bool IsFatal(Exception ex) =>
+        ex is OutOfMemoryException
+        or StackOverflowException
+        or AccessViolationException
+        or AppDomainUnloadedException
+        or BadImageFormatException
+        or CannotUnloadAppDomainException
+        or InvalidProgramException
+        or ThreadAbortException;
+}
+
+/// <summary>
+/// Built-in SQL and Kubernetes facet extractors and the process-wide
+/// default <see cref="FacetRegistry"/>.
+/// </summary>
+public static partial class ProtocolFacets
+{
+    private static readonly Lazy<FacetRegistry> s_default = new(() =>
+    {
+        var r = new FacetRegistry();
+        r.Register("sql", ExtractSqlFacets);
+        r.Register("k8s", ExtractK8sFacets);
+        return r;
+    });
+
+    /// <summary>
+    /// Process-wide default <see cref="FacetRegistry"/>, pre-loaded with SQL
+    /// and Kubernetes extractors. Add new protocols via <see cref="FacetRegistry.Register"/>.
+    /// </summary>
+    public static FacetRegistry DefaultRegistry => s_default.Value;
+
+    /// <summary>
+    /// Enrich a policy evaluation context with wire-protocol facets using
+    /// the default registry. Mutates <paramref name="context"/> in place.
+    /// </summary>
+    public static void ExtractProtocolFacets(IDictionary<string, object> context)
+        => DefaultRegistry.Extract(context);
+
+    /// <summary>
+    /// Enrich a policy evaluation context using a caller-supplied registry.
+    /// </summary>
+    public static void ExtractProtocolFacets(IDictionary<string, object> context, FacetRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        registry.Extract(context);
+    }
+
+    // ── SQL ─────────────────────────────────────────────────────────────
+
+    private static readonly HashSet<string> SqlKnownVerbs = new(StringComparer.Ordinal)
+    {
+        "SELECT", "INSERT", "UPDATE", "DELETE", "DROP", "TRUNCATE", "ALTER",
+        "CREATE", "GRANT", "REVOKE", "MERGE", "CALL", "EXECUTE", "EXPLAIN",
+        "WITH", "REPLACE", "RENAME", "COMMENT",
+    };
+
+    private static readonly HashSet<string> SqlFunctionDenylist = new(StringComparer.Ordinal)
+    {
+        "VALUES", "IN", "EXISTS", "ANY", "ALL", "SOME", "CAST", "CASE", "IF",
+        "DISTINCT", "ON", "USING", "WHEN", "THEN", "ELSE", "AND", "OR", "NOT",
+    };
+
+    private const string IdentPart =
+        @"(?:[A-Za-z_][A-Za-z0-9_]*|""[^""]+""|`[^`]+`|\[[^\]]+\])";
+    private const string Ident = "(" + IdentPart + @"(?:\." + IdentPart + ")*)";
+
+    // The two hottest patterns (first-word verb scan and function-call
+    // detection) are materialised as compile-time regexes via the
+    // `GeneratedRegex` source generator on .NET 7+. This skips the runtime
+    // compiler entirely and lets the JIT inline the matcher.
+    [GeneratedRegex(@"^\s*([A-Za-z]+)")]
+    private static partial Regex SqlFirstWord();
+
+    [GeneratedRegex(@"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")]
+    private static partial Regex FuncRe();
+
+    // Cache for dynamic (verb-templated) patterns produced by the verb
+    // dispatch in `PickTarget` / `ExtractTables`. The set of distinct
+    // patterns is fully determined by that dispatch and is therefore
+    // bounded by a small constant — there is no path from caller input to
+    // a new entry in this cache, so unbounded growth is impossible.
+    // If a future change ever lets caller-supplied strings flow into `Re`,
+    // this cache must be replaced with a bounded LRU.
+    private static readonly ConcurrentDictionary<string, Regex> _regexCache = new();
+    private static Regex Re(string pattern) =>
+        _regexCache.GetOrAdd(pattern, p => new Regex(p, RegexOptions.Compiled | RegexOptions.IgnoreCase));
+
+    /// <summary>
+    /// SQL facet extractor. Reads <c>sub["query"]</c> and returns
+    /// <c>{verb, target, tables, functions}</c> (all strings).
+    /// </summary>
+    public static IReadOnlyDictionary<string, object> ExtractSqlFacets(
+        IReadOnlyDictionary<string, object> sub)
+    {
+        ArgumentNullException.ThrowIfNull(sub);
+        if (!sub.TryGetValue("query", out var raw) || raw is not string rawStr || string.IsNullOrWhiteSpace(rawStr))
+        {
+            return EmptySqlFacets();
+        }
+
+        var stripped = StripSqlComments(rawStr).Trim();
+        if (stripped.Length == 0) return EmptySqlFacets();
+
+        var statements = SplitSqlStatements(stripped);
+        if (statements.Count > 1) return UnknownSqlFacets();
+        var query = statements.Count == 1 ? statements[0] : stripped;
+
+        var firstWordMatch = SqlFirstWord().Match(query);
+        if (!firstWordMatch.Success) return UnknownSqlFacets();
+        var surface = firstWordMatch.Groups[1].Value.ToUpperInvariant();
+
+        string verb = surface == "WITH"
+            ? DetectCteInnerVerb(query)
+            : SqlKnownVerbs.Contains(surface) ? surface : "UNKNOWN";
+
+        var tables = ExtractTables(query, verb);
+        var functions = ExtractFunctions(query);
+        var target = PickTarget(query, verb, tables);
+
+        return new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["verb"] = verb,
+            ["target"] = target,
+            ["tables"] = string.Join(",", tables),
+            ["functions"] = string.Join(",", functions),
+        };
+    }
+
+    private static Dictionary<string, object> EmptySqlFacets() => new(StringComparer.Ordinal)
+    {
+        ["verb"] = string.Empty,
+        ["target"] = string.Empty,
+        ["tables"] = string.Empty,
+        ["functions"] = string.Empty,
+    };
+
+    private static Dictionary<string, object> UnknownSqlFacets()
+    {
+        var m = EmptySqlFacets();
+        m["verb"] = "UNKNOWN";
+        return m;
+    }
+
+    /// <summary>
+    /// Quote-aware comment stripper. A naive regex `--[^\n]*` would
+    /// corrupt input like <c>SELECT '--'; DROP TABLE x</c> by treating the
+    /// in-string <c>--</c> as a line comment and consuming the rest of
+    /// the input.
+    /// </summary>
+    private static string StripSqlComments(string sql)
+    {
+        var sb = new System.Text.StringBuilder(sql.Length);
+        char quote = '\0';
+        int i = 0;
+        while (i < sql.Length)
+        {
+            char c = sql[i];
+            if (quote != '\0')
+            {
+                sb.Append(c);
+                if (c == quote)
+                {
+                    if (i + 1 < sql.Length && sql[i + 1] == quote)
+                    {
+                        // Doubled-quote escape
+                        sb.Append(sql[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    quote = '\0';
+                }
+                i++;
+                continue;
+            }
+            if (c == '\'' || c == '"' || c == '`')
+            {
+                quote = c;
+                sb.Append(c);
+                i++;
+                continue;
+            }
+            if (c == '-' && i + 1 < sql.Length && sql[i + 1] == '-')
+            {
+                i += 2;
+                while (i < sql.Length && sql[i] != '\n' && sql[i] != '\r') i++;
+                sb.Append(' ');
+                continue;
+            }
+            if (c == '/' && i + 1 < sql.Length && sql[i + 1] == '*')
+            {
+                i += 2;
+                while (i + 1 < sql.Length && !(sql[i] == '*' && sql[i + 1] == '/')) i++;
+                if (i + 1 < sql.Length) i += 2;
+                sb.Append(' ');
+                continue;
+            }
+            sb.Append(c);
+            i++;
+        }
+        return sb.ToString();
+    }
+
+    private static List<string> SplitSqlStatements(string sql)
+    {
+        var result = new List<string>();
+        var sb = new System.Text.StringBuilder();
+        char quote = '\0';
+        for (int i = 0; i < sql.Length; i++)
+        {
+            char c = sql[i];
+            if (quote != '\0')
+            {
+                sb.Append(c);
+                if (c == quote)
+                {
+                    if (i + 1 < sql.Length && sql[i + 1] == quote)
+                    {
+                        sb.Append(sql[++i]);
+                    }
+                    else
+                    {
+                        quote = '\0';
+                    }
+                }
+                continue;
+            }
+            if (c == '\'' || c == '"' || c == '`')
+            {
+                quote = c;
+                sb.Append(c);
+                continue;
+            }
+            if (c == ';')
+            {
+                var trimmed = sb.ToString().Trim();
+                if (trimmed.Length > 0) result.Add(trimmed);
+                sb.Clear();
+                continue;
+            }
+            sb.Append(c);
+        }
+        var tail = sb.ToString().Trim();
+        if (tail.Length > 0) result.Add(tail);
+        return result;
+    }
+
+    /// <summary>
+    /// For a <c>WITH ... &lt;verb&gt; ...</c> query, find the first DML
+    /// keyword at top-level paren depth (i.e. outside any CTE body or
+    /// subquery). Falls back to SELECT.
+    /// </summary>
+    private static string DetectCteInnerVerb(string query)
+    {
+        int depth = 0;
+        char quote = '\0';
+        var token = new System.Text.StringBuilder();
+        bool sawWith = false;
+
+        for (int i = 0; i <= query.Length; i++)
+        {
+            char c = i < query.Length ? query[i] : ' ';
+            if (quote != '\0')
+            {
+                if (c == quote) quote = '\0';
+                continue;
+            }
+            if (c == '\'' || c == '"' || c == '`')
+            {
+                quote = c;
+                continue;
+            }
+            if (c == '(') { depth++; token.Clear(); continue; }
+            if (c == ')') { depth = Math.Max(0, depth - 1); token.Clear(); continue; }
+            if (char.IsAsciiLetter(c) || c == '_')
+            {
+                token.Append(c);
+                continue;
+            }
+            if (token.Length > 0)
+            {
+                if (depth == 0)
+                {
+                    var up = token.ToString().ToUpperInvariant();
+                    if (!sawWith && up == "WITH") { sawWith = true; }
+                    else if (up is "SELECT" or "INSERT" or "UPDATE" or "DELETE" or "MERGE")
+                    {
+                        return up;
+                    }
+                }
+                token.Clear();
+            }
+        }
+        return "SELECT";
+    }
+
+    private static List<string> ExtractTables(string query, string verb)
+    {
+        var patterns = new List<Regex>
+        {
+            Re(@"\bFROM\s+" + Ident),
+            Re(@"\bJOIN\s+" + Ident),
+            Re(@"\bINTO\s+" + Ident),
+            Re(@"\bUPDATE\s+" + Ident),
+        };
+        if (verb is "DROP" or "TRUNCATE" or "ALTER" or "CREATE" or "RENAME")
+        {
+            patterns.Add(Re(@"\b" + verb +
+                @"\s+(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?" + Ident));
+            patterns.Add(Re(@"\bON\s+" + Ident));
+        }
+        if (verb is "GRANT" or "REVOKE")
+        {
+            patterns.Add(Re(@"\bON\s+(?:TABLE\s+)?" + Ident));
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>();
+        foreach (var re in patterns)
+        {
+            foreach (var name in re.Matches(query).Cast<Match>().Select(m => NormalizeIdent(m.Groups[1].Value)).Where(name => name.Length > 0))
+            {
+                if (seen.Add(name)) result.Add(name);
+            }
+        }
+        return result;
+    }
+
+    private static List<string> ExtractFunctions(string query)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>();
+        foreach (var up in FuncRe().Matches(query).Cast<Match>().Select(m => m.Groups[1].Value.ToUpperInvariant()).Where(up => !SqlFunctionDenylist.Contains(up)))
+        {
+            if (seen.Add(up)) result.Add(up);
+        }
+        return result;
+    }
+
+    private static string PickTarget(string query, string verb, List<string> tables)
+    {
+        string? pattern = verb switch
+        {
+            "INSERT" or "MERGE" => @"\bINTO\s+" + Ident,
+            "UPDATE" => @"\bUPDATE\s+" + Ident,
+            "DELETE" => @"\bDELETE\s+FROM\s+" + Ident,
+            "DROP" or "TRUNCATE" or "ALTER" or "CREATE" or "RENAME" =>
+                @"\b" + verb +
+                @"\s+(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?" + Ident,
+            "GRANT" or "REVOKE" => @"\bON\s+(?:TABLE\s+)?" + Ident,
+            _ => @"\bFROM\s+" + Ident,
+        };
+        var m = Re(pattern).Match(query);
+        if (m.Success) return NormalizeIdent(m.Groups[1].Value);
+
+        // Dialect-specific fallbacks.
+        if (verb == "INSERT")
+        {
+            // Some dialects allow `INSERT <table> (...) VALUES (...)` without INTO.
+            var bare = Re(@"\bINSERT\s+(?!INTO\b)" + Ident).Match(query);
+            if (bare.Success) return NormalizeIdent(bare.Groups[1].Value);
+        }
+        if (verb == "DELETE")
+        {
+            var fb = Re(@"\bFROM\s+" + Ident).Match(query);
+            if (fb.Success) return NormalizeIdent(fb.Groups[1].Value);
+        }
+        return tables.Count > 0 ? tables[0] : string.Empty;
+    }
+
+    /// <summary>
+    /// Take the last dotted segment of an identifier and strip surrounding
+    /// quotes / brackets so <c>"public"."users"</c> normalises to <c>users</c>
+    /// (matches the Python sqlglot <c>Table.name</c> behaviour).
+    /// </summary>
+    private static string NormalizeIdent(string ident)
+    {
+        var parts = new List<string>();
+        var buf = new System.Text.StringBuilder();
+        char depth = '\0';
+        foreach (var ch in ident.Trim())
+        {
+            if (depth != '\0')
+            {
+                buf.Append(ch);
+                char close = depth switch { '"' => '"', '`' => '`', '[' => ']', _ => '\0' };
+                if (ch == close) depth = '\0';
+                continue;
+            }
+            switch (ch)
+            {
+                case '"': case '`': case '[':
+                    depth = ch;
+                    buf.Append(ch);
+                    break;
+                case '.':
+                    parts.Add(buf.ToString());
+                    buf.Clear();
+                    break;
+                default:
+                    buf.Append(ch);
+                    break;
+            }
+        }
+        parts.Add(buf.ToString());
+        var last = parts[^1].Trim();
+        if ((last.StartsWith('"') && last.EndsWith('"')) ||
+            (last.StartsWith('`') && last.EndsWith('`')) ||
+            (last.StartsWith('[') && last.EndsWith(']')))
+        {
+            last = last.Substring(1, last.Length - 2);
+        }
+        return last;
+    }
+
+    // ── Kubernetes ──────────────────────────────────────────────────────
+
+    private static readonly IReadOnlyDictionary<string, string> MethodToVerbNamed =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["GET"] = "get",
+            ["DELETE"] = "delete",
+            ["PUT"] = "update",
+            ["PATCH"] = "patch",
+            ["POST"] = "create",
+            ["HEAD"] = "get",
+        };
+
+    private static readonly IReadOnlyDictionary<string, string> MethodToVerbCollection =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["GET"] = "list",
+            ["POST"] = "create",
+            ["DELETE"] = "deletecollection",
+            ["PUT"] = "update",
+            ["PATCH"] = "patch",
+            ["HEAD"] = "list",
+        };
+
+    private sealed class K8sPattern
+    {
+        public Regex Re { get; }
+        public string[] Groups { get; }
+        public bool IsWatch { get; }
+
+        public K8sPattern(string pattern, string[] groups, bool isWatch)
+        {
+            Re = new Regex(pattern, RegexOptions.Compiled);
+            Groups = groups;
+            IsWatch = isWatch;
+        }
+    }
+
+    private static readonly K8sPattern[] K8sPatterns =
+    {
+        // Watch — namespaced collection
+        new(@"^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$", new[] { "namespace", "resource" }, true),
+        new(@"^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$", new[] { "namespace", "resource" }, true),
+        // Watch — namespaced named
+        new(@"^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$", new[] { "namespace", "resource", "name" }, true),
+        new(@"^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$", new[] { "namespace", "resource", "name" }, true),
+        // Watch — cluster
+        new(@"^/api/[^/]+/watch/([^/]+)/?$", new[] { "resource" }, true),
+        new(@"^/apis/[^/]+/[^/]+/watch/([^/]+)/?$", new[] { "resource" }, true),
+        // Proxy tail
+        new(@"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
+            new[] { "namespace", "resource", "name", "subresource" }, false),
+        new(@"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
+            new[] { "namespace", "resource", "name", "subresource" }, false),
+        // Generic — most specific first
+        new(@"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$",
+            new[] { "namespace", "resource", "name", "subresource" }, false),
+        new(@"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$",
+            new[] { "namespace", "resource", "name", "subresource" }, false),
+        new(@"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
+            new[] { "namespace", "resource", "name" }, false),
+        new(@"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$",
+            new[] { "namespace", "resource", "name" }, false),
+        new(@"^/api/[^/]+/namespaces/([^/]+)/([^/]+)/?$",
+            new[] { "namespace", "resource" }, false),
+        new(@"^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/?$",
+            new[] { "namespace", "resource" }, false),
+        new(@"^/api/[^/]+/([^/]+)/([^/]+)/([^/]+)/?$", new[] { "resource", "name", "subresource" }, false),
+        new(@"^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/([^/]+)/?$", new[] { "resource", "name", "subresource" }, false),
+        new(@"^/api/[^/]+/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
+            new[] { "resource", "name", "subresource" }, false),
+        new(@"^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/(proxy)(?:/.*)?$",
+            new[] { "resource", "name", "subresource" }, false),
+        new(@"^/api/[^/]+/([^/]+)/([^/]+)/?$", new[] { "resource", "name" }, false),
+        new(@"^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/?$", new[] { "resource", "name" }, false),
+        new(@"^/api/[^/]+/([^/]+)/?$", new[] { "resource" }, false),
+        new(@"^/apis/[^/]+/[^/]+/([^/]+)/?$", new[] { "resource" }, false),
+    };
+
+    /// <summary>
+    /// Kubernetes facet extractor. Reads <c>sub["method"]</c> and
+    /// <c>sub["path"]</c> and returns <c>{verb, resource, namespace, name, subresource}</c>.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object> ExtractK8sFacets(
+        IReadOnlyDictionary<string, object> sub)
+    {
+        ArgumentNullException.ThrowIfNull(sub);
+
+        string method = sub.TryGetValue("method", out var m) && m is string ms ? ms.ToUpperInvariant() : string.Empty;
+        string rawPath = sub.TryGetValue("path", out var p) && p is string ps ? ps : string.Empty;
+
+        var result = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["verb"] = string.Empty,
+            ["resource"] = string.Empty,
+            ["namespace"] = string.Empty,
+            ["name"] = string.Empty,
+            ["subresource"] = string.Empty,
+        };
+        if (rawPath.Length == 0) return result;
+
+        // Strip query / fragment before matching so resources or namespaces
+        // with names containing "watch" cannot spoof the verb signal, and
+        // honour ?watch=true as an alternate watch indicator.
+        string pathOnly = rawPath;
+        string query = string.Empty;
+        int q = pathOnly.IndexOf('?');
+        if (q >= 0) { query = pathOnly[(q + 1)..]; pathOnly = pathOnly[..q]; }
+        int hash = pathOnly.IndexOf('#');
+        if (hash >= 0) pathOnly = pathOnly[..hash];
+
+        var matched = new Dictionary<string, string>(StringComparer.Ordinal);
+        bool matchedIsWatch = false;
+        foreach (var pat in K8sPatterns)
+        {
+            var match = pat.Re.Match(pathOnly);
+            if (!match.Success) continue;
+            for (int i = 0; i < pat.Groups.Length; i++)
+            {
+                matched[pat.Groups[i]] = match.Groups[i + 1].Value;
+            }
+            matchedIsWatch = pat.IsWatch;
+            break;
+        }
+
+        bool queryIsWatch = false;
+        if (query.Length > 0)
+        {
+            foreach (var kv in query.Split('&'))
+            {
+                int eq = kv.IndexOf('=');
+                if (eq < 0) continue;
+                if (kv[..eq].Equals("watch", StringComparison.Ordinal))
+                {
+                    var v = kv[(eq + 1)..];
+                    if (v is "true" or "1" or "True") { queryIsWatch = true; break; }
+                }
+            }
+        }
+
+        string resource = matched.GetValueOrDefault("resource", string.Empty);
+        string ns = matched.GetValueOrDefault("namespace", string.Empty);
+        string name = matched.GetValueOrDefault("name", string.Empty);
+        string subresource = matched.GetValueOrDefault("subresource", string.Empty);
+
+        // `watch` is a read-only verb in the Kubernetes API: it only makes
+        // sense for GET (or an empty/unspecified method). If a caller
+        // supplies a write method together with a watch path or
+        // ?watch=true, fall through to the method-derived verb so the rule
+        // engine sees the actual intent (e.g. POST on /watch/... becomes
+        // `create`, which is what the apiserver would consider it).
+        bool methodAllowsWatch = method.Length == 0 || method == "GET" || method == "HEAD";
+        bool isWatch = (matchedIsWatch || queryIsWatch) && methodAllowsWatch;
+        string verb;
+        if (isWatch) verb = "watch";
+        else if (method.Length > 0)
+        {
+            var tbl = name.Length > 0 ? MethodToVerbNamed : MethodToVerbCollection;
+            verb = tbl.TryGetValue(method, out var v) ? v : method.ToLowerInvariant();
+        }
+        else verb = string.Empty;
+
+        result["verb"] = verb;
+        result["resource"] = resource;
+        result["namespace"] = ns;
+        result["name"] = name;
+        result["subresource"] = subresource;
+        return result;
+    }
+}

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/ProtocolFacetsTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/ProtocolFacetsTests.cs
@@ -1,0 +1,553 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public class ProtocolFacetsTests
+{
+    // ── FacetRegistry ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Registry_RunsCustomExtractor_AndMergesIntoSubDict()
+    {
+        var r = new FacetRegistry();
+        r.Register("redis", sub =>
+        {
+            var cmd = sub.TryGetValue("command", out var v) ? v?.ToString() ?? string.Empty : string.Empty;
+            return new Dictionary<string, object> { ["verb"] = cmd.ToUpperInvariant() };
+        });
+
+        var ctx = new Dictionary<string, object>
+        {
+            ["redis"] = new Dictionary<string, object> { ["command"] = "flushall" }
+        };
+        r.Extract(ctx);
+
+        var sub = Assert.IsType<Dictionary<string, object>>(ctx["redis"]);
+        Assert.Equal("FLUSHALL", sub["verb"]);
+    }
+
+    [Fact]
+    public void Registry_SkipsMissingOrWrongTypeSubContexts()
+    {
+        var r = new FacetRegistry();
+        r.Register("sql", ProtocolFacets.ExtractSqlFacets);
+
+        var empty = new Dictionary<string, object>();
+        r.Extract(empty);
+        Assert.Empty(empty);
+
+        var wrong = new Dictionary<string, object> { ["sql"] = "not a dictionary" };
+        r.Extract(wrong);
+        Assert.Equal("not a dictionary", wrong["sql"]);
+    }
+
+    [Fact]
+    public void Registry_IsolatesThrowingExtractor()
+    {
+        var r = new FacetRegistry();
+        r.Register("bad", _ => throw new InvalidOperationException("boom"));
+        r.Register("good", _ => new Dictionary<string, object> { ["ok"] = true });
+
+        var ctx = new Dictionary<string, object>
+        {
+            ["bad"] = new Dictionary<string, object>(),
+            ["good"] = new Dictionary<string, object>(),
+        };
+        r.Extract(ctx);
+
+        var good = Assert.IsType<Dictionary<string, object>>(ctx["good"]);
+        Assert.True((bool)good["ok"]);
+    }
+
+    [Fact]
+    public void DefaultRegistry_HasSqlAndK8s()
+    {
+        Assert.True(ProtocolFacets.DefaultRegistry.Count >= 2);
+    }
+
+    // ── SQL ───────────────────────────────────────────────────────────────
+
+    private static Dictionary<string, object> Sql(string query) =>
+        (Dictionary<string, object>)ProtocolFacets.ExtractSqlFacets(
+            new Dictionary<string, object> { ["query"] = query });
+
+    [Fact]
+    public void Sql_EmptyOrMissingQuery_AllEmptyFields()
+    {
+        var none = (Dictionary<string, object>)ProtocolFacets.ExtractSqlFacets(
+            new Dictionary<string, object>());
+        Assert.Equal(string.Empty, none["verb"]);
+
+        Assert.Equal(string.Empty, Sql("")["verb"]);
+        Assert.Equal(string.Empty, Sql("   ")["verb"]);
+    }
+
+    [Theory]
+    [InlineData("SELECT * FROM users", "SELECT", "users")]
+    [InlineData("select id from users", "SELECT", "users")]
+    [InlineData("INSERT INTO orders (id) VALUES (1)", "INSERT", "orders")]
+    [InlineData("UPDATE accounts SET balance = 0 WHERE id = 1", "UPDATE", "accounts")]
+    [InlineData("DELETE FROM sessions WHERE expired = true", "DELETE", "sessions")]
+    [InlineData("DROP TABLE production", "DROP", "production")]
+    [InlineData("DROP TABLE IF EXISTS staging.payments", "DROP", "payments")]
+    [InlineData("TRUNCATE TABLE audit_log", "TRUNCATE", "audit_log")]
+    [InlineData("ALTER TABLE users ADD COLUMN age INT", "ALTER", "users")]
+    [InlineData("CREATE TABLE foo (id INT)", "CREATE", "foo")]
+    [InlineData("GRANT SELECT ON users TO bob", "GRANT", "users")]
+    [InlineData("MERGE INTO dst USING src ON dst.id = src.id", "MERGE", "dst")]
+    public void Sql_BasicVerbsAndTargets(string query, string verb, string target)
+    {
+        var f = Sql(query);
+        Assert.Equal(verb, f["verb"]);
+        Assert.Equal(target, f["target"]);
+    }
+
+    [Fact]
+    public void Sql_UnknownVerbForGarbage()
+    {
+        Assert.Equal("UNKNOWN", Sql("WAT IS THIS")["verb"]);
+    }
+
+    [Fact]
+    public void Sql_MultiStatementFailsClosed()
+    {
+        Assert.Equal("UNKNOWN", Sql("SELECT 1; DROP TABLE production")["verb"]);
+    }
+
+    [Fact]
+    public void Sql_TrailingSemicolonOk()
+    {
+        var f = Sql("SELECT * FROM users;");
+        Assert.Equal("SELECT", f["verb"]);
+        Assert.Equal("users", f["target"]);
+    }
+
+    [Fact]
+    public void Sql_SemicolonInStringIsNotABoundary()
+    {
+        Assert.Equal("SELECT", Sql("SELECT * FROM users WHERE name = 'a;b'")["verb"]);
+    }
+
+    [Fact]
+    public void Sql_DoubleDashInsideString_DoesNotHideInjection()
+    {
+        Assert.Equal("UNKNOWN", Sql("SELECT '--'; DROP TABLE production")["verb"]);
+    }
+
+    [Fact]
+    public void Sql_BlockCommentInsideStringPreserved()
+    {
+        var f = Sql("SELECT '/* not a comment */' FROM users");
+        Assert.Equal("SELECT", f["verb"]);
+        Assert.Equal("users", f["target"]);
+    }
+
+    [Fact]
+    public void Sql_CteClassifiesInnerVerb()
+    {
+        Assert.Equal("DELETE", Sql(
+            "WITH stale AS (SELECT id FROM users WHERE inactive) DELETE FROM users WHERE id IN (SELECT id FROM stale)")["verb"]);
+        Assert.Equal("INSERT", Sql(
+            "WITH new_rows AS (SELECT 1 AS id) INSERT INTO audit (id) SELECT id FROM new_rows")["verb"]);
+        Assert.Equal("SELECT", Sql("WITH x AS (SELECT 1) SELECT * FROM x")["verb"]);
+    }
+
+    [Fact]
+    public void Sql_InsertTargetIsWrittenObject()
+    {
+        var f = Sql("INSERT INTO protected SELECT * FROM source");
+        Assert.Equal("protected", f["target"]);
+        var tables = ((string)f["tables"]).Split(',');
+        Assert.Contains("protected", tables);
+        Assert.Contains("source", tables);
+    }
+
+    [Fact]
+    public void Sql_UpdateWithFromTargetIsWrittenObject()
+    {
+        var f = Sql("UPDATE protected SET val = src.val FROM source AS src WHERE protected.id = src.id");
+        Assert.Equal("protected", f["target"]);
+    }
+
+    [Fact]
+    public void Sql_DeleteFromTarget()
+    {
+        var f = Sql("DELETE FROM protected WHERE id IN (SELECT id FROM staging)");
+        Assert.Equal("DELETE", f["verb"]);
+        Assert.Equal("protected", f["target"]);
+    }
+
+    [Fact]
+    public void Sql_FunctionsDedupAndDenylist()
+    {
+        var f = Sql("SELECT COUNT(id), Count(name), NOW() FROM users");
+        var fns = ((string)f["functions"]).Split(',');
+        Assert.Contains("COUNT", fns);
+        Assert.Contains("NOW", fns);
+        Assert.Equal(1, fns.Count(x => x == "COUNT"));
+
+        var g = Sql("INSERT INTO t VALUES (CAST('1' AS INT))");
+        var gfns = ((string)g["functions"]).Split(',').Where(s => s.Length > 0).ToArray();
+        Assert.DoesNotContain("VALUES", gfns);
+        Assert.DoesNotContain("CAST", gfns);
+    }
+
+    [Fact]
+    public void Sql_StripsComments()
+    {
+        var f = Sql("/* hi */ -- comment\n SELECT id FROM users -- tail");
+        Assert.Equal("SELECT", f["verb"]);
+        Assert.Equal("users", f["target"]);
+    }
+
+    [Theory]
+    [InlineData("SELECT * FROM \"public\".\"users\"", "users")]
+    [InlineData("SELECT * FROM `db`.`orders`", "orders")]
+    [InlineData("SELECT * FROM [dbo].[items]", "items")]
+    public void Sql_StripsQuoting(string query, string expectedTable)
+    {
+        var tables = ((string)Sql(query)["tables"]).Split(',');
+        Assert.Contains(expectedTable, tables);
+    }
+
+    // ── K8s ───────────────────────────────────────────────────────────────
+
+    private static Dictionary<string, object> K8s(string method, string path) =>
+        (Dictionary<string, object>)ProtocolFacets.ExtractK8sFacets(
+            new Dictionary<string, object> { ["method"] = method, ["path"] = path });
+
+    [Fact]
+    public void K8s_EmptyPath_AllEmpty()
+    {
+        var f = (Dictionary<string, object>)ProtocolFacets.ExtractK8sFacets(
+            new Dictionary<string, object>());
+        Assert.Equal(string.Empty, f["verb"]);
+    }
+
+    [Fact]
+    public void K8s_ClusterList()
+    {
+        var f = K8s("GET", "/api/v1/nodes");
+        Assert.Equal("list", f["verb"]);
+        Assert.Equal("nodes", f["resource"]);
+    }
+
+    [Fact]
+    public void K8s_NamespacedCollectionList()
+    {
+        var f = K8s("GET", "/api/v1/namespaces/prod/pods");
+        Assert.Equal("list", f["verb"]);
+        Assert.Equal("pods", f["resource"]);
+        Assert.Equal("prod", f["namespace"]);
+    }
+
+    [Fact]
+    public void K8s_NamedObjectGet()
+    {
+        var f = K8s("GET", "/api/v1/namespaces/prod/pods/mypod");
+        Assert.Equal("get", f["verb"]);
+        Assert.Equal("mypod", f["name"]);
+    }
+
+    [Fact]
+    public void K8s_ExecSubresource()
+    {
+        var f = K8s("POST", "/api/v1/namespaces/prod/pods/mypod/exec");
+        Assert.Equal("exec", f["subresource"]);
+        Assert.Equal("create", f["verb"]);
+    }
+
+    [Fact]
+    public void K8s_DeleteCollectionVsNamed()
+    {
+        Assert.Equal("deletecollection", K8s("DELETE", "/api/v1/namespaces/prod/pods")["verb"]);
+        Assert.Equal("delete", K8s("DELETE", "/api/v1/namespaces/prod/pods/p1")["verb"]);
+    }
+
+    [Fact]
+    public void K8s_ApisGroup()
+    {
+        var f = K8s("GET", "/apis/apps/v1/namespaces/prod/deployments/web");
+        Assert.Equal("deployments", f["resource"]);
+        Assert.Equal("web", f["name"]);
+        Assert.Equal("get", f["verb"]);
+    }
+
+    [Fact]
+    public void K8s_TrailingSlash()
+    {
+        var f = K8s("GET", "/api/v1/namespaces/prod/pods/");
+        Assert.Equal("pods", f["resource"]);
+    }
+
+    [Fact]
+    public void K8s_UnknownMethodLowercased()
+    {
+        Assert.Equal("options", K8s("OPTIONS", "/api/v1/namespaces/prod/pods")["verb"]);
+    }
+
+    [Fact]
+    public void K8s_MissingMethod_NoVerb()
+    {
+        var f = (Dictionary<string, object>)ProtocolFacets.ExtractK8sFacets(
+            new Dictionary<string, object> { ["path"] = "/api/v1/namespaces/prod/pods" });
+        Assert.Equal(string.Empty, f["verb"]);
+        Assert.Equal("pods", f["resource"]);
+    }
+
+    [Fact]
+    public void K8s_WatchPathPatterns()
+    {
+        Assert.Equal("watch", K8s("GET", "/api/v1/watch/pods")["verb"]);
+        var f = K8s("GET", "/api/v1/watch/namespaces/prod/pods");
+        Assert.Equal("watch", f["verb"]);
+        Assert.Equal("prod", f["namespace"]);
+        var g = K8s("GET", "/api/v1/watch/namespaces/prod/pods/web");
+        Assert.Equal("watch", g["verb"]);
+        Assert.Equal("web", g["name"]);
+    }
+
+    [Fact]
+    public void K8s_ProxyTail()
+    {
+        var f = K8s("GET", "/api/v1/namespaces/prod/pods/web/proxy/healthz");
+        Assert.Equal("proxy", f["subresource"]);
+        Assert.Equal("pods", f["resource"]);
+        Assert.Equal("web", f["name"]);
+    }
+
+    [Fact]
+    public void K8s_LogAndStatusSubresources()
+    {
+        Assert.Equal("log", K8s("GET", "/api/v1/namespaces/prod/pods/web/log")["subresource"]);
+        var f = K8s("PATCH", "/apis/apps/v1/namespaces/prod/deployments/web/status");
+        Assert.Equal("status", f["subresource"]);
+        Assert.Equal("patch", f["verb"]);
+    }
+
+    [Fact]
+    public void K8s_QueryStringStrippedBeforePathMatch()
+    {
+        var f = K8s("GET", "/api/v1/namespaces/prod/pods?fieldManager=test");
+        Assert.Equal("pods", f["resource"]);
+        Assert.Equal("list", f["verb"]);
+    }
+
+    [Fact]
+    public void K8s_WatchQueryParamSignalsWatch()
+    {
+        var f = K8s("GET", "/api/v1/namespaces/prod/pods?watch=true");
+        Assert.Equal("watch", f["verb"]);
+    }
+
+    [Fact]
+    public void K8s_ResourceNamedWatchDoesNotFalseTrigger()
+    {
+        var f = K8s("GET", "/api/v1/namespaces/watch-test/pods");
+        Assert.Equal("list", f["verb"]);
+        Assert.Equal("watch-test", f["namespace"]);
+    }
+
+    [Fact]
+    public void K8s_FragmentStripped()
+    {
+        Assert.Equal("pods", K8s("GET", "/api/v1/namespaces/prod/pods#anchor")["resource"]);
+    }
+
+    // ── Regression: cluster-scoped subresources/proxy and watch gating ────
+
+    [Fact]
+    public void K8s_ClusterScopedSubresource_Status()
+    {
+        // /api/v1/nodes/node1/status is cluster-scoped — previously only
+        // namespaced subresource patterns existed and this fell through to
+        // the (resource, name) cluster pattern, dropping `status`.
+        var f = K8s("PATCH", "/api/v1/nodes/node1/status");
+        Assert.Equal("nodes", f["resource"]);
+        Assert.Equal("node1", f["name"]);
+        Assert.Equal("status", f["subresource"]);
+    }
+
+    [Fact]
+    public void K8s_ClusterScopedSubresource_Proxy()
+    {
+        var f = K8s("GET", "/api/v1/nodes/node1/proxy/metrics");
+        Assert.Equal("nodes", f["resource"]);
+        Assert.Equal("node1", f["name"]);
+        Assert.Equal("proxy", f["subresource"]);
+    }
+
+    [Fact]
+    public void K8s_WatchQueryParamWithWriteMethod_DoesNotEmitWatchVerb()
+    {
+        // ?watch=true on POST is nonsense; intent is a write, not a watch.
+        // Verb should reflect the HTTP method, not the spoofed query.
+        var f = K8s("POST", "/api/v1/namespaces/prod/pods?watch=true");
+        Assert.NotEqual("watch", f["verb"]);
+        Assert.Equal("create", f["verb"]);
+    }
+
+    [Fact]
+    public void Sql_InsertWithoutIntoTargetIsWrittenObject()
+    {
+        // Some dialects allow `INSERT <table> (...) VALUES (...)` without
+        // the INTO keyword.
+        var f = Sql("INSERT protected (id) VALUES (1)");
+        Assert.Equal("INSERT", f["verb"]);
+        Assert.Equal("protected", f["target"]);
+    }
+
+    // ── ExtractProtocolFacets default flow ────────────────────────────────
+
+    [Fact]
+    public void Default_Extract_PopulatesNestedSqlFields()
+    {
+        var ctx = new Dictionary<string, object>
+        {
+            ["sql"] = new Dictionary<string, object> { ["query"] = "DROP TABLE production" }
+        };
+        ProtocolFacets.ExtractProtocolFacets(ctx);
+
+        var sql = Assert.IsType<Dictionary<string, object>>(ctx["sql"]);
+        Assert.Equal("DROP", sql["verb"]);
+        Assert.Equal("production", sql["target"]);
+    }
+
+    [Fact]
+    public void Default_Extract_PopulatesNestedK8sFields()
+    {
+        var ctx = new Dictionary<string, object>
+        {
+            ["k8s"] = new Dictionary<string, object>
+            {
+                ["method"] = "DELETE",
+                ["path"] = "/api/v1/namespaces/prod/pods/p1",
+            }
+        };
+        ProtocolFacets.ExtractProtocolFacets(ctx);
+
+        var k8s = Assert.IsType<Dictionary<string, object>>(ctx["k8s"]);
+        Assert.Equal("delete", k8s["verb"]);
+        Assert.Equal("prod", k8s["namespace"]);
+    }
+
+    [Fact]
+    public void Extract_WithCustomRegistry_DoesNotTouchDefault()
+    {
+        var r = new FacetRegistry();
+        r.Register("sql", _ => new Dictionary<string, object> { ["verb"] = "CUSTOM" });
+
+        var ctx = new Dictionary<string, object>
+        {
+            ["sql"] = new Dictionary<string, object> { ["query"] = "SELECT 1" }
+        };
+        ProtocolFacets.ExtractProtocolFacets(ctx, r);
+
+        var sql = Assert.IsType<Dictionary<string, object>>(ctx["sql"]);
+        Assert.Equal("CUSTOM", sql["verb"]);
+    }
+
+    // ── PolicyEngine integration ──────────────────────────────────────────
+
+    [Fact]
+    public void PolicyEngine_DeniesDestructiveSqlViaSqlVerb()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(@"
+apiVersion: governance.toolkit/v1
+name: sql-guard
+scope: global
+default_action: allow
+rules:
+  - name: deny-destructive-sql
+    condition: ""sql.verb == 'DROP'""
+    action: deny
+    priority: 100
+");
+        var decision = engine.Evaluate("did:mesh:agent1", new Dictionary<string, object>
+        {
+            ["sql"] = new Dictionary<string, object> { ["query"] = "DROP TABLE production" }
+        });
+        Assert.False(decision.Allowed);
+        Assert.Equal("deny-destructive-sql", decision.MatchedRule);
+    }
+
+    [Fact]
+    public void PolicyEngine_DeniesPodExecViaK8sSubresource()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(@"
+apiVersion: governance.toolkit/v1
+name: k8s-guard
+scope: global
+default_action: allow
+rules:
+  - name: deny-exec
+    condition: ""k8s.subresource == 'exec'""
+    action: deny
+    priority: 100
+");
+        var decision = engine.Evaluate("did:mesh:agent1", new Dictionary<string, object>
+        {
+            ["k8s"] = new Dictionary<string, object>
+            {
+                ["method"] = "POST",
+                ["path"] = "/api/v1/namespaces/prod/pods/web/exec",
+            }
+        });
+        Assert.False(decision.Allowed);
+        Assert.Equal("deny-exec", decision.MatchedRule);
+    }
+
+    [Fact]
+    public void PolicyEngine_SqlTargetCanBeReferenced()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(@"
+apiVersion: governance.toolkit/v1
+name: sql-target-guard
+scope: global
+default_action: allow
+rules:
+  - name: deny-writes-to-protected
+    condition: ""sql.target == 'protected'""
+    action: deny
+    priority: 100
+");
+        var decision = engine.Evaluate("did:mesh:agent1", new Dictionary<string, object>
+        {
+            ["sql"] = new Dictionary<string, object>
+            {
+                ["query"] = "INSERT INTO protected SELECT * FROM staging"
+            }
+        });
+        Assert.False(decision.Allowed);
+        Assert.Equal("deny-writes-to-protected", decision.MatchedRule);
+    }
+
+    [Fact]
+    public void PolicyEngine_CallerContextNotMutated()
+    {
+        var engine = new PolicyEngine();
+        engine.LoadYaml(@"
+apiVersion: governance.toolkit/v1
+name: noop
+scope: global
+default_action: allow
+rules: []
+");
+        var sub = new Dictionary<string, object> { ["query"] = "SELECT 1" };
+        var ctx = new Dictionary<string, object> { ["sql"] = sub };
+
+        engine.Evaluate("did:mesh:agent1", ctx);
+
+        // The caller's sub-dictionary should not have facet fields injected.
+        Assert.Single(sub);
+        Assert.True(sub.ContainsKey("query"));
+        Assert.False(sub.ContainsKey("verb"));
+    }
+}
+

--- a/docs/WIRE-PROTOCOL-FACETS.md
+++ b/docs/WIRE-PROTOCOL-FACETS.md
@@ -162,54 +162,19 @@ for a full set of example rules.
 
 ## Language parity
 
-The same facet model is available in the language SDKs. Each SDK exposes
-`FacetRegistry`, `defaultRegistry`, and `extractProtocolFacets`, ships
-`sql.*` and `k8s.*` extractors with the same field names, and runs the
-extractors automatically inside policy evaluation.
+The same facet model is available across the language SDKs. Each SDK
+exposes a `FacetRegistry`, a default registry, and an
+`extract_protocol_facets`-equivalent helper, ships `sql.*` and `k8s.*`
+extractors with the same field names, and runs the extractors
+automatically inside policy evaluation.
 
 | Language   | Module / package | Status |
 |------------|------------------|--------|
 | Python     | `agentmesh.governance.protocol_facets` | Shipped (#2553) |
-| TypeScript | `@microsoft/agent-governance-sdk` → `protocol-facets` | Shipped (#2537) |
 | Rust       | `agentmesh::protocol_facets` | Shipped (#2588) |
-| .NET       | `agent-governance-dotnet` | Tracked in #2589 |
+| TypeScript | `@microsoft/agent-governance-sdk` → `protocol-facets` | Tracked in #2587 |
+| .NET       | `agent-governance-dotnet` → `AgentGovernance.Policy.ProtocolFacets` | Tracked in #2589 |
 | Go         | `agent-governance-golang` | Tracked in #2590 |
-
-### TypeScript usage
-
-```ts
-import {
-  PolicyEngine,
-  extractProtocolFacets,
-  defaultRegistry,
-} from '@microsoft/agent-governance-sdk';
-
-const engine = new PolicyEngine();
-engine.loadYaml(/* see agent-governance-typescript/examples/wire-protocol-rules.yaml */);
-
-// Facets are extracted automatically inside evaluatePolicy() — you only need
-// to populate the raw protocol context.
-const decision = engine.evaluatePolicy('did:example:agent1', {
-  sql: { query: 'DROP TABLE production' },
-});
-// decision.action === 'deny'
-
-// Register a custom protocol extractor on the module-level registry:
-defaultRegistry.register('redis', (ctx) => ({
-  verb: String(ctx.command ?? '').toUpperCase(),
-  key: String(ctx.key ?? ''),
-}));
-```
-
-Rule conditions in the TypeScript SDK use the expression-string format
-(`"sql.verb in ['DROP']"`) rather than the Python `{field, operator, value}`
-dict form, but the available fields and decision outcomes are identical.
-
-> **SQL parser note.** The TypeScript extractor uses a built-in regex
-> tokenizer that handles the common verb / target / function cases used by
-> policy rules. The Python implementation uses `sqlglot` for full AST
-> parsing. For complex dialect-specific SQL, register a custom extractor
-> backed by a full parser via `defaultRegistry.register('sql', ...)`.
 
 ### Rust usage
 
@@ -263,3 +228,59 @@ and decision outcomes are identical to the Python implementation.
 > that handles the common verb / target / function cases used by policy
 > rules. For complex dialect-specific SQL, register a custom extractor via
 > `default_registry().register("sql", ...)`.
+
+### .NET usage
+
+The .NET SDK exposes the same facet model under the
+`AgentGovernance.Policy` namespace: `FacetRegistry`,
+`ProtocolFacets.DefaultRegistry`, `ProtocolFacets.ExtractProtocolFacets`,
+`ProtocolFacets.ExtractSqlFacets`, `ProtocolFacets.ExtractK8sFacets`.
+`PolicyEngine.Evaluate` invokes the registry on its internal copy of the
+context before rules run, so callers only need to populate raw
+`sql`/`k8s` sub-dictionaries — the caller's own dictionary is never
+mutated.
+
+```csharp
+using AgentGovernance.Policy;
+
+var engine = new PolicyEngine();
+engine.LoadYaml(@"
+apiVersion: governance.toolkit/v1
+name: sql-guard
+scope: global
+default_action: allow
+rules:
+  - name: deny-destructive-sql
+    condition: ""sql.verb == 'DROP'""
+    action: deny
+    priority: 100
+");
+
+var decision = engine.Evaluate("did:mesh:agent1", new Dictionary<string, object>
+{
+    ["sql"] = new Dictionary<string, object> { ["query"] = "DROP TABLE production" },
+});
+// decision.Allowed == false, decision.MatchedRule == "deny-destructive-sql"
+
+// Register a custom protocol extractor:
+ProtocolFacets.DefaultRegistry.Register("redis", sub =>
+{
+    var cmd = sub.TryGetValue("command", out var v) ? v?.ToString() ?? "" : "";
+    return new Dictionary<string, object> { ["verb"] = cmd.ToUpperInvariant() };
+});
+```
+
+Rule conditions in the .NET SDK use the existing expression-string format
+(`"sql.verb == 'DROP'"`, dot-pathed field references, `and`/`or`
+compounds). Field names and high-level decision outcomes are consistent
+with the Python implementation; minor rule-syntax differences exist
+(notably, the .NET `in` operator references list-valued context fields
+rather than YAML literal lists, so split per-verb rules into individual
+`==` checks — see the example file for the pattern).
+
+> **SQL parser note.** The .NET extractor uses a built-in regex tokenizer
+> that handles the common verb / target / function cases used by policy
+> rules. It is not a full SQL parser and will not catch every dialect-
+> specific construct; for high-assurance environments, register a custom
+> extractor via `ProtocolFacets.DefaultRegistry.Register("sql", ...)`
+> backed by a real SQL parser.


### PR DESCRIPTION
Rebased cherry-pick of #2589 by Ricky-G onto current main.

Adds ProtocolFacets extraction and WireProtocolRule matching for .NET, mirroring the TypeScript implementation merged in #2587.

**Changes:**
- \ProtocolFacets.cs\: SQL/K8s facet extraction with fail-closed security
- \PolicyEngine.cs\: WireProtocolRule matching integration
- \ProtocolFacetsTests.cs\: Comprehensive test coverage
- \wire-protocol-rules.yaml\: Example rules for .NET quickstart
- \WIRE-PROTOCOL-FACETS.md\: Updated docs with .NET examples

Closes #2589

Co-authored-by: Ricky-G <56914614+Ricky-G@users.noreply.github.com>