### PR TITLE
fix(agent-os): release bounded-semaphore slot on wrapped-callable failure

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import logging
 import re
+import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -971,6 +972,7 @@ class BoundedSemaphore:
         self._active = 0
         self._total_acquired = 0
         self._total_rejected = 0
+        self._lock = threading.Lock()
 
     def try_acquire(self) -> tuple[bool, str | None]:
         """
@@ -978,17 +980,19 @@ class BoundedSemaphore:
 
         Returns (acquired, reason).
         """
-        if self._active >= self.max_concurrent:
-            self._total_rejected += 1
-            return False, f"Max concurrency reached ({self.max_concurrent})"
-        self._active += 1
-        self._total_acquired += 1
-        return True, None
+        with self._lock:
+            if self._active >= self.max_concurrent:
+                self._total_rejected += 1
+                return False, f"Max concurrency reached ({self.max_concurrent})"
+            self._active += 1
+            self._total_acquired += 1
+            return True, None
 
     def release(self) -> None:
         """Release a slot."""
-        if self._active > 0:
-            self._active -= 1
+        with self._lock:
+            if self._active > 0:
+                self._active -= 1
 
     @property
     def is_under_pressure(self) -> bool:
@@ -1965,10 +1969,18 @@ class AsyncGovernedWrapper:
             if not pre_result.allowed:
                 raise PolicyViolationError(pre_result.reason or "Policy check failed")
 
-            # Execute the wrapped callable
-            result = await self._fn(*args, **kwargs)
+            # Execute the wrapped callable. Wrap in try/finally so that a
+            # bounded-semaphore slot acquired during pre_execute_check is always
+            # released even when the wrapped callable raises. Without this the
+            # slot leaks permanently and repeated failures exhaust max_concurrent,
+            # deadlocking the integration into denying every subsequent request.
+            try:
+                result = await self._fn(*args, **kwargs)
+            except BaseException:
+                self._integration._release_semaphore_if_held(self._ctx)
+                raise
 
-            # Post-execution validation
+            # Post-execution validation (this also releases the semaphore slot).
             post_result = await self._integration.async_post_execute_check(self._ctx, result)
             if not post_result.allowed:
                 raise PolicyViolationError(post_result.reason or "Post-execution validation failed")

--- a/agent-governance-python/agent-os/tests/test_async_adapters.py
+++ b/agent-governance-python/agent-os/tests/test_async_adapters.py
@@ -204,6 +204,71 @@ async def test_concurrent_call_count_integrity():
 
 
 # =============================================================================
+# Tests: bounded-semaphore slot is released when the wrapped callable raises
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_semaphore_slot_released_on_wrapped_callable_failure():
+    """A wrapped callable that raises must not leak its bounded-semaphore slot.
+
+    Regression test for issue #2928: without a try/finally around the wrapped
+    call the acquired slot leaked on failure, so repeated failures exhausted
+    max_concurrent and the integration deadlocked into denying everything. Here
+    the callable raises more times than max_concurrent, then a successful call
+    must still be admitted.
+    """
+    max_concurrent = 2
+    policy = GovernancePolicy(
+        bounded_semaphore={"enabled": True, "max_concurrent": max_concurrent},
+    )
+    integration = DummyIntegration(policy=policy)
+
+    calls = {"n": 0}
+
+    async def flaky_fn() -> str:
+        calls["n"] += 1
+        if calls["n"] <= max_concurrent + 3:
+            raise RuntimeError("boom")
+        return "ok"
+
+    wrapper = AsyncGovernedWrapper(integration, flaky_fn, agent_id="flaky-agent")
+
+    # Fail more times than max_concurrent. Each failure must release its slot.
+    for _ in range(max_concurrent + 3):
+        with pytest.raises(RuntimeError, match="boom"):
+            await wrapper()
+
+    # The semaphore must not be exhausted by the leaked slots.
+    assert integration._bounded_semaphore is not None
+    assert integration._bounded_semaphore.active == 0
+
+    # A subsequent successful call must still be admitted (no PolicyViolationError).
+    result = await wrapper()
+    assert result == "ok"
+    assert integration._bounded_semaphore.active == 0
+
+
+def test_bounded_semaphore_counter_is_lock_guarded():
+    """BoundedSemaphore should guard its counters with a threading.Lock."""
+    from agent_os.integrations.base import BoundedSemaphore
+
+    sem = BoundedSemaphore(max_concurrent=1)
+    acquired, _ = sem.try_acquire()
+    assert acquired is True
+    assert sem.active == 1
+    # Second acquire is rejected while the slot is held.
+    acquired, reason = sem.try_acquire()
+    assert acquired is False
+    assert reason is not None
+    sem.release()
+    assert sem.active == 0
+    # Releasing below zero is a no-op.
+    sem.release()
+    assert sem.active == 0
+
+
+# =============================================================================
 # Tests: sync methods still work unchanged (backward compatibility)
 # =============================================================================
 


### PR DESCRIPTION
## What changed

`AsyncGovernedWrapper.__call__` acquired a `BoundedSemaphore` slot in `pre_execute_check` but released it only in `post_execute_check`. When the wrapped callable raised, the slot leaked. Since `_semaphore_held_sessions` is a per-session set, subsequent calls could not re-register the release, leaking one slot permanently per failure. Repeated failures exhausted `max_concurrent` and the integration deadlocked into denying every request.

- Wrap the wrapped-callable invocation in `try/except` so the slot acquired in `pre_execute_check` is released via `_release_semaphore_if_held` when the callable raises.
- Guard `BoundedSemaphore._active` mutations in `try_acquire`/`release` with a `threading.Lock`, since they run from thread contexts.
- Add regression tests in `test_async_adapters.py`: a callable that raises more times than `max_concurrent` must not exhaust the semaphore, and a later successful call must still be admitted.

Note: there is no sync `GovernedWrapper` class in this module, so only the async path needed the try/finally fix.

## Why

Without the release on failure path, the concurrency guard becomes a permanent denial trap after a few wrapped-callable errors.

## How validated

`python -m pytest tests/test_async_adapters.py -q` passes all 14 tests (12 existing plus 2 new regression tests). Remaining failures in `test_integrations.py` are pre-existing and unrelated (`ModuleNotFoundError: No module named 'agt'` in the OpenAI adapter).

Fixes #2928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
