### PR TITLE
fix(esrp): align publish.yml matrices with ESRP pipeline

### DIFF
--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -160,7 +160,7 @@ pool:
 
 stages:
   # =======================================================
-  # PYTHON (PyPI) — 9 packages (4 consolidated + 1 meta + 4 standalone)
+  # PYTHON (PyPI) — 10 packages (4 consolidated + 1 meta + 5 standalone)
   # =======================================================
   - stage: Build_PyPI
     displayName: 'Build Python Packages'
@@ -254,7 +254,7 @@ stages:
                 domaintenantid: '$(MICROSOFT_TENANT_ID)'
 
   # =======================================================
-  # NPM — 7 packages (@microsoft scope)
+  # NPM — 11 packages (@microsoft scope)
   # =======================================================
   - stage: Build_npm
     displayName: 'Build & Pack npm Packages'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
         description: >
           Package to publish. Use "all" for everything, "all-python" for all
           Python packages, "all-npm" for all npm packages, or a specific name
-          (e.g. "agent-governance-toolkit-core", "agent-governance-copilot-cli", "agent-governance-claude-code", "agent-governance-opencode").
+          (e.g. "agent-governance-toolkit-core", "agent-governance-copilot-cli", "agent-governance-claude-code", "agent-governance-opencode", "agent-governance-antigravity-cli", "agt-sandbox").
         required: true
         type: string
         default: "all"
@@ -41,7 +41,7 @@ jobs:
           INPUT: ${{ github.event.inputs.package }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          # Complete list of publishable Python packages (9 packages)
+          # Complete list of publishable Python packages (10 packages)
           ALL='[
             {"name":"agent-governance-toolkit-core","path":"agent-governance-python/agent-governance-toolkit-core"},
             {"name":"agent-governance-toolkit-integrations","path":"agent-governance-python/agent-governance-toolkit-integrations"},
@@ -51,7 +51,8 @@ jobs:
             {"name":"agent-discovery","path":"agent-governance-python/agent-discovery"},
             {"name":"agent-lightning","path":"agent-governance-python/agent-lightning"},
             {"name":"agent-marketplace","path":"agent-governance-python/agent-marketplace"},
-            {"name":"agent-rag-governance","path":"agent-governance-python/agent-rag-governance"}
+            {"name":"agent-rag-governance","path":"agent-governance-python/agent-rag-governance"},
+            {"name":"agt-sandbox","path":"agent-governance-python/agent-sandbox"}
           ]'
           # Compact the JSON
           ALL=$(echo "$ALL" | jq -c '.')
@@ -69,6 +70,8 @@ jobs:
             "@microsoft/agent-governance-claude-code",
             "agent-governance-opencode",
             "@microsoft/agent-governance-opencode",
+            "agent-governance-antigravity-cli",
+            "@microsoft/agent-governance-antigravity-cli",
             "agentmesh-sdk",
             "agent-governance-sdk",
             "@microsoft/agent-governance-sdk",
@@ -203,6 +206,7 @@ jobs:
             {"name":"agent-governance-copilot-cli","path":"agent-governance-copilot-cli","nodeVersion":"22","selectors":["agent-governance-copilot-cli","@microsoft/agent-governance-copilot-cli"]},
             {"name":"agent-governance-claude-code","path":"agent-governance-claude-code","nodeVersion":"22","selectors":["agent-governance-claude-code","@microsoft/agent-governance-claude-code"]},
             {"name":"agent-governance-opencode","path":"agent-governance-opencode","nodeVersion":"22","selectors":["agent-governance-opencode","@microsoft/agent-governance-opencode"]},
+            {"name":"agent-governance-antigravity-cli","path":"agent-governance-antigravity-cli","nodeVersion":"22","selectors":["agent-governance-antigravity-cli","@microsoft/agent-governance-antigravity-cli"]},
             {"name":"agentmesh-sdk","path":"agent-governance-typescript","nodeVersion":"20","selectors":["agentmesh-sdk","agent-governance-sdk","@microsoft/agent-governance-sdk"]},
             {"name":"agent-os-copilot-extension","path":"agent-governance-python/agent-os/extensions/copilot","nodeVersion":"20","selectors":["agent-os-copilot-extension","@microsoft/agent-os-copilot-extension"]},
             {"name":"agentos-mcp-server","path":"agent-governance-python/agent-os/extensions/mcp-server","nodeVersion":"20","selectors":["agentos-mcp-server","@microsoft/agentos-mcp-server"]}


### PR DESCRIPTION
## Summary

Aligns the GitHub release workflow (publish.yml) with the ADO ESRP pipeline (esrp-publish.yml) so that release-triggered builds produce artifacts for the same set of packages that ESRP later signs and publishes.

## Problem

The two pipelines had drifted after recent package additions:

| Package | esrp-publish.yml | publish.yml |
|---------|:---:|:---:|
| agt-sandbox (PyPI) | ✅ added in #2727 | ❌ missing |
| agent-governance-antigravity-cli (npm) | ✅ added in #2554 | ❌ missing from matrix & selectors |

This means a GitHub release event would build artifacts for only 9 PyPI + 10 npm packages, while ESRP expects 10 + 11. Manual ESRP runs for the missing packages would have to be triggered separately.

## Changes

| File | Change |
|------|--------|
| .github/workflows/publish.yml | Add agt-sandbox to Python matrix (10 packages) |
| .github/workflows/publish.yml | Add agent-governance-antigravity-cli to NPM matrix and selectors (11 packages) |
| .github/workflows/publish.yml | Update workflow_dispatch description with new package names |
| .github/pipelines/esrp-publish.yml | Fix stage header comments (PyPI 9->10, NPM 7->11) |

No publishing logic, ESRP configuration, or signing requirements change.

## Verification

Validated both YAML files parse correctly and that Python matrices match exactly between the two pipelines:

`
publish.yml Python (10): agent-governance-toolkit-core, *-integrations, *-cli, *-protocols,
                          agent-governance-toolkit, agent-discovery, agent-lightning,
                          agent-marketplace, agent-rag-governance, agt-sandbox
ESRP PyPI (10):           [identical list]

publish.yml NPM (11):     11 packages including agent-governance-antigravity-cli
ESRP NPM (11):            [identical set, agentmesh-sdk artifact name maps to
                           @microsoft/agent-governance-sdk]
`

All 21 packages (10 PyPI + 11 npm) currently published at v4.0.0 and in sync with repo versions.
