### PR TITLE
docs: update ADR count from 25 to 29 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Every major component has a formal RFC 2119 specification with conformance tests
 | [Audit and Compliance](docs/specs/AUDIT-COMPLIANCE-1.0.md) | Merkle audit, compliance mapping, Decision BOM | 157 |
 | [AgentMesh Wire Protocol](docs/specs/AGENTMESH-WIRE-1.0.md) | Message format, routing, serialization | -- |
 
-**992 conformance tests** ensure code stays aligned to specs. [25 Architecture Decision Records](docs/adr/) document why.
+**992 conformance tests** ensure code stays aligned to specs. [29 Architecture Decision Records](docs/adr/) document why.
 
 ---
 
@@ -386,7 +386,7 @@ See [Known Limitations](docs/LIMITATIONS.md) for honest design boundaries and re
 | Category | Links |
 |----------|-------|
 | **Getting Started** | [Quick Start](docs/quickstart.md) · [Tutorials](docs/tutorials/) (60+) · [FAQ](docs/FAQ.md) |
-| **Architecture** | [System Design](docs/ARCHITECTURE.md) · [Threat Model](docs/security/threat-model.md) · [ADRs](docs/adr/) (25) |
+| **Architecture** | [System Design](docs/ARCHITECTURE.md) · [Threat Model](docs/security/threat-model.md) · [ADRs](docs/adr/) (29) |
 | **Specifications** | [All Specs](docs/specs/) (10 formal specs, 992 conformance tests) |
 | **API Reference** | [Agent OS](agent-governance-python/agent-os/README.md) · [AgentMesh](agent-governance-python/agent-mesh/README.md) · [Agent SRE](agent-governance-python/agent-sre/README.md) |
 | **Compliance** | [OWASP](docs/compliance/owasp-agentic-top10-architecture.md) · [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [SOC 2](docs/compliance/soc2-mapping.md) |


### PR DESCRIPTION
## Description
README.md references \"25 Architecture Decision Records\" in two places, but `docs/adr/` contains ADRs 0001–0029 — 29 records. This updates both mentions to match the actual count.

## Type of Change
documentation

## Package(s) Affected
docs/root

## Checklist
- [x] ruff check — N/A (documentation only)
- [x] tests pass — N/A (documentation only)
- [x] docs updated — this IS the docs change
- [ ] CLA signed

## Attribution & Prior Art
Noticed while reviewing the repo structure; ADR count verified by listing `docs/adr/`.

## AI Assistance
Changes reviewed and verified manually. Able to explain every change.

## IP, Patents, and Licensing
No IP concerns — plain documentation correction.

## Related Issues
N/A