### PR TITLE
fix(agent-os): restore dev test deps stripped by package consolidation (#2794)

### DIFF
--- a/agent-governance-python/agent-os/pyproject.toml
+++ b/agent-governance-python/agent-os/pyproject.toml
@@ -13,6 +13,48 @@ authors = [
 ]
 dependencies = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
 
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the agent_os source tree under src/ (and tests/) is still exercised in CI via
+# `pip install -e ".[dev]"`. PR #2794 stripped [project.optional-dependencies]
+# entirely, which silently turned `.[dev]` into a no-op and left the test suite
+# unable to import fastapi/pynacl/cryptography/aiohttp — every `pytest tests/`
+# run failed at COLLECTION (ModuleNotFoundError) on Python 3.11-3.13. The `dev`
+# extra below restores exactly the test/dev dependencies the suite needs to
+# collect and run; the component extras mirror the pre-#2794 structure so the
+# `dev` bundle stays self-describing. This does NOT change the published runtime
+# dependency surface (the [project] stub still ships only the -core redirect).
+[project.optional-dependencies]
+# Test/dev dependencies required for `pytest tests/` to collect and run.
+# fastapi:      tests/test_server.py, tests/cloud_board/test_api_auth.py,
+#               services/cloud-board/api/* (imported by the cloud_board tests).
+# pynacl:       tests/cloud_board/test_api_auth.py (nacl.signing).
+# cryptography: tests/test_cmd_sign.py, modules/nexus (imported transitively
+#               by the cloud_board tests via services/cloud-board/api/main.py).
+# aiohttp:      modules/nexus.client (same transitive import path as above).
+# pyyaml:       tests/test_cmd_sign.py and several others (import yaml).
+dev = [
+    "pytest>=8.4.2,<10.0",
+    "pytest-asyncio>=0.21.0,<2.0",
+    "pytest-cov>=4.0.0,<8.0",
+    "mypy>=1.19.1,<3.0",
+    "ruff>=0.15.15,<1.0",
+    "import-linter>=2.0,<3.0",
+    "pyyaml>=6.0.0,<7.0",
+    "typer>=0.9.0,<1.0",
+    "rich>=15.0.0,<16.0",
+    "numpy>=1.20.0,<3.0",
+    "httpx>=0.27.0,<1.0",
+    "fastapi>=0.115.0,<1.0",
+    "uvicorn>=0.27.0,<1.0",
+    "anyio>=4.12.1,<5.0",
+    "aiohttp>=3.13.4,<4.0",
+    "structlog>=24.1.0,<27.0",
+    "redis>=4.0.0,<8.0",
+    "cryptography>=48.0.0,<49.0",
+    "pynacl>=1.6.2,<2.0",
+    "eval_type_backport>=0.2.0; python_version < '3.10'",
+]
+
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"
 "Migration Guide" = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md"


### PR DESCRIPTION
@
## Problem

The `test (agent-os)` CI job fails at **collection** on Python 3.11 / 3.12 / 3.13 with `ModuleNotFoundError`:

- `tests/test_server.py` -> `from fastapi.testclient import TestClient`
- `tests/cloud_board/test_api_auth.py` -> `fastapi` + `nacl.signing`, and it imports `services/cloud-board/api/main.py`, which transitively imports `modules.nexus` (pulls in `aiohttp` and `cryptography`)

## Root cause

PR #2794 (package consolidation) reduced `agent-governance-python/agent-os/pyproject.toml` to a dep-only deprecation stub and removed `[project.optional-dependencies]` **entirely**.

The agent-os matrix branch in `.github/workflows/ci.yml` installs the test env with:

```
pip install --no-cache-dir -e ".[dev]"
```

With the `dev` extra gone, `.[dev]` became a silent no-op (pip just warns about the missing extra), so `fastapi`, `pynacl`, `cryptography`, and `aiohttp` were never installed and `pytest tests/` could not even collect.

This is **pre-existing on `main`** and independent of any feature branch: `git show origin/main:agent-governance-python/agent-os/pyproject.toml` has no `optional-dependencies` block, so the same failure reproduces on a clean `main`. The earlier follow-up #2969 restored the `ruff`/`pytest` config that #2794 dropped, but not the `dev` extra.

## Fix

Restore the pre-#2794 `dev` extra in `[project.optional-dependencies]`. Deps that block collection / running of `pytest tests/`:

| dep | needed by |
|-----|-----------|
| `fastapi`, `uvicorn`, `httpx` | `tests/test_server.py`, `tests/cloud_board/test_api_auth.py`, cloud-board API |
| `pynacl` | `tests/cloud_board/test_api_auth.py` (`nacl.signing`) |
| `cryptography` | `tests/test_cmd_sign.py`, `modules.nexus` (transitive) |
| `aiohttp` | `modules.nexus.client` (transitive via cloud-board API) |
| `pyyaml` | `tests/test_cmd_sign.py` and others (`import yaml`) |

The remaining `dev` tooling entries (`pytest`, `pytest-asyncio`, `pytest-cov`, `mypy`, `ruff`, `import-linter`, `typer`, `rich`, `numpy`, `anyio`, `structlog`, `redis`) mirror the original pre-#2794 `dev` extra. `pynacl` is additionally included (it was previously only in the `iatp` extra, but `test_api_auth.py` imports it at module top level).

The published wheel remains a dep-only deprecation stub at version `4.1.0` — only the test/dev optional dependencies are restored. The runtime dependency surface is unchanged.

## Verification (local)

```
pip install -e ".[dev]"
python -m pytest tests/cloud_board/test_api_auth.py tests/test_server.py --co -q
# => 81 tests collected in 3.18s, no ModuleNotFoundError
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@