### PR TITLE
fix(mastra-agentmesh): make audit hash chain per-instance, race-safe, and tamper-evident

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -683,6 +683,7 @@ sprintf
 subparser
 summarise
 synthesised
+tamperable
 tamperedhash
 testserver
 tsfn

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/src/audit.ts
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/src/audit.ts
@@ -10,13 +10,15 @@
 
 import type { AuditConfig, AuditEntry, GovernanceResult, TrustVerification } from "./types";
 
-let previousHash = "0000000000000000000000000000000000000000000000000000000000000000";
-const entries: AuditEntry[] = [];
-let entryCounter = 0;
+const GENESIS_HASH = "0000000000000000000000000000000000000000000000000000000000000000";
 
 /**
  * Creates an audit middleware that records all tool executions
  * with tamper-evident hash chains.
+ *
+ * Each call to auditMiddleware() owns an independent chain: its entries,
+ * previousHash, and counter are private to the returned instance, so
+ * clear() and maxEntries on one instance never affect another.
  *
  * @example
  * ```ts
@@ -39,11 +41,86 @@ let entryCounter = 0;
 export function auditMiddleware(config: AuditConfig = {}) {
   const maxEntries = config.maxEntries ?? 10_000;
 
+  // Per-instance state. Living in this closure means every auditMiddleware()
+  // call gets its own isolated chain.
+  let previousHash = GENESIS_HASH;
+  const entries: AuditEntry[] = [];
+  let entryCounter = 0;
+
+  // Serializes record() so the read-compute-write of previousHash is atomic.
+  // Each append chains off the prior one, so two concurrent record() calls can
+  // never both read the same previousHash.
+  let tail: Promise<unknown> = Promise.resolve();
+
+  /** Build the canonical payload that an entry's hash covers. */
+  function hashPayload(entry: Pick<AuditEntry, "id" | "timestamp" | "toolId" | "agentId" | "action" | "previousHash">): string {
+    return JSON.stringify({
+      id: entry.id,
+      timestamp: entry.timestamp,
+      toolId: entry.toolId,
+      agentId: entry.agentId,
+      action: entry.action,
+      previousHash: entry.previousHash,
+    });
+  }
+
+  async function append(params: {
+    toolId: string;
+    agentId: string;
+    action: "invoke" | "complete" | "deny" | "error";
+    input?: unknown;
+    output?: unknown;
+    duration_ms?: number;
+    governance?: GovernanceResult;
+    trust?: TrustVerification;
+  }): Promise<AuditEntry> {
+    const id = `audit-${++entryCounter}-${Date.now()}`;
+    const timestamp = Date.now();
+    const prev = previousHash;
+
+    const hash = await computeHash(
+      hashPayload({ id, timestamp, toolId: params.toolId, agentId: params.agentId, action: params.action, previousHash: prev }),
+    );
+
+    const entry: AuditEntry = {
+      id,
+      timestamp,
+      toolId: params.toolId,
+      agentId: params.agentId,
+      action: params.action,
+      input: config.captureData ? params.input : undefined,
+      output: config.captureData ? params.output : undefined,
+      duration_ms: params.duration_ms,
+      governance: params.governance,
+      trust: params.trust,
+      hash,
+      previousHash: prev,
+    };
+
+    previousHash = hash;
+    entries.push(entry);
+
+    // Trim old entries
+    while (entries.length > maxEntries) {
+      entries.shift();
+    }
+
+    // Send to custom sink
+    if (config.sink) {
+      await config.sink(entry);
+    }
+
+    return entry;
+  }
+
   return {
     /**
      * Record an audit entry with hash chain integrity.
+     *
+     * Appends are serialized: the read-compute-write of previousHash is atomic
+     * across concurrent calls, so the chain stays consistent under concurrency.
      */
-    async record(params: {
+    record(params: {
       toolId: string;
       agentId: string;
       action: "invoke" | "complete" | "deny" | "error";
@@ -53,66 +130,50 @@ export function auditMiddleware(config: AuditConfig = {}) {
       governance?: GovernanceResult;
       trust?: TrustVerification;
     }): Promise<AuditEntry> {
-      const id = `audit-${++entryCounter}-${Date.now()}`;
-      const timestamp = Date.now();
-
-      const hashPayload = JSON.stringify({
-        id,
-        timestamp,
-        toolId: params.toolId,
-        agentId: params.agentId,
-        action: params.action,
-        previousHash,
-      });
-
-      const hash = await computeHash(hashPayload);
-
-      const entry: AuditEntry = {
-        id,
-        timestamp,
-        toolId: params.toolId,
-        agentId: params.agentId,
-        action: params.action,
-        input: config.captureData ? params.input : undefined,
-        output: config.captureData ? params.output : undefined,
-        duration_ms: params.duration_ms,
-        governance: params.governance,
-        trust: params.trust,
-        hash,
-        previousHash,
-      };
-
-      previousHash = hash;
-      entries.push(entry);
-
-      // Trim old entries
-      while (entries.length > maxEntries) {
-        entries.shift();
-      }
-
-      // Send to custom sink
-      if (config.sink) {
-        await config.sink(entry);
-      }
-
-      return entry;
+      // Chain this append onto the previous one. We swallow prior rejections
+      // for sequencing purposes only; the caller still sees its own result.
+      const result = tail.then(
+        () => append(params),
+        () => append(params),
+      );
+      tail = result;
+      return result;
     },
 
     /**
      * Get all audit entries (most recent first).
      */
     getEntries(limit?: number): AuditEntry[] {
-      const result = [...entries].reverse();
+      const result = [...entries].reverse().map((e) => ({ ...e }));
       return limit ? result.slice(0, limit) : result;
     },
 
     /**
      * Verify the integrity of the audit chain.
+     *
+     * Checks both the previousHash linkage between adjacent entries and that
+     * each entry's stored hash still matches a hash recomputed from its fields,
+     * so tampering with any covered field is detected.
+     *
      * Returns true if no entries have been tampered with.
      */
     async verifyChain(): Promise<{ valid: boolean; brokenAt?: number }> {
-      for (let i = 1; i < entries.length; i++) {
-        if (entries[i].previousHash !== entries[i - 1].hash) {
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+
+        // Linkage check. We anchor on each entry's own recorded previousHash
+        // for i === 0 because maxEntries trimming may have removed the
+        // genesis-anchored head, so the surviving head can legitimately carry
+        // an earlier entry's hash.
+        if (i > 0 && entry.previousHash !== entries[i - 1].hash) {
+          return { valid: false, brokenAt: i };
+        }
+
+        // Recompute the hash from the entry's fields so any tampering with a
+        // covered field (toolId, agentId, action, id, timestamp, previousHash)
+        // is detected even when the linkage still appears intact.
+        const expectedHash = await computeHash(hashPayload(entry));
+        if (entry.hash !== expectedHash) {
           return { valid: false, brokenAt: i };
         }
       }
@@ -127,12 +188,13 @@ export function auditMiddleware(config: AuditConfig = {}) {
     },
 
     /**
-     * Clear all entries (for testing).
+     * Clear all entries (for testing). Only affects this instance.
      */
     clear() {
       entries.length = 0;
       entryCounter = 0;
-      previousHash = "0000000000000000000000000000000000000000000000000000000000000000";
+      previousHash = GENESIS_HASH;
+      tail = Promise.resolve();
     },
   };
 }

--- a/agent-governance-python/agentmesh-integrations/mastra-agentmesh/tests/index.test.ts
+++ b/agent-governance-python/agentmesh-integrations/mastra-agentmesh/tests/index.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { governanceMiddleware } from "../src/governance";
 import { trustGate } from "../src/trust";
-import { auditMiddleware } from "../src/audit";
+import { auditMiddleware, type AuditEntry } from "../src/audit";
 import { createGovernedTool } from "../src/governed-tool";
 
 describe("governanceMiddleware", () => {
@@ -188,6 +188,85 @@ describe("auditMiddleware", () => {
 
     await withSink.record({ toolId: "t", agentId: "a", action: "invoke" });
     expect(sunk).toHaveLength(1);
+  });
+
+  it("produces a valid chain under concurrent record() calls", async () => {
+    const concurrent = auditMiddleware({ maxEntries: 100 });
+    concurrent.clear();
+
+    await Promise.all(
+      Array.from({ length: 25 }, (_, i) =>
+        concurrent.record({ toolId: `t${i}`, agentId: "a", action: "invoke" })
+      )
+    );
+
+    expect(concurrent.length).toBe(25);
+
+    // Every entry must link to the one before it, with no duplicate previousHash.
+    const entries = concurrent.getEntries().reverse(); // oldest first
+    const seenPrev = new Set<string>();
+    for (let i = 1; i < entries.length; i++) {
+      expect(entries[i].previousHash).toBe(entries[i - 1].hash);
+      expect(seenPrev.has(entries[i].previousHash)).toBe(false);
+      seenPrev.add(entries[i].previousHash);
+    }
+
+    const result = await concurrent.verifyChain();
+    expect(result.valid).toBe(true);
+  });
+
+  it("verifyChain detects field tampering on a stored entry", async () => {
+    // The sink receives the live entry object that is stored inside the chain,
+    // so mutating it here mutates the chain's own copy.
+    const stored: AuditEntry[] = [];
+    const tamperable = auditMiddleware({
+      maxEntries: 100,
+      sink: async (entry) => {
+        stored.push(entry);
+      },
+    });
+    tamperable.clear();
+
+    await tamperable.record({ toolId: "t1", agentId: "a", action: "invoke" });
+    await tamperable.record({ toolId: "t2", agentId: "a", action: "complete" });
+    await tamperable.record({ toolId: "t3", agentId: "a", action: "invoke" });
+
+    expect((await tamperable.verifyChain()).valid).toBe(true);
+
+    // Tamper a covered field without touching the hash. Linkage stays intact,
+    // but hash recomputation must catch the mismatch.
+    stored[1].toolId = "TAMPERED";
+
+    const result = await tamperable.verifyChain();
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt).toBe(1);
+  });
+
+  it("two middleware instances keep independent chains", async () => {
+    const a = auditMiddleware({ maxEntries: 100 });
+    const b = auditMiddleware({ maxEntries: 100 });
+    a.clear();
+    b.clear();
+
+    await a.record({ toolId: "ta", agentId: "agent-a", action: "invoke" });
+    await a.record({ toolId: "ta2", agentId: "agent-a", action: "complete" });
+
+    await b.record({ toolId: "tb", agentId: "agent-b", action: "invoke" });
+
+    expect(a.length).toBe(2);
+    expect(b.length).toBe(1);
+
+    // clear() on one must not touch the other.
+    a.clear();
+    expect(a.length).toBe(0);
+    expect(b.length).toBe(1);
+    expect((await b.verifyChain()).valid).toBe(true);
+
+    // First entries of independent chains both anchor on genesis.
+    const bEntries = b.getEntries();
+    expect(bEntries[0].previousHash).toBe(
+      "0000000000000000000000000000000000000000000000000000000000000000"
+    );
   });
 });
 

--- a/agent-governance-typescript/src/audit.ts
+++ b/agent-governance-typescript/src/audit.ts
@@ -81,7 +81,12 @@ export class AuditLogger {
       });
 
       const expectedHash = createHash('sha256').update(payload).digest('hex');
-      if (!timingSafeEqual(Buffer.from(entry.hash, 'utf8'), Buffer.from(expectedHash, 'utf8'))) return false;
+      const actual = Buffer.from(entry.hash, 'utf8');
+      const expected = Buffer.from(expectedHash, 'utf8');
+      // timingSafeEqual throws RangeError on length mismatch, so length-check
+      // first and treat a mismatch as a verification failure.
+      if (actual.length !== expected.length) return false;
+      if (!timingSafeEqual(actual, expected)) return false;
     }
     return true;
   }
@@ -105,7 +110,9 @@ export class AuditLogger {
       result = result.filter((e) => e.timestamp >= since);
     }
 
-    return result;
+    // Return defensive copies so callers cannot mutate the internal log and
+    // silently break chain integrity.
+    return result.map((e) => ({ ...e }));
   }
 
   /** Export the full log as a JSON string. */

--- a/agent-governance-typescript/tests/audit.test.ts
+++ b/agent-governance-typescript/tests/audit.test.ts
@@ -66,6 +66,17 @@ describe('AuditLogger', () => {
 
       expect(tampered.verify()).toBe(false);
     });
+
+    it('returns false (does not throw) when a hash length differs', () => {
+      logger.log({ agentId: 'a', action: 'x', decision: 'allow' });
+
+      const entries = (logger as any).entries as Array<{ hash: string }>;
+      // A truncated hash has a different byte length than the recomputed one.
+      entries[0].hash = 'deadbeef';
+
+      expect(() => logger.verify()).not.toThrow();
+      expect(logger.verify()).toBe(false);
+    });
   });
 
   describe('getEntries()', () => {
@@ -98,6 +109,15 @@ describe('AuditLogger', () => {
 
       const future = new Date(Date.now() + 60_000);
       expect(logger.getEntries({ since: future })).toHaveLength(0);
+    });
+
+    it('returns defensive copies that cannot mutate the internal log', () => {
+      const entries = logger.getEntries();
+      entries[0].action = 'MUTATED';
+
+      // The internal log and its chain integrity must be unaffected.
+      expect(logger.getEntries()[0].action).not.toBe('MUTATED');
+      expect(logger.verify()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## What changed

**`agent-governance-python/agentmesh-integrations/mastra-agentmesh/src/audit.ts`**
- Moved `previousHash`, `entries`, and `entryCounter` out of module scope and into the closure returned by `auditMiddleware()`, so each instance owns an independent chain. `clear()` and `maxEntries` no longer affect sibling instances.
- Serialized appends with a chained promise queue so the read-compute-write of `previousHash` in `record()` is atomic. Concurrent calls can no longer read the same `previousHash` and corrupt the chain.
- `verifyChain()` now recomputes each entry's hash from its fields and compares it to `entry.hash`, in addition to the existing linkage check, so tampering with a covered field is detected.
- `getEntries()` returns defensive copies.

**`agent-governance-typescript/src/audit.ts`**
- `verify()` length-checks the buffers before `timingSafeEqual` and returns `false` on mismatch instead of throwing `RangeError`.
- `getEntries()` returns defensive copies so callers cannot mutate the internal log.

## Why
The middleware advertised a tamper-evident, per-tool audit chain, but shared module state plus an await race corrupted the chain under concurrency, and `verifyChain()` never recomputed hashes so field tampering passed verification. See #2927.

## How validated
Added/extended unit tests: concurrent `record()` produces a valid chain with unique links; mutating a stored field makes `verifyChain()` return `false`; two middleware instances keep independent chains; `verify()` returns `false` (no throw) on hash length mismatch; `getEntries()` copies cannot mutate the log. No JS runtime is available in this worktree, so the suites were not executed here; changes were reviewed manually for type and logic correctness.

Fixes #2927

🤖 Generated with [Claude Code](https://claude.com/claude-code)