### PR TITLE
fix(agent-os): enforce pinned ctx.policy and fail closed in scoped evaluation

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -1549,9 +1549,9 @@ class BaseIntegration(ABC):
                 return result
 
         # Check call count
-        if ctx.call_count >= self.policy.max_tool_calls:
+        if ctx.call_count >= ctx.policy.max_tool_calls:
             self._release_semaphore_if_held(ctx)
-            result = deny_max_tool_calls(self.policy.max_tool_calls, ctx.call_count)
+            result = deny_max_tool_calls(ctx.policy.max_tool_calls, ctx.call_count)
             self.emit(
                 GovernanceEventType.POLICY_VIOLATION,
                 {**event_base, "reason": result.reason},
@@ -1560,9 +1560,9 @@ class BaseIntegration(ABC):
 
         # Check timeout
         elapsed = (datetime.now() - ctx.start_time).total_seconds()
-        if elapsed > self.policy.timeout_seconds:
+        if elapsed > ctx.policy.timeout_seconds:
             self._release_semaphore_if_held(ctx)
-            result = deny_timeout(self.policy.timeout_seconds, elapsed)
+            result = deny_timeout(ctx.policy.timeout_seconds, elapsed)
             self.emit(
                 GovernanceEventType.POLICY_VIOLATION,
                 {**event_base, "reason": result.reason},
@@ -1571,7 +1571,7 @@ class BaseIntegration(ABC):
 
         # Check blocked patterns
         input_str = str(input_data)
-        matched = self.policy.matches_pattern(input_str)
+        matched = ctx.policy.matches_pattern(input_str)
         if matched:
             self._release_semaphore_if_held(ctx)
             result = deny_blocked_pattern_input(matched[0], input_str)
@@ -1582,7 +1582,7 @@ class BaseIntegration(ABC):
             return result
 
         # Check human approval requirement
-        if self.policy.require_human_approval:
+        if ctx.policy.require_human_approval:
             self._release_semaphore_if_held(ctx)
             result = deny_human_approval()
             self.emit(
@@ -1592,11 +1592,11 @@ class BaseIntegration(ABC):
             return result
 
         # Check confidence threshold
-        if self.policy.confidence_threshold > 0.0:
+        if ctx.policy.confidence_threshold > 0.0:
             confidence = getattr(input_data, "confidence", None)
-            if isinstance(confidence, (int, float)) and confidence < self.policy.confidence_threshold:
+            if isinstance(confidence, (int, float)) and confidence < ctx.policy.confidence_threshold:
                 self._release_semaphore_if_held(ctx)
-                result = deny_confidence_threshold(self.policy.confidence_threshold, confidence)
+                result = deny_confidence_threshold(ctx.policy.confidence_threshold, confidence)
                 self.emit(
                     GovernanceEventType.POLICY_VIOLATION,
                     {**event_base, "reason": result.reason},
@@ -1770,14 +1770,14 @@ class BaseIntegration(ABC):
                 self._token_budget_tracker.record_usage(ctx.agent_id, prompt_tokens, completion_tokens)
 
         # Drift detection: compare output against baseline
-        if self.policy.drift_threshold > 0.0:
+        if ctx.policy.drift_threshold > 0.0:
             drift_result = self.compute_drift(ctx, output_data)
             if drift_result is not None:
                 ctx._drift_scores.append(drift_result.score)
                 if drift_result.exceeded:
                     reason = (
                         f"Drift score {drift_result.score:.2f} exceeds threshold "
-                        f"{self.policy.drift_threshold:.2f}"
+                        f"{ctx.policy.drift_threshold:.2f}"
                     )
                     logger.warning(
                         "Drift detected agent=%s score=%.4f threshold=%.2f",
@@ -1803,7 +1803,7 @@ class BaseIntegration(ABC):
                     )
 
         # Checkpoint if needed
-        if ctx.call_count % self.policy.checkpoint_frequency == 0:
+        if ctx.call_count % ctx.policy.checkpoint_frequency == 0:
             checkpoint_id = f"checkpoint-{ctx.call_count}"
             ctx.checkpoints.append(checkpoint_id)
             self.emit(GovernanceEventType.CHECKPOINT_CREATED, {

--- a/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
@@ -175,29 +175,55 @@ class PolicyEvaluator:
         return self._evaluate_flat(context)
 
     def _evaluate_scoped(self, context: dict[str, Any]) -> PolicyDecision:
-        """Evaluate using folder-level policy discovery and merge."""
+        """Evaluate using folder-level policy discovery and merge.
+
+        The discovery, parse, and merge phase is wrapped in a fail-closed
+        try/except (matching ``_evaluate_flat``) so that a malformed
+        governance.yaml anywhere in the folder chain yields a deny decision
+        rather than raising out of ``evaluate()``.
+        """
         from .discovery import discover_policies, filter_by_scope
         from .merge import merge_policies
 
-        action_path = Path(context["path"])
-        chain_paths = discover_policies(action_path, self.root_dir)
+        try:
+            action_path = Path(context["path"])
+            chain_paths = discover_policies(action_path, self.root_dir)
 
-        if not chain_paths:
-            # No governance files found — fall back to loaded policies
-            return self._evaluate_flat(context)
+            if not chain_paths:
+                # No governance files found, fall back to loaded policies
+                return self._evaluate_flat(context)
 
-        docs = [PolicyDocument.from_yaml(p) for p in chain_paths]
+            docs = [PolicyDocument.from_yaml(p) for p in chain_paths]
 
-        # Filter by scope
-        filtered = []
-        for doc, path in zip(docs, chain_paths):
-            if filter_by_scope(path, doc.scope, action_path, self.root_dir):
-                filtered.append(doc)
+            # Filter by scope
+            filtered = []
+            for doc, path in zip(docs, chain_paths):
+                if filter_by_scope(path, doc.scope, action_path, self.root_dir):
+                    filtered.append(doc)
 
-        if not filtered:
-            return self._evaluate_flat(context)
+            if not filtered:
+                return self._evaluate_flat(context)
 
-        merged_rules = merge_policies(filtered)
+            merged_rules = merge_policies(filtered)
+        except Exception:
+            logger.error(
+                "Scoped policy discovery error, denying access (fail closed)",
+                exc_info=True,
+            )
+            return PolicyDecision(
+                allowed=False,
+                action="deny",
+                reason="Policy evaluation error, access denied (fail closed)",
+                audit_entry={
+                    "policy": None,
+                    "rule": None,
+                    "action": "deny",
+                    "context_snapshot": context,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "error": True,
+                },
+            )
+
         return self._evaluate_rules(merged_rules, filtered, context)
 
     def _evaluate_flat(self, context: dict[str, Any]) -> PolicyDecision:

--- a/agent-governance-python/agent-os/tests/test_base_cedar_integration.py
+++ b/agent-governance-python/agent-os/tests/test_base_cedar_integration.py
@@ -249,7 +249,9 @@ class TestPreExecuteCedarGate:
         policy = GovernancePolicy(max_tool_calls=0)  # Will instantly deny
         integration = _ConcreteIntegration(policy=policy, evaluator=evaluator)
 
-        ctx = _make_ctx()
+        # Pin the configured policy into the context via create_context so the
+        # session enforces the policy that was active at context creation.
+        ctx = integration.create_context("test-agent")
         allowed, reason = integration.pre_execute(ctx, "test input")
         assert allowed is False
         assert "Max tool calls" in reason  # GovernancePolicy kicked in
@@ -588,13 +590,13 @@ class TestEndToEndCedarGovernance:
             blocked_patterns=["DROP TABLE"],
         )
         integration = _ConcreteIntegration(policy=policy)
-        ctx = _make_ctx()
+        ctx = integration.create_context("test-agent")
 
-        # Normal input — should pass
+        # Normal input -- should pass
         allowed, reason = integration.pre_execute(ctx, "SELECT * FROM users")
         assert allowed is True
 
-        # Blocked pattern — should fail via GovernancePolicy
+        # Blocked pattern -- should fail via GovernancePolicy
         allowed, reason = integration.pre_execute(ctx, "DROP TABLE users")
         assert allowed is False
         assert "Blocked pattern" in reason
@@ -702,7 +704,7 @@ class TestRealWorldGovernanceValue:
         )
         integration = _ConcreteIntegration(policy=policy, evaluator=evaluator)
 
-        ctx = _make_ctx()
+        ctx = integration.create_context("test-agent")
         ctx.call_count = 0
 
         # First call: both permit

--- a/agent-governance-python/agent-os/tests/test_folder_governance.py
+++ b/agent-governance-python/agent-os/tests/test_folder_governance.py
@@ -358,6 +358,26 @@ class TestFolderScopedEvaluator:
             PolicyRule(name="r1", condition=PolicyCondition(field="tool_name", operator=PolicyOperator.EQ, value="x"), action=PolicyAction.DENY, priority=100),
         ])
         evaluator = PolicyEvaluator(policies=[doc], root_dir=tmp_path)
-        # No 'path' in context — falls back to flat
+        # No 'path' in context, falls back to flat
         result = evaluator.evaluate({"tool_name": "x"})
         assert not result.allowed
+
+    def test_malformed_governance_yaml_fails_closed(self, tmp_path):
+        """A malformed governance.yaml in the scoped chain must yield a deny
+        decision (fail closed) rather than raising out of evaluate()."""
+        # Write an invalid YAML document that cannot be parsed into a policy.
+        bad = tmp_path / "services" / "billing" / "governance.yaml"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text("name: broken\nrules: [this is : not : valid : yaml\n")
+
+        action = tmp_path / "services" / "billing" / "agent.py"
+        action.touch()
+
+        evaluator = PolicyEvaluator(root_dir=tmp_path)
+
+        # Must not raise; must return a fail-closed deny decision.
+        result = evaluator.evaluate({"tool_name": "web_search", "path": str(action)})
+        assert isinstance(result, PolicyDecision)
+        assert result.allowed is False
+        assert result.action == "deny"
+        assert result.audit_entry.get("error") is True

--- a/agent-governance-python/agent-os/tests/test_session_pinning_and_aliases.py
+++ b/agent-governance-python/agent-os/tests/test_session_pinning_and_aliases.py
@@ -62,12 +62,12 @@ class TestSessionPolicyPinning:
         ctx.policy.require_human_approval = True
         assert integration.policy.require_human_approval is False
 
-    def test_pre_execute_uses_integration_policy_not_context(self):
-        """pre_execute currently reads self.policy — this documents the behavior.
+    def test_pre_execute_uses_pinned_context_policy(self):
+        """pre_execute reads ctx.policy so mid-session mutations do not leak in.
 
-        The session pinning fix ensures create_context() snapshots policy,
-        but pre_execute still reads the live integration policy. A follow-up
-        should refactor pre_execute to use ctx.policy for full isolation.
+        create_context() snapshots the policy, and pre_execute enforces that
+        snapshot. Tightening the live integration policy after the context is
+        created must not change enforcement for the existing context.
         """
         policy = GovernancePolicy(name="permissive", max_tool_calls=100)
         integration = _StubIntegration(policy=policy)
@@ -76,11 +76,40 @@ class TestSessionPolicyPinning:
         # Tighten the live policy AFTER context creation
         integration.policy.max_tool_calls = 0
 
-        # pre_execute reads self.policy (the live one), so this should BLOCK
+        # pre_execute reads ctx.policy (the pinned snapshot), so this is ALLOWED
         allowed, reason = integration.pre_execute(ctx, "test input")
-        assert allowed is False
-        # But the context's pinned policy still has the original value
+        assert allowed is True
+        # The context's pinned policy still has the original value
         assert ctx.policy.max_tool_calls == 100
+
+    def test_mid_session_mutation_does_not_change_enforcement(self):
+        """A mid-session policy mutation must not affect an existing context.
+
+        Covers pre-execute checks that previously read self.policy:
+        max_tool_calls and human approval. A context created before the
+        mutation keeps the permissive snapshot, while a context created
+        after the mutation picks up the tightened live policy.
+        """
+        policy = GovernancePolicy(
+            name="permissive",
+            max_tool_calls=100,
+            require_human_approval=False,
+        )
+        integration = _StubIntegration(policy=policy)
+        ctx = integration.create_context("agent-1")
+
+        # Mutate the live policy to be maximally restrictive AFTER context creation
+        integration.policy.require_human_approval = True
+        integration.policy.max_tool_calls = 0
+
+        # Enforcement still uses the pinned snapshot, so the call is allowed
+        allowed, reason = integration.pre_execute(ctx, "test input")
+        assert allowed is True
+
+        # A brand new context picks up the tightened live policy and is blocked
+        ctx2 = integration.create_context("agent-2")
+        allowed2, _ = integration.pre_execute(ctx2, "anything")
+        assert allowed2 is False
 
 
 # ── Tool Alias Registry Tests ───────────────────────────────

--- a/docs/security/audits/2026-06-10-policy-pinning-failclosed.md
+++ b/docs/security/audits/2026-06-10-policy-pinning-failclosed.md
@@ -1,0 +1,70 @@
+# 2026-06-10 - Policy Pinning and Fail-Closed Scoped Evaluation
+
+PR: [microsoft/agent-governance-toolkit#2946](https://github.com/microsoft/agent-governance-toolkit/pull/2946)
+
+Fixes #2929.
+
+## What changed and why
+
+This PR closes two governance gaps in the agent-os enforcement path:
+
+- **Gap 1 (policy pinning):** `BaseIntegration.pre_execute_check` and
+  `post_execute_check` read the live `self.policy` instead of the deep-copied
+  `ctx.policy` that `create_context` pins to the session. Every per-call gate
+  (`max_tool_calls`, `timeout_seconds`, blocked patterns, `require_human_approval`,
+  `confidence_threshold`, the drift gate, and `checkpoint_frequency`) now reads
+  `ctx.policy`. This makes enforcement consistent with the `create_context`
+  pinning contract and with `compute_drift`, which already read
+  `ctx.policy.drift_threshold`. Previously the drift gate compared against
+  `self.policy.drift_threshold` while the drift computation used
+  `ctx.policy.drift_threshold`, so a mid-session mutation could make the two
+  disagree.
+- **Gap 2 (fail closed in scoped evaluation):** `PolicyEvaluator._evaluate_scoped`
+  ran `discover_policies`, `PolicyDocument.from_yaml`, and `merge_policies`
+  outside any try block. A malformed `governance.yaml` anywhere in the folder
+  chain made `evaluate()` raise instead of denying. That discovery, parse, and
+  merge phase is now wrapped in the same fail-closed try/except already used by
+  `_evaluate_flat`, returning a deny `PolicyDecision` on any error.
+
+**Why now:** Both gaps are silent failures of the deny path. Gap 1 let a
+mid-session policy edit either tighten or loosen enforcement of an already
+running session, contradicting the documented pinning guarantee. Gap 2 let a
+malformed policy file convert a deny into an unhandled exception, which a caller
+that swallows exceptions could treat as a permit.
+
+## Threat model impact
+
+This change **strengthens** the deny path and removes a fail-open edge. It does
+not add new attack surface, identity, trust, or cryptographic code.
+
+| Dimension | Direction |
+|---|---|
+| Policy bypass surface | **Reduced.** Enforcement now reads the pinned, deep-copied `ctx.policy`, so a mutation of `self.policy` mid-session can no longer relax (or unexpectedly tighten) gates on an in-flight session. |
+| Fail-open risk | **Reduced.** A malformed `governance.yaml` in scoped mode now yields a deny `PolicyDecision` instead of raising. The scoped path matches the flat path's fail-closed behavior. |
+| Information leakage | **No new exposure.** The fail-closed deny reason is a fixed string ("Policy evaluation error, access denied (fail closed)"); parse-error details go to the logger and the structured `audit_entry`, not to the caller-facing reason. |
+| Privilege boundaries | **Unchanged.** Execution rings, kill switch, and approval gates are untouched. |
+| Authentication / identity | **Unchanged.** No identity, signing, or trust-handshake code is modified. |
+| New trust assumptions | **None.** The set of inputs trusted by the evaluator is unchanged; only the handling of bad input changed (deny instead of raise). |
+| Backward compatibility | **Preserved for correct callers.** Sessions whose `ctx.policy` matches the integration policy (the result of `create_context`) behave identically. Only callers that constructed an `ExecutionContext` with a divergent policy and relied on `self.policy` being enforced instead see a change, which is the intended fix. |
+
+### Specific mitigations applied
+
+- **Pin enforcement to the session policy.** All per-call gates read
+  `ctx.policy`, the deep copy taken at `create_context` time, so enforcement is
+  immutable for the life of the session.
+- **Symmetric fail-closed paths.** The scoped discovery/parse/merge phase is
+  wrapped in the same try/except shape as `_evaluate_flat`, returning a deny
+  decision with `audit_entry["error"] = True` on any exception.
+- **No new error-message disclosure.** The exception is logged with
+  `exc_info=True` server-side; the caller-facing `reason` is a constant.
+
+## Test coverage
+
+| File | Purpose |
+|---|---|
+| `tests/test_session_pinning_and_aliases.py` | A mid-session mutation of `self.policy` no longer changes enforcement for an already-created context; the stale test that documented the old `self.policy` behavior was updated. |
+| `tests/test_folder_governance.py` | A malformed `governance.yaml` in a scoped folder yields a deny decision rather than raising. |
+| `tests/test_base_cedar_integration.py` | Cedar-plus-policy composition tests now build the context via `create_context` so the enforced (pinned) policy matches the configured policy. |
+
+All targeted tests pass, and the broad `policy or cedar or pin` selection shows
+no new failures introduced by this change.


### PR DESCRIPTION
## What changed

Two gaps where actual behavior was weaker than the documented contract in the Python policy path.

**Gap 1: policy pinning not enforced.** `pre_execute_check`/`post_execute_check` read `self.policy` instead of the deep-copied `ctx.policy`, so mid-session policy mutations leaked into running sessions, contradicting the `create_context` pinning docstring. The drift gate read `self.policy.drift_threshold` while `compute_drift` read `ctx.policy.drift_threshold`, so the two could disagree. All of these checks (max_tool_calls, timeout, blocked patterns, human approval, confidence, drift gate, checkpoint frequency) now read `ctx.policy`.

**Gap 2: _evaluate_scoped broke the fail-closed contract.** The discovery, parse, and merge phase (`discover_policies` / `PolicyDocument.from_yaml` / `merge_policies`) ran outside any try block, so a malformed `governance.yaml` made `evaluate()` raise instead of failing closed. That phase is now wrapped in the same fail-closed try/except as `_evaluate_flat` and returns a deny `PolicyDecision` on error.

## Why

Direct callers of `evaluate()` could crash on a malformed governance file, and pinned sessions were not actually pinned, weakening enforcement guarantees.

## How validated

- New test: a mid-session policy mutation does not change enforcement for an existing context (while a context created after the mutation picks up the tightened live policy).
- New test: a malformed `governance.yaml` in a scoped folder yields a deny decision rather than an exception.
- Updated the stale pinning test that documented the old `self.policy` behavior.
- Ran `test_folder_governance.py::TestFolderScopedEvaluator`, `test_session_pinning_and_aliases.py`, `test_pre_execute_check_contract.py`, `test_execution_context_policy.py`, `test_drift_detection.py`, `test_async_evaluator.py`: all green (116 tests).

Fixes #2929