### PR TITLE
fix(ci): fail package-matrix jobs when pytest fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
         working-directory: agent-governance-python/${{ matrix.package }}
         run: |
           if [ -d tests ]; then
-            pytest tests/ -q --tb=short --cov=src --cov-report=xml:coverage.xml || true
+            pytest tests/ -q --tb=short --cov=src --cov-report=xml:coverage.xml
           else
             echo "No tests/ directory — skipping package tests"
           fi


### PR DESCRIPTION
Fixes #2709

## Summary

The Python package matrix test step in CI ran pytest with `|| true`, which kept the job green when tests failed. This change removes that guard so pytest failures fail the workflow.

## Test plan

- [ ] Confirm the package-matrix test job fails when a package test fails
- [ ] Confirm unchanged packages still skip correctly via the existing path gate