### PR TITLE
fix: add SC2193 to actionlint ignore list

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -35,7 +35,8 @@ jobs:
             -ignore 'unknown permission scope "models"' \
             -ignore 'undefined variable "pattern"' \
             -ignore 'SC2016' \
-            -ignore 'SC2001'
+            -ignore 'SC2001' \
+            -ignore 'SC2193'
 
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
actionlint's embedded shellcheck doesn't honor .shellcheckrc, so SC2193 (GHA expression placeholder false positive) must also be added as an \-ignore\ flag.