### PR TITLE
chore(deps): bump axios 1.16.0, @typescript-eslint 8.60.0

### DIFF
--- a/agent-governance-python/agent-os/extensions/copilot/package.json
+++ b/agent-governance-python/agent-os/extensions/copilot/package.json
@@ -50,7 +50,7 @@
     "@types/jest": "30.0.0",
     "@types/node": "25.9.1",
     "@typescript-eslint/eslint-plugin": "8.60.0",
-    "@typescript-eslint/parser": "8.59.4",
+    "@typescript-eslint/parser": "8.60.0",
     "eslint": "10.4.0",
     "jest": "30.4.2",
     "ts-jest": "29.4.11",

--- a/agent-governance-python/agent-os/extensions/cursor/package.json
+++ b/agent-governance-python/agent-os/extensions/cursor/package.json
@@ -265,6 +265,6 @@
     "@vscode/vsce": "2.22.0"
   },
   "dependencies": {
-    "axios": "1.15.2"
+    "axios": "1.16.0"
   }
 }

--- a/agent-governance-python/agent-os/extensions/mcp-server/package.json
+++ b/agent-governance-python/agent-os/extensions/mcp-server/package.json
@@ -49,7 +49,7 @@
     "@types/node": "25.9.1",
     "@types/uuid": "11.0.0",
     "@typescript-eslint/eslint-plugin": "8.60.0",
-    "@typescript-eslint/parser": "8.59.4",
+    "@typescript-eslint/parser": "8.60.0",
     "@vitest/coverage-v8": "4.1.7",
     "eslint": "10.4.0",
     "typescript": "6.0.3",

--- a/agent-governance-typescript/package.json
+++ b/agent-governance-typescript/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@types/jest": "30.0.0",
     "@types/node": "25.9.1",
-    "@typescript-eslint/eslint-plugin": "8.59.3",
+    "@typescript-eslint/eslint-plugin": "8.60.0",
     "@typescript-eslint/parser": "8.60.0",
     "eslint": "10.4.0",
     "jest": "30.4.2",


### PR DESCRIPTION
Consolidated dependency bumps. Supersedes dependabot PRs #2661, #2604, #2603, #2600.

- axios 1.15.2 -> 1.16.0 (cursor extension)
- @typescript-eslint/parser 8.59.4 -> 8.60.0 (copilot, mcp-server extensions)
- @typescript-eslint/eslint-plugin 8.59.3 -> 8.60.0 (agent-governance-typescript)
