### PR TITLE
feat: add sandbox subprocess code scanner

### DIFF
--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/aca_sandbox_provider/aca_sandbox_provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/aca_sandbox_provider/aca_sandbox_provider.py
@@ -62,6 +62,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from agent_sandbox.code_scanner import enforce_no_subprocess_execution
 from agent_sandbox.sandbox_provider import (
     ExecutionHandle,
     ExecutionStatus,
@@ -670,6 +671,8 @@ class ACASandboxProvider(SandboxProvider):
             decision = evaluator.evaluate(eval_ctx)
             if not decision.allowed:
                 raise PermissionError(f"Policy denied: {decision.reason}")
+
+        enforce_no_subprocess_execution(code)
 
         # Run the code over the per-sandbox `exec` endpoint. We
         # base64-encode the source so the body is opaque to the host

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/code_scanner.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/code_scanner.py
@@ -1,0 +1,193 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Static pre-execution scanner for sandboxed Python code.
+
+This is an intentionally lightweight guardrail. It catches obvious
+process-spawning APIs before code reaches a sandbox provider; it does not
+replace runtime process monitoring, seccomp, or eBPF tracing.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+_DANGEROUS_CALLS: dict[str, set[str]] = {
+    "subprocess": {
+        "Popen",
+        "call",
+        "check_call",
+        "check_output",
+        "getoutput",
+        "getstatusoutput",
+        "run",
+    },
+    "os": {
+        "execl",
+        "execle",
+        "execlp",
+        "execlpe",
+        "execv",
+        "execve",
+        "execvp",
+        "execvpe",
+        "popen",
+        "spawnl",
+        "spawnle",
+        "spawnlp",
+        "spawnlpe",
+        "spawnv",
+        "spawnve",
+        "spawnvp",
+        "spawnvpe",
+        "system",
+    },
+    "pty": {"spawn"},
+    "shutil": {"which"},
+}
+
+
+@dataclass(frozen=True)
+class CodeScanViolation:
+    """A static finding that should block sandbox execution."""
+
+    line: int
+    column: int
+    pattern: str
+    message: str
+
+
+class SandboxCodeViolation(PermissionError):
+    """Raised when static scanning finds a denied subprocess pattern."""
+
+    def __init__(self, violations: list[CodeScanViolation]) -> None:
+        self.violations = tuple(violations)
+        detail = "; ".join(
+            f"line {v.line}:{v.column + 1} {v.pattern}" for v in self.violations[:3]
+        )
+        suffix = "" if len(self.violations) <= 3 else f"; +{len(self.violations) - 3} more"
+        super().__init__(f"Sandbox code denied: potential subprocess execution ({detail}{suffix})")
+
+
+def scan_code_for_subprocesses(code: str) -> list[CodeScanViolation]:
+    """Return obvious subprocess/process-spawning patterns in Python source."""
+
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+
+    visitor = _SubprocessScanVisitor()
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def enforce_no_subprocess_execution(code: str) -> None:
+    """Raise when *code* contains denied subprocess execution patterns."""
+
+    violations = scan_code_for_subprocesses(code)
+    if violations:
+        raise SandboxCodeViolation(violations)
+
+
+class _SubprocessScanVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self._module_aliases: dict[str, str] = {}
+        self._call_aliases: dict[str, tuple[str, str]] = {}
+        self.violations: list[CodeScanViolation] = []
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        for alias in node.names:
+            root_module = alias.name.split(".", 1)[0]
+            if root_module in _DANGEROUS_CALLS:
+                local_name = alias.asname or root_module
+                self._module_aliases[local_name] = root_module
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        if node.module is None:
+            return
+        root_module = node.module.split(".", 1)[0]
+        dangerous = _DANGEROUS_CALLS.get(root_module)
+        if not dangerous:
+            return
+
+        for alias in node.names:
+            if alias.name == "*":
+                self._add_violation(
+                    node,
+                    f"{root_module}.*",
+                    f"Wildcard import from {root_module} can expose process-spawning APIs",
+                )
+                continue
+            if alias.name in dangerous:
+                local_name = alias.asname or alias.name
+                self._call_aliases[local_name] = (root_module, alias.name)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        pattern = self._resolve_call_pattern(node.func)
+        if pattern is not None:
+            self._add_violation(
+                node,
+                pattern,
+                f"{pattern} may spawn or discover subprocesses inside the sandbox",
+            )
+        self.generic_visit(node)
+
+    def _resolve_call_pattern(self, func: ast.expr) -> str | None:
+        if isinstance(func, ast.Name):
+            resolved = self._call_aliases.get(func.id)
+            if resolved is None:
+                return None
+            module, attr = resolved
+            return f"{module}.{attr}"
+
+        if not isinstance(func, ast.Attribute):
+            return None
+
+        module = self._resolve_module_name(func.value)
+        if module is None:
+            return None
+
+        dangerous = _DANGEROUS_CALLS.get(module)
+        if dangerous and func.attr in dangerous:
+            return f"{module}.{func.attr}"
+        return None
+
+    def _resolve_module_name(self, node: ast.expr) -> str | None:
+        if isinstance(node, ast.Name):
+            return self._module_aliases.get(node.id, node.id)
+        if isinstance(node, ast.Call):
+            return self._resolve_dynamic_import(node)
+        return None
+
+    def _resolve_dynamic_import(self, node: ast.Call) -> str | None:
+        if isinstance(node.func, ast.Name) and node.func.id == "__import__" and node.args:
+            return self._constant_module_name(node.args[0])
+
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "import_module"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "importlib"
+            and node.args
+        ):
+            return self._constant_module_name(node.args[0])
+
+        return None
+
+    def _constant_module_name(self, node: ast.expr) -> str | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value.split(".", 1)[0]
+        return None
+
+    def _add_violation(self, node: ast.AST, pattern: str, message: str) -> None:
+        self.violations.append(
+            CodeScanViolation(
+                line=getattr(node, "lineno", 1),
+                column=getattr(node, "col_offset", 0),
+                pattern=pattern,
+                message=message,
+            )
+        )

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -22,6 +22,8 @@ import time
 import uuid
 from typing import Any, Callable
 
+from agent_sandbox.code_scanner import enforce_no_subprocess_execution
+from agent_sandbox.docker_provider.state import SandboxCheckpoint, SandboxStateManager
 from agent_sandbox.isolation_runtime import IsolationRuntime
 from agent_sandbox.sandbox_provider import (
     ExecutionHandle,
@@ -32,7 +34,6 @@ from agent_sandbox.sandbox_provider import (
     SessionHandle,
     SessionStatus,
 )
-from agent_sandbox.docker_provider.state import SandboxCheckpoint, SandboxStateManager
 
 logger = logging.getLogger(__name__)
 
@@ -570,6 +571,8 @@ class DockerSandboxProvider(SandboxProvider):
                 raise PermissionError(
                     f"Policy denied: {decision.reason}"
                 )
+
+        enforce_no_subprocess_execution(code)
 
         # Run code with the session's configured timeout/env, not defaults.
         result = self.run(

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/hyperlight_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/hyperlight_provider/provider.py
@@ -39,6 +39,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable
 
+from agent_sandbox.code_scanner import enforce_no_subprocess_execution
 from agent_sandbox.hyperlight_provider.config import (
     HyperlightConfig,
     hyperlight_config_from_policy,
@@ -494,6 +495,8 @@ class HyperLightSandboxProvider(SandboxProvider):
             if not getattr(decision, "allowed", False):
                 reason = getattr(decision, "reason", "policy denied")
                 raise PermissionError(f"Policy denied: {reason}")
+
+        enforce_no_subprocess_execution(code)
 
         execution_id = uuid.uuid4().hex[:8]
         timeout_s = (cfg.max_execution_time_ms / 1000.0) if cfg else 60.0

--- a/agent-governance-python/agent-sandbox/tests/test_azure_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_azure_sandbox.py
@@ -35,6 +35,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent_sandbox.code_scanner import SandboxCodeViolation
 from agent_sandbox.aca_sandbox_provider import (
     ACASandboxProvider,
     aca_config_from_policy,
@@ -932,6 +933,22 @@ class TestExecuteCode:
         assert ctx["code"] == "print(1)"
         assert ctx["step_index"] == 3
         assert ctx["intent"] == "test"
+
+    def test_static_scan_blocks_subprocess_before_any_azure_exec(
+        self, provider_with_evaluator, fake_sdk
+    ):
+        provider, build = provider_with_evaluator
+        handle, _ev = build(allow=True)
+        fake_sdk.default_sandbox.exec.reset_mock()
+
+        with pytest.raises(SandboxCodeViolation, match="os.system"):
+            provider.execute_code(
+                handle.agent_id,
+                handle.session_id,
+                "import os\nos.system('kubectl get secrets')",
+            )
+
+        fake_sdk.default_sandbox.exec.assert_not_called()
 
     def test_code_is_base64_piped_into_python3(
         self, provider_with_evaluator, fake_sdk

--- a/agent-governance-python/agent-sandbox/tests/test_code_scanner.py
+++ b/agent-governance-python/agent-sandbox/tests/test_code_scanner.py
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for host-side sandbox code scanning."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_sandbox.code_scanner import (
+    SandboxCodeViolation,
+    enforce_no_subprocess_execution,
+    scan_code_for_subprocesses,
+)
+
+
+def _patterns(code: str) -> list[str]:
+    return [violation.pattern for violation in scan_code_for_subprocesses(code)]
+
+
+class TestCodeScanner:
+    @pytest.mark.parametrize(
+        ("code", "pattern"),
+        [
+            ("import subprocess\nsubprocess.run(['ls'])", "subprocess.run"),
+            ("import subprocess as sp\nsp.Popen(['az'])", "subprocess.Popen"),
+            ("from subprocess import check_output\ncheck_output(['id'])", "subprocess.check_output"),
+            ("import os\nos.system('id')", "os.system"),
+            ("from os import popen as pipe\npipe('whoami')", "os.popen"),
+            ("import shutil\nshutil.which('kubectl')", "shutil.which"),
+            ("import pty\npty.spawn('/bin/sh')", "pty.spawn"),
+            ("__import__('subprocess').run(['ls'])", "subprocess.run"),
+        ],
+    )
+    def test_detects_obvious_process_patterns(self, code, pattern):
+        assert pattern in _patterns(code)
+
+    def test_does_not_flag_strings_or_comments(self):
+        code = """
+# subprocess.run(['ls'])
+print("os.system('id')")
+"""
+        assert scan_code_for_subprocesses(code) == []
+
+    def test_syntax_errors_are_left_to_python_runtime(self):
+        assert scan_code_for_subprocesses("def broken(") == []
+
+    def test_wildcard_import_from_dangerous_module_blocks(self):
+        violations = scan_code_for_subprocesses("from subprocess import *")
+        assert violations[0].pattern == "subprocess.*"
+
+    def test_enforce_raises_with_violation_details(self):
+        with pytest.raises(SandboxCodeViolation, match="subprocess.run") as exc:
+            enforce_no_subprocess_execution("import subprocess\nsubprocess.run(['ls'])")
+
+        assert exc.value.violations[0].line == 2

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent_sandbox.code_scanner import SandboxCodeViolation
 from agent_sandbox.sandbox_provider import (
     ExecutionHandle,
     ExecutionStatus,
@@ -520,6 +521,19 @@ class TestDockerExecuteCode:
             "a1", h.session_id, "pass", context={"task": "test"},
         )
         assert eh.status == ExecutionStatus.COMPLETED
+
+    def test_static_scan_blocks_subprocess_before_container_exec(self, docker_provider):
+        h = docker_provider.create_session("a1")
+        container = docker_provider._containers[(h.agent_id, h.session_id)]
+
+        with pytest.raises(SandboxCodeViolation, match="subprocess.run"):
+            docker_provider.execute_code(
+                "a1",
+                h.session_id,
+                "import subprocess\nsubprocess.run(['az', 'account', 'list'])",
+            )
+
+        container.exec_run.assert_not_called()
 
     def test_policy_deny(self, docker_provider):
         try:

--- a/agent-governance-python/agent-sandbox/tests/test_hyperlight_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_hyperlight_sandbox.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import pytest
 
+from agent_sandbox.code_scanner import SandboxCodeViolation
 from agent_sandbox.sandbox_provider import (
     ExecutionStatus,
     SandboxConfig,
@@ -547,6 +548,19 @@ class TestExecuteCode:
     def test_execute_without_session_raises(self, provider):
         with pytest.raises(RuntimeError, match="No active session"):
             provider.execute_code("agent-1", "missing", "print(1)")
+
+    def test_static_scan_blocks_subprocess_before_guest_run(self, provider):
+        h = provider.create_session("agent-1")
+        sb = _FakeSandbox.instances[-1]
+
+        with pytest.raises(SandboxCodeViolation, match="subprocess.Popen"):
+            provider.execute_code(
+                "agent-1",
+                h.session_id,
+                "import subprocess\nsubprocess.Popen(['terraform', 'plan'])",
+            )
+
+        assert sb.run_calls == []
 
     def test_run_exception_returns_failed_handle_not_raise(self, provider):
         h = provider.create_session("agent-1")


### PR DESCRIPTION
## Summary
- add host-side static scanning for obvious subprocess and process-spawning patterns before sandbox execution
- wire the scanner into Docker, Hyperlight, and ACA `execute_code` paths after existing policy gates and before guest execution
- add scanner unit tests plus provider regression tests proving denied code does not reach the backend

## Problem
AGT sandbox providers isolate guest code, but they currently do not inspect subprocess trees once code starts inside the sandbox. Issue #2664 lists pre-execution static analysis as the lightest initial mitigation.

## Changes
| Area | Change |
| --- | --- |
| Scanner | Added AST-based detection for `subprocess`, `os.system`/`popen`/`exec*`/`spawn*`, `pty.spawn`, and `shutil.which` patterns, including common aliases and imports. |
| Providers | Docker, Hyperlight, and ACA call `enforce_no_subprocess_execution()` before handing code to the sandbox runtime. |
| Tests | Added scanner tests and provider-level tests that assert denied code never reaches `container.exec_run`, `sandbox.run`, or ACA `exec`. |

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_code_scanner.py tests/test_docker_sandbox.py::TestDockerExecuteCode tests/test_hyperlight_sandbox.py::TestExecuteCode tests/test_azure_sandbox.py::TestExecuteCode -q`
- `PYTHONPATH=src python3 -m ruff check src/agent_sandbox/code_scanner.py tests/test_code_scanner.py`
- `python3 -m py_compile src/agent_sandbox/code_scanner.py src/agent_sandbox/docker_provider/provider.py src/agent_sandbox/hyperlight_provider/provider.py src/agent_sandbox/aca_sandbox_provider/aca_sandbox_provider.py`
- `git diff --check`

## Notes
A broader mocked provider run over `tests/test_docker_sandbox.py`, `tests/test_hyperlight_sandbox.py`, and `tests/test_azure_sandbox.py` reached 369 passed / 5 skipped but has two unrelated existing Windows path-protection failures in `tests/test_docker_sandbox.py::TestWindowsPathProtection`.

Closes #2664
