### PR TITLE
fix(pipelines): publish cedarling_agentmesh to PyPI

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -159,6 +159,9 @@ parameters:
         path: agent-governance-python/agentmesh-integrations/mcp-trust-proxy
         wave: 2
       # Wave 3: Framework integrations
+      - name: cedarling-agentmesh
+        path: agent-governance-python/agentmesh-integrations/cedarling-agentmesh
+        wave: 3
       - name: crewai-agentmesh
         path: agent-governance-python/agentmesh-integrations/crewai-agentmesh
         wave: 3


### PR DESCRIPTION
## Summary

Add `cedarling-agentmesh` to the ESRP publish pipeline so it actually gets published to PyPI. Fixes #2609.

## Problem

The package at `agent-governance-python/agentmesh-integrations/cedarling-agentmesh/` has a valid `pyproject.toml` (`name = "cedarling_agentmesh"`, `version = "3.5.0"`) and its README instructs users to:

```bash
pip install cedarling_agentmesh
```

…but the package was never added to `.github/pipelines/esrp-publish.yml` — the only mechanism that publishes packages to PyPI via ESRP. As a result, `pip install cedarling_agentmesh` currently fails with:

```
ERROR: Could not find a version that satisfies the requirement cedarling_agentmesh
ERROR: No matching distribution found for cedarling_agentmesh
```

Verified with `https://pypi.org/pypi/cedarling_agentmesh/json` → `404`.

All other `agentmesh-integrations/*` packages (e.g. `langchain-agentmesh`, `crewai-agentmesh`, `llamaindex-agentmesh`) are present in the pipeline and live on PyPI — this entry was simply omitted.

## Changes

| File | What changed |
|------|-------------|
| `.github/pipelines/esrp-publish.yml` | Added a wave-3 entry for `cedarling-agentmesh` (path `agent-governance-python/agentmesh-integrations/cedarling-agentmesh`), placed alphabetically first within the Wave 3 framework-integrations block. |

Diff:

```yaml
       # Wave 3: Framework integrations
+      - name: cedarling-agentmesh
+        path: agent-governance-python/agentmesh-integrations/cedarling-agentmesh
+        wave: 3
       - name: crewai-agentmesh
         path: agent-governance-python/agentmesh-integrations/crewai-agentmesh
         wave: 3
```

## Testing

- Validated YAML with `yaml.safe_load` — file parses cleanly.
- Confirmed the new entry is present in the parsed Wave 3 list (14 packages, `cedarling-agentmesh` is first alphabetically).
- Verified `pyproject.toml` builds cleanly under hatchling (`name = cedarling_agentmesh`, `version = 3.5.0`, `build-backend = hatchling.build`).
- Confirmed the package's only declared dependency (`agent-os-kernel>=3.5.0`) is already registered on PyPI.

## Note on release timing

The ESRP pipeline is manually triggered (`trigger: none`, `pr: none`), so merging this PR does not by itself push to PyPI. `cedarling_agentmesh` will land on PyPI the next time a maintainer runs the ESRP release pipeline with target `pypi` or `all`.
