### PR TITLE
chore(scripts): remove hardcoded plugin name and add marketplace sync smoke tests

### DIFF
--- a/agent-governance-claude-code/test/sync-marketplace.test.mjs
+++ b/agent-governance-claude-code/test/sync-marketplace.test.mjs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(
+  new URL("../../scripts/sync-claude-marketplace-version.mjs", import.meta.url),
+);
+
+async function runScript(fixtureRoot, args = []) {
+  return new Promise((resolve) => {
+    const proc = spawn(process.execPath, [scriptPath, ...args], {
+      env: {
+        ...process.env,
+        AGT_TEST_REPO_ROOT: fixtureRoot,
+      },
+      stdio: "pipe",
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout.on("data", (chunk) => { stdout += chunk; });
+    proc.stderr.on("data", (chunk) => { stderr += chunk; });
+    proc.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function buildFixture(root, { version, pluginVersion, marketplaceVersion, omitPlugin = false }) {
+  const claudePlugin = join(root, "agent-governance-claude-code", ".claude-plugin");
+  const marketplaceDir = join(root, ".claude-plugin");
+
+  await mkdir(claudePlugin, { recursive: true });
+  await mkdir(marketplaceDir, { recursive: true });
+
+  await writeFile(
+    join(root, "agent-governance-claude-code", "package.json"),
+    JSON.stringify({ name: "agent-governance-toolkit", version }, null, 2) + "\n",
+  );
+
+  await writeFile(
+    join(claudePlugin, "plugin.json"),
+    JSON.stringify({ name: "agt-governance", version: pluginVersion }, null, 2) + "\n",
+  );
+
+  const plugins = omitPlugin
+    ? []
+    : [{ name: "agt-governance", version: marketplaceVersion }];
+
+  await writeFile(
+    join(marketplaceDir, "marketplace.json"),
+    JSON.stringify({ version: marketplaceVersion, plugins }, null, 2) + "\n",
+  );
+}
+
+test("check mode exits 0 when all versions match", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-mkt-ok-"));
+  try {
+    await buildFixture(root, {
+      version: "1.2.3",
+      pluginVersion: "1.2.3",
+      marketplaceVersion: "1.2.3",
+    });
+    const { code, stdout } = await runScript(root, ["--check"]);
+    assert.equal(code, 0, `expected exit 0, got ${code}`);
+    assert.match(stdout, /OK/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("check mode exits non-zero when marketplace.json version drifts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-mkt-drift-"));
+  try {
+    await buildFixture(root, {
+      version: "1.2.3",
+      pluginVersion: "1.2.3",
+      marketplaceVersion: "1.0.0",
+    });
+    const { code, stderr } = await runScript(root, ["--check"]);
+    assert.notEqual(code, 0, "expected non-zero exit when marketplace version drifts");
+    assert.match(stderr, /out of sync/i);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("check mode exits non-zero when plugin entry is missing from marketplace.json", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-mkt-missing-"));
+  try {
+    await buildFixture(root, {
+      version: "1.2.3",
+      pluginVersion: "1.2.3",
+      marketplaceVersion: "1.2.3",
+      omitPlugin: true,
+    });
+    const { code, stderr } = await runScript(root, ["--check"]);
+    assert.notEqual(code, 0, "expected non-zero exit when plugin entry is absent");
+    assert.match(stderr, /missing plugin entry/i);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("sync mode writes updated versions without check flag", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-mkt-sync-"));
+  try {
+    await buildFixture(root, {
+      version: "2.0.0",
+      pluginVersion: "1.0.0",
+      marketplaceVersion: "1.0.0",
+    });
+    const { code } = await runScript(root, []);
+    assert.equal(code, 0, `sync mode should exit 0, got ${code}`);
+
+    const { readFile } = await import("node:fs/promises");
+    const plugin = JSON.parse(await readFile(join(root, "agent-governance-claude-code", ".claude-plugin", "plugin.json"), "utf8"));
+    const marketplace = JSON.parse(await readFile(join(root, ".claude-plugin", "marketplace.json"), "utf8"));
+
+    assert.equal(plugin.version, "2.0.0");
+    assert.equal(marketplace.version, "2.0.0");
+    assert.equal(marketplace.plugins[0].version, "2.0.0");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/sync-claude-marketplace-version.mjs
+++ b/scripts/sync-claude-marketplace-version.mjs
@@ -6,7 +6,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = process.env.AGT_TEST_REPO_ROOT
+  || path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const check = process.argv.includes("--check");
 
 const packageJsonPath = path.join(repoRoot, "agent-governance-claude-code", "package.json");

--- a/scripts/sync-version.py
+++ b/scripts/sync-version.py
@@ -103,16 +103,21 @@ def sync_package_json(path: Path, version: str, check: bool) -> bool:
 def sync_claude_marketplace(version: str, check: bool) -> bool:
     """Update Claude Code plugin and marketplace versions."""
     ok = True
+
+    plugin_json_path = REPO_ROOT / "agent-governance-claude-code" / ".claude-plugin" / "plugin.json"
+    plugin_name: str | None = None
+    if plugin_json_path.exists():
+        plugin_name = json.loads(plugin_json_path.read_text(encoding="utf-8")).get("name")
+
     targets = [
-        (REPO_ROOT / "agent-governance-claude-code" / ".claude-plugin" / "plugin.json", ["version"]),
+        (plugin_json_path, ["version"]),
         (REPO_ROOT / ".claude-plugin" / "marketplace.json", ["version"]),
     ]
 
     for path, keys in targets:
         if not path.exists():
             continue
-        text = path.read_text(encoding="utf-8")
-        data = json.loads(text)
+        data = json.loads(path.read_text(encoding="utf-8"))
         changed = False
         for key in keys:
             if data.get(key) == version:
@@ -124,16 +129,16 @@ def sync_claude_marketplace(version: str, check: bool) -> bool:
             data[key] = version
             changed = True
 
-        if path.name == "marketplace.json":
+        if path.name == "marketplace.json" and plugin_name:
             for plugin in data.get("plugins", []):
-                if plugin.get("name") != "agt-governance":
+                if plugin.get("name") != plugin_name:
                     continue
                 if plugin.get("version") == version:
                     continue
                 if check:
                     print(
                         f"  DRIFT {path.relative_to(REPO_ROOT)}  "
-                        f"(agt-governance version has {plugin.get('version')})"
+                        f"({plugin_name} version has {plugin.get('version')})"
                     )
                     ok = False
                     continue


### PR DESCRIPTION
## What changed and why

Three follow-ups from issue #2625, identified during review of #2623.

**1. Plugin name read from plugin.json instead of hardcoded string**

`sync_claude_marketplace` in `scripts/sync-version.py` was comparing marketplace entries against the hardcoded string `"agt-governance"`. The JavaScript counterpart (`sync-claude-marketplace-version.mjs`) already reads the name from `plugin.json`, making the Python path the odd one out. If a second plugin is ever added, the Python sync would silently skip it. The fix reads the name from `plugin.json` once at the top of the function and uses it throughout.

**2. Unused text variable inlined**

The intermediate `text` variable in the same function served no purpose after the `json.loads` call. Inlined it.

**3. Smoke tests for sync-claude-marketplace-version.mjs**

The script runs in CI (TypeScript matrix gate) and during ESRP publish but had no automated test coverage. Added `agent-governance-claude-code/test/sync-marketplace.test.mjs` using `node:test` to cover:

- Check mode exits 0 when plugin.json, marketplace.json, and the plugin entry all match
- Check mode exits non-zero and prints a diagnostic when marketplace.json version drifts
- Check mode exits non-zero when the plugin entry is absent from marketplace.json
- Sync mode writes the updated version to all three locations

Tests use a `AGT_TEST_REPO_ROOT` environment variable (added to the script) to point at a temp fixture directory rather than the real repo, keeping the tests isolated and repeatable.

## Verification

```
node --test agent-governance-claude-code/test/sync-marketplace.test.mjs
4 passed
```

Closes #2625