### PR TITLE
fix(mastra): add @types/node for DTS build

### DIFF
--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package-lock.json
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@mastra/core": "1.37.1",
+        "@types/node": "^22.19.19",
         "tsup": "8.5.1",
         "typescript": "5.7.3",
         "vitest": "3.0.5",
@@ -1307,6 +1308,16 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -4888,6 +4899,13 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package.json
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@mastra/core": "1.37.1",
+    "@types/node": "^22.19.19",
     "tsup": "8.5.1",
     "typescript": "5.7.3",
     "vitest": "3.0.5",

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/tsconfig.json
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
## Summary

Fixes mastra-agentmesh DTS build failure. The audit.ts computeHash function uses Node.js crypto module and TextEncoder/crypto.subtle globals. Without @types/node, the DTS generation fails with TS2307/TS2304.

## Changes

- Added @types/node@22 to devDependencies
- Added types: [node] to tsconfig.json compilerOptions

## Testing

- tsc --noEmit: clean
- tsup: DTS build succeeds