### PR TITLE
fix: restore dropped public exports from #2794 stubs and fix replay/marketplace test bugs

### DIFF
--- a/agent-governance-python/agent-compliance/tests/test_policy_replay_metadata.py
+++ b/agent-governance-python/agent-compliance/tests/test_policy_replay_metadata.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import json
-import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -33,6 +32,7 @@ def _make_decision(action: str = "deny", allowed: bool = False, matched_rule: st
 def _write_fixture(tmp_path: Path, fixtures: list[dict], filename: str = "test.json") -> Path:
     """Write fixture(s) to a JSON file and return the path."""
     p = tmp_path / filename
+    p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(json.dumps(fixtures if len(fixtures) > 1 else fixtures[0], indent=2))
     return p
 

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/__init__.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/__init__.py
@@ -1,4 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Agent Hypervisor - runtime supervisor for multi-agent Shared Sessions.
+
+.. deprecated::
+    ``agent-hypervisor`` is deprecated and will be removed in a future
+    release. Use ``agent-governance-toolkit-core`` instead. See
+    https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md
+"""
+
 import warnings
+
 warnings.warn(
     "agent-hypervisor is deprecated and will be removed in a future release. "
     "Use agent-governance-toolkit-core instead. "
@@ -6,3 +17,159 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+# Keep in sync with the ``version`` field in pyproject.toml.
+__version__ = "4.1.0"
+
+# Centralized constants
+from hypervisor import constants  # noqa: F401,E402
+
+# Audit
+from hypervisor.audit.commitment import CommitmentEngine  # noqa: E402
+from hypervisor.audit.delta import DeltaEngine  # noqa: E402
+from hypervisor.audit.gc import EphemeralGC  # noqa: E402
+
+# Top-level orchestrator
+from hypervisor.core import Hypervisor  # noqa: E402
+
+# Liability
+from hypervisor.liability import LiabilityMatrix  # noqa: E402
+from hypervisor.liability.attribution import AttributionResult, CausalAttributor  # noqa: E402
+from hypervisor.liability.ledger import LedgerEntryType, LiabilityLedger  # noqa: E402
+from hypervisor.liability.quarantine import QuarantineManager, QuarantineReason  # noqa: E402
+from hypervisor.liability.slashing import SlashingEngine  # noqa: E402
+from hypervisor.liability.vouching import VouchingEngine, VouchRecord  # noqa: E402
+
+# Core models
+from hypervisor.models import (  # noqa: E402
+    ConsistencyMode,
+    ExecutionRing,
+    ReversibilityLevel,
+    SessionConfig,
+    SessionState,
+)
+
+# Observability
+from hypervisor.observability.causal_trace import CausalTraceId  # noqa: E402
+from hypervisor.observability.event_bus import (  # noqa: E402
+    EventType,
+    HypervisorEvent,
+    HypervisorEventBus,
+)
+
+# Reversibility
+from hypervisor.reversibility.registry import ReversibilityRegistry  # noqa: E402
+
+# Execution rings
+from hypervisor.rings.breach_detector import BreachSeverity, RingBreachDetector  # noqa: E402
+from hypervisor.rings.classifier import ActionClassifier  # noqa: E402
+from hypervisor.rings.elevation import (  # noqa: E402
+    ElevationDenialReason,
+    RingElevation,
+    RingElevationManager,
+)
+from hypervisor.rings.enforcer import RingEnforcer  # noqa: E402
+
+# Saga
+from hypervisor.saga.checkpoint import CheckpointManager, SemanticCheckpoint  # noqa: E402
+from hypervisor.saga.dsl import SagaDefinition, SagaDSLParser  # noqa: E402
+from hypervisor.saga.fan_out import FanOutOrchestrator, FanOutPolicy  # noqa: E402
+from hypervisor.saga.orchestrator import SagaOrchestrator, SagaTimeoutError  # noqa: E402
+from hypervisor.saga.state_machine import SagaState, StepState  # noqa: E402
+
+# Security
+from hypervisor.security.kill_switch import KillResult, KillSwitch  # noqa: E402
+from hypervisor.security.rate_limiter import AgentRateLimiter, RateLimitExceeded  # noqa: E402
+
+# Session management
+from hypervisor.session import SharedSessionObject  # noqa: E402
+from hypervisor.session.intent_locks import (  # noqa: E402
+    DeadlockError,
+    IntentLockManager,
+    LockContentionError,
+    LockIntent,
+)
+from hypervisor.session.isolation import IsolationLevel  # noqa: E402
+from hypervisor.session.sso import SessionVFS, VFSEdit, VFSPermissionError  # noqa: E402
+from hypervisor.session.vector_clock import (  # noqa: E402
+    CausalViolationError,
+    VectorClock,
+    VectorClockManager,
+)
+
+# Verification
+from hypervisor.verification.history import TransactionHistoryVerifier  # noqa: E402
+
+__all__ = [
+    # Version
+    "__version__",
+    # Core
+    "Hypervisor",
+    # Models
+    "ConsistencyMode",
+    "ExecutionRing",
+    "ReversibilityLevel",
+    "SessionConfig",
+    "SessionState",
+    # Session
+    "SharedSessionObject",
+    "SessionVFS",
+    "VFSEdit",
+    "VFSPermissionError",
+    "VectorClock",
+    "VectorClockManager",
+    "CausalViolationError",
+    "IntentLockManager",
+    "LockIntent",
+    "LockContentionError",
+    "DeadlockError",
+    "IsolationLevel",
+    # Liability
+    "VouchRecord",
+    "VouchingEngine",
+    "SlashingEngine",
+    "LiabilityMatrix",
+    "CausalAttributor",
+    "AttributionResult",
+    "QuarantineManager",
+    "QuarantineReason",
+    "LiabilityLedger",
+    "LedgerEntryType",
+    # Rings
+    "RingEnforcer",
+    "ActionClassifier",
+    "RingElevationManager",
+    "RingElevation",
+    "ElevationDenialReason",
+    "RingBreachDetector",
+    "BreachSeverity",
+    # Reversibility
+    "ReversibilityRegistry",
+    # Saga
+    "SagaOrchestrator",
+    "SagaTimeoutError",
+    "SagaState",
+    "StepState",
+    "FanOutOrchestrator",
+    "FanOutPolicy",
+    "CheckpointManager",
+    "SemanticCheckpoint",
+    "SagaDSLParser",
+    "SagaDefinition",
+    # Audit
+    "DeltaEngine",
+    "CommitmentEngine",
+    "EphemeralGC",
+    # Verification
+    "TransactionHistoryVerifier",
+    # Observability
+    "HypervisorEventBus",
+    "EventType",
+    "HypervisorEvent",
+    "CausalTraceId",
+    # Security
+    "AgentRateLimiter",
+    "RateLimitExceeded",
+    "KillSwitch",
+    "KillResult",
+]

--- a/agent-governance-python/agent-marketplace/tests/test_hooks_policy_path.py
+++ b/agent-governance-python/agent-marketplace/tests/test_hooks_policy_path.py
@@ -25,6 +25,8 @@ _POLICY_TEMPLATE = """\
 version: "1.0"
 name: {name}
 description: {name} policy
+defaults:
+  action: allow
 rules:
   - name: {name}-rule
     condition:

--- a/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/__init__.py
@@ -1,4 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""AgentMesh - the secure nervous system for cloud-native agent ecosystems.
+
+.. deprecated::
+    ``agentmesh-platform`` is deprecated and will be removed in a future
+    release. Use ``agent-governance-toolkit-core`` instead. See
+    https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md
+"""
+
 import warnings
+
 warnings.warn(
     "agentmesh-platform is deprecated and will be removed in a future release. "
     "Use agent-governance-toolkit-core instead. "
@@ -6,3 +17,147 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+# Keep in sync with the ``version`` field in pyproject.toml.
+__version__ = "4.1.0"
+
+# Telemetry bootstrap
+from agentmesh.telemetry import bootstrap_otel, is_bootstrapped  # noqa: E402
+
+# Trust types (shared across integrations)
+from agentmesh.trust_types import (  # noqa: E402
+    AgentProfile,
+    TrustRecord,
+    TrustTracker,
+)
+
+# Unified Client
+from .client import AgentMeshClient, GovernanceResult  # noqa: E402
+
+# Exceptions
+from .exceptions import (  # noqa: E402
+    AgentMeshError,
+    DelegationDepthError,
+    DelegationError,
+    GovernanceError,
+    HandshakeError,
+    HandshakeTimeoutError,
+    IdentityError,
+    StorageError,
+    TrustError,
+    TrustVerificationError,
+    TrustViolationError,
+)
+
+# Layer 3: Governance & Compliance Plane
+from .governance import (  # noqa: E402
+    AuditChain,
+    AuditEntry,
+    AuditLog,
+    ComplianceEngine,
+    ComplianceFramework,
+    ComplianceReport,
+    Policy,
+    PolicyDecision,
+    PolicyEngine,
+    PolicyRule,
+    ShadowMode,
+    ShadowResult,
+)
+from .identity import (  # noqa: E402
+    SVID,
+    AgentDID,
+    AgentIdentity,
+    Credential,
+    CredentialManager,
+    DelegationLink,
+    HumanSponsor,
+    RiskScore,
+    RiskScorer,
+    ScopeChain,
+    SPIFFEIdentity,
+)
+
+# Layer 4: Reward & Learning Engine
+from .reward import (  # noqa: E402
+    RewardDimension,
+    RewardEngine,
+    RewardSignal,
+    TrustScore,
+)
+
+# Layer 2: Trust & Protocol Bridge
+from .trust import (  # noqa: E402
+    CapabilityGrant,
+    CapabilityRegistry,
+    CapabilityScope,
+    HandshakeResult,
+    ProtocolBridge,
+    TrustBridge,
+    TrustHandshake,
+)
+
+__all__ = [
+    # Version
+    "__version__",
+    # Layer 1: Identity
+    "AgentIdentity",
+    "AgentDID",
+    "Credential",
+    "CredentialManager",
+    "ScopeChain",
+    "DelegationLink",
+    "HumanSponsor",
+    "RiskScorer",
+    "RiskScore",
+    "SPIFFEIdentity",
+    "SVID",
+    # Layer 2: Trust
+    "TrustBridge",
+    "ProtocolBridge",
+    "TrustHandshake",
+    "HandshakeResult",
+    "CapabilityScope",
+    "CapabilityGrant",
+    "CapabilityRegistry",
+    # Layer 3: Governance
+    "PolicyEngine",
+    "Policy",
+    "PolicyRule",
+    "PolicyDecision",
+    "ComplianceEngine",
+    "ComplianceFramework",
+    "ComplianceReport",
+    "AuditLog",
+    "AuditEntry",
+    "AuditChain",
+    "ShadowMode",
+    "ShadowResult",
+    # Exceptions
+    "AgentMeshError",
+    "IdentityError",
+    "TrustError",
+    "TrustVerificationError",
+    "TrustViolationError",
+    "DelegationError",
+    "DelegationDepthError",
+    "GovernanceError",
+    "HandshakeError",
+    "HandshakeTimeoutError",
+    "StorageError",
+    # Layer 4: Reward
+    "RewardEngine",
+    "TrustScore",
+    "RewardDimension",
+    "RewardSignal",
+    # Unified Client
+    "AgentMeshClient",
+    "GovernanceResult",
+    # Trust Types (shared across integrations)
+    "AgentProfile",
+    "TrustRecord",
+    "TrustTracker",
+    # Telemetry
+    "bootstrap_otel",
+    "is_bootstrapped",
+]

--- a/agent-governance-python/agent-os/src/agent_os/__init__.py
+++ b/agent-governance-python/agent-os/src/agent_os/__init__.py
@@ -1,4 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Agent OS - A Safety-First Kernel for Autonomous AI Agents.
+
+.. deprecated::
+    ``agent-os-kernel`` is deprecated and will be removed in a future
+    release. Use ``agent-governance-toolkit-core`` instead. See
+    https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md
+"""
+
+from __future__ import annotations
+
 import warnings
+
 warnings.warn(
     "agent-os-kernel is deprecated and will be removed in a future release. "
     "Use agent-governance-toolkit-core instead. "
@@ -9,3 +22,443 @@ warnings.warn(
 
 # Keep in sync with the ``version`` field in pyproject.toml.
 __version__ = "4.1.0"
+__author__ = "Microsoft Corporation"
+__license__ = "MIT"
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _check_optional(module_name: str) -> bool:
+    """Return True if *module_name* is importable."""
+    try:
+        __import__(module_name)
+        return True
+    except ImportError:
+        return False
+
+
+AVAILABLE_PACKAGES: dict[str, bool] = {
+    "control_plane": _check_optional("agent_control_plane"),
+    "primitives": _check_optional("agent_primitives"),
+    "cmvk": _check_optional("cmvk"),
+    "caas": _check_optional("caas"),
+    "emk": _check_optional("emk"),
+    "amb": _check_optional("amb_core"),
+    "atr": _check_optional("atr"),
+    "scak": _check_optional("agent_kernel"),
+    "mute_agent": _check_optional("mute_agent"),
+}
+
+
+def check_installation() -> None:
+    """Check which Agent OS packages are installed."""
+    logger.info("Agent OS Installation Status:")
+    logger.info("=" * 40)
+    for pkg, available in AVAILABLE_PACKAGES.items():
+        status = "Installed" if available else "Not installed"
+        logger.info(f"  {pkg:15} {status}")
+    logger.info("=" * 40)
+    logger.info("\nInstall missing packages with:")
+    logger.info("  pip install agent-os-kernel[full]")
+
+
+# ============================================================================
+# Control Plane (optional - requires agent_control_plane package)
+# ============================================================================
+
+try:
+    from agent_control_plane import (
+        AgentContext,
+        AgentControlPlane,
+        AgentKernelPanic,
+        AgentSignal,
+        AgentVFS,
+        ExecutionEngine,
+        ExecutionStatus,
+        FileMode,
+        FlightRecorder,
+        KernelSpace,
+        KernelState,
+        MemoryBackend,
+        PolicyEngine,
+        PolicyRule,
+        ProtectionRing,
+        SignalAwareAgent,
+        SignalDispatcher,
+        SyscallRequest,
+        SyscallResult,
+        SyscallType,
+        VFSBackend,
+        create_agent_vfs,
+        create_control_plane,
+        create_kernel,
+        kill_agent,
+        pause_agent,
+        policy_violation,
+        resume_agent,
+        user_space_execution,
+    )
+
+    _CONTROL_PLANE_AVAILABLE = True
+except ImportError:
+    _CONTROL_PLANE_AVAILABLE = False
+
+# ============================================================================
+# Core Governance Modules (always available)
+# ============================================================================
+
+# AGENTS.md Compatibility
+from agent_os.agents_compat import (
+    AgentConfig as AgentsConfig,
+)
+from agent_os.agents_compat import (
+    AgentSkill,
+    AgentsParser,
+    discover_agents,
+)
+
+# Base Agent Classes
+from agent_os.base_agent import (
+    AgentConfig,
+    AuditEntry,
+    BaseAgent,
+    PolicyDecision,
+    ToolUsingAgent,
+    TypedResult,
+)
+
+# Context Budget Scheduler
+from agent_os.context_budget import (
+    BudgetExceeded,
+    ContextPriority,
+    ContextScheduler,
+    ContextWindow,
+)
+
+# LlamaFirewall Integration
+try:
+    from agent_os.integrations.llamafirewall import (
+        FirewallMode,
+        FirewallResult,
+        FirewallVerdict,
+        LlamaFirewallAdapter,
+    )
+except ImportError:
+    pass
+
+# MCP Security - tool poisoning defense
+from agent_os.credential_redactor import CredentialMatch, CredentialPattern, CredentialRedactor
+from agent_os.credential_vault import (
+    DENY_REASON,
+    CredentialDecision,
+    CredentialError,
+    CredentialHandle,
+    CredentialInjector,
+    CredentialProfile,
+    CredentialRecord,
+    CredentialVault,
+    DenyReceipt,
+    EncryptionUnavailable,
+    InjectionContext,
+    InjectionResult,
+    PolicyOutcome,
+    VaultAuditEvent,
+    audit_digest,
+)
+from agent_os.mcp_message_signer import (
+    MCPMessageSigner,
+    MCPSignedEnvelope,
+    MCPVerificationResult,
+)
+from agent_os.mcp_protocols import (
+    InMemoryAuditSink,
+    InMemoryNonceStore,
+    InMemoryRateLimitStore,
+    InMemorySessionStore,
+    MCPAuditSink,
+    MCPNonceStore,
+    MCPRateLimitStore,
+    MCPSessionStore,
+)
+from agent_os.mcp_response_scanner import (
+    MCPResponseScanner,
+    MCPResponseScanResult,
+    MCPResponseThreat,
+)
+from agent_os.mcp_security import (
+    MCPSecurityScanner,
+    MCPSeverity,
+    MCPThreat,
+    MCPThreatType,
+    ScanResult,
+    ToolFingerprint,
+)
+from agent_os.mcp_session_auth import MCPSession, MCPSessionAuthenticator
+from agent_os.mcp_sliding_rate_limiter import MCPSlidingRateLimiter
+
+# Mute Agent Primitives - Face/Hands kernel-level decorators
+from agent_os.mute import (
+    ActionStatus,
+    ActionStep,
+    CapabilityViolation,
+    ExecutionPlan,
+    PipelineResult,
+    StepResult,
+    face_agent,
+    mute_agent,
+    pipe,
+)
+
+# Prompt Injection Detection
+from agent_os.prompt_injection import (
+    DetectionConfig,
+    DetectionResult,
+    InjectionType,
+    PromptInjectionDetector,
+    ThreatLevel,
+)
+
+# Semantic Policy Engine
+from agent_os.semantic_policy import (
+    IntentCategory,
+    IntentClassification,
+    PolicyDenied,
+    SemanticPolicyEngine,
+)
+
+# Stateless Kernel (MCP June 2026)
+from agent_os.stateless import (
+    ExecutionContext,
+    ExecutionRequest,
+    ExecutionResult,
+    StatelessKernel,
+    stateless_execute,
+)
+from agent_os.stateless import (
+    MemoryBackend as StatelessMemoryBackend,
+)
+
+# ============================================================================
+# Content Governance (v3.0.2+)
+# ============================================================================
+
+try:
+    from agent_os.content_governance import (
+        ContentDimension,
+        ContentQualityEvaluator,
+        ContentQualityReport,
+        QualityGate,
+    )
+except ImportError:
+    pass
+
+try:
+    from agent_os.execution_context_policy import (
+        ContextualPolicyEngine,
+        EnforcementLevel,
+    )
+    from agent_os.execution_context_policy import (
+        ExecutionContext as ContextualExecutionContext,
+    )
+except ImportError:
+    pass
+
+try:
+    from agent_os.github_enterprise import (
+        EnterpriseGovernanceManager,
+        GovernanceTier,
+    )
+except ImportError:
+    pass
+
+try:
+    from agent_os.shift_left_metrics import (
+        ShiftLeftTracker,
+        ViolationStage,
+    )
+except ImportError:
+    pass
+
+try:
+    from agent_os.audit_logger import GovernanceAuditLogger
+except ImportError:
+    pass
+
+try:
+    from agent_os.otel_audit_backend import OTelLogsBackend
+except ImportError:
+    pass
+
+# GovernanceEventSink SPI (v3.7+)
+from agent_os.event_sink import (
+    AuditBackendSinkAdapter,
+    GovernanceEvent,
+    GovernanceEventKind,
+    GovernanceEventProcessor,
+    GovernanceEventSink,
+    GovernanceEventSinkBase,
+    SinkExportResult,
+)
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+__all__ = [
+    # Metadata
+    "__version__",
+    "__author__",
+    "AVAILABLE_PACKAGES",
+    "check_installation",
+    # Control Plane
+    "AgentControlPlane",
+    "create_control_plane",
+    "AgentSignal",
+    "SignalDispatcher",
+    "AgentKernelPanic",
+    "SignalAwareAgent",
+    "kill_agent",
+    "pause_agent",
+    "resume_agent",
+    "policy_violation",
+    "AgentVFS",
+    "VFSBackend",
+    "MemoryBackend",
+    "FileMode",
+    "create_agent_vfs",
+    "KernelSpace",
+    "AgentContext",
+    "ProtectionRing",
+    "SyscallType",
+    "SyscallRequest",
+    "SyscallResult",
+    "KernelState",
+    "user_space_execution",
+    "create_kernel",
+    "PolicyEngine",
+    "PolicyRule",
+    "FlightRecorder",
+    "ExecutionEngine",
+    "ExecutionStatus",
+    # Mute Agent Primitives
+    "face_agent",
+    "mute_agent",
+    "pipe",
+    "ActionStep",
+    "ActionStatus",
+    "ExecutionPlan",
+    "StepResult",
+    "PipelineResult",
+    "CapabilityViolation",
+    # Stateless API
+    "StatelessKernel",
+    "ExecutionContext",
+    "ExecutionRequest",
+    "ExecutionResult",
+    "StatelessMemoryBackend",
+    "stateless_execute",
+    # Base Agent Classes
+    "BaseAgent",
+    "ToolUsingAgent",
+    "AgentConfig",
+    "AuditEntry",
+    "PolicyDecision",
+    "TypedResult",
+    # AGENTS.md Compatibility
+    "AgentsParser",
+    "AgentsConfig",
+    "AgentSkill",
+    "discover_agents",
+    # Semantic Policy Engine
+    "SemanticPolicyEngine",
+    "IntentCategory",
+    "IntentClassification",
+    "PolicyDenied",
+    # Prompt Injection Detection
+    "PromptInjectionDetector",
+    "InjectionType",
+    "ThreatLevel",
+    "DetectionResult",
+    "DetectionConfig",
+    # MCP Security
+    "MCPSecurityScanner",
+    "MCPThreatType",
+    "MCPSeverity",
+    "MCPThreat",
+    "ToolFingerprint",
+    "ScanResult",
+    "CredentialRedactor",
+    "CredentialPattern",
+    "CredentialMatch",
+    # Credential Vault & Injection (issue #2481)
+    "CredentialVault",
+    "CredentialInjector",
+    "CredentialHandle",
+    "CredentialProfile",
+    "CredentialRecord",
+    "CredentialDecision",
+    "CredentialError",
+    "EncryptionUnavailable",
+    "VaultAuditEvent",
+    "DenyReceipt",
+    "InjectionContext",
+    "InjectionResult",
+    "PolicyOutcome",
+    "DENY_REASON",
+    "audit_digest",
+    "MCPSessionStore",
+    "MCPNonceStore",
+    "MCPRateLimitStore",
+    "MCPAuditSink",
+    "InMemorySessionStore",
+    "InMemoryNonceStore",
+    "InMemoryRateLimitStore",
+    "InMemoryAuditSink",
+    "MCPResponseScanner",
+    "MCPResponseScanResult",
+    "MCPResponseThreat",
+    "MCPSessionAuthenticator",
+    "MCPSession",
+    "MCPMessageSigner",
+    "MCPSignedEnvelope",
+    "MCPVerificationResult",
+    "MCPSlidingRateLimiter",
+    # LlamaFirewall Integration
+    "LlamaFirewallAdapter",
+    "FirewallMode",
+    "FirewallVerdict",
+    "FirewallResult",
+    # Context Budget Scheduler
+    "ContextScheduler",
+    "ContextWindow",
+    "ContextPriority",
+    "BudgetExceeded",
+    # Content Governance
+    "ContentQualityEvaluator",
+    "ContentDimension",
+    "QualityGate",
+    "ContentQualityReport",
+    # Execution Context Policy
+    "ContextualPolicyEngine",
+    "ExecutionContext",
+    "EnforcementLevel",
+    # GitHub Enterprise Integration
+    "EnterpriseGovernanceManager",
+    "GovernanceTier",
+    # Shift-Left Metrics
+    "ShiftLeftTracker",
+    "ViolationStage",
+    # Audit Logger + OTel Backend
+    "GovernanceAuditLogger",
+    "OTelLogsBackend",
+    # GovernanceEventSink SPI
+    "GovernanceEvent",
+    "GovernanceEventKind",
+    "GovernanceEventSink",
+    "GovernanceEventSinkBase",
+    "GovernanceEventProcessor",
+    "SinkExportResult",
+    "AuditBackendSinkAdapter",
+]

--- a/agent-governance-python/agent-runtime/src/agent_runtime/__init__.py
+++ b/agent-governance-python/agent-runtime/src/agent_runtime/__init__.py
@@ -1,4 +1,18 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Agent Runtime - execution supervisor for multi-agent sessions.
+
+This package re-exports the full public API from ``hypervisor`` so that
+callers can migrate their imports incrementally.
+
+.. deprecated::
+    ``agentmesh-runtime`` is deprecated and will be removed in a future
+    release. Use ``agent-governance-toolkit-core`` instead. See
+    https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/package-consolidation/MIGRATION.md
+"""
+
 import warnings
+
 warnings.warn(
     "agentmesh-runtime is deprecated and will be removed in a future release. "
     "Use agent-governance-toolkit-core instead. "
@@ -6,3 +20,156 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
+# Keep in sync with the ``version`` field in pyproject.toml.
+__version__ = "4.1.0"
+
+from hypervisor import (  # noqa: E402,F401
+    # Core
+    Hypervisor,
+    # Models
+    ConsistencyMode,
+    ExecutionRing,
+    ReversibilityLevel,
+    SessionConfig,
+    SessionState,
+    # Session
+    SharedSessionObject,
+    SessionVFS,
+    VFSEdit,
+    VFSPermissionError,
+    VectorClock,
+    VectorClockManager,
+    CausalViolationError,
+    IntentLockManager,
+    LockIntent,
+    LockContentionError,
+    DeadlockError,
+    IsolationLevel,
+    # Liability
+    VouchRecord,
+    VouchingEngine,
+    SlashingEngine,
+    LiabilityMatrix,
+    CausalAttributor,
+    AttributionResult,
+    QuarantineManager,
+    QuarantineReason,
+    LiabilityLedger,
+    LedgerEntryType,
+    # Rings
+    RingEnforcer,
+    ActionClassifier,
+    RingElevationManager,
+    RingElevation,
+    ElevationDenialReason,
+    RingBreachDetector,
+    BreachSeverity,
+    # Reversibility
+    ReversibilityRegistry,
+    # Saga
+    SagaOrchestrator,
+    SagaTimeoutError,
+    SagaState,
+    StepState,
+    FanOutOrchestrator,
+    FanOutPolicy,
+    CheckpointManager,
+    SemanticCheckpoint,
+    SagaDSLParser,
+    SagaDefinition,
+    # Audit
+    DeltaEngine,
+    CommitmentEngine,
+    EphemeralGC,
+    # Verification
+    TransactionHistoryVerifier,
+    # Observability
+    HypervisorEventBus,
+    EventType,
+    HypervisorEvent,
+    CausalTraceId,
+    # Security
+    AgentRateLimiter,
+    RateLimitExceeded,
+    KillSwitch,
+    KillResult,
+)
+
+# Deployment Runtime (v3.0.2+)
+from agent_runtime.deploy import (  # noqa: E402
+    DeploymentResult,
+    DeploymentStatus,
+    DeploymentTarget,
+    DockerDeployer,
+    GovernanceConfig,
+    KubernetesDeployer,
+)
+
+__all__ = [
+    "__version__",
+    "Hypervisor",
+    "ConsistencyMode",
+    "ExecutionRing",
+    "ReversibilityLevel",
+    "SessionConfig",
+    "SessionState",
+    "SharedSessionObject",
+    "SessionVFS",
+    "VFSEdit",
+    "VFSPermissionError",
+    "VectorClock",
+    "VectorClockManager",
+    "CausalViolationError",
+    "IntentLockManager",
+    "LockIntent",
+    "LockContentionError",
+    "DeadlockError",
+    "IsolationLevel",
+    "VouchRecord",
+    "VouchingEngine",
+    "SlashingEngine",
+    "LiabilityMatrix",
+    "CausalAttributor",
+    "AttributionResult",
+    "QuarantineManager",
+    "QuarantineReason",
+    "LiabilityLedger",
+    "LedgerEntryType",
+    "RingEnforcer",
+    "ActionClassifier",
+    "RingElevationManager",
+    "RingElevation",
+    "ElevationDenialReason",
+    "RingBreachDetector",
+    "BreachSeverity",
+    "ReversibilityRegistry",
+    "SagaOrchestrator",
+    "SagaTimeoutError",
+    "SagaState",
+    "StepState",
+    "FanOutOrchestrator",
+    "FanOutPolicy",
+    "CheckpointManager",
+    "SemanticCheckpoint",
+    "SagaDSLParser",
+    "SagaDefinition",
+    "DeltaEngine",
+    "CommitmentEngine",
+    "EphemeralGC",
+    "TransactionHistoryVerifier",
+    "HypervisorEventBus",
+    "EventType",
+    "HypervisorEvent",
+    "CausalTraceId",
+    "AgentRateLimiter",
+    "RateLimitExceeded",
+    "KillSwitch",
+    "KillResult",
+    "DeploymentResult",
+    "DeploymentStatus",
+    "DeploymentTarget",
+    "DockerDeployer",
+    "GovernanceConfig",
+    "KubernetesDeployer",
+]


### PR DESCRIPTION
## Summary

Fixes several main-branch CI test failures. Four of them stem from PR #2794, which reduced legacy packages to deprecation-warning-only stubs and dropped the public re-exports their test suites depend on; the other two are independent test-setup bugs.

All deprecation warnings are preserved. Only `__init__.py` files and the two failing test files are touched. No `[tool.*]` / optional-dependency pyproject sections were modified.

## Changes

### 1. agent-os (`ImportError: cannot import name 'SemanticPolicyEngine'`)
Restored the full public re-export surface in `agent_os/__init__.py` from the in-package implementation modules (`semantic_policy`, `base_agent`, `mcp_*`, `credential_*`, `mute`, `stateless`, `event_sink`, etc.), including the optional control-plane / content-governance blocks guarded by `try/except ImportError`. Tests import `SemanticPolicyEngine`, `IntentCategory`, `IntentClassification`, `PolicyDenied`, `__version__` from the top level - all restored.

### 2. agent-runtime + agent-hypervisor (`ImportError: VectorClock / VectorClockManager / IntentLockManager / ConsistencyMode / ExecutionRing / ReversibilityLevel`)
The implementation modules live under `agent-hypervisor/src/hypervisor/`, which #2794 also stubbed. Restored `hypervisor/__init__.py` to re-export from its own submodules, then restored `agent_runtime/__init__.py` to re-export from `hypervisor` plus the local `agent_runtime.deploy` symbols. Every symbol the agent-runtime and agent-hypervisor test suites import from the top level is covered.

### 3. agent-compliance (`FileNotFoundError: .../fixtures/test.json`)
`_write_fixture` in `test_policy_replay_metadata.py` wrote into a `tmp_path/fixtures` subdirectory that was never created, so `Path.write_text` failed before the fixture existed. Added `p.parent.mkdir(parents=True, exist_ok=True)`. Assertions unchanged.

### 4. agent-marketplace (`assert 1 == 0`)
After policy engines standardized on default-deny (#2949), the test's `example-plugin` manifest matched no rule and was denied, so `evaluate_policy_cli` returned `1`. The test (written under the pre-#2949 default-allow behavior) verifies policy-path resolution, not the verdict. Restored its original assumption by adding an explicit `defaults: action: allow` to the policy template. Path-resolution assertions are unchanged.

## Validation
- `ruff check` passes on all six touched files (under each package's own config).
- `python -c "import ast; ast.parse(...)"` syntax check passes on all six files.
- Every symbol re-exported in the restored `__init__.py` files was AST-verified to still exist in its source module on current `main`.
- Test imports were exhaustively grepped per package so every needed symbol is restored in one pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)