### PR TITLE
fix(integrations): restore public re-exports on deprecated stub __init__

### DIFF
--- a/agent-governance-python/agentmesh-integrations/crewai-agentmesh/crewai_agentmesh/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/crewai-agentmesh/crewai_agentmesh/__init__.py
@@ -6,3 +6,19 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+from crewai_agentmesh.trust import (
+    AgentProfile,
+    CapabilityGate,
+    TrustedCrew,
+    TrustTracker,
+    TaskAssignment,
+)
+
+__all__ = [
+    "AgentProfile",
+    "CapabilityGate",
+    "TrustedCrew",
+    "TrustTracker",
+    "TaskAssignment",
+]

--- a/agent-governance-python/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/langchain-agentmesh/langchain_agentmesh/__init__.py
@@ -6,3 +6,36 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+from langchain_agentmesh.identity import VerificationIdentity, VerificationSignature, UserContext
+from langchain_agentmesh.trust import (
+    TrustedAgentCard,
+    TrustHandshake,
+    TrustVerificationResult,
+    TrustPolicy,
+    DelegationChain,
+    Delegation,
+    AgentDirectory,
+)
+from langchain_agentmesh.tools import TrustGatedTool, TrustedToolExecutor
+from langchain_agentmesh.callbacks import TrustCallbackHandler
+
+__all__ = [
+    # Identity
+    "VerificationIdentity",
+    "VerificationSignature",
+    "UserContext",
+    # Trust
+    "TrustedAgentCard",
+    "TrustHandshake",
+    "TrustVerificationResult",
+    "TrustPolicy",
+    "DelegationChain",
+    "Delegation",
+    "AgentDirectory",
+    # Tools
+    "TrustGatedTool",
+    "TrustedToolExecutor",
+    # Callbacks
+    "TrustCallbackHandler",
+]

--- a/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/openai_agents_agentmesh/__init__.py
+++ b/agent-governance-python/agentmesh-integrations/openai-agents-agentmesh/openai_agents_agentmesh/__init__.py
@@ -6,3 +6,19 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+from openai_agents_agentmesh.trust import (
+    AgentTrustContext,
+    HandoffResult,
+    HandoffVerifier,
+    FunctionCallResult,
+    TrustedFunctionGuard,
+)
+
+__all__ = [
+    "AgentTrustContext",
+    "HandoffResult",
+    "HandoffVerifier",
+    "FunctionCallResult",
+    "TrustedFunctionGuard",
+]


### PR DESCRIPTION
## Problem

The `test-integrations` CI legs for **crewai-agentmesh**, **langchain-agentmesh**, and **openai-agents-agentmesh** fail at pytest collection on every PR (including PR #2868), with:

- `ImportError: cannot import name 'AgentProfile' from 'crewai_agentmesh'`
- `ImportError: cannot import name 'AgentDirectory' from 'langchain_agentmesh'`
- `ImportError: cannot import name 'AgentTrustContext' from 'openai_agents_agentmesh'`

This is **pre-existing breakage on `main`** (confirmed: the same three jobs fail on the latest completed `main` CI run), independent of any PR branch.

## Root cause

The stub conversion in #2794 replaced the top-level `__init__.py` of these three packages with a bare `DeprecationWarning`, dropping the re-exports of the public trust-layer symbols. The implementation modules (`trust.py`, `identity.py`, `tools.py`, `callbacks.py`) were left in place and are still shipped (`packages = ["<pkg>"]`), but the symbols were no longer importable from the package root.

Each package's test suite — and any downstream code doing `from <pkg> import AgentProfile / AgentDirectory / AgentTrustContext` — therefore fails to import.

## Fix

Restore the original re-export blocks (keeping the new `DeprecationWarning` at the top of each file). No behavior change beyond re-exposing the existing, already-shipped symbols. The stale `__version__ = "3.2.2"` from the old langchain `__init__` is intentionally **not** restored (the package is now 4.x).

## Verification

Local pytest passes for all three packages:
- crewai-agentmesh: 34 passed
- openai-agents-agentmesh: 23 passed
- langchain-agentmesh: 51 passed

## Out of scope

The `haystack-agentmesh` integration job also fails, but for an unrelated reason (`AttributeError: '_Component' object has no attribute 'input_types'` — `governance.py` uses a `@component.input_types(...)` decorator that haystack-ai never exposed). That requires a source-code change, not a re-export, and is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)