### PR TITLE
fix: block async governance bypass in GovernedQueryEngine (llamaindex)

### DIFF
--- a/agent-governance-python/agent-rag-governance/src/agent_rag_governance/llamaindex.py
+++ b/agent-governance-python/agent-rag-governance/src/agent_rag_governance/llamaindex.py
@@ -175,8 +175,50 @@ class GovernedQueryEngine:
                 )
         return response
 
-    # Expose underlying query engine attributes transparently
+    # ── Blocked governance-bypassing methods ──────────────────────────
+    #
+    # The governance pipeline (collection ACL, rate limiting, content
+    # scanning, audit) is currently synchronous, so we cannot
+    # transparently extend it to async paths.  Forwarding those calls
+    # to the underlying query engine would silently bypass every check.
+    # Callers that need async surfaces must extend the wrapper
+    # explicitly with their own governance plumbing.
+
+    _BYPASSED_METHODS = (
+        "aquery",
+        "aretrieve",
+        "astream",
+    )
+
+    async def aquery(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            "GovernedQueryEngine does not implement async query. "
+            "The governance pipeline (collection ACL, rate limiting, "
+            "content scanning, audit) is synchronous; calling "
+            "aquery would silently bypass it. Use .query(...) or "
+            "extend GovernedQueryEngine with an async-aware governor."
+        )
+
+    async def aretrieve(self, *args: Any, **kwargs: Any) -> List[Any]:
+        raise NotImplementedError(
+            "GovernedQueryEngine does not implement async retrieval. "
+            "Use .retrieve(...) or .query(...)."
+        )
+
+    async def astream(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            "GovernedQueryEngine does not implement async streaming. "
+            "Use .query(...) instead."
+        )
+
+    # Expose underlying query engine attributes transparently, except
+    # for governance-bypassing methods which are blocked above.
     def __getattr__(self, name: str) -> Any:
+        if name in type(self)._BYPASSED_METHODS:
+            raise AttributeError(
+                f"GovernedQueryEngine blocks {name!r} to prevent governance "
+                "bypass. Use .query(...) or .retrieve(...) instead."
+            )
         return getattr(self._query_engine, name)
 
 

--- a/agent-governance-python/agent-rag-governance/tests/test_llamaindex.py
+++ b/agent-governance-python/agent-rag-governance/tests/test_llamaindex.py
@@ -402,3 +402,65 @@ def test_invalid_collection_name_none_allowed_by_default():
     # None is treated as a collection name — allowed when no restrictions set
     response = governed.query("query")
     assert len(response.source_nodes) == 1
+
+
+# ---------------------------------------------------------------------------
+# Governance bypass prevention tests
+# ---------------------------------------------------------------------------
+
+
+def test_aquery_blocked_by_explicit_method():
+    """Calling aquery should raise NotImplementedError, not bypass governance."""
+    engine = _FakeQueryEngine([])
+    governor = _make_governor(RAGPolicy())
+    governed = GovernedQueryEngine(engine, governor, collection="docs")
+    import asyncio
+
+    with pytest.raises(NotImplementedError, match="aquery"):
+        asyncio.run(governed.aquery("query"))
+
+
+def test_aretrieve_blocked_by_explicit_method():
+    """Calling aretrieve should raise NotImplementedError, not bypass governance."""
+    retriever = _FakeRetriever([_FakeNode("clean")])
+    governor = _make_governor(RAGPolicy(allowed_collections=["docs"]))
+    governed = GovernedQueryEngine(retriever, governor, collection="docs")
+    import asyncio
+
+    with pytest.raises(NotImplementedError, match="async retrieval"):
+        asyncio.run(governed.aretrieve("query"))
+
+
+def test_astream_blocked_by_explicit_method():
+    """Calling astream should raise NotImplementedError, not bypass governance."""
+    engine = _FakeQueryEngine([])
+    governor = _make_governor(RAGPolicy())
+    governed = GovernedQueryEngine(engine, governor, collection="docs")
+    import asyncio
+
+    with pytest.raises(NotImplementedError, match="async streaming"):
+        asyncio.run(governed.astream("query"))
+
+
+def test_bypass_methods_explicitly_defined():
+    """Bypass methods are explicitly defined (blocking) rather than forwarded."""
+    engine = _FakeQueryEngine([])
+    governor = _make_governor(RAGPolicy())
+    governed = GovernedQueryEngine(engine, governor, collection="docs")
+
+    for method_name in GovernedQueryEngine._BYPASSED_METHODS:
+        # Methods exist as explicit attributes (not forwarded via __getattr__)
+        method = getattr(type(governed), method_name, None)
+        assert method is not None, f"{method_name} should be explicitly defined"
+        # They are callable (async functions)
+        assert callable(method)
+
+
+def test_non_bypass_attributes_still_forwarded():
+    """Non-bypass attributes are still transparently forwarded to the engine."""
+    engine = _FakeQueryEngine([])
+    engine.custom_attr = "forwarded_value"  # type: ignore[attr-defined]
+    governor = _make_governor(RAGPolicy())
+    governed = GovernedQueryEngine(engine, governor, collection="docs")
+    # Custom attributes should still be forwarded via __getattr__
+    assert governed.custom_attr == "forwarded_value"


### PR DESCRIPTION
## Summary

GovernedQueryEngine`s `__getattr__` transparently forwarded all attribute access to the underlying LlamaIndex engine without any governance checks. This allowed async methods like `aquery()`, `aretrieve()`, and `astream()` to silently bypass all governance controls (collection ACL, rate limiting, content scanning, audit logging).

This was inconsistent with `GovernedRetriever` in the same package, which explicitly blocks `ainvoke`, `aget_relevant_documents`, `batch`, `abatch`, `stream`, and `astream`.

## Changes

- Add explicit `aquery`/`aretrieve`/`astream` methods raising `NotImplementedError` with guidance to use sync alternatives
- Add `_BYPASSED_METHODS` tuple and `__getattr__` defense-in-depth check consistent with `GovernedRetriever`
- Add 5 tests verifying bypass methods are blocked and non-bypass attributes remain forwarded

## Test Plan

- [x] All 104 existing tests pass (1 skipped: cedar requires agent-os)
- [x] 5 new tests added covering each bypass method
- [x] Existing `test_getattr_passthrough` still passes (non-bypass forwarding intact)