### PR TITLE
fix(ci): exempt routine Dependabot bumps from Dependency Audit Trail gate

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -63,12 +63,25 @@ jobs:
   vendored-patch-audit:
     name: Dependency Audit Trail
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+      # Routine Dependabot patch/minor bumps cannot author an audit doc, so
+      # exempt them (issue #2975). Resolve the bump type from Dependabot
+      # metadata; the step is skipped (and the gate enforced normally) for
+      # every non-Dependabot PR.
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        if: github.actor == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - env:
           BASE_REF: ${{ github.base_ref }}
+          PR_ACTOR: ${{ github.actor }}
+          DEPENDABOT_UPDATE_TYPE: ${{ steps.dependabot-metadata.outputs.update-type }}
         run: |
           chmod +x scripts/ci/vendored-patch-audit.sh
           scripts/ci/vendored-patch-audit.sh "origin/$BASE_REF"

--- a/scripts/ci/vendored-patch-audit.sh
+++ b/scripts/ci/vendored-patch-audit.sh
@@ -3,9 +3,17 @@
 #
 # When lockfiles or vendored content changes, a corresponding entry must exist
 # in docs/dependency-audits/ explaining what changed and why.
+#
+# Exception (issue #2975): routine Dependabot patch/minor bumps cannot author
+# that doc by construction, so they are exempt when the caller sets
+# PR_ACTOR=dependabot[bot] and DEPENDABOT_UPDATE_TYPE to a non-major update.
+# This mirrors auto-merge-dependabot.yml, which already auto-merges exactly that
+# set. Human PRs and Dependabot major bumps still require the doc.
 set -euo pipefail
 
 BASE_REF="${1:-origin/main}"
+PR_ACTOR="${PR_ACTOR:-}"
+DEPENDABOT_UPDATE_TYPE="${DEPENDABOT_UPDATE_TYPE:-}"
 
 # Lockfile patterns across all SDK ecosystems
 LOCK_PATTERNS=(
@@ -39,6 +47,16 @@ fi
 
 if [ "$LOCK_TOUCHED" = false ]; then
   echo "✅ vendored-patch-audit: no lockfiles or vendored content changed"
+  exit 0
+fi
+
+# Exempt routine Dependabot patch/minor bumps (issue #2975). "Not major"
+# matches the auto-merge policy in auto-merge-dependabot.yml. Human PRs (no
+# PR_ACTOR match) and Dependabot major bumps fall through and still need a doc.
+if [ "$PR_ACTOR" = "dependabot[bot]" ] && \
+   [ -n "$DEPENDABOT_UPDATE_TYPE" ] && \
+   [ "$DEPENDABOT_UPDATE_TYPE" != "version-update:semver-major" ]; then
+  echo "✅ vendored-patch-audit: exempt — Dependabot $DEPENDABOT_UPDATE_TYPE bump (#2975)"
   exit 0
 fi
 


### PR DESCRIPTION
## Problem

The `Dependency Audit Trail` gate (`vendored-patch-audit` job in `.github/workflows/quality-gates.yml`) requires every PR that changes a lockfile to also add a dated `docs/dependency-audits/YYYY-MM-DD-<desc>.md` doc. Dependabot changes lockfiles but never authors that doc, so **every Dependabot PR fails this required check by construction** — blocking routine patch/minor bumps unless a maintainer hand-authors a doc or admin-bypasses the gate. (#2975)

## Fix

Issue #2975 option 2: exempt routine Dependabot bumps, keep the control for everyone else.

- The `vendored-patch-audit` job now resolves the bump type with `dependabot/fetch-metadata` — the **same action and pinned SHA already used by `auto-merge-dependabot.yml`**. The step runs only when `github.actor == 'dependabot[bot]'`; it's skipped for every other PR.
- `scripts/ci/vendored-patch-audit.sh` exempts the audit-doc requirement when `PR_ACTOR=dependabot[bot]` **and** the update is non-major (`update-type != version-update:semver-major`). This is exactly the set `auto-merge-dependabot.yml` already auto-merges, so the policy stays consistent.

## Still enforced (fail-closed)

| Scenario | Result |
|----------|--------|
| Human PR changes a lockfile, no doc | ❌ doc required (unchanged) |
| Dependabot **patch/minor** bump | ✅ exempt |
| Dependabot **major** bump | ❌ doc still required |
| Dependabot PR but `update-type` empty/missing | ❌ doc required |
| Non-Dependabot actor spoofing a patch `update-type` | ❌ doc required (actor must be `dependabot[bot]`) |
| Any lockfile change **with** an audit doc | ✅ passes (unchanged) |

The required check name (`Dependency Audit Trail`) is unchanged, so branch protection is unaffected. The job gains `pull-requests: read` for the metadata lookup.

## Testing

Logic validated locally against a throwaway git repo covering all six scenarios above; the untrusted `update-type`/actor values are passed via `env:` and only ever referenced as quoted shell variables (no `run:` interpolation).

Closes #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
