### PR TITLE
feat(identity): add TEE keystore abstraction (ADR 0010 PR 3)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -155,3 +155,4 @@ uncallable
 endswith
 rfind
 lstrip
+keystore

--- a/agent-governance-python/agent-mesh/src/agentmesh/exceptions.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/exceptions.py
@@ -29,6 +29,10 @@ class AttestationVerificationError(AttestationError):
     """Attestation evidence failed verification against reference values."""
 
 
+class KeyAcquisitionError(IdentityError):
+    """TEE key acquisition failed (SKR denied, attestation expired, etc.)."""
+
+
 class TrustError(AgentMeshError):
     """Errors related to trust scoring and verification."""
 
@@ -75,6 +79,7 @@ __all__ = [
     "AttestationError",
     "AttestationCollectionError",
     "AttestationVerificationError",
+    "KeyAcquisitionError",
     "TrustError",
     "TrustVerificationError",
     "TrustViolationError",

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/__init__.py
@@ -50,6 +50,14 @@ from .risk import RiskScore, RiskScorer
 from .rotation import KeyRotationManager
 from .spiffe import SVID, SPIFFEIdentity
 from .sponsor import HumanSponsor
+from .tee_keystore import (
+    LocalTEEKeyStore,
+    MockSKRKeyStore,
+    SoftwareKeyHandle,
+    TEEKeyHandle,
+    TEEKeyStore,
+    require_tee_bound_key,
+)
 
 __all__ = [
     "AgentIdentity",
@@ -79,6 +87,12 @@ __all__ = [
     "KeyStore",
     "SoftwareKeyStore",
     "PKCS11KeyStore",
+    "TEEKeyStore",
+    "TEEKeyHandle",
+    "SoftwareKeyHandle",
+    "LocalTEEKeyStore",
+    "MockSKRKeyStore",
+    "require_tee_bound_key",
     "AttestationClaims",
     "AttestationEvidence",
     "ConfidentialLevel",

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/tee_keystore.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/tee_keystore.py
@@ -1,0 +1,297 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""TEE-aware key acquisition layer for confidential agent identity.
+
+Provides an async key store abstraction for TEE-bound key material (Secure Key
+Release, TEE-generated keys) alongside mock and local adapter implementations
+for CI testing.  The existing synchronous ``KeyStore`` is not modified.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from datetime import UTC, datetime, timedelta
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+from agentmesh.exceptions import KeyAcquisitionError
+
+from .attestation import KeyOrigin, public_key_hash_hex
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Key handle
+# ---------------------------------------------------------------------------
+
+
+class TEEKeyHandle(ABC):
+    """Opaque handle to a key acquired from a TEE key store.
+
+    Callers sign data through :meth:`sign` without direct access to raw
+    private key material.  Concrete implementations decide how signing
+    happens (in-memory, HSM call, remote signer, etc.).
+    """
+
+    @property
+    @abstractmethod
+    def key_id(self) -> str:
+        """Identifier of the acquired key."""
+
+    @property
+    @abstractmethod
+    def public_key(self) -> bytes:
+        """Raw Ed25519 public key bytes (32 bytes)."""
+
+    @property
+    @abstractmethod
+    def key_origin(self) -> KeyOrigin:
+        """Origin classification of this key."""
+
+    @property
+    @abstractmethod
+    def created_at(self) -> datetime:
+        """UTC timestamp of key acquisition."""
+
+    @property
+    @abstractmethod
+    def expires_at(self) -> datetime | None:
+        """UTC expiry, or ``None`` if the handle does not expire."""
+
+    # -- concrete helpers ---------------------------------------------------
+
+    def is_expired(self) -> bool:
+        """Return ``True`` when the handle has passed its expiry time."""
+        if self.expires_at is None:
+            return False
+        return datetime.now(UTC) >= self.expires_at
+
+    def public_key_hash(self) -> str:
+        """SHA-256 hex digest of the public key for attestation binding."""
+        return public_key_hash_hex(self.public_key)
+
+    @abstractmethod
+    async def sign(self, data: bytes) -> bytes:
+        """Sign *data* using the acquired key.
+
+        Raises:
+            KeyAcquisitionError: If the handle has expired.
+        """
+
+
+class SoftwareKeyHandle(TEEKeyHandle):
+    """Key handle backed by an in-memory Ed25519 private key.
+
+    Used by :class:`LocalTEEKeyStore` and :class:`MockSKRKeyStore`.
+    """
+
+    def __init__(
+        self,
+        *,
+        key_id: str,
+        key_origin: KeyOrigin,
+        private_key: ed25519.Ed25519PrivateKey,
+        created_at: datetime | None = None,
+        expires_at: datetime | None = None,
+    ) -> None:
+        self._key_id = key_id
+        self._key_origin = key_origin
+        self._private_key = private_key
+        self._public_key = private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        self._created_at = created_at or datetime.now(UTC)
+        self._expires_at = expires_at
+
+    @property
+    def key_id(self) -> str:
+        return self._key_id
+
+    @property
+    def public_key(self) -> bytes:
+        return self._public_key
+
+    @property
+    def key_origin(self) -> KeyOrigin:
+        return self._key_origin
+
+    @property
+    def created_at(self) -> datetime:
+        return self._created_at
+
+    @property
+    def expires_at(self) -> datetime | None:
+        return self._expires_at
+
+    async def sign(self, data: bytes) -> bytes:
+        """Sign *data*, rejecting expired handles."""
+        if self.is_expired():
+            raise KeyAcquisitionError(
+                f"Key handle '{self._key_id}' has expired"
+            )
+        return self._private_key.sign(data)
+
+
+# ---------------------------------------------------------------------------
+# Key store ABC
+# ---------------------------------------------------------------------------
+
+
+class TEEKeyStore(ABC):
+    """Async key store for TEE-bound key material.
+
+    Separate from the existing synchronous :class:`~agentmesh.identity.KeyStore`
+    because TEE key acquisition is async (network calls to AKV/MAA) and has
+    fundamentally different failure modes (SKR denied, attestation expired,
+    network errors).
+    """
+
+    @abstractmethod
+    async def acquire_key(self, key_id: str) -> TEEKeyHandle:
+        """Acquire a key from the backend.
+
+        Returns a :class:`TEEKeyHandle` on success.
+
+        Raises:
+            KeyAcquisitionError: If the key cannot be acquired.
+        """
+
+    @abstractmethod
+    def key_origin(self) -> KeyOrigin:
+        """Return the :class:`KeyOrigin` for keys from this store."""
+
+
+# ---------------------------------------------------------------------------
+# Local adapter
+# ---------------------------------------------------------------------------
+
+
+class LocalTEEKeyStore(TEEKeyStore):
+    """Adapter for non-TEE environments (``key_origin=LOCAL``).
+
+    Wraps in-memory Ed25519 key generation behind the :class:`TEEKeyStore`
+    interface so that downstream code (handshake, policy engine) can use a
+    uniform async API regardless of whether a real TEE is present.
+    """
+
+    def __init__(self) -> None:
+        self._keys: dict[str, tuple[ed25519.Ed25519PrivateKey, bytes]] = {}
+
+    async def acquire_key(self, key_id: str) -> TEEKeyHandle:
+        """Generate or return a cached in-memory Ed25519 key."""
+        if key_id not in self._keys:
+            private_key = ed25519.Ed25519PrivateKey.generate()
+            public_key = private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+            self._keys[key_id] = (private_key, public_key)
+            logger.debug("LocalTEEKeyStore generated key for %s", key_id)
+
+        private_key, _public_key = self._keys[key_id]
+        return SoftwareKeyHandle(
+            key_id=key_id,
+            key_origin=KeyOrigin.LOCAL,
+            private_key=private_key,
+        )
+
+    def key_origin(self) -> KeyOrigin:
+        return KeyOrigin.LOCAL
+
+
+# ---------------------------------------------------------------------------
+# Mock SKR store
+# ---------------------------------------------------------------------------
+
+
+class MockSKRKeyStore(TEEKeyStore):
+    """CI-safe mock that simulates Azure Key Vault Secure Key Release.
+
+    Supports configurable latency, error injection, key TTL, and
+    ``key_origin`` override for testing downstream policy and handshake
+    paths.
+    """
+
+    def __init__(
+        self,
+        *,
+        latency_seconds: float = 0.0,
+        error: Exception | None = None,
+        key_origin_value: KeyOrigin = KeyOrigin.SKR,
+        ttl_seconds: int | None = 3600,
+    ) -> None:
+        if latency_seconds < 0:
+            raise ValueError("latency_seconds must not be negative")
+        if ttl_seconds is not None and ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive when set")
+
+        self._latency = latency_seconds
+        self._error = error
+        self._key_origin = key_origin_value
+        self._ttl_seconds = ttl_seconds
+        self._keys: dict[str, tuple[ed25519.Ed25519PrivateKey, bytes]] = {}
+
+    async def acquire_key(self, key_id: str) -> TEEKeyHandle:
+        """Return a mock-released key, simulating SKR latency and errors."""
+        if self._latency:
+            await asyncio.sleep(self._latency)
+
+        if self._error is not None:
+            if isinstance(self._error, KeyAcquisitionError):
+                raise self._error
+            raise KeyAcquisitionError(
+                f"Mock SKR key acquisition failed for '{key_id}'"
+            ) from self._error
+
+        if key_id not in self._keys:
+            private_key = ed25519.Ed25519PrivateKey.generate()
+            public_key = private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+            self._keys[key_id] = (private_key, public_key)
+
+        private_key, _public_key = self._keys[key_id]
+        now = datetime.now(UTC)
+        expires_at = (
+            now + timedelta(seconds=self._ttl_seconds)
+            if self._ttl_seconds is not None
+            else None
+        )
+
+        return SoftwareKeyHandle(
+            key_id=key_id,
+            key_origin=self._key_origin,
+            private_key=private_key,
+            created_at=now,
+            expires_at=expires_at,
+        )
+
+    def key_origin(self) -> KeyOrigin:
+        return self._key_origin
+
+
+# ---------------------------------------------------------------------------
+# Policy helper
+# ---------------------------------------------------------------------------
+
+
+def require_tee_bound_key(handle: TEEKeyHandle, context: str = "") -> None:
+    """Raise if the key handle is not TEE-bound.
+
+    Intended for use in handshake or policy enforcement layers (PR 4/5).
+
+    Raises:
+        KeyAcquisitionError: If ``handle.key_origin`` is not TEE-bound.
+    """
+    if not handle.key_origin.is_tee_bound:
+        msg = (
+            f"TEE-bound key required but got key_origin={handle.key_origin.value}"
+        )
+        if context:
+            msg += f" ({context})"
+        raise KeyAcquisitionError(msg)

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/tee_keystore.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/tee_keystore.py
@@ -5,6 +5,14 @@
 Provides an async key store abstraction for TEE-bound key material (Secure Key
 Release, TEE-generated keys) alongside mock and local adapter implementations
 for CI testing.  The existing synchronous ``KeyStore`` is not modified.
+
+``LocalTEEKeyStore`` and ``MockSKRKeyStore`` are development/test adapters.
+They intentionally use in-process Ed25519 keys so downstream code can exercise
+the async interface in normal CI.  Production TEE/SKR implementations must use
+opaque signer handles backed by the TEE, HSM, or provider SDK so private key
+material is not cached in Python process memory; where a backend must expose
+software key bytes temporarily, it should use backend-supported memory locking
+and zeroization patterns.
 """
 
 from __future__ import annotations
@@ -85,7 +93,8 @@ class TEEKeyHandle(ABC):
 class SoftwareKeyHandle(TEEKeyHandle):
     """Key handle backed by an in-memory Ed25519 private key.
 
-    Used by :class:`LocalTEEKeyStore` and :class:`MockSKRKeyStore`.
+    Used by development/test adapters only. Real TEE or SKR providers should
+    return opaque signer handles instead of wrapping extractable private keys.
     """
 
     def __init__(
@@ -130,9 +139,7 @@ class SoftwareKeyHandle(TEEKeyHandle):
     async def sign(self, data: bytes) -> bytes:
         """Sign *data*, rejecting expired handles."""
         if self.is_expired():
-            raise KeyAcquisitionError(
-                f"Key handle '{self._key_id}' has expired"
-            )
+            raise KeyAcquisitionError(f"Key handle '{self._key_id}' has expired")
         return self._private_key.sign(data)
 
 
@@ -171,11 +178,16 @@ class TEEKeyStore(ABC):
 
 
 class LocalTEEKeyStore(TEEKeyStore):
-    """Adapter for non-TEE environments (``key_origin=LOCAL``).
+    """Development/test adapter for non-TEE environments (``key_origin=LOCAL``).
 
     Wraps in-memory Ed25519 key generation behind the :class:`TEEKeyStore`
     interface so that downstream code (handshake, policy engine) can use a
     uniform async API regardless of whether a real TEE is present.
+
+    This class is not a production TEE key store. It caches private keys in a
+    plain Python dictionary and should only be used for local development,
+    tests, and non-TEE compatibility paths where ``KeyOrigin.LOCAL`` is
+    acceptable.
     """
 
     def __init__(self) -> None:
@@ -213,7 +225,8 @@ class MockSKRKeyStore(TEEKeyStore):
 
     Supports configurable latency, error injection, key TTL, and
     ``key_origin`` override for testing downstream policy and handshake
-    paths.
+    paths. Like :class:`LocalTEEKeyStore`, this is not a production key store:
+    it uses in-memory private keys to keep CI hardware-independent.
     """
 
     def __init__(
@@ -258,9 +271,7 @@ class MockSKRKeyStore(TEEKeyStore):
         private_key, _public_key = self._keys[key_id]
         now = datetime.now(UTC)
         expires_at = (
-            now + timedelta(seconds=self._ttl_seconds)
-            if self._ttl_seconds is not None
-            else None
+            now + timedelta(seconds=self._ttl_seconds) if self._ttl_seconds is not None else None
         )
 
         return SoftwareKeyHandle(
@@ -289,9 +300,7 @@ def require_tee_bound_key(handle: TEEKeyHandle, context: str = "") -> None:
         KeyAcquisitionError: If ``handle.key_origin`` is not TEE-bound.
     """
     if not handle.key_origin.is_tee_bound:
-        msg = (
-            f"TEE-bound key required but got key_origin={handle.key_origin.value}"
-        )
+        msg = f"TEE-bound key required but got key_origin={handle.key_origin.value}"
         if context:
             msg += f" ({context})"
         raise KeyAcquisitionError(msg)

--- a/agent-governance-python/agent-mesh/tests/test_tee_keystore.py
+++ b/agent-governance-python/agent-mesh/tests/test_tee_keystore.py
@@ -1,0 +1,343 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the TEE key store abstraction (PR 3 / ADR 0010)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agentmesh.exceptions import KeyAcquisitionError
+from agentmesh.identity.attestation import KeyOrigin, public_key_hash_hex
+from agentmesh.identity.tee_keystore import (
+    LocalTEEKeyStore,
+    MockSKRKeyStore,
+    SoftwareKeyHandle,
+    TEEKeyHandle,
+    TEEKeyStore,
+    require_tee_bound_key,
+)
+
+# ---------------------------------------------------------------------------
+# SoftwareKeyHandle
+# ---------------------------------------------------------------------------
+
+
+class TestSoftwareKeyHandle:
+    """Tests for the concrete in-memory key handle."""
+
+    @pytest.fixture()
+    def _make_handle(self) -> Callable[..., SoftwareKeyHandle]:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        def factory(
+            key_id: str = "test-key",
+            key_origin: KeyOrigin = KeyOrigin.LOCAL,
+            expires_at: datetime | None = None,
+        ) -> SoftwareKeyHandle:
+            private_key = ed25519.Ed25519PrivateKey.generate()
+            return SoftwareKeyHandle(
+                key_id=key_id,
+                key_origin=key_origin,
+                private_key=private_key,
+                expires_at=expires_at,
+            )
+
+        return factory
+
+    @pytest.mark.asyncio
+    async def test_sign_and_verify(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle = _make_handle()
+        data = b"test-payload"
+        signature = await handle.sign(data)
+
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        pk = Ed25519PublicKey.from_public_bytes(handle.public_key)
+        pk.verify(signature, data)
+
+    def test_public_key_is_32_bytes(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle = _make_handle()
+        assert len(handle.public_key) == 32
+
+    def test_public_key_hash_matches_attestation_binding(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle = _make_handle()
+        assert handle.public_key_hash() == public_key_hash_hex(handle.public_key)
+
+    def test_key_origin_propagated(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle_local = _make_handle(key_origin=KeyOrigin.LOCAL)
+        handle_skr = _make_handle(key_origin=KeyOrigin.SKR)
+        handle_tee = _make_handle(key_origin=KeyOrigin.TEE_GENERATED)
+
+        assert handle_local.key_origin == KeyOrigin.LOCAL
+        assert handle_skr.key_origin == KeyOrigin.SKR
+        assert handle_tee.key_origin == KeyOrigin.TEE_GENERATED
+
+    def test_is_expired_false_when_no_expiry(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle = _make_handle(expires_at=None)
+        assert not handle.is_expired()
+
+    def test_is_expired_false_when_future(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle = _make_handle(expires_at=datetime.now(UTC) + timedelta(hours=1))
+        assert not handle.is_expired()
+
+    def test_is_expired_true_when_past(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle = _make_handle(expires_at=datetime.now(UTC) - timedelta(seconds=1))
+        assert handle.is_expired()
+
+    @pytest.mark.asyncio
+    async def test_sign_rejects_expired_handle(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        handle = _make_handle(expires_at=datetime.now(UTC) - timedelta(seconds=1))
+        with pytest.raises(KeyAcquisitionError, match="expired"):
+            await handle.sign(b"data")
+
+    def test_created_at_defaults_to_utc_now(
+        self, _make_handle: Callable[..., SoftwareKeyHandle]
+    ) -> None:
+        before = datetime.now(UTC)
+        handle = _make_handle()
+        after = datetime.now(UTC)
+        assert before <= handle.created_at <= after
+
+
+# ---------------------------------------------------------------------------
+# LocalTEEKeyStore
+# ---------------------------------------------------------------------------
+
+
+class TestLocalTEEKeyStore:
+    """Tests for the non-TEE adapter."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_returns_local_origin(self) -> None:
+        store = LocalTEEKeyStore()
+        handle = await store.acquire_key("agent-1")
+
+        assert handle.key_origin == KeyOrigin.LOCAL
+        assert handle.key_id == "agent-1"
+        assert len(handle.public_key) == 32
+
+    @pytest.mark.asyncio
+    async def test_acquire_returns_same_key_on_repeat(self) -> None:
+        store = LocalTEEKeyStore()
+        h1 = await store.acquire_key("agent-1")
+        h2 = await store.acquire_key("agent-1")
+
+        assert h1.public_key == h2.public_key
+
+    @pytest.mark.asyncio
+    async def test_acquire_different_ids_get_different_keys(self) -> None:
+        store = LocalTEEKeyStore()
+        h1 = await store.acquire_key("agent-1")
+        h2 = await store.acquire_key("agent-2")
+
+        assert h1.public_key != h2.public_key
+
+    @pytest.mark.asyncio
+    async def test_sign_produces_valid_signature(self) -> None:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        store = LocalTEEKeyStore()
+        handle = await store.acquire_key("agent-1")
+
+        data = b"hello-mesh"
+        sig = await handle.sign(data)
+
+        pk = Ed25519PublicKey.from_public_bytes(handle.public_key)
+        pk.verify(sig, data)
+
+    def test_key_origin_is_local(self) -> None:
+        store = LocalTEEKeyStore()
+        assert store.key_origin() == KeyOrigin.LOCAL
+
+    @pytest.mark.asyncio
+    async def test_handle_does_not_expire(self) -> None:
+        store = LocalTEEKeyStore()
+        handle = await store.acquire_key("agent-1")
+        assert handle.expires_at is None
+        assert not handle.is_expired()
+
+
+# ---------------------------------------------------------------------------
+# MockSKRKeyStore
+# ---------------------------------------------------------------------------
+
+
+class TestMockSKRKeyStore:
+    """Tests for the mock Secure Key Release store."""
+
+    @pytest.mark.asyncio
+    async def test_acquire_returns_skr_origin(self) -> None:
+        store = MockSKRKeyStore()
+        handle = await store.acquire_key("payment-key")
+
+        assert handle.key_origin == KeyOrigin.SKR
+        assert handle.key_id == "payment-key"
+        assert len(handle.public_key) == 32
+
+    @pytest.mark.asyncio
+    async def test_default_ttl_sets_expiry(self) -> None:
+        store = MockSKRKeyStore(ttl_seconds=60)
+        before = datetime.now(UTC)
+        handle = await store.acquire_key("k1")
+        after = datetime.now(UTC)
+
+        assert handle.expires_at is not None
+        assert before + timedelta(seconds=59) <= handle.expires_at
+        assert handle.expires_at <= after + timedelta(seconds=61)
+
+    @pytest.mark.asyncio
+    async def test_no_ttl_means_no_expiry(self) -> None:
+        store = MockSKRKeyStore(ttl_seconds=None)
+        handle = await store.acquire_key("k1")
+        assert handle.expires_at is None
+
+    @pytest.mark.asyncio
+    async def test_error_injection_wraps_in_key_acquisition_error(self) -> None:
+        store = MockSKRKeyStore(error=RuntimeError("SKR denied"))
+        with pytest.raises(KeyAcquisitionError, match="Mock SKR key acquisition failed"):
+            await store.acquire_key("k1")
+
+    @pytest.mark.asyncio
+    async def test_direct_key_acquisition_error_raised_as_is(self) -> None:
+        custom = KeyAcquisitionError("custom: policy mismatch")
+        store = MockSKRKeyStore(error=custom)
+        with pytest.raises(KeyAcquisitionError, match="custom: policy mismatch"):
+            await store.acquire_key("k1")
+
+    @pytest.mark.asyncio
+    async def test_latency_simulation(self) -> None:
+        store = MockSKRKeyStore(latency_seconds=0.05)
+        start = datetime.now(UTC)
+        await store.acquire_key("k1")
+        elapsed = (datetime.now(UTC) - start).total_seconds()
+        assert elapsed >= 0.04
+
+    @pytest.mark.asyncio
+    async def test_same_key_returned_on_repeat(self) -> None:
+        store = MockSKRKeyStore()
+        h1 = await store.acquire_key("k1")
+        h2 = await store.acquire_key("k1")
+        assert h1.public_key == h2.public_key
+
+    @pytest.mark.asyncio
+    async def test_custom_key_origin(self) -> None:
+        store = MockSKRKeyStore(key_origin_value=KeyOrigin.TEE_GENERATED)
+        handle = await store.acquire_key("k1")
+        assert handle.key_origin == KeyOrigin.TEE_GENERATED
+
+    def test_key_origin_method(self) -> None:
+        store = MockSKRKeyStore()
+        assert store.key_origin() == KeyOrigin.SKR
+
+    def test_rejects_negative_latency(self) -> None:
+        with pytest.raises(ValueError, match="latency_seconds"):
+            MockSKRKeyStore(latency_seconds=-1.0)
+
+    def test_rejects_non_positive_ttl(self) -> None:
+        with pytest.raises(ValueError, match="ttl_seconds"):
+            MockSKRKeyStore(ttl_seconds=0)
+
+    @pytest.mark.asyncio
+    async def test_sign_with_skr_handle(self) -> None:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        store = MockSKRKeyStore()
+        handle = await store.acquire_key("k1")
+
+        data = b"transaction-payload"
+        sig = await handle.sign(data)
+
+        pk = Ed25519PublicKey.from_public_bytes(handle.public_key)
+        pk.verify(sig, data)
+
+
+# ---------------------------------------------------------------------------
+# require_tee_bound_key helper
+# ---------------------------------------------------------------------------
+
+
+class TestRequireTEEBoundKey:
+    """Tests for the policy enforcement helper."""
+
+    @pytest.fixture()
+    def _local_handle(self) -> SoftwareKeyHandle:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        pk = ed25519.Ed25519PrivateKey.generate()
+        return SoftwareKeyHandle(
+            key_id="local-key",
+            key_origin=KeyOrigin.LOCAL,
+            private_key=pk,
+        )
+
+    @pytest.fixture()
+    def _skr_handle(self) -> SoftwareKeyHandle:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        pk = ed25519.Ed25519PrivateKey.generate()
+        return SoftwareKeyHandle(
+            key_id="skr-key",
+            key_origin=KeyOrigin.SKR,
+            private_key=pk,
+        )
+
+    def test_local_key_raises(self, _local_handle: SoftwareKeyHandle) -> None:
+        with pytest.raises(KeyAcquisitionError, match="TEE-bound key required"):
+            require_tee_bound_key(_local_handle)
+
+    def test_local_key_raises_with_context(
+        self, _local_handle: SoftwareKeyHandle
+    ) -> None:
+        with pytest.raises(KeyAcquisitionError, match="handshake"):
+            require_tee_bound_key(_local_handle, context="handshake")
+
+    def test_skr_key_passes(self, _skr_handle: SoftwareKeyHandle) -> None:
+        require_tee_bound_key(_skr_handle)
+
+    def test_tee_generated_key_passes(self) -> None:
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+
+        pk = ed25519.Ed25519PrivateKey.generate()
+        handle = SoftwareKeyHandle(
+            key_id="tee-key",
+            key_origin=KeyOrigin.TEE_GENERATED,
+            private_key=pk,
+        )
+        require_tee_bound_key(handle)
+
+
+# ---------------------------------------------------------------------------
+# Interface contract checks
+# ---------------------------------------------------------------------------
+
+
+class TestInterfaceContracts:
+    """Verify the ABC contracts are satisfied by all implementations."""
+
+    def test_local_store_is_tee_keystore(self) -> None:
+        assert issubclass(LocalTEEKeyStore, TEEKeyStore)
+
+    def test_mock_skr_store_is_tee_keystore(self) -> None:
+        assert issubclass(MockSKRKeyStore, TEEKeyStore)
+
+    def test_software_handle_is_tee_key_handle(self) -> None:
+        assert issubclass(SoftwareKeyHandle, TEEKeyHandle)

--- a/docs/security-audits/2026-05-14-tee-keystore-abstraction.md
+++ b/docs/security-audits/2026-05-14-tee-keystore-abstraction.md
@@ -1,0 +1,71 @@
+# Security Audit: TEE Keystore Abstraction
+
+**Date:** 2026-05-14
+**PR:** feat(identity): add TEE keystore abstraction
+**Scope:** `agentmesh.identity.tee_keystore`, `agentmesh.exceptions.KeyAcquisitionError`
+**Author:** Pawan Khandavilli
+
+## What changed and why
+
+Added an async TEE-aware key acquisition layer (ADR 0010, PR 3) that supports
+Secure Key Release and TEE-generated keys alongside the existing synchronous
+`KeyStore`. New types:
+
+- `TEEKeyHandle` (ABC): opaque signer handle with expiry enforcement
+- `SoftwareKeyHandle`: concrete in-memory Ed25519 implementation
+- `TEEKeyStore` (ABC): async key acquisition interface
+- `LocalTEEKeyStore`: non-TEE adapter (key_origin=LOCAL)
+- `MockSKRKeyStore`: CI-safe mock for Secure Key Release
+- `require_tee_bound_key()`: policy helper for fail-closed enforcement
+- `KeyAcquisitionError`: new exception for TEE key failures
+
+## Threat model impact
+
+### New attack surface
+
+1. **Key handle expiry bypass**: If callers bypass `sign()` and access
+   `_private_key` directly on `SoftwareKeyHandle`, they skip the expiry check.
+
+   **Mitigation:** `_private_key` is a private attribute (underscore-prefixed,
+   not exposed in any public interface). The `TEEKeyHandle` ABC does not expose
+   raw key material. Future real TEE implementations will use opaque signers
+   where the key is not extractable at all.
+
+2. **Silent downgrade from TEE to local keys**: If the handshake or policy
+   layer fails to check `key_origin`, an agent could claim TEE-bound identity
+   while using a local key.
+
+   **Mitigation:** `require_tee_bound_key()` helper provided for policy
+   enforcement. PR 5 (policy integration) will wire this into the trust policy
+   engine. The `KeyOrigin.is_tee_bound` property makes the check explicit.
+
+3. **Mock used in production**: `MockSKRKeyStore` or `LocalTEEKeyStore` could
+   be deployed instead of a real TEE store.
+
+   **Mitigation:** These stores honestly report `key_origin=LOCAL` or the
+   configured mock origin. The policy engine (PR 5) will reject non-TEE origins
+   when attestation is required. There is no silent fallback.
+
+### Existing security properties preserved
+
+- Existing `KeyStore`, `SoftwareKeyStore`, and `PKCS11KeyStore` are unchanged.
+- No new network calls or cloud dependencies introduced.
+- No new secrets or credentials handled (real SKR is PR 6).
+- All new code is testable without confidential hardware.
+
+## Mitigations
+
+| Risk | Mitigation | Verified by |
+|------|-----------|-------------|
+| Expired handle used for signing | `sign()` checks `is_expired()` before signing | `test_sign_rejects_expired_handle` |
+| Local key accepted as TEE-bound | `require_tee_bound_key()` raises `KeyAcquisitionError` | `TestRequireTEEBoundKey` |
+| KeyAcquisitionError not raised on SKR failure | MockSKRKeyStore wraps errors in `KeyAcquisitionError` | `test_error_injection_wraps_in_key_acquisition_error` |
+| Key origin misreported | All stores declare `key_origin()` matching actual behavior | `test_key_origin_*` tests |
+
+## Test coverage
+
+- 30+ test cases covering: handle signing, expiry, key_origin propagation,
+  store acquire/cache semantics, error injection, latency simulation,
+  fail-closed policy enforcement, ABC contract verification.
+- All tests run in standard CI without TEE hardware.
+- No mocked exceptions escape without proper wrapping.

--- a/docs/security-audits/2026-05-14-tee-keystore-abstraction.md
+++ b/docs/security-audits/2026-05-14-tee-keystore-abstraction.md
@@ -12,9 +12,9 @@ Secure Key Release and TEE-generated keys alongside the existing synchronous
 `KeyStore`. New types:
 
 - `TEEKeyHandle` (ABC): opaque signer handle with expiry enforcement
-- `SoftwareKeyHandle`: concrete in-memory Ed25519 implementation
+- `SoftwareKeyHandle`: concrete in-memory Ed25519 implementation for development/test adapters
 - `TEEKeyStore` (ABC): async key acquisition interface
-- `LocalTEEKeyStore`: non-TEE adapter (key_origin=LOCAL)
+- `LocalTEEKeyStore`: development/test non-TEE adapter (key_origin=LOCAL)
 - `MockSKRKeyStore`: CI-safe mock for Secure Key Release
 - `require_tee_bound_key()`: policy helper for fail-closed enforcement
 - `KeyAcquisitionError`: new exception for TEE key failures
@@ -39,12 +39,25 @@ Secure Key Release and TEE-generated keys alongside the existing synchronous
    enforcement. PR 5 (policy integration) will wire this into the trust policy
    engine. The `KeyOrigin.is_tee_bound` property makes the check explicit.
 
-3. **Mock used in production**: `MockSKRKeyStore` or `LocalTEEKeyStore` could
+3. **Dev/test adapter used in production**: `MockSKRKeyStore` or `LocalTEEKeyStore` could
    be deployed instead of a real TEE store.
 
    **Mitigation:** These stores honestly report `key_origin=LOCAL` or the
    configured mock origin. The policy engine (PR 5) will reject non-TEE origins
-   when attestation is required. There is no silent fallback.
+   when attestation is required. There is no silent fallback. The module
+   docstrings explicitly mark both classes as development/test adapters.
+
+4. **In-process private key cache**: `LocalTEEKeyStore` and `MockSKRKeyStore`
+   cache generated Ed25519 private keys in normal Python dictionaries so tests
+   can run without confidential hardware.
+
+   **Mitigation:** These classes are development/test adapters only and expose
+   `key_origin=LOCAL` or a configured mock origin. Production TEE/SKR providers
+   must return opaque signer handles backed by the TEE, HSM, or provider SDK so
+   raw key material is not retained in Python process memory. If a future
+   provider must handle software key bytes temporarily, it should use
+   backend-supported memory locking and zeroization patterns before exposing a
+   `TEEKeyHandle`.
 
 ### Existing security properties preserved
 
@@ -61,6 +74,7 @@ Secure Key Release and TEE-generated keys alongside the existing synchronous
 | Local key accepted as TEE-bound | `require_tee_bound_key()` raises `KeyAcquisitionError` | `TestRequireTEEBoundKey` |
 | KeyAcquisitionError not raised on SKR failure | MockSKRKeyStore wraps errors in `KeyAcquisitionError` | `test_error_injection_wraps_in_key_acquisition_error` |
 | Key origin misreported | All stores declare `key_origin()` matching actual behavior | `test_key_origin_*` tests |
+| Dev/test store mistaken for production TEE storage | Local and mock stores are documented as non-production adapters | Docstring and audit review |
 
 ## Test coverage
 


### PR DESCRIPTION
## Summary

Implements the async TEE-aware key acquisition layer as specified in ADR 0010 (PR 3 of 7).

This PR adds the foundational keystore abstraction that enables hardware-bound agent credentials via Secure Key Release (SKR) from Azure Key Vault, while maintaining testability in non-TEE environments.

## What's included

| Type | Description |
|------|-------------|
| TEEKeyHandle (ABC) | Opaque signer handle with expiry enforcement; callers never access raw private key material |
| SoftwareKeyHandle | Concrete Ed25519 implementation for both local and mock stores |
| TEEKeyStore (ABC) | Async key acquisition interface with cquire_key() and key_origin |
| LocalTEEKeyStore | Non-TEE adapter (key_origin=LOCAL) for interface uniformity |
| MockSKRKeyStore | CI-safe mock for SKR with configurable latency, errors, TTL, and key_origin |
| equire_tee_bound_key() | Fail-closed policy helper that raises KeyAcquisitionError for non-TEE origins |
| KeyAcquisitionError | New exception for TEE key acquisition failures |

## Design decisions

- **Separate async ABC** rather than extending existing sync KeyStore: TEE key acquisition is inherently async (network calls to AKV/MAA). A separate interface avoids forcing sync callers into async patterns.
- **Opaque handles**: TEEKeyHandle.sign() enforces expiry at the handle level. Real TEE implementations will wrap HSM signers where key material is never extractable.
- **Fail-closed**: No silent downgrade from TEE to local keys. equire_tee_bound_key() raises on non-TEE origins. The policy engine (PR 5) will wire this into trust decisions.
- **Honest reporting**: All stores declare their actual key_origin. Mock stores can be configured with any origin for testing, but default to honest reporting.

## Builds on

- PR 1 (#1763): Attestation evidence model and KeyOrigin enum
- PR 2 (#2226): Collector/verifier interfaces

## Enables (future PRs)

- PR 4: Trust handshake attestation integration (uses TEEKeyStore for signing handshake tokens)
- PR 5: Policy integration (wires equire_tee_bound_key() into the trust policy engine)
- PR 6: Real AKV SKR implementation (concrete TEEKeyStore for Azure environments)

## Testing

- 34 new tests covering all acceptance criteria
- All existing 27 keystore tests pass (no regression)
- Tests run without TEE hardware (CI-safe)

## Security audit

Included: docs/security-audits/2026-05-14-tee-keystore-abstraction.md

Threat model covers: handle expiry bypass, silent downgrade, mock-in-production risks.