### PR TITLE
fix(agent-sandbox): restore HARDENED_IMAGE_TAG class attrs broken by #2762 squash

### DIFF
--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -304,7 +304,9 @@ class DockerSandboxProvider(SandboxProvider):
     Parameters
     ----------
     image:
-        Base Docker image (default ``python:3.11-slim``).
+        Base Docker image. When ``None`` (default), the provider auto-
+        selects the hardened ``HARDENED_IMAGE_TAG`` if it is locally
+        available, and falls back to ``_LEGACY_DEFAULT_IMAGE`` otherwise.
     docker_url:
         Docker daemon URL (default: auto-detect via env).
     runtime:
@@ -314,14 +316,22 @@ class DockerSandboxProvider(SandboxProvider):
         ``ToolCallProxy`` when a policy has a ``tool_allowlist``.
     """
 
+    # Hardened, minimal-PATH image built from docker/Dockerfile.sandbox.
+    # Preferred when available; selected by ``_select_default_image``.
+    HARDENED_IMAGE_TAG: str = "agt-sandbox/python-minimal-path:3.11"
+
+    # Legacy fallback used when the hardened image is not on the local
+    # daemon. Kept stable so existing deployments do not break.
+    _LEGACY_DEFAULT_IMAGE: str = "python:3.11-slim"
+
     def __init__(
         self,
-        image: str = "python:3.11-slim",
+        image: str | None = None,
         docker_url: str | None = None,
         runtime: IsolationRuntime = IsolationRuntime.AUTO,
         tools: dict[str, Callable[..., Any]] | None = None,
     ) -> None:
-        self._image = image
+        self._image = image if image is not None else self._select_default_image()
         self._tools: dict[str, Callable[..., Any]] = tools or {}
         self._requested_runtime = runtime
 


### PR DESCRIPTION
## Summary

Hotfix for main. The squash merge of #2762 dropped the class-level constants HARDENED_IMAGE_TAG and _LEGACY_DEFAULT_IMAGE that _select_default_image() and TestDefaultImageSelection rely on, breaking CI:

`
AttributeError: type object DockerSandboxProvider has no attribute HARDENED_IMAGE_TAG
`

## Changes

- Restore the two class attributes on DockerSandboxProvider.
- Switch constructor signature back to image: str | None = None, delegating to _select_default_image() when not provided.
- No API break: explicit image= still overrides.

## Testing

`
pytest tests/test_docker_sandbox.py::TestDefaultImageSelection -q
4 passed
`
