### PR TITLE
fix(ci): green the deprecated llamaindex/haystack integration smoke tests

### DIFF
--- a/agent-governance-python/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/audit.py
+++ b/agent-governance-python/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/audit.py
@@ -22,12 +22,6 @@ except ImportError:  # pragma: no cover
             return cls
 
         @staticmethod
-        def input_types(**kwargs):
-            def decorator(func):
-                return func
-            return decorator
-
-        @staticmethod
         def output_types(**kwargs):
             def decorator(func):
                 return func
@@ -74,12 +68,11 @@ class AuditLogger:
 
     # ── Component interface ───────────────────────────────────────
 
-    @component.input_types(
-        action=str,
-        agent_id=str,
-        decision=str,
-        metadata=Optional[Dict[str, Any]],
-    )
+    # Input types are inferred by haystack-ai from the typed `run` signature.
+    # A previous `@component.input_types(...)` decorator was invalid (the real
+    # API exposes `component.set_input_types(self, ...)` from __init__, and that
+    # requires a `**kwargs` run parameter, which these components don't use).
+    # See https://github.com/microsoft/agent-governance-toolkit/issues/2971
     @component.output_types(entry_id=str, chain_hash=str)
     def run(
         self,

--- a/agent-governance-python/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/governance.py
+++ b/agent-governance-python/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/governance.py
@@ -24,12 +24,6 @@ except ImportError:  # pragma: no cover
             return cls
 
         @staticmethod
-        def input_types(**kwargs):
-            def decorator(func):
-                return func
-            return decorator
-
-        @staticmethod
         def output_types(**kwargs):
             def decorator(func):
                 return func
@@ -87,11 +81,11 @@ class GovernancePolicyChecker:
 
     # ── Component interface ───────────────────────────────────────
 
-    @component.input_types(
-        action=str,
-        params=Dict[str, Any],
-        agent_id=Optional[str],
-    )
+    # Input types are inferred by haystack-ai from the typed `run` signature.
+    # A previous `@component.input_types(...)` decorator was invalid (the real
+    # API exposes `component.set_input_types(self, ...)` from __init__, and that
+    # requires a `**kwargs` run parameter, which these components don't use).
+    # See https://github.com/microsoft/agent-governance-toolkit/issues/2971
     @component.output_types(decision=str, reason=str, passed=bool)
     def run(
         self,

--- a/agent-governance-python/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/trust_gate.py
+++ b/agent-governance-python/agentmesh-integrations/haystack-agentmesh/src/haystack_agentmesh/trust_gate.py
@@ -20,12 +20,6 @@ except ImportError:  # pragma: no cover
             return cls
 
         @staticmethod
-        def input_types(**kwargs):
-            def decorator(func):
-                return func
-            return decorator
-
-        @staticmethod
         def output_types(**kwargs):
             def decorator(func):
                 return func
@@ -105,7 +99,11 @@ class TrustGate:
 
     # ── Component interface ───────────────────────────────────────
 
-    @component.input_types(agent_id=str, min_score=Optional[float])
+    # Input types are inferred by haystack-ai from the typed `run` signature.
+    # A previous `@component.input_types(...)` decorator was invalid (the real
+    # API exposes `component.set_input_types(self, ...)` from __init__, and that
+    # requires a `**kwargs` run parameter, which these components don't use).
+    # See https://github.com/microsoft/agent-governance-toolkit/issues/2971
     @component.output_types(trusted=bool, score=float, action=str)
     def run(
         self,

--- a/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
+++ b/agent-governance-python/agentmesh-integrations/llamaindex-agentmesh/pyproject.toml
@@ -11,7 +11,16 @@ requires-python = ">=3.9,<4.0"
 authors = [
     {name = "Microsoft Corporation", email = "agentgovtoolkit@microsoft.com"},
 ]
-dependencies = ["agent-governance-toolkit-integrations[llamaindex]>=4.0.0,<5.0"]
+dependencies = [
+    "agent-governance-toolkit-integrations[llamaindex]>=4.0.0,<5.0",
+    # Deprecated stub. The worker imports `AgentRunner` from
+    # `llama_index.core.agent`, which upstream removed in llama-index-core 0.13.
+    # The published agent-governance-toolkit-integrations[llamaindex] extra only
+    # caps `<1.0`, so without this direct pin CI resolves 0.14 and the smoke
+    # import fails. Pin here so the editable install binds <0.13 directly.
+    # See https://github.com/microsoft/agent-governance-toolkit/issues/2955
+    "llama-index-core>=0.12,<0.13",
+]
 
 [project.urls]
 Homepage = "https://github.com/microsoft/agent-governance-toolkit"


### PR DESCRIPTION
## Summary

Two `test-integrations` matrix legs were red on main, both for **deprecated stub** integration packages whose code used upstream APIs that were removed in newer library versions:

- `test-integrations (llamaindex-agentmesh, llama_index.agent.agentmesh)`
- `test-integrations (haystack-agentmesh, haystack_agentmesh)`

Both are fixed with **real, minimal fixes** (no test skipping).

## llamaindex-agentmesh (refs #2955)

**Root cause:** `worker.py` imports `AgentRunner` from `llama_index.core.agent`, which upstream removed in `llama-index-core` 0.13. PR #2956 pinned `llama-index-core>=0.12,<0.13` inside `agent-governance-toolkit-integrations[llamaindex]`, but the **published PyPI release** of that package only declares `llama-index-core>=0.10,<1.0`. CI installs `llamaindex-agentmesh`, which depends on the PyPI package, so pip resolved `llama-index-core==0.14` and the smoke import failed with `ImportError: cannot import name 'AgentRunner'`.

**Fix:** Pin `llama-index-core>=0.12,<0.13` **directly** in `llamaindex-agentmesh/pyproject.toml` dependencies, so the editable install CI runs binds the constraint regardless of the transitive (uncapped) PyPI metadata. Verified the dep closure has nothing requiring `>=0.13`; the constraint resolves to `0.12.52.post1`, which still exports `AgentRunner`.

## haystack-agentmesh (refs #2971)

**Root cause:** `governance.py`, `audit.py`, and `trust_gate.py` decorated `run` with `@component.input_types(...)`, which the real `haystack-ai` API never exposed, raising `AttributeError: '_Component' object has no attribute 'input_types'` at import/collection time.

**Fix:** Removed the invalid decorator. `haystack-ai` infers input sockets from the typed `run` signature, so no replacement is needed; `@component.output_types` is kept as-is. (The real `component.set_input_types(self, ...)` requires a `**kwargs` run parameter, which these components do not have, so calling it would raise `ComponentError` — signature inference is the correct approach here.) The unused `input_types` shim in each `ImportError` fallback was also dropped.

## Validation

- haystack: with real `haystack-ai` installed, all **31** package tests pass and `import haystack_agentmesh` succeeds; confirmed input sockets are correctly inferred (e.g. `TrustGate` -> `agent_id`, `min_score`).
- llamaindex: confirmed `llama-index-core>=0.12,<0.13` resolves to `0.12.52.post1` and that wheel exports `AgentRunner` from `llama_index.core.agent`.

Both remain deprecated; tracking issues #2955 and #2971 are referenced in code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)