### PR TITLE
chore: bump Python package versions to 4.1.0

### DIFF
--- a/agent-governance-python/agent-compliance/pyproject.toml
+++ b/agent-governance-python/agent-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_governance_toolkit"
-version = "4.0.0"
+version = "4.1.0"
 description = "Public Preview — Unified installer and runtime policy enforcement for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-discovery/pyproject.toml
+++ b/agent-governance-python/agent-discovery/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_discovery"
-version = "4.0.0"
+version = "4.1.0"
 description = "Shadow AI agent discovery and inventory for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-governance-toolkit-cli"
-version = "4.0.0"
+version = "4.1.0"
 description = "CLI tools, SRE observability, and sandbox isolation for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-governance-toolkit-core"
-version = "4.0.0"
+version = "4.1.0"
 description = "Core runtime, kernel, and trust layer for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-governance-toolkit-integrations/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-integrations/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-governance-toolkit-integrations"
-version = "4.0.0"
+version = "4.1.0"
 description = "Framework adapters for the Agent Governance Toolkit (LangChain, CrewAI, OpenAI Agents, and more)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-governance-toolkit-protocols/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-protocols/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-governance-toolkit-protocols"
-version = "4.0.0"
+version = "4.1.0"
 description = "Protocol implementations (MCP governance, trust protocol, A2A, MCP receipts) for the Agent Governance Toolkit"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-hypervisor/pyproject.toml
+++ b/agent-governance-python/agent-hypervisor/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_hypervisor"
-version = "4.0.0"
+version = "4.1.0"
 description = "Deprecated — use agent-governance-toolkit-core instead. Agent Hypervisor: Runtime supervisor for multi-agent Shared Sessions"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-lightning/pyproject.toml
+++ b/agent-governance-python/agent-lightning/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_lightning"
-version = "4.0.0"
+version = "4.1.0"
 description = "Public Preview — Agent-Lightning RL integration for the Agent Governance Toolkit: governed training with policy enforcement"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-marketplace/pyproject.toml
+++ b/agent-governance-python/agent-marketplace/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_marketplace"
-version = "4.0.0"
+version = "4.1.0"
 description = "Plugin marketplace for the Agent Governance Toolkit — discover, install, verify, and manage plugins"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-mcp-governance/pyproject.toml
+++ b/agent-governance-python/agent-mcp-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent_mcp_governance"
-version = "4.0.0"
+version = "4.1.0"
 description = "Deprecated — use agent-governance-toolkit-protocols instead. MCP governance primitives for the Agent Governance Toolkit."
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-mesh/packages/mcp-trust-server/pyproject.toml
+++ b/agent-governance-python/agent-mesh/packages/mcp-trust-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_trust"
-version = "4.0.0"
+version = "4.1.0"
 description = "MCP server exposing AgentMesh trust management tools for Claude, GPT, and other AI agents"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_platform"
-version = "4.0.0"
+version = "4.1.0"
 description = "Deprecated — use agent-governance-toolkit-core instead. The Secure Nervous System for Cloud-Native Agent Ecosystems"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/examples/carbon-auditor/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/carbon-auditor/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "carbon_auditor_swarm"
-version = "4.0.0"
+version = "4.1.0"
 description = "Autonomous auditing system for the Voluntary Carbon Market (VCM)"
 license = {text = "MIT"}
 readme = "README.md"

--- a/agent-governance-python/agent-os/examples/defi-sentinel/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/defi-sentinel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defi_sentinel_demo"
-version = "4.0.0"
+version = "4.1.0"
 description = "DeFi Risk Sentinel demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/examples/grid-balancing/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/grid-balancing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "grid_balancing_demo"
-version = "4.0.0"
+version = "4.1.0"
 description = "Autonomous energy trading demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/examples/pharma-compliance/pyproject.toml
+++ b/agent-governance-python/agent-os/examples/pharma-compliance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pharma_compliance_demo"
-version = "4.0.0"
+version = "4.1.0"
 description = "Pharma Compliance demo using Agent OS"
 license = {text = "MIT"}
 requires-python = ">=3.10"

--- a/agent-governance-python/agent-os/modules/amb/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/amb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_message_bus"
-version = "4.0.0"
+version = "4.1.0"
 description = "A lightweight, broker-agnostic message bus designed specifically for AI Agents"
 license = {text = "MIT"}
 readme = "README.md"

--- a/agent-governance-python/agent-os/modules/atr/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/atr/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_tool_registry"
-version = "4.0.0"
+version = "4.1.0"
 description = "A decentralized marketplace for agent capabilities - The Hands of AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/agent-governance-python/agent-os/modules/caas/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/caas/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_context"
-version = "4.0.0"
+version = "4.1.0"
 description = "A pure, logic-only library for routing context, handling RAG fallacies, and managing context windows. Layer 1 Primitive - no agent dependencies."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/agent-governance-python/agent-os/modules/cmvk/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/cmvk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_drift"
-version = "4.0.0"
+version = "4.1.0"
 description = "Mathematical drift detection library for calculating drift/hallucination scores between outputs"
 readme = "README.md"
 license = { text = "MIT" }

--- a/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/control-plane/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_control_plane"
-version = "4.0.0"
+version = "4.1.0"
 description = "Layer 3: The Framework - A deterministic kernel for zero-violation governance in agentic AI systems with POSIX-style signals, VFS, and kernel/user space separation"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/agent-governance-python/agent-os/modules/emk/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/emk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_memory"
-version = "4.0.0"
+version = "4.1.0"
 description = "Public Preview — Episodic Memory Kernel for AI agent experience storage"
 authors = [
     { name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com" }

--- a/agent-governance-python/agent-os/modules/iatp/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/iatp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_trust_protocol"
-version = "4.0.0"
+version = "4.1.0"
 description = "Inter-Agent Trust Protocol (IATP) - The Envoy for AI Agents. A sidecar architecture with typed IPC pipes for preventing cascading hallucinations in autonomous agent networks."
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/mcp-kernel-server/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/mcp-kernel-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_mcp_server"
-version = "4.0.0"
+version = "4.1.0"
 description = "MCP Server for Claude Desktop - Agent OS kernel primitives including code safety verification, CMVK multi-model review, and IATP trust"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/nexus/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/nexus/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_nexus"
-version = "4.0.0"
+version = "4.1.0"
 description = "Agent Trust Exchange - viral registry and communication board for AI agents (RESEARCH PROTOTYPE)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/modules/observability/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/observability/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_observability"
-version = "4.0.0"
+version = "4.1.0"
 description = "Production observability for Agent OS - OpenTelemetry traces, Prometheus metrics, Grafana dashboards"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-os/pyproject.toml
+++ b/agent-governance-python/agent-os/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_os_kernel"
-version = "4.0.0"
+version = "4.1.0"
 description = "Deprecated — use agent-governance-toolkit-core instead. A kernel architecture for governing autonomous AI agents with Nexus Trust Exchange"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-primitives/pyproject.toml
+++ b/agent-governance-python/agent-primitives/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentmesh_primitives"
-version = "4.0.0"
+version = "4.1.0"
 description = "Deprecated — use agent-governance-toolkit-core instead. Shared primitive data models for Agent OS"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-rag-governance/pyproject.toml
+++ b/agent-governance-python/agent-rag-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-rag-governance"
-version = "4.0.0"
+version = "4.1.0"
 description = "Retrieval access control and vector store policy enforcement for RAG pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-runtime/pyproject.toml
+++ b/agent-governance-python/agent-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_runtime"
-version = "4.0.0"
+version = "4.1.0"
 description = "Deprecated — use agent-governance-toolkit-core instead. AgentMesh Runtime: Execution supervisor for multi-agent sessions"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-sandbox/pyproject.toml
+++ b/agent-governance-python/agent-sandbox/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agt_sandbox"
-version = "4.0.1"
+version = "4.1.0"
 description = "Agent Sandbox: sandbox execution isolation for AI agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agent-sre/pyproject.toml
+++ b/agent-governance-python/agent-sre/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent_sre"
-version = "4.0.0"
+version = "4.1.0"
 description = "Deprecated — use agent-governance-toolkit-cli instead. Reliability Engineering for AI Agent Systems"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/a2a-protocol/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/a2a-protocol/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "a2a_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "A2A protocol bridge for AgentMesh — trust-verified agent-to-agent communication via the A2A standard"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/adk-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/adk-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "adk_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Public Preview — Agent Governance Toolkit integration for Google ADK: policy enforcement, trust verification, and audit trails for ADK agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/agentmesh-avp/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/agentmesh-avp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "avp_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Agent Veil Protocol integration for AgentMesh trust engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/audit-accountability-export/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/audit-accountability-export/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_audit_export"
-version = "4.0.0"
+version = "4.1.0"
 description = "Example adapter from AgentMesh AuditEntry output to an external accountability export shape"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/cedarling-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cedarling_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Public Preview. Cedarling policy backend for AGT — community integration package"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/crewai-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/crewai-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "crewai_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh trust layer for CrewAI — trust-verified crew member selection and capability-gated task assignment"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/flowise-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/flowise-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "flowise_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh governance nodes for Flowise — policy enforcement, trust gating, audit logging, and rate limiting for visual AI flows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/haystack-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/haystack-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "haystack_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh governance components for Haystack pipelines — policy enforcement, trust scoring, and tamper-evident audit trails"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langchain-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_langchain"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh trust layer integration for LangChain - cryptographic identity and trust-gated tool execution"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/langflow-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langflow-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langflow_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Governance components for Langflow — policy enforcement, trust routing, audit logging, and compliance checking for visual AI flows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/langgraph-trust/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/langgraph-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Trust-gated checkpoint nodes for LangGraph — cryptographic identity, policy enforcement, and trust-aware routing for multi-agent graphs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
 
 [project]
 name = "llamaindex_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh trust layer integration for LlamaIndex agents"
 authors = [{name = "AgentMesh Contributors"}]
 requires-python = ">=3.9,<4.0"

--- a/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/mcp-receipt-governed/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_receipts"
-version = "4.0.0"
+version = "4.1.0"
 description = "MCP tool-call receipt signing — Cedar policy decisions linked to governance receipts"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/mcp-trust-proxy/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_mcp_proxy"
-version = "4.0.0"
+version = "4.1.0"
 description = "MCP proxy that wraps any MCP tool with AgentMesh trust verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/nostr-wot/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/nostr-wot/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nostr_wot_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Nostr Web of Trust integration for AgentMesh trust engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openai_agents_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh trust layer for OpenAI Agents SDK — trust-gated function calling and handoff verification"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-trust/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentmesh_openai_agents_trust"
-version = "4.0.0"
+version = "4.1.0"
 description = "Trust & governance layer for OpenAI Agents SDK — policy enforcement, trust-gated handoffs, and hash-chained audit trails"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/openshell-skill/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openshell-agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Public Preview - OpenShell + AgentMesh governance skill"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/pydantic-ai-governance/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pydantic_ai_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "Governance middleware for PydanticAI — semantic policy enforcement, trust scoring, and audit trails for agent tool execution"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/structural-authz-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "structural_authz_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh adapter for structural authorization gates — consumes external policy decisions, trust grades, and delegation scope chains as AGT trust signals"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agentmesh-integrations/template-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/template-agentmesh/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "template_agentmesh"
-version = "4.0.0"
+version = "4.1.0"
 description = "AgentMesh trust layer template — copy and rename for your framework"
 readme = "README.md"
 license = {text = "MIT"}

--- a/agent-governance-python/agt-policies/pyproject.toml
+++ b/agent-governance-python/agt-policies/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agt-policies"
-version = "5.0.0a1"
+version = "5.0.0"
 description = "AGT 5.0 policy layer over the AGT-vendored ACS engine"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Bumps all `4.0.x` Python packages to `4.1.0`
- Promotes `agt-policies` from `5.0.0a1` to `5.0.0` (alpha confirmed clean on PyPI)

**Changes since v4.0.0 captured by this release:**
- Skill-aware audit trail hardening (#2572)
- Ed25519 signature verification in Nexus registry/escrow (#2782)
- Ring enforcement wiring in sandbox providers (#2868)
- Dynamic policy conditions: time-based, cost-aware, quota-aware (#2870)
- Policy regression testing framework (`agt test`) (#2869)
- crewai/langchain/sk/google_adk adapter fixes (#2911)
- Various security fixes and dependabot updates

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, create GitHub release `v4.1.0` to trigger publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)