### PR TITLE
docs: fix mkdocs nav, dead tutorial links, and stale install commands

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -483,6 +483,8 @@ Key controls:
 | **Install** | `pip install agent-hypervisor` | `pip install agentmesh-runtime` |
 | **Import** | `from hypervisor import Hypervisor` | `from hypervisor import Hypervisor` (same) |
 
+> Note: most users should install the consolidated distribution with `pip install agent-governance-toolkit[full]`, which pulls in the hypervisor/runtime subsystem. The individual package names above are documented only to explain the PyPI naming.
+
 ### What the Hypervisor / Runtime Provides
 
 | Feature | Description |

--- a/docs/deployment/azure-foundry-agent-service.md
+++ b/docs/deployment/azure-foundry-agent-service.md
@@ -80,9 +80,6 @@ Each middleware works independently. Use any combination based on your requireme
 ```bash
 # Install the governance toolkit with MAF support
 pip install agent-governance-toolkit[full]
-
-# Or install individual packages
-pip install agent-os-kernel agentmesh-platform agent-sre
 ```
 
 ---

--- a/docs/deployment/openclaw-sidecar.md
+++ b/docs/deployment/openclaw-sidecar.md
@@ -379,7 +379,7 @@ curl http://localhost:8081/api/v1/audit/injections?limit=10
 You can also run the sidecar directly with Python — no Docker required:
 
 ```bash
-pip install agent-os-kernel
+pip install agent-governance-toolkit[full]
 python -m agent_os.server --host 127.0.0.1 --port 8081
 ```
 

--- a/docs/i18n/quickstart.ja.md
+++ b/docs/i18n/quickstart.ja.md
@@ -27,16 +27,10 @@ graph LR
 pip install agent-governance-toolkit[full]
 ```
 
-または、個別のパッケージをインストールします。
+`[full]` エクストラには、すべてのコンポーネントが含まれます。
 
 ```bash
-pip install agent-os-kernel        # Policy enforcement + framework integrations
-pip install agentmesh-platform     # Zero-trust identity + trust cards
-pip install agent-governance-toolkit    # OWASP ASI verification + integrity CLI
-pip install agent-sre              # SLOs, error budgets, chaos testing
-pip install agentmesh-runtime       # Execution supervisor + privilege rings
-pip install agentmesh-marketplace      # Plugin lifecycle management
-pip install agentmesh-lightning        # RL training governance
+pip install agent-governance-toolkit[full]  # ポリシー適用、ゼロトラスト ID、OWASP ASI 検証、SRE、マーケットプレイス、RL ガバナンス
 ```
 
 ### TypeScript / Node.js

--- a/docs/tutorials/32-e2e-encrypted-messaging.md
+++ b/docs/tutorials/32-e2e-encrypted-messaging.md
@@ -363,7 +363,7 @@ Alice                              Bob
 | [Tutorial 02 — Trust & Identity](02-trust-and-identity.md) | Ed25519 credentials, DIDs, trust scoring |
 | [Tutorial 07 — MCP Security Gateway](07-mcp-security-gateway.md) | Tool call governance |
 | [Tutorial 16 — Protocol Bridges](16-protocol-bridges.md) | A2A, MCP, IATP communication |
-| [Tutorial 31 — MCP Governance End-to-End](31-mcp-governance-end-to-end.md) | MCP message signing |
+| [Tutorial 31 - Entra Agent ID Bridge](31-entra-agent-id-bridge.md) | Agent identity federation |
 | [Signal X3DH Specification](https://signal.org/docs/specifications/x3dh/) | X3DH reference (CC0) |
 | [Signal Double Ratchet Specification](https://signal.org/docs/specifications/doubleratchet/) | Double Ratchet reference (CC0) |
 

--- a/docs/tutorials/44-a2a-conversation-policy.md
+++ b/docs/tutorials/44-a2a-conversation-policy.md
@@ -263,9 +263,9 @@ This tutorial addresses:
 
 ## Next Steps
 
-- [Tutorial 41 — Advisory Defense in Depth](41-advisory-defense-in-depth.md) for layered governance
-- [Conversation Guardian API reference](../reference/conversation-guardian.md) for advanced configuration
-- [A2A Adapter API reference](../reference/a2a-adapter.md) for full policy options
+- [Tutorial 41 - Advisory Defense in Depth](41-advisory-defense-in-depth.md) for layered governance
+- [Tutorial 16 - Protocol Bridges](16-protocol-bridges.md) for A2A adapter configuration and policy options
+- [Tutorial 09 - Prompt Injection Detection](09-prompt-injection-detection.md) for conversation guardian internals
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,7 +162,6 @@ nav:
     - Agent Discovery: tutorials/29-agent-discovery.md
     - Agent Lifecycle: tutorials/30-agent-lifecycle.md
     - Entra Agent ID Bridge: tutorials/31-entra-agent-id-bridge.md
-    - Chaos Testing Agents: tutorials/32-chaos-testing-agents.md
     - E2E Encrypted Messaging: tutorials/32-e2e-encrypted-messaging.md
     - Offline Verifiable Receipts: tutorials/33-offline-verifiable-receipts.md
     - MAF Integration: tutorials/34-maf-integration.md


### PR DESCRIPTION
## What changed

Repairs docs drift found during a hygiene review. A strict mkdocs build was failing on a missing nav target plus several dead in-page links.

- **mkdocs.yml**: removed the nav entry pointing at the non-existent `tutorials/32-chaos-testing-agents.md`. The real tutorial 32 (`32-e2e-encrypted-messaging.md`) was already listed on the next line, so this was a stray duplicate.
- **docs/tutorials/32-e2e-encrypted-messaging.md**: fixed a link to `31-mcp-governance-end-to-end.md` (does not exist) to point at the real `31-entra-agent-id-bridge.md`.
- **docs/tutorials/44-a2a-conversation-policy.md**: the two links into `../reference/a2a-adapter.md` and `../reference/conversation-guardian.md` had no targets (no such files exist). Repointed them at real tutorials: Tutorial 16 (Protocol Bridges, covers the A2A adapter) and Tutorial 09 (Prompt Injection Detection, covers conversation guarding).
- **Stale install commands** swept to the consolidated `pip install agent-governance-toolkit[full]` form:
  - `docs/deployment/azure-foundry-agent-service.md` (dropped the `agent-os-kernel agentmesh-platform agent-sre` alternative)
  - `docs/deployment/openclaw-sidecar.md` (`agent-os-kernel` to consolidated form)
  - `docs/i18n/quickstart.ja.md` (collapsed the per-package list)
  - `docs/FAQ.md`: this section intentionally documents the `agentmesh-runtime` PyPI wrapper name to explain a naming collision, so the comparison table is preserved and a note was added steering users to the consolidated install.

## Why

`mkdocs build --strict` failed on the missing nav target, and the dead links degrade the docs site.

## How validated

- Ran `mkdocs build --strict` (mkdocs 1.6.1) locally. All four dead references from this issue (`32-chaos`, `31-mcp-governance-end-to-end`, `reference/a2a-adapter`, `reference/conversation-guardian`) no longer appear in the build output. The build still reports many pre-existing anchor warnings in unrelated tutorials, which are out of scope for this issue.
- Confirmed no em dashes were introduced in any changed line.

## Recommendation

Consider wiring `mkdocs build --strict` into CI so nav and link drift is caught at PR time. (The remaining pre-existing anchor warnings would need a separate cleanup pass before strict mode can gate merges.)

Fixes #2937