### PR TITLE
fix(typescript): harden skill-aware audit trail for #2907

### DIFF
--- a/agent-governance-typescript/src/audit.ts
+++ b/agent-governance-typescript/src/audit.ts
@@ -37,6 +37,7 @@ export class AuditLogger {
       action: entry.action,
       decision: entry.decision,
       previousHash,
+      skillAuditMetadata: entry.skillAuditMetadata,
     });
 
     const hash = createHash('sha256').update(payload).digest('hex');
@@ -48,6 +49,7 @@ export class AuditLogger {
       decision: entry.decision,
       hash,
       previousHash,
+      skillAuditMetadata: entry.skillAuditMetadata,
     };
 
     this.entries.push(full);
@@ -78,6 +80,7 @@ export class AuditLogger {
         action: entry.action,
         decision: entry.decision,
         previousHash: entry.previousHash,
+        skillAuditMetadata: entry.skillAuditMetadata,
       });
 
       const expectedHash = createHash('sha256').update(payload).digest('hex');

--- a/agent-governance-typescript/src/client.ts
+++ b/agent-governance-typescript/src/client.ts
@@ -4,7 +4,7 @@ import { AgentIdentity } from './identity';
 import { TrustManager } from './trust';
 import { PolicyEngine } from './policy';
 import { AuditLogger } from './audit';
-import { AgentMeshConfig, GovernanceResult } from './types';
+import { AgentMeshConfig, GovernanceResult, SkillAuditMetadata } from './types';
 import { KillSwitch } from './kill-switch';
 import { LifecycleManager, LifecycleState } from './lifecycle';
 import { RingBreachError, RingEnforcer } from './rings';
@@ -53,6 +53,7 @@ export class AgentMeshClient {
   async executeWithGovernance(
     action: string,
     params: Record<string, unknown> = {},
+    skillAuditMetadata?: SkillAuditMetadata,
   ): Promise<GovernanceResult> {
     const start = performance.now();
 
@@ -106,6 +107,7 @@ export class AgentMeshClient {
       agentId: this.identity.did,
       action,
       decision,
+      skillAuditMetadata,
     });
 
     if (decision === 'allow') {

--- a/agent-governance-typescript/src/framework-adapter.ts
+++ b/agent-governance-typescript/src/framework-adapter.ts
@@ -9,7 +9,11 @@ import {
   TraceSpanKind,
   TraceSpanStatus,
 } from './metrics';
-import { GovernanceResult } from './types';
+import { GovernanceResult,
+         SkillAuditMetadata,
+         TrustedSkillMetadataSource,
+} from './types';
+import { createHash } from 'crypto';
 
 export interface FrameworkInvocation {
   name: string;
@@ -19,6 +23,7 @@ export interface FrameworkInvocation {
   agentId?: string;
   input?: Record<string, unknown>;
   attributes?: Record<string, unknown>;
+  trustedSkillMetadata?: TrustedSkillMetadataSource;
 }
 
 export interface FrameworkInvocationOutcome<TOutput = unknown> {
@@ -170,10 +175,14 @@ export class GenericFrameworkAdapter {
         ...(assertedAgentId ? { assertedAgentId } : {}),
       },
     );
+    const skillAuditMetadata = buildSkillAuditMetadata(
+      normalizedInvocation.trustedSkillMetadata,
+      normalizedInvocation.input,
+    );
 
     const governanceResult = identityMismatchReason
       ? this.rejectIdentityMismatch(action, canonicalAgentId, identityMismatchReason)
-      : await this.client.executeWithGovernance(action, normalizedInvocation.input ?? {});
+      : await this.client.executeWithGovernance(action, normalizedInvocation.input ?? {}, skillAuditMetadata,);
     this.metrics?.recordPolicyDecision(
       governanceResult.decision,
       governanceResult.executionTime,
@@ -305,4 +314,76 @@ function stringifyOutput(output: unknown): string {
   } catch {
     return String(output);
   }
+}
+
+function hashContext(context: unknown): string | undefined {
+  if (context === undefined || context === null) {
+    return undefined;
+  }
+
+  try {
+    const canonical = stableStringify(context);
+
+    return createHash('sha256')
+      .update(canonical, 'utf8')
+      .digest('hex');
+  } catch {
+    // Fail-safe: non-canonical payloads should not produce hashes.
+    return undefined;
+  }
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeys(value));
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+
+  if (
+    value !== null &&
+    typeof value === 'object'
+  ) {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeys(
+          (value as Record<string, unknown>)[key],
+        );
+        return acc;
+      }, {});
+  }
+
+  return value;
+}
+
+function buildSkillAuditMetadata(
+  trusted?: TrustedSkillMetadataSource,
+  contextBefore?: unknown,
+  contextAfter?: unknown,
+): SkillAuditMetadata | undefined {
+  const contextHashBefore = hashContext(contextBefore);
+  const contextHashAfter = hashContext(contextAfter);
+
+  if (
+    !trusted?.skillName &&
+    !trusted?.skillOrigin &&
+    !contextHashBefore &&
+    !contextHashAfter
+  ) {
+    return undefined;
+  }
+
+  return {
+    skillName: trusted?.skillName,
+    skillOrigin: trusted?.skillOrigin,
+    provenanceSourceTrust:
+      trusted?.skillName || trusted?.skillOrigin
+        ? 'trusted'
+        : undefined,
+    contextHashBefore,
+    contextHashAfter,
+  };
 }

--- a/agent-governance-typescript/src/types.ts
+++ b/agent-governance-typescript/src/types.ts
@@ -474,6 +474,20 @@ export interface AuditEntry {
   decision: LegacyPolicyDecision;
   hash: string;
   previousHash: string;
+  skillAuditMetadata?: SkillAuditMetadata;
+}
+
+export interface TrustedSkillMetadataSource {
+  skillName?: string;
+  skillOrigin?: string;
+}
+
+export interface SkillAuditMetadata {
+  skillName?: string;
+  skillOrigin?: string;
+  provenanceSourceTrust?: "trusted";
+  contextHashBefore?: string;
+  contextHashAfter?: string;
 }
 
 // ΓöÇΓöÇ Client ΓöÇΓöÇ
@@ -487,7 +501,6 @@ export interface AgentMeshConfig {
   execution?: ExecutionControlConfig;
   killSwitch?: KillSwitchConfig;
 }
-
 export interface GovernanceResult {
   decision: LegacyPolicyDecision;
   trustScore: TrustScore;

--- a/agent-governance-typescript/tests/audit.test.ts
+++ b/agent-governance-typescript/tests/audit.test.ts
@@ -161,4 +161,27 @@ describe('AuditLogger', () => {
       expect(small.verify()).toBe(false);
     });
   });
+
+  it('detects tampering of skill audit metadata', () => {
+  logger.log({
+    agentId: 'a',
+    action: 'x',
+    decision: 'allow',
+    skillAuditMetadata: {
+      skillName: 'search',
+      skillOrigin: 'langchain',
+      provenanceSourceTrust: 'trusted',
+    },
+  });
+
+  const entries = (logger as any).entries as Array<{
+    skillAuditMetadata?: {
+      skillName?: string;
+    };
+  }>;
+
+  entries[0].skillAuditMetadata!.skillName = 'TAMPERED';
+
+  expect(logger.verify()).toBe(false);
+  });
 });

--- a/agent-governance-typescript/tests/framework-adapter.test.ts
+++ b/agent-governance-typescript/tests/framework-adapter.test.ts
@@ -206,4 +206,121 @@ describe('GenericFrameworkAdapter', () => {
       event.name === 'trust.score' && event.attributes.agentId === client.identity.did
     )).toBe(true);
   });
+
+  it('attaches trusted skill metadata to audit entries', async () => {
+  const client = AgentMeshClient.create('adapter-agent', {
+    policyRules: [
+      { action: 'framework.tool_call.search', effect: 'allow' },
+    ],
+  });
+
+  const adapter = new GenericFrameworkAdapter(client);
+
+  const result = await adapter.run(
+    {
+      name: 'search',
+      kind: 'tool_call',
+      input: {
+        query: 'status',
+        skillName: 'spoofed-admin',
+      },
+      trustedSkillMetadata: {
+        skillName: 'search',
+        skillOrigin: 'langchain',
+      },
+    },
+    async () => ({ items: 3 }),
+  );
+
+  expect(result.allowed).toBe(true);
+
+  expect(
+    result.governanceResult.auditEntry.skillAuditMetadata,
+  ).toMatchObject({
+    skillName: 'search',
+    skillOrigin: 'langchain',
+    provenanceSourceTrust: 'trusted',
+  });
+  });
+  it('records a context hash before execution', async () => {
+  const client = AgentMeshClient.create('adapter-agent', {
+    policyRules: [
+      { action: 'framework.tool_call.search', effect: 'allow' },
+    ],
+  });
+
+  const adapter = new GenericFrameworkAdapter(client);
+
+  const result = await adapter.run(
+    {
+      name: 'search',
+      kind: 'tool_call',
+      input: {
+        query: 'status',
+      },
+      trustedSkillMetadata: {
+        skillName: 'search',
+        skillOrigin: 'langchain',
+      },
+    },
+    async () => ({ items: 3 }),
+  );
+
+  expect(
+    result.governanceResult.auditEntry.skillAuditMetadata
+      ?.contextHashBefore,
+  ).toBeDefined();
+
+  expect(
+    result.governanceResult.auditEntry.skillAuditMetadata
+      ?.contextHashAfter,
+  ).toBeUndefined();
+  });
+  it('produces identical hashes regardless of object key order', async () => {
+  const client = AgentMeshClient.create('adapter-agent', {
+    policyRules: [
+      { action: 'framework.tool_call.search', effect: 'allow' },
+    ],
+  });
+
+  const adapter = new GenericFrameworkAdapter(client);
+
+  const result1 = await adapter.run(
+    {
+      name: 'search',
+      kind: 'tool_call',
+      input: {
+        a: 1,
+        b: 2,
+      },
+      trustedSkillMetadata: {
+        skillName: 'search',
+      },
+    },
+    async () => 'ok',
+  );
+
+  const result2 = await adapter.run(
+    {
+      name: 'search',
+      kind: 'tool_call',
+      input: {
+        b: 2,
+        a: 1,
+      },
+      trustedSkillMetadata: {
+        skillName: 'search',
+      },
+    },
+    async () => 'ok',
+  );
+
+  expect(
+    result1.governanceResult.auditEntry.skillAuditMetadata
+      ?.contextHashBefore,
+  ).toBe(
+    result2.governanceResult.auditEntry.skillAuditMetadata
+      ?.contextHashBefore,
+  );
+  });
 });


### PR DESCRIPTION
## Description

Ports the skill-aware audit trail hardening introduced in the Python implementation (#2572) for issue #1609 to the TypeScript SDK.

This change adds trusted skill metadata support, provenance trust markers, deterministic context hashing, and audit-chain coverage for skill metadata. It also adds tests covering metadata propagation, spoof resistance, deterministic hashing, and tampering detection.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [x] Security fix

## Package(s) Affected

* [x] agent-governance

## Checklist

* [x] My code follows the project style guidelines (ruff check)
* [x] I have added tests that prove my fix/feature works
* [ ] All new and existing tests pass (pytest)
* [ ] I have updated documentation as needed
* [x] I have signed the Microsoft CLA

## Attribution & Prior Art

* [x] This contribution does not contain code copied or derived from other projects without attribution
* [x] Any external projects that inspired this design are credited in code comments or documentation
* [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

Python implementation introduced in #2572 for issue #1609.

## AI Assistance

* [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
* [x] I have run tests and verification appropriate for this change
* [x] No part of this PR was autonomously submitted by an AI agent without my review
* [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

ChatGPT and GitHub Copilot were used for implementation guidance and test generation. All generated output was reviewed and validated before inclusion.

## IP, Patents, and Licensing

* [x] This contribution does not implement patent-pending or patent-encumbered techniques
* [x] This contribution does not require an NDA or licensing agreement to understand or use
* [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Contributes to #2986.

Ports the TypeScript implementation to match the Python baseline introduced in #2572 for issue #1609.
