### PR TITLE
fix(ci): grant contents: write to build-python job in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,7 +147,7 @@ jobs:
     if: needs.resolve-python-matrix.outputs.any == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
     strategy:


### PR DESCRIPTION
## Summary

- `sigstore/gh-action-sigstore-python` uses `softprops/action-gh-release` internally to attach `.sigstore.json` bundles to the release as assets
- This requires `contents: write`, but the `build-python` job only had `contents: read`
- All 13 Python package builds in the v4.1.0 release run succeeded (wheels built and signed locally) but the sigstore step failed, killing subsequent steps including `Publish to PyPI`
- Nothing landed on PyPI

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger publish workflow via `workflow_dispatch` with `dry_run: false` and `package: all-python`
- [ ] Verify all 13 packages appear on PyPI at version 4.1.0 / 5.0.0 (agt-policies)