### PR TITLE
fix(ci): add gitleaks allowlist for squash-merged credential redaction commit

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -43,3 +43,8 @@ f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src
 f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:103
 f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:117
 f46be908f9286027b09e939a5cc7f3cd49069731:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:131
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-python/agent-discovery/tests/test_process_redaction.py:private-key:21
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:generic-api-key:257
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:103
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:117
+c88f4556b717acb6753df7b099dedfc6a5284d15:agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs:private-key:131


### PR DESCRIPTION
## Summary

Fixes gitleaks secret scanning failure on main. The squash merge of #2737 created commit c88f4556 with different SHA from the cherry-pick commit f46be908. Gitleaks fingerprints are commit-specific, so allowlist entries needed for both.

All flagged items are test SSH keys and regex patterns in credential redaction code, not real secrets.