### PR TITLE
fix: scan pushed range in gitleaks workflow

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -45,9 +45,17 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
         run: |
           if [ "$EVENT_NAME" = "pull_request" ]; then
             gitleaks detect --source . --log-opts "${BASE_SHA}..${HEAD_SHA}" --verbose
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [ -z "$PUSH_BEFORE_SHA" ] || [[ "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
+              gitleaks detect --source . --log-opts "${PUSH_HEAD_SHA}^..${PUSH_HEAD_SHA}" --verbose
+            else
+              gitleaks detect --source . --log-opts "${PUSH_BEFORE_SHA}..${PUSH_HEAD_SHA}" --verbose
+            fi
           else
             gitleaks detect --source . --verbose
           fi

--- a/tests/ci/test_secret_scanning_workflow.py
+++ b/tests/ci/test_secret_scanning_workflow.py
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Regression tests for the Secret Scanning workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "secret-scanning.yml"
+
+
+def _run_gitleaks_step() -> dict:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["gitleaks"]["steps"]
+    for step in steps:
+        if step.get("name") == "Run Gitleaks":
+            return step
+    raise AssertionError("Run Gitleaks step not found")
+
+
+def test_push_scans_only_pushed_commit_range() -> None:
+    step = _run_gitleaks_step()
+    env = step["env"]
+    script = step["run"]
+
+    assert env["PUSH_BEFORE_SHA"] == "${{ github.event.before }}"
+    assert env["PUSH_HEAD_SHA"] == "${{ github.sha }}"
+    assert '"$EVENT_NAME" = "push"' in script
+    assert '${PUSH_BEFORE_SHA}..${PUSH_HEAD_SHA}' in script
+
+
+def test_scheduled_and_manual_runs_keep_full_history_scan() -> None:
+    script = _run_gitleaks_step()["run"]
+
+    assert "else" in script
+    assert "gitleaks detect --source . --verbose" in script


### PR DESCRIPTION
## Summary

Limits gitleaks push scans to the pushed commit range so main-branch push CI does not rediscover historical fake-secret fixtures.

## Problem

The push workflow scanned full repository history, while PR scans already use a bounded `base..head` range. Full-history push scans repeatedly failed on old test fixtures and documentation examples unrelated to the pushed changes.

## Changes

| File | What changed |
|------|-------------|
| `.github/workflows/secret-scanning.yml` | Uses `github.event.before..github.sha` for push-event gitleaks scans, with a single-commit fallback for all-zero before SHAs. |
| `tests/ci/test_secret_scanning_workflow.py` | Adds regression coverage that push scans are range-limited while schedule/manual scans remain full-history. |

## Testing

- `pytest tests/ci/test_secret_scanning_workflow.py -q`
- `python3 -m py_compile tests/ci/test_secret_scanning_workflow.py`
- `gitleaks detect --source . --log-opts "HEAD~1..HEAD" --verbose`
