### PR TITLE
fix: wheel-only build for consolidated packages + marketplace version sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "agentgovtoolkit@microsoft.com"
   },
   "description": "Agent Governance Toolkit plugins for Claude Code",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "plugins": [
     {
       "name": "agt-governance",
       "source": "./agent-governance-claude-code",
       "description": "AGT governance hooks and MCP tools for Claude Code sessions",
-      "version": "3.6.0",
+      "version": "4.0.0",
       "author": {
         "name": "Microsoft Corporation",
         "email": "agentgovtoolkit@microsoft.com"

--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -182,9 +182,15 @@ stages:
               displayName: 'Install build tools'
 
             - script: |
-                python -m build
+                # Consolidated packages use force-include with sibling paths,
+                # which only works when building a wheel directly from source.
+                if [[ "${{ pkg.name }}" == agent-governance-toolkit-* ]]; then
+                  python -m build --wheel
+                else
+                  python -m build
+                fi
               workingDirectory: '${{ pkg.path }}'
-              displayName: 'Build ${{ pkg.name }} (sdist + wheel)'
+              displayName: 'Build ${{ pkg.name }}'
 
             - script: |
                 echo "=== Built artifacts for ${{ pkg.name }} ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,15 @@ jobs:
       - name: Build ${{ matrix.package }}
         if: steps.gate.outputs.run == 'true'
         working-directory: agent-governance-python/${{ matrix.package }}
-        run: python -m build
+        run: |
+          # Consolidated packages use force-include with sibling paths,
+          # which only works when building a wheel directly from source
+          # (not via sdist in a temp dir).
+          if [[ "${{ matrix.package }}" == agent-governance-toolkit-* ]]; then
+            python -m build --wheel
+          else
+            python -m build
+          fi
       - name: Verify wheel
         if: steps.gate.outputs.run == 'true'
         working-directory: agent-governance-python/${{ matrix.package }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,7 +138,12 @@ jobs:
 
       - name: Build ${{ matrix.name }}
         working-directory: ${{ matrix.path }}
-        run: python -m build
+        run: |
+          if [[ "${{ matrix.name }}" == agent-governance-toolkit-* ]]; then
+            python -m build --wheel
+          else
+            python -m build
+          fi
 
       - name: Validate build artifacts
         working-directory: ${{ matrix.path }}

--- a/agent-governance-claude-code/.claude-plugin/plugin.json
+++ b/agent-governance-claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agt-governance",
   "description": "AGT governance hooks and MCP tools for Claude Code sessions",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "author": {
     "name": "Microsoft Corporation",
     "email": "agentgovtoolkit@microsoft.com"


### PR DESCRIPTION
## Summary
- Use \python -m build --wheel\ for consolidated packages (agent-governance-toolkit-*) in ci.yml, publish.yml, and esrp-publish.yml
- Sync Claude Code marketplace version from 3.6.0 to 4.0.0

## Problem
Consolidated packages use hatchling \orce-include\ with sibling directory paths (\../agent-os/src/agent_os\). When \python -m build\ creates a wheel from sdist, the sibling dirs don't exist in the temp extraction dir, causing \FileNotFoundError\.

## Fix
- Conditional: \gent-governance-toolkit-*\ packages build with \--wheel\, all others use default \python -m build\
- Updated in all 3 pipeline files: ci.yml, publish.yml, esrp-publish.yml
- Ran marketplace version sync script to update plugin.json and marketplace.json