### PR TITLE
fix(ci): resolve CORS test type errors and flaky queue overflow test

### DIFF
--- a/agent-governance-python/agent-os/extensions/copilot/jest.config.cjs
+++ b/agent-governance-python/agent-os/extensions/copilot/jest.config.cjs
@@ -4,4 +4,12 @@ module.exports = {
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],
   verbose: false,
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: {
+        types: ['jest', 'node'],
+        esModuleInterop: true,
+      },
+    }],
+  },
 };

--- a/agent-governance-python/agent-os/tests/test_event_sink.py
+++ b/agent-governance-python/agent-os/tests/test_event_sink.py
@@ -159,13 +159,15 @@ class TestGovernanceEventProcessor:
         proc = GovernanceEventProcessor(
             max_queue_size=5, schedule_delay_ms=5000, max_batch_size=100
         )
-        proc.add_sink(sink)
-
-        # Enqueue 10 events into a queue of size 5
+        # Enqueue BEFORE adding sink so the worker thread is not yet started.
+        # This avoids a race where notify() wakes the worker which drains
+        # events between on_event() calls, preventing overflow.
         for i in range(10):
             proc.on_event(GovernanceEvent(agent_id=f"agent-{i}"))
 
         assert proc.dropped_count > 0
+
+        proc.add_sink(sink)
         proc.shutdown(timeout_ms=2000)
 
         # Should have received at most 5 events (queue max)


### PR DESCRIPTION
## Changes

1. **Copilot extension CORS tests** (build-npm failure): \	s-jest\ couldn't find Jest type definitions (\describe\, \	est\, \xpect\, \eforeEach\) because \	sconfig.json\ doesn't include \	ypes: ['jest']\. Fixed by adding a tsconfig override in \jest.config.cjs\.

2. **test_queue_overflow_drops_oldest** (docker-compose-test flaky failure): The test added a sink (starting the worker thread) before enqueueing events. The worker's \condition.notify()\ wake-up caused it to drain events between \on_event()\ calls, so the queue never actually overflowed. Fixed by enqueueing events before adding the sink, ensuring no worker is running during the overflow phase.

Fixes CI run 26595553399.