### PR TITLE
fix(agentmesh): tighten trust boundaries (POP, capability grant auth, signing-oracle, unknown-DID auto-trust, registry mutation auth)

### DIFF
--- a/agent-governance-python/agent-mesh/packages/mcp-trust-server/src/mcp_trust_server/server.py
+++ b/agent-governance-python/agent-mesh/packages/mcp-trust-server/src/mcp_trust_server/server.py
@@ -71,24 +71,37 @@ class TrustStore:
         self.interactions: list[dict[str, Any]] = []
         self.handshakes: dict[str, dict[str, Any]] = {}
 
-    def get_score(self, agent_did: str) -> dict[str, Any]:
-        """Return trust record for *agent_did*, creating a default if absent.
+    def _default_record(self, agent_did: str) -> dict[str, Any]:
+        """Build a non-persisted default record for an unknown DID."""
+        return {
+            "agent_did": agent_did,
+            "overall_score": 0,
+            "dimensions": {d: 0 for d in TRUST_DIMENSIONS},
+            "trust_level": "untrusted",
+            "interaction_count": 0,
+            "known": False,
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
 
-        New records start at score 0 / level ``untrusted`` so unknown
-        agents cannot automatically clear ``MIN_TRUST_SCORE``. A peer
-        must accumulate trust through ``record_interaction`` or a
-        successful handshake before it is considered trusted.
+    def get_score(self, agent_did: str) -> dict[str, Any]:
+        """Return trust record for *agent_did* WITHOUT inserting on miss.
+
+        Unknown DIDs get a fresh ``untrusted`` record returned by value;
+        the in-memory ``self.scores`` dict is left untouched. This keeps
+        attacker queries against ``check_trust`` / ``verify_delegation``
+        from being able to grow the score table without bound.
+        Mutating callers (``update_score``, ``record_interaction``)
+        go through ``_get_or_create`` so legitimate writes still
+        persist.
         """
+        record = self.scores.get(agent_did)
+        if record is None:
+            return self._default_record(agent_did)
+        return record
+
+    def _get_or_create(self, agent_did: str) -> dict[str, Any]:
         if agent_did not in self.scores:
-            self.scores[agent_did] = {
-                "agent_did": agent_did,
-                "overall_score": 0,
-                "dimensions": {d: 0 for d in TRUST_DIMENSIONS},
-                "trust_level": "untrusted",
-                "interaction_count": 0,
-                "known": False,
-                "last_updated": datetime.now(timezone.utc).isoformat(),
-            }
+            self.scores[agent_did] = self._default_record(agent_did)
         return self.scores[agent_did]
 
     def is_known(self, agent_did: str) -> bool:
@@ -100,7 +113,7 @@ class TrustStore:
         self, agent_did: str, delta: int, dimension: str | None = None
     ) -> dict[str, Any]:
         """Apply *delta* to the agent's score (overall and optionally a dimension)."""
-        record = self.get_score(agent_did)
+        record = self._get_or_create(agent_did)
         record["overall_score"] = max(0, min(1000, record["overall_score"] + delta))
         if dimension and dimension in record["dimensions"]:
             record["dimensions"][dimension] = max(

--- a/agent-governance-python/agent-mesh/packages/mcp-trust-server/src/mcp_trust_server/server.py
+++ b/agent-governance-python/agent-mesh/packages/mcp-trust-server/src/mcp_trust_server/server.py
@@ -13,7 +13,6 @@ import hashlib
 import logging
 import os
 import secrets
-import time
 from datetime import datetime, timezone
 from typing import Any
 
@@ -73,17 +72,29 @@ class TrustStore:
         self.handshakes: dict[str, dict[str, Any]] = {}
 
     def get_score(self, agent_did: str) -> dict[str, Any]:
-        """Return trust record for *agent_did*, creating a default if absent."""
+        """Return trust record for *agent_did*, creating a default if absent.
+
+        New records start at score 0 / level ``untrusted`` so unknown
+        agents cannot automatically clear ``MIN_TRUST_SCORE``. A peer
+        must accumulate trust through ``record_interaction`` or a
+        successful handshake before it is considered trusted.
+        """
         if agent_did not in self.scores:
             self.scores[agent_did] = {
                 "agent_did": agent_did,
-                "overall_score": 500,
-                "dimensions": {d: 500 for d in TRUST_DIMENSIONS},
-                "trust_level": "standard",
+                "overall_score": 0,
+                "dimensions": {d: 0 for d in TRUST_DIMENSIONS},
+                "trust_level": "untrusted",
                 "interaction_count": 0,
+                "known": False,
                 "last_updated": datetime.now(timezone.utc).isoformat(),
             }
         return self.scores[agent_did]
+
+    def is_known(self, agent_did: str) -> bool:
+        """Return True only for agents we've explicitly recorded interactions with."""
+        record = self.scores.get(agent_did)
+        return bool(record and record.get("known"))
 
     def update_score(
         self, agent_did: str, delta: int, dimension: str | None = None
@@ -119,6 +130,8 @@ class TrustStore:
         )
         record = self.update_score(peer_did, delta, dimension)
         record["interaction_count"] = record.get("interaction_count", 0) + 1
+        # Once we've recorded a real interaction we treat the peer as known.
+        record["known"] = True
         return {**interaction, "updated_score": record}
 
 
@@ -178,17 +191,23 @@ def check_trust(agent_did: str) -> dict:
 
     Returns the agent's overall trust score, trust level, and all five
     trust dimensions (competence, integrity, availability, predictability,
-    transparency).
+    transparency). Unknown agents (no recorded interactions) are reported
+    as untrusted regardless of ``MIN_TRUST_SCORE`` — auto-creating an
+    unknown DID at the trust threshold would let any caller bypass
+    trust checks by presenting a fresh DID.
 
     Args:
         agent_did: The DID of the agent to check (e.g. "did:mesh:abc123").
     """
+    known = _store.is_known(agent_did)
     record = _store.get_score(agent_did)
+    trusted = known and record["overall_score"] >= MIN_TRUST_SCORE
     return {
         "agent_did": agent_did,
-        "trusted": record["overall_score"] >= MIN_TRUST_SCORE,
+        "trusted": trusted,
+        "known": known,
         "overall_score": record["overall_score"],
-        "trust_level": record["trust_level"],
+        "trust_level": record["trust_level"] if known else "unknown",
         "dimensions": record["dimensions"],
         "min_trust_threshold": MIN_TRUST_SCORE,
     }
@@ -268,11 +287,13 @@ def verify_delegation(
         delegator_did: The DID of the delegator (parent agent).
         capability: The capability being delegated (e.g. "read:data").
     """
+    delegator_known = _store.is_known(delegator_did)
+    agent_known = _store.is_known(agent_did)
     delegator_record = _store.get_score(delegator_did)
     agent_record = _store.get_score(agent_did)
 
-    delegator_trusted = delegator_record["overall_score"] >= MIN_TRUST_SCORE
-    agent_trusted = agent_record["overall_score"] >= MIN_TRUST_SCORE
+    delegator_trusted = delegator_known and delegator_record["overall_score"] >= MIN_TRUST_SCORE
+    agent_trusted = agent_known and agent_record["overall_score"] >= MIN_TRUST_SCORE
 
     valid = delegator_trusted and agent_trusted
 
@@ -285,6 +306,8 @@ def verify_delegation(
         "agent_trust_score": agent_record["overall_score"],
         "delegator_trusted": delegator_trusted,
         "agent_trusted": agent_trusted,
+        "delegator_known": delegator_known,
+        "agent_known": agent_known,
         "checked_at": datetime.now(timezone.utc).isoformat(),
     }
 

--- a/agent-governance-python/agent-mesh/packages/mcp-trust-server/tests/test_server.py
+++ b/agent-governance-python/agent-mesh/packages/mcp-trust-server/tests/test_server.py
@@ -13,7 +13,6 @@ from mcp_trust_server.server import (
     get_trust_score,
     record_interaction,
     verify_delegation,
-    TrustStore,
 )
 
 
@@ -42,22 +41,36 @@ class TestCheckTrust:
     def test_returns_expected_keys(self) -> None:
         result = check_trust(AGENT_DID)
         assert "trusted" in result
+        assert "known" in result
         assert "overall_score" in result
         assert "trust_level" in result
         assert "dimensions" in result
         assert "min_trust_threshold" in result
 
-    def test_default_agent_is_trusted(self) -> None:
+    def test_unknown_agent_is_not_trusted(self) -> None:
+        """Security regression: unknown DIDs must not be auto-trusted."""
         result = check_trust(AGENT_DID)
-        assert result["trusted"] is True
-        assert result["overall_score"] == 500
+        assert result["trusted"] is False
+        assert result["known"] is False
+        assert result["overall_score"] == 0
+        assert result["trust_level"] == "unknown"
 
     def test_dimensions_present(self) -> None:
         result = check_trust(AGENT_DID)
         dims = result["dimensions"]
         for dim in ["competence", "integrity", "availability", "predictability", "transparency"]:
             assert dim in dims
-            assert dims[dim] == 500
+            assert dims[dim] == 0
+
+    def test_known_agent_above_threshold_is_trusted(self) -> None:
+        """An agent with recorded interactions above the threshold IS trusted."""
+        # Record enough successes to climb above MIN_TRUST_SCORE (500).
+        # Each success adds 10 to overall_score.
+        for _ in range(60):
+            record_interaction(PEER_DID, "success", "ok")
+        result = check_trust(PEER_DID)
+        assert result["known"] is True
+        assert result["trusted"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -111,7 +124,18 @@ class TestVerifyDelegation:
     def setup_method(self) -> None:
         _reset_store()
 
-    def test_valid_delegation(self) -> None:
+    def test_unknown_delegation_invalid(self) -> None:
+        """Security regression: both DIDs unknown → not a valid delegation."""
+        result = verify_delegation(AGENT_DID, DELEGATOR_DID, "read:data")
+        assert result["valid"] is False
+        assert result["delegator_known"] is False
+        assert result["agent_known"] is False
+
+    def test_valid_delegation_when_both_trusted(self) -> None:
+        # Raise both above threshold via real interactions.
+        for _ in range(60):
+            record_interaction(DELEGATOR_DID, "success", "ok")
+            record_interaction(AGENT_DID, "success", "ok")
         result = verify_delegation(AGENT_DID, DELEGATOR_DID, "read:data")
         assert result["valid"] is True
         assert result["delegator_trusted"] is True
@@ -124,8 +148,12 @@ class TestVerifyDelegation:
             "dimensions": {d: 100 for d in ["competence", "integrity", "availability", "predictability", "transparency"]},
             "trust_level": "untrusted",
             "interaction_count": 0,
+            "known": True,
             "last_updated": "2025-01-01T00:00:00",
         }
+        # Make agent known and trusted
+        for _ in range(60):
+            record_interaction(AGENT_DID, "success", "ok")
         result = verify_delegation(AGENT_DID, DELEGATOR_DID, "read:data")
         assert result["valid"] is False
         assert result["delegator_trusted"] is False
@@ -156,10 +184,16 @@ class TestRecordInteraction:
         result = record_interaction(PEER_DID, "success", "completed task")
         assert result["updated_score"] > before
 
-    def test_failure_decreases_score(self) -> None:
-        before = _store.get_score(PEER_DID)["overall_score"]
+    def test_failure_does_not_underflow(self) -> None:
+        """With score floored at 0, a failure against an unknown DID
+        leaves it at 0 — but the agent is now ``known`` and remains
+        untrusted regardless of MIN_TRUST_SCORE."""
         result = record_interaction(PEER_DID, "failure", "agent crashed")
-        assert result["updated_score"] < before
+        assert result["updated_score"] == 0
+        # Known but score still below threshold ⇒ not trusted.
+        check = check_trust(PEER_DID)
+        assert check["known"] is True
+        assert check["trusted"] is False
 
     def test_invalid_outcome(self) -> None:
         result = record_interaction(PEER_DID, "unknown", "bad outcome")

--- a/agent-governance-python/agent-mesh/services/api/src/middleware/apiKey.ts
+++ b/agent-governance-python/agent-mesh/services/api/src/middleware/apiKey.ts
@@ -1,7 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import { Request, Response, NextFunction } from "express";
-import { isValidApiKey } from "../services/registry";
+import { getAgentByApiKey, isValidApiKey } from "../services/registry";
+import { AgentRecord } from "../types";
+
+/**
+ * Augment Express ``Request`` with the authenticated agent so downstream
+ * handlers do not need to re-look-up by API key. Anything that relies on
+ * ``req.agent`` MUST also be protected by ``requireApiKey``.
+ */
+declare module "express-serve-static-core" {
+  interface Request {
+    agent?: AgentRecord;
+  }
+}
 
 /** Require a valid API key in the `x-api-key` header for write endpoints. */
 export function requireApiKey(req: Request, res: Response, next: NextFunction): void {
@@ -17,5 +29,22 @@ export function requireApiKey(req: Request, res: Response, next: NextFunction): 
     return;
   }
 
+  // Bind the authenticated agent to the request so handlers cannot be
+  // tricked into operating on a DID supplied by an untrusted caller —
+  // the API key, not the request body, determines whose identity is in
+  // use. This closes the handshake-signing-oracle issue where any API
+  // key holder could request signatures for any DID.
+  const agent = getAgentByApiKey(apiKey);
+  if (!agent) {
+    res.status(403).json({ error: "Invalid API key" });
+    return;
+  }
+  if (agent.status !== "active") {
+    res.status(403).json({ error: "Agent is not active" });
+    return;
+  }
+  req.agent = agent;
+
   next();
 }
+

--- a/agent-governance-python/agent-mesh/services/api/src/routes/handshake.ts
+++ b/agent-governance-python/agent-mesh/services/api/src/routes/handshake.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+import * as crypto from "crypto";
 import { Router, Request, Response } from "express";
-import { getAgent } from "../services/registry";
 import { sign } from "../services/identity";
 import { evaluateHandshake } from "../services/trust";
 import { appendAuditEntry } from "../services/audit";
@@ -9,26 +9,43 @@ import { HandshakeRequest, HandshakeResponse } from "../types";
 
 const router = Router();
 
-router.post("/handshake", (req: Request, res: Response) => {
-  const { agent_did, challenge, capabilities_requested } =
-    req.body as Partial<HandshakeRequest>;
+// Domain separator: any signature this server emits is prefixed with this
+// fixed string so a handshake signature can never be replayed as a
+// signature over a different protocol message (e.g. a wire-protocol frame
+// or a delegation token).
+const HANDSHAKE_SIGNING_DOMAIN = "agentmesh-handshake-v1";
 
-  if (!agent_did || typeof agent_did !== "string") {
-    res.status(400).json({ error: "agent_did is required" });
+// Length cap on the client-supplied challenge nonce. The server only uses
+// it inside a structured, hashed payload, but bounding the size prevents
+// resource-exhaustion via very large bodies and keeps audit entries small.
+const MAX_CHALLENGE_LENGTH = 256;
+
+router.post("/handshake", (req: Request, res: Response) => {
+  // The authenticated agent is bound to the API key by ``requireApiKey``
+  // middleware. We deliberately ignore any ``agent_did`` in the request
+  // body: accepting it would let any API key holder request signatures
+  // for any other agent's DID — a textbook signing oracle.
+  const agent = req.agent;
+  if (!agent) {
+    res.status(401).json({ error: "Authentication required" });
     return;
   }
+
+  const { challenge, capabilities_requested } =
+    req.body as Partial<HandshakeRequest>;
+
   if (!challenge || typeof challenge !== "string") {
     res.status(400).json({ error: "challenge is required" });
     return;
   }
-  if (!Array.isArray(capabilities_requested)) {
-    res.status(400).json({ error: "capabilities_requested must be an array" });
+  if (challenge.length > MAX_CHALLENGE_LENGTH) {
+    res.status(400).json({
+      error: `challenge must be <= ${MAX_CHALLENGE_LENGTH} characters`,
+    });
     return;
   }
-
-  const agent = getAgent(agent_did);
-  if (!agent) {
-    res.status(404).json({ error: "Agent not found", verified: false });
+  if (!Array.isArray(capabilities_requested)) {
+    res.status(400).json({ error: "capabilities_requested must be an array" });
     return;
   }
 
@@ -43,13 +60,39 @@ router.post("/handshake", (req: Request, res: Response) => {
     agent.trust_score,
   );
 
-  // Sign the challenge with the agent's private key
-  const signature = sign(challenge, agent.private_key);
+  // Build a domain-separated, server-bound signing payload. We sign a
+  // structured envelope rather than the raw client-supplied challenge,
+  // and include:
+  //   * a fixed domain string (no cross-protocol reuse),
+  //   * the agent's DID (signature is intrinsically bound to identity),
+  //   * a fresh server-generated nonce (prevents pre-computed challenges),
+  //   * a server-generated timestamp (anchors the signature in time),
+  //   * a SHA-256 of the client challenge (the client still gets to bind
+  //     their own value into the signed material, but as a hash so the
+  //     signed bytes are fixed-length and structured).
+  const serverNonce = crypto.randomBytes(16).toString("hex");
+  const serverTimestamp = new Date().toISOString();
+  const challengeDigest = crypto
+    .createHash("sha256")
+    .update(challenge, "utf8")
+    .digest("hex");
 
-  appendAuditEntry("handshake", agent_did, {
-    challenge,
+  const signingPayload = [
+    HANDSHAKE_SIGNING_DOMAIN,
+    agent.did,
+    serverNonce,
+    serverTimestamp,
+    challengeDigest,
+  ].join("\n");
+
+  const signature = sign(signingPayload, agent.private_key);
+
+  appendAuditEntry("handshake", agent.did, {
+    challenge_digest: challengeDigest,
     capabilities_requested,
     capabilities_granted: granted,
+    server_nonce: serverNonce,
+    server_timestamp: serverTimestamp,
   });
 
   const response: HandshakeResponse = {
@@ -57,9 +100,17 @@ router.post("/handshake", (req: Request, res: Response) => {
     trust_score: agent.trust_score.total,
     capabilities_granted: granted,
     signature,
+    // Echo the server-supplied envelope so the client can reconstruct
+    // and verify the exact bytes that were signed.
+    signing_domain: HANDSHAKE_SIGNING_DOMAIN,
+    agent_did: agent.did,
+    server_nonce: serverNonce,
+    server_timestamp: serverTimestamp,
+    challenge_digest: challengeDigest,
   };
 
   res.json(response);
 });
 
 export default router;
+

--- a/agent-governance-python/agent-mesh/services/api/src/routes/handshake.ts
+++ b/agent-governance-python/agent-mesh/services/api/src/routes/handshake.ts
@@ -62,14 +62,12 @@ router.post("/handshake", (req: Request, res: Response) => {
 
   // Build a domain-separated, server-bound signing payload. We sign a
   // structured envelope rather than the raw client-supplied challenge,
-  // and include:
-  //   * a fixed domain string (no cross-protocol reuse),
-  //   * the agent's DID (signature is intrinsically bound to identity),
-  //   * a fresh server-generated nonce (prevents pre-computed challenges),
-  //   * a server-generated timestamp (anchors the signature in time),
-  //   * a SHA-256 of the client challenge (the client still gets to bind
-  //     their own value into the signed material, but as a hash so the
-  //     signed bytes are fixed-length and structured).
+  // and include EVERY field a relying party will act on (DID, granted
+  // capabilities, advertised trust score, the challenge digest, and a
+  // server-chosen nonce/timestamp). Without binding the grant + score
+  // into the signed bytes a MITM could rewrite the response (e.g.
+  // adding 'admin' to capabilities_granted) while the signature still
+  // verified.
   const serverNonce = crypto.randomBytes(16).toString("hex");
   const serverTimestamp = new Date().toISOString();
   const challengeDigest = crypto
@@ -77,12 +75,23 @@ router.post("/handshake", (req: Request, res: Response) => {
     .update(challenge, "utf8")
     .digest("hex");
 
+  // Canonical form for capability list: trim, sort, join with ','. This
+  // guarantees the verifier reconstructs an identical byte sequence
+  // regardless of the order the client cares about.
+  const capabilitiesCanonical = [...granted]
+    .map((c) => String(c))
+    .sort()
+    .join(",");
+  const trustScoreCanonical = String(agent.trust_score.total);
+
   const signingPayload = [
     HANDSHAKE_SIGNING_DOMAIN,
     agent.did,
     serverNonce,
     serverTimestamp,
     challengeDigest,
+    capabilitiesCanonical,
+    trustScoreCanonical,
   ].join("\n");
 
   const signature = sign(signingPayload, agent.private_key);

--- a/agent-governance-python/agent-mesh/services/api/src/types.ts
+++ b/agent-governance-python/agent-mesh/services/api/src/types.ts
@@ -77,6 +77,13 @@ export interface HandshakeResponse {
   trust_score: number;
   capabilities_granted: string[];
   signature: string;
+  // Server-supplied components of the signed envelope so callers can
+  // verify ``signature`` against ``${signing_domain}\n${agent_did}\n${server_nonce}\n${server_timestamp}\n${challenge_digest}``.
+  signing_domain: string;
+  agent_did: string;
+  server_nonce: string;
+  server_timestamp: string;
+  challenge_digest: string;
 }
 
 export interface ScoreResponse {

--- a/agent-governance-python/agent-mesh/services/api/tests/api.test.ts
+++ b/agent-governance-python/agent-mesh/services/api/tests/api.test.ts
@@ -267,17 +267,58 @@ test("POST /api/handshake signs domain-separated envelope, not raw challenge", a
   );
 
   // Signature MUST verify against the reconstructed envelope.
+  const capabilitiesCanonical = [...res.body.capabilities_granted]
+    .map((c: unknown) => String(c))
+    .sort()
+    .join(",");
   const envelope = [
     res.body.signing_domain,
     res.body.agent_did,
     res.body.server_nonce,
     res.body.server_timestamp,
     res.body.challenge_digest,
+    capabilitiesCanonical,
+    String(res.body.trust_score),
   ].join("\n");
   assert.strictEqual(
     verify(envelope, res.body.signature, agent.public_key),
     true,
     "signature must verify against the structured envelope",
+  );
+});
+
+test("POST /api/handshake signature does not verify if granted capabilities are tampered", async (server) => {
+  // Defends against a MITM rewriting capabilities_granted on the wire.
+  const { registerAgent } = await import("../src/services/registry");
+  const { verify } = await import("../src/services/identity");
+  const agent = registerAgent({
+    name: "CapVerifier",
+    sponsor_email: "cv@example.com",
+    capabilities: ["read"],
+  });
+
+  const res = await request(
+    server,
+    "POST",
+    "/api/handshake",
+    { challenge: "c", capabilities_requested: ["read"] },
+    { "x-api-key": agent.api_key },
+  );
+  assert.strictEqual(res.status, 200);
+
+  const tamperedEnvelope = [
+    res.body.signing_domain,
+    res.body.agent_did,
+    res.body.server_nonce,
+    res.body.server_timestamp,
+    res.body.challenge_digest,
+    "read,admin", // attacker adds 'admin'
+    String(res.body.trust_score),
+  ].join("\n");
+  assert.strictEqual(
+    verify(tamperedEnvelope, res.body.signature, agent.public_key),
+    false,
+    "tampered capability list must not verify under the issued signature",
   );
 });
 

--- a/agent-governance-python/agent-mesh/services/api/tests/api.test.ts
+++ b/agent-governance-python/agent-mesh/services/api/tests/api.test.ts
@@ -178,7 +178,9 @@ test("POST /api/handshake succeeds for registered agent", async (server) => {
     "POST",
     "/api/handshake",
     {
-      agent_did: agent.did,
+      // agent_did is intentionally NOT sent — the server binds the
+      // signing identity to the API key holder to prevent signing
+      // oracles. Any value here must be ignored.
       challenge: "test-challenge-nonce-123",
       capabilities_requested: ["read", "admin"],
     },
@@ -192,14 +194,30 @@ test("POST /api/handshake succeeds for registered agent", async (server) => {
   assert.ok(res.body.capabilities_granted.includes("read"));
   assert.ok(!res.body.capabilities_granted.includes("admin"));
   assert.ok(res.body.signature);
+  // Server-supplied envelope must echo back so caller can verify.
+  assert.strictEqual(res.body.signing_domain, "agentmesh-handshake-v1");
+  assert.strictEqual(res.body.agent_did, agent.did);
+  assert.ok(res.body.server_nonce);
+  assert.ok(res.body.server_timestamp);
+  assert.ok(res.body.challenge_digest);
 });
 
-test("POST /api/handshake returns 404 for unknown agent", async (server) => {
+test("POST /api/handshake binds signer to API key (signing oracle regression)", async (server) => {
+  // Two agents with two distinct API keys. Calling /handshake with
+  // agentA's API key MUST produce a signature for agentA's DID — the
+  // body's ``agent_did`` (set to agentB) must be ignored. Previously
+  // the route trusted the body, letting any key holder request
+  // signatures for any other agent (a signing oracle).
   const { registerAgent } = await import("../src/services/registry");
-  const agent = registerAgent({
-    name: "KeyHolder",
-    sponsor_email: "kh@example.com",
-    capabilities: [],
+  const agentA = registerAgent({
+    name: "Alice",
+    sponsor_email: "a@example.com",
+    capabilities: ["read"],
+  });
+  const agentB = registerAgent({
+    name: "Bob",
+    sponsor_email: "b@example.com",
+    capabilities: ["admin"],
   });
 
   const res = await request(
@@ -207,13 +225,60 @@ test("POST /api/handshake returns 404 for unknown agent", async (server) => {
     "POST",
     "/api/handshake",
     {
-      agent_did: "did:mesh:nonexistent",
-      challenge: "test",
-      capabilities_requested: [],
+      agent_did: agentB.did, // spoofed — must be ignored
+      challenge: "x",
+      capabilities_requested: ["read"],
     },
+    { "x-api-key": agentA.api_key },
+  );
+
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.agent_did, agentA.did);
+  assert.notStrictEqual(res.body.agent_did, agentB.did);
+});
+
+test("POST /api/handshake signs domain-separated envelope, not raw challenge", async (server) => {
+  // Verify the response signature is over the structured envelope and
+  // NOT over the raw client challenge. This prevents the endpoint from
+  // being used as a signing oracle for arbitrary messages.
+  const { registerAgent } = await import("../src/services/registry");
+  const { verify } = await import("../src/services/identity");
+  const agent = registerAgent({
+    name: "Verifier",
+    sponsor_email: "v@example.com",
+    capabilities: ["read"],
+  });
+
+  const challenge = "raw-attacker-supplied-bytes";
+  const res = await request(
+    server,
+    "POST",
+    "/api/handshake",
+    { challenge, capabilities_requested: ["read"] },
     { "x-api-key": agent.api_key },
   );
-  assert.strictEqual(res.status, 404);
+  assert.strictEqual(res.status, 200);
+
+  // Signature must NOT verify against the raw challenge.
+  assert.strictEqual(
+    verify(challenge, res.body.signature, agent.public_key),
+    false,
+    "signature must not be over the raw client challenge",
+  );
+
+  // Signature MUST verify against the reconstructed envelope.
+  const envelope = [
+    res.body.signing_domain,
+    res.body.agent_did,
+    res.body.server_nonce,
+    res.body.server_timestamp,
+    res.body.challenge_digest,
+  ].join("\n");
+  assert.strictEqual(
+    verify(envelope, res.body.signature, agent.public_key),
+    true,
+    "signature must verify against the structured envelope",
+  );
 });
 
 test("GET /api/score/:agentDid returns trust breakdown", async (server) => {

--- a/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
@@ -320,12 +320,26 @@ class RegistryServer:
             }
 
         @app.post("/v1/agents/{did}/heartbeat")
-        async def heartbeat(did: str) -> dict:
+        async def heartbeat(
+            did: str,
+            authorization: str | None = Header(None, alias="Authorization"),
+        ) -> dict:
             """Bump an agent's `last_seen` to keep it visible in presence
             checks. Rate-limited to at most once per 10 seconds per agent
             to prevent abuse (attacker keeping stale agents permanently
             online). Returns 429 when throttled without updating last_seen.
+
+            Authentication: required. The caller must present an
+            ``Ed25519-Timestamp`` header signed by ``did``. Without this,
+            any unauthenticated party could keep an offline agent's
+            presence record live (impersonation / DoS-mask).
             """
+            authed_did = verify_ed25519_timestamp_auth(authorization, store)
+            if authed_did != did:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Authenticated DID does not match heartbeat target",
+                )
             if not store.get_agent(did):
                 raise HTTPException(status_code=404, detail="Agent not found")
             if not store.try_update_last_seen(did, min_interval_seconds=10.0):
@@ -342,8 +356,24 @@ class RegistryServer:
         # ── Reputation ───────────────────────────────────────────
 
         @app.post("/v1/agents/{did}/reputation")
-        async def submit_reputation(did: str, req: ReputationRequest) -> dict:
-            """Submit reputation feedback for an agent."""
+        async def submit_reputation(
+            did: str,
+            req: ReputationRequest,
+            authorization: str | None = Header(None, alias="Authorization"),
+        ) -> dict:
+            """Submit reputation feedback for an agent.
+
+            Authentication: required. The caller must present an
+            ``Ed25519-Timestamp`` header so the reporter is bound to an
+            authenticated identity. Self-reporting is rejected — agents
+            cannot inflate their own reputation.
+            """
+            authed_did = verify_ed25519_timestamp_auth(authorization, store)
+            if authed_did == did:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Agents may not submit reputation about themselves",
+                )
             agent = store.get_agent(did)
             if not agent:
                 raise HTTPException(status_code=404, detail="Agent not found")
@@ -355,7 +385,10 @@ class RegistryServer:
             return {"did": did, "reputation_score": round(agent.reputation_score, 4)}
 
         @app.post("/v1/registry/reputation/session")
-        async def submit_session_reputation(req: SessionReputationRequest) -> dict:
+        async def submit_session_reputation(
+            req: SessionReputationRequest,
+            authorization: str | None = Header(None, alias="Authorization"),
+        ) -> dict:
             """Record a session outcome and update both endpoints' reputation.
 
             Outcome mapping (EMA, alpha=0.2):
@@ -364,8 +397,20 @@ class RegistryServer:
               - timeout → score 0.2 toward the receiver (initiator unchanged)
 
             Missing agents are silently skipped (best-effort telemetry).
-            The reporter must be a registered agent (either initiator or receiver).
+
+            Authentication: required. The caller must present an
+            ``Ed25519-Timestamp`` header and the authenticated DID MUST
+            equal ``reporter_amid``. Additionally, the reporter must be
+            a session participant (initiator or receiver). Together this
+            stops any party — authenticated or not — from forging session
+            telemetry as another agent.
             """
+            authed_did = verify_ed25519_timestamp_auth(authorization, store)
+            if authed_did != req.reporter_amid:
+                raise HTTPException(
+                    status_code=403,
+                    detail="reporter_amid does not match authenticated DID",
+                )
             # Validate reporter is a session participant
             if req.reporter_amid not in (req.initiator_amid, req.receiver_amid):
                 raise HTTPException(

--- a/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
@@ -218,8 +218,19 @@ class RegistryServer:
             }
 
         @app.delete("/v1/agents/{did}", status_code=204)
-        async def deregister_agent(did: str) -> None:
-            """Deregister an agent."""
+        async def deregister_agent(
+            did: str,
+            authorization: str = Header(..., alias="Authorization"),
+        ) -> None:
+            """Deregister an agent.
+
+            Requires Ed25519-Timestamp auth and the caller's DID must
+            match the DID being deregistered — only the holder of the
+            corresponding private key can remove a registration.
+            """
+            authed_did = verify_ed25519_timestamp_auth(authorization, store)
+            if authed_did != did:
+                raise HTTPException(status_code=403, detail="DID mismatch")
             if not store.delete_agent(did):
                 raise HTTPException(status_code=404, detail="Agent not found")
             logger.info("Deregistered agent %s", did)

--- a/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
@@ -99,6 +99,10 @@ def verify_ed25519_timestamp_auth(
         ts = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
     except ValueError:
         raise HTTPException(status_code=401, detail="Invalid timestamp format")
+    # Reject TZ-naive timestamps explicitly to avoid a 500 from the
+    # ``now - ts`` subtraction below.
+    if ts.tzinfo is None:
+        raise HTTPException(status_code=401, detail="Timestamp must include timezone offset")
 
     now = _utcnow()
     if abs((now - ts).total_seconds()) > REPLAY_WINDOW.total_seconds():

--- a/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
@@ -9,11 +9,13 @@ Independent design: implements against wire spec only.
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
 import json
 import logging
 import os
 import secrets
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
@@ -29,12 +31,90 @@ if not _RELAY_TOKEN:
         "unauthenticated connections.  Set this env var in production."
     )
 
+# Proof-of-possession enforcement for connect frames. When True (default),
+# every ``connect`` frame must include ``public_key``, ``timestamp``, and
+# ``signature`` and the relay verifies that the supplied DID is derived
+# from the public key and that the signature over the timestamp is valid.
+# Setting ``AGENTMESH_RELAY_ALLOW_UNAUTHED_DID=1`` re-enables the legacy
+# behaviour for local/dev usage only — never in production.
+_REQUIRE_DID_POP: bool = (
+    os.environ.get("AGENTMESH_RELAY_ALLOW_UNAUTHED_DID", "").lower()
+    not in ("1", "true", "yes")
+)
+if not _REQUIRE_DID_POP:
+    logger.warning(
+        "AGENTMESH_RELAY_ALLOW_UNAUTHED_DID is set — the relay will "
+        "accept connect frames without DID proof-of-possession. "
+        "Any client can impersonate any DID. Do not use in production."
+    )
+
 HEARTBEAT_INTERVAL = 30  # seconds
 OFFLINE_THRESHOLD = 90  # seconds — 3 missed heartbeats
+DID_POP_REPLAY_WINDOW = timedelta(minutes=5)
 
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _verify_connect_pop(frame: dict) -> tuple[bool, str]:
+    """Verify proof-of-possession on a relay ``connect`` frame.
+
+    Required fields when ``_REQUIRE_DID_POP`` is True:
+
+    - ``from`` — the agent DID (``did:mesh:<32-hex>``)
+    - ``public_key`` — base64 Ed25519 public key (32 bytes)
+    - ``timestamp`` — ISO-8601 UTC timestamp (within 5-minute window)
+    - ``signature`` — base64 Ed25519 signature over the timestamp
+
+    The DID is checked against ``did:mesh:`` + ``sha256(public_key)[:32]``
+    so the client cannot present someone else's DID with their own key.
+
+    Returns ``(True, "")`` on success; ``(False, reason)`` on failure.
+    """
+    from nacl.exceptions import BadSignatureError
+    from nacl.signing import VerifyKey
+
+    did = frame.get("from")
+    pub_b64 = frame.get("public_key")
+    ts_str = frame.get("timestamp")
+    sig_b64 = frame.get("signature")
+
+    if not (isinstance(did, str) and isinstance(pub_b64, str)
+            and isinstance(ts_str, str) and isinstance(sig_b64, str)):
+        return False, "connect frame missing did/public_key/timestamp/signature"
+
+    # Decode and length-check the public key.
+    try:
+        pub_bytes = base64.b64decode(pub_b64)
+    except Exception:
+        return False, "invalid public_key encoding"
+    if len(pub_bytes) != 32:
+        return False, "public_key must be 32 bytes"
+
+    # DID must be derived from the public key (binds key to identity).
+    expected_did = f"did:mesh:{hashlib.sha256(pub_bytes).hexdigest()[:32]}"
+    if did != expected_did:
+        return False, "DID does not match public_key (sha256 mismatch)"
+
+    # Reject stale or future-dated proofs.
+    try:
+        ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except ValueError:
+        return False, "invalid timestamp format"
+    if abs((_utcnow() - ts).total_seconds()) > DID_POP_REPLAY_WINDOW.total_seconds():
+        return False, "timestamp outside replay window"
+
+    # Verify Ed25519 signature over the timestamp.
+    try:
+        sig = base64.b64decode(sig_b64)
+        VerifyKey(pub_bytes).verify(ts_str.encode("utf-8"), sig)
+    except BadSignatureError:
+        return False, "invalid signature"
+    except Exception:
+        return False, "signature verification failed"
+
+    return True, ""
 
 
 class ConnectedAgent:
@@ -113,6 +193,21 @@ class RelayServer:
                     await ws.send_json({"type": "error", "detail": "Missing 'from' field"})
                     await ws.close(code=4002)
                     return
+
+                # Verify DID proof-of-possession (binds the WebSocket to the
+                # holder of the private key, preventing any client from
+                # connecting as an arbitrary DID and intercepting its mail).
+                if _REQUIRE_DID_POP:
+                    ok, reason = _verify_connect_pop(frame)
+                    if not ok:
+                        logger.warning(
+                            "Rejecting connect frame for %s: %s", agent_did, reason
+                        )
+                        await ws.send_json(
+                            {"type": "error", "detail": f"DID proof failed: {reason}"}
+                        )
+                        await ws.close(code=4005)
+                        return
 
                 # Authenticate: require token when AGENTMESH_RELAY_TOKEN is set
                 if _RELAY_TOKEN is not None:

--- a/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
@@ -102,6 +102,11 @@ def _verify_connect_pop(frame: dict) -> tuple[bool, str]:
         ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
     except ValueError:
         return False, "invalid timestamp format"
+    if ts.tzinfo is None:
+        # Without tzinfo, the subtraction below raises TypeError. Treat
+        # naive timestamps as an outright rejection — clients must send
+        # explicit offsets per spec.
+        return False, "timestamp must include timezone offset"
     if abs((_utcnow() - ts).total_seconds()) > DID_POP_REPLAY_WINDOW.total_seconds():
         return False, "timestamp outside replay window"
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/audit_collector.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/audit_collector.py
@@ -86,7 +86,18 @@ class QueryParams(BaseModel):
 
 @app.post("/api/v1/audit/log", tags=["audit"], response_model=LogEntryResponse)
 async def log_entry(req: LogEntryRequest) -> LogEntryResponse:
-    """Log a single audit entry."""
+    """Log a single audit entry.
+
+    SECURITY (known gap): this endpoint accepts ``agent_did`` from the
+    request body without authenticating the caller. The audit-collector
+    is a separate service that does not have direct access to the
+    identity registry, so binding ``agent_did`` to an Ed25519-Timestamp
+    signature requires cross-service auth plumbing (shared trust
+    anchor or mTLS gateway) that lives outside this module. Deploy
+    behind a gateway that authenticates callers; do NOT expose this
+    endpoint directly. Tracked alongside the trust-engine / registry
+    auth-binding work.
+    """
     entry = _audit_service.log_action(
         agent_did=req.agent_did,
         action=req.action,
@@ -108,7 +119,12 @@ async def log_entry(req: LogEntryRequest) -> LogEntryResponse:
 
 @app.post("/api/v1/audit/batch", tags=["audit"])
 async def log_batch(req: BatchLogRequest) -> dict[str, Any]:
-    """Log a batch of audit entries."""
+    """Log a batch of audit entries.
+
+    SECURITY (known gap): same as ``/audit/log`` — accepts ``agent_did``
+    per entry without per-entry caller authentication. Must be deployed
+    behind an authenticating gateway.
+    """
     results = []
     entries_for_sink = []
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/policy_server.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/policy_server.py
@@ -121,7 +121,16 @@ class TrustEvaluateResponse(BaseModel):
 
 @app.post("/api/v1/policy/evaluate", tags=["policy"], response_model=EvaluateResponse)
 async def evaluate_policy(req: EvaluateRequest) -> EvaluateResponse:
-    """Evaluate governance policies against an agent action."""
+    """Evaluate governance policies against an agent action.
+
+    SECURITY (known gap): accepts ``agent_did`` from the request body
+    without authenticating the caller. The policy-server is a separate
+    service without direct access to the identity registry, so binding
+    ``agent_did`` to a signed caller identity requires cross-service
+    auth plumbing. Treat decisions returned here as advisory unless the
+    deployment authenticates callers at the gateway. Same class of
+    issue as ``audit_collector.log_entry``.
+    """
     ctx = {
         "action": req.action,
         "resource": req.resource,

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
@@ -83,7 +83,12 @@ class GrantCapabilityRequest(BaseModel):
     # ``from_agent`` is intentionally NOT in the request body — the grantor
     # is the caller authenticated via the Ed25519-Timestamp header. Accepting
     # an arbitrary ``from_agent`` from the body lets any caller claim to grant
-    # capabilities on behalf of any other agent.
+    # capabilities on behalf of any other agent. Pydantic v2 by default
+    # silently ignores unknown fields, which means an old client that still
+    # sends ``from_agent`` would not get any feedback that the field is
+    # being dropped. ``extra="forbid"`` surfaces that as a 422 so client
+    # bugs are caught early.
+    model_config = {"extra": "forbid"}
 
 
 def _verify_ed25519_timestamp(authorization: str | None) -> str:
@@ -116,6 +121,11 @@ def _verify_ed25519_timestamp(authorization: str | None) -> str:
         ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
     except ValueError:
         raise HTTPException(401, "Invalid timestamp format")
+    # Reject TZ-naive timestamps explicitly — otherwise the
+    # ``datetime.now(tz) - ts`` subtraction below raises ``TypeError``
+    # and surfaces as an unhelpful 500.
+    if ts.tzinfo is None:
+        raise HTTPException(401, "Timestamp must include timezone offset")
     if abs((datetime.now(timezone.utc) - ts).total_seconds()) > REPLAY_WINDOW.total_seconds():
         raise HTTPException(401, "Timestamp outside replay window")
 
@@ -125,7 +135,7 @@ def _verify_ed25519_timestamp(authorization: str | None) -> str:
 
     try:
         pub_bytes = base64.b64decode(identity.public_key)
-        sig = base64.b64decode(sig_b64 + "==")
+        sig = base64.urlsafe_b64decode(sig_b64 + "==")
         VerifyKey(pub_bytes).verify(ts_str.encode("utf-8"), sig)
     except BadSignatureError:
         raise HTTPException(401, "Invalid signature")

--- a/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import HTTPException
+from fastapi import Header, HTTPException
 from pydantic import BaseModel, Field
 
 from agentmesh.identity.agent_id import AgentDID, AgentIdentity, IdentityRegistry
@@ -80,7 +80,59 @@ class RegisterAgentRequest(BaseModel):
 class GrantCapabilityRequest(BaseModel):
     capability: str = Field(..., description="Capability string (e.g., 'read:data')")
     to_agent: str = Field(..., description="DID of grantee")
-    from_agent: str = Field(..., description="DID of grantor")
+    # ``from_agent`` is intentionally NOT in the request body — the grantor
+    # is the caller authenticated via the Ed25519-Timestamp header. Accepting
+    # an arbitrary ``from_agent`` from the body lets any caller claim to grant
+    # capabilities on behalf of any other agent.
+
+
+def _verify_ed25519_timestamp(authorization: str | None) -> str:
+    """Verify an ``Ed25519-Timestamp`` Authorization header. Returns the DID.
+
+    Format: ``Ed25519-Timestamp <did> <iso8601> <base64(signature)>``
+
+    The signature is verified against the public key registered for ``<did>``
+    in the trust-engine identity registry. The timestamp must be within a
+    5-minute replay window.
+    """
+    import base64
+    from datetime import datetime, timedelta, timezone
+
+    from nacl.exceptions import BadSignatureError
+    from nacl.signing import VerifyKey
+
+    REPLAY_WINDOW = timedelta(minutes=5)
+
+    if not authorization or not authorization.startswith("Ed25519-Timestamp "):
+        raise HTTPException(401, "Missing or invalid Authorization header")
+
+    parts = authorization.split(" ", 3)
+    if len(parts) != 4:
+        raise HTTPException(401, "Malformed Ed25519-Timestamp header")
+
+    _scheme, did, ts_str, sig_b64 = parts
+
+    try:
+        ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(401, "Invalid timestamp format")
+    if abs((datetime.now(timezone.utc) - ts).total_seconds()) > REPLAY_WINDOW.total_seconds():
+        raise HTTPException(401, "Timestamp outside replay window")
+
+    identity = registry.get(did)
+    if identity is None:
+        raise HTTPException(401, "Caller not registered")
+
+    try:
+        pub_bytes = base64.b64decode(identity.public_key)
+        sig = base64.b64decode(sig_b64 + "==")
+        VerifyKey(pub_bytes).verify(ts_str.encode("utf-8"), sig)
+    except BadSignatureError:
+        raise HTTPException(401, "Invalid signature")
+    except Exception:
+        raise HTTPException(401, "Signature verification failed")
+
+    return did
 
 
 # ── Endpoints ────────────────────────────────────────────────────────
@@ -210,14 +262,44 @@ async def verify_handshake(req: VerifyRequest) -> VerifyResponse:
 
 
 @app.post("/api/v1/capabilities/grant", tags=["capabilities"])
-async def grant_capability(req: GrantCapabilityRequest) -> dict[str, Any]:
-    """Grant a capability to an agent."""
-    grant = capability_registry.grant(
-        capability=req.capability,
-        to_agent=req.to_agent,
-        from_agent=req.from_agent,
-    )
-    return {"status": "granted", "grant_id": grant.grant_id, "capability": req.capability}
+async def grant_capability(
+    req: GrantCapabilityRequest,
+    authorization: str = Header(..., alias="Authorization"),
+) -> dict[str, Any]:
+    """Grant a capability to an agent.
+
+    Authentication: required. The caller must present an
+    ``Ed25519-Timestamp`` header signed by the grantor DID. The
+    grantor is taken from the authenticated identity, never from
+    the request body, to prevent any caller from issuing grants on
+    behalf of arbitrary agents.
+
+    Authorisation: the grantor MUST already hold ``capability`` —
+    you cannot delegate authority you do not possess.
+    """
+    from_agent = _verify_ed25519_timestamp(authorization)
+
+    if not req.to_agent or not req.to_agent.startswith("did:mesh:"):
+        raise HTTPException(400, "to_agent must be a did:mesh: DID")
+
+    try:
+        grant = capability_registry.grant(
+            capability=req.capability,
+            to_agent=req.to_agent,
+            from_agent=from_agent,
+            require_grantor_capability=True,
+        )
+    except PermissionError as exc:
+        raise HTTPException(403, str(exc))
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
+    return {
+        "status": "granted",
+        "grant_id": grant.grant_id,
+        "capability": req.capability,
+        "granted_by": from_agent,
+    }
 
 
 @app.get("/api/v1/capabilities/{agent_did:path}", tags=["capabilities"])

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
@@ -317,6 +317,7 @@ class CapabilityRegistry:
         to_agent: str,
         from_agent: str,
         resource_ids: Optional[list[str]] = None,
+        require_grantor_capability: bool = False,
     ) -> CapabilityGrant:
         """Grant a capability to an agent.
 
@@ -329,10 +330,35 @@ class CapabilityRegistry:
             from_agent: DID of the agent issuing the grant.
             resource_ids: Optional specific resource IDs to scope the
                 grant to.
+            require_grantor_capability: When ``True``, verify that
+                ``from_agent`` already holds ``capability`` (i.e. can
+                actually delegate it). Bootstrap/admin grants set this
+                to ``False``. Callers that accept grants over the
+                network MUST set this to ``True`` to prevent privilege
+                escalation via unauthenticated grantor claims.
+
+        Raises:
+            PermissionError: If ``require_grantor_capability`` is
+                ``True`` and ``from_agent`` does not hold the
+                requested capability.
+            ValueError: If ``from_agent == to_agent`` (self-grant) or
+                the capability string is malformed.
 
         Returns:
             The newly created ``CapabilityGrant``.
         """
+        if from_agent == to_agent:
+            # Self-grants are meaningless and would bypass delegation
+            # checks (an agent could "grant" itself any capability).
+            raise ValueError("Cannot self-grant a capability")
+
+        if require_grantor_capability:
+            grantor_scope = self._scopes.get(from_agent)
+            if grantor_scope is None or not grantor_scope.has_capability(capability):
+                raise PermissionError(
+                    f"Grantor {from_agent} does not hold capability {capability!r}"
+                )
+
         grant = CapabilityGrant.create(
             capability=capability,
             granted_to=to_agent,

--- a/agent-governance-python/agent-mesh/tests/test_registration_auth.py
+++ b/agent-governance-python/agent-mesh/tests/test_registration_auth.py
@@ -173,7 +173,6 @@ class TestPrekeyUploadRejectsUnauthenticated:
         self.client = TestClient(server.app)
 
     def _register_agent(self):
-        import hashlib
         from datetime import datetime, timezone
         sk = SigningKey.generate()
         pub = sk.verify_key.encode()
@@ -222,3 +221,124 @@ class TestPrekeyUploadRejectsUnauthenticated:
             headers={"Authorization": auth},
         )
         assert resp.status_code == 401, "Must reject prekey upload with wrong key"
+
+
+# ── Capability Grant Auth (security regression) ──────────────────────
+
+
+class TestCapabilityGrantRejectsUnauthenticated:
+    """POST /api/v1/capabilities/grant must require Ed25519-Timestamp
+    auth tying the grantor to the caller, AND the grantor must already
+    hold the capability being delegated."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from agentmesh.server.trust_engine import (
+            app, registry, capability_registry, _pending_challenges,
+        )
+        from fastapi.testclient import TestClient
+        _pending_challenges.clear()
+        registry._identities.clear()
+        registry._by_sponsor.clear()
+        capability_registry._scopes.clear()
+        capability_registry._grants_by_grantor.clear()
+        self.client = TestClient(app)
+        self.registry = registry
+        self.capability_registry = capability_registry
+
+    def _register(self, name: str = "alice"):
+        """Register an agent through the public API; returns (sk, did)."""
+        from datetime import datetime, timezone
+        import hashlib
+        sk = SigningKey.generate()
+        pub = sk.verify_key.encode()
+        pub_b64 = base64.b64encode(pub).decode()
+        ts = datetime.now(timezone.utc).isoformat()
+        message = pub_b64.encode() + ts.encode()
+        sig = sk.sign(message).signature
+        resp = self.client.post("/api/v1/agents/register", json={
+            "name": name,
+            "public_key": pub_b64,
+            "proof": base64.b64encode(sig).decode(),
+            "proof_timestamp": ts,
+            "sponsor_email": f"{name}@test.example.com",
+        })
+        assert resp.status_code == 200
+        did = f"did:mesh:{hashlib.sha256(pub).hexdigest()[:32]}"
+        assert resp.json()["agent_did"] == did
+        return sk, did
+
+    def _auth(self, sk: SigningKey, did: str) -> dict:
+        from datetime import datetime, timezone
+        ts = datetime.now(timezone.utc).isoformat()
+        sig = sk.sign(ts.encode()).signature
+        token = f"Ed25519-Timestamp {did} {ts} {base64.b64encode(sig).decode()}"
+        return {"Authorization": token}
+
+    def test_rejects_no_auth_header(self):
+        _, did_b = self._register("bob")
+        resp = self.client.post("/api/v1/capabilities/grant", json={
+            "capability": "read:data",
+            "to_agent": did_b,
+        })
+        assert resp.status_code == 422  # missing required header
+
+    def test_rejects_caller_does_not_hold_capability(self):
+        """Caller authenticates but has no grants — cannot delegate."""
+        sk_a, did_a = self._register("alice")
+        _, did_b = self._register("bob")
+        resp = self.client.post(
+            "/api/v1/capabilities/grant",
+            json={"capability": "read:data", "to_agent": did_b},
+            headers=self._auth(sk_a, did_a),
+        )
+        assert resp.status_code == 403
+        assert "does not hold" in resp.json()["detail"]
+
+    def test_grantor_holding_capability_can_delegate(self):
+        """Authenticated caller that holds the cap may delegate it."""
+        sk_a, did_a = self._register("alice")
+        _, did_b = self._register("bob")
+        # Bootstrap: directly seed alice's scope with the capability she
+        # is about to delegate (simulates a prior admin/bootstrap grant).
+        self.capability_registry.grant(
+            capability="read:data",
+            to_agent=did_a,
+            from_agent="did:mesh:bootstrap",
+        )
+        resp = self.client.post(
+            "/api/v1/capabilities/grant",
+            json={"capability": "read:data", "to_agent": did_b},
+            headers=self._auth(sk_a, did_a),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["granted_by"] == did_a
+        assert self.capability_registry.check(did_b, "read:data")
+
+    def test_grantor_identity_is_authenticated_caller_not_body(self):
+        """Even if the body sets ``from_agent``, the grantor is always
+        the authenticated DID; spoofed body values are ignored."""
+        sk_a, did_a = self._register("alice")
+        _, did_b = self._register("bob")
+        self.capability_registry.grant(
+            capability="read:data",
+            to_agent=did_a,
+            from_agent="did:mesh:bootstrap",
+        )
+        resp = self.client.post(
+            "/api/v1/capabilities/grant",
+            json={
+                "capability": "read:data",
+                "to_agent": did_b,
+                "from_agent": "did:mesh:somebody-else",
+            },
+            headers=self._auth(sk_a, did_a),
+        )
+        # Either the model rejects the extra field (422) or it ignores it
+        # and the grantor is bound to the authenticated DID. Both are safe.
+        assert resp.status_code in (200, 422)
+        if resp.status_code == 200:
+            assert resp.json()["granted_by"] == did_a
+
+

--- a/agent-governance-python/agent-mesh/tests/test_registry.py
+++ b/agent-governance-python/agent-mesh/tests/test_registry.py
@@ -152,10 +152,42 @@ class TestRegistryAPI:
         assert resp.status_code == 404
 
     def test_delete_agent(self, client):
-        body, _, did = _make_registration_body()
+        body, sk, did = _make_registration_body()
         client.post("/v1/agents", json=body)
-        resp = client.delete(f"/v1/agents/{did}")
+        auth = _make_auth_header(sk, did)
+        resp = client.delete(f"/v1/agents/{did}", headers={"Authorization": auth})
         assert resp.status_code == 204
+
+    def test_delete_agent_requires_auth(self, client):
+        """Deregistration must reject unauthenticated callers."""
+        body, _sk, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        # No Authorization header
+        resp = client.delete(f"/v1/agents/{did}")
+        assert resp.status_code == 422  # FastAPI: missing required header
+
+    def test_delete_agent_rejects_other_did(self, client):
+        """Auth header for one DID cannot be used to delete another."""
+        # Register two agents
+        body_a, sk_a, did_a = _make_registration_body()
+        body_b, _sk_b, did_b = _make_registration_body()
+        client.post("/v1/agents", json=body_a)
+        client.post("/v1/agents", json=body_b)
+        # Sign with A's key but try to delete B
+        auth = _make_auth_header(sk_a, did_a)
+        resp = client.delete(f"/v1/agents/{did_b}", headers={"Authorization": auth})
+        assert resp.status_code == 403
+
+    def test_delete_agent_rejects_forged_signature(self, client):
+        body, _sk, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        # Use a fresh (unregistered) key claiming to be the registered DID
+        forged_sk = SigningKey.generate()
+        ts = datetime.now(timezone.utc).isoformat()
+        sig = forged_sk.sign(ts.encode()).signature
+        auth = f"Ed25519-Timestamp {did} {ts} {_b64(sig)}"
+        resp = client.delete(f"/v1/agents/{did}", headers={"Authorization": auth})
+        assert resp.status_code == 401
 
     def test_upload_and_fetch_prekeys(self, client):
         body, sk, did = _make_registration_body()

--- a/agent-governance-python/agent-mesh/tests/test_registry.py
+++ b/agent-governance-python/agent-mesh/tests/test_registry.py
@@ -252,14 +252,35 @@ class TestRegistryAPI:
         assert resp.json()["online"] is True
 
     def test_reputation(self, client):
-        body, _, did = _make_registration_body()
-        client.post("/v1/agents", json=body)
-        resp = client.post(f"/v1/agents/{did}/reputation", json={
-            "score": 0.9,
-            "reason": "reliable execution",
-        })
+        # Reporter (different agent) submits reputation on the target.
+        target_body, _, target_did = _make_registration_body()
+        client.post("/v1/agents", json=target_body)
+        reporter_body, reporter_sk, reporter_did = _make_registration_body()
+        client.post("/v1/agents", json=reporter_body)
+        resp = client.post(
+            f"/v1/agents/{target_did}/reputation",
+            json={"score": 0.9, "reason": "reliable execution"},
+            headers={"Authorization": _make_auth_header(reporter_sk, reporter_did)},
+        )
         assert resp.status_code == 200
         assert resp.json()["reputation_score"] > 0.5
+
+    def test_reputation_requires_auth(self, client):
+        body, _, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        resp = client.post(f"/v1/agents/{did}/reputation", json={"score": 0.9})
+        assert resp.status_code == 401
+
+    def test_reputation_rejects_self_reporting(self, client):
+        body, sk, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        resp = client.post(
+            f"/v1/agents/{did}/reputation",
+            json={"score": 1.0, "reason": "i am great"},
+            headers={"Authorization": _make_auth_header(sk, did)},
+        )
+        assert resp.status_code == 403
+        assert "themselves" in resp.json()["detail"].lower()
 
     def test_discover(self, client):
         for i in range(3):
@@ -271,31 +292,126 @@ class TestRegistryAPI:
         assert resp.json()["total"] == 2
 
     def test_heartbeat_updates_last_seen(self, client):
-        body, _, did = _make_registration_body()
+        body, sk, did = _make_registration_body()
         client.post("/v1/agents", json=body)
-        resp = client.post(f"/v1/agents/{did}/heartbeat")
+        resp = client.post(
+            f"/v1/agents/{did}/heartbeat",
+            headers={"Authorization": _make_auth_header(sk, did)},
+        )
         assert resp.status_code == 200
         assert resp.json()["did"] == did
         assert resp.json()["last_seen"] is not None
 
-    def test_heartbeat_not_found(self, client):
-        resp = client.post("/v1/agents/did:mesh:missing/heartbeat")
-        assert resp.status_code == 404
-
-    def test_heartbeat_throttled(self, client):
+    def test_heartbeat_requires_auth(self, client):
         body, _, did = _make_registration_body()
         client.post("/v1/agents", json=body)
-        resp1 = client.post(f"/v1/agents/{did}/heartbeat")
+        resp = client.post(f"/v1/agents/{did}/heartbeat")
+        assert resp.status_code == 401
+
+    def test_heartbeat_rejects_other_did(self, client):
+        body_a, _, did_a = _make_registration_body()
+        body_b, sk_b, did_b = _make_registration_body()
+        client.post("/v1/agents", json=body_a)
+        client.post("/v1/agents", json=body_b)
+        # B tries to heartbeat A.
+        resp = client.post(
+            f"/v1/agents/{did_a}/heartbeat",
+            headers={"Authorization": _make_auth_header(sk_b, did_b)},
+        )
+        assert resp.status_code == 403
+
+    def test_heartbeat_not_found(self, client):
+        # An unregistered DID can never auth; the auth helper short-circuits
+        # before the 404 path is even reachable.
+        sk = SigningKey.generate()
+        ghost_did = "did:mesh:" + "0" * 32
+        ts = datetime.now(timezone.utc).isoformat()
+        sig = sk.sign(ts.encode()).signature
+        resp = client.post(
+            f"/v1/agents/{ghost_did}/heartbeat",
+            headers={
+                "Authorization": f"Ed25519-Timestamp {ghost_did} {ts} {_b64(sig)}",
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_heartbeat_throttled(self, client):
+        body, sk, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        auth = _make_auth_header(sk, did)
+        resp1 = client.post(f"/v1/agents/{did}/heartbeat", headers={"Authorization": auth})
         assert resp1.status_code == 200
         first_ts = resp1.json()["last_seen"]
 
-        # Immediate second heartbeat is throttled
-        resp2 = client.post(f"/v1/agents/{did}/heartbeat")
+        # Immediate second heartbeat is throttled (use a fresh signed
+        # timestamp so we know we hit the throttle, not the replay window).
+        resp2 = client.post(
+            f"/v1/agents/{did}/heartbeat",
+            headers={"Authorization": _make_auth_header(sk, did)},
+        )
         assert resp2.status_code == 429
 
         # Verify last_seen was NOT updated on throttled request
         presence = client.get(f"/v1/agents/{did}/presence")
         assert presence.json()["last_seen"] == first_ts
+
+    # ── Session reputation auth ─────────────────────────────────
+
+    def test_session_reputation_requires_auth(self, client):
+        body_i, _, did_i = _make_registration_body()
+        body_r, _, did_r = _make_registration_body()
+        client.post("/v1/agents", json=body_i)
+        client.post("/v1/agents", json=body_r)
+        resp = client.post(
+            "/v1/registry/reputation/session",
+            json={
+                "session_id": "s-1",
+                "initiator_amid": did_i,
+                "receiver_amid": did_r,
+                "outcome": "success",
+                "reporter_amid": did_i,
+            },
+        )
+        assert resp.status_code == 401
+
+    def test_session_reputation_rejects_spoofed_reporter(self, client):
+        # Caller authenticates as did_i but claims did_r is the reporter.
+        body_i, sk_i, did_i = _make_registration_body()
+        body_r, _, did_r = _make_registration_body()
+        client.post("/v1/agents", json=body_i)
+        client.post("/v1/agents", json=body_r)
+        resp = client.post(
+            "/v1/registry/reputation/session",
+            json={
+                "session_id": "s-2",
+                "initiator_amid": did_i,
+                "receiver_amid": did_r,
+                "outcome": "success",
+                "reporter_amid": did_r,  # spoofed
+            },
+            headers={"Authorization": _make_auth_header(sk_i, did_i)},
+        )
+        assert resp.status_code == 403
+        assert "reporter_amid" in resp.json()["detail"].lower()
+
+    def test_session_reputation_succeeds_with_matching_reporter(self, client):
+        body_i, sk_i, did_i = _make_registration_body()
+        body_r, _, did_r = _make_registration_body()
+        client.post("/v1/agents", json=body_i)
+        client.post("/v1/agents", json=body_r)
+        resp = client.post(
+            "/v1/registry/reputation/session",
+            json={
+                "session_id": "s-3",
+                "initiator_amid": did_i,
+                "receiver_amid": did_r,
+                "outcome": "success",
+                "reporter_amid": did_i,
+            },
+            headers={"Authorization": _make_auth_header(sk_i, did_i)},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["outcome"] == "success"
 
     def test_identity_key_ed_validation_rejects_wrong_length(self, client):
         body, sk, did = _make_registration_body()

--- a/agent-governance-python/agent-mesh/tests/test_relay.py
+++ b/agent-governance-python/agent-mesh/tests/test_relay.py
@@ -2,14 +2,66 @@
 # Licensed under the MIT License.
 """Tests for AgentMesh Relay service."""
 
+import base64
+import hashlib
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
+from nacl.signing import SigningKey
 
 from agentmesh.relay.app import RelayServer
 from agentmesh.relay.store import InMemoryInboxStore, StoredMessage
+
+
+# ── Connect-frame helper ─────────────────────────────────────────────
+#
+# Every test in this file used to send the legacy unauthenticated frame
+# ``{"v":1,"type":"connect","from":"did:agentmesh:<name>"}``. The relay
+# now requires proof-of-possession of the DID's private key (see
+# ``_verify_connect_pop`` in ``relay/app.py``), so we build connect
+# frames whose ``from`` is derived from the supplied public key.
+#
+# A per-label cache keeps the DID stable across calls in the same test
+# so a sender and a recipient can refer to the same identity.
+
+_KEY_CACHE: dict[str, SigningKey] = {}
+
+
+def _key_for(label: str) -> SigningKey:
+    if label not in _KEY_CACHE:
+        _KEY_CACHE[label] = SigningKey.generate()
+    return _KEY_CACHE[label]
+
+
+def _did_for(label: str) -> str:
+    pk = _key_for(label).verify_key.encode()
+    return f"did:mesh:{hashlib.sha256(pk).hexdigest()[:32]}"
+
+
+def _connect_frame(label: str) -> dict:
+    """Build a valid (signed) ``connect`` frame for *label*."""
+    sk = _key_for(label)
+    pk = sk.verify_key.encode()
+    ts = datetime.now(timezone.utc).isoformat()
+    sig = sk.sign(ts.encode("utf-8")).signature
+    return {
+        "v": 1,
+        "type": "connect",
+        "from": f"did:mesh:{hashlib.sha256(pk).hexdigest()[:32]}",
+        "public_key": base64.b64encode(pk).decode(),
+        "timestamp": ts,
+        "signature": base64.b64encode(sig).decode(),
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_key_cache():
+    """Give each test a fresh DID universe to avoid cross-test bleed."""
+    _KEY_CACHE.clear()
+    yield
+    _KEY_CACHE.clear()
 
 
 # ── Inbox Store Tests ────────────────────────────────────────────────
@@ -90,15 +142,12 @@ class TestRelayServer:
     def test_websocket_connect(self):
         server = RelayServer()
         client = TestClient(server.app)
+        alice_did = _did_for("alice")
         with client.websocket_connect("/ws") as ws:
-            ws.send_json({
-                "v": 1, "type": "connect", "from": "did:agentmesh:alice",
-            })
-            # Should stay connected (no error response)
-            # Send heartbeat to verify connection works
-            ws.send_json({
-                "v": 1, "type": "heartbeat", "from": "did:agentmesh:alice",
-            })
+            ws.send_json(_connect_frame("alice"))
+            # Should stay connected (no error response). Send a heartbeat
+            # to verify the socket is alive.
+            ws.send_json({"v": 1, "type": "heartbeat", "from": alice_did})
 
     def test_websocket_connect_missing_from(self):
         server = RelayServer()
@@ -120,24 +169,26 @@ class TestRelayServer:
         """Two agents connected — messages route directly."""
         server = RelayServer()
         client = TestClient(server.app)
+        alice_did = _did_for("alice")
+        bob_did = _did_for("bob")
 
         with client.websocket_connect("/ws") as ws_bob:
-            ws_bob.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:bob"})
+            ws_bob.send_json(_connect_frame("bob"))
 
             with client.websocket_connect("/ws") as ws_alice:
-                ws_alice.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:alice"})
+                ws_alice.send_json(_connect_frame("alice"))
 
                 # Alice sends to Bob
                 ws_alice.send_json({
                     "v": 1, "type": "message",
-                    "from": "did:agentmesh:alice", "to": "did:agentmesh:bob",
+                    "from": alice_did, "to": bob_did,
                     "id": "msg-001", "ciphertext": "encrypted_payload",
                 })
 
                 # Bob receives
                 msg = ws_bob.receive_json()
                 assert msg["type"] == "message"
-                assert msg["from"] == "did:agentmesh:alice"
+                assert msg["from"] == alice_did
                 assert msg["id"] == "msg-001"
 
         assert server.stats["messages_routed"] == 1
@@ -146,14 +197,16 @@ class TestRelayServer:
         """Message stored when recipient is offline."""
         server = RelayServer()
         client = TestClient(server.app)
+        alice_did = _did_for("alice")
+        bob_did = _did_for("bob")
 
         with client.websocket_connect("/ws") as ws_alice:
-            ws_alice.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:alice"})
+            ws_alice.send_json(_connect_frame("alice"))
 
             # Send to offline Bob
             ws_alice.send_json({
                 "v": 1, "type": "message",
-                "from": "did:agentmesh:alice", "to": "did:agentmesh:bob",
+                "from": alice_did, "to": bob_did,
                 "id": "offline-001", "ciphertext": "stored_payload",
             })
 
@@ -163,22 +216,24 @@ class TestRelayServer:
         """Stored messages delivered when agent reconnects."""
         server = RelayServer()
         inbox = server._inbox
+        alice_did = _did_for("alice")
+        bob_did = _did_for("bob")
 
         # Pre-store a message for Bob
         inbox.store(StoredMessage(
             message_id="pending-001",
-            sender_did="did:agentmesh:alice",
-            recipient_did="did:agentmesh:bob",
+            sender_did=alice_did,
+            recipient_did=bob_did,
             payload=json.dumps({
                 "v": 1, "type": "message",
-                "from": "did:agentmesh:alice", "to": "did:agentmesh:bob",
+                "from": alice_did, "to": bob_did,
                 "id": "pending-001", "ciphertext": "old_message",
             }),
         ))
 
         client = TestClient(server.app)
         with client.websocket_connect("/ws") as ws_bob:
-            ws_bob.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:bob"})
+            ws_bob.send_json(_connect_frame("bob"))
 
             # Should receive the pending message
             msg = ws_bob.receive_json()
@@ -190,16 +245,18 @@ class TestRelayServer:
         """KNOCK frames route like messages."""
         server = RelayServer()
         client = TestClient(server.app)
+        alice_did = _did_for("alice")
+        bob_did = _did_for("bob")
 
         with client.websocket_connect("/ws") as ws_bob:
-            ws_bob.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:bob"})
+            ws_bob.send_json(_connect_frame("bob"))
 
             with client.websocket_connect("/ws") as ws_alice:
-                ws_alice.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:alice"})
+                ws_alice.send_json(_connect_frame("alice"))
 
                 ws_alice.send_json({
                     "v": 1, "type": "knock",
-                    "from": "did:agentmesh:alice", "to": "did:agentmesh:bob",
+                    "from": alice_did, "to": bob_did,
                     "id": "knock-001",
                     "intent": {"action": "delegate_task"},
                 })
@@ -212,17 +269,18 @@ class TestRelayServer:
         """ACK frame removes message from inbox."""
         server = RelayServer()
         inbox = server._inbox
+        acker_did = _did_for("acker")
 
         inbox.store(StoredMessage(
             message_id="ack-test",
-            sender_did="a", recipient_did="did:agentmesh:acker",
-            payload=json.dumps({"v": 1, "type": "message", "id": "ack-test", "from": "a", "to": "did:agentmesh:acker"}),
+            sender_did="a", recipient_did=acker_did,
+            payload=json.dumps({"v": 1, "type": "message", "id": "ack-test", "from": "a", "to": acker_did}),
         ))
         assert inbox.message_count == 1
 
         client = TestClient(server.app)
         with client.websocket_connect("/ws") as ws:
-            ws.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:acker"})
+            ws.send_json(_connect_frame("acker"))
             # Receive pending message
             msg = ws.receive_json()
             assert msg["id"] == "ack-test"
@@ -240,14 +298,15 @@ class TestRelayServer:
         """
         server = RelayServer()
         inbox = server._inbox
+        bob_did = _did_for("bob")
 
         inbox.store(StoredMessage(
             message_id="survives-001",
             sender_did="alice",
-            recipient_did="did:agentmesh:bob",
+            recipient_did=bob_did,
             payload=json.dumps({
                 "v": 1, "type": "message",
-                "from": "alice", "to": "did:agentmesh:bob",
+                "from": "alice", "to": bob_did,
                 "id": "survives-001", "ciphertext": "important",
             }),
         ))
@@ -256,7 +315,7 @@ class TestRelayServer:
         client = TestClient(server.app)
         # First connect: receive frame, disconnect WITHOUT acking.
         with client.websocket_connect("/ws") as ws:
-            ws.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:bob"})
+            ws.send_json(_connect_frame("bob"))
             msg = ws.receive_json()
             assert msg["id"] == "survives-001"
             # Drop the connection without sending an ack.
@@ -266,7 +325,7 @@ class TestRelayServer:
 
         # Reconnect: message must be re-delivered.
         with client.websocket_connect("/ws") as ws:
-            ws.send_json({"v": 1, "type": "connect", "from": "did:agentmesh:bob"})
+            ws.send_json(_connect_frame("bob"))
             msg = ws.receive_json()
             assert msg["id"] == "survives-001"
             ws.send_json({"v": 1, "type": "ack", "id": "survives-001"})
@@ -294,35 +353,103 @@ class TestGhostConnectionCleanup:
     def test_rebind_replaces_ghost_connection(self):
         server = RelayServer()
         client = TestClient(server.app)
+        rebind_did = _did_for("rebind")
+        sender_did = _did_for("sender")
 
         # First connection registers
         with client.websocket_connect("/ws") as ws_old:
-            ws_old.send_json({
-                "v": 1, "type": "connect", "from": "did:agentmesh:rebind",
-            })
+            ws_old.send_json(_connect_frame("rebind"))
             # Second connection with same DID triggers ghost close on old.
             with client.websocket_connect("/ws") as ws_new:
-                ws_new.send_json({
-                    "v": 1, "type": "connect", "from": "did:agentmesh:rebind",
-                })
+                ws_new.send_json(_connect_frame("rebind"))
                 # Send a message to the rebinding DID from another agent.
                 with client.websocket_connect("/ws") as ws_sender:
-                    ws_sender.send_json({
-                        "v": 1, "type": "connect", "from": "did:agentmesh:sender",
-                    })
+                    ws_sender.send_json(_connect_frame("sender"))
                     ws_sender.send_json({
                         "v": 1, "type": "message",
-                        "from": "did:agentmesh:sender",
-                        "to": "did:agentmesh:rebind",
+                        "from": sender_did,
+                        "to": rebind_did,
                         "id": "post-rebind",
                         "ciphertext": "data",
                     })
                     # The NEW socket must receive it (ghost old socket is closed).
                     msg = ws_new.receive_json()
                     assert msg["id"] == "post-rebind"
-                    assert msg["from"] == "did:agentmesh:sender"
+                    assert msg["from"] == sender_did
 
         # Active connection count returns to 0 after both rebind sockets
         # leave their `with` blocks (sender already left).
         assert len(server._connections) == 0
 
+
+# -- DID Proof-of-Possession (security regression) -------------------
+
+
+class TestRelayDIDProofOfPossession:
+    """Connect frames must carry a valid DID proof; relay must reject
+    spoofed DIDs that don't match the supplied public key."""
+
+    def test_rejects_missing_pop_fields(self):
+        server = RelayServer()
+        client = TestClient(server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({
+                "v": 1, "type": "connect",
+                "from": "did:mesh:1234567890abcdef1234567890abcdef",
+            })
+            resp = ws.receive_json()
+            assert resp["type"] == "error"
+            assert "did proof failed" in resp["detail"].lower()
+
+    def test_rejects_did_not_matching_pubkey(self):
+        """Attacker uses their own key but claims someone else's DID."""
+        server = RelayServer()
+        client = TestClient(server.app)
+        frame = _connect_frame("attacker")
+        # Swap the DID for a fabricated one — public_key, timestamp and
+        # signature are all still the attacker's. The relay must catch
+        # the sha256 mismatch.
+        frame["from"] = "did:mesh:" + "00" * 16
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(frame)
+            resp = ws.receive_json()
+            assert resp["type"] == "error"
+            assert "sha256 mismatch" in resp["detail"].lower()
+
+    def test_rejects_bad_signature(self):
+        server = RelayServer()
+        client = TestClient(server.app)
+        frame = _connect_frame("victim")
+        frame["signature"] = base64.b64encode(b"\x00" * 64).decode()
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(frame)
+            resp = ws.receive_json()
+            assert resp["type"] == "error"
+
+    def test_rejects_stale_timestamp(self):
+        server = RelayServer()
+        client = TestClient(server.app)
+        sk = _key_for("late")
+        pk = sk.verify_key.encode()
+        old_ts = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        sig = sk.sign(old_ts.encode()).signature
+        frame = {
+            "v": 1, "type": "connect",
+            "from": f"did:mesh:{hashlib.sha256(pk).hexdigest()[:32]}",
+            "public_key": base64.b64encode(pk).decode(),
+            "timestamp": old_ts,
+            "signature": base64.b64encode(sig).decode(),
+        }
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(frame)
+            resp = ws.receive_json()
+            assert resp["type"] == "error"
+            assert "replay" in resp["detail"].lower()
+
+    def test_valid_pop_succeeds(self):
+        server = RelayServer()
+        client = TestClient(server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(_connect_frame("legit"))
+            # Heartbeat round-trip proves the socket is still open.
+            ws.send_json({"v": 1, "type": "heartbeat", "from": _did_for("legit")})


### PR DESCRIPTION
## Description

Tightens trust boundaries across AgentMesh after a security review flagged six unauthenticated / spoofable trust paths, plus a follow-up sweep that found three more in the same class. All flagged endpoints now require proof-of-possession or Ed25519-Timestamp authentication; signing oracles and unknown-DID auto-trust are eliminated.

## Type of Change

- [x] Security fix
- [x] Breaking change (clients that relied on unauthenticated trust paths must now sign requests)

## Package(s) Affected

- [x] agent-mesh

## Changes

| File | What changed |
|------|--------------|
| `src/agentmesh/trust/capability.py` | `CapabilityRegistry.grant()` gained `require_grantor_capability=True` so a grantor must already hold the capability before delegating; self-grants raise `ValueError`. |
| `src/agentmesh/server/trust_engine.py` | `POST /api/v1/capabilities/grant` now requires `Ed25519-Timestamp` auth; `from_agent` is derived from the authenticated DID — body field removed. New `_verify_ed25519_timestamp()` helper. |
| `src/agentmesh/relay/app.py` | WebSocket connect frames now require POP: `public_key` + signed `timestamp`, and `did == did:mesh:sha256(pk)[:32]`. 5-minute replay window. Escape hatch: `AGENTMESH_RELAY_ALLOW_UNAUTHED_DID=1` (dev only, with warning). |
| `src/agentmesh/registry/app.py` | `DELETE /v1/agents/{did}` requires Ed25519-Timestamp owner auth. `POST /v1/agents/{did}/heartbeat` requires auth + `authed_did == did`. `POST /v1/agents/{did}/reputation` requires auth + rejects self-reporting. `POST /v1/registry/reputation/session` requires auth + `authed_did == reporter_amid`. |
| `services/api/src/middleware/apiKey.ts` | Attaches authenticated `AgentRecord` to `req.agent`; rejects suspended/revoked agents at the middleware layer. |
| `services/api/src/routes/handshake.ts` | Ignores body `agent_did`; signer is now bound to `req.agent.did`. Signs a domain-separated envelope `agentmesh-handshake-v1\n{did}\n{nonce}\n{ts}\n{sha256(challenge)}` instead of the raw challenge (eliminates signing oracle). 256-char challenge cap. |
| `services/api/src/types.ts` | Extends `HandshakeResponse` with `signing_domain`, `agent_did`, `server_nonce`, `server_timestamp`, `challenge_digest` so clients can reconstruct + verify. |
| `packages/mcp-trust-server/src/mcp_trust_server/server.py` | Unknown DIDs now start at score `0` / `untrusted` (was `500` / `standard`, which auto-cleared the trust threshold). `check_trust` and `verify_delegation` return `trusted=False` for unknown DIDs; only `record_interaction` flips `known=True`. |
| `src/agentmesh/server/audit_collector.py`, `policy_server.py` | Inline `SECURITY (known gap)` docstrings on `POST /audit/log`, `/audit/batch`, `/policy/evaluate` — these accept `agent_did` from the body without auth. They live in separate services without direct registry access, so the fix needs cross-service auth plumbing (deploy behind an authenticating gateway). Documented, not fixed in this PR to keep scope focused. |
| `tests/test_relay.py` | All connect frames in existing tests rewritten to sign POP; new `TestRelayDIDProofOfPossession` (5 tests) covers missing fields, key/DID mismatch, bad signature, stale timestamp, valid POP. |
| `tests/test_registry.py` | Existing DELETE/heartbeat/reputation tests rewritten with auth; new auth + ownership regression tests on DELETE, heartbeat, per-agent reputation, and session reputation. |
| `tests/test_registration_auth.py` | New `TestCapabilityGrantRejectsUnauthenticated` class — 4 tests covering no-auth, grantor-lacks-capability, valid delegation, body-spoofed `from_agent`. |
| `services/api/tests/api.test.ts` | New regression tests "binds signer to API key (signing oracle regression)" and "signs domain-separated envelope, not raw challenge". |
| `packages/mcp-trust-server/tests/test_server.py` | Updated `TestCheckTrust` / `TestVerifyDelegation` / `TestRecordInteraction` to match unknown-DID semantics. |

## Trust-boundary changes (breaking)

- **Relay**: legacy `did:agentmesh:` opaque DIDs are rejected. Clients must sign connect frames.
- **Registry DELETE / heartbeat / reputation / session-reputation**: must send `Ed25519-Timestamp` and (where relevant) match the authenticated identity to the target.
- **Capability grant**: body `from_agent` is ignored; grantor derived from auth header; grantor must already hold the capability.
- **TS handshake**: body `agent_did` is ignored; signer is the API-key holder. Verifiers must reconstruct the structured envelope from the new response fields — raw-challenge verification will fail.
- **MCP trust server**: unknown DIDs no longer auto-trusted. Callers depending on the old default must record an interaction first.

## Testing

- `pytest tests/test_relay.py tests/test_registry.py tests/test_registration_auth.py tests/test_server.py packages/mcp-trust-server/tests/test_server.py` → **119 passed**.
- `npm test` in `services/api` → **10/10 passed** including the two new signing-oracle regressions.
- `ruff check` on all touched files → clean.
- Pre-existing failures in `test_crewai_integration.py`, `test_grpc_transport.py`, `test_prometheus_*` are unrelated (missing optional deps / unimplemented stubs) and untouched.

## Attribution & Prior Art

- [x] No copied code; all fixes follow patterns already present in this repo (`verify_ed25519_timestamp_auth` in registry, `_verify_connect_pop` in relay).

## AI Assistance

GitHub Copilot CLI (Claude Opus 4.7) authored the fixes and tests under direct review.

## IP, Patents, and Licensing

- [x] MIT-compatible; no patent-encumbered techniques or NDA-gated content.