### PR TITLE
fix: Docker provider docstring says pids_limit=256 but code uses 128

### DIFF
--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -4,7 +4,7 @@
 
 Each agent gets its own Docker container scoped to a session.  Containers
 are hardened by default: all capabilities dropped, ``no-new-privileges``,
-optional read-only root filesystem, non-root user, ``pids_limit=256``.
+optional read-only root filesystem, non-root user, ``pids_limit=128``.
 
 Policy-driven resource limits, tool proxies, and network proxies are set
 up at session creation time when a ``PolicyDocument`` is passed.


### PR DESCRIPTION
Closes #2663.

The Docker sandbox provider module docstring at `docker_provider/provider.py:7` advertises `pids_limit=256`, but the implementation at line 1106 sets `pids_limit=128`. This 1-character docstring fix updates the documentation to match the implementation.

The implementation value (128) is the correct one — keeping the hardening tighter than the docstring claimed. No behavior change.

## Before

```python
optional read-only root filesystem, non-root user, ``pids_limit=256``.
```

## After

```python
optional read-only root filesystem, non-root user, ``pids_limit=128``.
```

## Verification

```bash
grep pids_limit agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
# 7:optional read-only root filesystem, non-root user, ``pids_limit=128``.
# 1106:            "pids_limit": 128,
```