### PR TITLE
fix(ci): allowlist fastembed in dependency-confusion scan

### DIFF
--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -109,6 +109,9 @@ REGISTERED_PACKAGES = {
     # Optional integration deps in agt-integrations/pyproject.toml (all real PyPI packages):
     #   flowise (Flowise SDK), boto3 (AWS, for AVP), nostr-sdk (Nostr WoT), oso (Oso authz).
     "flowise", "boto3", "nostr-sdk", "oso",
+    # fastembed: Qdrant's embedding library, optional dep for the default-off
+    # embedding evidence signal (agent-os embedding extra, PR #2974).
+    "fastembed",
     "hypothesis", "fakeredis", "langflow", "langgraph",
     "agentmesh", "pydantic-ai", "haystack", "haystack-ai", "respx",
     "langfuse", "arize", "arize-phoenix", "llamaindex", "braintrust", "helicone",


### PR DESCRIPTION
fastembed (Qdrant embedding library, optional dep for the default-off embedding signal from #2974) was reintroduced into agent-os/pyproject.toml when its dev/embedding extras were restored (#2972/#2997). It is a real PyPI package but was missing from the dep-confusion allowlist, failing dep-confusion-scan on main. Validated locally: scan now exits 0.