### PR TITLE
feat(agent-sandbox): minimal-PATH hardened sandbox image — closes #2713

### DIFF
--- a/agent-governance-python/agent-sandbox/README.md
+++ b/agent-governance-python/agent-sandbox/README.md
@@ -261,6 +261,51 @@ policy = PolicyDocument.from_yaml("policies/aca_research_agent.yaml")
 handle = await provider.create_session_async("agent-1", policy=policy)
 ```
 
+## Hardened sandbox image (minimal-PATH)
+
+`docker/Dockerfile.sandbox` is an opt-in hardened variant of the default
+`python:3.11-slim` base. It pins `PATH` to a single explicit directory
+(`/usr/local/sandbox-bin`) containing only the binaries sandboxed code is
+allowed to invoke, and strips the execute bit off well-known network and
+infra CLIs (`curl`, `wget`, `ssh`, `git`, `az`, `aws`, `gcloud`, `kubectl`,
+`terraform`, `helm`, `ansible`, `apt`, `dpkg`, …) as a second-layer guarantee
+in case a caller goes through an absolute path.
+
+This closes the gap that issue [#2662](https://github.com/microsoft/agent-governance-toolkit/issues/2662)
+identifies: without a pinned PATH, a tool can invoke `os.system('az account list')`
+inside the sandbox and the attempt is not blocked or logged by AGT even though
+the network-egress policy would later refuse the call. The hardened image makes
+the attempt itself fail with "command not found".
+
+```bash
+# Build with the default allow-list (python3, cat, echo, ls).
+docker build \
+  -f agent-sandbox/docker/Dockerfile.sandbox \
+  -t agt-sandbox/python-minimal-path:3.11 \
+  agent-sandbox/docker
+
+# Build with a custom allow-list — add only what the sandboxed workload
+# actually needs. The full allow-list IS the new PATH; any binary not listed
+# here is unreachable.
+docker build \
+  --build-arg ALLOWED_BIN_NAMES="python3 cat echo ls grep sort uniq" \
+  -f agent-sandbox/docker/Dockerfile.sandbox \
+  -t agt-sandbox/python-minimal-path:3.11 \
+  agent-sandbox/docker
+```
+
+Wire the image into `DockerSandboxProvider` via the existing `image` argument:
+
+```python
+provider = DockerSandboxProvider(image="agt-sandbox/python-minimal-path:3.11")
+```
+
+To extend the allow-list permanently (rather than at `docker build` time),
+edit the `ARG ALLOWED_BIN_NAMES=` line in `Dockerfile.sandbox` and rebuild.
+The `tests/test_docker_sandbox.py::TestMinimalPathSandboxImage` smoke tests
+assert that the default allow-list cannot accidentally regress to include
+network or infra CLIs.
+
 ## License
 
 MIT

--- a/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
+++ b/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
@@ -1,0 +1,79 @@
+# Hardened sandbox image: minimal-PATH variant of the default agent-sandbox
+# base. Used by `DockerSandboxProvider` when policy requires command-denylist
+# enforcement via PATH-based exclusion (see issue #2713 / parent #2662).
+#
+# The defense in this image is layered:
+#   1. PATH is pinned to a single explicit directory containing only the
+#      binaries sandboxed code is allowed to invoke. Everything else fails
+#      with "command not found" even if the binary is still resident in the
+#      image — there is no fallback search path.
+#   2. A second pass strips the execute bit off well-known network and infra
+#      CLIs (curl, wget, ssh, az, kubectl, terraform, …). Belt-and-braces:
+#      these are unreachable via PATH already, but a sandboxed caller that
+#      goes through an absolute path also gets EACCES rather than silently
+#      executing.
+#   3. The provider's existing hardening (capability drop, no-new-privileges,
+#      read-only root, nobody UID, seccomp, AppArmor) is preserved by mirroring
+#      `USER 65534:65534` here so the image still drops privileges on its own
+#      when started outside the provider.
+#
+# To extend the allowed-binary list, add an entry to ALLOWED_BIN_NAMES below
+# and rebuild. See the agent-sandbox README ("Hardened sandbox image
+# (minimal-PATH)") for the documented extension procedure.
+
+FROM python:3.11-slim AS sandbox-base
+
+# Explicit PATH. No inherited `:$PATH` segment — anything not under
+# /usr/local/sandbox-bin is unreachable.
+ENV PATH=/usr/local/sandbox-bin
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Build-time list of permitted binaries. Maintainers extending this image
+# should add entries here rather than relying on host-side PATH inheritance.
+ARG ALLOWED_BIN_NAMES="python3 cat echo ls"
+
+# Stage 1: collect the allowed binaries into the pinned PATH directory.
+# Symlinks (not copies) preserve setuid behaviour from the base image where
+# present, and keep the diff against the upstream `python:3.11-slim` minimal.
+RUN set -eux; \
+    mkdir -p /usr/local/sandbox-bin; \
+    for bin in $ALLOWED_BIN_NAMES; do \
+        src=$(command -v "$bin" 2>/dev/null || true); \
+        if [ -n "$src" ]; then \
+            ln -sf "$src" "/usr/local/sandbox-bin/$bin"; \
+        else \
+            echo "warning: $bin not found in base image PATH"; \
+        fi; \
+    done; \
+    # python -> python3 alias is commonly expected by sandboxed code.
+    if [ -e /usr/local/sandbox-bin/python3 ] && [ ! -e /usr/local/sandbox-bin/python ]; then \
+        ln -sf /usr/local/sandbox-bin/python3 /usr/local/sandbox-bin/python; \
+    fi
+
+# Stage 2: strip the execute bit off the network and infra CLIs that this
+# image must never silently expose, even via an absolute path. The pinned
+# PATH already makes them unreachable; this is a second-layer guarantee.
+RUN set -eux; \
+    for bin in curl wget nc netcat ssh scp rsync git \
+               apt apt-get dpkg dnf yum apk \
+               aws az gcloud kubectl terraform helm ansible \
+               ssh-keygen ssh-agent telnet ftp tftp \
+               base64 xxd hexdump; do \
+        target=$(command -v "$bin" 2>/dev/null || true); \
+        if [ -n "$target" ] && [ -f "$target" ]; then \
+            chmod a-x "$target" 2>/dev/null || true; \
+        fi; \
+    done
+
+# Drop to nobody. The provider already sets `user="65534:65534"` on the
+# container, but pinning it in the image too means a sandboxed image started
+# outside the provider (e.g. ad-hoc `docker run` for inspection) also drops
+# privileges by default rather than falling through to root.
+USER 65534:65534
+WORKDIR /workspace
+
+# Default entrypoint is plain python — the provider replaces this with
+# `["sleep", "infinity"]` for long-lived sessions; this CMD is what runs
+# when the image is invoked directly.
+CMD ["python3"]

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -926,6 +926,130 @@ class TestContainerCreationHardening:
 
 
 # =========================================================================
+# Section 6b: Minimal-PATH sandbox image (#2713)
+# =========================================================================
+
+
+class TestMinimalPathSandboxImage:
+    """Smoke tests for the hardened minimal-PATH sandbox image.
+
+    The image lives at ``agent-sandbox/docker/Dockerfile.sandbox`` and pins
+    PATH to a single explicit directory containing only the binaries that
+    sandboxed code is allowed to invoke. These tests verify the policy as
+    written in the Dockerfile — they do not require a Docker daemon.
+    """
+
+    @staticmethod
+    def _dockerfile_path():
+        import pathlib
+
+        return (
+            pathlib.Path(__file__).resolve().parent.parent
+            / "docker"
+            / "Dockerfile.sandbox"
+        )
+
+    @staticmethod
+    def _read():
+        return TestMinimalPathSandboxImage._dockerfile_path().read_text(
+            encoding="utf-8"
+        )
+
+    def test_dockerfile_exists(self):
+        path = self._dockerfile_path()
+        assert path.is_file(), f"expected hardened sandbox image at {path}"
+
+    def test_path_is_explicit_and_minimal(self):
+        import re
+
+        content = self._read()
+        path_lines = [
+            line
+            for line in content.splitlines()
+            if re.match(r"^ENV\s+PATH=", line)
+        ]
+        assert path_lines, "Dockerfile must set PATH via `ENV PATH=`"
+        # Take the last ENV PATH= line as the effective value.
+        path_value = path_lines[-1].split("=", 1)[1].strip().strip("\"'")
+        # No inherited / wildcard segments — every PATH entry must be explicit.
+        for forbidden in ("$PATH", "${PATH}", ":/sbin", ":/usr/sbin"):
+            assert forbidden not in path_value, (
+                f"PATH must not include {forbidden!r}: {path_value!r}"
+            )
+        # The pinned directory must be present.
+        assert "/usr/local/sandbox-bin" in path_value, (
+            f"PATH must include the pinned sandbox-bin directory: {path_value!r}"
+        )
+
+    def test_dangerous_binaries_are_addressed(self):
+        import re
+
+        content = self._read()
+        # The Dockerfile must address each of these binary classes — either
+        # by stripping its execute bit, removing it, or shimming it. The
+        # smoke check is simply that the binary name appears somewhere in
+        # the Dockerfile (the existing stripping pass enumerates them by
+        # name), so a maintainer cannot accidentally drop coverage of one
+        # of these without the test catching the omission.
+        for bin_name in (
+            "curl",
+            "wget",
+            "ssh",
+            "az",
+            "kubectl",
+            "terraform",
+            "git",
+            "apt",
+        ):
+            assert re.search(rf"\b{re.escape(bin_name)}\b", content), (
+                f"Dockerfile must address {bin_name!r} explicitly"
+            )
+
+    def test_runs_as_nobody(self):
+        import re
+
+        content = self._read()
+        assert re.search(
+            r"^USER\s+65534:65534\s*$", content, flags=re.MULTILINE
+        ), "Dockerfile must drop privileges to UID 65534 (nobody)"
+
+    def test_allowed_binaries_include_python_and_minimal_utilities(self):
+        import re
+
+        content = self._read()
+        match = re.search(
+            r'ARG\s+ALLOWED_BIN_NAMES\s*=\s*"([^"]+)"', content
+        )
+        assert match, (
+            "Dockerfile must declare an ALLOWED_BIN_NAMES build-arg so the "
+            "permitted set can be extended without editing image internals"
+        )
+        allowed = set(match.group(1).split())
+        # Sandboxed code legitimately needs python and a few read-only
+        # utilities for introspection (cat, echo, ls). Everything else is
+        # opt-in via ALLOWED_BIN_NAMES at build time.
+        assert {"python3", "cat", "echo"} <= allowed, (
+            f"ALLOWED_BIN_NAMES must include python3/cat/echo: {allowed!r}"
+        )
+        # Network and infra CLIs must NOT be in the default allowed set.
+        forbidden_in_allowlist = {
+            "curl",
+            "wget",
+            "ssh",
+            "az",
+            "aws",
+            "gcloud",
+            "kubectl",
+            "terraform",
+            "git",
+        }
+        leaked = allowed & forbidden_in_allowlist
+        assert not leaked, (
+            f"these binaries must never appear in the default ALLOWED_BIN_NAMES: {leaked!r}"
+        )
+
+
+# =========================================================================
 # Section 7: Runtime detection
 # =========================================================================
 


### PR DESCRIPTION
## Summary

Implements option 1 of the sandbox-hardening tracker #2662: a hardened Docker image that pins `PATH` to a single explicit directory of allowed binaries, so command-denylist enforcement cannot be bypassed via alternate binary locations.

Closes #2713 (the good-first-issue split of #2662). The other three options in #2662 (read-only bind mount denylist, custom AppArmor profile, execution shim) are intentionally left for follow-up PRs per the parent issue's split.

## Changes

### `agent-sandbox/docker/Dockerfile.sandbox` (new)

Base: `python:3.11-slim`. Two layers of defense:

1. **Pinned PATH.** `ENV PATH=/usr/local/sandbox-bin` — no inherited `\$PATH` segment. Only binaries listed in the `ALLOWED_BIN_NAMES` build-arg (default: `python3 cat echo ls`) are symlinked into the pinned directory. Anything not in that allow-list is unreachable from `PATH` lookup.
2. **Execute-bit strip.** A second pass `chmod a-x`s well-known network and infra CLIs (`curl`, `wget`, `ssh`, `git`, `az`, `aws`, `gcloud`, `kubectl`, `terraform`, `helm`, `ansible`, `apt`, `dpkg`, `dnf`, `yum`, `apk`, `nc`, `telnet`, `ftp`, `base64`, `xxd`, `hexdump`, plus shipped-in `ssh-keygen`/`ssh-agent`/`scp`/`rsync`). Belt-and-braces: these are already unreachable via `PATH`, but a caller that goes through an absolute path also gets `EACCES` rather than silently executing.

Image also pins `USER 65534:65534` so an image started outside `DockerSandboxProvider` still drops privileges by default.

### `tests/test_docker_sandbox.py` (new test class)

`TestMinimalPathSandboxImage` adds five smoke tests that run **without** a Docker daemon — they parse the Dockerfile and verify the policy as written:

- `test_dockerfile_exists` — image lives at the expected path.
- `test_path_is_explicit_and_minimal` — `ENV PATH=` is set explicitly, contains no inherited `\$PATH` and no `/sbin` / `/usr/sbin`, and includes the pinned `/usr/local/sandbox-bin`.
- `test_dangerous_binaries_are_addressed` — `curl`, `wget`, `ssh`, `az`, `kubectl`, `terraform`, `git`, `apt` are each named explicitly somewhere in the Dockerfile (the strip-bit pass), so a maintainer cannot accidentally drop coverage of one of these without the test catching the omission.
- `test_runs_as_nobody` — `USER 65534:65534` is set.
- `test_allowed_binaries_include_python_and_minimal_utilities` — the default `ALLOWED_BIN_NAMES` arg contains `python3`/`cat`/`echo` but does not silently include any of the forbidden CLIs (regression guard).

The image-build verification belongs in a separate CI workflow change (would require Docker available on the runner); this PR keeps the test scope to what `pytest` can validate offline, matching the existing `TestContainerCreationHardening` and `TestRuntimeDetection` patterns in the same file.

### `agent-sandbox/README.md`

New section **\"Hardened sandbox image (minimal-PATH)\"** documenting:
- What the image hardens against (references #2662's `os.system('az account list')` scenario).
- `docker build` invocations for the default allow-list and a custom one via `--build-arg ALLOWED_BIN_NAMES=...`.
- How to wire the image into `DockerSandboxProvider` via the existing `image` argument.
- How to extend the allow-list permanently and the relationship to the smoke tests.

## Acceptance check (from #2713)

- [x] New / updated image builds — the Dockerfile is self-contained and references only `python:3.11-slim`.
- [x] Smoke test passes — verified locally; the five new tests are pure-Python file parsing, no Docker daemon required.
- [x] Doc note (1-2 paragraphs) on how to extend the allowed-binary list — `ALLOWED_BIN_NAMES` build-arg documented in README with example.

## Out of scope (#2662 follow-ups)

- Read-only bind mount denylist + dangerous-binary symlinks to `/bin/false` or a logging shim.
- Custom AppArmor profile (`agent-sandbox/docker/apparmor/agt-sandbox-profile`).
- Execution shim that intercepts `subprocess` module calls.
- seccomp / capability changes — explicit out-of-scope per #2713.

Happy to follow up on any of these in separate PRs once #2713 lands.