### PR TITLE
fix(embedding): address #2974 review follow-ups — cosine dimension check + doc alignment

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/prompt_injection_embedding.py
+++ b/agent-governance-python/agent-os/src/agent_os/prompt_injection_embedding.py
@@ -68,6 +68,8 @@ class EmbeddingSignalConfig:
 
 
 def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if len(a) != len(b):
+        raise ValueError(f"embedding dimension mismatch: {len(a)} != {len(b)}")
     dot = 0.0
     na = 0.0
     nb = 0.0
@@ -134,6 +136,8 @@ class EmbeddingSignal:
         if not self.config.enabled:
             return None
         if self._pos is None or self._neg is None:
+            # Deliberate Python-only convenience: rebuild lazily if `enabled` was
+            # flipped on after construction. Rust builds only in `new()`.
             self._build()
         assert self._pos is not None and self._neg is not None
         query = list(self._resolve_embedder()([text])[0])

--- a/agent-governance-python/agent-os/tests/test_prompt_injection_embedding.py
+++ b/agent-governance-python/agent-os/tests/test_prompt_injection_embedding.py
@@ -109,6 +109,17 @@ class TestFailSafe(unittest.TestCase):
         with self.assertRaises(ValueError):
             EmbeddingSignal(EmbeddingSignalConfig(enabled=True), attacks_only, embedder=fake_embedder)
 
+    def test_dimension_mismatch_rejected(self):
+        # an embedder whose query vectors differ in width from its bank vectors
+        # must fail loudly, not silently truncate the cosine
+        def mismatched(texts):
+            width = 3 if len(texts) > 1 else 5
+            return [[1.0] * width for _ in texts]
+
+        sig = EmbeddingSignal(EmbeddingSignalConfig(enabled=True, k=2), BANK, embedder=mismatched)
+        with self.assertRaises(ValueError):
+            sig.score("ignore previous instructions")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/agent-governance-rust/agentmesh/src/prompt_injection_embedding.rs
+++ b/agent-governance-rust/agentmesh/src/prompt_injection_embedding.rs
@@ -133,6 +133,7 @@ impl<E: Embedder> EmbeddingSignal<E> {
 }
 
 fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "embedding dimension mismatch: {} != {}", a.len(), b.len());
     let mut dot = 0.0f32;
     let mut na = 0.0f32;
     let mut nb = 0.0f32;
@@ -235,6 +236,23 @@ mod tests {
     fn empty_bank_rejected() {
         let result = EmbeddingSignal::new(EmbeddingSignalConfig::default(), &[], Fake);
         assert!(matches!(result, Err(EmbeddingSignalError::EmptyBank)));
+    }
+
+    /// Embedder whose query vectors differ in width from its bank vectors.
+    struct Mismatched;
+    impl Embedder for Mismatched {
+        fn embed(&self, texts: &[&str]) -> Vec<Vec<f32>> {
+            let width = if texts.len() > 1 { 3 } else { 5 };
+            texts.iter().map(|_| vec![1.0; width]).collect()
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "embedding dimension mismatch")]
+    fn dimension_mismatch_rejected() {
+        let cfg = EmbeddingSignalConfig { enabled: true, k: 2 };
+        let sig = EmbeddingSignal::new(cfg, &bank(), Mismatched).unwrap();
+        sig.score("ignore previous instructions");
     }
 
     #[test]

--- a/docs/benchmarks/prompt-injection-evaluation.md
+++ b/docs/benchmarks/prompt-injection-evaluation.md
@@ -21,7 +21,9 @@ The fixture covers:
 
 The fixture does not introduce:
 
-- an embedding detector
+- an embedding detector (the optional, default-off embedding evidence signal
+  lives in the SDK — `agent_os.prompt_injection_embedding` /
+  `agentmesh::prompt_injection_embedding` — not in this fixture)
 - new blocking policy
 - production thresholds
 - policy-routing integration

--- a/docs/benchmarks/prompt-injection-methodology.md
+++ b/docs/benchmarks/prompt-injection-methodology.md
@@ -32,12 +32,12 @@ profile:
   `indirect_injection`, `tool_abuse`, `tool_result_injection`,
   `output_exfiltration`, `memory_poisoning`, `data_boundary_abuse` — each defined
   by `ATTACK_TEMPLATES` with slot fillers `ACTIONS` / `TARGETS` / `TOOL_NAMES`.
-- **Bypass / mutation operators** (the obfuscation surface, `ALLOWED_BYPASS_CLASSES`,
-  14 classes incl. `none`/`plain`): `rot13`, `compact_alnum`, `compact_leet`,
-  `separator_spaced`, `chunked`, `homoglyph`, and `compact_pressure_mutations`,
-  plus `diacritics`, `letter_spaced`, `leet_spacing`, `leet_letter_spaced`,
-  `encoding`, `multilingual`. Each row records its `bypass_class`, so coverage and
-  per-class results are auditable.
+- **Bypass classes** (the obfuscation surface, `ALLOWED_BYPASS_CLASSES`,
+  14 classes): `none`, `plain`, `rot13`, `compact_plain`, `compact_leet`,
+  `chunked_leet`, `separator_spaced`, `letter_spaced`, `leet_spacing`,
+  `leet_letter_spaced`, `homoglyph`, `diacritics`, `encoding`, `multilingual`.
+  Each row records its `bypass_class`, so coverage and per-class results are
+  auditable.
 - **Provenance metadata per row:** `source_type`, `trust_level`, `attack_class`,
   `benign_subclass`, `family_id`, `group_id`, `split`, `bypass_class`. A
   fixed `TEXT_MARKER` (`PI1`) tags every synthetic row so fixture text can never

--- a/docs/slo/tickets/ticket-pr2-embedding-signal.md
+++ b/docs/slo/tickets/ticket-pr2-embedding-signal.md
@@ -3,7 +3,8 @@
 Source: `docs/UPSTREAM-PR-PLAN.md` "PR 2: Optional Embedding Signal" + the
 default-posture spec. Builds on PR1 (#2924 fixture) and the methodology doc
 (this branch's parent `slo/pr2-methodology`). Target branch:
-`slo/pr2-embedding-signal`. Stack: Python (`agent_os`). Ported from the research
+`slo/pr2-embedding-signal`. Stack: Python (`agent_os`) + Rust (`agentmesh`) —
+the signal shipped in both SDKs with matching semantics. Ported from the research
 repo's kNN-margin detector (`AGT-Embeddings-Experiment`, fastembed + bge-small).
 
 ## Smallest user-visible outcome
@@ -27,8 +28,8 @@ existing AGT enforcement behavior.
 | Row | Value |
 |---|---|
 | One outcome | yes — opt-in evidence signal |
-| Changed files | 4 (module + test + pyproject extra + SLO evidence) |
-| Public surface | 1 new module (`agent_os.prompt_injection_embedding`); no change to existing detector |
+| Changed files | 10 as merged (#2974): Python module + test + pyproject extra, Rust module + `lib.rs` export, methodology/evaluation docs, SLO evidence + tickets |
+| Public surface | 2 new modules (`agent_os.prompt_injection_embedding`, `agentmesh::prompt_injection_embedding`); no change to existing detectors |
 | Migration | none |
 | New deps | `fastembed` as an **optional** extra only (never a hard dep) |
 | One PR | yes |


### PR DESCRIPTION
## Summary

Follow-up to #2974, addressing the non-blocking nits from the [post-merge review](https://github.com/microsoft/agent-governance-toolkit/pull/2974#issuecomment-4688684484): one defensive correctness fix in the embedding signal (both SDKs, parity preserved) and three documentation alignments. **No behavior change on any default path** — the signal remains optional, default-off, and evidence-only (`blocks` is still hardcoded `false`; there is still no block/deny/enforce path).

### Related work

- Relates to #2918 (Proposal: optional embedding/kNN prompt-injection signal from research corpus)
- Follow-up to #2974 (embedding evidence signal, Python + Rust, merged) — addresses its review nits
- Builds on #2924 (prompt-injection evaluation fixture, merged; issue #2923)

## Changes

### Fix: `cosine` dimension check (Python + Rust)

`cosine` previously iterated with `zip`, which silently truncates to the shorter vector. A dimension-mismatched injected embedder would therefore produce a silently-wrong margin instead of an error — the one place where a misconfiguration degraded quietly rather than failing safe.

- Python ([prompt_injection_embedding.py](agent-governance-python/agent-os/src/agent_os/prompt_injection_embedding.py)): raises `ValueError("embedding dimension mismatch: …")`
- Rust ([prompt_injection_embedding.rs](agent-governance-rust/agentmesh/src/prompt_injection_embedding.rs)): `assert_eq!` with the same message

Both languages now fail loudly and identically, so Python/Rust parity is preserved. Regression tests added in both: `test_dimension_mismatch_rejected` (Python) and `dimension_mismatch_rejected` (Rust, `#[should_panic]`).

### Docs: align methodology bypass-class list with the generator

`docs/benchmarks/prompt-injection-methodology.md` enumerated the obfuscation surface by mixing mutation function names (`compact_alnum`, `chunked`, `compact_pressure_mutations`) with actual `bypass_class` labels, and omitted the real labels `chunked_leet` and `compact_plain`. The list now matches `ALLOWED_BYPASS_CLASSES` in `generate-corpus.py` exactly (the count of 14 was already correct).

### Docs: clarify fixture scope in the evaluation doc

`docs/benchmarks/prompt-injection-evaluation.md` says the fixture "does not introduce: an embedding detector" — still true, but now ambiguous since #2974 shipped the signal in the SDKs. Added a clarifying clause: the signal lives in `agent_os.prompt_injection_embedding` / `agentmesh::prompt_injection_embedding`, not in the fixture.

### Docs: correct ticket scope

`docs/slo/tickets/ticket-pr2-embedding-signal.md` said "Stack: Python" / "Changed files: 4", but #2974 also shipped the full Rust implementation (10 files, two SDK modules). The sizing gate and contract rows now reflect what actually merged.

### Code comment: make the parity divergence auditable

The Python-only lazy `_build()` fallback in `score()` (rebuild if `enabled` was flipped on after construction) is now annotated as a deliberate Python-only convenience versus Rust building only in `new()`, so the divergence reads as intentional rather than drift.

## Testing

| Check | Command | Result |
|---|---|---|
| Python unit tests | `python3 -m unittest tests.test_prompt_injection_embedding -v` | 9/9 pass (injected fake embedder; no model download) |
| Rust unit tests | `cargo test -p agentmesh --lib prompt_injection_embedding` | 7/7 pass, incl. the new should-panic mismatch test |
| Default-off invariant | disabled-inert tests in both languages | unchanged, passing |

## Risk

Low. The only runtime change converts a silent-wrong-answer path (mismatched injected embedder) into a loud error inside an opt-in, evidence-only module that is inert by default. Documentation changes are descriptive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
