### PR TITLE
fix(ci): add legacy-peer-deps to npm ci, add pyyaml to ci-test deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,7 +784,7 @@ jobs:
       - name: Install mastra-agentmesh
         working-directory: agent-governance-python/agentmesh-integrations/mastra-agentmesh
         # Lockfile required; fail fast rather than fall back to an unlocked install (supply-chain integrity).
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --legacy-peer-deps
       - name: Lint mastra-agentmesh
         working-directory: agent-governance-python/agentmesh-integrations/mastra-agentmesh
         run: npm run lint 2>/dev/null || true
@@ -794,7 +794,7 @@ jobs:
       - name: Install copilot-governance
         working-directory: agent-governance-python/agentmesh-integrations/copilot-governance
         # Lockfile required; fail fast rather than fall back to an unlocked install (supply-chain integrity).
-        run: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --legacy-peer-deps
       - name: Lint copilot-governance
         working-directory: agent-governance-python/agentmesh-integrations/copilot-governance
         run: npm run lint 2>/dev/null || true

--- a/agent-governance-python/requirements/ci-test.txt
+++ b/agent-governance-python/requirements/ci-test.txt
@@ -19,3 +19,6 @@ pygments==2.20.0 \
 # pytest-asyncio transitive dependencies (needed on Python <3.13)
 typing-extensions==4.15.0 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
+PyYAML==6.0.2 \
+    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e \
+    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476


### PR DESCRIPTION
Fixes two CI failures on main:

1. **test-integrations-ts**: npm ci failed with 'Missing react@19.2.6, openapi-types@12.1.3 from lock file'. The lockfiles were generated with --legacy-peer-deps but CI ran without it. Added --legacy-peer-deps to both mastra-agentmesh and copilot-governance install steps.

2. **workflow-lint inline-script-tests**: test_regression_a2_toolkit_regex.py imports yaml but PyYAML was missing from ci-test.txt. Added PyYAML==6.0.2 with hashes.