### PR TITLE
fix(contributor-check): fail closed on UNKNOWN aggregate risk

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -49,6 +49,7 @@ baseexception
 baselined
 behaviour
 behavioural
+BFBFBF
 bursty
 bypassable
 bytecodes

--- a/scripts/contributor_check_action.py
+++ b/scripts/contributor_check_action.py
@@ -86,7 +86,7 @@ def _aggregate_risk(*levels: str) -> str:
     """
     if not levels:
         return "LOW"
-    # Unrecognised labels are treated as UNKNOWN (uncertain), never LOW.
+    # Unrecognized labels are treated as UNKNOWN (uncertain), never LOW.
     max_val = max(RISK_ORDER.get(r, RISK_ORDER["UNKNOWN"]) for r in levels)
     for label, val in RISK_ORDER.items():
         if val == max_val:

--- a/scripts/contributor_check_action.py
+++ b/scripts/contributor_check_action.py
@@ -29,7 +29,11 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 MARKER = "<!-- agt-contributor-check -->"
-RISK_ORDER = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "UNKNOWN": 0}
+# Fail-closed ordering: UNKNOWN ("could not be determined") must outrank LOW so
+# a check that errored (e.g. GitHub API rate-limiting) cannot silently score a
+# contributor as the lowest risk. We rank it just below HIGH so an uncertain
+# result is treated as elevated/suspicious rather than clean. See issue #2950.
+RISK_ORDER = {"LOW": 1, "MEDIUM": 2, "UNKNOWN": 3, "HIGH": 4}
 
 
 # ── Helpers ───────────────────────────────────────────────────────
@@ -73,12 +77,21 @@ def _run_check(script: str, args: list[str], out_path: str) -> str:
 
 
 def _aggregate_risk(*levels: str) -> str:
-    """Return the highest risk level from a set of check results."""
-    max_val = max(RISK_ORDER.get(r, 0) for r in levels)
+    """Return the highest risk level from a set of check results.
+
+    Fail-closed: an UNKNOWN result (a check that could not be determined,
+    e.g. an errored or rate-limited probe) outranks LOW/MEDIUM and surfaces
+    as its own UNKNOWN aggregate rather than being silently scored LOW. See
+    issue #2950.
+    """
+    if not levels:
+        return "LOW"
+    # Unrecognised labels are treated as UNKNOWN (uncertain), never LOW.
+    max_val = max(RISK_ORDER.get(r, RISK_ORDER["UNKNOWN"]) for r in levels)
     for label, val in RISK_ORDER.items():
-        if val == max_val and label != "UNKNOWN":
+        if val == max_val:
             return label
-    return "LOW"
+    return "UNKNOWN"
 
 
 def _set_output(name: str, value: str) -> None:
@@ -103,7 +116,13 @@ def _write_summary(text: str) -> None:
 def _build_comment(username: str, overall: str, profile_risk: str,
                    cred_risk: str, cluster_risk: str) -> str:
     """Build a concise comment body with risk levels only."""
-    icon = "\U0001f534" if overall == "HIGH" else "\U0001f7e1"
+    # red=HIGH, white question=UNKNOWN (could not check), yellow=otherwise.
+    if overall == "HIGH":
+        icon = "\U0001f534"
+    elif overall == "UNKNOWN":
+        icon = "❔"
+    else:
+        icon = "\U0001f7e1"
 
     lines = [
         MARKER,
@@ -160,7 +179,8 @@ def _post_comment(token: str, owner: str, repo: str, number: int,
 def _apply_label(token: str, owner: str, repo: str, number: int,
                  risk: str) -> None:
     """Ensure the correct needs-review label is applied."""
-    color = "D93F0B" if risk == "HIGH" else "FFA500"
+    # red=HIGH, grey=UNKNOWN (could not check), orange=otherwise.
+    color = {"HIGH": "D93F0B", "UNKNOWN": "BFBFBF"}.get(risk, "FFA500")
     try:
         _api(token, "POST", f"/repos/{owner}/{repo}/labels", {
             "name": f"needs-review:{risk}",
@@ -170,7 +190,7 @@ def _apply_label(token: str, owner: str, repo: str, number: int,
     except HTTPError:
         pass
 
-    for level in ("LOW", "MEDIUM", "HIGH"):
+    for level in ("LOW", "MEDIUM", "HIGH", "UNKNOWN"):
         if level != risk:
             try:
                 req = Request(

--- a/scripts/tests/test_contributor_check_action.py
+++ b/scripts/tests/test_contributor_check_action.py
@@ -46,7 +46,7 @@ def test_medium_dominates_low():
     assert _aggregate_risk("LOW", "MEDIUM", "LOW") == "MEDIUM"
 
 
-def test_unrecognised_label_treated_as_unknown_not_low():
+def test_unrecognized_label_treated_as_unknown_not_low():
     # Defensive: an unexpected/garbage risk string fails closed, not open.
     assert _aggregate_risk("LOW", "BOGUS") == "UNKNOWN"
 

--- a/scripts/tests/test_contributor_check_action.py
+++ b/scripts/tests/test_contributor_check_action.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for contributor_check_action.py risk aggregation."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from contributor_check_action import _aggregate_risk
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed aggregation (issue #2950)
+# ---------------------------------------------------------------------------
+
+def test_all_unknown_aggregates_to_unknown_not_low():
+    # Regression for #2950: when every check could not be determined (e.g. all
+    # checks errored / were rate-limited), the aggregate must NOT be LOW.
+    assert _aggregate_risk("UNKNOWN", "UNKNOWN", "UNKNOWN") == "UNKNOWN"
+
+
+def test_unknown_outranks_low():
+    # A single UNKNOWN must not be hidden behind clean LOW results.
+    assert _aggregate_risk("LOW", "UNKNOWN", "LOW") == "UNKNOWN"
+
+
+def test_unknown_outranks_medium():
+    assert _aggregate_risk("MEDIUM", "UNKNOWN") == "UNKNOWN"
+
+
+def test_high_still_dominates_unknown():
+    # A confirmed HIGH signal is still worse than an uncertain one.
+    assert _aggregate_risk("UNKNOWN", "HIGH") == "HIGH"
+    assert _aggregate_risk("HIGH", "UNKNOWN", "LOW") == "HIGH"
+
+
+def test_all_low_aggregates_to_low():
+    assert _aggregate_risk("LOW", "LOW", "LOW") == "LOW"
+
+
+def test_medium_dominates_low():
+    assert _aggregate_risk("LOW", "MEDIUM", "LOW") == "MEDIUM"
+
+
+def test_unrecognised_label_treated_as_unknown_not_low():
+    # Defensive: an unexpected/garbage risk string fails closed, not open.
+    assert _aggregate_risk("LOW", "BOGUS") == "UNKNOWN"
+
+
+def test_empty_inputs_default_low():
+    # No checks supplied (all skipped) is not an error condition.
+    assert _aggregate_risk() == "LOW"


### PR DESCRIPTION
## Summary

Fixes #2950.

The contributor-check action's `_aggregate_risk` mapped an all-UNKNOWN
result to `LOW`. This is fail-open: when every check errored (the most
likely cause being GitHub API rate-limiting on external-user probes), a
contributor was silently scored `LOW` with no signal that the checks
never actually ran.

## Root cause

`scripts/contributor_check_action.py`:

- `RISK_ORDER` placed `UNKNOWN` at `0` (below `LOW`).
- `_aggregate_risk` explicitly skipped the `UNKNOWN` label when selecting
  the max and fell through to `return "LOW"`, so an all-UNKNOWN run
  aggregated to `LOW`.

## Fix (fail-closed)

- Re-rank `RISK_ORDER` so `UNKNOWN` sits just below `HIGH`
  (`LOW=1, MEDIUM=2, UNKNOWN=3, HIGH=4`).
- `_aggregate_risk` now surfaces `UNKNOWN` as its own aggregate tier
  instead of suppressing it, and treats any unrecognised label as
  `UNKNOWN` (never `LOW`).
- `UNKNOWN` gets a distinct comment icon and label colour so consumers
  can tell "checked and clean" (`LOW`) apart from "could not check"
  (`UNKNOWN`), and the label-cleanup loop now clears stale `UNKNOWN`
  labels too.

Because `UNKNOWN` now outranks the default `MEDIUM` threshold, an
all-errored run posts a comment and applies a label rather than passing
silently. Skipped checks (never run) still pass an empty string that
`main()` coerces to `LOW`, so this only elevates checks that actually
executed and could not determine a result.

## Tests

Adds `scripts/tests/test_contributor_check_action.py` covering the
fail-closed aggregation: all-UNKNOWN -> UNKNOWN, UNKNOWN outranks
LOW/MEDIUM, HIGH still dominates UNKNOWN, unrecognised label -> UNKNOWN,
and empty input -> LOW. All pass; existing contributor-check tests
remain green.

## Interaction with #2852

PR #2852 (org-aware / domain-specialist reputation heuristic) modifies
`scripts/contributor_check.py` and its tests. This PR touches only
`scripts/contributor_check_action.py` (the orchestrator that aggregates
each check's risk) plus a new test file, so there is no file overlap and
no merge conflict expected with #2852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
