### PR TITLE
fix(ci): restore stripped lint/test config for #2794-stubbed packages (agent-mesh, agent-hypervisor, agent-sre)

### DIFF
--- a/agent-governance-python/agent-hypervisor/pyproject.toml
+++ b/agent-governance-python/agent-hypervisor/pyproject.toml
@@ -13,9 +13,76 @@ authors = [
 ]
 dependencies = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
 
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the hypervisor source tree under src/ (and tests/) is still exercised in CI via
+# `pip install -e ".[dev]"`. PR #2794 stripped [project.optional-dependencies]
+# entirely, which silently turned `.[dev]` into a no-op and left the test suite
+# unable to import fastapi/pydantic/jsonschema — every `pytest tests/` run failed
+# at COLLECTION (ModuleNotFoundError). The `dev` extra below restores exactly the
+# test/dev dependencies the suite needs to collect and run. This does NOT change
+# the published runtime dependency surface (the [project] stub still ships only
+# the -core redirect). Mirrors the agent-os fix (#2969 + #2972).
+[project.optional-dependencies]
+# Test/dev dependencies required for `pytest tests/` to collect and run.
+# pydantic was previously a runtime dependency and fastapi lived in the `api`
+# extra; both are imported directly by the test suite at collection time, so the
+# stub's dev bundle must list them.
+dev = [
+    "pytest>=8.0.0,<10.0",
+    "pytest-asyncio>=0.23.0,<2.0",
+    "pytest-cov>=4.0.0,<8.0",
+    "hypothesis>=6.155.1,<7.0",
+    "ruff>=0.4.0,<1.0",
+    "mypy>=1.8.0,<3.0",
+    "jsonschema>=4.26.0,<5.0",
+    "pydantic>=2.13.4,<3.0",
+    "fastapi>=0.136.3,<1.0",
+    "uvicorn>=0.49.0,<1.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"
 "Migration Guide" = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/hypervisor"]
+
+# ============================================================================
+# Ruff - Fast Python Linter & Formatter
+#
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the hypervisor source tree under src/ is still linted in CI. These dev-tooling
+# sections were dropped during the package consolidation in #2794; without the
+# per-file-ignores, ruff reports F401 on re-export __init__.py files such as
+# hypervisor/liability/__init__.py and hypervisor/session/__init__.py. Restoring
+# them keeps CI green.
+# ============================================================================
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "B", "C4", "UP"]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "E741",   # ambiguous variable name
+    "B904",   # raise-without-from-inside-except
+    "B017",   # assert-raises-exception
+    "UP042",  # str+Enum → StrEnum (needs py311+)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/*" = ["F401"]
+
+# ============================================================================
+# Pytest
+# ============================================================================
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "-v --tb=short"
+markers = [
+    "slow: long-running tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
+]

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -13,9 +13,94 @@ authors = [
 ]
 dependencies = ["agent-governance-toolkit-core>=4.0.0,<5.0"]
 
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the agentmesh source tree under src/ (and tests/) is still exercised in CI via
+# `pip install -e ".[dev]"`. PR #2794 stripped [project.optional-dependencies]
+# entirely, which silently turned `.[dev]` into a no-op and left the test suite
+# unable to import fastapi/pydantic/cryptography/pynacl/pyyaml — every
+# `pytest tests/` run failed at COLLECTION (ModuleNotFoundError). The `dev` extra
+# below restores exactly the test/dev dependencies the suite needs to collect and
+# run. This does NOT change the published runtime dependency surface (the
+# [project] stub still ships only the -core redirect). Mirrors the agent-os fix
+# (#2969 + #2972).
+[project.optional-dependencies]
+# Test/dev dependencies required for `pytest tests/` to collect and run. The
+# entries beyond the pre-#2794 set (pydantic, cryptography, pynacl, pyyaml, rich,
+# click, python-dateutil) were previously satisfied by the package's runtime
+# `dependencies`, which the stub no longer carries; they are imported directly by
+# the test suite at collection time, so the dev bundle must list them.
+dev = [
+    "pytest>=7.4.0,<10.0",
+    "pytest-asyncio>=0.23.0,<2.0",
+    "pytest-cov>=4.1.0,<8.0",
+    "hypothesis>=6.155.2,<7.0",
+    "black>=26.5.1,<27.0",
+    "ruff>=0.1.0,<1.0",
+    "mypy>=1.8.0,<3.0",
+    "fakeredis>=2.36.0,<3.0",
+    "prometheus-client>=0.19.0,<1.0",
+    "websockets>=12.0,<17.0",
+    "fastapi>=0.136.3,<1.0",
+    "httpx>=0.27.0,<1.0",
+    "uvicorn[standard]>=0.27.0,<1.0",
+    "opentelemetry-api>=1.42.1,<2.0",
+    "opentelemetry-sdk>=1.42.1,<2.0",
+    "PyJWT[crypto]>=2.8.0,<3.0",
+    "pydantic[email]>=2.5.0,<3.0",
+    "cryptography>=46.0.7,<49.0",
+    "pynacl>=1.6.2,<2.0",
+    "pyyaml>=6.0,<7.0",
+    "rich>=13.0.0,<16.0",
+    "click>=8.4.1,<9.0",
+    "python-dateutil>=2.8.0,<3.0",
+    "structlog>=24.1.0,<27.0",
+    # Ring tests exercise the hypervisor; mirror the optional extra so
+    # `pip install agent-mesh[dev]` brings everything needed for tests.
+    "agent_hypervisor>=3.7.0,<5.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"
 "Migration Guide" = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agentmesh"]
+
+# ============================================================================
+# Ruff - Fast Python Linter & Formatter
+#
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the agentmesh source tree under src/ is still linted in CI. These dev-tooling
+# sections were dropped during the package consolidation in #2794; restoring them
+# (with per-file-ignores for re-export __init__.py files) keeps CI green.
+# ============================================================================
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP"]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "E402"]
+"tests/*" = ["F401", "E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["agentmesh"]
+
+# ============================================================================
+# Pytest
+# ============================================================================
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+markers = [
+    "fuzz: fuzzing tests with malformed inputs",
+    "benchmark: crypto operation benchmarks",
+    "slow: long-running load tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
+]

--- a/agent-governance-python/agent-sre/pyproject.toml
+++ b/agent-governance-python/agent-sre/pyproject.toml
@@ -13,9 +13,78 @@ authors = [
 ]
 dependencies = ["agent-governance-toolkit-cli>=4.0.0,<5.0"]
 
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the agent_sre source tree under src/ (and tests/) is still exercised in CI via
+# `pip install -e ".[dev]"`. PR #2794 stripped [project.optional-dependencies]
+# entirely, which silently turned `.[dev]` into a no-op and left the test suite
+# unable to import croniter/fastapi/opentelemetry/pydantic/pyyaml — every
+# `pytest tests/` run failed at COLLECTION (ModuleNotFoundError). The `dev` extra
+# below restores exactly the test/dev dependencies the suite needs to collect and
+# run. This does NOT change the published runtime dependency surface (the
+# [project] stub still ships only the -cli redirect). Mirrors the agent-os fix
+# (#2969 + #2972).
+[project.optional-dependencies]
+# Test/dev dependencies required for `pytest tests/` to collect and run. The
+# entries beyond the pre-#2794 set (pydantic, pyyaml, croniter, opentelemetry,
+# fastapi) were previously satisfied by the package's runtime `dependencies` or
+# the `api` extra, which the stub no longer carries; they are imported directly by
+# the test suite at collection time, so the dev bundle must list them.
+dev = [
+    "pytest>=8.0,<10.0",
+    "pytest-cov>=5.0,<8.0",
+    "pytest-asyncio>=0.23,<2.0",
+    "ruff>=0.8,<1.0",
+    "mypy>=1.10,<3.0",
+    "pydantic>=2.13.4,<3.0",
+    "pyyaml>=6.0.3,<7.0",
+    "croniter>=2.0,<7.0",
+    "opentelemetry-api>=1.20,<2.0",
+    "opentelemetry-sdk>=1.20,<2.0",
+    "fastapi>=0.115.0,<1.0",
+    "uvicorn>=0.49.0,<1.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"
 "Migration Guide" = "https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agent_sre"]
+
+# ============================================================================
+# Ruff - Fast Python Linter & Formatter
+#
+# The published wheel is a dep-only deprecation stub (see [project] above), but
+# the agent_sre source tree under src/ is still linted in CI. These dev-tooling
+# sections were dropped during the package consolidation in #2794; without the
+# per-file-ignores, ruff reports F401 on re-export __init__.py files across the
+# package (adapters, alerts, tracing, ...). Restoring them keeps CI green.
+# ============================================================================
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "SIM", "TCH"]
+ignore = [
+    "E501",   # line too long
+    "E741",   # ambiguous variable name
+    "UP035",  # deprecated typing imports (need py310 compat)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "E402"]
+"tests/*" = ["F401", "E402"]
+"src/agent_sre/integrations/*" = ["E402"]
+
+# ============================================================================
+# Pytest
+# ============================================================================
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+markers = [
+    "slow: long-running tests (skip with -m 'not slow')",
+    "integration: end-to-end integration tests",
+]


### PR DESCRIPTION
## Summary

PR #2794 (eb620ce2) converted **agent-mesh**, **agent-hypervisor**, and **agent-sre** to dep-only deprecation stubs and, in doing so, stripped their `[tool.ruff]`, `[tool.pytest.ini_options]`, and dev `[project.optional-dependencies]` sections from `pyproject.toml`.

Their `src/` (and `tests/`) trees still exist and CI still runs lint + test on them, so the stripped config broke CI:
- **ruff** reported `F401` on re-export `__init__.py` files (per-file-ignores gone).
- **pytest** failed at collection (`ModuleNotFoundError`) because `pip install -e ".[dev]"` became a no-op.

This restores those sections, recovered from each package's pre-#2794 `pyproject.toml` and aligned with the already-merged **agent-os** fix (#2969 + #2972):
- modern `[tool.ruff.lint]` layout with `per-file-ignores` for the re-export `__init__.py` files;
- `[tool.pytest.ini_options]`;
- a self-describing `dev` extra.

The `dev` extras additionally list the test-collection deps that the pre-#2794 packages got from their runtime `dependencies` / `api` extra (which the stubs no longer carry), so `pytest tests/` can collect: pydantic, cryptography, pynacl, pyyaml, croniter, opentelemetry, fastapi, etc.

The published runtime dependency surface is unchanged: each `[project]` stub still ships only its `-core`/`-cli` redirect at version `4.1.0`.

## Validation

Ran the exact CI lint command per package (`.github/workflows/ci.yml`):

```
ruff check src/ --select E,F,W --ignore E501
```

| Package | Result |
| --- | --- |
| agent-mesh | clean (exit 0) |
| agent-hypervisor | clean (exit 0) |
| agent-sre | clean (exit 0) |

Per-file-ignores confirmed against the actual ruff output: all pre-restore errors were `F401` in `__init__.py` files, covered by `"__init__.py"` ignores. Dev extras cross-checked against third-party imports in `tests/` and `src/` by reading (no installs/pytest run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)