### PR TITLE
feat: [agent-os] add dynamic policy conditions v1 for temporal and budget rules

### DIFF
--- a/agent-governance-python/agent-os/pyproject.toml
+++ b/agent-governance-python/agent-os/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "cryptography>=48.0.0,<49.0",
     "pynacl>=1.6.2,<2.0",
     "eval_type_backport>=0.2.0; python_version < '3.10'",
+    "tzdata>=2024.1,<2027.0",
 ]
 
 [project.urls]

--- a/agent-governance-python/agent-os/src/agent_os/policies/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/__init__.py
@@ -33,6 +33,8 @@ from .dynamic_context import (
 from .evaluator import PolicyDecision, PolicyEvaluator
 from .rate_limiting import RateLimitConfig, RateLimitExceeded, TokenBucket
 from .schema import (
+    DynamicCondition,
+    DynamicConditionType,
     PolicyAction,
     PolicyCondition,
     PolicyDefaults,
@@ -58,6 +60,8 @@ __all__ = [
     "ConcurrencyStats",
     "Condition",
     "ConflictResolutionStrategy",
+    "DynamicCondition",
+    "DynamicConditionType",
     "ExternalPolicyBackend",
     "OPABackend",
     "CostContext",

--- a/agent-governance-python/agent-os/src/agent_os/policies/dynamic_conditions.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/dynamic_conditions.py
@@ -1,0 +1,222 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from threading import Lock
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from agent_os.policies.schema import DynamicConditionType, PolicyRule
+
+
+def _parse_hhmm(value: str) -> tuple[int, int]:
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"Invalid HH:MM time value: {value}")
+    hour = int(parts[0])
+    minute = int(parts[1])
+    if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+        raise ValueError(f"Invalid HH:MM time value: {value}")
+    return hour, minute
+
+
+def _parse_window_seconds(value: str) -> int:
+    if not value:
+        raise ValueError("Window string is required")
+    unit = value[-1]
+    amount = int(value[:-1])
+    if amount <= 0:
+        raise ValueError("Window amount must be > 0")
+    if unit == "m":
+        return amount * 60
+    if unit == "h":
+        return amount * 3600
+    if unit == "d":
+        return amount * 86400
+    raise ValueError(f"Unsupported window unit in: {value}")
+
+
+def _coerce_timestamp(value: object | None) -> datetime:
+    if value is None:
+        return datetime.now(UTC)
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=UTC)
+    if isinstance(value, str):
+        # Accept either RFC3339-like values or trailing Z timestamps.
+        normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+        parsed = datetime.fromisoformat(normalized)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=UTC)
+        return parsed.astimezone(UTC)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+    raise ValueError(f"Unsupported timestamp type: {type(value)!r}")
+
+
+@dataclass
+class _WindowState:
+    window_start_epoch: int
+    value: float
+
+
+class DynamicBudgetTracker:
+    """Thread-safe in-memory per-rule budget tracker for v1 dynamic conditions."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        # V1 limitation: budget state is process-local only. No persistence or
+        # cross-worker coordination is provided by this tracker.
+        self._state: dict[str, _WindowState] = {}
+
+    def consume(
+        self,
+        *,
+        rule_name: str,
+        metric_name: str,
+        window_seconds: int,
+        current_timestamp: datetime,
+        amount: float,
+        limit: float,
+    ) -> bool:
+        bucket_start = int(current_timestamp.timestamp()) // window_seconds * window_seconds
+        bucket_key = f"{rule_name}:{metric_name}:{window_seconds}"
+        with self._lock:
+            # V1 limitation: retention follows rollover behavior only.
+            # Eviction, durability, and production-grade accounting are
+            # intentionally deferred outside v1 scope.
+            previous = self._state.get(bucket_key)
+            if previous is None or previous.window_start_epoch != bucket_start:
+                previous = _WindowState(window_start_epoch=bucket_start, value=0.0)
+            next_value = previous.value + amount
+            self._state[bucket_key] = _WindowState(
+                window_start_epoch=bucket_start,
+                value=next_value,
+            )
+            return next_value <= limit
+
+
+class DynamicConditionEvaluator:
+    """Evaluates optional v1 dynamic conditions for rules.
+
+    This evaluator is additive: if a rule has no dynamic condition, it returns True.
+    """
+
+    def __init__(self, budget_tracker: DynamicBudgetTracker | None = None) -> None:
+        self._budget_tracker = budget_tracker or DynamicBudgetTracker()
+
+    def evaluate(self, rule: PolicyRule, dynamic_context: dict | None = None) -> bool:
+        condition = rule.dynamic_condition
+        if condition is None:
+            return True
+        context = dynamic_context or {}
+        try:
+            if condition.type == DynamicConditionType.TIME_WINDOW:
+                return self._evaluate_time_window(
+                    condition.timezone,
+                    condition.start_time,
+                    condition.end_time,
+                    condition.days_of_week,
+                    context,
+                )
+            if condition.type == DynamicConditionType.DAY_OF_WEEK:
+                return self._evaluate_day_of_week(
+                    condition.timezone,
+                    condition.days_of_week,
+                    context,
+                )
+            if condition.type == DynamicConditionType.TOKEN_COUNT_PER_WINDOW:
+                return self._evaluate_budget_window(
+                    rule_name=rule.name,
+                    metric_name="token_count",
+                    window=condition.window,
+                    limit=float(condition.limit),
+                    context=context,
+                )
+            if condition.type == DynamicConditionType.COST_PER_WINDOW:
+                return self._evaluate_budget_window(
+                    rule_name=rule.name,
+                    metric_name="cost",
+                    window=condition.window,
+                    limit=float(condition.limit),
+                    context=context,
+                )
+            return False
+        except ValueError:
+            return False
+
+    def _resolve_local_time(self, timezone: str | None, context: dict) -> datetime:
+        tz_name = timezone or "UTC"
+        if tz_name.upper() == "UTC":
+            tzinfo = UTC
+        else:
+            try:
+                tzinfo = ZoneInfo(tz_name)
+            except ZoneInfoNotFoundError as exc:
+                raise ValueError(f"Unknown timezone: {tz_name}") from exc
+
+        ts_source = context.get("timestamp")
+        utc_now = _coerce_timestamp(ts_source)
+        return utc_now.astimezone(tzinfo)
+
+    def _evaluate_day_of_week(self, timezone: str | None, days_of_week: list[int] | None, context: dict) -> bool:
+        if not days_of_week:
+            return False
+        local_time = self._resolve_local_time(timezone, context)
+        return local_time.isoweekday() in days_of_week
+
+    def _evaluate_time_window(
+        self,
+        timezone: str | None,
+        start_time: str | None,
+        end_time: str | None,
+        days_of_week: list[int] | None,
+        context: dict,
+    ) -> bool:
+        if start_time is None or end_time is None:
+            return False
+        local_time = self._resolve_local_time(timezone, context)
+        if days_of_week and local_time.isoweekday() not in days_of_week:
+            return False
+
+        start_hour, start_minute = _parse_hhmm(start_time)
+        end_hour, end_minute = _parse_hhmm(end_time)
+        current_minutes = local_time.hour * 60 + local_time.minute
+        start_minutes = start_hour * 60 + start_minute
+        end_minutes = end_hour * 60 + end_minute
+
+        # Inclusive start, exclusive end. If start>end, the window wraps midnight.
+        if start_minutes <= end_minutes:
+            return start_minutes <= current_minutes < end_minutes
+        return current_minutes >= start_minutes or current_minutes < end_minutes
+
+    def _evaluate_budget_window(
+        self,
+        *,
+        rule_name: str,
+        metric_name: str,
+        window: str | None,
+        limit: float,
+        context: dict,
+    ) -> bool:
+        if not window:
+            return False
+        window_seconds = _parse_window_seconds(window)
+        budget = context.get("budget") or {}
+        amount = budget.get(metric_name, 0)
+        try:
+            amount_value = float(amount)
+        except (TypeError, ValueError):
+            return False
+        current_timestamp = _coerce_timestamp(context.get("timestamp"))
+        return self._budget_tracker.consume(
+            rule_name=rule_name,
+            metric_name=metric_name,
+            window_seconds=window_seconds,
+            current_timestamp=current_timestamp,
+            amount=amount_value,
+            limit=limit,
+        )

--- a/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
@@ -14,14 +14,12 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import BaseModel, Field
 
+from .dynamic_conditions import DynamicConditionEvaluator
 from .schema import PolicyAction, PolicyDocument, PolicyOperator, PolicyRule
-
-if TYPE_CHECKING:
-    from .dynamic_context import DynamicContext
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +58,7 @@ class PolicyEvaluator:
         self.policies: list[PolicyDocument] = policies or []
         self.root_dir: Path | None = Path(root_dir) if root_dir else None
         self._backends: list[Any] = []
+        self._dynamic_condition_evaluator = DynamicConditionEvaluator()
 
     def load_policies(self, directory: str | Path) -> None:
         """Load all YAML policy files from a directory."""
@@ -142,16 +141,15 @@ class PolicyEvaluator:
     def evaluate(
         self,
         context: dict[str, Any],
-        dynamic_context: DynamicContext | None = None,
+        dynamic_context: dict[str, Any] | None = None,
     ) -> PolicyDecision:
         """Evaluate all loaded policy rules against the given context.
 
         Args:
             context: Action-level properties (tool_name, token_count, etc.)
-            dynamic_context: Optional runtime context (time, cost, quota,
-                system).  When supplied, its fields are merged into the
-                evaluation dict under context.time.*, context.cost.*
-                etc.  Existing callers that omit this argument are unaffected.
+            dynamic_context: Optional runtime context used by v1 dynamic
+                conditions (timestamp, budget metrics, etc.). Existing
+                callers that omit this argument are unaffected.
 
         If root_dir is set and context contains a path key,
         folder-scoped policy discovery is used — governance.yaml files
@@ -164,18 +162,18 @@ class PolicyEvaluator:
         matches, the default action from the first policy (or global allow)
         is used.
         """
-        # Merge dynamic context into the evaluation dict (additive only)
-        if dynamic_context is not None:
-            context = {**context, **dynamic_context.to_flat_dict()}
-
         # Folder-scoped evaluation path
         if self.root_dir and "path" in context:
-            return self._evaluate_scoped(context)
+            return self._evaluate_scoped(context, dynamic_context)
 
         # Flat evaluation (original behavior)
-        return self._evaluate_flat(context)
+        return self._evaluate_flat(context, dynamic_context)
 
-    def _evaluate_scoped(self, context: dict[str, Any]) -> PolicyDecision:
+    def _evaluate_scoped(
+        self,
+        context: dict[str, Any],
+        dynamic_context: dict[str, Any] | None,
+    ) -> PolicyDecision:
         """Evaluate using folder-level policy discovery and merge.
 
         The discovery, parse, and merge phase is wrapped in a fail-closed
@@ -191,8 +189,8 @@ class PolicyEvaluator:
             chain_paths = discover_policies(action_path, self.root_dir)
 
             if not chain_paths:
-                # No governance files found, fall back to loaded policies
-                return self._evaluate_flat(context)
+                # No governance files found — fall back to loaded policies
+                return self._evaluate_flat(context, dynamic_context)
 
             docs = [PolicyDocument.from_yaml(p) for p in chain_paths]
 
@@ -203,7 +201,7 @@ class PolicyEvaluator:
                     filtered.append(doc)
 
             if not filtered:
-                return self._evaluate_flat(context)
+                return self._evaluate_flat(context, dynamic_context)
 
             merged_rules = merge_policies(filtered)
         except Exception:
@@ -225,9 +223,13 @@ class PolicyEvaluator:
                 },
             )
 
-        return self._evaluate_rules(merged_rules, filtered, context)
+        return self._evaluate_rules(merged_rules, filtered, context, dynamic_context)
 
-    def _evaluate_flat(self, context: dict[str, Any]) -> PolicyDecision:
+    def _evaluate_flat(
+        self,
+        context: dict[str, Any],
+        dynamic_context: dict[str, Any] | None,
+    ) -> PolicyDecision:
         """Flat evaluation using the loaded policy list (original behavior)."""
         try:
             all_rules: list[tuple[PolicyRule, PolicyDocument]] = []
@@ -239,20 +241,31 @@ class PolicyEvaluator:
             all_rules.sort(key=lambda pair: pair[0].priority, reverse=True)
 
             for rule, doc in all_rules:
-                if _match_condition(rule.condition, context):
+                if _match_condition(rule.condition, context) and self._dynamic_condition_evaluator.evaluate(
+                    rule,
+                    dynamic_context,
+                ):
                     allowed = rule.action in (PolicyAction.ALLOW, PolicyAction.AUDIT)
+                    audit_entry: dict[str, Any] = {
+                        "policy": doc.name,
+                        "rule": rule.name,
+                        "action": rule.action.value,
+                        "context_snapshot": context,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                    if rule.dynamic_condition is not None:
+                        audit_entry["dynamic_condition"] = rule.dynamic_condition.model_dump()
+                        budget_summary = _summarize_evaluated_budget(
+                            rule.dynamic_condition, dynamic_context
+                        )
+                        if budget_summary is not None:
+                            audit_entry["evaluated_budget"] = budget_summary
                     return PolicyDecision(
                         allowed=allowed,
                         matched_rule=rule.name,
                         action=rule.action.value,
                         reason=rule.message or f"Matched rule '{rule.name}'",
-                        audit_entry={
-                            "policy": doc.name,
-                            "rule": rule.name,
-                            "action": rule.action.value,
-                            "context_snapshot": copy.deepcopy(context),
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                        },
+                        audit_entry=audit_entry,
                     )
 
             # No YAML rule matched — consult external backends
@@ -331,25 +344,37 @@ class PolicyEvaluator:
         rules: list[PolicyRule],
         docs: list[PolicyDocument],
         context: dict[str, Any],
+        dynamic_context: dict[str, Any] | None,
     ) -> PolicyDecision:
         """Evaluate a merged rule list from folder-scoped discovery."""
         try:
             for rule in rules:
-                if _match_condition(rule.condition, context):
+                if _match_condition(rule.condition, context) and self._dynamic_condition_evaluator.evaluate(
+                    rule,
+                    dynamic_context,
+                ):
                     allowed = rule.action in (PolicyAction.ALLOW, PolicyAction.AUDIT)
+                    audit_entry: dict[str, Any] = {
+                        "policy": "folder-scoped",
+                        "rule": rule.name,
+                        "action": rule.action.value,
+                        "policy_chain": [d.name for d in docs],
+                        "context_snapshot": context,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    }
+                    if rule.dynamic_condition is not None:
+                        audit_entry["dynamic_condition"] = rule.dynamic_condition.model_dump()
+                        budget_summary = _summarize_evaluated_budget(
+                            rule.dynamic_condition, dynamic_context
+                        )
+                        if budget_summary is not None:
+                            audit_entry["evaluated_budget"] = budget_summary
                     return PolicyDecision(
                         allowed=allowed,
                         matched_rule=rule.name,
                         action=rule.action.value,
                         reason=rule.message or f"Matched rule '{rule.name}'",
-                        audit_entry={
-                            "policy": "folder-scoped",
-                            "rule": rule.name,
-                            "action": rule.action.value,
-                            "policy_chain": [d.name for d in docs],
-                            "context_snapshot": copy.deepcopy(context),
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                        },
+                        audit_entry=audit_entry,
                     )
 
             # No rule matched — consult external backends
@@ -426,3 +451,42 @@ def _match_condition(condition: Any, context: dict[str, Any]) -> bool:
         return bool(re.search(str(target), str(ctx_value)))
 
     return False
+
+
+def _summarize_evaluated_budget(
+    dynamic_condition: Any,
+    dynamic_context: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return a minimal budget summary for audit, or None for non-budget conditions.
+
+    Records only the metric actually evaluated and the current observed
+    amount (not the full dynamic_context), so audit logs do not persist
+    arbitrary runtime context.
+    """
+    from .schema import DynamicConditionType
+
+    budget_types = {
+        DynamicConditionType.TOKEN_COUNT_PER_WINDOW,
+        DynamicConditionType.COST_PER_WINDOW,
+    }
+    if dynamic_condition.type not in budget_types:
+        return None
+
+    metric = (
+        "token_count"
+        if dynamic_condition.type == DynamicConditionType.TOKEN_COUNT_PER_WINDOW
+        else "cost"
+    )
+    budget = (dynamic_context or {}).get("budget") or {}
+    raw_amount = budget.get(metric)
+    try:
+        amount = float(raw_amount) if raw_amount is not None else None
+    except (TypeError, ValueError):
+        amount = None
+
+    return {
+        "metric": metric,
+        "window": dynamic_condition.window,
+        "limit": float(dynamic_condition.limit) if dynamic_condition.limit is not None else None,
+        "amount": amount,
+    }

--- a/agent-governance-python/agent-os/src/agent_os/policies/policy_schema.json
+++ b/agent-governance-python/agent-os/src/agent_os/policies/policy_schema.json
@@ -49,6 +49,51 @@
       "description": "Action a policy rule prescribes.",
       "enum": ["allow", "deny", "audit", "block"]
     },
+    "DynamicConditionType": {
+      "type": "string",
+      "description": "Supported v1 dynamic condition types.",
+      "enum": ["time_window", "day_of_week", "token_count_per_window", "cost_per_window"]
+    },
+    "DynamicCondition": {
+      "type": "object",
+      "description": "Optional runtime-aware condition for temporal and per-window budget checks.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/DynamicConditionType"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "IANA timezone name, for example America/New_York."
+        },
+        "start_time": {
+          "type": "string",
+          "description": "Inclusive HH:MM start time in local timezone."
+        },
+        "end_time": {
+          "type": "string",
+          "description": "Exclusive HH:MM end time in local timezone."
+        },
+        "days_of_week": {
+          "type": "array",
+          "description": "ISO weekdays 1=Mon..7=Sun.",
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 7
+          }
+        },
+        "window": {
+          "type": "string",
+          "description": "Budget window duration, e.g. 15m, 1h, 1d."
+        },
+        "limit": {
+          "type": "number",
+          "description": "Per-window cap for token/cost conditions."
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
     "PolicyCondition": {
       "type": "object",
       "description": "A single condition evaluated against execution context.",
@@ -93,6 +138,10 @@
           "type": "string",
           "description": "Human-readable explanation of the rule.",
           "default": ""
+        },
+        "dynamic_condition": {
+          "$ref": "#/definitions/DynamicCondition",
+          "description": "Optional v1 runtime-aware condition."
         }
       },
       "required": ["name", "condition", "action"],

--- a/agent-governance-python/agent-os/src/agent_os/policies/schema.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/schema.py
@@ -14,7 +14,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class PolicyOperator(str, Enum):
@@ -41,6 +41,65 @@ class PolicyAction(str, Enum):
     BLOCK = "block"
 
 
+class DynamicConditionType(str, Enum):
+    """Supported dynamic condition types for v1."""
+
+    TIME_WINDOW = "time_window"
+    DAY_OF_WEEK = "day_of_week"
+    TOKEN_COUNT_PER_WINDOW = "token_count_per_window"
+    COST_PER_WINDOW = "cost_per_window"
+
+
+class DynamicCondition(BaseModel):
+    """Optional dynamic runtime condition attached to a policy rule.
+
+    This model is additive and does not alter existing field/operator/value
+    behavior for static conditions.
+    """
+
+    type: DynamicConditionType
+    timezone: str | None = Field(
+        default=None,
+        description="IANA timezone name (for temporal conditions), e.g. 'America/New_York'.",
+    )
+    start_time: str | None = Field(
+        default=None,
+        description="Inclusive window start in HH:MM (24-hour) local time.",
+    )
+    end_time: str | None = Field(
+        default=None,
+        description="Exclusive window end in HH:MM (24-hour) local time.",
+    )
+    days_of_week: list[int] | None = Field(
+        default=None,
+        description="ISO weekday numbers (1=Mon .. 7=Sun).",
+    )
+    window: str | None = Field(
+        default=None,
+        description="Budget window duration (e.g. '1h', '1d', '15m').",
+    )
+    limit: float | int | None = Field(
+        default=None,
+        description="Per-window budget cap for token/cost conditions.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> "DynamicCondition":
+        if self.type == DynamicConditionType.TIME_WINDOW:
+            if self.start_time is None or self.end_time is None:
+                raise ValueError("time_window requires start_time and end_time")
+        elif self.type == DynamicConditionType.DAY_OF_WEEK:
+            if not self.days_of_week:
+                raise ValueError("day_of_week requires days_of_week")
+        elif self.type in (
+            DynamicConditionType.TOKEN_COUNT_PER_WINDOW,
+            DynamicConditionType.COST_PER_WINDOW,
+        ):
+            if self.window is None or self.limit is None:
+                raise ValueError("budget conditions require window and limit")
+        return self
+
+
 class PolicyCondition(BaseModel):
     """A single condition evaluated against execution context."""
 
@@ -57,6 +116,10 @@ class PolicyRule(BaseModel):
     action: PolicyAction
     priority: int = Field(default=0, description="Higher priority rules are evaluated first")
     message: str = Field(default="", description="Human-readable explanation")
+    dynamic_condition: DynamicCondition | None = Field(
+        default=None,
+        description="Optional v1 dynamic runtime condition.",
+    )
     override: bool = Field(
         default=False,
         description="If true, replaces a parent rule with the same name during folder-level merge",

--- a/agent-governance-python/agent-os/tests/test_dynamic_policy_conditions.py
+++ b/agent-governance-python/agent-os/tests/test_dynamic_policy_conditions.py
@@ -31,6 +31,7 @@ def _temporal_evaluator(dynamic_condition: DynamicCondition) -> PolicyEvaluator:
                 action=PolicyAction.DENY,
             )
         ],
+        defaults=PolicyDefaults(action=PolicyAction.ALLOW),
     )
     return PolicyEvaluator(policies=[doc])
 

--- a/agent-governance-python/agent-os/tests/test_dynamic_policy_conditions.py
+++ b/agent-governance-python/agent-os/tests/test_dynamic_policy_conditions.py
@@ -1,478 +1,252 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Tests for Dynamic Policy Conditions (issue #2615).
-
-Covers:
-- TimeContext, CostContext, QuotaContext, SystemContext construction
-- DynamicContext.to_flat_dict() key naming
-- DynamicContext.from_dict() deserialization
-- PolicyEvaluator.evaluate() accepting optional dynamic_context
-- Time-based policy conditions (block outside business hours)
-- Cost-aware policy conditions (deny when budget exhausted)
-- Quota-aware policy conditions (block when api_calls_remaining is low)
-- Backward compatibility: existing callers without dynamic_context unaffected
-"""
 
 from __future__ import annotations
 
-import textwrap
-from pathlib import Path
-
-from agent_os.policies.dynamic_context import (
-    CostContext,
-    DynamicContext,
-    QuotaContext,
-    SystemContext,
-    TimeContext,
-)
 from agent_os.policies.evaluator import PolicyEvaluator
-from agent_os.policies.schema import PolicyDocument
+from agent_os.policies.schema import (
+    DynamicCondition,
+    DynamicConditionType,
+    PolicyAction,
+    PolicyCondition,
+    PolicyDefaults,
+    PolicyDocument,
+    PolicyOperator,
+    PolicyRule,
+)
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
-
-def _write_policy(tmp_path: Path, content: str) -> Path:
-    p = tmp_path / "policy.yaml"
-    p.write_text(textwrap.dedent(content), encoding="utf-8")
-    return p
-
-
-def _load_policy(path: Path) -> PolicyEvaluator:
-    doc = PolicyDocument.from_yaml(path)
+def _temporal_evaluator(dynamic_condition: DynamicCondition) -> PolicyEvaluator:
+    doc = PolicyDocument(
+        name="temporal-policy",
+        rules=[
+            PolicyRule(
+                name="temporal-rule",
+                condition=PolicyCondition(
+                    field="action_type",
+                    operator=PolicyOperator.EQ,
+                    value="tool_call",
+                ),
+                dynamic_condition=dynamic_condition,
+                action=PolicyAction.DENY,
+            )
+        ],
+    )
     return PolicyEvaluator(policies=[doc])
 
 
-# ---------------------------------------------------------------------------
-# TimeContext
-# ---------------------------------------------------------------------------
+def _budget_allow_evaluator(dynamic_condition: DynamicCondition) -> PolicyEvaluator:
+    doc = PolicyDocument(
+        name="budget-policy",
+        rules=[
+            PolicyRule(
+                name="budget-rule",
+                condition=PolicyCondition(
+                    field="action_type",
+                    operator=PolicyOperator.EQ,
+                    value="tool_call",
+                ),
+                dynamic_condition=dynamic_condition,
+                action=PolicyAction.ALLOW,
+            )
+        ],
+        defaults=PolicyDefaults(action=PolicyAction.DENY),
+    )
+    return PolicyEvaluator(policies=[doc])
 
 
-class TestTimeContext:
-    def test_defaults(self) -> None:
-        ctx = TimeContext()
-        assert ctx.hour == 0
-        assert ctx.day_of_week == 1
-        assert ctx.timezone == "UTC"
-        assert ctx.timestamp > 0
-
-    def test_now_utc(self) -> None:
-        ctx = TimeContext.now()
-        assert 0 <= ctx.hour <= 23
-        assert 1 <= ctx.day_of_week <= 7
-        assert ctx.timezone == "UTC"
-
-    def test_to_dict_keys(self) -> None:
-        ctx = TimeContext(timestamp=1_000_000, hour=14, day_of_week=3, timezone="UTC")
-        d = ctx.to_dict()
-        assert d == {"timestamp": 1_000_000, "hour": 14, "day_of_week": 3, "timezone": "UTC"}
-
-    def test_now_invalid_timezone_falls_back_to_utc(self) -> None:
-        ctx = TimeContext.now("Not/AReal_Zone")
-        assert ctx.timezone == "UTC"
-
-
-# ---------------------------------------------------------------------------
-# CostContext
-# ---------------------------------------------------------------------------
-
-
-class TestCostContext:
-    def test_defaults(self) -> None:
-        ctx = CostContext()
-        assert ctx.budget_total == 0.0
-        assert ctx.budget_used == 0.0
-        assert ctx.budget_remaining == 0.0
-
-    def test_to_dict(self) -> None:
-        ctx = CostContext(budget_total=100.0, budget_used=90.0, budget_remaining=10.0)
-        d = ctx.to_dict()
-        assert d["budget_remaining"] == 10.0
-        assert d["budget_total"] == 100.0
-
-    def test_negative_remaining(self) -> None:
-        ctx = CostContext(budget_total=100.0, budget_used=110.0, budget_remaining=-10.0)
-        assert ctx.budget_remaining == -10.0
-
-
-# ---------------------------------------------------------------------------
-# QuotaContext
-# ---------------------------------------------------------------------------
-
-
-class TestQuotaContext:
-    def test_to_dict(self) -> None:
-        ctx = QuotaContext(api_calls_remaining=50, rate_limit_remaining=200)
-        d = ctx.to_dict()
-        assert d["api_calls_remaining"] == 50
-        assert d["rate_limit_remaining"] == 200
-
-
-# ---------------------------------------------------------------------------
-# SystemContext
-# ---------------------------------------------------------------------------
-
-
-class TestSystemContext:
-    def test_to_dict(self) -> None:
-        ctx = SystemContext(load=0.85, error_rate=0.03)
-        d = ctx.to_dict()
-        assert d["load"] == 0.85
-        assert d["error_rate"] == 0.03
-
-
-# ---------------------------------------------------------------------------
-# DynamicContext
-# ---------------------------------------------------------------------------
-
-
-class TestDynamicContextFlatDict:
-    def test_empty_context_yields_empty_dict(self) -> None:
-        ctx = DynamicContext()
-        assert ctx.to_flat_dict() == {}
-
-    def test_time_keys_prefixed(self) -> None:
-        ctx = DynamicContext(time=TimeContext(timestamp=100, hour=10, day_of_week=2))
-        flat = ctx.to_flat_dict()
-        assert flat["context.time.hour"] == 10
-        assert flat["context.time.day_of_week"] == 2
-        assert flat["context.time.timestamp"] == 100
-
-    def test_cost_keys_prefixed(self) -> None:
-        ctx = DynamicContext(cost=CostContext(budget_remaining=5.0))
-        flat = ctx.to_flat_dict()
-        assert flat["context.cost.budget_remaining"] == 5.0
-
-    def test_quota_keys_prefixed(self) -> None:
-        ctx = DynamicContext(quota=QuotaContext(api_calls_remaining=15))
-        flat = ctx.to_flat_dict()
-        assert flat["context.quota.api_calls_remaining"] == 15
-
-    def test_system_keys_prefixed(self) -> None:
-        ctx = DynamicContext(system=SystemContext(load=0.9))
-        flat = ctx.to_flat_dict()
-        assert flat["context.system.load"] == 0.9
-
-    def test_all_sub_contexts(self) -> None:
-        ctx = DynamicContext(
-            time=TimeContext(hour=9),
-            cost=CostContext(budget_remaining=100.0),
-            quota=QuotaContext(api_calls_remaining=50),
-            system=SystemContext(load=0.5),
+def test_time_window_inside_match_denies():
+    evaluator = _temporal_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.TIME_WINDOW,
+            timezone="UTC",
+            start_time="09:00",
+            end_time="17:00",
+            days_of_week=[1, 2, 3, 4, 5],
         )
-        flat = ctx.to_flat_dict()
-        assert "context.time.hour" in flat
-        assert "context.cost.budget_remaining" in flat
-        assert "context.quota.api_calls_remaining" in flat
-        assert "context.system.load" in flat
+    )
+
+    result = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={"timestamp": "2026-01-05T10:00:00Z"},
+    )
+
+    assert not result.allowed
 
 
-class TestDynamicContextFromDict:
-    def test_from_empty_dict(self) -> None:
-        ctx = DynamicContext.from_dict({})
-        assert ctx.time is None
-        assert ctx.cost is None
-        assert ctx.quota is None
-        assert ctx.system is None
-
-    def test_from_dict_with_time(self) -> None:
-        ctx = DynamicContext.from_dict({
-            "time": {"hour": 22, "day_of_week": 6, "timezone": "UTC", "timestamp": 9999}
-        })
-        assert ctx.time is not None
-        assert ctx.time.hour == 22
-        assert ctx.time.day_of_week == 6
-
-    def test_from_dict_with_cost(self) -> None:
-        ctx = DynamicContext.from_dict({
-            "cost": {"budget_total": 1000.0, "budget_used": 980.0, "budget_remaining": 20.0}
-        })
-        assert ctx.cost is not None
-        assert ctx.cost.budget_remaining == 20.0
-
-    def test_from_dict_ignores_unknown_keys(self) -> None:
-        ctx = DynamicContext.from_dict({"unknown_key": "ignored", "cost": {"budget_remaining": 5.0}})
-        assert ctx.cost is not None
-        assert ctx.time is None
-
-
-# ---------------------------------------------------------------------------
-# Backward compatibility
-# ---------------------------------------------------------------------------
-
-
-class TestBackwardCompatibility:
-    def test_evaluate_without_dynamic_context(self, tmp_path: Path) -> None:
-        """Callers that omit dynamic_context must continue to work unchanged."""
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: compat-policy
-            rules:
-              - name: deny-shell
-                condition: {field: action, operator: eq, value: run_shell}
-                action: deny
-                priority: 100
-            defaults:
-              action: allow
-        """)
-        ev = _load_policy(policy)
-        # Original call signature — no dynamic_context
-        decision = ev.evaluate({"action": "run_shell"})
-        assert not decision.allowed
-        assert decision.action == "deny"
-
-    def test_existing_rules_unaffected(self, tmp_path: Path) -> None:
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: compat-policy
-            rules:
-              - name: allow-reads
-                condition: {field: action, operator: eq, value: read}
-                action: allow
-                priority: 50
-            defaults:
-              action: deny
-        """)
-        ev = _load_policy(policy)
-        assert ev.evaluate({"action": "read"}).allowed
-        assert not ev.evaluate({"action": "write"}).allowed
-
-    def test_policy_decision_has_metadata_field(self, tmp_path: Path) -> None:
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: meta-policy
-            rules: []
-            defaults:
-              action: allow
-        """)
-        ev = _load_policy(policy)
-        decision = ev.evaluate({})
-        # metadata field exists and defaults to empty dict
-        assert hasattr(decision, "metadata")
-        assert decision.metadata == {}
-
-
-# ---------------------------------------------------------------------------
-# Time-based conditions
-# ---------------------------------------------------------------------------
-
-
-class TestTimeBasedConditions:
-    def _make_evaluator(self, tmp_path: Path) -> PolicyEvaluator:
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: time-policy
-            rules:
-              - name: block-after-hours
-                condition:
-                  field: "context.time.hour"
-                  operator: gte
-                  value: 18
-                action: deny
-                priority: 90
-                message: "Operations blocked outside business hours (18:00+)"
-              - name: block-weekends
-                condition:
-                  field: "context.time.day_of_week"
-                  operator: gte
-                  value: 6
-                action: deny
-                priority: 80
-                message: "Operations blocked on weekends"
-            defaults:
-              action: allow
-        """)
-        return _load_policy(policy)
-
-    def test_within_business_hours_allowed(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(time=TimeContext(hour=14, day_of_week=3, timestamp=1000))
-        decision = ev.evaluate({"action": "read"}, dynamic_context=dctx)
-        assert decision.allowed
-
-    def test_after_hours_denied(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(time=TimeContext(hour=20, day_of_week=2, timestamp=1000))
-        decision = ev.evaluate({"action": "read"}, dynamic_context=dctx)
-        assert not decision.allowed
-        assert decision.matched_rule == "block-after-hours"
-
-    def test_exactly_cutoff_hour_denied(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(time=TimeContext(hour=18, day_of_week=1, timestamp=1000))
-        decision = ev.evaluate({"action": "write"}, dynamic_context=dctx)
-        assert not decision.allowed
-
-    def test_saturday_denied(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(time=TimeContext(hour=10, day_of_week=6, timestamp=1000))
-        decision = ev.evaluate({"action": "read"}, dynamic_context=dctx)
-        assert not decision.allowed
-        assert decision.matched_rule == "block-weekends"
-
-    def test_no_time_context_falls_through_to_default(self, tmp_path: Path) -> None:
-        """When time context is absent, time-based rules do not match."""
-        ev = self._make_evaluator(tmp_path)
-        # No dynamic_context — time rules cannot match
-        decision = ev.evaluate({"action": "read"})
-        assert decision.allowed  # default is allow
-
-
-# ---------------------------------------------------------------------------
-# Cost-aware conditions
-# ---------------------------------------------------------------------------
-
-
-class TestCostAwareConditions:
-    def _make_evaluator(self, tmp_path: Path) -> PolicyEvaluator:
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: cost-policy
-            rules:
-              - name: deny-budget-exhausted
-                condition:
-                  field: "context.cost.budget_remaining"
-                  operator: lte
-                  value: 0
-                action: deny
-                priority: 100
-                message: "Monthly budget exhausted"
-              - name: deny-budget-critical
-                condition:
-                  field: "context.cost.budget_remaining"
-                  operator: lt
-                  value: 10.0
-                action: deny
-                priority: 90
-                message: "Budget critically low (< 10 units)"
-            defaults:
-              action: allow
-        """)
-        return _load_policy(policy)
-
-    def test_budget_healthy_allowed(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(cost=CostContext(
-            budget_total=1000.0, budget_used=500.0, budget_remaining=500.0
-        ))
-        assert ev.evaluate({"action": "web_search"}, dynamic_context=dctx).allowed
-
-    def test_budget_exhausted_denied(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(cost=CostContext(
-            budget_total=1000.0, budget_used=1000.0, budget_remaining=0.0
-        ))
-        decision = ev.evaluate({"action": "web_search"}, dynamic_context=dctx)
-        assert not decision.allowed
-        assert decision.matched_rule == "deny-budget-exhausted"
-
-    def test_budget_negative_denied(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(cost=CostContext(budget_remaining=-5.0))
-        assert not ev.evaluate({}, dynamic_context=dctx).allowed
-
-    def test_budget_critically_low_denied(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(cost=CostContext(budget_remaining=5.0))
-        decision = ev.evaluate({"action": "image_generation"}, dynamic_context=dctx)
-        assert not decision.allowed
-        assert decision.matched_rule == "deny-budget-critical"
-
-    def test_no_cost_context_falls_through(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        # No cost context — cost rules do not match; default allow
-        assert ev.evaluate({"action": "read"}).allowed
-
-
-# ---------------------------------------------------------------------------
-# Quota-aware conditions
-# ---------------------------------------------------------------------------
-
-
-class TestQuotaAwareConditions:
-    def _make_evaluator(self, tmp_path: Path) -> PolicyEvaluator:
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: quota-policy
-            rules:
-              - name: block-quota-exhausted
-                condition:
-                  field: "context.quota.api_calls_remaining"
-                  operator: lte
-                  value: 0
-                action: deny
-                priority: 100
-            defaults:
-              action: allow
-        """)
-        return _load_policy(policy)
-
-    def test_quota_available(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(quota=QuotaContext(api_calls_remaining=500))
-        assert ev.evaluate({}, dynamic_context=dctx).allowed
-
-    def test_quota_exhausted(self, tmp_path: Path) -> None:
-        ev = self._make_evaluator(tmp_path)
-        dctx = DynamicContext(quota=QuotaContext(api_calls_remaining=0))
-        decision = ev.evaluate({}, dynamic_context=dctx)
-        assert not decision.allowed
-        assert decision.matched_rule == "block-quota-exhausted"
-
-
-# ---------------------------------------------------------------------------
-# Combined conditions
-# ---------------------------------------------------------------------------
-
-
-class TestCombinedConditions:
-    def test_time_and_cost_combined(self, tmp_path: Path) -> None:
-        """After-hours rule fires before budget rule when both match."""
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: combined-policy
-            rules:
-              - name: block-after-hours
-                condition:
-                  field: "context.time.hour"
-                  operator: gte
-                  value: 18
-                action: deny
-                priority: 100
-              - name: deny-budget-exhausted
-                condition:
-                  field: "context.cost.budget_remaining"
-                  operator: lte
-                  value: 0
-                action: deny
-                priority: 90
-            defaults:
-              action: allow
-        """)
-        ev = _load_policy(policy)
-        dctx = DynamicContext(
-            time=TimeContext(hour=22, day_of_week=2, timestamp=1000),
-            cost=CostContext(budget_remaining=0.0),
+def test_time_window_outside_window_does_not_match():
+    evaluator = _temporal_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.TIME_WINDOW,
+            timezone="UTC",
+            start_time="09:00",
+            end_time="17:00",
+            days_of_week=[1, 2, 3, 4, 5],
         )
-        decision = ev.evaluate({"action": "web_search"}, dynamic_context=dctx)
-        assert not decision.allowed
-        assert decision.matched_rule == "block-after-hours"  # higher priority
+    )
 
-    def test_action_context_not_shadowed_by_dynamic(self, tmp_path: Path) -> None:
-        """Action-level keys must survive dynamic context merging."""
-        policy = _write_policy(tmp_path, """\
-            version: "1.0"
-            name: shadow-policy
-            rules:
-              - name: allow-read
-                condition: {field: action, operator: eq, value: read}
-                action: allow
-                priority: 50
-            defaults:
-              action: deny
-        """)
-        ev = _load_policy(policy)
-        dctx = DynamicContext(time=TimeContext(hour=10))
-        decision = ev.evaluate({"action": "read"}, dynamic_context=dctx)
-        assert decision.allowed
+    result = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={"timestamp": "2026-01-05T19:00:00Z"},
+    )
+
+    assert result.allowed
+
+
+def test_day_of_week_match_denies():
+    evaluator = _temporal_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.DAY_OF_WEEK,
+            timezone="UTC",
+            days_of_week=[1],
+        )
+    )
+
+    monday = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={"timestamp": "2026-01-05T12:00:00Z"},
+    )
+    sunday = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={"timestamp": "2026-01-04T12:00:00Z"},
+    )
+
+    assert not monday.allowed
+    assert sunday.allowed
+
+
+def test_dst_spring_forward_uses_timezone_conversion():
+    evaluator = _temporal_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.TIME_WINDOW,
+            timezone="America/New_York",
+            start_time="03:00",
+            end_time="04:00",
+        )
+    )
+
+    # 2026-03-08 07:30:00Z == 03:30 local after DST spring-forward.
+    in_window = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={"timestamp": "2026-03-08T07:30:00Z"},
+    )
+    # 2026-03-08 06:30:00Z == 01:30 local before the jump.
+    out_window = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={"timestamp": "2026-03-08T06:30:00Z"},
+    )
+
+    assert not in_window.allowed
+    assert out_window.allowed
+
+
+def test_token_budget_within_limit_allows():
+    evaluator = _budget_allow_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.TOKEN_COUNT_PER_WINDOW,
+            window="1h",
+            limit=100,
+        )
+    )
+
+    result = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T10:00:00Z",
+            "budget": {"token_count": 80},
+        },
+    )
+
+    assert result.allowed
+
+
+def test_token_budget_exceed_limit_denies_via_default():
+    evaluator = _budget_allow_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.TOKEN_COUNT_PER_WINDOW,
+            window="1h",
+            limit=100,
+        )
+    )
+
+    first = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T10:00:00Z",
+            "budget": {"token_count": 60},
+        },
+    )
+    second = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T10:15:00Z",
+            "budget": {"token_count": 50},
+        },
+    )
+
+    assert first.allowed
+    assert not second.allowed
+
+
+def test_token_budget_boundary_equal_limit_allows():
+    evaluator = _budget_allow_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.TOKEN_COUNT_PER_WINDOW,
+            window="1h",
+            limit=100,
+        )
+    )
+
+    first = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T10:00:00Z",
+            "budget": {"token_count": 40},
+        },
+    )
+    second = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T10:30:00Z",
+            "budget": {"token_count": 60},
+        },
+    )
+
+    assert first.allowed
+    assert second.allowed
+
+
+def test_cost_budget_window_rollover_resets_accumulator():
+    evaluator = _budget_allow_evaluator(
+        DynamicCondition(
+            type=DynamicConditionType.COST_PER_WINDOW,
+            window="1h",
+            limit=10,
+        )
+    )
+
+    first = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T10:00:00Z",
+            "budget": {"cost": 8},
+        },
+    )
+    second = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T10:20:00Z",
+            "budget": {"cost": 5},
+        },
+    )
+    third = evaluator.evaluate(
+        {"action_type": "tool_call"},
+        dynamic_context={
+            "timestamp": "2026-01-05T11:00:00Z",
+            "budget": {"cost": 3},
+        },
+    )
+
+    assert first.allowed
+    assert not second.allowed
+    assert third.allowed

--- a/docs/specs/DYNAMIC-POLICY-CONDITIONS-1.0.md
+++ b/docs/specs/DYNAMIC-POLICY-CONDITIONS-1.0.md
@@ -1,0 +1,170 @@
+# Dynamic Policy Conditions 1.0
+
+Status: Draft (v1)
+
+## 1. Overview
+
+This specification defines additive dynamic condition support for the Python Agent-OS policy engine. Dynamic conditions are evaluated alongside existing static `field/operator/value` rule conditions and enable runtime-aware policy decisions.
+
+Version 1.0 scope is intentionally narrow:
+
+- Temporal conditions:
+  - `time_window`
+  - `day_of_week`
+- Budget conditions:
+  - `token_count_per_window`
+  - `cost_per_window`
+
+## 2. Data Model
+
+A rule MAY include an optional `dynamic_condition` object.
+
+```yaml
+rules:
+  - name: deny_after_hours
+    condition:
+      field: action_type
+      operator: eq
+      value: tool_call
+    dynamic_condition:
+      type: time_window
+      timezone: America/New_York
+      start_time: "09:00"
+      end_time: "17:00"
+      days_of_week: [1, 2, 3, 4, 5]
+    action: deny
+```
+
+`dynamic_condition.type` values:
+
+- `time_window`
+- `day_of_week`
+- `token_count_per_window`
+- `cost_per_window`
+
+## 3. Evaluation Semantics
+
+### 3.1 Ordering
+
+For each rule, evaluation order is:
+
+1. Evaluate static `condition`.
+2. If static condition is true and `dynamic_condition` exists, evaluate dynamic condition.
+3. Rule matches only if both are true.
+4. Rule selection still follows existing priority sorting and first-match-wins semantics.
+
+### 3.2 Runtime Context Input
+
+`PolicyEvaluator.evaluate(context, dynamic_context=None)` accepts optional runtime data.
+
+- Existing `context` behavior is unchanged.
+- `dynamic_context` is optional and additive.
+
+### 3.3 Temporal Conditions
+
+#### `time_window`
+
+Required fields:
+
+- `start_time` (HH:MM, inclusive)
+- `end_time` (HH:MM, exclusive)
+
+Optional fields:
+
+- `timezone` (IANA timezone string; default `UTC`)
+- `days_of_week` (`[1..7]`, ISO weekday numbers)
+
+Behavior:
+
+- Times are interpreted in local time of `timezone`.
+- If `start_time <= end_time`, window is same-day interval.
+- If `start_time > end_time`, window wraps midnight.
+- If `days_of_week` is supplied, local weekday MUST be in set.
+
+#### `day_of_week`
+
+Required fields:
+
+- `days_of_week` (`[1..7]`, ISO weekday numbers)
+
+Optional fields:
+
+- `timezone` (IANA timezone string; default `UTC`)
+
+Behavior:
+
+- Condition is true if local weekday in configured set.
+
+### 3.4 Timezone and DST
+
+- Runtime timestamp is interpreted as UTC and converted to local timezone for temporal checks.
+- Daylight Saving Time transitions MUST be handled by timezone-aware conversion using IANA zone data.
+- Spring-forward and fall-back behavior is derived from local civil time produced by conversion; no custom DST tables are used.
+
+### 3.5 Budget Conditions
+
+#### `token_count_per_window`
+
+Required fields:
+
+- `window` (`<int><unit>`, unit in `m|h|d`)
+- `limit` (numeric, inclusive)
+
+Runtime input:
+
+- `dynamic_context.budget.token_count` (numeric amount consumed by current evaluation event)
+
+#### `cost_per_window`
+
+Required fields:
+
+- `window` (`<int><unit>`, unit in `m|h|d`)
+- `limit` (numeric, inclusive)
+
+Runtime input:
+
+- `dynamic_context.budget.cost` (numeric amount consumed by current evaluation event)
+
+Window semantics:
+
+- Window alignment is epoch-bucketed by configured duration.
+- State is tracked in-memory per evaluator instance and per `(rule, metric, window)` tuple.
+- On bucket rollover, accumulated usage resets for that tuple.
+
+V1 Implementation Note:
+
+- Budget window counters are maintained in-memory, process-local, and non-persistent.
+- Counters reset on process restart and do not provide cross-process consistency.
+- Durable quota accounting is out of scope for v1.
+
+Boundary semantics:
+
+- Decision is allowed while cumulative usage is `<= limit`.
+- Once cumulative usage exceeds limit, condition evaluates false.
+
+## 4. Audit Semantics
+
+When a rule with dynamic condition is evaluated, audit metadata SHOULD include:
+
+- `dynamic_condition` (serialized condition config)
+- `runtime_snapshot` (provided runtime context)
+- existing static context snapshot and timestamp fields
+
+## 5. Failure Semantics
+
+- Unknown timezone, invalid time format, invalid window format, or malformed runtime budget values cause dynamic condition evaluation to return false for that rule.
+- Global evaluator fail-closed behavior remains unchanged for unexpected internal errors.
+
+## 6. Backward Compatibility
+
+- `dynamic_condition` is optional.
+- Existing policies without dynamic conditions remain valid and unchanged.
+- Existing `evaluate(context)` call sites remain valid because `dynamic_context` is optional.
+
+## 7. Out Of Scope For v1
+
+- Quota conditions.
+- System and behavior signal conditions.
+- Composite conditions.
+- Geo-based conditions.
+- External signal sources.

--- a/docs/specs/DYNAMIC-POLICY-CONDITIONS-1.0.md
+++ b/docs/specs/DYNAMIC-POLICY-CONDITIONS-1.0.md
@@ -146,9 +146,11 @@ Boundary semantics:
 
 When a rule with dynamic condition is evaluated, audit metadata SHOULD include:
 
-- `dynamic_condition` (serialized condition config)
-- `runtime_snapshot` (provided runtime context)
+- `dynamic_condition` (serialized condition config) — always present when the rule has a `dynamic_condition`.
+- `evaluated_budget` — present only for budget conditions (`token_count_per_window`, `cost_per_window`). Records a minimal summary of the budget check: `{metric, window, limit, amount}`. No other fields from `dynamic_context` are recorded.
 - existing static context snapshot and timestamp fields
+
+The full `dynamic_context` provided to `PolicyEvaluator.evaluate` is intentionally NOT persisted in audit entries. Hosts that need the full runtime context should record it at a layer that has its own redaction policy.
 
 ## 5. Failure Semantics
 


### PR DESCRIPTION
## Summary

Adds Dynamic Policy Conditions v1 to the Python Agent-OS policy engine for the approved initial scope: temporal conditions (`time_window`, `day_of_week`) and budget conditions (`token_count_per_window`, `cost_per_window`).

## Problem

The current policy engine evaluates static `field/operator/value` conditions only. Issue #2615 requests a scoped v1 extension for runtime-aware policy checks, with a spec document, initial evaluator support, and tests covering temporal and budget scenarios.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agent-os/src/agent_os/policies/schema.py` | Added `DynamicConditionType`, `DynamicCondition`, and optional `PolicyRule.dynamic_condition` for the approved v1 condition set. |
| `agent-governance-python/agent-os/src/agent_os/policies/policy_schema.json` | Added JSON schema parity for `dynamic_condition` and the four approved v1 dynamic condition types. |
| `agent-governance-python/agent-os/src/agent_os/policies/evaluator.py` | Extended `PolicyEvaluator.evaluate()` with optional `dynamic_context` and gated rule matches on static plus dynamic condition evaluation. |
| `agent-governance-python/agent-os/src/agent_os/policies/dynamic_conditions.py` | Added minimal evaluator support for `time_window`, `day_of_week`, `token_count_per_window`, and `cost_per_window`. |
| `agent-governance-python/agent-os/src/agent_os/policies/__init__.py` | Exported new schema symbols. |
| `agent-governance-python/agent-os/tests/test_dynamic_policy_conditions.py` | Added v1 tests covering happy paths plus DST spring-forward and budget window rollover edge cases. |
| `docs/specs/DYNAMIC-POLICY-CONDITIONS-1.0.md` | Added v1 spec document with explicit out-of-scope section and v1 budget-state implementation note. |
| `agent-governance-python/agent-os/pyproject.toml` | Added `tzdata` to dev extras to make the pinned America/New_York DST test deterministic on CI runners. |

## Testing

Ran:

- `python -m pytest agent-governance-python/agent-os/tests/test_dynamic_policy_conditions.py agent-governance-python/agent-os/tests/test_spec_policy_engine_conformance.py agent-governance-python/agent-os/tests/test_policy_cli.py`

Result:

- `102 passed, 0 skipped`

## Scope

- This draft is intentionally limited to the agreed v1 scope:
  - `time_window`
  - `day_of_week`
  - `token_count_per_window`
  - `cost_per_window`
  
### Out of Scope for v1
  - quota conditions
  - system and behavior signal conditions
  - composite conditions
  - geo conditions
  - external signal sources
- Budget window state is intentionally process-local and in-memory for v1; persistence, cross-process coordination, and durable quota accounting are explicitly deferred.
- Related to #2615.

## Clarification Request

Issue guidance mentioned an evaluator skeleton as the first draft checkpoint. This draft includes executable reference behavior plus the requested tests to make review concrete. If you prefer a stricter skeleton-only first PR, I can split behavior into a follow-up.

