### PR TITLE
fix(security): harden JWKS/revocation trust-fetch and URL allowlist matching

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/external_jwks.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/external_jwks.py
@@ -168,7 +168,16 @@ class ExternalJWKSProvider:
             return None
 
         revocation_url = self._revocation_url_for(endpoint, payload)
+        if revocation_url is None:
+            # Override URL failed validation (different host, non-https,
+            # or unparseable). Fail closed rather than fall back silently.
+            return None
         revoked = await self._get_revocation_list(revocation_url)
+        if revoked is None:
+            # Revocation fetch failed (network error, 5xx, malformed body).
+            # Fail closed — accepting a token whose revocation status we
+            # cannot determine would let revoked credentials pass.
+            return None
         if kid in revoked:
             return None
 
@@ -217,23 +226,71 @@ class ExternalJWKSProvider:
             return False
 
     @staticmethod
-    def _revocation_url_for(endpoint: TrustedEndpoint, verified_payload: dict) -> str:
+    def _normalize_host(host: Optional[str]) -> Optional[str]:
+        """Lowercase a hostname and strip a trailing dot.
+
+        Returns None for empty/None inputs so callers can fail closed.
+        """
+        if not host:
+            return None
+        normalized = host.strip().lower()
+        if normalized.endswith("."):
+            normalized = normalized[:-1]
+        return normalized or None
+
+    @classmethod
+    def _safe_host_from_url(cls, value: str) -> Optional[str]:
+        """Extract a normalized hostname from a URL or bare host string.
+
+        Uses urlparse's `.hostname` property so userinfo (`user@host`) and
+        ports are excluded. Returns None for inputs that don't yield a
+        parseable host so callers fail closed instead of fetching from
+        `https:///...` or attacker-controlled netloc tricks.
+        """
+        if not value or not isinstance(value, str):
+            return None
+        candidate = value if "://" in value else f"https://{value}"
+        try:
+            parsed = urlparse(candidate)
+        except ValueError:
+            return None
+        return cls._normalize_host(parsed.hostname)
+
+    @classmethod
+    def _revocation_url_for(
+        cls, endpoint: TrustedEndpoint, verified_payload: dict
+    ) -> Optional[str]:
         """Return revocation URL, preferring a verified claim override.
 
-        Override is taken only from the already-signature-verified payload,
-        not from unverified token contents, to prevent attackers steering
-        verifiers at attacker-controlled URLs. Default URL is derived by
-        rewriting the JWKS URL's path filename — robust against query
-        strings, fragments, and non-standard JWKS URL shapes.
+        Override is taken only from the already-signature-verified payload.
+        Even then, the override is constrained to the same scheme (https)
+        and host as the trusted JWKS endpoint — this prevents a malicious
+        or compromised issuer from steering verifiers at attacker-controlled
+        or internal (SSRF) URLs.
+
+        Returns None when the override is present but fails validation,
+        signalling the caller to fail the verification closed rather than
+        silently falling back to a default URL.
         """
         delegation = verified_payload.get("delegation_claims") or {}
         override = delegation.get("revocation_check_url")
+        jwks_host = cls._safe_host_from_url(str(endpoint.jwks_url))
         if override:
-            return str(override)
+            override_str = str(override)
+            try:
+                parsed_override = urlparse(override_str)
+            except ValueError:
+                return None
+            override_host = cls._normalize_host(parsed_override.hostname)
+            if (
+                parsed_override.scheme != "https"
+                or not override_host
+                or jwks_host is None
+                or override_host != jwks_host
+            ):
+                return None
+            return override_str
         parsed = urlparse(str(endpoint.jwks_url))
-        # Replace only the final path segment if it ends in jwks.json; else
-        # append the revocation filename to the path. Preserves scheme,
-        # netloc, params, query, and fragment.
         path = parsed.path
         if path.endswith("/jwks.json"):
             new_path = path[: -len("/jwks.json")] + "/jwks-revoked.json"
@@ -242,10 +299,16 @@ class ExternalJWKSProvider:
         return urlunparse(parsed._replace(path=new_path))
 
     def _resolve_endpoint(self, iss: str) -> Optional[TrustedEndpoint]:
-        domain = urlparse(iss if "://" in iss else f"https://{iss}").netloc
+        domain = self._safe_host_from_url(iss)
+        if domain is None:
+            return None
         for endpoint in self._policy.trusted_endpoints:
-            if endpoint.domain == domain:
+            if self._normalize_host(endpoint.domain) == domain:
                 return endpoint
+        # TOFU/open construct a JWKS URL from the issuer claim. Only the
+        # parsed hostname is reused — never raw `iss` substrings — so
+        # crafted values like "attacker.com/path" or "user@trusted.com"
+        # cannot smuggle a different netloc into the fetch URL.
         if self._policy.unknown_endpoint_policy == "tofu":
             return TrustedEndpoint(
                 domain=domain,
@@ -286,13 +349,22 @@ class ExternalJWKSProvider:
         except (httpx.HTTPError, ValueError):
             return None
 
-    async def _get_revocation_list(self, revocation_url: str) -> set[str]:
+    async def _get_revocation_list(self, revocation_url: str) -> Optional[set[str]]:
+        """Return the revocation set for `revocation_url`.
+
+        Returns:
+            - A (possibly empty) set of revoked kids on success or 404.
+            - None on transport/parse failure, signalling callers to fail
+              closed instead of treating "fetch failed" as "no revocations".
+        """
         async with self._cache_lock:
             entry = self._revocation_cache.get(revocation_url)
             if entry and entry.expires_at > time.monotonic():
                 return entry.value  # type: ignore[return-value]
 
         revoked = await self._fetch_revocation_list(revocation_url)
+        if revoked is None:
+            return None
         async with self._cache_lock:
             self._revocation_cache[revocation_url] = _CacheEntry(
                 value=revoked,
@@ -300,7 +372,15 @@ class ExternalJWKSProvider:
             )
         return revoked
 
-    async def _fetch_revocation_list(self, revocation_url: str) -> set[str]:
+    async def _fetch_revocation_list(self, revocation_url: str) -> Optional[set[str]]:
+        """Fetch a revocation list. Returns None on failure (fail closed).
+
+        A 404 is treated as "no revocation list published yet" and yields
+        an empty set, matching the design where issuers may bootstrap
+        without one. Any other transport or parse failure returns None so
+        the caller can deny the token rather than treat the absence of
+        signal as a positive signal.
+        """
         try:
             async with httpx.AsyncClient(timeout=self._http_timeout) as client:
                 resp = await client.get(revocation_url)
@@ -309,8 +389,8 @@ class ExternalJWKSProvider:
             resp.raise_for_status()
             data = resp.json()
             return {entry["kid"] for entry in data.get("revoked", [])}
-        except (httpx.HTTPError, KeyError, ValueError):
-            return set()
+        except (httpx.HTTPError, KeyError, ValueError, TypeError):
+            return None
 
     def _build_identity(
         self, payload: dict, endpoint: TrustedEndpoint

--- a/agent-governance-python/agent-mesh/tests/test_external_jwks.py
+++ b/agent-governance-python/agent-mesh/tests/test_external_jwks.py
@@ -309,3 +309,186 @@ def test_delegation_claims_accepts_dict_for_backwards_compat():
     assert claims.liveness_attestation_ref == "hb-1"
     assert claims.policy_context_id == "ctx-1"
     assert claims.revocation_check_url is None
+
+
+# ---------------------------------------------------------------------------
+# Security regressions — URL / trust-fetch hardening
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_revocation_url_override_on_different_host():
+    """A signed override pointing at a different host must be rejected.
+
+    Even though the override is inside the signature-verified payload, an
+    issuer (or attacker holding the issuer's key) must not be able to
+    steer verifiers at attacker-controlled or internal SSRF targets.
+    """
+    private_key, jwk = _make_keypair()
+    now = int(time.time())
+    payload = {
+        "iss": PARTNER_DOMAIN,
+        "sub": "x",
+        "exp": now + 900,
+        "delegation_claims": {
+            "revocation_check_url": "https://attacker.example.org/revoked.json",
+        },
+    }
+    token = _sign_jwt(private_key, payload)
+
+    fetched_urls: list[str] = []
+
+    async def tracking_get(self, url, *args, **kwargs):
+        fetched_urls.append(url)
+        request = httpx.Request("GET", url)
+        if "jwks.json" in url and "attacker" not in url:
+            return httpx.Response(200, json={"keys": [jwk]}, request=request)
+        return httpx.Response(200, json={"revoked": []}, request=request)
+
+    provider = ExternalJWKSProvider(policy=_make_policy())
+    with patch.object(httpx.AsyncClient, "get", tracking_get):
+        identity = await provider.verify(token)
+
+    assert identity is None
+    assert not any("attacker.example.org" in u for u in fetched_urls)
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_revocation_url_override_with_non_https_scheme():
+    private_key, jwk = _make_keypair()
+    now = int(time.time())
+    payload = {
+        "iss": PARTNER_DOMAIN,
+        "sub": "x",
+        "exp": now + 900,
+        "delegation_claims": {
+            # Same host but http:// must be rejected — downgrade attack.
+            "revocation_check_url": f"http://{PARTNER_DOMAIN}/custom/revoked.json",
+        },
+    }
+    token = _sign_jwt(private_key, payload)
+    provider = ExternalJWKSProvider(policy=_make_policy())
+    with patch.object(httpx.AsyncClient, "get", _http_mock({"keys": [jwk]})):
+        identity = await provider.verify(token)
+    assert identity is None
+
+
+@pytest.mark.asyncio
+async def test_verify_fails_closed_when_revocation_fetch_errors():
+    """Network/HTTP failures on revocation lookup must deny, not allow."""
+    private_key, jwk = _make_keypair()
+    now = int(time.time())
+    payload = {"iss": PARTNER_DOMAIN, "sub": "x", "exp": now + 900}
+    token = _sign_jwt(private_key, payload)
+
+    async def failing_get(self, url, *args, **kwargs):
+        request = httpx.Request("GET", url)
+        if "jwks-revoked.json" in url:
+            return httpx.Response(500, request=request)
+        if "jwks.json" in url:
+            return httpx.Response(200, json={"keys": [jwk]}, request=request)
+        return httpx.Response(404, request=request)
+
+    provider = ExternalJWKSProvider(policy=_make_policy())
+    with patch.object(httpx.AsyncClient, "get", failing_get):
+        identity = await provider.verify(token)
+    assert identity is None
+
+
+@pytest.mark.asyncio
+async def test_verify_fails_closed_when_revocation_body_malformed():
+    private_key, jwk = _make_keypair()
+    now = int(time.time())
+    payload = {"iss": PARTNER_DOMAIN, "sub": "x", "exp": now + 900}
+    token = _sign_jwt(private_key, payload)
+
+    async def bad_body_get(self, url, *args, **kwargs):
+        request = httpx.Request("GET", url)
+        if "jwks-revoked.json" in url:
+            return httpx.Response(200, text="not-json", request=request)
+        if "jwks.json" in url:
+            return httpx.Response(200, json={"keys": [jwk]}, request=request)
+        return httpx.Response(404, request=request)
+
+    provider = ExternalJWKSProvider(policy=_make_policy())
+    with patch.object(httpx.AsyncClient, "get", bad_body_get):
+        identity = await provider.verify(token)
+    assert identity is None
+
+
+@pytest.mark.asyncio
+async def test_verify_revocation_404_still_allows_token():
+    """A 404 on the revocation endpoint means 'no list published' — allow."""
+    private_key, jwk = _make_keypair()
+    now = int(time.time())
+    payload = {"iss": PARTNER_DOMAIN, "sub": "x", "exp": now + 900}
+    token = _sign_jwt(private_key, payload)
+    provider = ExternalJWKSProvider(policy=_make_policy())
+    with patch.object(httpx.AsyncClient, "get", _http_mock({"keys": [jwk]})):
+        identity = await provider.verify(token)
+    assert identity is not None
+
+
+@pytest.mark.asyncio
+async def test_verify_tofu_strips_userinfo_from_issuer_claim():
+    """`iss` with embedded userinfo must not redirect JWKS fetch.
+
+    Without `.hostname`-based parsing, `attacker.com@trusted.com` would
+    end up as a netloc that fools naive matchers. We must fetch from
+    `trusted.com` (the actual host), and the trust tier remains 'tofu'.
+    """
+    private_key, jwk = _make_keypair()
+    now = int(time.time())
+    target_host = "victim-tenant.example.com"
+    payload = {
+        "iss": f"https://attacker.example.org@{target_host}",
+        "sub": f"did:web:{target_host}",
+        "exp": now + 900,
+    }
+    token = _sign_jwt(private_key, payload)
+
+    fetched_urls: list[str] = []
+
+    async def tracking_get(self, url, *args, **kwargs):
+        fetched_urls.append(url)
+        request = httpx.Request("GET", url)
+        if "jwks.json" in url:
+            return httpx.Response(200, json={"keys": [jwk]}, request=request)
+        return httpx.Response(404, request=request)
+
+    provider = ExternalJWKSProvider(policy=_make_policy(unknown="tofu"))
+    with patch.object(httpx.AsyncClient, "get", tracking_get):
+        identity = await provider.verify(token)
+
+    assert identity is not None
+    assert identity.issuer_domain == target_host
+    # No request should have been issued to the attacker-controlled host.
+    assert not any("attacker.example.org" in u for u in fetched_urls)
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_issuer_with_no_parseable_host():
+    private_key, jwk = _make_keypair()
+    now = int(time.time())
+    payload = {"iss": "://", "sub": "x", "exp": now + 900}
+    token = _sign_jwt(private_key, payload)
+    provider = ExternalJWKSProvider(policy=_make_policy(unknown="tofu"))
+    with patch.object(httpx.AsyncClient, "get", _http_mock({"keys": [jwk]})):
+        identity = await provider.verify(token)
+    assert identity is None
+
+
+def test_resolve_endpoint_matches_trusted_domain_case_insensitively():
+    policy = FederationPolicy(
+        trusted_endpoints=[
+            TrustedEndpoint(
+                domain="Partner-Corp.Example.com",
+                jwks_url=PARTNER_JWKS_URL,
+                trust_tier="verified_partner",
+            )
+        ],
+    )
+    provider = ExternalJWKSProvider(policy=policy)
+    endpoint = provider._resolve_endpoint("partner-corp.example.com")
+    assert endpoint is not None
+    assert endpoint.trust_tier == "verified_partner"

--- a/agent-governance-python/agent-os/modules/atr/atr/tools/safe/http_client.py
+++ b/agent-governance-python/agent-os/modules/atr/atr/tools/safe/http_client.py
@@ -138,9 +138,16 @@ class HttpClientTool:
         if self._is_private_domain(domain):
             raise ValueError(f"Private/internal domains not allowed: {domain}")
         
-        # Check allowed domains (if whitelist set)
+        # Check allowed domains (if whitelist set). Use DNS-aware suffix
+        # matching: exact host or proper subdomain only. A naive
+        # `domain.endswith(allowed)` lets `evil-example.com` bypass an
+        # allowlist of `example.com`, and lets `attacker.com` match
+        # `er.com`. Both are SSRF/exfil vectors.
         if self.allowed_domains:
-            if not any(domain.endswith(allowed) for allowed in self.allowed_domains):
+            if not any(
+                domain == allowed.lower() or domain.endswith("." + allowed.lower())
+                for allowed in self.allowed_domains
+            ):
                 raise ValueError(
                     f"Domain '{domain}' not in allowed list. "
                     f"Allowed: {', '.join(self.allowed_domains)}"

--- a/agent-governance-python/agent-os/modules/control-plane/src/agent_control_plane/policy_engine.py
+++ b/agent-governance-python/agent-os/modules/control-plane/src/agent_control_plane/policy_engine.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Optional, Callable, Any, Tuple
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from types import MappingProxyType  # noqa: F401 — reserved for future immutable dict enforcement
+from urllib.parse import urlparse
 from .agent_kernel import ExecutionRequest, ActionType, PolicyRule
 import logging
 import uuid
@@ -33,6 +34,52 @@ import warnings
 logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)
+
+
+_VALID_HOSTNAME_RE = re.compile(r"^(?=.{1,253}$)[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?)*$")
+
+
+def _extract_host(value: Any) -> Optional[str]:
+    """Parse a URL or bare host string to a normalized hostname.
+
+    Uses urlparse's `.hostname` property so userinfo (`user@host`) and
+    explicit ports are excluded. Returns None when no host can be parsed
+    or when the result is not a syntactically valid DNS name, so callers
+    can fail closed instead of doing substring matches on attacker-
+    supplied strings.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    try:
+        parsed = urlparse(candidate if "://" in candidate else f"//{candidate}", scheme="")
+    except ValueError:
+        return None
+    host = parsed.hostname
+    if not host:
+        return None
+    host = host.lower()
+    if host.endswith("."):
+        host = host[:-1]
+    if not host or not _VALID_HOSTNAME_RE.match(host):
+        return None
+    return host
+
+
+def _host_matches(host: str, rule: str) -> bool:
+    """True if `host` equals `rule` or is a proper subdomain of `rule`.
+
+    Rule is normalized the same way as a parsed host (lowercased,
+    trailing dot stripped, port and userinfo discarded via `_extract_host`).
+    Substring matching is deliberately avoided — "evil.com" must not
+    match "safe-evil.com" or "safe.com/path?evil.com".
+    """
+    rule_host = _extract_host(rule)
+    if rule_host is None:
+        return False
+    return host == rule_host or host.endswith("." + rule_host)
 
 
 @dataclass
@@ -557,17 +604,28 @@ class PolicyEngine:
             # Check domain restrictions if applicable
             if "url" in request.parameters or "domain" in request.parameters:
                 url = request.parameters.get("url", request.parameters.get("domain", ""))
+                host = _extract_host(url)
 
-                # Check blocked domains
+                # If the request advertises a URL/domain we cannot parse a
+                # hostname out of, fail closed — substring matching on raw
+                # strings is unsafe and the policy intent here is allow/deny
+                # by host, not by arbitrary text.
+                if host is None:
+                    return False
+
+                # Check blocked domains: exact host match or proper subdomain.
+                # Substring matching is unsafe — "evil.com" would otherwise
+                # match "https://safe.com/?ref=evil.com" or be evaded by
+                # "https://safe-evil.com.attacker/".
                 for blocked in policy.blocked_domains:
-                    if blocked in url:
+                    if _host_matches(host, blocked):
                         return False
 
                 # Check allowed domains (if list is not empty, only allow listed domains)
                 if policy.allowed_domains:
                     allowed = False
                     for allowed_domain in policy.allowed_domains:
-                        if allowed_domain in url:
+                        if _host_matches(host, allowed_domain):
                             allowed = True
                             break
                     if not allowed:

--- a/agent-governance-python/agent-os/modules/control-plane/tests/test_policy_engine_url_validation.py
+++ b/agent-governance-python/agent-os/modules/control-plane/tests/test_policy_engine_url_validation.py
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""URL/domain validation tests for the PolicyEngine risk policies.
+
+These tests pin the security-review fixes that replaced substring-based
+domain matching with parsed, normalized hostname checks. Bypass cases
+from the original implementation are captured explicitly so regressions
+fail loudly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+
+from agent_control_plane.agent_kernel import (
+    ActionType,
+    AgentContext,
+    ExecutionRequest,
+)
+from agent_control_plane.policy_engine import (
+    PolicyEngine,
+    RiskPolicy,
+    _extract_host,
+    _host_matches,
+)
+
+
+def _make_request(parameters: dict) -> ExecutionRequest:
+    return ExecutionRequest(
+        request_id=str(uuid.uuid4()),
+        agent_context=AgentContext(
+            agent_id="test-agent",
+            session_id="sess-1",
+            created_at=datetime.utcnow(),
+        ),
+        action_type=ActionType.API_CALL,
+        parameters=parameters,
+        timestamp=datetime.utcnow(),
+    )
+
+
+def _engine_with_policy(policy: RiskPolicy) -> PolicyEngine:
+    engine = PolicyEngine()
+    engine.risk_policies["default"] = policy
+    return engine
+
+
+# --- _extract_host / _host_matches unit cases -------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("https://example.com/path?q=1", "example.com"),
+        ("https://Example.COM:8443/x", "example.com"),
+        ("example.com", "example.com"),
+        ("example.com.", "example.com"),
+        ("user:pass@example.com", "example.com"),
+        ("https://user@evil.com@trusted.com/x", "trusted.com"),
+        ("", None),
+        (None, None),
+        ("://", None),
+        ("not a url", None),
+        (12345, None),
+    ],
+)
+def test_extract_host(value, expected):
+    assert _extract_host(value) == expected
+
+
+@pytest.mark.parametrize(
+    "host,rule,expected",
+    [
+        ("example.com", "example.com", True),
+        ("api.example.com", "example.com", True),
+        ("example.com", "api.example.com", False),
+        ("evil-example.com", "example.com", False),
+        ("safe.com", "evil.com", False),
+        ("example.com.attacker.io", "example.com", False),
+        ("example.com", "Example.COM", True),
+    ],
+)
+def test_host_matches(host, rule, expected):
+    assert _host_matches(host, rule) is expected
+
+
+# --- PolicyEngine.validate_risk: blocked domains ----------------------------
+
+
+def test_blocked_domain_does_not_match_via_substring_in_query():
+    """Regression: 'evil.com' must not match 'https://safe.com/?ref=evil.com'."""
+    engine = _engine_with_policy(RiskPolicy(blocked_domains=["evil.com"]))
+    request = _make_request({"url": "https://safe.com/?ref=evil.com"})
+    assert engine.validate_risk(request, risk_score=0.1) is True
+
+
+def test_blocked_domain_does_not_match_lookalike_hostname():
+    """Regression: 'evil.com' must not match 'https://safe-evil.com/'."""
+    engine = _engine_with_policy(RiskPolicy(blocked_domains=["evil.com"]))
+    request = _make_request({"url": "https://safe-evil.com/path"})
+    assert engine.validate_risk(request, risk_score=0.1) is True
+
+
+def test_blocked_domain_blocks_exact_host():
+    engine = _engine_with_policy(RiskPolicy(blocked_domains=["evil.com"]))
+    request = _make_request({"url": "https://evil.com/payload"})
+    assert engine.validate_risk(request, risk_score=0.1) is False
+
+
+def test_blocked_domain_blocks_subdomain():
+    engine = _engine_with_policy(RiskPolicy(blocked_domains=["evil.com"]))
+    request = _make_request({"url": "https://api.evil.com/payload"})
+    assert engine.validate_risk(request, risk_score=0.1) is False
+
+
+# --- PolicyEngine.validate_risk: allowed domains ----------------------------
+
+
+def test_allowed_domain_does_not_match_lookalike_hostname():
+    """Regression: allowed='good.com' must not permit 'attacker-good.com.evil/'."""
+    engine = _engine_with_policy(RiskPolicy(allowed_domains=["good.com"]))
+    request = _make_request({"url": "https://attacker-good.com.evil/"})
+    assert engine.validate_risk(request, risk_score=0.1) is False
+
+
+def test_allowed_domain_does_not_match_substring_in_path():
+    engine = _engine_with_policy(RiskPolicy(allowed_domains=["good.com"]))
+    request = _make_request({"url": "https://attacker.io/redirect?to=good.com"})
+    assert engine.validate_risk(request, risk_score=0.1) is False
+
+
+def test_allowed_domain_permits_exact_host():
+    engine = _engine_with_policy(RiskPolicy(allowed_domains=["good.com"]))
+    request = _make_request({"url": "https://good.com/api"})
+    assert engine.validate_risk(request, risk_score=0.1) is True
+
+
+def test_allowed_domain_permits_subdomain():
+    engine = _engine_with_policy(RiskPolicy(allowed_domains=["good.com"]))
+    request = _make_request({"url": "https://api.good.com/v1"})
+    assert engine.validate_risk(request, risk_score=0.1) is True
+
+
+def test_allowlist_denies_unparseable_url_value():
+    """Fail closed when an allowlist is configured but the URL is junk."""
+    engine = _engine_with_policy(RiskPolicy(allowed_domains=["good.com"]))
+    request = _make_request({"url": "not a url at all"})
+    assert engine.validate_risk(request, risk_score=0.1) is False
+
+
+def test_blocklist_denies_unparseable_url_value():
+    """Fail closed for unparseable URLs even when only a blocklist is set."""
+    engine = _engine_with_policy(RiskPolicy(blocked_domains=["evil.com"]))
+    request = _make_request({"url": "not a url at all"})
+    assert engine.validate_risk(request, risk_score=0.1) is False
+
+
+def test_bare_domain_parameter_is_validated():
+    engine = _engine_with_policy(RiskPolicy(allowed_domains=["good.com"]))
+    request = _make_request({"domain": "api.good.com"})
+    assert engine.validate_risk(request, risk_score=0.1) is True
+
+
+def test_userinfo_in_url_does_not_bypass_allowlist():
+    """Regression: 'good.com@evil.com' must resolve to host 'evil.com'."""
+    engine = _engine_with_policy(RiskPolicy(allowed_domains=["good.com"]))
+    request = _make_request({"url": "https://good.com@evil.com/"})
+    assert engine.validate_risk(request, risk_score=0.1) is False

--- a/agent-governance-python/agent-os/tests/test_http_client_url_validation.py
+++ b/agent-governance-python/agent-os/tests/test_http_client_url_validation.py
@@ -50,7 +50,10 @@ class _MinimalHttpClient:
             raise ValueError(f"Private/internal domains not allowed: {domain}")
 
         if self.allowed_domains:
-            if not any(domain.endswith(allowed) for allowed in self.allowed_domains):
+            if not any(
+                domain == allowed.lower() or domain.endswith("." + allowed.lower())
+                for allowed in self.allowed_domains
+            ):
                 raise ValueError(
                     f"Domain '{domain}' not in allowed list. "
                     f"Allowed: {', '.join(self.allowed_domains)}"
@@ -217,6 +220,38 @@ class TestAllowlist:
     def test_port_does_not_affect_domain_check(self, allowlist_client):
         url = "https://example.com:8443/secure"
         assert allowlist_client._validate_url(url) == url
+
+    # --- Substring-bypass regressions -------------------------------------
+
+    def test_lookalike_suffix_rejected(self, allowlist_client):
+        """Regression: 'example.com' allowlist must not admit 'evil-example.com'.
+
+        The previous `domain.endswith(allowed)` check would accept any
+        domain that happens to end with the allowed string, including
+        attacker-controlled lookalikes like `evil-example.com` or
+        `attacker.example.com.evil`.
+        """
+        with pytest.raises(ValueError, match="not in allowed list"):
+            allowlist_client._validate_url("https://evil-example.com/payload")
+
+    def test_lookalike_prefix_rejected(self, allowlist_client):
+        with pytest.raises(ValueError, match="not in allowed list"):
+            allowlist_client._validate_url("https://example.com.attacker.io/x")
+
+    def test_short_suffix_does_not_match_unrelated_tld(self):
+        """Allowlist 'er.com' must NOT match 'attacker.com'."""
+        client = _MinimalHttpClient(allowed_domains=["er.com"])
+        with pytest.raises(ValueError, match="not in allowed list"):
+            client._validate_url("https://attacker.com/x")
+        # And it SHOULD match the exact host:
+        assert client._validate_url("https://er.com/x") == "https://er.com/x"
+
+    def test_allowlist_match_is_case_insensitive(self):
+        client = _MinimalHttpClient(allowed_domains=["Example.COM"])
+        assert (
+            client._validate_url("https://api.example.com/x")
+            == "https://api.example.com/x"
+        )
 
 
 class TestEmptyHostname:


### PR DESCRIPTION
## Description

Two related classes of trust-fetch / URL-validation bugs surfaced in the security review.

**1. `agent-mesh/identity/external_jwks` — JWKS / revocation trust-fetch**

- Issuer/JWKS host parsing used `urlparse(...).netloc`, which includes userinfo and ports. An `iss` like `https://attacker.example.org@victim-tenant.example.com` could (in TOFU/open mode) cause the verifier to construct a JWKS URL that points at the wrong host, depending on downstream logic.
- The signed `delegation_claims.revocation_check_url` override was used verbatim. An issuer (or anyone holding the issuer's signing key) could point the verifier at an attacker-controlled or internal URL — SSRF and an "always allow" revocation oracle.
- Revocation fetch failures (network errors, 5xx, malformed JSON) were silently swallowed and treated as "no revocations" — a revoked credential could be accepted whenever revocation lookup happened to fail.

**2. `agent-os/control-plane/policy_engine` and `agent-os/atr/tools/safe/http_client` — URL allowlist/blocklist matching**

- `policy_engine.validate_risk` used `if blocked in url` / `if allowed in url`. This means:
  - blocklist `evil.com` "matches" `https://safe.com/?ref=evil.com` (false positive on benign URL)
  - allowlist `good.com` admits `https://attacker-good.com.evil/` (false negative on attacker URL)
- `safe/http_client._validate_url` used `domain.endswith(allowed)`:
  - allowlist `example.com` admits `evil-example.com`
  - allowlist `er.com` admits `attacker.com`
  - Both are SSRF / exfil vectors.

## Type of Change

- [x] Security fix

## Package(s) Affected

- [x] agent-mesh
- [x] agent-os-kernel (`agent-os/modules/control-plane`, `agent-os/modules/atr`)

## Changes

| File | What changed |
|------|--------------|
| `agent-governance-python/agent-mesh/src/agentmesh/identity/external_jwks.py` | Added `_normalize_host` / `_safe_host_from_url` helpers that parse via `urlparse(...).hostname`. `_resolve_endpoint` normalizes trusted-endpoint domains case-insensitively and rejects issuers with no parseable host. `_revocation_url_for` now requires the signed override to share scheme (`https`) AND host with the trusted JWKS URL; returns `None` otherwise. `_get_revocation_list` / `_fetch_revocation_list` return `Optional[set]`; transport/parse failures return `None` and `verify()` denies the token. 404 still treated as "no list published" and allows. |
| `agent-governance-python/agent-mesh/tests/test_external_jwks.py` | +8 regression tests: revocation override on different host, http-scheme downgrade, revocation fetch 5xx / malformed body fail-closed, 404 still allows, TOFU userinfo strip, unparseable issuer denied, case-insensitive trusted-domain match. |
| `agent-governance-python/agent-os/modules/control-plane/src/agent_control_plane/policy_engine.py` | Added `_extract_host` (urlparse.hostname + DNS-name regex) and `_host_matches` (exact host OR proper subdomain). `validate_risk` now parses the URL/domain parameter; unparseable values fail closed when any allow- or block-list is configured. |
| `agent-governance-python/agent-os/modules/control-plane/tests/test_policy_engine_url_validation.py` | New file. 18 tests: helper unit cases plus end-to-end `validate_risk` substring-bypass regressions (querystring substrings, lookalike hostnames, userinfo bypass, unparseable URL fail-closed, exact-host and subdomain accept). |
| `agent-governance-python/agent-os/modules/atr/atr/tools/safe/http_client.py` | Replaced `domain.endswith(allowed)` with `domain == allowed.lower() OR domain.endswith("." + allowed.lower())`. |
| `agent-governance-python/agent-os/tests/test_http_client_url_validation.py` | Mirror the impl change in the in-test minimal client + 4 new regressions covering the lookalike-suffix / short-TLD / case-insensitive cases. |

## Testing

- `pytest agent-governance-python/agent-mesh/tests/test_external_jwks.py` → **20 passed**
- `pytest agent-governance-python/agent-os/modules/control-plane/tests/test_policy_engine_url_validation.py tests/test_control_plane.py` → **43 passed** (all pre-existing tests still green)
- `pytest agent-governance-python/agent-os/tests/test_http_client_url_validation.py` → **33 passed**
- `ruff check --select E,F,W --ignore E501` on touched files → no new errors (8 reported are pre-existing in unchanged regions).

## Behavioral changes (operator-visible)

- **Fail-closed on revocation lookup.** Verifications that previously succeeded when the revocation endpoint returned 5xx / network errors / malformed JSON now deny the token. 404 is still "no list published" → allow.
- **Revocation override constrained.** A `delegation_claims.revocation_check_url` pointing at a different host or non-`https` URL is now rejected. Issuers must host revocation on the same hostname as their JWKS endpoint.
- **No public-API signature changes.** Updated private helpers (`_revocation_url_for` → `@classmethod` returning `Optional[str]`; `_get_revocation_list` / `_fetch_revocation_list` → `Optional[set[str]]`).

## Out-of-scope findings (documented, not fixed in this PR)

Sweep surfaced these tangentially-related items. Filing follow-ups rather than expanding scope:

- `agent-os/modules/iatp/iatp/main.py` and `iatp/recovery.py`: `httpx.AsyncClient()` without explicit timeouts.
- `agent-os/modules/nexus/client.py`: `aiohttp.ClientSession()` without timeouts on multiple call sites.
- `agent-mesh/server/api_gateway.py`: `httpx.AsyncClient(..., follow_redirects=True)` on a general-purpose client — consider `False` plus an opt-in per-call.
- `agent-os/services/cloud-board/workers/reputation_sync.py`: webhook broadcast with neither timeout nor URL allowlist validation.
- `agent-compliance/.../supply_chain.py`: PyPI/npm URL construction interpolates package names without `urllib.quote`.

These are correctness/defensive gaps; none of them are the same bug class (signed-vs-unsigned trust mixing or substring URL matching) being fixed here.

## Checklist

- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed — N/A (private API and behavior-tightening only)
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**: None — straightforward hardening using stdlib `urllib.parse.urlparse(...).hostname`. Same-host constraint on signed redirect overrides matches the standard OAuth/OIDC pattern.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot CLI used for change drafting and test scaffolding; every change was reviewed and the test plan was validated end-to-end locally.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

(None linked — internal security-review follow-up.)
