### PR TITLE
fix(ci): allowlist test-fixture paths in gitleaks so main stops failing on squash-merged SHAs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,6 +37,12 @@ useDefault = true
 
     # Security scanner tests (intentional fake credentials)
     '''agent-governance-python/agent-compliance/tests/test_security_scanner\.py''',
+
+    # Policy template test fixtures (deterministic fake credentials for policy evaluation)
+    '''examples/policy-templates/fixtures/.*''',
+
+    # AgentMesh integration test suites (fake tokens, JWTs in test data)
+    '''agent-governance-python/agentmesh-integrations/.*/tests/.*''',
   ]
   regexes = [
     '''ghp_secret123''',

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -12,7 +12,6 @@ a0bfee741304548463c85252302720958772a192:docs/tutorials/32-e2e-encrypted-messagi
 de392848c0fbfd2566789a8ddee41b35c8cdf798:packages/agentmesh-integrations/sb-runtime-skill/sb_runtime_agentmesh/receipts.py:generic-api-key:92
 3130880d08313227c792a6a3b5837dee0938e1c0:packages/agentmesh-integrations/agentmesh-avp/tests/test_provider.py:generic-api-key:13
 46b56f5d1af93ce62cd14b6fa67679af4d99bc80:examples/atr-community-rules/test_atr_policy.py:generic-api-key:82
-7be9ff1699cb333c3ab721c79e1cc5569aa34a4c:examples/policy-templates/fixtures/general-saas-fixtures.json:generic-api-key:82
 8144506882383949be2e09bb08b6a633e6a31827:packages/agent-os/tests/test_credential_redactor.py:generic-api-key:18
 970dd88379d464a660a80a3b99996e581b046e93:packages/agent-mesh/sdks/rust/agentmesh-mcp/src/mcp/response.rs:generic-api-key:326
 970dd88379d464a660a80a3b99996e581b046e93:packages/agent-mesh/sdks/rust/agentmesh-mcp/src/mcp/redactor.rs:generic-api-key:188
@@ -67,7 +66,6 @@ f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-python/agent-os/tests/
 f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-python/agent-os/tests/test_security_skills.py:generic-api-key:271
 f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-python/agent-sre/src/agent_sre/signing.py:generic-api-key:92
 f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-python/agent-sre/tests/unit/test_capture.py:generic-api-key:62
-f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-python/agentmesh-integrations/agentmesh-avp/tests/test_provider.py:generic-api-key:13
 f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-python/agentmesh-integrations/langgraph-trust/langgraph_trust/identity.py:generic-api-key:30
 f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-rust/agentmesh-mcp/src/mcp/response.rs:generic-api-key:340
 f80fd4b5e3184f6f37a59aebeb824f5f5095dff7:agent-governance-typescript/agent-os-vscode/package.json:generic-api-key:231


### PR DESCRIPTION
## What changed

- `.gitleaks.toml`: added two path-based allowlist entries (the file already states it prefers paths over fingerprints):
  - `examples/policy-templates/fixtures/.*`
  - `agent-governance-python/agentmesh-integrations/.*/tests/.*`
- `.gitleaksignore`: removed the now-stale fingerprint entries that those path rules now cover durably (the `examples/policy-templates/fixtures/general-saas-fixtures.json` entry and the `agentmesh-integrations/agentmesh-avp/tests/test_provider.py` entry).

## Why

Push runs scan full history (`gitleaks detect --source .`, fetch-depth 0). The `.gitleaksignore` fingerprints reference old commit SHAs that squash merges invalidated, so Secret Scanning was permanently red on every push to main with `leaks found: 3`. PR runs only scan BASE..HEAD, so the breakage stayed invisible until merge. The three known findings are all intentional fake test credentials:
- `examples/policy-templates/fixtures/sql-agent-fixtures.json:37` (already covered by the new fixtures path rule)
- `examples/policy-templates/fixtures/general-saas-fixtures.json:83` (now covered by the fixtures path rule)
- `agent-governance-python/agentmesh-integrations/cedarling-agentmesh/tests/test_cedarling_backend.py` jwt (now covered by the integrations tests path rule)

Path-based rules are immune to SHA churn, which is the fix the toml comment itself recommends.

## How validated

- Confirmed the `.gitleaks.toml` parses as valid TOML (`tomllib`).
- Confirmed both new allowlist globs match real on-disk paths, including the cedarling tests directory.
- gitleaks is not installed in this environment, so `gitleaks detect --source . --no-banner` could not be run locally. The allowlist `paths` entries are standard gitleaks regex path rules and cover all three reported finding paths, so the next push-triggered full-history scan should report zero of the three known fixture findings.

Fixes #2931
