### PR TITLE
feat: consolidate 45 Python packages into 5 distributions (v4.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,24 +383,11 @@ jobs:
             agent-discovery,
             agent-rag-governance,
             agent-sandbox,
+            agent-governance-toolkit-core,
+            agent-governance-toolkit-integrations,
+            agent-governance-toolkit-cli,
+            agent-governance-toolkit-protocols,
           ]
-    steps:
-      - name: Determine if package changed
-        id: gate
-        env:
-          CHANGED: ${{ needs.changes.outputs.changed-py-pkgs }}
-          PKG: ${{ matrix.package }}
-          EVENT: ${{ github.event_name }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "push" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          elif printf '%s' "$CHANGED" | grep -q "\"$PKG\""; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Package $PKG unchanged on this PR — skipping build."
-          fi
       - name: Skip (unchanged package)
         if: steps.gate.outputs.run != 'true'
         run: echo "Package ${{ matrix.package }} unchanged — skipping wheel build"

--- a/agent-governance-python/agent-compliance/pyproject.toml
+++ b/agent-governance-python/agent-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_governance_toolkit"
-version = "3.7.0"
+version = "4.0.0"
 description = "Public Preview — Unified installer and runtime policy enforcement for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}
@@ -39,17 +39,31 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-kernel = ["agent-os-kernel>=2.0.0,<4.0"]
-mesh = ["agentmesh-platform>=2.0.0,<4.0"]
-runtime = ["agentmesh-runtime>=2.0.0,<3.0"]
-sre = ["agent-sre>=1.0.0,<4.0"]
+core = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
+integrations = ["agent-governance-toolkit-integrations>=4.0.0,<5.0"]
+cli = ["agent-governance-toolkit-cli>=4.0.0,<5.0"]
+protocols = ["agent-governance-toolkit-protocols>=4.0.0,<5.0"]
+# Framework-specific extras (delegated to integrations package)
+langchain = ["agent-governance-toolkit-integrations[langchain]>=4.0.0,<5.0"]
+crewai = ["agent-governance-toolkit-integrations[crewai]>=4.0.0,<5.0"]
+openai-agents = ["agent-governance-toolkit-integrations[openai-agents]>=4.0.0,<5.0"]
+langgraph = ["agent-governance-toolkit-integrations[langgraph]>=4.0.0,<5.0"]
+llamaindex = ["agent-governance-toolkit-integrations[llamaindex]>=4.0.0,<5.0"]
+haystack = ["agent-governance-toolkit-integrations[haystack]>=4.0.0,<5.0"]
+pydantic-ai = ["agent-governance-toolkit-integrations[pydantic-ai]>=4.0.0,<5.0"]
+adk = ["agent-governance-toolkit-integrations[adk]>=4.0.0,<5.0"]
+# Legacy extras (kept for backward compat)
+kernel = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
+mesh = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
+runtime = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
+sre = ["agent-governance-toolkit-cli>=4.0.0,<5.0"]
 opa = []
 cedar = ["cedarpy>=4.0.0,<5.0"]
 full = [
-    "agent-os-kernel>=2.0.0,<4.0",
-    "agentmesh-platform>=2.0.0,<4.0",
-    "agentmesh-runtime>=2.0.0,<3.0",
-    "agent-sre>=1.0.0,<4.0",
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
+    "agent-governance-toolkit-integrations>=4.0.0,<5.0",
+    "agent-governance-toolkit-cli>=4.0.0,<5.0",
+    "agent-governance-toolkit-protocols>=4.0.0,<5.0",
 ]
 
 [project.urls]

--- a/agent-governance-python/agent-discovery/pyproject.toml
+++ b/agent-governance-python/agent-discovery/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_discovery"
-version = "3.7.0"
+version = "4.0.0"
 description = "Shadow AI agent discovery and inventory for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-governance-toolkit-cli/README.md
+++ b/agent-governance-python/agent-governance-toolkit-cli/README.md
@@ -1,0 +1,16 @@
+# agent-governance-toolkit-cli
+
+CLI tools, SRE observability, and sandbox isolation for the
+[Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+Consolidates `agent-sre`, `agt-sandbox`, and `agentmesh-mcp-trust` into a
+single distribution.
+
+```bash
+pip install agent-governance-toolkit-cli
+pip install agent-governance-toolkit-cli[docker,mcp]
+```
+
+See the
+[migration guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md)
+for details.

--- a/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
@@ -1,0 +1,104 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-governance-toolkit-cli"
+version = "4.0.0"
+description = "CLI tools, SRE observability, and sandbox isolation for the Agent Governance Toolkit"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [
+    {name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com"},
+]
+maintainers = [
+    {name = "Agent Governance Toolkit Team", email = "agentgovtoolkit@microsoft.com"},
+]
+keywords = [
+    "ai-agents", "governance", "sre", "sandbox", "cli",
+    "observability", "mcp", "trust", "reliability",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: System :: Monitoring",
+    "Topic :: Software Development :: Libraries",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
+
+# Merged from agent-sre + agent-sandbox + mcp-trust-server
+dependencies = [
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
+    "pydantic>=2.4.0,<3.0",
+    "pyyaml>=6.0,<7.0",
+    "croniter>=2.0,<7.0",
+    "opentelemetry-api>=1.20,<2.0",
+    "opentelemetry-sdk>=1.20,<2.0",
+]
+
+[project.optional-dependencies]
+docker = ["docker>=7.1.0,<8.0"]
+hyperlight = ["hyperlight-sandbox>=0.4.0,<0.5"]
+policy = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
+mcp = ["mcp>=1.0.0,<2.0", "cryptography>=46.0.7,<49.0"]
+api = ["fastapi>=0.115.0,<1.0", "uvicorn>=0.27.0,<1.0"]
+otel = ["opentelemetry-exporter-otlp>=1.20,<2.0"]
+langfuse = ["langfuse>=2.0,<5.0"]
+arize = ["arize-phoenix>=4.0,<17.0"]
+langchain = ["langchain-core>=1.2.11,<2.0"]
+llamaindex = ["llama-index-core>=0.10,<1.0"]
+braintrust = ["braintrust>=0.0.100,<1.0"]
+helicone = ["helicone>=4.0,<5.0"]
+datadog = ["ddtrace>=2.0,<5.0"]
+sentry = ["sentry-sdk>=2.0,<3.0"]
+langsmith = ["langsmith>=0.1,<1.0"]
+wandb = ["wandb>=0.16,<1.0"]
+mlflow = ["mlflow>=2.10,<4.0"]
+agentops = ["agentops>=0.3,<1.0"]
+full = [
+    "agent-governance-toolkit-cli[docker,mcp,api,otel]",
+]
+dev = [
+    "pytest>=8.0,<10.0",
+    "pytest-asyncio>=0.23,<2.0",
+    "pytest-cov>=5.0,<8.0",
+    "ruff>=0.4.0,<1.0",
+    "mypy>=1.8.0,<3.0",
+]
+
+[project.scripts]
+agent-sre = "agent_sre.cli.main:cli"
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-governance-toolkit"
+Repository = "https://github.com/microsoft/agent-governance-toolkit"
+"Bug Tracker" = "https://github.com/microsoft/agent-governance-toolkit/issues"
+
+# ============================================================================
+# Hatchling: pull sources from sibling dirs
+# ============================================================================
+[tool.hatch.build.targets.wheel]
+packages = ["_placeholder"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"../agent-sre/src/agent_sre" = "agent_sre"
+"../agent-sandbox/src/agent_sandbox" = "agent_sandbox"
+"../agent-mesh/packages/mcp-trust-server/src/mcp_trust_server" = "mcp_trust_server"
+
+[tool.hatch.build.targets.sdist]
+include = ["README.md", "LICENSE"]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "B", "SIM"]
+ignore = ["E501"]

--- a/agent-governance-python/agent-governance-toolkit-core/README.md
+++ b/agent-governance-python/agent-governance-toolkit-core/README.md
@@ -1,0 +1,47 @@
+# agent-governance-toolkit-core
+
+Core runtime, kernel, and trust layer for the
+[Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+This package consolidates five previously separate distributions into a single
+install:
+
+| Old package | What it provides |
+|---|---|
+| `agent-os-kernel` | Kernel architecture, Nexus Trust Exchange, CMVK, IATP, AMB, ATR, control plane, observability |
+| `agentmesh-primitives` | Shared primitive data models (failure types, severity levels, base structures) |
+| `agentmesh-runtime` | Execution supervisor with privilege rings, saga orchestration, audit trails |
+| `agent-hypervisor` | Runtime supervisor for shared sessions, execution rings, joint liability, hash-chained audit |
+| `agentmesh-platform` | Identity, trust, reward, governance for cloud-native agent ecosystems |
+
+## Install
+
+```bash
+pip install agent-governance-toolkit-core
+```
+
+With optional extras:
+
+```bash
+pip install agent-governance-toolkit-core[full]
+pip install agent-governance-toolkit-core[iatp,observability]
+```
+
+## Migration from old packages
+
+If you previously installed any of the five packages listed above, replace them
+with `agent-governance-toolkit-core` in your requirements file. All import paths
+are unchanged:
+
+```python
+from agent_os.kernel import GovernanceKernel      # unchanged
+from agent_primitives.failures import FailureType  # unchanged
+from agent_runtime.supervisor import Supervisor    # unchanged
+from hypervisor.session import SharedSession       # unchanged
+from agentmesh.identity import AgentIdentity       # unchanged
+```
+
+The old package names continue to work as thin redirects but will emit
+deprecation warnings. See the
+[migration guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md)
+for details.

--- a/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
@@ -1,0 +1,194 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-governance-toolkit-core"
+version = "4.0.0"
+description = "Core runtime, kernel, and trust layer for the Agent Governance Toolkit"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+authors = [
+    {name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com"},
+]
+maintainers = [
+    {name = "Agent Governance Toolkit Team", email = "agentgovtoolkit@microsoft.com"},
+]
+keywords = [
+    "ai-agents", "governance", "multi-agent", "trust", "security",
+    "compliance", "audit", "policy-enforcement", "agent-os", "agentmesh",
+    "runtime", "kernel", "hypervisor", "identity", "zero-trust",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Security",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
+
+# Merged dependencies from agent-os-kernel, agentmesh-primitives,
+# agentmesh-runtime, agent-hypervisor, and agentmesh-platform.
+dependencies = [
+    "pydantic[email]>=2.5.0,<3.0",
+    "pyyaml>=6.0,<7.0",
+    "rich>=13.0.0,<16.0",
+    "cryptography>=46.0.7,<49.0",
+    "pynacl>=1.5.0,<2.0",
+    "httpx>=0.27.0,<1.0",
+    "aiohttp>=3.13.4,<4.0",
+    "structlog>=24.1.0,<26.0",
+    "click>=8.1.0,<9.0",
+    "python-dateutil>=2.8.0,<3.0",
+    "jsonschema>=4.0.0,<5.0",
+]
+
+[project.optional-dependencies]
+# --- Inherited from agent-os-kernel ---
+cmvk = ["numpy>=1.20.0,<3.0"]
+iatp = [
+    "fastapi>=0.115.0,<1.0",
+    "uvicorn>=0.27.0,<1.0",
+]
+amb = [
+    "anyio>=3.0.0,<5.0",
+    "aiofiles>=23.0.0,<26.0",
+]
+observability = [
+    "prometheus-client>=0.17.0,<1.0",
+    "opentelemetry-api>=1.20.0,<2.0",
+    "opentelemetry-sdk>=1.20.0,<2.0",
+]
+mcp = ["mcp>=1.0.0,<2.0"]
+nexus = ["agent-governance-toolkit-core[iatp]"]
+
+# --- Inherited from agent-hypervisor ---
+api = [
+    "fastapi>=0.115.0,<1.0",
+    "uvicorn>=0.27.0,<1.0",
+]
+blockchain = ["web3>=6.0.0,<8.0"]
+otel = ["opentelemetry-api>=1.20,<2.0"]
+
+# --- Inherited from agentmesh-platform ---
+redis = ["redis>=4.0,<8.0"]
+server = [
+    "fastapi>=0.115.0,<1.0",
+    "uvicorn[standard]>=0.27.0,<1.0",
+]
+storage = [
+    "redis[asyncio]>=5.0.0,<8.0",
+    "sqlalchemy[asyncio]>=2.0.0,<3.0",
+    "asyncpg>=0.29.0,<1.0",
+]
+langchain = ["langchain-core>=1.2.11,<2.0"]
+django = ["django>=4.2,<6.0"]
+websocket = ["websockets>=12.0,<17.0"]
+grpc = [
+    "grpcio>=1.60.0,<2.0",
+    "grpcio-tools>=1.60.0,<2.0",
+]
+
+# --- Bundles ---
+full = [
+    "agent-governance-toolkit-core[cmvk,iatp,amb,observability,mcp,nexus,api,otel,server,storage]",
+]
+
+dev = [
+    "pytest>=8.0.0,<10.0",
+    "pytest-asyncio>=0.23.0,<2.0",
+    "pytest-cov>=4.0.0,<8.0",
+    "hypothesis>=6.0.0,<7.0",
+    "mypy>=1.8.0,<3.0",
+    "ruff>=0.4.0,<1.0",
+    "import-linter>=2.0,<3.0",
+    "numpy>=1.20.0,<3.0",
+    "fastapi>=0.115.0,<1.0",
+    "uvicorn>=0.27.0,<1.0",
+    "anyio>=3.0.0,<5.0",
+    "redis>=4.0.0,<8.0",
+    "eval_type_backport>=0.2.0; python_version < '3.10'",
+]
+
+[project.scripts]
+agent-os = "agent_os.cli:main"
+mcp-scan = "agent_os.cli.mcp_scan:main"
+hypervisor = "hypervisor.cli.session_commands:main"
+agentmesh = "agentmesh.cli.main:main"
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-governance-toolkit"
+Documentation = "https://github.com/microsoft/agent-governance-toolkit/tree/main/docs"
+Repository = "https://github.com/microsoft/agent-governance-toolkit"
+"Bug Tracker" = "https://github.com/microsoft/agent-governance-toolkit/issues"
+
+# ============================================================================
+# Hatchling build config: pull sources from sibling package directories
+# ============================================================================
+[tool.hatch.build.targets.wheel]
+packages = ["_placeholder"]
+
+[tool.hatch.build.targets.wheel.force-include]
+# --- agent-os-kernel (kernel + all internal modules) ---
+"../agent-os/src/agent_os" = "agent_os"
+"../agent-os/modules/cmvk/src/cmvk" = "cmvk"
+"../agent-os/modules/caas/src/caas" = "caas"
+"../agent-os/modules/emk/emk" = "emk"
+"../agent-os/modules/iatp/iatp" = "iatp"
+"../agent-os/modules/amb/amb_core" = "amb_core"
+"../agent-os/modules/atr/atr" = "atr"
+"../agent-os/modules/control-plane/src/agent_control_plane" = "agent_control_plane"
+"../agent-os/modules/observability/src/agent_os_observability" = "agent_os_observability"
+"../agent-os/modules/nexus" = "nexus"
+"../agent-os/modules/scak/agent_kernel" = "agent_kernel"
+"../agent-os/modules/mute-agent/mute_agent" = "mute_agent"
+"../agent-os/modules/mcp-kernel-server/src/mcp_kernel_server" = "mcp_kernel_server"
+# --- agentmesh-primitives ---
+"../agent-primitives/agent_primitives" = "agent_primitives"
+# --- agentmesh-runtime ---
+"../agent-runtime/src/agent_runtime" = "agent_runtime"
+# --- agent-hypervisor ---
+"../agent-hypervisor/src/hypervisor" = "hypervisor"
+# --- agentmesh-platform ---
+"../agent-mesh/src/agentmesh" = "agentmesh"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "README.md",
+    "LICENSE",
+]
+
+# ============================================================================
+# Ruff
+# ============================================================================
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "B", "C4", "UP"]
+ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402", "F401"]
+
+# ============================================================================
+# Pytest
+# ============================================================================
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "-v --tb=short"
+markers = [
+    "benchmark: performance benchmark tests",
+    "slow: long-running tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
+]

--- a/agent-governance-python/agent-governance-toolkit-integrations/README.md
+++ b/agent-governance-python/agent-governance-toolkit-integrations/README.md
@@ -1,0 +1,15 @@
+# agent-governance-toolkit-integrations
+
+Framework adapters for the
+[Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+Install the base package and add extras for the frameworks you use:
+
+```bash
+pip install agent-governance-toolkit-integrations[langchain]
+pip install agent-governance-toolkit-integrations[crewai,openai-agents]
+```
+
+See the
+[migration guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md)
+for details on moving from the old per-framework packages.

--- a/agent-governance-python/agent-governance-toolkit-integrations/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-integrations/pyproject.toml
@@ -1,0 +1,111 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-governance-toolkit-integrations"
+version = "4.0.0"
+description = "Framework adapters for the Agent Governance Toolkit (LangChain, CrewAI, OpenAI Agents, and more)"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+authors = [
+    {name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com"},
+]
+maintainers = [
+    {name = "Agent Governance Toolkit Team", email = "agentgovtoolkit@microsoft.com"},
+]
+keywords = [
+    "ai-agents", "governance", "langchain", "crewai", "openai-agents",
+    "llamaindex", "haystack", "pydantic-ai", "multi-agent", "trust",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
+
+# No mandatory framework deps: each adapter is an optional extra.
+dependencies = [
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
+]
+
+[project.optional-dependencies]
+langchain = ["langchain-core>=1.2.11,<2.0"]
+crewai = ["crewai>=0.100.0,<1.0"]
+openai-agents = ["openai-agents>=0.0.3,<1.0"]
+langgraph = ["langgraph>=0.2.0,<1.0"]
+llamaindex = ["llama-index-core>=0.10,<1.0"]
+haystack = ["haystack-ai>=2.0,<3.0"]
+pydantic-ai = ["pydantic-ai>=0.0.10,<1.0"]
+flowise = []
+langflow = []
+adk = ["google-adk>=0.1.0,<1.0"]
+avp = []
+cedarling = ["cedarpy>=4.0.0,<5.0"]
+nostr-wot = []
+structural-authz = []
+openshell = ["pyyaml>=6.0,<7.0"]
+audit-export = []
+
+dev = [
+    "pytest>=8.0,<10.0",
+    "pytest-asyncio>=0.23,<2.0",
+    "ruff>=0.4.0,<1.0",
+]
+
+[project.scripts]
+openshell-agentmesh = "openshell_agentmesh.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-governance-toolkit"
+Documentation = "https://github.com/microsoft/agent-governance-toolkit/tree/main/docs"
+Repository = "https://github.com/microsoft/agent-governance-toolkit"
+"Bug Tracker" = "https://github.com/microsoft/agent-governance-toolkit/issues"
+
+# ============================================================================
+# Hatchling: pull adapter sources from agentmesh-integrations/
+# ============================================================================
+[tool.hatch.build.targets.wheel]
+packages = ["_placeholder"]
+
+[tool.hatch.build.targets.wheel.force-include]
+# Adapters with top-level module dirs
+"../agentmesh-integrations/langchain-agentmesh/langchain_agentmesh" = "langchain_agentmesh"
+"../agentmesh-integrations/crewai-agentmesh/crewai_agentmesh" = "crewai_agentmesh"
+"../agentmesh-integrations/openai-agents-agentmesh/openai_agents_agentmesh" = "openai_agents_agentmesh"
+"../agentmesh-integrations/langgraph-trust/langgraph_trust" = "langgraph_trust"
+"../agentmesh-integrations/llamaindex-agentmesh/llama_index" = "llama_index"
+"../agentmesh-integrations/cedarling-agentmesh/cedarling_agentmesh" = "cedarling_agentmesh"
+"../agentmesh-integrations/agentmesh-avp/agentmesh_avp" = "agentmesh_avp"
+"../agentmesh-integrations/nostr-wot/agentmesh_nostr_wot" = "agentmesh_nostr_wot"
+"../agentmesh-integrations/structural-authz-agentmesh/structural_authz_agentmesh" = "structural_authz_agentmesh"
+"../agentmesh-integrations/openshell-skill/openshell_agentmesh" = "openshell_agentmesh"
+"../agentmesh-integrations/audit-accountability-export/audit_accountability_export" = "audit_accountability_export"
+"../agentmesh-integrations/template-agentmesh/template_agentmesh" = "template_agentmesh"
+# Adapters with src/ layout
+"../agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh" = "haystack_agentmesh"
+"../agentmesh-integrations/flowise-agentmesh/src/flowise_agentmesh" = "flowise_agentmesh"
+"../agentmesh-integrations/langflow-agentmesh/src/langflow_agentmesh" = "langflow_agentmesh"
+"../agentmesh-integrations/adk-agentmesh/src/adk_agentmesh" = "adk_agentmesh"
+"../agentmesh-integrations/pydantic-ai-governance/src/pydantic_ai_governance" = "pydantic_ai_governance"
+"../agentmesh-integrations/openai-agents-trust/src/openai_agents_trust" = "openai_agents_trust"
+
+[tool.hatch.build.targets.sdist]
+include = ["README.md", "LICENSE"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+ignore = ["E501"]

--- a/agent-governance-python/agent-governance-toolkit-protocols/README.md
+++ b/agent-governance-python/agent-governance-toolkit-protocols/README.md
@@ -1,0 +1,15 @@
+# agent-governance-toolkit-protocols
+
+Protocol implementations for the
+[Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
+
+Includes MCP governance primitives, A2A protocol adapter, MCP receipt
+governance, and the MCP trust proxy.
+
+```bash
+pip install agent-governance-toolkit-protocols
+```
+
+See the
+[migration guide](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md)
+for details.

--- a/agent-governance-python/agent-governance-toolkit-protocols/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-protocols/pyproject.toml
@@ -1,0 +1,73 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-governance-toolkit-protocols"
+version = "4.0.0"
+description = "Protocol implementations (MCP governance, trust protocol, A2A, MCP receipts) for the Agent Governance Toolkit"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.10"
+authors = [
+    {name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com"},
+]
+maintainers = [
+    {name = "Agent Governance Toolkit Team", email = "agentgovtoolkit@microsoft.com"},
+]
+keywords = [
+    "ai-agents", "governance", "mcp", "trust-protocol",
+    "a2a", "receipts", "protocol", "security",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed",
+]
+
+dependencies = [
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<10.0",
+    "pytest-asyncio>=0.23,<2.0",
+    "ruff>=0.4.0,<1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/agent-governance-toolkit"
+Repository = "https://github.com/microsoft/agent-governance-toolkit"
+"Bug Tracker" = "https://github.com/microsoft/agent-governance-toolkit/issues"
+
+# ============================================================================
+# Hatchling: pull protocol sources
+# ============================================================================
+[tool.hatch.build.targets.wheel]
+packages = ["_placeholder"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"../agent-mcp-governance/src/agent_mcp_governance" = "agent_mcp_governance"
+"../agentmesh-integrations/a2a-protocol/a2a_agentmesh" = "a2a_agentmesh"
+"../agentmesh-integrations/mcp-receipt-governed/mcp_receipt_governed" = "mcp_receipt_governed"
+"../agentmesh-integrations/mcp-trust-proxy/mcp_trust_proxy" = "mcp_trust_proxy"
+
+[tool.hatch.build.targets.sdist]
+include = ["README.md", "LICENSE"]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+ignore = ["E501"]

--- a/agent-governance-python/agent-hypervisor/pyproject.toml
+++ b/agent-governance-python/agent-hypervisor/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_hypervisor"
-version = "3.7.0"
-description = "Public Preview — Agent Hypervisor: Runtime supervisor for multi-agent Shared Sessions with Execution Rings, Joint Liability, Saga Orchestration, and hash-chained audit trails"
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-core instead. Agent Hypervisor: Runtime supervisor for multi-agent Shared Sessions"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
@@ -34,9 +34,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-# Core: only pydantic required. Integration adapters use Protocol-based
-# interfaces (duck typing), so external backends are optional.
+# This package is deprecated. All functionality is now in agent-governance-toolkit-core.
 dependencies = [
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
     "pydantic>=2.4.0,<3.0",
 ]
 

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/__init__.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/__init__.py
@@ -16,6 +16,15 @@ Usage:
 Version: 2.0.0
 """
 
+
+import warnings as _warnings
+_warnings.warn(
+    "agent-hypervisor is deprecated. Use agent-governance-toolkit-core instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
 __version__ = "3.2.2"
 
 # Centralized constants

--- a/agent-governance-python/agent-lightning/pyproject.toml
+++ b/agent-governance-python/agent-lightning/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_lightning"
-version = "3.7.0"
+version = "4.0.0"
 description = "Public Preview — Agent-Lightning RL integration for the Agent Governance Toolkit: governed training with policy enforcement"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-marketplace/pyproject.toml
+++ b/agent-governance-python/agent-marketplace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_marketplace"
-version = "3.7.0"
+version = "4.0.0"
 description = "Plugin marketplace for the Agent Governance Toolkit — discover, install, verify, and manage plugins"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-mcp-governance/pyproject.toml
+++ b/agent-governance-python/agent-mcp-governance/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_mcp_governance"
-version = "3.7.0"
-description = "Public Preview — MCP governance primitives for the Agent Governance Toolkit."
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-protocols instead. MCP governance primitives for the Agent Governance Toolkit."
 readme = "README.md"
 license = {text = "MIT"}
 authors = [{name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com"}]
 requires-python = ">=3.10"
 dependencies = [
-    "agent-os-kernel>=3.0.0,<4.0.0",
+    "agent-governance-toolkit-protocols>=4.0.0,<5.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
+++ b/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
@@ -24,6 +24,15 @@ MCP-specific security primitives (from ``agent_os.mcp_security``):
 
 from __future__ import annotations
 
+import warnings as _warnings
+_warnings.warn(
+    "agent-mcp-governance is deprecated. Use agent-governance-toolkit-protocols instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
+
 __version__ = "3.6.0"
 
 from agent_os.governance.middleware import GovernanceMiddleware

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_platform"
-version = "3.7.0"
-description = "Public Preview — The Secure Nervous System for Cloud-Native Agent Ecosystems - Identity, Trust, Reward, Governance"
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-core instead. The Secure Nervous System for Cloud-Native Agent Ecosystems"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
@@ -45,7 +45,9 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    # Core dependencies
+    # Core dependency redirect
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
+    # Original deps kept for backward compat
     "pydantic[email]>=2.5.0,<3.0",
     "cryptography>=46.0.7,<49.0",
     "pynacl>=1.5.0,<2.0",

--- a/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
@@ -11,6 +11,15 @@ multi-vendor network of AI agents that will define enterprise operations.
 Version: 3.6.0
 """
 
+
+import warnings as _warnings
+_warnings.warn(
+    "agentmesh-platform is deprecated. Use agent-governance-toolkit-core instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
 __version__ = "3.6.0"
 
 # Layer 1: Identity & Zero-Trust Core

--- a/agent-governance-python/agent-os/pyproject.toml
+++ b/agent-governance-python/agent-os/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_os_kernel"
-version = "3.7.0"
-description = "Public Preview — A kernel architecture for governing autonomous AI agents with Nexus Trust Exchange"
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-core instead. A kernel architecture for governing autonomous AI agents with Nexus Trust Exchange"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
@@ -41,10 +41,12 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-# Core dependencies (minimal - just what's needed for kernel)
+# This package is deprecated. All functionality is now in agent-governance-toolkit-core.
+# The dependency below ensures existing installs continue to work.
 dependencies = [
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
     "pydantic>=2.4.0,<3.0",
-    "rich>=13.0.0,<16.0"
+    "rich>=13.0.0,<16.0",
 ]
 
 [project.urls]

--- a/agent-governance-python/agent-os/src/agent_os/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/__init__.py
@@ -44,7 +44,17 @@ Installation:
     pip install agent-os-kernel        # Core
 """
 
+
 from __future__ import annotations
+
+import warnings as _warnings
+_warnings.warn(
+    "agent-os-kernel is deprecated. Use agent-governance-toolkit-core instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
 
 __version__ = "3.2.2"
 __author__ = "Microsoft Corporation"

--- a/agent-governance-python/agent-primitives/agent_primitives/__init__.py
+++ b/agent-governance-python/agent-primitives/agent_primitives/__init__.py
@@ -7,6 +7,15 @@ This is a Layer 1 primitive package providing foundational models
 used across the Agent OS stack.
 """
 
+
+import warnings as _warnings
+_warnings.warn(
+    "agentmesh-primitives is deprecated. Use agent-governance-toolkit-core instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
 __version__ = "3.2.2"
 
 from .failures import (

--- a/agent-governance-python/agent-primitives/pyproject.toml
+++ b/agent-governance-python/agent-primitives/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_primitives"
-version = "3.7.0"
-description = "Shared primitive data models for Agent OS - failure types, severity levels, and base structures"
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-core instead. Shared primitive data models for Agent OS"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.8"
@@ -36,6 +36,7 @@ classifiers = [
 ]
 
 dependencies = [
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
     "pydantic>=2.4.0,<3.0",
 ]
 

--- a/agent-governance-python/agent-rag-governance/pyproject.toml
+++ b/agent-governance-python/agent-rag-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-rag-governance"
-version = "3.7.0"
+version = "4.0.0"
 description = "Retrieval access control and vector store policy enforcement for RAG pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-runtime/pyproject.toml
+++ b/agent-governance-python/agent-runtime/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_runtime"
-version = "3.7.0"
-description = "Public Preview — AgentMesh Runtime: Execution supervisor for multi-agent sessions with privilege rings, saga orchestration, and audit trails"
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-core instead. AgentMesh Runtime: Execution supervisor for multi-agent sessions"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
@@ -34,7 +34,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "agent-hypervisor>=2.1.0,<4.0",
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
     "jsonschema>=4.0.0,<5.0",
 ]
 

--- a/agent-governance-python/agent-runtime/src/agent_runtime/__init__.py
+++ b/agent-governance-python/agent-runtime/src/agent_runtime/__init__.py
@@ -16,6 +16,15 @@ The ``agent-hypervisor`` package remains available for backward compatibility
 and will be deprecated in a future release.
 """
 
+
+import warnings as _warnings
+_warnings.warn(
+    "agentmesh-runtime is deprecated. Use agent-governance-toolkit-core instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
 from hypervisor import (  # noqa: F401
     __version__,
     # Core

--- a/agent-governance-python/agent-sandbox/pyproject.toml
+++ b/agent-governance-python/agent-sandbox/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agt_sandbox"
-version = "3.7.0"
-description = "Public Preview — Agent Sandbox: Docker-based execution isolation for AI agents with policy-driven resource limits, tool proxies, network enforcement, and filesystem checkpointing"
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-cli instead. Agent Sandbox: Docker-based execution isolation for AI agents"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
@@ -33,7 +33,9 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = []
+dependencies = [
+    "agent-governance-toolkit-cli>=4.0.0,<5.0",
+]
 
 [project.optional-dependencies]
 docker = [

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/__init__.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/__init__.py
@@ -17,6 +17,15 @@ backends, plus three built-in implementations:
   egress allowlist enforcement.
 """
 
+
+import warnings as _warnings
+_warnings.warn(
+    "agt-sandbox is deprecated. Use agent-governance-toolkit-cli instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
 from importlib.metadata import PackageNotFoundError, version
 
 from agent_sandbox.sandbox_provider import (

--- a/agent-governance-python/agent-sre/pyproject.toml
+++ b/agent-governance-python/agent-sre/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_sre"
-version = "3.7.0"
-description = "Public Preview — Reliability Engineering for AI Agent Systems"
+version = "4.0.0"
+description = "Deprecated — use agent-governance-toolkit-cli instead. Reliability Engineering for AI Agent Systems"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
@@ -29,6 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
+    "agent-governance-toolkit-cli>=4.0.0,<5.0",
     "pydantic>=2.4.0,<3.0",
     "pyyaml>=6.0,<7.0",
     "croniter>=2.0,<7.0",

--- a/agent-governance-python/agent-sre/src/agent_sre/__init__.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/__init__.py
@@ -35,6 +35,15 @@ Quick start::
 See https://github.com/microsoft/agent-governance-toolkit for full documentation.
 """
 
+
+import warnings as _warnings
+_warnings.warn(
+    "agent-sre is deprecated. Use agent-governance-toolkit-cli instead. "
+    "See https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md",
+    DeprecationWarning,
+    stacklevel=2,
+)
+del _warnings
 from agent_sre.slo.indicators import SLI, SLIRegistry, SLIValue
 from agent_sre.slo.objectives import SLO, ErrorBudget
 


### PR DESCRIPTION
## Summary

Implements the approved package consolidation proposal from \docs/package-consolidation/PROPOSAL.md\ (tracks #2482).

Reduces 45 Python packages to 5 top-level distributions. Source code does not move. All existing import paths are preserved.

## New consolidated packages

| Package | Absorbs | Size |
|---|---|---|
| \gent-governance-toolkit-core\ | agent-os-kernel, agentmesh-primitives, agentmesh-runtime, agent-hypervisor, agentmesh-platform | 1.6 MB |
| \gent-governance-toolkit-integrations\ | All 21 framework adapters (as optional extras) | 114 KB |
| \gent-governance-toolkit-cli\ | agent-sre, agt-sandbox, mcp-trust-server | 273 KB |
| \gent-governance-toolkit-protocols\ | agent-mcp-governance, a2a, mcp-receipts, mcp-trust-proxy | 19 KB |

## Changes

- 4 new \pyproject.toml\ files using hatchling \orce-include\ to pull sources from sibling dirs
- 8 absorbed packages converted to v4.0.0 stubs (depend on new consolidated package)
- \DeprecationWarning\ added to all absorbed package \__init__.py\ files
- Meta-package (\gent-governance-toolkit\) extras updated for new structure
- All standalone packages bumped to v4.0.0
- CI \uild-pypi\ matrix updated for new packages

## Migration

\\\ash
# Before
pip install agent-os-kernel agentmesh-runtime agent-sre

# After
pip install agent-governance-toolkit-core agent-governance-toolkit-cli
\\\

Old package names still work as stubs. Deprecation warnings guide users to update.

## Testing

- All 4 consolidated packages build successfully
- All absorbed packages still build as stubs
- agent-os: 248 passed, agent-hypervisor: 770 passed, agent-sre: 1500 passed, agent-mesh: 290 passed
- No regressions introduced (pre-existing failures only: OPA backend test, Windows cp1252 encoding, missing deploy module)