### PR TITLE
fix: clean package consolidation, bump all languages to v4.0.0

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -69,152 +69,27 @@ parameters:
     type: object
     displayName: 'Python packages to publish'
     default:
-      # Wave 0: Consolidated distributions (v4.0.0) — must publish before
-      # stubs so pip can resolve the new dependency chain.
+      # Consolidated distributions (v4.0.0)
       - name: agent-governance-toolkit-core
         path: agent-governance-python/agent-governance-toolkit-core
-        wave: 0
       - name: agent-governance-toolkit-integrations
         path: agent-governance-python/agent-governance-toolkit-integrations
-        wave: 0
       - name: agent-governance-toolkit-cli
         path: agent-governance-python/agent-governance-toolkit-cli
-        wave: 0
       - name: agent-governance-toolkit-protocols
         path: agent-governance-python/agent-governance-toolkit-protocols
-        wave: 0
-      # Wave 1: Stub packages (redirect to consolidated distributions)
-      - name: agent-os
-        path: agent-governance-python/agent-os
-        wave: 1
-      - name: agent-mesh
-        path: agent-governance-python/agent-mesh
-        wave: 1
-      - name: agent-hypervisor
-        path: agent-governance-python/agent-hypervisor
-        wave: 1
-      - name: agent-sre
-        path: agent-governance-python/agent-sre
-        wave: 1
-      - name: agent-compliance
+      # Meta-package
+      - name: agent-governance-toolkit
         path: agent-governance-python/agent-compliance
-        wave: 1
-      - name: agent-runtime
-        path: agent-governance-python/agent-runtime
-        wave: 1
+      # Standalone packages
+      - name: agent-discovery
+        path: agent-governance-python/agent-discovery
       - name: agent-lightning
         path: agent-governance-python/agent-lightning
-        wave: 1
       - name: agent-marketplace
         path: agent-governance-python/agent-marketplace
-        wave: 1
-      - name: agent-mcp-governance
-        path: agent-governance-python/agent-mcp-governance
-        wave: 1
-      - name: agentmesh-message-bus
-        path: agent-governance-python/agent-os/modules/amb
-        wave: 1
-      - name: agentmesh-context
-        path: agent-governance-python/agent-os/modules/caas
-        wave: 1
-      - name: agentmesh-drift
-        path: agent-governance-python/agent-os/modules/cmvk
-        wave: 1
-      - name: agentmesh-mcp-server
-        path: agent-governance-python/agent-os/modules/mcp-kernel-server
-        wave: 1
-      - name: agentmesh-nexus
-        path: agent-governance-python/agent-os/modules/nexus
-        wave: 1
-      # Wave 2: Renamed/new standalone + modules
-      - name: agentmesh-discovery
-        path: agent-governance-python/agent-discovery
-        wave: 2
-      - name: agt-sandbox
-        path: agent-governance-python/agent-sandbox
-        wave: 2
-      - name: agentmesh-primitives
-        path: agent-governance-python/agent-primitives
-        wave: 2
-      - name: agentmesh-tool-registry
-        path: agent-governance-python/agent-os/modules/atr
-        wave: 2
-      - name: agentmesh-control-plane
-        path: agent-governance-python/agent-os/modules/control-plane
-        wave: 2
-      - name: agentmesh-memory
-        path: agent-governance-python/agent-os/modules/emk
-        wave: 2
-      - name: agentmesh-trust-protocol
-        path: agent-governance-python/agent-os/modules/iatp
-        wave: 2
-      - name: agentmesh-observability
-        path: agent-governance-python/agent-os/modules/observability
-        wave: 2
-      - name: agentmesh-mcp-trust
-        path: agent-governance-python/agent-mesh/packages/mcp-trust-server
-        wave: 2
-      - name: a2a-protocol
-        path: agent-governance-python/agentmesh-integrations/a2a-protocol
-        wave: 2
-      - name: adk-agentmesh
-        path: agent-governance-python/agentmesh-integrations/adk-agentmesh
-        wave: 2
-      - name: avp-agentmesh
-        path: agent-governance-python/agentmesh-integrations/agentmesh-avp
-        wave: 2
-      - name: agentmesh-audit-export
-        path: agent-governance-python/agentmesh-integrations/audit-accountability-export
-        wave: 2
-      - name: agentmesh-mcp-receipts
-        path: agent-governance-python/agentmesh-integrations/mcp-receipt-governed
-        wave: 2
-      - name: agentmesh-mcp-proxy
-        path: agent-governance-python/agentmesh-integrations/mcp-trust-proxy
-        wave: 2
-      # Wave 3: Framework integrations
-      - name: cedarling-agentmesh
-        path: agent-governance-python/agentmesh-integrations/cedarling-agentmesh
-        wave: 3
-      - name: crewai-agentmesh
-        path: agent-governance-python/agentmesh-integrations/crewai-agentmesh
-        wave: 3
-      - name: flowise-agentmesh
-        path: agent-governance-python/agentmesh-integrations/flowise-agentmesh
-        wave: 3
-      - name: haystack-agentmesh
-        path: agent-governance-python/agentmesh-integrations/haystack-agentmesh
-        wave: 3
-      - name: agentmesh-langchain
-        path: agent-governance-python/agentmesh-integrations/langchain-agentmesh
-        wave: 3
-      - name: langflow-agentmesh
-        path: agent-governance-python/agentmesh-integrations/langflow-agentmesh
-        wave: 3
-      - name: langgraph-agentmesh
-        path: agent-governance-python/agentmesh-integrations/langgraph-trust
-        wave: 3
-      - name: llamaindex-agentmesh
-        path: agent-governance-python/agentmesh-integrations/llamaindex-agentmesh
-        wave: 3
-      - name: nostr-wot-agentmesh
-        path: agent-governance-python/agentmesh-integrations/nostr-wot
-        wave: 3
-      - name: openai-agents-agentmesh
-        path: agent-governance-python/agentmesh-integrations/openai-agents-agentmesh
-        wave: 3
-      - name: agentmesh-openai-agents-trust
-        path: agent-governance-python/agentmesh-integrations/openai-agents-trust
-        wave: 3
-      - name: openshell-skill
-        path: agent-governance-python/agentmesh-integrations/openshell-skill
-        wave: 3
-      - name: pydantic-ai-agentmesh
-        path: agent-governance-python/agentmesh-integrations/pydantic-ai-governance
-        wave: 3
-      - name: structural-authz-agentmesh
-        path: agent-governance-python/agentmesh-integrations/structural-authz-agentmesh
-        wave: 3
+      - name: agent-rag-governance
+        path: agent-governance-python/agent-rag-governance
 
   - name: npmPackages
     type: object
@@ -283,7 +158,7 @@ pool:
 
 stages:
   # =======================================================
-  # PYTHON (PyPI) — 45 packages (4 consolidated + 41 stubs/modules/integrations)
+  # PYTHON (PyPI) — 9 packages (4 consolidated + 1 meta + 4 standalone)
   # =======================================================
   - stage: Build_PyPI
     displayName: 'Build Python Packages'
@@ -328,154 +203,40 @@ stages:
                 publishLocation: 'pipeline'
               displayName: 'Publish ${{ pkg.name }} artifacts'
 
-  # Publish in 4 waves to respect dependency order and PyPI rate limits.
-  # Wave 0: Consolidated distributions (must land first — stubs depend on them)
-  # Wave 1: Stub packages (already registered on PyPI, now redirect to consolidated)
-  # Wave 2: renamed/new standalone + modules
-  # Wave 3: framework integrations
-  - stage: Publish_PyPI_Wave0
-    displayName: 'Publish to PyPI — Wave 0 (consolidated)'
+  - stage: Publish_PyPI
+    displayName: 'Publish to PyPI'
     dependsOn: Build_PyPI
     condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
     jobs:
       - ${{ each pkg in parameters.pypiPackages }}:
-        - ${{ if eq(pkg.wave, 0) }}:
-          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
-            displayName: 'Publish ${{ pkg.name }} to PyPI'
-            steps:
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                  artifact: 'pypi-${{ pkg.name }}'
-                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                displayName: 'Download ${{ pkg.name }} artifacts'
+        - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
+          displayName: 'Publish ${{ pkg.name }} to PyPI'
+          steps:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifact: 'pypi-${{ pkg.name }}'
+                targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+              displayName: 'Download ${{ pkg.name }} artifacts'
 
-              - task: EsrpRelease@11
-                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
-                retryCountOnTaskFailure: 2
-                inputs:
-                  connectedservicename: 'Agent Governance Toolkit'
-                  usemanagedidentity: true
-                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
-                  signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
-                  clientid: '$(ESRP_CLIENT_ID)'
-                  intent: 'PackageDistribution'
-                  contenttype: 'PyPi'
-                  contentsource: 'Folder'
-                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                  waitforreleasecompletion: true
-                  owners: '$(ESRP_OWNERS)'
-                  approvers: '$(ESRP_APPROVERS)'
-                  serviceendpointurl: 'https://api.esrp.microsoft.com'
-                  mainpublisher: 'ESRPRELPACMAN'
-                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
-
-  - stage: Publish_PyPI_Wave1
-    displayName: 'Publish to PyPI — Wave 1 (stubs)'
-    dependsOn: Publish_PyPI_Wave0
-    condition: and(not(failed()), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
-    jobs:
-      - ${{ each pkg in parameters.pypiPackages }}:
-        - ${{ if eq(pkg.wave, 1) }}:
-          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
-            displayName: 'Publish ${{ pkg.name }} to PyPI'
-            steps:
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                  artifact: 'pypi-${{ pkg.name }}'
-                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                displayName: 'Download ${{ pkg.name }} artifacts'
-
-              - task: EsrpRelease@11
-                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
-                retryCountOnTaskFailure: 2
-                inputs:
-                  connectedservicename: 'Agent Governance Toolkit'
-                  usemanagedidentity: true
-                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
-                  signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
-                  clientid: '$(ESRP_CLIENT_ID)'
-                  intent: 'PackageDistribution'
-                  contenttype: 'PyPi'
-                  contentsource: 'Folder'
-                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                  waitforreleasecompletion: true
-                  owners: '$(ESRP_OWNERS)'
-                  approvers: '$(ESRP_APPROVERS)'
-                  serviceendpointurl: 'https://api.esrp.microsoft.com'
-                  mainpublisher: 'ESRPRELPACMAN'
-                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
-
-  - stage: Publish_PyPI_Wave2
-    displayName: 'Publish to PyPI — Wave 2 (modules)'
-    dependsOn: Publish_PyPI_Wave1
-    condition: and(not(failed()), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
-    jobs:
-      - ${{ each pkg in parameters.pypiPackages }}:
-        - ${{ if eq(pkg.wave, 2) }}:
-          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
-            displayName: 'Publish ${{ pkg.name }} to PyPI'
-            steps:
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                  artifact: 'pypi-${{ pkg.name }}'
-                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                displayName: 'Download ${{ pkg.name }} artifacts'
-
-              - task: EsrpRelease@11
-                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
-                retryCountOnTaskFailure: 2
-                inputs:
-                  connectedservicename: 'Agent Governance Toolkit'
-                  usemanagedidentity: true
-                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
-                  signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
-                  clientid: '$(ESRP_CLIENT_ID)'
-                  intent: 'PackageDistribution'
-                  contenttype: 'PyPi'
-                  contentsource: 'Folder'
-                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                  waitforreleasecompletion: true
-                  owners: '$(ESRP_OWNERS)'
-                  approvers: '$(ESRP_APPROVERS)'
-                  serviceendpointurl: 'https://api.esrp.microsoft.com'
-                  mainpublisher: 'ESRPRELPACMAN'
-                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
-
-  - stage: Publish_PyPI_Wave3
-    displayName: 'Publish to PyPI — Wave 3 (integrations)'
-    dependsOn: Publish_PyPI_Wave2
-    condition: and(not(failed()), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
-    jobs:
-      - ${{ each pkg in parameters.pypiPackages }}:
-        - ${{ if eq(pkg.wave, 3) }}:
-          - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
-            displayName: 'Publish ${{ pkg.name }} to PyPI'
-            steps:
-              - task: DownloadPipelineArtifact@2
-                inputs:
-                  artifact: 'pypi-${{ pkg.name }}'
-                  targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                displayName: 'Download ${{ pkg.name }} artifacts'
-
-              - task: EsrpRelease@11
-                displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
-                retryCountOnTaskFailure: 2
-                inputs:
-                  connectedservicename: 'Agent Governance Toolkit'
-                  usemanagedidentity: true
-                  keyvaultname: '$(ESRP_KEYVAULT_NAME)'
-                  signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
-                  clientid: '$(ESRP_CLIENT_ID)'
-                  intent: 'PackageDistribution'
-                  contenttype: 'PyPi'
-                  contentsource: 'Folder'
-                  folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
-                  waitforreleasecompletion: true
-                  owners: '$(ESRP_OWNERS)'
-                  approvers: '$(ESRP_APPROVERS)'
-                  serviceendpointurl: 'https://api.esrp.microsoft.com'
-                  mainpublisher: 'ESRPRELPACMAN'
-                  domaintenantid: '$(MICROSOFT_TENANT_ID)'
+            - task: EsrpRelease@11
+              displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
+              retryCountOnTaskFailure: 2
+              inputs:
+                connectedservicename: 'Agent Governance Toolkit'
+                usemanagedidentity: true
+                keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+                signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
+                clientid: '$(ESRP_CLIENT_ID)'
+                intent: 'PackageDistribution'
+                contenttype: 'PyPi'
+                contentsource: 'Folder'
+                folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                waitforreleasecompletion: true
+                owners: '$(ESRP_OWNERS)'
+                approvers: '$(ESRP_APPROVERS)'
+                serviceendpointurl: 'https://api.esrp.microsoft.com'
+                mainpublisher: 'ESRPRELPACMAN'
+                domaintenantid: '$(MICROSOFT_TENANT_ID)'
 
   # =======================================================
   # NPM — 7 packages (@microsoft scope)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,23 +374,15 @@ jobs:
       matrix:
         package:
           [
-            agent-os,
-            agent-mesh,
-            agent-hypervisor,
-            agent-sre,
-            agent-compliance,
-            agent-runtime,
-            agent-lightning,
-            agent-primitives,
-            agent-mcp-governance,
-            agent-marketplace,
-            agent-discovery,
-            agent-rag-governance,
-            agent-sandbox,
             agent-governance-toolkit-core,
             agent-governance-toolkit-integrations,
             agent-governance-toolkit-cli,
             agent-governance-toolkit-protocols,
+            agent-compliance,
+            agent-discovery,
+            agent-lightning,
+            agent-marketplace,
+            agent-rag-governance,
           ]
       - name: Skip (unchanged package)
         if: steps.gate.outputs.run != 'true'
@@ -436,7 +428,7 @@ jobs:
           # Install each package. A failure here means safety would scan
           # against the wrong dependency set, so surface it instead of
           # silently `|| true`-ing past it.
-          for pkg in agent-os agent-mesh agent-hypervisor agent-sre agent-compliance agent-runtime agent-lightning agent-primitives agent-mcp-governance agent-marketplace agent-discovery agent-rag-governance agent-sandbox; do
+          for pkg in agent-governance-toolkit-core agent-governance-toolkit-integrations agent-governance-toolkit-cli agent-governance-toolkit-protocols agent-compliance agent-discovery agent-lightning agent-marketplace agent-rag-governance; do
             echo "=== $pkg ==="
             (cd "agent-governance-python/$pkg" \
               && pip install --no-cache-dir -e .)  # Scorecard: pinned to repo checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
         description: >
           Package to publish. Use "all" for everything, "all-python" for all
           Python packages, "all-npm" for all npm packages, or a specific name
-          (e.g. "agent-os", "agentmesh-langchain", "agent-governance-copilot-cli", "agent-governance-claude-code", "agent-governance-opencode").
+          (e.g. "agent-governance-toolkit-core", "agent-governance-copilot-cli", "agent-governance-claude-code", "agent-governance-opencode").
         required: true
         type: string
         default: "all"
@@ -41,53 +41,17 @@ jobs:
           INPUT: ${{ github.event.inputs.package }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Complete list of publishable Python packages (45 packages)
+          # Complete list of publishable Python packages (9 packages)
           ALL='[
             {"name":"agent-governance-toolkit-core","path":"agent-governance-python/agent-governance-toolkit-core"},
             {"name":"agent-governance-toolkit-integrations","path":"agent-governance-python/agent-governance-toolkit-integrations"},
             {"name":"agent-governance-toolkit-cli","path":"agent-governance-python/agent-governance-toolkit-cli"},
             {"name":"agent-governance-toolkit-protocols","path":"agent-governance-python/agent-governance-toolkit-protocols"},
-            {"name":"agent-os","path":"agent-governance-python/agent-os"},
-            {"name":"agent-mesh","path":"agent-governance-python/agent-mesh"},
-            {"name":"agent-hypervisor","path":"agent-governance-python/agent-hypervisor"},
-            {"name":"agent-sre","path":"agent-governance-python/agent-sre"},
-            {"name":"agent-compliance","path":"agent-governance-python/agent-compliance"},
-            {"name":"agent-runtime","path":"agent-governance-python/agent-runtime"},
+            {"name":"agent-governance-toolkit","path":"agent-governance-python/agent-compliance"},
+            {"name":"agent-discovery","path":"agent-governance-python/agent-discovery"},
             {"name":"agent-lightning","path":"agent-governance-python/agent-lightning"},
             {"name":"agent-marketplace","path":"agent-governance-python/agent-marketplace"},
-            {"name":"agent-mcp-governance","path":"agent-governance-python/agent-mcp-governance"},
-            {"name":"agentmesh-discovery","path":"agent-governance-python/agent-discovery"},
-            {"name":"agentmesh-primitives","path":"agent-governance-python/agent-primitives"},
-            {"name":"agentmesh-message-bus","path":"agent-governance-python/agent-os/modules/amb"},
-            {"name":"agentmesh-tool-registry","path":"agent-governance-python/agent-os/modules/atr"},
-            {"name":"agentmesh-context","path":"agent-governance-python/agent-os/modules/caas"},
-            {"name":"agentmesh-drift","path":"agent-governance-python/agent-os/modules/cmvk"},
-            {"name":"agentmesh-control-plane","path":"agent-governance-python/agent-os/modules/control-plane"},
-            {"name":"agentmesh-memory","path":"agent-governance-python/agent-os/modules/emk"},
-            {"name":"agentmesh-trust-protocol","path":"agent-governance-python/agent-os/modules/iatp"},
-            {"name":"agentmesh-mcp-server","path":"agent-governance-python/agent-os/modules/mcp-kernel-server"},
-            {"name":"agentmesh-nexus","path":"agent-governance-python/agent-os/modules/nexus"},
-            {"name":"agentmesh-observability","path":"agent-governance-python/agent-os/modules/observability"},
-            {"name":"agentmesh-mcp-trust","path":"agent-governance-python/agent-mesh/packages/mcp-trust-server"},
-            {"name":"a2a-protocol","path":"agent-governance-python/agentmesh-integrations/a2a-protocol"},
-            {"name":"adk-agentmesh","path":"agent-governance-python/agentmesh-integrations/adk-agentmesh"},
-            {"name":"avp-agentmesh","path":"agent-governance-python/agentmesh-integrations/agentmesh-avp"},
-            {"name":"agentmesh-audit-export","path":"agent-governance-python/agentmesh-integrations/audit-accountability-export"},
-            {"name":"crewai-agentmesh","path":"agent-governance-python/agentmesh-integrations/crewai-agentmesh"},
-            {"name":"flowise-agentmesh","path":"agent-governance-python/agentmesh-integrations/flowise-agentmesh"},
-            {"name":"haystack-agentmesh","path":"agent-governance-python/agentmesh-integrations/haystack-agentmesh"},
-            {"name":"agentmesh-langchain","path":"agent-governance-python/agentmesh-integrations/langchain-agentmesh"},
-            {"name":"langflow-agentmesh","path":"agent-governance-python/agentmesh-integrations/langflow-agentmesh"},
-            {"name":"langgraph-agentmesh","path":"agent-governance-python/agentmesh-integrations/langgraph-trust"},
-            {"name":"llamaindex-agentmesh","path":"agent-governance-python/agentmesh-integrations/llamaindex-agentmesh"},
-            {"name":"agentmesh-mcp-receipts","path":"agent-governance-python/agentmesh-integrations/mcp-receipt-governed"},
-            {"name":"agentmesh-mcp-proxy","path":"agent-governance-python/agentmesh-integrations/mcp-trust-proxy"},
-            {"name":"nostr-wot-agentmesh","path":"agent-governance-python/agentmesh-integrations/nostr-wot"},
-            {"name":"openai-agents-agentmesh","path":"agent-governance-python/agentmesh-integrations/openai-agents-agentmesh"},
-            {"name":"agentmesh-openai-agents-trust","path":"agent-governance-python/agentmesh-integrations/openai-agents-trust"},
-            {"name":"openshell-skill","path":"agent-governance-python/agentmesh-integrations/openshell-skill"},
-            {"name":"pydantic-ai-agentmesh","path":"agent-governance-python/agentmesh-integrations/pydantic-ai-governance"},
-            {"name":"structural-authz-agentmesh","path":"agent-governance-python/agentmesh-integrations/structural-authz-agentmesh"}
+            {"name":"agent-rag-governance","path":"agent-governance-python/agent-rag-governance"}
           ]'
           # Compact the JSON
           ALL=$(echo "$ALL" | jq -c '.')

--- a/agent-governance-antigravity-cli/package.json
+++ b/agent-governance-antigravity-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-governance-antigravity-cli",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "Public Preview — Antigravity CLI governance installer for Agent Governance Toolkit developer protection policies",
   "type": "module",
   "bin": {

--- a/agent-governance-claude-code/package.json
+++ b/agent-governance-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-governance-claude-code",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "description": "Public Preview — Claude Code governance plugin for Agent Governance Toolkit developer protection policies",
   "type": "module",
   "files": [

--- a/agent-governance-copilot-cli/assets/extensions/agt-global-policy/package.json
+++ b/agent-governance-copilot-cli/assets/extensions/agt-global-policy/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
   "type": "module",
-  "version": "3.7.0"
+  "version": "4.0.0"
 }

--- a/agent-governance-copilot-cli/package.json
+++ b/agent-governance-copilot-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-governance-copilot-cli",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — Copilot CLI governance installer for Agent Governance Toolkit developer protection policies",
   "type": "module",
   "bin": {

--- a/agent-governance-dotnet/Directory.Build.props
+++ b/agent-governance-dotnet/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>3.7.0</Version>
+    <Version>4.0.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft Corporation</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/agent-governance-opencode/package.json
+++ b/agent-governance-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-governance-opencode",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "description": "Public Preview — OpenCode CLI governance plugin for Agent Governance Toolkit developer protection policies",
   "type": "module",
   "main": "src/index.mjs",

--- a/agent-governance-python/agent-mesh/packages/mcp-proxy/package.json
+++ b/agent-governance-python/agent-mesh/packages/mcp-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-mcp-proxy",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — Security proxy for MCP servers: The Firewall for Model Context Protocol",
   "keywords": [
     "mcp",

--- a/agent-governance-python/agent-mesh/services/api/package.json
+++ b/agent-governance-python/agent-mesh/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-api",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — AgentMesh Public API for trust verification and agent registration",
   "main": "dist/index.js",
   "scripts": {

--- a/agent-governance-python/agent-os/extensions/chrome/package.json
+++ b/agent-governance-python/agent-os/extensions/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentos-browser-extension",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "AgentOS - Safe AI Agents for GitHub, Jira & More",
   "private": true,
   "scripts": {

--- a/agent-governance-python/agent-os/extensions/copilot/package.json
+++ b/agent-governance-python/agent-os/extensions/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-os-copilot-extension",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — AgentOS GitHub Copilot Extension: Build safe AI agents with natural language and 0% policy violations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-python/agent-os/extensions/cursor/package.json
+++ b/agent-governance-python/agent-os/extensions/cursor/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/agent-os-cursor",
   "displayName": "Agent OS for Cursor - The AI IDE with a Safety Kernel",
   "description": "Kernel-level safety for Cursor AI. Block destructive operations, verify AI suggestions with multi-model review, and audit all Composer actions. The safest AI IDE experience.",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "publisher": "agent-os",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/agent-governance-python/agent-os/extensions/mcp-server/package.json
+++ b/agent-governance-python/agent-os/extensions/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentos-mcp-server",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — AgentOS MCP Server for Claude Desktop: Build, deploy, and manage policy-compliant autonomous agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-python/agentmesh-integrations/copilot-governance/package.json
+++ b/agent-governance-python/agentmesh-integrations/copilot-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-copilot-governance",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — GitHub Copilot Extension for agent governance code review: detects missing policy checks, unguarded tool calls, and audit logging gaps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package.json
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agentmesh-mastra",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — Governance, trust verification, and audit middleware for Mastra AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/agent-governance-rust/Cargo.toml
+++ b/agent-governance-rust/Cargo.toml
@@ -3,14 +3,14 @@ members = ["agentmesh", "agentmesh-mcp"]
 resolver = "2"
 
 [workspace.package]
-version = "3.7.0"
+version = "4.0.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/microsoft/agent-governance-toolkit"
 rust-version = "1.70"
 
 [workspace.dependencies]
-agentmesh-mcp = { path = "agentmesh-mcp", version = "3.6.0" }
+agentmesh-mcp = { path = "agentmesh-mcp", version = "4.0.0" }
 aes-gcm = "=0.10.3"
 assert_cmd = "=2.2.2"
 base64 = "=0.22.1"

--- a/agent-governance-typescript/agent-os-vscode/package.json
+++ b/agent-governance-typescript/agent-os-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/agent-os-vscode",
   "displayName": "Agent OS - AI Safety for Code",
   "description": "Kernel-level safety for AI coding assistants. Block destructive operations, verify with multi-model review, and audit all AI suggestions.",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "publisher": "agent-os",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/agent-governance-typescript/package.json
+++ b/agent-governance-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/agent-governance-sdk",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Public Preview — TypeScript SDK for the Agent Governance Toolkit: agent identity, trust scoring, policy evaluation, and audit logging",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/examples/copilot-cli-agt/.github/extensions/agt-global-policy/package.json
+++ b/examples/copilot-cli-agt/.github/extensions/agt-global-policy/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
   "type": "module",
-  "version": "3.7.0"
+  "version": "4.0.0"
 }

--- a/examples/copilot-cli-agt/package.json
+++ b/examples/copilot-cli-agt/package.json
@@ -10,5 +10,5 @@
     "check": "node --check ./.github/extensions/agt-global-policy/extension.mjs && node --check ./.github/extensions/agt-global-policy/main.mjs && node --check ./.github/extensions/agt-global-policy/lib/policy.mjs && node --check ./.github/extensions/agt-global-policy/lib/poisoning.mjs && node --check ./.github/extensions/agt-global-policy/lib/sdk-loader.mjs && node --check ./test/policy-engine.test.mjs",
     "test": "node --test ./test/*.test.mjs"
   },
-  "version": "3.7.0"
+  "version": "4.0.0"
 }


### PR DESCRIPTION
## Summary

Clean consolidation: only publish the 9 packages that matter, bump everything to v4.0.0 across all 5 languages.

### ESRP Pipeline (esrp-publish.yml)
- **Before**: 45 Python packages across 4 wave stages (Wave 0-3)
- **After**: 9 packages in a single publish stage
- Packages published: 4 consolidated + 1 meta-package + 4 standalone

### GitHub Actions (publish.yml, ci.yml)
- publish.yml: 45 -> 9 publishable packages
- ci.yml build-pypi matrix: removed absorbed packages
- ci.yml safety check: updated package list

### Version Bumps (all to 4.0.0)
- **Python**: All pyproject.toml files
- **npm**: All package.json files
- **.NET**: Directory.Build.props
- **Rust**: Cargo.toml

### Published Package Set
| Package | Type |
|---------|------|
| agent-governance-toolkit-core | Consolidated |
| agent-governance-toolkit-integrations | Consolidated |
| agent-governance-toolkit-cli | Consolidated |
| agent-governance-toolkit-protocols | Consolidated |
| agent-governance-toolkit | Meta-package |
| agent-discovery | Standalone |
| agent-lightning | Standalone |
| agent-marketplace | Standalone |
| agent-rag-governance | Standalone |
