### PR TITLE
fix(ci): harden JS lint steps — fix mastra-agentmesh TS errors, remove soft-fail masks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -794,7 +794,7 @@ jobs:
         run: npm ci --ignore-scripts --legacy-peer-deps
       - name: Lint mastra-agentmesh
         working-directory: agent-governance-python/agentmesh-integrations/mastra-agentmesh
-        run: npm run lint 2>/dev/null || true
+        run: npm run lint
       - name: Test mastra-agentmesh
         working-directory: agent-governance-python/agentmesh-integrations/mastra-agentmesh
         run: npm test
@@ -804,7 +804,7 @@ jobs:
         run: npm ci --ignore-scripts --legacy-peer-deps
       - name: Lint copilot-governance
         working-directory: agent-governance-python/agentmesh-integrations/copilot-governance
-        run: npm run lint 2>/dev/null || true
+        run: npm run lint
       - name: Test copilot-governance
         working-directory: agent-governance-python/agentmesh-integrations/copilot-governance
         run: npm test

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/src/audit.ts
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/src/audit.ts
@@ -139,18 +139,11 @@ export function auditMiddleware(config: AuditConfig = {}) {
 
 export type { AuditEntry };
 
-/** Compute SHA-256 hash of a string. Works in Node.js and Edge. */
+/** Compute SHA-256 hash of a string. Uses the Web Crypto API (available in Node.js 18+ and all edge runtimes). */
 async function computeHash(data: string): Promise<string> {
-  // Node.js crypto
-  try {
-    const { createHash } = await import("crypto");
-    return createHash("sha256").update(data).digest("hex");
-  } catch {
-    // Fallback for edge runtimes
-    const encoder = new TextEncoder();
-    const buf = await crypto.subtle.digest("SHA-256", encoder.encode(data));
-    return Array.from(new Uint8Array(buf))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-  }
+  const encoder = new TextEncoder();
+  const buf = await crypto.subtle.digest("SHA-256", encoder.encode(data));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/tsconfig.json
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Description
Both `Lint mastra-agentmesh` and `Lint copilot-governance` CI steps used `2>/dev/null || true`, silently swallowing TypeScript errors and making those lint gates meaningless.

**mastra-agentmesh** had three real TS errors:
- `TS2307` – `Cannot find module 'crypto'` (dynamic `import("crypto")` requires `@types/node`)
- `TS2304` – `Cannot find name 'TextEncoder'` (DOM type not in lib)
- `TS2304` – `Cannot find name 'crypto'` (DOM global not in lib)

Fixes applied:
1. `tsconfig.json`: added `"DOM"` to `lib` — resolves `TextEncoder` and `crypto.subtle` globals.
2. `src/audit.ts`: replaced the Node.js `crypto` try/catch fallback with the Web Crypto API path only. Node 18+ (CI uses Node 20) exposes `crypto.subtle` as a global, so the dynamic `import("crypto")` that required `@types/node` is no longer needed.
3. `ci.yml`: removed `2>/dev/null || true` from both lint steps so failures surface in CI going forward.

`tsc --noEmit` passes with zero errors in both packages after this change.

## Type of Change
maintenance

## Package(s) Affected
docs/root

## Checklist
- [x] ruff check — N/A (TS/CI only)
- [x] tests pass — tsc --noEmit passes in both packages after fix
- [x] docs updated — N/A
- [ ] CLA signed

## Attribution & Prior Art
N/A

## AI Assistance
Changes reviewed and verified manually. Able to explain every change.

## IP, Patents, and Licensing
No IP concerns.

## Related Issues
N/A