### PR TITLE
docs(opencode): fix dead absolute link to examples dir

### DIFF
--- a/docs/packages/opencode-governance.md
+++ b/docs/packages/opencode-governance.md
@@ -95,4 +95,4 @@ A minimal review-heavy policy:
 ## Tutorials and examples
 
 - [Tutorial: govern an OpenCode CLI session](../tutorials/54-opencode-cli-governance.md)
-- [`examples/opencode-agt`](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/opencode-agt)
+- [`examples/opencode-agt`](../../examples/opencode-agt/README.md)

--- a/docs/tutorials/54-opencode-cli-governance.md
+++ b/docs/tutorials/54-opencode-cli-governance.md
@@ -150,4 +150,4 @@ Both surfaces share the same policy and audit log.
 - [OpenCode CLI governance package reference](../packages/opencode-governance.md)
 - [Antigravity CLI Governance tutorial](52-antigravity-cli-governance.md) — the
   closest sibling package
-- [`examples/opencode-agt`](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/opencode-agt) — runnable scenario
+- [`examples/opencode-agt`](../../examples/opencode-agt/README.md) — runnable scenario


### PR DESCRIPTION
## Description

Follow-up to #2658. Fixes the dead absolute GitHub link to `examples/opencode-agt` in the OpenCode package and tutorial docs by converting it to a relative link (mirrors the pattern used in `docs/packages/claude-code-governance.md`).

This was caught by `markdown-link-check` after #2658 landed — the absolute `tree/main/examples/opencode-agt` URL 404s because link-check runs against the live `main` ref.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines
- [x] I have added tests that prove my fix/feature works (n/a — docs-only)
- [x] All new and existing tests pass (n/a — docs-only)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects:**

Mirrors the relative-link pattern already used in `docs/packages/claude-code-governance.md` (this repo, MIT).

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

GitHub Copilot CLI was used to apply the two-line fix and open this PR. Both edits were reviewed.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Follow-up to #2658.
