### PR TITLE
fix(agent-os): restore ruff/pytest config dropped by #2794 (fixes lint (agent-os) CI)

### DIFF
--- a/agent-governance-python/agent-os/pyproject.toml
+++ b/agent-governance-python/agent-os/pyproject.toml
@@ -19,3 +19,51 @@ Homepage = "https://github.com/microsoft/agent-governance-toolkit"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_os"]
+
+# ============================================================================
+# Ruff - Fast Python Linter & Formatter
+#
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the agent_os source tree under src/ is still linted and tested in CI. These
+# dev-tooling sections were dropped during the package consolidation in #2794;
+# without per-file-ignores, ruff reports E402/F401 on previously-clean files
+# such as agent_os/integrations/__init__.py. Restoring them keeps CI green.
+# ============================================================================
+[tool.ruff]
+target-version = "py39"
+line-length = 100
+src = ["src", "modules"]
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # Pyflakes
+    "I",      # isort
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "UP",     # pyupgrade
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402", "F401"]
+"src/agent_os/integrations/*.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["agent_os"]
+
+# ============================================================================
+# Pytest
+# ============================================================================
+[tool.pytest.ini_options]
+testpaths = ["tests", "modules/*/tests"]
+asyncio_mode = "auto"
+addopts = "-v --tb=short"
+markers = [
+    "benchmark: performance benchmark tests",
+    "slow: long-running tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
+]


### PR DESCRIPTION
## Problem

The repo-wide **`lint (agent-os)`** CI job is failing on `main` and on every PR, blocking all merges.

### Root cause

PR #2794 (*"chore: convert legacy and integration packages to dep-only stubs"*) reduced `agent-governance-python/agent-os/pyproject.toml` to a dep-only deprecation stub. Converting the **published wheel** to a stub is intentional (package consolidation into `agent-governance-toolkit-core`), and the `src/agent_os/` source tree is fully intact — agent-os was **not** wrongly deleted.

However, the rewrite also dropped the `[tool.ruff]` and `[tool.pytest]` dev-tooling config as collateral damage. The `agent_os` source under `src/` is still linted by CI (`.github/workflows/ci.yml`), and the lint step relies on `pyproject.toml` for `per-file-ignores`:

```toml
[tool.ruff.lint.per-file-ignores]
"__init__.py" = ["E402", "F401"]
"src/agent_os/integrations/*.py" = ["E402"]
```

With those gone, ruff reports **21 E402/F401 errors** on previously-clean files. Example errors reproduced locally with the exact CI command:

```
src/agent_os/integrations/__init__.py:128:1: E402 Module level import not at top of file
src/agent_os/integrations/__init__.py:133:5: F401 `.base.ContentHashInterceptor` imported but unused
src/agent_os/integrations/crewai_adapter.py:54:1: E402 Module level import not at top of file
src/agent_os/integrations/openai_agents_sdk.py:72:1: E402 Module level import not at top of file
src/agent_os/integrations/registry.py:18:1: E402 Module level import not at top of file
... (Found 21 errors.)
```

## Fix

Restore the `[tool.ruff]` and `[tool.pytest.ini_options]` sections (including the `per-file-ignores`) from the pre-#2794 version. This is a config-only change:

- The dep-only `[project]` stub and `version = "4.1.0"` introduced by #2794 are **preserved**.
- Only the dropped dev-tooling config is brought back — none of the build-target/optional-dependency trimming #2794 did deliberately is reintroduced.

## Verification

Ran the exact lint command from `.github/workflows/ci.yml` (`ruff check src/ --select E,F,W --ignore E501`, ruff 0.12.4):

```
$ cd agent-governance-python/agent-os && ruff check src/ --select E,F,W --ignore E501
All checks passed!
```

Signed-off-by: Imran Siddique <imran.siddique@opaque.co>

🤖 Generated with [Claude Code](https://claude.com/claude-code)