### PR TITLE
fix(ci): restore missing steps block and gate step in build-pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,23 @@ jobs:
             agent-marketplace,
             agent-rag-governance,
           ]
+    steps:
+      - name: Determine if package changed
+        id: gate
+        env:
+          CHANGED: ${{ needs.changes.outputs.changed-py-pkgs }}
+          PKG: ${{ matrix.package }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "push" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s' "$CHANGED" | grep -q "\"$PKG\""; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Package $PKG unchanged on this PR — skipping build."
+          fi
       - name: Skip (unchanged package)
         if: steps.gate.outputs.run != 'true'
         run: echo "Package ${{ matrix.package }} unchanged — skipping wheel build"


### PR DESCRIPTION
The package matrix edit in #2668 accidentally removed the \steps:\ keyword and the 'Determine if package changed' gate step from the \uild-pypi\ job, causing an actionlint YAML parse error on every CI run.

Restores the missing block.