### PR TITLE
docs: add data drift governance checks to data quality example

### DIFF
--- a/examples/data-quality-aware-governance/README.md
+++ b/examples/data-quality-aware-governance/README.md
@@ -27,7 +27,7 @@ Request
   │       ├─ NO  → Block (policy violation)
   │       └─ YES → proceed to Layer 2
   │
-Layer 2: Data Quality Registry
+  └─ Layer 2: Data Quality Registry
     └─ Is the target dataset trustworthy right now?
         ├─ Freshness Check
         ├─ Quality Check

--- a/examples/data-quality-aware-governance/README.md
+++ b/examples/data-quality-aware-governance/README.md
@@ -27,7 +27,7 @@ Request
   │       ├─ NO  → Block (policy violation)
   │       └─ YES → proceed to Layer 2
   │
-Layer 2: Data Trust Registry
+Layer 2: Data Quality Registry
     └─ Is the target dataset trustworthy right now?
         ├─ Freshness Check
         ├─ Quality Check
@@ -84,6 +84,7 @@ Where the snapshot contains:
 - dataset_owner_did — DID of the dataset owner
 - quality_score — current quality assessment
 - drift_score — statistical drift measurement relative to baseline
+- drift_threshold — maximum acceptable drift before governance blocks access
 
 This means:
 - AGT evaluates the **typed fields** at policy decision time

--- a/examples/data-quality-aware-governance/README.md
+++ b/examples/data-quality-aware-governance/README.md
@@ -11,8 +11,9 @@ In data-heavy workflows, there is a second question that matters equally:
 > Is the **data** this agent is about to use actually trustworthy right now?
 
 An agent can be fully authorized to query a dataset. But if that dataset
-failed freshness checks, validation tests, or ownership requirements
-earlier that day, authorization alone is not enough.
+failed freshness checks, validation tests, ownership requirements, or
+has drifted significantly from its expected statistical behavior,
+authorization alone is not enough.
 
 ## The Pattern
 
@@ -26,10 +27,13 @@ Request
   │       ├─ NO  → Block (policy violation)
   │       └─ YES → proceed to Layer 2
   │
-  └─ Layer 2: Data Quality Registry
-      └─ Is the target dataset trustworthy right now?
-          ├─ NO  → Block (data quality violation)
-          └─ YES → Allow + write to unified audit log
+Layer 2: Data Trust Registry
+    └─ Is the target dataset trustworthy right now?
+        ├─ Freshness Check
+        ├─ Quality Check
+        ├─ Drift Check
+        ├─ Any failure → Block
+        └─ All pass → Allow + write to unified audit log
 ```
 
 The request is blocked if **either** layer fails.
@@ -48,6 +52,15 @@ Reason:
   - Dataset stale by 14h (threshold: 6h)
   - Quality score: 0.72 (below 0.85 minimum)
   - Failed tests: not_null_user_id, accepted_values_event_type
+
+Another dataset may be fresh and high quality but still be blocked:
+
+Dataset: customer_behavior
+
+Reason:
+  - Drift score: 0.41
+  - Drift threshold: 0.25
+  - Statistical behavior differs from expected baseline
 ```
 
 Without Layer 2, the agent queries broken data with a clean audit trail.
@@ -66,9 +79,11 @@ that travels as a `data-quality` scheme in the CTEF v0.3.2
 ```
 
 Where the snapshot contains:
-- `freshness_at` — last successful validation timestamp
-- `validation_status` — pass | warn | fail
-- `dataset_owner_did` — DID of the dataset owner
+- freshness_at — last successful validation timestamp
+- validation_status — pass | warn | fail
+- dataset_owner_did — DID of the dataset owner
+- quality_score — current quality assessment
+- drift_score — statistical drift measurement relative to baseline
 
 This means:
 - AGT evaluates the **typed fields** at policy decision time
@@ -122,6 +137,13 @@ Agent 'analyst-agent-01' requesting 'database_query' on dataset 'revenue_metrics
 Agent 'report-agent-02' requesting 'database_query' on dataset 'revenue_metrics'
   [AGT_POLICY] ✗ BLOCKED — Role report-agent-02 cannot use tool database_query
   Final decision: BLOCKED (agt_policy)
+```
+```
+--- Scenario 4: Authorized agent, high drift dataset ---
+Agent 'analyst-agent-01' requesting 'database_query' on dataset 'customer_behavior'
+  [AGT_POLICY] ✓ ALLOWED — Agent authorized for action
+  [DATA_QUALITY] ✗ BLOCKED — Drift score 0.41 exceeds threshold 0.25
+  Final decision: BLOCKED (data_quality)
 ```
 
 ## The Data Quality Registry

--- a/examples/data-quality-aware-governance/example.py
+++ b/examples/data-quality-aware-governance/example.py
@@ -87,7 +87,6 @@ class DatasetQualitySnapshot:
         return (
             self.is_fresh
             and self.meets_quality_threshold
-            and self.within_drift_threshold
             and not self.failed_tests
         )
 

--- a/examples/data-quality-aware-governance/example.py
+++ b/examples/data-quality-aware-governance/example.py
@@ -87,6 +87,7 @@ class DatasetQualitySnapshot:
         return (
             self.is_fresh
             and self.meets_quality_threshold
+            and self.within_drift_threshold
             and not self.failed_tests
         )
 

--- a/examples/data-quality-aware-governance/example.py
+++ b/examples/data-quality-aware-governance/example.py
@@ -66,7 +66,9 @@ class DatasetQualitySnapshot:
     quality_threshold: float          # Minimum acceptable score
     failed_tests: list[str]           # Names of failed validation tests
     validation_status: str            # "pass" | "warn" | "fail"
-
+    drift_score: float                # 0.0 - 1.0
+    drift_threshold: float            # Maximum acceptable drift
+    
     @property
     def is_fresh(self) -> bool:
         age_hours = (datetime.now() - self.freshness_at).total_seconds() / 3600
@@ -77,8 +79,17 @@ class DatasetQualitySnapshot:
         return self.quality_score >= self.quality_threshold
 
     @property
+    def within_drift_threshold(self) -> bool:
+        return self.drift_score <= self.drift_threshold
+
+    @property
     def is_trustworthy(self) -> bool:
-        return self.is_fresh and self.meets_quality_threshold and not self.failed_tests
+        return (
+            self.is_fresh
+            and self.meets_quality_threshold
+            and self.within_drift_threshold
+            and not self.failed_tests
+        )
 
 
 class DataQualityRegistry:
@@ -240,6 +251,26 @@ async def governed_query(
         ))
         return {"decision": "blocked", "layer": "data_quality", "reason": reason}
 
+    if not snapshot.within_drift_threshold:
+        reason = (
+            f"Drift score {snapshot.drift_score} exceeds threshold "
+            f"{snapshot.drift_threshold}"
+        )
+        audit_log.record(AuditEntry(
+            timestamp=timestamp,
+            agent_id=agent_id,
+            action=action,
+            dataset_id=dataset_id,
+            layer="data_quality",
+            decision="blocked",
+            reason=reason,
+        ))
+        return {
+            "decision": "blocked",
+            "layer": "data_quality",
+            "reason": reason,
+        }
+
     if snapshot.failed_tests:
         reason = f"Failed validation tests: {', '.join(snapshot.failed_tests)}"
         audit_log.record(AuditEntry(
@@ -324,6 +355,8 @@ async def main():
         quality_threshold=0.85,
         failed_tests=["not_null_user_id", "accepted_values_event_type"],
         validation_status="fail",
+        drift_score=0.12,
+        drift_threshold=0.25,
     ))
 
     # revenue_metrics: FRESH and PASSING — should be allowed
@@ -336,6 +369,22 @@ async def main():
         quality_threshold=0.85,
         failed_tests=[],
         validation_status="pass",
+        drift_score=0.08,
+        drift_threshold=0.25,
+    ))
+    
+    # customer_behavior: FRESH and HIGH QUALITY but DRIFTING — should be blocked
+    registry.register(DatasetQualitySnapshot(
+        dataset_id="customer_behavior",
+        owner_did="did:web:marketing.example.com",
+        freshness_at=datetime.now() - timedelta(hours=1),
+        freshness_threshold_hours=6.0,
+        quality_score=0.96,
+        quality_threshold=0.85,
+        failed_tests=[],
+        validation_status="pass",
+        drift_score=0.41,
+        drift_threshold=0.25,
     ))
 
     audit_log = AuditLog()
@@ -377,14 +426,26 @@ async def main():
     print(f"  Final decision: {result['decision'].upper()} ({result['layer']})")
 
     # ------------------------------------------------------------------
+    # Scenario 4: Authorized agent, high drift → blocked at Layer 2
+    # ------------------------------------------------------------------
+    print("\n--- Scenario 4: Authorized agent, high drift dataset ---")
+    result = await governed_query(
+        kernel, policy_engine, registry, audit_log,
+        agent_id="analyst-agent-01",
+        action="database_query",
+        dataset_id="customer_behavior",
+    )
+    print(f"  Final decision: {result['decision'].upper()} ({result['layer']})")
+
+    # ------------------------------------------------------------------
     # Audit log
     # ------------------------------------------------------------------
     audit_log.summary()
 
     print("\n" + "=" * 60)
     print("Key insight: Scenario 1 shows why authorization alone is not enough.")
-    print("The agent was permitted. The data was not trustworthy.")
-    print("Without Layer 2, the agent queries broken data with a clean audit trail.")
+    print("The agent was permitted. The data was stale, invalid, or drifted.")
+    print("Authorization alone does not guarantee trustworthy inputs.")
     print("=" * 60)
 
 


### PR DESCRIPTION
## Summary

Extends the data-quality-aware-governance example with data drift checks.

## Changes

- Added drift_score and drift_threshold to DatasetQualitySnapshot
- Added within_drift_threshold evaluation
- Extended is_trustworthy to include drift validation
- Added governance blocking when drift exceeds threshold
- Added customer_behavior dataset demonstrating drift-based blocking
- Added Scenario 4 for drift governance
- Updated README documentation and expected output

## Motivation

A dataset may be fresh and pass validation tests while still exhibiting
significant statistical drift. This example demonstrates how AGT governance
can incorporate drift signals as an additional trust gate before allowing
agent actions.