### PR TITLE
fix(contributor-check): normalize credential_audit NONE to LOW in _run_check

### DIFF
--- a/scripts/contributor_check_action.py
+++ b/scripts/contributor_check_action.py
@@ -71,7 +71,12 @@ def _run_check(script: str, args: list[str], out_path: str) -> str:
         )
         Path(out_path).write_text(result.stdout)
         data = json.loads(result.stdout)
-        return data.get("risk", "UNKNOWN")
+        risk = data.get("risk", "UNKNOWN")
+        # credential_audit returns "NONE" when a user has no merged PRs in the
+        # target repo (nothing to launder = not applicable). Normalize to "LOW"
+        # so it aggregates correctly rather than being treated as UNKNOWN (which
+        # is reserved for checks that errored or could not be determined).
+        return "LOW" if risk == "NONE" else risk
     except Exception:
         return "UNKNOWN"
 

--- a/scripts/tests/test_contributor_check_action.py
+++ b/scripts/tests/test_contributor_check_action.py
@@ -5,12 +5,15 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+import textwrap
+import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from contributor_check_action import _aggregate_risk
+from contributor_check_action import _aggregate_risk, _run_check
 
 
 # ---------------------------------------------------------------------------
@@ -54,3 +57,71 @@ def test_unrecognized_label_treated_as_unknown_not_low():
 def test_empty_inputs_default_low():
     # No checks supplied (all skipped) is not an error condition.
     assert _aggregate_risk() == "LOW"
+
+
+# ---------------------------------------------------------------------------
+# _run_check NONE normalization (issue #3007)
+# ---------------------------------------------------------------------------
+
+def _make_script(risk: str, tmp_dir: str) -> str:
+    """Write a tiny fake check script that prints JSON with the given risk."""
+    path = os.path.join(tmp_dir, "fake_check.py")
+    with open(path, "w") as f:
+        f.write(textwrap.dedent(f"""\
+            import json, sys
+            print(json.dumps({{"risk": "{risk}"}}))
+        """))
+    return path
+
+
+def test_run_check_none_normalizes_to_low():
+    # credential_audit returns "NONE" when a user has no merged PRs.
+    # _run_check must normalize that to "LOW" so the aggregate does not
+    # treat an absence of credential risk as UNKNOWN (regression for #3007).
+    with tempfile.TemporaryDirectory() as tmp:
+        script = _make_script("NONE", tmp)
+        out = os.path.join(tmp, "out.json")
+        result = _run_check(script, [], out)
+    assert result == "LOW", f"expected LOW, got {result!r}"
+
+
+def test_run_check_low_passes_through():
+    with tempfile.TemporaryDirectory() as tmp:
+        script = _make_script("LOW", tmp)
+        out = os.path.join(tmp, "out.json")
+        assert _run_check(script, [], out) == "LOW"
+
+
+def test_run_check_high_passes_through():
+    with tempfile.TemporaryDirectory() as tmp:
+        script = _make_script("HIGH", tmp)
+        out = os.path.join(tmp, "out.json")
+        assert _run_check(script, [], out) == "HIGH"
+
+
+def test_run_check_crash_returns_unknown():
+    # A script that crashes must not silently score as LOW.
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "crasher.py")
+        with open(path, "w") as f:
+            f.write("raise RuntimeError('simulated failure')\n")
+        out = os.path.join(tmp, "out.json")
+        assert _run_check(path, [], out) == "UNKNOWN"
+
+
+def test_run_check_none_plus_low_aggregate_stays_low():
+    # End-to-end: profile=LOW, credential=NONE → overall LOW, not UNKNOWN.
+    with tempfile.TemporaryDirectory() as tmp:
+        none_script = _make_script("NONE", tmp)
+        low_script = os.path.join(tmp, "low.py")
+        with open(low_script, "w") as f:
+            f.write('import json; print(json.dumps({"risk": "LOW"}))\n')
+        out1 = os.path.join(tmp, "out1.json")
+        out2 = os.path.join(tmp, "out2.json")
+        profile_risk = _run_check(low_script, [], out1)
+        cred_risk = _run_check(none_script, [], out2)
+    overall = _aggregate_risk(
+        profile_risk or "LOW",
+        cred_risk or "LOW",
+    )
+    assert overall == "LOW", f"expected LOW, got {overall!r}"


### PR DESCRIPTION
## Summary

- `credential_audit.py` returns `{"risk": "NONE"}` when a contributor has no merged PRs in the target repo (no merges = nothing to use as credential spray = not applicable).
- `"NONE"` is not in `RISK_ORDER`, so `_aggregate_risk` falls back to treating any unrecognized label as `UNKNOWN` (value 3 -- same as a failed/rate-limited check).
- Result: every new contributor who has never merged a PR gets labeled `needs-review:UNKNOWN`, which is wrong. `UNKNOWN` is reserved for checks that **errored** or **could not be determined**, not for checks that ran cleanly and found nothing.

**Fix:** `_run_check` normalizes `"NONE"` to `"LOW"` before returning. The credential check ran, found no merges, and that is a clean result.

The fail-closed behavior for true errors (subprocess crash, JSON decode failure, rate-limit timeout) is unchanged: those still return `UNKNOWN`.

## Test plan

- [x] `test_run_check_none_normalizes_to_low` -- the core regression test
- [x] `test_run_check_none_plus_low_aggregate_stays_low` -- end-to-end: profile=LOW + credential=NONE -> overall=LOW
- [x] `test_run_check_crash_returns_unknown` -- crashes still propagate as UNKNOWN
- [x] All existing aggregation tests pass unchanged (fail-closed behavior preserved)