### PR TITLE
fix(lint): remove unused ResourceType import to unblock CI

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
@@ -247,7 +247,7 @@ class GovernedCallable:
         ``ring`` and ``ring_constraints`` into *context* so downstream policy
         rules can reference them (e.g. ``ring.subprocess_allowed == false``).
         """
-        from hypervisor.rings.enforcer import RING_CONSTRAINTS, ResourceType
+        from hypervisor.rings.enforcer import RING_CONSTRAINTS
 
         ring = self._config.ring
 


### PR DESCRIPTION
Fixes ruff F401 lint failure on main introduced by #2761.

## Problem
`ResourceType` was imported but never used; the symbol is only referenced as a string in the rule grammar, not at runtime.

## Change
- Removed unused import in `agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py:250`

## Testing
- `ruff check src/ --select E,F,W --ignore E501` clean locally
