### PR TITLE
docs: engine API contract spec + OpenAPI 3.1 document (Epic 0, issue #3011)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -8,6 +8,7 @@ AEAD
 aenter
 aexit
 aiter
+Redocly
 AgentGovernance
 AgentMesh
 AgentOS

--- a/docs/studio/engine-api-contract.md
+++ b/docs/studio/engine-api-contract.md
@@ -193,8 +193,13 @@ extended support.
 | `/api/v1/agents` | GET | false | false | true |
 | `/api/v1/decisions` | GET | false | false | true |
 | `/api/v1/versions` | GET | false | false | true |
+| `/api/v1/events` | WS | false | false | true |
 
 Exactly one endpoint has `runtime_mutating: true`: `POST /api/v1/policy/save`.
+
+`/api/v1/events` is a reserved WebSocket route (see section 12). It carries
+read-only flags but is not implemented in v1 and is excluded from the client
+allowlist below.
 
 ---
 
@@ -246,6 +251,11 @@ Applying this rule to AGT Studio v1:
 **Blocked (1 operation):**
 
 - `POST /api/v1/policy/save` (`runtime_mutating: true, read_only_surface: false`)
+
+Reserved routes (the WebSocket `/api/v1/events` channel in section 12) are
+excluded from the v1 allowlist entirely: they are not callable operations in v1,
+so they appear in neither the allowlisted nor the blocked set above. The math
+covers the 12 implemented HTTP operations only.
 
 The Studio client enforces this allowlist at the UI layer: "Save" controls are
 not rendered in read-only mode. The engine enforces it at the auth layer: the
@@ -379,7 +389,13 @@ only.
 
 `FixtureResult` fields: `fixture_id`, `passed`, `expected_verdict`,
 `actual_verdict`, `expected_rule` (optional), `actual_rule` (optional),
-`fixture_path` (optional).
+`fixture_path` (optional), `resolution_metadata` (object, optional).
+
+The engine adapts the inline `fixtures` array into the form the existing
+`policy_test.replay` helper expects (which reads policy and fixture files from
+disk) by materializing the inline fixtures into a temporary working directory
+for the duration of the request, then discarding it. No caller-visible files are
+created and no engine state is mutated.
 
 ---
 
@@ -468,7 +484,7 @@ persistent audit store.
 |-------|------|-------------|
 | `agent_did` | string | Agent DID |
 | `trust_score` | integer (0-1000) | Numeric trust score |
-| `trust_level` | enum | `untrusted`, `low`, `medium`, `high`, `full` |
+| `trust_level` | enum | `untrusted`, `probationary`, `standard`, `trusted`, `verified_partner` |
 | `last_updated` | string (date-time, optional) | When the score was last changed |
 
 ---
@@ -511,7 +527,7 @@ Relationship values: `"trusts"`, `"delegates"`, `"sponsors"`.
 | `did` | string | Agent DID (`did:mesh:...`) |
 | `name` | string (optional) | Human-readable name |
 | `trust_score` | integer (0-1000) | Current trust score |
-| `trust_level` | enum | `untrusted`, `low`, `medium`, `high`, `full` |
+| `trust_level` | enum | `untrusted`, `probationary`, `standard`, `trusted`, `verified_partner` |
 | `last_active` | string (date-time, optional) | Timestamp of most recent event |
 | `capabilities` | array of string | List of granted capability strings |
 
@@ -749,6 +765,11 @@ client.
 
 **This endpoint is not implemented in v1.** It will be fully defined in Epic 7a
 (issue #16).
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`. The route carries read-only flags because the future
+stream is a read-only push channel, but because it is reserved and not callable
+in v1 it is excluded from the client allowlist derived in section 6.2.
 
 Conformance requirement: a v1 engine MUST return `426 Upgrade Required` when an
 HTTP (non-WebSocket) request is made to `/api/v1/events`. The engine MUST NOT

--- a/docs/studio/engine-api-contract.md
+++ b/docs/studio/engine-api-contract.md
@@ -602,7 +602,7 @@ without requiring user intent. It is `runtime_mutating: true` and would need to 
 `user_intent_required: true` to appear in the Studio contract. However, policy
 reload has no safe Studio use case: the `POST /api/v1/policy/save` endpoint already
 triggers a reload as a side effect of saving. Exposing a standalone reload button
-in the Studio UI would create a footgun (reloading with no visible change to the
+in the Studio UI would create a dangerous pattern (reloading with no visible change to the
 user). The endpoint remains available as an internal sidecar-management endpoint
 but is explicitly excluded from this contract and from the Studio allowlist.
 

--- a/docs/studio/engine-api-contract.md
+++ b/docs/studio/engine-api-contract.md
@@ -1,0 +1,773 @@
+---
+title: "Engine API Contract: AGT Studio v1"
+last_reviewed: 2026-06-13
+owner: studio-team
+---
+
+<!-- Copyright (c) Microsoft Corporation. Licensed under the MIT License. -->
+
+> **Maintainer note:** This document was originally planned as ADR 0029, referenced in
+> [ADR 0028](../adr/0028-agt-studio-unified-ui.md) lines 142-148
+> ("Engine API contract is the hard gate"). The decision was made to ship this as a
+> versioned spec document rather than a formal ADR so that it can travel alongside the
+> implementation PRs in the Studio epic. The intent is preserved: the Engine API
+> contract must exist before Studio implementation code lands. Anyone reading ADR 0028
+> and looking for the follow-up document it mandated will find it here.
+
+# Engine API Contract: AGT Studio v1
+
+> **Status:** Approved for implementation
+> **Date:** 2026-06-13
+> **Tracker:** microsoft/agent-governance-toolkit#3011 (Epic 0, issue 1/32)
+> **Machine-readable companion:** `docs/studio/openapi.yaml` (OpenAPI 3.1)
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119 and RFC 8174.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Transport](#2-transport)
+3. [Versioning](#3-versioning)
+4. [Authentication](#4-authentication)
+5. [Capability Metadata](#5-capability-metadata)
+6. [Read-only Invariant](#6-read-only-invariant)
+7. [Endpoint Catalog](#7-endpoint-catalog)
+8. [Excluded Endpoints](#8-excluded-endpoints)
+9. [Conformance Rules](#9-conformance-rules)
+10. [Error Model](#10-error-model)
+11. [Pagination Model](#11-pagination-model)
+12. [Reserved Routes](#12-reserved-routes)
+13. [References](#13-references)
+
+---
+
+## 1. Overview
+
+AGT Studio is the single first-class UI for AGT, as decided in ADR 0028. Studio
+communicates with a local engine process over a stable HTTP API. This document
+defines that API: every route, its purpose, request and response shapes, and
+the rules an engine implementation MUST satisfy to be considered conformant.
+
+The engine is a local process started with `agt serve`. The Studio SPA (standalone
+or VS Code webview) calls the engine over HTTP for all data operations. A WebSocket
+channel (`/api/v1/events`) is reserved for streaming updates and will be defined in
+Epic 7a (issue #16).
+
+### 1.1 Scope
+
+**In scope:**
+
+- Every HTTP route exposed to the Studio client, including method, purpose, and
+  capability flags
+- Full request/response schemas (summarized here; full detail in `openapi.yaml`)
+- Capability metadata: the three flags and how the Studio allowlist is derived
+- Transport, versioning, auth model, error model, and pagination
+- Conformance rules for engine implementations
+- Excluded endpoints (routes that exist in existing code but MUST NOT appear in
+  the Studio surface)
+
+**Out of scope:**
+
+- FastAPI implementation (issue #3)
+- Capability metadata decorator (issue #2)
+- Conformance test suite (issue #4)
+- WebSocket transport (Epic 7a, issue #16)
+- Threat model details (issue #6)
+
+---
+
+## 2. Transport
+
+### 2.1 HTTP for v1
+
+All Studio API traffic uses HTTP/1.1 or HTTP/2 over a loopback TCP connection.
+The default listen address is `127.0.0.1:8080`. Engines MUST accept connections
+on the loopback interface. Engines MAY also accept connections on non-loopback
+interfaces (e.g., for remote Studio access), subject to the authentication
+requirements in section 4.
+
+All request and response bodies use `application/json`. Engines MUST set
+`Content-Type: application/json` on all JSON responses.
+
+### 2.2 WebSocket reservation
+
+The path `/api/v1/events` is reserved for a WebSocket streaming channel. It MUST
+NOT be implemented as an HTTP endpoint. A conformant v1 engine MUST return
+`426 Upgrade Required` if a non-WebSocket connection is made to that path. Full
+WebSocket semantics are defined in Epic 7a (issue #16).
+
+---
+
+## 3. Versioning
+
+### 3.1 URL versioning
+
+All routes are prefixed with `/api/v1/`. Future breaking changes will use `/api/v2/`,
+etc. The version prefix is part of the contract and MUST be preserved.
+
+### 3.2 Version negotiation
+
+The `GET /api/v1/versions` endpoint returns both the engine software version and
+the API contract version. Clients SHOULD check `api` equals `1.0.0` on startup
+and display an actionable upgrade message if it does not match. Clients MUST NOT
+silently degrade when versions mismatch (per ADR 0028 success criteria).
+
+### 3.3 Breaking-change policy
+
+A breaking change is any of the following:
+
+- Removing or renaming an endpoint
+- Changing a required request field to a different type or removing it
+- Adding a required field to a response schema that clients are expected to parse
+- Changing an HTTP method for an existing path
+- Changing the capability flags of an existing endpoint
+
+Breaking changes require incrementing the URL version (`/api/v2/`). The previous
+version MUST remain available for at least one full release cycle after the new
+version ships. Additive changes (new optional fields, new endpoints) do not
+require a version bump.
+
+---
+
+## 4. Authentication
+
+### 4.1 Loopback connections (no token required)
+
+When the Studio client connects from `127.0.0.1` or `::1`, no authentication
+token is required. The engine MAY still check that the token is absent or valid
+if one is provided.
+
+### 4.2 Non-loopback connections (token required)
+
+When the Studio client connects from any address other than the loopback, the
+engine MUST require a Bearer token. The client reads the token from
+`~/.config/agt/studio-token`. Requests without a valid token MUST be rejected
+with `401 Unauthorized`.
+
+The token format and rotation policy are defined in the threat model (issue #6).
+
+### 4.3 Scope
+
+The `GET /api/v1/health` and `GET /api/v1/versions` endpoints MUST be accessible
+without authentication even on non-loopback interfaces. All other endpoints
+require authentication on non-loopback connections.
+
+---
+
+## 5. Capability Metadata
+
+### 5.1 The three flags
+
+Every endpoint in this contract carries three boolean capability flags. These
+flags are authoritative: they define the behavioral contract of the endpoint, not
+just documentation.
+
+| Flag | Type | Meaning |
+|------|------|---------|
+| `runtime_mutating` | boolean | The endpoint persists a change to engine state (writes to disk, modifies loaded policy, changes trust state, etc.). |
+| `user_intent_required` | boolean | The endpoint MUST only be invoked in response to an explicit user gesture (button click, confirm dialog). It MUST NOT be called speculatively or in a background job. |
+| `read_only_surface` | boolean | The endpoint is safe to expose on a read-only Studio surface (guest viewer, demo mode, CI surface). An endpoint is read-only if and only if `runtime_mutating == false`. |
+
+Flags are declared in `openapi.yaml` as the `x-capability-flags` extension on each
+operation object. Engine implementations MUST expose these flags via
+`GET /api/v1/versions` in a `capabilities` array if they wish to advertise
+extended support.
+
+### 5.2 Flag values by endpoint
+
+| Route | Method | `runtime_mutating` | `user_intent_required` | `read_only_surface` |
+|-------|--------|--------------------|------------------------|---------------------|
+| `/api/v1/health` | GET | false | false | true |
+| `/api/v1/policies` | GET | false | false | true |
+| `/api/v1/policies/{id}` | GET | false | false | true |
+| `/api/v1/policy/validate` | POST | false | false | true |
+| `/api/v1/policy/test` | POST | false | false | true |
+| `/api/v1/policy/save` | POST | **true** | **true** | **false** |
+| `/api/v1/audit/log` | GET | false | false | true |
+| `/api/v1/trust/scores` | GET | false | false | true |
+| `/api/v1/trust/graph` | GET | false | false | true |
+| `/api/v1/agents` | GET | false | false | true |
+| `/api/v1/decisions` | GET | false | false | true |
+| `/api/v1/versions` | GET | false | false | true |
+
+Exactly one endpoint has `runtime_mutating: true`: `POST /api/v1/policy/save`.
+
+---
+
+## 6. Read-only Invariant
+
+### 6.1 Definition
+
+**Invariant:** No operation with `read_only_surface: true` may have a permanent
+side effect on engine state. Specifically:
+
+- No file writes (including policy files, config, or audit sinks)
+- No policy reload triggered as a side effect of the request
+- No trust-state mutations (trust score changes, capability grants, DID registry
+  changes)
+
+Memory-only state changes that do not survive a process restart (e.g., caching a
+computed query result in RAM) are acceptable and do not violate this invariant.
+
+Note that `POST /api/v1/policy/validate` and `POST /api/v1/policy/test` both use
+the `POST` method and accept a body. They are still `read_only_surface: true`
+because they perform computation only: no state persists after the response
+completes.
+
+### 6.2 Worked example: client-allowlist derivation
+
+A Studio surface configured for read-only access (guest viewer, demo mode, or a
+CI read-only check) builds its allowlist as follows:
+
+1. Iterate over all operations in the Engine API endpoint catalog.
+2. Keep only operations where `read_only_surface == true`.
+3. Block the client from calling any operation not in this list.
+
+Applying this rule to AGT Studio v1:
+
+**Allowlisted (11 operations):**
+
+- `GET /api/v1/health`
+- `GET /api/v1/policies`
+- `GET /api/v1/policies/{id}`
+- `POST /api/v1/policy/validate`
+- `POST /api/v1/policy/test`
+- `GET /api/v1/audit/log`
+- `GET /api/v1/trust/scores`
+- `GET /api/v1/trust/graph`
+- `GET /api/v1/agents`
+- `GET /api/v1/decisions`
+- `GET /api/v1/versions`
+
+**Blocked (1 operation):**
+
+- `POST /api/v1/policy/save` (`runtime_mutating: true, read_only_surface: false`)
+
+The Studio client enforces this allowlist at the UI layer: "Save" controls are
+not rendered in read-only mode. The engine enforces it at the auth layer: the
+`studio-token` for non-loopback connections carries a `read_only` scope claim.
+Detailed token scoping is in the threat model (issue #6).
+
+---
+
+## 7. Endpoint Catalog
+
+All routes are relative to the `/api/v1/` base path. Request and response schemas
+are summarized here; full JSON Schema definitions are in `openapi.yaml`.
+
+### 7.1 GET /api/v1/health
+
+**Purpose:** Liveness probe. Reports engine status and version.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Auth:** Not required (loopback or non-loopback).
+
+**Response (200):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | `"ok"` or `"degraded"` | Engine health status |
+| `version` | string | Engine software version (e.g., `"0.3.0"`) |
+| `uptime_seconds` | number | Seconds since engine process start |
+
+---
+
+### 7.2 GET /api/v1/policies
+
+**Purpose:** List all policies currently loaded in the engine. Fixes the
+counts-only gap in the existing `policy_server.py` `GET /api/v1/policies`
+implementation (which currently returns only totals, not policy objects).
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Query parameters:** `page`, `limit` (see section 11).
+
+**Response (200):** Paginated list of `PolicySummary` objects.
+
+`PolicySummary` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier derived from filename |
+| `name` | string | Human-readable policy name |
+| `format` | `"yaml"` or `"json"` | File format |
+| `source` | string | File path relative to policy directory |
+| `description` | string (optional) | Policy description if present in file |
+
+---
+
+### 7.3 GET /api/v1/policies/{id}
+
+**Purpose:** Retrieve full detail for a single policy.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Path parameter:** `id` - Policy identifier.
+
+**Response (200):** `PolicyDetail` object (all `PolicySummary` fields plus):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `content` | string | Raw policy file content |
+| `rules_count` | integer | Number of rules in the policy |
+| `last_modified` | string (date-time) | Last modification timestamp of the policy file |
+
+**Response (404):** Error envelope with `code: "POLICY_NOT_FOUND"`.
+
+---
+
+### 7.4 POST /api/v1/policy/validate
+
+**Purpose:** Lint and parse a policy document. No side effects; computation only.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | string | yes | Raw policy content to validate |
+| `format` | `"yaml"` or `"json"` | yes | Format of the content |
+
+**Response (200):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `valid` | boolean | True if the policy parses and passes all lint rules |
+| `errors` | array of `ValidationError` | Parse or lint errors (empty when valid) |
+
+`ValidationError` fields: `line` (integer), `col` (integer), `message` (string).
+
+---
+
+### 7.5 POST /api/v1/policy/test
+
+**Purpose:** Run regression fixtures against loaded policies. Wraps the
+`policy_test.replay` engine from `agent-compliance`. No side effects; computation
+only.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fixtures` | array of `FixtureInput` | yes | Inline fixtures to execute |
+| `policy_dir` | string | no | Policy directory override (defaults to engine `policy_dir`) |
+
+`FixtureInput` fields: `id` (string), `input` (object), `expected_verdict` (enum),
+`expected_rule` (string, optional).
+
+**Response (200):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total` | integer | Total fixtures run |
+| `passed` | integer | Fixtures that matched expected verdict |
+| `failed` | integer | Fixtures that did not match |
+| `results` | array of `FixtureResult` | Per-fixture outcomes |
+
+`FixtureResult` fields: `fixture_id`, `passed`, `expected_verdict`,
+`actual_verdict`, `expected_rule` (optional), `actual_rule` (optional),
+`fixture_path` (optional).
+
+---
+
+### 7.6 POST /api/v1/policy/save
+
+**Purpose:** Persist a new or updated policy to the engine's policy directory. This
+is the single write endpoint in the Studio surface.
+
+**Capability flags:** `runtime_mutating: true`, `user_intent_required: true`,
+`read_only_surface: false`
+
+The `user_intent_required: true` flag means the Studio client MUST only call this
+endpoint from a direct user gesture (clicking a "Save" or "Publish" button). It
+MUST NOT be called speculatively, from a timer, or as a background side effect.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | yes | Policy identifier (becomes filename). Pattern: `^[a-z0-9][a-z0-9_-]{0,63}$` |
+| `content` | string | yes | Policy content to persist |
+| `format` | `"yaml"` or `"json"` | yes | File format to write |
+| `commit_message` | string | no | Human description for the audit log (max 512 chars) |
+
+**Response (200):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Saved policy identifier |
+| `saved_at` | string (date-time) | Timestamp of the save |
+| `version` | string | Opaque version token for optimistic concurrency |
+
+**Response (401):** Unauthenticated non-loopback request.
+**Response (403):** Token present but lacks write scope.
+
+---
+
+### 7.7 GET /api/v1/audit/log
+
+**Purpose:** Retrieve paginated audit log entries from the engine's in-memory and
+persistent audit store.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Query parameters:** `page`, `limit` (see section 11), plus:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `agent_did` | string | Filter to a single agent DID |
+| `from` | string (date-time) | Earliest entry timestamp (inclusive) |
+| `to` | string (date-time) | Latest entry timestamp (inclusive) |
+
+**Response (200):** Paginated list of `AuditLogEntry` objects.
+
+`AuditLogEntry` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `entry_id` | string | Unique entry identifier |
+| `timestamp` | string (date-time) | Entry timestamp |
+| `agent_did` | string | Acting agent DID |
+| `action` | string | Action performed |
+| `outcome` | `"success"`, `"failure"`, `"denied"` | Result |
+| `resource` | string (optional) | Target resource |
+| `target_did` | string (optional) | Target agent DID |
+| `policy_decision` | string (optional) | Policy verdict that produced this entry |
+| `entry_hash` | string | SHA-256 hash for Merkle chain integrity (see ADR 0017) |
+
+---
+
+### 7.8 GET /api/v1/trust/scores
+
+**Purpose:** List trust scores for all known agents, or for a specific agent.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Query parameters:** `page`, `limit`, `agent_did` (filter to one agent).
+
+**Response (200):** Paginated list of `TrustScoreItem` objects.
+
+`TrustScoreItem` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_did` | string | Agent DID |
+| `trust_score` | integer (0-1000) | Numeric trust score |
+| `trust_level` | enum | `untrusted`, `low`, `medium`, `high`, `full` |
+| `last_updated` | string (date-time, optional) | When the score was last changed |
+
+---
+
+### 7.9 GET /api/v1/trust/graph
+
+**Purpose:** Return the full trust graph: all agents as nodes and all trust/
+delegation relationships as directed edges. Useful for the Studio graph
+visualization panel.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Response (200):** `TrustGraph` object.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `nodes` | array of `TrustGraphNode` | Agents (did, trust_score, name) |
+| `edges` | array of `TrustGraphEdge` | Directed relationships (from_did, to_did, relationship, weight) |
+
+Relationship values: `"trusts"`, `"delegates"`, `"sponsors"`.
+
+---
+
+### 7.10 GET /api/v1/agents
+
+**Purpose:** List registered agents and their metadata.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Query parameters:** `page`, `limit`.
+
+**Response (200):** Paginated list of `AgentSummary` objects.
+
+`AgentSummary` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `did` | string | Agent DID (`did:mesh:...`) |
+| `name` | string (optional) | Human-readable name |
+| `trust_score` | integer (0-1000) | Current trust score |
+| `trust_level` | enum | `untrusted`, `low`, `medium`, `high`, `full` |
+| `last_active` | string (date-time, optional) | Timestamp of most recent event |
+| `capabilities` | array of string | List of granted capability strings |
+
+---
+
+### 7.11 GET /api/v1/decisions
+
+**Purpose:** Retrieve recent policy decisions as an HTTP-poll endpoint. In v1 the
+client polls this endpoint; in Epic 7a the same decisions will also stream over
+the WebSocket channel at `/api/v1/events`.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Query parameters:** `page`, `limit`, plus:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `agent_did` | string | Filter by agent DID |
+| `verdict` | enum | Filter by verdict: `allow`, `deny`, `warn`, `require_approval` |
+
+**Response (200):** Paginated list of `Decision` objects.
+
+`Decision` fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `decision_id` | string | Unique decision identifier |
+| `timestamp` | string (date-time) | When the decision was made |
+| `agent_did` | string | Acting agent DID |
+| `action` | string | Action that was evaluated |
+| `resource` | string (optional) | Target resource |
+| `verdict` | enum | `allow`, `deny`, `warn`, `require_approval` |
+| `matched_rule` | string (optional) | Name of the rule that produced the verdict |
+| `policy_name` | string (optional) | Name of the policy that matched |
+| `reason` | string | Human-readable reason for the verdict |
+
+---
+
+### 7.12 GET /api/v1/versions
+
+**Purpose:** Report engine software version and API contract version. Used by
+clients to detect version mismatches.
+
+**Capability flags:** `runtime_mutating: false`, `user_intent_required: false`,
+`read_only_surface: true`
+
+**Auth:** Not required (loopback or non-loopback).
+
+**Response (200):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `engine` | string | Engine software version (e.g., `"0.3.0"`) |
+| `api` | string | API contract version (e.g., `"1.0.0"`) |
+| `python` | string (optional) | Python runtime version |
+| `capabilities` | array of string (optional) | Supported capability identifiers |
+
+---
+
+## 8. Excluded Endpoints
+
+The following routes appear in existing engine code but MUST NOT be exposed through
+the Studio surface.
+
+### 8.1 POST /api/v1/policy/reload
+
+**Source:** `policy_server.py`, line 178.
+
+**Rationale for exclusion:** This endpoint reloads all policy files from disk
+without requiring user intent. It is `runtime_mutating: true` and would need to be
+`user_intent_required: true` to appear in the Studio contract. However, policy
+reload has no safe Studio use case: the `POST /api/v1/policy/save` endpoint already
+triggers a reload as a side effect of saving. Exposing a standalone reload button
+in the Studio UI would create a footgun (reloading with no visible change to the
+user). The endpoint remains available as an internal sidecar-management endpoint
+but is explicitly excluded from this contract and from the Studio allowlist.
+
+Engines that implement the Studio surface MUST NOT route `POST /api/v1/policy/reload`
+through the Studio auth path.
+
+---
+
+## 9. Conformance Rules
+
+An engine implementation is conformant with this contract when ALL of the following
+hold:
+
+1. **Route presence:** Every route in section 7 exists and responds to its
+   specified HTTP method. A `404` on any specified route is a conformance failure.
+
+2. **Schema compliance:** Request and response bodies match the schemas in
+   `openapi.yaml`. Extra optional fields are permitted in responses. Missing
+   required fields are a conformance failure.
+
+3. **Capability flags declared:** Every operation exposes its `x-capability-flags`
+   values in the OpenAPI document generated by the engine (if the engine generates
+   one). Engines that do not generate an OpenAPI document MUST document flags
+   elsewhere; the values MUST match section 5.
+
+4. **Read-only invariant holds:** Every endpoint with `runtime_mutating: false`
+   MUST NOT produce permanent side effects (see section 6.1).
+
+5. **Exactly one write endpoint:** Only `POST /api/v1/policy/save` has
+   `runtime_mutating: true`. If an engine exposes additional mutating endpoints
+   on the `/api/v1/` prefix, they MUST be documented and their flags MUST be
+   declared accordingly.
+
+6. **Excluded endpoint absent:** `POST /api/v1/policy/reload` MUST NOT be reachable
+   through the Studio auth path (section 8.1).
+
+7. **Error envelope:** All error responses MUST use the envelope schema defined in
+   section 10.
+
+8. **Pagination:** All list endpoints that carry pagination query parameters MUST
+   return a `pagination` object in the response matching section 11.
+
+9. **Version endpoint accurate:** `GET /api/v1/versions` MUST return the correct
+   `api` value (`"1.0.0"` for this contract version). Mismatched values are a
+   conformance failure.
+
+10. **Authentication enforced:** Non-loopback connections to endpoints other than
+    `/health` and `/versions` MUST be rejected with `401` when no valid token is
+    provided.
+
+The conformance test suite is defined in issue #4.
+
+---
+
+## 10. Error Model
+
+### 10.1 Status codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Malformed request (invalid JSON, missing required field) |
+| 401 | Unauthenticated (non-loopback, no token) |
+| 403 | Forbidden (token present but insufficient scope) |
+| 404 | Resource not found |
+| 422 | Request body is syntactically valid JSON but semantically invalid |
+| 429 | Rate limit exceeded |
+| 500 | Internal engine error |
+| 503 | Engine not ready (startup or degraded) |
+
+### 10.2 Error envelope schema
+
+All error responses MUST use this JSON envelope regardless of status code:
+
+```json
+{
+  "status": 404,
+  "code": "POLICY_NOT_FOUND",
+  "message": "Policy with id 'my-policy' not found",
+  "details": {}
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | integer | yes | HTTP status code (mirrors the HTTP response status) |
+| `code` | string | yes | Machine-readable code in `SCREAMING_SNAKE_CASE` |
+| `message` | string | yes | Human-readable description safe to display in the UI |
+| `details` | object | no | Endpoint-specific diagnostic information |
+
+### 10.3 Standard error codes
+
+| Code | Status | Context |
+|------|--------|---------|
+| `POLICY_NOT_FOUND` | 404 | Requested policy ID does not exist |
+| `POLICY_PARSE_ERROR` | 422 | Policy content failed to parse |
+| `FIXTURE_LOAD_ERROR` | 422 | A fixture in a test request is malformed |
+| `VALIDATION_ERROR` | 422 | Request body field validation failed |
+| `UNAUTHORIZED` | 401 | No token provided on non-loopback connection |
+| `FORBIDDEN` | 403 | Token present but lacks required scope |
+| `RATE_LIMITED` | 429 | Too many requests; retry after the `Retry-After` header value |
+| `ENGINE_UNAVAILABLE` | 503 | Engine is starting up or in degraded state |
+| `INTERNAL_ERROR` | 500 | Unexpected engine error |
+
+---
+
+## 11. Pagination Model
+
+### 11.1 Query parameters
+
+All list endpoints that support pagination accept these query parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | integer | 1 | 1-based page number |
+| `limit` | integer | 20 | Items per page (minimum 1, maximum 100) |
+
+### 11.2 Response object
+
+Paginated responses MUST include a top-level `pagination` object:
+
+```json
+{
+  "items": [ ... ],
+  "pagination": {
+    "page": 1,
+    "limit": 20,
+    "total": 87,
+    "has_next": true
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `page` | integer | Current page number (1-based) |
+| `limit` | integer | Items per page |
+| `total` | integer | Total number of items across all pages |
+| `has_next` | boolean | Whether more pages exist after this one |
+
+### 11.3 Paginated endpoints
+
+The following endpoints MUST implement the pagination model:
+
+- `GET /api/v1/policies`
+- `GET /api/v1/audit/log`
+- `GET /api/v1/trust/scores`
+- `GET /api/v1/agents`
+- `GET /api/v1/decisions`
+
+---
+
+## 12. Reserved Routes
+
+### 12.1 WebSocket: /api/v1/events
+
+The path `/api/v1/events` is reserved for a WebSocket streaming channel that will
+deliver real-time policy decisions, agent events, and trust updates to the Studio
+client.
+
+**This endpoint is not implemented in v1.** It will be fully defined in Epic 7a
+(issue #16).
+
+Conformance requirement: a v1 engine MUST return `426 Upgrade Required` when an
+HTTP (non-WebSocket) request is made to `/api/v1/events`. The engine MUST NOT
+implement this path as an HTTP endpoint.
+
+---
+
+## 13. References
+
+- [ADR 0028: AGT Studio, a single unified UI for governance](../adr/0028-agt-studio-unified-ui.md) (the binding scope document)
+- `docs/studio/openapi.yaml` (OpenAPI 3.1 machine-readable companion to this document)
+- `agent-governance-python/agent-mesh/src/agentmesh/server/sidecar.py` (existing sidecar surface)
+- `agent-governance-python/agent-mesh/src/agentmesh/server/policy_server.py` (existing policy server)
+- `agent-governance-python/agent-mesh/src/agentmesh/server/audit_collector.py` (existing audit collector)
+- `agent-governance-python/agent-mesh/src/agentmesh/server/trust_engine.py` (existing trust engine)
+- `agent-governance-python/agent-mesh/src/agentmesh/dashboard/api.py` (existing dashboard backend)
+- `agent-governance-python/agent-compliance/src/agent_compliance/policy_test.py` (replay engine wrapped by `/policy/test`)
+- Issue #2: Capability metadata decorator implementation
+- Issue #3: FastAPI implementation
+- Issue #4: Conformance test suite
+- Issue #6: Threat model and token security
+- Issue #16 (Epic 7a): WebSocket transport definition

--- a/docs/studio/openapi.yaml
+++ b/docs/studio/openapi.yaml
@@ -1,0 +1,1296 @@
+# Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+#
+# AGT Studio Engine API - OpenAPI 3.1 specification
+#
+# This is the machine-readable companion to docs/studio/engine-api-contract.md.
+# Every operation declares x-capability-flags with runtime_mutating,
+# user_intent_required, and read_only_surface.
+#
+# Validate: npx @redocly/cli lint docs/studio/openapi.yaml
+
+openapi: "3.1.0"
+
+info:
+  title: "AGT Studio Engine API"
+  version: "1.0.0"
+  description: |
+    Engine API for AGT Studio (AGT v1).
+
+    This document is the machine-readable companion to
+    `docs/studio/engine-api-contract.md`. All requests and responses
+    conform to the schemas defined here.
+
+    **Capability flags** (`x-capability-flags`) appear on every operation:
+    - `runtime_mutating`: the operation persists state changes to disk
+    - `user_intent_required`: MUST only be invoked from an explicit user gesture
+    - `read_only_surface`: safe to expose on a read-only Studio surface
+
+    Exactly one operation has `runtime_mutating: true`: `POST /policy/save`.
+
+    **Authentication:** Loopback connections (127.0.0.1 / ::1) require no
+    token. Non-loopback connections must supply a Bearer token read from
+    `~/.config/agt/studio-token`. `GET /health` and `GET /versions` are
+    exempt from authentication on all connections.
+
+    **Reserved route:** `GET /events` is reserved for a WebSocket channel
+    defined in Epic 7a. A v1 engine MUST return `426 Upgrade Required` for
+    non-WebSocket requests to that path.
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+  contact:
+    name: Agent Governance Toolkit
+    email: agentgovtoolkit@microsoft.com
+
+servers:
+  - url: "http://127.0.0.1:{port}/api/v1"
+    description: "Local loopback (no authentication required)"
+    variables:
+      port:
+        default: "8080"
+        description: "Engine listen port (set via AGT_PORT)"
+
+security:
+  - BearerToken: []
+
+tags:
+  - name: health
+    description: Liveness and version probes
+  - name: policy
+    description: Policy listing, validation, testing, and saving
+  - name: audit
+    description: Audit log retrieval
+  - name: trust
+    description: Trust scores and trust graph
+  - name: agents
+    description: Registered agent listing
+  - name: decisions
+    description: Policy decision history (HTTP poll; WS in Epic 7a)
+  - name: meta
+    description: Engine metadata and version negotiation
+
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      summary: Engine health probe
+      description: |
+        Returns engine health status and version. No authentication required
+        on any connection type. Used by Studio on startup and for periodic
+        health checks.
+      tags:
+        - health
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      security: []
+      responses:
+        "200":
+          description: Engine is healthy or degraded but responsive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                status: ok
+                version: "0.3.0"
+                uptime_seconds: 3661.4
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /policies:
+    get:
+      operationId: listPolicies
+      summary: List all loaded policies
+      description: |
+        Returns a paginated list of all policies currently loaded in the
+        engine. This endpoint fixes the counts-only gap in the existing
+        `policy_server.py` implementation, which returns only totals rather
+        than full policy objects.
+      tags:
+        - policy
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/LimitParam"
+      responses:
+        "200":
+          description: Paginated policy list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyListResponse"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /policies/{id}:
+    get:
+      operationId: getPolicy
+      summary: Get a single policy by ID
+      description: Returns full detail for one policy, including raw content and rule count.
+      tags:
+        - policy
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Policy identifier (derived from filename)
+          example: "pg-staging-reads"
+      responses:
+        "200":
+          description: Policy detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PolicyDetail"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /policy/validate:
+    post:
+      operationId: validatePolicy
+      summary: Validate policy syntax (lint only, no side effects)
+      description: |
+        Parses and lints a policy document. This operation is read-only:
+        no state persists after the response. Uses POST because request bodies
+        can be large.
+      tags:
+        - policy
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ValidatePolicyRequest"
+            example:
+              content: "name: example\nrules:\n  - id: r1\n    action: allow\n"
+              format: yaml
+      responses:
+        "200":
+          description: Validation result (valid or list of errors)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidatePolicyResponse"
+              examples:
+                valid:
+                  summary: Policy is valid
+                  value:
+                    valid: true
+                    errors: []
+                invalid:
+                  summary: Policy has errors
+                  value:
+                    valid: false
+                    errors:
+                      - line: 3
+                        col: 5
+                        message: "Unknown field 'actiom'; did you mean 'action'?"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /policy/test:
+    post:
+      operationId: testPolicy
+      summary: Run regression fixtures against policies
+      description: |
+        Executes a set of test fixtures against the loaded policies using the
+        `policy_test.replay` engine. No state persists after the response.
+        Uses POST because fixture bodies can be large.
+      tags:
+        - policy
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestPolicyRequest"
+            example:
+              fixtures:
+                - id: "allow-read-staging"
+                  input:
+                    action: "sql_select"
+                    resource: "staging.users"
+                  expected_verdict: "allow"
+                  expected_rule: "pg-staging-reads"
+      responses:
+        "200":
+          description: Replay report with per-fixture results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestPolicyResponse"
+              example:
+                total: 1
+                passed: 1
+                failed: 0
+                results:
+                  - fixture_id: "allow-read-staging"
+                    passed: true
+                    expected_verdict: "allow"
+                    actual_verdict: "allow"
+                    expected_rule: "pg-staging-reads"
+                    actual_rule: "pg-staging-reads"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /policy/save:
+    post:
+      operationId: savePolicy
+      summary: Persist a policy to disk (the sole write endpoint)
+      description: |
+        Writes a policy to the engine's policy directory. This is the ONLY
+        endpoint with `runtime_mutating: true` in the Studio surface.
+
+        `user_intent_required: true` means the Studio client MUST only call
+        this endpoint from a direct user gesture (clicking "Save" or "Publish").
+        It MUST NOT be called speculatively, from a timer, or as a background
+        side effect.
+
+        Requires authentication on non-loopback connections. The studio-token
+        must carry write scope; read-only tokens are rejected with 403.
+      tags:
+        - policy
+      x-capability-flags:
+        runtime_mutating: true
+        user_intent_required: true
+        read_only_surface: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SavePolicyRequest"
+            example:
+              id: "my-new-policy"
+              content: "name: my-new-policy\nrules:\n  - id: r1\n    action: allow\n"
+              format: yaml
+              commit_message: "Add allow rule for staging reads"
+      responses:
+        "200":
+          description: Policy saved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SavePolicyResponse"
+              example:
+                id: "my-new-policy"
+                saved_at: "2026-06-13T10:35:00Z"
+                version: "a1b2c3d4"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "403":
+          $ref: "#/components/responses/ErrorResponse"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /audit/log:
+    get:
+      operationId: getAuditLog
+      summary: Retrieve paginated audit log entries
+      description: |
+        Returns audit log entries from the engine's in-memory and persistent
+        audit store. Supports filtering by agent DID and time range.
+        Entries include the Merkle chain hash from ADR 0017.
+      tags:
+        - audit
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/LimitParam"
+        - name: agent_did
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter entries to a specific agent DID
+          example: "did:mesh:abc123"
+        - name: from
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Earliest entry timestamp to include (ISO 8601, inclusive)
+          example: "2026-06-01T00:00:00Z"
+        - name: to
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Latest entry timestamp to include (ISO 8601, inclusive)
+          example: "2026-06-13T23:59:59Z"
+      responses:
+        "200":
+          description: Paginated audit log entries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuditLogListResponse"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /trust/scores:
+    get:
+      operationId: getTrustScores
+      summary: List agent trust scores
+      description: |
+        Returns trust scores for all known agents, or for a single agent
+        when `agent_did` is specified.
+      tags:
+        - trust
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/LimitParam"
+        - name: agent_did
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter to a single agent DID
+          example: "did:mesh:abc123"
+      responses:
+        "200":
+          description: Paginated trust score list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrustScoreListResponse"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /trust/graph:
+    get:
+      operationId: getTrustGraph
+      summary: Get the full trust graph
+      description: |
+        Returns all agents as nodes and all trust, delegation, and sponsor
+        relationships as directed edges. Used by the Studio graph
+        visualization panel.
+      tags:
+        - trust
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      responses:
+        "200":
+          description: Trust graph with nodes and edges
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TrustGraph"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /agents:
+    get:
+      operationId: listAgents
+      summary: List registered agents
+      description: Returns a paginated list of all agents registered in the engine.
+      tags:
+        - agents
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/LimitParam"
+      responses:
+        "200":
+          description: Paginated agent list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentListResponse"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /decisions:
+    get:
+      operationId: listDecisions
+      summary: Retrieve recent policy decisions (HTTP poll)
+      description: |
+        Returns a paginated list of recent policy decisions. In v1, Studio
+        polls this endpoint for updates. In Epic 7a, decisions will also
+        stream in real time over the WebSocket channel at `/api/v1/events`.
+      tags:
+        - decisions
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      parameters:
+        - $ref: "#/components/parameters/PageParam"
+        - $ref: "#/components/parameters/LimitParam"
+        - name: agent_did
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter decisions by agent DID
+        - name: verdict
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - allow
+              - deny
+              - warn
+              - require_approval
+          description: Filter decisions by verdict
+      responses:
+        "200":
+          description: Paginated decision list
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DecisionListResponse"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+  /versions:
+    get:
+      operationId: getVersions
+      summary: Engine and API contract version information
+      description: |
+        Returns the engine software version and the API contract version.
+        Studio checks `api` on startup and shows an upgrade message if it
+        does not equal `"1.0.0"`. No authentication required on any
+        connection type.
+      tags:
+        - meta
+      x-capability-flags:
+        runtime_mutating: false
+        user_intent_required: false
+        read_only_surface: true
+      security: []
+      responses:
+        "200":
+          description: Version information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VersionInfo"
+              example:
+                engine: "0.3.0"
+                api: "1.0.0"
+                python: "3.12.3"
+                capabilities:
+                  - "capability-flags-v1"
+                  - "pagination-v1"
+        "4XX":
+          $ref: "#/components/responses/ErrorResponse"
+        "5XX":
+          $ref: "#/components/responses/ErrorResponse"
+
+components:
+  securitySchemes:
+    BearerToken:
+      type: http
+      scheme: bearer
+      description: |
+        Bearer token read from `~/.config/agt/studio-token`.
+
+        Required for non-loopback connections (all addresses other than
+        127.0.0.1 and ::1). Loopback connections do not require a token.
+
+        `GET /health` and `GET /versions` are exempt from authentication
+        on all connection types.
+
+        Full token format and rotation policy: see the threat model in
+        issue #6 (microsoft/agent-governance-toolkit#6).
+
+  parameters:
+    PageParam:
+      name: page
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+      description: "1-based page number (default: 1)"
+
+    LimitParam:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+      description: "Items per page, 1-100 (default: 20)"
+
+  responses:
+    ErrorResponse:
+      description: Error response using the standard error envelope
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            status: 404
+            code: POLICY_NOT_FOUND
+            message: "Policy with id 'my-policy' not found"
+            details: {}
+
+  schemas:
+
+    # ── Error envelope ──────────────────────────────────────────────────
+
+    Error:
+      type: object
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          description: HTTP status code mirrored in the response body
+          minimum: 400
+          maximum: 599
+          example: 404
+        code:
+          type: string
+          description: Machine-readable error code in SCREAMING_SNAKE_CASE
+          pattern: "^[A-Z][A-Z0-9_]*$"
+          example: POLICY_NOT_FOUND
+        message:
+          type: string
+          description: Human-readable description safe to display in the UI
+          example: "Policy with id 'my-policy' not found"
+        details:
+          type: object
+          description: Optional endpoint-specific diagnostic information
+          additionalProperties: true
+
+    # ── Pagination ──────────────────────────────────────────────────────
+
+    PaginationMeta:
+      type: object
+      required:
+        - page
+        - limit
+        - total
+        - has_next
+      properties:
+        page:
+          type: integer
+          minimum: 1
+          description: Current page number (1-based)
+          example: 1
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Items per page
+          example: 20
+        total:
+          type: integer
+          minimum: 0
+          description: Total number of items across all pages
+          example: 87
+        has_next:
+          type: boolean
+          description: Whether more pages exist after this one
+          example: true
+
+    # ── Health ──────────────────────────────────────────────────────────
+
+    HealthResponse:
+      type: object
+      required:
+        - status
+        - version
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+            - degraded
+          description: Engine health status
+        version:
+          type: string
+          description: Engine software version
+          example: "0.3.0"
+        uptime_seconds:
+          type: number
+          format: double
+          description: Seconds since engine process start
+          example: 3661.4
+
+    # ── Policy ──────────────────────────────────────────────────────────
+
+    PolicySummary:
+      type: object
+      required:
+        - id
+        - name
+        - format
+        - source
+      properties:
+        id:
+          type: string
+          description: Unique identifier derived from the policy filename
+          example: "pg-staging-reads"
+        name:
+          type: string
+          description: Human-readable policy name
+          example: "PostgreSQL Staging Read Access"
+        format:
+          type: string
+          enum:
+            - yaml
+            - json
+          description: File format of the policy
+        source:
+          type: string
+          description: File path relative to the policy directory
+          example: "pg-staging-reads.yaml"
+        description:
+          type: string
+          description: Policy description if present in the file header
+          example: "Allows SELECT on staging schema tables"
+
+    PolicyListResponse:
+      type: object
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/PolicySummary"
+        pagination:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    PolicyDetail:
+      allOf:
+        - $ref: "#/components/schemas/PolicySummary"
+        - type: object
+          required:
+            - content
+            - rules_count
+          properties:
+            content:
+              type: string
+              description: Raw policy file content
+            rules_count:
+              type: integer
+              minimum: 0
+              description: Number of rules declared in the policy
+              example: 3
+            last_modified:
+              type: string
+              format: date-time
+              description: Last modification timestamp of the policy file on disk
+
+    ValidationError:
+      type: object
+      required:
+        - message
+      properties:
+        line:
+          type: integer
+          minimum: 1
+          description: Line number of the error (1-based)
+          example: 3
+        col:
+          type: integer
+          minimum: 1
+          description: Column number of the error (1-based)
+          example: 5
+        message:
+          type: string
+          description: Human-readable error description
+          example: "Unknown field 'actiom'; did you mean 'action'?"
+
+    ValidatePolicyRequest:
+      type: object
+      required:
+        - content
+        - format
+      properties:
+        content:
+          type: string
+          description: Raw policy content to validate
+        format:
+          type: string
+          enum:
+            - yaml
+            - json
+          description: Format of the content
+
+    ValidatePolicyResponse:
+      type: object
+      required:
+        - valid
+        - errors
+      properties:
+        valid:
+          type: boolean
+          description: True if the policy passes all parse and lint checks
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationError"
+          description: List of parse or lint errors; empty when valid
+
+    FixtureInput:
+      type: object
+      required:
+        - id
+        - input
+        - expected_verdict
+      properties:
+        id:
+          type: string
+          description: Unique fixture identifier
+          example: "allow-read-staging"
+        input:
+          type: object
+          description: Evaluation context passed to the policy engine
+          additionalProperties: true
+          example:
+            action: "sql_select"
+            resource: "staging.users"
+        expected_verdict:
+          type: string
+          enum:
+            - allow
+            - deny
+            - warn
+            - require_approval
+          description: Expected policy verdict for this input
+        expected_rule:
+          type: string
+          description: Expected matched rule name (optional assertion)
+          example: "pg-staging-reads"
+
+    FixtureResult:
+      type: object
+      required:
+        - fixture_id
+        - passed
+        - expected_verdict
+        - actual_verdict
+      properties:
+        fixture_id:
+          type: string
+          example: "allow-read-staging"
+        passed:
+          type: boolean
+        expected_verdict:
+          type: string
+        actual_verdict:
+          type: string
+        expected_rule:
+          type:
+            - string
+            - "null"
+          description: Expected rule (null if not asserted)
+        actual_rule:
+          type:
+            - string
+            - "null"
+          description: Actual matched rule (null if no rule matched)
+        fixture_path:
+          type: string
+          description: Path to the fixture file (empty for inline fixtures)
+
+    TestPolicyRequest:
+      type: object
+      required:
+        - fixtures
+      properties:
+        policy_dir:
+          type: string
+          description: Policy directory override (defaults to engine policy_dir)
+        fixtures:
+          type: array
+          items:
+            $ref: "#/components/schemas/FixtureInput"
+          description: Inline fixtures to execute against the loaded policies
+          minItems: 1
+
+    TestPolicyResponse:
+      type: object
+      required:
+        - total
+        - passed
+        - failed
+        - results
+      properties:
+        total:
+          type: integer
+          minimum: 0
+          description: Total number of fixtures run
+        passed:
+          type: integer
+          minimum: 0
+          description: Fixtures that matched their expected verdict
+        failed:
+          type: integer
+          minimum: 0
+          description: Fixtures that did not match their expected verdict
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/FixtureResult"
+
+    SavePolicyRequest:
+      type: object
+      required:
+        - id
+        - content
+        - format
+      properties:
+        id:
+          type: string
+          description: |
+            Policy identifier used as the filename. Must match the pattern
+            `^[a-z0-9][a-z0-9_-]{0,63}$`.
+          pattern: "^[a-z0-9][a-z0-9_-]{0,63}$"
+          example: "my-new-policy"
+        content:
+          type: string
+          description: Full policy content to persist to disk
+        format:
+          type: string
+          enum:
+            - yaml
+            - json
+          description: File format to write
+        commit_message:
+          type: string
+          description: Human-readable description of this change, written to the audit log
+          maxLength: 512
+          example: "Add allow rule for staging reads"
+
+    SavePolicyResponse:
+      type: object
+      required:
+        - id
+        - saved_at
+      properties:
+        id:
+          type: string
+          description: Saved policy identifier
+          example: "my-new-policy"
+        saved_at:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp of when the policy was written to disk
+          example: "2026-06-13T10:35:00Z"
+        version:
+          type: string
+          description: Opaque version token for optimistic concurrency checks
+          example: "a1b2c3d4"
+
+    # ── Audit ───────────────────────────────────────────────────────────
+
+    AuditLogEntry:
+      type: object
+      required:
+        - entry_id
+        - timestamp
+        - agent_did
+        - action
+        - outcome
+      properties:
+        entry_id:
+          type: string
+          description: Unique entry identifier
+          example: "aud-0001"
+        timestamp:
+          type: string
+          format: date-time
+          description: When the audited event occurred
+          example: "2026-06-13T10:30:00Z"
+        agent_did:
+          type: string
+          description: DID of the agent that performed the action
+          example: "did:mesh:abc123"
+        action:
+          type: string
+          description: Action that was audited
+          example: "sql_execute"
+        outcome:
+          type: string
+          enum:
+            - success
+            - failure
+            - denied
+          description: Result of the action
+        resource:
+          type:
+            - string
+            - "null"
+          description: Target resource of the action
+          example: "staging.users"
+        target_did:
+          type:
+            - string
+            - "null"
+          description: DID of a target agent if applicable
+        policy_decision:
+          type:
+            - string
+            - "null"
+          description: Policy verdict that produced this audit entry
+          example: "allow"
+        entry_hash:
+          type: string
+          description: SHA-256 hash of this entry for Merkle chain integrity (ADR 0017)
+          example: "e3b0c44298fc1c149afb"
+
+    AuditLogListResponse:
+      type: object
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AuditLogEntry"
+        pagination:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    # ── Trust ───────────────────────────────────────────────────────────
+
+    TrustScoreItem:
+      type: object
+      required:
+        - agent_did
+        - trust_score
+        - trust_level
+      properties:
+        agent_did:
+          type: string
+          description: Agent DID
+          example: "did:mesh:abc123"
+        trust_score:
+          type: integer
+          minimum: 0
+          maximum: 1000
+          description: Numeric trust score (0-1000)
+          example: 750
+        trust_level:
+          type: string
+          enum:
+            - untrusted
+            - low
+            - medium
+            - high
+            - full
+          description: Categorical trust level derived from the score
+          example: "high"
+        last_updated:
+          type: string
+          format: date-time
+          description: Timestamp of the most recent score change
+
+    TrustScoreListResponse:
+      type: object
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrustScoreItem"
+        pagination:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    TrustGraphNode:
+      type: object
+      required:
+        - agent_did
+        - trust_score
+      properties:
+        agent_did:
+          type: string
+          description: Agent DID
+          example: "did:mesh:abc123"
+        trust_score:
+          type: integer
+          minimum: 0
+          maximum: 1000
+          description: Current trust score for graph rendering
+          example: 750
+        name:
+          type: string
+          description: Human-readable agent name (if registered)
+          example: "data-agent-prod"
+
+    TrustGraphEdge:
+      type: object
+      required:
+        - from_did
+        - to_did
+        - relationship
+      properties:
+        from_did:
+          type: string
+          description: Source agent DID
+          example: "did:mesh:abc123"
+        to_did:
+          type: string
+          description: Target agent DID
+          example: "did:mesh:def456"
+        relationship:
+          type: string
+          enum:
+            - trusts
+            - delegates
+            - sponsors
+          description: Type of trust relationship from source to target
+          example: "trusts"
+        weight:
+          type: number
+          format: double
+          description: Optional edge weight for graph layout (0.0-1.0)
+          minimum: 0.0
+          maximum: 1.0
+
+    TrustGraph:
+      type: object
+      required:
+        - nodes
+        - edges
+      properties:
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrustGraphNode"
+          description: All registered agents as graph nodes
+        edges:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrustGraphEdge"
+          description: All trust, delegation, and sponsor relationships as directed edges
+
+    # ── Agents ──────────────────────────────────────────────────────────
+
+    AgentSummary:
+      type: object
+      required:
+        - did
+        - trust_score
+      properties:
+        did:
+          type: string
+          description: Agent DID (did:mesh:...)
+          example: "did:mesh:abc123"
+        name:
+          type: string
+          description: Human-readable agent name
+          example: "data-agent-prod"
+        trust_score:
+          type: integer
+          minimum: 0
+          maximum: 1000
+          description: Current numeric trust score
+          example: 750
+        trust_level:
+          type: string
+          enum:
+            - untrusted
+            - low
+            - medium
+            - high
+            - full
+          description: Categorical trust level
+          example: "high"
+        last_active:
+          type:
+            - string
+            - "null"
+          format: date-time
+          description: Timestamp of the most recent event from this agent
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: List of granted capability strings
+          example:
+            - "read:data"
+            - "write:audit"
+
+    AgentListResponse:
+      type: object
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentSummary"
+        pagination:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    # ── Decisions ───────────────────────────────────────────────────────
+
+    Decision:
+      type: object
+      required:
+        - decision_id
+        - timestamp
+        - agent_did
+        - action
+        - verdict
+        - reason
+      properties:
+        decision_id:
+          type: string
+          description: Unique decision identifier
+          example: "dec-001"
+        timestamp:
+          type: string
+          format: date-time
+          description: When the policy decision was made
+          example: "2026-06-13T10:30:00Z"
+        agent_did:
+          type: string
+          description: DID of the agent whose action was evaluated
+          example: "did:mesh:abc123"
+        action:
+          type: string
+          description: Action that was evaluated
+          example: "sql_execute"
+        resource:
+          type:
+            - string
+            - "null"
+          description: Target resource of the evaluated action
+          example: "production.orders"
+        verdict:
+          type: string
+          enum:
+            - allow
+            - deny
+            - warn
+            - require_approval
+          description: Policy verdict
+          example: "deny"
+        matched_rule:
+          type:
+            - string
+            - "null"
+          description: Name of the rule that produced the verdict
+          example: "deny-prod-writes"
+        policy_name:
+          type:
+            - string
+            - "null"
+          description: Name of the policy that matched
+          example: "production-guardrails"
+        reason:
+          type: string
+          description: Human-readable reason for the verdict
+          example: "Rule 'deny-prod-writes' matched: direct writes to production are blocked"
+
+    DecisionListResponse:
+      type: object
+      required:
+        - items
+        - pagination
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Decision"
+        pagination:
+          $ref: "#/components/schemas/PaginationMeta"
+
+    # ── Version ─────────────────────────────────────────────────────────
+
+    VersionInfo:
+      type: object
+      required:
+        - engine
+        - api
+      properties:
+        engine:
+          type: string
+          description: Engine software version (semver)
+          example: "0.3.0"
+        api:
+          type: string
+          description: |
+            API contract version. Must equal "1.0.0" for this spec.
+            Studio shows an upgrade message if this does not match.
+          example: "1.0.0"
+        python:
+          type: string
+          description: Python runtime version (informational)
+          example: "3.12.3"
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: |
+            Optional list of capability identifiers the engine supports.
+            Well-known values: "capability-flags-v1", "pagination-v1".
+          example:
+            - "capability-flags-v1"
+            - "pagination-v1"

--- a/docs/studio/openapi.yaml
+++ b/docs/studio/openapi.yaml
@@ -224,7 +224,7 @@ paths:
                     errors:
                       - line: 3
                         col: 5
-                        message: "Unknown field 'actiom'; did you mean 'action'?"
+                        message: "Policy rule 'r1' references an undefined action type."
         "4XX":
           $ref: "#/components/responses/ErrorResponse"
         "5XX":
@@ -776,7 +776,7 @@ components:
         message:
           type: string
           description: Human-readable error description
-          example: "Unknown field 'actiom'; did you mean 'action'?"
+          example: "Policy rule 'r1' references an undefined action type."
 
     ValidatePolicyRequest:
       type: object

--- a/docs/studio/openapi.yaml
+++ b/docs/studio/openapi.yaml
@@ -69,6 +69,23 @@ tags:
   - name: meta
     description: Engine metadata and version negotiation
 
+# Reserved routes are not callable HTTP operations in v1, so they are declared
+# here (with capability flags) instead of under `paths`, where every operation
+# would be required to define success responses. The WebSocket message schema is
+# defined in Epic 7a (issue #16).
+x-reserved-routes:
+  - route: /api/v1/events
+    method: WS
+    summary: Real-time event stream (policy decisions, agent events, trust updates)
+    reserved_for: Epic 7a (issue #16)
+    http_behavior: >-
+      A v1 engine MUST return 426 Upgrade Required for plain HTTP requests to
+      this path and MUST NOT implement it as a regular HTTP endpoint.
+    x-capability-flags:
+      runtime_mutating: false
+      user_intent_required: false
+      read_only_surface: true
+
 paths:
   /health:
     get:
@@ -853,6 +870,14 @@ components:
         fixture_path:
           type: string
           description: Path to the fixture file (empty for inline fixtures)
+        resolution_metadata:
+          type:
+            - object
+            - "null"
+          additionalProperties: true
+          description: >-
+            Optional diagnostic metadata from the policy resolver, passed
+            through verbatim from policy_test.FixtureResult.resolution_metadata.
 
     TestPolicyRequest:
       type: object
@@ -1036,12 +1061,15 @@ components:
           type: string
           enum:
             - untrusted
-            - low
-            - medium
-            - high
-            - full
-          description: Categorical trust level derived from the score
-          example: "high"
+            - probationary
+            - standard
+            - trusted
+            - verified_partner
+          description: >-
+            Categorical trust level derived from the score. Mirrors
+            trust_level_for_score in agentmesh.trust.levels (the single source
+            of truth used by the trust engine and CLI).
+          example: "trusted"
         last_updated:
           type: string
           format: date-time
@@ -1154,12 +1182,14 @@ components:
           type: string
           enum:
             - untrusted
-            - low
-            - medium
-            - high
-            - full
-          description: Categorical trust level
-          example: "high"
+            - probationary
+            - standard
+            - trusted
+            - verified_partner
+          description: >-
+            Categorical trust level. Mirrors trust_level_for_score in
+            agentmesh.trust.levels.
+          example: "trusted"
         last_active:
           type:
             - string

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,6 +203,8 @@ nav:
     - Post-Market Monitoring: compliance/post-market-monitoring.md
     - Record Retention Policy: compliance/record-retention-policy.md
     - Data Provenance Model: compliance/data-provenance-model.md
+  - Studio:
+    - Engine API Contract: studio/engine-api-contract.md
   - Specifications:
     - "Agent OS Policy Engine": specs/AGENT-OS-POLICY-ENGINE-1.0.md
     - "AgentMesh Identity & Trust": specs/AGENTMESH-IDENTITY-TRUST-1.0.md


### PR DESCRIPTION
## Summary

Define the AGT Studio Engine API by shipping two artifacts: a human-readable spec (`docs/studio/engine-api-contract.md`) and a machine-readable OpenAPI 3.1 document (`docs/studio/openapi.yaml`). This is the gate for Epic 0 issues 2-4 and all of Epic 1, fulfilling the contract requirement from [ADR 0028](docs/adr/0028-agt-studio-unified-ui.md) lines 142-148.

## Problem

ADR 0028 mandates that an Engine API contract must exist before Studio implementation lands. Without this spec, issues #2 (capability metadata decorator), #3 (FastAPI implementation), and #4 (conformance tests) have no contract to implement or test against.

## Changes

| File | What changed |
|------|-------------|
| `docs/studio/engine-api-contract.md` | New human-readable spec: maintainer note (ADR 0029 skip rationale), 12 HTTP endpoint definitions, 3 capability flags, read-only invariant with client-allowlist worked example, auth model, error envelope, pagination model, conformance rules, excluded endpoints, and WebSocket reservation |
| `docs/studio/openapi.yaml` | New OpenAPI 3.1 document: all 12 HTTP endpoints with `x-capability-flags` extension, full request/response schemas, reusable `Error` and `PaginationMeta` components, `BearerToken` security scheme; zero warnings from `npx @redocly/cli lint` |
| `mkdocs.yml` | Added Studio nav section linking to `engine-api-contract.md` |

No existing source files modified. This is a doc-only PR.

## Acceptance criteria verification

- [x] `docs/studio/engine-api-contract.md` exists and includes the maintainer note about skipping ADR 0029
- [x] `docs/studio/openapi.yaml` exists and passes `npx @redocly/cli lint` (zero warnings, exit 0)
- [x] Every endpoint in the issue table is documented in both files
- [x] Every endpoint declares all three capability metadata flags
- [x] Exactly one endpoint has `runtime_mutating: true` (`POST /api/v1/policy/save`)
- [x] `POST /api/v1/policy/reload` is named in the "Excluded Endpoints" section with rationale
- [x] Read-only invariant is explained with a worked example of the client-allowlist derivation
- [x] Conformance-rules section enumerates what an engine must implement to be conformant
- [x] Versioning section defines URL-versioning and breaking-change policy
- [x] Auth summary references issue #6 for the full threat model
- [x] WebSocket route `/api/v1/events` is reserved with a pointer to Epic 7a
- [x] Error envelope schema is defined (status, code, message, optional details)
- [x] Pagination model is defined for `/policies`, `/audit/log`, `/decisions`, `/agents`
- [x] No existing source code modified

## Testing

Doc-only PR. Validated with:

- `npx @redocly/cli lint docs/studio/openapi.yaml` passes (zero warnings, exit 0)
- `python scripts/docs/check_links.py` passes (0 new broken links, exit 0)
- `python scripts/docs/check_frontmatter.py` passes (all 300 warnings are pre-existing, exit 0)
