### PR TITLE
fix(ci): add pypi environment to build-python job for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,6 +146,7 @@ jobs:
     needs: resolve-python-matrix
     if: needs.resolve-python-matrix.outputs.any == 'true'
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
The `build-python` job in `publish.yml` was missing `environment: pypi`. PyPI's OIDC trusted publisher configuration requires the `environment` claim in the token. Without it, the token's `environment` field is `MISSING` and PyPI rejects the exchange with `invalid-publisher`.

The `publish-nuget` job already had `environment: nuget` using the same pattern. This PR mirrors that for Python.

Once merged, the `v4.1.0` tag will need to be moved to this commit and the release re-triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)