### PR TITLE
feat: document acs policy layer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,19 +6,19 @@
 # See: docs/CONTRIBUTING.md and .github/workflows/require-maintainer-approval.yml
 
 # Default owners for everything in the repo
-* @microsoft/agent-governance-toolkit
+* @microsoft/agent-governance-toolkit @MohammadHaroonAbuomar
 
 # Security-sensitive paths — require maintainer review, no exceptions
-/.github/                    @imran-siddique,MohammadHaroonAbuomar
+/.github/                    @imran-siddique @MohammadHaroonAbuomar
 
 # Infrastructure & container security — require maintainer review
-/scripts/                    @imran-siddique,MohammadHaroonAbuomar
-**/Dockerfile                @imran-siddique,MohammadHaroonAbuomar
-**/docker-compose*           @imran-siddique,MohammadHaroonAbuomar
-/.dockerignore               @imran-siddique,MohammadHaroonAbuomar
-/.clusterfuzzlite/           @imran-siddique,MohammadHaroonAbuomar
+/scripts/                    @imran-siddique @MohammadHaroonAbuomar
+**/Dockerfile                @imran-siddique @MohammadHaroonAbuomar
+**/docker-compose*           @imran-siddique @MohammadHaroonAbuomar
+/.dockerignore               @imran-siddique @MohammadHaroonAbuomar
+/.clusterfuzzlite/           @imran-siddique @MohammadHaroonAbuomar
 
 # Documentation
-/docs/                       @imran-siddique,MohammadHaroonAbuomar
-/site/                       @imran-siddique,MohammadHaroonAbuomar
-*.md                         @microsoft/agent-governance-toolkit
+/docs/                       @imran-siddique @MohammadHaroonAbuomar
+/site/                       @imran-siddique @MohammadHaroonAbuomar
+*.md                         @microsoft/agent-governance-toolkit @MohammadHaroonAbuomar

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Every layer is optional. Start with `govern()` and add layers as your risk profi
 | Package | Description |
 |---------|-------------|
 | [**Agent OS**](agent-governance-python/agent-os/) | Policy engine, agent lifecycle, governance gate |
-| [**Agent Control Specification**](policy-engine/) | Stateless, deterministic, fail-closed policy decision runtime (Rust core) backing the AGT policy layer |
+| [**Agent Control Specification**](policy-engine/) ([README](policy-engine/README.md)) | Stateless, deterministic, fail-closed policy decision runtime (Rust core) backing the AGT policy layer |
 | [**Agent Mesh**](agent-governance-python/agent-mesh/) | Agent discovery, routing, and trust mesh |
 | [**Agent Runtime**](agent-governance-python/agent-runtime/) | Execution sandboxing with four privilege rings |
 | [**Agent SRE**](agent-governance-python/agent-sre/) | Kill switch, SLO monitoring, chaos testing |

--- a/agent-governance-python/agt-policies/README.md
+++ b/agent-governance-python/agt-policies/README.md
@@ -1,11 +1,47 @@
 # agt-policies (5.0.0a1)
 
-AGT 5.0 policy layer. Wraps the AGT-vendored ACS engine at
-`policy-engine/`, adds AGT-specific extensions (manifest resolution,
-snapshot builder, evaluation result), and exposes the public Python
-API that AGT host code calls.
+Agent Control Specification, or ACS, is the AGT policy engine. It is a
+stateless, deterministic, fail-closed policy decision runtime for agent
+security. A host acts as the policy enforcement point, calls ACS at
+defined intervention points with a complete snapshot, receives a
+normalized verdict, and enforces that verdict before the agent action
+proceeds.
 
-Status: alpha.
+ACS gives AGT one portable contract for policy decisions across the
+agent lifecycle. Instead of scattering governance through prompts,
+framework callbacks, and application-specific checks, hosts submit the
+same manifest and snapshot shape at each point in the loop.
+
+```text
+Input -> Model -> Tool Call -> Tool Result -> Output
+```
+
+ACS covers the full agent loop: input, model calls, tool calls, tool
+results, output, startup, and shutdown. A manifest declares which
+policy runs at each intervention point, what part of the snapshot is
+the policy target, which tool metadata is projected, and which
+annotators contribute additional context.
+
+`agt-policies` is the Python package that exposes ACS to AGT hosts and
+adapters. Use it when host code needs to:
+
+- discover, scope, merge, and materialize AGT governance manifests
+- build complete AGT snapshots for ACS intervention points
+- call the ACS Python SDK through `AgtRuntime`
+- enforce `allow`, `warn`, `deny`, `escalate`, and `transform` verdicts
+- preserve v4 Agent OS adapter behavior while routing through ACS
+
+The native runtime evaluates; this package prepares the AGT host
+context and turns the returned decision into the Python objects that
+AGT adapters enforce.
+
+## How ACS and `agt-policies` fit together
+
+| Layer | Responsibility |
+| --- | --- |
+| AGT host | Intercepts the agent loop, owns side effects, and enforces the verdict. |
+| `agt-policies` | Python-facing ACS package for AGT hosts. Resolves manifests, builds snapshots, calls the runtime, and returns `EvaluationResult`. |
+| ACS runtime | Evaluates the manifest and snapshot as a stateless policy decision runtime. |
 
 ## What is here
 
@@ -23,6 +59,35 @@ Status: alpha.
   loads a resolved manifest, runs intervention points, applies the
   transform verdict, enforces approval, and emits AGT telemetry events.
 
+## Runtime flow
+
+1. The host identifies the intervention point, such as `input` or
+   `pre_tool_call`.
+2. `SnapshotBuilder` creates the complete AGT snapshot for that call,
+   including the agent/session envelope and current budget counters.
+3. `AgtRuntime` resolves the manifest when needed, sanitizes AGT-only
+   fields for the native engine, and calls the ACS Python SDK.
+4. The returned ACS verdict is mapped to `EvaluationResult`, including
+   `verdict`, `reason`, optional `transform`, optional `evidence`, and
+   the `input_identity` / `enforced_identity` audit fields.
+5. The host enforces the result. `allow`, `warn`, and `transform`
+   proceed; `deny` blocks; `escalate` routes through the configured
+   approval resolver or fails closed.
+
+## Compatibility bridge
+
+Existing Agent OS adapters still accept the v4 `GovernancePolicy`
+dataclass. `agt.policies.bridge` renders that policy into an ACS
+manifest plus a generated Rego bundle. The bridge preserves v4
+semantics where they differ from the native ACS defaults, including an
+empty `allowed_tools` list meaning no allowlist and `max_tool_calls=0`
+meaning deny every tool call.
+
+The generated compatibility policy is identified as `agt_legacy_rules`
+inside the resolved ACS manifest. If merged governance rules are
+present but no intervention point binds to `agt_legacy_rules`,
+resolution fails closed rather than producing rules that never run.
+
 ## Security invariants
 
 The host layer is fail-closed by design. Notably: governance files
@@ -32,6 +97,11 @@ neutralised by a child `allow` whose condition overlaps it; malformed
 budget counters and approval-resolver timeouts deny rather than
 silently allow.
 
+Resolved Rego bundles are materialized outside the governed workspace
+for runtime use and cleaned up when the runtime closes. This prevents a
+workspace-writable policy bundle from being overwritten between
+resolution and evaluation.
+
 ## Install (development)
 
 ```sh
@@ -39,3 +109,15 @@ cd agent-governance-python/agt-policies
 pip install -e ".[dev]"
 pytest
 ```
+
+Tests that exercise `agt.policies.runtime` require the native ACS Python
+SDK from `policy-engine/sdk/python`. In a repository checkout, build it
+first:
+
+```sh
+cd ../../policy-engine
+pip install ./sdk/python
+```
+
+OPA-backed Rego evaluations also require `opa` on `PATH` or
+`ACS_OPA_PATH` pointing at an OPA executable.


### PR DESCRIPTION
## Summary

Clarifies the `agt-policies` README as the Python-facing ACS package and adds Mohammad to CODEOWNERS.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agt-policies/README.md` | Removed the alpha status line and added a conceptual ACS overview, runtime flow, compatibility bridge, security, and install details. |
| `README.md` | Keeps the ACS package directory link and adds a parenthetical README link. |
| `.github/CODEOWNERS` | Adds `@MohammadHaroonAbuomar` to default, infrastructure, and documentation ownership entries. |

## Testing

- `python scripts/docs/check_links.py`
- `cspell agent-governance-python/agt-policies/README.md --config .cspell.json --no-progress --no-summary`
