### PR TITLE
ci: add dedicated conformance step for agent-os (#2695)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,13 @@ jobs:
             echo "::warning::ci-test.txt not found at $CI_TEST_REQS — skipping shared test deps"
           fi
           pip install --no-cache-dir pytest-cov==7.1.0  # Scorecard: version-pinned
+      - name: Conformance (agent-os parity + adapter contract)
+        if: steps.gate.outputs.run == 'true' && matrix.package == 'agent-os'
+        working-directory: agent-governance-python/agent-os
+        run: |
+          pytest tests/test_governance_parity.py \
+                 tests/test_spec_adapter_contract_conformance.py \
+                 -v --tb=short
       - name: Test ${{ matrix.package }}
         if: steps.gate.outputs.run == 'true'
         working-directory: agent-governance-python/${{ matrix.package }}


### PR DESCRIPTION
## Description
Adds a dedicated CI step that hard-fails on governance parity and adapter contract conformance tests for the `agent-os` package. Previously these tests ran inside the general `Test` step, so conformance failures were buried in combined output.

The new step runs before `Test ${{ matrix.package }}` and is scoped exclusively to `agent-os` via `matrix.package == 'agent-os'`. It reuses the installation from the preceding `Install ${{ matrix.package }}` step — no duplicate pip invocation.

## Type of Change
maintenance

## Package(s) Affected
agent-os-kernel

## Checklist
- [x] ruff check — N/A (CI YAML only)
- [x] tests pass — step runs existing test files that already pass
- [x] docs updated — N/A
- [ ] CLA signed

## Attribution & Prior Art
Previous attempt: PR #2717 (closed — had a duplicate pip install block). This PR avoids that issue by reusing the existing install step.

Test files verified to exist:
- `agent-governance-python/agent-os/tests/test_governance_parity.py`
- `agent-governance-python/agent-os/tests/test_spec_adapter_contract_conformance.py`

## AI Assistance
Changes reviewed and verified manually. Able to explain every change.

## IP, Patents, and Licensing
No IP concerns — CI configuration only.

## Related Issues
Closes #2695