### PR TITLE
feat(golang): wire-protocol-aware policy evaluation for SQL and Kubernetes

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -66,6 +66,7 @@ containerd
 contoso
 coro
 Cpus
+crds
 cref
 CrewAI
 crun
@@ -128,6 +129,7 @@ FLUSHALL
 FLUSHDB
 fmean
 fnmatch
+Fprintf
 fria
 fromisoformat
 fromtimestamp

--- a/agent-governance-golang/examples/wire-protocol-rules.yaml
+++ b/agent-governance-golang/examples/wire-protocol-rules.yaml
@@ -1,0 +1,38 @@
+# Wire-protocol-aware policy rules (Go SDK)
+#
+# Mirrors examples/policy-templates/wire-protocol-rules.yaml from the Python
+# SDK. Load with engine.LoadFromYAML("wire-protocol-rules.yaml").
+rules:
+  # ── SQL ────────────────────────────────────────────────────────────────
+  - action: db.exec
+    effect: deny
+    conditions:
+      sql.verb:
+        $in: [DROP, TRUNCATE, DELETE]
+
+  - action: db.exec
+    effect: deny
+    conditions:
+      sql.verb:
+        $in: [ALTER, GRANT, REVOKE]
+
+  - action: db.exec
+    effect: deny
+    conditions:
+      sql.target: protected
+
+  # ── Kubernetes ─────────────────────────────────────────────────────────
+  - action: k8s.request
+    effect: deny
+    conditions:
+      k8s.namespace: production
+
+  - action: k8s.request
+    effect: deny
+    conditions:
+      k8s.subresource: exec
+
+  - action: k8s.request
+    effect: deny
+    conditions:
+      k8s.verb: deletecollection

--- a/agent-governance-golang/packages/agentmesh/policy.go
+++ b/agent-governance-golang/packages/agentmesh/policy.go
@@ -85,12 +85,19 @@ func (pe *PolicyEngine) LoadCedar(options CedarOptions) {
 // Concurrency: the rule scan runs under RLock so concurrent evaluations
 // don't serialize. Only checkRateLimit acquires the write lock.
 func (pe *PolicyEngine) Evaluate(action string, context map[string]interface{}) PolicyDecision {
+	// Enrich a defensive copy of the context with wire-protocol facets
+	// (sql.*, k8s.*) so policy rules can reference protocol-level fields
+	// via flat keys without any rule-schema changes. The caller's map and
+	// any nested sub-maps it owns are never mutated.
+	evalContext := clonePolicyContext(context)
+	ExtractProtocolFacets(evalContext)
+
 	pe.mu.RLock()
 
 	var matched *PolicyRule
 	for i := range pe.rules {
 		r := &pe.rules[i]
-		if matchAction(r.Action, action) && matchConditions(r.Conditions, context) {
+		if matchAction(r.Action, action) && matchConditions(r.Conditions, evalContext) {
 			matched = r
 			break
 		}
@@ -100,7 +107,7 @@ func (pe *PolicyEngine) Evaluate(action string, context map[string]interface{}) 
 
 	if matched != nil {
 		if matched.MaxCalls > 0 {
-			return pe.checkRateLimit(*matched, context)
+			return pe.checkRateLimit(*matched, evalContext)
 		}
 		if matched.MinApprovals > 0 {
 			return RequiresApproval
@@ -108,7 +115,7 @@ func (pe *PolicyEngine) Evaluate(action string, context map[string]interface{}) 
 		return matched.Effect
 	}
 
-	backendContext := clonePolicyContext(context)
+	backendContext := clonePolicyContext(evalContext)
 	if _, ok := backendContext["action"]; !ok {
 		backendContext["action"] = action
 	}

--- a/agent-governance-golang/packages/agentmesh/protocol_facets.go
+++ b/agent-governance-golang/packages/agentmesh/protocol_facets.go
@@ -1,0 +1,714 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Package agentmesh — protocol-aware facet extraction for policy evaluation.
+//
+// Populates sql.* and k8s.* fields in the policy evaluation context so rules
+// can reference wire-level semantics (e.g. sql.verb, k8s.namespace) alongside
+// HTTP metadata. This is the Go port of protocol_facets.py and mirrors its
+// public contract: FacetRegistry, DefaultRegistry, ExtractProtocolFacets.
+//
+// Add support for a new protocol via DefaultRegistry().Register:
+//
+//	DefaultRegistry().Register("redis", func(sub map[string]any) map[string]any {
+//	    cmd, _ := sub["command"].(string)
+//	    return map[string]any{"verb": strings.ToUpper(cmd)}
+//	})
+
+package agentmesh
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+// FacetExtractor receives the sub-map stored at its registered context key
+// and returns the facet fields to merge back into that sub-map and to
+// expose as flat `<key>.<field>` entries on the top-level context.
+type FacetExtractor func(sub map[string]any) map[string]any
+
+// FacetRegistry holds protocol facet extractors keyed by context field name.
+// Errors thrown inside an extractor are caught (via recover) and logged so a
+// broken parser can never block policy evaluation.
+type FacetRegistry struct {
+	mu         sync.RWMutex
+	extractors []registeredExtractor
+}
+
+type registeredExtractor struct {
+	key string
+	fn  FacetExtractor
+}
+
+// NewFacetRegistry returns an empty registry with no built-in extractors.
+func NewFacetRegistry() *FacetRegistry {
+	return &FacetRegistry{}
+}
+
+// Register adds an extractor for sub-maps stored at contextKey.
+func (r *FacetRegistry) Register(contextKey string, fn FacetExtractor) {
+	if contextKey == "" || fn == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.extractors = append(r.extractors, registeredExtractor{key: contextKey, fn: fn})
+}
+
+// Len returns the number of registered extractors. Primarily for tests.
+func (r *FacetRegistry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.extractors)
+}
+
+// Clear removes all registered extractors. Primarily for tests.
+func (r *FacetRegistry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.extractors = nil
+}
+
+// Extract runs all registered extractors against context in place. For each
+// registered key whose value is a map[string]any, the extractor is called and
+// the returned fields are:
+//
+//  1. Merged back into a fresh copy of the sub-map (which replaces the
+//     original slot, so caller-side aliases are not mutated), and
+//  2. Flattened to `<key>.<field>` top-level entries so the existing
+//     condition matcher (which is keyed by string) can resolve them
+//     without dot-path traversal.
+//
+// Snapshot-then-invoke pattern avoids holding the registry lock while
+// arbitrary extractor code runs (no deadlock if an extractor calls
+// Register from within itself).
+func (r *FacetRegistry) Extract(context map[string]any) {
+	if context == nil {
+		return
+	}
+	r.mu.RLock()
+	snapshot := make([]registeredExtractor, len(r.extractors))
+	copy(snapshot, r.extractors)
+	r.mu.RUnlock()
+
+	for _, ex := range snapshot {
+		raw, ok := context[ex.key]
+		if !ok || raw == nil {
+			continue
+		}
+		sub, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		facets := runExtractor(ex.key, ex.fn, sub)
+		if facets == nil {
+			continue
+		}
+		// Replace slot with a merged copy so we don't mutate the caller's map.
+		merged := make(map[string]any, len(sub)+len(facets))
+		for k, v := range sub {
+			merged[k] = v
+		}
+		for k, v := range facets {
+			merged[k] = v
+		}
+		context[ex.key] = merged
+		for k, v := range facets {
+			context[ex.key+"."+k] = v
+		}
+	}
+}
+
+func runExtractor(key string, fn FacetExtractor, sub map[string]any) (out map[string]any) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			fmt.Fprintf(os.Stderr, "[protocol-facets] extractor for %q panicked: %v\n", key, rec)
+			out = nil
+		}
+	}()
+	// Hand the extractor a defensive copy so a buggy implementation cannot
+	// mutate the caller's input.
+	copied := make(map[string]any, len(sub))
+	for k, v := range sub {
+		copied[k] = v
+	}
+	return fn(copied)
+}
+
+var (
+	defaultRegistryOnce sync.Once
+	defaultRegistry     *FacetRegistry
+)
+
+// DefaultRegistry returns the process-wide default registry, pre-loaded with
+// SQL and Kubernetes extractors. Call Register on it to add support for
+// new protocols.
+func DefaultRegistry() *FacetRegistry {
+	defaultRegistryOnce.Do(func() {
+		defaultRegistry = NewFacetRegistry()
+		defaultRegistry.Register("sql", ExtractSQLFacets)
+		defaultRegistry.Register("k8s", ExtractK8sFacets)
+	})
+	return defaultRegistry
+}
+
+// ExtractProtocolFacets enriches a policy evaluation context with wire-
+// protocol facets using DefaultRegistry. Mutates context in place.
+func ExtractProtocolFacets(context map[string]any) {
+	DefaultRegistry().Extract(context)
+}
+
+// ExtractProtocolFacetsWith is the same as ExtractProtocolFacets but accepts
+// a caller-supplied registry. Mirrors the Python
+// extract_protocol_facets(context, registry=...) overload.
+func ExtractProtocolFacetsWith(context map[string]any, registry *FacetRegistry) {
+	if registry == nil {
+		return
+	}
+	registry.Extract(context)
+}
+
+// ── SQL ──────────────────────────────────────────────────────────────────────
+
+var sqlKnownVerbs = map[string]struct{}{
+	"SELECT": {}, "INSERT": {}, "UPDATE": {}, "DELETE": {}, "DROP": {},
+	"TRUNCATE": {}, "ALTER": {}, "CREATE": {}, "GRANT": {}, "REVOKE": {},
+	"MERGE": {}, "CALL": {}, "EXECUTE": {}, "EXPLAIN": {}, "WITH": {},
+	"REPLACE": {}, "RENAME": {}, "COMMENT": {},
+}
+
+var sqlFunctionDenylist = map[string]struct{}{
+	"VALUES": {}, "IN": {}, "EXISTS": {}, "ANY": {}, "ALL": {}, "SOME": {},
+	"CAST": {}, "CASE": {}, "IF": {}, "DISTINCT": {}, "ON": {}, "USING": {},
+	"WHEN": {}, "THEN": {}, "ELSE": {}, "AND": {}, "OR": {}, "NOT": {},
+}
+
+const identPart = `(?:[A-Za-z_][A-Za-z0-9_]*|"[^"]+"|` + "`[^`]+`" + `|\[[^\]]+\])`
+
+var (
+	identPattern  = `(` + identPart + `(?:\.` + identPart + `)*)`
+	sqlFirstWord  = regexp.MustCompile(`^\s*([A-Za-z]+)`)
+	funcCallRe    = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*)\s*\(`)
+	reCache       sync.Map // pattern string -> *regexp.Regexp
+)
+
+func reCompile(pat string) *regexp.Regexp {
+	if v, ok := reCache.Load(pat); ok {
+		return v.(*regexp.Regexp)
+	}
+	re := regexp.MustCompile(`(?i)` + pat)
+	reCache.Store(pat, re)
+	return re
+}
+
+func emptySQL() map[string]any {
+	return map[string]any{"verb": "", "target": "", "tables": "", "functions": ""}
+}
+
+func unknownSQL() map[string]any {
+	m := emptySQL()
+	m["verb"] = "UNKNOWN"
+	return m
+}
+
+// ExtractSQLFacets is the built-in SQL extractor. Reads sub["query"] and
+// returns {verb, target, tables, functions} as flat strings.
+func ExtractSQLFacets(sub map[string]any) map[string]any {
+	raw, _ := sub["query"].(string)
+	if strings.TrimSpace(raw) == "" {
+		return emptySQL()
+	}
+	stripped := stripSQLComments(raw)
+	stripped = strings.TrimSpace(stripped)
+	if stripped == "" {
+		return emptySQL()
+	}
+
+	statements := splitSQLStatements(stripped)
+	if len(statements) > 1 {
+		return unknownSQL()
+	}
+	query := stripped
+	if len(statements) == 1 {
+		query = statements[0]
+	}
+
+	first := sqlFirstWord.FindStringSubmatch(query)
+	if first == nil {
+		return unknownSQL()
+	}
+	surface := strings.ToUpper(first[1])
+
+	var verb string
+	if surface == "WITH" {
+		verb = detectCTEInnerVerb(query)
+	} else if _, ok := sqlKnownVerbs[surface]; ok {
+		verb = surface
+	} else {
+		verb = "UNKNOWN"
+	}
+
+	tables := extractTables(query, verb)
+	functions := extractFunctions(query)
+	target := pickTarget(query, verb, tables)
+
+	return map[string]any{
+		"verb":      verb,
+		"target":    target,
+		"tables":    strings.Join(tables, ","),
+		"functions": strings.Join(functions, ","),
+	}
+}
+
+// stripSQLComments is a quote-aware comment stripper. A naive regex strip
+// would corrupt input like SELECT '--'; DROP TABLE x by treating the
+// in-string -- as a line comment and consuming the rest of the input.
+func stripSQLComments(sql string) string {
+	var b strings.Builder
+	b.Grow(len(sql))
+	runes := []rune(sql)
+	var quote rune
+	i := 0
+	for i < len(runes) {
+		c := runes[i]
+		if quote != 0 {
+			b.WriteRune(c)
+			if c == quote {
+				if i+1 < len(runes) && runes[i+1] == quote {
+					b.WriteRune(runes[i+1])
+					i += 2
+					continue
+				}
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if c == '\'' || c == '"' || c == '`' {
+			quote = c
+			b.WriteRune(c)
+			i++
+			continue
+		}
+		if c == '-' && i+1 < len(runes) && runes[i+1] == '-' {
+			i += 2
+			for i < len(runes) && runes[i] != '\n' && runes[i] != '\r' {
+				i++
+			}
+			b.WriteByte(' ')
+			continue
+		}
+		if c == '/' && i+1 < len(runes) && runes[i+1] == '*' {
+			i += 2
+			for i+1 < len(runes) && !(runes[i] == '*' && runes[i+1] == '/') {
+				i++
+			}
+			if i+1 < len(runes) {
+				i += 2
+			}
+			b.WriteByte(' ')
+			continue
+		}
+		b.WriteRune(c)
+		i++
+	}
+	return b.String()
+}
+
+func splitSQLStatements(sql string) []string {
+	var out []string
+	var b strings.Builder
+	var quote rune
+	runes := []rune(sql)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		if quote != 0 {
+			b.WriteRune(c)
+			if c == quote {
+				if i+1 < len(runes) && runes[i+1] == quote {
+					b.WriteRune(runes[i+1])
+					i++
+				} else {
+					quote = 0
+				}
+			}
+			continue
+		}
+		if c == '\'' || c == '"' || c == '`' {
+			quote = c
+			b.WriteRune(c)
+			continue
+		}
+		if c == ';' {
+			t := strings.TrimSpace(b.String())
+			if t != "" {
+				out = append(out, t)
+			}
+			b.Reset()
+			continue
+		}
+		b.WriteRune(c)
+	}
+	tail := strings.TrimSpace(b.String())
+	if tail != "" {
+		out = append(out, tail)
+	}
+	return out
+}
+
+// detectCTEInnerVerb finds the first DML keyword at top-level paren depth in
+// a WITH-prefixed query. Falls back to SELECT.
+func detectCTEInnerVerb(query string) string {
+	depth := 0
+	var quote rune
+	var token strings.Builder
+	sawWith := false
+	// Iterate over runes (not bytes) so multi-byte UTF-8 sequences in
+	// identifiers or string literals can't be misinterpreted mid-rune.
+	runes := []rune(query)
+	for i := 0; i <= len(runes); i++ {
+		var c rune
+		if i < len(runes) {
+			c = runes[i]
+		} else {
+			c = ' '
+		}
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' || c == '`' {
+			quote = c
+			continue
+		}
+		if c == '(' {
+			depth++
+			token.Reset()
+			continue
+		}
+		if c == ')' {
+			if depth > 0 {
+				depth--
+			}
+			token.Reset()
+			continue
+		}
+		if unicode.IsLetter(c) || c == '_' {
+			token.WriteRune(c)
+			continue
+		}
+		if token.Len() > 0 {
+			if depth == 0 {
+				up := strings.ToUpper(token.String())
+				if !sawWith && up == "WITH" {
+					sawWith = true
+				} else {
+					switch up {
+					case "SELECT", "INSERT", "UPDATE", "DELETE", "MERGE":
+						return up
+					}
+				}
+			}
+			token.Reset()
+		}
+	}
+	return "SELECT"
+}
+
+func extractTables(query string, verb string) []string {
+	patterns := []string{
+		`\bFROM\s+` + identPattern,
+		`\bJOIN\s+` + identPattern,
+		`\bINTO\s+` + identPattern,
+		`\bUPDATE\s+` + identPattern,
+	}
+	switch verb {
+	case "DROP", "TRUNCATE", "ALTER", "CREATE", "RENAME":
+		patterns = append(patterns,
+			`\b`+verb+`\s+(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?`+identPattern,
+			`\bON\s+`+identPattern)
+	case "GRANT", "REVOKE":
+		patterns = append(patterns, `\bON\s+(?:TABLE\s+)?`+identPattern)
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	for _, p := range patterns {
+		for _, m := range reCompile(p).FindAllStringSubmatch(query, -1) {
+			name := normalizeIdent(m[1])
+			if name == "" {
+				continue
+			}
+			if _, ok := seen[name]; ok {
+				continue
+			}
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func extractFunctions(query string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, m := range funcCallRe.FindAllStringSubmatch(query, -1) {
+		up := strings.ToUpper(m[1])
+		if _, deny := sqlFunctionDenylist[up]; deny {
+			continue
+		}
+		if _, ok := seen[up]; ok {
+			continue
+		}
+		seen[up] = struct{}{}
+		out = append(out, up)
+	}
+	return out
+}
+
+func pickTarget(query, verb string, tables []string) string {
+	// Optional modifier keywords that can appear between the verb and the
+	// target table in common SQL dialects:
+	//   INSERT [OR REPLACE | OR IGNORE | IGNORE] [INTO] <t>
+	//   UPDATE [ONLY] <t>
+	//   DELETE FROM [ONLY] <t>
+	//   CREATE [OR REPLACE] [TABLE|VIEW|...] <t>
+	const insertMods = `(?:OR\s+(?:REPLACE|IGNORE|ABORT|FAIL|ROLLBACK)\s+|IGNORE\s+)?`
+	const createMods = `(?:OR\s+REPLACE\s+)?`
+	const onlyMod = `(?:ONLY\s+)?`
+
+	var pat string
+	switch verb {
+	case "INSERT":
+		pat = `\bINSERT\s+` + insertMods + `(?:INTO\s+)?` + identPattern
+	case "MERGE":
+		pat = `\bINTO\s+` + identPattern
+	case "UPDATE":
+		pat = `\bUPDATE\s+` + onlyMod + identPattern
+	case "DELETE":
+		pat = `\bDELETE\s+FROM\s+` + onlyMod + identPattern
+	case "DROP", "TRUNCATE", "ALTER", "RENAME":
+		pat = `\b` + verb + `\s+(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?` + identPattern
+	case "CREATE":
+		pat = `\bCREATE\s+` + createMods + `(?:TABLE|VIEW|INDEX|SEQUENCE|SCHEMA|DATABASE|TRIGGER|FUNCTION|PROCEDURE)?\s*(?:IF\s+(?:NOT\s+)?EXISTS\s+)?` + identPattern
+	case "GRANT", "REVOKE":
+		pat = `\bON\s+(?:TABLE\s+)?` + identPattern
+	default:
+		pat = `\bFROM\s+` + identPattern
+	}
+	if m := reCompile(pat).FindStringSubmatch(query); m != nil {
+		return normalizeIdent(m[1])
+	}
+	if verb == "DELETE" {
+		if m := reCompile(`\bFROM\s+` + onlyMod + identPattern).FindStringSubmatch(query); m != nil {
+			return normalizeIdent(m[1])
+		}
+	}
+	if len(tables) > 0 {
+		return tables[0]
+	}
+	return ""
+}
+
+// normalizeIdent takes the last dotted segment of an identifier and strips
+// surrounding quotes/brackets, mirroring Python sqlglot Table.name.
+func normalizeIdent(ident string) string {
+	s := strings.TrimSpace(ident)
+	var parts []string
+	var b strings.Builder
+	var depth rune
+	for _, ch := range s {
+		if depth != 0 {
+			b.WriteRune(ch)
+			var close rune
+			switch depth {
+			case '"':
+				close = '"'
+			case '`':
+				close = '`'
+			case '[':
+				close = ']'
+			}
+			if ch == close {
+				depth = 0
+			}
+			continue
+		}
+		switch ch {
+		case '"', '`', '[':
+			depth = ch
+			b.WriteRune(ch)
+		case '.':
+			parts = append(parts, b.String())
+			b.Reset()
+		default:
+			b.WriteRune(ch)
+		}
+	}
+	parts = append(parts, b.String())
+	last := strings.TrimSpace(parts[len(parts)-1])
+	if (strings.HasPrefix(last, `"`) && strings.HasSuffix(last, `"`)) ||
+		(strings.HasPrefix(last, "`") && strings.HasSuffix(last, "`")) ||
+		(strings.HasPrefix(last, "[") && strings.HasSuffix(last, "]")) {
+		if len(last) >= 2 {
+			last = last[1 : len(last)-1]
+		}
+	}
+	return last
+}
+
+// Note: helper `reCompile` panics if the pattern is invalid. All patterns in
+// this file are package-level constants, so misuse would surface at startup
+// in tests rather than at runtime.
+
+// ── Kubernetes ───────────────────────────────────────────────────────────────
+
+var methodToVerbNamed = map[string]string{
+	"GET": "get", "DELETE": "delete", "PUT": "update",
+	"PATCH": "patch", "POST": "create", "HEAD": "get",
+}
+
+var methodToVerbCollection = map[string]string{
+	"GET": "list", "POST": "create", "DELETE": "deletecollection",
+	"PUT": "update", "PATCH": "patch", "HEAD": "list",
+}
+
+type k8sPattern struct {
+	re      *regexp.Regexp
+	groups  []string
+	isWatch bool
+}
+
+var k8sPatterns = []k8sPattern{
+	// Watch — namespaced collection
+	{regexp.MustCompile(`^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource"}, true},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource"}, true},
+	// Watch — namespaced named
+	{regexp.MustCompile(`^/api/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource", "name"}, true},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/watch/namespaces/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource", "name"}, true},
+	// Watch — cluster
+	{regexp.MustCompile(`^/api/[^/]+/watch/([^/]+)/?$`), []string{"resource"}, true},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/watch/([^/]+)/?$`), []string{"resource"}, true},
+	// Proxy tail — namespaced
+	{regexp.MustCompile(`^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$`), []string{"namespace", "resource", "name", "subresource"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/(proxy)(?:/.*)?$`), []string{"namespace", "resource", "name", "subresource"}, false},
+	// Generic namespaced — most specific first
+	{regexp.MustCompile(`^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource", "name", "subresource"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource", "name", "subresource"}, false},
+	{regexp.MustCompile(`^/api/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource", "name"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource", "name"}, false},
+	{regexp.MustCompile(`^/api/[^/]+/namespaces/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/namespaces/([^/]+)/([^/]+)/?$`), []string{"namespace", "resource"}, false},
+	// Cluster-scoped subresource (e.g. /api/v1/nodes/n1/status, /apis/.../crds/foo/status)
+	{regexp.MustCompile(`^/api/[^/]+/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"resource", "name", "subresource"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/([^/]+)/?$`), []string{"resource", "name", "subresource"}, false},
+	// Cluster-scoped proxy tail
+	{regexp.MustCompile(`^/api/[^/]+/([^/]+)/([^/]+)/(proxy)(?:/.*)?$`), []string{"resource", "name", "subresource"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/(proxy)(?:/.*)?$`), []string{"resource", "name", "subresource"}, false},
+	{regexp.MustCompile(`^/api/[^/]+/([^/]+)/([^/]+)/?$`), []string{"resource", "name"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/([^/]+)/([^/]+)/?$`), []string{"resource", "name"}, false},
+	{regexp.MustCompile(`^/api/[^/]+/([^/]+)/?$`), []string{"resource"}, false},
+	{regexp.MustCompile(`^/apis/[^/]+/[^/]+/([^/]+)/?$`), []string{"resource"}, false},
+}
+
+// ExtractK8sFacets is the built-in Kubernetes extractor. Reads sub["method"]
+// and sub["path"] and returns {verb, resource, namespace, name, subresource}.
+func ExtractK8sFacets(sub map[string]any) map[string]any {
+	method := ""
+	if s, ok := sub["method"].(string); ok {
+		method = strings.ToUpper(s)
+	}
+	rawPath := ""
+	if s, ok := sub["path"].(string); ok {
+		rawPath = s
+	}
+
+	out := map[string]any{
+		"verb": "", "resource": "", "namespace": "", "name": "", "subresource": "",
+	}
+	if rawPath == "" {
+		return out
+	}
+
+	// Strip query / fragment before matching so resources or namespaces with
+	// names containing "watch" cannot spoof the verb signal, and honor
+	// ?watch=true as an alternate watch indicator.
+	pathOnly := rawPath
+	query := ""
+	if idx := strings.IndexByte(pathOnly, '?'); idx >= 0 {
+		query = pathOnly[idx+1:]
+		pathOnly = pathOnly[:idx]
+	}
+	if idx := strings.IndexByte(pathOnly, '#'); idx >= 0 {
+		pathOnly = pathOnly[:idx]
+	}
+
+	matched := map[string]string{}
+	matchedIsWatch := false
+	for _, pat := range k8sPatterns {
+		m := pat.re.FindStringSubmatch(pathOnly)
+		if m == nil {
+			continue
+		}
+		for i, g := range pat.groups {
+			matched[g] = m[i+1]
+		}
+		matchedIsWatch = pat.isWatch
+		break
+	}
+
+	queryIsWatch := false
+	if query != "" {
+		for _, kv := range strings.Split(query, "&") {
+			eq := strings.IndexByte(kv, '=')
+			if eq < 0 {
+				continue
+			}
+			if kv[:eq] == "watch" {
+				v := kv[eq+1:]
+				if v == "true" || v == "1" || v == "True" {
+					queryIsWatch = true
+					break
+				}
+			}
+		}
+	}
+
+	resource := matched["resource"]
+	namespace := matched["namespace"]
+	name := matched["name"]
+	subresource := matched["subresource"]
+
+	// watch is read-only; only gate on GET / HEAD / empty so a write method
+	// with ?watch=true doesn't silently classify as a benign watch.
+	methodAllowsWatch := method == "" || method == "GET" || method == "HEAD"
+	isWatch := (matchedIsWatch || queryIsWatch) && methodAllowsWatch
+
+	var verb string
+	switch {
+	case isWatch:
+		verb = "watch"
+	case method != "":
+		tbl := methodToVerbCollection
+		if name != "" {
+			tbl = methodToVerbNamed
+		}
+		if v, ok := tbl[method]; ok {
+			verb = v
+		} else {
+			verb = strings.ToLower(method)
+		}
+	}
+
+	out["verb"] = verb
+	out["resource"] = resource
+	out["namespace"] = namespace
+	out["name"] = name
+	out["subresource"] = subresource
+	return out
+}

--- a/agent-governance-golang/packages/agentmesh/protocol_facets_test.go
+++ b/agent-governance-golang/packages/agentmesh/protocol_facets_test.go
@@ -1,0 +1,616 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ── FacetRegistry ────────────────────────────────────────────────────────────
+
+func TestFacetRegistry_CustomExtractor_FlattensAndMerges(t *testing.T) {
+	r := NewFacetRegistry()
+	r.Register("redis", func(sub map[string]any) map[string]any {
+		cmd, _ := sub["command"].(string)
+		return map[string]any{"verb": strings.ToUpper(cmd)}
+	})
+
+	ctx := map[string]any{
+		"redis": map[string]any{"command": "flushall"},
+	}
+	r.Extract(ctx)
+
+	if got := ctx["redis.verb"]; got != "FLUSHALL" {
+		t.Fatalf("redis.verb = %v, want FLUSHALL", got)
+	}
+	sub, ok := ctx["redis"].(map[string]any)
+	if !ok {
+		t.Fatalf("ctx['redis'] is not a map")
+	}
+	if sub["verb"] != "FLUSHALL" {
+		t.Fatalf("nested redis.verb = %v, want FLUSHALL", sub["verb"])
+	}
+}
+
+func TestFacetRegistry_SkipsMissingOrWrongType(t *testing.T) {
+	r := NewFacetRegistry()
+	r.Register("sql", ExtractSQLFacets)
+
+	empty := map[string]any{}
+	r.Extract(empty)
+	if len(empty) != 0 {
+		t.Fatalf("expected empty, got %v", empty)
+	}
+
+	wrong := map[string]any{"sql": "not a map"}
+	r.Extract(wrong)
+	if _, ok := wrong["sql.verb"]; ok {
+		t.Fatalf("should not flatten for non-map sub")
+	}
+}
+
+func TestFacetRegistry_IsolatesPanickingExtractor(t *testing.T) {
+	r := NewFacetRegistry()
+	r.Register("bad", func(_ map[string]any) map[string]any { panic("boom") })
+	r.Register("good", func(_ map[string]any) map[string]any {
+		return map[string]any{"ok": true}
+	})
+
+	ctx := map[string]any{
+		"bad":  map[string]any{},
+		"good": map[string]any{},
+	}
+	r.Extract(ctx)
+	if ctx["good.ok"] != true {
+		t.Fatalf("good extractor should have run; got %v", ctx["good.ok"])
+	}
+}
+
+func TestDefaultRegistry_HasSQLAndK8s(t *testing.T) {
+	if DefaultRegistry().Len() < 2 {
+		t.Fatalf("expected at least 2 extractors, got %d", DefaultRegistry().Len())
+	}
+}
+
+// ── SQL ──────────────────────────────────────────────────────────────────────
+
+func sql(query string) map[string]any {
+	return ExtractSQLFacets(map[string]any{"query": query})
+}
+
+func TestSQL_EmptyOrBlankQuery(t *testing.T) {
+	cases := []map[string]any{{}, {"query": ""}, {"query": "   "}}
+	for _, c := range cases {
+		f := ExtractSQLFacets(c)
+		if f["verb"] != "" {
+			t.Fatalf("expected empty verb for %v, got %v", c, f["verb"])
+		}
+	}
+}
+
+func TestSQL_BasicVerbsAndTargets(t *testing.T) {
+	cases := []struct {
+		q, verb, target string
+	}{
+		{"SELECT * FROM users", "SELECT", "users"},
+		{"select id from users", "SELECT", "users"},
+		{"INSERT INTO orders (id) VALUES (1)", "INSERT", "orders"},
+		{"UPDATE accounts SET balance = 0 WHERE id = 1", "UPDATE", "accounts"},
+		{"DELETE FROM sessions WHERE expired = true", "DELETE", "sessions"},
+		{"DROP TABLE production", "DROP", "production"},
+		{"DROP TABLE IF EXISTS staging.payments", "DROP", "payments"},
+		{"TRUNCATE TABLE audit_log", "TRUNCATE", "audit_log"},
+		{"ALTER TABLE users ADD COLUMN age INT", "ALTER", "users"},
+		{"CREATE TABLE foo (id INT)", "CREATE", "foo"},
+		{"GRANT SELECT ON users TO bob", "GRANT", "users"},
+		{"MERGE INTO dst USING src ON dst.id = src.id", "MERGE", "dst"},
+	}
+	for _, c := range cases {
+		f := sql(c.q)
+		if f["verb"] != c.verb {
+			t.Errorf("%s: verb = %v, want %s", c.q, f["verb"], c.verb)
+		}
+		if f["target"] != c.target {
+			t.Errorf("%s: target = %v, want %s", c.q, f["target"], c.target)
+		}
+	}
+}
+
+func TestSQL_UnknownVerbForGarbage(t *testing.T) {
+	if sql("WAT IS THIS")["verb"] != "UNKNOWN" {
+		t.Fatalf("expected UNKNOWN")
+	}
+}
+
+func TestSQL_MultiStatementFailsClosed(t *testing.T) {
+	if sql("SELECT 1; DROP TABLE production")["verb"] != "UNKNOWN" {
+		t.Fatalf("expected UNKNOWN for multi-statement")
+	}
+}
+
+func TestSQL_TrailingSemicolonOK(t *testing.T) {
+	f := sql("SELECT * FROM users;")
+	if f["verb"] != "SELECT" || f["target"] != "users" {
+		t.Fatalf("got verb=%v target=%v", f["verb"], f["target"])
+	}
+}
+
+func TestSQL_SemicolonInsideStringLiteral(t *testing.T) {
+	if sql("SELECT * FROM users WHERE name = 'a;b'")["verb"] != "SELECT" {
+		t.Fatalf("expected SELECT (semicolon inside literal should not split)")
+	}
+}
+
+func TestSQL_DoubleDashInsideStringDoesNotHideInjection(t *testing.T) {
+	if sql("SELECT '--'; DROP TABLE production")["verb"] != "UNKNOWN" {
+		t.Fatalf("quote-aware comment stripper should preserve the second statement")
+	}
+}
+
+func TestSQL_BlockCommentInsideStringPreserved(t *testing.T) {
+	f := sql("SELECT '/* not a comment */' FROM users")
+	if f["verb"] != "SELECT" || f["target"] != "users" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestSQL_CTE_ClassifiesInnerVerb(t *testing.T) {
+	cases := []struct {
+		q, want string
+	}{
+		{"WITH stale AS (SELECT id FROM users WHERE inactive) DELETE FROM users WHERE id IN (SELECT id FROM stale)", "DELETE"},
+		{"WITH new_rows AS (SELECT 1 AS id) INSERT INTO audit (id) SELECT id FROM new_rows", "INSERT"},
+		{"WITH x AS (SELECT 1) SELECT * FROM x", "SELECT"},
+	}
+	for _, c := range cases {
+		if got := sql(c.q)["verb"]; got != c.want {
+			t.Errorf("CTE %s: got %v, want %s", c.q, got, c.want)
+		}
+	}
+}
+
+func TestSQL_InsertTargetIsWrittenObject(t *testing.T) {
+	f := sql("INSERT INTO protected SELECT * FROM source")
+	if f["target"] != "protected" {
+		t.Fatalf("target = %v, want protected", f["target"])
+	}
+	tables := strings.Split(f["tables"].(string), ",")
+	sort.Strings(tables)
+	want := []string{"protected", "source"}
+	for _, w := range want {
+		found := false
+		for _, t2 := range tables {
+			if t2 == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %s in tables=%v", w, tables)
+		}
+	}
+}
+
+func TestSQL_UpdateWithFromTargetIsWrittenObject(t *testing.T) {
+	f := sql("UPDATE protected SET val = src.val FROM source AS src WHERE protected.id = src.id")
+	if f["target"] != "protected" {
+		t.Fatalf("target = %v, want protected", f["target"])
+	}
+}
+
+func TestSQL_DeleteFromTarget(t *testing.T) {
+	f := sql("DELETE FROM protected WHERE id IN (SELECT id FROM staging)")
+	if f["verb"] != "DELETE" || f["target"] != "protected" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestSQL_InsertWithoutInto(t *testing.T) {
+	f := sql("INSERT protected (id) VALUES (1)")
+	if f["verb"] != "INSERT" || f["target"] != "protected" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestSQL_FunctionsDedupAndDenylist(t *testing.T) {
+	f := sql("SELECT COUNT(id), Count(name), NOW() FROM users")
+	fns := strings.Split(f["functions"].(string), ",")
+	if !contains(fns, "COUNT") || !contains(fns, "NOW") {
+		t.Fatalf("expected COUNT and NOW in %v", fns)
+	}
+	n := 0
+	for _, x := range fns {
+		if x == "COUNT" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("expected COUNT once, got %d in %v", n, fns)
+	}
+
+	g := sql("INSERT INTO t VALUES (CAST('1' AS INT))")
+	gfns := strings.Split(g["functions"].(string), ",")
+	if contains(gfns, "VALUES") || contains(gfns, "CAST") {
+		t.Fatalf("denylist failed: %v", gfns)
+	}
+}
+
+func TestSQL_StripsComments(t *testing.T) {
+	f := sql("/* hi */ -- comment\n SELECT id FROM users -- tail")
+	if f["verb"] != "SELECT" || f["target"] != "users" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestSQL_StripsQuoting(t *testing.T) {
+	cases := []struct{ q, want string }{
+		{`SELECT * FROM "public"."users"`, "users"},
+		{"SELECT * FROM `db`.`orders`", "orders"},
+		{"SELECT * FROM [dbo].[items]", "items"},
+	}
+	for _, c := range cases {
+		tables := strings.Split(sql(c.q)["tables"].(string), ",")
+		if !contains(tables, c.want) {
+			t.Errorf("%s: expected %s in %v", c.q, c.want, tables)
+		}
+	}
+}
+
+// ── K8s ──────────────────────────────────────────────────────────────────────
+
+func k8s(method, path string) map[string]any {
+	return ExtractK8sFacets(map[string]any{"method": method, "path": path})
+}
+
+func TestK8s_EmptyPath(t *testing.T) {
+	f := ExtractK8sFacets(map[string]any{})
+	if f["verb"] != "" {
+		t.Fatalf("empty path should produce empty verb, got %v", f["verb"])
+	}
+}
+
+func TestK8s_ClusterList(t *testing.T) {
+	f := k8s("GET", "/api/v1/nodes")
+	if f["verb"] != "list" || f["resource"] != "nodes" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestK8s_NamespacedCollectionAndNamed(t *testing.T) {
+	f := k8s("GET", "/api/v1/namespaces/prod/pods")
+	if f["verb"] != "list" || f["namespace"] != "prod" || f["resource"] != "pods" {
+		t.Fatalf("collection: %+v", f)
+	}
+	g := k8s("GET", "/api/v1/namespaces/prod/pods/mypod")
+	if g["verb"] != "get" || g["name"] != "mypod" {
+		t.Fatalf("named: %+v", g)
+	}
+}
+
+func TestK8s_Subresources(t *testing.T) {
+	exec := k8s("POST", "/api/v1/namespaces/prod/pods/mypod/exec")
+	if exec["subresource"] != "exec" || exec["verb"] != "create" {
+		t.Fatalf("exec: %+v", exec)
+	}
+	logs := k8s("GET", "/api/v1/namespaces/prod/pods/mypod/log")
+	if logs["subresource"] != "log" {
+		t.Fatalf("log: %+v", logs)
+	}
+	status := k8s("PATCH", "/apis/apps/v1/namespaces/prod/deployments/web/status")
+	if status["subresource"] != "status" || status["verb"] != "patch" {
+		t.Fatalf("status: %+v", status)
+	}
+}
+
+func TestK8s_DeleteCollectionVsNamed(t *testing.T) {
+	if k8s("DELETE", "/api/v1/namespaces/prod/pods")["verb"] != "deletecollection" {
+		t.Fatalf("expected deletecollection")
+	}
+	if k8s("DELETE", "/api/v1/namespaces/prod/pods/p1")["verb"] != "delete" {
+		t.Fatalf("expected delete")
+	}
+}
+
+func TestK8s_ApisGroup(t *testing.T) {
+	f := k8s("GET", "/apis/apps/v1/namespaces/prod/deployments/web")
+	if f["resource"] != "deployments" || f["name"] != "web" || f["verb"] != "get" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestK8s_TrailingSlash(t *testing.T) {
+	if k8s("GET", "/api/v1/namespaces/prod/pods/")["resource"] != "pods" {
+		t.Fatalf("trailing slash not tolerated")
+	}
+}
+
+func TestK8s_MissingMethod_NoVerb(t *testing.T) {
+	f := ExtractK8sFacets(map[string]any{"path": "/api/v1/namespaces/prod/pods"})
+	if f["verb"] != "" || f["resource"] != "pods" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestK8s_WatchPaths(t *testing.T) {
+	if k8s("GET", "/api/v1/watch/pods")["verb"] != "watch" {
+		t.Fatalf("cluster watch")
+	}
+	if k8s("GET", "/api/v1/watch/namespaces/prod/pods")["verb"] != "watch" {
+		t.Fatalf("namespaced collection watch")
+	}
+	if k8s("GET", "/api/v1/watch/namespaces/prod/pods/web")["verb"] != "watch" {
+		t.Fatalf("namespaced named watch")
+	}
+}
+
+func TestK8s_ProxyTail(t *testing.T) {
+	f := k8s("GET", "/api/v1/namespaces/prod/pods/web/proxy/healthz")
+	if f["subresource"] != "proxy" || f["name"] != "web" {
+		t.Fatalf("got %+v", f)
+	}
+	c := k8s("GET", "/api/v1/nodes/n1/proxy/metrics")
+	if c["subresource"] != "proxy" || c["resource"] != "nodes" {
+		t.Fatalf("cluster proxy: %+v", c)
+	}
+}
+
+func TestK8s_ClusterSubresource_Status(t *testing.T) {
+	f := k8s("PATCH", "/api/v1/nodes/node1/status")
+	if f["subresource"] != "status" || f["resource"] != "nodes" || f["name"] != "node1" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestK8s_QueryStringStripped(t *testing.T) {
+	f := k8s("GET", "/api/v1/namespaces/prod/pods?fieldManager=test")
+	if f["resource"] != "pods" || f["verb"] != "list" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestK8s_WatchQueryParam_GetOnly(t *testing.T) {
+	if k8s("GET", "/api/v1/namespaces/prod/pods?watch=true")["verb"] != "watch" {
+		t.Fatalf("watch=true on GET should yield watch")
+	}
+	// On POST, ?watch=true must not downgrade to a misleading watch verb.
+	if got := k8s("POST", "/api/v1/namespaces/prod/pods?watch=true")["verb"]; got == "watch" {
+		t.Fatalf("watch=true on POST must not yield watch (got %v)", got)
+	}
+}
+
+func TestK8s_ResourceNamedWatchDoesNotFalseTrigger(t *testing.T) {
+	f := k8s("GET", "/api/v1/namespaces/watch-test/pods")
+	if f["verb"] != "list" || f["namespace"] != "watch-test" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestK8s_FragmentStripped(t *testing.T) {
+	if k8s("GET", "/api/v1/namespaces/prod/pods#anchor")["resource"] != "pods" {
+		t.Fatalf("# fragment not stripped")
+	}
+}
+
+// ── extract_protocol_facets default flow ─────────────────────────────────────
+
+func TestExtract_FlattensSQLAtTopLevel(t *testing.T) {
+	ctx := map[string]any{
+		"sql": map[string]any{"query": "DROP TABLE production"},
+	}
+	ExtractProtocolFacets(ctx)
+	if ctx["sql.verb"] != "DROP" || ctx["sql.target"] != "production" {
+		t.Fatalf("got %+v", ctx)
+	}
+}
+
+func TestExtract_FlattensK8sAtTopLevel(t *testing.T) {
+	ctx := map[string]any{
+		"k8s": map[string]any{
+			"method": "DELETE",
+			"path":   "/api/v1/namespaces/prod/pods/p1",
+		},
+	}
+	ExtractProtocolFacets(ctx)
+	if ctx["k8s.verb"] != "delete" || ctx["k8s.namespace"] != "prod" {
+		t.Fatalf("got %+v", ctx)
+	}
+}
+
+func TestExtractWith_CustomRegistry(t *testing.T) {
+	r := NewFacetRegistry()
+	r.Register("sql", func(_ map[string]any) map[string]any {
+		return map[string]any{"verb": "CUSTOM"}
+	})
+	ctx := map[string]any{"sql": map[string]any{"query": "SELECT 1"}}
+	ExtractProtocolFacetsWith(ctx, r)
+	if ctx["sql.verb"] != "CUSTOM" {
+		t.Fatalf("custom registry not respected: %+v", ctx)
+	}
+}
+
+// ── PolicyEngine integration ─────────────────────────────────────────────────
+
+func TestPolicyEngine_DeniesDestructiveSQL(t *testing.T) {
+	engine := NewPolicyEngine([]PolicyRule{
+		{
+			Action: "db.exec",
+			Effect: Deny,
+			Conditions: map[string]any{
+				"sql.verb": map[string]any{
+					"$in": []any{"DROP", "TRUNCATE", "DELETE"},
+				},
+			},
+		},
+	})
+	ctx := map[string]any{
+		"sql": map[string]any{"query": "DROP TABLE production"},
+	}
+	if got := engine.Evaluate("db.exec", ctx); got != Deny {
+		t.Fatalf("expected Deny, got %v", got)
+	}
+}
+
+func TestPolicyEngine_AllowsSelectWhenNotInDestructiveSet(t *testing.T) {
+	engine := NewPolicyEngine([]PolicyRule{
+		{
+			Action: "db.exec",
+			Effect: Deny,
+			Conditions: map[string]any{
+				"sql.verb": map[string]any{
+					"$in": []any{"DROP", "TRUNCATE", "DELETE"},
+				},
+			},
+		},
+		{Action: "db.exec", Effect: Allow},
+	})
+	ctx := map[string]any{
+		"sql": map[string]any{"query": "SELECT * FROM users"},
+	}
+	if got := engine.Evaluate("db.exec", ctx); got != Allow {
+		t.Fatalf("expected Allow, got %v", got)
+	}
+}
+
+func TestPolicyEngine_DeniesK8sExec(t *testing.T) {
+	engine := NewPolicyEngine([]PolicyRule{
+		{
+			Action: "k8s.request",
+			Effect: Deny,
+			Conditions: map[string]any{
+				"k8s.subresource": "exec",
+			},
+		},
+	})
+	ctx := map[string]any{
+		"k8s": map[string]any{
+			"method": "POST",
+			"path":   "/api/v1/namespaces/prod/pods/web/exec",
+		},
+	}
+	if got := engine.Evaluate("k8s.request", ctx); got != Deny {
+		t.Fatalf("expected Deny, got %v", got)
+	}
+}
+
+func TestPolicyEngine_DeniesProductionNamespace(t *testing.T) {
+	engine := NewPolicyEngine([]PolicyRule{
+		{
+			Action: "k8s.request",
+			Effect: Deny,
+			Conditions: map[string]any{
+				"k8s.namespace": "production",
+			},
+		},
+	})
+	ctx := map[string]any{
+		"k8s": map[string]any{
+			"method": "DELETE",
+			"path":   "/api/v1/namespaces/production/pods/web",
+		},
+	}
+	if got := engine.Evaluate("k8s.request", ctx); got != Deny {
+		t.Fatalf("expected Deny, got %v", got)
+	}
+}
+
+func TestPolicyEngine_SQLTargetReferenceable(t *testing.T) {
+	engine := NewPolicyEngine([]PolicyRule{
+		{
+			Action: "db.exec",
+			Effect: Deny,
+			Conditions: map[string]any{
+				"sql.target": "protected",
+			},
+		},
+	})
+	ctx := map[string]any{
+		"sql": map[string]any{"query": "INSERT INTO protected SELECT * FROM staging"},
+	}
+	if got := engine.Evaluate("db.exec", ctx); got != Deny {
+		t.Fatalf("expected Deny, got %v", got)
+	}
+}
+
+func TestPolicyEngine_DoesNotMutateCallerContext(t *testing.T) {
+	engine := NewPolicyEngine(nil)
+	sub := map[string]any{"query": "SELECT 1"}
+	ctx := map[string]any{"sql": sub}
+
+	_ = engine.Evaluate("anything", ctx)
+
+	if len(sub) != 1 {
+		t.Fatalf("caller sub-map mutated; size=%d, contents=%+v", len(sub), sub)
+	}
+	if _, ok := sub["verb"]; ok {
+		t.Fatalf("caller sub-map mutated; got verb=%v", sub["verb"])
+	}
+	if _, ok := ctx["sql.verb"]; ok {
+		t.Fatalf("caller top-level map mutated; got sql.verb=%v", ctx["sql.verb"])
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func contains(s []string, x string) bool {
+	for _, v := range s {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+// ── Regressions for dialect modifiers and example loader ────────────────────
+
+func TestSQL_InsertOrReplaceIntoTarget(t *testing.T) {
+	cases := []string{
+		"INSERT OR REPLACE INTO protected (id) VALUES (1)",
+		"INSERT OR IGNORE INTO protected (id) VALUES (1)",
+		"INSERT IGNORE INTO protected (id) VALUES (1)",
+	}
+	for _, q := range cases {
+		f := sql(q)
+		if f["verb"] != "INSERT" || f["target"] != "protected" {
+			t.Errorf("%s: got %+v", q, f)
+		}
+	}
+}
+
+func TestSQL_UpdateOnlyTarget(t *testing.T) {
+	f := sql("UPDATE ONLY protected SET v = 1 WHERE id = 2")
+	if f["target"] != "protected" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestSQL_DeleteFromOnlyTarget(t *testing.T) {
+	f := sql("DELETE FROM ONLY protected WHERE id = 2")
+	if f["verb"] != "DELETE" || f["target"] != "protected" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestSQL_CreateOrReplaceTarget(t *testing.T) {
+	f := sql("CREATE OR REPLACE VIEW protected AS SELECT 1")
+	if f["verb"] != "CREATE" || f["target"] != "protected" {
+		t.Fatalf("got %+v", f)
+	}
+}
+
+func TestExampleYAML_LoadsCleanly(t *testing.T) {
+	path := "../../examples/wire-protocol-rules.yaml"
+	engine := NewPolicyEngine(nil)
+	if err := engine.LoadFromYAML(path); err != nil {
+		t.Fatalf("LoadFromYAML failed: %v", err)
+	}
+	// A DROP must be denied by the loaded ruleset.
+	ctx := map[string]any{
+		"sql": map[string]any{"query": "DROP TABLE production"},
+	}
+	if got := engine.Evaluate("db.exec", ctx); got != Deny {
+		t.Fatalf("example yaml did not deny DROP: got %v", got)
+	}
+}


### PR DESCRIPTION
Rebased cherry-pick of #2590 by Ricky-G onto current main.

Adds FacetRegistry-based protocol facet extraction for Go SDK. Includes SQL and K8s extractors with top-level key flattening for Go's structured condition matcher.

**Changes:**
- \protocol_facets.go\: FacetRegistry, SQL/K8s extractors, panic-safe execution
- \policy.go\: Integration with ExtractProtocolFacets in Evaluate()
- \protocol_facets_test.go\: Comprehensive test coverage
- \wire-protocol-rules.yaml\: Example rules for Go

Closes #2590

Co-authored-by: Ricky-G <56914614+Ricky-G@users.noreply.github.com>