### PR TITLE
fix(policy-engine): update pyo3-build-config to 0.29 and replace removed API

### DIFF
--- a/policy-engine/sdk/python/Cargo.toml
+++ b/policy-engine/sdk/python/Cargo.toml
@@ -12,8 +12,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 agent_control_specification_core = { version = "0.3.1-beta.0", path = "../../core", features = ["opa", "cedar", "default-dispatchers", "aacs", "openai_moderation", "perspective", "llama_guard", "lakera_guard", "auto"] }
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py311"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py311"] }
 serde_json = "1"
 
 [build-dependencies]
-pyo3-build-config = "0.28"
+pyo3-build-config = "0.29"

--- a/policy-engine/sdk/python/build.rs
+++ b/policy-engine/sdk/python/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    pyo3_build_config::use_pyo3_cfgs();
+    pyo3_build_config::add_extension_module_link_args();
 }


### PR DESCRIPTION
## Summary

Dependabot PR #3002 bumped `pyo3` from 0.28 to 0.29 but left two things behind, causing CI to fail across Rust core, Python SDK, and agt-policies:

- `pyo3-build-config` in `[build-dependencies]` was still pinned to `0.28`
- `build.rs` was still calling `pyo3_build_config::use_pyo3_cfgs()`, which was removed in pyo3-build-config 0.29

The replacement for `use_pyo3_cfgs()` is `add_extension_module_link_args()`.

## Changes

- `policy-engine/sdk/python/Cargo.toml`: bump `pyo3` and `pyo3-build-config` to `0.29`
- `policy-engine/sdk/python/build.rs`: replace removed `use_pyo3_cfgs()` with `add_extension_module_link_args()`

Closes #3002 (supersedes the Dependabot PR with the missing pieces included).

## Test plan

- [ ] Rust core build passes
- [ ] Python SDK build passes
- [ ] agt-policies matrix (py3.11, py3.12, py3.13) passes
- [ ] docker-compose-test passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)