### PR TITLE
fix(nexus): guard verify() against verification_key without ed25519 prefix

### DIFF
--- a/agent-governance-python/agent-os/modules/nexus/crypto.py
+++ b/agent-governance-python/agent-os/modules/nexus/crypto.py
@@ -66,6 +66,13 @@ def verify(verification_key: str, message: bytes, signature: str) -> bool:
     Returns:
         True if the signature is valid, False otherwise.
     """
+    if not verification_key.startswith("ed25519:"):
+        _log.warning(
+            "verify: verification_key does not start with the expected 'ed25519:' prefix: %r",
+            verification_key,
+        )
+        return False
+
     try:
         key_bytes = base64.b64decode(verification_key[len("ed25519:"):])
         sig_bytes = base64.b64decode(signature)

--- a/agent-governance-python/agent-os/modules/nexus/tests/test_crypto.py
+++ b/agent-governance-python/agent-os/modules/nexus/tests/test_crypto.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the Ed25519 crypto helpers."""
+
+import os
+import sys
+
+_nexus_parent = os.path.join(os.path.dirname(__file__), "..", "..")
+if _nexus_parent not in sys.path:
+    sys.path.insert(0, _nexus_parent)
+
+from nexus.crypto import generate_keypair, sign, verify
+
+
+class TestVerify:
+    """Tests for crypto.verify()."""
+
+    def test_valid_signature(self):
+        private_key, verification_key = generate_keypair()
+        message = b"hello"
+        signature = sign(private_key, message)
+        assert verify(verification_key, message, signature) is True
+
+    def test_wrong_key_returns_false(self):
+        private_key, _ = generate_keypair()
+        _, other_verification_key = generate_keypair()
+        message = b"hello"
+        signature = sign(private_key, message)
+        assert verify(other_verification_key, message, signature) is False
+
+    def test_tampered_message_returns_false(self):
+        private_key, verification_key = generate_keypair()
+        signature = sign(private_key, b"hello")
+        assert verify(verification_key, b"goodbye", signature) is False
+
+    def test_missing_prefix_returns_false(self):
+        private_key, verification_key = generate_keypair()
+        message = b"hello"
+        signature = sign(private_key, message)
+        raw_key = verification_key[len("ed25519:"):]
+        assert verify(raw_key, message, signature) is False
+
+    def test_wrong_prefix_returns_false(self):
+        private_key, verification_key = generate_keypair()
+        message = b"hello"
+        signature = sign(private_key, message)
+        raw_key = verification_key[len("ed25519:"):]
+        assert verify(f"rsa:{raw_key}", message, signature) is False


### PR DESCRIPTION
## Summary

Follow-up to #2782. The final review left a non-blocking nit: `crypto.verify()` slices off the `"ed25519:"` prefix unconditionally before base64-decoding the key. If `verification_key` doesn't actually start with `"ed25519:"`, the slice removes the wrong characters and the decode fails with a generic base64 error, caught by the broad `except Exception` and logged as an "unexpected exception".

## What changed

`crypto.py` - `verify()` now checks for the `"ed25519:"` prefix first. If it's missing, logs a specific warning and returns `False` before attempting to decode.

`tests/test_crypto.py` (new) - direct unit tests for `verify()`: valid signature, wrong key, tampered message, missing prefix, wrong prefix.

## Test plan

- `python -m pytest agent-governance-python/agent-os/modules/nexus/tests/ -v` - all pass except one pre-existing failure in `test_schemas.py::test_to_iatp_manifest`, confirmed unrelated (fails identically on main without this change).