### PR TITLE
fix: update community blog link to governance.ai-mvp.com

### DIFF
--- a/docs/COMMUNITY.md
+++ b/docs/COMMUNITY.md
@@ -36,7 +36,7 @@ Community-written content about agent governance, security, and the toolkit.
 | [Decentralized Identity in Multi-Agent Systems — From Theory to Production](https://dev.to/moltycel/decentralized-identity-in-multi-agent-systems-from-theory-to-production-1oe3) | [@MoltyCel](https://github.com/MoltyCel) | Dev.to |
 | [Scaling AI Agents from 10 to 10,000 — Governance Lessons from the Trenches](https://dev.to/zhangzeyu/scaling-ai-agents-from-10-to-10000-governance-lessons-from-the-trenches-31pd) | [@lawcontinue](https://github.com/lawcontinue) | Dev.to |
 | [OWASP Agentic Top 10 — What Every AI Developer Should Know in 2026](https://dev.to/zhangzeyu/owasp-agentic-top-10-what-every-ai-developer-should-know-in-2026-55hi) | [@lawcontinue](https://github.com/lawcontinue) | Dev.to |
-| [EU AI Act for AI Agent Developers: A Practical Compliance Checklist](https://eu-ai-act.ai-mvp.com/2026/04/10/eu-ai-act-compliance-checklist-for-ai-agent-developers/) | [@carloshvp](https://github.com/carloshvp) | ai-mvp.com |
+| [EU AI Act for AI Agent Developers: A Practical Compliance Checklist](https://governance.ai-mvp.com/2026/04/10/eu-ai-act-compliance-checklist-for-ai-agent-developers/) | [@carloshvp](https://github.com/carloshvp) | ai-mvp.com |
 | [MCP Security: Why Your AI Agents Need a Firewall for Tool Calls](https://dev.to/aymenhmaidi/mcp-security-why-your-ai-agents-tool-calls-need-a-firewall-3h48) | [@aymenhmaidiwastaken](https://github.com/aymenhmaidiwastaken) | Dev.to |
 
 ---


### PR DESCRIPTION
## What

Updates the broken link to my community blog post in `docs/COMMUNITY.md`.

The post moved domains: `eu-ai-act.ai-mvp.com` → `governance.ai-mvp.com`. The old subdomain no longer resolves, so the existing link (added in #918) is dead. This points it at the live URL.

## Change

One line in `docs/COMMUNITY.md`:

- Before: `https://eu-ai-act.ai-mvp.com/2026/04/10/eu-ai-act-compliance-checklist-for-ai-agent-developers/`
- After: `https://governance.ai-mvp.com/2026/04/10/eu-ai-act-compliance-checklist-for-ai-agent-developers/`

The article content is unchanged; only the domain moved.