### PR TITLE
fix: add file-level ruff noqa E402 to all deprecated stub packages

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/__init__.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+# ruff: noqa: E402 — deprecation warning must fire before re-exports
 """
 Agent Hypervisor v2.0
 

--- a/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
+++ b/agent-governance-python/agent-mcp-governance/src/agent_mcp_governance/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""agent_mcp_governance — MCP governance primitives for the Agent Governance Toolkit.
+# ruff: noqa: E402 — deprecation warning must fire before re-exports
+"""agent_mcp_governance— MCP governance primitives for the Agent Governance Toolkit.
 
 This package provides a focused surface for governing agents that communicate
 over the Model Context Protocol (MCP). It re-exports:

--- a/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+# ruff: noqa: E402 — deprecation warning must fire before re-exports
 """
 AgentMesh - The Secure Nervous System for Cloud-Native Agent Ecosystems
 

--- a/agent-governance-python/agent-os/src/agent_os/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+# ruff: noqa: E402 — deprecation warning must fire before re-exports
 """
 Agent OS - A Safety-First Kernel for Autonomous AI Agents
 

--- a/agent-governance-python/agent-runtime/src/agent_runtime/__init__.py
+++ b/agent-governance-python/agent-runtime/src/agent_runtime/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+# ruff: noqa: E402 — deprecation warning must fire before re-exports
 """
 Agent Runtime — Execution supervisor for multi-agent sessions.
 
@@ -25,7 +26,7 @@ _warnings.warn(
     stacklevel=2,
 )
 del _warnings
-from hypervisor import (  # noqa: F401, E402
+from hypervisor import (  # noqa: F401
     __version__,
     # Core
     Hypervisor,

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/__init__.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+# ruff: noqa: E402 — deprecation warning must fire before re-exports
 """Agent Sandbox — execution isolation for AI agents.
 
 Provides ``SandboxProvider``, the abstract base class for all sandbox

--- a/agent-governance-python/agent-sre/src/agent_sre/__init__.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+# ruff: noqa: E402 — deprecation warning must fire before re-exports
 """Agent SRE — Reliability Engineering for AI Agent Systems.
 
 agent-sre brings Site Reliability Engineering practices to AI agents.


### PR DESCRIPTION
All deprecated stubs have \warnings.warn()\ before re-export imports, triggering E402. Adds \# ruff: noqa: E402\ at file level to all 7 affected packages.