### PR TITLE
feat: add openshell shell interception

### DIFF
--- a/agent-governance-python/agentmesh-integrations/openshell-skill/README.md
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/README.md
@@ -12,11 +12,26 @@ pip install openshell-agentmesh
 ## Quick Start
 
 ```python
-from openshell_agentmesh import GovernanceSkill
+import subprocess
+
+from openshell_agentmesh import GovernanceSkill, governed_shell
 
 skill = GovernanceSkill(policy_dir="./policies")
 decision = skill.check_policy("shell:python test.py")
 print(decision.allowed)  # True
+
+with governed_shell(skill):
+    subprocess.run(["python", "test.py"], check=True)
+```
+
+`governed_shell()` is opt-in and scoped. While active, `subprocess.run`,
+`subprocess.Popen`, `os.system`, and `os.popen` are checked against policy before
+execution. Denied commands raise `ShellPolicyViolation` and are not executed.
+
+For persistent audit records, pass a JSONL path:
+
+```python
+skill = GovernanceSkill(policy_dir="./policies", audit_path="./audit/openshell.jsonl")
 ```
 
 ## Related

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/__init__.py
@@ -2,6 +2,11 @@
 # Licensed under the MIT License.
 """OpenShell + AgentMesh governance skill."""
 
-from openshell_agentmesh.skill import GovernanceSkill, PolicyDecision
+from openshell_agentmesh.skill import (
+    GovernanceSkill,
+    PolicyDecision,
+    ShellPolicyViolation,
+    governed_shell,
+)
 
-__all__ = ["GovernanceSkill", "PolicyDecision"]
+__all__ = ["GovernanceSkill", "PolicyDecision", "ShellPolicyViolation", "governed_shell"]

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/cli.py
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/cli.py
@@ -22,6 +22,7 @@ def main(argv=None):
     cp.add_argument("--action", required=True, help="Action string to evaluate (e.g. shell:python)")
     cp.add_argument("--context", default="{}", help="JSON object with evaluation context")
     cp.add_argument("--policy-dir", required=True, help="Path to directory containing policy YAML files")
+    cp.add_argument("--audit-path", help="Optional JSONL audit log path")
 
     ts = sub.add_parser("trust-score", help="Query the trust score for an agent DID")
     ts.add_argument("--agent-did", required=True, help="Agent DID to look up")
@@ -38,7 +39,7 @@ def main(argv=None):
         except json.JSONDecodeError as exc:
             print(json.dumps({"error": f"Invalid --context JSON: {exc}"}), file=sys.stderr)
             return 2
-        skill = GovernanceSkill(policy_dir=policy_path)
+        skill = GovernanceSkill(policy_dir=policy_path, audit_path=Path(args.audit_path) if args.audit_path else None)
         d = skill.check_policy(args.action, ctx)
         print(json.dumps({"allowed": d.allowed, "action": d.action, "reason": d.reason, "policy_name": d.policy_name}))
         return 0 if d.allowed else 1

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/skill.py
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/openshell_agentmesh/skill.py
@@ -3,11 +3,17 @@
 """Governance skill for OpenShell sandboxed agents."""
 
 from __future__ import annotations
+from contextlib import contextmanager
+import json
+import os
 import re
+import shlex
+import subprocess
+import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 import yaml
 
 @dataclass
@@ -17,6 +23,14 @@ class PolicyDecision:
     reason: str
     policy_name: Optional[str] = None
     trust_score: float = 0.0
+
+
+class ShellPolicyViolation(PermissionError):
+    """Raised when shell interception blocks a command before execution."""
+
+    def __init__(self, decision: PolicyDecision) -> None:
+        self.decision = decision
+        super().__init__(decision.reason)
 
 @dataclass
 class _PolicyRule:
@@ -29,11 +43,17 @@ class _PolicyRule:
     message: str = ""
 
 class GovernanceSkill:
-    def __init__(self, policy_dir: Optional[Path] = None, trust_threshold: float = 0.5) -> None:
+    def __init__(
+        self,
+        policy_dir: Optional[Path] = None,
+        trust_threshold: float = 0.5,
+        audit_path: Optional[Path] = None,
+    ) -> None:
         self._rules: list[_PolicyRule] = []
         self._trust_scores: dict[str, float] = {}
         self._audit_log: list[dict] = []
         self._trust_threshold = trust_threshold
+        self._audit_path = Path(audit_path) if audit_path else None
         if policy_dir:
             self.load_policies(policy_dir)
 
@@ -74,6 +94,36 @@ class GovernanceSkill:
         self.log_action(action, "deny", agent_did, context)
         return decision
 
+    def authorize_shell_command(
+        self,
+        command: Any,
+        *,
+        api: str,
+        shell: bool = False,
+        context: Optional[dict] = None,
+    ) -> PolicyDecision:
+        action, shell_context = _shell_action_and_context(
+            command,
+            api=api,
+            shell=shell,
+            context=context,
+        )
+        decision = self.check_policy(action, shell_context)
+        if not decision.allowed:
+            raise ShellPolicyViolation(decision)
+        return decision
+
+    def activate(self, context: Optional[dict] = None) -> "GovernanceSkill":
+        """Enable opt-in shell interception for this process."""
+
+        _activate_shell_interception(self, context)
+        return self
+
+    def deactivate(self) -> None:
+        """Disable this skill's shell interception activation."""
+
+        _deactivate_shell_interception(self)
+
     def get_trust_score(self, agent_did: str) -> float:
         return self._trust_scores.get(agent_did, 1.0)
 
@@ -86,6 +136,10 @@ class GovernanceSkill:
     def log_action(self, action: str, decision: str, agent_did: str = "unknown", context: Optional[dict] = None) -> dict:
         entry = {"timestamp": datetime.now(timezone.utc).isoformat(), "action": action, "decision": decision, "agent_did": agent_did, "trust_score": self.get_trust_score(agent_did), "context": context or {}}
         self._audit_log.append(entry)
+        if self._audit_path:
+            self._audit_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self._audit_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry, default=str, sort_keys=True) + "\n")
         return entry
 
     def get_audit_log(self, limit: int = 50) -> list[dict]:
@@ -99,3 +153,153 @@ class GovernanceSkill:
         if operator == "matches": return bool(re.search(str(value), target))
         if operator == "in": return target in (value if isinstance(value, list) else [value])
         return False
+
+
+@contextmanager
+def governed_shell(skill: GovernanceSkill, context: Optional[dict] = None) -> Iterator[GovernanceSkill]:
+    """Temporarily route Python shell APIs through an OpenShell governance skill."""
+
+    skill.activate(context=context)
+    try:
+        yield skill
+    finally:
+        skill.deactivate()
+
+
+_SHELL_PATCH_LOCK = threading.RLock()
+_SHELL_PATCH_LOCAL = threading.local()
+_SHELL_ORIGINALS: dict[str, Any] = {}
+_ACTIVE_SHELL_SKILLS: list[tuple[GovernanceSkill, dict[str, Any]]] = []
+
+
+def _activate_shell_interception(skill: GovernanceSkill, context: Optional[dict]) -> None:
+    with _SHELL_PATCH_LOCK:
+        if not _SHELL_ORIGINALS:
+            _SHELL_ORIGINALS.update(
+                {
+                    "subprocess.run": subprocess.run,
+                    "subprocess.Popen": subprocess.Popen,
+                    "os.system": os.system,
+                    "os.popen": os.popen,
+                }
+            )
+            subprocess.run = _governed_subprocess_run
+            subprocess.Popen = _governed_subprocess_popen
+            os.system = _governed_os_system
+            os.popen = _governed_os_popen
+        _ACTIVE_SHELL_SKILLS.append((skill, dict(context or {})))
+
+
+def _deactivate_shell_interception(skill: GovernanceSkill) -> None:
+    with _SHELL_PATCH_LOCK:
+        for index in range(len(_ACTIVE_SHELL_SKILLS) - 1, -1, -1):
+            if _ACTIVE_SHELL_SKILLS[index][0] is skill:
+                del _ACTIVE_SHELL_SKILLS[index]
+                break
+
+        if not _ACTIVE_SHELL_SKILLS and _SHELL_ORIGINALS:
+            subprocess.run = _SHELL_ORIGINALS.pop("subprocess.run")
+            subprocess.Popen = _SHELL_ORIGINALS.pop("subprocess.Popen")
+            os.system = _SHELL_ORIGINALS.pop("os.system")
+            os.popen = _SHELL_ORIGINALS.pop("os.popen")
+
+
+def _current_shell_skill() -> Optional[tuple[GovernanceSkill, dict[str, Any]]]:
+    with _SHELL_PATCH_LOCK:
+        if not _ACTIVE_SHELL_SKILLS:
+            return None
+        skill, context = _ACTIVE_SHELL_SKILLS[-1]
+        return skill, dict(context)
+
+
+def _authorize_active_shell(command: Any, *, api: str, shell: bool = False) -> None:
+    if getattr(_SHELL_PATCH_LOCAL, "bypass", False):
+        return
+    active = _current_shell_skill()
+    if not active:
+        return
+    skill, context = active
+    skill.authorize_shell_command(command, api=api, shell=shell, context=context)
+
+
+def _with_popen_bypass(callable_obj, *args, **kwargs):
+    previous = getattr(_SHELL_PATCH_LOCAL, "bypass", False)
+    _SHELL_PATCH_LOCAL.bypass = True
+    try:
+        return callable_obj(*args, **kwargs)
+    finally:
+        _SHELL_PATCH_LOCAL.bypass = previous
+
+
+def _governed_subprocess_run(*popenargs, **kwargs):
+    command = popenargs[0] if popenargs else kwargs.get("args")
+    _authorize_active_shell(command, api="subprocess.run", shell=bool(kwargs.get("shell", False)))
+    return _with_popen_bypass(_SHELL_ORIGINALS["subprocess.run"], *popenargs, **kwargs)
+
+
+def _governed_subprocess_popen(*popenargs, **kwargs):
+    if getattr(_SHELL_PATCH_LOCAL, "bypass", False):
+        return _SHELL_ORIGINALS["subprocess.Popen"](*popenargs, **kwargs)
+    command = popenargs[0] if popenargs else kwargs.get("args")
+    _authorize_active_shell(command, api="subprocess.Popen", shell=bool(kwargs.get("shell", False)))
+    return _SHELL_ORIGINALS["subprocess.Popen"](*popenargs, **kwargs)
+
+
+def _governed_os_system(command):
+    _authorize_active_shell(command, api="os.system", shell=True)
+    return _SHELL_ORIGINALS["os.system"](command)
+
+
+def _governed_os_popen(command, mode="r", buffering=-1):
+    _authorize_active_shell(command, api="os.popen", shell=True)
+    return _SHELL_ORIGINALS["os.popen"](command, mode, buffering)
+
+
+def _shell_action_and_context(
+    command: Any,
+    *,
+    api: str,
+    shell: bool,
+    context: Optional[dict],
+) -> tuple[str, dict[str, Any]]:
+    args = _command_args(command)
+    binary = Path(args[0]).name if args else ""
+    command_text = _command_text(command)
+    shell_context = dict(context or {})
+    shell_context.update(
+        {
+            "shell_api": api,
+            "shell_binary": binary,
+            "shell_command": command_text,
+            "shell_args": args,
+            "shell": shell,
+        }
+    )
+    return f"shell:{binary}", shell_context
+
+
+def _command_args(command: Any) -> list[str]:
+    if command is None:
+        return []
+    if isinstance(command, (list, tuple)):
+        return [_stringify_arg(arg) for arg in command]
+    text = _stringify_arg(command)
+    try:
+        return shlex.split(text)
+    except ValueError:
+        return [text]
+
+
+def _command_text(command: Any) -> str:
+    if isinstance(command, (list, tuple)):
+        return " ".join(shlex.quote(_stringify_arg(arg)) for arg in command)
+    return _stringify_arg(command)
+
+
+def _stringify_arg(arg: Any) -> str:
+    if isinstance(arg, bytes):
+        return os.fsdecode(arg)
+    if isinstance(arg, os.PathLike):
+        path = os.fspath(arg)
+        return os.fsdecode(path) if isinstance(path, bytes) else path
+    return str(arg)

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/tests/test_skill.py
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/tests/test_skill.py
@@ -1,8 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-import yaml, pytest, json
+import json
+import os
 from pathlib import Path
-from openshell_agentmesh.skill import GovernanceSkill
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+from openshell_agentmesh.skill import GovernanceSkill, ShellPolicyViolation, governed_shell
 from openshell_agentmesh.cli import main as cli_main
 
 SAMPLE = {"apiVersion": "governance.toolkit/v1", "rules": [{"name": "allow-read", "condition": {"field": "action", "operator": "starts_with", "value": "file:read"}, "action": "allow", "priority": 90},{"name": "allow-shell", "condition": {"field": "action", "operator": "in", "value": ["shell:ls", "shell:python", "shell:git"]}, "action": "allow", "priority": 80},{"name": "block-danger", "condition": {"field": "action", "operator": "matches", "value": "shell:(rm|dd|curl)"}, "action": "deny", "priority": 100, "message": "Blocked"}]}
@@ -105,6 +112,15 @@ class TestEdgeCases:
         assert len(skill.get_audit_log(limit=10)) == 10
         assert len(skill.get_audit_log()) == 50
 
+    def test_audit_path_writes_jsonl(self, policy_dir, tmp_path):
+        audit_path = tmp_path / "audit.jsonl"
+        skill = GovernanceSkill(policy_dir=policy_dir, audit_path=audit_path)
+        skill.check_policy("file:read:/t")
+
+        row = json.loads(audit_path.read_text(encoding="utf-8").strip())
+        assert row["action"] == "file:read:/t"
+        assert row["decision"] == "allow"
+
     def test_audit_entry_has_timestamp(self, policy_dir):
         skill = GovernanceSkill(policy_dir=policy_dir)
         skill.check_policy("file:read:/t")
@@ -120,6 +136,71 @@ class TestEdgeCases:
             Path(fresh_dir, "one.yaml").write_text("rules:\n- name: only\n  condition:\n    field: action\n    operator: equals\n    value: test\n  action: allow\n", encoding="utf-8")
             skill.load_policies(Path(fresh_dir))
             assert len(skill._rules) == 1
+
+
+class TestShellInterception:
+    def test_governed_shell_blocks_subprocess_run_before_execution(self, policy_dir):
+        skill = GovernanceSkill(policy_dir=policy_dir)
+        with governed_shell(skill):
+            with pytest.raises(ShellPolicyViolation) as exc:
+                subprocess.run(["curl", "https://example.invalid"], check=False)
+
+        assert exc.value.decision.action == "shell:curl"
+        assert exc.value.decision.policy_name == "block-danger"
+        log = skill.get_audit_log()
+        assert log[-1]["decision"] == "deny"
+        assert log[-1]["context"]["shell_api"] == "subprocess.run"
+        assert log[-1]["context"]["shell_binary"] == "curl"
+
+    def test_governed_shell_allows_subprocess_run(self, tmp_path):
+        python_action = f"shell:{Path(sys.executable).name}"
+        policy = {"rules": [{"name": "allow-python", "condition": {"field": "action", "operator": "equals", "value": python_action}, "action": "allow"}]}
+        with open(tmp_path / "python.yaml", "w", encoding="utf-8") as f:
+            yaml.dump(policy, f)
+
+        skill = GovernanceSkill(policy_dir=tmp_path)
+        with governed_shell(skill):
+            result = subprocess.run([sys.executable, "-c", "print('ok')"], capture_output=True, text=True, check=True)
+
+        assert result.stdout.strip() == "ok"
+        assert skill.get_audit_log()[-1]["action"] == python_action
+
+    def test_governed_shell_blocks_subprocess_popen(self, policy_dir):
+        skill = GovernanceSkill(policy_dir=policy_dir)
+        with governed_shell(skill):
+            with pytest.raises(ShellPolicyViolation):
+                subprocess.Popen(["rm", "-rf", "/"])
+
+        assert skill.get_audit_log()[-1]["context"]["shell_api"] == "subprocess.Popen"
+
+    def test_governed_shell_blocks_os_system(self, policy_dir):
+        skill = GovernanceSkill(policy_dir=policy_dir)
+        with governed_shell(skill):
+            with pytest.raises(ShellPolicyViolation):
+                os.system("curl https://example.invalid")
+
+        assert skill.get_audit_log()[-1]["action"] == "shell:curl"
+        assert skill.get_audit_log()[-1]["context"]["shell"] is True
+
+    def test_governed_shell_blocks_os_popen(self, policy_dir):
+        skill = GovernanceSkill(policy_dir=policy_dir)
+        with governed_shell(skill):
+            with pytest.raises(ShellPolicyViolation):
+                os.popen("rm -rf /")
+
+        assert skill.get_audit_log()[-1]["context"]["shell_api"] == "os.popen"
+
+    def test_activate_deactivate_restore_shell_apis(self, policy_dir):
+        skill = GovernanceSkill(policy_dir=policy_dir)
+        original_run = subprocess.run
+
+        skill.activate()
+        try:
+            assert subprocess.run is not original_run
+        finally:
+            skill.deactivate()
+
+        assert subprocess.run is original_run
 
 
 class TestCLI:


### PR DESCRIPTION
## Summary
- add opt-in shell interception for OpenShell GovernanceSkill via activate()/deactivate() and governed_shell()
- route subprocess.run, subprocess.Popen, os.system, and os.popen through policy checks before execution
- add ShellPolicyViolation, shell command metadata in audit context, JSONL audit persistence, docs, and regression tests

## Problem
OpenShell governance currently relies on integrations manually calling check_policy() before every shell command. If an integration forgets that call, shell execution can proceed ungoverned.

## Changes
| Area | Change |
| --- | --- |
| Runtime | Added scoped monkey-patching for Python shell APIs with restoration on deactivate/context exit. |
| Policy | Parses shell commands to shell:<binary> actions and records shell_api, shell_binary, shell_command, shell_args, and shell in context. |
| Audit | Added optional JSONL audit_path persistence. |
| Package API | Exported governed_shell and ShellPolicyViolation. |
| Docs/tests | Documented usage and added coverage for allow, deny, restore, and audit behavior. |

## Testing
- python3 -m pytest tests -q
- python3 -m py_compile openshell_agentmesh/skill.py openshell_agentmesh/cli.py
- git diff --check

Closes #2665