### PR TITLE
fix(tracing): enforce TLS by default for OTLP exporters

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -792,4 +792,6 @@ anchore
 octocat
 sboms
 Syft
+laintext
+nsecure
 syft

--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -794,4 +794,6 @@ sboms
 Syft
 laintext
 nsecure
+pyatr
+tzdata
 syft

--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -70,6 +70,8 @@ casefold
 CCPA
 cedarling
 cedarpy
+centralised
+Centralised
 changeme
 chdir
 cheatsheet
@@ -199,6 +201,8 @@ gmtime
 gomod
 GOPROXY
 governancepolicy
+grpc
+GRPC
 gvisor
 h├⌐llo
 hardlinks
@@ -330,6 +334,8 @@ openshell
 ORAS
 oserror
 ospo
+OTLP
+otlp
 oxycodone
 packument
 paramref
@@ -662,6 +668,7 @@ llamaguard
 llms
 logdir
 logprobs
+loopback
 makedirs
 materialisation
 materialises

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "uvicorn[standard]>=0.27.0,<1.0",
     "opentelemetry-api>=1.42.1,<2.0",
     "opentelemetry-sdk>=1.42.1,<2.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.42.1,<2.0",
     "PyJWT[crypto]>=2.8.0,<3.0",
     "pydantic[email]>=2.5.0,<3.0",
     "cryptography>=46.0.7,<49.0",

--- a/agent-governance-python/agent-mesh/src/agentmesh/observability/_tls_utils.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/observability/_tls_utils.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Shared TLS / endpoint-locality utilities for OTLP exporters.
+
+Centralised here so that ``agentmesh.observability.tracing`` and
+``agentmesh.telemetry`` stay in sync without copy-pasting.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+
+_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def is_local_endpoint(endpoint: str) -> bool:
+    """Return True if *endpoint* resolves to a loopback address.
+
+    Handles bare ``host:port`` strings (no scheme) by injecting a
+    dummy ``grpc://`` prefix so :func:`urllib.parse.urlparse` can
+    extract the hostname correctly.
+    """
+    if not endpoint:
+        return False
+    if "://" not in endpoint:
+        endpoint = "grpc://" + endpoint
+    try:
+        hostname = urllib.parse.urlparse(endpoint).hostname or ""
+    except Exception:
+        return False
+    return hostname in _LOCAL_HOSTS

--- a/agent-governance-python/agent-mesh/src/agentmesh/observability/tracing.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/observability/tracing.py
@@ -10,10 +10,31 @@ trust handshakes, identity verification, scope chains, and policy checks.
 from typing import Optional, Any, Callable, TypeVar
 from functools import wraps
 import inspect
+import logging
 import os
 import time
+import urllib.parse
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+_logger = logging.getLogger(__name__)
+
+_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def _is_local_endpoint(endpoint: str) -> bool:
+    """Return True if *endpoint* resolves to a loopback address."""
+    if not endpoint:
+        return False
+    # Handle bare "host:port" without a scheme so urllib can parse it.
+    if "://" not in endpoint:
+        endpoint = "grpc://" + endpoint
+    try:
+        hostname = urllib.parse.urlparse(endpoint).hostname or ""
+    except Exception:
+        return False
+    return hostname in _LOCAL_HOSTS
+
 
 # Check if OpenTelemetry is available
 _OTEL_AVAILABLE = False
@@ -49,7 +70,9 @@ def setup_tracing(
     Args:
         service_name: Service name for traces
         endpoint: OTLP endpoint (default: from OTEL_EXPORTER_OTLP_ENDPOINT env)
-        insecure: Whether to use insecure connection (default: False, use TLS)
+        insecure: Whether to use insecure connection (default: False, use TLS).
+            Only permitted for loopback endpoints; raises :exc:`ValueError` for
+            non-local endpoints to prevent accidental plaintext export.
     """
     try:
         from opentelemetry import trace
@@ -66,6 +89,19 @@ def setup_tracing(
     if not endpoint:
         # No endpoint configured, skip
         return
+
+    if insecure and not _is_local_endpoint(endpoint):
+        raise ValueError(
+            f"Insecure (plaintext) OTLP transport is not permitted for "
+            f"non-local endpoint '{endpoint}'. Set insecure=False or use a "
+            f"TLS-enabled collector."
+        )
+    if insecure:
+        _logger.warning(
+            "OTLP exporter is using an insecure (plaintext) channel to %s. "
+            "This is only acceptable for local development.",
+            endpoint,
+        )
 
     # Create resource
     resource = Resource.create({
@@ -236,6 +272,7 @@ def configure_tracing(
     service_name: str = "agentmesh",
     endpoint: Optional[str] = None,
     console: bool = False,
+    allow_insecure: bool = False,
 ) -> Optional[Any]:
     """Configure OpenTelemetry tracing with optional OTLP or console export.
 
@@ -243,6 +280,9 @@ def configure_tracing(
         service_name: Service name for traces.
         endpoint: OTLP endpoint. Falls back to OTEL_EXPORTER_OTLP_ENDPOINT env var.
         console: If True, add a ConsoleSpanExporter for local debugging.
+        allow_insecure: Permit plaintext transport.  Only valid for loopback
+            endpoints (``localhost`` / ``127.0.0.1``).  Setting this for a
+            non-local endpoint raises :exc:`ValueError`.
 
     Returns:
         TracerProvider if OTel is available, else None.
@@ -251,6 +291,19 @@ def configure_tracing(
         return None
 
     endpoint = endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+    if allow_insecure and endpoint:
+        if not _is_local_endpoint(endpoint):
+            raise ValueError(
+                f"Insecure (plaintext) OTLP transport is not permitted for "
+                f"non-local endpoint '{endpoint}'. Remove allow_insecure=True "
+                f"or use a TLS-enabled collector."
+            )
+        _logger.warning(
+            "OTLP exporter is using an insecure (plaintext) channel to %s. "
+            "This is only acceptable for local development.",
+            endpoint,
+        )
 
     resource = Resource.create(
         {
@@ -263,7 +316,8 @@ def configure_tracing(
     provider = TracerProvider(resource=resource)
 
     if endpoint and _OTLP_AVAILABLE:
-        otlp_exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+        use_insecure = allow_insecure and _is_local_endpoint(endpoint)
+        otlp_exporter = OTLPSpanExporter(endpoint=endpoint, insecure=use_insecure)
         provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
 
     if console:

--- a/agent-governance-python/agent-mesh/src/agentmesh/observability/tracing.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/observability/tracing.py
@@ -13,27 +13,12 @@ import inspect
 import logging
 import os
 import time
-import urllib.parse
+
+from agentmesh.observability._tls_utils import is_local_endpoint as _is_local_endpoint
 
 F = TypeVar("F", bound=Callable[..., Any])
 
 _logger = logging.getLogger(__name__)
-
-_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
-
-
-def _is_local_endpoint(endpoint: str) -> bool:
-    """Return True if *endpoint* resolves to a loopback address."""
-    if not endpoint:
-        return False
-    # Handle bare "host:port" without a scheme so urllib can parse it.
-    if "://" not in endpoint:
-        endpoint = "grpc://" + endpoint
-    try:
-        hostname = urllib.parse.urlparse(endpoint).hostname or ""
-    except Exception:
-        return False
-    return hostname in _LOCAL_HOSTS
 
 
 # Check if OpenTelemetry is available

--- a/agent-governance-python/agent-mesh/src/agentmesh/telemetry.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/telemetry.py
@@ -19,11 +19,27 @@ from __future__ import annotations
 
 import logging
 import os
+import urllib.parse
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 _bootstrapped = False
+
+_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def _is_local_endpoint(endpoint: str) -> bool:
+    """Return True if *endpoint* resolves to a loopback address."""
+    if not endpoint:
+        return False
+    if "://" not in endpoint:
+        endpoint = "grpc://" + endpoint
+    try:
+        hostname = urllib.parse.urlparse(endpoint).hostname or ""
+    except Exception:
+        return False
+    return hostname in _LOCAL_HOSTS
 
 
 def bootstrap_otel(
@@ -132,7 +148,33 @@ def bootstrap_otel(
 def _attach_trace_exporter(
     provider: object, endpoint: str, protocol: str
 ) -> None:
-    """Attach OTLP span exporter to the tracer provider (best-effort)."""
+    """Attach OTLP span exporter to the tracer provider (best-effort).
+
+    Raises:
+        ValueError: If the endpoint uses ``http://`` with a non-local host,
+            preventing accidental plaintext telemetry export to remote collectors.
+    """
+    parsed_scheme = (
+        urllib.parse.urlparse(endpoint).scheme.lower()
+        if "://" in endpoint
+        else ""
+    )
+    is_plaintext = parsed_scheme == "http"
+    is_local = _is_local_endpoint(endpoint)
+
+    if is_plaintext and not is_local:
+        raise ValueError(
+            f"Plaintext (http://) OTLP transport is not permitted for "
+            f"non-local endpoint '{endpoint}'. Use https:// or point to a "
+            f"TLS-enabled collector."
+        )
+    if is_plaintext and is_local:
+        logger.warning(
+            "OTLP exporter is using an insecure (plaintext) channel to %s. "
+            "This is only acceptable for local development.",
+            endpoint,
+        )
+
     try:
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
@@ -140,12 +182,16 @@ def _attach_trace_exporter(
             from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
                 OTLPSpanExporter,
             )
+            exporter = OTLPSpanExporter(endpoint=endpoint)
         else:
             from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
                 OTLPSpanExporter,
             )
+            # For gRPC, insecure=True only when caller explicitly opted in via
+            # a loopback http:// URL.
+            insecure = is_plaintext and is_local
+            exporter = OTLPSpanExporter(endpoint=endpoint, insecure=insecure)
 
-        exporter = OTLPSpanExporter(endpoint=endpoint)
         provider.add_span_processor(BatchSpanProcessor(exporter))  # type: ignore[attr-defined]
     except ImportError:
         logger.debug("OTLP exporter not available, traces will use in-memory provider only")

--- a/agent-governance-python/agent-mesh/src/agentmesh/telemetry.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/telemetry.py
@@ -22,24 +22,11 @@ import os
 import urllib.parse
 from typing import Optional
 
+from agentmesh.observability._tls_utils import is_local_endpoint as _is_local_endpoint
+
 logger = logging.getLogger(__name__)
 
 _bootstrapped = False
-
-_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
-
-
-def _is_local_endpoint(endpoint: str) -> bool:
-    """Return True if *endpoint* resolves to a loopback address."""
-    if not endpoint:
-        return False
-    if "://" not in endpoint:
-        endpoint = "grpc://" + endpoint
-    try:
-        hostname = urllib.parse.urlparse(endpoint).hostname or ""
-    except Exception:
-        return False
-    return hostname in _LOCAL_HOSTS
 
 
 def bootstrap_otel(

--- a/agent-governance-python/agent-mesh/tests/test_otel_bootstrap.py
+++ b/agent-governance-python/agent-mesh/tests/test_otel_bootstrap.py
@@ -218,3 +218,61 @@ class TestMetricsWithGovernance:
             mm.record_handshake(0.05, "success")
             response = client.get("/metrics")
             assert "agentmesh_handshake_duration_seconds" in response.text
+
+
+# ---------------------------------------------------------------------------
+# TLS enforcement tests for _attach_trace_exporter (security regression)
+# ---------------------------------------------------------------------------
+
+
+class TestAttachTraceExporterTLSEnforcement:
+    """Security tests: _attach_trace_exporter must block non-local plaintext."""
+
+    def test_non_local_http_endpoint_raises(self):
+        """http:// pointing to a non-local host must raise ValueError."""
+        from agentmesh.telemetry import _attach_trace_exporter
+        from unittest.mock import MagicMock
+
+        provider = MagicMock()
+        with pytest.raises(ValueError, match="[Pp]laintext"):
+            _attach_trace_exporter(provider, "http://collector.prod.example.com:4317", "grpc")
+
+    def test_local_http_endpoint_warns_and_proceeds(self):
+        """http://localhost is allowed but must log a WARNING."""
+        from agentmesh.telemetry import _attach_trace_exporter
+        from unittest.mock import MagicMock, patch
+
+        provider = MagicMock()
+        with patch("agentmesh.telemetry.logger") as mock_logger:
+            with patch("agentmesh.telemetry._attach_trace_exporter.__wrapped__", create=True):
+                # Use try/except in case exporter not installed; only care about warning.
+                try:
+                    _attach_trace_exporter(provider, "http://localhost:4317", "grpc")
+                except ImportError:
+                    pass
+            mock_logger.warning.assert_called()
+
+    def test_https_remote_endpoint_does_not_raise(self):
+        """https:// for a remote host must NOT raise (TLS is fine)."""
+        from agentmesh.telemetry import _attach_trace_exporter
+        from unittest.mock import MagicMock
+
+        provider = MagicMock()
+        # Should not raise ValueError; ImportError is acceptable if exporter is absent.
+        try:
+            _attach_trace_exporter(provider, "https://collector.example.com:4317", "grpc")
+        except ImportError:
+            pass  # exporter not installed — that's fine, security check passed
+
+    def test_bootstrap_otel_non_local_http_raises(self):
+        """bootstrap_otel() with a non-local http:// endpoint must raise ValueError."""
+        from agentmesh.telemetry import bootstrap_otel, reset
+
+        reset()
+        with pytest.raises(ValueError, match="[Pp]laintext"):
+            bootstrap_otel(
+                service_name="test",
+                endpoint="http://remote.collector.internal:4317",
+                enable_metrics=False,
+            )
+        reset()

--- a/agent-governance-python/agent-mesh/tests/test_otel_bootstrap.py
+++ b/agent-governance-python/agent-mesh/tests/test_otel_bootstrap.py
@@ -244,13 +244,8 @@ class TestAttachTraceExporterTLSEnforcement:
 
         provider = MagicMock()
         with patch("agentmesh.telemetry.logger") as mock_logger:
-            with patch("agentmesh.telemetry._attach_trace_exporter.__wrapped__", create=True):
-                # Use try/except in case exporter not installed; only care about warning.
-                try:
-                    _attach_trace_exporter(provider, "http://localhost:4317", "grpc")
-                except ImportError:
-                    pass
-            mock_logger.warning.assert_called()
+            _attach_trace_exporter(provider, "http://localhost:4317", "grpc")
+        mock_logger.warning.assert_called_once()
 
     def test_https_remote_endpoint_does_not_raise(self):
         """https:// for a remote host must NOT raise (TLS is fine)."""

--- a/agent-governance-python/agent-mesh/tests/test_otel_tracing.py
+++ b/agent-governance-python/agent-mesh/tests/test_otel_tracing.py
@@ -322,6 +322,96 @@ class TestConfigureTracing:
 
 
 # ---------------------------------------------------------------------------
+# TLS enforcement tests (security regression tests)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureTracingTLSEnforcement:
+    """Security tests: configure_tracing must default to TLS and block insecure on non-local endpoints."""
+
+    def test_default_non_local_endpoint_does_not_use_insecure(self):
+        """configure_tracing() with a non-local endpoint MUST NOT pass insecure=True."""
+        if not _OTEL_AVAILABLE:
+            pytest.skip("opentelemetry not installed")
+
+        with patch("agentmesh.observability.tracing._OTLP_AVAILABLE", True):
+            with patch("agentmesh.observability.tracing.OTLPSpanExporter") as mock_exporter:
+                configure_tracing(
+                    service_name="test",
+                    endpoint="https://collector.example.com:4317",
+                )
+                mock_exporter.assert_called_once()
+                call_kwargs = mock_exporter.call_args[1]
+                assert call_kwargs.get("insecure") is not True, (
+                    "configure_tracing() must NOT use insecure=True for non-local endpoints"
+                )
+
+    def test_localhost_allow_insecure_flag_permits_plaintext_and_warns(self):
+        """Localhost + allow_insecure=True is permitted but must log a WARNING."""
+        if not _OTEL_AVAILABLE:
+            pytest.skip("opentelemetry not installed")
+
+        import logging
+
+        with patch("agentmesh.observability.tracing._OTLP_AVAILABLE", True):
+            with patch("agentmesh.observability.tracing.OTLPSpanExporter") as mock_exporter:
+                with patch("agentmesh.observability.tracing._logger") as mock_logger:
+                    configure_tracing(
+                        service_name="test-local",
+                        endpoint="localhost:4317",
+                        allow_insecure=True,
+                    )
+                    mock_exporter.assert_called_once()
+                    call_kwargs = mock_exporter.call_args[1]
+                    assert call_kwargs.get("insecure") is True, (
+                        "localhost + allow_insecure=True must set insecure=True"
+                    )
+                    mock_logger.warning.assert_called()
+
+    def test_127_0_0_1_allow_insecure_flag_permits_plaintext(self):
+        """127.0.0.1 + allow_insecure=True is a valid local-dev override."""
+        if not _OTEL_AVAILABLE:
+            pytest.skip("opentelemetry not installed")
+
+        with patch("agentmesh.observability.tracing._OTLP_AVAILABLE", True):
+            with patch("agentmesh.observability.tracing.OTLPSpanExporter") as mock_exporter:
+                with patch("agentmesh.observability.tracing._logger"):
+                    configure_tracing(
+                        service_name="test-loopback",
+                        endpoint="127.0.0.1:4317",
+                        allow_insecure=True,
+                    )
+                    mock_exporter.assert_called_once()
+                    call_kwargs = mock_exporter.call_args[1]
+                    assert call_kwargs.get("insecure") is True
+
+    def test_non_local_allow_insecure_raises(self):
+        """Non-local endpoint + allow_insecure=True must raise ValueError (deny)."""
+        if not _OTEL_AVAILABLE:
+            pytest.skip("opentelemetry not installed")
+
+        with pytest.raises(ValueError, match="[Ii]nsecure"):
+            configure_tracing(
+                service_name="test",
+                endpoint="collector.prod.example.com:4317",
+                allow_insecure=True,
+            )
+
+    def test_env_var_non_local_endpoint_uses_tls(self):
+        """OTEL_EXPORTER_OTLP_ENDPOINT pointing to non-local host must use TLS."""
+        if not _OTEL_AVAILABLE:
+            pytest.skip("opentelemetry not installed")
+
+        with patch("agentmesh.observability.tracing._OTLP_AVAILABLE", True):
+            with patch("agentmesh.observability.tracing.OTLPSpanExporter") as mock_exporter:
+                with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel.example.com:4317"}):
+                    configure_tracing(service_name="test-env")
+                    mock_exporter.assert_called_once()
+                    call_kwargs = mock_exporter.call_args[1]
+                    assert call_kwargs.get("insecure") is not True
+
+
+# ---------------------------------------------------------------------------
 # Async decorator support
 # ---------------------------------------------------------------------------
 

--- a/agent-governance-python/agent-mesh/tests/test_otel_tracing.py
+++ b/agent-governance-python/agent-mesh/tests/test_otel_tracing.py
@@ -3,7 +3,7 @@
 """Tests for OpenTelemetry tracing of trust operations."""
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from agentmesh.observability.tracing import (
     MeshTracer,
@@ -329,6 +329,11 @@ class TestConfigureTracing:
 class TestConfigureTracingTLSEnforcement:
     """Security tests: configure_tracing must default to TLS and block insecure on non-local endpoints."""
 
+    _otlp = pytest.importorskip(
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+        reason="opentelemetry-exporter-otlp-proto-grpc not installed",
+    )
+
     def test_default_non_local_endpoint_does_not_use_insecure(self):
         """configure_tracing() with a non-local endpoint MUST NOT pass insecure=True."""
         if not _OTEL_AVAILABLE:
@@ -350,8 +355,6 @@ class TestConfigureTracingTLSEnforcement:
         """Localhost + allow_insecure=True is permitted but must log a WARNING."""
         if not _OTEL_AVAILABLE:
             pytest.skip("opentelemetry not installed")
-
-        import logging
 
         with patch("agentmesh.observability.tracing._OTLP_AVAILABLE", True):
             with patch("agentmesh.observability.tracing.OTLPSpanExporter") as mock_exporter:

--- a/agent-governance-python/agent-sre/pyproject.toml
+++ b/agent-governance-python/agent-sre/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "croniter>=2.0,<7.0",
     "opentelemetry-api>=1.20,<2.0",
     "opentelemetry-sdk>=1.20,<2.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0,<2.0",
     "fastapi>=0.115.0,<1.0",
     "uvicorn>=0.49.0,<1.0",
 ]

--- a/agent-governance-python/agent-sre/src/agent_sre/tracing/_tls_utils.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/tracing/_tls_utils.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Shared TLS / endpoint-locality utilities for agent-sre OTLP exporters.
+
+Centralised here so that ``agent_sre.tracing.exporters`` and any future
+sre tracing helpers stay in sync without copy-pasting.
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+
+_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def is_local_endpoint(endpoint: str) -> bool:
+    """Return True if *endpoint* resolves to a loopback address.
+
+    Handles bare ``host:port`` strings (no scheme) by injecting a
+    dummy ``grpc://`` prefix so :func:`urllib.parse.urlparse` can
+    extract the hostname correctly.
+    """
+    if not endpoint:
+        return False
+    if "://" not in endpoint:
+        endpoint = "grpc://" + endpoint
+    try:
+        hostname = urllib.parse.urlparse(endpoint).hostname or ""
+    except Exception:
+        return False
+    return hostname in _LOCAL_HOSTS

--- a/agent-governance-python/agent-sre/src/agent_sre/tracing/exporters.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/tracing/exporters.py
@@ -8,6 +8,9 @@ instances with BatchSpanProcessor for gRPC, HTTP, and console export.
 
 from __future__ import annotations
 
+import logging
+import urllib.parse
+
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
@@ -15,6 +18,23 @@ from opentelemetry.sdk.trace.export import (
     ConsoleSpanExporter,
     SimpleSpanProcessor,
 )
+
+_logger = logging.getLogger(__name__)
+
+_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def _is_local_endpoint(endpoint: str) -> bool:
+    """Return True if *endpoint* resolves to a loopback address."""
+    if not endpoint:
+        return False
+    if "://" not in endpoint:
+        endpoint = "grpc://" + endpoint
+    try:
+        hostname = urllib.parse.urlparse(endpoint).hostname or ""
+    except Exception:
+        return False
+    return hostname in _LOCAL_HOSTS
 
 
 def _build_resource(service_name: str = "agent-sre") -> Resource:
@@ -25,7 +45,7 @@ def _build_resource(service_name: str = "agent-sre") -> Resource:
 def configure_otlp_grpc(
     endpoint: str = "localhost:4317",
     headers: dict[str, str] | None = None,
-    insecure: bool = True,
+    insecure: bool = False,
     service_name: str = "agent-sre",
 ) -> TracerProvider:
     """Configure a TracerProvider exporting via OTLP/gRPC.
@@ -33,7 +53,10 @@ def configure_otlp_grpc(
     Args:
         endpoint: Collector gRPC endpoint (e.g. ``localhost:4317``).
         headers: Optional metadata headers for authentication.
-        insecure: Whether to use an insecure channel.
+        insecure: Whether to use an insecure (plaintext) channel.  Only
+            permitted for loopback endpoints; raises :exc:`ValueError` for
+            non-local endpoints to prevent accidental plaintext export.
+            Defaults to ``False`` (TLS required).
         service_name: Service name for the OTel resource.
 
     Returns:
@@ -42,7 +65,21 @@ def configure_otlp_grpc(
     Raises:
         ImportError: If ``opentelemetry-exporter-otlp-proto-grpc`` is
             not installed.
+        ValueError: If ``insecure=True`` is requested for a non-local endpoint.
     """
+    if insecure and not _is_local_endpoint(endpoint):
+        raise ValueError(
+            f"Insecure (plaintext) OTLP/gRPC transport is not permitted for "
+            f"non-local endpoint '{endpoint}'. Set insecure=False or use a "
+            f"TLS-enabled collector."
+        )
+    if insecure:
+        _logger.warning(
+            "OTLP/gRPC exporter is using an insecure (plaintext) channel to %s. "
+            "This is only acceptable for local development.",
+            endpoint,
+        )
+
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
         OTLPSpanExporter,
     )

--- a/agent-governance-python/agent-sre/src/agent_sre/tracing/exporters.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/tracing/exporters.py
@@ -9,7 +9,6 @@ instances with BatchSpanProcessor for gRPC, HTTP, and console export.
 from __future__ import annotations
 
 import logging
-import urllib.parse
 
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -19,22 +18,9 @@ from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
 )
 
+from agent_sre.tracing._tls_utils import is_local_endpoint as _is_local_endpoint
+
 _logger = logging.getLogger(__name__)
-
-_LOCAL_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
-
-
-def _is_local_endpoint(endpoint: str) -> bool:
-    """Return True if *endpoint* resolves to a loopback address."""
-    if not endpoint:
-        return False
-    if "://" not in endpoint:
-        endpoint = "grpc://" + endpoint
-    try:
-        hostname = urllib.parse.urlparse(endpoint).hostname or ""
-    except Exception:
-        return False
-    return hostname in _LOCAL_HOSTS
 
 
 def _build_resource(service_name: str = "agent-sre") -> Resource:

--- a/agent-governance-python/agent-sre/tests/test_tracing.py
+++ b/agent-governance-python/agent-sre/tests/test_tracing.py
@@ -348,6 +348,10 @@ class TestExporters:
 class TestOtlpGrpcTLSEnforcement:
     """configure_otlp_grpc must default to TLS and deny insecure on non-local endpoints."""
 
+    _otlp = pytest.importorskip(
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+        reason="opentelemetry-exporter-otlp-proto-grpc not installed",
+    )
     _EXPORTER_PATH = "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
 
     def test_default_is_not_insecure(self):

--- a/agent-governance-python/agent-sre/tests/test_tracing.py
+++ b/agent-governance-python/agent-sre/tests/test_tracing.py
@@ -338,3 +338,47 @@ class TestExporters:
         resource_attrs = dict(provider.resource.attributes)
         assert resource_attrs["service.name"] == "my-agent"
         provider.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Tests — OTLP TLS enforcement (security regression)
+# ---------------------------------------------------------------------------
+
+
+class TestOtlpGrpcTLSEnforcement:
+    """configure_otlp_grpc must default to TLS and deny insecure on non-local endpoints."""
+
+    _EXPORTER_PATH = "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
+
+    def test_default_is_not_insecure(self):
+        """configure_otlp_grpc() default must use TLS (insecure=False)."""
+        from unittest.mock import patch, MagicMock
+        from agent_sre.tracing.exporters import configure_otlp_grpc
+
+        with patch(self._EXPORTER_PATH) as mock_exporter:
+            mock_exporter.return_value = MagicMock()
+            configure_otlp_grpc(endpoint="collector.prod.example.com:4317")
+            mock_exporter.assert_called_once()
+            call_kwargs = mock_exporter.call_args[1]
+            assert call_kwargs.get("insecure") is not True, (
+                "configure_otlp_grpc() default must NOT use insecure=True"
+            )
+
+    def test_localhost_explicit_insecure_is_allowed_with_warning(self):
+        """localhost + insecure=True must be allowed but log a WARNING."""
+        from unittest.mock import patch, MagicMock
+        from agent_sre.tracing.exporters import configure_otlp_grpc
+
+        with patch(self._EXPORTER_PATH) as mock_exporter:
+            with patch("agent_sre.tracing.exporters._logger") as mock_logger:
+                mock_exporter.return_value = MagicMock()
+                provider = configure_otlp_grpc(endpoint="localhost:4317", insecure=True)
+                assert provider is not None
+                mock_logger.warning.assert_called()
+
+    def test_non_local_insecure_raises(self):
+        """Non-local endpoint + insecure=True must raise ValueError."""
+        from agent_sre.tracing.exporters import configure_otlp_grpc
+
+        with pytest.raises(ValueError, match="[Ii]nsecure"):
+            configure_otlp_grpc(endpoint="otel.prod.example.com:4317", insecure=True)

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -95,6 +95,7 @@ REGISTERED_PACKAGES = {
     # Telemetry / monitoring
     "sentry-sdk",
     "opentelemetry-instrumentation-fastapi", "opentelemetry-exporter-otlp",
+    "opentelemetry-exporter-otlp-proto-grpc", "opentelemetry-exporter-otlp-proto-http",
     "opentelemetry-instrumentation-httpx", "opentelemetry-instrumentation-asyncio",
     # pyproject.toml optional-dependency group names (not real packages)
     "dev", "cli", "all", "server", "storage", "observability",

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -158,6 +158,10 @@ REGISTERED_PACKAGES = {
     "autogen-core", "autogen_core", "autogen-ext", "autogen_ext",
     "agentdojo",
     # With extras (base name is what matters)
+    # ACS annotator example dependency (real PyPI package)
+    "pyatr", "pyatr_core",
+    # Timezone data package (real PyPI package, used on Windows/Alpine)
+    "tzdata",
 }
 
 # Local-only packages that should NEVER appear with version pins in


### PR DESCRIPTION
## Description

Enforce TLS by default on all OTLP telemetry exporters. Previously, `configure_tracing()` hardcoded `insecure=True` on `OTLPSpanExporter`, exposing agent identity, policy decisions, and trace data in plaintext on any network path. This fix enforces TLS by default and permits insecure mode **only** for local-development endpoints (localhost / 127.0.0.1 / ::1) with an explicit `allow_insecure=True` opt-in and a WARNING-level log.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [x] agent-mesh
- [ ] agent-runtime
- [x] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agent-mesh/src/agentmesh/observability/tracing.py` | Added `_is_local_endpoint()`, `allow_insecure` param, double-gate pattern, `ValueError` for non-local plaintext |
| `agent-governance-python/agent-mesh/src/agentmesh/telemetry.py` | Added `_is_local_endpoint()`, explicit `insecure=` on gRPC exporter, blocks env-var bypass via `OTEL_EXPORTER_OTLP_INSECURE` |
| `agent-governance-python/agent-sre/src/agent_sre/tracing/exporters.py` | Changed `insecure: bool = True` default to `False`; added locality guard |
| `agent-governance-python/agent-mesh/tests/test_otel_tracing.py` | Added `TestConfigureTracingTLSEnforcement` (5 regression tests) |
| `agent-governance-python/agent-sre/tests/test_tracing.py` | Added `TestOtlpGrpcTLSEnforcement` (3 regression tests) |
| `agent-governance-python/agent-mesh/tests/test_otel_bootstrap.py` | Added `TestAttachTraceExporterTLSEnforcement` (4 regression tests) |

## Security Context

- **CVE class**: CWE-319 Cleartext Transmission of Sensitive Information
- **CVSS**: 7.4 (Medium) - network eavesdropping of agent identity, policy decisions, and trace spans
- **Root cause**: `insecure=True` hardcoded on `OTLPSpanExporter`; two additional plaintext-default variants in `telemetry.py` and `agent-sre/exporters.py`
- **Fix**: TLS enforced by default; insecure allowed only for localhost/loopback with explicit opt-in + WARNING log

## Testing

- 12 new security regression tests (all pass)
- Full otel suite: 96 passed, 6 skipped (pre-existing env-based skips, unrelated to this fix)
- agent-sre suite: 19 passed
- `ruff check --select E,F,W --ignore E501` clean on both packages

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any): Standard OTLP/gRPC TLS enforcement pattern per OpenTelemetry specification.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [ ] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

GitHub Copilot (Claude Sonnet 4.6) assisted with implementation and test generation; all output reviewed.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->