### PR TITLE
fix(ci): update workflow paths after packages/ layout migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
               - 'agent-governance-typescript/**'
               - 'agent-governance-antigravity-cli/**'
               - 'agent-governance-opencode/**'
-              - 'packages/agent-os/extensions/**'
-              - 'packages/agentmesh-integrations/mastra-agentmesh/**'
-              - 'packages/agentmesh-integrations/copilot-governance/**'
+              - 'agent-governance-python/agent-os/extensions/**'
+              - 'agent-governance-python/agentmesh-integrations/mastra-agentmesh/**'
+              - 'agent-governance-python/agentmesh-integrations/copilot-governance/**'
             integrations:
               - 'agent-governance-python/agentmesh-integrations/**'
             workflows:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -242,30 +242,13 @@ jobs:
       attestations: write
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: agentmesh-copilot-governance
-            path: packages/agentmesh-integrations/copilot-governance
-          - name: agentmesh-mastra
-            path: packages/agentmesh-integrations/mastra-agentmesh
-          - name: agentmesh-api
-            path: packages/agent-mesh/services/api
-          - name: agentmesh-mcp-proxy
-            path: packages/agent-mesh/packages/mcp-proxy
-          - name: agentmesh-sdk
-            path: agent-governance-typescript
-          - name: agent-governance-antigravity-cli
-            path: agent-governance-antigravity-cli
-          - name: agent-os-copilot-extension
-            path: packages/agent-os/extensions/copilot
-          - name: agentos-mcp-server
-            path: packages/agent-os/extensions/mcp-server
+      matrix: ${{ fromJSON(needs.resolve-npm-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: ${{ matrix.nodeVersion }}
 
       - name: Install dependencies
         working-directory: ${{ matrix.path }}


### PR DESCRIPTION
Fixes #2711

## Summary

The repo no longer has a top-level `packages/` directory, but CI and publish workflows still referenced it in two places. This updates the TypeScript path filters in `ci.yml` and makes `build-npm` use the resolved matrix from `resolve-npm-matrix`, which already carries the correct `agent-governance-python/...` paths and per-package Node versions.

## Test plan

- [ ] Confirm CI typescript path filters match current package locations
- [ ] Confirm `build-npm` matrix is populated from `resolve-npm-matrix` on a release or manual publish run
- [ ] Confirm npm build steps run in existing directories