### PR TITLE
feat(agent-sandbox): add fail-closed hardened image selection

### DIFF
--- a/agent-governance-python/agent-sandbox/README.md
+++ b/agent-governance-python/agent-sandbox/README.md
@@ -278,7 +278,7 @@ the network-egress policy would later refuse the call. The hardened image makes
 the attempt itself fail with "command not found".
 
 ```bash
-# Build with the default allow-list (python3, cat, echo, ls).
+# Build with the default allow-list (python3, cat, echo, ls, sleep).
 docker build \
   -f agent-sandbox/docker/Dockerfile.sandbox \
   -t agt-sandbox/python-minimal-path:3.11 \
@@ -288,7 +288,7 @@ docker build \
 # actually needs. The full allow-list IS the new PATH; any binary not listed
 # here is unreachable.
 docker build \
-  --build-arg ALLOWED_BIN_NAMES="python3 cat echo ls grep sort uniq" \
+  --build-arg ALLOWED_BIN_NAMES="python3 cat echo ls sleep grep sort uniq" \
   -f agent-sandbox/docker/Dockerfile.sandbox \
   -t agt-sandbox/python-minimal-path:3.11 \
   agent-sandbox/docker
@@ -299,6 +299,17 @@ Wire the image into `DockerSandboxProvider` via the existing `image` argument:
 ```python
 provider = DockerSandboxProvider(image="agt-sandbox/python-minimal-path:3.11")
 ```
+
+For security-sensitive deployments, require the hardened image so the
+provider fails instead of silently falling back to `python:3.11-slim` when
+the local image is unavailable:
+
+```python
+provider = DockerSandboxProvider(require_hardened_image=True)
+```
+
+Build the image before creating the provider. `require_hardened_image=True`
+cannot be combined with a custom `image=`.
 
 To extend the allow-list permanently (rather than at `docker build` time),
 edit the `ARG ALLOWED_BIN_NAMES=` line in `Dockerfile.sandbox` and rebuild.

--- a/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
+++ b/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
@@ -31,7 +31,8 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 # Build-time list of permitted binaries. Maintainers extending this image
 # should add entries here rather than relying on host-side PATH inheritance.
-ARG ALLOWED_BIN_NAMES="python3 cat echo ls"
+# `sleep` is required by DockerSandboxProvider's long-lived session command.
+ARG ALLOWED_BIN_NAMES="python3 cat echo ls sleep"
 
 # Stage 1: collect the allowed binaries into the pinned PATH directory.
 # Symlinks (not copies) preserve setuid behaviour from the base image where

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -307,6 +307,9 @@ class DockerSandboxProvider(SandboxProvider):
         Base Docker image. When ``None`` (default), the provider auto-
         selects the hardened ``HARDENED_IMAGE_TAG`` if it is locally
         available, and falls back to ``_LEGACY_DEFAULT_IMAGE`` otherwise.
+    require_hardened_image:
+        When ``True``, require the local hardened image and fail instead of
+        falling back to the legacy image. Cannot be combined with ``image``.
     docker_url:
         Docker daemon URL (default: auto-detect via env).
     runtime:
@@ -330,8 +333,20 @@ class DockerSandboxProvider(SandboxProvider):
         docker_url: str | None = None,
         runtime: IsolationRuntime = IsolationRuntime.AUTO,
         tools: dict[str, Callable[..., Any]] | None = None,
+        require_hardened_image: bool = False,
     ) -> None:
-        self._image = image if image is not None else self._select_default_image()
+        if image is not None and require_hardened_image:
+            raise ValueError(
+                "image and require_hardened_image cannot be used together; "
+                "omit image to require the built-in hardened image"
+            )
+        if require_hardened_image:
+            self._image = self._select_default_image(
+                require_hardened_image=True,
+                docker_url=docker_url,
+            )
+        else:
+            self._image = image if image is not None else self._select_default_image()
         self._tools: dict[str, Callable[..., Any]] = tools or {}
         self._requested_runtime = runtime
 
@@ -390,21 +405,36 @@ class DockerSandboxProvider(SandboxProvider):
     # ------------------------------------------------------------------
 
     @classmethod
-    def _select_default_image(cls) -> str:
+    def _select_default_image(
+        cls,
+        *,
+        require_hardened_image: bool = False,
+        docker_url: str | None = None,
+    ) -> str:
         """Pick the hardened image if it's available locally, else legacy.
 
         Tries to query the local Docker daemon for ``HARDENED_IMAGE_TAG``.
         Any failure (no Docker, image not built, permission denied) falls
         back silently to ``python:3.11-slim`` so existing setups keep
-        working. Callers who want to force one or the other should pass
-        ``image=...`` explicitly.
+        working unless ``require_hardened_image`` is true.
         """
         try:
             import docker  # type: ignore[import-untyped]
-            client = docker.from_env()
+            client = (
+                docker.DockerClient(base_url=docker_url)
+                if docker_url
+                else docker.from_env()
+            )
             client.images.get(cls.HARDENED_IMAGE_TAG)
             return cls.HARDENED_IMAGE_TAG
-        except Exception:
+        except Exception as exc:
+            if require_hardened_image:
+                raise RuntimeError(
+                    f"Hardened sandbox image '{cls.HARDENED_IMAGE_TAG}' is "
+                    "required but is not available locally. Build it from "
+                    "agent-sandbox/docker/Dockerfile.sandbox before creating "
+                    "the provider."
+                ) from exc
             return cls._LEGACY_DEFAULT_IMAGE
 
     def _detect_runtime(self) -> IsolationRuntime:

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -1026,10 +1026,11 @@ class TestMinimalPathSandboxImage:
         )
         allowed = set(match.group(1).split())
         # Sandboxed code legitimately needs python and a few read-only
-        # utilities for introspection (cat, echo, ls). Everything else is
-        # opt-in via ALLOWED_BIN_NAMES at build time.
-        assert {"python3", "cat", "echo"} <= allowed, (
-            f"ALLOWED_BIN_NAMES must include python3/cat/echo: {allowed!r}"
+        # utilities for introspection (cat, echo, ls). The provider also
+        # starts long-lived sessions with `sleep infinity`, so sleep must
+        # remain resolvable from the pinned PATH.
+        assert {"python3", "cat", "echo", "sleep"} <= allowed, (
+            f"ALLOWED_BIN_NAMES must include python3/cat/echo/sleep: {allowed!r}"
         )
         # Network and infra CLIs must NOT be in the default allowed set.
         forbidden_in_allowlist = {
@@ -2349,7 +2350,8 @@ class TestHardeningAdditions:
 class TestDefaultImageSelection:
     """The DockerSandboxProvider prefers the hardened minimal-PATH image
     when it is locally available, and falls back to python:3.11-slim
-    otherwise so existing deployments keep working."""
+    otherwise so existing deployments keep working. Callers can opt into
+    fail-closed selection when command restrictions are required."""
 
     def test_prefers_hardened_image_when_available(self, monkeypatch):
         from agent_sandbox.docker_provider.provider import DockerSandboxProvider
@@ -2374,6 +2376,75 @@ class TestDefaultImageSelection:
         from agent_sandbox.docker_provider.provider import DockerSandboxProvider
         p = DockerSandboxProvider(image="my-custom:tag")
         assert p._image == "my-custom:tag"
+
+    def test_require_hardened_image_selects_hardened_image(self, monkeypatch):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        selected_with = []
+
+        def fake_select(
+            cls,
+            *,
+            require_hardened_image=False,
+            docker_url=None,
+        ):
+            selected_with.append((require_hardened_image, docker_url))
+            return cls.HARDENED_IMAGE_TAG
+
+        monkeypatch.setattr(
+            DockerSandboxProvider,
+            "_select_default_image",
+            classmethod(fake_select),
+        )
+
+        p = DockerSandboxProvider(require_hardened_image=True)
+
+        assert p._image == DockerSandboxProvider.HARDENED_IMAGE_TAG
+        assert selected_with == [(True, None)]
+
+    def test_require_hardened_image_uses_configured_docker_url(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        docker_module = MagicMock()
+
+        with patch.dict("sys.modules", {"docker": docker_module}):
+            selected = DockerSandboxProvider._select_default_image(
+                require_hardened_image=True,
+                docker_url="tcp://docker.example:2376",
+            )
+
+        assert selected == DockerSandboxProvider.HARDENED_IMAGE_TAG
+        docker_module.DockerClient.assert_called_once_with(
+            base_url="tcp://docker.example:2376"
+        )
+        docker_module.from_env.assert_not_called()
+
+    def test_require_hardened_image_fails_when_unavailable(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        docker_module = MagicMock()
+        docker_module.from_env.return_value.images.get.side_effect = Exception(
+            "image not found"
+        )
+
+        with patch.dict("sys.modules", {"docker": docker_module}):
+            with pytest.raises(
+                RuntimeError,
+                match="required but is not available locally",
+            ):
+                DockerSandboxProvider(require_hardened_image=True)
+
+    def test_require_hardened_image_rejects_custom_image(self):
+        from agent_sandbox.docker_provider.provider import DockerSandboxProvider
+
+        with pytest.raises(
+            ValueError,
+            match="image and require_hardened_image cannot be used together",
+        ):
+            DockerSandboxProvider(
+                image="my-custom:tag",
+                require_hardened_image=True,
+            )
 
     def test_hardened_image_tag_documented(self):
         from agent_sandbox.docker_provider.provider import DockerSandboxProvider


### PR DESCRIPTION
## Summary

- add `require_hardened_image=True` to `DockerSandboxProvider`
- fail clearly when the built-in minimal-PATH image is unavailable instead of silently falling back
- honor a configured `docker_url` during hardened-image selection
- keep the existing fallback behavior unchanged by default
- include `sleep` in the hardened image because the provider uses `sleep infinity` for long-lived sessions

## Root cause

The provider currently falls back to `python:3.11-slim` whenever the hardened image cannot be found. Deployments that depend on minimal-PATH command restrictions therefore have no way to require that protection and fail closed.

The hardened image also omitted `sleep` from its pinned PATH even though every Docker sandbox session starts with `["sleep", "infinity"]`.

## Impact

Security-sensitive callers can now opt into fail-closed image selection:

```python
provider = DockerSandboxProvider(require_hardened_image=True)
```

Existing callers retain the current best-effort hardened-image selection and legacy fallback.

Refs #2662

## Validation

- `PYTHONPATH=src:../agent-os/src python3 -m pytest tests -q`
  - 401 passed, 59 skipped
- `ruff check src/agent_sandbox/docker_provider/provider.py`
- `ruff check tests/test_docker_sandbox.py --ignore I001,F401`
- `python3 -m compileall -q src/agent_sandbox`
- `git diff --check`

Docker is not installed in the development environment, so the image was validated through the existing Dockerfile contract tests rather than a live build.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

Codex assisted with implementation and test drafting; all output was reviewed and validated.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License
