### PR TITLE
ci: re-ignore redactor.rs key-pattern false positives

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -43,3 +43,10 @@ f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src
 f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:103
 f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:117
 f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:131
+
+# redactor.rs detection patterns re-fingerprinted after commit c88f4556 touched the file
+# (these are BEGIN/END PRIVATE KEY and API-key regex patterns used to scrub secrets, not real secrets)
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:generic-api-key:257
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:103
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:117
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:131


### PR DESCRIPTION
## Problem

The `gitleaks` secret-scanning job is currently failing on **every open PR**. The findings are false positives in `agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs` (the `-----BEGIN ... PRIVATE KEY-----` and API-key **regex patterns** the redactor uses to detect and scrub secrets, not real credentials).

`.gitleaksignore` already allowlisted these at commit `f46be908`. A later commit (`c88f4556`) touched `redactor.rs`, which changed the gitleaks fingerprints, so the old ignore entries went stale and the false positives resurfaced.

## Fix

Add the re-fingerprinted entries for the four findings (`generic-api-key:257`, `private-key:103`, `private-key:117`, `private-key:131`) to `.gitleaksignore`, matching the existing convention.

## Note for maintainers

Fingerprint-based ignores are commit-specific, so this will go stale again the next time `redactor.rs` is edited. A more durable fix would be a path- or regex-based allowlist in a `.gitleaks.toml` (`[extend] useDefault = true` + allowlist the redactor source paths or the `BEGIN PRIVATE KEY` regex). I'm happy to send that as a follow-up if you'd prefer it over the per-commit fingerprint approach.

Surfaced while opening #2736; the gitleaks failure there is the same false positive.