### PR TITLE
fix(ci): compute DCO commit range from merge-base so rebased branches pass

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -18,14 +18,23 @@ jobs:
 
       - name: Check DCO sign-off on commits
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           MISSING=()
 
-          for SHA in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
-            # Skip merge commits (commits with more than one parent)
-            PARENT_COUNT=$(git cat-file -p "$SHA" | grep -c '^parent ')
+          # Compute the range from the merge base of the base branch and the PR
+          # head, not from the stale base.sha recorded when the PR was opened.
+          # After main advances and the branch is rebased, base.sha would sweep
+          # in already-merged main commits the PR author does not own.
+          git fetch origin "$BASE_REF"
+          MERGE_BASE=$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")
+
+          for SHA in $(git rev-list "$MERGE_BASE".."$HEAD_SHA"); do
+            # Skip merge commits (commits with more than one parent). Count the
+            # parents via %P so commit-message lines starting with "parent"
+            # cannot misclassify a normal commit as a merge.
+            PARENT_COUNT=$(git show -s --format=%P "$SHA" | wc -w)
             if [ "$PARENT_COUNT" -gt 1 ]; then
               continue
             fi


### PR DESCRIPTION
Fixes #2932

## What changed

`.github/workflows/dco.yml` now computes the commit range to check from the merge base of the PR base ref and the PR head, instead of from `github.event.pull_request.base.sha`.

- Range: `git fetch origin "$BASE_REF"` then `git rev-list "$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")".."$HEAD_SHA"`, with `BASE_REF` derived from `github.event.pull_request.base.ref`. Checkout already uses `fetch-depth: 0`.
- Merge-commit detection now counts parents via `git show -s --format=%P "$SHA" | wc -w` instead of `git cat-file -p "$SHA" | grep -c '^parent '`, so a commit message line starting with "parent" cannot misclassify a normal commit as a merge.

## Why

`base.sha` is the base tip recorded when the PR was opened. After main advances and the branch is rebased, the old `git rev-list "$BASE_SHA".."$HEAD_SHA"` range sweeps in already-merged main commits the PR author does not own. Many main commits lack a `Signed-off-by` trailer, so any rebased branch whose stale range includes them fails DCO for commits it did not author. Using the merge base scopes the check to only the commits actually introduced by the PR.

## How validated

- Dry-ran the new range and parent-count logic locally: the merge-base computation resolves correctly and `git show -s --format=%P` reports 1 parent for normal commits and 2 for a real merge commit.
- Validated `dco.yml` parses as valid YAML.