### PR TITLE
docs: add Prashan Sapkota as external maintainer, move ALRubinger to emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,7 @@ see [GOVERNANCE.md](GOVERNANCE.md).
 |------|-------------|--------|------|-------|
 | Jack Batzner | Microsoft | [@jackbatzner](https://github.com/jackbatzner) | Python SDK, Agent OS | Jan 2025 |
 | Elton Carr | Microsoft | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | .NET SDK, CI/CD | Feb 2025 |
-| Andrew Lee Rubinger | Aileron | [@ALRubinger](https://github.com/ALRubinger) | Governance runtime, integrations | May 2026 |
+| Prashan Sapkota | Robert Half Inc. | [@prashansapkota](https://github.com/prashansapkota) | Cloud infrastructure, deployment | May 2026 |
 | Kevin Knapp | MythologIQ | [@Knapp-Kevin](https://github.com/Knapp-Kevin) | Policy engine, LangChain integration | May 2026 |
 | Nishar Miya | Dayos | [@miyannishar](https://github.com/miyannishar) | Observability, adopter integrations | May 2026 |
 
@@ -49,4 +49,6 @@ contributing and reach out in [GitHub Discussions](https://github.com/microsoft/
 
 ## Emeritus Maintainers
 
-None yet.
+| Name | Organization | GitHub | Contribution Period |
+|------|-------------|--------|-------------------|
+| Andrew Lee Rubinger | Aileron | [@ALRubinger](https://github.com/ALRubinger) | May 2026 |

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -9,6 +9,7 @@ Current maintainers of the Agent Governance Toolkit.
 | Imran Siddique | [@imran-siddique](https://github.com/imran-siddique) | Project Lead | All packages |
 | Jack Batzner | [@jackbatzner](https://github.com/jackbatzner) | Maintainer | CI/CD, documentation |
 | Elton Carr | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | Maintainer | CI workflows, security tooling |
+| Prashan Sapkota | [@prashansapkota](https://github.com/prashansapkota) | External Maintainer | Cloud infrastructure, deployment |
 
 ## Maintainer Responsibilities
 
@@ -33,7 +34,7 @@ Maintainers who are no longer active but made significant contributions.
 
 | Name | GitHub | Contribution Period |
 |------|--------|-------------------|
-| | | |
+| Andrew Lee Rubinger | [@ALRubinger](https://github.com/ALRubinger) | May 2026 |
 
 ## Contact
 


### PR DESCRIPTION
## Summary

Update maintainer roster: add Prashan Sapkota as external maintainer, move Andrew Lee Rubinger to emeritus.

## Changes

| File | Change |
|------|--------|
| MAINTAINERS.md | Replace ALRubinger with prashansapkota in Core Maintainers, add ALRubinger to Emeritus |
| docs/MAINTAINERS.md | Add prashansapkota to Active Maintainers, add ALRubinger to Emeritus |

## Details

- **New maintainer:** @prashansapkota (Robert Half Inc.) - Cloud infrastructure and deployment
- **Emeritus:** @ALRubinger (Aileron) - moved from active to emeritus
