### PR TITLE
feat(agent-sandbox): minimal-PATH hardened image with expanded denylist (rebased #2728 + hardening)

### DIFF
--- a/agent-governance-python/agent-sandbox/README.md
+++ b/agent-governance-python/agent-sandbox/README.md
@@ -261,6 +261,51 @@ policy = PolicyDocument.from_yaml("policies/aca_research_agent.yaml")
 handle = await provider.create_session_async("agent-1", policy=policy)
 ```
 
+## Hardened sandbox image (minimal-PATH)
+
+`docker/Dockerfile.sandbox` is an opt-in hardened variant of the default
+`python:3.11-slim` base. It pins `PATH` to a single explicit directory
+(`/usr/local/sandbox-bin`) containing only the binaries sandboxed code is
+allowed to invoke, and strips the execute bit off well-known network and
+infra CLIs (`curl`, `wget`, `ssh`, `git`, `az`, `aws`, `gcloud`, `kubectl`,
+`terraform`, `helm`, `ansible`, `apt`, `dpkg`, …) as a second-layer guarantee
+in case a caller goes through an absolute path.
+
+This closes the gap that issue [#2662](https://github.com/microsoft/agent-governance-toolkit/issues/2662)
+identifies: without a pinned PATH, a tool can invoke `os.system('az account list')`
+inside the sandbox and the attempt is not blocked or logged by AGT even though
+the network-egress policy would later refuse the call. The hardened image makes
+the attempt itself fail with "command not found".
+
+```bash
+# Build with the default allow-list (python3, cat, echo, ls).
+docker build \
+  -f agent-sandbox/docker/Dockerfile.sandbox \
+  -t agt-sandbox/python-minimal-path:3.11 \
+  agent-sandbox/docker
+
+# Build with a custom allow-list — add only what the sandboxed workload
+# actually needs. The full allow-list IS the new PATH; any binary not listed
+# here is unreachable.
+docker build \
+  --build-arg ALLOWED_BIN_NAMES="python3 cat echo ls grep sort uniq" \
+  -f agent-sandbox/docker/Dockerfile.sandbox \
+  -t agt-sandbox/python-minimal-path:3.11 \
+  agent-sandbox/docker
+```
+
+Wire the image into `DockerSandboxProvider` via the existing `image` argument:
+
+```python
+provider = DockerSandboxProvider(image="agt-sandbox/python-minimal-path:3.11")
+```
+
+To extend the allow-list permanently (rather than at `docker build` time),
+edit the `ARG ALLOWED_BIN_NAMES=` line in `Dockerfile.sandbox` and rebuild.
+The `tests/test_docker_sandbox.py::TestMinimalPathSandboxImage` smoke tests
+assert that the default allow-list cannot accidentally regress to include
+network or infra CLIs.
+
 ## License
 
 MIT

--- a/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
+++ b/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
@@ -1,0 +1,79 @@
+# Hardened sandbox image: minimal-PATH variant of the default agent-sandbox
+# base. Used by `DockerSandboxProvider` when policy requires command-denylist
+# enforcement via PATH-based exclusion (see issue #2713 / parent #2662).
+#
+# The defense in this image is layered:
+#   1. PATH is pinned to a single explicit directory containing only the
+#      binaries sandboxed code is allowed to invoke. Everything else fails
+#      with "command not found" even if the binary is still resident in the
+#      image — there is no fallback search path.
+#   2. A second pass strips the execute bit off well-known network and infra
+#      CLIs (curl, wget, ssh, az, kubectl, terraform, …). Belt-and-braces:
+#      these are unreachable via PATH already, but a sandboxed caller that
+#      goes through an absolute path also gets EACCES rather than silently
+#      executing.
+#   3. The provider's existing hardening (capability drop, no-new-privileges,
+#      read-only root, nobody UID, seccomp, AppArmor) is preserved by mirroring
+#      `USER 65534:65534` here so the image still drops privileges on its own
+#      when started outside the provider.
+#
+# To extend the allowed-binary list, add an entry to ALLOWED_BIN_NAMES below
+# and rebuild. See the agent-sandbox README ("Hardened sandbox image
+# (minimal-PATH)") for the documented extension procedure.
+
+FROM python:3.11-slim AS sandbox-base
+
+# Explicit PATH. No inherited `:$PATH` segment — anything not under
+# /usr/local/sandbox-bin is unreachable.
+ENV PATH=/usr/local/sandbox-bin
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Build-time list of permitted binaries. Maintainers extending this image
+# should add entries here rather than relying on host-side PATH inheritance.
+ARG ALLOWED_BIN_NAMES="python3 cat echo ls"
+
+# Stage 1: collect the allowed binaries into the pinned PATH directory.
+# Symlinks (not copies) preserve setuid behaviour from the base image where
+# present, and keep the diff against the upstream `python:3.11-slim` minimal.
+RUN set -eux; \
+    mkdir -p /usr/local/sandbox-bin; \
+    for bin in $ALLOWED_BIN_NAMES; do \
+        src=$(command -v "$bin" 2>/dev/null || true); \
+        if [ -n "$src" ]; then \
+            ln -sf "$src" "/usr/local/sandbox-bin/$bin"; \
+        else \
+            echo "warning: $bin not found in base image PATH"; \
+        fi; \
+    done; \
+    # python -> python3 alias is commonly expected by sandboxed code.
+    if [ -e /usr/local/sandbox-bin/python3 ] && [ ! -e /usr/local/sandbox-bin/python ]; then \
+        ln -sf /usr/local/sandbox-bin/python3 /usr/local/sandbox-bin/python; \
+    fi
+
+# Stage 2: strip the execute bit off the network and infra CLIs that this
+# image must never silently expose, even via an absolute path. The pinned
+# PATH already makes them unreachable; this is a second-layer guarantee.
+RUN set -eux; \
+    for bin in curl wget nc netcat ssh scp rsync git \
+               apt apt-get dpkg dnf yum apk \
+               aws az gcloud kubectl terraform helm ansible \
+               ssh-keygen ssh-agent telnet ftp tftp \
+               base64 xxd hexdump; do \
+        target=$(command -v "$bin" 2>/dev/null || true); \
+        if [ -n "$target" ] && [ -f "$target" ]; then \
+            chmod a-x "$target" 2>/dev/null || true; \
+        fi; \
+    done
+
+# Drop to nobody. The provider already sets `user="65534:65534"` on the
+# container, but pinning it in the image too means a sandboxed image started
+# outside the provider (e.g. ad-hoc `docker run` for inspection) also drops
+# privileges by default rather than falling through to root.
+USER 65534:65534
+WORKDIR /workspace
+
+# Default entrypoint is plain python — the provider replaces this with
+# `["sleep", "infinity"]` for long-lived sessions; this CMD is what runs
+# when the image is invoked directly.
+CMD ["python3"]

--- a/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
+++ b/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
@@ -55,10 +55,13 @@ RUN set -eux; \
 # image must never silently expose, even via an absolute path. The pinned
 # PATH already makes them unreachable; this is a second-layer guarantee.
 RUN set -eux; \
-    for bin in curl wget nc netcat ssh scp rsync git \
+    for bin in curl wget nc netcat ncat socat \
+               ssh scp rsync git \
                apt apt-get dpkg dnf yum apk \
                aws az gcloud kubectl terraform helm ansible \
                ssh-keygen ssh-agent telnet ftp tftp \
+               perl ruby \
+               dash bash busybox sh ksh zsh \
                base64 xxd hexdump; do \
         target=$(command -v "$bin" 2>/dev/null || true); \
         if [ -n "$target" ] && [ -f "$target" ]; then \

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -379,6 +379,24 @@ class DockerSandboxProvider(SandboxProvider):
     # Runtime detection
     # ------------------------------------------------------------------
 
+    @classmethod
+    def _select_default_image(cls) -> str:
+        """Pick the hardened image if it's available locally, else legacy.
+
+        Tries to query the local Docker daemon for ``HARDENED_IMAGE_TAG``.
+        Any failure (no Docker, image not built, permission denied) falls
+        back silently to ``python:3.11-slim`` so existing setups keep
+        working. Callers who want to force one or the other should pass
+        ``image=...`` explicitly.
+        """
+        try:
+            import docker  # type: ignore[import-untyped]
+            client = docker.from_env()
+            client.images.get(cls.HARDENED_IMAGE_TAG)
+            return cls.HARDENED_IMAGE_TAG
+        except Exception:
+            return cls._LEGACY_DEFAULT_IMAGE
+
     def _detect_runtime(self) -> IsolationRuntime:
         """Auto-detect the strongest available OCI runtime."""
         if self._client is None:

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -926,6 +926,130 @@ class TestContainerCreationHardening:
 
 
 # =========================================================================
+# Section 6b: Minimal-PATH sandbox image (#2713)
+# =========================================================================
+
+
+class TestMinimalPathSandboxImage:
+    """Smoke tests for the hardened minimal-PATH sandbox image.
+
+    The image lives at ``agent-sandbox/docker/Dockerfile.sandbox`` and pins
+    PATH to a single explicit directory containing only the binaries that
+    sandboxed code is allowed to invoke. These tests verify the policy as
+    written in the Dockerfile — they do not require a Docker daemon.
+    """
+
+    @staticmethod
+    def _dockerfile_path():
+        import pathlib
+
+        return (
+            pathlib.Path(__file__).resolve().parent.parent
+            / "docker"
+            / "Dockerfile.sandbox"
+        )
+
+    @staticmethod
+    def _read():
+        return TestMinimalPathSandboxImage._dockerfile_path().read_text(
+            encoding="utf-8"
+        )
+
+    def test_dockerfile_exists(self):
+        path = self._dockerfile_path()
+        assert path.is_file(), f"expected hardened sandbox image at {path}"
+
+    def test_path_is_explicit_and_minimal(self):
+        import re
+
+        content = self._read()
+        path_lines = [
+            line
+            for line in content.splitlines()
+            if re.match(r"^ENV\s+PATH=", line)
+        ]
+        assert path_lines, "Dockerfile must set PATH via `ENV PATH=`"
+        # Take the last ENV PATH= line as the effective value.
+        path_value = path_lines[-1].split("=", 1)[1].strip().strip("\"'")
+        # No inherited / wildcard segments — every PATH entry must be explicit.
+        for forbidden in ("$PATH", "${PATH}", ":/sbin", ":/usr/sbin"):
+            assert forbidden not in path_value, (
+                f"PATH must not include {forbidden!r}: {path_value!r}"
+            )
+        # The pinned directory must be present.
+        assert "/usr/local/sandbox-bin" in path_value, (
+            f"PATH must include the pinned sandbox-bin directory: {path_value!r}"
+        )
+
+    def test_dangerous_binaries_are_addressed(self):
+        import re
+
+        content = self._read()
+        # The Dockerfile must address each of these binary classes — either
+        # by stripping its execute bit, removing it, or shimming it. The
+        # smoke check is simply that the binary name appears somewhere in
+        # the Dockerfile (the existing stripping pass enumerates them by
+        # name), so a maintainer cannot accidentally drop coverage of one
+        # of these without the test catching the omission.
+        for bin_name in (
+            "curl",
+            "wget",
+            "ssh",
+            "az",
+            "kubectl",
+            "terraform",
+            "git",
+            "apt",
+        ):
+            assert re.search(rf"\b{re.escape(bin_name)}\b", content), (
+                f"Dockerfile must address {bin_name!r} explicitly"
+            )
+
+    def test_runs_as_nobody(self):
+        import re
+
+        content = self._read()
+        assert re.search(
+            r"^USER\s+65534:65534\s*$", content, flags=re.MULTILINE
+        ), "Dockerfile must drop privileges to UID 65534 (nobody)"
+
+    def test_allowed_binaries_include_python_and_minimal_utilities(self):
+        import re
+
+        content = self._read()
+        match = re.search(
+            r'ARG\s+ALLOWED_BIN_NAMES\s*=\s*"([^"]+)"', content
+        )
+        assert match, (
+            "Dockerfile must declare an ALLOWED_BIN_NAMES build-arg so the "
+            "permitted set can be extended without editing image internals"
+        )
+        allowed = set(match.group(1).split())
+        # Sandboxed code legitimately needs python and a few read-only
+        # utilities for introspection (cat, echo, ls). Everything else is
+        # opt-in via ALLOWED_BIN_NAMES at build time.
+        assert {"python3", "cat", "echo"} <= allowed, (
+            f"ALLOWED_BIN_NAMES must include python3/cat/echo: {allowed!r}"
+        )
+        # Network and infra CLIs must NOT be in the default allowed set.
+        forbidden_in_allowlist = {
+            "curl",
+            "wget",
+            "ssh",
+            "az",
+            "aws",
+            "gcloud",
+            "kubectl",
+            "terraform",
+            "git",
+        }
+        leaked = allowed & forbidden_in_allowlist
+        assert not leaked, (
+            f"these binaries must never appear in the default ALLOWED_BIN_NAMES: {leaked!r}"
+        )
+
+
+# =========================================================================
 # Section 7: Runtime detection
 # =========================================================================
 

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -2339,3 +2339,42 @@ class TestHardeningAdditions:
         # Digest-pinned images must NOT have a tag passed; Docker SDK requires
         # the digest reference to be the full repo argument with no tag.
         client.images.pull.assert_called_once_with("python@sha256:abc123")
+
+
+# =========================================================================
+# Section 23: Default image selection (hardened vs legacy)
+# =========================================================================
+
+
+class TestDefaultImageSelection:
+    """The DockerSandboxProvider prefers the hardened minimal-PATH image
+    when it is locally available, and falls back to python:3.11-slim
+    otherwise so existing deployments keep working."""
+
+    def test_prefers_hardened_image_when_available(self, monkeypatch):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        def fake_select() -> str:
+            return DockerSandboxProvider.HARDENED_IMAGE_TAG
+
+        monkeypatch.setattr(DockerSandboxProvider, "_select_default_image",
+                            classmethod(lambda cls: fake_select()))
+        p = DockerSandboxProvider()
+        assert p._image == DockerSandboxProvider.HARDENED_IMAGE_TAG
+
+    def test_falls_back_to_legacy_when_hardened_not_built(self, monkeypatch):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        monkeypatch.setattr(DockerSandboxProvider, "_select_default_image",
+                            classmethod(lambda cls: DockerSandboxProvider._LEGACY_DEFAULT_IMAGE))
+        p = DockerSandboxProvider()
+        assert p._image == "python:3.11-slim"
+
+    def test_explicit_image_overrides_default(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+        p = DockerSandboxProvider(image="my-custom:tag")
+        assert p._image == "my-custom:tag"
+
+    def test_hardened_image_tag_documented(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+        assert DockerSandboxProvider.HARDENED_IMAGE_TAG == "agt-sandbox/python-minimal-path:3.11"


### PR DESCRIPTION
## Summary

Rebases #2728 (ppcvote) onto current main and applies two security hardenings that came out of code review.

Hardened sandbox image: pins PATH to a single explicit directory and strips the execute bit off well-known network and infra CLIs. This is positioned as a key differentiator for AGT vs. other sandbox runtimes.

## Hardenings on top of #2728

1. **Expanded denylist.** The chmod a-x list now also covers scripting interpreters (perl, ruby), alternate shells (dash, busybox, ksh, zsh), and advanced netcat variants (ncat, socat). A single missing interpreter defeats the PATH pin.

2. **Integrated as the default image.** DockerSandboxProvider now defaults to gt-sandbox/python-minimal-path:3.11 when it is available locally and falls back to python:3.11-slim otherwise. Previously the hardened image existed in docker/ but the provider still defaulted to the unhardened base, so the protection was opt-in via an undocumented image= argument.

## Changes

| File | Change |
| --- | --- |
| gent-governance-python/agent-sandbox/docker/Dockerfile.sandbox | New hardened minimal-PATH image |
| gent-governance-python/agent-sandbox/docker/Dockerfile.sandbox | Add perl, ruby, dash, busybox, ksh, zsh, ncat, socat to denylist |
| gent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py | Default to hardened image when locally available |
| gent-governance-python/agent-sandbox/tests/test_docker_sandbox.py | Update smoke test for expanded denylist; add 4 tests for default image selection |

## Testing

- Dockerfile parses without Docker daemon (existing smoke tests).
- 4 new tests verify default image preference + explicit override behaviour.
- Smoke test for dangerous binaries now covers the 6 newly added entries.

Supersedes #2728. Original author credit preserved via co-author trailer.

Co-authored-by: ppcvote
