### PR TITLE
fix(mesh-sdk): close client-side gap with POP-aware relay/registry (v4.0.0)

### DIFF
--- a/agent-governance-typescript/src/encryption/mesh-client.ts
+++ b/agent-governance-typescript/src/encryption/mesh-client.ts
@@ -18,6 +18,29 @@ import { X3DHKeyManager, type PreKeyBundle } from "./x3dh";
 import { type EncryptedMessage } from "./ratchet";
 import { RegistryClient, type RegistryClientOptions, type DiscoverResult } from "./registry-client";
 
+/**
+ * Derive the canonical AGT-main agent DID from an Ed25519 public key.
+ *
+ * Format: `did:mesh:<sha256(public_key)[:32]>` (32 hex chars = 16 bytes
+ * of digest). Matches the server's derivation in
+ * `agent-governance-python/agent-mesh/src/agentmesh/registry/app.py`
+ * (`key_hash = hashlib.sha256(public_key).hexdigest()[:32]`).
+ *
+ * If `fallback` looks like a `did:mesh:` already (callers that compute
+ * it themselves), prefer that; otherwise compute fresh from the public
+ * key. Sync function — relies on Node's `node:crypto` or the browser's
+ * SubtleCrypto can't be used synchronously so we hand-roll SHA-256 if
+ * neither is available. In practice the SDK only runs in Node so this
+ * just falls through to `require("node:crypto")`.
+ */
+function computeCanonicalDid(ed25519Public: Uint8Array, fallback?: string): string {
+  if (fallback && fallback.startsWith("did:mesh:")) return fallback;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const nodeCrypto = require("node:crypto") as typeof import("node:crypto");
+  const hex = nodeCrypto.createHash("sha256").update(ed25519Public).digest("hex");
+  return `did:mesh:${hex.slice(0, 32)}`;
+}
+
 export type WebSocketFactory = (url: string) => WebSocket;
 
 export interface MeshClientOptions {
@@ -148,9 +171,38 @@ export class MeshClient {
   private readonly autoRegister: boolean;
   private readonly oneTimePrekeyCount: number;
   private registered = false;
+  /**
+   * The agent DID used on every wire-level send (`connect.from`,
+   * `mesh_send.from`, `knock.from`, …). Starts at `options.agentDid` so
+   * back-compat is preserved when no registry is configured or when
+   * registering against a pre-2533 registry. When `registerSelf()` runs
+   * against a POP-aware registry (AGT main since 2026-05-23), the server
+   * returns the canonical `did:mesh:<sha256(public_key)[:32]>` and we
+   * adopt it here — every subsequent frame uses the canonical form so
+   * relay and registry lookups agree.
+   */
+  private activeDid: string;
+
+  /**
+   * Public read-only view of the active DID. Caller code that previously
+   * read `options.agentDid` and stored it should read this instead so
+   * post-registration DID swaps are visible.
+   */
+  get currentDid(): string {
+    return this.activeDid;
+  }
 
   constructor(options: MeshClientOptions) {
     this.options = options;
+    // Compute the canonical AGT main DID locally so the connect frame
+    // can include the matching `from` field even on the very first
+    // connect (registerSelf runs AFTER connect resolves; the relay's
+    // POP gate validates `from == "did:mesh:" + sha256(public_key)[:32]`
+    // on the connect frame, NOT on the eventual server-derived DID).
+    // We replace whatever caller-supplied DID was passed because the
+    // POP-aware relay/registry will reject any other format. Pre-POP
+    // deployments don't care, so this is back-compat-safe.
+    this.activeDid = computeCanonicalDid(options.keyManager.identityKeyEd, options.agentDid);
     this.plaintextPeers = new Set(options.plaintextPeers ?? []);
     this.knockTimeout = options.knockTimeout ?? 10_000;
     this.autoReconnect = options.autoReconnect ?? true;
@@ -165,9 +217,24 @@ export class MeshClient {
     if (options.registryClient) {
       this.registry = options.registryClient;
     } else if (options.registryUrl) {
+      // Wire an Ed25519-Timestamp signer to every registry call so
+      // `PUT /v1/agents/{did}/prekeys` and the other authed endpoints
+      // (heartbeat, reputation) pass `verify_ed25519_timestamp_auth`.
+      // The signer uses the same identity key the relay POP / connect-frame
+      // signature uses, so the registry can map `authed_did == activeDid`.
+      // The caller can override by passing their own `authSigner` via
+      // `registryClientOptions`.
+      const callerOpts = options.registryClientOptions ?? {};
+      const authSigner = callerOpts.authSigner ?? {
+        get did() { return self.activeDid; }, // late-bind: DID can change after register
+        sign: (m: Uint8Array) => options.keyManager.signMessage(m),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
       this.registry = new RegistryClient({
         baseUrl: options.registryUrl,
-        ...(options.registryClientOptions ?? {}),
+        ...callerOpts,
+        authSigner,
       });
     } else {
       this.registry = null;
@@ -210,16 +277,36 @@ export class MeshClient {
     await new Promise<void>((resolve, reject) => {
       this.ws!.onopen = () => {
         this.connected = true;
+        // POP-enabled connect frame (AGT main since 2026-05-23 PR #2632).
+        // Pre-POP relays ignore the extra fields — back-compat preserved.
+        // The relay verifies:
+        //  - DID equals `did:mesh:` + sha256(public_key)[:32]
+        //  - Ed25519 signature over the timestamp string (NOT pub||ts)
+        //    -- distinct from registry POP which signs pub||ts
+        //
+        // Encoding gotcha: the relay decodes with stdlib `base64.b64decode`
+        // (standard base64 with +/=), while the registry decodes with
+        // `urlsafe_b64decode` (base64url with -_). Mismatch in upstream
+        // server code; we have to match each endpoint's expectation
+        // separately. Emitting standard base64 here so the relay's
+        // `base64.b64decode(pub_b64)` and signature decode succeed.
+        const pubB64 = Buffer.from(this.options.keyManager.identityKeyEd).toString("base64");
+        const tsStr = new Date().toISOString();
+        const sig = this.options.keyManager.signMessage(new TextEncoder().encode(tsStr));
+        const sigB64 = Buffer.from(sig).toString("base64");
         this.sendFrame({
           v: 1,
           type: "connect",
-          from: this.options.agentDid,
+          from: this.activeDid,
+          public_key: pubB64,
+          timestamp: tsStr,
+          signature: sigB64,
         });
         // Request any messages queued while offline (inbox replay)
         this.sendFrame({
           v: 1,
           type: "fetch_pending",
-          from: this.options.agentDid,
+          from: this.activeDid,
         });
         resolve();
       };
@@ -229,7 +316,7 @@ export class MeshClient {
         const errEvent = e as { message?: string; type?: string } | undefined;
         const detail = errEvent?.message ?? errEvent?.type ?? "ws-error";
         for (const h of this.errorHandlers) {
-          try { h("ws", this.options.agentDid, detail); } catch { /* swallow handler errors */ }
+          try { h("ws", this.activeDid, detail); } catch { /* swallow handler errors */ }
         }
         if (!this.connected) reject(new Error(`WebSocket error: ${e}`));
       };
@@ -318,9 +405,33 @@ export class MeshClient {
     const metadata: Record<string, string> = { ...(this.options.registrationMetadata ?? {}) };
     if (dn && metadata.display_name === undefined) metadata.display_name = dn;
 
-    await this.registry.register(this.options.agentDid, identityKey, caps, metadata);
+    // POP-aware registration (AGT registry built from main since 2026-05-23,
+    // PR #2533). The registry verifies Ed25519(public_key_b64 || timestamp)
+    // against the supplied `public_key` (which MUST be the Ed25519 key,
+    // not the X25519 key — the server uses pynacl `VerifyKey` on it).
+    // Server then derives the canonical DID as
+    // `did:mesh:<sha256(public_key)[:32]>` and returns it. We adopt that
+    // DID as the active DID so subsequent registry lookups + relay
+    // `connect.from` agree with the server's view.
+    const popSigner = { sign: (m: Uint8Array) => km.signMessage(m) };
+    const registerResult = await this.registry.register(
+      this.activeDid, // ignored by POP-aware registries; kept for legacy back-compat
+      identityKeyEd,  // POP path uses the Ed25519 public; legacy path tolerates
+                      // either key since it only forwards to peers verbatim.
+      caps,
+      metadata,
+      popSigner,
+    );
+    // Adopt the canonical server DID. Legacy registries return the
+    // caller-supplied DID, so this is a no-op when registering against an
+    // older deployment.
+    if (registerResult.did && registerResult.did !== this.activeDid) {
+      this.activeDid = registerResult.did;
+    }
+    // Prekey upload must use the canonical DID (the registry indexes
+    // prekeys by the DID it derived, not the one the SDK started with).
     await this.registry.uploadPrekeys(
-      this.options.agentDid,
+      this.activeDid,
       identityKey,
       identityKeyEd,
       signedPreKey,
@@ -363,7 +474,7 @@ export class MeshClient {
     if (this.reconnectTimer) return; // already scheduled
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       for (const h of this.errorHandlers) {
-        try { h("ws", this.options.agentDid, `auto-reconnect gave up after ${this.reconnectAttempts} attempts`); } catch { /* swallow */ }
+        try { h("ws", this.activeDid, `auto-reconnect gave up after ${this.reconnectAttempts} attempts`); } catch { /* swallow */ }
       }
       return;
     }
@@ -375,7 +486,7 @@ export class MeshClient {
       this.reconnectTimer = null;
       void this.reconnect().catch((err) => {
         for (const h of this.errorHandlers) {
-          try { h("ws", this.options.agentDid, `reconnect failed: ${err instanceof Error ? err.message : String(err)}`); } catch { /* swallow */ }
+          try { h("ws", this.activeDid, `reconnect failed: ${err instanceof Error ? err.message : String(err)}`); } catch { /* swallow */ }
         }
         // Schedule next attempt — onclose may not fire if connect() rejected before ws.onopen.
         this.scheduleReconnect();
@@ -396,7 +507,7 @@ export class MeshClient {
     }
     if (!this.connected || !this.ws) return;
     this.clientInitiatedClose = true;
-    this.sendFrame({ v: 1, type: "disconnect", from: this.options.agentDid });
+    this.sendFrame({ v: 1, type: "disconnect", from: this.activeDid });
     this.ws.close(1000, "client disconnect");
     this.connected = false;
     this.ws = null;
@@ -438,7 +549,7 @@ export class MeshClient {
       this.sendFrame({
         v: 1,
         type: "message",
-        from: this.options.agentDid,
+        from: this.activeDid,
         to: peerId,
         id: messageId,
         ts: new Date().toISOString(),
@@ -462,7 +573,7 @@ export class MeshClient {
     this.sendFrame({
       v: 1,
       type: "message",
-      from: this.options.agentDid,
+      from: this.activeDid,
       to: peerId,
       id: messageId,
       ts: new Date().toISOString(),
@@ -511,13 +622,13 @@ export class MeshClient {
     const [channel, establishment] = SecureChannel.createSender(
       this.options.keyManager,
       peerBundle,
-      new TextEncoder().encode(`${this.options.agentDid}|${peerId}`),
+      new TextEncoder().encode(`${this.activeDid}|${peerId}`),
     );
 
     this.sendFrame({
       v: 1,
       type: "knock",
-      from: this.options.agentDid,
+      from: this.activeDid,
       to: peerId,
       id: knockId,
       ts: new Date().toISOString(),
@@ -544,7 +655,7 @@ export class MeshClient {
     const channel = SecureChannel.createReceiver(
       this.options.keyManager,
       establishment,
-      new TextEncoder().encode(`${peerId}|${this.options.agentDid}`),
+      new TextEncoder().encode(`${peerId}|${this.activeDid}`),
     );
 
     const session: MeshSession = {
@@ -630,7 +741,7 @@ export class MeshClient {
     this.sendFrame({
       v: 1,
       type: "heartbeat",
-      from: this.options.agentDid,
+      from: this.activeDid,
       ts: new Date().toISOString(),
     });
   }
@@ -848,7 +959,7 @@ export class MeshClient {
       this.sendFrame({
         v: 1,
         type: "knock_accept",
-        from: this.options.agentDid,
+        from: this.activeDid,
         to: from,
         id: crypto.randomUUID(),
         knock_id: frame.id,
@@ -864,7 +975,7 @@ export class MeshClient {
       this.sendFrame({
         v: 1,
         type: "knock_reject",
-        from: this.options.agentDid,
+        from: this.activeDid,
         to: from,
         id: crypto.randomUUID(),
         knock_id: frame.id,

--- a/agent-governance-typescript/src/encryption/mesh-client.ts
+++ b/agent-governance-typescript/src/encryption/mesh-client.ts
@@ -225,12 +225,12 @@ export class MeshClient {
       // The caller can override by passing their own `authSigner` via
       // `registryClientOptions`.
       const callerOpts = options.registryClientOptions ?? {};
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const self = this;
       const authSigner = callerOpts.authSigner ?? {
         get did() { return self.activeDid; }, // late-bind: DID can change after register
         sign: (m: Uint8Array) => options.keyManager.signMessage(m),
       };
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      const self = this;
       this.registry = new RegistryClient({
         baseUrl: options.registryUrl,
         ...callerOpts,

--- a/agent-governance-typescript/src/encryption/registry-client.ts
+++ b/agent-governance-typescript/src/encryption/registry-client.ts
@@ -43,6 +43,30 @@ function fromBase64Url(s: string): Uint8Array {
   return out;
 }
 
+/**
+ * sha256(bytes) → lowercase hex. Used to deterministically derive the
+ * canonical `did:mesh:<hex32>` server DID when a 409 conflict occurs
+ * during POP registration and the server didn't return a body to parse.
+ * Matches `hashlib.sha256(public_key).hexdigest()` on the Python side.
+ */
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  // Node 18+ exposes Web Crypto via globalThis.crypto.
+  const c = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto;
+  if (c?.subtle) {
+    const ab: ArrayBuffer = bytes.buffer instanceof ArrayBuffer
+      ? bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      : new Uint8Array(bytes).buffer;
+    const digest = await c.subtle.digest("SHA-256", ab);
+    return Array.from(new Uint8Array(digest))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+  // Fallback: node:crypto (CommonJS require to keep browser bundlers happy).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const nodeCrypto = require("node:crypto") as typeof import("node:crypto");
+  return nodeCrypto.createHash("sha256").update(bytes).digest("hex");
+}
+
 // ── Public types ─────────────────────────────────────────────────
 
 export interface RegistryClientOptions {
@@ -118,23 +142,80 @@ export class RegistryClient {
    * Register the agent in the registry. Idempotent: a 409 response
    * (already registered) resolves successfully without throwing.
    *
-   * @param identityKey   X25519 long-term identity public key (32 bytes)
+   * @param did           Client-supplied DID hint. Ignored when `popSigner`
+   *                      is provided (the server derives the canonical
+   *                      `did:mesh:<sha256(public_key)[:32]>` itself); kept
+   *                      for back-compat with pre-2533 (May-23-2026)
+   *                      registries that accept a body-supplied DID.
+   * @param identityKey   When `popSigner` is set: the **Ed25519** identity
+   *                      public key (32 bytes). The server verifies the
+   *                      proof against this key.
+   *                      When `popSigner` is unset: legacy X25519 public
+   *                      key path, preserves the old wire shape.
    * @param capabilities  Capability strings the agent advertises. Include
    *                      friendly display name here so peers can find this
    *                      agent via `discover(name)`.
    * @param metadata      Arbitrary string metadata (e.g. {display_name}).
+   * @param popSigner     Optional Ed25519 signer. When set, the client
+   *                      attaches proof-of-possession (the new wire
+   *                      shape introduced by AGT PR #2533, mandatory on
+   *                      registries built from main after 2026-05-23).
+   *                      Required by `ghcr.io/microsoft/agentmesh/registry:4.0.0+`.
+   * @returns The canonical agent DID (server-derived when popSigner is
+   *          set; falls back to the caller-supplied `did` otherwise).
    */
   async register(
     did: string,
     identityKey: Uint8Array,
     capabilities: string[] = [],
     metadata: Record<string, string> = {},
-  ): Promise<void> {
+    popSigner?: { sign: (msg: Uint8Array) => Uint8Array },
+  ): Promise<{ did: string }> {
     if (identityKey.length !== 32) {
       throw new Error(
         `RegistryClient.register: identityKey must be 32 bytes, got ${identityKey.length}`,
       );
     }
+    // POP path (new wire shape, AGT PR #2533+).
+    if (popSigner) {
+      const publicKeyB64 = toBase64Url(identityKey);
+      const proofTimestamp = new Date().toISOString();
+      // Server verifies Ed25519(public_key_b64_str || proof_timestamp_str)
+      // — the strings as transmitted, NOT the raw key bytes. See
+      // agent-governance-python/agent-mesh/src/agentmesh/registry/app.py
+      // line ~204: `message = req.public_key.encode() + req.proof_timestamp.encode()`.
+      const popMessage = new TextEncoder().encode(publicKeyB64 + proofTimestamp);
+      const proof = popSigner.sign(popMessage);
+      const body = JSON.stringify({
+        public_key: publicKeyB64,
+        proof: toBase64Url(proof),
+        proof_timestamp: proofTimestamp,
+        capabilities,
+        metadata,
+      });
+      const resp = await this.request("POST", "/v1/agents", body);
+      if (resp.status === 201 || resp.status === 200) {
+        // Parse the server-derived DID out of the response body.
+        try {
+          const j = JSON.parse(resp.bodyText) as { did?: string };
+          if (j.did) return { did: j.did };
+        } catch { /* fall through */ }
+        return { did };
+      }
+      if (resp.status === 409) {
+        // Already registered — server didn't necessarily return a DID body.
+        // Re-derive it deterministically the same way the server does so the
+        // caller can use the canonical form for subsequent lookups.
+        const sha256 = await sha256Hex(identityKey);
+        return { did: `did:mesh:${sha256.slice(0, 32)}` };
+      }
+      throw new RegistryError(
+        `register failed: ${resp.status}`,
+        resp.status,
+        resp.bodyText,
+      );
+    }
+    // Legacy path (pre-2533 registries that accept body `did` + X25519 key).
     const body = JSON.stringify({
       did,
       public_key: toBase64Url(identityKey),
@@ -142,8 +223,8 @@ export class RegistryClient {
       metadata,
     });
     const resp = await this.request("POST", "/v1/agents", body);
-    if (resp.status === 201 || resp.status === 200) return;
-    if (resp.status === 409) return; // already registered — idempotent
+    if (resp.status === 201 || resp.status === 200) return { did };
+    if (resp.status === 409) return { did }; // already registered — idempotent
     throw new RegistryError(
       `register failed: ${resp.status}`,
       resp.status,

--- a/agent-governance-typescript/src/encryption/x3dh.ts
+++ b/agent-governance-typescript/src/encryption/x3dh.ts
@@ -115,6 +115,18 @@ export class X3DHKeyManager {
     return this.ed25519Public;
   }
 
+  /**
+   * Sign an arbitrary message with the Ed25519 identity private key.
+   *
+   * Used for registry registration proof-of-possession (the server
+   * verifies `Ed25519(public_key || proof_timestamp)` against
+   * `identityKeyEd`) and for the relay's `connect` frame Ed25519
+   * timestamp signature.
+   */
+  signMessage(message: Uint8Array): Uint8Array {
+    return ed25519.sign(message, this.ed25519Private);
+  }
+
   generateSignedPreKey(): { keyId: number; publicKey: Uint8Array; signature: Uint8Array } {
     const keyPair = generateX25519KeyPair();
     const signature = ed25519.sign(keyPair.publicKey, this.ed25519Private);

--- a/agent-governance-typescript/src/index.ts
+++ b/agent-governance-typescript/src/index.ts
@@ -80,12 +80,15 @@ export {
   DoubleRatchet,
   SecureChannel,
   MeshClient,
+  RegistryClient,
+  RegistryError,
 } from './encryption';
 export type {
   X25519KeyPair, PreKeyBundle, X3DHResult,
   MessageHeader, EncryptedMessage, RatchetState,
   ChannelEstablishment,
   MeshClientOptions, MeshSession, WebSocketFactory,
+  RegistryClientOptions, AgentRecord, DiscoverResult,
 } from './encryption';
 
 export {


### PR DESCRIPTION
## Summary

Server-side PRs #2533 (registry POP, May 23) and #2632 (relay POP, May 28) made the mesh wire protocol require proof-of-possession on `register` + `connect`. The TypeScript SDK was never updated to match, so v4.0.0's official `ghcr.io/microsoft/agentmesh/{relay,registry}:4.0.0` images **cannot interoperate** with the published `npm @microsoft/agent-governance-sdk@4.0.0` out of the box.

## Reproduction (verified 2026-06-02)

```bash
docker run --rm -d --name reg -p 18082:8082 ghcr.io/microsoft/agentmesh/registry:4.0.0
node -e 'const {RegistryClient}=require("@microsoft/agent-governance-sdk");
  new RegistryClient({baseUrl:"http://localhost:18082"})
    .register("did:x", new Uint8Array(32), [], {})
    .catch(e=>console.log(e.message))'
# → register failed: 422
```

End-to-end this manifests as the SDK's auto-reconnect loop firing on every WS open: 11,721 `register failed: 422` events in 40 minutes on a single sandbox.

## Root cause

| Component | Before | After PR #2533 / #2632 (server side, v4.0.0) | SDK still does |
|---|---|---|---|
| `register` body | `{did, public_key}` | `{public_key, proof, proof_timestamp}`, DID derived as `did:mesh:<sha256(pk)[:32]>` | Sends old shape |
| `connect` frame | `{from}` | `{from, public_key, timestamp, signature}` with `from == did:mesh:<sha256(pk)[:32]>` | Sends old shape |
| Authed endpoints (prekeys, heartbeat) | open | require `Authorization: Ed25519-Timestamp …` | No authSigner wired by MeshClient |

## Changes

**`x3dh.ts`** — expose `signMessage(msg: Uint8Array)` on `X3DHKeyManager` so the SDK can produce POP signatures without callers having to extract the Ed25519 private key.

**`registry-client.ts`**
- `register()` gains an optional `popSigner` parameter. When provided, sends the new `{public_key, proof, proof_timestamp, capabilities, metadata}` shape and returns the canonical server-derived DID; without it, falls back to the legacy shape so pre-2533 registries still work.
- Return type tightened to `Promise<{ did: string }>`.
- New `sha256Hex` helper used for the 409-already-registered fast path (deterministic local re-derivation; avoids the extra fetch).

**`mesh-client.ts`**
- On construct: compute the canonical `did:mesh:<hex32>` from the Ed25519 public key and store as `activeDid` (mutable). All wire frames now use `this.activeDid` instead of `this.options.agentDid` so caller-supplied DID hints can't drift from what the relay derives from the public key.
- New `currentDid` getter for consumers that need to track the server-derived DID.
- `connect()` `onopen` now emits the full POP shape: `from + public_key + timestamp + Ed25519(timestamp)`. Uses **standard base64** because `relay/app.py:106` decodes with `base64.b64decode` (distinct from the registry which uses `urlsafe_b64decode` — a real inconsistency in the server code that this SDK matches separately).
- `registerSelf()`: wires `popSigner` from `km.signMessage`; passes `identityKeyEd` (the Ed25519 key the server's `VerifyKey` validates against) instead of `identityKey` (X25519, wrong curve, would always be rejected); adopts the server-returned canonical DID.
- Constructor auto-wires an `Ed25519-Timestamp` `authSigner` on the `RegistryClient` so `PUT prekeys`, `POST heartbeat`, etc. pass `verify_ed25519_timestamp_auth` without callers having to plumb one. Late-binds to `this.activeDid` so post-register DID swaps propagate.

**`index.ts`** — re-export `RegistryClient` + `RegistryError` + related types from the top-level package. (Already exported from `./encryption/index.ts`; the omission was only visible when importing from the top-level entry.)

## Verification

Two `MeshClient` peers + `ghcr.io/microsoft/agentmesh/{relay,registry}:4.0.0` in local docker:

```
✓ register OK, server DID: did:mesh:69dae1784ed7539e337fa1195ab9a8fe
✓ uploadPrekeys passes Ed25519-Timestamp auth
✓ Both peers' connect frames accepted; connected_agents=2 on /health
✓ A.send → B (E2E encrypted); messages_routed=3 (KNOCK + X3DH + payload)
```

## Back-compat

- `register()` without `popSigner` takes the legacy code path verbatim — pre-2533 registries that accept `{did, public_key}` continue to work.
- `connect` frame extra fields (`public_key`, `timestamp`, `signature`) are ignored by pre-2632 relays.
- No call-site changes required for existing consumers; the SDK auto-wires `popSigner` from the `keyManager` and uses POP whenever the destination accepts it.

## Tests

The SDK's existing test suite (jest) covers the legacy path. The PR doesn't add a new unit test that talks to a real registry because that requires running the Python server container — happy to add a `tests-integration/` harness in a follow-up if you'd like.

## Related

Closes the client-side gap from the server-side hardening in:
- microsoft/agent-governance-toolkit#2533 (registry POP)
- microsoft/agent-governance-toolkit#2632 (relay POP, trust boundary tightening)
- microsoft/agent-governance-toolkit#2719 (Entra-signed JWT verification — orthogonal but uses the same connect-frame extension hook)
