### PR TITLE
fix(agent-os): restore __version__ attribute on agent_os package

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/__init__.py
@@ -6,3 +6,6 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+# Keep in sync with the ``version`` field in pyproject.toml.
+__version__ = "4.1.0"


### PR DESCRIPTION
## Problem

Multiple tests and modules fail with:

```
ImportError: cannot import name '__version__' from 'agent_os'
```

(e.g. `tests/test_server.py`, `tests/test_cli.py`), which in turn fails the agent-os test job for any PR touching agent-os.

## Root cause

PR #2794 (package consolidation) reduced `agent-governance-python/agent-os/src/agent_os/__init__.py` to a deprecation-warning stub and, in doing so, dropped the module-level `__version__` attribute that existed before the change. Several modules still import it:

- `src/agent_os/server/app.py`
- `src/agent_os/cli/__init__.py`
- `src/agent_os/cli/mcp_scan.py`
- `tests/test_server.py`

## Fix

Restore `__version__` as a literal (the way it was defined before #2794 and the way sibling packages like `agent_compliance` declare it), set to the current package version `4.1.0` from `pyproject.toml`. This does **not** undo the consolidation; it only re-exposes the documented attribute on the deprecated stub.

## Verification

```
$ python -c "from agent_os import __version__; print(__version__)"
4.1.0

$ pytest tests/test_server.py tests/test_cli.py --collect-only
117 tests collected   # no ImportError

$ pytest tests/test_server.py::TestRootEndpoint::test_root_version_matches
1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)