### PR TITLE
fix(ci): set conventional-commit prefix for Dependabot nuget PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,6 +96,12 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    # nuget does not auto-apply the repo's conventional-commit prefix, so the
+    # generated PR title ("Bump X from A to B") fails the pr-title check. Set
+    # it explicitly so nuget bumps match the required title format.
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   # Rust
   - package-ecosystem: "cargo"


### PR DESCRIPTION
## Problem

Dependabot nuget PRs (e.g. #2966, #2967) are titled `Bump X from A to B`, which fails the `Validate PR title` check (it requires conventional-commit format). Unlike pip/npm/cargo, the nuget ecosystem did not auto-apply the repo's conventional-commit prefix, so every .NET dependency bump fails the title gate and reverts to the non-compliant title on each `@dependabot rebase`.

## Fix

Set `commit-message.prefix: "chore(deps)"` (and `prefix-development: "chore(deps-dev)"`) on the nuget update entry so Dependabot generates compliant titles automatically.

Relates to #2975 (Dependabot mergeability). Does not retroactively fix the existing #2966/#2967 titles (those were edited manually), but prevents recurrence for all future nuget bumps.