### PR TITLE
fix(ci): disable sigstore release-signing-artifacts to prevent parallel upload race

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -203,6 +203,7 @@ jobs:
         uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
         with:
           inputs: ${{ matrix.path }}/dist/*
+          release-signing-artifacts: false
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0


### PR DESCRIPTION
`gh-action-sigstore-python` has `release-signing-artifacts: true` by default. This makes each job download the release source archives (`v4.1.0.zip`, `v4.1.0.tar.gz`), sign them, and re-upload them. With 13 `build-python` jobs running in parallel they all race to upload the same files, causing `HttpError: Not Found` failures in the sigstore step.

Setting `release-signing-artifacts: false` restricts signing to the per-package `dist/*` wheel artifacts only. The release source archives will not be signed, which is acceptable since they are auto-generated by GitHub and the wheel artifacts themselves are signed and attested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)