### PR TITLE
fix(ci): re-evaluate maintainer-approval gate on review events; fix dead service-account entry

### DIFF
--- a/.github/workflows/require-maintainer-approval.yml
+++ b/.github/workflows/require-maintainer-approval.yml
@@ -11,6 +11,12 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches: [main]
+  # Re-run the gate when a review is submitted or dismissed so an approval
+  # flips the check green immediately instead of waiting for a new push.
+  # github.event.pull_request.number is present for both pull_request_target
+  # and pull_request_review payloads, so PR resolution works for both events.
+  pull_request_review:
+    types: [submitted, dismissed]
 
 permissions:
   contents: read
@@ -31,7 +37,13 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const MAINTAINERS = ['imran-siddique', 'microsoft-github-policy-service'];
+            // NOTE: only human (type === 'User') maintainers count below, so a
+            // service account such as microsoft-github-policy-service can never
+            // satisfy this gate. Listing it here was dead code, and relaxing the
+            // type filter to admit a Bot would re-open the bot-approval bypass
+            // that this policy exists to prevent (see PRs #357 / #362). The
+            // safer fix is to keep the bot exclusion and list only humans.
+            const MAINTAINERS = ['imran-siddique'];
 
             const reviews = await github.rest.pulls.listReviews({
               owner: context.repo.owner,


### PR DESCRIPTION
## What changed

`.github/workflows/require-maintainer-approval.yml`:

1. Added a `pull_request_review: types: [submitted, dismissed]` trigger alongside the existing `pull_request_target` trigger. A maintainer approval now re-runs the gate and flips the check green immediately, instead of staying red until a new push or a manual `gh run rerun`. The PR resolves from `github.event.pull_request.number`, which is present in both payloads, so the existing `context.payload.pull_request.number` lookup works unchanged for both events.
2. Dropped the dead `microsoft-github-policy-service` maintainer entry. The gate requires `r.user.type === 'User'`, so that service account could never satisfy it. Relaxing the type filter to admit a Bot would re-open the bot-approval bypass this policy exists to prevent (PRs #357 / #362), so the safer fix keeps the bot exclusion and lists only humans. Documented in a comment.

## Why

The gate never re-evaluated after approval, leaving a persistent red X on PRs (the five dependabot PRs noted in the issue) and requiring manual reruns. The service-account entry was inert.

## Safety

Still safe for `pull_request_target` base context: no PR head checkout, no untrusted code executed. `pull_request_review` also runs in base context.

## Validated

YAML parses cleanly (`yaml.safe_load`).

Fixes #2933
