### PR TITLE
fix(ci): fix conftest import and add python-dateutil to marketplace dev deps

### DIFF
--- a/agent-governance-python/agent-marketplace/pyproject.toml
+++ b/agent-governance-python/agent-marketplace/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 cli = ["click>=8.0,<9.0", "rich>=13.0,<16.0"]
-dev = ["pytest>=7.0,<10.0", "pytest-cov", "click>=8.0,<9.0", "rich>=13.0,<16.0", "httpx>=0.27.0,<1.0"]
+dev = ["pytest>=7.0,<10.0", "pytest-cov", "click>=8.0,<9.0", "rich>=13.0,<16.0", "httpx>=0.27.0,<1.0", "python-dateutil>=2.8"]
 
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"

--- a/agent-governance-python/agent-mesh/tests/test_backend.py
+++ b/agent-governance-python/agent-mesh/tests/test_backend.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import shutil
+
 import pytest
 
 from agentmesh.governance.backend import (
@@ -13,7 +15,10 @@ from agentmesh.governance.backend import (
 )
 from agentmesh.governance.opa import OPAEvaluator, OPAPolicyBackend
 from agentmesh.governance.cedar import CedarEvaluator, CedarPolicyBackend
-from conftest import requires_cedar, requires_opa
+
+requires_opa = pytest.mark.skipif(
+    not shutil.which("opa"), reason="opa CLI not installed"
+)
 
 
 # ── Sample policies ───────────────────────────────────────────

--- a/agent-governance-python/agent-mesh/tests/test_opa.py
+++ b/agent-governance-python/agent-mesh/tests/test_opa.py
@@ -2,10 +2,16 @@
 # Licensed under the MIT License.
 """Tests for OPA/Rego policy adapter and PolicyEngine integration."""
 
+import shutil
+
 import pytest
+
 from agentmesh.governance.opa import OPAEvaluator, OPADecision
 from agentmesh.governance.policy import PolicyEngine
-from conftest import requires_opa
+
+requires_opa = pytest.mark.skipif(
+    not shutil.which("opa"), reason="opa CLI not installed"
+)
 
 
 # ── Sample Rego policies ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Round 3 CI fix: addresses two remaining failures from round 2.

## Problem

1. **agent-mesh**: rom conftest import requires_opa fails with ModuleNotFoundError: No module named 'conftest'. Pytest auto-loads conftest.py but it cannot be imported as a regular module.
2. **agent-marketplace**: ModuleNotFoundError: No module named 'dateutil' in backward compat test.

## Changes

| File | Change |
|------|--------|
| agent-mesh/tests/test_opa.py | Replace conftest import with inline shutil.which + skipif |
| agent-mesh/tests/test_backend.py | Replace conftest import with inline shutil.which + skipif |
| agent-marketplace/pyproject.toml | Add python-dateutil to [dev] extra |

## Testing

Fixes collection errors in agent-mesh and the single test failure in agent-marketplace.
