### PR TITLE
fix: restore ESRP package publish fallback

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -712,3 +712,15 @@ mitapache
 dctx
 isoweekday
 zoneinfo
+Authenticode
+Signtool
+signtool
+nupkgs
+LASTEXITCODE
+covermode
+coverprofile
+shopt
+nullglob
+pypa
+snupkg
+Hotfixes

--- a/.github/pipelines/AGENTS.md
+++ b/.github/pipelines/AGENTS.md
@@ -1,0 +1,33 @@
+# Pipelines - Coding Agent Instructions
+
+## Project Overview
+
+The `pipelines/` directory contains Azure DevOps release automation, especially ESRP-backed
+publishing flows for Python, npm, NuGet, Rust, and Go artifacts.
+
+## Critical Rules
+
+- Treat every pipeline edit as security-sensitive.
+- Keep secrets, client IDs, key vault names, and certificate identifiers in pipeline secrets or
+  variables, not inline in YAML.
+- Pin package-install commands to explicit versions where applicable.
+- Preserve least privilege and existing release gates.
+- Prefer comments that explain non-obvious ESRP or platform constraints.
+
+## What To Watch For
+
+- Azure DevOps compile-time vs runtime variable behavior
+- Windows-vs-Unix path differences in publishing tasks
+- artifact naming consistency across build and publish stages
+- package path correctness for monorepo publishing
+
+## Boundaries
+
+- Do not weaken release approvals or bypass ESRP requirements.
+- Do not introduce plaintext credentials into YAML.
+- Do not mix unrelated publishing changes into the same PR as product code.
+
+## Validation
+
+- Re-check all referenced package paths after edits.
+- Verify each changed stage still matches the package name, artifact name, and target registry.

--- a/.github/pipelines/esrp-publish.yml
+++ b/.github/pipelines/esrp-publish.yml
@@ -1,0 +1,1193 @@
+# ---------------------------------------------------------
+# Azure DevOps Pipeline: Unified ESRP Release Publishing
+#
+# Publishes Python (PyPI), npm, and NuGet packages via ESRP
+# Release — Microsoft's approved OSS publishing path.
+#
+# Usage:
+#   - Select target: pypi, npm, nuget, or all
+#   - Use dryRun=true for build-only validation
+#
+# Prerequisites:
+#   1. Complete ESRP Release onboarding (https://aka.ms/esrp-onboarding)
+#   2. Configure Azure Identity (Managed Identity recommended)
+#   3. Set up signing certificate in Azure Key Vault
+#   4. Install ESRP Release ADO Task extension (v11)
+#   5. Configure ADO pipeline variables (see below)
+#
+# See: PUBLISHING.md for full setup guide.
+# ---------------------------------------------------------
+
+trigger: none  # Manual or release-gated trigger only
+
+pr: none
+
+parameters:
+  - name: target
+    type: string
+    displayName: 'What to publish'
+    default: 'all'
+    values:
+      - pypi
+      - npm
+      - nuget
+      - rust
+      - go
+      - all
+
+  - name: dryRun
+    type: boolean
+    displayName: 'Dry run (build only, skip ESRP publish)'
+    default: false
+
+  - name: pythonVersion
+    type: string
+    displayName: 'Python version'
+    default: '3.11'
+
+  - name: nodeVersion
+    type: string
+    displayName: 'Node.js version'
+    default: '20'
+
+  - name: dotnetVersion
+    type: string
+    displayName: '.NET SDK version'
+    default: '8.0.x'
+
+  - name: rustVersion
+    type: string
+    displayName: 'Rust toolchain version'
+    default: '1.89.0'
+
+  - name: goVersion
+    type: string
+    displayName: 'Go version'
+    default: '1.21'
+
+  - name: pypiPackages
+    type: object
+    displayName: 'Python packages to publish'
+    default:
+      # Consolidated distributions (v4.0.0)
+      - name: agent-governance-toolkit-core
+        path: agent-governance-python/agent-governance-toolkit-core
+      - name: agent-governance-toolkit-integrations
+        path: agent-governance-python/agent-governance-toolkit-integrations
+      - name: agent-governance-toolkit-cli
+        path: agent-governance-python/agent-governance-toolkit-cli
+      - name: agent-governance-toolkit-protocols
+        path: agent-governance-python/agent-governance-toolkit-protocols
+      # Meta-package
+      - name: agent-governance-toolkit
+        path: agent-governance-python/agent-compliance
+      # Standalone packages
+      - name: agent-discovery
+        path: agent-governance-python/agent-discovery
+      - name: agent-lightning
+        path: agent-governance-python/agent-lightning
+      - name: agent-marketplace
+        path: agent-governance-python/agent-marketplace
+      - name: agent-rag-governance
+        path: agent-governance-python/agent-rag-governance
+      - name: agt-sandbox
+        path: agent-governance-python/agent-sandbox
+      # ACS policy layer, Python SDK, and artifact generator
+      - name: agent-control-specification
+        path: policy-engine/sdk/python
+      - name: agt-policies
+        path: agent-governance-python/agt-policies
+      - name: acs-generator
+        path: policy-engine/generator
+        noBuildIsolation: 'true'
+
+  - name: npmPackages
+    type: object
+    displayName: 'npm packages to publish'
+    default:
+      - name: agentmesh-copilot-governance
+        path: agent-governance-python/agentmesh-integrations/copilot-governance
+        nodeVersion: '20'
+      - name: agentmesh-mastra
+        path: agent-governance-python/agentmesh-integrations/mastra-agentmesh
+        nodeVersion: '20'
+      - name: agentmesh-api
+        path: agent-governance-python/agent-mesh/services/api
+        nodeVersion: '20'
+      - name: agentmesh-mcp-proxy
+        path: agent-governance-python/agent-mesh/packages/mcp-proxy
+        nodeVersion: '20'
+      - name: agent-governance-copilot-cli
+        path: agent-governance-copilot-cli
+        nodeVersion: '22'
+      - name: agent-governance-claude-code
+        path: agent-governance-claude-code
+        nodeVersion: '22'
+      - name: agent-governance-sdk
+        path: agent-governance-typescript
+      - name: agent-governance-antigravity-cli
+        path: agent-governance-antigravity-cli
+      - name: agent-governance-opencode
+        path: agent-governance-opencode
+        nodeVersion: '22'
+      - name: agent-os-copilot-extension
+        path: agent-governance-python/agent-os/extensions/copilot
+        nodeVersion: '20'
+      - name: agentos-mcp-server
+        path: agent-governance-python/agent-os/extensions/mcp-server
+        nodeVersion: '20'
+
+  - name: acsNodeNativePackages
+    type: object
+    displayName: 'ACS Node native packages to publish'
+    default:
+      - name: agent-control-specification-linux-x64-gnu
+        binary: agent-control-specification.linux-x64-gnu.node
+        rustTarget: x86_64-unknown-linux-gnu
+        vmImage: ubuntu-latest
+      - name: agent-control-specification-linux-arm64-gnu
+        binary: agent-control-specification.linux-arm64-gnu.node
+        rustTarget: aarch64-unknown-linux-gnu
+        vmImage: ubuntu-latest
+        aptPackages: gcc-aarch64-linux-gnu
+        linkerEnv: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
+        linker: aarch64-linux-gnu-gcc
+      - name: agent-control-specification-darwin-x64
+        binary: agent-control-specification.darwin-x64.node
+        rustTarget: x86_64-apple-darwin
+        vmImage: macOS-latest
+      - name: agent-control-specification-darwin-arm64
+        binary: agent-control-specification.darwin-arm64.node
+        rustTarget: aarch64-apple-darwin
+        vmImage: macOS-latest
+      - name: agent-control-specification-win32-x64-msvc
+        binary: agent-control-specification.win32-x64-msvc.node
+        rustTarget: x86_64-pc-windows-msvc
+        vmImage: windows-latest
+
+  - name: acsNodeOpaPackages
+    type: object
+    displayName: 'ACS Node OPA packages to publish'
+    default:
+      - name: agent-control-specification-opa-linux-x64
+        platform: linux-x64
+      - name: agent-control-specification-opa-linux-arm64
+        platform: linux-arm64
+      - name: agent-control-specification-opa-darwin-x64
+        platform: darwin-x64
+      - name: agent-control-specification-opa-darwin-arm64
+        platform: darwin-arm64
+      - name: agent-control-specification-opa-win32-x64
+        platform: win32-x64
+
+  - name: rustPackages
+    type: object
+    displayName: 'Rust crates to publish'
+    default:
+      - name: agentmesh
+        path: agent-governance-rust
+        crate: agentmesh
+      - name: agentmesh-mcp
+        path: agent-governance-rust
+        crate: agentmesh-mcp
+      - name: agent-control-specification-core
+        path: policy-engine
+        crate: agent_control_specification_core
+
+  - name: acsDotnetNativeAssets
+    type: object
+    displayName: 'ACS .NET native runtime assets'
+    default:
+      - rid: linux-x64
+        nativeLib: libagent_control_specification_core.so
+        rustTarget: x86_64-unknown-linux-gnu
+        vmImage: ubuntu-latest
+      - rid: linux-arm64
+        nativeLib: libagent_control_specification_core.so
+        rustTarget: aarch64-unknown-linux-gnu
+        vmImage: ubuntu-latest
+        aptPackages: gcc-aarch64-linux-gnu
+        linkerEnv: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
+        linker: aarch64-linux-gnu-gcc
+      - rid: osx-x64
+        nativeLib: libagent_control_specification_core.dylib
+        rustTarget: x86_64-apple-darwin
+        vmImage: macOS-latest
+      - rid: osx-arm64
+        nativeLib: libagent_control_specification_core.dylib
+        rustTarget: aarch64-apple-darwin
+        vmImage: macOS-latest
+      - rid: win-x64
+        nativeLib: agent_control_specification_core.dll
+        rustTarget: x86_64-pc-windows-msvc
+        vmImage: windows-latest
+
+# -------------------------------------------------------
+# ESRP Configuration
+# Service connection name is hardcoded (required at compile time by ADO).
+# All other values sourced from ADO pipeline variables (mark as secret):
+#   ESRP_KEYVAULT_NAME, ESRP_AUTH_CERT_IDENTIFIER, ESRP_SIGN_CERT_IDENTIFIER,
+#   ESRP_RELEASE_CERT_IDENTIFIER, ESRP_NUGET_SIGN_CERT_IDENTIFIER,
+#   ESRP_CLIENT_ID, ESRP_OWNERS, ESRP_APPROVERS
+#
+# ESRP_AUTH_CERT_IDENTIFIER    = authentication certificate for EsrpCodeSigning (Public CA)
+# ESRP_SIGN_CERT_IDENTIFIER   = signing certificate for Authenticode (Private CA)
+# ESRP_RELEASE_CERT_IDENTIFIER = release certificate for EsrpRelease tasks (separate from sign cert)
+# ESRP_NUGET_SIGN_CERT_IDENTIFIER = signing certificate for NuGet package signing
+# These MUST be separate certificates from the appropriate CAs.
+# Do NOT reuse the signing certificate for release tasks.
+#
+# Note: ESRP_DOMAIN_TENANT_ID was removed from pipeline variables due to
+# cyclical reference. The ESRP cert lives in the PME (Partner Managed
+# Engineering) tenant, not the Microsoft corporate tenant. If
+# ESRP_DOMAIN_TENANT_ID still exists in ADO pipeline variables, DELETE
+# IT — it causes a cyclical variable expansion warning that confuses
+# log triage.
+# -------------------------------------------------------
+
+variables:
+  MICROSOFT_TENANT_ID: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  # =======================================================
+  # PYTHON (PyPI) — AGT packages plus ACS policy/runtime packages
+  # =======================================================
+  - stage: Build_PyPI
+    displayName: 'Build Python Packages'
+    dependsOn: []
+    condition: or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all'))
+    jobs:
+      - ${{ each pkg in parameters.pypiPackages }}:
+        - job: Build_PyPI_${{ replace(pkg.name, '-', '_') }}
+          displayName: 'Build ${{ pkg.name }}'
+          steps:
+            - checkout: self
+
+            - task: UsePythonVersion@0
+              inputs:
+                versionSpec: '${{ parameters.pythonVersion }}'
+              displayName: 'Use Python ${{ parameters.pythonVersion }}'
+
+            - script: |
+                # Hash-pinned lockfile. --require-hashes refuses any wheel/sdist
+                # whose SHA-256 is not in release-tools.txt; --no-deps stops
+                # pip from quietly resolving extra transitives the lockfile
+                # would not cover. See .github/release-tools/release-tools.txt for the
+                # regeneration command.
+                python -m pip install --no-cache-dir --disable-pip-version-check \
+                  --require-hashes --no-deps \
+                  -r $(Build.SourcesDirectory)/.github/release-tools/release-tools.txt
+              displayName: 'Install build tools (hash-pinned)'
+
+            - ${{ if eq(coalesce(pkg.rust, 'false'), 'true') }}:
+              - script: |
+                  set -euo pipefail
+                  RUSTUP_VERSION="1.27.1"
+                  RUSTUP_SHA256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d"
+                  # ``${{ parameters.rustVersion }}`` is expanded at YAML template
+                  # compile time. The runtime regex is a defense-in-depth guard
+                  # if a future edit promotes rustVersion to a runtime variable.
+                  # Queue-time parameter ACLs remain the primary defense.
+                  RUST_TOOLCHAIN="${{ parameters.rustVersion }}"
+                  if ! printf '%s' "$RUST_TOOLCHAIN" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                    echo "##[error]rustVersion must be an exact version such as 1.70.0, not a mutable channel"
+                    exit 1
+                  fi
+                  curl --proto '=https' --tlsv1.2 -fsSLo rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init"
+                  echo "${RUSTUP_SHA256}  rustup-init" | sha256sum -c -
+                  chmod +x rustup-init
+                  ./rustup-init -y --profile minimal --default-toolchain "$RUST_TOOLCHAIN"
+                  echo "##vso[task.prependpath]$HOME/.cargo/bin"
+                  "$HOME/.cargo/bin/rustc" --version
+                  "$HOME/.cargo/bin/cargo" --version
+                displayName: 'Install Rust ${{ parameters.rustVersion }}'
+
+            - script: |
+                # Consolidated packages use force-include with sibling paths,
+                # which only works when building a wheel directly from source.
+                if [[ "${{ pkg.name }}" == "agent-control-specification" ]]; then
+                  bash "$(Build.SourcesDirectory)/scripts/ci/build_acs_python_wheel.sh" "$(Build.SourcesDirectory)"
+                elif [[ "${{ coalesce(pkg.noBuildIsolation, 'false') }}" == "true" ]]; then
+                  python -m build --no-isolation
+                elif [[ "${{ pkg.name }}" == agent-governance-toolkit-* ]]; then
+                  python -m build --wheel
+                else
+                  python -m build
+                fi
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Build ${{ pkg.name }}'
+
+            - script: |
+                echo "=== Built artifacts for ${{ pkg.name }} ==="
+                ls -la dist/
+                if ! ls dist/*.whl 1>/dev/null 2>&1; then
+                  echo "##[error]No wheel (.whl) found"
+                  exit 1
+                fi
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Validate build artifacts'
+
+            - task: PublishPipelineArtifact@1
+              inputs:
+                targetPath: '${{ pkg.path }}/dist'
+                artifact: 'pypi-${{ pkg.name }}'
+                publishLocation: 'pipeline'
+              displayName: 'Publish ${{ pkg.name }} artifacts'
+
+  # All PyPI packages publish in parallel after build completes.
+  - stage: Publish_PyPI
+    displayName: 'Publish All Packages to PyPI'
+    dependsOn: Build_PyPI
+    condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'pypi'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - ${{ each pkg in parameters.pypiPackages }}:
+        - job: Publish_PyPI_${{ replace(pkg.name, '-', '_') }}
+          displayName: 'Publish ${{ pkg.name }} to PyPI'
+          steps:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifact: 'pypi-${{ pkg.name }}'
+                targetPath: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+              displayName: 'Download ${{ pkg.name }} artifacts'
+
+            - task: EsrpRelease@11
+              displayName: 'ESRP Publish ${{ pkg.name }} to PyPI'
+              retryCountOnTaskFailure: 2
+              inputs:
+                connectedservicename: 'Agent Governance Toolkit'
+                usemanagedidentity: true
+                keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+                signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
+                clientid: '$(ESRP_CLIENT_ID)'
+                intent: 'PackageDistribution'
+                contenttype: 'PyPi'
+                contentsource: 'Folder'
+                folderlocation: '$(Pipeline.Workspace)/dist-${{ pkg.name }}'
+                waitforreleasecompletion: true
+                owners: '$(ESRP_OWNERS)'
+                approvers: '$(ESRP_APPROVERS)'
+                serviceendpointurl: 'https://api.esrp.microsoft.com'
+                mainpublisher: 'ESRPRELPACMAN'
+                domaintenantid: '$(MICROSOFT_TENANT_ID)'
+
+  # =======================================================
+  # NPM — AGT packages plus ACS SDK/native support packages
+  # =======================================================
+  - stage: Build_npm
+    displayName: 'Build & Pack npm Packages'
+    dependsOn: []
+    condition: or(eq('${{ parameters.target }}', 'npm'), eq('${{ parameters.target }}', 'all'))
+    jobs:
+      - ${{ each pkg in parameters.npmPackages }}:
+        - job: Build_npm_${{ replace(pkg.name, '-', '_') }}
+          displayName: 'Build ${{ pkg.name }}'
+          steps:
+            - checkout: self
+
+            - task: UseNode@1
+              inputs:
+                version: '${{ coalesce(pkg.nodeVersion, parameters.nodeVersion) }}'
+
+            - script: npm ci --ignore-scripts --legacy-peer-deps
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Install dependencies'
+
+            - script: npm run build
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Build ${{ pkg.name }}'
+
+            - ${{ if eq(pkg.name, 'agent-governance-claude-code') }}:
+              - script: node scripts/sync-claude-marketplace-version.mjs --check
+                workingDirectory: '$(Build.SourcesDirectory)'
+                displayName: 'Check Claude Code marketplace version'
+
+            - script: |
+                mkdir -p $(Pipeline.Workspace)/npm-out
+                npm pack --pack-destination $(Pipeline.Workspace)/npm-out
+                if ! ls $(Pipeline.Workspace)/npm-out/*.tgz 1>/dev/null 2>&1; then
+                  echo "##[error]No .tgz found for ${{ pkg.name }}"
+                  exit 1
+                fi
+                PRIVATE=$(node -e "console.log(require('./package.json').private || false)")
+                if [ "$PRIVATE" = "true" ]; then
+                  echo "##[error]${{ pkg.name }} is marked private"
+                  exit 1
+                fi
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Pack & validate ${{ pkg.name }}'
+
+            - task: PublishPipelineArtifact@1
+              inputs:
+                targetPath: '$(Pipeline.Workspace)/npm-out'
+                artifact: 'npm-${{ pkg.name }}'
+                publishLocation: 'pipeline'
+              displayName: 'Publish ${{ pkg.name }} artifact'
+
+      - job: Build_npm_agent_control_specification
+        displayName: 'Build agent-control-specification'
+        steps:
+          - checkout: self
+
+          - task: UseNode@1
+            inputs:
+              version: '${{ parameters.nodeVersion }}'
+
+          - script: |
+              rustup toolchain install ${{ parameters.rustVersion }} --profile minimal
+              rustup default ${{ parameters.rustVersion }}
+              rustc --version
+              cargo --version
+            workingDirectory: 'policy-engine/sdk/node'
+            displayName: 'Install Rust ${{ parameters.rustVersion }}'
+
+          - script: npm ci --ignore-scripts --legacy-peer-deps
+            workingDirectory: 'policy-engine/sdk/node'
+            displayName: 'Install ACS Node dependencies'
+
+          - script: npm run build
+            workingDirectory: 'policy-engine/sdk/node'
+            displayName: 'Build agent-control-specification'
+
+          - script: |
+              mkdir -p $(Pipeline.Workspace)/npm-out
+              npm pack --pack-destination $(Pipeline.Workspace)/npm-out
+              if ! ls $(Pipeline.Workspace)/npm-out/*.tgz 1>/dev/null 2>&1; then
+                echo "##[error]No .tgz found for agent-control-specification"
+                exit 1
+              fi
+              if tar -tzf $(Pipeline.Workspace)/npm-out/agent-control-specification-*.tgz | grep -E '^package/dist/.*\.node$'; then
+                echo "##[error]Root agent-control-specification package must not embed a host-specific native addon"
+                exit 1
+              fi
+            workingDirectory: 'policy-engine/sdk/node'
+            displayName: 'Pack agent-control-specification'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: '$(Pipeline.Workspace)/npm-out'
+              artifact: 'npm-agent-control-specification'
+              publishLocation: 'pipeline'
+            displayName: 'Publish agent-control-specification artifact'
+
+      - ${{ each native in parameters.acsNodeNativePackages }}:
+        - job: Build_npm_${{ replace(native.name, '-', '_') }}
+          displayName: 'Build ${{ native.name }}'
+          pool:
+            vmImage: '${{ native.vmImage }}'
+          steps:
+            - checkout: self
+
+            - task: UseNode@1
+              inputs:
+                version: '${{ parameters.nodeVersion }}'
+
+            - bash: |
+                set -euo pipefail
+                if [ -n "${{ coalesce(native.aptPackages, '') }}" ]; then
+                  sudo apt-get update
+                  sudo apt-get install -y ${{ native.aptPackages }}
+                fi
+                rustup toolchain install ${{ parameters.rustVersion }} --profile minimal
+                rustup default ${{ parameters.rustVersion }}
+                rustup target add ${{ native.rustTarget }}
+                rustc --version
+                cargo --version
+              workingDirectory: 'policy-engine/sdk/node'
+              displayName: 'Install Rust ${{ parameters.rustVersion }}'
+
+            - script: npm ci --ignore-scripts --legacy-peer-deps
+              workingDirectory: 'policy-engine/sdk/node'
+              displayName: 'Install ACS Node dependencies'
+
+            - bash: |
+                set -euo pipefail
+                if [ -n "${{ coalesce(native.linkerEnv, '') }}" ]; then
+                  export ${{ native.linkerEnv }}="${{ native.linker }}"
+                fi
+                npx napi build --platform --release --target ${{ native.rustTarget }} --js native.js --dts native.d.ts
+                test -s "${{ native.binary }}"
+                mkdir -p "$(Pipeline.Workspace)/npm-out"
+                node scripts/package-native.mjs \
+                  --package "${{ native.name }}" \
+                  --binary "${{ native.binary }}" \
+                  --pack-destination "$(Pipeline.Workspace)/npm-out"
+              workingDirectory: 'policy-engine/sdk/node'
+              displayName: 'Pack ${{ native.name }}'
+
+            - task: PublishPipelineArtifact@1
+              inputs:
+                targetPath: '$(Pipeline.Workspace)/npm-out'
+                artifact: 'npm-${{ native.name }}'
+                publishLocation: 'pipeline'
+              displayName: 'Publish ${{ native.name }} artifact'
+
+      - job: Build_npm_agent_control_specification_opa
+        displayName: 'Build ACS OPA npm packages'
+        steps:
+          - checkout: self
+
+          - task: UseNode@1
+            inputs:
+              version: '${{ parameters.nodeVersion }}'
+
+          - ${{ each opa in parameters.acsNodeOpaPackages }}:
+            - script: |
+                node ../../scripts/fetch-opa.mjs --platform ${{ opa.platform }}
+                mkdir -p $(Pipeline.Workspace)/npm-out
+                npm pack --pack-destination $(Pipeline.Workspace)/npm-out
+              workingDirectory: 'policy-engine/sdk/node/npm/${{ opa.name }}'
+              displayName: 'Pack ${{ opa.name }}'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: '$(Pipeline.Workspace)/npm-out'
+              artifact: 'npm-agent-control-specification-opa'
+              publishLocation: 'pipeline'
+            displayName: 'Publish ACS OPA npm artifacts'
+
+  - stage: Publish_npm
+    displayName: 'Publish to npm via ESRP'
+    dependsOn: Build_npm
+    condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'npm'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - job: Publish_npm
+        displayName: 'Publish all packages to npm'
+        steps:
+          - ${{ each pkg in parameters.npmPackages }}:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifact: 'npm-${{ pkg.name }}'
+                targetPath: '$(Pipeline.Workspace)/npm-publish'
+              displayName: 'Download ${{ pkg.name }}'
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'npm-agent-control-specification'
+              targetPath: '$(Pipeline.Workspace)/npm-publish'
+            displayName: 'Download agent-control-specification'
+
+          - ${{ each native in parameters.acsNodeNativePackages }}:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifact: 'npm-${{ native.name }}'
+                targetPath: '$(Pipeline.Workspace)/npm-publish'
+              displayName: 'Download ${{ native.name }}'
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'npm-agent-control-specification-opa'
+              targetPath: '$(Pipeline.Workspace)/npm-publish'
+            displayName: 'Download ACS OPA npm packages'
+
+          - script: |
+              echo "=== All packages to publish ==="
+              find $(Pipeline.Workspace)/npm-publish -name "*.tgz" -type f
+              TOTAL=$(find $(Pipeline.Workspace)/npm-publish -name "*.tgz" -type f | wc -l)
+              echo "Total packages: $TOTAL"
+            displayName: 'List all .tgz packages'
+
+          - task: EsrpRelease@11
+            displayName: 'ESRP Publish to npm'
+            inputs:
+              connectedservicename: 'Agent Governance Toolkit'
+              usemanagedidentity: true
+              keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+              signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
+              clientid: '$(ESRP_CLIENT_ID)'
+              intent: 'PackageDistribution'
+              contenttype: 'npm'
+              contentsource: 'Folder'
+              folderlocation: '$(Pipeline.Workspace)/npm-publish'
+              waitforreleasecompletion: true
+              owners: '$(ESRP_OWNERS)'
+              approvers: '$(ESRP_APPROVERS)'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: 'ESRPRELPACMAN'
+              domaintenantid: '$(MICROSOFT_TENANT_ID)'
+
+  # =======================================================
+  # NUGET — Microsoft.AgentGovernance plus ACS .NET packages
+  # =======================================================
+  - stage: Build_NuGet
+    displayName: 'Build & Test .NET SDK'
+    dependsOn: []
+    condition: or(eq('${{ parameters.target }}', 'nuget'), eq('${{ parameters.target }}', 'all'))
+    jobs:
+      - job: BuildAndPack
+        displayName: 'Build, Test, Pack'
+        steps:
+          - checkout: self
+
+          - task: UseDotNet@2
+            inputs:
+              packageType: 'sdk'
+              version: '${{ parameters.dotnetVersion }}'
+            displayName: 'Use .NET SDK ${{ parameters.dotnetVersion }}'
+
+          - script: |
+              dotnet build --configuration Release
+            workingDirectory: 'agent-governance-dotnet'
+            displayName: 'Build .NET SDK'
+
+          - script: |
+              dotnet test --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
+            workingDirectory: 'agent-governance-dotnet'
+            displayName: 'Run .NET tests'
+
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: 'VSTest'
+              testResultsFiles: 'agent-governance-dotnet/**/test-results.trx'
+            displayName: 'Publish test results'
+            condition: always()
+
+          - script: |
+              dotnet pack src/AgentGovernance/AgentGovernance.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
+              dotnet pack src/AgentGovernance.Extensions.ModelContextProtocol/AgentGovernance.Extensions.ModelContextProtocol.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
+              dotnet pack src/AgentGovernance.Extensions.Microsoft.Agents/AgentGovernance.Extensions.Microsoft.Agents.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
+              echo "=== Packed NuGet artifacts ==="
+              ls -la ./nupkg/
+            workingDirectory: 'agent-governance-dotnet'
+            displayName: 'Pack NuGet packages'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'agent-governance-dotnet/nupkg'
+              artifact: 'nuget-unsigned'
+              publishLocation: 'pipeline'
+            displayName: 'Publish unsigned NuGet artifacts'
+
+      - ${{ each native in parameters.acsDotnetNativeAssets }}:
+        - job: Build_ACS_Native_${{ replace(native.rid, '-', '_') }}
+          displayName: 'Build ACS .NET native asset ${{ native.rid }}'
+          pool:
+            vmImage: '${{ native.vmImage }}'
+          steps:
+            - checkout: self
+
+            - bash: |
+                set -euo pipefail
+                if [ -n "${{ coalesce(native.aptPackages, '') }}" ]; then
+                  sudo apt-get update
+                  sudo apt-get install -y ${{ native.aptPackages }}
+                fi
+                rustup toolchain install ${{ parameters.rustVersion }} --profile minimal
+                rustup default ${{ parameters.rustVersion }}
+                rustup target add ${{ native.rustTarget }}
+                if [ -n "${{ coalesce(native.linkerEnv, '') }}" ]; then
+                  export ${{ native.linkerEnv }}="${{ native.linker }}"
+                fi
+                cargo build --release \
+                  -p agent_control_specification_core \
+                  --features default-dispatchers,aacs,openai_moderation,perspective,llama_guard,lakera_guard,auto \
+                  --target ${{ native.rustTarget }} \
+                  --manifest-path policy-engine/Cargo.toml
+                mkdir -p "$(Pipeline.Workspace)/acs-dotnet-native/${{ native.rid }}/native"
+                cp "policy-engine/target/${{ native.rustTarget }}/release/${{ native.nativeLib }}" \
+                  "$(Pipeline.Workspace)/acs-dotnet-native/${{ native.rid }}/native/${{ native.nativeLib }}"
+                ls -la "$(Pipeline.Workspace)/acs-dotnet-native/${{ native.rid }}/native"
+              displayName: 'Build native library ${{ native.rid }}'
+
+            - task: PublishPipelineArtifact@1
+              inputs:
+                targetPath: '$(Pipeline.Workspace)/acs-dotnet-native'
+                artifact: 'acs-dotnet-native-${{ native.rid }}'
+                publishLocation: 'pipeline'
+              displayName: 'Publish ACS native asset ${{ native.rid }}'
+
+      - job: BuildAndPack_ACS
+        displayName: 'Build, Test, Pack ACS .NET SDK'
+        dependsOn:
+          - Build_ACS_Native_linux_x64
+          - Build_ACS_Native_linux_arm64
+          - Build_ACS_Native_osx_x64
+          - Build_ACS_Native_osx_arm64
+          - Build_ACS_Native_win_x64
+        steps:
+          - checkout: self
+
+          - task: UseDotNet@2
+            inputs:
+              packageType: 'sdk'
+              version: '${{ parameters.dotnetVersion }}'
+            displayName: 'Use .NET SDK ${{ parameters.dotnetVersion }}'
+
+          - ${{ each native in parameters.acsDotnetNativeAssets }}:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifact: 'acs-dotnet-native-${{ native.rid }}'
+                targetPath: '$(Build.SourcesDirectory)/policy-engine/sdk/dotnet/src/AgentControlSpecification/runtimes'
+              displayName: 'Download ACS native asset ${{ native.rid }}'
+
+          - script: |
+              curl --proto '=https' --tlsv1.2 -fSLo "$(Pipeline.Workspace)/opa" \
+                --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+                "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+              echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $(Pipeline.Workspace)/opa" | sha256sum -c -
+              chmod +x "$(Pipeline.Workspace)/opa"
+              echo "##vso[task.prependpath]$(Pipeline.Workspace)"
+              echo "##vso[task.setvariable variable=ACS_OPA_PATH]$(Pipeline.Workspace)/opa"
+              "$(Pipeline.Workspace)/opa" version
+            displayName: 'Install OPA for ACS .NET tests'
+
+          - script: |
+              dotnet build AgentControlSpecification.sln \
+                --configuration Release \
+                -p:AgentControlSpecificationSkipNativeBuild=true
+            workingDirectory: 'policy-engine/sdk/dotnet'
+            displayName: 'Build ACS .NET SDK'
+
+          - script: |
+              dotnet run --project tests/AgentControlSpecification.Tests \
+                --configuration Release \
+                --no-build
+            workingDirectory: 'policy-engine/sdk/dotnet'
+            displayName: 'Run ACS .NET tests'
+
+          - script: |
+              dotnet pack src/AgentControlSpecification/AgentControlSpecification.csproj \
+                --configuration Release \
+                --no-build \
+                -p:AgentControlSpecificationSkipNativeBuild=true \
+                --output ./nupkg
+              dotnet pack src/AgentControlSpecification.AI/AgentControlSpecification.AI.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
+              dotnet pack src/AgentControlSpecification.AgentFramework/AgentControlSpecification.AgentFramework.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
+              dotnet pack src/AgentControlSpecification.AutoGen/AgentControlSpecification.AutoGen.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
+              dotnet pack src/AgentControlSpecification.SemanticKernel/AgentControlSpecification.SemanticKernel.csproj \
+                --configuration Release \
+                --no-build \
+                --output ./nupkg
+              echo "=== Packed ACS NuGet artifacts ==="
+              ls -la ./nupkg/
+            workingDirectory: 'policy-engine/sdk/dotnet'
+            displayName: 'Pack ACS NuGet packages'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'policy-engine/sdk/dotnet/nupkg'
+              artifact: 'nuget-acs-unsigned'
+              publishLocation: 'pipeline'
+            displayName: 'Publish unsigned ACS NuGet artifacts'
+
+  - stage: Publish_NuGet
+    displayName: 'Sign & Publish to NuGet.org'
+    dependsOn: Build_NuGet
+    condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'nuget'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - job: PublishNuGet
+        displayName: 'ESRP Sign + NuGet Push'
+        pool:
+          vmImage: windows-latest  # ESRP Code Signing requires Windows agent
+        steps:
+          - task: UseDotNet@2
+            inputs:
+              packageType: 'sdk'
+              version: '${{ parameters.dotnetVersion }}'
+            displayName: 'Use .NET SDK ${{ parameters.dotnetVersion }}'
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'nuget-unsigned'
+              targetPath: '$(Pipeline.Workspace)\nuget-unsigned'
+            displayName: 'Download unsigned NuGet artifacts'
+
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'nuget-acs-unsigned'
+              targetPath: '$(Pipeline.Workspace)\nuget-unsigned'
+            displayName: 'Download unsigned ACS NuGet artifacts'
+
+          - powershell: |
+              Write-Host "=== Unsigned packages ==="
+              Get-ChildItem "$(Pipeline.Workspace)\nuget-unsigned" -Recurse
+            displayName: 'List unsigned packages'
+
+          # Step 1: Authenticode sign DLLs inside the NuGet package
+          # Microsoft compliance requires all binaries within .nupkg to be
+          # Authenticode signed before NuGet package signing.
+          # Ref: https://aka.ms/Microsoft-NuGet-Compliance
+          - task: EsrpCodeSigning@6
+            displayName: 'ESRP Authenticode sign DLLs'
+            inputs:
+              ConnectedServiceName: 'Agent Governance Toolkit'
+              AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
+              AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
+              AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
+              AuthCertName: '$(ESRP_AUTH_CERT_IDENTIFIER)'
+              AuthSignCertName: '$(ESRP_SIGN_CERT_IDENTIFIER)'
+              FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
+              Pattern: '*.dll'
+              signConfigType: 'inlineSignParams'
+              inlineOperation: |
+                [
+                  {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                      {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                      },
+                      {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                      },
+                      {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                      },
+                      {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd sha256"
+                      },
+                      {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      }
+                    ],
+                    "toolName": "signtool.exe",
+                    "toolVersion": "6.2.9304.0"
+                  },
+                  {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [],
+                    "toolName": "signtool.exe",
+                    "toolVersion": "6.2.9304.0"
+                  }
+                ]
+
+          # Step 2: Sign the .nupkg with ESRP NuGet Signing (CP-401405)
+          # Uses ESRP_NUGET_SIGN_CERT_IDENTIFIER (separate from Authenticode signing cert)
+          - task: EsrpCodeSigning@6
+            displayName: 'ESRP Code Sign NuGet package'
+            inputs:
+              ConnectedServiceName: 'Agent Governance Toolkit'
+              AppRegistrationClientId: '$(ESRP_CLIENT_ID)'
+              AppRegistrationTenantId: '$(MICROSOFT_TENANT_ID)'
+              AuthAKVName: '$(ESRP_KEYVAULT_NAME)'
+              AuthCertName: '$(ESRP_AUTH_CERT_IDENTIFIER)'
+              AuthSignCertName: '$(ESRP_NUGET_SIGN_CERT_IDENTIFIER)'
+              FolderPath: '$(Pipeline.Workspace)\nuget-unsigned'
+              Pattern: '*.nupkg'
+              signConfigType: 'inlineSignParams'
+              inlineOperation: |
+                [
+                  {
+                    "keyCode": "CP-401405",
+                    "operationSetCode": "NuGetSign",
+                    "parameters": [],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                  }
+                ]
+
+          - powershell: |
+              Write-Host "=== Signed packages ==="
+              Get-ChildItem "$(Pipeline.Workspace)\nuget-unsigned" -Recurse
+            displayName: 'List signed packages'
+
+          # Step 3: Verify the signed NuGet package
+          - powershell: |
+              Write-Host "=== Verifying NuGet package signatures ==="
+              $nupkgs = Get-ChildItem "$(Pipeline.Workspace)\nuget-unsigned" -Filter *.nupkg -Recurse
+              foreach ($pkg in $nupkgs) {
+                Write-Host "--- Verifying: $($pkg.Name) ---"
+                dotnet nuget verify $pkg.FullName --all
+                if ($LASTEXITCODE -ne 0) {
+                  Write-Host "##[warning]Signature verification returned non-zero (unsigned packages are expected at this stage)"
+                }
+              }
+            displayName: 'Verify NuGet package signatures'
+
+          # Step 4: Push signed package to NuGet.org
+          - powershell: |
+              dotnet nuget push "$(Pipeline.Workspace)\nuget-unsigned\*.nupkg" `
+                --source https://api.nuget.org/v3/index.json `
+                --api-key "$env:NUGET_API_KEY" `
+                --skip-duplicate
+            env:
+              NUGET_API_KEY: $(NUGET_API_KEY)
+            displayName: 'Push signed package to NuGet.org'
+
+  # =======================================================
+  # RUST (crates.io) — AgentMesh plus ACS crates
+  # =======================================================
+  - stage: Build_Rust
+    displayName: 'Build & Test Rust Crates'
+    dependsOn: []
+    condition: or(eq('${{ parameters.target }}', 'rust'), eq('${{ parameters.target }}', 'all'))
+    jobs:
+      - ${{ each pkg in parameters.rustPackages }}:
+        - job: BuildAndTest_${{ replace(pkg.name, '-', '_') }}
+          displayName: 'Build, Test, Package ${{ pkg.name }}'
+          steps:
+            - checkout: self
+
+            - script: |
+                set -euo pipefail
+                RUSTUP_VERSION="1.27.1"
+                RUSTUP_SHA256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d"
+                # ``${{ parameters.rustVersion }}`` is expanded at YAML template
+                # *compile* time, before this script ever runs. The runtime
+                # regex below validates the resulting literal one more time as
+                # defense-in-depth: if a future edit promotes rustVersion to a
+                # runtime variable (e.g. ``$(rustVersion)``), the check still
+                # rejects an attacker-controlled toolchain spec like
+                # ``stable --default-toolchain malicious`` that would otherwise
+                # reach ``rustup-init``. The *primary* defense remains the ADO
+                # queue-time parameter ACL: only authorized pipeline runners
+                # may set rustVersion at all.
+                RUST_TOOLCHAIN="${{ parameters.rustVersion }}"
+                if ! printf '%s' "$RUST_TOOLCHAIN" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                  echo "##[error]rustVersion must be an exact version such as 1.70.0, not a mutable channel"
+                  exit 1
+                fi
+                curl --proto '=https' --tlsv1.2 -fsSLo rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init"
+                echo "${RUSTUP_SHA256}  rustup-init" | sha256sum -c -
+                chmod +x rustup-init
+                ./rustup-init -y --profile minimal --default-toolchain "$RUST_TOOLCHAIN"
+                echo "##vso[task.prependpath]$HOME/.cargo/bin"
+                "$HOME/.cargo/bin/rustc" --version
+                "$HOME/.cargo/bin/cargo" --version
+              displayName: 'Install Rust ${{ parameters.rustVersion }}'
+
+            - script: |
+                curl --proto '=https' --tlsv1.2 -fSLo "$(Pipeline.Workspace)/opa" \
+                  --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
+                  "https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static"
+                echo "00d114b94fdb1606a48cccdfc73c9ccdc62c38721150131ae578d5ff3df5c084  $(Pipeline.Workspace)/opa" | sha256sum -c -
+                chmod +x "$(Pipeline.Workspace)/opa"
+                echo "##vso[task.prependpath]$(Pipeline.Workspace)"
+                "$(Pipeline.Workspace)/opa" version
+              condition: eq('${{ pkg.path }}', 'policy-engine')
+              displayName: 'Install OPA for ACS tests'
+
+            - script: |
+                cargo build --release --workspace
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Build all crates'
+
+            - script: |
+                cargo test --release --workspace
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Run all tests'
+
+            - script: |
+                mkdir -p $(Pipeline.Workspace)/rust-packages-${{ pkg.name }}
+                echo "=== Packaging ${{ pkg.crate }} ==="
+                cargo package -p "${{ pkg.crate }}" --allow-dirty
+                cp target/package/"${{ pkg.crate }}"-*.crate $(Pipeline.Workspace)/rust-packages-${{ pkg.name }}/
+                echo "=== Packaged crates ==="
+                ls -la $(Pipeline.Workspace)/rust-packages-${{ pkg.name }}/
+              workingDirectory: '${{ pkg.path }}'
+              displayName: 'Package ${{ pkg.name }} crates'
+
+            - task: PublishPipelineArtifact@1
+              inputs:
+                targetPath: '$(Pipeline.Workspace)/rust-packages-${{ pkg.name }}'
+                artifact: 'rust-crates-${{ pkg.name }}'
+                publishLocation: 'pipeline'
+              displayName: 'Publish ${{ pkg.name }} crate artifacts'
+
+  - stage: Publish_Rust
+    displayName: 'Publish to crates.io via ESRP'
+    dependsOn: Build_Rust
+    condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'rust'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - job: PublishCrates
+        displayName: 'ESRP Publish Rust crates'
+        steps:
+          - ${{ each pkg in parameters.rustPackages }}:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifact: 'rust-crates-${{ pkg.name }}'
+                targetPath: '$(Pipeline.Workspace)/rust-publish/${{ pkg.name }}'
+              displayName: 'Download ${{ pkg.name }} crate artifacts'
+
+          - ${{ each pkg in parameters.rustPackages }}:
+            - script: |
+                echo "=== ${{ pkg.name }} crate package ==="
+                find "$(Pipeline.Workspace)/rust-publish/${{ pkg.name }}" -name "*.crate" -type f -print
+              displayName: 'List ${{ pkg.name }} crate package'
+
+            - task: EsrpRelease@11
+              displayName: 'ESRP Publish ${{ pkg.name }} to crates.io'
+              inputs:
+                connectedservicename: 'Agent Governance Toolkit'
+                usemanagedidentity: true
+                keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+                signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
+                clientid: '$(ESRP_CLIENT_ID)'
+                intent: 'PackageDistribution'
+                contenttype: 'Rust'
+                contentsource: 'Folder'
+                folderlocation: '$(Pipeline.Workspace)/rust-publish/${{ pkg.name }}'
+                waitforreleasecompletion: true
+                owners: '$(ESRP_OWNERS)'
+                approvers: '$(ESRP_APPROVERS)'
+                serviceendpointurl: 'https://api.esrp.microsoft.com'
+                mainpublisher: 'ESRPRELPACMAN'
+                domaintenantid: '$(MICROSOFT_TENANT_ID)'
+
+          # agent_control_specification depends on agent_control_specification_core.
+          # Cargo refuses to package it until the core crate version exists in
+          # the crates.io index, so the SDK crate is packaged and released only
+          # after the core ESRP release completes.
+          - checkout: self
+
+          - script: |
+              set -euo pipefail
+              RUSTUP_VERSION="1.27.1"
+              RUSTUP_SHA256="6aeece6993e902708983b209d04c0d1dbb14ebb405ddb87def578d41f920f56d"
+              # ``${{ parameters.rustVersion }}`` is expanded at YAML template
+              # compile time. The runtime regex is a defense-in-depth guard
+              # if a future edit promotes rustVersion to a runtime variable.
+              # Queue-time parameter ACLs remain the primary defense.
+              RUST_TOOLCHAIN="${{ parameters.rustVersion }}"
+              if ! printf '%s' "$RUST_TOOLCHAIN" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                echo "##[error]rustVersion must be an exact version such as 1.70.0, not a mutable channel"
+                exit 1
+              fi
+              curl --proto '=https' --tlsv1.2 -fsSLo rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/x86_64-unknown-linux-gnu/rustup-init"
+              echo "${RUSTUP_SHA256}  rustup-init" | sha256sum -c -
+              chmod +x rustup-init
+              ./rustup-init -y --profile minimal --default-toolchain "$RUST_TOOLCHAIN"
+              echo "##vso[task.prependpath]$HOME/.cargo/bin"
+              "$HOME/.cargo/bin/rustc" --version
+              "$HOME/.cargo/bin/cargo" --version
+            displayName: 'Install Rust ${{ parameters.rustVersion }} for ACS SDK package'
+
+          - script: |
+              mkdir -p "$(Pipeline.Workspace)/rust-publish/agent-control-specification"
+              for ATTEMPT in 1 2 3 4 5; do
+                if cargo package -p agent_control_specification --allow-dirty; then
+                  break
+                fi
+                if [ "$ATTEMPT" = "5" ]; then
+                  exit 1
+                fi
+                echo "agent_control_specification_core is not visible in the crates.io index yet; retrying..."
+                sleep 30
+              done
+              cp target/package/agent_control_specification-*.crate "$(Pipeline.Workspace)/rust-publish/agent-control-specification/"
+              find "$(Pipeline.Workspace)/rust-publish/agent-control-specification" -name "*.crate" -type f -print
+            workingDirectory: 'policy-engine'
+            displayName: 'Package agent-control-specification crate'
+
+          - task: EsrpRelease@11
+            displayName: 'ESRP Publish agent-control-specification to crates.io'
+            inputs:
+              connectedservicename: 'Agent Governance Toolkit'
+              usemanagedidentity: true
+              keyvaultname: '$(ESRP_KEYVAULT_NAME)'
+              signcertname: '$(ESRP_RELEASE_CERT_IDENTIFIER)'
+              clientid: '$(ESRP_CLIENT_ID)'
+              intent: 'PackageDistribution'
+              contenttype: 'Rust'
+              contentsource: 'Folder'
+              folderlocation: '$(Pipeline.Workspace)/rust-publish/agent-control-specification'
+              waitforreleasecompletion: true
+              owners: '$(ESRP_OWNERS)'
+              approvers: '$(ESRP_APPROVERS)'
+              serviceendpointurl: 'https://api.esrp.microsoft.com'
+              mainpublisher: 'ESRPRELPACMAN'
+              domaintenantid: '$(MICROSOFT_TENANT_ID)'
+
+  # =======================================================
+  # GO — github.com/microsoft/agent-governance-toolkit module
+  # =======================================================
+  - stage: Build_Go
+    displayName: 'Build & Test Go Module'
+    dependsOn: []
+    condition: or(eq('${{ parameters.target }}', 'go'), eq('${{ parameters.target }}', 'all'))
+    jobs:
+      - job: BuildAndTest
+        displayName: 'Build, Test, Vet'
+        steps:
+          - checkout: self
+
+          - task: GoTool@0
+            inputs:
+              version: '${{ parameters.goVersion }}'
+            displayName: 'Use Go ${{ parameters.goVersion }}'
+
+          - script: |
+              go build ./...
+            workingDirectory: 'agent-governance-golang'
+            displayName: 'Build Go module'
+
+          - script: |
+              go vet ./...
+            workingDirectory: 'agent-governance-golang'
+            displayName: 'Vet Go module'
+
+          - script: |
+              export CGO_ENABLED=1
+              go test -v -race -covermode=atomic -coverprofile=coverage.out ./packages/...
+            workingDirectory: 'agent-governance-golang'
+            displayName: 'Run tests with coverage'
+
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'agent-governance-golang/coverage.out'
+              artifact: 'go-coverage'
+              publishLocation: 'pipeline'
+            displayName: 'Publish coverage artifact'
+            condition: succeededOrFailed()
+
+  - stage: Publish_Go
+    displayName: 'Tag Go Module Release'
+    dependsOn: Build_Go
+    condition: and(succeeded(), eq('${{ parameters.dryRun }}', false), or(eq('${{ parameters.target }}', 'go'), eq('${{ parameters.target }}', 'all')))
+    jobs:
+      - job: TagModule
+        displayName: 'Validate and tag Go module'
+        steps:
+          - checkout: self
+            persistCredentials: true
+
+          - task: GoTool@0
+            inputs:
+              version: '${{ parameters.goVersion }}'
+            displayName: 'Use Go ${{ parameters.goVersion }}'
+
+          - script: |
+              MODULE_PATH="agent-governance-golang"
+              VERSION=$(grep '^// Version:' ${MODULE_PATH}/doc.go 2>/dev/null | awk '{print $3}' || echo "")
+              if [ -z "$VERSION" ]; then
+                echo "##[warning]No version found in doc.go — skipping tag"
+                echo "To publish, add '// Version: v0.1.0' to doc.go"
+                exit 0
+              fi
+              TAG="${MODULE_PATH}/${VERSION}"
+              echo "Module tag: ${TAG}"
+              if git rev-parse "${TAG}" >/dev/null 2>&1; then
+                echo "##[warning]Tag ${TAG} already exists — skipping"
+              else
+                git tag "${TAG}"
+                git push origin "${TAG}"
+                echo "Tagged ${TAG} — Go module proxy will index automatically"
+              fi
+            displayName: 'Tag Go module for proxy indexing'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,9 +50,9 @@ jobs:
           retention-days: 30
 
   # -------------------------------------------------------------------
-  # Build, attest, and publish Python packages from GitHub Actions.
-  # Canonical AAIF releases must be operable by foundation maintainers
-  # without Microsoft ESRP, ADO, tenant, or certificate infrastructure.
+  # Build and attest Python packages from GitHub Actions.
+  # Temporary registry publication uses the restored ESRP ADO pipeline until
+  # PyPI trusted publishers and registry tokens are configured for GitHub.
   # -------------------------------------------------------------------
   resolve-python-matrix:
     if: >-
@@ -211,7 +211,7 @@ jobs:
           subject-path: ${{ matrix.path }}/dist/*
 
       - name: Prepare PyPI upload artifacts
-        if: github.event_name == 'release' || github.event.inputs.dry_run == 'false'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
         working-directory: ${{ matrix.path }}
         run: |
           rm -rf pypi-upload
@@ -232,16 +232,16 @@ jobs:
           retention-days: 30
 
       - name: Publish to PyPI
-        if: github.event_name == 'release' || github.event.inputs.dry_run == 'false'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: ${{ matrix.path }}/pypi-upload/
           skip-existing: true
 
   # -------------------------------------------------------------------
-  # Build npm packages, pack .tgz, attest provenance, and publish.
-  # Foundation-owned npm packages should configure npm trusted publishing
-  # or a repository environment token; Microsoft ESRP is not a release path.
+  # Build npm packages, pack .tgz, and attest provenance.
+  # Temporary registry publication uses the restored ESRP ADO pipeline until
+  # npm publishing credentials are configured for GitHub.
   # -------------------------------------------------------------------
   resolve-npm-matrix:
     needs: resolve-python-matrix
@@ -343,7 +343,7 @@ jobs:
           retention-days: 30
 
       - name: Publish to npm
-        if: github.event_name == 'release' || github.event.inputs.dry_run == 'false'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
         working-directory: ${{ matrix.path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -422,7 +422,7 @@ jobs:
         continue-on-error: true
 
       - name: Publish to NuGet
-        if: github.event_name == 'release' || github.event.inputs.dry_run == 'false'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'
         working-directory: agent-governance-dotnet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -6,8 +6,9 @@ AAIF hosting in `aaif/project-proposals#19`; do not describe the project as
 donated until TC approval, Governing Board approval, governance finalization, and
 the contribution agreement are complete.
 
-Canonical AGT releases are published from GitHub Actions. Azure DevOps ESRP is not
-a release path for this repository.
+Canonical AGT release artifacts are built and attested from GitHub Actions.
+Registry publication temporarily uses Azure DevOps ESRP while PyPI trusted
+publisher configuration and npm/NuGet GitHub credentials are completed.
 
 ## Release authority
 
@@ -15,13 +16,13 @@ a release path for this repository.
 |---|---|
 | Release approval | Maintainers and CODEOWNERS for release workflows |
 | Build and attest | `.github/workflows/publish.yml` and `.github/workflows/sbom.yml` |
-| Package registries | Registry-native foundation or project ownership |
+| Package registries | Temporary ESRP ADO pipeline; registry-native GitHub publishing after credentials are ready |
 | Containers | Foundation or repository-owner GHCR namespace |
 | Security advisories | GitHub Security Advisories for the canonical repository |
 
-Release managers must be able to build, attest, and publish canonical artifacts
-without Microsoft tenant secrets, Microsoft Key Vault, ESRP service connections,
-or Microsoft certificate infrastructure.
+Release managers must be able to build, attest, and inspect canonical artifacts
+from GitHub Actions. Registry publication remains temporarily bound to Microsoft
+ESRP/ADO publishing authority until registry-native GitHub credentials are ready.
 
 ## Dry-run releases and release manifest
 
@@ -53,40 +54,45 @@ Do not add a package to a release matrix without adding it to the package map.
 
 ## PyPI
 
-Python packages are built by `.github/workflows/publish.yml` and published through
-registry-native PyPI publishing from the canonical release workflow.
+Python packages are built and attested by `.github/workflows/publish.yml`.
+Temporary registry publication uses `.github/pipelines/esrp-publish.yml`.
 
 Required release behavior:
 
 - build wheels for each published package;
 - use hash-pinned release build tools from `.github/release-tools/`;
 - attest build provenance;
-- publish from the GitHub release workflow;
+- publish through ESRP until PyPI trusted publishers are configured for all
+  package names;
 - preserve legacy package names only through explicit stubs or documented
   deprecation.
 
 ## npm
 
-npm packages are packed and published by `.github/workflows/publish.yml`.
+npm packages are packed and attested by `.github/workflows/publish.yml`.
+Temporary registry publication uses `.github/pipelines/esrp-publish.yml`.
 
 Required release behavior:
 
 - install with `npm ci --ignore-scripts`;
 - run package build checks before packing;
-- publish tarballs with provenance where supported;
+- publish tarballs through ESRP until GitHub has an npm token or trusted
+  publishing configuration;
 - treat `@microsoft/*` package names as compatibility names, not the long-term
   foundation identity;
 - document package renames in `docs/package-migration.md`.
 
 ## NuGet
 
-NuGet packages are built, packed, attested, and published from GitHub Actions.
+NuGet packages are built, packed, and attested from GitHub Actions. Temporary
+registry publication uses `.github/pipelines/esrp-publish.yml`.
 `Microsoft.AgentGovernance*` package IDs are compatibility names for the
 Microsoft-origin package family. Foundation-owned canonical package IDs must be
 recorded in `docs/package-migration.md` before registry migration.
 
-NuGet release signing must use the foundation-approved signing process selected
-for canonical releases. Do not add ESRP signing steps back to this repository.
+NuGet release signing uses ESRP while Microsoft-origin package IDs remain under
+Microsoft registry authority. Do not add plaintext signing or registry secrets to
+GitHub workflow YAML.
 
 ## Rust crates
 
@@ -144,10 +150,11 @@ Every release should include:
 1. Confirm `main` is green for relevant CI.
 2. Confirm package map and release matrix agree.
 3. Run a dry-run release and inspect `release-manifest.json`.
-4. Confirm no canonical release workflow references ESRP, ADO, Microsoft tenant
-   IDs, Microsoft Key Vault, or Microsoft signing certificates.
+4. Run the ESRP ADO pipeline for package registry publication until registry
+   credentials are configured for GitHub.
 5. Confirm SBOM and provenance workflows are enabled.
 6. Create a signed release tag.
-7. Publish package and container artifacts from GitHub Actions.
+7. Publish container artifacts from GitHub Actions and package artifacts through
+   the ESRP ADO pipeline.
 8. Verify artifacts are available from canonical registries.
 9. Post any compatibility/deprecation notices for legacy package names.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,7 +14,8 @@ from the same tag even when only a subset changed.
 ## Release authority
 
 Canonical releases are approved by maintainers with release-workflow ownership.
-Release approval is a project authority, not a Microsoft ESRP approval.
+Package registry publication temporarily uses Microsoft ESRP while registry-native
+GitHub publishing credentials are configured.
 
 ## Supported registries
 
@@ -36,12 +37,14 @@ Release approval is a project authority, not a Microsoft ESRP approval.
 4. Release manager runs `Publish Container Images` with `dry_run: true` when
    container artifacts are in scope.
 5. Release manager creates a signed release tag.
-6. `.github/workflows/publish.yml` builds, tests, packages, attests, and
-   publishes language packages.
-7. `.github/workflows/publish-containers.yml` builds, attests, and publishes
+6. `.github/workflows/publish.yml` builds, tests, packages, attests, and uploads
+   language package artifacts.
+7. `.github/pipelines/esrp-publish.yml` publishes package artifacts to PyPI, npm,
+   and NuGet while registry-native GitHub credentials are pending.
+8. `.github/workflows/publish-containers.yml` builds, attests, and publishes
    container images.
-8. `.github/workflows/sbom.yml` produces release SBOMs and provenance.
-9. Release manager verifies artifacts and publishes release notes.
+9. `.github/workflows/sbom.yml` produces release SBOMs and provenance.
+10. Release manager verifies artifacts and publishes release notes.
 
 ## Supply-chain requirements
 
@@ -65,8 +68,9 @@ For critical bugs or security issues:
 4. Cut a patch release.
 5. Cherry-pick the fix back to `main` if needed.
 
-## Deprecated release paths
+## Temporary release paths
 
-Azure DevOps ESRP is not a canonical AGT release path. Do not reintroduce ESRP,
-Microsoft tenant IDs, Microsoft Key Vault, or Microsoft signing certificates into
-canonical AGT release workflows.
+Azure DevOps ESRP is the temporary package registry publication path for
+Microsoft-origin package identities. Keep ESRP configuration in ADO secrets and
+pipeline variables; do not put Microsoft tenant IDs, Key Vault names,
+certificates, or registry tokens in GitHub workflow YAML.

--- a/tests/ci/test_release_tooling.py
+++ b/tests/ci/test_release_tooling.py
@@ -1,12 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Regression tests for release tooling hardening.
-
-The canonical AGT release path is GitHub Actions. Azure DevOps ESRP, Microsoft
-tenant IDs, Key Vault variables, and Microsoft signing certificates must not be
-required to publish canonical artifacts.
-"""
+"""Regression tests for release tooling hardening."""
 
 from __future__ import annotations
 
@@ -17,6 +12,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PUBLISH = REPO_ROOT / ".github" / "workflows" / "publish.yml"
 CONTAINERS = REPO_ROOT / ".github" / "workflows" / "publish-containers.yml"
+ESRP_PIPELINE = REPO_ROOT / ".github" / "pipelines" / "esrp-publish.yml"
 LOCKFILE = REPO_ROOT / ".github" / "release-tools" / "release-tools.txt"
 SRC = REPO_ROOT / ".github" / "release-tools" / "release-tools.in"
 ACS_PYTHON_WHEEL_HELPER = REPO_ROOT / "scripts" / "ci" / "build_acs_python_wheel.sh"
@@ -54,7 +50,15 @@ def test_publish_workflow_uses_hashed_release_tools() -> None:
     assert ".github/release-tools/release-tools.txt" in text
 
 
-def test_publish_workflow_has_no_esrp_release_path() -> None:
+def test_esrp_pipeline_is_restored_as_temporary_registry_publish_path() -> None:
+    text = ESRP_PIPELINE.read_text(encoding="utf-8")
+    assert "EsrpRelease@11" in text
+    assert "dryRun" in text
+    assert ".github/release-tools/release-tools.txt" in text
+    assert ".github/pipelines/release-tools" not in text
+
+
+def test_publish_workflow_has_no_embedded_esrp_credentials_or_tasks() -> None:
     text = PUBLISH.read_text(encoding="utf-8")
     forbidden = [
         "EsrpRelease",
@@ -63,7 +67,6 @@ def test_publish_workflow_has_no_esrp_release_path() -> None:
         "ESRP_CERT_IDENTIFIER",
         "MICROSOFT_TENANT_ID",
         "ESRPRELPACMAN",
-        ".github/pipelines/esrp-publish.yml",
         "CertificateFingerprint",
     ]
     for marker in forbidden:
@@ -97,10 +100,10 @@ def test_pypi_prepare_and_publish_conditions_match() -> None:
     prepare = prepare[: prepare.index("- name: Upload build artifacts")]
     publish = text[text.index("- name: Publish to PyPI") :]
     publish = publish[: publish.index("uses: pypa/gh-action-pypi-publish")]
-    condition = "if: github.event_name == 'release' || github.event.inputs.dry_run == 'false'"
+    condition = "if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'"
     assert condition in prepare
     assert condition in publish
-    assert "github.event.inputs.dry_run == 'false'" in text
+    assert "github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false'" in text
 
 
 def test_release_manifest_generator_covers_artifact_families(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Restore Azure DevOps ESRP as the temporary package-registry publishing path while keeping GitHub Actions as the build, attestation, artifact, and dry-run path.

## Problem

The `v4.1.0` release proved GitHub Actions builds and container publishing work, but direct registry publishing is not yet configured: PyPI trusted publishers reject the new AGT package names, NuGet rejects the current API key, and npm has no `NPM_TOKEN`. Until those registry credentials are ready, release events should not attempt direct PyPI/npm/NuGet publishing from GitHub Actions.

## Changes

| File | What changed |
|------|-------------|
| `.github/pipelines/esrp-publish.yml` | Restored the ESRP ADO package-publishing pipeline and updated the build-tool lockfile path to `.github/release-tools/release-tools.txt`. |
| `.github/pipelines/AGENTS.md` | Restored local pipeline-editing guidance for security-sensitive ADO release automation. |
| `.github/workflows/publish.yml` | Keeps release builds, signatures, attestations, and artifacts, but direct PyPI/npm/NuGet publish steps now run only on explicit `workflow_dispatch` with `dry_run=false`, not on release events. |
| `docs/PUBLISHING.md`, `docs/RELEASE.md` | Documents the temporary split: GitHub Actions builds/attests artifacts; ESRP publishes package registries until GitHub registry credentials are configured. |
| `tests/ci/test_release_tooling.py` | Updates release-tooling tests to assert the restored ESRP pipeline and the new direct-publish gating. |
| `.cspell-repo-terms.txt` | Adds ESRP/ADO signing and pipeline terminology used by the restored pipeline. |

## Testing

- `python -m pytest tests/ci/test_release_tooling.py -q` — 11 passed
- `python scripts/docs/check_links.py` — 0 new broken links
- `npx --yes cspell@8.17.3 --config .cspell.json --no-progress --no-summary .github/pipelines/AGENTS.md .github/pipelines/esrp-publish.yml .github/workflows/publish.yml docs/PUBLISHING.md docs/RELEASE.md tests/ci/test_release_tooling.py .cspell-repo-terms.txt`
- YAML parse for `.github/workflows/publish.yml`, `.github/workflows/publish-containers.yml`, and `.github/pipelines/esrp-publish.yml`
- `git diff --check`
