### PR TITLE
fix(docs): correct maintainer since dates from commit history

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,11 +16,11 @@ see [GOVERNANCE.md](GOVERNANCE.md).
 
 | Name | Organization | GitHub | Area | Since |
 |------|-------------|--------|------|-------|
-| Jack Batzner | Microsoft | [@jackbatzner](https://github.com/jackbatzner) | Python SDK, Agent OS | Jan 2025 |
-| Elton Carr | Microsoft | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | .NET SDK, CI/CD | Feb 2025 |
-| Prashan Sapkota | Robert Half Inc. | [@prashansapkota](https://github.com/prashansapkota) | Cloud infrastructure, deployment | May 2026 |
-| Kevin Knapp | MythologIQ | [@Knapp-Kevin](https://github.com/Knapp-Kevin) | Policy engine, LangChain integration | May 2026 |
-| Nishar Miya | Dayos | [@miyannishar](https://github.com/miyannishar) | Observability, adopter integrations | May 2026 |
+| Jack Batzner | Microsoft | [@jackbatzner](https://github.com/jackbatzner) | Python SDK, Agent OS | Apr 2026 |
+| Elton Carr | Microsoft | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | .NET SDK, CI/CD | Apr 2026 |
+| Kevin Knapp | MythologIQ | [@Knapp-Kevin](https://github.com/Knapp-Kevin) | Policy engine, LangChain integration | Apr 2026 |
+| Nishar Miya | Dayos | [@miyannishar](https://github.com/miyannishar) | Observability, adopter integrations | Apr 2026 |
+| Prashan Sapkota | Robert Half Inc. | [@prashansapkota](https://github.com/prashansapkota) | Cloud infrastructure, deployment | Apr 2026 |
 
 ## Package Maintainers
 
@@ -29,8 +29,8 @@ Package maintainers have publish rights to one or more registries (PyPI, npm, Nu
 | Name | Organization | GitHub | Package(s) | Since |
 |------|-------------|--------|-----------|-------|
 | Imran Siddique | Microsoft | [@imran-siddique](https://github.com/imran-siddique) | agent-os-kernel, agentmesh-platform, agent-governance-toolkit (PyPI) | Oct 2024 |
-| Jack Batzner | Microsoft | [@jackbatzner](https://github.com/jackbatzner) | @microsoft/agent-governance (npm), Microsoft.AgentGovernance (NuGet) | Jan 2025 |
-| Elton Carr | Microsoft | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | Microsoft.AgentGovernance.* (NuGet) | Feb 2025 |
+| Jack Batzner | Microsoft | [@jackbatzner](https://github.com/jackbatzner) | @microsoft/agent-governance (npm), Microsoft.AgentGovernance (NuGet) | Apr 2026 |
+| Elton Carr | Microsoft | [@eltoncarr-ms](https://github.com/eltoncarr-ms) | Microsoft.AgentGovernance.* (NuGet) | Apr 2026 |
 
 _We welcome additional maintainers from any organization. See
 [Contributing](#becoming-a-maintainer) below._


### PR DESCRIPTION
## Summary

Fix inaccurate Since dates in MAINTAINERS.md. Previous values (Jan 2025, Feb 2025, May 2026) were wrong. Corrected all dates by checking each contributor first commit via git log.

## Changes

| Maintainer | Old Date | Correct Date | First Commit |
|-----------|----------|-------------|--------------|
| Jack Batzner | Jan 2025 | Apr 2026 | 2026-04-04 (CrewAI demo) |
| Elton Carr | Feb 2025 | Apr 2026 | 2026-04-22 (agent-sre version fix) |
| Kevin Knapp | May 2026 | Apr 2026 | 2026-04-03 (allowlist validation) |
| Nishar Miya | May 2026 | Apr 2026 | 2026-04-25 (X3DH tests) |
| Prashan Sapkota | May 2026 | Apr 2026 | 2026-04-27 (auth gates adapter) |

Package Maintainer dates for Jack and Elton also corrected from Jan/Feb 2025 to Apr 2026.
