### PR TITLE
fix: expand credential redaction coverage

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -1,4 +1,5 @@
 AAIF
+abprs
 abspath
 abstractmethod
 Acta
@@ -23,6 +24,7 @@ Amol
 anomalyco
 antigravity
 APIM
+apikey
 apiserver
 approv
 approvеd
@@ -149,6 +151,7 @@ exfil
 exfiltrated
 exfiltration
 expanduser
+FAKEFORTESTING
 fastapi
 Fatalf
 Fernet
@@ -342,6 +345,7 @@ Printf
 Println
 privatelink
 promptdefense
+psour
 PSMODULEPATH
 psmodules
 pycache
@@ -415,6 +419,7 @@ setext
 setitem
 setuid
 setuptools
+sharedaccesskey
 shortone
 shutil
 siddique
@@ -525,6 +530,7 @@ ABAC
 AGENTDOJO
 AILLM
 AKIAFAKE
+AKIAFAKEFORTEST
 AKIDEXAMPLE
 BLOCKME
 BOTO
@@ -552,6 +558,7 @@ Threadsafe
 Uninstrumented
 Ureq
 XFORM
+xoxq
 x86
 ababa
 achat

--- a/agent-governance-dotnet/src/AgentGovernance/Mcp/McpCredentialRedactor.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Mcp/McpCredentialRedactor.cs
@@ -19,6 +19,14 @@ public enum CredentialKind
     SecretAssignment,
     /// <summary>GitHub access token.</summary>
     GitHubToken,
+    /// <summary>OpenAI API token.</summary>
+    OpenAiToken,
+    /// <summary>Slack access token.</summary>
+    SlackToken,
+    /// <summary>AWS access key identifier.</summary>
+    AwsAccessKey,
+    /// <summary>Google API key.</summary>
+    GoogleApiKey,
     /// <summary>RFC 7468 PEM private key block.</summary>
     PemPrivateKey
 }
@@ -68,6 +76,22 @@ public sealed class McpCredentialRedactor
         (CredentialKind.GitHubToken,
          new Regex(@"(?<![A-Za-z0-9_])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9_])", RegexOptions.Compiled, RegexTimeout),
          "[REDACTED_GITHUB_TOKEN]"),
+
+        (CredentialKind.OpenAiToken,
+         new Regex(@"(?<![A-Za-z0-9_-])sk-[A-Za-z0-9][A-Za-z0-9_-]{18,}(?![A-Za-z0-9_-])", RegexOptions.Compiled, RegexTimeout),
+         "[REDACTED_OPENAI_TOKEN]"),
+
+        (CredentialKind.SlackToken,
+         new Regex(@"(?<![A-Za-z0-9-])xox[abprs]-[A-Za-z0-9-]+(?![A-Za-z0-9-])", RegexOptions.Compiled, RegexTimeout),
+         "[REDACTED_SLACK_TOKEN]"),
+
+        (CredentialKind.AwsAccessKey,
+         new Regex(@"\bAKIA[A-Z0-9]{16}\b", RegexOptions.Compiled, RegexTimeout),
+         "[REDACTED_AWS_ACCESS_KEY]"),
+
+        (CredentialKind.GoogleApiKey,
+         new Regex(@"\bAIza[0-9A-Za-z\-_]{35}\b", RegexOptions.Compiled, RegexTimeout),
+         "[REDACTED_GOOGLE_API_KEY]"),
 
         (CredentialKind.PemPrivateKey,
          new Regex(@"-----BEGIN (?<label>(?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY)-----(?:\r?\n[!-~ \t]*)*?\r?\n-----END \k<label>-----", RegexOptions.Compiled, RegexTimeout),
@@ -125,6 +149,10 @@ public sealed class McpCredentialRedactor
         CredentialKind.ConnectionString => "[REDACTED_CONNECTION_STRING]",
         CredentialKind.SecretAssignment => "[REDACTED_SECRET]",
         CredentialKind.GitHubToken => "[REDACTED_GITHUB_TOKEN]",
+        CredentialKind.OpenAiToken => "[REDACTED_OPENAI_TOKEN]",
+        CredentialKind.SlackToken => "[REDACTED_SLACK_TOKEN]",
+        CredentialKind.AwsAccessKey => "[REDACTED_AWS_ACCESS_KEY]",
+        CredentialKind.GoogleApiKey => "[REDACTED_GOOGLE_API_KEY]",
         CredentialKind.PemPrivateKey => "[REDACTED_PEM_PRIVATE_KEY]",
         _ => "[REDACTED]"
     };

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/McpCredentialRedactorTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/McpCredentialRedactorTests.cs
@@ -91,6 +91,26 @@ public class McpCredentialRedactorTests
         Assert.Contains(CredentialKind.GitHubToken, result.Detected);
     }
 
+    [Fact]
+    public void Redact_ModernProviderTokenPatterns()
+    {
+        var openAiToken = $"sk-FAKEFORTESTING{new string('x', 20)}";
+        var slackToken = "xoxb-FAKE-FOR-TESTING-0000000000";
+        var awsAccessKey = $"AKIA{new string('A', 16)}";
+        var googleApiKey = $"AIza{new string('A', 35)}";
+
+        var result = _redactor.Redact(
+            $"openai {openAiToken} slack {slackToken} aws {awsAccessKey} google {googleApiKey}");
+
+        Assert.Equal(
+            "openai [REDACTED_OPENAI_TOKEN] slack [REDACTED_SLACK_TOKEN] aws [REDACTED_AWS_ACCESS_KEY] google [REDACTED_GOOGLE_API_KEY]",
+            result.Sanitized);
+        Assert.Contains(CredentialKind.OpenAiToken, result.Detected);
+        Assert.Contains(CredentialKind.SlackToken, result.Detected);
+        Assert.Contains(CredentialKind.AwsAccessKey, result.Detected);
+        Assert.Contains(CredentialKind.GoogleApiKey, result.Detected);
+    }
+
     [Theory]
     [InlineData("RSA PRIVATE KEY")]
     [InlineData("EC PRIVATE KEY")]
@@ -112,6 +132,10 @@ public class McpCredentialRedactorTests
     [InlineData("-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----")]
     [InlineData("-----BEGIN RSA PRIVATE KEY-----\nZmFrZQ==\n-----END EC PRIVATE KEY-----")]
     [InlineData("github_pat_short")]
+    [InlineData("sk-short")]
+    [InlineData("xoxq-FAKE-FOR-TESTING-0000000000")]
+    [InlineData("AKIAFAKEFORTEST0000")]
+    [InlineData("AIzaFAKE_FOR_TESTING_000000000000000")]
     public void Redact_DoesNotRedactMalformedCredentialLookalikes(string text)
     {
         var result = _redactor.Redact(text);

--- a/agent-governance-python/agent-mesh/packages/mcp-proxy/src/audit.ts
+++ b/agent-governance-python/agent-mesh/packages/mcp-proxy/src/audit.ts
@@ -28,6 +28,10 @@ export interface AuditEvent {
 export class AuditLogger {
   private static readonly credentialPatterns = [
     /(?<![A-Za-z0-9_])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9_])/g,
+    /(?<![A-Za-z0-9_-])sk-[A-Za-z0-9][A-Za-z0-9_-]{18,}(?![A-Za-z0-9_-])/g,
+    /(?<![A-Za-z0-9-])xox[abprs]-[A-Za-z0-9-]+(?![A-Za-z0-9-])/g,
+    /\bAKIA[A-Z0-9]{16}\b/g,
+    /\bAIza[0-9A-Za-z\-_]{35}\b/g,
     /-----BEGIN (?<label>(?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY)-----(?:\r?\n[!-~ \t]*)*?\r?\n-----END \k<label>-----/g,
   ];
 

--- a/agent-governance-python/agent-mesh/packages/mcp-proxy/tests/policy-audit.test.ts
+++ b/agent-governance-python/agent-mesh/packages/mcp-proxy/tests/policy-audit.test.ts
@@ -57,6 +57,10 @@ describe('evaluatePolicy', () => {
 });
 
 describe('AuditLogger', () => {
+  const fakeOpenAiToken = `sk-FAKEFORTESTING${'x'.repeat(20)}`;
+  const fakeAwsAccessKey = `AKIA${'A'.repeat(16)}`;
+  const fakeGoogleApiKey = `AIza${'A'.repeat(35)}`;
+
   it('includes mitigates in CloudEvents data only when present', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'mcp-proxy-audit-'));
     tempDirs.push(tempDir);
@@ -105,8 +109,11 @@ describe('AuditLogger', () => {
       decision: 'allow',
       arguments: {
         publicField: 'github_pat_FAKE_FOR_TESTING_0000000000000000000000',
+        openAiToken: fakeOpenAiToken,
+        slackToken: 'xoxb-FAKE-FOR-TESTING-0000000000',
         nested: {
           note: '-----BEGIN DSA PRIVATE KEY-----\nZmFrZQ==\n-----END DSA PRIVATE KEY-----',
+          cloud: [fakeAwsAccessKey, fakeGoogleApiKey],
         },
       },
     });
@@ -124,7 +131,10 @@ describe('AuditLogger', () => {
       .map((line) => JSON.parse(line) as { data: { arguments: Record<string, any> } });
 
     expect(entry.data.arguments.publicField).toBe('[REDACTED]');
+    expect(entry.data.arguments.openAiToken).toBe('[REDACTED]');
+    expect(entry.data.arguments.slackToken).toBe('[REDACTED]');
     expect(entry.data.arguments.nested.note).toBe('[REDACTED]');
+    expect(entry.data.arguments.nested.cloud).toEqual(['[REDACTED]', '[REDACTED]']);
   });
 
   it('redacts arguments in plain json audit format', async () => {

--- a/agent-governance-python/agent-mesh/packages/mcp-proxy/tests/policy-audit.test.ts
+++ b/agent-governance-python/agent-mesh/packages/mcp-proxy/tests/policy-audit.test.ts
@@ -108,7 +108,7 @@ describe('AuditLogger', () => {
       tool: 'echo',
       decision: 'allow',
       arguments: {
-        publicField: 'github_pat_FAKE_FOR_TESTING_0000000000000000000000',
+        embeddedToken: 'github_pat_FAKE_FOR_TESTING_0000000000000000000000',
         openAiToken: fakeOpenAiToken,
         slackToken: 'xoxb-FAKE-FOR-TESTING-0000000000',
         nested: {
@@ -130,7 +130,7 @@ describe('AuditLogger', () => {
       .split('\n')
       .map((line) => JSON.parse(line) as { data: { arguments: Record<string, any> } });
 
-    expect(entry.data.arguments.publicField).toBe('[REDACTED]');
+    expect(entry.data.arguments.embeddedToken).toBe('[REDACTED]');
     expect(entry.data.arguments.openAiToken).toBe('[REDACTED]');
     expect(entry.data.arguments.slackToken).toBe('[REDACTED]');
     expect(entry.data.arguments.nested.note).toBe('[REDACTED]');

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/redactor.rs
@@ -15,6 +15,10 @@ pub enum CredentialKind {
     ConnectionString,
     SecretAssignment,
     GitHubToken,
+    OpenAiToken,
+    SlackToken,
+    AwsAccessKey,
+    GoogleApiKey,
     PemPrivateKey,
 }
 
@@ -26,6 +30,10 @@ impl CredentialKind {
             Self::ConnectionString => "connection_string",
             Self::SecretAssignment => "secret_assignment",
             Self::GitHubToken => "github_token",
+            Self::OpenAiToken => "openai_token",
+            Self::SlackToken => "slack_token",
+            Self::AwsAccessKey => "aws_access_key",
+            Self::GoogleApiKey => "google_api_key",
             Self::PemPrivateKey => "pem_private_key",
         }
     }
@@ -37,6 +45,10 @@ impl CredentialKind {
             Self::ConnectionString => "[REDACTED_CONNECTION_STRING]",
             Self::SecretAssignment => "[REDACTED_SECRET]",
             Self::GitHubToken => "[REDACTED_GITHUB_TOKEN]",
+            Self::OpenAiToken => "[REDACTED_OPENAI_TOKEN]",
+            Self::SlackToken => "[REDACTED_SLACK_TOKEN]",
+            Self::AwsAccessKey => "[REDACTED_AWS_ACCESS_KEY]",
+            Self::GoogleApiKey => "[REDACTED_GOOGLE_API_KEY]",
             Self::PemPrivateKey => "[REDACTED_PEM_PRIVATE_KEY]",
         }
     }
@@ -53,6 +65,7 @@ pub struct RedactionResult {
 #[derive(Debug, Clone)]
 pub struct CredentialRedactor {
     patterns: Vec<(CredentialKind, Regex)>,
+    bounded_patterns: Vec<(CredentialKind, Regex)>,
 }
 
 impl CredentialRedactor {
@@ -91,11 +104,6 @@ impl CredentialRedactor {
                         r#"(?i)\b(?:password|secret|token)\s*[:=]\s*["']?[^\s"';,]{4,}["']?"#,
                     )
                     .expect("SecretAssignment regex literal must compile"),
-                ),
-                (
-                    CredentialKind::GitHubToken,
-                    Regex::new(r"\b(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})\b")
-                        .expect("GitHubToken regex literal must compile"),
                 ),
                 (
                     CredentialKind::PemPrivateKey,
@@ -140,6 +148,33 @@ impl CredentialRedactor {
                     .expect("PemPrivateKey regex literal must compile"),
                 ),
             ],
+            bounded_patterns: vec![
+                (
+                    CredentialKind::GitHubToken,
+                    Regex::new(r"(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})")
+                        .expect("GitHubToken regex literal must compile"),
+                ),
+                (
+                    CredentialKind::OpenAiToken,
+                    Regex::new(r"sk-[A-Za-z0-9][A-Za-z0-9_-]{18,}")
+                        .expect("OpenAiToken regex literal must compile"),
+                ),
+                (
+                    CredentialKind::SlackToken,
+                    Regex::new(r"xox[abprs]-[A-Za-z0-9-]+")
+                        .expect("SlackToken regex literal must compile"),
+                ),
+                (
+                    CredentialKind::AwsAccessKey,
+                    Regex::new(r"AKIA[A-Z0-9]{16}")
+                        .expect("AwsAccessKey regex literal must compile"),
+                ),
+                (
+                    CredentialKind::GoogleApiKey,
+                    Regex::new(r"AIza[0-9A-Za-z\-_]{35}")
+                        .expect("GoogleApiKey regex literal must compile"),
+                ),
+            ],
         }
     }
 
@@ -154,9 +189,64 @@ impl CredentialRedactor {
                 .replace_all(&sanitized, kind.placeholder())
                 .into_owned();
         }
+        for (kind, pattern) in &self.bounded_patterns {
+            let (redacted, modified) = Self::redact_bounded_token(&sanitized, pattern, *kind);
+            if modified && !detected.contains(kind) {
+                detected.push(*kind);
+            }
+            sanitized = redacted;
+        }
         RedactionResult {
             sanitized,
             detected,
+        }
+    }
+
+    fn redact_bounded_token(input: &str, pattern: &Regex, kind: CredentialKind) -> (String, bool) {
+        let mut result = String::with_capacity(input.len());
+        let mut last = 0;
+        let mut modified = false;
+
+        for candidate in pattern.find_iter(input) {
+            let previous = input[..candidate.start()].chars().next_back();
+            let next = input[candidate.end()..].chars().next();
+            if previous.is_some_and(|ch| Self::is_left_boundary_char(kind, ch))
+                || next.is_some_and(|ch| Self::is_right_boundary_char(kind, ch))
+            {
+                continue;
+            }
+
+            result.push_str(&input[last..candidate.start()]);
+            result.push_str(kind.placeholder());
+            last = candidate.end();
+            modified = true;
+        }
+
+        if modified {
+            result.push_str(&input[last..]);
+            (result, true)
+        } else {
+            (input.to_string(), false)
+        }
+    }
+
+    fn is_left_boundary_char(kind: CredentialKind, ch: char) -> bool {
+        match kind {
+            CredentialKind::GitHubToken => ch.is_ascii_alphanumeric() || ch == '_',
+            CredentialKind::OpenAiToken | CredentialKind::GoogleApiKey => {
+                ch.is_ascii_alphanumeric() || ch == '_' || ch == '-'
+            }
+            CredentialKind::SlackToken => ch.is_ascii_alphanumeric() || ch == '-',
+            CredentialKind::AwsAccessKey => ch.is_ascii_alphanumeric(),
+            _ => ch.is_ascii_alphanumeric() || ch == '_',
+        }
+    }
+
+    fn is_right_boundary_char(kind: CredentialKind, ch: char) -> bool {
+        match kind {
+            CredentialKind::OpenAiToken => ch.is_ascii_alphanumeric() || ch == '_' || ch == '-',
+            CredentialKind::SlackToken => ch.is_ascii_alphanumeric() || ch == '-',
+            _ => false,
         }
     }
 
@@ -277,6 +367,76 @@ mod tests {
             let result = redactor.redact(&format!("value {token} end"));
             assert_eq!(result.sanitized, "value [REDACTED_GITHUB_TOKEN] end");
             assert!(result.detected.contains(&CredentialKind::GitHubToken));
+        }
+    }
+
+    #[test]
+    fn redacts_github_tokens_with_non_word_boundaries() {
+        let redactor = CredentialRedactor::new();
+        let token = "ghp_FAKEFORTESTING000000000000000000";
+        let result = redactor.redact(&format!("({token}), {token}."));
+
+        assert_eq!(
+            result.sanitized,
+            "([REDACTED_GITHUB_TOKEN]), [REDACTED_GITHUB_TOKEN]."
+        );
+        assert!(result.detected.contains(&CredentialKind::GitHubToken));
+    }
+
+    #[test]
+    fn does_not_redact_embedded_github_token_lookalikes() {
+        let redactor = CredentialRedactor::new();
+        for text in ["prefix_ghp_FAKEFORTESTING000000000000000000"] {
+            let result = redactor.redact(text);
+            assert_eq!(result.sanitized, text);
+            assert!(result.detected.is_empty());
+        }
+    }
+
+    #[test]
+    fn redacts_recoverable_github_token_before_underscore_suffix() {
+        let redactor = CredentialRedactor::new();
+        let result = redactor.redact("ghp_FAKEFORTESTING000000000000000000_suffix");
+
+        assert_eq!(result.sanitized, "[REDACTED_GITHUB_TOKEN]_suffix");
+        assert!(result.detected.contains(&CredentialKind::GitHubToken));
+    }
+
+    #[test]
+    fn redacts_modern_provider_token_patterns() {
+        let redactor = CredentialRedactor::new();
+        let openai_token = format!("sk-FAKEFORTESTING{}", "x".repeat(20));
+        let slack_token = "xoxb-FAKE-FOR-TESTING-0000000000";
+        let aws_access_key = format!("AKIA{}", "A".repeat(16));
+        let google_api_key = format!("AIza{}", "A".repeat(35));
+
+        let result = redactor.redact(&format!(
+            "openai {openai_token} slack {slack_token} aws {aws_access_key} google {google_api_key}"
+        ));
+
+        assert_eq!(
+            result.sanitized,
+            "openai [REDACTED_OPENAI_TOKEN] slack [REDACTED_SLACK_TOKEN] aws [REDACTED_AWS_ACCESS_KEY] google [REDACTED_GOOGLE_API_KEY]"
+        );
+        assert!(result.detected.contains(&CredentialKind::OpenAiToken));
+        assert!(result.detected.contains(&CredentialKind::SlackToken));
+        assert!(result.detected.contains(&CredentialKind::AwsAccessKey));
+        assert!(result.detected.contains(&CredentialKind::GoogleApiKey));
+    }
+
+    #[test]
+    fn does_not_redact_malformed_provider_token_lookalikes() {
+        let redactor = CredentialRedactor::new();
+        let embedded_aws_access_key = format!("prefix{}", format!("AKIA{}", "A".repeat(16)));
+        for text in [
+            "sk-short",
+            "xoxq-FAKE-FOR-TESTING-0000000000",
+            embedded_aws_access_key.as_str(),
+            "AIzaFAKE_FOR_TESTING_000000000000000",
+        ] {
+            let result = redactor.redact(text);
+            assert_eq!(result.sanitized, text);
+            assert!(result.detected.is_empty());
         }
     }
 


### PR DESCRIPTION
## Description
Security fix for credential redaction gaps found in PR Bucket D: expands full PEM private-key block redaction and modern GitHub token prefix coverage, then applies the same upgraded patterns to related audit/redaction persistence paths found during the variant hunt.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue) - closes credential redaction false negatives.
- [ ] New feature (non-breaking change that adds functionality) - not applicable; this tightens existing redaction behavior.
- [ ] Breaking change (fix or feature that would cause existing functionality to change) - no public API break intended.
- [ ] Documentation update - not documentation-only.
- [ ] Maintenance (dependency updates, CI/CD, refactoring) - not primarily maintenance.
- [x] Security fix - addresses credential leakage risks in redaction and audit paths.

## Package(s) Affected
- [x] agent-os-kernel - central Python credential redactor and tests.
- [x] agent-mesh - MCP proxy audit sanitizer and Rust MCP redactor variants.
- [ ] agent-runtime - not touched.
- [ ] agent-sre - not touched.
- [x] agent-governance - .NET MCP credential redactor parity.
- [ ] docs / root - not touched.

## Checklist
- [x] My code follows the project style guidelines (ruff check) - changed Python files pass ruff.
- [x] I have added tests that prove my fix/feature works - added Python, .NET, Rust, and TypeScript regression coverage.
- [ ] All new and existing tests pass (pytest) - scoped tests pass; full agent-os pytest is blocked by pre-existing conftest import collision.
- [ ] I have updated documentation as needed - no docs update needed for internal redaction behavior.
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/) - commit includes DCO signoff.

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution - regexes are purpose-built for documented token/PEM formats.
- [x] Any external projects that inspired this design are credited in code comments or documentation - not applicable.
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below - not applicable.

**Prior art / related projects** (if any):
N/A - implements repository security requirements for RFC 7468-style PEM private-key blocks and known GitHub token prefixes.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered.
- [x] I have run tests and verification appropriate for this change.
- [x] No part of this PR was autonomously submitted by an AI agent without my review.
- [x] I have not used AI to generate review comments on others' PRs.

If AI tools materially shaped this change, briefly note what was used:
GitHub Copilot assisted with implementation and test drafting; outputs were reviewed and validated locally.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques.
- [x] This contribution does not require an NDA or licensing agreement to understand or use.
- [x] Any AI tools used have terms compatible with the MIT License.

## Related Issues
Related to internal exploit-hunt PR Bucket D: Credential redaction gaps.

## Validation
- TDD focused credential-redactor tests failed before implementation, then passed after the fix.
- `pytest agent-governance-python\agent-os\tests\test_credential_redactor.py agent-governance-python\agent-discovery\tests\test_process_redaction.py -q` with package PYTHONPATH: 38 passed, 3 existing warnings.
- `ruff check --select E,F,W --ignore E501` on changed Python files: passed.
- `dotnet test agent-governance-dotnet\tests\AgentGovernance.Tests\AgentGovernance.Tests.csproj --filter McpCredentialRedactorTests --no-restore --verbosity minimal`: 22 passed.
- `cargo test -p agentmesh-mcp redactor --release --quiet --locked`: 6 passed.
- `npm test -- --run tests\policy-audit.test.ts` in `agent-governance-python\agent-mesh\packages\mcp-proxy`: 5 passed.
- `git diff --check`: passed.
- Unsafe primitive scan on changed files: no matches.

Known baseline caveats:
- `pytest agent-governance-python\agent-os -q` fails during collection before running tests due to a pre-existing `tests.conftest` import-path collision between `modules\caas\tests\conftest.py` and `modules\cmvk\tests\conftest.py`.
- Full `ruff check --select E,F,W --ignore E501 agent-governance-python\agent-os` reports pre-existing repo-wide issues; changed-file ruff passes.
