### PR TITLE
feat(contributor-check): make reputation heuristic org-aware and domain-specialist-aware

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -56,7 +56,11 @@
     "pymdownx",
     "pygments",
     "javascripts",
-    "tabindex"
+    "tabindex",
+    "dampenable",
+    "forgeable",
+    "unstarred",
+    "getcode"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/scripts/contributor_check.py
+++ b/scripts/contributor_check.py
@@ -23,6 +23,7 @@ import math
 import os
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1225,6 +1226,11 @@ def _is_public_org_member(org: str, login: str) -> bool:
         return False
 
 
+# Seconds to wait between successive per-PR detail calls in the maintainer-merged
+# lookup, to stay under GitHub's secondary rate limit. Tests set this to 0.
+_MAINTAINER_LOOKUP_PACE_SECONDS = 0.5
+
+
 def _has_prior_target_contribution(username: str, target_repo: str | None) -> bool:
     """Return True if the user has >=2 merged PRs in the target repo each merged by
     a DISTINCT maintainer (a public member of the target org), other than the author.
@@ -1254,12 +1260,20 @@ def _count_maintainer_merged(
     user's PRs. Capped at ten candidates, early-exit once ``need`` distinct
     maintainers are seen. Fail-closed: an unconfirmed merger, a self-merge, or a
     non-member merger does not count.
+
+    Paces the per-PR detail calls by ``_MAINTAINER_LOOKUP_PACE_SECONDS`` to stay
+    under GitHub's secondary rate limit when a candidate has many merged PRs but
+    few distinct maintainer merges (the no-early-exit path).
     """
     maintainers: set[str] = set()
+    made_api_call = False
     for pr in prs[:10]:
         number = pr.get("number")
         if not number:
             continue
+        if made_api_call and _MAINTAINER_LOOKUP_PACE_SECONDS:
+            time.sleep(_MAINTAINER_LOOKUP_PACE_SECONDS)
+        made_api_call = True
         detail = _api(f"/repos/{target_repo}/pulls/{number}")
         merged_login = ((detail or {}).get("merged_by") or {}).get("login", "")
         if not merged_login or merged_login.lower() == username.lower():

--- a/scripts/contributor_check.py
+++ b/scripts/contributor_check.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import quote
@@ -511,6 +512,14 @@ def check_feature_overlap(username: str, target_repo: str | None = None) -> list
                 if kw in full_text:
                     final_buckets.add(bucket)
                     break
+
+        # A repo that is itself AGED + well-starred (>=1yr, >=10 stars) is a
+        # domain specialist's own mature project, not a fresh clone. Skip it.
+        # The age branch (not the bare 50-star branch) is required so a same-week
+        # star-bought clone cannot suppress its own overlap signal; a young/thin
+        # repo matching the same buckets still fires below.
+        if _is_established_repo_aged(repo):
+            continue
 
         created = datetime.fromisoformat(repo["created_at"].replace("Z", "+00:00"))
         age_days = (now - created).days
@@ -1003,9 +1012,74 @@ def check_contributor(username: str, target_repo: str | None = None) -> Reputati
         for signal in check_feature_overlap(username, target_repo):
             report.add(signal)
 
-    _dampen_for_established_accounts(report, user)
+    # Org-aware + prior-interaction established credibility: a contributor who
+    # CONTRIBUTED to an aged org repo, or already landed maintainer-merged PRs
+    # here, earns credit even with a thin personal account. Fail-closed: any
+    # error in these network paths abstains (credibility from personal signal
+    # only) rather than crashing or granting credit.
+    try:
+        org_backed, _org_evidence = _org_owned_established(username)
+        prior_interaction = _has_prior_target_contribution(username, target_repo)
+    except Exception:
+        org_backed, prior_interaction = False, False
+    established, full_tier = _established_credibility(user, org_backed, prior_interaction)
+
+    _dampen_for_established_accounts(report, user, established=established, full=full_tier)
     report.compute_risk()
+
+    # Maintainer-curated allowlist: a final, auditable escape hatch. It only
+    # SOFTENS the auto-flag (HIGH -> MEDIUM, still surfaced for human review);
+    # it never sets LOW and never bypasses code review. Ships empty.
+    allow_users, allow_orgs = _load_allowlist()
+    if allow_users or allow_orgs:
+        try:
+            _orgs_resp = _api(f"/users/{username}/orgs", {"per_page": "100"})
+        except Exception:
+            _orgs_resp = []
+        user_orgs = (
+            [o.get("login", "") for o in _orgs_resp if isinstance(o, dict)]
+            if isinstance(_orgs_resp, list)
+            else []
+        )
+        if _is_allowlisted(username, user_orgs, (allow_users, allow_orgs)):
+            _apply_allowlist(report)
+
     return report
+
+
+def _apply_allowlist(report: ReputationReport) -> None:
+    """Apply the maintainer allowlist to an already-matched contributor.
+
+    The allowlist only SOFTENS the auto-flag (HIGH -> MEDIUM, still surfaced for
+    human review); it never sets LOW and never bypasses code review. It does NOT
+    apply -- and records the refusal -- when either hard guard that
+    :func:`_dampen_for_established_accounts` enforces is present (SG: abuse
+    cannot be whitewashed):
+
+      * any of the four deliberate-abuse signals, or
+      * a multi-repo split-clone (>=2 ``feature_overlap`` HIGH signals).
+    """
+    abuse = bool({s.name for s in report.signals} & _ABUSE_SIGNALS)
+    split_clone = sum(
+        1 for s in report.signals
+        if s.name == "feature_overlap" and s.severity == "HIGH"
+    ) >= 2
+    if abuse or split_clone:
+        report.add(Signal(
+            name="allowlist_blocked",
+            severity="HIGH",
+            detail="maintainer allowlist NOT applied: "
+                   + ("deliberate-abuse signal present" if abuse
+                      else "multi-repo split-clone pattern present"),
+        ))
+    elif report.risk == "HIGH":
+        report.risk = "MEDIUM"
+        report.add(Signal(
+            name="allowlisted",
+            severity="MEDIUM",
+            detail="maintainer allowlist: auto-flag softened HIGH→MEDIUM "
+                   "(still surfaced; does not bypass code review)",
+        ))
 
 
 # ---------------------------------------------------------------------------
@@ -1019,7 +1093,12 @@ _ABUSE_SIGNALS = frozenset({
     "credential_laundering",
     "coordinated_promotion",
     "self_promotion_spray",
-    "feature_overlap",
+    # NOTE: feature_overlap is intentionally NOT an abuse signal. It measures
+    # domain overlap with this project, which is expected for a domain
+    # specialist and is not a deliberate-abuse pattern. It is dampening-eligible
+    # (see _DAMPEN_RULES) and its own check skips repos that are themselves
+    # established. The four signals above are deliberate abuse and still block
+    # dampening entirely.
 })
 
 # Signals eligible for dampening and the maximum value at which dampening
@@ -1031,7 +1110,23 @@ _DAMPEN_RULES: dict[str, tuple[str, int | None]] = {
     "cross_repo_spray":  ("MEDIUM", 8),     # >8 repos in 7d stays HIGH
     "cross_repo_spread": ("LOW", None),     # always safe to lower
     "awesome_fork_burst": ("MEDIUM", 6),    # >6 awesome forks stays HIGH
+    "feature_overlap": ("MEDIUM", 5),       # single established overlap; >=6/6 buckets stays HIGH
 }
+
+# Signals a PARTIAL credibility tier (org-backed / prior-interaction only, with a
+# thin personal account) is allowed to dampen. Raw volume/velocity bursts are
+# excluded: org/prior history does not vouch for a sudden personal repo/issue
+# burst, so those stay at full severity for a thin-but-org-backed account.
+#
+# NOTE (reviewer-visible by design): for a partial-tier account, a single
+# feature_overlap HIGH (-> MEDIUM) together with a cross_repo_spread MEDIUM
+# (-> LOW) can net to overall LOW. That softening is intentional -- the partial
+# tier exists to vouch for domain overlap -- and it is reachable only by an
+# account that already EARNED the tier (contributor to an aged >=1yr/>=10-star
+# org repo, or >=2 distinct-maintainer merges here), neither of which is cheaply
+# forgeable. Two or more feature_overlap HIGH (a split clone) remain
+# non-dampenable regardless (see _dampen_for_established_accounts).
+_PARTIAL_DAMPEN_SIGNALS = frozenset({"feature_overlap", "cross_repo_spread"})
 
 
 def _is_established(user: dict) -> bool:
@@ -1043,14 +1138,213 @@ def _is_established(user: dict) -> bool:
     return age_days >= 366 and followers >= 50 and public_repos >= 20
 
 
-def _dampen_for_established_accounts(report: ReputationReport, user: dict) -> None:
+def _is_established_repo_aged(repo: dict) -> bool:
+    """Stricter establishment: only the AGE branch (>=1yr old AND >=10 stars).
+
+    Used where star-count alone is too cheap to trust (org-credibility grant and
+    the feature_overlap source-skip). A same-week star-bought repo cannot
+    qualify -- only one that has existed >=1 year with sustained traction.
+    """
+    stars = repo.get("stargazers_count", 0)
+    created = repo.get("created_at", "")
+    if not created or stars < 10:
+        return False
+    try:
+        age = (datetime.now(timezone.utc) - datetime.fromisoformat(
+            created.replace("Z", "+00:00")
+        )).days
+    except (ValueError, TypeError):
+        return False
+    return age >= 365
+
+
+def _user_contributed_to(owner: str, repo_name: str, username: str) -> bool:
+    """Return True if ``username`` appears in the repo's contributor list.
+
+    Guards org-credibility against "member of an org that owns a repo I did not
+    build" and mirror-a-popular-repo: org credit requires the user to actually
+    be a contributor to the established repo. Fail-closed on error.
+    """
+    contributors = _api(f"/repos/{owner}/{repo_name}/contributors", {"per_page": "100"})
+    if not isinstance(contributors, list):
+        return False
+    uname = username.lower()
+    return any(
+        isinstance(c, dict) and str(c.get("login", "")).lower() == uname
+        for c in contributors
+    )
+
+
+def _org_owned_established(username: str) -> tuple[bool, str]:
+    """Return (True, evidence) if the user is a CONTRIBUTOR to an AGED, well-starred
+    repo owned by an org they publicly belong to.
+
+    Hardened against cheap forgery (SG: star-buying / mirror-into-org): the repo
+    must pass ``_is_established_repo_aged`` (>=1yr old AND >=10 stars, so same-week
+    star-buying cannot qualify) AND the user must appear in that repo's
+    contributors (so merely belonging to an org that owns someone else's repo, or
+    mirroring a popular project, grants no credit). Only PUBLIC org memberships
+    are visible; a concealed membership yields no credit (UNKNOWN, not negative).
+    """
+    orgs = _api(f"/users/{username}/orgs", {"per_page": "100"})
+    if not isinstance(orgs, list):
+        return False, ""
+    for org in orgs[:10]:
+        login = org.get("login")
+        if not login:
+            continue
+        repos = _api(f"/orgs/{login}/repos", {"per_page": "100", "sort": "pushed"})
+        if not isinstance(repos, list):
+            continue
+        for repo in repos[:50]:
+            name = repo.get("name")
+            if (not repo.get("fork") and name and _is_established_repo_aged(repo)
+                    and _user_contributed_to(login, name, username)):
+                stars = repo.get("stargazers_count", 0)
+                return True, f"{login}/{name} ({stars} stars)"
+    return False, ""
+
+
+def _is_public_org_member(org: str, login: str) -> bool:
+    """Return True if ``login`` is a PUBLIC member of ``org``.
+
+    The public-members membership endpoint returns HTTP 204 for a member and 404
+    otherwise, with no JSON body -- so it cannot go through ``_api`` (which parses
+    JSON). Fail-closed: any error or non-204 status -> False.
+    """
+    if not org or not login:
+        return False
+    req = Request(f"https://api.github.com/orgs/{org}/public_members/{login}")
+    req.add_header("Authorization", f"Bearer {_get_token()}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    try:
+        with urlopen(req, timeout=15) as resp:
+            return getattr(resp, "status", resp.getcode()) == 204
+    except Exception:
+        return False
+
+
+def _has_prior_target_contribution(username: str, target_repo: str | None) -> bool:
+    """Return True if the user has >=2 merged PRs in the target repo each merged by
+    a DISTINCT maintainer (a public member of the target org), other than the author.
+
+    Hardened against the 2-account merge ring (SG): "merged_by != author" is not
+    enough -- the merger must be a public org member (a real maintainer), and the
+    two qualifying merges must be by DISTINCT maintainers. A sock-puppet that
+    merged a colluder's PR is not an org member, so the ring no longer
+    manufactures credibility. Bare COLLABORATOR association is no longer a
+    fast-path (it is grantable and the weakest role).
+    """
+    if not target_repo or "/" not in target_repo:
+        return False
+    target_org = target_repo.split("/")[0]
+    prs = _search_issues(
+        f"repo:{target_repo} author:{username} is:pr is:merged", per_page=10
+    )
+    if not prs:
+        return False
+    return _count_maintainer_merged(target_repo, target_org, username, prs, need=2) >= 2
+
+
+def _count_maintainer_merged(
+    target_repo: str, target_org: str, username: str, prs: list[dict], need: int
+) -> int:
+    """Count distinct maintainers (public org members != author) who merged the
+    user's PRs. Capped at ten candidates, early-exit once ``need`` distinct
+    maintainers are seen. Fail-closed: an unconfirmed merger, a self-merge, or a
+    non-member merger does not count.
+    """
+    maintainers: set[str] = set()
+    for pr in prs[:10]:
+        number = pr.get("number")
+        if not number:
+            continue
+        detail = _api(f"/repos/{target_repo}/pulls/{number}")
+        merged_login = ((detail or {}).get("merged_by") or {}).get("login", "")
+        if not merged_login or merged_login.lower() == username.lower():
+            continue
+        if merged_login.lower() in maintainers:
+            continue
+        if _is_public_org_member(target_org, merged_login):
+            maintainers.add(merged_login.lower())
+            if len(maintainers) >= need:
+                break
+    return len(maintainers)
+
+
+def _established_credibility(
+    user: dict, org_backed: bool = False, prior_interaction: bool = False
+) -> tuple[bool, bool]:
+    """Return ``(credible, full_tier)``.
+
+    ``full_tier`` is True only for the personal ``_is_established`` signal, which
+    vouches for the whole account. ``org_backed`` / ``prior_interaction`` are a
+    PARTIAL tier: real but narrower credibility that dampens domain-overlap and
+    spread signals but NOT raw volume/velocity bursts (which they do not speak
+    to). ``credible`` is True if any signal holds.
+    """
+    full = _is_established(user)
+    credible = full or org_backed or prior_interaction
+    return credible, full
+
+
+_ALLOWLIST_PATH = Path(__file__).resolve().parent / "contributor_check_allowlist.json"
+
+
+def _load_allowlist(path: "Path | None" = None) -> tuple[set[str], set[str]]:
+    """Load the maintainer-curated allowlist of trusted users and orgs.
+
+    Returns ``(users, orgs)`` as lowercased sets. A missing or invalid file
+    yields empty sets (fail-closed: an absent allowlist grants no exemption).
+    The allowlist only downgrades the auto-flag; it never bypasses code review.
+    """
+    p = path or _ALLOWLIST_PATH
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set(), set()
+    users = {str(u).lower() for u in data.get("users", []) if isinstance(u, str)}
+    orgs = {str(o).lower() for o in data.get("orgs", []) if isinstance(o, str)}
+    return users, orgs
+
+
+def _is_allowlisted(
+    username: str, user_orgs: list[str], allowlist: tuple[set[str], set[str]]
+) -> bool:
+    """Return True if the user, or one of their orgs, is on the allowlist."""
+    users, orgs = allowlist
+    if username.lower() in users:
+        return True
+    return any(o.lower() in orgs for o in user_orgs)
+
+
+def _dampen_for_established_accounts(
+    report: ReputationReport,
+    user: dict,
+    *,
+    established: "bool | None" = None,
+    full: bool = True,
+) -> None:
     """Down-grade volume/activity signals for accounts with organic credibility.
 
-    Dampening is skipped entirely when abuse-pattern signals (credential
-    laundering, coordinated promotion, etc.) are present, so mature but
-    compromised accounts are not whitewashed.
+    ``established`` lets the caller pass a richer org/prior-interaction-aware
+    credibility verdict (see ``_established_credibility``). When omitted it
+    falls back to the personal ``_is_established`` check, preserving the prior
+    behavior and call signature (``full`` defaults to True).
+
+    ``full=False`` selects the PARTIAL tier (org-backed / prior-interaction with
+    a thin personal account): only ``_PARTIAL_DAMPEN_SIGNALS`` are eligible, so
+    raw volume/velocity bursts stay at full severity.
+
+    Two hard guards (SG: abuse cannot be whitewashed):
+      * any of the four deliberate-abuse signals present -> dampen nothing;
+      * two or more distinct ``feature_overlap`` HIGH signals (a split, multi-repo
+        clone) -> ``feature_overlap`` is non-dampenable and stays HIGH.
     """
-    if not _is_established(user):
+    if established is None:
+        established = _is_established(user)
+    if not established:
         return
 
     # If any abuse-pattern signal exists, skip dampening entirely
@@ -1058,10 +1352,21 @@ def _dampen_for_established_accounts(report: ReputationReport, user: dict) -> No
     if signal_names & _ABUSE_SIGNALS:
         return
 
+    # Multi-repo split-clone: two or more feature_overlap HIGH signals are treated
+    # as abuse and are NOT dampened (a single overlap is the legit-specialist case).
+    overlap_high = sum(
+        1 for s in report.signals if s.name == "feature_overlap" and s.severity == "HIGH"
+    )
+    multi_overlap = overlap_high >= 2
+
     for signal in report.signals:
         rule = _DAMPEN_RULES.get(signal.name)
         if rule is None:
             continue
+        if not full and signal.name not in _PARTIAL_DAMPEN_SIGNALS:
+            continue  # partial tier does not vouch for volume/velocity bursts
+        if signal.name == "feature_overlap" and multi_overlap:
+            continue  # split-clone stays HIGH
         new_severity, max_value = rule
         if max_value is not None and signal.value is not None and signal.value > max_value:
             continue  # extreme value, keep original severity

--- a/scripts/contributor_check_allowlist.json
+++ b/scripts/contributor_check_allowlist.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Maintainer-curated allowlist for the contributor reputation check. Entries here ONLY downgrade the automated risk flag to LOW; they NEVER bypass code review or branch protection. Add a username to 'users' or an org login to 'orgs' (case-insensitive) when a known-good contributor is repeatedly mis-flagged by the heuristic. Each addition should be made by a maintainer in a reviewable commit with a rationale in the PR description. Ships empty by design.",
+  "_comment": "Maintainer-curated allowlist for the contributor reputation check. Entries here ONLY soften an automated HIGH flag to MEDIUM (still surfaced for human review); they NEVER set LOW and NEVER bypass code review or branch protection. The softening is REFUSED (recorded as an 'allowlist_blocked' signal) when a deliberate-abuse signal or a multi-repo split-clone is present, so the allowlist cannot rescue an actively abusive contributor. Add a username to 'users' or an org login to 'orgs' (case-insensitive) when a known-good contributor is repeatedly mis-flagged by the heuristic. Each addition should be made by a maintainer in a reviewable commit with a rationale in the PR description. Ships empty by design.",
   "users": [],
   "orgs": []
 }

--- a/scripts/contributor_check_allowlist.json
+++ b/scripts/contributor_check_allowlist.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Maintainer-curated allowlist for the contributor reputation check. Entries here ONLY downgrade the automated risk flag to LOW; they NEVER bypass code review or branch protection. Add a username to 'users' or an org login to 'orgs' (case-insensitive) when a known-good contributor is repeatedly mis-flagged by the heuristic. Each addition should be made by a maintainer in a reviewable commit with a rationale in the PR description. Ships empty by design.",
+  "users": [],
+  "orgs": []
+}

--- a/scripts/tests/test_contributor_check.py
+++ b/scripts/tests/test_contributor_check.py
@@ -3,6 +3,9 @@
 # Licensed under the MIT License.
 """Tests for contributor_check.py."""
 
+# Synthetic GitHub usernames/org logins used only as test fixtures below.
+# cspell:ignore myorg trustedorg randomorg freshclone
+
 from __future__ import annotations
 
 import json

--- a/scripts/tests/test_contributor_check.py
+++ b/scripts/tests/test_contributor_check.py
@@ -28,6 +28,9 @@ from contributor_check import (
     _check_batch_naming,
     _check_self_promotion,
     _fork_has_outgoing_pr,
+    _apply_allowlist,
+    _is_allowlisted,
+    _load_allowlist,
 )
 
 
@@ -667,3 +670,137 @@ class TestFalsePositiveRegression:
         ]
         signals = _check_self_promotion("dev", issues, user_repos)
         assert len(signals) == 0
+
+
+# ---------------------------------------------------------------------------
+# feature_overlap: established repo skip (Phase 2)
+# ---------------------------------------------------------------------------
+
+class TestFeatureOverlapEstablishedSkip:
+    def _repo(self, name, stars, days):
+        # Description spans 4 AGT feature buckets (mcp_security, policy_engine,
+        # identity_crypto, runtime_controls).
+        return {
+            "name": name,
+            "description": "mcp security policy engine ed25519 kill switch",
+            "topics": [],
+            "fork": False,
+            "created_at": (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "stargazers_count": stars,
+        }
+
+    def test_skips_established_repo(self):
+        """A mature, well-starred domain repo is expertise, not cloning."""
+        repo = self._repo("flagship", stars=60, days=400)
+
+        def fake_api(path, params=None):
+            if path == "/users/spec/repos":
+                return [repo]
+            return None  # readme fetch -> none
+
+        with patch("contributor_check._api", side_effect=fake_api):
+            signals = check_feature_overlap("spec", "microsoft/agent-governance-toolkit")
+        assert all(s.name != "feature_overlap" for s in signals)
+
+    def test_fires_on_thin_repo(self):
+        """A young, unstarred repo matching the same buckets still fires HIGH."""
+        repo = self._repo("freshclone", stars=0, days=5)
+
+        def fake_api(path, params=None):
+            if path == "/users/clone/repos":
+                return [repo]
+            return None
+
+        with patch("contributor_check._api", side_effect=fake_api):
+            signals = check_feature_overlap("clone", "microsoft/agent-governance-toolkit")
+        overlap = [s for s in signals if s.name == "feature_overlap"]
+        assert overlap and overlap[0].severity == "HIGH"
+
+
+# ---------------------------------------------------------------------------
+# Maintainer allowlist (Phase 3)
+# ---------------------------------------------------------------------------
+
+class TestAllowlist:
+    def test_load_reads_users_and_orgs(self, tmp_path):
+        p = tmp_path / "al.json"
+        p.write_text('{"users": ["Alice"], "orgs": ["MyOrg"]}', encoding="utf-8")
+        users, orgs = _load_allowlist(p)
+        assert users == {"alice"}
+        assert orgs == {"myorg"}
+
+    def test_load_missing_file_is_empty(self, tmp_path):
+        users, orgs = _load_allowlist(tmp_path / "nope.json")
+        assert users == set()
+        assert orgs == set()
+
+    def test_load_invalid_json_is_empty(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{not json", encoding="utf-8")
+        assert _load_allowlist(p) == (set(), set())
+
+    def test_is_allowlisted_user(self):
+        assert _is_allowlisted("Alice", [], ({"alice"}, set())) is True
+
+    def test_is_allowlisted_org(self):
+        assert _is_allowlisted("bob", ["TrustedOrg"], (set(), {"trustedorg"})) is True
+
+    def test_not_allowlisted(self):
+        assert _is_allowlisted("mallory", ["randomorg"], ({"alice"}, {"trustedorg"})) is False
+
+    def test_shipped_allowlist_is_empty(self):
+        """The committed allowlist ships EMPTY -- no self-exemption."""
+        users, orgs = _load_allowlist()  # default path: scripts/contributor_check_allowlist.json
+        assert users == set()
+        assert orgs == set()
+
+
+class TestApplyAllowlist:
+    """The allowlist only SOFTENS (HIGH->MEDIUM); it never sets LOW and never
+    whitewashes a deliberate-abuse signal or a multi-repo split-clone."""
+
+    @staticmethod
+    def _report(*signals: Signal) -> ReputationReport:
+        report = ReputationReport(username="trusted")
+        for s in signals:
+            report.add(s)
+        report.compute_risk()
+        return report
+
+    def test_softens_high_to_medium(self):
+        # Two non-abuse HIGH signals -> HIGH; allowlist softens to MEDIUM.
+        report = self._report(
+            Signal(name="repo_velocity", severity="HIGH", detail=""),
+            Signal(name="new_account_burst", severity="HIGH", detail=""),
+        )
+        assert report.risk == "HIGH"
+        _apply_allowlist(report)
+        assert report.risk == "MEDIUM"
+        assert any(s.name == "allowlisted" for s in report.signals)
+
+    def test_never_sets_low(self):
+        # A single non-abuse HIGH signal is only MEDIUM; allowlist leaves it,
+        # never downgrading to LOW.
+        report = self._report(Signal(name="repo_velocity", severity="HIGH", detail=""))
+        assert report.risk == "MEDIUM"
+        _apply_allowlist(report)
+        assert report.risk == "MEDIUM"
+
+    def test_blocked_by_deliberate_abuse_signal(self):
+        report = self._report(
+            Signal(name="thin_credibility", severity="HIGH", detail=""),
+            Signal(name="repo_velocity", severity="HIGH", detail=""),
+        )
+        _apply_allowlist(report)
+        assert report.risk == "HIGH"
+        assert any(s.name == "allowlist_blocked" for s in report.signals)
+        assert not any(s.name == "allowlisted" for s in report.signals)
+
+    def test_blocked_by_split_clone(self):
+        report = self._report(
+            Signal(name="feature_overlap", severity="HIGH", detail=""),
+            Signal(name="feature_overlap", severity="HIGH", detail=""),
+        )
+        _apply_allowlist(report)
+        assert report.risk == "HIGH"
+        assert any(s.name == "allowlist_blocked" for s in report.signals)

--- a/scripts/tests/test_contributor_dampening.py
+++ b/scripts/tests/test_contributor_dampening.py
@@ -3,12 +3,15 @@
 # Licensed under the MIT License.
 """Tests for established-account dampening in contributor_check.py."""
 
+# Synthetic GitHub usernames/org logins used only as test fixtures below.
+# cspell:ignore someoneelse freshorg freerider bigorg realauthor sockpuppet orgbacked splitcloner maint
+
 from __future__ import annotations
 
 import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -24,6 +27,14 @@ from contributor_check import (
     _is_established,
     _org_owned_established,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_api_pacing(monkeypatch):
+    """Zero the maintainer-lookup API pacing so unit tests do not sleep."""
+    monkeypatch.setattr(
+        "contributor_check._MAINTAINER_LOOKUP_PACE_SECONDS", 0, raising=False
+    )
 
 
 def _make_user(age_days: int = 2000, followers: int = 200, public_repos: int = 50) -> dict:
@@ -313,6 +324,33 @@ class TestPriorTargetContribution:
 
     def test_false_without_target(self):
         assert _has_prior_target_contribution("dev", None) is False
+
+    def test_paces_between_pr_detail_calls(self):
+        """Per-PR detail calls are paced (sleep BETWEEN calls), but never before
+        the first call. Non-member mergers force the no-early-exit path so all
+        three PRs are looked up -> exactly two pacing sleeps."""
+        prs = self._prs(3)
+        sleep_mock = MagicMock()
+        with patch("contributor_check._search_issues", return_value=prs), \
+             patch("contributor_check._api", return_value={"merged_by": {"login": "x"}}), \
+             patch("contributor_check._is_public_org_member", return_value=False), \
+             patch("contributor_check._MAINTAINER_LOOKUP_PACE_SECONDS", 0.5), \
+             patch("contributor_check.time.sleep", sleep_mock):
+            assert _has_prior_target_contribution("dev", self.TARGET) is False
+        assert sleep_mock.call_count == 2
+        sleep_mock.assert_called_with(0.5)
+
+    def test_no_pacing_for_single_pr(self):
+        """A single PR lookup makes one API call and never paces."""
+        prs = self._prs(1)
+        sleep_mock = MagicMock()
+        with patch("contributor_check._search_issues", return_value=prs), \
+             patch("contributor_check._api", return_value={"merged_by": {"login": "x"}}), \
+             patch("contributor_check._is_public_org_member", return_value=False), \
+             patch("contributor_check._MAINTAINER_LOOKUP_PACE_SECONDS", 0.5), \
+             patch("contributor_check.time.sleep", sleep_mock):
+            assert _has_prior_target_contribution("dev", self.TARGET) is False
+        assert sleep_mock.call_count == 0
 
 
 class TestEstablishedCredibility:

--- a/scripts/tests/test_contributor_dampening.py
+++ b/scripts/tests/test_contributor_dampening.py
@@ -19,7 +19,10 @@ from contributor_check import (
     ReputationReport,
     Signal,
     _dampen_for_established_accounts,
+    _established_credibility,
+    _has_prior_target_contribution,
     _is_established,
+    _org_owned_established,
 )
 
 
@@ -184,3 +187,264 @@ class TestDampening:
         assert report.signals[1].severity == "MEDIUM"
         assert report.risk != "HIGH"
         assert report.risk == "LOW"  # 0 HIGH, 1 MEDIUM -> LOW
+
+
+# ---------------------------------------------------------------------------
+# Org-aware + prior-interaction established credibility (Phase 1)
+# ---------------------------------------------------------------------------
+
+def _recent_iso(days: int = 10) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _aged_iso(days: int = 800) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TestOrgOwnedEstablished:
+    def test_true_when_aged_repo_and_user_contributed(self):
+        def fake_api(path, params=None):
+            if path == "/users/consolidator/orgs":
+                return [{"login": "myorg"}]
+            if path == "/orgs/myorg/repos":
+                return [{"name": "flagship", "stargazers_count": 40,
+                         "fork": False, "created_at": _aged_iso(800)}]
+            if path == "/repos/myorg/flagship/contributors":
+                return [{"login": "someoneelse"}, {"login": "Consolidator"}]
+            return []
+        with patch("contributor_check._api", side_effect=fake_api):
+            ok, evidence = _org_owned_established("consolidator")
+        assert ok is True
+        assert "myorg/flagship" in evidence
+
+    def test_false_when_repo_not_aged(self):
+        """60 stars but created this week: fails the age branch (star-buying guard)."""
+        def fake_api(path, params=None):
+            if path == "/users/promo/orgs":
+                return [{"login": "freshorg"}]
+            if path == "/orgs/freshorg/repos":
+                return [{"name": "bought", "stargazers_count": 60,
+                         "fork": False, "created_at": _recent_iso(5)}]
+            return []
+        with patch("contributor_check._api", side_effect=fake_api):
+            ok, _ = _org_owned_established("promo")
+        assert ok is False
+
+    def test_false_when_user_not_contributor(self):
+        """Aged, well-starred org repo but the user is NOT a contributor
+        (mirror-a-famous-repo guard)."""
+        def fake_api(path, params=None):
+            if path == "/users/freerider/orgs":
+                return [{"login": "bigorg"}]
+            if path == "/orgs/bigorg/repos":
+                return [{"name": "famous", "stargazers_count": 5000,
+                         "fork": False, "created_at": _aged_iso(1500)}]
+            if path == "/repos/bigorg/famous/contributors":
+                return [{"login": "realauthor"}]
+            return []
+        with patch("contributor_check._api", side_effect=fake_api):
+            ok, _ = _org_owned_established("freerider")
+        assert ok is False
+
+    def test_false_when_no_orgs(self):
+        with patch("contributor_check._api", return_value=[]):
+            ok, _ = _org_owned_established("loner")
+        assert ok is False
+
+
+class TestPriorTargetContribution:
+    TARGET = "microsoft/agent-governance-toolkit"
+
+    def _prs(self, n):
+        return [{"number": i, "author_association": "CONTRIBUTOR"} for i in range(1, n + 1)]
+
+    def test_true_two_distinct_maintainer_merges(self):
+        prs = self._prs(2)
+
+        def fake_api(path, params=None):
+            if path == f"/repos/{self.TARGET}/pulls/1":
+                return {"merged_by": {"login": "maintA"}}
+            if path == f"/repos/{self.TARGET}/pulls/2":
+                return {"merged_by": {"login": "maintB"}}
+            return None
+
+        with patch("contributor_check._search_issues", return_value=prs), \
+             patch("contributor_check._api", side_effect=fake_api), \
+             patch("contributor_check._is_public_org_member", return_value=True):
+            assert _has_prior_target_contribution("dev", self.TARGET) is True
+
+    def test_false_single_maintainer_merge(self):
+        prs = self._prs(1)
+        with patch("contributor_check._search_issues", return_value=prs), \
+             patch("contributor_check._api", return_value={"merged_by": {"login": "maintA"}}), \
+             patch("contributor_check._is_public_org_member", return_value=True):
+            assert _has_prior_target_contribution("dev", self.TARGET) is False
+
+    def test_false_merger_not_org_member(self):
+        """Sock-puppet-ring defense: non-member mergers do not count."""
+        prs = self._prs(2)
+
+        def fake_api(path, params=None):
+            return {"merged_by": {"login": "sockpuppet"}}
+
+        with patch("contributor_check._search_issues", return_value=prs), \
+             patch("contributor_check._api", side_effect=fake_api), \
+             patch("contributor_check._is_public_org_member", return_value=False):
+            assert _has_prior_target_contribution("dev", self.TARGET) is False
+
+    def test_false_same_maintainer_twice(self):
+        """Distinct-maintainer requirement: same merger on both PRs counts once."""
+        prs = self._prs(2)
+        with patch("contributor_check._search_issues", return_value=prs), \
+             patch("contributor_check._api", return_value={"merged_by": {"login": "maintA"}}), \
+             patch("contributor_check._is_public_org_member", return_value=True):
+            assert _has_prior_target_contribution("dev", self.TARGET) is False
+
+    def test_false_self_merged(self):
+        prs = self._prs(2)
+        with patch("contributor_check._search_issues", return_value=prs), \
+             patch("contributor_check._api", return_value={"merged_by": {"login": "dev"}}), \
+             patch("contributor_check._is_public_org_member", return_value=True):
+            assert _has_prior_target_contribution("dev", self.TARGET) is False
+
+    def test_false_when_none(self):
+        with patch("contributor_check._search_issues", return_value=[]):
+            assert _has_prior_target_contribution("dev", self.TARGET) is False
+
+    def test_false_without_target(self):
+        assert _has_prior_target_contribution("dev", None) is False
+
+
+class TestEstablishedCredibility:
+    def test_personal_established_full_tier(self):
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        assert _established_credibility(user) == (True, True)
+
+    def test_org_backed_is_partial_tier(self):
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        assert _established_credibility(user, org_backed=True) == (True, False)
+
+    def test_prior_interaction_is_partial_tier(self):
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        assert _established_credibility(user, prior_interaction=True) == (True, False)
+
+    def test_none_not_credible(self):
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        assert _established_credibility(user) == (False, False)
+
+
+class TestDampenFullTier:
+    def test_explicit_established_dampens_thin_personal_account(self):
+        report = ReputationReport(username="consolidator")
+        report.add(Signal(name="recent_repo_burst", severity="HIGH",
+                          detail="20 repos in 90 days", value=20))
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        assert _is_established(user) is False
+        _dampen_for_established_accounts(report, user, established=True, full=True)
+        assert report.signals[0].severity == "LOW"
+
+    def test_backward_compatible_default(self):
+        report = ReputationReport(username="established")
+        report.add(Signal(name="recent_repo_burst", severity="HIGH",
+                          detail="20 repos in 90 days", value=20))
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        _dampen_for_established_accounts(report, user)  # no established=/full=
+        assert report.signals[0].severity == "LOW"
+
+    def test_explicit_false_blocks_dampening(self):
+        report = ReputationReport(username="x")
+        report.add(Signal(name="recent_repo_burst", severity="HIGH",
+                          detail="20 repos", value=20))
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        _dampen_for_established_accounts(report, user, established=False)
+        assert report.signals[0].severity == "HIGH"
+
+
+class TestPartialTier:
+    def test_partial_does_not_dampen_volume_burst(self):
+        """Org/prior credibility does NOT vouch for a sudden volume burst."""
+        report = ReputationReport(username="orgbacked")
+        report.add(Signal(name="recent_repo_burst", severity="HIGH", detail="20", value=20))
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        _dampen_for_established_accounts(report, user, established=True, full=False)
+        assert report.signals[0].severity == "HIGH"
+
+    def test_partial_dampens_single_feature_overlap(self):
+        report = ReputationReport(username="specialist")
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="4/6", value=4))
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        _dampen_for_established_accounts(report, user, established=True, full=False)
+        assert report.signals[0].severity == "MEDIUM"
+
+
+class TestFeatureOverlapDampening:
+    def test_single_overlap_dampened_full_tier(self):
+        report = ReputationReport(username="specialist")
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="4/6", value=4))
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        _dampen_for_established_accounts(report, user, established=True, full=True)
+        assert report.signals[0].severity == "MEDIUM"
+
+    def test_multi_overlap_stays_high(self):
+        """Two-plus feature_overlap HIGH = split multi-repo clone -> non-dampenable."""
+        report = ReputationReport(username="splitcloner")
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="repoA 4/6", value=4))
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="repoB 5/6", value=5))
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        _dampen_for_established_accounts(report, user, established=True, full=True)
+        assert all(s.severity == "HIGH" for s in report.signals)
+
+    def test_single_overlap_no_longer_blocks_burst(self):
+        report = ReputationReport(username="specialist")
+        report.add(Signal(name="recent_repo_burst", severity="HIGH", detail="20", value=20))
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="4/6", value=4))
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        _dampen_for_established_accounts(report, user, established=True, full=True)
+        burst = next(s for s in report.signals if s.name == "recent_repo_burst")
+        assert burst.severity == "LOW"
+
+    def test_six_bucket_overlap_stays_high(self):
+        report = ReputationReport(username="cloner")
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="6/6", value=6))
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        _dampen_for_established_accounts(report, user, established=True, full=True)
+        assert report.signals[0].severity == "HIGH"
+
+    def test_real_abuse_still_blocks_dampening(self):
+        report = ReputationReport(username="abuser")
+        report.add(Signal(name="recent_repo_burst", severity="HIGH", detail="20", value=20))
+        report.add(Signal(name="credential_laundering", severity="HIGH", detail="x"))
+        user = _make_user(age_days=2000, followers=200, public_repos=50)
+        _dampen_for_established_accounts(report, user, established=True, full=True)
+        burst = next(s for s in report.signals if s.name == "recent_repo_burst")
+        assert burst.severity == "HIGH"
+
+
+class TestDomainSpecialistIntegration:
+    def test_single_overlap_partial_credibility_not_high(self):
+        """Domain specialist: ONE overlapping repo + partial credibility -> not HIGH."""
+        report = ReputationReport(username="specialist")
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="repoA 4/6", value=4))
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        _dampen_for_established_accounts(report, user, established=True, full=False)
+        report.compute_risk()
+        assert report.risk != "HIGH"
+
+    def test_multi_overlap_stays_high_even_credible(self):
+        """Split multi-repo clone stays HIGH even for a credible account."""
+        report = ReputationReport(username="splitcloner")
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="repoA 4/6", value=4))
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="repoB 5/6", value=5))
+        user = _make_user(age_days=2000, followers=11, public_repos=3)
+        _dampen_for_established_accounts(report, user, established=True, full=False)
+        report.compute_risk()
+        assert report.risk == "HIGH"
+
+    def test_throwaway_promoter_still_high(self):
+        report = ReputationReport(username="throwaway")
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="repoA 4/6", value=4))
+        report.add(Signal(name="feature_overlap", severity="HIGH", detail="repoB 5/6", value=5))
+        user = _make_user(age_days=20, followers=0, public_repos=3)
+        _dampen_for_established_accounts(report, user, established=False)
+        report.compute_risk()
+        assert report.risk == "HIGH"

--- a/scripts/tests/test_contributor_scenarios.py
+++ b/scripts/tests/test_contributor_scenarios.py
@@ -20,6 +20,9 @@ The router raises on any unexpected path, so a missing mock can never fall
 through to a live network call.
 """
 
+# Synthetic GitHub usernames/org logins used only as test fixtures below.
+# cspell:ignore myorg someoneelse freshorg selfmerge
+
 from __future__ import annotations
 
 import sys
@@ -27,9 +30,19 @@ import os
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from contributor_check import check_contributor
+
+
+@pytest.fixture(autouse=True)
+def _no_api_pacing(monkeypatch):
+    """Zero the maintainer-lookup API pacing so end-to-end tests do not sleep."""
+    monkeypatch.setattr(
+        "contributor_check._MAINTAINER_LOOKUP_PACE_SECONDS", 0, raising=False
+    )
 
 
 def _iso(days_ago: int) -> str:

--- a/scripts/tests/test_contributor_scenarios.py
+++ b/scripts/tests/test_contributor_scenarios.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""End-to-end PoC scenarios for the org-aware contributor-reputation check.
+
+Each scenario drives the FULL ``check_contributor`` pipeline (all signal
+checkers + credibility + dampening + allowlist + compute_risk) against a
+synthetic GitHub persona, patching only ``_api`` (which ``_search_issues`` calls
+through), ``_is_public_org_member`` (a status-only call outside ``_api``), and,
+where relevant, ``_load_allowlist``. They prove, end to end:
+
+  S1  aged-repo + org-backed specialist        -> NOT HIGH  (mature repos source-skipped; org credit earned)
+  S2  throwaway promoter                        -> HIGH      (true positive kept)
+  S3  manufactured thin promo org               -> HIGH      (org credit needs an AGED, contributed repo)
+  S4  self-merged-only PR history               -> HIGH      (self-merge grants no credibility)
+  S5  maintainer-allowlisted split-clone         -> HIGH      (allowlist never whitewashes abuse)
+  S6  established account + real abuse signal    -> HIGH      (abuse still blocks dampening)
+
+The router raises on any unexpected path, so a missing mock can never fall
+through to a live network call.
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from contributor_check import check_contributor
+
+
+def _iso(days_ago: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# 4-bucket governance description (mcp_security, policy_engine, identity_crypto, runtime_controls)
+_BUCKET_DESC = "mcp security policy engine ed25519 kill switch"
+
+
+def _repo(name, *, stars, days, desc=_BUCKET_DESC, fork=False, owner="u"):
+    return {
+        "name": name,
+        "full_name": f"{owner}/{name}",
+        "description": desc,
+        "topics": [],
+        "fork": fork,
+        "created_at": _iso(days),
+        "stargazers_count": stars,
+        "language": "Python",
+    }
+
+
+TARGET = "microsoft/agent-governance-toolkit"
+
+
+class _FakeGitHub:
+    """Path-routing fake for ``_api`` (covers ``_search_issues`` via /search/issues)."""
+
+    def __init__(self, *, username, user, repos, orgs=None, org_repos=None,
+                 contributors=None, issues=None, merged_prs=None, pull_details=None):
+        self.username = username
+        self.user = user
+        self.repos = repos
+        self.orgs = orgs or []
+        self.org_repos = org_repos or {}
+        self.contributors = contributors or {}   # "owner/name" -> [logins]
+        self.issues = issues or []
+        self.merged_prs = merged_prs or []
+        self.pull_details = pull_details or {}
+
+    def api(self, path, params=None):
+        if path == "/search/issues":
+            q = (params or {}).get("q", "")
+            if "is:pr is:merged" in q:
+                return {"items": self.merged_prs}
+            if "is:issue" in q:
+                return {"items": self.issues}
+            return {"items": []}
+        if path == f"/users/{self.username}":
+            return self.user
+        if path == f"/users/{self.username}/repos":
+            return self.repos
+        if path == f"/users/{self.username}/orgs":
+            return self.orgs
+        if path.startswith("/orgs/") and path.endswith("/repos"):
+            return self.org_repos.get(path[len("/orgs/"):-len("/repos")], [])
+        if path.startswith("/repos/") and path.endswith("/contributors"):
+            slug = path[len("/repos/"):-len("/contributors")]
+            return [{"login": x} for x in self.contributors.get(slug, [])]
+        if path.startswith(f"/repos/{TARGET}/pulls/"):
+            return self.pull_details.get(int(path.rsplit("/", 1)[1]))
+        if path.endswith("/readme"):
+            return None
+        if path.startswith("/repos/") and path.endswith("/pulls"):
+            return []
+        raise AssertionError(f"unexpected API path in scenario: {path}")
+
+
+def _run(fake: _FakeGitHub, *, org_members=(), allowlist=(frozenset(), frozenset())):
+    members = {m.lower() for m in org_members}
+    with patch("contributor_check._api", side_effect=fake.api), \
+         patch("contributor_check._is_public_org_member",
+               side_effect=lambda org, login: login.lower() in members), \
+         patch("contributor_check._load_allowlist", return_value=allowlist):
+        return check_contributor(fake.username, TARGET)
+
+
+# ---------------------------------------------------------------------------
+# Fixed false positives (NOT HIGH)
+# ---------------------------------------------------------------------------
+
+def test_s1_aged_repo_org_backed_specialist_not_high():
+    """A domain specialist whose own repos are AGED + well-starred (source-skipped
+    by feature_overlap) and who contributed to an aged repo in their org. No HIGH
+    signals -> NOT HIGH. Exercises _is_established_repo_aged source-skip and
+    _org_owned_established (aged repo + contributor)."""
+    fake = _FakeGitHub(
+        username="specialist",
+        user={"login": "specialist", "created_at": _iso(800), "public_repos": 3,
+              "followers": 11, "following": 20, "name": "Dev", "bio": "governance"},
+        repos=[_repo("mature-gov", stars=40, days=600, owner="specialist")],
+        orgs=[{"login": "myorg"}],
+        org_repos={"myorg": [_repo("flagship", stars=80, days=700, owner="myorg")]},
+        contributors={"myorg/flagship": ["someoneelse", "specialist"]},
+        issues=[], merged_prs=[],
+    )
+    report = _run(fake)
+    assert report.risk != "HIGH", [s.name + ":" + s.severity for s in report.signals]
+
+
+def test_s5_allowlist_does_not_whitewash_split_clone():
+    """A maintainer-allowlisted user who is ALSO a split-clone (>=2 feature_overlap
+    HIGH) stays HIGH. The allowlist softens residual false-positives; it never
+    whitewashes an abuse pattern, and it records the refusal for audit."""
+    fake = _FakeGitHub(
+        username="trusted",
+        user={"login": "trusted", "created_at": _iso(40), "public_repos": 3,
+              "followers": 0, "following": 0, "name": "", "bio": ""},
+        repos=[_repo("clone-a", stars=0, days=10, owner="trusted"),
+               _repo("clone-b", stars=0, days=8, owner="trusted")],
+        orgs=[], issues=[], merged_prs=[],
+    )
+    report = _run(fake, allowlist=({"trusted"}, frozenset()))
+    assert report.risk == "HIGH", [s.name + ":" + s.severity for s in report.signals]
+    assert any(s.name == "allowlist_blocked" for s in report.signals)
+    assert not any(s.name == "allowlisted" for s in report.signals)
+
+
+# ---------------------------------------------------------------------------
+# True positives / attacks that MUST stay HIGH
+# ---------------------------------------------------------------------------
+
+def test_s2_throwaway_promoter_still_high():
+    """New account, no org, no prior PRs, two young bucket repos -> HIGH."""
+    fake = _FakeGitHub(
+        username="throwaway",
+        user={"login": "throwaway", "created_at": _iso(20), "public_repos": 3,
+              "followers": 0, "following": 0, "name": "", "bio": ""},
+        repos=[_repo("clone-a", stars=0, days=10, owner="throwaway"),
+               _repo("clone-b", stars=0, days=8, owner="throwaway")],
+        orgs=[], issues=[], merged_prs=[],
+    )
+    report = _run(fake)
+    assert report.risk == "HIGH", [s.name + ":" + s.severity for s in report.signals]
+
+
+def test_s3_thin_promo_org_not_credited_still_high():
+    """Org repos all thin/young -> NOT aged -> no org credit. Two young bucket
+    repos (split clone) -> HIGH."""
+    fake = _FakeGitHub(
+        username="promo",
+        user={"login": "promo", "created_at": _iso(800), "public_repos": 3,
+              "followers": 11, "following": 20, "name": "P", "bio": "x"},
+        repos=[_repo("clone-a", stars=0, days=15, owner="promo"),
+               _repo("clone-b", stars=0, days=15, owner="promo")],
+        orgs=[{"login": "freshorg"}],
+        org_repos={"freshorg": [_repo("bought", stars=60, days=10, owner="freshorg")]},  # 60 stars but young -> not aged
+        contributors={"freshorg/bought": ["promo"]},
+        issues=[], merged_prs=[],
+    )
+    report = _run(fake)
+    assert report.risk == "HIGH", [s.name + ":" + s.severity for s in report.signals]
+
+
+def test_s4_self_merged_only_not_credited_still_high():
+    """Two merged PRs but both self-merged -> prior-interaction NOT credited.
+    Two young bucket repos -> HIGH."""
+    fake = _FakeGitHub(
+        username="selfmerge",
+        user={"login": "selfmerge", "created_at": _iso(800), "public_repos": 3,
+              "followers": 11, "following": 20, "name": "S", "bio": "x"},
+        repos=[_repo("clone-a", stars=0, days=15, owner="selfmerge"),
+               _repo("clone-b", stars=0, days=15, owner="selfmerge")],
+        orgs=[], issues=[],
+        merged_prs=[{"number": 1, "author_association": "CONTRIBUTOR"},
+                    {"number": 2, "author_association": "CONTRIBUTOR"}],
+        pull_details={1: {"merged_by": {"login": "selfmerge"}},
+                      2: {"merged_by": {"login": "selfmerge"}}},
+    )
+    report = _run(fake, org_members={"selfmerge"})  # even if a member, self-merge does not count
+    assert report.risk == "HIGH", [s.name + ":" + s.severity for s in report.signals]
+
+
+def test_s6_established_but_real_abuse_still_high():
+    """Established personal account, but a young thin repo is promoted across
+    multiple orgs (thin_credibility, a real abuse signal) -> dampening blocked
+    -> stays HIGH."""
+    promoted = "scam-tool"
+    fake = _FakeGitHub(
+        username="vet",
+        user={"login": "vet", "created_at": _iso(2000), "public_repos": 50,
+              "followers": 200, "following": 30, "name": "Vet", "bio": "x"},
+        repos=[_repo(promoted, stars=1, days=10, owner="vet", desc="a tool"),
+               _repo("clone-a", stars=0, days=15, owner="vet"),
+               _repo("clone-b", stars=0, days=15, owner="vet")],
+        orgs=[],
+        issues=[
+            {"title": f"try {promoted}", "body": f"check out {promoted}",
+             "repository_url": "https://api.github.com/repos/orgone/x",
+             "created_at": _iso(5)},
+            {"title": f"use {promoted}", "body": f"{promoted} is great",
+             "repository_url": "https://api.github.com/repos/orgtwo/y",
+             "created_at": _iso(4)},
+        ],
+        merged_prs=[],
+    )
+    report = _run(fake)
+    names = {s.name for s in report.signals}
+    assert "thin_credibility" in names, names
+    assert report.risk == "HIGH", [s.name + ":" + s.severity for s in report.signals]


### PR DESCRIPTION
## Motivation

The contributor-check flags two legitimate patterns as abuse:

- **Org-consolidation** — moving personal repos into a GitHub org leaves a thin personal account that drops out of established-account dampening (`_is_established` needs `followers>=50 AND public_repos>=20`).
- **Domain specialization** — a governance contributor's repos match >=4 of the 6 AGT feature buckets, and `feature_overlap` (then in `_ABUSE_SIGNALS`) reaching HIGH on two repos alone produced an overall HIGH.

This is a general correction, not a self-exemption (the allowlist below ships empty).

## What changed

1. **Org-aware credibility** — an org-owned repo counts toward "established" only when it is **aged** (>=1yr **and** >=10 stars) **and** the user appears in its **contributors** list. Star-buying a fresh repo, or merely belonging to an org that owns a repo you did not build (or a mirror of one), grants nothing.
2. **Prior-interaction credibility** — credit requires **>=2 of your PRs here merged by distinct public org members** (real maintainers), never self-merges and not a two-account merge ring.
3. **`feature_overlap` correctness** — a *single* overlap on a credible account is dampenable to MEDIUM, but **two or more overlapping repos (a split clone) stay HIGH**; the source-skip that exempts a contributor's own mature project uses the age branch (so a star-bought clone cannot suppress its own signal).
4. **Partial credibility tier** — org/prior history dampens domain-overlap and spread signals but **not** raw volume/velocity bursts (which it does not vouch for).
5. **Maintainer allowlist** (`contributor_check_allowlist.json`, ships **empty**) — it only **softens** the auto-flag **HIGH→MEDIUM** (still surfaced, never sets LOW, never bypasses code review), and it is **refused outright** — recording an `allowlist_blocked` signal — when any deliberate-abuse signal **or** a multi-repo split-clone is present, the same hard guards that block established-account dampening. The empty allowlist short-circuits the orgs API lookup entirely.

## Safety / posture

All four deliberate-abuse signals (`thin_credibility`, `credential_laundering`, `coordinated_promotion`, `self_promotion_spray`) still **block dampening entirely**, and non-established accounts stay fully gated. The design is deliberately **conservative**: a contributor with multiple *young, low-star* overlapping repos is still flagged (it is genuinely indistinguishable from a split-cloner via cheap signals), and the maintainer allowlist softens — but never whitewashes — residual cases.

This change was put through an **independent adversarial review**, which initially returned DO-NOT-SHIP on four forgeability findings; all four are now closed (aged+contributor org credit, maintainer-merge validation, non-dampenable split-clone, fail-closed network paths) and re-review cleared it. Approach informed by OpenSSF Scorecard contributor heuristics and anti-Sybil literature; heavier signals (temporal-shape / ring detection) are noted as follow-ups.

## Tests

108 tests pass, including **6 end-to-end scenarios** that drive the full `check_contributor` pipeline: aged-repo org-backed specialist resolves to non-HIGH; throwaway promoter, thin promo-org, self-merged-only history, an allowlisted **split-clone**, and an established-account-with-real-abuse all stay HIGH. No new dependencies.

---

*AI-assisted disclosure. Portions of this contribution were generated under human direction through an agentic, gated SDLC governance process. The governance controls and decision records that shaped this code are maintained in their open-source project and can be furnished in fuller detail on request.*