### PR TITLE
fix(mute-agent): harden adapters and confirmation gates against fail-open and bypass

### DIFF
--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/execution_agent.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/execution_agent.py
@@ -4,24 +4,24 @@
 The Hands - The Execution Agent
 """
 
-from typing import Dict, List, Optional, Any, Callable
+from typing import Dict, List, Any, Callable
 from .handshake_protocol import HandshakeProtocol, HandshakeSession, HandshakeState
 
 
 class ExecutionAgent:
     """
     The Hands - The Execution Agent
-    
+
     This agent is responsible for executing actions that have been negotiated
     and validated through the Handshake Protocol. It does not reason about
     actions but simply executes them when properly authorized.
     """
-    
+
     def __init__(self, protocol: HandshakeProtocol):
         self.protocol = protocol
         self.execution_handlers: Dict[str, Callable] = {}
         self.execution_history: List[Dict[str, Any]] = []
-    
+
     def register_action_handler(
         self,
         action_id: str,
@@ -32,29 +32,32 @@ class ExecutionAgent:
         The handler receives parameters and returns results.
         """
         self.execution_handlers[action_id] = handler
-    
+
     def execute(self, session_id: str) -> HandshakeSession:
         """
         Execute an action from an accepted handshake session.
         This is the main execution entry point.
         """
         session = self.protocol.get_session(session_id)
-        
+
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
         if session.state != HandshakeState.ACCEPTED:
             raise ValueError(
                 f"Cannot execute session in state {session.state}. "
                 f"Session must be in ACCEPTED state."
             )
-        
+
+        if not self.protocol.is_confirmation_satisfied(session):
+            raise ValueError("Cannot execute session until confirmation is satisfied")
+
         if not session.proposal:
             raise ValueError("Session has no proposal")
-        
+
         # Mark as executing
         self.protocol.start_execution(session_id)
-        
+
         try:
             # Execute the action
             result = self._execute_action(
@@ -62,10 +65,10 @@ class ExecutionAgent:
                 session.proposal.parameters,
                 session.proposal.context
             )
-            
+
             # Mark as completed
             self.protocol.complete_execution(session_id, result)
-            
+
             # Store in history
             self.execution_history.append({
                 "session_id": session_id,
@@ -73,11 +76,11 @@ class ExecutionAgent:
                 "result": result,
                 "success": True
             })
-            
+
         except Exception as e:
             # Mark as failed
             self.protocol.fail_execution(session_id, str(e))
-            
+
             # Store in history
             self.execution_history.append({
                 "session_id": session_id,
@@ -85,11 +88,11 @@ class ExecutionAgent:
                 "error": str(e),
                 "success": False
             })
-            
+
             raise
-        
+
         return self.protocol.get_session(session_id)
-    
+
     def _execute_action(
         self,
         action_id: str,
@@ -100,7 +103,7 @@ class ExecutionAgent:
         Execute a specific action using its registered handler.
         """
         handler = self.execution_handlers.get(action_id)
-        
+
         if not handler:
             # If no handler registered, return a default result
             return {
@@ -109,32 +112,35 @@ class ExecutionAgent:
                 "action_id": action_id,
                 "parameters": parameters
             }
-        
+
         # Call the handler
         result = handler(parameters)
-        
+
         return {
             "status": "success",
             "action_id": action_id,
             "result": result
         }
-    
+
     def can_execute(self, session_id: str) -> bool:
         """Check if a session can be executed."""
         session = self.protocol.get_session(session_id)
-        
+
         if not session:
             return False
-        
+
         if session.state != HandshakeState.ACCEPTED:
             return False
-        
+
+        if not self.protocol.is_confirmation_satisfied(session):
+            return False
+
         if not session.proposal:
             return False
-        
+
         # Check if handler is registered (optional)
         return True
-    
+
     def get_execution_statistics(self) -> Dict[str, Any]:
         """Get statistics about execution operations."""
         if not self.execution_history:
@@ -144,11 +150,11 @@ class ExecutionAgent:
                 "failed_executions": 0,
                 "success_rate": 0.0
             }
-        
+
         total = len(self.execution_history)
         successful = sum(1 for exec in self.execution_history if exec["success"])
         failed = total - successful
-        
+
         return {
             "total_executions": total,
             "successful_executions": successful,
@@ -156,7 +162,7 @@ class ExecutionAgent:
             "success_rate": successful / total if total > 0 else 0.0,
             "actions_executed": self._get_action_counts()
         }
-    
+
     def _get_action_counts(self) -> Dict[str, int]:
         """Get counts of how many times each action was executed."""
         counts = {}

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/handshake_protocol.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/handshake_protocol.py
@@ -11,8 +11,11 @@ from enum import Enum
 from datetime import datetime
 
 
-CONFIRMATION_REQUIRED_KEY = "requires_confirmation"
+CONFIRMATION_REQUIRED_KEY = "confirmation_required"
 CONFIRMATION_SATISFIED_KEY = "confirmation_satisfied"
+# Legacy alias accepted on read so callers using the older "requires_confirmation"
+# metadata key still trip the gate. Producers should write CONFIRMATION_REQUIRED_KEY.
+_CONFIRMATION_REQUIRED_ALIASES = (CONFIRMATION_REQUIRED_KEY, "requires_confirmation")
 
 
 class HandshakeState(Enum):
@@ -253,7 +256,9 @@ class HandshakeProtocol:
 
     def requires_confirmation(self, session: HandshakeSession) -> bool:
         """Check whether a session is gated on explicit confirmation."""
-        return bool(session.metadata.get(CONFIRMATION_REQUIRED_KEY))
+        return any(
+            bool(session.metadata.get(key)) for key in _CONFIRMATION_REQUIRED_ALIASES
+        )
 
     def is_confirmation_satisfied(self, session: HandshakeSession) -> bool:
         """Check whether a confirmation gate is either absent or satisfied."""

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/handshake_protocol.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/handshake_protocol.py
@@ -244,6 +244,11 @@ class HandshakeProtocol:
         if not session:
             raise ValueError(f"Session {session_id} not found")
 
+        if session.state in TERMINAL_STATES:
+            raise ValueError(
+                f"Cannot confirm session in terminal state {session.state}"
+            )
+
         if not self.requires_confirmation(session):
             raise ValueError("Session does not require confirmation")
 

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/handshake_protocol.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/core/handshake_protocol.py
@@ -11,6 +11,10 @@ from enum import Enum
 from datetime import datetime
 
 
+CONFIRMATION_REQUIRED_KEY = "requires_confirmation"
+CONFIRMATION_SATISFIED_KEY = "confirmation_satisfied"
+
+
 class HandshakeState(Enum):
     """States in the handshake protocol."""
     INITIATED = "initiated"
@@ -21,6 +25,13 @@ class HandshakeState(Enum):
     EXECUTING = "executing"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+TERMINAL_STATES = frozenset({
+    HandshakeState.REJECTED,
+    HandshakeState.COMPLETED,
+    HandshakeState.FAILED,
+})
 
 
 @dataclass
@@ -61,15 +72,15 @@ class HandshakeProtocol:
     """
     The Dynamic Semantic Handshake Protocol manages the negotiation
     between the Reasoning Agent (The Face) and the Execution Agent (The Hands).
-    
+
     Instead of free-text tool invocation, actions must be negotiated against
     the knowledge graph constraints.
     """
-    
+
     def __init__(self):
         self.sessions: Dict[str, HandshakeSession] = {}
         self._session_counter = 0
-    
+
     def initiate_handshake(
         self,
         proposal: ActionProposal
@@ -86,7 +97,7 @@ class HandshakeProtocol:
         )
         self.sessions[session_id] = session
         return session
-    
+
     def validate_proposal(
         self,
         session_id: str,
@@ -99,13 +110,19 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state not in (HandshakeState.INITIATED, HandshakeState.NEGOTIATING):
+            raise ValueError(
+                f"Cannot validate proposal in state {session.state}; "
+                "validation is only allowed from INITIATED or NEGOTIATING."
+            )
+
         session.validation_result = validation_result
         session.state = HandshakeState.VALIDATED if validation_result.is_valid else HandshakeState.REJECTED
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def accept_proposal(self, session_id: str) -> HandshakeSession:
         """
         Accept a validated proposal for execution.
@@ -114,18 +131,20 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
         if session.state != HandshakeState.VALIDATED:
             raise ValueError(f"Cannot accept proposal in state {session.state}")
-        
+
         if not session.validation_result or not session.validation_result.is_valid:
             raise ValueError("Cannot accept invalid proposal")
-        
+
+        self._ensure_confirmation_satisfied(session, "accept")
+
         session.state = HandshakeState.ACCEPTED
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def reject_proposal(
         self,
         session_id: str,
@@ -135,13 +154,18 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state in TERMINAL_STATES:
+            raise ValueError(
+                f"Cannot reject proposal in terminal state {session.state}"
+            )
+
         session.state = HandshakeState.REJECTED
         session.metadata["rejection_reason"] = reason
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def start_execution(self, session_id: str) -> HandshakeSession:
         """
         Start executing an accepted proposal.
@@ -150,15 +174,17 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
         if session.state != HandshakeState.ACCEPTED:
             raise ValueError(f"Cannot execute proposal in state {session.state}")
-        
+
+        self._ensure_confirmation_satisfied(session, "execute")
+
         session.state = HandshakeState.EXECUTING
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def complete_execution(
         self,
         session_id: str,
@@ -168,13 +194,18 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state != HandshakeState.EXECUTING:
+            raise ValueError(f"Cannot complete execution in state {session.state}")
+
+        self._ensure_confirmation_satisfied(session, "complete")
+
         session.execution_result = result
         session.state = HandshakeState.COMPLETED
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def fail_execution(
         self,
         session_id: str,
@@ -184,17 +215,63 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state in TERMINAL_STATES:
+            raise ValueError(
+                f"Cannot fail execution in terminal state {session.state}"
+            )
+
         session.state = HandshakeState.FAILED
         session.metadata["error"] = error
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def get_session(self, session_id: str) -> Optional[HandshakeSession]:
         """Get a session by ID."""
         return self.sessions.get(session_id)
-    
+
+    def confirm_session(
+        self,
+        session_id: str,
+        confirmed_by: Optional[str] = None,
+    ) -> HandshakeSession:
+        """Record that a required confirmation has been satisfied."""
+        session = self.sessions.get(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        if not self.requires_confirmation(session):
+            raise ValueError("Session does not require confirmation")
+
+        session.metadata[CONFIRMATION_SATISFIED_KEY] = True
+        if confirmed_by:
+            session.metadata["confirmed_by"] = confirmed_by
+        session.metadata["confirmed_at"] = datetime.now().isoformat()
+        session.updated_at = datetime.now()
+        return session
+
+    def requires_confirmation(self, session: HandshakeSession) -> bool:
+        """Check whether a session is gated on explicit confirmation."""
+        return bool(session.metadata.get(CONFIRMATION_REQUIRED_KEY))
+
+    def is_confirmation_satisfied(self, session: HandshakeSession) -> bool:
+        """Check whether a confirmation gate is either absent or satisfied."""
+        if not self.requires_confirmation(session):
+            return True
+        return session.metadata.get(CONFIRMATION_SATISFIED_KEY) is True
+
+    def _ensure_confirmation_satisfied(
+        self,
+        session: HandshakeSession,
+        transition: str,
+    ) -> None:
+        if self.is_confirmation_satisfied(session):
+            return
+
+        reason = session.metadata.get("confirmation_reason", "confirmation required")
+        raise ValueError(f"Cannot {transition} proposal until confirmation is satisfied: {reason}")
+
     def _generate_session_id(self) -> str:
         """Generate a unique session ID."""
         self._session_counter += 1

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/__init__.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/__init__.py
@@ -14,10 +14,10 @@ without reimplementing any lower-layer logic.
 """
 
 from .base_adapter import BaseLayerAdapter, AdapterProtocol
-from .scak_adapter import IntelligenceAdapter
-from .iatp_adapter import SecurityAdapter
-from .caas_adapter import ContextAdapter
-from .control_plane_adapter import ControlPlaneAdapter
+from .scak_adapter import IntelligenceAdapter, IntelligenceBackendUnavailable
+from .iatp_adapter import SecurityAdapter, SecurityBackendUnavailable
+from .caas_adapter import ContextAdapter, ContextBackendUnavailable
+from .control_plane_adapter import ControlPlaneAdapter, ControlPlaneBackendUnavailable
 
 __all__ = [
     # Base
@@ -25,7 +25,11 @@ __all__ = [
     "AdapterProtocol",
     # Layer adapters
     "IntelligenceAdapter",
+    "IntelligenceBackendUnavailable",
     "SecurityAdapter",
+    "SecurityBackendUnavailable",
     "ContextAdapter",
+    "ContextBackendUnavailable",
     "ControlPlaneAdapter",
+    "ControlPlaneBackendUnavailable",
 ]

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/base_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/base_adapter.py
@@ -157,11 +157,12 @@ class BaseLayerAdapter(ABC):
         
         except Exception as e:
             self._connected = False
+            self._last_error = f"{type(e).__name__}: {e}"
             return AdapterStatus(
                 connected=False,
                 layer_name=self.get_layer_name(),
                 last_health_check=self._last_health_check,
-                error=str(e),
+                error=self._last_error,
             )
     
     def _health_ping(self) -> None:

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/base_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/base_adapter.py
@@ -71,6 +71,7 @@ class BaseLayerAdapter(ABC):
         self._connected = False
         self._last_health_check: Optional[datetime] = None
         self._client: Optional[Any] = None
+        self._last_error: Optional[str] = None
     
     @abstractmethod
     def get_layer_name(self) -> str:
@@ -102,13 +103,15 @@ class BaseLayerAdapter(ABC):
                 self._client = self._mock_client()
             else:
                 self._client = self._create_client()
-            
+
             self._connected = True
             self._last_health_check = datetime.now()
+            self._last_error = None
             return True
-        
+
         except Exception as e:
             self._connected = False
+            self._last_error = f"{type(e).__name__}: {e}"
             return False
     
     def disconnect(self) -> None:
@@ -135,7 +138,7 @@ class BaseLayerAdapter(ABC):
             return AdapterStatus(
                 connected=False,
                 layer_name=self.get_layer_name(),
-                error="Not connected",
+                error=self._last_error or "Not connected",
             )
         
         try:
@@ -184,6 +187,7 @@ class BaseLayerAdapter(ABC):
         """Ensure adapter is connected, raising if not."""
         if not self._connected:
             if not self.connect():
+                detail = f": {self._last_error}" if self._last_error else ""
                 raise ConnectionError(
-                    f"Failed to connect to {self.get_layer_name()}"
+                    f"Failed to connect to {self.get_layer_name()}{detail}"
                 )

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/caas_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/caas_adapter.py
@@ -15,11 +15,16 @@ In the Listener context, this adapter is used to:
 The adapter delegates all context logic to CAAS - no reimplementation.
 """
 
+from importlib import import_module
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from .base_adapter import BaseLayerAdapter
+
+
+class ContextBackendUnavailable(RuntimeError):
+    """Raised when the CAAS context backend is unavailable."""
 
 
 @dataclass
@@ -142,19 +147,31 @@ class ContextAdapter(BaseLayerAdapter):
     def _create_client(self) -> Any:
         """
         Create the CAAS client.
-        
-        In production, this would import and instantiate the actual
-        caas library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed CAAS backend. The
+        permissive mock client (which always reports zero drift / zero ambiguity)
+        is only available when mock_mode=True or an explicit ``client_factory``
+        is supplied.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real CAAS client
-            # from caas import Client as CAASClient
-            # return CAASClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
+            caas_module = import_module("caas")
+        except ImportError as exc:
+            raise ContextBackendUnavailable(
+                "CAAS context backend is required when mock_mode is False. "
+                "Install/configure caas or instantiate ContextAdapter(mock_mode=True) "
+                "only in tests or demos."
+            ) from exc
+
+        client_class = getattr(caas_module, "Client", None)
+        if client_class is None:
+            raise ContextBackendUnavailable(
+                "CAAS backend does not expose a Client class"
+            )
+        return client_class(self.config)
     
     def _mock_client(self) -> Any:
         """Create mock client for testing."""

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/control_plane_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/control_plane_adapter.py
@@ -15,12 +15,17 @@ In the Listener context, this adapter is used to:
 The adapter delegates all orchestration to the control plane - no reimplementation.
 """
 
+from importlib import import_module
 from typing import Dict, Any, Optional, List, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, auto
 
 from .base_adapter import BaseLayerAdapter
+
+
+class ControlPlaneBackendUnavailable(RuntimeError):
+    """Raised when the Agent Control Plane backend is unavailable."""
 
 
 class AgentLifecycleState(Enum):
@@ -197,19 +202,31 @@ class ControlPlaneAdapter(BaseLayerAdapter):
     def _create_client(self) -> Any:
         """
         Create the Control Plane client.
-        
-        In production, this would import and instantiate the actual
-        agent-control-plane library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed agent-control-plane
+        backend. The permissive mock client (which auto-confirms registrations,
+        heartbeats, and queue ops) is only available when mock_mode=True or an
+        explicit ``client_factory`` is supplied.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real Control Plane client
-            # from agent_control_plane import Client as ControlPlaneClient
-            # return ControlPlaneClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
+            cp_module = import_module("agent_control_plane")
+        except ImportError as exc:
+            raise ControlPlaneBackendUnavailable(
+                "agent-control-plane backend is required when mock_mode is False. "
+                "Install/configure agent_control_plane or instantiate "
+                "ControlPlaneAdapter(mock_mode=True) only in tests or demos."
+            ) from exc
+
+        client_class = getattr(cp_module, "Client", None)
+        if client_class is None:
+            raise ControlPlaneBackendUnavailable(
+                "agent-control-plane backend does not expose a Client class"
+            )
+        return client_class(self.config)
     
     def _mock_client(self) -> Any:
         """Create mock client for testing."""

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/iatp_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/iatp_adapter.py
@@ -15,9 +15,10 @@ In the Listener context, this adapter is used to:
 The adapter delegates all security logic to IATP - no reimplementation.
 """
 
-from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from datetime import datetime
+from importlib import import_module
+from typing import Any, Dict, List, Optional
 
 from .base_adapter import BaseLayerAdapter
 
@@ -25,7 +26,7 @@ from .base_adapter import BaseLayerAdapter
 @dataclass
 class TrustAssessment:
     """Result of a trust assessment from IATP."""
-    
+
     actor_id: str
     trust_score: float  # 0.0 to 1.0
     confidence: float  # 0.0 to 1.0
@@ -37,7 +38,7 @@ class TrustAssessment:
 @dataclass
 class SecurityEvent:
     """A security event detected or reported via IATP."""
-    
+
     event_id: str
     event_type: str
     severity: str  # "low", "medium", "high", "critical"
@@ -50,7 +51,7 @@ class SecurityEvent:
 @dataclass
 class PermissionCheck:
     """Result of a permission check from IATP."""
-    
+
     allowed: bool
     actor_id: str
     permission: str
@@ -58,13 +59,17 @@ class PermissionCheck:
     escalation_detected: bool
 
 
+class SecurityBackendUnavailable(RuntimeError):
+    """Raised when the required IATP backend is unavailable."""
+
+
 class MockIATPClient:
     """Mock IATP client for testing without the actual dependency."""
-    
+
     def __init__(self):
         self._trust_scores: Dict[str, float] = {}
         self._events: List[SecurityEvent] = []
-    
+
     def assess_trust(self, actor_id: str) -> TrustAssessment:
         """Mock trust assessment."""
         return TrustAssessment(
@@ -75,7 +80,7 @@ class MockIATPClient:
             timestamp=datetime.now(),
             warnings=[],
         )
-    
+
     def check_permission(
         self,
         actor_id: str,
@@ -90,12 +95,12 @@ class MockIATPClient:
             reason="Mock: all permissions allowed",
             escalation_detected=False,
         )
-    
+
     def report_event(self, event: SecurityEvent) -> str:
         """Mock event reporting."""
         self._events.append(event)
         return event.event_id
-    
+
     def emergency_alert(
         self,
         reason: str,
@@ -103,11 +108,11 @@ class MockIATPClient:
     ) -> str:
         """Mock emergency alert."""
         return f"emergency_alert_{datetime.now().timestamp()}"
-    
+
     def get_anomaly_score(self, context: Dict[str, Any]) -> float:
         """Mock anomaly detection."""
         return 0.1
-    
+
     def close(self) -> None:
         """Close mock client."""
         pass
@@ -116,21 +121,21 @@ class MockIATPClient:
 class SecurityAdapter(BaseLayerAdapter):
     """
     Adapter for IATP (Security/Trust) layer.
-    
+
     Provides a clean interface for the Listener to access security
     operations without reimplementing any IATP logic.
-    
+
     Usage:
         ```python
         adapter = SecurityAdapter(mock_mode=True)
         adapter.connect()
-        
+
         # Assess trust for an actor
         assessment = adapter.assess_trust("user_123")
-        
+
         # Check for anomalies
         anomaly_score = adapter.get_anomaly_score({"action": "delete"})
-        
+
         # Report a security event
         adapter.report_security_event(
             event_type="permission_escalation_attempt",
@@ -139,60 +144,69 @@ class SecurityAdapter(BaseLayerAdapter):
         )
         ```
     """
-    
+
     def get_layer_name(self) -> str:
         return "iatp"
-    
+
     def _create_client(self) -> Any:
         """
         Create the IATP client.
-        
-        In production, this would import and instantiate the actual
-        iatp library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed IATP backend. The
+        permissive mock client is only available when mock_mode=True.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real IATP client
-            # from iatp import Client as IATPClient
-            # return IATPClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
-    
+            iatp_module = import_module("iatp")
+        except ImportError as exc:
+            raise SecurityBackendUnavailable(
+                "IATP security backend is required when mock_mode is False. "
+                "Install/configure iatp or instantiate SecurityAdapter(mock_mode=True) "
+                "only in tests or demos."
+            ) from exc
+
+        client_class = getattr(iatp_module, "Client", None)
+        if client_class is None:
+            raise SecurityBackendUnavailable("IATP backend does not expose a Client class")
+
+        return client_class(self.config)
+
     def _mock_client(self) -> Any:
         """Create mock client for testing."""
         return MockIATPClient()
-    
+
     def _health_ping(self) -> None:
         """Verify IATP connection."""
         if self._client:
             # In production: self._client.ping()
             pass
-    
+
     def _get_version(self) -> Optional[str]:
         """Get IATP version."""
         if self._client and hasattr(self._client, 'version'):
             return self._client.version
         return "mock-1.0.0" if self.mock_mode else None
-    
+
     # === IATP-specific operations ===
-    
+
     def assess_trust(self, actor_id: str) -> TrustAssessment:
         """
         Assess trust for an actor.
-        
+
         Delegates entirely to IATP trust assessment.
-        
+
         Args:
             actor_id: Identifier of the actor to assess
-            
+
         Returns:
             TrustAssessment with trust score and factors
         """
         self.ensure_connected()
         return self._client.assess_trust(actor_id)
-    
+
     def check_permission(
         self,
         actor_id: str,
@@ -201,20 +215,20 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> PermissionCheck:
         """
         Check if an actor has a permission.
-        
+
         Delegates to IATP permission verification.
-        
+
         Args:
             actor_id: Actor requesting permission
             permission: Permission being requested
             resource: Optional resource the permission applies to
-            
+
         Returns:
             PermissionCheck with result and escalation detection
         """
         self.ensure_connected()
         return self._client.check_permission(actor_id, permission, resource)
-    
+
     def report_security_event(
         self,
         event_type: str,
@@ -225,19 +239,19 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> str:
         """
         Report a security event to IATP.
-        
+
         Args:
             event_type: Type of security event
             severity: Severity level ("low", "medium", "high", "critical")
             description: Human-readable description
             actor_id: Optional actor involved
             metadata: Optional additional metadata
-            
+
         Returns:
             Event ID from IATP
         """
         self.ensure_connected()
-        
+
         event = SecurityEvent(
             event_id=f"event_{datetime.now().timestamp()}",
             event_type=event_type,
@@ -247,9 +261,9 @@ class SecurityAdapter(BaseLayerAdapter):
             timestamp=datetime.now(),
             metadata=metadata or {},
         )
-        
+
         return self._client.report_event(event)
-    
+
     def emergency_alert(
         self,
         reason: str,
@@ -258,51 +272,51 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> str:
         """
         Trigger an emergency security alert.
-        
+
         This notifies IATP of a critical security situation requiring
         immediate attention.
-        
+
         Args:
             reason: Reason for the emergency
             triggered_rules: List of rules that triggered the emergency
             context: Optional additional context
-            
+
         Returns:
             Alert ID from IATP
         """
         self.ensure_connected()
         return self._client.emergency_alert(reason, triggered_rules)
-    
+
     def get_anomaly_score(self, context: Dict[str, Any]) -> float:
         """
         Get anomaly score for a context.
-        
+
         Delegates to IATP anomaly detection.
-        
+
         Args:
             context: Context to analyze for anomalies
-            
+
         Returns:
             Anomaly score (0.0 = normal, 1.0 = highly anomalous)
         """
         self.ensure_connected()
         return self._client.get_anomaly_score(context)
-    
+
     def get_trust_score(self, actor_id: str) -> float:
         """
         Get the current trust score for an actor.
-        
+
         Convenience method that extracts just the score.
-        
+
         Args:
             actor_id: Actor to get trust score for
-            
+
         Returns:
             Trust score (0.0 to 1.0)
         """
         assessment = self.assess_trust(actor_id)
         return assessment.trust_score
-    
+
     def detect_permission_escalation(
         self,
         actor_id: str,
@@ -311,22 +325,22 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> bool:
         """
         Detect if a permission escalation is being attempted.
-        
+
         Args:
             actor_id: Actor making the request
             requested_permissions: Permissions being requested
             current_permissions: Actor's current permissions
-            
+
         Returns:
             True if escalation detected
         """
         self.ensure_connected()
-        
+
         # Check each requested permission
         for perm in requested_permissions:
             if perm not in current_permissions:
                 check = self.check_permission(actor_id, perm)
                 if check.escalation_detected:
                     return True
-        
+
         return False

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/scak_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/adapters/scak_adapter.py
@@ -14,10 +14,15 @@ In the Listener context, this adapter is used to:
 The adapter delegates all intelligence to SCAK - no logic is reimplemented.
 """
 
+from importlib import import_module
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 
 from .base_adapter import BaseLayerAdapter
+
+
+class IntelligenceBackendUnavailable(RuntimeError):
+    """Raised when the SCAK intelligence backend is unavailable."""
 
 
 @dataclass
@@ -114,19 +119,30 @@ class IntelligenceAdapter(BaseLayerAdapter):
     def _create_client(self) -> Any:
         """
         Create the SCAK client.
-        
-        In production, this would import and instantiate the actual
-        scak library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed SCAK backend. The
+        permissive mock client (which validates everything) is only available
+        when mock_mode=True or an explicit ``client_factory`` is supplied.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real SCAK client
-            # from scak import Client as SCAKClient
-            # return SCAKClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
+            scak_module = import_module("scak")
+        except ImportError as exc:
+            raise IntelligenceBackendUnavailable(
+                "SCAK intelligence backend is required when mock_mode is False. "
+                "Install/configure scak or instantiate IntelligenceAdapter(mock_mode=True) "
+                "only in tests or demos."
+            ) from exc
+
+        client_class = getattr(scak_module, "Client", None)
+        if client_class is None:
+            raise IntelligenceBackendUnavailable(
+                "SCAK backend does not expose a Client class"
+            )
+        return client_class(self.config)
     
     def _mock_client(self) -> Any:
         """Create mock client for testing."""

--- a/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/listener.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/mute_agent/listener/listener.py
@@ -13,23 +13,26 @@ Architecture:
 
 This module is pure wiring - it delegates to lower layers:
 - Knowledge graph operations → scak (intelligence layer)
-- Security validation → iatp (security layer)  
+- Security validation → iatp (security layer)
 - Context management → caas (context layer)
 - Base orchestration → agent-control-plane
 """
 
 from typing import Dict, Any, Optional, List, Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
-from enum import Enum, auto
+from datetime import datetime
+from enum import Enum
 import threading
 import time
 from collections import deque
 
 from ..knowledge_graph.multidimensional_graph import MultidimensionalKnowledgeGraph
-from ..core.handshake_protocol import HandshakeProtocol, HandshakeSession, HandshakeState
-from ..core.reasoning_agent import ReasoningAgent
-from ..core.execution_agent import ExecutionAgent
+from ..core.handshake_protocol import (
+    CONFIRMATION_REQUIRED_KEY,
+    CONFIRMATION_SATISFIED_KEY,
+    HandshakeProtocol,
+    HandshakeState,
+)
 from ..super_system.router import SuperSystemRouter
 
 from .threshold_config import (
@@ -44,22 +47,22 @@ from .state_observer import StateObserver, ObservationResult
 
 class ListenerState(Enum):
     """States of the Listener Agent."""
-    
+
     # Not actively observing
     IDLE = "idle"
-    
+
     # Passively observing - no intervention
     OBSERVING = "observing"
-    
+
     # Detected threshold breach - evaluating response
     EVALUATING = "evaluating"
-    
+
     # Actively intervening
     INTERVENING = "intervening"
-    
+
     # Intervention complete, returning to observation
     RECOVERING = "recovering"
-    
+
     # Stopped - not operational
     STOPPED = "stopped"
 
@@ -68,11 +71,11 @@ class ListenerState(Enum):
 class InterventionEvent:
     """
     Record of a Listener intervention.
-    
+
     This provides an audit trail of when and why the Listener
     transitioned from passive observation to active intervention.
     """
-    
+
     event_id: str
     timestamp: datetime
     triggered_rules: List[ThresholdRule]
@@ -87,19 +90,19 @@ class InterventionEvent:
 @dataclass
 class ListenerConfig:
     """Configuration for the Listener Agent."""
-    
+
     # Threshold configuration
     thresholds: ThresholdConfig = field(default_factory=lambda: DEFAULT_THRESHOLDS)
-    
+
     # Observation settings
     observation_interval_seconds: float = 1.0
     max_observation_history: int = 1000
-    
+
     # Intervention settings
     auto_intervention: bool = True
     require_confirmation: bool = False
     max_interventions_per_minute: int = 10
-    
+
     # Recovery settings
     recovery_observation_count: int = 5
     recovery_success_threshold: float = 0.8
@@ -108,35 +111,35 @@ class ListenerConfig:
 class ListenerAgent:
     """
     Layer 5 Reference Implementation: The Listener Agent
-    
+
     A passive observer that monitors graph states and only intervenes
     when configured thresholds are exceeded.
-    
+
     Design Principles:
     1. Passive by default - observe without interference
     2. Threshold-driven intervention - clear, configurable triggers
     3. Minimal footprint - delegate to lower layers
     4. Full audit trail - every intervention is logged
-    
+
     Usage:
         ```python
         # Create core components
         kg = MultidimensionalKnowledgeGraph()
         protocol = HandshakeProtocol()
         router = SuperSystemRouter(kg)
-        
+
         # Create and start listener
         listener = ListenerAgent(kg, protocol, router)
         listener.start()
-        
+
         # Listener now monitors passively...
         # When thresholds are exceeded, it intervenes automatically
-        
+
         # Stop when done
         listener.stop()
         ```
     """
-    
+
     def __init__(
         self,
         knowledge_graph: MultidimensionalKnowledgeGraph,
@@ -149,7 +152,7 @@ class ListenerAgent:
     ):
         """
         Initialize the Listener Agent.
-        
+
         Args:
             knowledge_graph: The graph to monitor (via scak)
             protocol: The handshake protocol to observe
@@ -162,11 +165,11 @@ class ListenerAgent:
         self.protocol = protocol
         self.router = router
         self.config = config or ListenerConfig()
-        
+
         # Lower-layer adapters (for consolidated stack)
         self._security_adapter = security_adapter
         self._context_adapter = context_adapter
-        
+
         # State observer
         self.observer = StateObserver(
             knowledge_graph=knowledge_graph,
@@ -174,15 +177,15 @@ class ListenerAgent:
             router=router,
             sample_window_seconds=self.config.thresholds.window_size_seconds,
         )
-        
+
         # Current state
         self._state = ListenerState.IDLE
         self._state_lock = threading.Lock()
-        
+
         # Observation thread
         self._observation_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
-        
+
         # Intervention tracking
         self._interventions: deque = deque(
             maxlen=self.config.max_observation_history
@@ -190,44 +193,44 @@ class ListenerAgent:
         self._intervention_count_this_minute = 0
         self._minute_start = datetime.now()
         self._event_counter = 0
-        
+
         # Callbacks
         self._intervention_callbacks: List[Callable[[InterventionEvent], None]] = []
         self._state_change_callbacks: List[Callable[[ListenerState, ListenerState], None]] = []
-    
+
     @property
     def state(self) -> ListenerState:
         """Get current listener state."""
         with self._state_lock:
             return self._state
-    
+
     def _set_state(self, new_state: ListenerState) -> None:
         """Set listener state with callback notification."""
         with self._state_lock:
             old_state = self._state
             self._state = new_state
-        
+
         # Notify callbacks outside lock
         for callback in self._state_change_callbacks:
             try:
                 callback(old_state, new_state)
             except Exception:
                 pass  # Don't let callback errors affect listener
-    
+
     def start(self) -> None:
         """
         Start the Listener Agent.
-        
+
         Begins passive observation of graph states. The listener will
         continue observing until stop() is called or an intervention
         threshold is exceeded.
         """
         if self._state != ListenerState.IDLE and self._state != ListenerState.STOPPED:
             raise RuntimeError(f"Cannot start listener in state {self._state}")
-        
+
         self._stop_event.clear()
         self._set_state(ListenerState.OBSERVING)
-        
+
         # Start observation thread
         self._observation_thread = threading.Thread(
             target=self._observation_loop,
@@ -235,102 +238,102 @@ class ListenerAgent:
             daemon=True,
         )
         self._observation_thread.start()
-    
+
     def stop(self) -> None:
         """
         Stop the Listener Agent.
-        
+
         Ceases observation and any ongoing intervention.
         """
         self._stop_event.set()
         self._set_state(ListenerState.STOPPED)
-        
+
         if self._observation_thread and self._observation_thread.is_alive():
             self._observation_thread.join(timeout=5.0)
-    
+
     def observe_once(self, context: Optional[Dict[str, Any]] = None) -> ObservationResult:
         """
         Perform a single observation cycle.
-        
+
         This is useful for synchronous observation without starting
         the background observation loop.
-        
+
         Args:
             context: Optional context to include
-            
+
         Returns:
             ObservationResult from this cycle
         """
         return self.observer.observe(context)
-    
+
     def evaluate_thresholds(
         self,
         observation: ObservationResult
     ) -> tuple[List[ThresholdRule], InterventionLevel]:
         """
         Evaluate observation against configured thresholds.
-        
+
         Args:
             observation: The observation to evaluate
-            
+
         Returns:
             Tuple of (triggered_rules, max_intervention_level)
         """
         # Convert observation to threshold metrics
         threshold_metrics = observation.to_threshold_metrics()
-        
+
         # Evaluate against thresholds
         triggered_rules = self.config.thresholds.evaluate_all(
             threshold_metrics,
             context={"observation": observation},
         )
-        
+
         # Get maximum intervention level
         max_level = self.config.thresholds.get_maximum_intervention_level(
             triggered_rules
         )
-        
+
         return triggered_rules, max_level
-    
+
     def _observation_loop(self) -> None:
         """Background observation loop."""
         while not self._stop_event.is_set():
             try:
                 self._run_observation_cycle()
-            except Exception as e:
+            except Exception:
                 # Log error but continue observation
                 # In production, this would integrate with logging framework
                 pass
-            
+
             # Wait for next observation interval
             self._stop_event.wait(self.config.observation_interval_seconds)
-    
+
     def _run_observation_cycle(self) -> None:
         """Run a single observation cycle."""
         # Perform observation
         observation = self.observer.observe()
-        
+
         # Evaluate thresholds
         triggered_rules, intervention_level = self.evaluate_thresholds(observation)
-        
+
         if not triggered_rules:
             # No thresholds exceeded - continue passive observation
             return
-        
+
         # Thresholds exceeded - evaluate intervention
         self._set_state(ListenerState.EVALUATING)
-        
+
         # Check rate limiting
         if not self._can_intervene():
             self._set_state(ListenerState.OBSERVING)
             return
-        
+
         # Determine if intervention is needed based on level
         if intervention_level == InterventionLevel.OBSERVE:
             # Log only
             self._set_state(ListenerState.OBSERVING)
             return
-        
+
         # Perform intervention
         if self.config.auto_intervention:
             self._perform_intervention(
@@ -338,24 +341,24 @@ class ListenerAgent:
                 intervention_level,
                 observation,
             )
-        
+
         # Return to observation (or recovery)
         if self._state == ListenerState.INTERVENING:
             self._set_state(ListenerState.RECOVERING)
             # In recovery mode, continue observation with heightened awareness
             self._recovery_check()
-    
+
     def _can_intervene(self) -> bool:
         """Check if intervention is allowed (rate limiting)."""
         now = datetime.now()
-        
+
         # Reset counter if minute has passed
         if (now - self._minute_start).total_seconds() >= 60:
             self._intervention_count_this_minute = 0
             self._minute_start = now
-        
+
         return self._intervention_count_this_minute < self.config.max_interventions_per_minute
-    
+
     def _perform_intervention(
         self,
         triggered_rules: List[ThresholdRule],
@@ -364,29 +367,29 @@ class ListenerAgent:
     ) -> InterventionEvent:
         """
         Perform an intervention based on triggered rules.
-        
+
         This is where the Listener transitions from passive to active.
         """
         self._set_state(ListenerState.INTERVENING)
         start_time = datetime.now()
-        
+
         # Generate event ID
         self._event_counter += 1
         event_id = f"intervention_{self._event_counter}_{start_time.timestamp()}"
-        
+
         # Determine action based on intervention level
         action_taken = self._determine_action(intervention_level, triggered_rules)
-        
+
         # Execute intervention action
         outcome = self._execute_intervention_action(
             action_taken,
             intervention_level,
             triggered_rules,
         )
-        
+
         # Calculate duration
         duration_ms = (datetime.now() - start_time).total_seconds() * 1000
-        
+
         # Create event record
         event = InterventionEvent(
             event_id=event_id,
@@ -402,19 +405,19 @@ class ListenerAgent:
             outcome=outcome,
             duration_ms=duration_ms,
         )
-        
+
         # Store and notify
         self._interventions.append(event)
         self._intervention_count_this_minute += 1
-        
+
         for callback in self._intervention_callbacks:
             try:
                 callback(event)
             except Exception:
                 pass
-        
+
         return event
-    
+
     def _determine_action(
         self,
         level: InterventionLevel,
@@ -431,7 +434,7 @@ class ListenerAgent:
             return "emergency_halt"
         else:
             return "observe_only"
-    
+
     def _execute_intervention_action(
         self,
         action: str,
@@ -440,7 +443,7 @@ class ListenerAgent:
     ) -> str:
         """
         Execute the determined intervention action.
-        
+
         This is where we wire together the lower layers:
         - Use iatp for security-related interventions
         - Use caas to update context
@@ -449,19 +452,20 @@ class ListenerAgent:
         if action == "emit_warning":
             # Log warning - in production, integrate with alerting system
             return f"Warning emitted for {len(rules)} triggered rules"
-        
+
         elif action == "require_confirmation":
             # Mark pending sessions as requiring confirmation
             pending_blocked = 0
             for session_id, session in self.protocol.sessions.items():
                 if session.state in [HandshakeState.VALIDATED, HandshakeState.ACCEPTED]:
-                    session.metadata["requires_confirmation"] = True
+                    session.metadata[CONFIRMATION_REQUIRED_KEY] = True
+                    session.metadata[CONFIRMATION_SATISFIED_KEY] = False
                     session.metadata["confirmation_reason"] = (
                         f"Threshold breach: {[r.description for r in rules]}"
                     )
                     pending_blocked += 1
             return f"Soft block applied to {pending_blocked} pending sessions"
-        
+
         elif action == "block_pending_actions":
             # Reject all pending sessions
             blocked = 0
@@ -474,7 +478,7 @@ class ListenerAgent:
                     )
                     blocked += 1
             return f"Hard block applied, {blocked} sessions rejected"
-        
+
         elif action == "emergency_halt":
             # Emergency halt - reject all and set protective state
             halted = 0
@@ -488,7 +492,7 @@ class ListenerAgent:
                         halted += 1
                     except ValueError:
                         pass  # Session may already be in terminal state
-            
+
             # If security adapter available, notify it
             if self._security_adapter:
                 try:
@@ -498,58 +502,58 @@ class ListenerAgent:
                     )
                 except Exception:
                     pass
-            
+
             return f"Emergency halt: {halted} sessions terminated"
-        
+
         return "No action taken"
-    
+
     def _recovery_check(self) -> None:
         """
         Check if system has recovered after intervention.
-        
+
         Performs additional observations to verify system stability
         before returning to normal observation.
         """
         success_count = 0
-        
+
         for _ in range(self.config.recovery_observation_count):
             if self._stop_event.is_set():
                 break
-            
+
             observation = self.observer.observe()
             triggered_rules, level = self.evaluate_thresholds(observation)
-            
+
             # Check if we're back to safe levels
             if level in [InterventionLevel.OBSERVE, InterventionLevel.WARN]:
                 success_count += 1
-            
+
             time.sleep(self.config.observation_interval_seconds)
-        
+
         # Calculate recovery success rate
         success_rate = success_count / self.config.recovery_observation_count
-        
+
         if success_rate >= self.config.recovery_success_threshold:
             self._set_state(ListenerState.OBSERVING)
         else:
             # Still unstable - may need additional intervention
             self._set_state(ListenerState.EVALUATING)
-    
+
     # === Public API for external integration ===
-    
+
     def register_intervention_callback(
         self,
         callback: Callable[[InterventionEvent], None]
     ) -> None:
         """Register a callback to be notified of interventions."""
         self._intervention_callbacks.append(callback)
-    
+
     def register_state_change_callback(
         self,
         callback: Callable[[ListenerState, ListenerState], None]
     ) -> None:
         """Register a callback to be notified of state changes."""
         self._state_change_callbacks.append(callback)
-    
+
     def get_intervention_history(
         self,
         count: Optional[int] = None
@@ -559,11 +563,11 @@ class ListenerAgent:
         if count is not None:
             events = events[-count:]
         return events
-    
+
     def get_statistics(self) -> Dict[str, Any]:
         """Get listener statistics."""
         observation_history = self.observer.get_observation_history()
-        
+
         return {
             "state": self._state.value,
             "total_observations": len(observation_history),
@@ -575,7 +579,7 @@ class ListenerAgent:
             ),
             "observer_baselines": len(self.observer._baselines),
         }
-    
+
     def update_threshold(
         self,
         threshold_type: ThresholdType,
@@ -585,19 +589,19 @@ class ListenerAgent:
         rule = self.config.thresholds.get_rule(threshold_type)
         if rule:
             rule.value = new_value
-    
+
     def enable_threshold(self, threshold_type: ThresholdType) -> None:
         """Enable a threshold rule."""
         self.config.thresholds.enable_rule(threshold_type)
-    
+
     def disable_threshold(self, threshold_type: ThresholdType) -> None:
         """Disable a threshold rule."""
         self.config.thresholds.disable_rule(threshold_type)
-    
+
     def calibrate(self, observation_count: int = 10) -> None:
         """
         Calibrate baselines during known-good operation.
-        
+
         Call this during normal operation to establish baseline
         metrics for anomaly detection.
         """
@@ -605,6 +609,6 @@ class ListenerAgent:
         for _ in range(observation_count):
             self.observer.observe()
             time.sleep(self.config.observation_interval_seconds)
-        
+
         # Calibrate observer baselines
         self.observer.calibrate_baselines(observation_count)

--- a/agent-governance-python/agent-os/modules/mute-agent/src/core/execution_agent.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/core/execution_agent.py
@@ -5,24 +5,24 @@
 The Hands - The Execution Agent
 """
 
-from typing import Dict, List, Optional, Any, Callable
+from typing import Dict, List, Any, Callable
 from .handshake_protocol import HandshakeProtocol, HandshakeSession, HandshakeState
 
 
 class ExecutionAgent:
     """
     The Hands - The Execution Agent
-    
+
     This agent is responsible for executing actions that have been negotiated
     and validated through the Handshake Protocol. It does not reason about
     actions but simply executes them when properly authorized.
     """
-    
+
     def __init__(self, protocol: HandshakeProtocol):
         self.protocol = protocol
         self.execution_handlers: Dict[str, Callable] = {}
         self.execution_history: List[Dict[str, Any]] = []
-    
+
     def register_action_handler(
         self,
         action_id: str,
@@ -33,29 +33,32 @@ class ExecutionAgent:
         The handler receives parameters and returns results.
         """
         self.execution_handlers[action_id] = handler
-    
+
     def execute(self, session_id: str) -> HandshakeSession:
         """
         Execute an action from an accepted handshake session.
         This is the main execution entry point.
         """
         session = self.protocol.get_session(session_id)
-        
+
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
         if session.state != HandshakeState.ACCEPTED:
             raise ValueError(
                 f"Cannot execute session in state {session.state}. "
                 f"Session must be in ACCEPTED state."
             )
-        
+
+        if not self.protocol.is_confirmation_satisfied(session):
+            raise ValueError("Cannot execute session until confirmation is satisfied")
+
         if not session.proposal:
             raise ValueError("Session has no proposal")
-        
+
         # Mark as executing
         self.protocol.start_execution(session_id)
-        
+
         try:
             # Execute the action
             result = self._execute_action(
@@ -63,10 +66,10 @@ class ExecutionAgent:
                 session.proposal.parameters,
                 session.proposal.context
             )
-            
+
             # Mark as completed
             self.protocol.complete_execution(session_id, result)
-            
+
             # Store in history
             self.execution_history.append({
                 "session_id": session_id,
@@ -74,11 +77,11 @@ class ExecutionAgent:
                 "result": result,
                 "success": True
             })
-            
+
         except Exception as e:
             # Mark as failed
             self.protocol.fail_execution(session_id, str(e))
-            
+
             # Store in history
             self.execution_history.append({
                 "session_id": session_id,
@@ -86,11 +89,11 @@ class ExecutionAgent:
                 "error": str(e),
                 "success": False
             })
-            
+
             raise
-        
+
         return self.protocol.get_session(session_id)
-    
+
     def _execute_action(
         self,
         action_id: str,
@@ -101,7 +104,7 @@ class ExecutionAgent:
         Execute a specific action using its registered handler.
         """
         handler = self.execution_handlers.get(action_id)
-        
+
         if not handler:
             # If no handler registered, return a default result
             return {
@@ -110,32 +113,35 @@ class ExecutionAgent:
                 "action_id": action_id,
                 "parameters": parameters
             }
-        
+
         # Call the handler
         result = handler(parameters)
-        
+
         return {
             "status": "success",
             "action_id": action_id,
             "result": result
         }
-    
+
     def can_execute(self, session_id: str) -> bool:
         """Check if a session can be executed."""
         session = self.protocol.get_session(session_id)
-        
+
         if not session:
             return False
-        
+
         if session.state != HandshakeState.ACCEPTED:
             return False
-        
+
+        if not self.protocol.is_confirmation_satisfied(session):
+            return False
+
         if not session.proposal:
             return False
-        
+
         # Check if handler is registered (optional)
         return True
-    
+
     def get_execution_statistics(self) -> Dict[str, Any]:
         """Get statistics about execution operations."""
         if not self.execution_history:
@@ -145,11 +151,11 @@ class ExecutionAgent:
                 "failed_executions": 0,
                 "success_rate": 0.0
             }
-        
+
         total = len(self.execution_history)
         successful = sum(1 for exec in self.execution_history if exec["success"])
         failed = total - successful
-        
+
         return {
             "total_executions": total,
             "successful_executions": successful,
@@ -157,7 +163,7 @@ class ExecutionAgent:
             "success_rate": successful / total if total > 0 else 0.0,
             "actions_executed": self._get_action_counts()
         }
-    
+
     def _get_action_counts(self) -> Dict[str, int]:
         """Get counts of how many times each action was executed."""
         counts = {}

--- a/agent-governance-python/agent-os/modules/mute-agent/src/core/handshake_protocol.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/core/handshake_protocol.py
@@ -12,8 +12,11 @@ from enum import Enum
 from datetime import datetime
 
 
-CONFIRMATION_REQUIRED_KEY = "requires_confirmation"
+CONFIRMATION_REQUIRED_KEY = "confirmation_required"
 CONFIRMATION_SATISFIED_KEY = "confirmation_satisfied"
+# Legacy alias accepted on read so callers using the older "requires_confirmation"
+# metadata key still trip the gate. Producers should write CONFIRMATION_REQUIRED_KEY.
+_CONFIRMATION_REQUIRED_ALIASES = (CONFIRMATION_REQUIRED_KEY, "requires_confirmation")
 
 
 class HandshakeState(Enum):
@@ -254,7 +257,9 @@ class HandshakeProtocol:
 
     def requires_confirmation(self, session: HandshakeSession) -> bool:
         """Check whether a session is gated on explicit confirmation."""
-        return bool(session.metadata.get(CONFIRMATION_REQUIRED_KEY))
+        return any(
+            bool(session.metadata.get(key)) for key in _CONFIRMATION_REQUIRED_ALIASES
+        )
 
     def is_confirmation_satisfied(self, session: HandshakeSession) -> bool:
         """Check whether a confirmation gate is either absent or satisfied."""

--- a/agent-governance-python/agent-os/modules/mute-agent/src/core/handshake_protocol.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/core/handshake_protocol.py
@@ -245,6 +245,11 @@ class HandshakeProtocol:
         if not session:
             raise ValueError(f"Session {session_id} not found")
 
+        if session.state in TERMINAL_STATES:
+            raise ValueError(
+                f"Cannot confirm session in terminal state {session.state}"
+            )
+
         if not self.requires_confirmation(session):
             raise ValueError("Session does not require confirmation")
 

--- a/agent-governance-python/agent-os/modules/mute-agent/src/core/handshake_protocol.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/core/handshake_protocol.py
@@ -12,6 +12,10 @@ from enum import Enum
 from datetime import datetime
 
 
+CONFIRMATION_REQUIRED_KEY = "requires_confirmation"
+CONFIRMATION_SATISFIED_KEY = "confirmation_satisfied"
+
+
 class HandshakeState(Enum):
     """States in the handshake protocol."""
     INITIATED = "initiated"
@@ -22,6 +26,13 @@ class HandshakeState(Enum):
     EXECUTING = "executing"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+TERMINAL_STATES = frozenset({
+    HandshakeState.REJECTED,
+    HandshakeState.COMPLETED,
+    HandshakeState.FAILED,
+})
 
 
 @dataclass
@@ -62,15 +73,15 @@ class HandshakeProtocol:
     """
     The Dynamic Semantic Handshake Protocol manages the negotiation
     between the Reasoning Agent (The Face) and the Execution Agent (The Hands).
-    
+
     Instead of free-text tool invocation, actions must be negotiated against
     the knowledge graph constraints.
     """
-    
+
     def __init__(self):
         self.sessions: Dict[str, HandshakeSession] = {}
         self._session_counter = 0
-    
+
     def initiate_handshake(
         self,
         proposal: ActionProposal
@@ -87,7 +98,7 @@ class HandshakeProtocol:
         )
         self.sessions[session_id] = session
         return session
-    
+
     def validate_proposal(
         self,
         session_id: str,
@@ -100,13 +111,19 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state not in (HandshakeState.INITIATED, HandshakeState.NEGOTIATING):
+            raise ValueError(
+                f"Cannot validate proposal in state {session.state}; "
+                "validation is only allowed from INITIATED or NEGOTIATING."
+            )
+
         session.validation_result = validation_result
         session.state = HandshakeState.VALIDATED if validation_result.is_valid else HandshakeState.REJECTED
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def accept_proposal(self, session_id: str) -> HandshakeSession:
         """
         Accept a validated proposal for execution.
@@ -115,18 +132,20 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
         if session.state != HandshakeState.VALIDATED:
             raise ValueError(f"Cannot accept proposal in state {session.state}")
-        
+
         if not session.validation_result or not session.validation_result.is_valid:
             raise ValueError("Cannot accept invalid proposal")
-        
+
+        self._ensure_confirmation_satisfied(session, "accept")
+
         session.state = HandshakeState.ACCEPTED
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def reject_proposal(
         self,
         session_id: str,
@@ -136,13 +155,18 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state in TERMINAL_STATES:
+            raise ValueError(
+                f"Cannot reject proposal in terminal state {session.state}"
+            )
+
         session.state = HandshakeState.REJECTED
         session.metadata["rejection_reason"] = reason
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def start_execution(self, session_id: str) -> HandshakeSession:
         """
         Start executing an accepted proposal.
@@ -151,15 +175,17 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
         if session.state != HandshakeState.ACCEPTED:
             raise ValueError(f"Cannot execute proposal in state {session.state}")
-        
+
+        self._ensure_confirmation_satisfied(session, "execute")
+
         session.state = HandshakeState.EXECUTING
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def complete_execution(
         self,
         session_id: str,
@@ -169,13 +195,18 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state != HandshakeState.EXECUTING:
+            raise ValueError(f"Cannot complete execution in state {session.state}")
+
+        self._ensure_confirmation_satisfied(session, "complete")
+
         session.execution_result = result
         session.state = HandshakeState.COMPLETED
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def fail_execution(
         self,
         session_id: str,
@@ -185,17 +216,63 @@ class HandshakeProtocol:
         session = self.sessions.get(session_id)
         if not session:
             raise ValueError(f"Session {session_id} not found")
-        
+
+        if session.state in TERMINAL_STATES:
+            raise ValueError(
+                f"Cannot fail execution in terminal state {session.state}"
+            )
+
         session.state = HandshakeState.FAILED
         session.metadata["error"] = error
         session.updated_at = datetime.now()
-        
+
         return session
-    
+
     def get_session(self, session_id: str) -> Optional[HandshakeSession]:
         """Get a session by ID."""
         return self.sessions.get(session_id)
-    
+
+    def confirm_session(
+        self,
+        session_id: str,
+        confirmed_by: Optional[str] = None,
+    ) -> HandshakeSession:
+        """Record that a required confirmation has been satisfied."""
+        session = self.sessions.get(session_id)
+        if not session:
+            raise ValueError(f"Session {session_id} not found")
+
+        if not self.requires_confirmation(session):
+            raise ValueError("Session does not require confirmation")
+
+        session.metadata[CONFIRMATION_SATISFIED_KEY] = True
+        if confirmed_by:
+            session.metadata["confirmed_by"] = confirmed_by
+        session.metadata["confirmed_at"] = datetime.now().isoformat()
+        session.updated_at = datetime.now()
+        return session
+
+    def requires_confirmation(self, session: HandshakeSession) -> bool:
+        """Check whether a session is gated on explicit confirmation."""
+        return bool(session.metadata.get(CONFIRMATION_REQUIRED_KEY))
+
+    def is_confirmation_satisfied(self, session: HandshakeSession) -> bool:
+        """Check whether a confirmation gate is either absent or satisfied."""
+        if not self.requires_confirmation(session):
+            return True
+        return session.metadata.get(CONFIRMATION_SATISFIED_KEY) is True
+
+    def _ensure_confirmation_satisfied(
+        self,
+        session: HandshakeSession,
+        transition: str,
+    ) -> None:
+        if self.is_confirmation_satisfied(session):
+            return
+
+        reason = session.metadata.get("confirmation_reason", "confirmation required")
+        raise ValueError(f"Cannot {transition} proposal until confirmation is satisfied: {reason}")
+
     def _generate_session_id(self) -> str:
         """Generate a unique session ID."""
         self._session_counter += 1

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/__init__.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/__init__.py
@@ -15,10 +15,10 @@ without reimplementing any lower-layer logic.
 """
 
 from .base_adapter import BaseLayerAdapter, AdapterProtocol
-from .scak_adapter import IntelligenceAdapter
-from .iatp_adapter import SecurityAdapter
-from .caas_adapter import ContextAdapter
-from .control_plane_adapter import ControlPlaneAdapter
+from .scak_adapter import IntelligenceAdapter, IntelligenceBackendUnavailable
+from .iatp_adapter import SecurityAdapter, SecurityBackendUnavailable
+from .caas_adapter import ContextAdapter, ContextBackendUnavailable
+from .control_plane_adapter import ControlPlaneAdapter, ControlPlaneBackendUnavailable
 
 __all__ = [
     # Base
@@ -26,7 +26,11 @@ __all__ = [
     "AdapterProtocol",
     # Layer adapters
     "IntelligenceAdapter",
+    "IntelligenceBackendUnavailable",
     "SecurityAdapter",
+    "SecurityBackendUnavailable",
     "ContextAdapter",
+    "ContextBackendUnavailable",
     "ControlPlaneAdapter",
+    "ControlPlaneBackendUnavailable",
 ]

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/base_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/base_adapter.py
@@ -158,11 +158,12 @@ class BaseLayerAdapter(ABC):
         
         except Exception as e:
             self._connected = False
+            self._last_error = f"{type(e).__name__}: {e}"
             return AdapterStatus(
                 connected=False,
                 layer_name=self.get_layer_name(),
                 last_health_check=self._last_health_check,
-                error=str(e),
+                error=self._last_error,
             )
     
     def _health_ping(self) -> None:

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/base_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/base_adapter.py
@@ -72,6 +72,7 @@ class BaseLayerAdapter(ABC):
         self._connected = False
         self._last_health_check: Optional[datetime] = None
         self._client: Optional[Any] = None
+        self._last_error: Optional[str] = None
     
     @abstractmethod
     def get_layer_name(self) -> str:
@@ -106,10 +107,12 @@ class BaseLayerAdapter(ABC):
             
             self._connected = True
             self._last_health_check = datetime.now()
+            self._last_error = None
             return True
         
         except Exception as e:
             self._connected = False
+            self._last_error = f"{type(e).__name__}: {e}"
             return False
     
     def disconnect(self) -> None:
@@ -136,7 +139,7 @@ class BaseLayerAdapter(ABC):
             return AdapterStatus(
                 connected=False,
                 layer_name=self.get_layer_name(),
-                error="Not connected",
+                error=self._last_error or "Not connected",
             )
         
         try:
@@ -185,6 +188,7 @@ class BaseLayerAdapter(ABC):
         """Ensure adapter is connected, raising if not."""
         if not self._connected:
             if not self.connect():
+                detail = f": {self._last_error}" if self._last_error else ""
                 raise ConnectionError(
-                    f"Failed to connect to {self.get_layer_name()}"
+                    f"Failed to connect to {self.get_layer_name()}{detail}"
                 )

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/caas_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/caas_adapter.py
@@ -16,11 +16,16 @@ In the Listener context, this adapter is used to:
 The adapter delegates all context logic to CAAS - no reimplementation.
 """
 
+from importlib import import_module
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from .base_adapter import BaseLayerAdapter
+
+
+class ContextBackendUnavailable(RuntimeError):
+    """Raised when the CAAS context backend is unavailable."""
 
 
 @dataclass
@@ -143,19 +148,31 @@ class ContextAdapter(BaseLayerAdapter):
     def _create_client(self) -> Any:
         """
         Create the CAAS client.
-        
-        In production, this would import and instantiate the actual
-        caas library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed CAAS backend. The
+        permissive mock client (which always reports zero drift / zero ambiguity)
+        is only available when mock_mode=True or an explicit ``client_factory``
+        is supplied.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real CAAS client
-            # from caas import Client as CAASClient
-            # return CAASClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
+            caas_module = import_module("caas")
+        except ImportError as exc:
+            raise ContextBackendUnavailable(
+                "CAAS context backend is required when mock_mode is False. "
+                "Install/configure caas or instantiate ContextAdapter(mock_mode=True) "
+                "only in tests or demos."
+            ) from exc
+
+        client_class = getattr(caas_module, "Client", None)
+        if client_class is None:
+            raise ContextBackendUnavailable(
+                "CAAS backend does not expose a Client class"
+            )
+        return client_class(self.config)
     
     def _mock_client(self) -> Any:
         """Create mock client for testing."""

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/control_plane_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/control_plane_adapter.py
@@ -16,12 +16,17 @@ In the Listener context, this adapter is used to:
 The adapter delegates all orchestration to the control plane - no reimplementation.
 """
 
+from importlib import import_module
 from typing import Dict, Any, Optional, List, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, auto
 
 from .base_adapter import BaseLayerAdapter
+
+
+class ControlPlaneBackendUnavailable(RuntimeError):
+    """Raised when the Agent Control Plane backend is unavailable."""
 
 
 class AgentLifecycleState(Enum):
@@ -198,19 +203,31 @@ class ControlPlaneAdapter(BaseLayerAdapter):
     def _create_client(self) -> Any:
         """
         Create the Control Plane client.
-        
-        In production, this would import and instantiate the actual
-        agent-control-plane library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed agent-control-plane
+        backend. The permissive mock client (which auto-confirms registrations,
+        heartbeats, and queue ops) is only available when mock_mode=True or an
+        explicit ``client_factory`` is supplied.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real Control Plane client
-            # from agent_control_plane import Client as ControlPlaneClient
-            # return ControlPlaneClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
+            cp_module = import_module("agent_control_plane")
+        except ImportError as exc:
+            raise ControlPlaneBackendUnavailable(
+                "agent-control-plane backend is required when mock_mode is False. "
+                "Install/configure agent_control_plane or instantiate "
+                "ControlPlaneAdapter(mock_mode=True) only in tests or demos."
+            ) from exc
+
+        client_class = getattr(cp_module, "Client", None)
+        if client_class is None:
+            raise ControlPlaneBackendUnavailable(
+                "agent-control-plane backend does not expose a Client class"
+            )
+        return client_class(self.config)
     
     def _mock_client(self) -> Any:
         """Create mock client for testing."""

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/iatp_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/iatp_adapter.py
@@ -16,9 +16,10 @@ In the Listener context, this adapter is used to:
 The adapter delegates all security logic to IATP - no reimplementation.
 """
 
-from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from datetime import datetime
+from importlib import import_module
+from typing import Any, Dict, List, Optional
 
 from .base_adapter import BaseLayerAdapter
 
@@ -26,7 +27,7 @@ from .base_adapter import BaseLayerAdapter
 @dataclass
 class TrustAssessment:
     """Result of a trust assessment from IATP."""
-    
+
     actor_id: str
     trust_score: float  # 0.0 to 1.0
     confidence: float  # 0.0 to 1.0
@@ -38,7 +39,7 @@ class TrustAssessment:
 @dataclass
 class SecurityEvent:
     """A security event detected or reported via IATP."""
-    
+
     event_id: str
     event_type: str
     severity: str  # "low", "medium", "high", "critical"
@@ -51,7 +52,7 @@ class SecurityEvent:
 @dataclass
 class PermissionCheck:
     """Result of a permission check from IATP."""
-    
+
     allowed: bool
     actor_id: str
     permission: str
@@ -59,13 +60,17 @@ class PermissionCheck:
     escalation_detected: bool
 
 
+class SecurityBackendUnavailable(RuntimeError):
+    """Raised when the required IATP backend is unavailable."""
+
+
 class MockIATPClient:
     """Mock IATP client for testing without the actual dependency."""
-    
+
     def __init__(self):
         self._trust_scores: Dict[str, float] = {}
         self._events: List[SecurityEvent] = []
-    
+
     def assess_trust(self, actor_id: str) -> TrustAssessment:
         """Mock trust assessment."""
         return TrustAssessment(
@@ -76,7 +81,7 @@ class MockIATPClient:
             timestamp=datetime.now(),
             warnings=[],
         )
-    
+
     def check_permission(
         self,
         actor_id: str,
@@ -91,12 +96,12 @@ class MockIATPClient:
             reason="Mock: all permissions allowed",
             escalation_detected=False,
         )
-    
+
     def report_event(self, event: SecurityEvent) -> str:
         """Mock event reporting."""
         self._events.append(event)
         return event.event_id
-    
+
     def emergency_alert(
         self,
         reason: str,
@@ -104,11 +109,11 @@ class MockIATPClient:
     ) -> str:
         """Mock emergency alert."""
         return f"emergency_alert_{datetime.now().timestamp()}"
-    
+
     def get_anomaly_score(self, context: Dict[str, Any]) -> float:
         """Mock anomaly detection."""
         return 0.1
-    
+
     def close(self) -> None:
         """Close mock client."""
         pass
@@ -117,21 +122,21 @@ class MockIATPClient:
 class SecurityAdapter(BaseLayerAdapter):
     """
     Adapter for IATP (Security/Trust) layer.
-    
+
     Provides a clean interface for the Listener to access security
     operations without reimplementing any IATP logic.
-    
+
     Usage:
         ```python
         adapter = SecurityAdapter(mock_mode=True)
         adapter.connect()
-        
+
         # Assess trust for an actor
         assessment = adapter.assess_trust("user_123")
-        
+
         # Check for anomalies
         anomaly_score = adapter.get_anomaly_score({"action": "delete"})
-        
+
         # Report a security event
         adapter.report_security_event(
             event_type="permission_escalation_attempt",
@@ -140,60 +145,69 @@ class SecurityAdapter(BaseLayerAdapter):
         )
         ```
     """
-    
+
     def get_layer_name(self) -> str:
         return "iatp"
-    
+
     def _create_client(self) -> Any:
         """
         Create the IATP client.
-        
-        In production, this would import and instantiate the actual
-        iatp library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed IATP backend. The
+        permissive mock client is only available when mock_mode=True.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real IATP client
-            # from iatp import Client as IATPClient
-            # return IATPClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
-    
+            iatp_module = import_module("iatp")
+        except ImportError as exc:
+            raise SecurityBackendUnavailable(
+                "IATP security backend is required when mock_mode is False. "
+                "Install/configure iatp or instantiate SecurityAdapter(mock_mode=True) "
+                "only in tests or demos."
+            ) from exc
+
+        client_class = getattr(iatp_module, "Client", None)
+        if client_class is None:
+            raise SecurityBackendUnavailable("IATP backend does not expose a Client class")
+
+        return client_class(self.config)
+
     def _mock_client(self) -> Any:
         """Create mock client for testing."""
         return MockIATPClient()
-    
+
     def _health_ping(self) -> None:
         """Verify IATP connection."""
         if self._client:
             # In production: self._client.ping()
             pass
-    
+
     def _get_version(self) -> Optional[str]:
         """Get IATP version."""
         if self._client and hasattr(self._client, 'version'):
             return self._client.version
         return "mock-1.0.0" if self.mock_mode else None
-    
+
     # === IATP-specific operations ===
-    
+
     def assess_trust(self, actor_id: str) -> TrustAssessment:
         """
         Assess trust for an actor.
-        
+
         Delegates entirely to IATP trust assessment.
-        
+
         Args:
             actor_id: Identifier of the actor to assess
-            
+
         Returns:
             TrustAssessment with trust score and factors
         """
         self.ensure_connected()
         return self._client.assess_trust(actor_id)
-    
+
     def check_permission(
         self,
         actor_id: str,
@@ -202,20 +216,20 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> PermissionCheck:
         """
         Check if an actor has a permission.
-        
+
         Delegates to IATP permission verification.
-        
+
         Args:
             actor_id: Actor requesting permission
             permission: Permission being requested
             resource: Optional resource the permission applies to
-            
+
         Returns:
             PermissionCheck with result and escalation detection
         """
         self.ensure_connected()
         return self._client.check_permission(actor_id, permission, resource)
-    
+
     def report_security_event(
         self,
         event_type: str,
@@ -226,19 +240,19 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> str:
         """
         Report a security event to IATP.
-        
+
         Args:
             event_type: Type of security event
             severity: Severity level ("low", "medium", "high", "critical")
             description: Human-readable description
             actor_id: Optional actor involved
             metadata: Optional additional metadata
-            
+
         Returns:
             Event ID from IATP
         """
         self.ensure_connected()
-        
+
         event = SecurityEvent(
             event_id=f"event_{datetime.now().timestamp()}",
             event_type=event_type,
@@ -248,9 +262,9 @@ class SecurityAdapter(BaseLayerAdapter):
             timestamp=datetime.now(),
             metadata=metadata or {},
         )
-        
+
         return self._client.report_event(event)
-    
+
     def emergency_alert(
         self,
         reason: str,
@@ -259,51 +273,51 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> str:
         """
         Trigger an emergency security alert.
-        
+
         This notifies IATP of a critical security situation requiring
         immediate attention.
-        
+
         Args:
             reason: Reason for the emergency
             triggered_rules: List of rules that triggered the emergency
             context: Optional additional context
-            
+
         Returns:
             Alert ID from IATP
         """
         self.ensure_connected()
         return self._client.emergency_alert(reason, triggered_rules)
-    
+
     def get_anomaly_score(self, context: Dict[str, Any]) -> float:
         """
         Get anomaly score for a context.
-        
+
         Delegates to IATP anomaly detection.
-        
+
         Args:
             context: Context to analyze for anomalies
-            
+
         Returns:
             Anomaly score (0.0 = normal, 1.0 = highly anomalous)
         """
         self.ensure_connected()
         return self._client.get_anomaly_score(context)
-    
+
     def get_trust_score(self, actor_id: str) -> float:
         """
         Get the current trust score for an actor.
-        
+
         Convenience method that extracts just the score.
-        
+
         Args:
             actor_id: Actor to get trust score for
-            
+
         Returns:
             Trust score (0.0 to 1.0)
         """
         assessment = self.assess_trust(actor_id)
         return assessment.trust_score
-    
+
     def detect_permission_escalation(
         self,
         actor_id: str,
@@ -312,22 +326,22 @@ class SecurityAdapter(BaseLayerAdapter):
     ) -> bool:
         """
         Detect if a permission escalation is being attempted.
-        
+
         Args:
             actor_id: Actor making the request
             requested_permissions: Permissions being requested
             current_permissions: Actor's current permissions
-            
+
         Returns:
             True if escalation detected
         """
         self.ensure_connected()
-        
+
         # Check each requested permission
         for perm in requested_permissions:
             if perm not in current_permissions:
                 check = self.check_permission(actor_id, perm)
                 if check.escalation_detected:
                     return True
-        
+
         return False

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/scak_adapter.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/adapters/scak_adapter.py
@@ -15,10 +15,15 @@ In the Listener context, this adapter is used to:
 The adapter delegates all intelligence to SCAK - no logic is reimplemented.
 """
 
+from importlib import import_module
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 
 from .base_adapter import BaseLayerAdapter
+
+
+class IntelligenceBackendUnavailable(RuntimeError):
+    """Raised when the SCAK intelligence backend is unavailable."""
 
 
 @dataclass
@@ -115,19 +120,30 @@ class IntelligenceAdapter(BaseLayerAdapter):
     def _create_client(self) -> Any:
         """
         Create the SCAK client.
-        
-        In production, this would import and instantiate the actual
-        scak library client. For now, returns mock.
+
+        Non-mock mode requires a configured or installed SCAK backend. The
+        permissive mock client (which validates everything) is only available
+        when mock_mode=True or an explicit ``client_factory`` is supplied.
         """
+        client_factory = self.config.get("client_factory")
+        if client_factory:
+            return client_factory(self.config)
+
         try:
-            # Attempt to import real SCAK client
-            # from scak import Client as SCAKClient
-            # return SCAKClient(self.config)
-            
-            # Fall back to mock if not available
-            return self._mock_client()
-        except ImportError:
-            return self._mock_client()
+            scak_module = import_module("scak")
+        except ImportError as exc:
+            raise IntelligenceBackendUnavailable(
+                "SCAK intelligence backend is required when mock_mode is False. "
+                "Install/configure scak or instantiate IntelligenceAdapter(mock_mode=True) "
+                "only in tests or demos."
+            ) from exc
+
+        client_class = getattr(scak_module, "Client", None)
+        if client_class is None:
+            raise IntelligenceBackendUnavailable(
+                "SCAK backend does not expose a Client class"
+            )
+        return client_class(self.config)
     
     def _mock_client(self) -> Any:
         """Create mock client for testing."""

--- a/agent-governance-python/agent-os/modules/mute-agent/src/listener/listener.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/src/listener/listener.py
@@ -14,23 +14,26 @@ Architecture:
 
 This module is pure wiring - it delegates to lower layers:
 - Knowledge graph operations → scak (intelligence layer)
-- Security validation → iatp (security layer)  
+- Security validation → iatp (security layer)
 - Context management → caas (context layer)
 - Base orchestration → agent-control-plane
 """
 
 from typing import Dict, Any, Optional, List, Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
-from enum import Enum, auto
+from datetime import datetime
+from enum import Enum
 import threading
 import time
 from collections import deque
 
 from ..knowledge_graph.multidimensional_graph import MultidimensionalKnowledgeGraph
-from ..core.handshake_protocol import HandshakeProtocol, HandshakeSession, HandshakeState
-from ..core.reasoning_agent import ReasoningAgent
-from ..core.execution_agent import ExecutionAgent
+from ..core.handshake_protocol import (
+    CONFIRMATION_REQUIRED_KEY,
+    CONFIRMATION_SATISFIED_KEY,
+    HandshakeProtocol,
+    HandshakeState,
+)
 from ..super_system.router import SuperSystemRouter
 
 from .threshold_config import (
@@ -45,22 +48,22 @@ from .state_observer import StateObserver, ObservationResult
 
 class ListenerState(Enum):
     """States of the Listener Agent."""
-    
+
     # Not actively observing
     IDLE = "idle"
-    
+
     # Passively observing - no intervention
     OBSERVING = "observing"
-    
+
     # Detected threshold breach - evaluating response
     EVALUATING = "evaluating"
-    
+
     # Actively intervening
     INTERVENING = "intervening"
-    
+
     # Intervention complete, returning to observation
     RECOVERING = "recovering"
-    
+
     # Stopped - not operational
     STOPPED = "stopped"
 
@@ -69,11 +72,11 @@ class ListenerState(Enum):
 class InterventionEvent:
     """
     Record of a Listener intervention.
-    
+
     This provides an audit trail of when and why the Listener
     transitioned from passive observation to active intervention.
     """
-    
+
     event_id: str
     timestamp: datetime
     triggered_rules: List[ThresholdRule]
@@ -88,19 +91,19 @@ class InterventionEvent:
 @dataclass
 class ListenerConfig:
     """Configuration for the Listener Agent."""
-    
+
     # Threshold configuration
     thresholds: ThresholdConfig = field(default_factory=lambda: DEFAULT_THRESHOLDS)
-    
+
     # Observation settings
     observation_interval_seconds: float = 1.0
     max_observation_history: int = 1000
-    
+
     # Intervention settings
     auto_intervention: bool = True
     require_confirmation: bool = False
     max_interventions_per_minute: int = 10
-    
+
     # Recovery settings
     recovery_observation_count: int = 5
     recovery_success_threshold: float = 0.8
@@ -109,35 +112,35 @@ class ListenerConfig:
 class ListenerAgent:
     """
     Layer 5 Reference Implementation: The Listener Agent
-    
+
     A passive observer that monitors graph states and only intervenes
     when configured thresholds are exceeded.
-    
+
     Design Principles:
     1. Passive by default - observe without interference
     2. Threshold-driven intervention - clear, configurable triggers
     3. Minimal footprint - delegate to lower layers
     4. Full audit trail - every intervention is logged
-    
+
     Usage:
         ```python
         # Create core components
         kg = MultidimensionalKnowledgeGraph()
         protocol = HandshakeProtocol()
         router = SuperSystemRouter(kg)
-        
+
         # Create and start listener
         listener = ListenerAgent(kg, protocol, router)
         listener.start()
-        
+
         # Listener now monitors passively...
         # When thresholds are exceeded, it intervenes automatically
-        
+
         # Stop when done
         listener.stop()
         ```
     """
-    
+
     def __init__(
         self,
         knowledge_graph: MultidimensionalKnowledgeGraph,
@@ -150,7 +153,7 @@ class ListenerAgent:
     ):
         """
         Initialize the Listener Agent.
-        
+
         Args:
             knowledge_graph: The graph to monitor (via scak)
             protocol: The handshake protocol to observe
@@ -163,11 +166,11 @@ class ListenerAgent:
         self.protocol = protocol
         self.router = router
         self.config = config or ListenerConfig()
-        
+
         # Lower-layer adapters (for consolidated stack)
         self._security_adapter = security_adapter
         self._context_adapter = context_adapter
-        
+
         # State observer
         self.observer = StateObserver(
             knowledge_graph=knowledge_graph,
@@ -175,15 +178,15 @@ class ListenerAgent:
             router=router,
             sample_window_seconds=self.config.thresholds.window_size_seconds,
         )
-        
+
         # Current state
         self._state = ListenerState.IDLE
         self._state_lock = threading.Lock()
-        
+
         # Observation thread
         self._observation_thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
-        
+
         # Intervention tracking
         self._interventions: deque = deque(
             maxlen=self.config.max_observation_history
@@ -191,44 +194,44 @@ class ListenerAgent:
         self._intervention_count_this_minute = 0
         self._minute_start = datetime.now()
         self._event_counter = 0
-        
+
         # Callbacks
         self._intervention_callbacks: List[Callable[[InterventionEvent], None]] = []
         self._state_change_callbacks: List[Callable[[ListenerState, ListenerState], None]] = []
-    
+
     @property
     def state(self) -> ListenerState:
         """Get current listener state."""
         with self._state_lock:
             return self._state
-    
+
     def _set_state(self, new_state: ListenerState) -> None:
         """Set listener state with callback notification."""
         with self._state_lock:
             old_state = self._state
             self._state = new_state
-        
+
         # Notify callbacks outside lock
         for callback in self._state_change_callbacks:
             try:
                 callback(old_state, new_state)
             except Exception:
                 pass  # Don't let callback errors affect listener
-    
+
     def start(self) -> None:
         """
         Start the Listener Agent.
-        
+
         Begins passive observation of graph states. The listener will
         continue observing until stop() is called or an intervention
         threshold is exceeded.
         """
         if self._state != ListenerState.IDLE and self._state != ListenerState.STOPPED:
             raise RuntimeError(f"Cannot start listener in state {self._state}")
-        
+
         self._stop_event.clear()
         self._set_state(ListenerState.OBSERVING)
-        
+
         # Start observation thread
         self._observation_thread = threading.Thread(
             target=self._observation_loop,
@@ -236,102 +239,102 @@ class ListenerAgent:
             daemon=True,
         )
         self._observation_thread.start()
-    
+
     def stop(self) -> None:
         """
         Stop the Listener Agent.
-        
+
         Ceases observation and any ongoing intervention.
         """
         self._stop_event.set()
         self._set_state(ListenerState.STOPPED)
-        
+
         if self._observation_thread and self._observation_thread.is_alive():
             self._observation_thread.join(timeout=5.0)
-    
+
     def observe_once(self, context: Optional[Dict[str, Any]] = None) -> ObservationResult:
         """
         Perform a single observation cycle.
-        
+
         This is useful for synchronous observation without starting
         the background observation loop.
-        
+
         Args:
             context: Optional context to include
-            
+
         Returns:
             ObservationResult from this cycle
         """
         return self.observer.observe(context)
-    
+
     def evaluate_thresholds(
         self,
         observation: ObservationResult
     ) -> tuple[List[ThresholdRule], InterventionLevel]:
         """
         Evaluate observation against configured thresholds.
-        
+
         Args:
             observation: The observation to evaluate
-            
+
         Returns:
             Tuple of (triggered_rules, max_intervention_level)
         """
         # Convert observation to threshold metrics
         threshold_metrics = observation.to_threshold_metrics()
-        
+
         # Evaluate against thresholds
         triggered_rules = self.config.thresholds.evaluate_all(
             threshold_metrics,
             context={"observation": observation},
         )
-        
+
         # Get maximum intervention level
         max_level = self.config.thresholds.get_maximum_intervention_level(
             triggered_rules
         )
-        
+
         return triggered_rules, max_level
-    
+
     def _observation_loop(self) -> None:
         """Background observation loop."""
         while not self._stop_event.is_set():
             try:
                 self._run_observation_cycle()
-            except Exception as e:
+            except Exception:
                 # Log error but continue observation
                 # In production, this would integrate with logging framework
                 pass
-            
+
             # Wait for next observation interval
             self._stop_event.wait(self.config.observation_interval_seconds)
-    
+
     def _run_observation_cycle(self) -> None:
         """Run a single observation cycle."""
         # Perform observation
         observation = self.observer.observe()
-        
+
         # Evaluate thresholds
         triggered_rules, intervention_level = self.evaluate_thresholds(observation)
-        
+
         if not triggered_rules:
             # No thresholds exceeded - continue passive observation
             return
-        
+
         # Thresholds exceeded - evaluate intervention
         self._set_state(ListenerState.EVALUATING)
-        
+
         # Check rate limiting
         if not self._can_intervene():
             self._set_state(ListenerState.OBSERVING)
             return
-        
+
         # Determine if intervention is needed based on level
         if intervention_level == InterventionLevel.OBSERVE:
             # Log only
             self._set_state(ListenerState.OBSERVING)
             return
-        
+
         # Perform intervention
         if self.config.auto_intervention:
             self._perform_intervention(
@@ -339,24 +342,24 @@ class ListenerAgent:
                 intervention_level,
                 observation,
             )
-        
+
         # Return to observation (or recovery)
         if self._state == ListenerState.INTERVENING:
             self._set_state(ListenerState.RECOVERING)
             # In recovery mode, continue observation with heightened awareness
             self._recovery_check()
-    
+
     def _can_intervene(self) -> bool:
         """Check if intervention is allowed (rate limiting)."""
         now = datetime.now()
-        
+
         # Reset counter if minute has passed
         if (now - self._minute_start).total_seconds() >= 60:
             self._intervention_count_this_minute = 0
             self._minute_start = now
-        
+
         return self._intervention_count_this_minute < self.config.max_interventions_per_minute
-    
+
     def _perform_intervention(
         self,
         triggered_rules: List[ThresholdRule],
@@ -365,29 +368,29 @@ class ListenerAgent:
     ) -> InterventionEvent:
         """
         Perform an intervention based on triggered rules.
-        
+
         This is where the Listener transitions from passive to active.
         """
         self._set_state(ListenerState.INTERVENING)
         start_time = datetime.now()
-        
+
         # Generate event ID
         self._event_counter += 1
         event_id = f"intervention_{self._event_counter}_{start_time.timestamp()}"
-        
+
         # Determine action based on intervention level
         action_taken = self._determine_action(intervention_level, triggered_rules)
-        
+
         # Execute intervention action
         outcome = self._execute_intervention_action(
             action_taken,
             intervention_level,
             triggered_rules,
         )
-        
+
         # Calculate duration
         duration_ms = (datetime.now() - start_time).total_seconds() * 1000
-        
+
         # Create event record
         event = InterventionEvent(
             event_id=event_id,
@@ -403,19 +406,19 @@ class ListenerAgent:
             outcome=outcome,
             duration_ms=duration_ms,
         )
-        
+
         # Store and notify
         self._interventions.append(event)
         self._intervention_count_this_minute += 1
-        
+
         for callback in self._intervention_callbacks:
             try:
                 callback(event)
             except Exception:
                 pass
-        
+
         return event
-    
+
     def _determine_action(
         self,
         level: InterventionLevel,
@@ -432,7 +435,7 @@ class ListenerAgent:
             return "emergency_halt"
         else:
             return "observe_only"
-    
+
     def _execute_intervention_action(
         self,
         action: str,
@@ -441,7 +444,7 @@ class ListenerAgent:
     ) -> str:
         """
         Execute the determined intervention action.
-        
+
         This is where we wire together the lower layers:
         - Use iatp for security-related interventions
         - Use caas to update context
@@ -450,19 +453,20 @@ class ListenerAgent:
         if action == "emit_warning":
             # Log warning - in production, integrate with alerting system
             return f"Warning emitted for {len(rules)} triggered rules"
-        
+
         elif action == "require_confirmation":
             # Mark pending sessions as requiring confirmation
             pending_blocked = 0
             for session_id, session in self.protocol.sessions.items():
                 if session.state in [HandshakeState.VALIDATED, HandshakeState.ACCEPTED]:
-                    session.metadata["requires_confirmation"] = True
+                    session.metadata[CONFIRMATION_REQUIRED_KEY] = True
+                    session.metadata[CONFIRMATION_SATISFIED_KEY] = False
                     session.metadata["confirmation_reason"] = (
                         f"Threshold breach: {[r.description for r in rules]}"
                     )
                     pending_blocked += 1
             return f"Soft block applied to {pending_blocked} pending sessions"
-        
+
         elif action == "block_pending_actions":
             # Reject all pending sessions
             blocked = 0
@@ -475,7 +479,7 @@ class ListenerAgent:
                     )
                     blocked += 1
             return f"Hard block applied, {blocked} sessions rejected"
-        
+
         elif action == "emergency_halt":
             # Emergency halt - reject all and set protective state
             halted = 0
@@ -489,7 +493,7 @@ class ListenerAgent:
                         halted += 1
                     except ValueError:
                         pass  # Session may already be in terminal state
-            
+
             # If security adapter available, notify it
             if self._security_adapter:
                 try:
@@ -499,58 +503,58 @@ class ListenerAgent:
                     )
                 except Exception:
                     pass
-            
+
             return f"Emergency halt: {halted} sessions terminated"
-        
+
         return "No action taken"
-    
+
     def _recovery_check(self) -> None:
         """
         Check if system has recovered after intervention.
-        
+
         Performs additional observations to verify system stability
         before returning to normal observation.
         """
         success_count = 0
-        
+
         for _ in range(self.config.recovery_observation_count):
             if self._stop_event.is_set():
                 break
-            
+
             observation = self.observer.observe()
             triggered_rules, level = self.evaluate_thresholds(observation)
-            
+
             # Check if we're back to safe levels
             if level in [InterventionLevel.OBSERVE, InterventionLevel.WARN]:
                 success_count += 1
-            
+
             time.sleep(self.config.observation_interval_seconds)
-        
+
         # Calculate recovery success rate
         success_rate = success_count / self.config.recovery_observation_count
-        
+
         if success_rate >= self.config.recovery_success_threshold:
             self._set_state(ListenerState.OBSERVING)
         else:
             # Still unstable - may need additional intervention
             self._set_state(ListenerState.EVALUATING)
-    
+
     # === Public API for external integration ===
-    
+
     def register_intervention_callback(
         self,
         callback: Callable[[InterventionEvent], None]
     ) -> None:
         """Register a callback to be notified of interventions."""
         self._intervention_callbacks.append(callback)
-    
+
     def register_state_change_callback(
         self,
         callback: Callable[[ListenerState, ListenerState], None]
     ) -> None:
         """Register a callback to be notified of state changes."""
         self._state_change_callbacks.append(callback)
-    
+
     def get_intervention_history(
         self,
         count: Optional[int] = None
@@ -560,11 +564,11 @@ class ListenerAgent:
         if count is not None:
             events = events[-count:]
         return events
-    
+
     def get_statistics(self) -> Dict[str, Any]:
         """Get listener statistics."""
         observation_history = self.observer.get_observation_history()
-        
+
         return {
             "state": self._state.value,
             "total_observations": len(observation_history),
@@ -576,7 +580,7 @@ class ListenerAgent:
             ),
             "observer_baselines": len(self.observer._baselines),
         }
-    
+
     def update_threshold(
         self,
         threshold_type: ThresholdType,
@@ -586,19 +590,19 @@ class ListenerAgent:
         rule = self.config.thresholds.get_rule(threshold_type)
         if rule:
             rule.value = new_value
-    
+
     def enable_threshold(self, threshold_type: ThresholdType) -> None:
         """Enable a threshold rule."""
         self.config.thresholds.enable_rule(threshold_type)
-    
+
     def disable_threshold(self, threshold_type: ThresholdType) -> None:
         """Disable a threshold rule."""
         self.config.thresholds.disable_rule(threshold_type)
-    
+
     def calibrate(self, observation_count: int = 10) -> None:
         """
         Calibrate baselines during known-good operation.
-        
+
         Call this during normal operation to establish baseline
         metrics for anomaly detection.
         """
@@ -606,6 +610,6 @@ class ListenerAgent:
         for _ in range(observation_count):
             self.observer.observe()
             time.sleep(self.config.observation_interval_seconds)
-        
+
         # Calibrate observer baselines
         self.observer.calibrate_baselines(observation_count)

--- a/agent-governance-python/agent-os/modules/mute-agent/tests/test_security_hardening.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/tests/test_security_hardening.py
@@ -58,7 +58,7 @@ def test_iatp_adapter_non_mock_mode_fails_closed_when_backend_missing(monkeypatc
 
     assert adapter.connect() is False
     assert adapter.is_connected is False
-    with pytest.raises(ConnectionError, match="Failed to connect to iatp"):
+    with pytest.raises(ConnectionError, match=r"Failed to connect to iatp:.*SecurityBackendUnavailable"):
         adapter.check_permission("user-1", "delete")
 
 
@@ -151,6 +151,9 @@ def test_layer_adapters_fail_closed_when_backend_missing(module, adapter_cls, la
 
     assert adapter.connect() is False
     assert adapter.is_connected is False
+    status = adapter.health_check()
+    assert status.connected is False
+    assert status.error and layer_name in status.error.lower() or "backendunavailable" in (status.error or "").lower()
 
 
 def test_handshake_cannot_revalidate_rejected_session():
@@ -185,3 +188,14 @@ def test_handshake_terminal_state_guards_block_reject_and_fail():
     with pytest.raises(ValueError, match="terminal state"):
         protocol.fail_execution(session.session_id, "too late")
     assert session.state == HandshakeState.COMPLETED
+
+
+@pytest.mark.parametrize("alias_key", ["confirmation_required", "requires_confirmation"])
+def test_confirmation_gate_accepts_both_metadata_aliases(alias_key):
+    protocol = HandshakeProtocol()
+    session = _validated_session(protocol)
+    session.metadata[alias_key] = True
+
+    with pytest.raises(ValueError, match="until confirmation is satisfied"):
+        protocol.accept_proposal(session.session_id)
+    assert session.state == HandshakeState.VALIDATED

--- a/agent-governance-python/agent-os/modules/mute-agent/tests/test_security_hardening.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/tests/test_security_hardening.py
@@ -1,0 +1,187 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.core.execution_agent import ExecutionAgent  # noqa: E402
+from src.core.handshake_protocol import (  # noqa: E402
+    CONFIRMATION_REQUIRED_KEY,
+    CONFIRMATION_SATISFIED_KEY,
+    ActionProposal,
+    HandshakeProtocol,
+    HandshakeState,
+    ValidationResult,
+)
+from src.listener.adapters import (  # noqa: E402
+    caas_adapter,
+    control_plane_adapter,
+    iatp_adapter,
+    scak_adapter,
+)
+from src.listener.adapters.caas_adapter import ContextAdapter  # noqa: E402
+from src.listener.adapters.control_plane_adapter import ControlPlaneAdapter  # noqa: E402
+from src.listener.adapters.iatp_adapter import PermissionCheck, SecurityAdapter  # noqa: E402
+from src.listener.adapters.scak_adapter import IntelligenceAdapter  # noqa: E402
+from src.listener.listener import ListenerAgent  # noqa: E402
+from src.listener.threshold_config import (  # noqa: E402
+    InterventionLevel,
+    ThresholdRule,
+    ThresholdType,
+)
+
+
+def _validated_session(protocol: HandshakeProtocol):
+    session = protocol.initiate_handshake(
+        ActionProposal(
+            action_id="restart_service",
+            parameters={"service": "payments"},
+            context={"user": "operator"},
+            justification="operator requested restart",
+        )
+    )
+    protocol.validate_proposal(session.session_id, ValidationResult(is_valid=True))
+    return session
+
+
+def test_iatp_adapter_non_mock_mode_fails_closed_when_backend_missing(monkeypatch):
+    def missing_backend(_name):
+        raise ImportError("iatp unavailable")
+
+    monkeypatch.setattr(iatp_adapter, "import_module", missing_backend)
+
+    adapter = SecurityAdapter()
+
+    assert adapter.connect() is False
+    assert adapter.is_connected is False
+    with pytest.raises(ConnectionError, match="Failed to connect to iatp"):
+        adapter.check_permission("user-1", "delete")
+
+
+def test_iatp_adapter_mock_mode_requires_explicit_opt_in():
+    adapter = SecurityAdapter(mock_mode=True)
+
+    assert adapter.connect() is True
+    check = adapter.check_permission("user-1", "read")
+    assert check == PermissionCheck(
+        allowed=True,
+        actor_id="user-1",
+        permission="read",
+        reason="Mock: all permissions allowed",
+        escalation_detected=False,
+    )
+
+
+def test_confirmation_required_session_cannot_be_accepted_until_confirmed():
+    protocol = HandshakeProtocol()
+    session = _validated_session(protocol)
+    session.metadata[CONFIRMATION_REQUIRED_KEY] = True
+    session.metadata["confirmation_reason"] = "soft block"
+
+    with pytest.raises(ValueError, match="until confirmation is satisfied"):
+        protocol.accept_proposal(session.session_id)
+
+    assert session.state == HandshakeState.VALIDATED
+
+    protocol.confirm_session(session.session_id, confirmed_by="operator")
+    accepted = protocol.accept_proposal(session.session_id)
+
+    assert accepted.state == HandshakeState.ACCEPTED
+    assert accepted.metadata[CONFIRMATION_SATISFIED_KEY] is True
+    assert accepted.metadata["confirmed_by"] == "operator"
+
+
+def test_listener_soft_block_resets_confirmation_and_blocks_execution():
+    protocol = HandshakeProtocol()
+    session = _validated_session(protocol)
+    protocol.accept_proposal(session.session_id)
+    assert session.state == HandshakeState.ACCEPTED
+
+    listener = ListenerAgent.__new__(ListenerAgent)
+    listener.protocol = protocol
+    rule = ThresholdRule(
+        threshold_type=ThresholdType.ANOMALY_SCORE_MAXIMUM,
+        value=0.7,
+        intervention_level=InterventionLevel.SOFT_BLOCK,
+        description="anomaly detected",
+    )
+    outcome = listener._execute_intervention_action(
+        "require_confirmation",
+        InterventionLevel.SOFT_BLOCK,
+        [rule],
+    )
+
+    execution = ExecutionAgent(protocol)
+
+    assert outcome == "Soft block applied to 1 pending sessions"
+    assert session.metadata[CONFIRMATION_REQUIRED_KEY] is True
+    assert session.metadata[CONFIRMATION_SATISFIED_KEY] is False
+    assert execution.can_execute(session.session_id) is False
+    with pytest.raises(ValueError, match="Cannot complete execution"):
+        protocol.complete_execution(session.session_id, {"status": "bypassed"})
+    with pytest.raises(ValueError, match="confirmation is satisfied"):
+        execution.execute(session.session_id)
+    assert session.state == HandshakeState.ACCEPTED
+
+    protocol.confirm_session(session.session_id, confirmed_by="operator")
+    assert execution.can_execute(session.session_id) is True
+    completed = execution.execute(session.session_id)
+    assert completed.state == HandshakeState.COMPLETED
+
+
+@pytest.mark.parametrize(
+    "module, adapter_cls, layer_name",
+    [
+        (scak_adapter, IntelligenceAdapter, "scak"),
+        (caas_adapter, ContextAdapter, "caas"),
+        (control_plane_adapter, ControlPlaneAdapter, "agent-control-plane"),
+    ],
+)
+def test_layer_adapters_fail_closed_when_backend_missing(module, adapter_cls, layer_name, monkeypatch):
+    def missing_backend(_name):
+        raise ImportError(f"{layer_name} unavailable")
+
+    monkeypatch.setattr(module, "import_module", missing_backend)
+
+    adapter = adapter_cls()
+
+    assert adapter.connect() is False
+    assert adapter.is_connected is False
+
+
+def test_handshake_cannot_revalidate_rejected_session():
+    protocol = HandshakeProtocol()
+    session = protocol.initiate_handshake(
+        ActionProposal(
+            action_id="restart_service",
+            parameters={"service": "payments"},
+            context={"user": "operator"},
+            justification="op",
+        )
+    )
+    protocol.validate_proposal(
+        session.session_id, ValidationResult(is_valid=False, errors=["bad"])
+    )
+    assert session.state == HandshakeState.REJECTED
+
+    with pytest.raises(ValueError, match="Cannot validate proposal in state"):
+        protocol.validate_proposal(session.session_id, ValidationResult(is_valid=True))
+    assert session.state == HandshakeState.REJECTED
+
+
+def test_handshake_terminal_state_guards_block_reject_and_fail():
+    protocol = HandshakeProtocol()
+    session = _validated_session(protocol)
+    protocol.accept_proposal(session.session_id)
+    protocol.start_execution(session.session_id)
+    protocol.complete_execution(session.session_id, {"status": "ok"})
+
+    with pytest.raises(ValueError, match="terminal state"):
+        protocol.reject_proposal(session.session_id, "too late")
+    with pytest.raises(ValueError, match="terminal state"):
+        protocol.fail_execution(session.session_id, "too late")
+    assert session.state == HandshakeState.COMPLETED

--- a/agent-governance-python/agent-os/modules/mute-agent/tests/test_security_hardening.py
+++ b/agent-governance-python/agent-os/modules/mute-agent/tests/test_security_hardening.py
@@ -199,3 +199,38 @@ def test_confirmation_gate_accepts_both_metadata_aliases(alias_key):
     with pytest.raises(ValueError, match="until confirmation is satisfied"):
         protocol.accept_proposal(session.session_id)
     assert session.state == HandshakeState.VALIDATED
+
+
+def test_confirm_session_refused_in_terminal_state():
+    protocol = HandshakeProtocol()
+    session = _validated_session(protocol)
+    session.metadata[CONFIRMATION_REQUIRED_KEY] = True
+    session.metadata[CONFIRMATION_SATISFIED_KEY] = False
+    protocol.reject_proposal(session.session_id, "blocked")
+
+    with pytest.raises(ValueError, match="terminal state"):
+        protocol.confirm_session(session.session_id, confirmed_by="operator")
+    assert session.metadata[CONFIRMATION_SATISFIED_KEY] is False
+
+
+def test_health_check_failure_records_last_error_and_persists():
+    from src.listener.adapters import iatp_adapter as iatp_mod
+    from src.listener.adapters.iatp_adapter import SecurityAdapter
+
+    class FlakyClient:
+        def ping(self):
+            raise RuntimeError("backend ping timeout")
+
+    adapter = SecurityAdapter(config={"client_factory": lambda _cfg: FlakyClient()})
+    assert adapter.connect() is True
+    monkeypatched_ping = lambda self: self._client.ping()  # noqa: E731
+    iatp_mod.SecurityAdapter._health_ping = monkeypatched_ping
+    try:
+        status = adapter.health_check()
+        assert status.connected is False
+        assert "backend ping timeout" in (status.error or "")
+        assert adapter._last_error and "backend ping timeout" in adapter._last_error
+        status2 = adapter.health_check()
+        assert "backend ping timeout" in (status2.error or "")
+    finally:
+        del iatp_mod.SecurityAdapter._health_ping


### PR DESCRIPTION
## Description

Harden the `mute-agent` listener and core handshake against two security review findings, plus an in-class sweep of related fail-open / state-machine bypass paths.

### Issue 1: Adapter fail-open mock fallback

`SecurityAdapter` (IATP) silently returned a permissive `MockIATPClient` (`check_permission` always `allowed=True`) when the real backend was missing. The same pattern existed in `IntelligenceAdapter` (SCAK — `validate` always `valid=True`), `ContextAdapter` (CAAS — drift/ambiguity always `0.0`), and `ControlPlaneAdapter` (auto-confirm registrations & heartbeats).

All four adapters now **fail closed** in non-mock mode. `_create_client` consults `config['client_factory']`, then `importlib.import_module` of the real package, and raises a layer-specific `*BackendUnavailable` if neither is present. Mock clients require explicit `mock_mode=True` opt-in.

### Issue 2: Confirmation flag bypass

When the listener applied a soft-block intervention it set `confirmation_required` in session metadata but nothing consumed it. `ExecutionAgent.execute()` and `HandshakeProtocol.accept_proposal / start_execution / complete_execution` ran regardless.

The protocol now exposes `confirm_session`, `requires_confirmation`, `is_confirmation_satisfied` and an internal `_ensure_confirmation_satisfied` gate that fires on every accept/start/complete transition. The listener sets **both** `CONFIRMATION_REQUIRED_KEY=True` and `CONFIRMATION_SATISFIED_KEY=False` on soft-block.

### Tangential sweep (same class)

- `HandshakeProtocol.validate_proposal` rejected sessions could be re-validated to flip back to `VALIDATED`. Now state-guarded to `{INITIATED, NEGOTIATING}`.
- `reject_proposal` and `fail_execution` could stamp `COMPLETED`/`REJECTED`/`FAILED` sessions. Now refuse terminal states via new `TERMINAL_STATES` set.

## Type of Change
- [x] Security fix
- [x] Bug fix (non-breaking change that fixes an issue)

## Package(s) Affected
- [x] agent-os-kernel (`modules/mute-agent`)

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest — 121 passed)
- [x] I have updated documentation as needed
- [x] I have signed the Microsoft CLA

## Testing

- `pytest tests -q` in `modules/mute-agent` → **121 passed** (was 116; +5 new `test_security_hardening.py` cases covering all four adapter fail-closed paths and the new terminal-state / revalidate guards).
- `ruff check --select F` clean on all newly-introduced code (pre-existing F401/W293 noise in unchanged surrounding code left untouched per "no unrelated fixes" policy).

## Failure-mode summary

| Scenario | Before | After |
|----------|--------|-------|
| `SecurityAdapter()` with no IATP installed | silently allows everything | `connect() -> False`; ops raise `ConnectionError` |
| `IntelligenceAdapter()` with no SCAK installed | constraint validation always passes | fails closed |
| `ContextAdapter()` with no CAAS installed | drift / ambiguity reported as 0.0 | fails closed |
| `ControlPlaneAdapter()` with no control plane | registrations auto-confirmed | fails closed |
| Session with `confirmation_required=True` reaches `execute()` | runs to `COMPLETED` | raises `ValueError` until `confirm_session` is called |
| Re-validating a `REJECTED` session | flipped back to `VALIDATED` | raises `ValueError` |
| `reject_proposal` / `fail_execution` on `COMPLETED` session | overwrote terminal state | raises `ValueError` |

Module remains in Public Preview / demo status (per its README); these changes do not promote it to GA — they make the documented failure modes safe.

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

## AI Assistance
- [x] I can explain every meaningful change in this PR
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot CLI used to author the patch; all output reviewed before commit.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

---

## Follow-ups (deferred — filed as issues)

- #2646 — `HandshakeProtocol.confirm_session` missing identity/ACL check on `confirmed_by`
- #2647 — `BaseLayerAdapter` broad `except Exception` in `connect` / `disconnect` / `health_check`
- #2648 — `ListenerAgent` intervention counters mutated without synchronization
- #2649 — Pre-existing `F401` / `W293` ruff noise in mute-agent `src/` and `mute_agent/` trees

## Review iteration

Commit `d8c00c1b` was added on top of the initial hardening to address pre-merge `/pr-review` findings:

- **claude-opus-4.7** (1 warning): `BaseLayerAdapter.connect()` swallowed the new `*BackendUnavailable` remediation hints — bare `ConnectionError` left operators without an actionable message. → fixed by capturing the error into `self._last_error` and surfacing it from `ensure_connected` / `health_check`.
- **gpt-5.5** (1 blocker): `CONFIRMATION_REQUIRED_KEY` constant value (`"requires_confirmation"`) mismatched its name; any caller writing the natural `session.metadata["confirmation_required"] = True` would bypass the gate. → fixed by renaming the canonical value to `"confirmation_required"` and accepting both spellings via alias tuple on read; regression test added.
