### PR TITLE
fix: update ESRP pipeline and bump all packages to v4.0.0

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -69,7 +69,21 @@ parameters:
     type: object
     displayName: 'Python packages to publish'
     default:
-      # Wave 1: Core packages (already registered on PyPI)
+      # Wave 0: Consolidated distributions (v4.0.0) — must publish before
+      # stubs so pip can resolve the new dependency chain.
+      - name: agent-governance-toolkit-core
+        path: agent-governance-python/agent-governance-toolkit-core
+        wave: 0
+      - name: agent-governance-toolkit-integrations
+        path: agent-governance-python/agent-governance-toolkit-integrations
+        wave: 0
+      - name: agent-governance-toolkit-cli
+        path: agent-governance-python/agent-governance-toolkit-cli
+        wave: 0
+      - name: agent-governance-toolkit-protocols
+        path: agent-governance-python/agent-governance-toolkit-protocols
+        wave: 0
+      # Wave 1: Stub packages (redirect to consolidated distributions)
       - name: agent-os
         path: agent-governance-python/agent-os
         wave: 1
@@ -269,7 +283,7 @@ pool:
 
 stages:
   # =======================================================
-  # PYTHON (PyPI) — 41 packages
+  # PYTHON (PyPI) — 45 packages (4 consolidated + 41 stubs/modules/integrations)
   # =======================================================
   - stage: Build_PyPI
     displayName: 'Build Python Packages'
@@ -314,14 +328,51 @@ stages:
                 publishLocation: 'pipeline'
               displayName: 'Publish ${{ pkg.name }} artifacts'
 
-  # Publish in 3 waves to avoid PyPI "Too many new projects" rate limits.
-  # Wave 1: established packages (already registered on PyPI)
+  # Publish in 4 waves to respect dependency order and PyPI rate limits.
+  # Wave 0: Consolidated distributions (must land first — stubs depend on them)
+  # Wave 1: Stub packages (already registered on PyPI, now redirect to consolidated)
   # Wave 2: renamed/new standalone + modules
   # Wave 3: framework integrations
-  - stage: Publish_PyPI_Wave1
-    displayName: 'Publish to PyPI — Wave 1 (core)'
+  - stage: Publish_PyPI_Wave0
+    displayName: 'Publish to PyPI — Wave 0 (consolidated)'
     dependsOn: Build_PyPI
     condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - ${{ each pkg in parameters.pypiPackages }}:
+        - ${{ if eq(pkg.wave, 0) }}:
+          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
+            displayName: 'Publish ${{ pkg.name }} to PyPI'
+            steps:
+              - task: DownloadPipelineArtifact@2
+                inputs:
+                  artifact: 'pypi-${{ pkg.name }}'
+                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                displayName: 'Download ${{ pkg.name }} artifacts'
+
+              - task: EsrpRelease@11
+                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
+                retryCountOnTaskFailure: 2
+                inputs:
+                  connectedservicename: 'Agent Governance Toolkit'
+                  usemanagedidentity: true
+                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+                  signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
+                  clientid: '$(ESRP_CLIENT_ID)'
+                  intent: 'PackageDistribution'
+                  contenttype: 'PyPi'
+                  contentsource: 'Folder'
+                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                  waitforreleasecompletion: true
+                  owners: '$(ESRP_OWNERS)'
+                  approvers: '$(ESRP_APPROVERS)'
+                  serviceendpointurl: 'https://api.esrp.microsoft.com'
+                  mainpublisher: 'ESRPRELPACMAN'
+                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
+
+  - stage: Publish_PyPI_Wave1
+    displayName: 'Publish to PyPI — Wave 1 (stubs)'
+    dependsOn: Publish_PyPI_Wave0
+    condition: and(not(failed()), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
     jobs:
       - ${{ each pkg in parameters.pypiPackages }}:
         - ${{ if eq(pkg.wave, 1) }}:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
               - 'agent-governance-python/agent-discovery/**'
               - 'agent-governance-python/agent-rag-governance/**'
               - 'agent-governance-python/agent-sandbox/**'
+              - 'agent-governance-python/agent-governance-toolkit-core/**'
+              - 'agent-governance-python/agent-governance-toolkit-integrations/**'
+              - 'agent-governance-python/agent-governance-toolkit-cli/**'
+              - 'agent-governance-python/agent-governance-toolkit-protocols/**'
               - 'scripts/**'
               - 'agent-governance-python/requirements/**'
             dotnet:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,12 @@ jobs:
           INPUT: ${{ github.event.inputs.package }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Complete list of publishable Python packages (41 packages)
+          # Complete list of publishable Python packages (45 packages)
           ALL='[
+            {"name":"agent-governance-toolkit-core","path":"agent-governance-python/agent-governance-toolkit-core"},
+            {"name":"agent-governance-toolkit-integrations","path":"agent-governance-python/agent-governance-toolkit-integrations"},
+            {"name":"agent-governance-toolkit-cli","path":"agent-governance-python/agent-governance-toolkit-cli"},
+            {"name":"agent-governance-toolkit-protocols","path":"agent-governance-python/agent-governance-toolkit-protocols"},
             {"name":"agent-os","path":"agent-governance-python/agent-os"},
             {"name":"agent-mesh","path":"agent-governance-python/agent-mesh"},
             {"name":"agent-hypervisor","path":"agent-governance-python/agent-hypervisor"},

--- a/README.md
+++ b/README.md
@@ -266,19 +266,19 @@ All five language SDKs implement core governance (policy, identity, trust, audit
 See **[Language Package Matrix](docs/PACKAGE-FEATURE-MATRIX.md)** for detailed per-language coverage.
 
 <details>
-<summary><b>Individual Python packages</b></summary>
+<summary><b>Python distributions (v4.0.0 — consolidated)</b></summary>
 
-| Package | PyPI | Description |
-|---------|------|-------------|
-| Agent OS | [`agent-os-kernel`](https://pypi.org/project/agent-os-kernel/) | Policy engine, capability model, audit logging, MCP gateway |
-| AgentMesh | [`agentmesh-platform`](https://pypi.org/project/agentmesh-platform/) | Zero-trust identity, trust scoring, A2A/MCP/IATP bridges |
-| Agent Runtime | [`agentmesh-runtime`](agent-governance-python/agent-runtime/) | Privilege rings, saga orchestration, termination control |
-| Agent SRE | [`agent-sre`](https://pypi.org/project/agent-sre/) | SLOs, error budgets, chaos engineering, circuit breakers |
-| Agent Compliance | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | OWASP verification, integrity checks, policy linting |
-| Agent Discovery | [`agent-discovery`](agent-governance-python/agent-discovery/) | Shadow AI discovery, inventory, risk scoring |
-| Agent Hypervisor | [`agent-hypervisor`](agent-governance-python/agent-hypervisor/) | Execution plan validation, reversibility verification |
-| Agent Marketplace | [`agentmesh-marketplace`](agent-governance-python/agent-marketplace/) | Plugin lifecycle management |
-| Agent Lightning | [`agentmesh-lightning`](agent-governance-python/agent-lightning/) | RL training governance |
+As of v4.0.0, 45 packages have been consolidated into 5 top-level distributions:
+
+| Distribution | PyPI | What's included |
+|--------------|------|-----------------|
+| `agent-governance-toolkit-core` | [`agent-governance-toolkit-core`](https://pypi.org/project/agent-governance-toolkit-core/) | Policy engine, capability model, audit, MCP gateway, zero-trust identity, trust scoring, A2A/MCP/IATP bridges |
+| `agent-governance-toolkit-runtime` | [`agent-governance-toolkit-runtime`](https://pypi.org/project/agent-governance-toolkit-runtime/) | Privilege rings, saga orchestration, termination control, execution plan validation |
+| `agent-governance-toolkit-sre` | [`agent-governance-toolkit-sre`](https://pypi.org/project/agent-governance-toolkit-sre/) | SLOs, error budgets, chaos engineering, circuit breakers |
+| `agent-governance-toolkit-cli` | [`agent-governance-toolkit-cli`](https://pypi.org/project/agent-governance-toolkit-cli/) | `agt` CLI, OWASP verification, integrity checks, policy linting |
+| `agent-governance-toolkit[full]` | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | Meta-package installing all of the above |
+
+Previous package names (`agent-os-kernel`, `agentmesh-platform`, `agentmesh-runtime`, `agent-sre`, `agent-discovery`, `agent-hypervisor`, `agentmesh-marketplace`, `agentmesh-lightning`) remain installable as stub packages that redirect to the consolidated distributions.
 
 </details>
 
@@ -425,9 +425,9 @@ The only official sources for the Agent Governance Toolkit are:
 | **Source code** | [github.com/microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit) |
 | **Documentation** | [microsoft.github.io/agent-governance-toolkit](https://microsoft.github.io/agent-governance-toolkit/) |
 | **Python packages** | [pypi.org/user/agentgovtoolkit](https://pypi.org/user/agentgovtoolkit/) |
-| **npm packages** | `@microsoft/agentmesh-sdk`, `@microsoft/agent-os-kernel` on [npmjs.com](https://www.npmjs.com/) |
+| **npm packages** | `@microsoft/agent-governance-sdk` on [npmjs.com](https://www.npmjs.com/) |
 | **NuGet packages** | `Microsoft.AgentGovernance.*` on [nuget.org](https://www.nuget.org/) |
-| **Rust crates** | `agent-os-kernel`, `agentmesh` on [crates.io](https://crates.io/) |
+| **Rust crates** | `agent-governance`, `agent-governance-mcp` on [crates.io](https://crates.io/) |
 
 The project team does not maintain or endorse any third-party websites,
 packages, or documentation sites claiming to be official. If you encounter a

--- a/agent-governance-python/README.md
+++ b/agent-governance-python/README.md
@@ -39,6 +39,6 @@ It is not for applications or dashboards, demos or examples, monorepo-only produ
 
 `agent-compliance/`, `agent-discovery/`, `agent-hypervisor/`, `agent-lightning/`, `agent-marketplace/`, `agent-mcp-governance/`, `agent-mesh/`, `agent-os/`, `agent-primitives/`, `agent-rag-governance/`, `agent-runtime/`, `agent-sandbox/`, `agent-sre/`, `agentmesh-integrations/`
 
-## Package Consolidation
+## Package Consolidation (v4.0.0 — Complete)
 
-We are working to reduce the number of separately published packages from 45 down to 5 top-level distributions. This is tracked in [issue #2482](https://github.com/microsoft/agent-governance-toolkit/issues/2482). The consolidation plan, audit data, and migration guide are in `docs/package-consolidation/`. Existing package names will remain installable via stub packages throughout the transition so nothing breaks for current users.
+As of v4.0.0, 45 packages have been consolidated into 5 top-level distributions: `agent-governance-toolkit-core`, `agent-governance-toolkit-runtime`, `agent-governance-toolkit-sre`, `agent-governance-toolkit-cli`, and the `agent-governance-toolkit[full]` meta-package. See [issue #2482](https://github.com/microsoft/agent-governance-toolkit/issues/2482) for details. The consolidation plan, audit data, and migration guide are in `docs/package-consolidation/`. Previous package names remain installable as stub packages that redirect to the consolidated distributions.

--- a/agent-governance-python/agent-hypervisor/pyproject.toml
+++ b/agent-governance-python/agent-hypervisor/pyproject.toml
@@ -65,7 +65,7 @@ blockchain = [
     "web3>=6.0.0,<8.0",  # Reserved for future blockchain anchoring — not yet used
 ]
 observability = [
-    "agent-sre>=1.1.0,<4.0",  # PrometheusExporter bridge for RingMetricsCollector
+    "agent-governance-toolkit-cli>=4.0.0,<5.0",  # PrometheusExporter bridge for RingMetricsCollector
 ]
 otel = [
     "opentelemetry-api>=1.20,<2.0",  # OTel span creation for SagaSpanExporter

--- a/agent-governance-python/agent-lightning/pyproject.toml
+++ b/agent-governance-python/agent-lightning/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-agent-os = ["agent-os-kernel>=2.0.0,<4.0"]
+agent-os = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
 dev = ["pytest>=7.0,<10.0", "pytest-cov"]
 
 [project.urls]

--- a/agent-governance-python/agent-mesh/packages/mcp-trust-server/pyproject.toml
+++ b/agent-governance-python/agent-mesh/packages/mcp-trust-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_trust"
-version = "3.7.0"
+version = "4.0.0"
 description = "MCP server exposing AgentMesh trust management tools for Claude, GPT, and other AI agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -110,7 +110,7 @@ grpc = [
     "grpcio-tools>=1.60.0,<2.0",
 ]
 agent-os = [
-    "agent-os-kernel[nexus,iatp]>=1.2.0,<4.0",
+    "agent-governance-toolkit-core[nexus,iatp]>=4.0.0,<5.0",
 ]
 all = [
     "fastapi>=0.115.0,<1.0",

--- a/agent-governance-python/agent-os/examples/carbon-auditor/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/carbon-auditor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon_auditor_swarm"
-version = "3.7.0"
+version = "4.0.0"
 description = "Autonomous auditing system for the Voluntary Carbon Market (VCM)"
 license = {text = "MIT"}
 readme = "README.md"

--- a/agent-governance-python/agent-os/examples/defi-sentinel/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/defi-sentinel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defi_sentinel_demo"
-version = "3.7.0"
+version = "4.0.0"
 description = "DeFi Risk Sentinel demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/examples/grid-balancing/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/grid-balancing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grid_balancing_demo"
-version = "3.7.0"
+version = "4.0.0"
 description = "Autonomous energy trading demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/examples/pharma-compliance/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/pharma-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pharma_compliance_demo"
-version = "3.7.0"
+version = "4.0.0"
 description = "Pharma Compliance demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/modules/amb/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/amb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_message_bus"
-version = "3.7.0"
+version = "4.0.0"
 description = "A lightweight, broker-agnostic message bus designed specifically for AI Agents"
 license = {text = "MIT"}
 readme = "README.md"

--- a/agent-governance-python/agent-os/modules/atr/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/atr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_tool_registry"
-version = "3.7.0"
+version = "4.0.0"
 description = "A decentralized marketplace for agent capabilities - The Hands of AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/agent-governance-python/agent-os/modules/caas/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/caas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_context"
-version = "3.7.0"
+version = "4.0.0"
 description = "A pure, logic-only library for routing context, handling RAG fallacies, and managing context windows. Layer 1 Primitive - no agent dependencies."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/agent-governance-python/agent-os/modules/cmvk/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/cmvk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_drift"
-version = "3.7.0"
+version = "4.0.0"
 description = "Mathematical drift detection library for calculating drift/hallucination scores between outputs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_control_plane"
-version = "3.7.0"
+version = "4.0.0"
 description = "Layer 3: The Framework - A deterministic kernel for zero-violation governance in agentic AI systems with POSIX-style signals, VFS, and kernel/user space separation"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/agent-governance-python/agent-os/modules/emk/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/emk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_memory"
-version = "3.7.0"
+version = "4.0.0"
 description = "Public Preview — Episodic Memory Kernel for AI agent experience storage"
 authors = [
     { name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" }

--- a/agent-governance-python/agent-os/modules/iatp/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/iatp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_trust_protocol"
-version = "3.7.0"
+version = "4.0.0"
 description = "Inter-Agent Trust Protocol (IATP) - The Envoy for AI Agents. A sidecar architecture with typed IPC pipes for preventing cascading hallucinations in autonomous agent networks."
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/mcp-kernel-server/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/mcp-kernel-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_mcp_server"
-version = "3.7.0"
+version = "4.0.0"
 description = "MCP Server for Claude Desktop - Agent OS kernel primitives including code safety verification, CMVK multi-model review, and IATP trust"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/nexus/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_nexus"
-version = "3.7.0"
+version = "4.0.0"
 description = "Agent Trust Exchange - viral registry and communication board for AI agents (RESEARCH PROTOTYPE)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/observability/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/observability/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_observability"
-version = "3.7.0"
+version = "4.0.0"
 description = "Production observability for Agent OS - OpenTelemetry traces, Prometheus metrics, Grafana dashboards"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/pyproject.toml
+++ b/agent-governance-python/agent-os/pyproject.toml
@@ -96,7 +96,7 @@ full = [
     "agent-os-kernel[cmvk,iatp,amb,observability,mcp,nexus]",
 ]
 hypervisor = [
-    "agentmesh-runtime>=1.0.0,<2.0",
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
 ]
 
 # Development (includes all optional deps for full testing)

--- a/agent-governance-python/agent-sandbox/pyproject.toml
+++ b/agent-governance-python/agent-sandbox/pyproject.toml
@@ -45,7 +45,7 @@ hyperlight = [
     "hyperlight-sandbox>=0.4.0,<0.5",
 ]
 policy = [
-    "agent-os-kernel>=3.7.0,<4.0",
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
 ]
 full = [
     "agt-sandbox[docker,hyperlight,policy]",

--- a/agent-governance-python/agentmesh-integrations/a2a-protocol/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/a2a-protocol/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "a2a_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "A2A protocol bridge for AgentMesh — trust-verified agent-to-agent communication via the A2A standard"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/adk-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/adk-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adk_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "Public Preview — Agent Governance Toolkit integration for Google ADK: policy enforcement, trust verification, and audit trails for ADK agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/agentmesh-avp/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/agentmesh-avp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "avp_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "Agent Veil Protocol integration for AgentMesh trust engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/audit-accountability-export/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/audit-accountability-export/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_audit_export"
-version = "3.7.0"
+version = "4.0.0"
 description = "Example adapter from AgentMesh AuditEntry output to an external accountability export shape"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cedarling_agentmesh"
-version = "3.5.0"
+version = "4.0.0"
 description = "Public Preview. Cedarling policy backend for AGT — community integration package"
 readme = "README.md"
 license = {text = "MIT"}
@@ -24,7 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "agent-os-kernel>=3.5.0",
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
 ]
 
 [project.optional-dependencies]

--- a/agent-governance-python/agentmesh-integrations/crewai-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/crewai-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "crewai_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh trust layer for CrewAI — trust-verified crew member selection and capability-gated task assignment"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/flowise-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/flowise-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowise_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh governance nodes for Flowise — policy enforcement, trust gating, audit logging, and rate limiting for visual AI flows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/haystack-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/haystack-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "haystack_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh governance components for Haystack pipelines — policy enforcement, trust scoring, and tamper-evident audit trails"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_langchain"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust-gated tool execution"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/langflow-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langflow-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langflow_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "Governance components for Langflow — policy enforcement, trust routing, audit logging, and compliance checking for visual AI flows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/langgraph-trust/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langgraph-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "Trust-gated checkpoint nodes for LangGraph — cryptographic identity, policy enforcement, and trust-aware routing for multi-agent graphs"
 readme = "README.md"
 license = {text = "MIT"}
@@ -45,7 +45,7 @@ langgraph = [
     "langgraph>=0.2.0,<1.0",
 ]
 agentmesh = [
-    "agentmesh-platform>=0.1.0,<1.0",
+    "agent-governance-toolkit-core>=4.0.0,<5.0",
 ]
 dev = [
     "pytest>=7.0,<8.0",

--- a/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
 
 [project]
 name = "llamaindex_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh trust layer integration for LlamaIndex agents"
 authors = [{name = "AgentMesh Contributors"}]
 requires-python = ">=3.9,<4.0"

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_receipts"
-version = "3.7.0"
+version = "4.0.0"
 description = "MCP tool-call receipt signing — Cedar policy decisions linked to governance receipts"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_proxy"
-version = "3.7.0"
+version = "4.0.0"
 description = "MCP proxy that wraps any MCP tool with AgentMesh trust verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/nostr-wot/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/nostr-wot/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nostr_wot_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "Nostr Web of Trust integration for AgentMesh trust engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openai_agents_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh trust layer for OpenAI Agents SDK — trust-gated function calling and handoff verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_openai_agents_trust"
-version = "3.7.0"
+version = "4.0.0"
 description = "Trust & governance layer for OpenAI Agents SDK — policy enforcement, trust-gated handoffs, and hash-chained audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openshell-agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "Public Preview - OpenShell + AgentMesh governance skill"
 readme = "README.md"
 license = {text = "MIT"}
@@ -13,7 +13,7 @@ authors = [{ name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.
 dependencies = ["pyyaml>=6.0,<7.0"]
 
 [project.optional-dependencies]
-agentmesh = ["agentmesh-platform>=3.0,<4.0"]
+agentmesh = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
 dev = ["pytest>=7.0"]
 
 [project.urls]

--- a/agent-governance-python/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pydantic_ai_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "Governance middleware for PydanticAI — semantic policy enforcement, trust scoring, and audit trails for agent tool execution"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "structural_authz_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh adapter for structural authorization gates — consumes external policy decisions, trust grades, and delegation scope chains as AGT trust signals"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/template-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/template-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "template_agentmesh"
-version = "3.7.0"
+version = "4.0.0"
 description = "AgentMesh trust layer template — copy and rename for your framework"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/notebooks/05_citadel_foundry_governance.ipynb
+++ b/agent-governance-python/notebooks/05_citadel_foundry_governance.ipynb
@@ -32,7 +32,7 @@
     "4. (Optional) Export governance events to Citadel\n",
     "\n",
     "**Prerequisites:**\n",
-    "- `pip install agent-os-kernel` (for local governance simulation)\n",
+    "- `pip install agent-governance-toolkit-core` (for local governance simulation)\n",
     "- Azure AI Foundry project + `azd` (for deployment only)\n",
     "- (Optional) Citadel deployment with Event Hub for governance telemetry\n",
     "\n",
@@ -72,7 +72,7 @@
    "id": "install",
    "outputs": [],
    "source": [
-    "!pip install agent-os-kernel requests -q"
+    "!pip install agent-governance-toolkit-core requests -q"
    ]
   },
   {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@ Community video series covering the toolkit architecture:
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════╗
-║                    AGENT GOVERNANCE TOOLKIT  v3.7.0                     ║
+║                    AGENT GOVERNANCE TOOLKIT  v4.0.0                     ║
 ║              pip install agent-governance-toolkit[full]                  ║
 ║                                                                         ║
 ║  Agent Action ──► POLICY CHECK ──► Allow / Deny    (< 0.1 ms)          ║

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -18,55 +18,55 @@ guides.
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------| 
-| – | [Retrofit Governance onto an Existing Agent](retrofit-governance.md) | Add policy enforcement to any existing agent in 3 steps | `agent-os-kernel` |
+| – | [Retrofit Governance onto an Existing Agent](retrofit-governance.md) | Add policy enforcement to any existing agent in 3 steps | `agent-governance-toolkit-core` |
 | – | [Progressive Governance — Start Simple, Add Layers](progressive-governance.md) | 5-level progressive complexity model; pick the level that matches your risk | All |
 
 ## Core Governance
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 01 | [Policy Engine](01-policy-engine.md) | YAML rules, operators, conflict resolution, middleware integration | `agent-os-kernel` |
-| 02 | [Trust & Identity](02-trust-and-identity.md) | Ed25519 credentials, DIDs, SPIFFE/SVID, trust scoring (0–1000) | `agentmesh-platform` |
-| 03 | [Framework Integrations](03-framework-integrations.md) | Govern LangChain, CrewAI, AutoGen, OpenAI Agents, Google ADK | `agent-os-kernel` |
-| 04 | [Audit & Compliance](04-audit-and-compliance.md) | Append-only audit logs, hash chains, OWASP ASI mapping | `agent-governance-toolkit` |
+| 01 | [Policy Engine](01-policy-engine.md) | YAML rules, operators, conflict resolution, middleware integration | `agent-governance-toolkit-core` |
+| 02 | [Trust & Identity](02-trust-and-identity.md) | Ed25519 credentials, DIDs, SPIFFE/SVID, trust scoring (0–1000) | `agent-governance-toolkit-core` |
+| 03 | [Framework Integrations](03-framework-integrations.md) | Govern LangChain, CrewAI, AutoGen, OpenAI Agents, Google ADK | `agent-governance-toolkit-core` |
+| 04 | [Audit & Compliance](04-audit-and-compliance.md) | Append-only audit logs, hash chains, OWASP ASI mapping | `agent-governance-toolkit-cli` |
 
 ## Policy & Security
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 07 | [MCP Security Gateway](07-mcp-security-gateway.md) | Tool poisoning detection, parameter sanitization, human-in-the-loop | `agent-os-kernel` |
-| 08 | [OPA/Rego & Cedar Policies](08-opa-rego-cedar-policies.md) | External policy backends, 3 evaluation modes, enterprise policies | `agent-os-kernel` |
-| 09 | [Prompt Injection Detection](09-prompt-injection-detection.md) | 7 attack types, MemoryGuard, ConversationGuardian, red-teaming | `agent-os-kernel` |
+| 07 | [MCP Security Gateway](07-mcp-security-gateway.md) | Tool poisoning detection, parameter sanitization, human-in-the-loop | `agent-governance-toolkit-core` |
+| 08 | [OPA/Rego & Cedar Policies](08-opa-rego-cedar-policies.md) | External policy backends, 3 evaluation modes, enterprise policies | `agent-governance-toolkit-core` |
+| 09 | [Prompt Injection Detection](09-prompt-injection-detection.md) | 7 attack types, MemoryGuard, ConversationGuardian, red-teaming | `agent-governance-toolkit-core` |
 
 ## Runtime & Execution
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 05 | [Agent Reliability (SRE)](05-agent-reliability.md) | SLOs, error budgets, circuit breakers, chaos testing | `agent-sre` |
-| 06 | [Execution Sandboxing](06-execution-sandboxing.md) | 4-tier privilege rings, resource limits, termination control | `agentmesh-runtime` |
-| 11 | [Saga Orchestration](11-saga-orchestration.md) | Multi-step transactions, DSL, fan-out, compensating actions | `agentmesh-runtime` |
-| 12 | [Liability & Attribution](12-liability-and-attribution.md) | Vouching, slashing, causal attribution, quarantine | `agentmesh-runtime` |
-| 14 | [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) | Emergency termination, rate limiting, ring elevation | `agentmesh-runtime` |
-| 51 | [Cost Governance](51-cost-governance.md) | Tiered budgets, auto-throttle, kill switch, anomaly detection, cost optimization | `agent-sre` |
+| 05 | [Agent Reliability (SRE)](05-agent-reliability.md) | SLOs, error budgets, circuit breakers, chaos testing | `agent-governance-toolkit-sre` |
+| 06 | [Execution Sandboxing](06-execution-sandboxing.md) | 4-tier privilege rings, resource limits, termination control | `agent-governance-toolkit-runtime` |
+| 11 | [Saga Orchestration](11-saga-orchestration.md) | Multi-step transactions, DSL, fan-out, compensating actions | `agent-governance-toolkit-runtime` |
+| 12 | [Liability & Attribution](12-liability-and-attribution.md) | Vouching, slashing, causal attribution, quarantine | `agent-governance-toolkit-runtime` |
+| 14 | [Kill Switch & Rate Limiting](14-kill-switch-and-rate-limiting.md) | Emergency termination, rate limiting, ring elevation | `agent-governance-toolkit-runtime` |
+| 51 | [Cost Governance](51-cost-governance.md) | Tiered budgets, auto-throttle, kill switch, anomaly detection, cost optimization | `agent-governance-toolkit-sre` |
 
 ## Trust & Networking
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 16 | [Protocol Bridges](16-protocol-bridges.md) | A2A, MCP proxy, IATP attestation, trust-gated communication | `agentmesh-platform` |
-| 17 | [Advanced Trust & Behavior](17-advanced-trust-and-behavior.md) | Behavior monitoring, reward engine, trust policies, shadow mode | `agentmesh-platform` |
-| 31 | [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridge DID identity with Microsoft Entra Agent ID, Conditional Access, sponsor accountability | `agentmesh-platform` |
-| 32 | [E2E Encrypted Messaging](32-e2e-encrypted-messaging.md) | Signal protocol (X3DH + Double Ratchet), SecureChannel, trust-gated encryption | `agentmesh-platform` |
+| 16 | [Protocol Bridges](16-protocol-bridges.md) | A2A, MCP proxy, IATP attestation, trust-gated communication | `agent-governance-toolkit-core` |
+| 17 | [Advanced Trust & Behavior](17-advanced-trust-and-behavior.md) | Behavior monitoring, reward engine, trust policies, shadow mode | `agent-governance-toolkit-core` |
+| 31 | [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridge DID identity with Microsoft Entra Agent ID, Conditional Access, sponsor accountability | `agent-governance-toolkit-core` |
+| 32 | [E2E Encrypted Messaging](32-e2e-encrypted-messaging.md) | Signal protocol (X3DH + Double Ratchet), SecureChannel, trust-gated encryption | `agent-governance-toolkit-core` |
 
 ## Ecosystem
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 10 | [Plugin Marketplace](10-plugin-marketplace.md) | Plugin signing, verification, CLI, supply-chain security | `agentmesh-marketplace` |
-| 13 | [Observability & Tracing](13-observability-and-tracing.md) | Causal traces, event bus, Prometheus, OpenTelemetry | `agentmesh-runtime` |
-| 15 | [RL Training Governance](15-rl-training-governance.md) | GovernedRunner, PolicyReward, Gym-compatible environments | `agentmesh-lightning` |
-| 18 | [Compliance Verification](18-compliance-verification.md) | Governance grading, regulatory frameworks, attestation | `agent-governance-toolkit` |
-| 50 | [Decision BOM](50-decision-bom.md) | Reconstruct full decision context from observability signals, completeness scoring, batch audit | `agentmesh-platform` |
+| 10 | [Plugin Marketplace](10-plugin-marketplace.md) | Plugin signing, verification, CLI, supply-chain security | `agent-governance-toolkit-core` |
+| 13 | [Observability & Tracing](13-observability-and-tracing.md) | Causal traces, event bus, Prometheus, OpenTelemetry | `agent-governance-toolkit-runtime` |
+| 15 | [RL Training Governance](15-rl-training-governance.md) | GovernedRunner, PolicyReward, Gym-compatible environments | `agent-governance-toolkit-core` |
+| 18 | [Compliance Verification](18-compliance-verification.md) | Governance grading, regulatory frameworks, attestation | `agent-governance-toolkit-cli` |
+| 50 | [Decision BOM](50-decision-bom.md) | Reconstruct full decision context from observability signals, completeness scoring, batch audit | `agent-governance-toolkit-core` |
 
 ## Multi-Language Packages
 
@@ -83,17 +83,17 @@ guides.
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
 | 23 | [Delegation Chains](23-delegation-chains.md) | Monotonic scope narrowing, multi-agent delegation, cascade revocation | `@microsoft/agent-governance-sdk` |
-| 24 | [Cost & Token Budgets](24-cost-and-token-budgets.md) | Per-session token limits, context scheduling, budget signals | `agent-os-kernel` |
-| 49 | [Multi-Agent Collective Policies](49-multi-agent-policies.md) | Aggregate constraints across agents: rate limits, concurrent caps, alert-only monitoring | `agentmesh-platform` |
+| 24 | [Cost & Token Budgets](24-cost-and-token-budgets.md) | Per-session token limits, context scheduling, budget signals | `agent-governance-toolkit-core` |
+| 49 | [Multi-Agent Collective Policies](49-multi-agent-policies.md) | Aggregate constraints across agents: rate limits, concurrent caps, alert-only monitoring | `agent-governance-toolkit-core` |
 
 ## Supply Chain Security
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 25 | [Security Hardening](25-security-hardening.md) | Gitleaks, Dependabot, CodeQL, fuzzing, Scorecard, branch protection | `agent-governance-toolkit` |
-| 26 | [SBOM & Signing](26-sbom-and-signing.md) | SPDX/CycloneDX SBOMs, Ed25519 artifact signing, attestation | `agent-compliance` |
-| 27 | [MCP Scan CLI](27-mcp-scan-cli.md) | MCP tool scanning, rug-pull detection, CI integration | `agent-os-kernel` |
-| 45 | [Shift-Left Governance](45-shift-left-governance.md) | Pre-commit hooks, GitHub Actions, CI gates, language-specific build-time enforcement | `agent-governance-toolkit` |
+| 25 | [Security Hardening](25-security-hardening.md) | Gitleaks, Dependabot, CodeQL, fuzzing, Scorecard, branch protection | `agent-governance-toolkit-cli` |
+| 26 | [SBOM & Signing](26-sbom-and-signing.md) | SPDX/CycloneDX SBOMs, Ed25519 artifact signing, attestation | `agent-governance-toolkit-cli` |
+| 27 | [MCP Scan CLI](27-mcp-scan-cli.md) | MCP tool scanning, rug-pull detection, CI integration | `agent-governance-toolkit-core` |
+| 45 | [Shift-Left Governance](45-shift-left-governance.md) | Pre-commit hooks, GitHub Actions, CI gates, language-specific build-time enforcement | `agent-governance-toolkit-cli` |
 
 ---
 
@@ -101,33 +101,33 @@ guides.
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 29 | [Agent Discovery](29-agent-discovery.md) | Shadow AI scanning, inventory dedup, reconciliation, risk scoring, CI/CD integration | `agent-discovery` |
-| 30 | [Agent Lifecycle Management](30-agent-lifecycle.md) | Provisioning, approval workflows, credential rotation, orphan detection, decommissioning | `agentmesh-platform` |
+| 29 | [Agent Discovery](29-agent-discovery.md) | Shadow AI scanning, inventory dedup, reconciliation, risk scoring, CI/CD integration | `agent-governance-toolkit-core` |
+| 30 | [Agent Lifecycle Management](30-agent-lifecycle.md) | Provisioning, approval workflows, credential rotation, orphan detection, decommissioning | `agent-governance-toolkit-core` |
 
 ## Enterprise Identity
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 31 | [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridge AGT DIDs with Microsoft Entra Agent ID / Agent365, AKS workload identity, roles & responsibilities | `agentmesh-platform` |
+| 31 | [Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Bridge AGT DIDs with Microsoft Entra Agent ID / Agent365, AKS workload identity, roles & responsibilities | `agent-governance-toolkit-core` |
 
 ## Advanced Governance (v3.2+)
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 35 | [Policy Composition](35-policy-composition.md) | `extends` for 3-tier governance hierarchies (CISO → platform → app), additive-only merge, diamond dedup | `agentmesh-platform` |
-| 36 | [2-Line Governance with govern()](36-govern-quickstart.md) | The `govern()` wrapper — policy enforcement + audit in 2 lines of code | `agentmesh-platform` |
-| 37 | [Multi-Stage Policy Pipeline](37-multi-stage-pipeline.md) | 4-stage lifecycle: pre_input → pre_tool → post_tool → pre_output | `agentmesh-platform` |
-| 38 | [Approval Workflows](38-approval-workflows.md) | Human-in-the-loop gates with Callback, Webhook, and Console handlers | `agentmesh-platform` |
-| 39 | [DLP with Attribute Ratchets](39-dlp-attribute-ratchets.md) | Monotonic session state — sensitivity only goes up, never resets | `agentmesh-platform` |
-| 40 | [OTel Observability](40-otel-observability.md) | OpenTelemetry spans + metrics for policy, approval, and trust operations | `agentmesh-platform` |
-| 41 | [Advisory Defense-in-Depth](41-advisory-defense-in-depth.md) | Pattern, ML, and HTTP classifiers as non-deterministic defense layer | `agentmesh-platform` |
-| 48 | [Intent-Based Authorization](48-intent-based-authorization.md) | Declare/approve/execute/verify lifecycle, drift detection, child intent scope narrowing | `agent-os-kernel` |
+| 35 | [Policy Composition](35-policy-composition.md) | `extends` for 3-tier governance hierarchies (CISO → platform → app), additive-only merge, diamond dedup | `agent-governance-toolkit-core` |
+| 36 | [2-Line Governance with govern()](36-govern-quickstart.md) | The `govern()` wrapper — policy enforcement + audit in 2 lines of code | `agent-governance-toolkit-core` |
+| 37 | [Multi-Stage Policy Pipeline](37-multi-stage-pipeline.md) | 4-stage lifecycle: pre_input → pre_tool → post_tool → pre_output | `agent-governance-toolkit-core` |
+| 38 | [Approval Workflows](38-approval-workflows.md) | Human-in-the-loop gates with Callback, Webhook, and Console handlers | `agent-governance-toolkit-core` |
+| 39 | [DLP with Attribute Ratchets](39-dlp-attribute-ratchets.md) | Monotonic session state — sensitivity only goes up, never resets | `agent-governance-toolkit-core` |
+| 40 | [OTel Observability](40-otel-observability.md) | OpenTelemetry spans + metrics for policy, approval, and trust operations | `agent-governance-toolkit-core` |
+| 41 | [Advisory Defense-in-Depth](41-advisory-defense-in-depth.md) | Pattern, ML, and HTTP classifiers as non-deterministic defense layer | `agent-governance-toolkit-core` |
+| 48 | [Intent-Based Authorization](48-intent-based-authorization.md) | Declare/approve/execute/verify lifecycle, drift detection, child intent scope narrowing | `agent-governance-toolkit-core` |
 
 ## Extending the Toolkit
 
 | # | Tutorial | What You'll Learn | Package |
 |---|----------|-------------------|---------|
-| 28 | [Building Custom Integrations](28-build-custom-integration.md) | Trust integrations, kernel adapters, publishing your own governance package | `agent-os-kernel` / standalone |
+| 28 | [Building Custom Integrations](28-build-custom-integration.md) | Trust integrations, kernel adapters, publishing your own governance package | `agent-governance-toolkit-core` / standalone |
 
 ## Policy-as-Code Deep Dive
 

--- a/examples/agent-mesh/README.md
+++ b/examples/agent-mesh/README.md
@@ -11,7 +11,7 @@ Runnable examples demonstrating AgentMesh multi-agent governance capabilities.
 ## Prerequisites
 
 - Python 3.10+
-- `pip install agentmesh-platform`
+- `pip install agent-governance-toolkit-core`
 
 ## Related
 

--- a/examples/agent-mesh/multi-agent-chat/README.md
+++ b/examples/agent-mesh/multi-agent-chat/README.md
@@ -65,7 +65,7 @@ Notes on what to expect run-to-run:
 | File | Purpose |
 | --- | --- |
 | `main.py` | The runnable demo (single file, no async, no external services) |
-| `requirements.txt` | Pins `agentmesh-platform==3.4.0` |
+| `requirements.txt` | Pins `agent-governance-toolkit-core>=4.0.0,<5.0` |
 | `README.md` | This file |
 
 ## How It Maps to the SDK

--- a/examples/agent-mesh/multi-agent-chat/requirements.txt
+++ b/examples/agent-mesh/multi-agent-chat/requirements.txt
@@ -1,1 +1,1 @@
-agentmesh-platform==3.4.0
+agent-governance-toolkit-core>=4.0.0,<5.0

--- a/examples/agent-sre/README.md
+++ b/examples/agent-sre/README.md
@@ -11,7 +11,7 @@ Runnable examples demonstrating AGT's SRE observability and cost governance capa
 ## Prerequisites
 
 - Python 3.10+
-- `pip install agent-sre`
+- `pip install agent-governance-toolkit-cli`
 
 ## Related
 

--- a/examples/agent-sre/basic-runbook/README.md
+++ b/examples/agent-sre/basic-runbook/README.md
@@ -62,7 +62,7 @@ Notes on what to expect run-to-run:
 | File | Purpose |
 | --- | --- |
 | `main.py` | The runnable demo (single file, no async, no external services) |
-| `requirements.txt` | Pins `agent-sre==3.4.0` |
+| `requirements.txt` | Pins `agent-governance-toolkit-cli>=4.0.0,<5.0` |
 | `README.md` | This file |
 
 ## How It Maps to the SDK

--- a/examples/agent-sre/basic-runbook/requirements.txt
+++ b/examples/agent-sre/basic-runbook/requirements.txt
@@ -1,1 +1,1 @@
-agent-sre==3.4.0
+agent-governance-toolkit-cli>=4.0.0,<5.0


### PR DESCRIPTION
## Summary

Updates the ESRP publish pipeline and bumps all remaining packages to v4.0.0 for the package consolidation release.

### ESRP Pipeline Changes
- Added 4 consolidated packages as **Wave 0** (must publish before stubs)
- New publish stage: Build -> Wave 0 (consolidated) -> Wave 1 (stubs) -> Wave 2 -> Wave 3
- Updated package count comment: 41 -> 45

### Version Bumps (all to 4.0.0)
- 21 integration packages (from 3.7.0)
- cedarling-agentmesh (from 3.5.0)
- 14 agent-os modules and examples (from 3.7.0)
- mcp-trust-server (from 3.7.0)

### Dependency Fixes
- Fixed upper bounds in cedarling, langgraph-trust, openshell-skill
- Updated CI paths-filter and publish.yml for new packages

### Docs/Examples (from fix-docs agent)
- README.md, ARCHITECTURE.md, tutorials/README.md
- Example requirements.txt files and READMEs
- Notebook pip install commands
