### PR TITLE
fix(ci): remove duplicate dependabot directory configs that invalidated the file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
 version: 2
 updates:
-  # Shared Python dev tooling (mypy, pytest, structlog, ruff) across every
-  # Python package directory. The docker-compose-test image installs all of
-  # these packages with their [dev] extras into a single pip environment, so
-  # bumping one package's dev-tool floor past another package's cap makes the
-  # resolver unsolvable (see issue #2930). Grouping the dev-tool bumps across
-  # directories lands them as one PR, keeping the shared environment solvable.
+  # All Python packages under agent-governance-python/, covered by a single
+  # multi-directory entry. A separate per-directory entry for any of these
+  # dirs would be a duplicate ecosystem+directory config and invalidate the
+  # whole file, so they are intentionally consolidated here.
+  #
+  # The python-dev-tooling group (mypy, pytest, structlog, ruff) is grouped
+  # across all directories: the docker-compose-test image installs every
+  # package's [dev] extras into a single pip environment, so bumping one
+  # package's dev-tool floor past another's cap makes the resolver unsolvable
+  # (see issue #2930). Grouping lands those bumps as one PR. Every other
+  # dependency still gets its own individual PR per directory.
   - package-ecosystem: "pip"
     directories:
       - "/agent-governance-python/agent-os"
@@ -33,113 +38,6 @@ updates:
           - "pytest*"
           - "structlog"
           - "ruff"
-
-  # Python packages — one entry per package under agent-governance-python/.
-  # (Non dev-tooling deps still update per directory; the dev-tooling matches
-  # above are grouped via the shared entry.)
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-os"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-mesh"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-hypervisor"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-sre"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-compliance"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-discovery"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-lightning"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-marketplace"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-mcp-governance"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-primitives"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-rag-governance"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-runtime"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/agent-governance-python/agent-sandbox"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
 
   # npm packages
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Problem

The Dependabot config validation check (`dependabot-api.githubapp.com`) is failing on every PR, and Dependabot rebases on open PRs never complete. Root cause: `.github/dependabot.yml` is invalid.

PR #2943 (issue #2930) added a multi-directory pip entry using `directories:` to group the shared dev-tooling bumps across 13 Python package directories, but left the original per-directory `directory:` pip entries for those same 13 dirs in place. Dependabot does not allow two update configs with the same `package-ecosystem` and directory, so the whole file is rejected.

## Fix

Consolidate onto the single multi-directory pip entry. It already:
- groups the dev-tooling (`mypy`, `pytest*`, `structlog`, `ruff`) across all 13 dirs into one PR (the original intent of #2930), and
- opens individual PRs for every other dependency in those dirs.

Removed the 13 redundant singular `directory:` pip entries. Config now validates (verified: 0 duplicate ecosystem+directory pairs).

## Behavior note

The consolidated entry shares one `open-pull-requests-limit: 5` across the 13 pip dirs (previously 5 per dir). This caps concurrent pip PRs lower but does not block any update. Adjust if a higher limit is desired.

Unblocks the stuck rebases on #2898, #2894, #2891, #2889, #2878, #2822.