### PR TITLE
fix(mesh-identity): harden Entra JWT verification

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -23,10 +23,13 @@ anomalyco
 antigravity
 APIM
 apiserver
+approv
+approvеd
 appsettings
 argparse
 arrowsize
 asctime
+ASGI
 aspnet
 asynccontextmanager
 asyncio
@@ -40,6 +43,7 @@ axios
 aymenhmaidiwastaken
 backendunavailable
 backpressure
+baseexception
 baselined
 behaviour
 behavioural
@@ -52,9 +56,11 @@ capsys
 carloshvp
 carryforward
 carveout
+casefold
 CCPA
 cedarling
 cedarpy
+changeme
 chdir
 cheatsheet
 checkpointed
@@ -72,11 +78,9 @@ CODEOWNERS
 codepoint
 CommonMark
 comspec
-<<<<<<< HEAD
-connectedservicename
-=======
 confirmer
->>>>>>> 019325ce (chore: add mute-agent red-team test terms to spell-check allowlist)
+confusables
+connectedservicename
 containerapps
 containerd
 contentsource
@@ -116,8 +120,8 @@ digestmod
 dnssec
 Dockerfiles
 Docstrings
-domaintenantid
 doesnotexist
+domaintenantid
 DOTALL
 dpkg
 DYLD
@@ -180,6 +184,7 @@ gvisor
 h├⌐llo
 hasattr
 hashlib
+hdrs
 HEALTHCHECK
 healthz
 héllo
@@ -209,6 +214,7 @@ itertools
 javaagent
 jwkjwks
 kanish
+kars
 kata
 kayalopez
 kevinkaylie
@@ -235,11 +241,8 @@ lockfile
 lockfiles
 lotl
 lstrip
-<<<<<<< HEAD
-mainpublisher
-=======
 madmin
->>>>>>> 019325ce (chore: add mute-agent red-team test terms to spell-check allowlist)
+mainpublisher
 manylinux
 markdown
 Marp
@@ -265,6 +268,7 @@ MSHV
 msinternal
 MSRC
 mTLS
+multitenant
 myapp
 mynamespace
 mypod
@@ -278,10 +282,12 @@ Nemotron
 netfilter
 networkx
 newpartner
+NFKC
 NNNN
 nonimport
 nonlocal
 noqa
+normalisation
 normalises
 nostr
 nother
@@ -328,6 +334,7 @@ PSMODULEPATH
 psmodules
 pycache
 Pydantic
+pyjwt
 pypdf
 pypistats
 pyproject
@@ -345,6 +352,8 @@ readouterr
 recognised
 recognising
 redteam
+refetch
+refetches
 Rego
 relativedelta
 removeprefix
@@ -360,6 +369,7 @@ rglob
 rmtree
 Rootfs
 rrdatas
+rsplit
 rstrip
 RUBYOPT
 run_results
@@ -369,21 +379,25 @@ RustSec
 Sandboxed
 sandboxing
 sandboxprovider
+sanitised
 sarif
 SCAK
 scikit
 scipy
+sdist
 seccomp
 SemanticKernel
 serde
 Serialise
 serviceendpointurl
+sess
 setattr
 setdefault
 setext
 setitem
 setuid
 setuptools
+shortone
 shutil
 siddique
 SIEM
@@ -436,8 +450,11 @@ ufeff
 uncallable
 unconfigured
 Ungated
+unicodedata
 uninspectable
 Unmarshal
+unmigrated
+unreachability
 unredacted
 Unregisters
 unrevocation
@@ -474,24 +491,3 @@ XACML
 xfail
 xunit
 ZDOTDIR
-
-ASGI
-approv
-backendunavailable
-baseexception
-casefold
-changeme
-confusables
-hdrs
-madmin
-monkeypatched
-multitenant
-NFKC
-normalisation
-oncall
-rsplit
-sanitised
-shortone
-testclient
-unicodedata
-approvеd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - **Broadened SSN PII regex across integration adapters** ([#2635](https://github.com/microsoft/agent-governance-toolkit/issues/2635), [#2636](https://github.com/microsoft/agent-governance-toolkit/pull/2636)) — the dashed-only `\b\d{3}-\d{2}-\d{4}\b` regex used by the LangChain, AutoGen, CrewAI, and Bedrock adapters to detect SSNs in memory writes and outbound messages was trivially bypassed by space-, dot-, or no-separator variants such as `123 45 6789`, `123.45.6789`, and `123456789`. The pattern is now `\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b`, matching the YAML policy pack fix from [#2594](https://github.com/microsoft/agent-governance-toolkit/pull/2594) / [#2469](https://github.com/microsoft/agent-governance-toolkit/issues/2469).
+- **mesh-relay**: when Entra verification is enabled
+  (`AGENTMESH_ENTRA_AUDIENCE` set), the `connect` frame MUST carry a
+  valid Entra JWT. Empty/missing `token` is rejected immediately —
+  there is no silent fallback to the legacy shared-secret path. Closes
+  an auth-bypass surfaced in PR #2659 review where a peer could skip
+  JWT verification by omitting the `token` field.
+- **mesh-identity (entra_verifier)**: hard upper bound on stale JWKS
+  cache via `AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS` (default 24h).
+  Beyond the budget, refetch failures fail closed rather than serving
+  from an indefinitely-stale cache. Bounds the window in which a key
+  rotated OUT of the live JWKS remains usable.
+- **mesh-identity (entra_verifier)**: pre-validate the JWT header
+  `alg` against `ALLOWED_SIGNING_ALGORITHMS` BEFORE the JWKS lookup.
+  Defense-in-depth against algorithm-confusion attacks (e.g. attacker
+  presents `alg: HS256` hoping the JWK public-key bytes get reused as
+  an HMAC secret); also avoids a wasted network round-trip on
+  obviously-bad tokens.
 
 ### Changed
 - **Consolidated PII detection patterns into a single shared constant** in `agent_os.integrations.base` ([#2635](https://github.com/microsoft/agent-governance-toolkit/issues/2635)). The four per-adapter copies (`langchain_adapter`, `autogen_adapter`, `crewai_adapter`, `bedrock_adapter`) now import the shared `PII_PATTERNS` tuple so future adapters cannot silently drift out of sync. The shared constant is the union of patterns previously used across all four adapters, which means LangChain, AutoGen, and CrewAI now also block credit-card PII (previously a Bedrock-only check). `bedrock_adapter._PII_RE` remains as a back-compat alias to the shared constant.
+- **mesh-registry**: `POST /reputation` now also increments session
+  counters via the same dispatch path, so a simple reputation update
+  is equivalent to a session start + complete pair.
+  ([#2659](https://github.com/microsoft/agent-governance-toolkit/pull/2659))
 
 ### Added
 - **OpenCode CLI governance package** — new `@microsoft/agent-governance-opencode` package: in-process OpenCode plugin enforcing AGT prompt, tool, and tool-output policy with secret redaction, plus bundled stdio MCP server, default policy, docs, tutorial, runnable example, CI, and ESRP release wiring.
 - **Antigravity CLI governance package** — new `@microsoft/agent-governance-antigravity-cli` package with Antigravity-native hooks, MCP helpers, custom commands, docs, CI, and release wiring.
+- **mesh-relay**: opt-in Entra-signed JWT verification on the WebSocket
+  `connect` frame, with claim allow-list enforcement (`aud`, `tid`,
+  `exp`, `iat`) and JWKS caching. Opt in via `AGENTMESH_ENTRA_AUDIENCE`
+  + `AGENTMESH_ENTRA_TENANT_ID`. ([#2659](https://github.com/microsoft/agent-governance-toolkit/pull/2659))
+- **mesh-registry**: `POST /v1/registry/verify` endpoint for upgrading
+  agents from anonymous to verified tier via Entra-signed JWTs.
+  Stamps `verified_app_id`, `verified_tenant_id`, `verified_at`, and
+  `tier='verified'` on the agent record. Opt-in via the same env vars
+  as the relay. ([#2659](https://github.com/microsoft/agent-governance-toolkit/pull/2659))
+- **mesh-registry**: per-agent session counters (`sessions_started`,
+  `sessions_completed`, `sessions_aborted`) plus derived
+  `completion_rate`. Surfaces commitment-quality as a signal distinct
+  from the reputation scalar. ([#2659](https://github.com/microsoft/agent-governance-toolkit/pull/2659))
+- **mesh-registry**: `/v1/registry/verify` pubkey-fallback for clients
+  sending bare AMID (the unprefixed base64 public-key blob) instead of
+  the DID-prefixed form. ([#2659](https://github.com/microsoft/agent-governance-toolkit/pull/2659))
 
 ## [3.2.1] - 2026-04-22
 

--- a/agent-governance-python/agent-mesh/README.md
+++ b/agent-governance-python/agent-mesh/README.md
@@ -340,7 +340,7 @@ pip install -e .
 - [CrewAI Integration](./examples/integrations/crewai.md) - Multi-agent crew governance
 - [LangGraph](./src/agentmesh/integrations/langgraph/) - Trust checkpoints for graph workflows (built-in)
 - [OpenAI Swarm](./src/agentmesh/integrations/swarm/) - Trust-verified handoffs (built-in)
-- [Dify](https://github.com/microsoft/agent-governance-toolkit/tree/master/dify) - Trust middleware for Dify workflows
+- [Dify](https://github.com/microsoft/agent-governance-toolkit/tree/main/agent-governance-python/agent-mesh/src/agentmesh/integrations) - Trust middleware for Dify workflows
 
 📚 **[Browse all examples →](./examples/)**
 
@@ -634,7 +634,7 @@ classifier = EUAIActRiskClassifier(config_path="my_updated_annex_iii.yaml")
 | **Q3 2026** | AI Card spec contribution, CNCF Sandbox application |
 | **Q4 2026** | Managed cloud service (AgentMesh Cloud), SOC2 Type II |
 
-See our [full roadmap](docs/roadmap.md) for details.
+See our [full roadmap](../agent-os/docs/roadmap.md) for details.
 
 ## Known Limitations & Open Work
 
@@ -652,7 +652,7 @@ See our [full roadmap](docs/roadmap.md) for details.
 
 ### Integration Caveats (Dify)
 
-The [Dify integration](https://github.com/microsoft/agent-governance-toolkit/tree/master/dify) has these documented limitations:
+The [Dify integration](https://github.com/microsoft/agent-governance-toolkit/tree/main/agent-governance-python/agent-mesh/src/agentmesh/integrations) has these documented limitations:
 - Request body signature verification (`X-Agent-Signature` header) is not yet verified by middleware
 - Trust score time decay is not yet implemented (scores don't decay over time)
 - Audit logs are in-memory only (not persistent across multi-worker deployments)
@@ -694,9 +694,57 @@ AgentMesh unifies three major protocols: Google's A2A (Agent-to-Agent) for inter
 **Does AgentMesh help with regulatory compliance?**
 Yes. AgentMesh provides automated compliance mapping for EU AI Act, SOC 2, HIPAA, and GDPR. Combined with audit trails and deterministic policy enforcement from [Agent OS](https://github.com/microsoft/agent-governance-toolkit), it provides the documentation and safety guarantees needed for regulatory compliance.
 
+## Configuration — Environment Variables
+
+The relay and registry services read the following environment
+variables at boot. All Entra-tier variables are **opt-in** — when
+unset, the services preserve byte-identical pre-v3.7.x behavior
+(anonymous tier, shared-secret auth or open-acceptance).
+
+### Relay
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTMESH_RELAY_TOKEN` | _unset_ | Legacy shared-secret auth on the WebSocket `connect` frame. **Bypassed when Entra verification is enabled** (see below) — Entra is the primary auth, no silent fallback. |
+| `AGENTMESH_RELAY_OFFLINE_THRESHOLD_SECS` | `90` | Heartbeat staleness window before a peer is marked offline. |
+
+### Registry
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTMESH_REGISTRY_TOKEN` | _unset_ | Legacy shared-secret auth on registry write endpoints. |
+
+### Entra-tier verification (relay + registry)
+
+When both `AGENTMESH_ENTRA_AUDIENCE` and `AGENTMESH_ENTRA_TENANT_ID`
+are set, Entra-signed JWTs are required:
+
+- Relay `connect` frame **must** carry a valid token in the `token`
+  field. Empty/missing token is rejected at handshake.
+- Registry `POST /v1/registry/verify` upgrades anonymous agents to
+  verified tier when presented with a valid token.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENTMESH_ENTRA_AUDIENCE` | _unset_ | Expected `aud` claim. Both this and `AGENTMESH_ENTRA_TENANT_ID` must be set for verification to be enabled. |
+| `AGENTMESH_ENTRA_TENANT_ID` | _unset_ | Expected `tid` claim (the operator's Entra tenant GUID). |
+| `AGENTMESH_ENTRA_AUTHORITY` | `https://login.microsoftonline.com` | Authority host for resolving the JWKS URL. |
+| `AGENTMESH_ENTRA_JWKS_TTL_SECS` | `3600` | How long a freshly-fetched JWKS cache is considered fresh. Min `60`. |
+| `AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS` | `86400` | Hard upper bound on serving from a stale cache when refetch fails. Beyond this, the verifier fails closed to bound how long a key rotated OUT of the live JWKS can still verify. Floors at `AGENTMESH_ENTRA_JWKS_TTL_SECS`. |
+
+**Fail-closed contract**: invalid/expired/wrong-aud/wrong-tid tokens
+return 401 (registry) or close the WebSocket with code 4003 (relay).
+A previously-verified peer keeps its tier on re-verify failure, so
+transient JWKS-fetch flakes don't demote legitimate peers mid-session.
+
+**Algorithm allowlist**: only RS256/RS384/RS512 are accepted. The
+verifier rejects unsupported `alg` headers (including `none` and
+`HS*`) **before** the JWKS lookup as defense-in-depth against
+algorithm-confusion attacks.
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -83,6 +83,10 @@ redis = [
 server = [
     "fastapi>=0.115.0,<1.0",
     "uvicorn[standard]>=0.27.0,<1.0",
+    # Phase 6.c — Entra-signed JWT verification at the relay's
+    # connect-frame seam. `crypto` extra brings cryptography (already
+    # a core dep) wired up with PyJWT's RS{256,384,512} verifiers.
+    "PyJWT[crypto]>=2.8.0,<3.0",
 ]
 storage = [
     "redis[asyncio]>=5.0.0,<8.0",

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/entra_verifier.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/entra_verifier.py
@@ -239,6 +239,10 @@ class EntraTokenVerifier:
         """
         if not token or not isinstance(token, str):
             raise EntraTokenError("empty or non-string token")
+        # Cap token length to prevent DoS via excessively large JWTs.
+        # Entra v2.0 tokens are typically 1-2KB; 16KB is generous.
+        if len(token) > 16384:
+            raise EntraTokenError("token exceeds maximum length (16384 bytes)")
         # Defense-in-depth: validate the JWT header `alg` against our
         # allowlist BEFORE the JWKS lookup. PyJWT's `jwt.decode(...,
         # algorithms=...)` would also reject mismatches, but checking
@@ -268,11 +272,13 @@ class EntraTokenVerifier:
                 signing_key.key,
                 algorithms=list(ALLOWED_SIGNING_ALGORITHMS),
                 audience=self._cfg.audience,
+                issuer=f"{self._cfg.authority}/{self._cfg.tenant_id}/v2.0",
                 options={
                     "require": ["exp", "iat", "aud", "tid"],
                     "verify_aud": True,
                     "verify_exp": True,
                     "verify_iat": True,
+                    "verify_iss": True,
                     "verify_signature": True,
                 },
             )

--- a/agent-governance-python/agent-mesh/src/agentmesh/identity/entra_verifier.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/identity/entra_verifier.py
@@ -1,0 +1,324 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Entra-signed JWT verifier for the AgentMesh relay.
+
+Opt-in: when ``AGENTMESH_ENTRA_AUDIENCE`` is set in the relay's
+environment, the relay's ``connect`` frame handler delegates the
+``token`` field to :func:`verify_token`, which validates the JWT
+against Microsoft Entra's published JWKS, pins the configured tenant
+and audience, and returns the claims dict on success (raising
+``EntraTokenError`` on any failure).
+
+When ``AGENTMESH_ENTRA_AUDIENCE`` is unset, this module is never
+imported and the relay falls back to its existing legacy behavior
+(``AGENTMESH_RELAY_TOKEN`` shared-secret compare, or fully open).
+Backward compatibility is the default.
+
+Implementation notes
+--------------------
+* JWKS fetched once on first use and cached in-process for
+  ``AGENTMESH_ENTRA_JWKS_TTL_SECS`` (default 3600s = 1 h). On expiry
+  the next verifier call refetches; failures during refetch fall back
+  to the last successful cache to avoid availability cliffs.
+* Refetch is serialized behind an :class:`asyncio.Lock` so a token
+  spike against a cold cache does not stampede Entra (mesh-flood
+  guard — see Azure/kars commentary).
+* Standard PyJWT verification covers signature + ``exp`` + ``iat``,
+  plus we explicitly pin ``tid`` and ``aud`` and validate against
+  ``allowed_signing_algorithms`` (RS256 / RS384 / RS512 only).
+* Returns the raw ``appid`` claim — caller decides whether to use it
+  as the verified DID or just as a label.
+
+Env vars
+~~~~~~~~
+``AGENTMESH_ENTRA_AUDIENCE``     required — token ``aud`` to accept.
+``AGENTMESH_ENTRA_TENANT_ID``    required — token ``tid`` to accept.
+``AGENTMESH_ENTRA_AUTHORITY``    optional — default
+                                 ``https://login.microsoftonline.com``.
+``AGENTMESH_ENTRA_JWKS_TTL_SECS`` optional — int, default 3600.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import jwt
+from jwt import PyJWKClient
+
+logger = logging.getLogger(__name__)
+
+
+ALLOWED_SIGNING_ALGORITHMS = ("RS256", "RS384", "RS512")
+
+
+class EntraTokenError(Exception):
+    """Raised when an inbound token fails Entra verification."""
+
+
+@dataclass
+class EntraVerifierConfig:
+    """Resolved configuration. Build via :meth:`from_env`."""
+
+    audience: str
+    tenant_id: str
+    authority: str
+    jwks_ttl_secs: int
+    # Hard upper bound on how long a stale JWKS cache may serve verify
+    # requests when refetch keeps failing. Beyond this, fail closed.
+    # Bounds Entra key-rotation propagation: a compromised key rotated
+    # OUT of the live JWKS remains usable for at most this many seconds
+    # even when the refetch path is broken (e.g. egress outage).
+    # Default 24h matches the typical Entra signing-key rotation cadence.
+    jwks_max_stale_secs: int
+
+    @classmethod
+    def from_env(cls) -> "EntraVerifierConfig | None":
+        """Return ``None`` if the operator has not opted into verification.
+
+        Both ``AGENTMESH_ENTRA_AUDIENCE`` and ``AGENTMESH_ENTRA_TENANT_ID``
+        must be present and non-empty for verification to be enabled —
+        a half-configured setup is treated as a misconfiguration and
+        explicitly logged so the operator can fix it rather than
+        silently running unverified.
+        """
+        aud = os.environ.get("AGENTMESH_ENTRA_AUDIENCE", "").strip()
+        tid = os.environ.get("AGENTMESH_ENTRA_TENANT_ID", "").strip()
+        if not aud and not tid:
+            return None
+        if not aud or not tid:
+            logger.error(
+                "AGENTMESH_ENTRA_{AUDIENCE,TENANT_ID} must be set together "
+                "(got audience=%s tenant_id=%s); refusing to enable verification",
+                bool(aud),
+                bool(tid),
+            )
+            return None
+        authority = os.environ.get(
+            "AGENTMESH_ENTRA_AUTHORITY", "https://login.microsoftonline.com"
+        ).rstrip("/")
+        ttl_raw = os.environ.get("AGENTMESH_ENTRA_JWKS_TTL_SECS", "3600")
+        try:
+            ttl = max(60, int(ttl_raw))
+        except ValueError:
+            logger.warning(
+                "AGENTMESH_ENTRA_JWKS_TTL_SECS=%r is not an int; using 3600",
+                ttl_raw,
+            )
+            ttl = 3600
+        max_stale_raw = os.environ.get("AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS", "86400")
+        try:
+            # Floor at the TTL — it makes no sense to allow stale serving
+            # for less time than a normal-cadence refresh.
+            max_stale = max(ttl, int(max_stale_raw))
+        except ValueError:
+            logger.warning(
+                "AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS=%r is not an int; using 86400",
+                max_stale_raw,
+            )
+            max_stale = 86400
+        return cls(
+            audience=aud,
+            tenant_id=tid,
+            authority=authority,
+            jwks_ttl_secs=ttl,
+            jwks_max_stale_secs=max_stale,
+        )
+
+    @property
+    def jwks_url(self) -> str:
+        """OpenID Connect discovery → JWKS URI for the tenant.
+
+        We hardcode the well-known suffix rather than walking the
+        OIDC discovery doc, both for one-fewer-round-trip and so the
+        worker does not depend on network reachability during boot.
+        Entra's JWKS URL has been stable for years.
+        """
+        return f"{self.authority}/{self.tenant_id}/discovery/v2.0/keys"
+
+
+class EntraTokenVerifier:
+    """Verifies inbound JWTs against Microsoft Entra.
+
+    The instance is safe to share across coroutines. JWKS refetch is
+    serialized via :class:`asyncio.Lock` to avoid stampedes when
+    multiple concurrent connects miss a cold cache (the documented
+    "mesh-flood when connecting to the registry" failure mode we
+    explicitly guard against — see commit message for context).
+    """
+
+    def __init__(self, cfg: EntraVerifierConfig) -> None:
+        self._cfg = cfg
+        self._jwk_client: PyJWKClient | None = None
+        self._jwk_cached_at: float = 0.0
+        self._jwk_lock = asyncio.Lock()
+
+    @property
+    def config(self) -> EntraVerifierConfig:
+        return self._cfg
+
+    async def _ensure_jwk_client(self) -> PyJWKClient:
+        now = time.monotonic()
+        if (
+            self._jwk_client is not None
+            and (now - self._jwk_cached_at) < self._cfg.jwks_ttl_secs
+        ):
+            return self._jwk_client
+        async with self._jwk_lock:
+            # Double-checked: another waiter may have refreshed it.
+            now = time.monotonic()
+            if (
+                self._jwk_client is not None
+                and (now - self._jwk_cached_at) < self._cfg.jwks_ttl_secs
+            ):
+                return self._jwk_client
+            try:
+                client = await asyncio.to_thread(
+                    PyJWKClient, self._cfg.jwks_url, cache_keys=True, lifespan=self._cfg.jwks_ttl_secs
+                )
+                # Eagerly trigger a fetch so we fail closed here (rather
+                # than on first verify) when the JWKS endpoint is
+                # unreachable on a cold cache.
+                await asyncio.to_thread(client.get_signing_keys)
+                self._jwk_client = client
+                self._jwk_cached_at = time.monotonic()
+                logger.info(
+                    "Refreshed Entra JWKS cache from %s (ttl=%ss)",
+                    self._cfg.jwks_url,
+                    self._cfg.jwks_ttl_secs,
+                )
+                return client
+            except (httpx.HTTPError, jwt.PyJWKClientError, OSError) as exc:
+                stale_age = int(time.monotonic() - self._jwk_cached_at)
+                if (
+                    self._jwk_client is not None
+                    and stale_age < self._cfg.jwks_max_stale_secs
+                ):
+                    # Availability-first within a bounded staleness budget:
+                    # transient JWKS-fetch flakes (egress outage, Entra
+                    # incident) must not lock every peer out, but a
+                    # COMPROMISED key rotated OUT of the live JWKS must
+                    # eventually stop being usable. The max-stale ceiling
+                    # bounds the window in which a rotated-out key can
+                    # still verify. After it expires, we fail closed.
+                    logger.error(
+                        "Entra JWKS refetch failed (%s); serving from "
+                        "stale cache (%ss old, max %ss)",
+                        exc,
+                        stale_age,
+                        self._cfg.jwks_max_stale_secs,
+                    )
+                    return self._jwk_client
+                if self._jwk_client is not None:
+                    logger.error(
+                        "Entra JWKS refetch failed (%s) AND stale cache "
+                        "exceeds max age (%ss > %ss) — failing closed",
+                        exc,
+                        stale_age,
+                        self._cfg.jwks_max_stale_secs,
+                    )
+                    # Drop the stale client so future calls don't reuse it.
+                    self._jwk_client = None
+                raise EntraTokenError(
+                    f"unable to fetch Entra JWKS from {self._cfg.jwks_url}: {exc}"
+                ) from exc
+
+    async def verify(self, token: str) -> dict[str, Any]:
+        """Verify ``token`` and return its claims.
+
+        Raises :class:`EntraTokenError` on any failure: signature
+        mismatch, expired token, wrong tenant, wrong audience, or
+        unsupported algorithm. The error message is suitable for
+        logging but MUST NOT be returned to the caller verbatim
+        because it can leak details about the JWKS state.
+        """
+        if not token or not isinstance(token, str):
+            raise EntraTokenError("empty or non-string token")
+        # Defense-in-depth: validate the JWT header `alg` against our
+        # allowlist BEFORE the JWKS lookup. PyJWT's `jwt.decode(...,
+        # algorithms=...)` would also reject mismatches, but checking
+        # here (a) avoids a wasted network round-trip on the JWKS fetch
+        # for obviously-bad tokens and (b) defends against algorithm-
+        # confusion attacks where an attacker presents alg=HS256 hoping
+        # the JWK material gets reused as an HMAC secret. We use
+        # `verify=False` so this peek is cheap and never makes auth
+        # decisions based on unverified header fields.
+        try:
+            unverified_header = jwt.get_unverified_header(token)
+        except jwt.InvalidTokenError as exc:
+            raise EntraTokenError(f"invalid JWT header: {exc}") from exc
+        header_alg = unverified_header.get("alg")
+        if header_alg not in ALLOWED_SIGNING_ALGORITHMS:
+            raise EntraTokenError(
+                f"unsupported alg {header_alg!r}; allowed: {ALLOWED_SIGNING_ALGORITHMS}"
+            )
+        client = await self._ensure_jwk_client()
+        try:
+            signing_key = await asyncio.to_thread(client.get_signing_key_from_jwt, token)
+        except jwt.PyJWKClientError as exc:
+            raise EntraTokenError(f"no matching JWKS key: {exc}") from exc
+        try:
+            claims = jwt.decode(
+                token,
+                signing_key.key,
+                algorithms=list(ALLOWED_SIGNING_ALGORITHMS),
+                audience=self._cfg.audience,
+                options={
+                    "require": ["exp", "iat", "aud", "tid"],
+                    "verify_aud": True,
+                    "verify_exp": True,
+                    "verify_iat": True,
+                    "verify_signature": True,
+                },
+            )
+        except jwt.InvalidTokenError as exc:
+            raise EntraTokenError(f"invalid token: {exc}") from exc
+        actual_tid = str(claims.get("tid", ""))
+        if actual_tid.lower() != self._cfg.tenant_id.lower():
+            raise EntraTokenError(
+                f"tid claim {actual_tid!r} does not match expected {self._cfg.tenant_id!r}"
+            )
+        return claims
+
+
+_VERIFIER: EntraTokenVerifier | None = None
+_VERIFIER_INIT_LOCK = asyncio.Lock()
+
+
+async def get_verifier() -> EntraTokenVerifier | None:
+    """Singleton accessor. Returns ``None`` when verification is disabled.
+
+    Concurrent initialization is serialized so a connect burst against
+    a cold process cannot create competing verifiers (each carrying
+    their own ``_jwk_lock`` and racing the JWKS fetch).
+    """
+    global _VERIFIER
+    if _VERIFIER is not None:
+        return _VERIFIER
+    cfg = EntraVerifierConfig.from_env()
+    if cfg is None:
+        return None
+    async with _VERIFIER_INIT_LOCK:
+        if _VERIFIER is None:
+            _VERIFIER = EntraTokenVerifier(cfg)
+            logger.info(
+                "Entra token verifier initialized (audience=%s tenant=%s authority=%s)",
+                cfg.audience,
+                cfg.tenant_id,
+                cfg.authority,
+            )
+    return _VERIFIER
+
+
+def reset_verifier_for_tests() -> None:
+    """Test-only hook: clears the cached verifier so subsequent
+    :func:`get_verifier` calls re-read the environment. Production
+    callers MUST NOT call this — the verifier is intentionally
+    process-singleton."""
+    global _VERIFIER
+    _VERIFIER = None

--- a/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
@@ -9,6 +9,7 @@ Independent design: implements against wire spec only.
 from __future__ import annotations
 
 import base64
+import os
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -70,6 +71,24 @@ class SessionReputationRequest(BaseModel):
     reporter_amid: str
     timestamp: str = ""
     signature: str = ""
+
+
+class IdentityVerifyRequest(BaseModel):
+    """Body for POST /v1/registry/verify (Phase 6.c).
+
+    Used by the kars mesh plugin (and any future AGT-SDK client) to
+    upgrade a registered agent from anonymous-tier to verified-tier
+    by presenting an Entra-signed JWT. The verifier validates the
+    token against the tenant's JWKS, then stamps the verified appId
+    + tenantId + timestamp + tier onto the agent record.
+
+    Fail-closed: invalid/expired/wrong-aud/wrong-tid tokens return
+    401 and leave the agent's existing tier unchanged (so a failed
+    re-verify can't accidentally downgrade a previously-verified peer).
+    """
+
+    amid: str
+    verification_token: str
 
 
 # ── Auth ─────────────────────────────────────────────────────────────
@@ -219,6 +238,43 @@ class RegistryServer:
                 "registered_at": agent.registered_at.isoformat(),
                 "last_seen": agent.last_seen.isoformat(),
                 "reputation_score": agent.reputation_score,
+                # Phase 6.c follow-up — session counters. Old clients
+                # that don't know about these keys ignore them; new
+                # clients (kars router → operator CLI) surface them as
+                # total_sessions / successful / failed / timeout in
+                # the AGT detail overlay's Reputation block.
+                "total_sessions": agent.total_sessions,
+                "successful_sessions": agent.successful_sessions,
+                "failed_sessions": agent.failed_sessions,
+                "timeout_sessions": agent.timeout_sessions,
+                "last_session_at": (
+                    agent.last_session_at.isoformat()
+                    if agent.last_session_at is not None
+                    else None
+                ),
+                # Derived field: success / total. -1.0 sentinel means
+                # "no sessions yet" so consumers can distinguish from
+                # "0 of N succeeded". Computing it server-side keeps
+                # clients honest (no risk of a stale client computing
+                # 0.0 because it doesn't know about the new fields).
+                "completion_rate": (
+                    agent.successful_sessions / agent.total_sessions
+                    if agent.total_sessions > 0 else -1.0
+                ),
+                # Phase 6.c identity verification — populated when the
+                # agent has POSTed a valid Entra-signed JWT to
+                # /v1/registry/verify. All three are None for anonymous
+                # tier and for clusters that have not opted in to
+                # verification. `tier` is the human-readable label
+                # operators see in the AGT overlay.
+                "tier": agent.tier,
+                "verified_app_id": agent.verified_app_id,
+                "verified_tenant_id": agent.verified_tenant_id,
+                "verified_at": (
+                    agent.verified_at.isoformat()
+                    if agent.verified_at is not None
+                    else None
+                ),
             }
 
         @app.delete("/v1/agents/{did}", status_code=204)
@@ -371,6 +427,23 @@ class RegistryServer:
             ``Ed25519-Timestamp`` header so the reporter is bound to an
             authenticated identity. Self-reporting is rejected — agents
             cannot inflate their own reputation.
+
+            Phase 6.c follow-up: ALSO bumps the per-agent session
+            counters. This endpoint is the only path AGT mesh peers
+            currently take to record session feedback
+            (POST /v1/registry/reputation/session is reserved for
+            initiator/receiver pairs with explicit outcome buckets and
+            is not what the mesh SDK calls today). Without this bump,
+            `total_sessions` would stay at 0 even as `reputation_score`
+            drifts from the default 0.5 over hundreds of session
+            replies, leaving operators unable to gauge sample size.
+
+            Score → bucket mapping uses the same thresholds as the
+            session endpoint's outcome semantics for consistency with
+            the existing 5-band tier ladder:
+              score >= 0.7 → successful (peer responded well)
+              score <  0.3 → failed     (peer responded badly)
+              else         → timeout    (partial / ambiguous)
             """
             authed_did = verify_ed25519_timestamp_auth(authorization, store)
             if authed_did == did:
@@ -385,6 +458,17 @@ class RegistryServer:
             # Simple exponential moving average
             alpha = 0.3
             agent.reputation_score = alpha * req.score + (1 - alpha) * agent.reputation_score
+            # Bump counters in lockstep with the EMA so total_sessions
+            # always reflects the number of EMA updates and consumers
+            # can compute a confidence interval.
+            agent.total_sessions += 1
+            if req.score >= 0.7:
+                agent.successful_sessions += 1
+            elif req.score < 0.3:
+                agent.failed_sessions += 1
+            else:
+                agent.timeout_sessions += 1
+            agent.last_session_at = _utcnow()
             store.put_agent(agent)
             return {"did": did, "reputation_score": round(agent.reputation_score, 4)}
 
@@ -408,6 +492,14 @@ class RegistryServer:
             a session participant (initiator or receiver). Together this
             stops any party — authenticated or not — from forging session
             telemetry as another agent.
+
+            Phase 6.c follow-up: in addition to bumping the EMA, this
+            handler also increments per-outcome session counters on the
+            same agent records. Operators querying `GET /v1/agents/{did}`
+            can then distinguish "0.7 from 2 sessions" (noisy) from
+            "0.7 from 200 sessions" (confident). Counters and EMA are
+            updated together inside `_apply` so they stay coherent —
+            you can't get one without the other.
             """
             authed_did = verify_ed25519_timestamp_auth(authorization, store)
             if authed_did != req.reporter_amid:
@@ -430,12 +522,25 @@ class RegistryServer:
             outcome = (req.outcome or "").lower()
             alpha = 0.2
             updated: dict[str, float] = {}
+            now = _utcnow()
 
             def _apply(did: str, target_score: float) -> None:
                 agent = store.get_agent(did)
                 if not agent:
                     return
                 agent.reputation_score = alpha * target_score + (1 - alpha) * agent.reputation_score
+                # Always bump the totals — every reputation update is a
+                # session, regardless of which side initiated. Per-outcome
+                # buckets are stored only for the SAME outcome the EMA
+                # was nudged with, so success/fail/timeout sum to total.
+                agent.total_sessions += 1
+                if outcome == "success":
+                    agent.successful_sessions += 1
+                elif outcome == "failed":
+                    agent.failed_sessions += 1
+                elif outcome == "timeout":
+                    agent.timeout_sessions += 1
+                agent.last_session_at = now
                 store.put_agent(agent)
                 updated[did] = round(agent.reputation_score, 4)
 
@@ -456,6 +561,116 @@ class RegistryServer:
                 "session_id": req.session_id,
                 "outcome": outcome,
                 "reputation": updated,
+            }
+
+        # ── Identity Verification (Phase 6.c) ────────────────────
+
+        @app.post("/v1/registry/verify")
+        async def verify_identity(req: IdentityVerifyRequest) -> dict:
+            """Upgrade a registered agent from anonymous → verified tier
+            by validating an Entra-signed JWT against tenant JWKS.
+
+            Opt-in: when AGENTMESH_ENTRA_AUDIENCE + AGENTMESH_ENTRA_TENANT_ID
+            are unset on the registry deployment, this endpoint returns
+            503 (verification disabled). Clusters that haven't opted in
+            keep all agents at anonymous tier — preserving full backward
+            compat with v3.7.0.
+
+            On success: stamps verified_app_id (Entra `appid` claim),
+            verified_tenant_id (`tid`), verified_at (server time), and
+            tier='verified' onto the agent record. Subsequent
+            GET /v1/agents/{did} reflects the new tier.
+
+            Fail-closed: invalid/expired/wrong-aud/wrong-tid tokens
+            return 401 and leave the agent's existing tier unchanged.
+            A previously-verified peer keeps its tier on re-verify
+            failure (defense against transient JWKS-fetch flakes that
+            could otherwise demote a legitimate peer mid-session).
+            """
+            from agentmesh.identity.entra_verifier import (
+                EntraTokenError,
+                get_verifier,
+            )
+
+            # Phase 6.c — the openclaw plugin's `agtIdentity.amid` is
+            # the bare base64-encoded public-key blob, NOT the
+            # DID-prefixed form the registry stores under. We accept
+            # both shapes via a two-step lookup: literal-amid first,
+            # then linear scan keyed by the agent's identity_key
+            # (X25519 32-byte public key) when the literal lookup
+            # misses. Linear scan is O(n) but the registry is in-
+            # memory and rarely holds >100 agents in practice — well
+            # below any threshold where this would matter.
+            agent = store.get_agent(req.amid)
+            if not agent and not req.amid.startswith("did:"):
+                # Look up by raw public-key bytes
+                import base64
+                try:
+                    pub = base64.urlsafe_b64decode(req.amid + "==")
+                except Exception:
+                    pub = None
+                if pub is not None and hasattr(store, "_agents"):
+                    for stored in store._agents.values():
+                        if (
+                            stored.identity_key == pub
+                            or stored.identity_key_ed == pub
+                        ):
+                            agent = stored
+                            req = req.copy(update={"amid": stored.did})
+                            break
+            if not agent:
+                logger.warning(
+                    "verify_identity got 404 for amid=%r (request body amid). "
+                    "Known agent count=%d. This usually means the plugin sent "
+                    "a different amid from the one it registered with — check "
+                    "agtIdentity.amid vs RegistryClient.register payload.",
+                    req.amid,
+                    len(store._agents) if hasattr(store, "_agents") else -1,
+                )
+                raise HTTPException(status_code=404, detail="Agent not registered")
+
+            verifier = await get_verifier()
+            if verifier is None:
+                # Opt-out path: registry deployed without env vars →
+                # verification disabled cluster-wide. Distinct from
+                # "token rejected" so clients can log/skip cleanly.
+                raise HTTPException(
+                    status_code=503,
+                    detail="Entra verification not configured on this registry",
+                )
+
+            try:
+                claims = await verifier.verify(req.verification_token)
+            except EntraTokenError as exc:
+                logger.warning(
+                    "verify_identity rejected token for %s: %s",
+                    req.amid, exc,
+                )
+                raise HTTPException(status_code=401, detail="Token verification failed")
+
+            app_id = str(claims.get("appid") or claims.get("azp") or "").strip()
+            tenant_id = str(claims.get("tid", "")).strip()
+            if not app_id:
+                raise HTTPException(
+                    status_code=401,
+                    detail="Verified token missing appid/azp claim",
+                )
+
+            agent.verified_app_id = app_id
+            agent.verified_tenant_id = tenant_id
+            agent.verified_at = _utcnow()
+            agent.tier = "verified"
+            store.put_agent(agent)
+            logger.info(
+                "verify_identity: %s upgraded to verified tier (appid=%s tenant=%s)",
+                req.amid, app_id, tenant_id,
+            )
+            return {
+                "did": req.amid,
+                "tier": agent.tier,
+                "verified_app_id": app_id,
+                "verified_tenant_id": tenant_id,
+                "verified_at": agent.verified_at.isoformat(),
             }
 
         # ── Discovery ────────────────────────────────────────────
@@ -484,6 +699,17 @@ class RegistryServer:
 
         @app.get("/health")
         async def health() -> dict:
-            return {"status": "healthy", "service": "agentmesh-registry"}
+            # Phase 6.c — surface the verification toggle so the kars
+            # operator CLI can tell whether the cluster has opted in
+            # to verified-tier mesh peers. Same shape as relay /health.
+            entra_enabled = bool(
+                os.environ.get("AGENTMESH_ENTRA_AUDIENCE", "").strip()
+                and os.environ.get("AGENTMESH_ENTRA_TENANT_ID", "").strip()
+            )
+            return {
+                "status": "healthy",
+                "service": "agentmesh-registry",
+                "entra_verify_enabled": entra_enabled,
+            }
 
         return app

--- a/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
@@ -88,7 +88,7 @@ class IdentityVerifyRequest(BaseModel):
     """
 
     amid: str
-    verification_token: str
+    verification_token: str = Field(..., max_length=8192)
 
 
 # ── Auth ─────────────────────────────────────────────────────────────
@@ -616,7 +616,7 @@ class RegistryServer:
                             or stored.identity_key_ed == pub
                         ):
                             agent = stored
-                            req = req.copy(update={"amid": stored.did})
+                            req = req.model_copy(update={"amid": stored.did})
                             break
             if not agent:
                 logger.warning(

--- a/agent-governance-python/agent-mesh/src/agentmesh/registry/store.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/registry/store.py
@@ -39,6 +39,33 @@ class AgentRecord:
     # Reputation
     reputation_score: float = 0.5
 
+    # Session counters (Phase 6.c follow-up). The EMA above is a
+    # rolling average — operators also want to see how many sessions
+    # contributed to it. Counters are bumped exclusively by
+    # `submit_session_reputation` (POST /v1/registry/reputation/session).
+    # Resetting requires `delete_agent` followed by re-registration —
+    # this is intentional so a buggy peer can't roll back its own
+    # history.
+    total_sessions: int = 0
+    successful_sessions: int = 0
+    failed_sessions: int = 0
+    timeout_sessions: int = 0
+    # ISO-8601 timestamp of the most recent session that scored this
+    # agent (initiator OR receiver). `None` until the first session.
+    last_session_at: datetime | None = None
+
+    # Entra Agent ID verification (Phase 6.c). Set by
+    # `POST /v1/registry/verify` after the verifier confirms an Entra
+    # JWT against tenant JWKS. `verified_app_id` is the Entra `appid`
+    # claim from the verified token; `tier` is bumped to "verified"
+    # so trust-scoring downstream can prefer cryptographically
+    # identified peers over anonymous ones. Both stay `None` for
+    # anonymous-tier agents and for clusters that haven't opted in.
+    verified_app_id: str | None = None
+    verified_tenant_id: str | None = None
+    verified_at: datetime | None = None
+    tier: str = "anonymous"
+
 
 class RegistryStore(Protocol):
     """Protocol for registry persistence backends."""

--- a/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
@@ -31,12 +31,29 @@ if not _RELAY_TOKEN:
         "unauthenticated connections.  Set this env var in production."
     )
 
+# Phase 6.c — optional Entra-signed JWT verification for the connect
+# frame's ``token`` field. Opt-in via AGENTMESH_ENTRA_AUDIENCE +
+# AGENTMESH_ENTRA_TENANT_ID. When disabled the legacy shared-secret /
+# open-connect behavior is preserved exactly.
+_ENTRA_VERIFY_ENABLED = bool(
+    os.environ.get("AGENTMESH_ENTRA_AUDIENCE", "").strip()
+    and os.environ.get("AGENTMESH_ENTRA_TENANT_ID", "").strip()
+)
+if _ENTRA_VERIFY_ENABLED:
+    logger.info(
+        "Entra-signed JWT verification enabled (audience=%s tenant=%s) — "
+        "shared-secret AGENTMESH_RELAY_TOKEN path is BYPASSED when an "
+        "Entra token is supplied",
+        os.environ.get("AGENTMESH_ENTRA_AUDIENCE"),
+        os.environ.get("AGENTMESH_ENTRA_TENANT_ID"),
+    )
+
 # Proof-of-possession enforcement for connect frames. When True (default),
 # every ``connect`` frame must include ``public_key``, ``timestamp``, and
 # ``signature`` and the relay verifies that the supplied DID is derived
 # from the public key and that the signature over the timestamp is valid.
 # Setting ``AGENTMESH_RELAY_ALLOW_UNAUTHED_DID=1`` re-enables the legacy
-# behaviour for local/dev usage only — never in production.
+# behavior for local/dev usage only — never in production.
 _REQUIRE_DID_POP: bool = (
     os.environ.get("AGENTMESH_RELAY_ALLOW_UNAUTHED_DID", "").lower()
     not in ("1", "true", "yes")
@@ -125,11 +142,20 @@ def _verify_connect_pop(frame: dict) -> tuple[bool, str]:
 class ConnectedAgent:
     """Tracks a connected agent's WebSocket and heartbeat."""
 
-    def __init__(self, did: str, ws: WebSocket) -> None:
+    def __init__(
+        self,
+        did: str,
+        ws: WebSocket,
+        verified_app_id: str | None = None,
+    ) -> None:
         self.did = did
         self.ws = ws
         self.connected_at = _utcnow()
         self.last_heartbeat = _utcnow()
+        # Phase 6.c — populated when the connect frame's ``token`` was
+        # an Entra-signed JWT and verification succeeded. Operators
+        # can correlate did→appid via this field on /health.
+        self.verified_app_id = verified_app_id
 
     @property
     def is_stale(self) -> bool:
@@ -171,10 +197,15 @@ class RelayServer:
 
         @app.get("/health")
         async def health() -> dict:
+            verified_count = sum(
+                1 for c in self._connections.values() if c.verified_app_id
+            )
             return {
                 "status": "healthy",
                 "service": "agentmesh-relay",
                 "connected_agents": len(self._connections),
+                "verified_agents": verified_count,
+                "entra_verify_enabled": _ENTRA_VERIFY_ENABLED,
                 "stats": self._stats,
             }
 
@@ -199,9 +230,12 @@ class RelayServer:
                     await ws.close(code=4002)
                     return
 
-                # Verify DID proof-of-possession (binds the WebSocket to the
-                # holder of the private key, preventing any client from
-                # connecting as an arbitrary DID and intercepting its mail).
+                # DID proof-of-possession check (upstream main). Binds the
+                # WebSocket to the holder of the private key, preventing
+                # any client from connecting as an arbitrary DID and
+                # intercepting its mail. Applies in both Entra and
+                # shared-secret auth modes — it's an independent layer
+                # over identity, not over tokens.
                 if _REQUIRE_DID_POP:
                     ok, reason = _verify_connect_pop(frame)
                     if not ok:
@@ -214,9 +248,109 @@ class RelayServer:
                         await ws.close(code=4005)
                         return
 
-                # Authenticate: require token when AGENTMESH_RELAY_TOKEN is set
-                if _RELAY_TOKEN is not None:
-                    client_token = frame.get("token")
+                # Authenticate. Three modes, in priority order:
+                #
+                # 1. Entra-signed JWT verification (Phase 6.c). When the
+                #    operator has set both AGENTMESH_ENTRA_AUDIENCE and
+                #    AGENTMESH_ENTRA_TENANT_ID, the connect frame MUST
+                #    carry a valid Entra-issued JWT in ``token``. We
+                #    extract ``appid`` and stamp it on the
+                #    ConnectedAgent so /health and trust-scoring can
+                #    correlate did→appid. There is NO fallback to the
+                #    legacy shared-secret path when Entra is enabled —
+                #    that would let an attacker bypass JWT verification
+                #    by simply omitting the ``token`` field.
+                # 2. Legacy shared-secret. When AGENTMESH_RELAY_TOKEN is
+                #    set AND Entra verification is disabled, accept the
+                #    shared secret. Preserves backward compat for
+                #    clusters that haven't migrated to Entra.
+                # 3. Open. When neither is configured, accept anything.
+                #    The boot-time WARNING tells the operator about it.
+                verified_app_id: str | None = None
+                client_token = frame.get("token")
+                if _ENTRA_VERIFY_ENABLED:
+                    # Lazy import keeps PyJWT off the cold path when
+                    # verification is disabled. Verifier lives under
+                    # `agentmesh.identity` so the registry (which also
+                    # validates inbound Entra tokens via /v1/registry/verify)
+                    # can reuse it without a cross-module dependency.
+                    from agentmesh.identity.entra_verifier import (
+                        EntraTokenError,
+                        get_verifier,
+                    )
+
+                    if not client_token:
+                        # Reject empty/missing tokens IMMEDIATELY when
+                        # Entra is enabled. Falling through to the
+                        # shared-secret branch (or open-acceptance)
+                        # would let a peer skip the JWT presentation
+                        # entirely — exactly the bypass we're meant
+                        # to prevent.
+                        logger.warning(
+                            "Entra enabled but no token presented by %s",
+                            agent_did,
+                        )
+                        await ws.send_json(
+                            {
+                                "type": "error",
+                                "detail": "Authentication required (Entra)",
+                            }
+                        )
+                        await ws.close(code=4003)
+                        return
+
+                    verifier = await get_verifier()
+                    if verifier is None:
+                        # Should not happen if _ENTRA_VERIFY_ENABLED — but
+                        # if the verifier failed to initialize post-boot
+                        # (e.g. JWKS reachability issue), fail closed
+                        # rather than silently downgrading to shared-secret.
+                        logger.error(
+                            "Entra verification enabled but get_verifier() "
+                            "returned None — refusing connect for %s",
+                            agent_did,
+                        )
+                        await ws.send_json(
+                            {
+                                "type": "error",
+                                "detail": "Authentication unavailable (Entra)",
+                            }
+                        )
+                        await ws.close(code=4003)
+                        return
+
+                    try:
+                        claims = await verifier.verify(client_token)
+                        verified_app_id = str(
+                            claims.get("appid") or claims.get("azp") or ""
+                        ) or None
+                        logger.info(
+                            "Entra token verified for %s (appid=%s)",
+                            agent_did,
+                            verified_app_id,
+                        )
+                    except EntraTokenError as exc:
+                        # Differentiated path: only the Entra branch
+                        # was tried, so we MUST NOT fall back to the
+                        # shared-secret compare — an attacker could
+                        # otherwise present a malformed JWT to skip
+                        # straight to the shared-secret check.
+                        logger.warning(
+                            "Entra token rejected for %s: %s",
+                            agent_did,
+                            exc,
+                        )
+                        await ws.send_json(
+                            {
+                                "type": "error",
+                                "detail": "Authentication failed (Entra)",
+                            }
+                        )
+                        await ws.close(code=4003)
+                        return
+                elif _RELAY_TOKEN is not None:
+                    # Legacy shared-secret path. Reached only when Entra
+                    # verification is disabled (operator hasn't opted in).
                     if not client_token or not secrets.compare_digest(
                         client_token, _RELAY_TOKEN
                     ):
@@ -250,8 +384,17 @@ class RelayServer:
                     except Exception:  # noqa: BLE001 - best-effort cleanup
                         pass
 
-                self._connections[agent_did] = ConnectedAgent(agent_did, ws)
-                logger.info("Agent connected: %s", agent_did)
+                self._connections[agent_did] = ConnectedAgent(
+                    agent_did, ws, verified_app_id=verified_app_id
+                )
+                if verified_app_id:
+                    logger.info(
+                        "Agent connected: %s (verified appid=%s)",
+                        agent_did,
+                        verified_app_id,
+                    )
+                else:
+                    logger.info("Agent connected: %s", agent_did)
 
                 # Deliver pending messages
                 await self._deliver_pending(agent_did, ws)
@@ -364,7 +507,7 @@ class RelayServer:
         Messages stay in the inbox until the recipient explicitly sends
         an ``ack`` frame for them — see the ``ack`` branch in
         :meth:`_handle_frame`. Acknowledging on send (the previous
-        behaviour) silently dropped messages whenever the recipient
+        behavior) silently dropped messages whenever the recipient
         disconnected after ``send_json`` returned but before the frame
         actually reached them.
         """

--- a/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/relay/app.py
@@ -279,8 +279,10 @@ class RelayServer:
                         get_verifier,
                     )
 
-                    if not client_token:
-                        # Reject empty/missing tokens IMMEDIATELY when
+                    if not client_token or (
+                        isinstance(client_token, str) and len(client_token) > 16384
+                    ):
+                        # Reject empty/missing/oversized tokens IMMEDIATELY when
                         # Entra is enabled. Falling through to the
                         # shared-secret branch (or open-acceptance)
                         # would let a peer skip the JWT presentation

--- a/agent-governance-python/agent-mesh/tests/test_entra_verifier.py
+++ b/agent-governance-python/agent-mesh/tests/test_entra_verifier.py
@@ -60,10 +60,10 @@ def _good_claims(now: int | None = None) -> dict:
     return {
         "aud": VALID_AUDIENCE,
         "tid": VALID_TENANT,
+        "iss": f"https://login.microsoftonline.com/{VALID_TENANT}/v2.0",
         "appid": VALID_APPID,
         "iat": now,
         "exp": now + 3600,
-        "iss": f"https://login.microsoftonline.com/{VALID_TENANT}/v2.0",
     }
 
 
@@ -216,6 +216,21 @@ class TestVerify:
         token = _sign_token(rsa_keypair, claims)
         out = await v.verify(token)
         assert out.get("azp") == "00000000-1111-2222-3333-444444444444"
+
+    @pytest.mark.asyncio
+    async def test_oversized_token_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        with pytest.raises(EntraTokenError, match="maximum length"):
+            await v.verify("x" * 16385)
+
+    @pytest.mark.asyncio
+    async def test_wrong_issuer_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        claims = _good_claims()
+        claims["iss"] = "https://evil.example.com/v2.0"
+        token = _sign_token(rsa_keypair, claims)
+        with pytest.raises(EntraTokenError):
+            await v.verify(token)
 
 
 # ── PR #2659 review fixes: stale-JWKS hard ceiling + alg-confusion guard ──

--- a/agent-governance-python/agent-mesh/tests/test_entra_verifier.py
+++ b/agent-governance-python/agent-mesh/tests/test_entra_verifier.py
@@ -1,0 +1,341 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for the Phase 6.c relay Entra-JWT verifier.
+
+These tests exercise the configuration boundary + claim-validation
+logic without an Entra round-trip. The JWKS HTTP layer is faked by
+seeding the verifier's internal PyJWKClient with an in-process RSA
+keypair via attribute injection. Production code paths that touch
+``PyJWKClient`` itself are unchanged.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Iterator
+from unittest.mock import patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from agentmesh.identity import entra_verifier
+from agentmesh.identity.entra_verifier import (
+    EntraTokenError,
+    EntraTokenVerifier,
+    EntraVerifierConfig,
+)
+
+
+VALID_AUDIENCE = "api://agentmesh"
+VALID_TENANT = "11111111-2222-3333-4444-555555555555"
+VALID_APPID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> Iterator[None]:
+    """Prevent process-singleton leakage across tests."""
+    entra_verifier.reset_verifier_for_tests()
+    yield
+    entra_verifier.reset_verifier_for_tests()
+
+
+@pytest.fixture
+def rsa_keypair() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _sign_token(key: rsa.RSAPrivateKey, claims: dict) -> str:
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return jwt.encode(claims, pem, algorithm="RS256")
+
+
+def _good_claims(now: int | None = None) -> dict:
+    now = now or int(time.time())
+    return {
+        "aud": VALID_AUDIENCE,
+        "tid": VALID_TENANT,
+        "appid": VALID_APPID,
+        "iat": now,
+        "exp": now + 3600,
+        "iss": f"https://login.microsoftonline.com/{VALID_TENANT}/v2.0",
+    }
+
+
+def _build_verifier(rsa_keypair: rsa.RSAPrivateKey) -> EntraTokenVerifier:
+    cfg = EntraVerifierConfig(
+        audience=VALID_AUDIENCE,
+        tenant_id=VALID_TENANT,
+        authority="https://login.microsoftonline.com",
+        jwks_ttl_secs=3600,
+        jwks_max_stale_secs=86400,
+    )
+    verifier = EntraTokenVerifier(cfg)
+
+    # In-test JWKS shim: pretend the JWKS endpoint already returned
+    # our keypair. The verifier asks PyJWKClient for the signing key;
+    # we stub the resolver to hand back our RSA public key wrapped in
+    # the shape PyJWKClient.get_signing_key_from_jwt returns.
+    class _StubSigningKey:
+        def __init__(self, key: rsa.RSAPublicKey) -> None:
+            self.key = key
+
+    class _StubClient:
+        def __init__(self, public_key: rsa.RSAPublicKey) -> None:
+            self._pub = public_key
+
+        def get_signing_key_from_jwt(self, _token: str) -> _StubSigningKey:
+            return _StubSigningKey(self._pub)
+
+        def get_signing_keys(self) -> list:
+            return [_StubSigningKey(self._pub)]
+
+    verifier._jwk_client = _StubClient(rsa_keypair.public_key())  # type: ignore[assignment]
+    verifier._jwk_cached_at = time.monotonic()
+    return verifier
+
+
+# ── Config tests ────────────────────────────────────────────────────
+
+
+class TestConfig:
+    def test_from_env_returns_none_when_both_unset(self, monkeypatch):
+        monkeypatch.delenv("AGENTMESH_ENTRA_AUDIENCE", raising=False)
+        monkeypatch.delenv("AGENTMESH_ENTRA_TENANT_ID", raising=False)
+        assert EntraVerifierConfig.from_env() is None
+
+    def test_from_env_refuses_half_configured(self, monkeypatch):
+        # Only audience set → operator misconfiguration. Refuse rather
+        # than silently running without tenant pinning.
+        monkeypatch.setenv("AGENTMESH_ENTRA_AUDIENCE", VALID_AUDIENCE)
+        monkeypatch.delenv("AGENTMESH_ENTRA_TENANT_ID", raising=False)
+        assert EntraVerifierConfig.from_env() is None
+
+    def test_from_env_populated(self, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_ENTRA_AUDIENCE", VALID_AUDIENCE)
+        monkeypatch.setenv("AGENTMESH_ENTRA_TENANT_ID", VALID_TENANT)
+        monkeypatch.delenv("AGENTMESH_ENTRA_AUTHORITY", raising=False)
+        cfg = EntraVerifierConfig.from_env()
+        assert cfg is not None
+        assert cfg.audience == VALID_AUDIENCE
+        assert cfg.tenant_id == VALID_TENANT
+        assert cfg.authority == "https://login.microsoftonline.com"
+        assert cfg.jwks_url.endswith(f"/{VALID_TENANT}/discovery/v2.0/keys")
+
+    def test_jwks_ttl_floor_at_60s(self, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_ENTRA_AUDIENCE", VALID_AUDIENCE)
+        monkeypatch.setenv("AGENTMESH_ENTRA_TENANT_ID", VALID_TENANT)
+        monkeypatch.setenv("AGENTMESH_ENTRA_JWKS_TTL_SECS", "10")
+        cfg = EntraVerifierConfig.from_env()
+        assert cfg is not None
+        assert cfg.jwks_ttl_secs == 60
+
+    def test_jwks_ttl_falls_back_to_default_on_garbage(self, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_ENTRA_AUDIENCE", VALID_AUDIENCE)
+        monkeypatch.setenv("AGENTMESH_ENTRA_TENANT_ID", VALID_TENANT)
+        monkeypatch.setenv("AGENTMESH_ENTRA_JWKS_TTL_SECS", "not-an-int")
+        cfg = EntraVerifierConfig.from_env()
+        assert cfg is not None
+        assert cfg.jwks_ttl_secs == 3600
+
+
+# ── Verification tests ──────────────────────────────────────────────
+
+
+class TestVerify:
+    @pytest.mark.asyncio
+    async def test_good_token_returns_claims(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        token = _sign_token(rsa_keypair, _good_claims())
+        claims = await v.verify(token)
+        assert claims["appid"] == VALID_APPID
+
+    @pytest.mark.asyncio
+    async def test_wrong_audience_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        claims = _good_claims()
+        claims["aud"] = "api://attacker"
+        token = _sign_token(rsa_keypair, claims)
+        with pytest.raises(EntraTokenError):
+            await v.verify(token)
+
+    @pytest.mark.asyncio
+    async def test_wrong_tenant_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        claims = _good_claims()
+        claims["tid"] = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        token = _sign_token(rsa_keypair, claims)
+        with pytest.raises(EntraTokenError) as ei:
+            await v.verify(token)
+        assert "tid claim" in str(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_expired_token_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        past = int(time.time()) - 7200
+        token = _sign_token(rsa_keypair, _good_claims(now=past))
+        with pytest.raises(EntraTokenError):
+            await v.verify(token)
+
+    @pytest.mark.asyncio
+    async def test_missing_tid_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        claims = _good_claims()
+        del claims["tid"]
+        token = _sign_token(rsa_keypair, claims)
+        with pytest.raises(EntraTokenError):
+            await v.verify(token)
+
+    @pytest.mark.asyncio
+    async def test_wrong_signing_key_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        token = _sign_token(other, _good_claims())
+        with pytest.raises(EntraTokenError):
+            await v.verify(token)
+
+    @pytest.mark.asyncio
+    async def test_empty_token_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        with pytest.raises(EntraTokenError):
+            await v.verify("")
+
+    @pytest.mark.asyncio
+    async def test_azp_falls_back_when_appid_absent(self, rsa_keypair):
+        # Real Entra tokens carry appid; v2.0 tokens use azp. The
+        # relay's connect-handler extracts whichever exists.
+        v = _build_verifier(rsa_keypair)
+        claims = _good_claims()
+        del claims["appid"]
+        claims["azp"] = "00000000-1111-2222-3333-444444444444"
+        token = _sign_token(rsa_keypair, claims)
+        out = await v.verify(token)
+        assert out.get("azp") == "00000000-1111-2222-3333-444444444444"
+
+
+# ── PR #2659 review fixes: stale-JWKS hard ceiling + alg-confusion guard ──
+
+
+class TestAlgConfusionGuard:
+    """The `alg` header is validated against ALLOWED_SIGNING_ALGORITHMS
+    BEFORE the JWKS lookup, so an attacker that smuggles `alg: HS256`
+    can't trick PyJWT into using the JWK's public-key bytes as an HMAC
+    secret. PyJWT's own algorithms-allowlist also blocks this; the
+    pre-check is defense-in-depth that also avoids a wasted network
+    round-trip on obviously-bad tokens.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hs256_token_rejected_before_jwks_lookup(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        # Hand-craft an HS256 header + good claims body. PyJWT itself
+        # refuses to encode HS256 with a PEM-shaped key, so the
+        # attacker would similarly assemble the token bytes manually
+        # — that's the threat model we defend against.
+        import base64, hmac, hashlib, json
+        header = base64.urlsafe_b64encode(
+            json.dumps({"alg": "HS256", "typ": "JWT"}).encode()
+        ).rstrip(b"=").decode()
+        payload = base64.urlsafe_b64encode(
+            json.dumps(_good_claims()).encode()
+        ).rstrip(b"=").decode()
+        pub_pem = rsa_keypair.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        sig = hmac.new(pub_pem, f"{header}.{payload}".encode(), hashlib.sha256).digest()
+        token = f"{header}.{payload}.{base64.urlsafe_b64encode(sig).rstrip(b'=').decode()}"
+        # Track whether the JWKS resolver was called — it must NOT be.
+        called: list[str] = []
+        original = v._jwk_client.get_signing_key_from_jwt  # type: ignore[attr-defined]
+        def _trip(token_: str):
+            called.append(token_)
+            return original(token_)
+        v._jwk_client.get_signing_key_from_jwt = _trip  # type: ignore[attr-defined]
+        with pytest.raises(EntraTokenError, match="unsupported alg"):
+            await v.verify(token)
+        assert called == [], "JWKS lookup must not be reached for unsupported alg"
+
+    @pytest.mark.asyncio
+    async def test_none_alg_token_rejected_before_jwks_lookup(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        # alg=none — historic PyJWT CVE-2022-29217 class.
+        token = jwt.encode(_good_claims(), key="", algorithm="none")
+        with pytest.raises(EntraTokenError, match="unsupported alg"):
+            await v.verify(token)
+
+    @pytest.mark.asyncio
+    async def test_missing_alg_header_rejected(self, rsa_keypair):
+        v = _build_verifier(rsa_keypair)
+        # Hand-craft a token with no alg header.
+        import base64, json
+        header = base64.urlsafe_b64encode(b'{}').rstrip(b'=').decode()
+        payload = base64.urlsafe_b64encode(
+            json.dumps(_good_claims()).encode()
+        ).rstrip(b'=').decode()
+        token = f"{header}.{payload}."
+        with pytest.raises(EntraTokenError):
+            await v.verify(token)
+
+
+class TestJwksStaleCeiling:
+    """Stale cache must serve verify requests within a bounded window
+    when JWKS refetch fails (availability over consistency), but MUST
+    fail closed beyond that window to bound how long a key rotated
+    OUT of the live JWKS remains usable.
+    """
+
+    def test_max_stale_floors_at_ttl(self, monkeypatch):
+        # Even if operator sets max_stale < ttl, the floor protects
+        # the invariant "stale > fresh always".
+        monkeypatch.setenv("AGENTMESH_ENTRA_AUDIENCE", VALID_AUDIENCE)
+        monkeypatch.setenv("AGENTMESH_ENTRA_TENANT_ID", VALID_TENANT)
+        monkeypatch.setenv("AGENTMESH_ENTRA_JWKS_TTL_SECS", "3600")
+        monkeypatch.setenv("AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS", "60")
+        cfg = EntraVerifierConfig.from_env()
+        assert cfg is not None
+        assert cfg.jwks_max_stale_secs >= cfg.jwks_ttl_secs
+
+    def test_max_stale_default_24h(self, monkeypatch):
+        monkeypatch.setenv("AGENTMESH_ENTRA_AUDIENCE", VALID_AUDIENCE)
+        monkeypatch.setenv("AGENTMESH_ENTRA_TENANT_ID", VALID_TENANT)
+        monkeypatch.delenv("AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS", raising=False)
+        cfg = EntraVerifierConfig.from_env()
+        assert cfg is not None
+        assert cfg.jwks_max_stale_secs == 86400
+
+    @pytest.mark.asyncio
+    async def test_stale_serve_within_budget(self, rsa_keypair):
+        # Cache aged 1h with a 24h ceiling — refetch failure should
+        # serve from stale cache, NOT fail closed.
+        import httpx
+        v = _build_verifier(rsa_keypair)
+        # Pretend the cache is 1h old (well within 24h budget).
+        v._jwk_cached_at = time.monotonic() - 3700  # 1h + 100s (past ttl)
+        # Force the refresh path to throw.
+        original_client_ctor = entra_verifier.PyJWKClient
+        def _explode(*args, **kwargs):
+            raise httpx.ConnectError("egress outage")
+        with patch.object(entra_verifier, "PyJWKClient", _explode):
+            # Should NOT raise — stale cache still in budget.
+            client = await v._ensure_jwk_client()
+            assert client is not None
+
+    @pytest.mark.asyncio
+    async def test_stale_serve_beyond_budget_fails_closed(self, rsa_keypair):
+        import httpx
+        v = _build_verifier(rsa_keypair)
+        # Pretend the cache is 25h old — past the 24h ceiling.
+        v._jwk_cached_at = time.monotonic() - (25 * 3600)
+        def _explode(*args, **kwargs):
+            raise httpx.ConnectError("egress outage")
+        with patch.object(entra_verifier, "PyJWKClient", _explode):
+            with pytest.raises(EntraTokenError, match="unable to fetch Entra JWKS"):
+                await v._ensure_jwk_client()
+        # Stale client must be dropped so future calls don't reuse it.
+        assert v._jwk_client is None

--- a/agent-governance-python/agent-mesh/tests/test_registry.py
+++ b/agent-governance-python/agent-mesh/tests/test_registry.py
@@ -432,3 +432,332 @@ class TestRegistryAPI:
         )
         assert resp.status_code == 400
         assert "32 bytes" in resp.json()["detail"]
+
+    def test_session_reputation_requires_participant(self, client):
+        body_i, sk_i, did_i = _make_registration_body()
+        body_r, _, did_r = _make_registration_body()
+        body_out, sk_out, did_out = _make_registration_body()
+        for b in (body_i, body_r, body_out):
+            client.post("/v1/agents", json=b)
+        # Reporter is authenticated but not a session participant
+        resp = client.post(
+            "/v1/registry/reputation/session",
+            json={
+                "session_id": "sess-1",
+                "initiator_amid": did_i,
+                "receiver_amid": did_r,
+                "outcome": "success",
+                "reporter_amid": did_out,
+            },
+            headers={"Authorization": _make_auth_header(sk_out, did_out)},
+        )
+        assert resp.status_code == 403
+
+    def test_session_counters_initialize_to_zero(self, client):
+        """Freshly-registered agent must expose all counters at zero
+        + completion_rate sentinel so consumers can distinguish
+        'no history' from '0 of N succeeded'."""
+        body, _, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        result = client.get(f"/v1/agents/{did}").json()
+        assert result["total_sessions"] == 0
+        assert result["successful_sessions"] == 0
+        assert result["failed_sessions"] == 0
+        assert result["timeout_sessions"] == 0
+        assert result["completion_rate"] == -1.0
+        assert result["last_session_at"] is None
+
+    def test_session_counters_bump_on_success(self, client):
+        """Success increments BOTH endpoints' total + successful (the
+        EMA already applies to both; counters mirror that exactly)."""
+        body_i, sk_i, did_i = _make_registration_body()
+        body_r, _, did_r = _make_registration_body()
+        client.post("/v1/agents", json=body_i)
+        client.post("/v1/agents", json=body_r)
+        client.post(
+            "/v1/registry/reputation/session",
+            json={
+                "session_id": "s1",
+                "initiator_amid": did_i,
+                "receiver_amid": did_r,
+                "outcome": "success",
+                "reporter_amid": did_i,
+            },
+            headers={"Authorization": _make_auth_header(sk_i, did_i)},
+        )
+        for did in (did_i, did_r):
+            result = client.get(f"/v1/agents/{did}").json()
+            assert result["total_sessions"] == 1
+            assert result["successful_sessions"] == 1
+            assert result["failed_sessions"] == 0
+            assert result["timeout_sessions"] == 0
+            assert result["completion_rate"] == 1.0
+            assert result["last_session_at"] is not None
+
+    def test_session_counters_bump_only_receiver_on_failure(self, client):
+        """Failed outcome scores only the receiver (matches the EMA
+        semantics) — and only the receiver's counters bump. The
+        initiator stays untouched so a flaky receiver can't drag
+        down its caller."""
+        body_i, sk_i, did_i = _make_registration_body()
+        body_r, _, did_r = _make_registration_body()
+        client.post("/v1/agents", json=body_i)
+        client.post("/v1/agents", json=body_r)
+        client.post(
+            "/v1/registry/reputation/session",
+            json={
+                "session_id": "s2",
+                "initiator_amid": did_i,
+                "receiver_amid": did_r,
+                "outcome": "failed",
+                "reporter_amid": did_i,
+            },
+            headers={"Authorization": _make_auth_header(sk_i, did_i)},
+        )
+        recv = client.get(f"/v1/agents/{did_r}").json()
+        init = client.get(f"/v1/agents/{did_i}").json()
+        assert recv["total_sessions"] == 1
+        assert recv["failed_sessions"] == 1
+        assert recv["successful_sessions"] == 0
+        assert recv["completion_rate"] == 0.0
+        # initiator counters MUST stay at zero — failure is the
+        # receiver's fault, not the initiator's
+        assert init["total_sessions"] == 0
+        assert init["completion_rate"] == -1.0
+
+    def test_session_counters_bump_only_receiver_on_timeout(self, client):
+        """Timeout is partial blame on the receiver only."""
+        body_i, _, did_i = _make_registration_body()
+        body_r, sk_r, did_r = _make_registration_body()
+        client.post("/v1/agents", json=body_i)
+        client.post("/v1/agents", json=body_r)
+        client.post(
+            "/v1/registry/reputation/session",
+            json={
+                "session_id": "s3",
+                "initiator_amid": did_i,
+                "receiver_amid": did_r,
+                "outcome": "timeout",
+                "reporter_amid": did_r,
+            },
+            headers={"Authorization": _make_auth_header(sk_r, did_r)},
+        )
+        recv = client.get(f"/v1/agents/{did_r}").json()
+        assert recv["total_sessions"] == 1
+        assert recv["timeout_sessions"] == 1
+        assert recv["successful_sessions"] == 0
+        assert recv["failed_sessions"] == 0
+
+    def test_session_counters_completion_rate_after_mixed_outcomes(self, client):
+        """3 success + 1 failed → 0.75 completion."""
+        body_i, sk_i, did_i = _make_registration_body()
+        body_r, _, did_r = _make_registration_body()
+        client.post("/v1/agents", json=body_i)
+        client.post("/v1/agents", json=body_r)
+        for i, outcome in enumerate(["success", "success", "success", "failed"]):
+            client.post(
+                "/v1/registry/reputation/session",
+                json={
+                    "session_id": f"mix-{i}",
+                    "initiator_amid": did_i,
+                    "receiver_amid": did_r,
+                    "outcome": outcome,
+                    "reporter_amid": did_i,
+                },
+                headers={"Authorization": _make_auth_header(sk_i, did_i)},
+            )
+        recv = client.get(f"/v1/agents/{did_r}").json()
+        assert recv["total_sessions"] == 4
+        assert recv["successful_sessions"] == 3
+        assert recv["failed_sessions"] == 1
+        assert recv["completion_rate"] == 0.75
+
+    def test_simple_reputation_endpoint_bumps_counters(self, client):
+        """POST /v1/agents/{did}/reputation is what AGT mesh peers
+        actually use (the session endpoint is reserved for explicit
+        initiator/receiver outcome reporting). Without bumping counters
+        here, total_sessions would stay at 0 even after hundreds of
+        peer-replies that successfully drift reputation_score.
+        Pins score → bucket mapping: ≥0.7 success, <0.3 failed,
+        else timeout.
+
+        Upstream auth: the caller must authenticate as a DIFFERENT
+        agent (no self-reporting), so we register two agents and have
+        the second one rate the first."""
+        body_tgt, _, did_tgt = _make_registration_body()
+        body_rep, sk_rep, did_rep = _make_registration_body()
+        client.post("/v1/agents", json=body_tgt)
+        client.post("/v1/agents", json=body_rep)
+        auth = {"Authorization": _make_auth_header(sk_rep, did_rep)}
+        # 0.9 → success
+        client.post(f"/v1/agents/{did_tgt}/reputation",
+                    json={"score": 0.9, "reason": "fast"}, headers=auth)
+        result = client.get(f"/v1/agents/{did_tgt}").json()
+        assert result["total_sessions"] == 1
+        assert result["successful_sessions"] == 1
+        # 0.1 → failed
+        client.post(f"/v1/agents/{did_tgt}/reputation",
+                    json={"score": 0.1, "reason": "broken"}, headers=auth)
+        result = client.get(f"/v1/agents/{did_tgt}").json()
+        assert result["total_sessions"] == 2
+        assert result["failed_sessions"] == 1
+        # 0.5 → timeout (mid-band)
+        client.post(f"/v1/agents/{did_tgt}/reputation",
+                    json={"score": 0.5, "reason": "slow"}, headers=auth)
+        result = client.get(f"/v1/agents/{did_tgt}").json()
+        assert result["total_sessions"] == 3
+        assert result["timeout_sessions"] == 1
+        # Buckets must sum to total
+        assert (result["successful_sessions"] + result["failed_sessions"] +
+                result["timeout_sessions"]) == result["total_sessions"]
+        assert result["last_session_at"] is not None
+
+
+class TestIdentityVerify:
+    """Phase 6.c — POST /v1/registry/verify upgrades anonymous → verified.
+
+    Tests use a stub PyJWKClient and explicit env so we don't need a
+    live Entra tenant. The real verifier is exercised via the
+    test_entra_verifier.py suite.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_verifier(self, monkeypatch):
+        # Stub the verifier so the test client can call verify()
+        # without needing real JWKS / real tokens. The contract we
+        # care about for the *route* is the agent-record stamping
+        # behavior — that the route does the right thing when given
+        # a valid claims dict. The verifier itself is tested
+        # elsewhere.
+        from agentmesh.identity import entra_verifier
+        entra_verifier.reset_verifier_for_tests()
+        monkeypatch.setenv("AGENTMESH_ENTRA_AUDIENCE", "api://test-mesh")
+        monkeypatch.setenv("AGENTMESH_ENTRA_TENANT_ID",
+                           "11111111-2222-3333-4444-555555555555")
+        yield
+        entra_verifier.reset_verifier_for_tests()
+
+    def _stub_verifier(self, monkeypatch, *, raises=None, claims=None):
+        """Install a stub verifier that either raises EntraTokenError
+        or returns the supplied claims dict."""
+        from agentmesh.identity import entra_verifier
+
+        class _StubVerifier:
+            async def verify(self, _token):
+                if raises is not None:
+                    raise raises
+                return claims or {}
+        async def _get():
+            return _StubVerifier()
+        monkeypatch.setattr(entra_verifier, "get_verifier", _get)
+
+    def test_verify_unregistered_agent_returns_404(self, client, monkeypatch):
+        self._stub_verifier(monkeypatch, claims={
+            "appid": "00000000-1111-2222-3333-444444444444",
+            "tid": "11111111-2222-3333-4444-555555555555",
+        })
+        resp = client.post("/v1/registry/verify", json={
+            "amid": "did:mesh:" + "00" * 16,
+            "verification_token": "stub-token",
+        })
+        assert resp.status_code == 404
+
+    def test_verify_disabled_returns_503(self, client, monkeypatch):
+        # Simulate operator NOT opting in by making get_verifier return None
+        from agentmesh.identity import entra_verifier
+        async def _none():
+            return None
+        monkeypatch.setattr(entra_verifier, "get_verifier", _none)
+        body, _, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        resp = client.post("/v1/registry/verify", json={
+            "amid": did,
+            "verification_token": "anything",
+        })
+        assert resp.status_code == 503
+        assert "not configured" in resp.json()["detail"].lower()
+
+    def test_verify_rejects_bad_token(self, client, monkeypatch):
+        from agentmesh.identity.entra_verifier import EntraTokenError
+        self._stub_verifier(monkeypatch, raises=EntraTokenError("wrong tenant"))
+        body, _, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        resp = client.post("/v1/registry/verify", json={
+            "amid": did,
+            "verification_token": "junk",
+        })
+        assert resp.status_code == 401
+        # Agent tier must stay anonymous on failure (no stamping)
+        result = client.get(f"/v1/agents/{did}").json()
+        assert result["tier"] == "anonymous"
+        assert result["verified_app_id"] is None
+
+    def test_verify_rejects_token_missing_appid(self, client, monkeypatch):
+        """A verified token without appid/azp must NOT promote to
+        verified — we need the principal claim to stamp the record."""
+        self._stub_verifier(monkeypatch, claims={
+            "tid": "11111111-2222-3333-4444-555555555555",
+            # no appid, no azp
+        })
+        body, _, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        resp = client.post("/v1/registry/verify", json={
+            "amid": did,
+            "verification_token": "missing-claim",
+        })
+        assert resp.status_code == 401
+        assert "appid" in resp.json()["detail"].lower()
+
+    def test_verify_success_stamps_record(self, client, monkeypatch):
+        self._stub_verifier(monkeypatch, claims={
+            "appid": "abcdef01-2345-6789-abcd-ef0123456789",
+            "tid": "11111111-2222-3333-4444-555555555555",
+        })
+        body, _, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        resp = client.post("/v1/registry/verify", json={
+            "amid": did,
+            "verification_token": "good",
+        })
+        assert resp.status_code == 200
+        out = resp.json()
+        assert out["tier"] == "verified"
+        assert out["verified_app_id"] == "abcdef01-2345-6789-abcd-ef0123456789"
+        # GET /v1/agents/{did} reflects the verified fields
+        result = client.get(f"/v1/agents/{did}").json()
+        assert result["tier"] == "verified"
+        assert result["verified_app_id"] == "abcdef01-2345-6789-abcd-ef0123456789"
+        assert result["verified_tenant_id"] == "11111111-2222-3333-4444-555555555555"
+        assert result["verified_at"] is not None
+
+    def test_verify_falls_back_to_azp_when_appid_missing(self, client, monkeypatch):
+        """v2.0 Entra tokens use `azp` instead of `appid` — the route
+        must accept either."""
+        self._stub_verifier(monkeypatch, claims={
+            "azp": "00000000-1111-2222-3333-444444444444",
+            "tid": "11111111-2222-3333-4444-555555555555",
+        })
+        body, _, did = _make_registration_body()
+        client.post("/v1/agents", json=body)
+        resp = client.post("/v1/registry/verify", json={
+            "amid": did,
+            "verification_token": "v2-token",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["verified_app_id"] == "00000000-1111-2222-3333-444444444444"
+
+
+class TestRegistryStoreRateLimiting:
+    def test_try_update_last_seen_first_call_succeeds(self, store):
+        record = AgentRecord(did="did:agentmesh:rl1", public_key=b"\x01" * 32)
+        store.put_agent(record)
+        assert store.try_update_last_seen("did:agentmesh:rl1", min_interval_seconds=10.0) is True
+
+    def test_try_update_last_seen_immediate_retry_throttled(self, store):
+        record = AgentRecord(did="did:agentmesh:rl2", public_key=b"\x01" * 32)
+        store.put_agent(record)
+        assert store.try_update_last_seen("did:agentmesh:rl2") is True
+        assert store.try_update_last_seen("did:agentmesh:rl2") is False
+
+    def test_try_update_last_seen_missing_agent(self, store):
+        assert store.try_update_last_seen("did:agentmesh:missing") is False

--- a/agent-governance-python/agent-mesh/tests/test_relay.py
+++ b/agent-governance-python/agent-mesh/tests/test_relay.py
@@ -382,6 +382,145 @@ class TestGhostConnectionCleanup:
         assert len(server._connections) == 0
 
 
+
+# ── PR #2659 review fix: Entra-enabled connect MUST require a token ──
+
+
+class TestEntraAuthBypassFix:
+    """When ``_ENTRA_VERIFY_ENABLED`` is true, the relay must REQUIRE
+    a valid Entra JWT on connect. Specifically:
+
+      * Empty/missing ``token`` field MUST NOT silently fall through
+        to the shared-secret check or to open-acceptance.
+      * Verifier-init failure MUST NOT downgrade to shared-secret.
+
+    Regression guard for the bypass flagged in PR #2659 review:
+      _ENTRA_VERIFY_ENABLED and client_token  →  if either side
+      is falsy, the if-branch is skipped entirely and execution
+      falls through to the legacy auth path or to open-accept.
+    """
+
+    def _connect_with_entra_enabled(
+        self,
+        monkeypatch,
+        frame: dict,
+    ) -> tuple[str, dict | None]:
+        """Connect with Entra enabled. Returns (close_reason, error_payload)."""
+        from agentmesh.relay import app as relay_app
+        monkeypatch.setattr(relay_app, "_ENTRA_VERIFY_ENABLED", True)
+        # Disable upstream DID proof-of-possession for these tests —
+        # PoP and Entra auth are independent layers; we're testing the
+        # Entra-bypass fix here, not PoP. PoP is exercised in the
+        # dedicated TestRelayDIDProofOfPossession class.
+        monkeypatch.setattr(relay_app, "_REQUIRE_DID_POP", False)
+        # Force get_verifier() to return None so we don't actually
+        # try to validate — the bypass we care about happens BEFORE
+        # any JWT decode work.
+        async def _no_verifier():
+            return None
+        monkeypatch.setattr(
+            "agentmesh.identity.entra_verifier.get_verifier",
+            _no_verifier,
+        )
+        server = RelayServer()
+        client = TestClient(server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json(frame)
+            try:
+                resp = ws.receive_json()
+            except Exception:
+                resp = None
+            return ("ok", resp)
+
+    def test_missing_token_field_rejected_when_entra_enabled(self, monkeypatch):
+        """A connect frame with no ``token`` field must be rejected."""
+        _, resp = self._connect_with_entra_enabled(
+            monkeypatch,
+            {"v": 1, "type": "connect", "from": "did:agentmesh:attacker"},
+        )
+        assert resp is not None
+        assert resp["type"] == "error"
+        assert "Entra" in resp["detail"], (
+            "Error must distinguish Entra-required from generic auth-failed"
+        )
+
+    def test_empty_token_rejected_when_entra_enabled(self, monkeypatch):
+        """``token: \"\"`` is a bypass attempt — reject."""
+        _, resp = self._connect_with_entra_enabled(
+            monkeypatch,
+            {"v": 1, "type": "connect", "from": "did:agentmesh:attacker", "token": ""},
+        )
+        assert resp is not None
+        assert resp["type"] == "error"
+        assert "Entra" in resp["detail"]
+
+    def test_null_token_rejected_when_entra_enabled(self, monkeypatch):
+        """``token: null`` is also a bypass attempt — reject."""
+        _, resp = self._connect_with_entra_enabled(
+            monkeypatch,
+            {"v": 1, "type": "connect", "from": "did:agentmesh:attacker", "token": None},
+        )
+        assert resp is not None
+        assert resp["type"] == "error"
+        assert "Entra" in resp["detail"]
+
+    def test_verifier_init_failure_fails_closed(self, monkeypatch):
+        """If Entra is enabled but ``get_verifier()`` returns None
+        (e.g. post-boot JWKS reachability issue), MUST fail closed.
+        Falling through to shared-secret would let an attacker
+        downgrade auth by triggering JWKS unavailability."""
+        from agentmesh.relay import app as relay_app
+        monkeypatch.setattr(relay_app, "_ENTRA_VERIFY_ENABLED", True)
+        # PoP is an independent upstream gate; disable for this test.
+        monkeypatch.setattr(relay_app, "_REQUIRE_DID_POP", False)
+        # Set a legacy shared-secret too — even with the secret
+        # present, Entra-enabled mode must NOT silently downgrade.
+        monkeypatch.setattr(relay_app, "_RELAY_TOKEN", "legacy-shared-secret")
+        async def _no_verifier():
+            return None
+        monkeypatch.setattr(
+            "agentmesh.identity.entra_verifier.get_verifier",
+            _no_verifier,
+        )
+        server = RelayServer()
+        client = TestClient(server.app)
+        with client.websocket_connect("/ws") as ws:
+            # Attacker presents the legacy shared secret hoping for
+            # silent downgrade.
+            ws.send_json({
+                "v": 1,
+                "type": "connect",
+                "from": "did:agentmesh:attacker",
+                "token": "legacy-shared-secret",
+            })
+            resp = ws.receive_json()
+        assert resp["type"] == "error", "shared-secret downgrade must be rejected"
+
+    def test_shared_secret_still_works_when_entra_disabled(self, monkeypatch):
+        """Backward compat: when ENTRA is OFF, the legacy shared-secret
+        path is unchanged. (This guards against over-tightening: we
+        only want to block the bypass under the new Entra-enabled
+        contract, not change behavior for unmigrated clusters.)"""
+        from agentmesh.relay import app as relay_app
+        monkeypatch.setattr(relay_app, "_ENTRA_VERIFY_ENABLED", False)
+        # PoP is an independent upstream gate; disable for this back-compat test.
+        monkeypatch.setattr(relay_app, "_REQUIRE_DID_POP", False)
+        monkeypatch.setattr(relay_app, "_RELAY_TOKEN", "legacy-shared-secret")
+        server = RelayServer()
+        client = TestClient(server.app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({
+                "v": 1,
+                "type": "connect",
+                "from": "did:agentmesh:legit",
+                "token": "legacy-shared-secret",
+            })
+            # No error response — connect accepted.
+            ws.send_json({
+                "v": 1, "type": "heartbeat", "from": "did:agentmesh:legit",
+            })
+
+
 # -- DID Proof-of-Possession (security regression) -------------------
 
 

--- a/agent-governance-python/requirements/ci-test.txt
+++ b/agent-governance-python/requirements/ci-test.txt
@@ -19,6 +19,21 @@ pygments==2.20.0 \
 # pytest-asyncio transitive dependencies (needed on Python <3.13)
 typing-extensions==4.15.0 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
-PyYAML==6.0.2 \
-    --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e \
-    --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476
+# PyYAML — imported by tests/ci/test_regression_a2_toolkit_regex.py
+# (introduced in PR #2654). Workflow-lint job runs `pytest tests/ci/ -v`
+# after installing only this requirements file. Without PyYAML pinned
+# here, `import yaml` in that test fails with ModuleNotFoundError and
+# every PR's inline-script-tests gate fails red. Pinned at 6.0.3 with
+# hashes for cp311/cp312/cp313 manylinux + the universal sdist so
+# Scorecard's pinned-dependencies check stays green.
+PyYAML==6.0.3 \
+    --hash=sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c \
+    --hash=sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00 \
+    --hash=sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d \
+    --hash=sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28 \
+    --hash=sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c \
+    --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc \
+    --hash=sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c \
+    --hash=sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5 \
+    --hash=sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6 \
+    --hash=sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f

--- a/docs/security/audits/2026-05-30-entra-signed-jwt-verification.md
+++ b/docs/security/audits/2026-05-30-entra-signed-jwt-verification.md
@@ -1,0 +1,74 @@
+# 2026-05-30 — Entra-signed JWT verification for AgentMesh relay + registry
+
+PR: [microsoft/agent-governance-toolkit#2659](https://github.com/microsoft/agent-governance-toolkit/pull/2659)
+
+## What changed and why
+
+This PR adds **opt-in Entra-signed JWT verification** to the AgentMesh
+relay and registry so peers can register and connect under a
+cryptographically verifiable identity (Entra tenant + `appid`) instead
+of the existing anonymous-tier registration path. Closes the gap
+between the mesh SDK (which has been attempting verified-tier
+registration via `MeshClient.verify()` since v3.5) and the server side,
+which until now ignored the presented JWT.
+
+The change is **opt-in everywhere**. With `AGENTMESH_ENTRA_AUDIENCE` /
+`AGENTMESH_ENTRA_TENANT_ID` unset, the relay and registry preserve
+byte-identical pre-v3.7.x behavior (anonymous tier; shared-secret auth
+or open accept on the relay; no verify endpoint on the registry).
+
+### Files touched (capability-path scope)
+
+| File | Change |
+|------|--------|
+| `agent-governance-python/agent-mesh/src/agentmesh/identity/entra_verifier.py` | New module — JWKS fetcher + RS256/RS384/RS512 signature verifier with `aud`, `tid`, `exp`, `iat` claim enforcement, JWKS caching with hard staleness ceiling, header-`alg` pre-validation against an allowlist. |
+| `agent-governance-python/agent-mesh/src/agentmesh/relay/app.py` | Three-mode connect-frame auth: Entra → shared-secret → open. When Entra is enabled, an empty/missing `token` is rejected immediately. The new mode is **orthogonal to** and runs **after** the upstream DID-PoP gate. |
+| `agent-governance-python/agent-mesh/src/agentmesh/registry/app.py` | New `POST /v1/registry/verify` endpoint that upgrades an agent from `tier: anonymous` to `tier: verified` after JWT verification. Stamps `verified_app_id`, `verified_tenant_id`, `verified_at` on the agent record. Also adds per-agent session counters (`total_sessions`, `successful_sessions`, `failed_sessions`, `timeout_sessions`, `completion_rate`) that are bumped by both the existing reputation endpoints. |
+
+## Threat model impact
+
+| Dimension | Direction |
+|---|---|
+| **Peer identity verification** | **Strengthened (when opt-in).** Previously the relay had no way to bind a connecting peer's DID to a verifiable identity. With Entra verification enabled, the relay rejects WebSocket connects without a valid Entra-signed JWT and stamps `appid` on the connection for trust-scoring downstream. |
+| **Auth bypass surface** | **Closed.** The connect-handler restructure (`if Entra → require token; elif legacy → shared-secret`) eliminates the silent fall-through that the original PR had where an empty/missing token would skip Entra verification and land on the legacy shared-secret check (raised in review and fixed in commit `324f270d`). |
+| **JWKS poisoning / stale-key reuse** | **Bounded.** Refetch failures fall back to the cached JWKS for availability, but only within a hard `AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS` budget (default 24h). Beyond the budget, the verifier drops the stale client and fails closed. This bounds the window in which a key rotated OUT of the live JWKS can still verify a token. |
+| **Algorithm confusion** | **Defended.** Header `alg` is pre-validated against `ALLOWED_SIGNING_ALGORITHMS` (`RS256`/`RS384`/`RS512`) **before** the JWKS lookup. PyJWT's `algorithms=` parameter would also reject it inside `decode()`, but the pre-check (a) avoids a wasted JWKS network round-trip on obviously-bad tokens and (b) makes the defense visible in our code path rather than relying on a downstream library's allowlist. |
+| **Self-reporting reputation** | **Already mitigated upstream.** Reputation endpoints now require `Ed25519-Timestamp` auth (upstream `main`, predates this PR) and reject self-reporting. This PR's session-counter additions inherit that auth contract. |
+| **Backward compatibility** | **Preserved.** Both `AGENTMESH_ENTRA_AUDIENCE` and `AGENTMESH_ENTRA_TENANT_ID` must be set for verification to be enabled. With either unset, the relay's pre-existing shared-secret + open-accept paths are reached unchanged. The registry's `/v1/registry/verify` returns 503 when the verifier is disabled. |
+| **Fail-closed contract** | **Honored everywhere.** Verifier-init failure (e.g. JWKS unreachable on cold cache) returns 503 from the registry and closes the WebSocket with code 4003 on the relay — never silently downgrades to a weaker auth path. |
+
+### Specific mitigations applied
+
+- **Hard JWKS staleness ceiling** (`AGENTMESH_ENTRA_JWKS_MAX_STALE_SECS`, default 86400s, floors at `JWKS_TTL_SECS`). Closes [PR review point 1](https://github.com/microsoft/agent-governance-toolkit/pull/2659#pullrequestreview-…) — stale cache had no upper bound, signing keys rotated out of Entra could be reused indefinitely.
+- **Connect-frame token-required check** when Entra is enabled. Closes PR review point 2 — empty/missing `token` no longer falls through to the legacy shared-secret path.
+- **Header `alg` pre-validation** against the explicit allowlist. Closes PR review point 3 — defense-in-depth against algorithm-confusion exploit shapes.
+- **Verifier-init failure fail-closed.** Even when both Entra is enabled AND `AGENTMESH_RELAY_TOKEN` is set, a verifier-init failure does not downgrade to the shared-secret path. An attacker who can trigger JWKS unreachability does not get a weaker auth surface as a result.
+- **DID PoP independence.** The new Entra branch runs **after** the upstream `_REQUIRE_DID_POP` check. The two gates are orthogonal — PoP binds the WebSocket to the private-key holder (identity layer); Entra/shared-secret authenticates the token (token layer). Either can be disabled without weakening the other.
+
+### Specific bypass tests (regression guards)
+
+- **`TestEntraAuthBypassFix::test_missing_token_field_rejected_when_entra_enabled`** — connect with `{from: ..., (no token)}` must be rejected with `Authentication required (Entra)` and WebSocket code 4003.
+- **`TestEntraAuthBypassFix::test_empty_token_rejected_when_entra_enabled`** — `token: ""`.
+- **`TestEntraAuthBypassFix::test_null_token_rejected_when_entra_enabled`** — `token: null`.
+- **`TestEntraAuthBypassFix::test_verifier_init_failure_fails_closed`** — even with `_RELAY_TOKEN` set, verifier-init failure does NOT silently downgrade to the shared-secret path.
+- **`TestEntraAuthBypassFix::test_shared_secret_still_works_when_entra_disabled`** — backward-compat guard: when Entra is OFF, the legacy shared-secret path behaves identically.
+- **`TestAlgConfusionGuard::test_hs256_token_rejected_before_jwks_lookup`** — hand-crafted HS256 token (PyJWT refuses to encode HS256 with a PEM key, mirroring the attacker's wire-format path). Asserts the JWKS resolver is **never** called.
+- **`TestAlgConfusionGuard::test_none_alg_token_rejected_before_jwks_lookup`** — CVE-2022-29217 class.
+- **`TestJwksStaleCeiling::test_stale_serve_beyond_budget_fails_closed`** — cache aged 25h, refetch throws, MUST raise + drop the stale client.
+
+### Specific verify-route tests
+
+- **`TestIdentityVerify::test_verify_disabled_returns_503`** — operator has not opted in; route returns 503 with `"not configured"`.
+- **`TestIdentityVerify::test_verify_rejects_bad_token`** — bad token → 401 AND agent tier stays `anonymous` (no partial stamping).
+- **`TestIdentityVerify::test_verify_rejects_token_missing_appid`** — verified token without `appid`/`azp` → 401 (no principal claim to stamp).
+- **`TestIdentityVerify::test_verify_success_stamps_record`** — happy path: `tier: verified`, `verified_app_id`, `verified_tenant_id`, `verified_at` all populated, `GET /v1/agents/{did}` reflects.
+- **`TestIdentityVerify::test_verify_falls_back_to_azp_when_appid_missing`** — v2.0 Entra tokens use `azp` instead of `appid`; route accepts either.
+
+## Test coverage for security-relevant behavior
+
+- `tests/test_entra_verifier.py` — 20 tests covering the verifier in isolation (config, signature, claims, alg-confusion, stale-ceiling).
+- `tests/test_relay.py::TestEntraAuthBypassFix` — 5 tests covering the connect-handler restructure.
+- `tests/test_registry.py::TestIdentityVerify` — 6 tests covering the verify route.
+- `tests/test_registry.py::TestRegistryAPI::test_session_counters_*` — 5 tests covering the counter bumps (initial-zero invariant, success bump, receiver-only-on-failure, completion-rate computation, mixed-outcome accounting).
+
+All **97 tests in the touched test files pass post-merge** with `origin/main`. Pre-existing failures elsewhere in the suite (`test_policy_provider`, `test_server`, `test_spec_identity_trust_conformance`) are Python 3.14 `asyncio.get_event_loop()` API churn, unrelated to this PR.

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -65,6 +65,9 @@ REGISTERED_PACKAGES = {
     "google-adk", "safety", "jupyter", "vitest", "tsup", "typescript",
     "requests",
     "twine",
+    # PyJWT — required by agent-mesh/identity/entra_verifier.py for
+    # Entra-signed JWT verification (PR #2659). Real package, on PyPI.
+    "pyjwt", "PyJWT",
     # Dashboard / visualization (used in examples)
     "streamlit", "plotly", "pandas", "networkx", "matplotlib", "pyvis",
     # Async / caching (used in examples)


### PR DESCRIPTION
## Summary

Security and performance hardening applied on top of PR #2659 (Entra-signed JWT verification end-to-end).

## Changes

| File | Change |
|------|--------|
| ntra_verifier.py | 16KB token length cap before processing; issuer validation pinned to tenant |
| 
elay/app.py | Token length check in WebSocket connect handler |
| 
egistry/app.py | Pydantic v2 .model_copy() fix; max_length=8192 on verification_token field |
| 	est_entra_verifier.py | Tests for oversized token rejection and wrong issuer rejection |

## Testing

All 22 entra verifier tests pass including 2 new test cases.
