### PR TITLE
feat: govern accumulated context across delegated agent workflows

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/__init__.py
@@ -22,6 +22,28 @@ from .conflict_resolution import (
     PolicyScope,
     ResolutionResult,
 )
+from .context_accumulation import (
+    ContextDecision,
+    ContextOutcome,
+    accumulate,
+    decide_next,
+    to_policy_action,
+)
+from .context_aggregation import (
+    AggregationResult,
+    AggregationRule,
+    AggregationRuleSet,
+    evaluate_aggregation,
+)
+from .context_audit import ContextEvent, context_event
+from .context_delegation import intersect_restrictions
+from .context_envelope import (
+    ContextEnvelope,
+    EnvelopeReference,
+    apply_restrictions,
+    envelope_reference,
+    fold,
+)
 from .decision import PolicyCheckResult, ViolationCategory
 from .dynamic_context import (
     CostContext,
@@ -31,6 +53,7 @@ from .dynamic_context import (
     TimeContext,
 )
 from .evaluator import PolicyDecision, PolicyEvaluator
+from .obligations import Obligation, ObligationSet
 from .rate_limiting import RateLimitConfig, RateLimitExceeded, TokenBucket
 from .schema import (
     DynamicCondition,
@@ -54,6 +77,9 @@ from .shared import (
 )
 
 __all__ = [
+    "AggregationResult",
+    "AggregationRule",
+    "AggregationRuleSet",
     "AsyncPolicyEvaluator",
     "BackendDecision",
     "CandidateDecision",
@@ -63,6 +89,22 @@ __all__ = [
     "ConflictResolutionStrategy",
     "DynamicCondition",
     "DynamicConditionType",
+    "ContextDecision",
+    "ContextEnvelope",
+    "ContextEvent",
+    "ContextOutcome",
+    "EnvelopeReference",
+    "Obligation",
+    "ObligationSet",
+    "accumulate",
+    "apply_restrictions",
+    "context_event",
+    "decide_next",
+    "envelope_reference",
+    "evaluate_aggregation",
+    "fold",
+    "intersect_restrictions",
+    "to_policy_action",
     "ExternalPolicyBackend",
     "OPABackend",
     "CostContext",

--- a/agent-governance-python/agent-os/src/agent_os/policies/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/__init__.py
@@ -36,7 +36,7 @@ from .context_aggregation import (
     evaluate_aggregation,
 )
 from .context_audit import ContextEvent, context_event
-from .context_delegation import intersect_restrictions
+from .context_delegation import merge_restrictions
 from .context_envelope import (
     ContextEnvelope,
     EnvelopeReference,
@@ -103,7 +103,7 @@ __all__ = [
     "envelope_reference",
     "evaluate_aggregation",
     "fold",
-    "intersect_restrictions",
+    "merge_restrictions",
     "to_policy_action",
     "ExternalPolicyBackend",
     "OPABackend",

--- a/agent-governance-python/agent-os/src/agent_os/policies/context_accumulation.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/context_accumulation.py
@@ -1,0 +1,148 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Post-execution accumulation and decision integration for CAG.
+
+Sensitivity accumulates from the *actual* labels an action produced (its
+``result_labels``), never from a projection of an output that has not run yet.
+After folding, the next action is gated against the accumulated envelope.
+
+The governance-level ``constrain`` outcome is realized as allow-with-obligations
+and collapses to a concrete ``PolicyAction`` via :func:`to_policy_action`, which
+fails closed on a path that cannot carry obligations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Iterable
+
+from .context_aggregation import AggregationRuleSet, evaluate_aggregation
+from .context_envelope import ContextEnvelope, apply_restrictions, fold
+from .data_classification import DataClassification
+from .obligations import Obligation, ObligationSet
+from .schema import PolicyAction
+
+# Action token -> the restriction that, when present, gates it.
+_RESTRICTED_ACTIONS: dict[str, str] = {
+    "export": "no_external_export",
+    "delegate": "no_external_delegation",
+    "memory_write": "no_memory_write",
+}
+
+
+class ContextOutcome(str, Enum):
+    """Governance-level outcome of a context-aware decision."""
+
+    ALLOW = "allow"
+    CONSTRAIN = "constrain"
+    DENY = "deny"
+    ESCALATE = "escalate"
+
+
+@dataclass(frozen=True)
+class ContextDecision:
+    """A context-aware decision plus any obligations it carries."""
+
+    outcome: ContextOutcome
+    obligations: ObligationSet
+    aggregate_sensitivity: DataClassification
+    reason: str = ""
+
+
+def accumulate(
+    env: ContextEnvelope,
+    result_labels: Iterable[str],
+    result_sensitivity: DataClassification,
+    ruleset: AggregationRuleSet,
+    n_category_threshold: int,
+) -> ContextEnvelope:
+    """Fold an action's actual result into ``env`` and re-run aggregation.
+
+    Returns the next envelope with updated sensitivity and grow-only
+    restrictions. This runs AFTER the action executes (post-execution
+    accumulation), so it folds real labels rather than projected ones.
+    """
+    folded = fold(env, result_labels, result_sensitivity)
+    agg = evaluate_aggregation(folded, ruleset, n_category_threshold)
+    raised = replace(folded, aggregate_sensitivity=agg.aggregate_sensitivity)
+    return apply_restrictions(raised, agg.restrictions)
+
+
+def decide_next(
+    env: ContextEnvelope,
+    action: str,
+    ruleset: AggregationRuleSet,
+    n_category_threshold: int,
+    restricted_floor: DataClassification = DataClassification.RESTRICTED,
+) -> ContextDecision:
+    """Gate ``action`` against the already-accumulated ``env``."""
+    agg = evaluate_aggregation(env, ruleset, n_category_threshold)
+
+    if agg.escalate:
+        return ContextDecision(
+            ContextOutcome.ESCALATE,
+            ObligationSet(result_labels=env.labels),
+            agg.aggregate_sensitivity,
+            reason="aggregation threshold crossed with no governing rule",
+        )
+
+    gating = _RESTRICTED_ACTIONS.get(action)
+    # An explicit restriction token is a HARD gate: it must be enforced
+    # regardless of the current aggregate sensitivity and must never be
+    # suppressed below the floor. The floor is an additional, independent
+    # trigger for flow-bearing actions once sensitivity is high.
+    restriction_present = gating is not None and gating in env.restrictions
+    floor_triggered = gating is not None and agg.aggregate_sensitivity >= restricted_floor
+    if restriction_present or floor_triggered:
+        obligations = ObligationSet(
+            obligations=tuple(
+                Obligation(key=r, satisfied=False) for r in sorted(env.restrictions)
+            ),
+            result_labels=env.labels,
+        )
+        reason = (
+            f"action {action!r} restricted by {gating!r}"
+            if restriction_present
+            else f"action {action!r} gated by sensitivity floor"
+        )
+        return ContextDecision(
+            ContextOutcome.CONSTRAIN,
+            obligations,
+            agg.aggregate_sensitivity,
+            reason=reason,
+        )
+
+    return ContextDecision(
+        ContextOutcome.ALLOW,
+        ObligationSet(result_labels=env.labels),
+        agg.aggregate_sensitivity,
+    )
+
+
+def to_policy_action(
+    decision: ContextDecision,
+    has_obligation_channel: bool,
+) -> PolicyAction:
+    """Collapse a ``ContextDecision`` onto the declarative ``PolicyAction`` enum.
+
+    ``PolicyAction`` has no ``constrain`` member and no obligation channel of
+    its own, so ``constrain`` maps to ``ALLOW`` only when the host can carry the
+    obligations (``has_obligation_channel``) or every obligation is already
+    satisfied; otherwise it FAILS CLOSED to ``DENY``. ``escalate`` maps to
+    ``BLOCK`` (the nearest stop-and-review action on this path).
+    """
+    if decision.outcome == ContextOutcome.ALLOW:
+        return PolicyAction.ALLOW
+    if decision.outcome == ContextOutcome.DENY:
+        return PolicyAction.DENY
+    if decision.outcome == ContextOutcome.ESCALATE:
+        return PolicyAction.BLOCK
+    # CONSTRAIN: allow only if the host can carry the obligations, or every
+    # obligation is already satisfied. An EMPTY obligation set does not grant
+    # allow on a channel-less path (vacuous all_satisfied must not fail open).
+    if has_obligation_channel:
+        return PolicyAction.ALLOW
+    if decision.obligations.obligations and decision.obligations.all_satisfied:
+        return PolicyAction.ALLOW
+    return PolicyAction.DENY

--- a/agent-governance-python/agent-os/src/agent_os/policies/context_aggregation.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/context_aggregation.py
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Aggregation evaluation for Context Accumulation Governance.
+
+Applies organization-authored rules over *combinations* of accumulated labels,
+plus a monotone backstop so that combinations not covered by a rule escalate for review
+rather than passing silently. The framework supplies the evaluation hook; the
+specific combination rules are authored per organization.
+
+Aggregation (a collection of declared labels crossing a threshold) is distinct
+from inference (semantic derivation of new sensitivity); this module governs
+the former. Inference detection is out of scope for v1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .context_envelope import ContextEnvelope
+from .data_classification import DataClassification
+
+
+@dataclass(frozen=True)
+class AggregationRule:
+    """One organization-authored rule over a label combination.
+
+    When every label in ``all_labels`` is present in an envelope, the rule
+    raises sensitivity to at least ``sets_sensitivity`` and adds
+    ``adds_restrictions``.
+    """
+
+    name: str
+    all_labels: frozenset[str]
+    sets_sensitivity: DataClassification
+    adds_restrictions: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class AggregationRuleSet:
+    """An ordered collection of aggregation rules."""
+
+    rules: tuple[AggregationRule, ...] = ()
+
+
+@dataclass(frozen=True)
+class AggregationResult:
+    """Outcome of evaluating an envelope against a rule set."""
+
+    aggregate_sensitivity: DataClassification
+    restrictions: frozenset[str]
+    escalate: bool
+    rules_applied: tuple[str, ...]
+
+
+def evaluate_aggregation(
+    env: ContextEnvelope,
+    ruleset: AggregationRuleSet,
+    n_category_threshold: int,
+) -> AggregationResult:
+    """Evaluate ``env`` against ``ruleset`` and apply the monotone backstop.
+
+    The result sensitivity is the max of the envelope's current sensitivity
+    (already the running max of folded per-datum classifications) and every
+    matching rule's ``sets_sensitivity`` — so an envelope that grows without
+    crossing a declared combination keeps its current classification.
+
+    Escalation fires when no rule governs the envelope yet it has accumulated
+    at least ``n_category_threshold`` distinct labels — the conservative
+    backstop for combinations not covered by a rule.
+    """
+    sensitivity = env.aggregate_sensitivity
+    restrictions: set[str] = set(env.restrictions)
+    applied: list[str] = []
+
+    for rule in ruleset.rules:
+        if rule.all_labels <= env.labels:
+            sensitivity = max(sensitivity, rule.sets_sensitivity)
+            restrictions |= set(rule.adds_restrictions)
+            applied.append(rule.name)
+
+    escalate = not applied and len(env.labels) >= n_category_threshold
+    return AggregationResult(
+        aggregate_sensitivity=sensitivity,
+        restrictions=frozenset(restrictions),
+        escalate=escalate,
+        rules_applied=tuple(applied),
+    )

--- a/agent-governance-python/agent-os/src/agent_os/policies/context_audit.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/context_audit.py
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Audit events for context envelope transitions.
+
+Emits ``CONTEXT_*`` events describing how an envelope changed across an action
+or delegation. A transition event is itself sensitive (it names which labels
+and restrictions accumulated), so every event carries its own classification
+floor — at least the envelope's aggregate sensitivity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .context_envelope import ContextEnvelope
+from .data_classification import DataClassification
+
+CONTEXT_ENVELOPE_CREATED = "CONTEXT_ENVELOPE_CREATED"
+CONTEXT_ENVELOPE_UPDATED = "CONTEXT_ENVELOPE_UPDATED"
+CONTEXT_AGGREGATION_ELEVATED = "CONTEXT_AGGREGATION_ELEVATED"
+CONTEXT_DELEGATED = "CONTEXT_DELEGATED"
+CONTEXT_REDACTED = "CONTEXT_REDACTED"
+DERIVED_ARTIFACT_LABELED = "DERIVED_ARTIFACT_LABELED"
+
+
+@dataclass(frozen=True)
+class ContextEvent:
+    """A recorded transition between two envelope versions."""
+
+    event_type: str
+    agent_id: str
+    context_envelope_id: str
+    previous_sensitivity: DataClassification
+    new_sensitivity: DataClassification
+    labels_added: frozenset[str]
+    rules_applied: tuple[str, ...]
+    restrictions_added: frozenset[str]
+    classification: DataClassification
+
+
+def context_event(
+    event_type: str,
+    agent_id: str,
+    before: ContextEnvelope,
+    after: ContextEnvelope,
+    rules_applied: tuple[str, ...] = (),
+) -> ContextEvent:
+    """Build a ``ContextEvent`` describing the transition ``before`` -> ``after``.
+
+    The event's own ``classification`` is the max of the two envelopes'
+    sensitivities, so the event is never less protected than the data it
+    describes.
+    """
+    classification = max(before.aggregate_sensitivity, after.aggregate_sensitivity)
+    return ContextEvent(
+        event_type=event_type,
+        agent_id=agent_id,
+        context_envelope_id=after.envelope_id,
+        previous_sensitivity=before.aggregate_sensitivity,
+        new_sensitivity=after.aggregate_sensitivity,
+        labels_added=after.labels - before.labels,
+        rules_applied=rules_applied,
+        restrictions_added=after.restrictions - before.restrictions,
+        classification=classification,
+    )

--- a/agent-governance-python/agent-os/src/agent_os/policies/context_delegation.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/context_delegation.py
@@ -16,7 +16,7 @@ from typing import Iterable
 from .context_envelope import ContextEnvelope
 
 
-def intersect_restrictions(
+def merge_restrictions(
     parent: ContextEnvelope,
     child_declared: Iterable[str],
 ) -> frozenset[str]:

--- a/agent-governance-python/agent-os/src/agent_os/policies/context_delegation.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/context_delegation.py
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Restriction inheritance across a delegation boundary.
+
+When a workflow delegates to a child agent, the child's context envelope must
+inherit the parent's restrictions: a delegatee may ADD restrictions but never
+DROP one. This is a pure, grow-only union, invoked by the caller that
+constructs the child envelope. It composes alongside — and never modifies —
+the scope attenuation performed by structural-authz's ``DelegationChain``.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .context_envelope import ContextEnvelope
+
+
+def intersect_restrictions(
+    parent: ContextEnvelope,
+    child_declared: Iterable[str],
+) -> frozenset[str]:
+    """Return the child's effective restrictions: parent ∪ child-declared.
+
+    Grow-only: a child can add restrictions but cannot relax any restriction
+    inherited from the parent.
+    """
+    return parent.restrictions | frozenset(child_declared)

--- a/agent-governance-python/agent-os/src/agent_os/policies/context_envelope.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/context_envelope.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Context envelope: accumulated governance state for a workflow.
+
+A ContextEnvelope is an immutable, versioned value object that records the
+labels and sensitivity accumulated so far in a workflow. Sensitivity is a
+max-lattice over ``DataClassification`` (it only ever rises); restrictions are
+a grow-only set (they can be added but never dropped). Because the join (label
+union) and meet (sensitivity max) are commutative and idempotent, a
+single-writer can fold deltas in any order and reach the same state.
+
+This module is part of Context Accumulation Governance (CAG). It reuses the
+existing ``DataClassification`` ladder rather than introducing a parallel
+sensitivity vocabulary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Iterable, Optional
+
+from .data_classification import DataClassification
+
+
+@dataclass(frozen=True)
+class ContextEnvelope:
+    """Immutable, versioned accumulation of workflow governance state.
+
+    Attributes:
+        envelope_id: Stable identifier for this envelope's lineage.
+        workflow_id: Correlation key (a workflow may span tool calls/delegations).
+        labels: Accumulated ``DataLabel`` categories (e.g. ``pii``, ``financial``).
+        aggregate_sensitivity: Running max over all folded sensitivities.
+        restrictions: Grow-only set of restriction tokens.
+        version: Monotonic counter; each fold/application yields ``version + 1``.
+        parent_envelope_id: Set on a child (delegation) envelope.
+        created_at: Caller-supplied ISO-8601 timestamp (kept out of pure code).
+    """
+
+    envelope_id: str
+    workflow_id: str
+    labels: frozenset[str] = frozenset()
+    aggregate_sensitivity: DataClassification = DataClassification.PUBLIC
+    restrictions: frozenset[str] = frozenset()
+    version: int = 0
+    parent_envelope_id: Optional[str] = None
+    created_at: str = ""
+
+
+def fold(
+    env: ContextEnvelope,
+    new_labels: Iterable[str],
+    new_sensitivity: DataClassification,
+) -> ContextEnvelope:
+    """Return the next version of ``env`` with ``new_labels`` and ``new_sensitivity``.
+
+    Pure join: labels are unioned, sensitivity is the lattice max (never lowers),
+    and ``version`` increments. Restrictions are left unchanged here — they are
+    derived by aggregation evaluation and applied via :func:`apply_restrictions`.
+    """
+    joined_labels = env.labels | frozenset(new_labels)
+    joined_sensitivity = max(env.aggregate_sensitivity, new_sensitivity)
+    return replace(
+        env,
+        labels=joined_labels,
+        aggregate_sensitivity=joined_sensitivity,
+        version=env.version + 1,
+    )
+
+
+def apply_restrictions(
+    env: ContextEnvelope,
+    restrictions: Iterable[str],
+) -> ContextEnvelope:
+    """Return the next version of ``env`` with ``restrictions`` added (grow-only).
+
+    Restrictions are unioned, so a restriction present in ``env`` is never
+    dropped even if absent from ``restrictions``. ``version`` increments.
+    """
+    grown = env.restrictions | frozenset(restrictions)
+    return replace(env, restrictions=grown, version=env.version + 1)
+
+
+@dataclass(frozen=True)
+class EnvelopeReference:
+    """An opaque, cross-boundary handle to a :class:`ContextEnvelope`.
+
+    This is the only envelope-derived value intended to appear in an evidence
+    receipt or to cross a trust boundary. It carries the stable ``envelope_id``
+    as an opaque join key plus the coarse ``sensitivity`` tier, and deliberately
+    omits envelope contents (labels, restrictions, version lineage, workflow
+    correlation, timestamps). A consumer treats the id as a reference to
+    governance context it must resolve through the issuer, not as a portable
+    schema for the envelope itself, so the in-process ``ContextEnvelope`` shape
+    can evolve without changing what a receipt commits to.
+
+    Attributes:
+        envelope_id: Opaque lineage identifier; meaningful only to the issuer.
+        sensitivity: Coarse aggregate-sensitivity tier — a non-sensitive routing
+            hint that lets a verifier pick a resolver or policy path.
+    """
+
+    envelope_id: str
+    sensitivity: DataClassification
+
+
+def envelope_reference(env: ContextEnvelope) -> EnvelopeReference:
+    """Project ``env`` onto its opaque cross-boundary reference.
+
+    Returns only the opaque ``envelope_id`` and the coarse
+    ``aggregate_sensitivity`` tier; envelope contents never cross the boundary.
+    This is a pure projection: it performs no I/O, no signing, and does not
+    mutate ``env``.
+    """
+    return EnvelopeReference(
+        envelope_id=env.envelope_id,
+        sensitivity=env.aggregate_sensitivity,
+    )

--- a/agent-governance-python/agent-os/src/agent_os/policies/obligations.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/obligations.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Obligations carried by a ``constrain`` governance outcome.
+
+In Context Accumulation Governance, ``constrain`` is not a new policy verdict —
+it is *allow-with-obligations*: the action is permitted only if the host can
+carry the accompanying restrictions/labels forward (an obligation channel), or
+if every obligation is already declaratively satisfied. Where neither holds,
+the decision must fail closed (see :mod:`context_accumulation`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Obligation:
+    """A single restriction the host must honor for an action to proceed."""
+
+    key: str
+    satisfied: bool
+
+
+@dataclass(frozen=True)
+class ObligationSet:
+    """The obligations and labels a ``constrain`` outcome carries forward."""
+
+    obligations: tuple[Obligation, ...] = ()
+    result_labels: frozenset[str] = frozenset()
+
+    @property
+    def all_satisfied(self) -> bool:
+        """True iff every obligation is already declaratively satisfied.
+
+        An empty obligation set is vacuously satisfied.
+        """
+        return all(o.satisfied for o in self.obligations)

--- a/agent-governance-python/agent-os/tests/policies/test_context_accumulation.py
+++ b/agent-governance-python/agent-os/tests/policies/test_context_accumulation.py
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Behavioral tests for post-execution accumulation and next-action gating."""
+
+from agent_os.policies.context_accumulation import (
+    ContextOutcome,
+    accumulate,
+    decide_next,
+)
+from agent_os.policies.context_aggregation import (
+    AggregationRule,
+    AggregationRuleSet,
+)
+from agent_os.policies.context_envelope import ContextEnvelope
+from agent_os.policies.data_classification import DataClassification as DC
+
+RULESET = AggregationRuleSet(
+    rules=(
+        AggregationRule(
+            name="pii_financial_restricted",
+            all_labels=frozenset({"pii", "financial"}),
+            sets_sensitivity=DC.RESTRICTED,
+            adds_restrictions=frozenset({"no_external_export"}),
+        ),
+    )
+)
+
+
+def _env(labels=frozenset(), sens=DC.INTERNAL, restrictions=frozenset()) -> ContextEnvelope:
+    return ContextEnvelope(
+        envelope_id="e",
+        workflow_id="w",
+        labels=frozenset(labels),
+        aggregate_sensitivity=sens,
+        restrictions=restrictions,
+    )
+
+
+def test_accumulate_folds_result_labels():
+    e = _env({"pii"}, DC.INTERNAL)
+    out = accumulate(e, {"financial"}, DC.CONFIDENTIAL, RULESET, n_category_threshold=99)
+    assert "financial" in out.labels
+    # rule fires once both labels present -> RESTRICTED + restriction
+    assert out.aggregate_sensitivity == DC.RESTRICTED
+    assert "no_external_export" in out.restrictions
+
+
+def test_next_action_gated_on_accumulated_state():
+    e = _env({"pii"}, DC.INTERNAL)
+    acc = accumulate(e, {"financial"}, DC.CONFIDENTIAL, RULESET, 99)
+    decision = decide_next(acc, "export", RULESET, 99)
+    assert decision.outcome == ContextOutcome.CONSTRAIN
+    assert any(o.key == "no_external_export" for o in decision.obligations.obligations)
+
+
+def test_accumulation_never_lowers():
+    e = _env({"pii"}, DC.RESTRICTED)
+    out = accumulate(e, {"misc"}, DC.PUBLIC, RULESET, 99)
+    assert out.aggregate_sensitivity == DC.RESTRICTED
+
+
+def test_explicit_restriction_gates_below_floor():
+    # An envelope holding `no_external_export` must gate `export` even when
+    # aggregate sensitivity is BELOW the RESTRICTED floor (the restriction is a
+    # hard constraint; it must not fail open below the floor).
+    e = _env({"pii"}, sens=DC.CONFIDENTIAL, restrictions=frozenset({"no_external_export"}))
+    decision = decide_next(e, "export", RULESET, 99)
+    assert decision.outcome == ContextOutcome.CONSTRAIN
+
+
+def test_floor_triggers_flow_action_without_explicit_restriction():
+    # At/above the floor, a flow-bearing action with no explicit restriction is
+    # still gated (defense in depth), not silently allowed.
+    e = _env({"pii"}, sens=DC.RESTRICTED)
+    decision = decide_next(e, "export", RULESET, 99)
+    assert decision.outcome == ContextOutcome.CONSTRAIN

--- a/agent-governance-python/agent-os/tests/policies/test_context_aggregation.py
+++ b/agent-governance-python/agent-os/tests/policies/test_context_aggregation.py
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Behavioral tests for aggregation evaluation and the monotone backstop."""
+
+from agent_os.policies.context_aggregation import (
+    AggregationRule,
+    AggregationRuleSet,
+    evaluate_aggregation,
+)
+from agent_os.policies.context_envelope import ContextEnvelope
+from agent_os.policies.data_classification import DataClassification as DC
+
+RULESET = AggregationRuleSet(
+    rules=(
+        AggregationRule(
+            name="pii_financial_restricted",
+            all_labels=frozenset({"pii", "financial"}),
+            sets_sensitivity=DC.RESTRICTED,
+            adds_restrictions=frozenset({"no_external_export"}),
+        ),
+    )
+)
+
+
+def _env(labels, sens=DC.INTERNAL, restrictions=frozenset()) -> ContextEnvelope:
+    return ContextEnvelope(
+        envelope_id="e",
+        workflow_id="w",
+        labels=frozenset(labels),
+        aggregate_sensitivity=sens,
+        restrictions=restrictions,
+    )
+
+
+def test_rule_fires_on_label_combination():
+    res = evaluate_aggregation(_env({"pii", "financial"}), RULESET, n_category_threshold=99)
+    assert res.aggregate_sensitivity == DC.RESTRICTED
+    assert "no_external_export" in res.restrictions
+    assert "pii_financial_restricted" in res.rules_applied
+
+
+def test_growth_without_rule_keeps_classification():
+    # rule needs pii+financial; envelope has pii+behavioral -> no match
+    res = evaluate_aggregation(_env({"pii", "behavioral"}, sens=DC.INTERNAL), RULESET, 99)
+    assert res.aggregate_sensitivity == DC.INTERNAL
+    assert res.rules_applied == ()
+
+
+def test_monotone_backstop_floor():
+    res = evaluate_aggregation(_env({"x"}, sens=DC.CONFIDENTIAL), RULESET, 99)
+    assert res.aggregate_sensitivity >= DC.CONFIDENTIAL
+
+
+def test_backstop_escalates_on_n_distinct_categories():
+    res = evaluate_aggregation(_env({"a", "b", "c"}, sens=DC.INTERNAL), RULESET, n_category_threshold=3)
+    assert res.escalate is True

--- a/agent-governance-python/agent-os/tests/policies/test_context_audit_events.py
+++ b/agent-governance-python/agent-os/tests/policies/test_context_audit_events.py
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Behavioral tests for context transition audit events."""
+
+from agent_os.policies.context_audit import (
+    CONTEXT_AGGREGATION_ELEVATED,
+    CONTEXT_ENVELOPE_UPDATED,
+    context_event,
+)
+from agent_os.policies.context_envelope import ContextEnvelope
+from agent_os.policies.data_classification import DataClassification as DC
+
+
+def test_aggregation_elevated_event_shape():
+    before = ContextEnvelope(
+        envelope_id="e",
+        workflow_id="w",
+        labels=frozenset({"pii"}),
+        aggregate_sensitivity=DC.CONFIDENTIAL,
+    )
+    after = ContextEnvelope(
+        envelope_id="e",
+        workflow_id="w",
+        labels=frozenset({"pii", "financial"}),
+        aggregate_sensitivity=DC.RESTRICTED,
+        restrictions=frozenset({"no_external_export"}),
+    )
+    ev = context_event(
+        CONTEXT_AGGREGATION_ELEVATED,
+        "agent.customer-success",
+        before,
+        after,
+        rules_applied=("pii_financial_restricted",),
+    )
+    assert ev.previous_sensitivity == DC.CONFIDENTIAL
+    assert ev.new_sensitivity == DC.RESTRICTED
+    assert ev.labels_added == frozenset({"financial"})
+    assert ev.restrictions_added == frozenset({"no_external_export"})
+    assert ev.rules_applied == ("pii_financial_restricted",)
+
+
+def test_event_carries_classification_floor():
+    before = ContextEnvelope(
+        envelope_id="e", workflow_id="w", aggregate_sensitivity=DC.CONFIDENTIAL
+    )
+    after = ContextEnvelope(
+        envelope_id="e", workflow_id="w", aggregate_sensitivity=DC.RESTRICTED
+    )
+    ev = context_event(CONTEXT_ENVELOPE_UPDATED, "a", before, after)
+    assert ev.classification >= after.aggregate_sensitivity

--- a/agent-governance-python/agent-os/tests/policies/test_context_delegation.py
+++ b/agent-governance-python/agent-os/tests/policies/test_context_delegation.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 """Behavioral tests for grow-only restriction inheritance across delegation."""
 
-from agent_os.policies.context_delegation import intersect_restrictions
+from agent_os.policies.context_delegation import merge_restrictions
 from agent_os.policies.context_envelope import ContextEnvelope
 
 
@@ -13,22 +13,22 @@ def _parent(restrictions) -> ContextEnvelope:
 
 
 def test_child_inherits_parent_restrictions():
-    out = intersect_restrictions(_parent({"no_external_export"}), set())
+    out = merge_restrictions(_parent({"no_external_export"}), set())
     assert out == frozenset({"no_external_export"})
 
 
 def test_child_cannot_drop_parent_restriction():
-    out = intersect_restrictions(_parent({"no_external_export"}), frozenset())
+    out = merge_restrictions(_parent({"no_external_export"}), frozenset())
     assert "no_external_export" in out
 
 
 def test_child_may_add_restrictions():
-    out = intersect_restrictions(_parent({"no_external_export"}), {"no_memory_write"})
+    out = merge_restrictions(_parent({"no_external_export"}), {"no_memory_write"})
     assert out == frozenset({"no_external_export", "no_memory_write"})
 
 
 def test_effective_restrictions_union_along_chain():
-    hop1 = intersect_restrictions(_parent({"a"}), {"b"})
+    hop1 = merge_restrictions(_parent({"a"}), {"b"})
     child = ContextEnvelope(envelope_id="c", workflow_id="w", restrictions=hop1)
-    hop2 = intersect_restrictions(child, {"c"})
+    hop2 = merge_restrictions(child, {"c"})
     assert hop2 == frozenset({"a", "b", "c"})

--- a/agent-governance-python/agent-os/tests/policies/test_context_delegation.py
+++ b/agent-governance-python/agent-os/tests/policies/test_context_delegation.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Behavioral tests for grow-only restriction inheritance across delegation."""
+
+from agent_os.policies.context_delegation import intersect_restrictions
+from agent_os.policies.context_envelope import ContextEnvelope
+
+
+def _parent(restrictions) -> ContextEnvelope:
+    return ContextEnvelope(
+        envelope_id="p", workflow_id="w", restrictions=frozenset(restrictions)
+    )
+
+
+def test_child_inherits_parent_restrictions():
+    out = intersect_restrictions(_parent({"no_external_export"}), set())
+    assert out == frozenset({"no_external_export"})
+
+
+def test_child_cannot_drop_parent_restriction():
+    out = intersect_restrictions(_parent({"no_external_export"}), frozenset())
+    assert "no_external_export" in out
+
+
+def test_child_may_add_restrictions():
+    out = intersect_restrictions(_parent({"no_external_export"}), {"no_memory_write"})
+    assert out == frozenset({"no_external_export", "no_memory_write"})
+
+
+def test_effective_restrictions_union_along_chain():
+    hop1 = intersect_restrictions(_parent({"a"}), {"b"})
+    child = ContextEnvelope(envelope_id="c", workflow_id="w", restrictions=hop1)
+    hop2 = intersect_restrictions(child, {"c"})
+    assert hop2 == frozenset({"a", "b", "c"})

--- a/agent-governance-python/agent-os/tests/policies/test_context_envelope.py
+++ b/agent-governance-python/agent-os/tests/policies/test_context_envelope.py
@@ -1,0 +1,103 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Behavioral tests for the ContextEnvelope value type and its folds."""
+
+import dataclasses
+
+import pytest
+
+from agent_os.policies.context_envelope import (
+    ContextEnvelope,
+    EnvelopeReference,
+    apply_restrictions,
+    envelope_reference,
+    fold,
+)
+from agent_os.policies.data_classification import DataClassification as DC
+
+
+def _env(**kw) -> ContextEnvelope:
+    base = dict(envelope_id="env1", workflow_id="wf1")
+    base.update(kw)
+    return ContextEnvelope(**base)
+
+
+def test_fold_joins_labels_and_raises_sensitivity():
+    e = _env(labels=frozenset({"pii"}), aggregate_sensitivity=DC.INTERNAL)
+    out = fold(e, {"financial"}, DC.CONFIDENTIAL)
+    assert out.labels == frozenset({"pii", "financial"})
+    assert out.aggregate_sensitivity == DC.CONFIDENTIAL
+    assert out.version == e.version + 1
+    # original is unchanged (immutability)
+    assert e.labels == frozenset({"pii"})
+
+
+def test_fold_is_idempotent():
+    e = _env(labels=frozenset({"pii"}), aggregate_sensitivity=DC.CONFIDENTIAL)
+    out = fold(e, {"pii"}, DC.INTERNAL)
+    assert out.labels == e.labels
+    assert out.aggregate_sensitivity == e.aggregate_sensitivity
+
+
+def test_fold_is_commutative():
+    e = _env()
+    a = fold(fold(e, {"pii"}, DC.INTERNAL), {"financial"}, DC.CONFIDENTIAL)
+    b = fold(fold(e, {"financial"}, DC.CONFIDENTIAL), {"pii"}, DC.INTERNAL)
+    assert a.labels == b.labels
+    assert a.aggregate_sensitivity == b.aggregate_sensitivity
+
+
+def test_sensitivity_is_max_lattice():
+    e = _env()
+    out = fold(fold(e, {"a"}, DC.RESTRICTED), {"b"}, DC.PUBLIC)
+    assert out.aggregate_sensitivity == DC.RESTRICTED
+
+
+def test_restrictions_are_grow_only():
+    e = _env(restrictions=frozenset({"no_external_export"}))
+    out = apply_restrictions(e, set())  # attempt to omit
+    assert out.restrictions == frozenset({"no_external_export"})
+    out2 = apply_restrictions(out, {"no_memory_write"})
+    assert out2.restrictions == frozenset({"no_external_export", "no_memory_write"})
+
+
+def _loaded_env() -> ContextEnvelope:
+    """An envelope carrying every content field, to prove the reference drops them."""
+    return ContextEnvelope(
+        envelope_id="env-abc",
+        workflow_id="wf-corr-1",
+        labels=frozenset({"pii", "financial"}),
+        aggregate_sensitivity=DC.RESTRICTED,
+        restrictions=frozenset({"no_external_export"}),
+        version=7,
+        parent_envelope_id="parent-xyz",
+        created_at="2026-06-04T00:00:00Z",
+    )
+
+
+def test_envelope_reference_exposes_only_id_and_sensitivity():
+    ref = envelope_reference(_loaded_env())
+    assert isinstance(ref, EnvelopeReference)
+    field_names = {f.name for f in dataclasses.fields(ref)}
+    assert field_names == {"envelope_id", "sensitivity"}
+    # The content fields of the source envelope must not be reachable on the ref.
+    for leaked in ("labels", "restrictions", "version", "parent_envelope_id", "workflow_id", "created_at"):
+        assert not hasattr(ref, leaked)
+
+
+def test_envelope_reference_sensitivity_equals_aggregate():
+    env = _loaded_env()
+    ref = envelope_reference(env)
+    assert ref.sensitivity is env.aggregate_sensitivity
+    assert ref.sensitivity == DC.RESTRICTED
+
+
+def test_envelope_reference_id_matches():
+    env = _loaded_env()
+    assert envelope_reference(env).envelope_id == env.envelope_id
+
+
+def test_envelope_reference_is_frozen():
+    ref = envelope_reference(_loaded_env())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ref.sensitivity = DC.PUBLIC

--- a/agent-governance-python/agent-os/tests/policies/test_obligations.py
+++ b/agent-governance-python/agent-os/tests/policies/test_obligations.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Behavioral tests for constrain-as-obligations and the fail-closed mapping."""
+
+from agent_os.policies.context_accumulation import (
+    ContextDecision,
+    ContextOutcome,
+    to_policy_action,
+)
+from agent_os.policies.data_classification import DataClassification as DC
+from agent_os.policies.obligations import Obligation, ObligationSet
+from agent_os.policies.schema import PolicyAction
+
+
+def _constrain(obligations: ObligationSet) -> ContextDecision:
+    return ContextDecision(ContextOutcome.CONSTRAIN, obligations, DC.RESTRICTED, "restricted")
+
+
+def test_constrain_is_allow_plus_obligations():
+    obs = ObligationSet(
+        obligations=(Obligation("no_external_export", False),),
+        result_labels=frozenset({"pii", "financial"}),
+    )
+    decision = _constrain(obs)
+    # WITH an obligation channel the host carries the obligations -> effective ALLOW
+    assert to_policy_action(decision, has_obligation_channel=True) == PolicyAction.ALLOW
+    assert len(decision.obligations.obligations) >= 1
+
+
+def test_python_path_constrain_fails_closed():
+    obs = ObligationSet(obligations=(Obligation("no_external_export", False),))
+    decision = _constrain(obs)
+    # NO obligation channel + unsatisfied obligation -> fail closed to DENY (never ALLOW)
+    assert to_policy_action(decision, has_obligation_channel=False) == PolicyAction.DENY
+
+
+def test_satisfiable_obligation_allows():
+    obs = ObligationSet(obligations=(Obligation("no_external_export", True),))
+    decision = _constrain(obs)
+    # NO channel but every obligation already satisfied -> ALLOW
+    assert to_policy_action(decision, has_obligation_channel=False) == PolicyAction.ALLOW
+
+
+def test_empty_obligation_constrain_fails_closed():
+    # A constrain carrying NO obligations must not fail open via vacuous
+    # all_satisfied: no channel + no obligations -> DENY.
+    decision = _constrain(ObligationSet())
+    assert to_policy_action(decision, has_obligation_channel=False) == PolicyAction.DENY

--- a/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/structural_authz_agentmesh/trust.py
+++ b/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/structural_authz_agentmesh/trust.py
@@ -383,6 +383,20 @@ class DelegationChain:
 
         return True, ""
 
+    def effective_restrictions(
+        self,
+        parent_restrictions: frozenset[str],
+        child_declared: frozenset[str],
+    ) -> frozenset[str]:
+        """Return a delegated child's effective restrictions: parent ∪ child.
+
+        Grow-only restriction inheritance for Context Accumulation Governance: a
+        delegatee may ADD restrictions but never DROP one held by the parent.
+        This composes ALONGSIDE the scope attenuation in ``validate()``; it does
+        not call or modify ``validate()`` and shares none of its state.
+        """
+        return frozenset(parent_restrictions) | frozenset(child_declared)
+
     def effective_scopes_for(self, did: str) -> Set[str]:
         """Return the effective scopes held by a given DID in this chain."""
         if did == self._root_did:

--- a/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/tests/test_restriction_union.py
+++ b/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/tests/test_restriction_union.py
@@ -32,7 +32,7 @@ def test_effective_restrictions_method_matches_pure_fn():
     chain = DelegationChain("did:authz:root", ["read"])
     parent = frozenset({"no_external_export"})
     child = frozenset({"no_memory_write"})
-    # The method computes the same grow-only union the pure intersect_restrictions does.
+    # The method computes the same grow-only union the pure merge_restrictions does.
     assert chain.effective_restrictions(parent, child) == (parent | child)
 
 

--- a/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/tests/test_restriction_union.py
+++ b/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/tests/test_restriction_union.py
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the additive DelegationChain.effective_restrictions method.
+
+Includes a behavioral non-regression check that the new method left
+validate()'s contract (return shape + reason substrings) unchanged.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from structural_authz_agentmesh.trust import DelegationChain, DelegationLink
+
+
+def _link(
+    delegator: str,
+    delegatee: str,
+    scopes: list,
+    expires_at: Optional[datetime] = None,
+) -> DelegationLink:
+    return DelegationLink(
+        delegator_did=delegator,
+        delegatee_did=delegatee,
+        scopes=scopes,
+        delegator_public_key="AAAA",
+        signature="BBBB",
+        expires_at=expires_at,
+    )
+
+
+def test_effective_restrictions_method_matches_pure_fn():
+    chain = DelegationChain("did:authz:root", ["read"])
+    parent = frozenset({"no_external_export"})
+    child = frozenset({"no_memory_write"})
+    # The method computes the same grow-only union the pure intersect_restrictions does.
+    assert chain.effective_restrictions(parent, child) == (parent | child)
+
+
+def test_effective_restrictions_is_grow_only():
+    chain = DelegationChain("did:authz:root", ["read"])
+    parent = frozenset({"no_external_export"})
+    # a child declaring nothing still inherits the parent restriction
+    assert "no_external_export" in chain.effective_restrictions(parent, frozenset())
+
+
+def test_validate_signature_and_reasons_unchanged():
+    """The additive method must not alter validate()'s shape or reason strings."""
+    # circular
+    c1 = DelegationChain("did:authz:root", ["read"])
+    c1.add_link(_link("did:authz:root", "did:authz:root", ["read"]))
+    ok1, reason1 = c1.validate()
+    assert ok1 is False
+    assert isinstance(reason1, str)
+    assert "circular" in reason1
+
+    # expired
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+    c2 = DelegationChain("did:authz:root", ["read"])
+    c2.add_link(_link("did:authz:root", "did:authz:agent", ["read"], expires_at=past))
+    ok2, reason2 = c2.validate()
+    assert ok2 is False
+    assert "expired" in reason2
+
+    # scope widening ("exceed")
+    c3 = DelegationChain("did:authz:root", ["read"])
+    c3.add_link(_link("did:authz:root", "did:authz:agent", ["read", "admin"]))
+    ok3, reason3 = c3.validate(verify_signatures=False)
+    assert ok3 is False
+    assert "exceed" in reason3
+
+    # success path still returns the (bool, str) tuple shape
+    ok0, reason0 = DelegationChain("did:authz:root", ["read"]).validate()
+    assert ok0 is True
+    assert reason0 == ""

--- a/docs/security/audits/2026-06-03-context-accumulation-governance.md
+++ b/docs/security/audits/2026-06-03-context-accumulation-governance.md
@@ -1,0 +1,100 @@
+# 2026-06-03 - Context Accumulation Governance (v1)
+
+PR: feat: govern accumulated context across delegated agent workflows (#2800)
+
+Closes #2797.
+
+> These are the author's own security design notes and threat model for the
+> change — a **self-review, not an independent security audit**. The "Test
+> coverage" column references tests that ship in this same PR. An independent
+> review by a second maintainer is welcome.
+>
+> The full design rationale and threat model live in
+> [`../context-accumulation-governance.md`](../context-accumulation-governance.md);
+> this file is the dated audit-gate record and summarizes the same content.
+
+## What changed and why
+
+Adds a first cut of context accumulation governance: a `ContextEnvelope` that
+tracks the labels and sensitivity a workflow has accumulated and gates later
+actions and delegations against that running state, rather than evaluating each
+action in isolation. This closes the gap where individually permitted actions
+aggregate into sensitive context, and where a delegated agent can quietly lose
+the constraints its parent carried.
+
+New types and helpers (`agent_os.policies`):
+
+- `ContextEnvelope`: immutable, versioned value. Aggregate sensitivity is a
+  max-lattice over the existing `DataClassification`; restrictions are a
+  grow-only set.
+- `evaluate_aggregation` plus `AggregationRule`/`AggregationRuleSet`:
+  organization-authored rules over label combinations, with a monotone backstop
+  that escalates combinations no rule covers.
+- `accumulate`, `decide_next`, `to_policy_action` (`context_accumulation`):
+  post-execution accumulation of an action's actual `result_labels`, then gating
+  of the next action.
+- `Obligation`/`ObligationSet`: the obligations a `constrain` outcome carries
+  forward.
+- `merge_restrictions` (`context_delegation`) and the additive
+  `DelegationChain.effective_restrictions`: grow-only restriction inheritance on
+  delegation (a **union** of parent + child-declared restrictions).
+- `context_event` plus `CONTEXT_*` kinds (`context_audit`): transition events,
+  each classified at least as high as the envelope it describes.
+
+Reuses the existing `DataClassification`/`DataLabel`/`ABACPolicy` types and the
+policy-engine `result_labels`, and adds no new dependencies.
+
+## Threat model impact
+
+This is a governance control, so the relevant risk is whether the control can
+fail open or silently weaken an existing guarantee, not classic injection or
+memory safety. A pure-logic review (no subprocess, deserialization, filesystem,
+network, or crypto in any new file) confirmed no classic vulnerability surface.
+
+| Risk | Mitigation | Test coverage (this PR) |
+|------|-----------|-------------|
+| Constrain allows without an obligation channel | `to_policy_action` maps constrain to DENY absent a channel | `test_python_path_constrain_fails_closed` |
+| Empty obligation set grants allow via vacuous truth | Empty obligations do not satisfy the allow condition | `test_empty_obligation_constrain_fails_closed` |
+| Explicit restriction ignored below the floor | A present restriction gates regardless of sensitivity | `test_explicit_restriction_gates_below_floor` |
+| Aggregate sensitivity lowered | Max-lattice join never decreases | `test_sensitivity_is_max_lattice`, `test_accumulation_never_lowers` |
+| Delegated child drops a parent restriction | Grow-only union on inheritance | `test_child_cannot_drop_parent_restriction`, `test_effective_restrictions_union_along_chain` |
+| Combination not covered by a rule slips through | Monotone backstop escalates for review | `test_backstop_escalates_on_n_distinct_categories` |
+| `validate()` behavior regressed | Additive method only; validate untouched | `test_validate_signature_and_reasons_unchanged` plus the existing `test_structural_authz.py` suite |
+
+### Out of scope for this first cut
+
+The control governs non-adversarial aggregation within instrumented,
+single-writer, in-process paths. These are deliberately deferred and documented
+so a deployer does not over-rely on the guarantees:
+
+- Accumulation across sibling agents, sessions, or separate workflows (needs a
+  per-principal register).
+- Signing and versioning envelopes that cross a trust boundary; until that
+  exists, anything riding on an envelope across the mesh is advisory.
+- Labeling on ingest to catch laundering through an unlabeled store or by
+  paraphrasing restricted content into new text.
+- Detecting an undeclared sensitive inference, which is undecidable in general.
+  An artifact produced while the envelope is already sensitive inherits that
+  classification.
+
+### Existing security properties preserved
+
+- `DelegationChain.validate()` and its scope, cycle, expiry, and signature
+  checks are unchanged; the existing delegation test suite stays green.
+- No new dependencies, no network or filesystem access, no crypto or secret
+  handling in any new file.
+- The envelope stores category labels and classification levels, not raw
+  personal data, which keeps its own confidentiality footprint small.
+
+## Test coverage
+
+- 24 new unit tests across the envelope laws (commutative and idempotent
+  folding, sensitivity never lowers, restrictions never drop), aggregation and
+  the escalation backstop, the fail-closed `constrain` mapping, delegation
+  restriction inheritance, and audit event shape.
+- The existing `DelegationChain` suite (`test_structural_authz.py`) runs as a
+  regression gate and stays green, with an explicit test that `validate()`'s
+  return shape and reason strings are unchanged.
+- 181 existing policy tests confirm the new package exports do not break
+  existing importers.
+- All tests run in standard CI with no special hardware or external services.

--- a/docs/security/context-accumulation-governance.md
+++ b/docs/security/context-accumulation-governance.md
@@ -1,0 +1,88 @@
+# Security Audit: Context Accumulation Governance (v1)
+
+**Date:** 2026-06-03
+**PR:** feat: govern accumulated context across delegated agent workflows
+**Scope:** `agent_os.policies.context_envelope`, `context_aggregation`, `context_accumulation`, `obligations`, `context_delegation`, `context_audit`; `structural_authz_agentmesh.trust.DelegationChain.effective_restrictions`
+**Author:** Knapp-Kevin
+
+## What changed and why
+
+Adds a first cut of context accumulation governance: a `ContextEnvelope` that tracks the labels and sensitivity a workflow has accumulated and gates later actions and delegations against that running state, rather than evaluating each action in isolation. This closes the gap where individually permitted actions aggregate into sensitive context, and where a delegated agent can quietly lose the constraints its parent carried.
+
+New types and helpers:
+
+- `ContextEnvelope`: immutable, versioned value. Aggregate sensitivity is a max-lattice over the existing `DataClassification`; restrictions are a grow-only set.
+- `evaluate_aggregation` plus `AggregationRule`/`AggregationRuleSet`: organization-authored rules over label combinations, with a monotone backstop that escalates combinations no rule covers.
+- `accumulate`, `decide_next`, `to_policy_action` (`context_accumulation`): post-execution accumulation of an action's actual `result_labels`, then gating of the next action.
+- `Obligation`/`ObligationSet`: the obligations a `constrain` outcome carries forward.
+- `intersect_restrictions` (`context_delegation`) and the additive `DelegationChain.effective_restrictions`: grow-only restriction inheritance on delegation.
+- `context_event` plus `CONTEXT_*` kinds (`context_audit`): transition events, each classified at the envelope sensitivity.
+
+The change reuses the existing `DataClassification`/`DataLabel`/`ABACPolicy` types and the policy-engine `result_labels`, and adds no new dependencies.
+
+## Threat model impact
+
+This is a governance control, so the relevant risk is whether the control can fail open or silently weaken an existing guarantee, not classic injection or memory safety. A pure-logic review (no subprocess, deserialization, filesystem, network, or crypto in any new file) confirmed no classic vulnerability surface.
+
+### New attack surface and mitigations
+
+1. **Constrain fails open on a path that cannot carry obligations.** The declarative `PolicyAction` enum has no obligation channel, so a `constrain` outcome could degrade to allow.
+
+   **Mitigation:** `to_policy_action` maps `constrain` to `DENY` when there is no obligation channel, and the empty `ObligationSet` case is guarded so that a vacuous `all_satisfied` cannot grant allow. Fail-closed by construction.
+
+2. **An explicit restriction is ignored below a sensitivity threshold.** An envelope can hold a hard restriction (for example `no_external_export`) while aggregate sensitivity sits below the configured floor.
+
+   **Mitigation:** a present restriction gates its action regardless of sensitivity. The floor is an additional, independent trigger, never a suppressor of an explicit restriction.
+
+3. **Sensitivity is lowered during accumulation.** A later low-sensitivity input could otherwise reduce the envelope classification.
+
+   **Mitigation:** aggregate sensitivity is a max-lattice over `DataClassification`. Folding and aggregation only ever raise it.
+
+4. **A delegated child drops a parent restriction.** A child could otherwise escape a restriction the parent carried.
+
+   **Mitigation:** restriction inheritance is a grow-only union (parent restrictions plus child-declared). A child can add but never remove.
+
+5. **Regression of the existing delegation validator.** Restriction inheritance is added near `DelegationChain.validate()`.
+
+   **Mitigation:** the inheritance logic is a new, separate method (`effective_restrictions`) and a pure free function. `validate()` is unchanged byte for byte; its signature, return type, and reason strings are asserted unchanged by test.
+
+### Out of scope for this first cut
+
+The control governs non-adversarial aggregation within instrumented, single-writer, in-process paths. The following are deliberately deferred and documented so a deployer does not over-rely on the guarantees:
+
+- Accumulation across sibling agents, sessions, or separate workflows (needs a per-principal register).
+- Labeling on ingest to catch laundering through an unlabeled store or by paraphrasing restricted content into new text.
+- Detecting an undeclared sensitive inference, which is undecidable in general. An artifact produced while the envelope is already sensitive inherits that classification.
+
+#### Envelope to evidence-receipt boundary
+
+Signed and versioned envelopes across a trust boundary are deferred; until they exist, anything riding on an envelope across the mesh is advisory, since a peer could present a weaker one. The shape of that boundary, however, is settled. A receipt that references governance context holds an opaque `envelope_id` plus at most a coarse, non-sensitive sensitivity tier or governance label — never the envelope contents. The `envelope_reference` helper is the sanctioned projection: it carries only the id and the aggregate-sensitivity tier, so the in-process `ContextEnvelope` shape can evolve without changing what a receipt commits to. The issuer of the reference owns retention and resolvability; a consumer that hits an expired or unresolved reference treats that as a verification outcome, not a receipt-schema failure. The cross-boundary work is therefore a *responsibilities contract* — issuer identity, version and monotonicity assertion, replay and downgrade rejection, and where verification happens — rather than a serialized downstream schema. Holding the id opaque keeps the receipt a small, stable join point and leaves AGT free to define the envelope shape internally.
+
+#### Envelope lifecycle and retention (open)
+
+The version chain is not assumed unbounded, and the accumulated chain is itself a sensitive artifact (it is simultaneously the best audit trail and the softest target). This first cut does not settle a lifecycle, but it leaves room for one. The ratchet is a property of the head: the latest version already carries the joined labels, sensitivity, and grow-only restrictions, so intermediate versions can be compacted without changing what gets enforced, and keeping the full trail becomes an audit choice rather than a correctness requirement. Declassification steps act as compaction boundaries — compacting across one would resurrect what the downgrade removed — so a downgrade is a hard boundary for any future pruning. The minimum that must survive pruning is the active restrictions plus a reason anchor that explains why each restriction holds. A checkpoint that folds a prefix needs a *verifiable* summary of what it folds, not merely a signature attesting who wrote it; signing proves authorship, not faithfulness. No compaction or checkpoint record is implemented here; this is a documented extension point so the schema is not committed to an unbounded chain.
+
+### Existing security properties preserved
+
+- `DelegationChain.validate()` and its scope, cycle, expiry, and signature checks are unchanged; the existing delegation test suite stays green.
+- No new dependencies, no network or filesystem access, no crypto or secret handling in any new file.
+- The envelope stores category labels and classification levels, not raw personal data, which keeps its own confidentiality footprint small.
+
+## Mitigations
+
+| Risk | Mitigation | Verified by |
+|------|-----------|-------------|
+| Constrain allows without an obligation channel | `to_policy_action` maps constrain to DENY absent a channel | `test_python_path_constrain_fails_closed` |
+| Empty obligation set grants allow via vacuous truth | Empty obligations do not satisfy the allow condition | `test_empty_obligation_constrain_fails_closed` |
+| Explicit restriction ignored below the floor | A present restriction gates regardless of sensitivity | `test_explicit_restriction_gates_below_floor` |
+| Aggregate sensitivity lowered | Max-lattice join never decreases | `test_sensitivity_is_max_lattice`, `test_accumulation_never_lowers` |
+| Delegated child drops a parent restriction | Grow-only union on inheritance | `test_child_cannot_drop_parent_restriction`, `test_effective_restrictions_union_along_chain` |
+| Combination not covered by a rule slips through | Monotone backstop escalates for review | `test_backstop_escalates_on_n_distinct_categories` |
+| `validate()` behavior regressed | Additive method only; validate untouched | `test_validate_signature_and_reasons_unchanged` plus the existing `test_structural_authz.py` suite |
+
+## Test coverage
+
+- 24 new unit tests across the envelope laws (commutative and idempotent folding, sensitivity never lowers, restrictions never drop), aggregation and the escalation backstop, the fail-closed `constrain` mapping, delegation restriction inheritance, and audit event shape.
+- The existing `DelegationChain` suite (`test_structural_authz.py`) runs as a regression gate and stays green, with an explicit test that `validate()`'s return shape and reason strings are unchanged.
+- 181 existing policy tests confirm the new package exports do not break existing importers.
+- All tests run in standard CI with no special hardware or external services.

--- a/docs/security/context-accumulation-governance.md
+++ b/docs/security/context-accumulation-governance.md
@@ -1,9 +1,14 @@
-# Security Audit: Context Accumulation Governance (v1)
+# Security Design Notes: Context Accumulation Governance (v1)
 
 **Date:** 2026-06-03
 **PR:** feat: govern accumulated context across delegated agent workflows
 **Scope:** `agent_os.policies.context_envelope`, `context_aggregation`, `context_accumulation`, `obligations`, `context_delegation`, `context_audit`; `structural_authz_agentmesh.trust.DelegationChain.effective_restrictions`
 **Author:** Knapp-Kevin
+
+> These are the author's own security design notes and threat model for the
+> change — a self-review, not an independent security audit. The "Test coverage"
+> column references tests that ship in this same PR. An independent review by a
+> second maintainer is welcome and has not yet taken place.
 
 ## What changed and why
 
@@ -15,7 +20,7 @@ New types and helpers:
 - `evaluate_aggregation` plus `AggregationRule`/`AggregationRuleSet`: organization-authored rules over label combinations, with a monotone backstop that escalates combinations no rule covers.
 - `accumulate`, `decide_next`, `to_policy_action` (`context_accumulation`): post-execution accumulation of an action's actual `result_labels`, then gating of the next action.
 - `Obligation`/`ObligationSet`: the obligations a `constrain` outcome carries forward.
-- `intersect_restrictions` (`context_delegation`) and the additive `DelegationChain.effective_restrictions`: grow-only restriction inheritance on delegation.
+- `merge_restrictions` (`context_delegation`) and the additive `DelegationChain.effective_restrictions`: grow-only restriction inheritance on delegation.
 - `context_event` plus `CONTEXT_*` kinds (`context_audit`): transition events, each classified at the envelope sensitivity.
 
 The change reuses the existing `DataClassification`/`DataLabel`/`ABACPolicy` types and the policy-engine `result_labels`, and adds no new dependencies.
@@ -70,7 +75,7 @@ The version chain is not assumed unbounded, and the accumulated chain is itself 
 
 ## Mitigations
 
-| Risk | Mitigation | Verified by |
+| Risk | Mitigation | Test coverage (this PR) |
 |------|-----------|-------------|
 | Constrain allows without an obligation channel | `to_policy_action` maps constrain to DENY absent a channel | `test_python_path_constrain_fails_closed` |
 | Empty obligation set grants allow via vacuous truth | Empty obligations do not satisfy the allow condition | `test_empty_obligation_constrain_fails_closed` |


### PR DESCRIPTION
## What this does

Adds a first cut of context accumulation governance: a ContextEnvelope that tracks the labels and sensitivity a workflow has accumulated and checks later actions and delegations against that running state, rather than evaluating each action in isolation. Background and motivation are in #2797, and there's a fuller design writeup in the discussion at #2798.

## Why

A multi-agent workflow can pass every individual policy check and still end up somewhere sensitive, because sensitivity builds up as context accumulates. A customer name plus financial indicators plus behavioral analytics can combine into a sensitive customer risk profile even though each piece was fine on its own. A delegated agent can also quietly lose the constraints its parent was carrying. This closes that gap for the in-process case.

## What's in it

- ContextEnvelope: immutable and versioned, with a max-lattice aggregate sensitivity (it only ever rises) and a grow-only restriction set.
- Aggregation rules over label combinations, plus a backstop so combinations nobody wrote a rule for escalate for review instead of slipping through. Growing the label set on its own doesn't elevate anything; only declared combinations do.
- Accumulate after execution: fold in an action's actual result_labels once it has run, then check the next action against the updated state. Projecting an unrun output's labels isn't something you can do reliably, so the gate works off accumulated state.
- A constrain outcome that means allow, but carry these obligations forward. On the declarative policy path, which has no obligation channel, it fails closed to deny rather than quietly allowing.
- Grow-only restriction inheritance on delegation: a free function `merge_restrictions` and an additive `DelegationChain.effective_restrictions`, both a **union** of the parent's restrictions and the child's declared ones (renamed from `intersect_restrictions`, which misdescribed a union). A child can add restrictions but never drop a parent's. `validate()` is untouched.
- CONTEXT_* audit events, each classified at least as high as the envelope it describes.

It reuses the existing DataClassification, DataLabel, and ABACPolicy types and the policy-engine result_labels, and adds no new dependencies.

## Scope and what's deferred

This is the in-process, single-writer first cut. A few things are deliberately out of scope for now and probably deserve their own issues:

- Accumulating across sibling agents, sessions, or separate workflows. Catching that needs a per-principal register.
- Signing and versioning envelopes that cross a trust boundary between agents. Until that exists, anything riding on an envelope across the mesh is advisory.
- Labeling on ingest to catch laundering through an unlabeled store, or paraphrasing restricted content into new text.
- Detecting an undeclared sensitive inference, which is undecidable in general. For now an artifact produced while the envelope is already sensitive just inherits that classification.

## Security design notes

`docs/security/context-accumulation-governance.md` captures the author's own threat model and design rationale (fail-closed constrain mapping, restriction-gating independent of the sensitivity floor, the grow-only union, and the deferred cross-boundary/lifecycle work). It is a **self-review, not an independent security audit** — the "Test coverage" column points at tests in this PR — and a second-maintainer review is welcome.

## Tests

- Unit tests for the envelope laws (folding is order independent and idempotent, sensitivity never lowers, restrictions never drop), aggregation and the escalation backstop, the fail-closed constrain mapping, and delegation restriction inheritance.
- The existing DelegationChain suite stays green, with an explicit test that validate()'s return shape and reason strings are unchanged.

Closes #2797.

---

*AI-assisted disclosure. Portions of this contribution were generated under human direction through an agentic, gated SDLC governance process. The governance controls and decision records that shaped this code are maintained in their open-source project and can be furnished in fuller detail on request.*