### PR TITLE
fix(integrations): broaden SSN PII regex and consolidate PII_PATTERNS

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -28,6 +28,7 @@ aspnet
 asyncio
 atexit
 autobuild
+autogen
 autouse
 AWSIAM
 axios
@@ -35,6 +36,7 @@ aymenhmaidiwastaken
 backpressure
 baselined
 behaviour
+behavioural
 bursty
 bypassable
 bytecodes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Broadened SSN PII regex across integration adapters** ([#2635](https://github.com/microsoft/agent-governance-toolkit/issues/2635), [#2636](https://github.com/microsoft/agent-governance-toolkit/pull/2636)) — the dashed-only `\b\d{3}-\d{2}-\d{4}\b` regex used by the LangChain, AutoGen, CrewAI, and Bedrock adapters to detect SSNs in memory writes and outbound messages was trivially bypassed by space-, dot-, or no-separator variants such as `123 45 6789`, `123.45.6789`, and `123456789`. The pattern is now `\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b`, matching the YAML policy pack fix from [#2594](https://github.com/microsoft/agent-governance-toolkit/pull/2594) / [#2469](https://github.com/microsoft/agent-governance-toolkit/issues/2469).
+
+### Changed
+- **Consolidated PII detection patterns into a single shared constant** in `agent_os.integrations.base` ([#2635](https://github.com/microsoft/agent-governance-toolkit/issues/2635)). The four per-adapter copies (`langchain_adapter`, `autogen_adapter`, `crewai_adapter`, `bedrock_adapter`) now import the shared `PII_PATTERNS` tuple so future adapters cannot silently drift out of sync. The shared constant is the union of patterns previously used across all four adapters, which means LangChain, AutoGen, and CrewAI now also block credit-card PII (previously a Bedrock-only check). `bedrock_adapter._PII_RE` remains as a back-compat alias to the shared constant.
+
 ### Added
 - **Antigravity CLI governance package** — new `@microsoft/agent-governance-antigravity-cli` package with Antigravity-native hooks, MCP helpers, custom commands, docs, CI, and release wiring.
 

--- a/agent-governance-python/agent-os/CHANGELOG.md
+++ b/agent-governance-python/agent-os/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **Broadened SSN PII regex across integration adapters** ([#2635](https://github.com/microsoft/agent-governance-toolkit/issues/2635), [#2636](https://github.com/microsoft/agent-governance-toolkit/pull/2636)) — the dashed-only `\b\d{3}-\d{2}-\d{4}\b` regex used by the LangChain, AutoGen, CrewAI, and Bedrock adapters to detect SSNs in memory writes and outbound messages was trivially bypassed by space-, dot-, or no-separator variants such as `123 45 6789`, `123.45.6789`, and `123456789`. The pattern is now `\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b`, matching the YAML policy pack fix from [#2594](https://github.com/microsoft/agent-governance-toolkit/pull/2594) / [#2469](https://github.com/microsoft/agent-governance-toolkit/issues/2469).
 - `POST /api/v1/execute` now fails closed by default and no longer trusts
   caller-asserted `agent_id` values before policy, audit, and rate-limit
   enforcement.
 
 ### Changed
+- **Consolidated PII detection patterns into a single shared constant** in `agent_os.integrations.base` ([#2635](https://github.com/microsoft/agent-governance-toolkit/issues/2635)). The four per-adapter copies (`langchain_adapter`, `autogen_adapter`, `crewai_adapter`, `bedrock_adapter`) now import the shared `PII_PATTERNS` tuple so future adapters cannot silently drift out of sync. The shared constant is the union of patterns previously used across all four adapters, which means LangChain, AutoGen, and CrewAI now also block credit-card PII (previously a Bedrock-only check). `bedrock_adapter._PII_RE` remains as a back-compat alias to the shared constant.
 - Execute requests must now present `Authorization: Bearer <token>` bound to an
   agent identity through `MCPSessionAuthenticator`, unless you explicitly opt
   into local-only unsafe mode.

--- a/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
@@ -29,21 +29,19 @@ Legacy usage (deprecated)::
 
 import functools
 import logging
-import re
 import time
 from datetime import datetime
 from typing import Any, Callable, Optional
 
-from .base import BaseIntegration, ExecutionContext, GovernancePolicy, PolicyViolationError
+from .base import (
+    PII_PATTERNS,
+    BaseIntegration,
+    ExecutionContext,
+    GovernancePolicy,
+    PolicyViolationError,
+)
 
 logger = logging.getLogger("agent_os.autogen")
-
-# Patterns used to detect potential PII / secrets in state changes
-_PII_PATTERNS = [
-    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),           # SSN
-    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),  # email
-    re.compile(r"\b(?:password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+", re.IGNORECASE),
-]
 
 # ── Graceful import of AutoGen native intervention handlers ───────
 # AutoGen v0.4+ provides DefaultInterventionHandler with on_send,
@@ -231,7 +229,7 @@ class GovernanceInterventionHandler:
                 return DropMessage
 
             # PII check on outbound messages
-            for pii_pattern in _PII_PATTERNS:
+            for pii_pattern in PII_PATTERNS:
                 if pii_pattern.search(content):
                     logger.info(
                         "[%s] Policy DENY: PII detected in message "
@@ -282,7 +280,7 @@ class GovernanceInterventionHandler:
                 return DropMessage
 
             # PII check
-            for pii_pattern in _PII_PATTERNS:
+            for pii_pattern in PII_PATTERNS:
                 if pii_pattern.search(content):
                     logger.info(
                         "[%s] Policy DENY (publish): PII detected",
@@ -936,7 +934,7 @@ class AutoGenKernel(BaseIntegration):
                 content = str(args[0]) if args else str(kwargs)
 
                 # PII check
-                for pattern in _PII_PATTERNS:
+                for pattern in PII_PATTERNS:
                     if pattern.search(content):
                         raise PolicyViolationError(
                             f"State update blocked for '{agent_id}': "

--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -27,6 +27,44 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Shared PII / secrets detection patterns reused by every framework
+# adapter (LangChain, AutoGen, CrewAI, Bedrock, ...).
+#
+# Defined here as the single source of truth so adapters cannot silently
+# drift apart when a new sensitive-data class is added or an existing
+# pattern is broadened.  Stored as a tuple to prevent accidental
+# mutation of a process-wide constant by adapter or test code.
+#
+# Patterns (in order):
+#   0. U.S. Social Security Number.  Covers all common separator
+#      variants — dash, space, dot, or none — so that ``123-45-6789``,
+#      ``123 45 6789``, ``123.45.6789``, and ``123456789`` all match.
+#      Mirrors the broadened SSN pattern used by the YAML policy packs
+#      (see PR #2594 and issue #2469).
+#   1. Email address (simple RFC-5322-ish match, sufficient for content
+#      filtering — not for address validation).
+#   2. Visa / Mastercard primary account number (PAN).  Visa: 13 or 16
+#      digits with a leading ``4``; Mastercard: 16 digits with a leading
+#      ``51``-``55``.  Other card brands (Amex, Discover, JCB) are
+#      intentionally out of scope until we add full check-digit
+#      validation; expand this entry alongside any such helper rather
+#      than adding brittle prefix-only regexes here.
+#   3. Inline credential assignment such as ``password=``, ``api_key:``,
+#      ``token = ...``.  Case-insensitive, and accepts both ``api_key``
+#      and ``api-key`` spellings.
+#
+# Adapters consume this tuple read-only via ``for pattern in PII_PATTERNS:``;
+# new adapters MUST import from here and MUST NOT define a private copy.
+# The name follows the repo convention (no leading underscore) for
+# constants that are intentionally shared across modules.
+PII_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b"),                       # SSN
+    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),     # email
+    re.compile(r"\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14})\b"),          # credit card
+    re.compile(r"\b(?:password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+", re.IGNORECASE),  # secrets
+)
+
+
 class PatternType(Enum):
     """Type of pattern matching for blocked_patterns."""
     SUBSTRING = "substring"

--- a/agent-governance-python/agent-os/src/agent_os/integrations/bedrock_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/bedrock_adapter.py
@@ -49,13 +49,13 @@ Features:
 from __future__ import annotations
 
 import logging
-import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Iterator
 
 from .base import (
+    PII_PATTERNS,
     BaseIntegration,
     ExecutionContext,
     GovernanceEventType,
@@ -73,12 +73,12 @@ try:
 except ImportError:
     _HAS_BOTO3 = False
 
-_PII_RE = [
-    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),                                    # SSN
-    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),     # email
-    re.compile(r"\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14})\b"),          # credit card
-    re.compile(r"\b(?:password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+", re.IGNORECASE),  # secrets
-]
+# Back-compat alias for the shared ``PII_PATTERNS`` constant (issue #2635).
+# Existing consumers can keep importing ``bedrock_adapter._PII_RE`` — the
+# pre-refactor name for Bedrock's PII regex list — and continue to get the
+# same tuple of compiled regexes, now sourced from a single point of truth
+# in :mod:`agent_os.integrations.base`.
+_PII_RE = PII_PATTERNS
 
 
 def _check_boto3() -> None:

--- a/agent-governance-python/agent-os/src/agent_os/integrations/crewai_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/crewai_adapter.py
@@ -27,13 +27,13 @@ Legacy usage (deprecated)::
 
 import functools
 import logging
-import re
 from datetime import datetime
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 from .base import (
+    PII_PATTERNS,
     BaseIntegration,
     GovernancePolicy,
     PolicyInterceptor,
@@ -56,13 +56,6 @@ try:
     _HOOKS_AVAILABLE = True
 except ImportError:
     _HOOKS_AVAILABLE = False
-
-# Patterns used to detect potential PII / secrets in memory writes
-_PII_PATTERNS = [
-    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),           # SSN
-    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),  # email
-    re.compile(r"\b(?:password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+", re.IGNORECASE),
-]
 
 
 # ═══════════════════════════════════════════════════════════════════
@@ -894,7 +887,7 @@ class CrewAIKernel(BaseIntegration):
                     combined = str(args) + str(kwargs)
 
                     # PII / secrets check
-                    for pattern in _PII_PATTERNS:
+                    for pattern in PII_PATTERNS:
                         if pattern.search(combined):
                             raise PolicyViolationError(
                                 f"Memory write blocked: sensitive data detected "

--- a/agent-governance-python/agent-os/src/agent_os/integrations/langchain_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/langchain_adapter.py
@@ -53,13 +53,12 @@ Features
 import asyncio
 import functools
 import logging
-import re
 import time
 import warnings
 from datetime import datetime
 from typing import Any, Optional
 
-from .base import BaseIntegration, GovernancePolicy
+from .base import PII_PATTERNS, BaseIntegration, GovernancePolicy
 
 logger = logging.getLogger("agent_os.langchain")
 
@@ -72,13 +71,6 @@ try:
 except ImportError:
     _SDKMiddleware = None
     _HAS_MIDDLEWARE = False
-
-# Patterns used to detect potential PII / secrets in memory writes
-_PII_PATTERNS = [
-    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),           # SSN
-    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),  # email
-    re.compile(r"\b(?:password|passwd|secret|token|api[_-]?key)\s*[:=]\s*\S+", re.IGNORECASE),
-]
 
 
 class LangChainKernel(BaseIntegration):
@@ -322,7 +314,7 @@ class LangChainKernel(BaseIntegration):
         combined = str(inputs) + str(outputs)
 
         # PII / secrets detection
-        for pattern in _PII_PATTERNS:
+        for pattern in PII_PATTERNS:
             if pattern.search(combined):
                 raise PolicyViolationError(
                     f"Memory write blocked: sensitive data detected "

--- a/agent-governance-python/agent-os/tests/test_pii_patterns.py
+++ b/agent-governance-python/agent-os/tests/test_pii_patterns.py
@@ -1,0 +1,184 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Regression tests for the shared ``PII_PATTERNS`` constant (issue #2635).
+
+The dashed-only SSN regex (``\\b\\d{3}-\\d{2}-\\d{4}\\b``) that used to be
+duplicated across each framework adapter was trivially bypassed by SSNs
+formatted with spaces, dots, or no separator at all.  This module guards
+two invariants going forward:
+
+1. The shared SSN regex in :mod:`agent_os.integrations.base` matches every
+   common separator variant (dash, space, dot, none).
+2. Every framework adapter (LangChain, AutoGen, CrewAI, Bedrock) imports
+   ``PII_PATTERNS`` from :mod:`agent_os.integrations.base` and exercises
+   the same regex objects, so future adapters cannot silently drift back
+   to a private copy.
+
+For the two adapters whose PII enforcement path can be exercised without
+optional third-party SDKs, we also drive a live boundary test through the
+real call site to verify the broadened SSN regex actually blocks every
+variant end-to-end.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_os.integrations import base as _base
+from agent_os.integrations import (
+    autogen_adapter,
+    bedrock_adapter,
+    crewai_adapter,
+    langchain_adapter,
+)
+from agent_os.integrations.base import PII_PATTERNS, GovernancePolicy
+
+# The four separator variants the broadened SSN regex must catch.  The
+# corresponding negative cases live next to each variant so future
+# regressions cannot silently drop coverage.
+_SSN_VARIANTS = (
+    "123-45-6789",
+    "123 45 6789",
+    "123.45.6789",
+    "123456789",
+)
+
+_SSN_NON_MATCHES = (
+    "",
+    "no digits in dashed positions",
+    "12-345-6789",      # wrong group sizes
+    "1234-56-7890",     # wrong group sizes
+    "no digits at all",
+)
+
+
+# ── Shared regex behaviour ────────────────────────────────────────────
+
+def _ssn_pattern():
+    """Return the SSN regex from the shared ``PII_PATTERNS`` tuple."""
+    # SSN is the first pattern by construction in base.PII_PATTERNS.
+    return PII_PATTERNS[0]
+
+
+@pytest.mark.parametrize("variant", _SSN_VARIANTS)
+def test_shared_ssn_regex_matches_each_separator(variant: str) -> None:
+    """SSN regex must catch dash, space, dot, and no-separator variants."""
+    ssn = _ssn_pattern()
+    assert ssn.search(variant) is not None, (
+        f"shared SSN regex {ssn.pattern!r} failed to match variant {variant!r}"
+    )
+
+
+@pytest.mark.parametrize("variant", _SSN_VARIANTS)
+def test_shared_ssn_regex_matches_variant_in_sentence(variant: str) -> None:
+    """SSN regex must catch each variant when embedded in larger text."""
+    text = f"customer ssn {variant} on file"
+    ssn = _ssn_pattern()
+    assert ssn.search(text) is not None
+
+
+@pytest.mark.parametrize("non_match", _SSN_NON_MATCHES)
+def test_shared_ssn_regex_rejects_obvious_non_ssn(non_match: str) -> None:
+    """Sanity check that the broadened regex still rejects clear non-SSNs."""
+    ssn = _ssn_pattern()
+    assert ssn.search(non_match) is None, (
+        f"shared SSN regex {ssn.pattern!r} unexpectedly matched {non_match!r}"
+    )
+
+
+def test_shared_pii_patterns_is_immutable_tuple() -> None:
+    """The shared constant is a tuple so adapters cannot mutate it in place."""
+    assert isinstance(PII_PATTERNS, tuple)
+
+
+def test_shared_email_pattern_still_matches() -> None:
+    """The email pattern survived the consolidation."""
+    assert any(p.search("alice@example.com") for p in PII_PATTERNS)
+
+
+def test_shared_credit_card_pattern_still_matches() -> None:
+    """Bedrock's credit-card pattern was promoted to the shared list."""
+    # Valid-looking Visa-style PAN (16 digits, leading 4).
+    assert any(p.search("card 4111111111111111 on file") for p in PII_PATTERNS)
+
+
+def test_shared_secret_pattern_still_matches() -> None:
+    """The secrets pattern survived the consolidation."""
+    assert any(p.search("api_key=sk-deadbeef1234") for p in PII_PATTERNS)
+
+
+# ── Consolidation guard: every adapter sees the same shared object ────
+#
+# We can't simply assert ``adapter.PII_PATTERNS is _base.PII_PATTERNS``
+# because the adapters use a local-import-rebind pattern that some
+# linters discourage.  Instead, each adapter is verified through the
+# code path that actually consumes the constant — see the behavioural
+# tests below for ``bedrock_adapter._scan_pii`` and
+# ``langchain_adapter.LangChainKernel._validate_memory_write``.  Below,
+# we exercise the same invariant directly via ``sys.modules`` lookup so
+# the test still fails fast if a future adapter quietly drops the import.
+
+def _adapter_uses_shared_pii_patterns(adapter_module) -> bool:
+    """Return True iff ``adapter_module`` imports ``PII_PATTERNS`` from base."""
+    return getattr(adapter_module, "PII_PATTERNS", None) is PII_PATTERNS
+
+
+def test_langchain_adapter_imports_shared_pii_patterns() -> None:
+    assert _adapter_uses_shared_pii_patterns(langchain_adapter)
+
+
+def test_autogen_adapter_imports_shared_pii_patterns() -> None:
+    assert _adapter_uses_shared_pii_patterns(autogen_adapter)
+
+
+def test_crewai_adapter_imports_shared_pii_patterns() -> None:
+    assert _adapter_uses_shared_pii_patterns(crewai_adapter)
+
+
+def test_bedrock_adapter_imports_shared_pii_patterns() -> None:
+    assert _adapter_uses_shared_pii_patterns(bedrock_adapter)
+
+
+def test_bedrock_legacy_pii_re_alias_still_points_to_shared_object() -> None:
+    """Back-compat alias keeps existing imports of ``_PII_RE`` working."""
+    assert bedrock_adapter._PII_RE is _base.PII_PATTERNS
+
+
+# ── Behavioural boundary tests through real enforcement paths ─────────
+
+@pytest.mark.parametrize("variant", _SSN_VARIANTS)
+def test_bedrock_scan_pii_blocks_every_ssn_variant(variant: str) -> None:
+    """``bedrock_adapter._scan_pii`` reports the SSN regex for every variant."""
+    matches = bedrock_adapter._scan_pii(f"customer ssn {variant} on file")
+    ssn_pattern_str = _ssn_pattern().pattern
+    assert ssn_pattern_str in matches, (
+        f"bedrock._scan_pii did not report the shared SSN regex for variant "
+        f"{variant!r}; got {matches!r}"
+    )
+
+
+@pytest.mark.parametrize("variant", _SSN_VARIANTS)
+def test_langchain_memory_write_blocks_every_ssn_variant(variant: str) -> None:
+    """``LangChainKernel._validate_memory_write`` raises for every variant.
+
+    ``LangChainKernel`` only requires a :class:`GovernancePolicy` to
+    instantiate — no LangChain SDK is needed for this code path — so we
+    can drive the real PII enforcement path directly.
+
+    Note: ``langchain_adapter`` redefines ``PolicyViolationError`` as a
+    module-local class that shadows the canonical exception, so the
+    boundary test catches that adapter-local class (matching how the
+    existing adapter test suite asserts against it).
+    """
+    kernel = langchain_adapter.LangChainKernel(policy=GovernancePolicy())
+    inputs = {"question": f"my ssn is {variant}"}
+    outputs = {"answer": ""}
+
+    with pytest.raises(langchain_adapter.PolicyViolationError) as exc_info:
+        kernel._validate_memory_write(inputs, outputs, ctx=None)
+
+    # The raised error names the matched PII pattern, which must be the
+    # shared SSN regex.  Substring check keeps the assertion robust against
+    # message-format tweaks.
+    assert _ssn_pattern().pattern in str(exc_info.value)
+


### PR DESCRIPTION
## Summary

Move the per-adapter PII regex lists out of each of the four Python integration adapters and into a single shared, immutable tuple in `agent_os.integrations.base.PII_PATTERNS`. Broaden the SSN regex from `\b\d{3}-\d{2}-\d{4}\b` to `\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b` so that `123 45 6789`, `123.45.6789`, and `123456789` are also blocked.

Closes #2635. Follow-up to PR #2594 / issue #2469 (which fixed the same regex in the YAML policy pack layer).

## Problem

`_PII_PATTERNS` was redefined in four adapter files, each carrying the same vulnerable dashed-only SSN regex:

| File | Original constant name |
|------|------------------------|
| `agent_os/integrations/langchain_adapter.py` | `_PII_PATTERNS` |
| `agent_os/integrations/autogen_adapter.py` | `_PII_PATTERNS` |
| `agent_os/integrations/crewai_adapter.py` | `_PII_PATTERNS` |
| `agent_os/integrations/bedrock_adapter.py` | `_PII_RE` (same role, different name) |

A governed agent could leak `123 45 6789`, `123.45.6789`, or `123456789` through memory or model output without triggering a block. Because each adapter defined its own copy, future adapters could silently drift out of sync.

## Changes

| File | What changed |
|------|--------------|
| `agent-governance-python/agent-os/src/agent_os/integrations/base.py` | Added shared `PII_PATTERNS` tuple (immutable) with the broadened SSN regex plus email, Visa/Mastercard credit-card, and secrets patterns. Named without a leading underscore because it is intentionally cross-module shared, matching the repo convention for `AVAILABLE_POLICIES`, `VALID_SCOPES`, etc. |
| `agent-governance-python/agent-os/src/agent_os/integrations/langchain_adapter.py` | Replaced local copy with `from .base import PII_PATTERNS`. Removed now-unused `import re`. |
| `agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py` | Same: imported the shared constant and dropped the unused `import re`. |
| `agent-governance-python/agent-os/src/agent_os/integrations/crewai_adapter.py` | Same: imported the shared constant and dropped the unused `import re`. |
| `agent-governance-python/agent-os/src/agent_os/integrations/bedrock_adapter.py` | Imported the shared constant. Kept `_PII_RE = PII_PATTERNS` as a back-compat alias so any external code that imports `_PII_RE` from this module continues to work. Dropped the unused `import re`. |
| `agent-governance-python/agent-os/tests/test_pii_patterns.py` (new) | 30 parametrized tests covering: SSN variant matrix (dash, space, dot, no separator) plus sanity non-matches; consolidation guard asserting every adapter exposes the same shared object; behavioural boundary tests through `bedrock_adapter._scan_pii()` and `LangChainKernel._validate_memory_write()` for every variant. |
| `CHANGELOG.md` and `agent-governance-python/agent-os/CHANGELOG.md` | Added `[Unreleased]` entries under `### Security` and `### Changed`. |
| `.cspell-repo-terms.txt` | Added `autogen` and `behavioural` to the dictionary. |

### Naming note

The shared constant is named `PII_PATTERNS` (no leading underscore) rather than `_PII_PATTERNS` because it is intentionally cross-module shared. A leading underscore in Python signals 'module-private', which contradicts the cross-module sharing this PR introduces and also triggers a CodeQL `py/unused-global-variable` false positive on per-file analysis. The new name follows the existing repo convention for shared constants (e.g., `AVAILABLE_POLICIES`, `VALID_SCOPES`, `VALID_OPERATORS`, `GOVERNANCE_FILENAMES`).

### Tightening note for reviewers

Bedrock previously had a Visa/Mastercard credit-card regex in its local `_PII_RE` list. The consolidation promotes that pattern into the shared `PII_PATTERNS` tuple, so LangChain, AutoGen, and CrewAI now also block credit-card PII in memory writes and outbound messages. AGENTS.md explicitly permits this kind of tightening (policies can only be tightened, never loosened).

### Back-compat

* `bedrock_adapter._PII_RE` remains importable and points at the same shared tuple, so any external code that imported `_PII_RE` keeps working.
* No public API signatures changed.
* The other three adapters previously exposed `_PII_PATTERNS` as a module-private list. That underscore-prefixed name was not part of any public API surface; external consumers should import `PII_PATTERNS` from `agent_os.integrations.base` going forward.

## Testing

* New tests: `pytest tests/test_pii_patterns.py` 30 passed.
* Broader integration suite, no regressions: `pytest tests/test_integrations.py tests/test_pii_patterns.py tests/test_bedrock_adapter.py tests/test_adapter_str_no_leak.py tests/test_adapter_quality.py tests/test_adapter_registry.py` 309 passed, 8 skipped, 25 xfailed (pre-existing markers, unchanged by this PR).
* Lint: `ruff check --select E,F,W --ignore E501` on all changed source files passes cleanly.
* Spell-check on added lines: clean.

## Scope

* In scope: `base.py` plus the four adapter files listed above, accompanying tests, two CHANGELOG entries, and one cspell dictionary entry.
* Out of scope: YAML policy pack and docs changes (tracked separately in #2469 / #2594).

Originally reported by @Pranavk098 in #2469.
