### PR TITLE
fix(sandbox): harden in-process sandbox against stdlib escape paths

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/sandbox.py
+++ b/agent-governance-python/agent-os/src/agent_os/sandbox.py
@@ -578,16 +578,28 @@ def _install_hook_reentrant(hook: Any) -> None:
     Must be called while ``_SANDBOX_SHADOW_LOCK`` is held (i.e. between
     ``_enter_sys_modules_shadow`` and ``_exit_sys_modules_shadow``) to
     serialize updates to ``sys.meta_path``.
+
+    Tracks whether *this* call owns the install: ``SandboxImportHook.install``
+    is idempotent, so nested same-instance calls would otherwise let the
+    inner ``_uninstall_hook_reentrant`` remove the hook while the outer
+    call still needs it.
     """
+    already_installed = hook in sys.meta_path
     hook.install()
-    _SANDBOX_INSTALLED_HOOKS.append(hook)
+    _SANDBOX_INSTALLED_HOOKS.append((hook, not already_installed))
 
 
 def _uninstall_hook_reentrant() -> None:
-    """Remove the most recently installed hook (LIFO)."""
+    """Remove the most recently installed hook (LIFO).
+
+    Only calls ``hook.uninstall()`` if this layer was the one that actually
+    installed it; nested same-instance calls leave the hook in place for
+    the outer call.
+    """
     if _SANDBOX_INSTALLED_HOOKS:
-        hook = _SANDBOX_INSTALLED_HOOKS.pop()
-        hook.uninstall()
+        hook, owns_install = _SANDBOX_INSTALLED_HOOKS.pop()
+        if owns_install:
+            hook.uninstall()
 
 
 
@@ -791,6 +803,12 @@ class ExecutionSandbox:
             on the same thread share the shadow without double-snapshotting.
             Disable ``shadow_sys_modules`` if you need concurrent host
             access to those modules.
+
+            Because the shared shadow lock is held for the entire duration
+            of ``func`` execution, a long-running or non-terminating
+            sandboxed function will block other threads that try to enter
+            the sandbox. Use the subprocess-based providers in
+            :mod:`agent_os.sandbox_provider` for adversarial workloads.
         """
         if self.config.shadow_sys_modules:
             # Acquire the shared lock + reentrant shadow first, then install

--- a/agent-governance-python/agent-os/src/agent_os/sandbox.py
+++ b/agent-governance-python/agent-os/src/agent_os/sandbox.py
@@ -3,13 +3,28 @@
 """
 Execution Sandbox for Agent OS
 
-Prevents agents from bypassing the kernel via direct stdlib calls
-(subprocess, os, eval, etc.) using import hooks and AST-based static analysis.
+Provides defense-in-depth restrictions on agent-supplied code via import hooks,
+restricted builtins, sys.modules shadowing, and AST-based static analysis.
+
+.. warning::
+   This is an **in-process, soft sandbox**. It raises the cost of common
+   stdlib-bypass techniques (``subprocess``, ``os.system``, ``eval``,
+   ``importlib.import_module``, ``sys.modules`` lookup, dunder traversal),
+   but a determined attacker who can execute arbitrary Python in this
+   interpreter can still escape (e.g. via C-extension memory tricks, frame
+   introspection in compiled code, ``gc`` walks of live objects, or simply
+   by exploiting any unblocked third-party module already loaded).
+
+   **For strong isolation, run untrusted code in a separate OS process** with
+   ``seccomp``/AppArmor/landlock/Job-Objects, a container, a microVM
+   (Firecracker/gVisor), or a WASM runtime. Use this sandbox only as a
+   defense-in-depth layer.
 """
 
 from __future__ import annotations
 
 import ast
+import builtins as _py_builtins
 import importlib.abc
 import importlib.machinery
 import os
@@ -23,12 +38,28 @@ from pydantic import BaseModel, Field
 
 from agent_os.exceptions import SecurityError
 
+
+class SandboxSecurityWarning(UserWarning):
+    """Warning category emitted by the sandbox for security-relevant events.
+
+    Lets callers filter sandbox warnings independently of other ``UserWarning``s.
+    """
+
+
 _SAMPLE_DISCLAIMER = (
     "\u26a0\ufe0f  These are SAMPLE sandbox rules provided as a starting point. "
     "You MUST review, customise, and extend them for your specific use case "
     "before deploying to production."
 )
 
+# Modules whose top-level name must be blocked from import inside the sandbox.
+# Each of these has been used in real Python sandbox-escape PoCs:
+#   sys, builtins         -> sys.modules / __builtins__ traversal
+#   gc, inspect           -> walking live objects to reach dangerous classes
+#   pickle, marshal, code -> arbitrary code execution on deserialisation
+#   posix, nt, _posixsubprocess -> low-level stdlib backends behind os/subprocess
+#   multiprocessing, threading  -> spawn helpers that wrap subprocess/os
+#   pty, fcntl, signal    -> process-control surface
 _DEFAULT_BLOCKED_MODULES: list[str] = [
     "subprocess",
     "os",
@@ -36,6 +67,24 @@ _DEFAULT_BLOCKED_MODULES: list[str] = [
     "socket",
     "ctypes",
     "importlib",
+    "sys",
+    "builtins",
+    "gc",
+    "inspect",
+    "pickle",
+    "marshal",
+    "code",
+    "codeop",
+    "pty",
+    "fcntl",
+    "signal",
+    "posix",
+    "nt",
+    "_posixsubprocess",
+    "multiprocessing",
+    "threading",
+    "_thread",
+    "asyncio",
 ]
 
 _DEFAULT_BLOCKED_BUILTINS: list[str] = [
@@ -43,7 +92,56 @@ _DEFAULT_BLOCKED_BUILTINS: list[str] = [
     "eval",
     "compile",
     "__import__",
+    "open",
+    "breakpoint",
+    "input",
+    "help",
+    "globals",
+    "locals",
+    "vars",
+    "getattr",
+    "setattr",
+    "delattr",
+    "memoryview",
 ]
+
+# Builtins permitted by default inside ``create_restricted_globals``. Anything
+# not on this list and not explicitly blocked is omitted (fail-closed).
+_SAFE_BUILTINS_WHITELIST: frozenset[str] = frozenset({
+    # Constants
+    "True", "False", "None", "Ellipsis", "NotImplemented", "__build_class__",
+    # Core types
+    "bool", "int", "float", "complex", "str", "bytes", "bytearray",
+    "list", "tuple", "set", "frozenset", "dict", "slice", "range",
+    "type", "object", "property", "staticmethod", "classmethod", "super",
+    # Numeric / iteration helpers
+    "abs", "all", "any", "ascii", "bin", "chr", "divmod", "enumerate",
+    "filter", "format", "hex", "id", "isinstance", "issubclass", "iter",
+    "len", "map", "max", "min", "next", "oct", "ord", "pow", "print",
+    "repr", "reversed", "round", "sorted", "sum", "zip", "hash",
+    "callable",
+    # Exception classes (allow user code to raise/handle)
+    "Exception", "BaseException", "ArithmeticError", "AssertionError",
+    "AttributeError", "EOFError", "FloatingPointError", "GeneratorExit",
+    "ImportError", "IndexError", "KeyError", "KeyboardInterrupt",
+    "LookupError", "MemoryError", "NameError", "NotImplementedError",
+    "OSError", "OverflowError", "RecursionError", "ReferenceError",
+    "RuntimeError", "StopIteration", "StopAsyncIteration", "SyntaxError",
+    "SystemError", "TypeError", "UnboundLocalError", "UnicodeError",
+    "ValueError", "ZeroDivisionError",
+})
+
+# Dunder attribute names commonly used in Python sandbox escapes
+# (e.g. ``().__class__.__bases__[0].__subclasses__()``).
+_DANGEROUS_ATTR_NAMES: frozenset[str] = frozenset({
+    "__class__", "__bases__", "__base__", "__mro__", "__subclasses__",
+    "__globals__", "__builtins__", "__import__", "__loader__", "__spec__",
+    "__dict__", "__getattribute__", "__reduce__", "__reduce_ex__",
+    "__subclasshook__", "__init_subclass__", "__code__", "__closure__",
+    "__func__", "__self__", "__module__", "__wrapped__",
+    "func_globals", "gi_frame", "gi_code", "cr_frame", "cr_code",
+    "f_globals", "f_locals", "f_builtins", "f_back",
+})
 
 
 # ---------------------------------------------------------------------------
@@ -98,13 +196,34 @@ def load_sandbox_config(path: str) -> SandboxSecurityConfig:
 
 
 class SandboxConfig(BaseModel):
-    """Configuration for the execution sandbox."""
+    """Configuration for the execution sandbox.
+
+    Attributes:
+        blocked_modules: Top-level module names denied at import time and
+            shadowed in ``sys.modules`` while a sandboxed function runs.
+        blocked_builtins: Built-in names replaced with raising stubs in the
+            restricted globals.
+        allowed_paths: Filesystem roots that ``check_file_access`` will permit.
+        max_memory_mb / max_cpu_seconds: Informational hints — this in-process
+            sandbox does not enforce resource limits. Use OS-level isolation
+            (cgroups, Job Objects, rlimit) for hard guarantees.
+        shadow_sys_modules: When True (default), ``execute_sandboxed`` replaces
+            blocked entries in ``sys.modules`` with a trap proxy that raises
+            ``SecurityError`` on any access, closing the
+            ``sys.modules['os'].system(...)`` escape. Disable only when you
+            know other concurrent threads need these modules during execution.
+        enforce_ast_validation: When True (default), ``execute_code_sandboxed``
+            runs ``validate_code`` first and refuses to execute on any
+            violation (fail-closed).
+    """
 
     blocked_modules: list[str] = Field(default_factory=lambda: list(_DEFAULT_BLOCKED_MODULES))
     blocked_builtins: list[str] = Field(default_factory=lambda: list(_DEFAULT_BLOCKED_BUILTINS))
     allowed_paths: list[str] = Field(default_factory=list)
     max_memory_mb: int | None = None
     max_cpu_seconds: int | None = None
+    shadow_sys_modules: bool = True
+    enforce_ast_validation: bool = True
 
 
 @dataclass
@@ -222,6 +341,30 @@ class _ASTSecurityVisitor(ast.NodeVisitor):
                 )
             )
 
+        # Detect getattr(x, '<dangerous_dunder>') bypass
+        if (
+            isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+        ):
+            attr_arg = node.args[1]
+            if (
+                isinstance(attr_arg, ast.Constant)
+                and isinstance(attr_arg.value, str)
+                and attr_arg.value in _DANGEROUS_ATTR_NAMES
+            ):
+                self.violations.append(
+                    SecurityViolation(
+                        line=node.lineno,
+                        column=node.col_offset,
+                        violation_type="dunder_escape",
+                        description=(
+                            f"getattr() used to reach dangerous attribute "
+                            f"'{attr_arg.value}'"
+                        ),
+                    )
+                )
+
         # Detect os.system(...) style calls
         if isinstance(node.func, ast.Attribute):
             if isinstance(node.func.value, ast.Name):
@@ -264,12 +407,103 @@ class _ASTSecurityVisitor(ast.NodeVisitor):
 
         self.generic_visit(node)
 
+    def visit_Attribute(self, node: ast.Attribute) -> None:  # noqa: N802
+        """Detect dunder traversal escapes like ``().__class__.__bases__``."""
+        if node.attr in _DANGEROUS_ATTR_NAMES:
+            self.violations.append(
+                SecurityViolation(
+                    line=node.lineno,
+                    column=node.col_offset,
+                    violation_type="dunder_escape",
+                    description=(
+                        f"Access to dangerous attribute '{node.attr}' "
+                        "(common sandbox-escape pattern)"
+                    ),
+                    severity="critical",
+                )
+            )
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:  # noqa: N802
+        """Detect ``sys.modules['os']`` lookups even though ``sys`` is blocked."""
+        if (
+            isinstance(node.value, ast.Attribute)
+            and node.value.attr == "modules"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "sys"
+        ):
+            self.violations.append(
+                SecurityViolation(
+                    line=node.lineno,
+                    column=node.col_offset,
+                    violation_type="sys_modules_access",
+                    description="Access to sys.modules (sandbox bypass attempt)",
+                    severity="critical",
+                )
+            )
+        self.generic_visit(node)
+
+
+class _BlockedModuleProxy:
+    """Trap object substituted into ``sys.modules`` for blocked modules.
+
+    Any attribute access, call, item lookup, or repr raises ``SecurityError``,
+    closing the ``sys.modules['os'].system(...)`` escape path.
+
+    Notes:
+        ``__class__`` is also denied at the Python level to frustrate the
+        ``type(proxy).__mro__[1].__subclasses__()`` traversal escape. Python
+        callers that need the type can still use ``type(obj)`` (C-level
+        ``Py_TYPE``), but a sandboxed *function* (where AST validation does
+        not apply) at least cannot reach the proxy's class through standard
+        attribute lookup.
+    """
+
+    __slots__ = ("_name",)
+
+    def __init__(self, name: str) -> None:
+        object.__setattr__(self, "_name", name)
+
+    def _deny(self, op: str) -> None:
+        name = object.__getattribute__(self, "_name")
+        raise SecurityError(
+            f"Access to blocked module '{name}' (operation: {op}) "
+            "is denied by sandbox policy",
+            error_code="BLOCKED_MODULE_ACCESS",
+            details={"module": name, "operation": op},
+        )
+
+    def __getattribute__(self, item: str) -> Any:
+        # ``_deny`` must be retrievable by our own methods, but nothing else
+        # (including ``__class__``) is allowed through.
+        if item == "_deny":
+            return object.__getattribute__(self, item)
+        object.__getattribute__(self, "_deny")(f"getattr {item}")
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        object.__getattribute__(self, "_deny")(f"setattr {key}")
+
+    def __delattr__(self, item: str) -> None:
+        object.__getattribute__(self, "_deny")(f"delattr {item}")
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        object.__getattribute__(self, "_deny")("call")
+
+    def __getitem__(self, item: Any) -> None:
+        object.__getattribute__(self, "_deny")("getitem")
+
+    def __repr__(self) -> str:
+        name = object.__getattribute__(self, "_name")
+        return f"<BlockedModuleProxy {name!r}>"
+
 
 class ExecutionSandbox:
-    """Restricted execution environment that prevents stdlib bypass.
+    """Restricted execution environment that frustrates stdlib bypass.
 
-    Uses import hooks and AST-based static analysis to enforce security
-    policies on agent code execution.
+    Combines import hooks, ``sys.modules`` shadowing, restricted builtins, and
+    AST-based static analysis. **This is not a true security boundary** — see
+    the module docstring for the threat model and recommended OS-level
+    alternatives.
     """
 
     def __init__(
@@ -279,15 +513,22 @@ class ExecutionSandbox:
     ) -> None:
         if config is None:
             warnings.warn(
-                "ExecutionSandbox() uses built-in sample rules that may not "
-                "cover all sandbox evasion techniques. For production use, load an "
-                "explicit config with load_sandbox_config(). "
-                "See examples/policies/sandbox-safety.yaml for a sample configuration.",
+                "ExecutionSandbox() uses built-in sample rules. This is an "
+                "in-process soft sandbox and does NOT provide a security "
+                "boundary against a determined attacker. Use OS-level "
+                "isolation (containers, seccomp, microVMs) for untrusted "
+                "code. For production sandbox rules, load an explicit config "
+                "via load_sandbox_config(). "
+                "See examples/policies/sandbox-safety.yaml.",
+                category=SandboxSecurityWarning,
                 stacklevel=2,
             )
         self.config = config or SandboxConfig()
         self.policy = policy
         self._hook = SandboxImportHook(self.config.blocked_modules)
+        # Snapshot of sys.modules entries replaced during execute_sandboxed,
+        # so we can restore them on exit. Empty when no shadow is active.
+        self._shadowed_modules: dict[str, Any] = {}
 
     def check_import(self, module_name: str) -> bool:
         """Check if a module import is allowed.
@@ -347,18 +588,29 @@ class ExecutionSandbox:
         self,
         user_globals: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Create a restricted globals dict that blocks dangerous builtins.
+        """Create a restricted globals dict with a whitelist of safe builtins.
+
+        Only names in :data:`_SAFE_BUILTINS_WHITELIST` are exposed. Names in
+        ``config.blocked_builtins`` are replaced with raising stubs so that
+        explicit attempts to call them produce a clear ``SecurityError``.
+        Everything else (e.g. ``open``, ``__import__``, ``breakpoint``,
+        ``__loader__``) is omitted entirely — fail-closed.
 
         Args:
             user_globals: Optional dict of user-provided globals to merge in.
+                A ``__builtins__`` key in ``user_globals`` is ignored.
 
         Returns:
-            A globals dict with blocked builtins replaced by raising functions.
+            A globals dict suitable for ``exec(code, restricted)``.
         """
-        import builtins as _builtins
+        safe_builtins: dict[str, Any] = {}
+        all_builtins = vars(_py_builtins)
+        for name in _SAFE_BUILTINS_WHITELIST:
+            if name in all_builtins:
+                safe_builtins[name] = all_builtins[name]
 
-        safe_builtins = dict(vars(_builtins).items())
-
+        # Replace blocked names with raising stubs so callers get a clear
+        # SecurityError instead of NameError (better signal for auditors).
         for name in self.config.blocked_builtins:
             safe_builtins[name] = _make_blocked_builtin(name)
 
@@ -400,8 +652,35 @@ class ExecutionSandbox:
         visitor.visit(tree)
         return visitor.violations
 
+    def _shadow_sys_modules(self) -> None:
+        """Replace blocked entries in ``sys.modules`` with trap proxies.
+
+        Closes the ``sys.modules['os'].system(...)`` escape that the import
+        hook alone cannot stop (preloaded modules are already cached).
+        Caller must invoke :meth:`_restore_sys_modules` to clean up.
+        """
+        if self._shadowed_modules:
+            # Already shadowed (nested execute) — don't double-snapshot.
+            return
+        for name in self.config.blocked_modules:
+            # Shadow the top-level module AND any cached submodules
+            # (e.g. ``os.path``, ``importlib.util``).
+            to_shadow = [
+                key for key in list(sys.modules)
+                if key == name or key.startswith(name + ".")
+            ]
+            for key in to_shadow:
+                self._shadowed_modules[key] = sys.modules[key]
+                sys.modules[key] = _BlockedModuleProxy(key)
+
+    def _restore_sys_modules(self) -> None:
+        """Restore ``sys.modules`` entries replaced by :meth:`_shadow_sys_modules`."""
+        for key, original in self._shadowed_modules.items():
+            sys.modules[key] = original
+        self._shadowed_modules.clear()
+
     def execute_sandboxed(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        """Run a function with import hooks that enforce the sandbox.
+        """Run a function with import hooks and (optionally) sys.modules shadowing.
 
         Args:
             func: The function to execute.
@@ -410,12 +689,100 @@ class ExecutionSandbox:
 
         Returns:
             The return value of the function.
+
+        Note:
+            ``func`` is already-compiled bytecode and is **not** AST-validated
+            — this path therefore only protects against accidental misuse by
+            *trusted* host code. For untrusted source code, always use
+            :meth:`execute_code_sandboxed`, which runs AST validation first.
+
+            When ``config.shadow_sys_modules`` is True (default), this
+            temporarily replaces blocked entries in the *process-wide*
+            ``sys.modules`` cache. Other threads in the same process will
+            see those replacements while ``func`` is running. Disable if
+            you need concurrent host access to those modules.
         """
         self._hook.install()
+        if self.config.shadow_sys_modules:
+            self._shadow_sys_modules()
         try:
             return func(*args, **kwargs)
         finally:
+            if self.config.shadow_sys_modules:
+                self._restore_sys_modules()
             self._hook.uninstall()
+
+    def execute_code_sandboxed(
+        self,
+        code: str,
+        user_globals: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Validate, then ``exec`` source code under all sandbox protections.
+
+        Fail-closed flow:
+
+        1. Parse and AST-validate ``code``. Any violation raises
+           ``SecurityError`` before any code runs (when
+           ``config.enforce_ast_validation`` is True).
+        2. Build restricted globals (whitelist builtins + raising stubs).
+        3. Install the import hook and shadow ``sys.modules``.
+        4. Execute ``code`` and return the resulting globals dict.
+
+        Args:
+            code: Python source to execute.
+            user_globals: Optional extra names to expose to the code.
+
+        Returns:
+            The post-execution globals dict (without ``__builtins__``).
+
+        Raises:
+            SecurityError: If validation finds any violation, or if execution
+                triggers a blocked import / builtin / sys.modules access.
+        """
+        if self.config.enforce_ast_validation:
+            violations = self.validate_code(code)
+            if violations:
+                descriptions = "; ".join(
+                    f"line {v.line}: {v.description}" for v in violations
+                )
+                raise SecurityError(
+                    f"Sandboxed code rejected by static analysis: {descriptions}",
+                    error_code="SANDBOX_VALIDATION_FAILED",
+                    details={
+                        "violations": [
+                            {
+                                "line": v.line,
+                                "column": v.column,
+                                "type": v.violation_type,
+                                "description": v.description,
+                                "severity": v.severity,
+                            }
+                            for v in violations
+                        ]
+                    },
+                )
+
+        restricted = self.create_restricted_globals(user_globals)
+
+        def _run() -> None:
+            exec(code, restricted)  # noqa: S102 - sandboxed execution by design
+
+        try:
+            self.execute_sandboxed(_run)
+        except SecurityError:
+            raise
+        except Exception as e:
+            # Re-wrap unexpected errors so callers always see SecurityError
+            # for sandbox-related failures (fail-closed signalling).
+            raise SecurityError(
+                f"Sandboxed execution failed: {e}",
+                error_code="SANDBOX_EXECUTION_ERROR",
+                details={"error_type": type(e).__name__, "error": str(e)},
+            ) from e
+
+        # Strip restricted builtins from the returned dict; callers only
+        # want the user-visible names that were created.
+        return {k: v for k, v in restricted.items() if k != "__builtins__"}
 
 
 def _make_blocked_builtin(name: str) -> Callable[..., None]:

--- a/agent-governance-python/agent-os/src/agent_os/sandbox.py
+++ b/agent-governance-python/agent-os/src/agent_os/sandbox.py
@@ -30,6 +30,7 @@ import importlib.machinery
 import os
 import pathlib
 import sys
+import threading
 import warnings
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -497,6 +498,101 @@ class _BlockedModuleProxy:
         return f"<BlockedModuleProxy {name!r}>"
 
 
+# ---------------------------------------------------------------------------
+# Process-wide shadow coordination
+# ---------------------------------------------------------------------------
+#
+# ``sys.modules`` is a process-global mapping, so all ``ExecutionSandbox``
+# instances must coordinate when they replace its entries with proxies.
+# Without this, two failure modes are possible:
+#
+#   1. Nested ``execute_sandboxed`` calls: an inner call's ``finally`` clears
+#      the shadow while the outer call is still executing, restoring real
+#      ``os``/``subprocess``/etc. mid-flight.
+#   2. Concurrent calls from multiple threads (or multiple sandbox instances):
+#      a thread's restore step can wipe another thread's still-active shadow,
+#      or can write proxies back into ``sys.modules`` as "originals" and
+#      leak them permanently.
+#
+# We solve both with a single module-level ``RLock`` plus a shared snapshot
+# and depth counter. Only the *outermost* enter snapshots, and only the
+# *outermost* exit restores. Overlapping sandboxed execution across threads
+# serializes on the lock — this is the correct behaviour since
+# ``sys.modules`` cannot be partitioned per thread.
+_SANDBOX_SHADOW_LOCK = threading.RLock()
+_SANDBOX_SHADOW_DEPTH = 0
+_SANDBOX_SHADOW_ORIGINALS: dict[str, Any] = {}
+_SANDBOX_INSTALLED_HOOKS: list[Any] = []
+
+
+def _enter_sys_modules_shadow(blocked_modules: list[str]) -> None:
+    """Acquire the shadow lock and (if outermost) replace blocked modules.
+
+    Safe to call recursively from the same thread; other threads block on
+    the lock until the holder exits. Callers MUST pair every call with
+    :func:`_exit_sys_modules_shadow` in a ``finally`` block.
+    """
+    global _SANDBOX_SHADOW_DEPTH
+    _SANDBOX_SHADOW_LOCK.acquire()
+    try:
+        if _SANDBOX_SHADOW_DEPTH == 0:
+            _SANDBOX_SHADOW_ORIGINALS.clear()
+            for name in blocked_modules:
+                to_shadow = [
+                    key for key in list(sys.modules)
+                    if key == name or key.startswith(name + ".")
+                ]
+                for key in to_shadow:
+                    current = sys.modules[key]
+                    # Defensive: never snapshot a proxy as the "original".
+                    if isinstance(current, _BlockedModuleProxy):
+                        continue
+                    _SANDBOX_SHADOW_ORIGINALS[key] = current
+                    sys.modules[key] = _BlockedModuleProxy(key)
+        _SANDBOX_SHADOW_DEPTH += 1
+    except BaseException:
+        _SANDBOX_SHADOW_LOCK.release()
+        raise
+
+
+def _exit_sys_modules_shadow() -> None:
+    """Decrement depth; restore ``sys.modules`` on the outermost exit."""
+    global _SANDBOX_SHADOW_DEPTH
+    try:
+        _SANDBOX_SHADOW_DEPTH -= 1
+        if _SANDBOX_SHADOW_DEPTH <= 0:
+            _SANDBOX_SHADOW_DEPTH = 0
+            for key, original in _SANDBOX_SHADOW_ORIGINALS.items():
+                # Only restore if the proxy we installed is still there.
+                # If something else replaced it, leave that in place.
+                if isinstance(sys.modules.get(key), _BlockedModuleProxy):
+                    sys.modules[key] = original
+            _SANDBOX_SHADOW_ORIGINALS.clear()
+    finally:
+        _SANDBOX_SHADOW_LOCK.release()
+
+
+def _install_hook_reentrant(hook: Any) -> None:
+    """Install a meta-path hook with depth tracking.
+
+    Must be called while ``_SANDBOX_SHADOW_LOCK`` is held (i.e. between
+    ``_enter_sys_modules_shadow`` and ``_exit_sys_modules_shadow``) to
+    serialize updates to ``sys.meta_path``.
+    """
+    hook.install()
+    _SANDBOX_INSTALLED_HOOKS.append(hook)
+
+
+def _uninstall_hook_reentrant() -> None:
+    """Remove the most recently installed hook (LIFO)."""
+    if _SANDBOX_INSTALLED_HOOKS:
+        hook = _SANDBOX_INSTALLED_HOOKS.pop()
+        hook.uninstall()
+
+
+
+
+
 class ExecutionSandbox:
     """Restricted execution environment that frustrates stdlib bypass.
 
@@ -526,9 +622,6 @@ class ExecutionSandbox:
         self.config = config or SandboxConfig()
         self.policy = policy
         self._hook = SandboxImportHook(self.config.blocked_modules)
-        # Snapshot of sys.modules entries replaced during execute_sandboxed,
-        # so we can restore them on exit. Empty when no shadow is active.
-        self._shadowed_modules: dict[str, Any] = {}
 
     def check_import(self, module_name: str) -> bool:
         """Check if a module import is allowed.
@@ -658,26 +751,21 @@ class ExecutionSandbox:
         Closes the ``sys.modules['os'].system(...)`` escape that the import
         hook alone cannot stop (preloaded modules are already cached).
         Caller must invoke :meth:`_restore_sys_modules` to clean up.
+
+        Reentrant and thread-safe via :func:`_enter_sys_modules_shadow`:
+        only the outermost call across the whole process actually snapshots
+        and replaces entries; concurrent calls from other threads serialize
+        on the shared shadow lock.
         """
-        if self._shadowed_modules:
-            # Already shadowed (nested execute) — don't double-snapshot.
-            return
-        for name in self.config.blocked_modules:
-            # Shadow the top-level module AND any cached submodules
-            # (e.g. ``os.path``, ``importlib.util``).
-            to_shadow = [
-                key for key in list(sys.modules)
-                if key == name or key.startswith(name + ".")
-            ]
-            for key in to_shadow:
-                self._shadowed_modules[key] = sys.modules[key]
-                sys.modules[key] = _BlockedModuleProxy(key)
+        _enter_sys_modules_shadow(self.config.blocked_modules)
 
     def _restore_sys_modules(self) -> None:
-        """Restore ``sys.modules`` entries replaced by :meth:`_shadow_sys_modules`."""
-        for key, original in self._shadowed_modules.items():
-            sys.modules[key] = original
-        self._shadowed_modules.clear()
+        """Restore ``sys.modules`` entries replaced by :meth:`_shadow_sys_modules`.
+
+        Only the outermost paired call across the whole process actually
+        restores; inner calls just decrement the depth counter.
+        """
+        _exit_sys_modules_shadow()
 
     def execute_sandboxed(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         """Run a function with import hooks and (optionally) sys.modules shadowing.
@@ -698,19 +786,32 @@ class ExecutionSandbox:
 
             When ``config.shadow_sys_modules`` is True (default), this
             temporarily replaces blocked entries in the *process-wide*
-            ``sys.modules`` cache. Other threads in the same process will
-            see those replacements while ``func`` is running. Disable if
-            you need concurrent host access to those modules.
+            ``sys.modules`` cache. Concurrent ``execute_sandboxed`` calls
+            from other threads serialize on a shared lock; nested calls
+            on the same thread share the shadow without double-snapshotting.
+            Disable ``shadow_sys_modules`` if you need concurrent host
+            access to those modules.
         """
-        self._hook.install()
         if self.config.shadow_sys_modules:
+            # Acquire the shared lock + reentrant shadow first, then install
+            # the per-instance import hook under that lock. Pairing both
+            # under one lock prevents another thread from observing a
+            # half-installed sandbox.
             self._shadow_sys_modules()
-        try:
-            return func(*args, **kwargs)
-        finally:
-            if self.config.shadow_sys_modules:
+            try:
+                _install_hook_reentrant(self._hook)
+                try:
+                    return func(*args, **kwargs)
+                finally:
+                    _uninstall_hook_reentrant()
+            finally:
                 self._restore_sys_modules()
-            self._hook.uninstall()
+        else:
+            self._hook.install()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                self._hook.uninstall()
 
     def execute_code_sandboxed(
         self,

--- a/agent-governance-python/agent-os/tests/test_sandbox.py
+++ b/agent-governance-python/agent-os/tests/test_sandbox.py
@@ -483,6 +483,25 @@ class TestSysModulesBypass:
         import os as _os
         assert sys.modules["os"] is _os
 
+    def test_nested_execute_sandboxed_keeps_outer_hook(self):
+        """Regression: inner call must not uninstall the import hook.
+
+        Previously ``_install_hook_reentrant`` LIFO-popped without tracking
+        whether the inner layer actually owned the install, so nested
+        same-instance calls left the outer call without an import hook.
+        """
+        sandbox = ExecutionSandbox()
+
+        def inner():
+            sandbox.execute_sandboxed(lambda: None)
+            # After the inner call returns, the import hook must still
+            # be on sys.meta_path so the outer call can block imports.
+            return sandbox._hook in sys.meta_path
+
+        assert sandbox.execute_sandboxed(inner) is True
+        # And after the outer call exits, the hook is cleaned up.
+        assert sandbox._hook not in sys.meta_path
+
     def test_concurrent_execute_sandboxed_is_thread_safe(self):
         """Regression: two threads must not corrupt each other's shadow.
 

--- a/agent-governance-python/agent-os/tests/test_sandbox.py
+++ b/agent-governance-python/agent-os/tests/test_sandbox.py
@@ -463,6 +463,60 @@ class TestSysModulesBypass:
         with pytest.raises(SecurityError):
             sandbox.execute_sandboxed(grab_proxy)
 
+    def test_nested_execute_sandboxed_keeps_outer_shadow(self):
+        """Regression: inner call's restore must not unshadow the outer call.
+
+        Previously the inner ``finally`` cleared the shared shadow dict,
+        leaving the outer call running with real ``sys.modules['os']``.
+        """
+        sandbox = ExecutionSandbox()
+
+        def inner():
+            # Inner sandboxed call exits and runs its own restore.
+            sandbox.execute_sandboxed(lambda: None)
+            # Outer must still see the proxy.
+            return type(sys.modules["os"]).__name__
+
+        result_type = sandbox.execute_sandboxed(inner)
+        assert result_type == "_BlockedModuleProxy"
+        # And after both exits, sys.modules is fully restored.
+        import os as _os
+        assert sys.modules["os"] is _os
+
+    def test_concurrent_execute_sandboxed_is_thread_safe(self):
+        """Regression: two threads must not corrupt each other's shadow.
+
+        Without the shared lock + depth counter, a fast thread's restore
+        wiped a slow thread's still-active shadow, exposing real
+        ``sys.modules['os']`` mid-execution.
+        """
+        import threading
+        import time
+
+        sandbox = ExecutionSandbox()
+        observed: dict[str, str] = {}
+
+        def worker(name: str, sleep_s: float):
+            def body():
+                time.sleep(sleep_s)
+                observed[name] = type(sys.modules["os"]).__name__
+            sandbox.execute_sandboxed(body)
+
+        t_slow = threading.Thread(target=worker, args=("slow", 0.30))
+        t_fast = threading.Thread(target=worker, args=("fast", 0.05))
+        t_slow.start()
+        # Give slow a head start so its shadow is up before fast enters.
+        time.sleep(0.05)
+        t_fast.start()
+        t_slow.join()
+        t_fast.join()
+
+        assert observed["slow"] == "_BlockedModuleProxy"
+        assert observed["fast"] == "_BlockedModuleProxy"
+        # Process-wide restore: nothing left over.
+        import os as _os
+        assert sys.modules["os"] is _os
+
 
 class TestExecuteCodeSandboxed:
     """End-to-end fail-closed code execution path."""

--- a/agent-governance-python/agent-os/tests/test_sandbox.py
+++ b/agent-governance-python/agent-os/tests/test_sandbox.py
@@ -207,6 +207,39 @@ class TestRestrictedGlobals:
         restricted = sandbox.create_restricted_globals({"my_var": 42})
         assert restricted["my_var"] == 42
 
+    def test_whitelist_drops_open(self):
+        """Hardening: ``open`` is not in the safe whitelist by default."""
+        sandbox = ExecutionSandbox()
+        restricted = sandbox.create_restricted_globals()
+        # 'open' is now in blocked_builtins, so it's a raising stub (not missing)
+        # but the key property is it cannot be called successfully.
+        assert "open" in restricted["__builtins__"]
+        with pytest.raises(SecurityError):
+            restricted["__builtins__"]["open"]("/etc/passwd")
+
+    def test_whitelist_drops_dangerous_unlisted_builtins(self):
+        """Hardening: builtins neither whitelisted nor blocked are omitted."""
+        sandbox = ExecutionSandbox()
+        restricted = sandbox.create_restricted_globals()
+        # __loader__, __spec__, __build_class__ flavour — must not leak
+        # arbitrary unfiltered builtins. We pick a few that are real but
+        # neither on the safe whitelist nor in the explicit blocked list.
+        for name in ("copyright", "credits", "license", "exit", "quit"):
+            assert name not in restricted["__builtins__"], (
+                f"{name} should not leak into restricted globals"
+            )
+
+    def test_user_globals_cannot_inject_builtins(self):
+        sandbox = ExecutionSandbox()
+        evil_builtins = {"eval": lambda s: "pwned"}
+        restricted = sandbox.create_restricted_globals(
+            {"__builtins__": evil_builtins}
+        )
+        # The injected __builtins__ must be ignored
+        assert restricted["__builtins__"] is not evil_builtins
+        with pytest.raises(SecurityError):
+            restricted["__builtins__"]["eval"]("1")
+
 
 # ---------------------------------------------------------------------------
 # Import hook install / uninstall
@@ -301,3 +334,222 @@ class TestSecurityViolation:
             line=1, column=0, violation_type="test", description="test",
         )
         assert v.severity == "high"
+
+
+# ---------------------------------------------------------------------------
+# Hardening: dunder traversal, sys.modules bypass, AST enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestDunderEscapeDetection:
+    """Regression coverage for ``().__class__.__bases__[0].__subclasses__()``."""
+
+    def test_detects_class_traversal(self):
+        sandbox = ExecutionSandbox()
+        violations = sandbox.validate_code(
+            "x = ().__class__.__bases__[0].__subclasses__()"
+        )
+        kinds = {v.violation_type for v in violations}
+        assert "dunder_escape" in kinds
+
+    def test_detects_globals_access(self):
+        sandbox = ExecutionSandbox()
+        violations = sandbox.validate_code("f.__globals__['os']")
+        assert any(v.violation_type == "dunder_escape" for v in violations)
+
+    def test_detects_getattr_dunder_bypass(self):
+        sandbox = ExecutionSandbox()
+        violations = sandbox.validate_code(
+            "cls = getattr((), '__class__')"
+        )
+        assert any(v.violation_type == "dunder_escape" for v in violations)
+
+    def test_clean_attribute_access_ok(self):
+        sandbox = ExecutionSandbox()
+        violations = sandbox.validate_code("y = obj.normal_attr")
+        assert violations == []
+
+
+class TestSysModulesBypass:
+    """The original escape path: import hook blocks NEW imports, but
+    ``sys.modules['os']`` already has a cached reference."""
+
+    def test_ast_detects_sys_modules_lookup(self):
+        sandbox = ExecutionSandbox()
+        violations = sandbox.validate_code("sys.modules['os'].system('id')")
+        kinds = {v.violation_type for v in violations}
+        # sys is a blocked module call AND sys.modules subscript is flagged
+        assert "sys_modules_access" in kinds
+
+    def test_sys_module_is_blocked_by_default(self):
+        sandbox = ExecutionSandbox()
+        assert sandbox.check_import("sys") is False
+        assert sandbox.check_import("builtins") is False
+        assert sandbox.check_import("gc") is False
+        assert sandbox.check_import("inspect") is False
+
+    def test_shadow_sys_modules_blocks_runtime_access(self):
+        """The key hardening: even with cached sys.modules entries,
+        runtime attribute access on shadowed modules raises SecurityError."""
+        sandbox = ExecutionSandbox()
+        captured: dict = {}
+
+        def attempt_escape():
+            # 'sys' is in blocked_modules and already cached in sys.modules.
+            # After shadowing, sys.modules['sys'] is a proxy.
+            captured["proxy"] = sys.modules["sys"]
+            # Any attribute access raises SecurityError
+            return captured["proxy"].modules
+
+        with pytest.raises(SecurityError):
+            sandbox.execute_sandboxed(attempt_escape)
+
+        # sys.modules must be restored after execution
+        assert sys.modules["sys"] is sys
+        assert sys.modules["os"] is __import__("os")
+
+    def test_shadow_sys_modules_blocks_os_access(self):
+        sandbox = ExecutionSandbox()
+
+        def attempt_escape():
+            return sys.modules["os"].getcwd()
+
+        with pytest.raises(SecurityError):
+            sandbox.execute_sandboxed(attempt_escape)
+
+        # Restored
+        import os as _os
+        assert sys.modules["os"] is _os
+
+    def test_shadow_sys_modules_restored_on_exception(self):
+        sandbox = ExecutionSandbox()
+        original_os = sys.modules["os"]
+
+        def boom():
+            raise RuntimeError("user error")
+
+        with pytest.raises(RuntimeError):
+            sandbox.execute_sandboxed(boom)
+
+        assert sys.modules["os"] is original_os
+
+    def test_shadow_can_be_disabled(self):
+        """Opt-out flag preserves prior behaviour for hosts that need it."""
+        import os as _os
+        sandbox = ExecutionSandbox(
+            config=SandboxConfig(shadow_sys_modules=False)
+        )
+
+        def safe():
+            return sys.modules["os"].path.sep  # Would raise if shadowed
+
+        result = sandbox.execute_sandboxed(safe)
+        assert result == _os.path.sep
+
+    def test_shadow_proxy_denies_class_traversal(self):
+        """Hardening: ``type(proxy).__mro__[1].__subclasses__()`` escape.
+
+        Even when bytecode bypasses AST validation (e.g. a trusted host
+        function calls into the sandbox), the proxy itself must refuse to
+        leak its own ``__class__`` via Python-level attribute lookup.
+        """
+        sandbox = ExecutionSandbox()
+        captured: dict = {}
+
+        def grab_proxy():
+            captured["proxy"] = sys.modules["os"]
+            return captured["proxy"].__class__  # must raise
+
+        with pytest.raises(SecurityError):
+            sandbox.execute_sandboxed(grab_proxy)
+
+
+class TestExecuteCodeSandboxed:
+    """End-to-end fail-closed code execution path."""
+
+    def test_validation_rejects_blocked_import_before_exec(self):
+        sandbox = ExecutionSandbox()
+        with pytest.raises(SecurityError) as exc_info:
+            sandbox.execute_code_sandboxed("import subprocess")
+        assert exc_info.value.error_code == "SANDBOX_VALIDATION_FAILED"
+        assert "violations" in exc_info.value.details
+
+    def test_validation_rejects_dunder_escape(self):
+        sandbox = ExecutionSandbox()
+        with pytest.raises(SecurityError):
+            sandbox.execute_code_sandboxed(
+                "x = ().__class__.__bases__[0].__subclasses__()"
+            )
+
+    def test_validation_rejects_sys_modules(self):
+        sandbox = ExecutionSandbox()
+        with pytest.raises(SecurityError):
+            sandbox.execute_code_sandboxed(
+                "result = sys.modules['os'].system('whoami')"
+            )
+
+    def test_clean_code_executes(self):
+        sandbox = ExecutionSandbox()
+        result = sandbox.execute_code_sandboxed("x = 1 + 2\ny = x * 10")
+        assert result["x"] == 3
+        assert result["y"] == 30
+        assert "__builtins__" not in result
+
+    def test_user_globals_available(self):
+        sandbox = ExecutionSandbox()
+        result = sandbox.execute_code_sandboxed(
+            "out = base + 5", user_globals={"base": 100}
+        )
+        assert result["out"] == 105
+
+    def test_validation_can_be_disabled(self):
+        """If a host opts out of AST validation, runtime guards still fire."""
+        sandbox = ExecutionSandbox(
+            config=SandboxConfig(enforce_ast_validation=False)
+        )
+        # eval is still replaced in restricted builtins -> raises at runtime,
+        # which execute_code_sandboxed rewraps as SecurityError.
+        with pytest.raises(SecurityError):
+            sandbox.execute_code_sandboxed("eval('1+1')")
+
+    def test_fail_closed_on_runtime_error(self):
+        """Unexpected exceptions during sandboxed exec become SecurityError."""
+        sandbox = ExecutionSandbox(
+            config=SandboxConfig(enforce_ast_validation=False)
+        )
+        with pytest.raises(SecurityError) as exc_info:
+            sandbox.execute_code_sandboxed("raise RuntimeError('inner')")
+        assert exc_info.value.error_code == "SANDBOX_EXECUTION_ERROR"
+
+
+class TestDefaultBlockedModulesExpanded:
+    """Hardening: confirm escape-vector modules are blocked by default."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "sys", "builtins", "gc", "inspect", "pickle", "marshal",
+            "code", "codeop", "_posixsubprocess", "multiprocessing",
+            "threading", "_thread",
+        ],
+    )
+    def test_escape_vector_module_blocked(self, name):
+        cfg = SandboxConfig()
+        assert name in cfg.blocked_modules
+
+    @pytest.mark.parametrize(
+        "name", ["open", "breakpoint", "globals", "locals", "getattr"],
+    )
+    def test_escape_vector_builtin_blocked(self, name):
+        cfg = SandboxConfig()
+        assert name in cfg.blocked_builtins
+
+
+class TestWarningCategory:
+    """SandboxSecurityWarning lets callers filter sandbox warnings precisely."""
+
+    def test_default_init_emits_sandbox_warning(self):
+        from agent_os.sandbox import SandboxSecurityWarning
+
+        with pytest.warns(SandboxSecurityWarning):
+            ExecutionSandbox()

--- a/examples/policies/sandbox-safety.yaml
+++ b/examples/policies/sandbox-safety.yaml
@@ -5,6 +5,11 @@
 # use case before deploying to production. Microsoft does not guarantee
 # that these rules are comprehensive or sufficient for your security
 # requirements.
+#
+# This in-process sandbox is a defense-in-depth layer, NOT a true security
+# boundary. For untrusted code, run in a separate OS process with seccomp /
+# AppArmor / landlock / Job-Objects, a container, a microVM (Firecracker /
+# gVisor), or a WASM runtime.
 
 version: "1.0"
 name: sandbox-safety
@@ -17,16 +22,61 @@ disclaimer: >
   customized for your specific security requirements.
 
 sandbox:
+  # Top-level module names blocked at import time AND shadowed in
+  # sys.modules during execute_sandboxed() so that previously-cached
+  # references (e.g. sys.modules['os']) cannot be reached either.
   blocked_modules:
-    - subprocess      # shell command execution
-    - os              # filesystem and process operations
-    - shutil          # high-level file operations (copy, move, delete)
-    - socket          # raw network access
-    - ctypes          # foreign function interface / memory access
-    - importlib       # dynamic module loading (bypass vector)
+    # --- Process / shell execution ----------------------------------
+    - subprocess         # shell command execution
+    - os                 # filesystem and process operations
+    - shutil             # high-level file operations (copy, move, delete)
+    - posix              # POSIX backend for os
+    - nt                 # NT backend for os (Windows)
+    - _posixsubprocess   # low-level subprocess backend
+    - pty                # pseudo-terminal control
+    - fcntl              # file/IO control
+    - signal             # process signals
+    # --- Networking -------------------------------------------------
+    - socket             # raw network access
+    # --- Native code / FFI ------------------------------------------
+    - ctypes             # foreign function interface / memory access
+    # --- Dynamic code loading ---------------------------------------
+    - importlib          # dynamic module loading (bypass vector)
+    - code               # interactive interpreter / arbitrary exec
+    - codeop             # compile-and-exec helpers
+    - pickle             # deserialisation RCE
+    - marshal            # deserialisation RCE
+    # --- Introspection / sandbox-escape vectors ---------------------
+    - sys                # sys.modules cache traversal
+    - builtins           # direct __builtins__ access
+    - gc                 # live-object graph walks
+    - inspect            # frame / closure introspection
+    # --- Concurrency wrappers around subprocess/os ------------------
+    - multiprocessing    # spawns subprocesses, wraps os
+    - threading          # GIL-aware host-thread access
+    - _thread            # low-level thread API
+    - asyncio            # event loop / subprocess primitives
 
+  # Built-in names replaced with raising stubs inside the restricted
+  # globals returned by ExecutionSandbox.create_restricted_globals().
   blocked_builtins:
-    - exec            # execute arbitrary code strings
-    - eval            # evaluate arbitrary expressions
-    - compile         # compile code objects
-    - __import__      # dynamic import function
+    # --- Arbitrary code execution -----------------------------------
+    - exec               # execute arbitrary code strings
+    - eval               # evaluate arbitrary expressions
+    - compile            # compile code objects
+    - __import__         # dynamic import function
+    # --- Filesystem & I/O -------------------------------------------
+    - open               # arbitrary file open
+    - input              # blocking stdin read
+    - memoryview         # buffer protocol access
+    # --- Debugger / REPL --------------------------------------------
+    - breakpoint         # drops into pdb
+    - help               # interactive help (subprocess on some platforms)
+    # --- Introspection / sandbox-escape -----------------------------
+    - globals            # exposes module globals
+    - locals             # exposes calling frame locals
+    - vars               # exposes any object's __dict__
+    - getattr            # dynamic attribute access (dunder bypass)
+    - setattr            # dynamic attribute mutation
+    - delattr            # dynamic attribute deletion
+


### PR DESCRIPTION
## Description

Hardens the in-process Python sandbox in `agent-os` against multiple escape paths flagged by a security review (sibling CTF-hunt session), and syncs the published `examples/policies/sandbox-safety.yaml` so users adopting the sample inherit the same protection.

The canonical escape — `sys.modules["os"].system("...")` — and several related introspection bypasses (`__class__.__bases__`, `__subclasses__()`, `__globals__`, `__builtins__`, `getattr(x, "__dunder__")`, frame/code walks) are now blocked at both the AST validation layer **and** the runtime globals layer, with fail-closed semantics on every execution path.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Package(s) Affected
- [x] agent-os-kernel
- [x] docs / root (examples/policies sample)

## Problem

The prior sandbox had several practical escape paths:

1. **`sys.modules` cache bypass** — even with `import os` blocked, `sys.modules["os"].system("calc.exe")` reached the real module because the host process had already imported it.
2. **Allow-by-default builtins** — `create_restricted_globals()` copied **all** builtins and only overrode 4 names; anything not in the small blocklist (e.g. `open`, `breakpoint`, `globals`) leaked through.
3. **No dunder-traversal detection** — `().__class__.__bases__[0].__subclasses__()` was structurally accepted.
4. **`execute_sandboxed()` never called `validate_code()`** — callers had to opt in manually.
5. **Sample YAML weaker than code** — users copying `sandbox-safety.yaml` got a 6-module / 4-builtin blocklist while in-code defaults were tighter.

## Changes

| File | What changed |
|------|--------------|
| `agent-governance-python/agent-os/src/agent_os/sandbox.py` | Shadow `sys.modules` entries with a deny-all proxy (incl. `__class__`) during `execute_sandboxed()`; whitelist-based safe builtins; AST visitor detects dunder access, `sys.modules[...]` subscripts, and `getattr(x, "__dunder__")` bypasses; new `execute_code_sandboxed()` fail-closes on `validate_code()` violations; expanded default blocked_modules 6→24 and blocked_builtins 4→15; new `SandboxSecurityWarning` category; documented threat model and OS-isolation recommendations. |
| `agent-governance-python/agent-os/tests/test_sandbox.py` | +26 tests: `TestDunderEscapeDetection`, `TestSysModulesBypass`, `TestExecuteCodeSandboxed`, `TestDefaultBlockedModulesExpanded`, `TestWarningCategory`, and proxy `__class__`-deny regression. |
| `examples/policies/sandbox-safety.yaml` | Rewritten with categorised comments + full expanded module/builtin lists matching in-code defaults + threat-model preamble. |

## Testing

```
# from agent-governance-python/agent-os
python -m pytest tests/test_sandbox.py tests/test_policy_sandbox_fields.py tests/test_security_policy_enforcement.py -q
# => 144 passed in 10.60s
```

## Threat Model / Residual Limitations

This is **defense-in-depth, not a security boundary**. The in-process sandbox now blocks the documented escape vectors and fails closed, but it cannot defend against:

- C-extension memory corruption, native-code escapes, or speculative execution side channels.
- `execute_sandboxed(func)` callers who pass already-compiled bytecode that bypasses AST validation (mitigated by `sys.modules` shadowing + builtins whitelist, but `type(x).__mro__[-1].__subclasses__()` on user-instantiated objects is still reachable in that trusted-bytecode path).
- Resource exhaustion not covered by `ResourceLimits` on Windows (POSIX `resource` module).

For untrusted code, use OS-level isolation — containers with seccomp/AppArmor, gVisor, microVMs (Firecracker), or WASM runtimes. `sandbox_provider.py` and `agentmesh.marketplace.sandbox` already provide subprocess-isolated execution and remain the recommended path for adversarial workloads.

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed (module docstring + sample YAML)
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**: Whitelist-based-builtins and AST denylist patterns are standard sandboxing techniques (cf. RestrictedPython, historical PySandbox post-mortems). No code copied.

## AI Assistance
- [x] I can explain every meaningful change in this PR
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot CLI used for exploration, edits, and test scaffolding — all output reviewed.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License
