### PR TITLE
fix: make ACS NuGet metadata compliant

### DIFF
--- a/docs/dependency-audits/2026-06-04-acs-node-lockfile-sync.md
+++ b/docs/dependency-audits/2026-06-04-acs-node-lockfile-sync.md
@@ -1,0 +1,50 @@
+# Dependency audit: ACS Node lockfile sync
+
+## Which dependencies changed and why
+
+This PR updates `policy-engine/sdk/node/package-lock.json` to match the
+optional native packages already declared in
+`policy-engine/sdk/node/package.json`. `npm ci` failed in
+`policy-engine-ci / Node SDK` because npm requires each optional dependency
+declared by the root package to have a corresponding lockfile package entry.
+
+The lockfile now records registry metadata for these first-party ACS packages:
+
+| Package | Version | Reason |
+|---|---:|---|
+| `agent-control-specification-darwin-arm64` | `0.3.1-beta.0` | macOS arm64 native binding already declared as optional |
+| `agent-control-specification-darwin-x64` | `0.3.1-beta.0` | macOS x64 native binding already declared as optional |
+| `agent-control-specification-linux-arm64-gnu` | `0.3.1-beta.0` | Linux arm64 glibc native binding already declared as optional |
+| `agent-control-specification-linux-x64-gnu` | `0.3.1-beta.0` | Linux x64 glibc native binding already declared as optional |
+| `agent-control-specification-win32-x64-msvc` | `0.3.1-beta.0` | Windows x64 MSVC native binding already declared as optional |
+| `agent-control-specification-opa-darwin-arm64` | `0.3.1-beta.0` | macOS arm64 OPA companion package already declared as optional |
+| `agent-control-specification-opa-darwin-x64` | `0.3.1-beta.0` | macOS x64 OPA companion package already declared as optional |
+| `agent-control-specification-opa-linux-arm64` | `0.3.1-beta.0` | Linux arm64 OPA companion package already declared as optional |
+| `agent-control-specification-opa-linux-x64` | `0.3.1-beta.0` | Linux x64 OPA companion package already declared as optional |
+| `agent-control-specification-opa-win32-x64` | `0.3.1-beta.0` | Windows x64 OPA companion package already declared as optional |
+
+No `package.json` dependency intent changed. The lockfile was regenerated with
+`npm install --package-lock-only --ignore-scripts --no-audit --no-fund`, then
+validated with `npm ci` and `npm test`.
+
+## Security advisory relevance
+
+No CVE-specific remediation is claimed. The changed entries are first-party ACS
+native and OPA companion packages for the same `0.3.1-beta.0` release already
+declared in the root Node package.
+
+The entries are new to the lockfile because the native packages were published
+after the optional dependency declarations landed. The usual release-age risk is
+lower here than for an arbitrary third-party dependency because these packages
+are part of the ACS artifact set produced by this repository's release flow and
+must match the root package version exactly.
+
+## Breaking change risk assessment
+
+Risk is low. The change does not alter source code, exported APIs, scripts, or
+declared dependencies. It only records the resolved tarballs, integrity hashes,
+license metadata, and OS/CPU constraints that `npm ci` requires for packages
+already listed under `optionalDependencies`.
+
+The runtime selection behavior remains unchanged. npm will still install only
+the optional native and OPA packages compatible with the host platform.

--- a/policy-engine/sdk/dotnet/Directory.Build.props
+++ b/policy-engine/sdk/dotnet/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <PropertyGroup>
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft Corporation</Company>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/microsoft/agent-governance-toolkit</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/microsoft/agent-governance-toolkit</RepositoryUrl>
+  </PropertyGroup>
+</Project>

--- a/policy-engine/sdk/dotnet/src/AgentControlSpecification/AgentControlSpecification.csproj
+++ b/policy-engine/sdk/dotnet/src/AgentControlSpecification/AgentControlSpecification.csproj
@@ -6,7 +6,6 @@
     <IsPackable>true</IsPackable>
     <PackageId>AgentControlSpecification</PackageId>
     <Version>0.3.1-beta.0</Version>
-    <Authors>Agent Control Specification contributors</Authors>
     <Description>Thin .NET SDK surface for the stateless Agent Control Specification runtime.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/policy-engine/sdk/node/package-lock.json
+++ b/policy-engine/sdk/node/package-lock.json
@@ -453,6 +453,136 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-control-specification-darwin-arm64": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-darwin-arm64/-/agent-control-specification-darwin-arm64-0.3.1-beta.0.tgz",
+      "integrity": "sha512-6kr1DAeFOBf/8Q7eNFqLtUoUfRqIDTqZ2QvkIvSKxDYh3iY2/8cizn0bzbJJofuba02aDV1oLEd5vvgcYkbWAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/agent-control-specification-darwin-x64": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-darwin-x64/-/agent-control-specification-darwin-x64-0.3.1-beta.0.tgz",
+      "integrity": "sha512-yFLEv/u77ZnErjcfLPCExL+ZeNRlOQ1Gg7l1VZjuTH9VQyIrTBXDHVb5czH6T9WFyozHRtt/NPud1XANeKGk+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/agent-control-specification-linux-arm64-gnu": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-linux-arm64-gnu/-/agent-control-specification-linux-arm64-gnu-0.3.1-beta.0.tgz",
+      "integrity": "sha512-y1eKUzmkuPBr4HymQXdVImQA/opjuwv+I1nYkH1TTnkZf9Yvo9PWePbrhDTNH/ZFE/FvUtGLZfUIPU5PJceVEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/agent-control-specification-linux-x64-gnu": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-linux-x64-gnu/-/agent-control-specification-linux-x64-gnu-0.3.1-beta.0.tgz",
+      "integrity": "sha512-AaC7jPQe2RX56nGdnrcqL2JmjLMw4bP+J6rJyrNTr8YGgZtAL5R+hcbHZdqNnsUssoD57mJLOjl8OdnOJ07+SA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/agent-control-specification-opa-darwin-arm64": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-opa-darwin-arm64/-/agent-control-specification-opa-darwin-arm64-0.3.1-beta.0.tgz",
+      "integrity": "sha512-Sdqgve222Y+aq20Rfa4yOWnD+u1SygeFWLD+N0dsrFzSKQCkW3aRg3EJkYBmgzGXvHi6qheL9zWRYkaxqaypww==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/agent-control-specification-opa-darwin-x64": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-opa-darwin-x64/-/agent-control-specification-opa-darwin-x64-0.3.1-beta.0.tgz",
+      "integrity": "sha512-6hZCNloScj0RlwvkzOUNcnYEpkvObcy9P88a1tKZA7vztcKfTsKCwAjq1rPUWAvI48BG3bldOLdLaHXbyvutdw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/agent-control-specification-opa-linux-arm64": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-opa-linux-arm64/-/agent-control-specification-opa-linux-arm64-0.3.1-beta.0.tgz",
+      "integrity": "sha512-7n/0kqzuXVmX/eccpw6yEjD4n5aFd0aRqpXs0EtDZS5P1DhIORKR/w1flrr1FOvVv0UJoFDM7p78STwO8IdIHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/agent-control-specification-opa-linux-x64": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-opa-linux-x64/-/agent-control-specification-opa-linux-x64-0.3.1-beta.0.tgz",
+      "integrity": "sha512-UgvO8h8c3cEVht/Nkflx0BbA5vKFatX3B5Q1D/g6pD+tXidZzs4HmZaKcazaniPuuqzbrz70eAYF92yoyjP4OA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/agent-control-specification-opa-win32-x64": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-opa-win32-x64/-/agent-control-specification-opa-win32-x64-0.3.1-beta.0.tgz",
+      "integrity": "sha512-hNHRXGxQ3pnagMdeowu3WgskHrF3QqX/gclesv3fesTq6xn0IKDW2/4iKdAq5lLYFk49f/fQYPV/ybtpaVwmow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/agent-control-specification-win32-x64-msvc": {
+      "version": "0.3.1-beta.0",
+      "resolved": "https://registry.npmjs.org/agent-control-specification-win32-x64-msvc/-/agent-control-specification-win32-x64-msvc-0.3.1-beta.0.tgz",
+      "integrity": "sha512-+9/DAvNb1bGPQwYOppaiVctxDs0i8RalbZnUuobJLxghqmR4GN9JpqGKBwdk4Du9EIRwRkP5C4/AjmPj5vr+RA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",


### PR DESCRIPTION
## Summary

Fixes NuGet.org Microsoft package compliance for the ACS .NET packages by centralizing required package metadata and removing the base package's non-Microsoft `Authors` override. Also syncs the ACS Node lockfile so the required `policy-engine-ci / Node SDK` job can run for this `policy-engine/**` PR.

## Problem

NuGet rejected `AgentControlSpecification.0.3.1-beta.0.nupkg` because its metadata used `Agent Control Specification contributors`, had a non-compliant copyright element, and omitted `ProjectUrl`. The same release job packs the companion ACS packages, so fixing only the rejected `.csproj` would risk sequential publish failures.

`policy-engine-ci` runs every SDK job for any `policy-engine/**` change. The Node job was failing before tests because `package.json` declared ten optional ACS native packages, but `package-lock.json` lacked the corresponding `node_modules/...` lock entries required by `npm ci`.

## Changes

| File | What changed |
|------|-------------|
| `policy-engine/sdk/dotnet/Directory.Build.props` | Adds shared `Authors=Microsoft`, `Company`, compliant copyright, `PackageProjectUrl`, and git repository metadata for ACS .NET projects. |
| `policy-engine/sdk/dotnet/src/AgentControlSpecification/AgentControlSpecification.csproj` | Removes the package-local `Authors` override so the base package inherits the compliant shared value. |
| `policy-engine/sdk/node/package-lock.json` | Adds lock entries for the ten already-declared optional ACS native packages so `npm ci` accepts the Node SDK lockfile. |
| `docs/dependency-audits/2026-06-04-acs-node-lockfile-sync.md` | Documents the lockfile-only dependency audit required by `vendored-patch-audit`. |

## Audit

Checked all packable NuGet projects in the repo: the three `agent-governance-dotnet` packages were already compliant, and the five ACS .NET packages now resolve to `Authors=Microsoft` with copyright and project URL metadata. No remaining `.csproj`, `.props`, or `.nuspec` file contains the rejected `Agent Control Specification contributors` author string.

Checked ACS Node package metadata in `policy-engine/sdk/node/package.json` and all `policy-engine/sdk/node/npm/*/package.json` native package templates: none define `author`, `authors`, or `contributors`, and none contain `Agent Control Specification contributors`.

## Testing

- `dotnet build AgentControlSpecification.sln --configuration Release --nologo -p:RestoreSources=https://api.nuget.org/v3/index.json`
- `dotnet run --project tests/AgentControlSpecification.Tests --configuration Release --no-build --no-restore`
- Packed all five ACS NuGet packages and inspected each generated `.nuspec` with Python `zipfile` assertions for `authors`, `copyright`, `projectUrl`, and repository metadata.
- Ran a structured audit over all eight packable NuGet projects in the repo for effective `Authors`, copyright, and project URL values.
- `npm ci` from `policy-engine/sdk/node`
- `npm test` from `policy-engine/sdk/node` passed with 100 Node tests.
- `bash scripts/ci/vendored-patch-audit.sh origin/main`
- `python scripts/docs/check_links.py`
- `python scripts/docs/check_frontmatter.py` completed with existing warn-only missing-frontmatter warnings.
