### PR TITLE
fix(mute-agent): harden against red-team findings (TDD: 11 RED→GREEN regressions)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -1,4 +1,5 @@
 AAIF
+abspath
 abstractmethod
 Acta
 addinfourl
@@ -24,6 +25,7 @@ APIM
 apiserver
 appsettings
 argparse
+arrowsize
 asctime
 aspnet
 asyncio
@@ -35,6 +37,7 @@ autouse
 AWSIAM
 axios
 aymenhmaidiwastaken
+backendunavailable
 backpressure
 baselined
 behaviour
@@ -68,7 +71,11 @@ CODEOWNERS
 codepoint
 CommonMark
 comspec
+<<<<<<< HEAD
 connectedservicename
+=======
+confirmer
+>>>>>>> 019325ce (chore: add mute-agent red-team test terms to spell-check allowlist)
 containerapps
 containerd
 contentsource
@@ -223,13 +230,18 @@ lockfile
 lockfiles
 lotl
 lstrip
+<<<<<<< HEAD
 mainpublisher
+=======
+madmin
+>>>>>>> 019325ce (chore: add mute-agent red-team test terms to spell-check allowlist)
 manylinux
 markdown
 Marp
 masquerade
 mastra
 materialised
+matplotlib
 maxlen
 Mevil
 mgmt
@@ -241,7 +253,9 @@ modelcontextprotocol
 Moltbook
 Molty
 monkeypatch
+monkeypatched
 monkeypatching
+mpatches
 MSHV
 msinternal
 MSRC
@@ -269,6 +283,7 @@ npmjs
 numpy
 octo
 omitempty
+oncall
 OpenAI
 OpenClaw
 opencode
@@ -323,10 +338,12 @@ Ravande
 readouterr
 recognised
 recognising
+redteam
 Rego
 relativedelta
 removeprefix
 removesuffix
+repr
 repudiable
 requireapproval
 reqwest


### PR DESCRIPTION
## Description

Harden the `mute-agent` module against the 10 findings from a multi-model red-team review (Claude Opus 4.7 + GPT-5.5), plus 2 prior consensus warnings. Built test-driven: every fix lands as a RED→GREEN commit pair so each vulnerability is proved real before the fix closes it.

Scope is limited to `agent-governance-python/agent-os/modules/mute-agent/` (package tree and `src/` mirror).

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

### Breaking changes (call out)

1. **`HandshakeProtocol(allowed_confirmers=None)` is now fail-closed.** Previously `None` meant "accept any confirmer." Callers that relied on the permissive default must now pass the explicit `ALLOW_ANY` sentinel (exported from `mute_agent.core.handshake_protocol`). Documented in the module docstring.
2. **Adapter `mock_mode` is write-once-at-construction.** Setting `adapter.mock_mode = True` (or `_mock_mode`) after `__init__` raises `AttributeError`. This closes an in-process attacker escalation primitive (H3).

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance _(mute-agent module under `agent-os/modules/`)_
- [ ] docs / root

## Findings closed — RED → GREEN test transitions

Each test below was first committed as RED on the pre-fix tree (`5997d781`) and reproducibly failed for the documented reason. The matching fix commit turns it GREEN.

| # | Sev | Finding | Test | Pre-fix failure | Fix |
|---|-----|---------|------|-----------------|-----|
| C1 | Crit | metadata bypass — `metadata['confirmation_satisfied']=True` reaches executable state without audit | `test_C1_metadata_satisfied_flag_does_not_bypass_audit` | satisfied flag set via dict mutation, executable reachable | `is_confirmation_satisfied` reads `ConfirmationRecord` audit trail only |
| H1 | High | state rollback — `session.state = STATE.PROPOSED` accepted from any state | `test_H1_state_cannot_be_rolled_back_from_executable_to_pending` | rollback accepted | `__slots__` + property-only setter validates transition graph |
| C2 | Crit | `RuntimeError('dictionary changed size during iteration')` on emergency halt | `test_C2_emergency_halt_safe_under_concurrent_session_creation` | reliably trips under 8 churners × 50 listener iterations × 100 pre-pop sessions | `protocol.snapshot_sessions()` (lock-protected list copy) used by all three intervention branches |
| H5 | High | `emergency_alert` failure silently swallowed in outcome string | `test_H5_emergency_alert_delivery_failure_is_surfaced` | outcome `"Emergency halt: 1 sessions terminated"` masks the alert exception | outcome carries `alert=skipped\|delivered\|failed`; `logger.exception(exc_info=True)` on failure |
| H6 | High | `allowed_confirmers=None` defaults to permissive | `test_H6_unset_allowlist_now_fails_closed` | random principal accepted | `None` → fail-closed; new `ALLOW_ANY` sentinel restores old behavior |
| H2 | High | `client_factory` test hook honored without `mock_mode` | `test_H2_client_factory_only_fires_in_mock_mode` | hostile factory called with `mock_mode=False` | hook gated on `mock_mode==True` opt-in |
| H3 | High | `mock_mode` mutable post-construction | `test_H3_mock_mode_cannot_be_flipped_post_construction` | `adapter.mock_mode = True` succeeded | `__setattr__` guards `_IMMUTABLE_ATTRS={'mock_mode','_mock_mode'}` |
| H4 | High | `_last_error` leaks driver credentials via `str(e)` | `test_H4_last_error_does_not_leak_driver_credentials` | `_last_error == 'RuntimeError: upstream auth failed: token=Bearer ...'` | `_safe_error_text` returns `TypeName (static hint)` only; driver detail goes to `logger.exception` |
| M1 | Med | `connect()` returns True with `_client=None` | `test_M1_connect_fails_closed_when_create_client_returns_none` | `connect() → True` with no client | None client rejected; `_connected` stays `False`, `_last_error` records hint |
| L1 | Low | allowlist entries not normalized | `test_L1_allowlist_entries_are_normalized` | `"  alice  "` in allowlist ≠ `"alice"` lookup | `.strip()` on insert + on compare |
| L2 | Low | `confirmed_by` allows log/ANSI injection | `test_L2_confirmed_by_strips_ansi_and_log_injection_chars` | `"alice\n\x1b[31mFAKE"` stored verbatim | CR/LF/control/CSI stripped before audit-trail store |

**Prior consensus warnings folded in:** raw-text credential leak on `AdapterStatus.error` (subsumed by H4 via shared `_safe_error_text` surface); old `and/or` precedence assertions in `test_security_hardening.py` rewritten to match the new sanitized surface.

## Commits (oldest → newest)

| SHA | Type | Findings |
|-----|------|----------|
| `14ebaecc` | RED | C1, H1, H6, L1, L2 |
| `6fbbab8e` | GREEN | C1, H1, H6, L1, L2 — opaque session state + audited confirmation truth source |
| `9cf9d5fa` | RED | C2, H5 |
| `888d26f7` | GREEN | C2, H5 — listener snapshot iteration + alert delivery surfacing |
| `be682e66` | RED | H2, H3, H4, M1 |
| `96c7787e` | GREEN | H2, H3, H4, M1 — immutable mock_mode + factory gated on mock_mode + sanitized error surface + fail-closed on None client |

## Files touched

- `mute_agent/core/handshake_protocol.py` + `src/core/handshake_protocol.py`
- `mute_agent/listener/state_observer.py` + `src/listener/state_observer.py`
- `mute_agent/listener/listener.py` + `src/listener/listener.py`
- `mute_agent/listener/adapters/{base,iatp,scak,caas,control_plane}_adapter.py` + src mirrors
- `tests/test_redteam_handshake.py` (new)
- `tests/test_redteam_listener.py` (new)
- `tests/test_redteam_adapters.py` (new)
- `tests/test_security_hardening.py` (updated to match new surfaces)

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed _(docstrings on `handshake_protocol.py` + `base_adapter.py` document the new security model)_
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

**Test totals**: `pytest tests -q` → **154 passed in ~3s**. **Lint**: `ruff check --select F,W mute_agent src tests` → clean.

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**: None. Hardening patterns (frozen state, immutable attrs, sanitized error surfaces, snapshot iteration under lock) are standard defensive Python idioms.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot used for diff exploration and TDD scaffolding. Red-team analysis was multi-model (Claude Opus 4.7 + GPT-5.5). All output reviewed and verified.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Closes the in-class issues from the prior follow-up cycle (red-team findings + the two consensus warnings).

---

cc @imran-siddique for review.
