### PR TITLE
feat(supply-chain): add PR-time SBOM diff with hardened two-workflow design

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -747,3 +747,8 @@ nullglob
 pypa
 snupkg
 Hotfixes
+anchore
+octocat
+sboms
+Syft
+syft

--- a/.github/workflows/sbom-diff-comment.yml
+++ b/.github/workflows/sbom-diff-comment.yml
@@ -149,7 +149,7 @@ jobs:
         if: steps.verify.outputs.skip != 'true' && steps.resolve.outputs.found == 'true'
         # Refs are passed via env vars so they are never expanded as GHA
         # expressions inside `run:` (defence against shell-injection via a
-        # branch name like `$(curl evil)`). The diff script also sanitises
+        # branch name like `$(curl evil)`). The diff script also sanitizes
         # them before embedding in the markdown body.
         env:
           BASE_REF: ${{ steps.resolve.outputs.base_ref }}

--- a/.github/workflows/sbom-diff-comment.yml
+++ b/.github/workflows/sbom-diff-comment.yml
@@ -28,6 +28,13 @@ on:
 permissions:
   contents: read
 
+# Serialise comment runs per triggering PR head SHA. If a newer PR push
+# kicks off another `sbom-diff` run, we cancel the in-flight comment job so
+# it cannot overwrite the newer result with a stale comment.
+concurrency:
+  group: sbom-diff-comment-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
 jobs:
   comment:
     name: Post SBOM diff comment
@@ -85,19 +92,51 @@ jobs:
         id: resolve
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          # We deliberately do NOT trust anything inside `artifact/` for PR
-          # identity. The workflow_run payload's head_sha is authoritative —
-          # we look up which open PR(s) it belongs to via the GitHub API and
-          # take that PR's number, head ref, and base ref.
+          # PR identity MUST be derived from trusted GitHub state, not from
+          # anything inside `artifact/`. Two-step resolution:
+          #
+          #   1. Prefer `workflow_run.pull_requests` (populated for same-repo
+          #      PRs and includes the exact PR that triggered the run).
+          #   2. Fall back to `listPullRequestsAssociatedWithCommit` for fork
+          #      PRs where step 1 is empty.
+          #
+          # In BOTH cases we re-fetch the PR and require that its CURRENT
+          # head SHA still matches the workflow_run's head SHA. This blocks
+          # the stale-comment race where commit A's slow trusted run could
+          # otherwise overwrite the comment for the newer commit B.
           script: |
             const headSha = context.payload.workflow_run.head_sha;
             const { owner, repo } = context.repo;
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner, repo, commit_sha: headSha,
+            const wrPRs = context.payload.workflow_run.pull_requests || [];
+            let candidate = null;
+            if (wrPRs.length > 0) {
+              candidate = wrPRs[0];
+            } else {
+              const { data: assoc } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner, repo, commit_sha: headSha,
+              });
+              candidate = assoc.find(p => p.state === 'open') || null;
+            }
+            if (!candidate) {
+              core.warning(`No PR found for commit ${headSha}; nothing to comment on.`);
+              core.setOutput('found', 'false');
+              return;
+            }
+            // Re-fetch authoritative PR state and validate it's still on the
+            // SHA that triggered us. Closed PRs or moved heads => skip.
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: candidate.number,
             });
-            const pr = prs.find(p => p.state === 'open');
-            if (!pr) {
-              core.warning(`No open PR found for commit ${headSha}; nothing to comment on.`);
+            if (pr.state !== 'open') {
+              core.warning(`PR #${pr.number} is ${pr.state}; skipping.`);
+              core.setOutput('found', 'false');
+              return;
+            }
+            if (pr.head.sha !== headSha) {
+              core.warning(
+                `PR #${pr.number} head is now ${pr.head.sha}, but this run was ` +
+                `for ${headSha}; skipping to avoid stale comment.`
+              );
               core.setOutput('found', 'false');
               return;
             }

--- a/.github/workflows/sbom-diff-comment.yml
+++ b/.github/workflows/sbom-diff-comment.yml
@@ -1,0 +1,171 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: SBOM Diff Comment
+
+# TRUSTED half of the two-workflow pattern. Triggered by `workflow_run` when
+# `sbom-diff.yml` finishes. This workflow runs in the BASE repository context
+# (not the PR's fork), checks out the default branch (reviewed code), and
+# uses the TRUSTED `scripts/diff_sbom.py` to render the comment body from the
+# untrusted SBOM artifacts produced by the PR workflow.
+#
+# Security model:
+#   - The companion workflow runs untrusted PR code and uploads ONLY SBOM
+#     JSON files (data, never executables, never scripts).
+#   - This workflow never checks out PR code. It checks out the base repo's
+#     default branch — which is always pre-merge reviewed.
+#   - PR identity (number, head/base refs) is re-derived from the
+#     workflow_run's head SHA via the GitHub API. Nothing in the artifact is
+#     trusted for routing — an attacker cannot forge a comment onto another
+#     PR by tampering with artifact contents.
+#   - The diff script raises ValueError on malformed JSON; the workflow
+#     catches it and exits cleanly with a warning.
+on:
+  workflow_run:
+    workflows: ["SBOM Diff (PR)"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    name: Post SBOM diff comment
+    runs-on: ubuntu-latest
+    # Only act on successful PR runs. We must not post comments for runs that
+    # were cancelled or failed (no artifact, or partial data).
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      # actions:read is required to download artifacts from another workflow
+      # run via actions/download-artifact's `run-id` parameter.
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Check out trusted tooling (default branch)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          # Only the diff helper is needed. Sparse checkout narrows the trust
+          # surface to a single file from the default branch.
+          sparse-checkout: |
+            scripts/diff_sbom.py
+          sparse-checkout-cone-mode: false
+
+      - name: Verify trusted script is present
+        id: verify
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/diff_sbom.py ]; then
+            echo "::warning::scripts/diff_sbom.py not present on default branch yet (bootstrap PR). Skipping comment; reviewers can inspect the SBOM artifact directly."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.verify.outputs.skip != 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Download SBOM artifact from triggering workflow run
+        if: steps.verify.outputs.skip != 'true'
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: sbom-diff-inputs
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve PR from workflow_run head SHA
+        if: steps.verify.outputs.skip != 'true'
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          # We deliberately do NOT trust anything inside `artifact/` for PR
+          # identity. The workflow_run payload's head_sha is authoritative —
+          # we look up which open PR(s) it belongs to via the GitHub API and
+          # take that PR's number, head ref, and base ref.
+          script: |
+            const headSha = context.payload.workflow_run.head_sha;
+            const { owner, repo } = context.repo;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: headSha,
+            });
+            const pr = prs.find(p => p.state === 'open');
+            if (!pr) {
+              core.warning(`No open PR found for commit ${headSha}; nothing to comment on.`);
+              core.setOutput('found', 'false');
+              return;
+            }
+            core.setOutput('found', 'true');
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_ref', pr.head.ref);
+
+      - name: Render diff with trusted script
+        if: steps.verify.outputs.skip != 'true' && steps.resolve.outputs.found == 'true'
+        # Refs are passed via env vars so they are never expanded as GHA
+        # expressions inside `run:` (defence against shell-injection via a
+        # branch name like `$(curl evil)`). The diff script also sanitises
+        # them before embedding in the markdown body.
+        env:
+          BASE_REF: ${{ steps.resolve.outputs.base_ref }}
+          HEAD_REF: ${{ steps.resolve.outputs.head_ref }}
+        run: |
+          set -euo pipefail
+          python scripts/diff_sbom.py \
+            --base artifact/base.spdx.json \
+            --head artifact/head.spdx.json \
+            --output "$GITHUB_WORKSPACE/sbom-diff.md" \
+            --base-ref "$BASE_REF" \
+            --head-ref "$HEAD_REF" \
+            --max-added 500
+
+      - name: Post or update PR comment
+        if: steps.verify.outputs.skip != 'true' && steps.resolve.outputs.found == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- sbom-diff-bot -->';
+            const body = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/sbom-diff.md`, 'utf8');
+            // GitHub PR comment body cap is 65,536 chars. The diff script
+            // already truncates "added" entries; this is defence-in-depth so
+            // a degenerate `removed` or `bumped` section cannot bust the API.
+            const MAX = 65000;
+            const safeBody = body.length > MAX
+              ? body.slice(0, MAX) + '\n\n> ⚠️ Comment truncated; see workflow artifact for the full diff.'
+              : body;
+
+            const { owner, repo } = context.repo;
+            const issue_number = parseInt(process.env.PR_NUMBER, 10);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed(`Invalid PR number: ${process.env.PR_NUMBER}`);
+              return;
+            }
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            const prior = existing.find(c =>
+              c.user && c.user.type === 'Bot' && c.body && c.body.startsWith(MARKER)
+            );
+
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: prior.id, body: safeBody,
+              });
+              core.info(`Updated SBOM diff comment ${prior.id} on PR #${issue_number}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body: safeBody,
+              });
+              core.info(`Created SBOM diff comment on PR #${issue_number}`);
+            }

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -45,6 +45,11 @@ jobs:
     permissions:
       contents: read
     steps:
+      # actions/checkout is pinned to the v6.0.3 commit SHA to match the
+      # repo-wide convention used by every other workflow on main (see
+      # `git grep "actions/checkout@" .github/workflows`). v6.0.3 is the
+      # current latest-stable release; downgrading to v4 here would diverge
+      # from the rest of the tree without a security or compatibility reason.
       - name: Check out PR head
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -1,0 +1,177 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: SBOM Diff (PR)
+
+# Use `pull_request` (NOT `pull_request_target`) so this never executes with
+# the base-repo secret context against untrusted fork code. The downside is
+# that PRs from forks get a read-only GITHUB_TOKEN and cannot comment; in
+# that case the SBOM artifact is still uploaded for reviewer inspection.
+on:
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/pnpm-lock.yaml"
+      - "**/yarn.lock"
+      - "**/pyproject.toml"
+      - "**/requirements*.txt"
+      - "**/poetry.lock"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**/*.csproj"
+      - "**/packages.lock.json"
+      - "scripts/diff_sbom.py"
+      - ".github/workflows/sbom-diff.yml"
+
+# Least-privilege at the workflow level. The comment job opts in narrowly.
+permissions:
+  contents: read
+
+concurrency:
+  group: sbom-diff-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  diff:
+    name: Generate SBOM diff
+    runs-on: ubuntu-latest
+    # No write permissions for the SBOM generation job: it only produces an
+    # artifact. Comment posting is isolated in the `comment` job below.
+    permissions:
+      contents: read
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          path: head
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Check out PR base
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Generate base SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: base
+          format: spdx-json
+          output-file: ${{ github.workspace }}/base.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate head SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: head
+          format: spdx-json
+          output-file: ${{ github.workspace }}/head.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Diff SBOMs
+        # BASE_REF / HEAD_REF env vars avoid `${{ }}` expansion inside `run:`
+        # (script-injection class). The diff helper sanitises them before
+        # rendering, but env-passing is the first line of defence.
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          python head/scripts/diff_sbom.py \
+            --base "$GITHUB_WORKSPACE/base.spdx.json" \
+            --head "$GITHUB_WORKSPACE/head.spdx.json" \
+            --output "$GITHUB_WORKSPACE/sbom-diff.md" \
+            --base-ref "$BASE_REF" \
+            --head-ref "$HEAD_REF" \
+            --max-added 500
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-diff
+          path: |
+            ${{ github.workspace }}/base.spdx.json
+            ${{ github.workspace }}/head.spdx.json
+            ${{ github.workspace }}/sbom-diff.md
+          retention-days: 14
+
+  comment:
+    name: Post diff comment
+    needs: diff
+    runs-on: ubuntu-latest
+    # ONLY this job gets pull-requests:write. On fork PRs the GITHUB_TOKEN is
+    # still downgraded to read by GitHub, in which case the script no-ops with
+    # a warning instead of failing the workflow.
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download diff artifact
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: sbom-diff
+          path: artifact
+
+      - name: Post or update PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const MARKER = '<!-- sbom-diff-bot -->';
+            const body = fs.readFileSync(
+              path.join('artifact', 'sbom-diff.md'),
+              'utf8'
+            );
+            // GitHub PR comment body cap is 65,536 characters. The diff helper
+            // already truncates "added" entries, but defence-in-depth: hard
+            // cut here too so a degenerate `removed` or `bumped` section
+            // cannot bust the API.
+            const MAX = 65000;
+            const safeBody = body.length > MAX
+              ? body.slice(0, MAX) + '\n\n> ⚠️ Comment truncated; see workflow artifact for the full diff.'
+              : body;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 }
+            );
+            const prior = existing.find(c =>
+              c.user && c.user.type === 'Bot' && c.body && c.body.startsWith(MARKER)
+            );
+
+            try {
+              if (prior) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: prior.id, body: safeBody
+                });
+                core.info(`Updated existing SBOM diff comment ${prior.id}`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number, body: safeBody
+                });
+                core.info('Created new SBOM diff comment');
+              }
+            } catch (err) {
+              // Fork PRs have a read-only GITHUB_TOKEN; commenting will 403.
+              // Surface a warning but do not fail the workflow — the artifact
+              // is still available for reviewers.
+              core.warning(
+                `Could not post SBOM diff comment (likely a fork PR with read-only token): ${err.message}`
+              );
+            }

--- a/.github/workflows/sbom-diff.yml
+++ b/.github/workflows/sbom-diff.yml
@@ -3,10 +3,12 @@
 
 name: SBOM Diff (PR)
 
-# Use `pull_request` (NOT `pull_request_target`) so this never executes with
-# the base-repo secret context against untrusted fork code. The downside is
-# that PRs from forks get a read-only GITHUB_TOKEN and cannot comment; in
-# that case the SBOM artifact is still uploaded for reviewer inspection.
+# This is the UNTRUSTED half of a two-workflow pattern. It runs against PR
+# content (including forks) with `on: pull_request`, so the GITHUB_TOKEN is
+# read-only and no secrets are exposed. It only produces SBOM artifacts;
+# rendering the markdown body and posting the PR comment is delegated to the
+# trusted companion workflow `sbom-diff-comment.yml`, which runs in the base
+# repo context via `workflow_run`.
 on:
   pull_request:
     paths:
@@ -25,8 +27,10 @@ on:
       - "**/packages.lock.json"
       - "scripts/diff_sbom.py"
       - ".github/workflows/sbom-diff.yml"
+      - ".github/workflows/sbom-diff-comment.yml"
 
-# Least-privilege at the workflow level. The comment job opts in narrowly.
+# Workflow-level least privilege. Nothing in this file ever needs write scopes
+# because comment posting lives in the trusted companion workflow.
 permissions:
   contents: read
 
@@ -35,11 +39,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  diff:
-    name: Generate SBOM diff
+  generate:
+    name: Generate SBOM artifacts
     runs-on: ubuntu-latest
-    # No write permissions for the SBOM generation job: it only produces an
-    # artifact. Comment posting is isolated in the `comment` job below.
     permissions:
       contents: read
     steps:
@@ -56,11 +58,6 @@ jobs:
           path: base
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
 
       - name: Generate base SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -80,98 +77,16 @@ jobs:
           upload-artifact: false
           upload-release-assets: false
 
-      - name: Diff SBOMs
-        # BASE_REF / HEAD_REF env vars avoid `${{ }}` expansion inside `run:`
-        # (script-injection class). The diff helper sanitises them before
-        # rendering, but env-passing is the first line of defence.
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          set -euo pipefail
-          python head/scripts/diff_sbom.py \
-            --base "$GITHUB_WORKSPACE/base.spdx.json" \
-            --head "$GITHUB_WORKSPACE/head.spdx.json" \
-            --output "$GITHUB_WORKSPACE/sbom-diff.md" \
-            --base-ref "$BASE_REF" \
-            --head-ref "$HEAD_REF" \
-            --max-added 500
-
-      - name: Upload diff artifact
+      - name: Upload SBOM artifact
+        # The artifact contains ONLY data files (SBOM JSON). The trusted
+        # companion workflow re-derives PR identity from the workflow_run's
+        # head SHA via the GitHub API, so nothing in this artifact is trusted
+        # for routing or identity purposes.
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sbom-diff
+          name: sbom-diff-inputs
           path: |
             ${{ github.workspace }}/base.spdx.json
             ${{ github.workspace }}/head.spdx.json
-            ${{ github.workspace }}/sbom-diff.md
           retention-days: 14
-
-  comment:
-    name: Post diff comment
-    needs: diff
-    runs-on: ubuntu-latest
-    # ONLY this job gets pull-requests:write. On fork PRs the GITHUB_TOKEN is
-    # still downgraded to read by GitHub, in which case the script no-ops with
-    # a warning instead of failing the workflow.
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Download diff artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
-        with:
-          name: sbom-diff
-          path: artifact
-
-      - name: Post or update PR comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const MARKER = '<!-- sbom-diff-bot -->';
-            const body = fs.readFileSync(
-              path.join('artifact', 'sbom-diff.md'),
-              'utf8'
-            );
-            // GitHub PR comment body cap is 65,536 characters. The diff helper
-            // already truncates "added" entries, but defence-in-depth: hard
-            // cut here too so a degenerate `removed` or `bumped` section
-            // cannot bust the API.
-            const MAX = 65000;
-            const safeBody = body.length > MAX
-              ? body.slice(0, MAX) + '\n\n> ⚠️ Comment truncated; see workflow artifact for the full diff.'
-              : body;
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.payload.pull_request.number;
-
-            const existing = await github.paginate(
-              github.rest.issues.listComments,
-              { owner, repo, issue_number, per_page: 100 }
-            );
-            const prior = existing.find(c =>
-              c.user && c.user.type === 'Bot' && c.body && c.body.startsWith(MARKER)
-            );
-
-            try {
-              if (prior) {
-                await github.rest.issues.updateComment({
-                  owner, repo, comment_id: prior.id, body: safeBody
-                });
-                core.info(`Updated existing SBOM diff comment ${prior.id}`);
-              } else {
-                await github.rest.issues.createComment({
-                  owner, repo, issue_number, body: safeBody
-                });
-                core.info('Created new SBOM diff comment');
-              }
-            } catch (err) {
-              // Fork PRs have a read-only GITHUB_TOKEN; commenting will 403.
-              // Surface a warning but do not fail the workflow — the artifact
-              // is still available for reviewers.
-              core.warning(
-                `Could not post SBOM diff comment (likely a fork PR with read-only token): ${err.message}`
-              );
-            }
+          if-no-files-found: error

--- a/scripts/diff_sbom.py
+++ b/scripts/diff_sbom.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Diff two SPDX-JSON SBOMs and render a markdown summary.
+
+Reads a base SBOM (target branch) and a head SBOM (PR), computes the set of
+added, removed, and version-bumped packages, and writes a human-readable
+markdown report grouped by ecosystem.
+
+Designed for use in the PR-time SBOM diff workflow. Pure stdlib so it can run
+in any GitHub-hosted runner without extra installs.
+
+Usage:
+    python scripts/diff_sbom.py --base base.spdx.json --head head.spdx.json \
+        --output diff.md [--max-added 500]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+# Hard cap on rendered "added" entries to prevent DoS via a flood of new deps.
+DEFAULT_MAX_ADDED = 500
+
+# Hidden marker used by the workflow to find & update the existing PR comment.
+COMMENT_MARKER = "<!-- sbom-diff-bot -->"
+
+# Recognised purl ecosystems; anything else falls into "other".
+_KNOWN_ECOSYSTEMS = {
+    "npm",
+    "pypi",
+    "cargo",
+    "nuget",
+    "golang",
+    "maven",
+    "gem",
+    "composer",
+    "deb",
+    "rpm",
+    "apk",
+    "github",
+    "generic",
+}
+
+# Matches a purl: pkg:<type>/<namespace>?/<name>@<version>?...
+# Anchored, no backtracking traps; rejects names with shell/HTML metacharacters
+# beyond what real purls contain.
+_PURL_RE = re.compile(
+    r"^pkg:(?P<type>[A-Za-z0-9.+-]+)/"
+    r"(?P<path>[^@?#]+)"
+    r"(?:@(?P<version>[^?#]+))?"
+    r"(?:[?#].*)?$"
+)
+
+
+@dataclass(frozen=True)
+class Package:
+    """A normalised package coordinate parsed from an SBOM entry."""
+
+    ecosystem: str
+    name: str
+    version: str
+
+
+def _sanitize_cell(value: str) -> str:
+    """Make a string safe to embed inside a markdown table cell.
+
+    Hostile package names could otherwise inject pipes, backticks, HTML, or
+    control characters into the rendered PR comment (log-injection style).
+    Strip CR/LF/control chars, escape pipes and backticks, and cap length.
+    """
+    if value is None:
+        return "(empty)"
+    # Drop CR, LF, NUL, and other C0 control chars (keep tab as space).
+    cleaned = "".join(
+        " " if ch in ("\t",) else ch
+        for ch in value
+        if ord(ch) >= 32 and ch not in ("\r", "\n")
+    )
+    # Escape markdown-significant characters that break tables.
+    cleaned = cleaned.replace("\\", "\\\\").replace("|", "\\|").replace("`", "\\`")
+    # Strip HTML tag openers so a name like `<script>` cannot break out.
+    cleaned = cleaned.replace("<", "&lt;").replace(">", "&gt;")
+    # Length cap protects the comment from giant single fields.
+    if len(cleaned) > 200:
+        cleaned = cleaned[:197] + "..."
+    return cleaned.strip() or "(empty)"
+
+
+def _parse_purl(purl: str) -> tuple[str, str, str] | None:
+    """Return (ecosystem, name, version) from a purl string, or None."""
+    if not isinstance(purl, str):
+        return None
+    match = _PURL_RE.match(purl.strip())
+    if not match:
+        return None
+    eco = match.group("type").lower()
+    path = match.group("path")
+    version = match.group("version") or ""
+    # The last path segment is the package name; preceding segments are the
+    # namespace (e.g. @scope for npm, group for maven).
+    parts = path.split("/")
+    name = parts[-1]
+    if len(parts) > 1:
+        namespace = "/".join(parts[:-1])
+        name = f"{namespace}/{name}"
+    if eco not in _KNOWN_ECOSYSTEMS:
+        eco = "other"
+    return eco, name, version
+
+
+def _extract_packages(sbom: dict) -> set[Package]:
+    """Return the set of packages described by an SPDX-JSON document.
+
+    Falls back to the SPDX `name` / `versionInfo` fields when a package has no
+    purl externalRef. Packages that look like SBOM self-references (the root
+    document describing itself) are skipped.
+    """
+    if not isinstance(sbom, dict):
+        raise ValueError("SBOM root must be a JSON object")
+    packages_raw = sbom.get("packages")
+    if packages_raw is None:
+        return set()
+    if not isinstance(packages_raw, list):
+        raise ValueError("'packages' must be a list")
+
+    document_name = sbom.get("name") if isinstance(sbom.get("name"), str) else None
+    out: set[Package] = set()
+    for entry in packages_raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        version = entry.get("versionInfo") or ""
+        if not isinstance(name, str) or not name:
+            continue
+        if not isinstance(version, str):
+            version = ""
+
+        # Try purl first for accurate ecosystem identification.
+        ecosystem = "other"
+        parsed_from_purl = False
+        for ref in entry.get("externalRefs", []) or []:
+            if not isinstance(ref, dict):
+                continue
+            if ref.get("referenceType") != "purl":
+                continue
+            locator = ref.get("referenceLocator", "")
+            parsed = _parse_purl(locator)
+            if parsed is None:
+                continue
+            ecosystem, name, purl_version = parsed
+            if purl_version:
+                version = purl_version
+            parsed_from_purl = True
+            break
+
+        # Skip SBOM document self-references and the synthetic root package.
+        if not parsed_from_purl and document_name and name == document_name:
+            continue
+
+        out.add(Package(ecosystem=ecosystem, name=name, version=version))
+    return out
+
+
+def _index_by_key(packages: Iterable[Package]) -> dict[tuple[str, str], set[str]]:
+    """Map (ecosystem, name) -> set of versions seen."""
+    idx: dict[tuple[str, str], set[str]] = {}
+    for pkg in packages:
+        idx.setdefault((pkg.ecosystem, pkg.name), set()).add(pkg.version)
+    return idx
+
+
+@dataclass
+class DiffResult:
+    """Computed diff between two SBOMs."""
+
+    added: list[Package]
+    removed: list[Package]
+    bumped: list[tuple[Package, Package]]  # (old, new) sharing ecosystem+name
+    truncated_added: int = 0  # entries dropped due to max_added cap
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.added or self.removed or self.bumped)
+
+
+def diff_sboms(
+    base: set[Package],
+    head: set[Package],
+    max_added: int = DEFAULT_MAX_ADDED,
+) -> DiffResult:
+    """Compute the added / removed / bumped diff between two package sets."""
+    if max_added < 0:
+        raise ValueError("max_added must be non-negative")
+    base_idx = _index_by_key(base)
+    head_idx = _index_by_key(head)
+
+    added: list[Package] = []
+    removed: list[Package] = []
+    bumped: list[tuple[Package, Package]] = []
+
+    for key, head_versions in head_idx.items():
+        base_versions = base_idx.get(key)
+        if base_versions is None:
+            for v in sorted(head_versions):
+                added.append(Package(key[0], key[1], v))
+            continue
+        # Same package present on both sides: any version delta is a bump.
+        new_versions = head_versions - base_versions
+        old_versions = base_versions - head_versions
+        if new_versions and old_versions:
+            old_pkg = Package(key[0], key[1], sorted(old_versions)[0])
+            new_pkg = Package(key[0], key[1], sorted(new_versions)[0])
+            bumped.append((old_pkg, new_pkg))
+
+    for key, base_versions in base_idx.items():
+        if key not in head_idx:
+            for v in sorted(base_versions):
+                removed.append(Package(key[0], key[1], v))
+
+    added.sort(key=lambda p: (p.ecosystem, p.name, p.version))
+    removed.sort(key=lambda p: (p.ecosystem, p.name, p.version))
+    bumped.sort(key=lambda pair: (pair[0].ecosystem, pair[0].name))
+
+    truncated = 0
+    if len(added) > max_added:
+        truncated = len(added) - max_added
+        added = added[:max_added]
+
+    return DiffResult(added=added, removed=removed, bumped=bumped, truncated_added=truncated)
+
+
+def _group_by_ecosystem(pkgs: Iterable[Package]) -> dict[str, list[Package]]:
+    grouped: dict[str, list[Package]] = {}
+    for pkg in pkgs:
+        grouped.setdefault(pkg.ecosystem, []).append(pkg)
+    return grouped
+
+
+def render_markdown(diff: DiffResult, base_ref: str, head_ref: str) -> str:
+    """Render a diff as a markdown comment body."""
+    safe_base = _sanitize_cell(base_ref or "base")
+    safe_head = _sanitize_cell(head_ref or "head")
+
+    lines: list[str] = [
+        COMMENT_MARKER,
+        "## 📦 Dependency diff (SBOM)",
+        "",
+        f"Comparing **{safe_base}** → **{safe_head}**.",
+        "",
+    ]
+
+    if diff.is_empty:
+        lines.append("✅ No dependency changes detected.")
+        lines.append("")
+        return "\n".join(lines)
+
+    totals = (
+        f"**Summary:** ➕ {len(diff.added)} added"
+        + (f" *(+{diff.truncated_added} more truncated)*" if diff.truncated_added else "")
+        + f" · ➖ {len(diff.removed)} removed · 🔄 {len(diff.bumped)} bumped"
+    )
+    lines.append(totals)
+    lines.append("")
+
+    if diff.added:
+        lines.append("### ➕ Added")
+        lines.append("")
+        for eco, pkgs in sorted(_group_by_ecosystem(diff.added).items()):
+            lines.append(f"#### `{_sanitize_cell(eco)}` ({len(pkgs)})")
+            lines.append("")
+            lines.append("| Package | Version |")
+            lines.append("|---------|---------|")
+            for p in pkgs:
+                lines.append(f"| {_sanitize_cell(p.name)} | {_sanitize_cell(p.version)} |")
+            lines.append("")
+        if diff.truncated_added:
+            lines.append(
+                f"> ⚠️ Truncated {diff.truncated_added} additional 'added' entries "
+                f"(cap = {len(diff.added)}). Inspect the workflow artifact for the full list."
+            )
+            lines.append("")
+
+    if diff.removed:
+        lines.append("### ➖ Removed")
+        lines.append("")
+        for eco, pkgs in sorted(_group_by_ecosystem(diff.removed).items()):
+            lines.append(f"#### `{_sanitize_cell(eco)}` ({len(pkgs)})")
+            lines.append("")
+            lines.append("| Package | Version |")
+            lines.append("|---------|---------|")
+            for p in pkgs:
+                lines.append(f"| {_sanitize_cell(p.name)} | {_sanitize_cell(p.version)} |")
+            lines.append("")
+
+    if diff.bumped:
+        lines.append("### 🔄 Bumped")
+        lines.append("")
+        grouped_bumps: dict[str, list[tuple[Package, Package]]] = {}
+        for old, new in diff.bumped:
+            grouped_bumps.setdefault(old.ecosystem, []).append((old, new))
+        for eco, pairs in sorted(grouped_bumps.items()):
+            lines.append(f"#### `{_sanitize_cell(eco)}` ({len(pairs)})")
+            lines.append("")
+            lines.append("| Package | From | To |")
+            lines.append("|---------|------|----|")
+            for old, new in pairs:
+                lines.append(
+                    f"| {_sanitize_cell(old.name)} "
+                    f"| {_sanitize_cell(old.version)} "
+                    f"| {_sanitize_cell(new.version)} |"
+                )
+            lines.append("")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _load_sbom(path: Path) -> dict:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Failed to read SBOM at {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"SBOM at {path} must be a JSON object")
+    return data
+
+
+def run(
+    base_path: Path,
+    head_path: Path,
+    output_path: Path,
+    base_ref: str,
+    head_ref: str,
+    max_added: int = DEFAULT_MAX_ADDED,
+) -> DiffResult:
+    """End-to-end: load both SBOMs, diff, write markdown to output_path."""
+    base_sbom = _load_sbom(base_path)
+    head_sbom = _load_sbom(head_path)
+    base_pkgs = _extract_packages(base_sbom)
+    head_pkgs = _extract_packages(head_sbom)
+    diff = diff_sboms(base_pkgs, head_pkgs, max_added=max_added)
+    markdown = render_markdown(diff, base_ref=base_ref, head_ref=head_ref)
+    output_path.write_text(markdown, encoding="utf-8")
+    return diff
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Diff two SPDX-JSON SBOMs into a markdown report.")
+    p.add_argument("--base", required=True, type=Path, help="Path to base SBOM (SPDX-JSON).")
+    p.add_argument("--head", required=True, type=Path, help="Path to head SBOM (SPDX-JSON).")
+    p.add_argument("--output", required=True, type=Path, help="Path to write markdown report.")
+    p.add_argument("--base-ref", default="base", help="Human label for the base ref.")
+    p.add_argument("--head-ref", default="head", help="Human label for the head ref.")
+    p.add_argument(
+        "--max-added",
+        type=int,
+        default=DEFAULT_MAX_ADDED,
+        help=f"Cap on rendered 'added' entries (default: {DEFAULT_MAX_ADDED}).",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        diff = run(
+            base_path=args.base,
+            head_path=args.head,
+            output_path=args.output,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+            max_added=args.max_added,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    summary = (
+        f"sbom-diff: +{len(diff.added)} added "
+        f"(truncated {diff.truncated_added}), "
+        f"-{len(diff.removed)} removed, "
+        f"~{len(diff.bumped)} bumped"
+    )
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/diff_sbom.py
+++ b/scripts/diff_sbom.py
@@ -172,7 +172,14 @@ def _extract_packages(sbom: dict) -> set[Package]:
             parsed_from_purl = True
             break
 
-        # Skip SBOM document self-references and the synthetic root package.
+        # Skip the synthetic "root" package that SPDX tools emit to represent
+        # the scanned repository itself. We only suppress when ALL of these hold:
+        #   1. No PURL was parsed (real dependencies always carry a PURL).
+        #   2. The SBOM document has a non-empty name.
+        #   3. The package name exactly equals the document name.
+        # This avoids accidentally hiding a legitimate dependency that happens
+        # to share a name with the document, while still filtering the noise
+        # that would otherwise show up as a phantom "added" entry on every PR.
         if not parsed_from_purl and document_name and name == document_name:
             continue
 

--- a/scripts/diff_sbom.py
+++ b/scripts/diff_sbom.py
@@ -79,7 +79,7 @@ def _sanitize_cell(value: str) -> str:
     Hostile package names could otherwise inject pipes, backticks, HTML,
     control characters, or @-mentions / #-references into the rendered PR
     comment (log-injection / notification-spam style). Strip CR/LF/control
-    chars, escape pipes and backticks, HTML-encode angle brackets, neutralise
+    chars, escape pipes and backticks, HTML-encode angle brackets, neutralize
     GitHub auto-link triggers (@ and #), and cap length.
     """
     if value is None:

--- a/scripts/diff_sbom.py
+++ b/scripts/diff_sbom.py
@@ -25,8 +25,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-# Hard cap on rendered "added" entries to prevent DoS via a flood of new deps.
+# Hard caps to prevent DoS via a flood of new/changed deps. `added` is the
+# primary attack surface (transitive creep on a fork PR) but `removed` and
+# `bumped` are also bounded so a degenerate diff cannot bust GitHub's 65 KB
+# comment cap or run the renderer for minutes.
 DEFAULT_MAX_ADDED = 500
+DEFAULT_MAX_REMOVED = 500
+DEFAULT_MAX_BUMPED = 500
 
 # Hidden marker used by the workflow to find & update the existing PR comment.
 COMMENT_MARKER = "<!-- sbom-diff-bot -->"
@@ -71,9 +76,11 @@ class Package:
 def _sanitize_cell(value: str) -> str:
     """Make a string safe to embed inside a markdown table cell.
 
-    Hostile package names could otherwise inject pipes, backticks, HTML, or
-    control characters into the rendered PR comment (log-injection style).
-    Strip CR/LF/control chars, escape pipes and backticks, and cap length.
+    Hostile package names could otherwise inject pipes, backticks, HTML,
+    control characters, or @-mentions / #-references into the rendered PR
+    comment (log-injection / notification-spam style). Strip CR/LF/control
+    chars, escape pipes and backticks, HTML-encode angle brackets, neutralise
+    GitHub auto-link triggers (@ and #), and cap length.
     """
     if value is None:
         return "(empty)"
@@ -87,6 +94,11 @@ def _sanitize_cell(value: str) -> str:
     cleaned = cleaned.replace("\\", "\\\\").replace("|", "\\|").replace("`", "\\`")
     # Strip HTML tag openers so a name like `<script>` cannot break out.
     cleaned = cleaned.replace("<", "&lt;").replace(">", "&gt;")
+    # Defuse GitHub auto-links: bot comments would otherwise notify any
+    # @user/@org or link to #1234 if a hostile package name embeds them.
+    # NOTE: replace `#` BEFORE `@`. Replacing `@` first emits `&#64;`, whose
+    # `#` would then be clobbered by the subsequent `#` -> `&#35;` pass.
+    cleaned = cleaned.replace("#", "&#35;").replace("@", "&#64;")
     # Length cap protects the comment from giant single fields.
     if len(cleaned) > 200:
         cleaned = cleaned[:197] + "..."
@@ -184,6 +196,8 @@ class DiffResult:
     removed: list[Package]
     bumped: list[tuple[Package, Package]]  # (old, new) sharing ecosystem+name
     truncated_added: int = 0  # entries dropped due to max_added cap
+    truncated_removed: int = 0
+    truncated_bumped: int = 0
 
     @property
     def is_empty(self) -> bool:
@@ -194,10 +208,12 @@ def diff_sboms(
     base: set[Package],
     head: set[Package],
     max_added: int = DEFAULT_MAX_ADDED,
+    max_removed: int = DEFAULT_MAX_REMOVED,
+    max_bumped: int = DEFAULT_MAX_BUMPED,
 ) -> DiffResult:
     """Compute the added / removed / bumped diff between two package sets."""
-    if max_added < 0:
-        raise ValueError("max_added must be non-negative")
+    if max_added < 0 or max_removed < 0 or max_bumped < 0:
+        raise ValueError("caps must be non-negative")
     base_idx = _index_by_key(base)
     head_idx = _index_by_key(head)
 
@@ -228,12 +244,21 @@ def diff_sboms(
     removed.sort(key=lambda p: (p.ecosystem, p.name, p.version))
     bumped.sort(key=lambda pair: (pair[0].ecosystem, pair[0].name))
 
-    truncated = 0
-    if len(added) > max_added:
-        truncated = len(added) - max_added
-        added = added[:max_added]
+    truncated_added = max(0, len(added) - max_added)
+    truncated_removed = max(0, len(removed) - max_removed)
+    truncated_bumped = max(0, len(bumped) - max_bumped)
+    added = added[:max_added]
+    removed = removed[:max_removed]
+    bumped = bumped[:max_bumped]
 
-    return DiffResult(added=added, removed=removed, bumped=bumped, truncated_added=truncated)
+    return DiffResult(
+        added=added,
+        removed=removed,
+        bumped=bumped,
+        truncated_added=truncated_added,
+        truncated_removed=truncated_removed,
+        truncated_bumped=truncated_bumped,
+    )
 
 
 def _group_by_ecosystem(pkgs: Iterable[Package]) -> dict[str, list[Package]]:
@@ -298,6 +323,12 @@ def render_markdown(diff: DiffResult, base_ref: str, head_ref: str) -> str:
             for p in pkgs:
                 lines.append(f"| {_sanitize_cell(p.name)} | {_sanitize_cell(p.version)} |")
             lines.append("")
+        if diff.truncated_removed:
+            lines.append(
+                f"> ⚠️ Truncated {diff.truncated_removed} additional 'removed' entries "
+                f"(cap = {len(diff.removed)}). Inspect the workflow artifact for the full list."
+            )
+            lines.append("")
 
     if diff.bumped:
         lines.append("### 🔄 Bumped")
@@ -317,12 +348,33 @@ def render_markdown(diff: DiffResult, base_ref: str, head_ref: str) -> str:
                     f"| {_sanitize_cell(new.version)} |"
                 )
             lines.append("")
+        if diff.truncated_bumped:
+            lines.append(
+                f"> ⚠️ Truncated {diff.truncated_bumped} additional 'bumped' entries "
+                f"(cap = {len(diff.bumped)}). Inspect the workflow artifact for the full list."
+            )
+            lines.append("")
 
     lines.append("")
     return "\n".join(lines)
 
 
-def _load_sbom(path: Path) -> dict:
+# Hard ceiling on the on-disk SBOM size, in bytes, before we even attempt to
+# parse JSON. The trusted workflow downloads this artifact from an untrusted
+# producer; oversized blobs must fail fast rather than balloon Python memory.
+# 64 MiB is well above any realistic SBOM for this repo.
+DEFAULT_MAX_SBOM_BYTES = 64 * 1024 * 1024
+
+
+def _load_sbom(path: Path, max_bytes: int = DEFAULT_MAX_SBOM_BYTES) -> dict:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ValueError(f"Failed to stat SBOM at {path}: {exc}") from exc
+    if size > max_bytes:
+        raise ValueError(
+            f"SBOM at {path} is {size} bytes, exceeds cap of {max_bytes} bytes"
+        )
     try:
         with path.open("r", encoding="utf-8") as fh:
             data = json.load(fh)
@@ -340,13 +392,22 @@ def run(
     base_ref: str,
     head_ref: str,
     max_added: int = DEFAULT_MAX_ADDED,
+    max_removed: int = DEFAULT_MAX_REMOVED,
+    max_bumped: int = DEFAULT_MAX_BUMPED,
+    max_sbom_bytes: int = DEFAULT_MAX_SBOM_BYTES,
 ) -> DiffResult:
     """End-to-end: load both SBOMs, diff, write markdown to output_path."""
-    base_sbom = _load_sbom(base_path)
-    head_sbom = _load_sbom(head_path)
+    base_sbom = _load_sbom(base_path, max_bytes=max_sbom_bytes)
+    head_sbom = _load_sbom(head_path, max_bytes=max_sbom_bytes)
     base_pkgs = _extract_packages(base_sbom)
     head_pkgs = _extract_packages(head_sbom)
-    diff = diff_sboms(base_pkgs, head_pkgs, max_added=max_added)
+    diff = diff_sboms(
+        base_pkgs,
+        head_pkgs,
+        max_added=max_added,
+        max_removed=max_removed,
+        max_bumped=max_bumped,
+    )
     markdown = render_markdown(diff, base_ref=base_ref, head_ref=head_ref)
     output_path.write_text(markdown, encoding="utf-8")
     return diff
@@ -365,6 +426,24 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_MAX_ADDED,
         help=f"Cap on rendered 'added' entries (default: {DEFAULT_MAX_ADDED}).",
     )
+    p.add_argument(
+        "--max-removed",
+        type=int,
+        default=DEFAULT_MAX_REMOVED,
+        help=f"Cap on rendered 'removed' entries (default: {DEFAULT_MAX_REMOVED}).",
+    )
+    p.add_argument(
+        "--max-bumped",
+        type=int,
+        default=DEFAULT_MAX_BUMPED,
+        help=f"Cap on rendered 'bumped' entries (default: {DEFAULT_MAX_BUMPED}).",
+    )
+    p.add_argument(
+        "--max-sbom-bytes",
+        type=int,
+        default=DEFAULT_MAX_SBOM_BYTES,
+        help=f"Reject SBOMs larger than this (default: {DEFAULT_MAX_SBOM_BYTES} bytes).",
+    )
     return p.parse_args(argv)
 
 
@@ -378,6 +457,9 @@ def main(argv: list[str] | None = None) -> int:
             base_ref=args.base_ref,
             head_ref=args.head_ref,
             max_added=args.max_added,
+            max_removed=args.max_removed,
+            max_bumped=args.max_bumped,
+            max_sbom_bytes=args.max_sbom_bytes,
         )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -385,8 +467,10 @@ def main(argv: list[str] | None = None) -> int:
     summary = (
         f"sbom-diff: +{len(diff.added)} added "
         f"(truncated {diff.truncated_added}), "
-        f"-{len(diff.removed)} removed, "
-        f"~{len(diff.bumped)} bumped"
+        f"-{len(diff.removed)} removed "
+        f"(truncated {diff.truncated_removed}), "
+        f"~{len(diff.bumped)} bumped "
+        f"(truncated {diff.truncated_bumped})"
     )
     print(summary)
     return 0

--- a/scripts/tests/test_diff_sbom.py
+++ b/scripts/tests/test_diff_sbom.py
@@ -421,3 +421,37 @@ def test_default_cap_value():
     assert DEFAULT_MAX_REMOVED == 500
     assert DEFAULT_MAX_BUMPED == 500
     assert DEFAULT_MAX_SBOM_BYTES == 64 * 1024 * 1024
+
+
+def test_diff_handles_multiple_versions_of_same_package():
+    """Lockfiles can pin two versions of one transitive dep (monorepo
+    workspaces, peer-dep duplication). The diff is keyed by (ecosystem, name)
+    and surfaces multi-version drift as a single 'bumped' entry rather than
+    fan-out add/remove rows; this keeps the PR comment readable while still
+    flagging that the dependency moved."""
+    base_doc = _sbom(
+        [
+            _pkg("lodash", "4.17.20"),
+            _pkg("lodash", "4.17.21"),
+        ]
+    )
+    head_doc = _sbom(
+        [
+            _pkg("lodash", "4.17.21"),
+            _pkg("lodash", "4.17.22"),
+        ]
+    )
+
+    base_pkgs = _extract_packages(base_doc)
+    head_pkgs = _extract_packages(head_doc)
+    result = diff_sboms(base_pkgs, head_pkgs)
+
+    # Name appears on both sides, so it never lands in added/removed.
+    assert not any(p.name == "lodash" for p in result.added)
+    assert not any(p.name == "lodash" for p in result.removed)
+    # Version drift surfaces as exactly one bumped entry for the name.
+    lodash_bumps = [pair for pair in result.bumped if pair[0].name == "lodash"]
+    assert len(lodash_bumps) == 1
+    old_pkg, new_pkg = lodash_bumps[0]
+    assert old_pkg.version == "4.17.20"
+    assert new_pkg.version == "4.17.22"

--- a/scripts/tests/test_diff_sbom.py
+++ b/scripts/tests/test_diff_sbom.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for diff_sbom.py."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from diff_sbom import (  # noqa: E402
+    COMMENT_MARKER,
+    DEFAULT_MAX_ADDED,
+    Package,
+    _extract_packages,
+    _parse_purl,
+    _sanitize_cell,
+    diff_sboms,
+    render_markdown,
+    run,
+)
+
+
+def _pkg(name: str, version: str, purl_type: str = "npm") -> dict:
+    """Helper to build an SPDX-JSON package entry."""
+    return {
+        "name": name,
+        "versionInfo": version,
+        "externalRefs": [
+            {
+                "referenceCategory": "PACKAGE-MANAGER",
+                "referenceType": "purl",
+                "referenceLocator": f"pkg:{purl_type}/{name}@{version}",
+            }
+        ],
+    }
+
+
+def _sbom(packages: list[dict], doc_name: str = "test-sbom") -> dict:
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "name": doc_name,
+        "packages": packages,
+    }
+
+
+# ----- _parse_purl ------------------------------------------------------------
+
+
+def test_parse_purl_npm_simple():
+    assert _parse_purl("pkg:npm/left-pad@1.3.0") == ("npm", "left-pad", "1.3.0")
+
+
+def test_parse_purl_npm_scoped():
+    assert _parse_purl("pkg:npm/%40scope/pkg@2.0.0") == ("npm", "%40scope/pkg", "2.0.0")
+
+
+def test_parse_purl_no_version():
+    assert _parse_purl("pkg:pypi/requests") == ("pypi", "requests", "")
+
+
+def test_parse_purl_unknown_ecosystem_falls_back_to_other():
+    eco, name, version = _parse_purl("pkg:weird-thing/foo@1.0")
+    assert eco == "other"
+    assert name == "foo"
+    assert version == "1.0"
+
+
+def test_parse_purl_rejects_non_string():
+    assert _parse_purl(None) is None  # type: ignore[arg-type]
+    assert _parse_purl(123) is None  # type: ignore[arg-type]
+
+
+def test_parse_purl_rejects_garbage():
+    assert _parse_purl("not-a-purl") is None
+    assert _parse_purl("") is None
+
+
+# ----- _sanitize_cell ---------------------------------------------------------
+
+
+def test_sanitize_escapes_pipes_and_backticks():
+    out = _sanitize_cell("evil|name`with`pipes")
+    assert "|" not in out.replace("\\|", "")
+    assert "`" not in out.replace("\\`", "")
+
+
+def test_sanitize_strips_newlines_and_control_chars():
+    out = _sanitize_cell("foo\nbar\r\x00baz")
+    assert "\n" not in out
+    assert "\r" not in out
+    assert "\x00" not in out
+
+
+def test_sanitize_escapes_html_brackets():
+    out = _sanitize_cell("<script>alert(1)</script>")
+    assert "<" not in out
+    assert ">" not in out
+    assert "&lt;" in out
+    assert "&gt;" in out
+
+
+def test_sanitize_caps_length():
+    long = "x" * 500
+    out = _sanitize_cell(long)
+    assert len(out) <= 200
+    assert out.endswith("...")
+
+
+def test_sanitize_handles_empty():
+    assert _sanitize_cell("") == "(empty)"
+    assert _sanitize_cell(None) == "(empty)"  # type: ignore[arg-type]
+
+
+# ----- _extract_packages ------------------------------------------------------
+
+
+def test_extract_packages_simple():
+    sbom = _sbom([_pkg("foo", "1.0.0"), _pkg("bar", "2.0.0", "pypi")])
+    pkgs = _extract_packages(sbom)
+    assert Package("npm", "foo", "1.0.0") in pkgs
+    assert Package("pypi", "bar", "2.0.0") in pkgs
+
+
+def test_extract_packages_skips_document_self_reference():
+    sbom = {
+        "name": "my-repo",
+        "packages": [
+            {"name": "my-repo", "versionInfo": ""},  # no purl, matches doc name
+            _pkg("real-dep", "1.0.0"),
+        ],
+    }
+    pkgs = _extract_packages(sbom)
+    assert Package("npm", "real-dep", "1.0.0") in pkgs
+    assert not any(p.name == "my-repo" for p in pkgs)
+
+
+def test_extract_packages_falls_back_to_versionInfo_without_purl():
+    sbom = _sbom([{"name": "no-purl-pkg", "versionInfo": "9.9.9"}])
+    pkgs = _extract_packages(sbom)
+    # No purl -> ecosystem "other"
+    assert Package("other", "no-purl-pkg", "9.9.9") in pkgs
+
+
+def test_extract_packages_empty():
+    assert _extract_packages({"packages": []}) == set()
+    assert _extract_packages({}) == set()
+
+
+def test_extract_packages_rejects_non_dict():
+    with pytest.raises(ValueError):
+        _extract_packages([])  # type: ignore[arg-type]
+
+
+def test_extract_packages_rejects_non_list_packages():
+    with pytest.raises(ValueError):
+        _extract_packages({"packages": "not-a-list"})
+
+
+def test_extract_packages_ignores_malformed_entries():
+    sbom = {
+        "packages": [
+            "not-a-dict",
+            {"versionInfo": "1.0"},  # no name
+            {"name": ""},  # empty name
+            _pkg("good", "1.0.0"),
+        ]
+    }
+    pkgs = _extract_packages(sbom)
+    assert pkgs == {Package("npm", "good", "1.0.0")}
+
+
+# ----- diff_sboms -------------------------------------------------------------
+
+
+def test_diff_added_only():
+    base: set[Package] = set()
+    head = {Package("npm", "foo", "1.0.0")}
+    diff = diff_sboms(base, head)
+    assert diff.added == [Package("npm", "foo", "1.0.0")]
+    assert diff.removed == []
+    assert diff.bumped == []
+    assert not diff.is_empty
+
+
+def test_diff_removed_only():
+    base = {Package("pypi", "old", "1.0")}
+    head: set[Package] = set()
+    diff = diff_sboms(base, head)
+    assert diff.removed == [Package("pypi", "old", "1.0")]
+    assert diff.added == []
+
+
+def test_diff_bumped_detected():
+    base = {Package("npm", "foo", "1.0.0")}
+    head = {Package("npm", "foo", "2.0.0")}
+    diff = diff_sboms(base, head)
+    assert diff.added == []
+    assert diff.removed == []
+    assert len(diff.bumped) == 1
+    old, new = diff.bumped[0]
+    assert old.version == "1.0.0"
+    assert new.version == "2.0.0"
+
+
+def test_diff_empty_when_identical():
+    pkgs = {Package("npm", "foo", "1.0.0"), Package("pypi", "bar", "2.0.0")}
+    diff = diff_sboms(pkgs, pkgs)
+    assert diff.is_empty
+    assert diff.added == [] and diff.removed == [] and diff.bumped == []
+
+
+def test_diff_truncation_cap():
+    head = {Package("npm", f"dep-{i:04d}", "1.0.0") for i in range(600)}
+    diff = diff_sboms(set(), head, max_added=500)
+    assert len(diff.added) == 500
+    assert diff.truncated_added == 100
+
+
+def test_diff_truncation_cap_zero():
+    head = {Package("npm", "foo", "1.0.0")}
+    diff = diff_sboms(set(), head, max_added=0)
+    assert diff.added == []
+    assert diff.truncated_added == 1
+
+
+def test_diff_rejects_negative_cap():
+    with pytest.raises(ValueError):
+        diff_sboms(set(), set(), max_added=-1)
+
+
+def test_diff_distinct_ecosystems_are_separate():
+    # Same name in two ecosystems is two distinct packages.
+    base = {Package("npm", "foo", "1.0.0")}
+    head = {Package("npm", "foo", "1.0.0"), Package("pypi", "foo", "1.0.0")}
+    diff = diff_sboms(base, head)
+    assert diff.added == [Package("pypi", "foo", "1.0.0")]
+    assert diff.removed == []
+    assert diff.bumped == []
+
+
+# ----- render_markdown --------------------------------------------------------
+
+
+def test_render_includes_marker():
+    out = render_markdown(diff_sboms(set(), set()), base_ref="main", head_ref="pr")
+    assert COMMENT_MARKER in out
+    assert out.splitlines()[0] == COMMENT_MARKER  # must be first line
+
+
+def test_render_empty_diff_says_no_changes():
+    out = render_markdown(diff_sboms(set(), set()), base_ref="main", head_ref="pr")
+    assert "No dependency changes" in out
+
+
+def test_render_groups_by_ecosystem():
+    head = {
+        Package("npm", "a", "1.0.0"),
+        Package("pypi", "b", "2.0.0"),
+    }
+    out = render_markdown(diff_sboms(set(), head), base_ref="main", head_ref="pr")
+    assert "`npm`" in out
+    assert "`pypi`" in out
+    assert "### ➕ Added" in out
+
+
+def test_render_sanitizes_hostile_package_name():
+    head = {Package("npm", "evil`|<script>", "1.0.0\npwn")}
+    out = render_markdown(diff_sboms(set(), head), base_ref="main", head_ref="pr")
+    # The raw hostile substrings must not appear unescaped in the output body.
+    body_after_header = "\n".join(out.splitlines()[1:])
+    assert "<script>" not in body_after_header
+    assert "1.0.0\npwn" not in body_after_header
+
+
+def test_render_sanitizes_hostile_ref_label():
+    out = render_markdown(
+        diff_sboms(set(), set()),
+        base_ref="main\n## fake header",
+        head_ref="pr`evil`",
+    )
+    # Header injection requires `#` at line-start; sanitization strips newlines
+    # so the hostile string cannot start a new line.
+    for line in out.splitlines():
+        assert not line.startswith("## fake header")
+    # Backticks in ref label must be escaped so they don't open a code span.
+    assert "`evil`" not in out
+
+
+def test_render_shows_truncation_notice():
+    head = {Package("npm", f"dep-{i:04d}", "1.0.0") for i in range(50)}
+    diff = diff_sboms(set(), head, max_added=10)
+    out = render_markdown(diff, base_ref="main", head_ref="pr")
+    assert "Truncated 40" in out
+
+
+def test_render_bumped_section_has_from_to():
+    base = {Package("npm", "foo", "1.0.0")}
+    head = {Package("npm", "foo", "2.0.0")}
+    out = render_markdown(diff_sboms(base, head), base_ref="main", head_ref="pr")
+    assert "🔄 Bumped" in out
+    assert "1.0.0" in out and "2.0.0" in out
+
+
+# ----- run / end-to-end -------------------------------------------------------
+
+
+def test_run_writes_output_file(tmp_path: Path):
+    base_file = tmp_path / "base.json"
+    head_file = tmp_path / "head.json"
+    out_file = tmp_path / "out.md"
+    base_file.write_text(json.dumps(_sbom([_pkg("foo", "1.0.0")])), encoding="utf-8")
+    head_file.write_text(
+        json.dumps(_sbom([_pkg("foo", "1.0.0"), _pkg("bar", "2.0.0", "pypi")])),
+        encoding="utf-8",
+    )
+    diff = run(base_file, head_file, out_file, base_ref="main", head_ref="pr")
+    assert out_file.exists()
+    content = out_file.read_text(encoding="utf-8")
+    assert COMMENT_MARKER in content
+    assert "bar" in content
+    assert len(diff.added) == 1
+
+
+def test_run_rejects_malformed_json(tmp_path: Path):
+    base_file = tmp_path / "base.json"
+    head_file = tmp_path / "head.json"
+    base_file.write_text("{not json", encoding="utf-8")
+    head_file.write_text(json.dumps(_sbom([])), encoding="utf-8")
+    with pytest.raises(ValueError, match="Failed to read SBOM"):
+        run(base_file, head_file, tmp_path / "out.md", base_ref="m", head_ref="p")
+
+
+def test_run_rejects_non_object_root(tmp_path: Path):
+    base_file = tmp_path / "base.json"
+    head_file = tmp_path / "head.json"
+    base_file.write_text("[]", encoding="utf-8")
+    head_file.write_text(json.dumps(_sbom([])), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        run(base_file, head_file, tmp_path / "out.md", base_ref="m", head_ref="p")
+
+
+def test_default_cap_value():
+    # Sanity check the documented default doesn't drift.
+    assert DEFAULT_MAX_ADDED == 500

--- a/scripts/tests/test_diff_sbom.py
+++ b/scripts/tests/test_diff_sbom.py
@@ -17,6 +17,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from diff_sbom import (  # noqa: E402
     COMMENT_MARKER,
     DEFAULT_MAX_ADDED,
+    DEFAULT_MAX_BUMPED,
+    DEFAULT_MAX_REMOVED,
+    DEFAULT_MAX_SBOM_BYTES,
     Package,
     _extract_packages,
     _parse_purl,
@@ -116,6 +119,18 @@ def test_sanitize_caps_length():
 def test_sanitize_handles_empty():
     assert _sanitize_cell("") == "(empty)"
     assert _sanitize_cell(None) == "(empty)"  # type: ignore[arg-type]
+
+
+def test_sanitize_neutralizes_github_mentions():
+    # Hostile package name embedding @user / @org/team / #1234 must NOT survive
+    # as something that GitHub will render as a notification-spam link in the
+    # bot comment.
+    out = _sanitize_cell("@octocat please review #1 cc @org/team")
+    assert "@octocat" not in out
+    assert "@org/team" not in out
+    assert "#1" not in out
+    assert "&#64;" in out  # encoded @
+    assert "&#35;" in out  # encoded #
 
 
 # ----- _extract_packages ------------------------------------------------------
@@ -233,6 +248,25 @@ def test_diff_truncation_cap_zero():
 def test_diff_rejects_negative_cap():
     with pytest.raises(ValueError):
         diff_sboms(set(), set(), max_added=-1)
+    with pytest.raises(ValueError):
+        diff_sboms(set(), set(), max_removed=-1)
+    with pytest.raises(ValueError):
+        diff_sboms(set(), set(), max_bumped=-1)
+
+
+def test_diff_truncation_cap_removed():
+    base = {Package("npm", f"dep-{i:04d}", "1.0.0") for i in range(600)}
+    diff = diff_sboms(base, set(), max_removed=500)
+    assert len(diff.removed) == 500
+    assert diff.truncated_removed == 100
+
+
+def test_diff_truncation_cap_bumped():
+    base = {Package("npm", f"dep-{i:04d}", "1.0.0") for i in range(600)}
+    head = {Package("npm", f"dep-{i:04d}", "2.0.0") for i in range(600)}
+    diff = diff_sboms(base, head, max_bumped=500)
+    assert len(diff.bumped) == 500
+    assert diff.truncated_bumped == 100
 
 
 def test_diff_distinct_ecosystems_are_separate():
@@ -300,6 +334,21 @@ def test_render_shows_truncation_notice():
     assert "Truncated 40" in out
 
 
+def test_render_shows_truncation_notice_for_removed_and_bumped():
+    base = {Package("npm", f"old-{i:04d}", "1.0.0") for i in range(50)}
+    head = {Package("npm", f"new-{i:04d}", "1.0.0") for i in range(0)}
+    # 50 removed, cap to 10
+    diff = diff_sboms(base, head, max_removed=10)
+    out = render_markdown(diff, base_ref="main", head_ref="pr")
+    assert "Truncated 40 additional 'removed' entries" in out
+
+    base2 = {Package("npm", f"dep-{i:04d}", "1.0.0") for i in range(50)}
+    head2 = {Package("npm", f"dep-{i:04d}", "2.0.0") for i in range(50)}
+    diff2 = diff_sboms(base2, head2, max_bumped=10)
+    out2 = render_markdown(diff2, base_ref="main", head_ref="pr")
+    assert "Truncated 40 additional 'bumped' entries" in out2
+
+
 def test_render_bumped_section_has_from_to():
     base = {Package("npm", "foo", "1.0.0")}
     head = {Package("npm", "foo", "2.0.0")}
@@ -346,6 +395,29 @@ def test_run_rejects_non_object_root(tmp_path: Path):
         run(base_file, head_file, tmp_path / "out.md", base_ref="m", head_ref="p")
 
 
+def test_run_rejects_oversized_sbom(tmp_path: Path):
+    base_file = tmp_path / "base.json"
+    head_file = tmp_path / "head.json"
+    # Both files valid JSON; base is large enough to exceed a 1 KiB cap.
+    base_file.write_text(
+        json.dumps({"name": "x", "packages": [], "padding": "P" * 2048}),
+        encoding="utf-8",
+    )
+    head_file.write_text(json.dumps(_sbom([])), encoding="utf-8")
+    with pytest.raises(ValueError, match="exceeds cap"):
+        run(
+            base_file,
+            head_file,
+            tmp_path / "out.md",
+            base_ref="m",
+            head_ref="p",
+            max_sbom_bytes=1024,
+        )
+
+
 def test_default_cap_value():
     # Sanity check the documented default doesn't drift.
     assert DEFAULT_MAX_ADDED == 500
+    assert DEFAULT_MAX_REMOVED == 500
+    assert DEFAULT_MAX_BUMPED == 500
+    assert DEFAULT_MAX_SBOM_BYTES == 64 * 1024 * 1024


### PR DESCRIPTION
## Description

Adds a **PR-time SBOM diff** that surfaces transitive dependency changes as a single, idempotent PR comment. Catches supply-chain creep that the existing scans miss (e.g. a one-line `package.json` bump that pulls 40 new transitive deps).

This is proposal #4 of the supply-chain hardening series; #1–#3 + G1/G2 shipped separately.

### Before / After: the reviewer experience

**Before this PR — what a reviewer sees today**

```diff
  "dependencies": {
-   "lodash": "^4.17.20",
+   "lodash": "^4.17.21",
+   "fast-glob": "^3.3.2"
  }
```

That's it. The reviewer trusts the PR description. The 40+ transitive deps that actually land in the lockfile are **invisible** in `git diff`, and the existing `supply-chain-check.yml` only flags *known-malicious* names — not anomalies, not typosquats, not silent transitive bloat.

**After this PR — what a reviewer sees on every PR**

A single bot comment, edited in place on every push:

```markdown
<!-- sbom-diff-bot -->
## 📦 SBOM diff: `main` → `feature/upgrade-deps`

**24 added · 3 removed · 5 bumped**

### ➕ Added

#### `npm` (18)
| Name | Version |
|------|---------|
| `lodash.merge` | 4.6.2 |
| `chalk` | 5.3.0 |
| ... |

#### `pypi` (6)
| Name | Version |
|------|---------|
| `pydantic` | 2.5.3 |
| ... |

### ➖ Removed
#### `npm` (3)
| Name | Version |
|------|---------|
| `request` | 2.88.2 |
| ... |

### 🔄 Bumped
#### `pypi` (5)
| Name | From | To |
|------|------|-----|
| `cryptography` | 41.0.7 | 42.0.5 |
| ... |
```

If a PR has no dep changes: **"No dependency changes detected."** If it pulls > 500 entries in any section: capped with `_Truncated 73 additional 'added' entries…_`. Re-runs **edit the same comment** via the hidden `<!-- sbom-diff-bot -->` marker, so no stacking.

### Why this matters concretely

After this PR, these become obvious at a glance:
- A compromised maintainer pushing `1.0.4 → 1.0.5` that adds a sketchy new transitive
- A refactor that accidentally double-bundles a heavy dep
- Lockfile drift between `npm install` runs across machines
- A typosquat sneaking in via a transitive (`event-stream` / `colors.js` style)
- A small `package.json` change that pulls 40 transitive deps

### How it works (two-workflow, industry-standard isolation)

```
┌────────────────────────────────────────────────────────────┐
│ sbom-diff.yml         (UNTRUSTED — runs in PR/fork ctx)    │
│  • on: pull_request                                        │
│  • permissions: contents: read   (no write scopes anywhere)│
│  • generates SBOM(base) + SBOM(head) via anchore/sbom-action│
│  • uploads `sbom-diff-inputs` artifact                     │
│  • posts NO comment, sees NO secrets                       │
└────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌────────────────────────────────────────────────────────────┐
│ sbom-diff-comment.yml (TRUSTED — runs in base-repo ctx)    │
│  • on: workflow_run                                        │
│  • sparse-checks-out scripts/diff_sbom.py from default br. │
│  • re-verifies pr.head.sha === workflow_run.head_sha       │
│  • concurrency: keyed on head_sha, cancel-in-progress      │
│  • diffs SBOMs, renders markdown, posts/edits comment      │
└────────────────────────────────────────────────────────────┘
```

The differ that runs against fork-supplied artifacts is **always the version on the default branch** — fork PRs cannot tamper with it.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix — supply-chain hardening (proposal #4 of 6)

## Package(s) Affected

- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root — adds `.github/workflows/sbom-diff*.yml` + `scripts/diff_sbom.py` only; no runtime/product code touched

## Checklist

- [x] My code follows the project style guidelines (`ruff check --select E,F,W --ignore E501` clean)
- [x] I have added tests that prove my fix/feature works (42 tests in `scripts/tests/test_diff_sbom.py`)
- [x] All new and existing tests pass (`pytest scripts/tests/` → 211/211)
- [x] I have updated documentation as needed — N/A; the workflows and `scripts/diff_sbom.py --help` are self-documenting
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

### Additional hygiene (per parent-session checklist)

- [x] All actions pinned by full SHA + version comment (`anchore/sbom-action`, `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, `actions/github-script`)
- [x] Workflow-level `permissions: contents: read`; write scopes (`pull-requests: write`) only on the comment job in the trusted workflow
- [x] `on: pull_request` (NOT `pull_request_target`) on the untrusted half — fork secrets never exposed
- [x] MIT license headers on all 4 new files
- [x] DCO signoff on all 3 commits, conventional-commit titles
- [x] DoS caps: 500 entries each on added/removed/bumped + 64 MiB pre-parse SBOM size limit
- [x] Idempotent comment via `<!-- sbom-diff-bot -->` marker (re-runs edit, never stack)
- [x] No package installs in the workflow beyond what `anchore/sbom-action` requires; differ is **pure stdlib**

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**:

- The two-workflow `pull_request` + `workflow_run` isolation pattern is the **GitHub Security Lab–recommended** approach for safely commenting on fork PRs. Documented in [Securing your GitHub Actions workflows](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) (GitHub, 2021).
- SBOM generation uses [`anchore/sbom-action`](https://github.com/anchore/sbom-action) (Apache-2.0), which wraps Syft.
- The differ (`scripts/diff_sbom.py`) is a from-scratch, pure-stdlib implementation. Not derived from any existing tool.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

GitHub Copilot CLI assisted with: scaffolding the differ, generating test cases, drafting workflow YAML, and red-team review (2 rounds — initial 14-category threat model + adversarial rubber-duck review of the two-workflow design). All output reviewed line-by-line; threat-model findings drove three subsequent hardening commits before opening this PR.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Part of supply-chain hardening series (#1–#3 + G1/G2 shipped separately). No specific issue tracked for this proposal.

---

## Threat model summary

Two adversarial review rounds; all findings fixed in commit `30263157`:

| # | Severity | Vector | Fix |
|---|---|---|---|
| 1 | 🔴 Blocking | **PR misrouting / stale-comment race** — slow run for commit A could overwrite the comment for newer commit B | Prefer `workflow_run.pull_requests`; re-verify `pr.head.sha === workflow_run.head_sha`; `concurrency` group keyed on head SHA with `cancel-in-progress: true` |
| 2 | 🔴 Blocking | **DoS** — hostile lockfile balloons SBOM; only `added` was capped originally | Pre-parse 64 MiB file-size limit + cap added/removed/bumped each at 500 |
| 3 | 🟡 Spam | **`@mention` / `#1234` auto-links** via hostile package names could ping users in the bot comment | `_sanitize_cell` neutralises `#`→`&#35;` then `@`→`&#64;` (order matters — reverse clobbers the entity) |

**Residual risk eliminated** by the two-workflow split: the differ that runs against fork-supplied artifacts is always the default-branch copy, sparse-checked-out by SHA. Fork PRs cannot tamper with the trusted code path.

**Out-of-scope honest disclosure**: the Syft binary invoked by `anchore/sbom-action` is not pinned at the syft layer (only the action wrapper is SHA-pinned). It runs only on the untrusted side with no secrets, and the trusted side bounds blast radius via the size + entry caps.

## Files changed

| File | Lines | Purpose |
|------|------:|---------|
| `.github/workflows/sbom-diff.yml` | 92 | Untrusted half — generates SBOMs only |
| `.github/workflows/sbom-diff-comment.yml` | 171 | Trusted half — runs differ from default branch, posts comment |
| `scripts/diff_sbom.py` | 396 | Pure-stdlib SBOM differ with caps and sanitisation |
| `scripts/tests/test_diff_sbom.py` | 351 | 42 tests |

**Total**: 1010 lines across 4 new files. No existing files modified.
