### PR TITLE
fix(ci): stop masking BinSkim and smoke-import; use reliable OPA download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,10 +610,13 @@ jobs:
       - name: BinSkim — binary security analysis
         working-directory: agent-governance-dotnet
         run: |
-          dotnet tool install --global Microsoft.CodeAnalysis.BinSkim --version 4.* 2>/dev/null || true
+          # No error-swallowing: a missing tool, crash, or real finding must
+          # fail this step. Only the SARIF upload below is allowed to soft-fail
+          # (GitHub Advanced Security availability is the sole concern there).
+          dotnet tool install --global Microsoft.CodeAnalysis.BinSkim --version 4.*
           BinSkim analyze "src/AgentGovernance/bin/Release/net8.0/*.dll" \
             --output binskim-results.sarif \
-            --verbose 2>/dev/null || echo "BinSkim completed with warnings"
+            --verbose
       - name: Upload BinSkim SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
@@ -697,13 +700,15 @@ jobs:
           "
       - name: Smoke test — import ${{ matrix.import-module }}
         run: python -c "import ${{ matrix.import-module }}"
-        continue-on-error: true
       - name: Run tests
         working-directory: agent-governance-python/agentmesh-integrations/${{ matrix.package }}
         run: |
           if [ -d tests ]; then
             pytest tests/ -q --tb=short
           else
+            # The smoke-import step above already ran and must have succeeded
+            # to reach here (it no longer swallows failures), so this branch is
+            # only printed when the import actually passed.
             echo "No tests/ directory — smoke import passed"
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN for i in 1 2 3; do apt-get update && break || sleep 5; done \
     # OPA CLI — required by OPAEvaluator local mode (opa eval subprocess)
     && curl --proto '=https' --tlsv1.2 -fSLo /usr/local/bin/opa \
         --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 \
-        https://openpolicyagent.org/downloads/v1.4.2/opa_linux_amd64_static \
+        https://github.com/open-policy-agent/opa/releases/download/v1.4.2/opa_linux_amd64_static \
     && echo "2c0ccdbbe0b8e2a5d12d9c42d92f1f34f494ffb32d1f3c4ddc36101be637d66f  /usr/local/bin/opa" \
         | sha256sum -c - \
     && chmod 755 /usr/local/bin/opa


### PR DESCRIPTION
## What changed

Three CI checks could never fail, and the OPA download in the Docker base image was flaky. This PR covers only the workflow and Dockerfile changes.

- **BinSkim** (`.github/workflows/ci.yml`): removed the `|| true` on tool install, the `2>/dev/null` stderr discards, and the `|| echo "BinSkim completed with warnings"` swallow. The analyze step now fails on a real finding or tool error. `continue-on-error: true` is kept only on the SARIF upload step, where GitHub Advanced Security availability is the concern.
- **Integration smoke-import** (`.github/workflows/ci.yml`): removed `continue-on-error: true` from the import step so a broken package import fails the job. The "No tests/ directory" branch now only prints success when the import actually succeeded (it can only be reached after a passing import).
- **OPA download** (`Dockerfile`): switched the base stage from `openpolicyagent.org/downloads` to the GitHub releases URL (`github.com/open-policy-agent/opa/releases/download/v1.4.2/opa_linux_amd64_static`), preserving the same pinned version and sha256 verification. This addresses the scheduled-run 504 failures.

## Why

Masked steps produced green results on crashes, missing tools, or real findings, so they did not gate anything. The OPA endpoint returned repeated 504s in scheduled runs.

## How validated

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- Reviewed the diff to confirm the soft-fail remains only on the SARIF upload.

## Out of scope (admin follow-up)

The branch-protection ruleset is a repo admin setting, not a workflow file, so it is not changed here. Recommendation: make `ci-complete` the single required status check in the `main` ruleset and drop the individual matrix-leg names (`test (agent-os, 3.11)`, etc.). That makes docker-compose-test, lint, security, and the 3.13 legs actually gate auto-merge, and stops a renamed matrix entry from stranding an "Expected" check.

Fixes #2934
