### PR TITLE
fix: standardize policy engines on default-deny and consistent warn/log semantics

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -5,6 +5,56 @@ entries appear first.
 
 ---
 
+## Policy engines: default-deny and consistent warn/log semantics
+
+**Date:** TBD (next release of `microsoft/agent-governance-toolkit`)
+
+**Affected:**
+
+- `agent-governance-python` (`agent_os.policies`)
+- `agent-governance-typescript` (`src/policy.ts`)
+- `agent-governance-dotnet` (`AgentGovernance.Policy`)
+
+**What changed:**
+
+The three SDKs previously disagreed on authorization outcomes for the same
+policy input. This release standardizes all three on fail-closed semantics:
+
+1. **Default action is now deny.** When `defaults.action` is omitted, or when
+   no policies are loaded at all, the decision is now `deny` in every SDK.
+   - Python: `PolicyDefaults.action` now defaults to `PolicyAction.DENY`, and
+     the evaluator returns `deny` when no policies are loaded (previously both
+     were `allow`, fail-open).
+   - .NET: the zero-policy path now returns `PolicyDecision.DenyDefault`
+     (previously `AllowDefault`).
+   - TypeScript already defaulted to `deny`; no change.
+
+2. **`warn` and `log` rules are advisory and still allow the request.** In
+   TypeScript a matched `warn` or `log` rule now produces `allowed: true`,
+   matching the existing .NET and Python behavior (previously TS denied them).
+
+**Why:**
+
+For a governance toolkit, an omitted default or an empty policy set producing
+`allow` in one language and `deny` in another is a trust-boundary
+inconsistency, not just a style difference. Fail-closed is the safe default.
+
+**How to migrate:**
+
+If you relied on the previous fail-open behavior (an empty or default policy
+allowing requests), opt back in explicitly by setting the default action to
+allow in your policy document:
+
+```yaml
+defaults:
+  action: allow
+```
+
+No migration is required for consumers who already define explicit rules and
+a default action.
+
+---
+
 ## Composite actions: `toolkit-version` is now **required**
 
 **Date:** TBD (next release of `microsoft/agent-governance-toolkit`)

--- a/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
@@ -284,7 +284,9 @@ public sealed class PolicyEngine
     {
         if (snapshot.Count == 0)
         {
-            return new InternalEvaluation(PolicyDecision.AllowDefault(evaluatedAt, sw.Elapsed.TotalMilliseconds), HadPolicies: false, HadMatches: false);
+            // Fail closed when no policies are loaded so all three SDKs agree on default-deny.
+            // To opt back into permissive behavior, load a policy with an explicit allow default.
+            return new InternalEvaluation(PolicyDecision.DenyDefault(evaluatedAt, sw.Elapsed.TotalMilliseconds), HadPolicies: false, HadMatches: false);
         }
 
         var candidates = new List<CandidateDecision>();

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceClientAndPolicyEvaluationTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceClientAndPolicyEvaluationTests.cs
@@ -205,18 +205,18 @@ rules:
     // -----------------------------------------------------------------
 
     [Fact]
-    public void EvaluateToolCall_NoPolicies_AllowsByDefault()
+    public void EvaluateToolCall_NoPolicies_DeniesByDefault()
     {
         using var kernel = new GovernanceKernel();
 
-        // PolicyEngine returns AllowDefault when no policies are loaded.
+        // PolicyEngine returns DenyDefault when no policies are loaded (fail closed).
         var result = kernel.EvaluateToolCall("did:agentmesh:test", "read");
 
         Assert.NotNull(result);
         Assert.NotNull(result.PolicyDecision);
-        Assert.True(result.Allowed);
-        Assert.True(result.PolicyDecision!.Allowed);
-        Assert.Equal("allow", result.PolicyDecision.Action);
+        Assert.False(result.Allowed);
+        Assert.False(result.PolicyDecision!.Allowed);
+        Assert.Equal("deny", result.PolicyDecision.Action);
         Assert.Null(result.PolicyDecision.MatchedRule);
     }
 

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyAdvancedTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyAdvancedTests.cs
@@ -283,11 +283,12 @@ rules:
     }
 
     [Fact]
-    public void Evaluate_NoPolicies_DefaultsToAllow()
+    public void Evaluate_NoPolicies_DefaultsToDeny()
     {
         var engine = new PolicyEngine();
         var decision = engine.Evaluate("did:agentmesh:a", new Dictionary<string, object>());
-        Assert.True(decision.Allowed);
+        Assert.False(decision.Allowed);
+        Assert.Equal("deny", decision.Action);
     }
 
     [Fact]

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyEngineTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/PolicyEngineTests.cs
@@ -29,13 +29,16 @@ rules:
 ";
 
     [Fact]
-    public void Evaluate_NoPoliciesLoaded_AllowsByDefault()
+    public void Evaluate_NoPoliciesLoaded_DeniesByDefault()
     {
+        // Fail closed when no policies are loaded so the .NET, Python, and TS
+        // SDKs agree on default-deny (issue #2926). Opt back into permissive
+        // behavior by loading a policy with default_action: allow.
         var engine = new PolicyEngine();
         var decision = engine.Evaluate("did:mesh:test", new Dictionary<string, object>());
 
-        Assert.True(decision.Allowed);
-        Assert.Equal("allow", decision.Action);
+        Assert.False(decision.Allowed);
+        Assert.Equal("deny", decision.Action);
         Assert.Null(decision.PolicyName);
     }
 
@@ -95,6 +98,32 @@ rules:
         Assert.False(decision.Allowed);
         Assert.Equal("deny", decision.Action);
         Assert.Null(decision.MatchedRule);
+    }
+
+    [Fact]
+    public void Evaluate_LogRuleMatches_ReturnsAllowedWithLog()
+    {
+        // log is advisory and still allows, matching the Python and TS SDKs
+        // (issue #2926).
+        var yaml = @"
+apiVersion: governance.toolkit/v1
+name: log-policy
+default_action: deny
+rules:
+  - name: log-read
+    condition: ""tool_name == 'read'""
+    action: log
+    priority: 10
+";
+        var engine = new PolicyEngine();
+        engine.LoadYaml(yaml);
+
+        var decision = engine.Evaluate("did:mesh:test",
+            new Dictionary<string, object> { ["tool_name"] = "read" });
+
+        Assert.True(decision.Allowed);
+        Assert.Equal("log", decision.Action);
+        Assert.Equal("log-read", decision.MatchedRule);
     }
 
     [Fact]

--- a/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
@@ -260,8 +260,11 @@ class PolicyEvaluator:
                         },
                     )
 
-            # No rule matched — apply defaults
-            default_action = PolicyAction.ALLOW
+            # No rule matched, apply defaults.
+            # Fail closed when no policies are loaded so Python matches the TS
+            # and .NET SDKs (default-deny). To opt back into permissive
+            # behavior, load a policy with defaults.action: allow.
+            default_action = PolicyAction.DENY
             if self.policies:
                 default_action = self.policies[0].defaults.action
             allowed = default_action in (PolicyAction.ALLOW, PolicyAction.AUDIT)

--- a/agent-governance-python/agent-os/src/agent_os/policies/schema.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/schema.py
@@ -72,7 +72,9 @@ class PolicyDefaults(BaseModel):
     ignored by the rule engine itself.
     """
 
-    action: PolicyAction = PolicyAction.ALLOW
+    # Fail closed by default so Python matches the TS and .NET SDKs.
+    # To opt back into permissive behavior, set defaults.action: allow explicitly.
+    action: PolicyAction = PolicyAction.DENY
     max_tokens: int = 4096
     max_tool_calls: int = 10
     confidence_threshold: float = 0.8

--- a/agent-governance-python/agent-os/tests/test_e2e_governance_pipeline.py
+++ b/agent-governance-python/agent-os/tests/test_e2e_governance_pipeline.py
@@ -33,6 +33,7 @@ agent_sre = pytest.importorskip("agent_sre", reason="agent_sre not installed")
 from agent_os.policies.schema import (
     PolicyAction,
     PolicyCondition,
+    PolicyDefaults,
     PolicyDocument,
     PolicyOperator,
     PolicyRule,
@@ -892,7 +893,15 @@ class TestPipelineErrorHandling:
     @pytest.mark.asyncio
     async def test_middleware_with_empty_messages(self, tmp_path):
         """Policy middleware handles context with no messages."""
-        evaluator = PolicyEvaluator()
+        # The engine now fails closed by default (issue #2926), so load a
+        # permissive policy to assert the middleware tolerates empty input
+        # without terminating.
+        evaluator = PolicyEvaluator(policies=[
+            PolicyDocument(
+                name="permissive",
+                defaults=PolicyDefaults(action=PolicyAction.ALLOW),
+            )
+        ])
         policy_mw = GovernancePolicyMiddleware(evaluator=evaluator)
 
         ctx = MockAgentContext(agent_name="test", messages=[])

--- a/agent-governance-python/agent-os/tests/test_maf_adapter.py
+++ b/agent-governance-python/agent-os/tests/test_maf_adapter.py
@@ -79,8 +79,24 @@ def _make_function_context(
 class TestGovernancePolicyMiddleware:
     @pytest.fixture
     def allow_evaluator(self) -> PolicyEvaluator:
-        """An evaluator with no loaded policies → allows everything."""
-        return PolicyEvaluator()
+        """An evaluator that allows everything.
+
+        The engine now fails closed by default (issue #2926), so an empty
+        evaluator denies. Load a permissive policy with an explicit allow
+        default to express "allow everything".
+        """
+        from agent_os.policies import (
+            PolicyAction,
+            PolicyDefaults,
+            PolicyDocument,
+        )
+
+        return PolicyEvaluator(policies=[
+            PolicyDocument(
+                name="permissive",
+                defaults=PolicyDefaults(action=PolicyAction.ALLOW),
+            )
+        ])
 
     @pytest.fixture
     def deny_evaluator(self, monkeypatch) -> PolicyEvaluator:

--- a/agent-governance-python/agent-os/tests/test_optional_deps_integration.py
+++ b/agent-governance-python/agent-os/tests/test_optional_deps_integration.py
@@ -37,6 +37,7 @@ from agent_os.integrations.base import (
 from agent_os.policies.schema import (
     PolicyAction,
     PolicyCondition,
+    PolicyDefaults,
     PolicyDocument,
     PolicyOperator,
     PolicyRule,
@@ -568,10 +569,13 @@ class TestAsyncPolicyEvaluator:
 
     def _make_evaluator(self, rules):
         from agent_os.policies.evaluator import PolicyEvaluator
+        # Explicit allow default so non-matching contexts fall through to allow,
+        # isolating these tests from the engine-wide default-deny (issue #2926).
         doc = PolicyDocument(
             version="1.0",
             name="async-test-policy",
             rules=rules,
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
         )
         return PolicyEvaluator(policies=[doc])
 

--- a/agent-governance-python/agent-os/tests/test_policy_backends.py
+++ b/agent-governance-python/agent-os/tests/test_policy_backends.py
@@ -516,10 +516,15 @@ default allow = true
         assert "evaluation_ms" in decision.audit_entry
 
     def test_default_action_when_no_backends(self):
-        """Default action applies when no policies or backends match."""
+        """Default action applies when no policies or backends match.
+
+        The engine now fails closed by default (issue #2926): with no policies
+        loaded the decision is deny.
+        """
         evaluator = PolicyEvaluator()
         decision = evaluator.evaluate({"tool_name": "anything"})
-        assert decision.allowed is True
+        assert decision.allowed is False
+        assert decision.action == "deny"
         assert "default" in decision.reason.lower()
 
     def test_load_rego_returns_backend(self):

--- a/agent-governance-python/agent-os/tests/test_policy_language.py
+++ b/agent-governance-python/agent-os/tests/test_policy_language.py
@@ -223,6 +223,9 @@ class TestEvaluator:
                         action=PolicyAction.DENY,
                     ),
                 ],
+                # Explicit allow default so a non-match is distinguishable from a
+                # deny-match now that the default is deny (issue #2926).
+                defaults=PolicyDefaults(action=PolicyAction.ALLOW),
             )
             evaluator = PolicyEvaluator(policies=[doc])
             decision = evaluator.evaluate({"f": ctx_val})
@@ -250,6 +253,9 @@ class TestEvaluator:
                     action=PolicyAction.DENY,
                 ),
             ],
+            # Explicit allow default isolates the not_in match check from the
+            # default-deny behavior (issue #2926).
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
         )
         decision = PolicyEvaluator(policies=[doc]).evaluate({"tool_name": "read_file"})
         assert decision.allowed
@@ -288,6 +294,8 @@ class TestEvaluator:
                     action=PolicyAction.DENY,
                 ),
             ],
+            # Explicit allow default (issue #2926): a non-match must allow here.
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
         )
         ne_doc = PolicyDocument(
             name="not-in-vs-ne",
@@ -302,6 +310,7 @@ class TestEvaluator:
                     action=PolicyAction.DENY,
                 ),
             ],
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
         )
 
         not_in_decision = PolicyEvaluator(policies=[not_in_doc]).evaluate({"tool_name": value})
@@ -324,6 +333,9 @@ class TestEvaluator:
                     action=PolicyAction.DENY,
                 ),
             ],
+            # Explicit allow default (issue #2926): a missing field is no match,
+            # which must allow here rather than fall through to default-deny.
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
         )
         decision = PolicyEvaluator(policies=[doc]).evaluate({})
         assert decision.allowed

--- a/agent-governance-python/agent-os/tests/test_security_policy_enforcement.py
+++ b/agent-governance-python/agent-os/tests/test_security_policy_enforcement.py
@@ -33,6 +33,7 @@ from agent_os.integrations.base import (
 from agent_os.policies.schema import (
     PolicyAction,
     PolicyCondition,
+    PolicyDefaults,
     PolicyDocument,
     PolicyOperator,
     PolicyRule,
@@ -276,10 +277,14 @@ class TestPolicyEvaluatorEnforcement:
     """Test declarative policy rule evaluation."""
 
     def _make_evaluator(self, rules):
+        # Use an explicit allow default so these rule-semantics tests isolate
+        # matching behavior from the engine-wide default-deny (issue #2926):
+        # a non-matching request should fall through to allow here.
         doc = PolicyDocument(
             version="1.0",
             name="test-policy",
             rules=rules,
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
         )
         return PolicyEvaluator(policies=[doc])
 

--- a/agent-governance-python/agent-os/tests/test_spec_policy_engine_conformance.py
+++ b/agent-governance-python/agent-os/tests/test_spec_policy_engine_conformance.py
@@ -76,7 +76,24 @@ class TestConditionOperatorsSpec:
         assert not result.allowed
 
     def test_eq_no_match(self):
-        ev = self._make_evaluator("tool_name", "eq", "exec")
+        # With default-deny (issue #2926) an unmatched request is denied. Use an
+        # explicit allow default so this test isolates operator matching.
+        doc = PolicyDocument(
+            name="test",
+            rules=[
+                PolicyRule(
+                    name="r1",
+                    condition=PolicyCondition(
+                        field="tool_name",
+                        operator=PolicyOperator.EQ,
+                        value="exec",
+                    ),
+                    action=PolicyAction.DENY,
+                )
+            ],
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
+        )
+        ev = PolicyEvaluator(policies=[doc])
         result = ev.evaluate({"tool_name": "read"})
         assert result.allowed
 
@@ -125,6 +142,8 @@ class TestMissingFieldSpec:
     """Spec Section 5.2: Missing fields MUST evaluate to false."""
 
     def test_missing_field_does_not_match(self):
+        # Explicit allow default isolates the "missing field => no match" check
+        # from the default-deny behavior introduced in issue #2926.
         doc = PolicyDocument(
             name="test",
             rules=[
@@ -138,6 +157,7 @@ class TestMissingFieldSpec:
                     action=PolicyAction.DENY,
                 )
             ],
+            defaults=PolicyDefaults(action=PolicyAction.ALLOW),
         )
         ev = PolicyEvaluator(policies=[doc])
         result = ev.evaluate({"tool_name": "exec"})
@@ -272,10 +292,32 @@ class TestDefaultActionSpec:
         result = ev.evaluate({"x": 999})
         assert not result.allowed
 
-    def test_no_policies_defaults_to_allow(self):
+    def test_no_policies_defaults_to_deny(self):
+        # Cross-language parity fix (issue #2926): with no policies loaded the
+        # engine fails closed, matching the TS and .NET SDKs. Opt back into
+        # permissive behavior with an explicit defaults.action: allow policy.
         ev = PolicyEvaluator()
         result = ev.evaluate({"x": 1})
-        assert result.allowed, "No loaded policies MUST default to allow (Section 7.3)"
+        assert not result.allowed, "No loaded policies MUST default to deny (fail closed)"
+        assert result.action == "deny"
+
+    def test_unmatched_request_defaults_to_deny(self):
+        # An omitted defaults.action now means deny, not allow.
+        doc = PolicyDocument(
+            name="test",
+            rules=[
+                PolicyRule(
+                    name="r1",
+                    condition=PolicyCondition(
+                        field="x", operator=PolicyOperator.EQ, value=1
+                    ),
+                    action=PolicyAction.ALLOW,
+                )
+            ],
+        )
+        ev = PolicyEvaluator(policies=[doc])
+        result = ev.evaluate({"x": 999})
+        assert not result.allowed, "Omitted default action MUST deny (fail closed)"
 
 
 # ===================================================================

--- a/agent-governance-typescript/src/policy.ts
+++ b/agent-governance-typescript/src/policy.ts
@@ -521,7 +521,9 @@ export class PolicyEngine {
         }
 
         return {
-          allowed: winner.action === 'allow',
+          // warn and log are advisory actions that still permit the request,
+          // matching the .NET and Python SDKs (parity fix).
+          allowed: ['allow', 'warn', 'log'].includes(winner.action),
           action: winner.action,
           matchedRule: winner.ruleName,
           policyName: winner.policyName,

--- a/agent-governance-typescript/tests/policy-parity.test.ts
+++ b/agent-governance-typescript/tests/policy-parity.test.ts
@@ -389,6 +389,54 @@ rules:
     });
   });
 
+  // ── Cross-language conformance (issue #2926) ──
+
+  describe('cross-language conformance', () => {
+    it('denies when no policies are loaded (default-deny)', () => {
+      const engine = new PolicyEngine();
+      const result = engine.evaluatePolicy('did:test', {});
+      expect(result.allowed).toBe(false);
+      expect(result.action).toBe('deny');
+    });
+
+    it('denies an unmatched request under a default-deny policy', () => {
+      const engine = new PolicyEngine();
+      engine.loadPolicy({
+        name: 'p',
+        agents: ['*'],
+        rules: [{ name: 'r1', condition: "role == 'admin'", ruleAction: 'allow' }],
+        default_action: 'deny',
+      });
+      expect(engine.evaluatePolicy('did:test', { role: 'viewer' }).allowed).toBe(false);
+    });
+
+    it('allows a matched warn rule (advisory)', () => {
+      const engine = new PolicyEngine();
+      engine.loadPolicy({
+        name: 'p',
+        agents: ['*'],
+        rules: [{ name: 'r1', ruleAction: 'warn' }],
+        default_action: 'deny',
+      });
+      const result = engine.evaluatePolicy('did:test', {});
+      expect(result.action).toBe('warn');
+      expect(result.allowed).toBe(true);
+    });
+
+    it('allows a matched log rule (advisory)', () => {
+      const engine = new PolicyEngine();
+      engine.loadPolicy({
+        name: 'p',
+        agents: ['*'],
+        rules: [{ name: 'r1', ruleAction: 'log' }],
+        default_action: 'deny',
+      });
+      const result = engine.evaluatePolicy('did:test', {});
+      expect(result.action).toBe('log');
+      expect(result.allowed).toBe(true);
+    });
+  });
+
   // ── Rate limiting ──
 
   describe('rate limiting', () => {
@@ -529,3 +577,4 @@ rules:
     expect(r3.matchedRule).toBe('admin-bypass');
   });
 });
+

--- a/docs/security/audits/2026-06-10-policy-default-deny-parity.md
+++ b/docs/security/audits/2026-06-10-policy-default-deny-parity.md
@@ -1,0 +1,74 @@
+# 2026-06-10 — Policy Engine Default-Deny Parity
+
+PR: [microsoft/agent-governance-toolkit#2949](https://github.com/microsoft/agent-governance-toolkit/pull/2949)
+
+Issue: [microsoft/agent-governance-toolkit#2926](https://github.com/microsoft/agent-governance-toolkit/issues/2926)
+
+## What changed and why
+
+The Python, TypeScript, and .NET policy engines disagreed on the authorization
+outcome for the same input. For an omitted `defaults.action` or an empty policy
+set, Python was fail-open (default allow) while TypeScript and .NET were
+inconsistent, and a matched `warn`/`log` rule denied in TypeScript while it
+allowed in Python and .NET. For a governance toolkit, a trust-boundary that
+behaves differently per SDK is itself a security defect: the same policy bundle
+could authorize a tool call in one runtime and block it in another.
+
+This PR standardizes all three SDKs on **fail-closed default-deny** and on
+treating a matched `warn`/`log` rule as **allowed**:
+
+- **Python** (`agent_os.policies`): `PolicyDefaults.action` now defaults to
+  `DENY` (`schema.py`), and `PolicyEvaluator.evaluate()` uses `DENY` as the
+  fallback default action when no policies are loaded (`evaluator.py`). When a
+  policy *is* loaded, its explicit `defaults.action` still governs, so an
+  operator can opt back into permissive behavior with `defaults.action: allow`.
+- **.NET** (`AgentGovernance.Policy.PolicyEngine`): the zero-policy path now
+  returns `PolicyDecision.DenyDefault(...)` instead of
+  `PolicyDecision.AllowDefault(...)`.
+- **TypeScript**: a matched `warn` or `log` rule now counts as allowed, matching
+  the .NET and Python SDKs.
+- `BREAKING_CHANGES.md` documents the new default and the explicit opt-out.
+
+## Threat model impact
+
+This change **tightens** the trust boundary; it does not introduce a new attack
+surface.
+
+| Dimension | Direction |
+|---|---|
+| Authorization default | **Strengthened (fail-open → fail-closed).** A missing or empty policy configuration now denies rather than allows. A misconfigured or unloaded policy bundle can no longer silently authorize every tool call. |
+| Cross-SDK consistency | **Strengthened.** The same policy bundle now yields the same allow/deny decision in Python, TypeScript, and .NET, removing a class of "works in one runtime, blocked in another" trust-boundary bugs. |
+| Policy bypass surface | **Reduced.** There is no longer an implicit allow path reachable by simply omitting `defaults.action` or shipping an empty policy set. |
+| Privilege boundaries | **Unchanged.** Execution rings, kill switch, and approval gates are untouched. |
+| Authentication / identity | **Unchanged.** No identity, signing, or trust-handshake code is modified. |
+| Availability | **Operational regression risk only.** Deployments that relied on the implicit default-allow will start denying. This is the intended fail-closed behavior; the documented mitigation is an explicit `defaults.action: allow` for environments that genuinely want permissive defaults. |
+
+### Specific notes
+
+- **Explicit allow is preserved.** When a policy is loaded with
+  `defaults.action: allow`, behavior is unchanged. Only the *implicit* fallback
+  changed from allow to deny.
+- **No new code execution or input paths.** This is a default-value and
+  branch-outcome change in existing evaluation logic; it adds no parsing, no new
+  caller-supplied input, and no dynamic evaluation.
+- **Audit/warn/log semantics aligned.** `AUDIT` and matched `warn`/`log` rules
+  remain allowed across all SDKs, so observability rules do not accidentally
+  become deny gates.
+
+## Test coverage
+
+Default-deny and warn/log parity are asserted in all three SDKs:
+
+- **.NET** (`agent-governance-dotnet/tests/AgentGovernance.Tests`):
+  - `PolicyEngineTests.Evaluate_NoPoliciesLoaded_DeniesByDefault` and the
+    `PolicyDecision_DenyDefault_HasExpectedShape` shape test.
+  - `GovernanceClientAndPolicyEvaluationTests.EvaluateToolCall_NoPolicies_DeniesByDefault`
+    (updated from the former `_AllowsByDefault` to assert deny via the kernel).
+  - `PolicyAdvancedTests.Evaluate_NoPolicies_DefaultsToDeny` (updated from the
+    former `_DefaultsToAllow`).
+  - Tests that isolate rule-matching semantics load an explicit
+    `default_action: allow` so they exercise rule behavior, not the default.
+- **Python / TypeScript**: conformance tests assert that an empty policy set and
+  an unmatched request both deny, and that a matched `warn`/`log` rule is
+  allowed; tests that previously depended on the implicit default-allow were
+  updated to set an explicit allow default.


### PR DESCRIPTION
## What

Standardizes the Python, TypeScript, and .NET policy engines on fail-closed semantics so the same policy input yields the same authorization decision in every SDK.

- Python: `PolicyDefaults.action` now defaults to `DENY`, and the evaluator returns `deny` when no policies are loaded (`schema.py`, `evaluator.py`).
- .NET: the zero-policy path now returns `PolicyDecision.DenyDefault` instead of `AllowDefault` (`PolicyEngine.cs`).
- TypeScript: a matched `warn` or `log` rule now counts as allowed (`allowed: ['allow','warn','log'].includes(winner.action)`), matching the .NET and Python SDKs (`policy.ts`).
- `BREAKING_CHANGES.md`: documents the new default-deny behavior and how to opt back into permissive behavior (explicit `defaults.action: allow`).

## Why

Previously an omitted `defaults.action` or an empty policy set was fail-open in Python and fail-closed in TS, and identical warn/log rules denied in TS while allowing in Python/.NET. For a governance toolkit this is a trust-boundary inconsistency. This change makes all three SDKs fail closed by default.

This is a behavior change. Consumers that relied on the previous fail-open default can opt back in with an explicit `defaults.action: allow`.

## How validated

- Added conformance tests in all three SDKs: an empty policy set and an unmatched request both deny, and a matched warn/log rule is allowed.
- Updated existing tests that relied on the old default-allow to set an explicit allow default where they isolate rule-matching semantics.
- Python: targeted policy test suites pass (conformance, language, security enforcement, backends, async evaluator). Full agent-os run shows no net-new failures versus the base branch (pre-existing failures are unrelated missing-optional-dependency / ModuleNotFound errors).
- .NET and TypeScript: no toolchain available in this environment to execute; changes are minimal and type-safe (`warn`/`log` are valid `PolicyAction` values in TS; `DenyDefault` already exists in .NET with the same signature as `AllowDefault`).

Fixes #2926

🤖 Generated with [Claude Code](https://claude.com/claude-code)