### PR TITLE
fix: harden acs publish pipeline

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -407,6 +407,7 @@ serviceendpointurl
 sess
 setattr
 setdefault
+setvariable
 setext
 setitem
 setuid

--- a/.github/ci/workflows.toml
+++ b/.github/ci/workflows.toml
@@ -84,7 +84,7 @@ pytest sdk/python generator
 """
 [[workflow.job.step]]
 name = "Package Python SDK"
-run = "python -m build --no-isolation ./sdk/python"
+run = "python -m maturin build --release --sdist --out sdk/python/dist --compatibility manylinux_2_39 --manifest-path sdk/python/Cargo.toml"
 [[workflow.job.step]]
 name = "Package ACS generator"
 run = "python -m build --no-isolation ./generator"

--- a/.github/ci/workflows.toml
+++ b/.github/ci/workflows.toml
@@ -84,7 +84,7 @@ pytest sdk/python generator
 """
 [[workflow.job.step]]
 name = "Package Python SDK"
-run = "python -m maturin build --release --sdist --out sdk/python/dist --compatibility manylinux_2_39 --manifest-path sdk/python/Cargo.toml"
+run = "bash ../scripts/ci/build_acs_python_wheel.sh .."
 [[workflow.job.step]]
 name = "Package ACS generator"
 run = "python -m build --no-isolation ./generator"

--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -95,8 +95,6 @@ parameters:
       # ACS policy layer, Python SDK, and artifact generator
       - name: agent-control-specification
         path: policy-engine/sdk/python
-        rust: 'true'
-        noBuildIsolation: 'true'
       - name: agt-policies
         path: agent-governance-python/agt-policies
       - name: acs-generator
@@ -311,8 +309,7 @@ stages:
                 # Consolidated packages use force-include with sibling paths,
                 # which only works when building a wheel directly from source.
                 if [[ "${{ pkg.name }}" == "agent-control-specification" ]]; then
-                  rm -rf dist
-                  python -m maturin build --release --sdist --out dist --compatibility manylinux_2_39
+                  bash "$(Build.SourcesDirectory)/scripts/ci/build_acs_python_wheel.sh" "$(Build.SourcesDirectory)"
                 elif [[ "${{ coalesce(pkg.noBuildIsolation, 'false') }}" == "true" ]]; then
                   python -m build --no-isolation
                 elif [[ "${{ pkg.name }}" == agent-governance-toolkit-* ]]; then

--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -310,7 +310,10 @@ stages:
             - script: |
                 # Consolidated packages use force-include with sibling paths,
                 # which only works when building a wheel directly from source.
-                if [[ "${{ coalesce(pkg.noBuildIsolation, 'false') }}" == "true" ]]; then
+                if [[ "${{ pkg.name }}" == "agent-control-specification" ]]; then
+                  rm -rf dist
+                  python -m maturin build --release --sdist --out dist --compatibility manylinux_2_39
+                elif [[ "${{ coalesce(pkg.noBuildIsolation, 'false') }}" == "true" ]]; then
                   python -m build --no-isolation
                 elif [[ "${{ pkg.name }}" == agent-governance-toolkit-* ]]; then
                   python -m build --wheel
@@ -507,7 +510,7 @@ stages:
                 if [ -n "${{ coalesce(native.linkerEnv, '') }}" ]; then
                   export ${{ native.linkerEnv }}="${{ native.linker }}"
                 fi
-                npx napi build --release --target ${{ native.rustTarget }} --js native.js --dts native.d.ts
+                npx napi build --platform --release --target ${{ native.rustTarget }} --js native.js --dts native.d.ts
                 test -s "${{ native.binary }}"
                 mkdir -p "$(Pipeline.Workspace)/npm-out"
                 node scripts/package-native.mjs \
@@ -730,6 +733,17 @@ stages:
                 artifact: 'acs-dotnet-native-${{ native.rid }}'
                 targetPath: '$(Build.SourcesDirectory)/policy-engine/sdk/dotnet/src/AgentControlSpecification/runtimes'
               displayName: 'Download ACS native asset ${{ native.rid }}'
+
+          - script: |
+              curl --proto '=https' --tlsv1.2 -fSLo "$(Pipeline.Workspace)/opa" \
+                --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+                "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+              echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $(Pipeline.Workspace)/opa" | sha256sum -c -
+              chmod +x "$(Pipeline.Workspace)/opa"
+              echo "##vso[task.prependpath]$(Pipeline.Workspace)"
+              echo "##vso[task.setvariable variable=ACS_OPA_PATH]$(Pipeline.Workspace)/opa"
+              "$(Pipeline.Workspace)/opa" version
+            displayName: 'Install OPA for ACS .NET tests'
 
           - script: |
               dotnet build AgentControlSpecification.sln \
@@ -961,6 +975,17 @@ stages:
                 "$HOME/.cargo/bin/rustc" --version
                 "$HOME/.cargo/bin/cargo" --version
               displayName: 'Install Rust ${{ parameters.rustVersion }}'
+
+            - script: |
+                curl --proto '=https' --tlsv1.2 -fSLo "$(Pipeline.Workspace)/opa" \
+                  --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+                  "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+                echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $(Pipeline.Workspace)/opa" | sha256sum -c -
+                chmod +x "$(Pipeline.Workspace)/opa"
+                echo "##vso[task.prependpath]$(Pipeline.Workspace)"
+                "$(Pipeline.Workspace)/opa" version
+              condition: eq('${{ pkg.path }}', 'policy-engine')
+              displayName: 'Install OPA for ACS tests'
 
             - script: |
                 cargo build --release --workspace

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -200,6 +200,7 @@ jobs:
     if: always()
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - name: Collect agent comments and post summary
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -278,14 +279,22 @@ jobs:
             ].join('\n');
 
             const existing = allComments.find(c => isWorkflowComment(c) && c.body && c.body.includes(SUMMARY_MARKER));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner, repo, comment_id: existing.id, body: summaryBody,
-              });
-              core.info(`Updated summary comment ${existing.id}`);
-            } else {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: prNumber, body: summaryBody,
-              });
-              core.info('Created summary comment');
+            try {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body: summaryBody,
+                });
+                core.info(`Updated summary comment ${existing.id}`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: prNumber, body: summaryBody,
+                });
+                core.info('Created summary comment');
+              }
+            } catch (error) {
+              if (error?.status === 403 && String(error?.message || '').includes('Resource not accessible')) {
+                core.warning('Unable to post advisory AI review summary because this run token cannot write PR comments.');
+              } else {
+                throw error;
+              }
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,9 @@ jobs:
         if: steps.gate.outputs.run == 'true' && (matrix.package == 'agent-os' || matrix.package == 'agt-policies')
         run: |
           set -euo pipefail
-          curl -fsSL -o "$RUNNER_TEMP/opa" "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+          curl --proto '=https' --tlsv1.2 -fSLo "$RUNNER_TEMP/opa" \
+            --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+            "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
           echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $RUNNER_TEMP/opa" | sha256sum -c -
           chmod +x "$RUNNER_TEMP/opa"
           echo "ACS_OPA_PATH=$RUNNER_TEMP/opa" >> "$GITHUB_ENV"

--- a/.github/workflows/policy-engine-ci.yml
+++ b/.github/workflows/policy-engine-ci.yml
@@ -94,7 +94,7 @@ jobs:
           pytest sdk/python generator
       - name: Package Python SDK
         run: |
-          python -m build --no-isolation ./sdk/python
+          python -m maturin build --release --sdist --out sdk/python/dist --compatibility manylinux_2_39 --manifest-path sdk/python/Cargo.toml
       - name: Package ACS generator
         run: |
           python -m build --no-isolation ./generator

--- a/.github/workflows/policy-engine-ci.yml
+++ b/.github/workflows/policy-engine-ci.yml
@@ -94,7 +94,7 @@ jobs:
           pytest sdk/python generator
       - name: Package Python SDK
         run: |
-          python -m maturin build --release --sdist --out sdk/python/dist --compatibility manylinux_2_39 --manifest-path sdk/python/Cargo.toml
+          bash ../scripts/ci/build_acs_python_wheel.sh ..
       - name: Package ACS generator
         run: |
           python -m build --no-isolation ./generator

--- a/.github/workflows/policy-engine-ci.yml
+++ b/.github/workflows/policy-engine-ci.yml
@@ -39,7 +39,7 @@ jobs:
           components: rustfmt, clippy
       - name: Install OPA
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/opa" "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+          curl --proto '=https' --tlsv1.2 -fSLo "$RUNNER_TEMP/opa" --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
           echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $RUNNER_TEMP/opa" | sha256sum -c -
           chmod +x "$RUNNER_TEMP/opa"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
@@ -77,7 +77,7 @@ jobs:
           components: rustfmt, clippy
       - name: Install OPA
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/opa" "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+          curl --proto '=https' --tlsv1.2 -fSLo "$RUNNER_TEMP/opa" --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
           echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $RUNNER_TEMP/opa" | sha256sum -c -
           chmod +x "$RUNNER_TEMP/opa"
           echo "ACS_OPA_PATH=$RUNNER_TEMP/opa" >> "$GITHUB_ENV"
@@ -114,7 +114,7 @@ jobs:
           node-version: '20'
       - name: Install OPA
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/opa" "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+          curl --proto '=https' --tlsv1.2 -fSLo "$RUNNER_TEMP/opa" --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
           echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $RUNNER_TEMP/opa" | sha256sum -c -
           chmod +x "$RUNNER_TEMP/opa"
           echo "ACS_OPA_PATH=$RUNNER_TEMP/opa" >> "$GITHUB_ENV"
@@ -146,7 +146,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Install OPA
         run: |
-          curl -fsSL -o "$RUNNER_TEMP/opa" "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+          curl --proto '=https' --tlsv1.2 -fSLo "$RUNNER_TEMP/opa" --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
           echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $RUNNER_TEMP/opa" | sha256sum -c -
           chmod +x "$RUNNER_TEMP/opa"
           echo "ACS_OPA_PATH=$RUNNER_TEMP/opa" >> "$GITHUB_ENV"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
             {"name":"agent-marketplace","path":"agent-governance-python/agent-marketplace"},
             {"name":"agent-rag-governance","path":"agent-governance-python/agent-rag-governance"},
             {"name":"agt-sandbox","path":"agent-governance-python/agent-sandbox"},
-            {"name":"agent-control-specification","path":"policy-engine/sdk/python","rust":true,"noBuildIsolation":true},
+            {"name":"agent-control-specification","path":"policy-engine/sdk/python"},
             {"name":"agt-policies","path":"agent-governance-python/agt-policies"},
             {"name":"acs-generator","path":"policy-engine/generator","noBuildIsolation":true}
           ]'
@@ -150,8 +150,7 @@ jobs:
           BUILD_NO_ISOLATION: ${{ matrix.noBuildIsolation || 'false' }}
         run: |
           if [[ "${{ matrix.name }}" == "agent-control-specification" ]]; then
-            rm -rf dist
-            python -m maturin build --release --sdist --out dist --compatibility manylinux_2_39
+            bash "$GITHUB_WORKSPACE/scripts/ci/build_acs_python_wheel.sh" "$GITHUB_WORKSPACE"
           elif [[ "$BUILD_NO_ISOLATION" == "true" ]]; then
             python -m build --no-isolation
           elif [[ "${{ matrix.name }}" == agent-governance-toolkit-* ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,7 +149,10 @@ jobs:
         env:
           BUILD_NO_ISOLATION: ${{ matrix.noBuildIsolation || 'false' }}
         run: |
-          if [[ "$BUILD_NO_ISOLATION" == "true" ]]; then
+          if [[ "${{ matrix.name }}" == "agent-control-specification" ]]; then
+            rm -rf dist
+            python -m maturin build --release --sdist --out dist --compatibility manylinux_2_39
+          elif [[ "$BUILD_NO_ISOLATION" == "true" ]]; then
             python -m build --no-isolation
           elif [[ "${{ matrix.name }}" == agent-governance-toolkit-* ]]; then
             python -m build --wheel

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN for i in 1 2 3; do apt-get update && break || sleep 5; done \
     && python -m pip install --upgrade pip==24.3.1 setuptools==75.8.0 wheel==0.45.1 \
     && rm -rf /var/lib/apt/lists/* \
     # OPA CLI — required by OPAEvaluator local mode (opa eval subprocess)
-    && curl -fsSL -o /usr/local/bin/opa \
+    && curl --proto '=https' --tlsv1.2 -fSLo /usr/local/bin/opa \
+        --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
         https://openpolicyagent.org/downloads/v1.4.2/opa_linux_amd64_static \
     && echo "2c0ccdbbe0b8e2a5d12d9c42d92f1f34f494ffb32d1f3c4ddc36101be637d66f  /usr/local/bin/opa" \
         | sha256sum -c - \

--- a/policy-engine/sdk/node/scripts/fetch-opa.mjs
+++ b/policy-engine/sdk/node/scripts/fetch-opa.mjs
@@ -22,6 +22,7 @@ import { get } from "node:https";
 const VERSION = process.env.OPA_VERSION ?? "0.70.0";
 const here = dirname(fileURLToPath(import.meta.url));
 const npmDir = join(here, "..", "npm");
+const MAX_FETCH_ATTEMPTS = 5;
 
 // node platform-arch -> { asset on the OPA download host, sub-package, bin name }
 const TARGETS = {
@@ -69,12 +70,32 @@ function fetch(url, redirectsLeft = 5) {
   });
 }
 
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url) {
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt += 1) {
+    try {
+      return await fetch(url);
+    } catch (error) {
+      lastError = error;
+      if (attempt === MAX_FETCH_ATTEMPTS) break;
+      const delayMs = attempt * 5000;
+      process.stderr.write(`fetch attempt ${attempt} failed for ${url}: ${error?.message ?? error}; retrying in ${delayMs / 1000}s\n`);
+      await sleep(delayMs);
+    }
+  }
+  throw lastError;
+}
+
 async function vendorOne(key) {
   const target = TARGETS[key];
   if (target === undefined) throw new Error(`unknown platform '${key}'. Known: ${Object.keys(TARGETS).join(", ")}`);
   const url = `https://openpolicyagent.org/downloads/v${VERSION}/${target.asset}`;
   process.stdout.write(`fetching ${key} <- ${url}\n`);
-  const buf = await fetch(url);
+  const buf = await fetchWithRetry(url);
   const digest = createHash("sha256").update(buf).digest("hex");
 
   const expected = CHECKSUMS[VERSION]?.[key];

--- a/scripts/ci/build_acs_python_wheel.sh
+++ b/scripts/ci/build_acs_python_wheel.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 ROOT="${1:-$(git rev-parse --show-toplevel)}"
 ROOT="$(cd "$ROOT" && pwd)"
 IMAGE="quay.io/pypa/manylinux_2_28_x86_64@sha256:d4290a169db70a3349c89a92ab2304103910759ad97a21044487e1d233ce43b0"
+RUSTUP_VERSION="1.27.1"
+RUSTUP_SHA256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d"
+RUST_TOOLCHAIN="1.89.0"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required to build the ACS Python manylinux wheel" >&2
@@ -14,11 +17,23 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 docker run --rm \
+  -e RUSTUP_VERSION \
+  -e RUSTUP_SHA256 \
+  -e RUST_TOOLCHAIN \
   -v "$ROOT:/work" \
   -w /work/policy-engine \
   "$IMAGE" \
   /bin/bash -lc '
     set -euo pipefail
+    curl --proto '"'"'=https'"'"' --tlsv1.2 -fSLo /tmp/rustup-init \
+      --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+      "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init"
+    echo "${RUSTUP_SHA256}  /tmp/rustup-init" | sha256sum -c -
+    chmod +x /tmp/rustup-init
+    /tmp/rustup-init -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}"
+    export PATH="$HOME/.cargo/bin:$PATH"
+    rustc --version
+    cargo --version
     /opt/python/cp311-cp311/bin/python -m pip install --no-cache-dir --disable-pip-version-check \
       --require-hashes --no-deps \
       -r /work/.github/pipelines/release-tools/release-tools.txt

--- a/scripts/ci/build_acs_python_wheel.sh
+++ b/scripts/ci/build_acs_python_wheel.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+set -euo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel)}"
+ROOT="$(cd "$ROOT" && pwd)"
+IMAGE="quay.io/pypa/manylinux_2_28_x86_64@sha256:d4290a169db70a3349c89a92ab2304103910759ad97a21044487e1d233ce43b0"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to build the ACS Python manylinux wheel" >&2
+  exit 1
+fi
+
+docker run --rm \
+  -v "$ROOT:/work" \
+  -w /work/policy-engine \
+  "$IMAGE" \
+  /bin/bash -lc '
+    set -euo pipefail
+    /opt/python/cp311-cp311/bin/python -m pip install --no-cache-dir --disable-pip-version-check \
+      --require-hashes --no-deps \
+      -r /work/.github/pipelines/release-tools/release-tools.txt
+    rm -rf /work/policy-engine/sdk/python/dist
+    mkdir -p /work/policy-engine/sdk/python/dist
+    /opt/python/cp311-cp311/bin/python -m maturin build \
+      --release \
+      --sdist \
+      --out /work/policy-engine/sdk/python/dist \
+      --compatibility manylinux_2_28 \
+      --manifest-path /work/policy-engine/sdk/python/Cargo.toml
+  '

--- a/scripts/ci/build_acs_python_wheel.sh
+++ b/scripts/ci/build_acs_python_wheel.sh
@@ -25,9 +25,17 @@ docker run --rm \
   "$IMAGE" \
   /bin/bash -lc '
     set -euo pipefail
-    curl --proto '"'"'=https'"'"' --tlsv1.2 -fSLo /tmp/rustup-init \
-      --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
-      "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init"
+    for attempt in 1 2 3 4 5; do
+      if curl --proto '"'"'=https'"'"' --tlsv1.2 -fSLo /tmp/rustup-init \
+        --connect-timeout 20 \
+        "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init"; then
+        break
+      fi
+      if [ "$attempt" = "5" ]; then
+        exit 1
+      fi
+      sleep $((attempt * 5))
+    done
     echo "${RUSTUP_SHA256}  /tmp/rustup-init" | sha256sum -c -
     chmod +x /tmp/rustup-init
     /tmp/rustup-init -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}"

--- a/scripts/ci/build_acs_python_wheel.sh
+++ b/scripts/ci/build_acs_python_wheel.sh
@@ -17,9 +17,9 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 docker run --rm \
-  -e RUSTUP_VERSION \
-  -e RUSTUP_SHA256 \
-  -e RUST_TOOLCHAIN \
+  -e "RUSTUP_VERSION=$RUSTUP_VERSION" \
+  -e "RUSTUP_SHA256=$RUSTUP_SHA256" \
+  -e "RUST_TOOLCHAIN=$RUST_TOOLCHAIN" \
   -v "$ROOT:/work" \
   -w /work/policy-engine \
   "$IMAGE" \

--- a/scripts/ci/generate_workflows.py
+++ b/scripts/ci/generate_workflows.py
@@ -139,7 +139,8 @@ def _toolchain_steps(toolchain: str, actions: dict[str, str]) -> list[str]:
 
 def _opa_step(on_path: bool = False, set_env: bool = True) -> list[str]:
     lines = [
-        f'curl -fsSL -o "$RUNNER_TEMP/opa" '
+        f'curl --proto \'=https\' --tlsv1.2 -fSLo "$RUNNER_TEMP/opa" '
+        '--retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 '
         f'"https://openpolicyagent.org/downloads/v{OPA_VERSION}/opa_linux_amd64_static"\n',
         f'echo "{OPA_LINUX_AMD64_SHA256}  $RUNNER_TEMP/opa" | sha256sum -c -\n',
         'chmod +x "$RUNNER_TEMP/opa"\n',

--- a/tests/ci/test_generate_workflows.py
+++ b/tests/ci/test_generate_workflows.py
@@ -80,7 +80,7 @@ def test_policy_engine_workflow_packages_acs_artifacts():
     content = gen.build_outputs()[REPO_ROOT / ".github" / "workflows" / "policy-engine-ci.yml"]
     assert "cargo package -p agent_control_specification_core --allow-dirty" in content
     assert "cargo package -p agent_control_specification --allow-dirty" not in content
-    assert "python -m build --no-isolation ./sdk/python" in content
+    assert "python -m maturin build --release --sdist --out sdk/python/dist --compatibility manylinux_2_39 --manifest-path sdk/python/Cargo.toml" in content
     assert "python -m build --no-isolation ./generator" in content
     assert "npm pack --pack-destination" in content
     assert "node scripts/package-native.mjs --package agent-control-specification-linux-x64-gnu" in content

--- a/tests/ci/test_generate_workflows.py
+++ b/tests/ci/test_generate_workflows.py
@@ -80,7 +80,7 @@ def test_policy_engine_workflow_packages_acs_artifacts():
     content = gen.build_outputs()[REPO_ROOT / ".github" / "workflows" / "policy-engine-ci.yml"]
     assert "cargo package -p agent_control_specification_core --allow-dirty" in content
     assert "cargo package -p agent_control_specification --allow-dirty" not in content
-    assert "python -m maturin build --release --sdist --out sdk/python/dist --compatibility manylinux_2_39 --manifest-path sdk/python/Cargo.toml" in content
+    assert "bash ../scripts/ci/build_acs_python_wheel.sh .." in content
     assert "python -m build --no-isolation ./generator" in content
     assert "npm pack --pack-destination" in content
     assert "node scripts/package-native.mjs --package agent-control-specification-linux-x64-gnu" in content

--- a/tests/ci/test_generate_workflows.py
+++ b/tests/ci/test_generate_workflows.py
@@ -63,6 +63,7 @@ def test_generated_opa_downloads_verify_checksum():
         if "openpolicyagent.org/downloads" in content:
             assert "sha256sum -c -" in content
             assert gen.OPA_LINUX_AMD64_SHA256 in content
+            assert "--retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20" in content
 
 
 def test_policy_engine_python_job_uses_pinned_tooling():

--- a/tests/ci/test_regression_a4_a5_esrp.py
+++ b/tests/ci/test_regression_a4_a5_esrp.py
@@ -29,6 +29,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ESRP = REPO_ROOT / ".github" / "pipelines" / "esrp-publish.yml"
 LOCKFILE = REPO_ROOT / ".github" / "pipelines" / "release-tools" / "release-tools.txt"
 SRC = REPO_ROOT / ".github" / "pipelines" / "release-tools" / "release-tools.in"
+ACS_PYTHON_WHEEL_HELPER = REPO_ROOT / "scripts" / "ci" / "build_acs_python_wheel.sh"
 
 
 def test_a4_release_tools_lockfile_exists_and_pins_hashes() -> None:
@@ -97,8 +98,7 @@ def test_esrp_publishes_acs_python_and_rust_artifacts() -> None:
     text = ESRP.read_text(encoding="utf-8")
     assert "name: agent-control-specification" in text
     assert "path: policy-engine/sdk/python" in text
-    assert "python -m maturin build --release --sdist --out dist --compatibility manylinux_2_39" in text
-    assert "noBuildIsolation: 'true'" in text
+    assert "build_acs_python_wheel.sh" in text
     assert "name: agt-policies" in text
     assert "path: agent-governance-python/agt-policies" in text
     assert "name: acs-generator" in text
@@ -107,6 +107,13 @@ def test_esrp_publishes_acs_python_and_rust_artifacts() -> None:
     assert "crate: agent_control_specification_core" in text
     assert "cargo package -p agent_control_specification --allow-dirty" in text
     assert "after the core ESRP release completes" in text
+
+
+def test_acs_python_wheel_helper_uses_pinned_manylinux_build() -> None:
+    text = ACS_PYTHON_WHEEL_HELPER.read_text(encoding="utf-8")
+    assert "manylinux_2_28_x86_64@sha256:" in text
+    assert "--require-hashes --no-deps" in text
+    assert "--compatibility manylinux_2_28" in text
 
 
 def test_esrp_publishes_acs_node_artifacts() -> None:

--- a/tests/ci/test_regression_a4_a5_esrp.py
+++ b/tests/ci/test_regression_a4_a5_esrp.py
@@ -112,6 +112,10 @@ def test_esrp_publishes_acs_python_and_rust_artifacts() -> None:
 def test_acs_python_wheel_helper_uses_pinned_manylinux_build() -> None:
     text = ACS_PYTHON_WHEEL_HELPER.read_text(encoding="utf-8")
     assert "manylinux_2_28_x86_64@sha256:" in text
+    assert "https://static.rust-lang.org/rustup/archive/" in text
+    assert "6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d" in text
+    assert 'RUST_TOOLCHAIN="1.89.0"' in text
+    assert '--default-toolchain "${RUST_TOOLCHAIN}"' in text
     assert "--require-hashes --no-deps" in text
     assert "--compatibility manylinux_2_28" in text
 

--- a/tests/ci/test_regression_a4_a5_esrp.py
+++ b/tests/ci/test_regression_a4_a5_esrp.py
@@ -97,6 +97,7 @@ def test_esrp_publishes_acs_python_and_rust_artifacts() -> None:
     text = ESRP.read_text(encoding="utf-8")
     assert "name: agent-control-specification" in text
     assert "path: policy-engine/sdk/python" in text
+    assert "python -m maturin build --release --sdist --out dist --compatibility manylinux_2_39" in text
     assert "noBuildIsolation: 'true'" in text
     assert "name: agt-policies" in text
     assert "path: agent-governance-python/agt-policies" in text
@@ -118,6 +119,7 @@ def test_esrp_publishes_acs_node_artifacts() -> None:
     assert "agent-control-specification-win32-x64-msvc" in text
     assert "agent-control-specification-opa-linux-x64" in text
     assert "agent-control-specification-opa-win32-x64" in text
+    assert "npx napi build --platform --release --target ${{ native.rustTarget }}" in text
     assert "Root agent-control-specification package must not embed" in text
 
 
@@ -126,8 +128,17 @@ def test_esrp_publishes_acs_dotnet_artifacts() -> None:
     assert "Build_ACS_Native_" in text
     assert "BuildAndPack_ACS" in text
     assert "nuget-acs-unsigned" in text
+    assert "Install OPA for ACS .NET tests" in text
     assert "AgentControlSpecification/AgentControlSpecification.csproj" in text
     assert "AgentControlSpecification.AI/AgentControlSpecification.AI.csproj" in text
     assert "AgentControlSpecification.AgentFramework/AgentControlSpecification.AgentFramework.csproj" in text
     assert "AgentControlSpecification.AutoGen/AgentControlSpecification.AutoGen.csproj" in text
     assert "AgentControlSpecification.SemanticKernel/AgentControlSpecification.SemanticKernel.csproj" in text
+
+
+def test_esrp_installs_opa_for_policy_engine_rust_tests() -> None:
+    text = ESRP.read_text(encoding="utf-8")
+    assert "Install OPA for ACS tests" in text
+    assert "--retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20" in text
+    assert "openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static" in text
+    assert "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084" in text


### PR DESCRIPTION
## Summary

Hardens the ACS publish pipeline after the first post-merge release run exposed OPA download flakes and native/package build issues.

## Problem

Commit `b53c3dd` failed several publish checks after the ACS publishing PR merged. The GitHub `policy-engine-ci / Rust core and SDK` log showed an OPA download reset. The ADO checks only exposed generic annotations, but the failure pattern pointed to missing OPA setup in release tests, native npm package binary-name mismatches, and a PyPI native wheel build path that needed a broadly compatible manylinux build environment.

## Changes

| File | What changed |
|------|-------------|
| `scripts/ci/generate_workflows.py`, `.github/workflows/policy-engine-ci.yml` | Adds retry-hardened OPA downloads to generated policy-engine CI. |
| `.github/workflows/ci.yml`, `Dockerfile` | Adds the same retry policy to ACS-backed package CI and the dev/test image OPA install. |
| `policy-engine/sdk/node/scripts/fetch-opa.mjs` | Adds retry/backoff to OPA downloads for npm OPA support packages. |
| `scripts/ci/build_acs_python_wheel.sh` | Builds the ACS Python wheel inside a digest-pinned PyPA `manylinux_2_28` container using hash-locked release tooling. |
| `.github/pipelines/esrp-publish.yml` | Uses the manylinux helper for `agent-control-specification`, uses `napi build --platform` for native npm package filenames, and installs OPA before ACS Rust and .NET release tests. |
| `.github/workflows/publish.yml` | Mirrors the manylinux helper for GitHub release artifact builds. |
| `tests/ci/*` | Adds regression coverage for OPA retry flags, ACS manylinux container packaging, native npm `--platform`, and ESRP OPA setup. |

## Testing

Validated generated workflow drift, CI regression tests, YAML parsing, retry flag coverage, `fetch-opa.mjs` download plus checksum verification, `maturin` manylinux artifact output behavior, native npm package output naming with `napi build --platform`, and helper script syntax/license checks.
