### PR TITLE
docs(adr): propose ADR 0028 for AGT Studio unified UI

### DIFF
--- a/docs/adr/0028-agt-studio-unified-ui.md
+++ b/docs/adr/0028-agt-studio-unified-ui.md
@@ -1,0 +1,131 @@
+# ADR 0028: AGT Studio, a single unified UI for governance
+
+- Status: proposed
+- Date: 2026-05-29
+
+## Context
+
+AGT currently ships seven separate UI surfaces that each cover a slice of the
+product:
+
+- Six Streamlit dashboards (governance, trust, SRE, hypervisor, SCAK,
+  observability) that mostly use simulated data and are rarely consumed in
+  production.
+- IDE extensions (Cursor, Copilot, JetBrains) whose UI panels duplicate parts
+  of the dashboards.
+- A Chrome extension targeted at browsing safety on GitHub, Jira, and AWS.
+- A static `console.html` pitch asset.
+
+This creates three problems:
+
+1. **No front door for evaluators or customers.** Sales and demo conversations
+   require diagrams and verbal explanation because there is no single place to
+   see what AGT does. The CLI plus YAML workflow does not land.
+2. **The policy lifecycle has no UI.** AGT ships 70+ example policies and 14
+   templates and has a full replay/test engine via `agt test`, but provides no
+   visual way to author, lint, simulate, diff, or version policies. Policy is
+   the project's core IP.
+3. **Surfaces drift.** Each extension and dashboard exposes overlapping
+   concepts (active policies, audit, decisions) with inconsistent shapes, no
+   shared contract, and no canonical experience.
+
+A separate review considered building a full operator/SOC console with
+approvals, quarantine, and runtime control. That option was rejected: the
+write-path requires SSO, RBAC, multi-tenancy, audit non-repudiation, and 24/7
+support that AGT cannot sustain, and Azure Sentinel, Defender, and Foundry
+already own that space.
+
+## Decision
+
+Build **AGT Studio** as the single first-class UI for AGT.
+
+- Launched standalone with `agt ui`. A local sidecar (`agt serve`) exposes the
+  engine over HTTP/WebSocket. The browser opens to the SPA.
+- Same SPA packaged as a VS Code and Cursor webview. One code base, two
+  shells. The shells inject a transport (HTTP for standalone, postMessage for
+  webview) so the SPA is host-agnostic.
+- Policy-first scope. Authoring, testing, simulation, and visibility for AGT
+  policies. Modelled on the Azure Policy experience in the Azure Portal:
+  browse definitions, see active assignments, author, test, assign.
+
+### In scope
+
+| Capability | Phase |
+|---|---|
+| Browse all policies (70+ examples, 14 templates, plus Copilot, Claude, and Antigravity CLI policy configs) | MVP |
+| Author policies with schema-aware editing and inline lint | MVP |
+| Test and validate policies (wraps `agent_compliance.policy_test.replay`) | MVP |
+| What-if simulator (action + identity + context to decision and rule) | MVP |
+| Regression view (rule change to fixture pass/fail diff) | MVP |
+| Version both engine and policies; test against either | MVP |
+| Live decisions feed (from `agentmesh.dashboard.api.DashboardAPI`) | V1 |
+| Shadow-agent and credential lifecycle signals | V1 |
+| Trust network, scores, and decay views | V1 |
+| Audit log viewer with chain-integrity badge and evidence export | V1 |
+
+### Explicitly out of scope
+
+- Operator/SOC console capabilities: approvals queue, quarantine, hot-reload
+  to production, write-path runtime control.
+- SSO, SAML, OIDC, RBAC, and multi-tenancy. Studio is an authoring and
+  visibility tool. Production deployments wrap the engine API behind their
+  own auth.
+- Replacement for runtime enforcement hooks in the IDE extensions or the
+  Chrome extension. Only the UI surfaces collapse into Studio. The
+  interception logic stays where it is.
+- SRE, FinOps, incident management, deployment tooling. These belong in
+  Grafana, Sentinel, Datadog, PagerDuty, ServiceNow, Argo, and similar.
+
+## Triage of existing dashboards
+
+| # | Dashboard | Current purpose | Disposition |
+|---|---|---|---|
+| 1 | `examples/demos/governance-dashboard` | Fleet, shadow agents, lifecycle funnel, allow/deny feed, trust heatmap (simulated) | Partial port to Studio: policy feed, shadow agents. Drop fleet table and lifecycle funnel. |
+| 2 | `agent-mesh/examples/06-trust-score-dashboard` | Trust graph, scores, credentials, protocol traffic, compliance | Mostly port to Studio: trust graph, credentials, compliance. Protocol traffic moves to a Grafana template. |
+| 3 | `agent-sre/examples/dashboard` | SLOs, cost, chaos, incidents, progressive delivery | Replace with Grafana templates. |
+| 4 | `agent-hypervisor/examples/dashboard` | Sessions, rings, sagas, liability, events | Archive. Niche runtime supervision. |
+| 5 | `agent-os/modules/scak/dashboard.py` | SCAK memory and telemetry | Archive with module. |
+| 6 | `agent-os/modules/observability/dashboards.py` | Pre-built Grafana JSON templates | Keep and expand. This is the embed-first integration story. |
+
+Net effect: six dashboards collapse to one UI plus one Grafana template pack.
+`console.html` is deleted.
+
+## Alternatives considered
+
+1. **Full operator/SOC console.** Rejected. Write-path risk, auth surface,
+   and ongoing support cost are out of scale for AGT, and Sentinel, Defender,
+   and Foundry are better homes for that telemetry.
+2. **Embed-only via Grafana, Sentinel, and Foundry plugins.** Useful and
+   continues alongside Studio (item 6 above), but does not solve the policy
+   authoring and demo gaps that motivated this decision.
+3. **Status quo.** Six surfaces stay scattered, the policy lifecycle stays
+   CLI-only, demos keep failing to land.
+
+## Consequences
+
+- **One canonical surface for AGT.** New features land in Studio, not in a
+  new dashboard. The contributor question "where does this UI go" has one
+  answer.
+- **Forces an engine API contract.** Studio needs a stable HTTP/WebSocket
+  surface from the engine. This contract benefits every SDK, not just the
+  UI, and unblocks a future conformance test suite for cross-SDK parity.
+- **Demos improve immediately.** Sales, evaluator, and customer conversations
+  gain a visual surface that does not require CLI familiarity.
+- **Ongoing cost.** A real product surface to maintain: accessibility,
+  browser matrix, dependency hygiene, release cadence, security review of a
+  new API. Owners and release cadence must be named before code lands.
+- **Deprecation work.** Six dashboards must be deprecated in sequence with
+  clear migration notes and at least one release of overlap.
+- **Marketplace is a separate, later decision.** Studio is the prerequisite.
+  A policy marketplace (curated AGT packs, enterprise distribution,
+  "awesome-policy" community hub) will be proposed as a follow-up ADR once
+  Studio is shipping.
+
+## References
+
+- Policy replay engine: `agent-governance-python/agent-compliance/src/agent_compliance/policy_test.py`.
+- Dashboard backend: `agent-governance-python/agent-mesh/src/agentmesh/dashboard/api.py`.
+- Existing IDE extension UI surfaces under `agent-governance-python/agent-os/extensions/`.
+- Existing Streamlit dashboards listed in the triage table above.
+- Related ADR-0015 (pluggable external policy backends) and ADR-0022
+  (compliance framework auto-mapping).

--- a/docs/adr/0028-agt-studio-unified-ui.md
+++ b/docs/adr/0028-agt-studio-unified-ui.md
@@ -45,8 +45,29 @@ Build **AGT Studio** as the single first-class UI for AGT.
   shells. The shells inject a transport (HTTP for standalone, postMessage for
   webview) so the SPA is host-agnostic.
 - Policy-first scope. Authoring, testing, simulation, and visibility for AGT
-  policies. Modelled on the Azure Policy experience in the Azure Portal:
-  browse definitions, see active assignments, author, test, assign.
+  policies. Inspired by Azure Policy's lifecycle shape, not a clone of Azure
+  Portal UX: browse definitions, inspect assignments, author, test, and
+  simulate decisions.
+
+### Scope boundary
+
+Studio is policy-first and read-only for runtime state. Visibility features
+may explain policy decisions, audit evidence, trust posture, and shadow-mode
+findings only insofar as they help author, test, debug, or validate policies.
+Studio must not perform operational write-path actions such as approvals,
+quarantine, credential rotation, production hot-reload, incident workflow
+changes, or runtime control. Any move from policy-adjacent visibility to
+operational control requires a separate ADR.
+
+### CLI ownership and version compatibility
+
+`agt ui` is the user-facing launcher. `agt serve` is the local engine sidecar
+used by Studio and any other local client. The `agent-compliance` maintainers
+own the policy and test API surface; `agent-mesh` maintainers own the
+dashboard and audit event sources; extension maintainers own the webview
+transport shells. Studio must detect incompatible engine/API versions on
+startup and fail with an actionable upgrade message rather than silently
+degrading.
 
 ### In scope
 
@@ -75,6 +96,12 @@ Build **AGT Studio** as the single first-class UI for AGT.
   interception logic stays where it is.
 - SRE, FinOps, incident management, deployment tooling. These belong in
   Grafana, Sentinel, Datadog, PagerDuty, ServiceNow, Argo, and similar.
+- Studio plugin or extension marketplace, or third-party Studio plugins.
+- Product telemetry, usage analytics, and phone-home behavior.
+- i18n and localization, theming and white-labeling, and offline-first mode.
+- Packaging and update channels beyond the initial agreed distribution path.
+- Any marketplace or community policy distribution model (deferred to a
+  follow-up ADR; see Consequences).
 
 ## Triage of existing dashboards
 
@@ -89,6 +116,12 @@ Build **AGT Studio** as the single first-class UI for AGT.
 
 Net effect: six dashboards collapse to one UI plus one Grafana template pack.
 `console.html` is deleted.
+
+These dispositions are proposed deprecation directions, not immediate
+removals. Because the change spans multiple packages, each affected
+maintainer must be notified before implementation. Deprecated dashboards
+receive migration notes and at least one release of overlap before archival
+or deletion.
 
 ## Alternatives considered
 
@@ -106,14 +139,21 @@ Net effect: six dashboards collapse to one UI plus one Grafana template pack.
 - **One canonical surface for AGT.** New features land in Studio, not in a
   new dashboard. The contributor question "where does this UI go" has one
   answer.
-- **Forces an engine API contract.** Studio needs a stable HTTP/WebSocket
-  surface from the engine. This contract benefits every SDK, not just the
-  UI, and unblocks a future conformance test suite for cross-SDK parity.
+- **Requires an engine API contract.** Studio depends on a stable local
+  HTTP/WebSocket API and a webview transport contract. This ADR does not
+  define that contract. Before Studio implementation lands, a follow-up ADR
+  or versioned spec must define endpoint and event schemas, transport
+  behavior, version negotiation, compatibility rules, and conformance tests.
+  Approving this ADR approves Studio as the canonical UI; it does not
+  approve the engine API surface, which is a separate gate.
 - **Demos improve immediately.** Sales, evaluator, and customer conversations
   gain a visual surface that does not require CLI familiarity.
-- **Ongoing cost.** A real product surface to maintain: accessibility,
-  browser matrix, dependency hygiene, release cadence, security review of a
-  new API. Owners and release cadence must be named before code lands.
+- **Ongoing cost.** Studio creates a maintained product surface:
+  accessibility review, browser compatibility, dependency and npm/PyPI CVE
+  response, API security review, local sidecar hardening, webview security
+  review, support load when browser or IDE updates break the UI, and
+  release/version compatibility management. Owners and release cadence must
+  be named before code lands.
 - **Deprecation work.** Six dashboards must be deprecated in sequence with
   clear migration notes and at least one release of overlap.
 - **Marketplace is a separate, later decision.** Studio is the prerequisite.
@@ -121,11 +161,36 @@ Net effect: six dashboards collapse to one UI plus one Grafana template pack.
   "awesome-policy" community hub) will be proposed as a follow-up ADR once
   Studio is shipping.
 
+## Success criteria
+
+This ADR is considered to have landed correctly when:
+
+- Policy authoring, testing, simulation, and regression workflows are usable
+  end-to-end in Studio without CLI-only steps.
+- All six existing dashboards have documented dispositions, owner sign-off,
+  migration paths, and at least one release of overlap with Studio.
+- Studio and engine version mismatches fail loudly with an actionable
+  upgrade message, never silently.
+- No new runtime write-path control is introduced as part of Studio.
+- The engine API contract referenced above ships as its own ADR or spec
+  before Studio MVP code merges.
+
 ## References
 
 - Policy replay engine: `agent-governance-python/agent-compliance/src/agent_compliance/policy_test.py`.
 - Dashboard backend: `agent-governance-python/agent-mesh/src/agentmesh/dashboard/api.py`.
 - Existing IDE extension UI surfaces under `agent-governance-python/agent-os/extensions/`.
 - Existing Streamlit dashboards listed in the triage table above.
-- Related ADR-0015 (pluggable external policy backends) and ADR-0022
-  (compliance framework auto-mapping).
+- ADR-0004 (deterministic policy evaluation): Studio's simulator and replay
+  views depend on this guarantee.
+- ADR-0015 (pluggable external policy backends): Studio must work uniformly
+  across YAML rules and external backends (OPA/Rego, Cedar).
+- ADR-0017 (Merkle chain for audit tamper evidence): Studio's audit-chain
+  integrity badge depends on this mechanism.
+- ADR-0021 (CloudEvents envelope for mesh audit): Studio's evidence export
+  uses this envelope.
+- ADR-0022 (compliance framework auto-mapping): Studio's compliance view
+  surfaces these mappings.
+- ADR-0025 (structural typing for sink and source protocols): Studio's
+  visibility panels consume `AuditSource`, `TrustSource`, `PolicySource`,
+  and `TraceSource` via these protocols.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ Each ADR captures:
 - [ADR 0008: Cross-org policy federation](0008-cross-org-policy-federation.md)
 - [ADR 0009: RFC 9334 (RATS) architecture alignment](0009-rfc-9334-rats-architecture-alignment.md)
 - [ADR 0027: Adopt a dual-stack migration for MCP `2026-07-28`](0027-adopt-dual-stack-migration-for-mcp-2026-07-28.md)
+- [ADR 0028: AGT Studio, a single unified UI for governance](0028-agt-studio-unified-ui.md)
 
 ## Template
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -41,3 +41,4 @@ Key architectural decisions and their rationale. Each ADR follows the standard f
 | [ADR-0011](0011-additive-policy-check-contract.md) | Additive policy check contract | Policy |
 | [ADR-0026](0026-foundry-ai-gateway-functions-pdp.md) | Azure Functions PDP behind AI Gateway for Foundry prompt-based agents | Policy |
 | [ADR-0027](0027-adopt-dual-stack-migration-for-mcp-2026-07-28.md) | Dual-stack migration for MCP `2026-07-28` | MCP |
+| [ADR-0028](0028-agt-studio-unified-ui.md) | AGT Studio, a single unified UI for governance | UI |


### PR DESCRIPTION
## Summary

Proposes **ADR 0028: AGT Studio, a single unified UI for governance**, which collapses the seven scattered AGT UI surfaces (six Streamlit dashboards, three IDE extensions' UI panels, a Chrome extension, and a static `console.html`) into a single first-class, policy-first UI shipped as both a standalone web app (`agt ui`) and a VS Code / Cursor webview from one SPA codebase.

Tracks RFC #2638.

## Problem

Today AGT has the engine, the SDKs, and the sinks, but no front door:

- Six Streamlit dashboards mostly using simulated data, rarely used in production, each doing one bespoke thing.
- Three IDE extensions with overlapping tree views for policies, audit, and stats.
- A Chrome extension targeted at browsing safety.
- A static `console.html` pitch asset.

This leaves the policy lifecycle CLI-only despite 70+ example policies and 14 templates already shipping, makes demos require whiteboard diagrams to land, and gives new contributors no canonical place to put UI work.

A separate review explicitly ruled out building a full operator/SOC console (write-path risk, auth surface, ongoing support cost, and existing competition from Sentinel / Defender / Foundry). AGT Studio is the smaller, policy-first answer.

## Changes

| File | What changed |
|------|-------------|
| `docs/adr/0028-agt-studio-unified-ui.md` | New ADR (proposed): Context, Decision, Scope Boundary, CLI ownership, In/Out of scope tables, Dashboard triage table for the six existing dashboards, Alternatives, Consequences, Success Criteria, References. |
| `docs/adr/index.md` | One row added under the Proposed table. |
| `docs/adr/README.md` | One bullet added to the ADR Index list. |

## Process notes

- **Pre-PR rubber-duck pass applied.** The second commit on this branch adopts findings from a focused critique of the ADR before submission: explicit scope-boundary text preventing V1 visibility from drifting into operator-console territory, reframing the engine API contract as "Requires" (not "Forces") with explicit deferral to a separate ADR, dashboard triage deprecation process, success criteria, expanded out-of-scope list, and missing ADR cross-references (0004, 0017, 0021, 0025).
- **Cross-package scope.** This decision affects `agent-compliance` (CLI), `agent-mesh` (dashboard backend), and `agent-os` (IDE extensions). Per the project's escalation rules, this is exactly the cross-cutting scope that needs maintainer approval, which is what this ADR PR is asking for.
- **No code yet.** Implementation requires a separate engine API ADR/spec before Studio MVP can land. This PR is the strategic gate.
- **Marketplace deferred.** Captured as a future ADR; not part of this proposal.

## Testing

Docs-only change. Verified:

- `python scripts/docs/check_links.py` against the new ADR: 0 broken links.
- `python scripts/docs/check_frontmatter.py`: only a warn-level "missing frontmatter" finding, which matches house style for ADRs (no other ADR in the directory uses frontmatter).
- Manual em-dash scan: clean (project rule).
- Manual house-style match against ADRs 0015, 0022, 0025, 0027: dash-list status header, MADR sections, conventional commit message, DCO signoff.

## Related

- Closes / addresses: #2638 (RFC: AGT Studio, a single unified UI for governance)
- Builds on: ADR-0004 (deterministic policy evaluation), ADR-0015 (pluggable external policy backends), ADR-0017 (Merkle chain audit), ADR-0021 (CloudEvents envelope), ADR-0022 (compliance framework mapping), ADR-0025 (structural typing for sink/source protocols).
- Future follow-ups (not in this PR): engine API contract ADR, policy marketplace ADR.
