### PR TITLE
feat(agent-sandbox): log denied-command attempts via hardened-image shim (#2662 option 2)

### DIFF
--- a/agent-governance-python/agent-sandbox/README.md
+++ b/agent-governance-python/agent-sandbox/README.md
@@ -294,8 +294,22 @@ dir (so by-name calls are caught). Any attempt:
 
 The shim is Python (not shell) because the image strips the execute bit off
 every shell; `python3` is an allowed interpreter. Shells, interpreters, and
-encoders stay execute-bit-stripped — disabled but not logged. Extend the routed
-set via the `DENIED_LOGGED_BIN_NAMES` build-arg in `Dockerfile.sandbox`.
+encoders stay execute-bit-stripped — disabled but not logged.
+
+**Behavior change vs. the bare minimal-PATH image.** Routing a denied binary
+through the shim makes it *executable again* (the shim itself runs), so an
+absolute-path call now exits `126` with a logged record instead of raising
+`EACCES`/`PermissionError`. The denial signal is the non-zero exit plus the
+`command_denied` record, not an OS-level permission error. (No in-tree caller
+relies on the `PermissionError` form; sandboxed code is still denied either
+way.)
+
+**Customizing the routed set.** The `DENIED_LOGGED_BIN_NAMES` build-arg
+*replaces* the default set rather than extending it — pass the full list you
+want logged, not just additions, or the image will silently under-restrict.
+The allow-list wins: a name present in both `ALLOWED_BIN_NAMES` and
+`DENIED_LOGGED_BIN_NAMES` is left allowed (not shimmed), so do not list the same
+binary in both.
 
 ```bash
 # Build with the default allow-list (python3, cat, echo, ls).

--- a/agent-governance-python/agent-sandbox/README.md
+++ b/agent-governance-python/agent-sandbox/README.md
@@ -272,10 +272,30 @@ infra CLIs (`curl`, `wget`, `ssh`, `git`, `az`, `aws`, `gcloud`, `kubectl`,
 in case a caller goes through an absolute path.
 
 This closes the gap that issue [#2662](https://github.com/microsoft/agent-governance-toolkit/issues/2662)
-identifies: without a pinned PATH, a tool can invoke `os.system('az account list')`
+identifies: without a pinned PATH, a tool can shell out to `az account list`
 inside the sandbox and the attempt is not blocked or logged by AGT even though
-the network-egress policy would later refuse the call. The hardened image makes
-the attempt itself fail with "command not found".
+the network-egress policy would later refuse the call.
+
+### Logging denial shim (#2662 option 2)
+
+The pinned PATH and execute-bit stripping *prevent* denied commands, but a bare
+"command not found" / `EACCES` is silent — and for compliance, detecting the
+attempt matters as much as preventing it. The image therefore routes the denied
+network/infra CLIs (`curl`, `az`, `kubectl`, `terraform`, …) to a small Python
+logging shim (`docker/agt-deny-shim.py`), installed both at each binary's real
+path (so absolute-path calls are caught) and under its name in the pinned PATH
+dir (so by-name calls are caught). Any attempt:
+
+- writes a structured `command_denied` JSON record to stderr (captured in
+  `SandboxResult.stderr`), e.g. `{"argv":["account","list"],"binary":"az",...}`;
+- optionally appends the same record to `$AGT_DENIED_LOG` when that path is set
+  and writable;
+- exits `126`, so the real command never runs.
+
+The shim is Python (not shell) because the image strips the execute bit off
+every shell; `python3` is an allowed interpreter. Shells, interpreters, and
+encoders stay execute-bit-stripped — disabled but not logged. Extend the routed
+set via the `DENIED_LOGGED_BIN_NAMES` build-arg in `Dockerfile.sandbox`.
 
 ```bash
 # Build with the default allow-list (python3, cat, echo, ls).

--- a/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
+++ b/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
@@ -69,6 +69,33 @@ RUN set -eux; \
         fi; \
     done
 
+# Stage 3: route denied network/infra CLIs to a logging denial shim so that
+# attempts are *recorded* (structured `command_denied` JSON on stderr, captured
+# in SandboxResult.stderr), not silently blocked. Issue #2662 (option 2).
+#
+# The shim is Python, not shell: stage 2 strips the execute bit off every shell,
+# so a shell shim could not run; `python3` is an allowed interpreter. Shells,
+# interpreters, and encoders stay execute-bit-stripped above (we disable them
+# but do not need to log them); the network/infra tooling below is what carries
+# the compliance signal when an agent tries to reach out.
+COPY agt-deny-shim.py /usr/local/lib/agt-deny-shim.py
+ARG DENIED_LOGGED_BIN_NAMES="curl wget nc netcat ncat socat ssh scp rsync git apt apt-get dpkg dnf yum apk aws az gcloud kubectl terraform helm ansible telnet ftp tftp"
+RUN set -eux; \
+    chmod 0755 /usr/local/lib/agt-deny-shim.py; \
+    for bin in $DENIED_LOGGED_BIN_NAMES; do \
+        # Replace the real binary wherever it resides (explicit dirs, not a
+        # PATH lookup, since PATH is pinned to the sandbox-bin allow-list) so
+        # absolute-path invocations are logged too, not silently EACCES.
+        for dir in /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin; do \
+            if [ -e "$dir/$bin" ] || [ -L "$dir/$bin" ]; then \
+                ln -sf /usr/local/lib/agt-deny-shim.py "$dir/$bin"; \
+            fi; \
+        done; \
+        # Expose the name in the pinned PATH dir so a by-name call is logged
+        # rather than failing with a bare "command not found".
+        ln -sf /usr/local/lib/agt-deny-shim.py "/usr/local/sandbox-bin/$bin"; \
+    done
+
 # Drop to nobody. The provider already sets `user="65534:65534"` on the
 # container, but pinning it in the image too means a sandboxed image started
 # outside the provider (e.g. ad-hoc `docker run` for inspection) also drops

--- a/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
+++ b/agent-governance-python/agent-sandbox/docker/Dockerfile.sandbox
@@ -81,8 +81,15 @@ RUN set -eux; \
 COPY agt-deny-shim.py /usr/local/lib/agt-deny-shim.py
 ARG DENIED_LOGGED_BIN_NAMES="curl wget nc netcat ncat socat ssh scp rsync git apt apt-get dpkg dnf yum apk aws az gcloud kubectl terraform helm ansible telnet ftp tftp"
 RUN set -eux; \
+    set -f; \
     chmod 0755 /usr/local/lib/agt-deny-shim.py; \
     for bin in $DENIED_LOGGED_BIN_NAMES; do \
+        # Allow-list wins: if this name is already an allowed entry in the
+        # pinned PATH dir (created above from ALLOWED_BIN_NAMES), leave it
+        # alone rather than silently clobbering it with the deny shim. A name
+        # should not appear in both lists; if it does, the allow-list is
+        # treated as the intentional one.
+        if [ -e "/usr/local/sandbox-bin/$bin" ]; then continue; fi; \
         # Replace the real binary wherever it resides (explicit dirs, not a
         # PATH lookup, since PATH is pinned to the sandbox-bin allow-list) so
         # absolute-path invocations are logged too, not silently EACCES.

--- a/agent-governance-python/agent-sandbox/docker/agt-deny-shim.py
+++ b/agent-governance-python/agent-sandbox/docker/agt-deny-shim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/local/bin/python3
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """Logging denial shim for the hardened sandbox image (issue #2662, option 2).
@@ -13,7 +13,10 @@ the shim exits non-zero, so the real command never runs.
 
 It is written in Python on purpose: the hardened image strips the execute bit
 off every shell, so a shell shim could not run, whereas ``python3`` is an
-allowed interpreter. It depends only on the standard library.
+allowed interpreter. The shebang is the absolute interpreter path
+(``/usr/local/bin/python3`` in the ``python:3.11-slim`` base) rather than
+``/usr/bin/env python3`` so it does not depend on ``env`` or on PATH resolution.
+It depends only on the standard library.
 """
 
 import json
@@ -23,6 +26,9 @@ import time
 
 # Conventional "permission denied" exit status. Distinct from 127 ("command
 # not found") so logs/tests can tell an explicit denial from an absent binary.
+# Note (issue #2662 review): routing through this shim means an absolute-path
+# call to a denied binary now exits 126 rather than raising EACCES; the denial
+# signal is the non-zero exit plus the stderr record, not a PermissionError.
 DENY_EXIT_CODE = 126
 
 
@@ -32,27 +38,43 @@ def main(argv: list[str]) -> int:
         "event": "command_denied",
         "binary": invoked,
         "argv": argv[1:],
-        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "issue": 2662,
     }
     line = json.dumps(record, separators=(",", ":"), sort_keys=True)
-    # Structured record first (machine-parseable), then a human-readable line.
-    sys.stderr.write(line + "\n")
+    # Emit the structured record and the human-readable line in a single write
+    # so concurrent shim processes cannot interleave a partial record on the
+    # shared stderr stream.
     sys.stderr.write(
-        f"agt-sandbox: command denied: {invoked} "
+        line
+        + "\n"
+        + f"agt-sandbox: command denied: {invoked} "
         "(blocked by sandbox command denylist)\n"
     )
 
     # Best-effort append to an audit log when a writable path is configured.
     # The hardened image runs read-only as nobody, so this is normally a no-op;
     # it lets an embedder point at a writable mount when one exists.
+    #
+    # O_NOFOLLOW refuses to open a symlink at the final path component, so a
+    # planted AGT_DENIED_LOG symlink cannot redirect the append to an arbitrary
+    # file. A write failure is surfaced on stderr rather than swallowed.
     log_path = os.environ.get("AGT_DENIED_LOG")
     if log_path:
         try:
-            with open(log_path, "a", encoding="utf-8") as handle:
-                handle.write(line + "\n")
-        except OSError:
-            pass
+            fd = os.open(
+                log_path,
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW,
+                0o600,
+            )
+            try:
+                os.write(fd, (line + "\n").encode("utf-8"))
+            finally:
+                os.close(fd)
+        except OSError as exc:
+            sys.stderr.write(
+                f"agt-sandbox: warning: could not write AGT_DENIED_LOG: {exc}\n"
+            )
 
     return DENY_EXIT_CODE
 

--- a/agent-governance-python/agent-sandbox/docker/agt-deny-shim.py
+++ b/agent-governance-python/agent-sandbox/docker/agt-deny-shim.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Logging denial shim for the hardened sandbox image (issue #2662, option 2).
+
+The minimal-PATH image already makes denied network/infra CLIs unreachable, but
+a blocked attempt is *silent* ("command not found" / EACCES). For compliance,
+detecting the attempt matters as much as preventing it. This shim is installed
+in place of those CLIs (and exposed under their names in the pinned PATH dir),
+so any attempt to run one lands here: the attempt is recorded as a structured
+``command_denied`` record on stderr — captured in ``SandboxResult.stderr`` — and
+the shim exits non-zero, so the real command never runs.
+
+It is written in Python on purpose: the hardened image strips the execute bit
+off every shell, so a shell shim could not run, whereas ``python3`` is an
+allowed interpreter. It depends only on the standard library.
+"""
+
+import json
+import os
+import sys
+import time
+
+# Conventional "permission denied" exit status. Distinct from 127 ("command
+# not found") so logs/tests can tell an explicit denial from an absent binary.
+DENY_EXIT_CODE = 126
+
+
+def main(argv: list[str]) -> int:
+    invoked = os.path.basename(argv[0]) if argv and argv[0] else "unknown"
+    record = {
+        "event": "command_denied",
+        "binary": invoked,
+        "argv": argv[1:],
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "issue": 2662,
+    }
+    line = json.dumps(record, separators=(",", ":"), sort_keys=True)
+    # Structured record first (machine-parseable), then a human-readable line.
+    sys.stderr.write(line + "\n")
+    sys.stderr.write(
+        f"agt-sandbox: command denied: {invoked} "
+        "(blocked by sandbox command denylist)\n"
+    )
+
+    # Best-effort append to an audit log when a writable path is configured.
+    # The hardened image runs read-only as nobody, so this is normally a no-op;
+    # it lets an embedder point at a writable mount when one exists.
+    log_path = os.environ.get("AGT_DENIED_LOG")
+    if log_path:
+        try:
+            with open(log_path, "a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+        except OSError:
+            pass
+
+    return DENY_EXIT_CODE
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/agent-governance-python/agent-sandbox/tests/test_deny_shim.py
+++ b/agent-governance-python/agent-sandbox/tests/test_deny_shim.py
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the hardened-image logging denial shim (issue #2662, option 2).
+
+These exercise the shim directly and assert the Dockerfile wires it in. They do
+not require a Docker daemon: the shim is plain-stdlib Python invoked through a
+symlink so ``argv[0]`` carries the denied command name, exactly as it would in
+the image.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+_DOCKER_DIR = pathlib.Path(__file__).resolve().parent.parent / "docker"
+SHIM = _DOCKER_DIR / "agt-deny-shim.py"
+DOCKERFILE = _DOCKER_DIR / "Dockerfile.sandbox"
+DENY_EXIT_CODE = 126
+
+
+def _invoke_as(tmp_path, name: str, *args: str, env: dict | None = None):
+    """Run the shim through a symlink named *name*, returning the result."""
+    link = tmp_path / name
+    link.symlink_to(SHIM)
+    return subprocess.run(
+        [sys.executable, str(link), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestDenyShim:
+    def test_denies_with_nonzero_exit(self, tmp_path):
+        result = _invoke_as(tmp_path, "az", "account", "list")
+        assert result.returncode == DENY_EXIT_CODE
+        # The real command must never run, so there is nothing on stdout.
+        assert result.stdout == ""
+
+    def test_emits_structured_record(self, tmp_path):
+        result = _invoke_as(tmp_path, "kubectl", "get", "pods")
+        # First stderr line is the machine-parseable record.
+        first = result.stderr.splitlines()[0]
+        record = json.loads(first)
+        assert record["event"] == "command_denied"
+        assert record["binary"] == "kubectl"
+        assert record["argv"] == ["get", "pods"]
+        assert record["issue"] == 2662
+        assert record["ts"].endswith("Z")
+
+    def test_emits_human_readable_line(self, tmp_path):
+        result = _invoke_as(tmp_path, "terraform", "apply")
+        assert "command denied: terraform" in result.stderr
+
+    def test_records_binary_name_from_argv0(self, tmp_path):
+        # The same shim file reports whichever name it was invoked under.
+        assert json.loads(_invoke_as(tmp_path, "curl").stderr.splitlines()[0])["binary"] == "curl"
+        assert json.loads(_invoke_as(tmp_path, "wget").stderr.splitlines()[0])["binary"] == "wget"
+
+    def test_appends_to_audit_log_when_configured(self, tmp_path):
+        log = tmp_path / "denied.log"
+        result = _invoke_as(
+            tmp_path, "az", "login", env={"AGT_DENIED_LOG": str(log)}
+        )
+        assert result.returncode == DENY_EXIT_CODE
+        record = json.loads(log.read_text(encoding="utf-8").splitlines()[0])
+        assert record["binary"] == "az"
+        assert record["argv"] == ["login"]
+
+    def test_unwritable_audit_log_does_not_crash(self, tmp_path):
+        # A bad log path must not turn a denial into a hard error.
+        result = _invoke_as(
+            tmp_path, "az", env={"AGT_DENIED_LOG": "/nonexistent-dir/x.log"}
+        )
+        assert result.returncode == DENY_EXIT_CODE
+
+
+class TestDockerfileWiresShim:
+    """Validate the Dockerfile wiring as text (no Docker daemon needed)."""
+
+    @staticmethod
+    def _read() -> str:
+        return DOCKERFILE.read_text(encoding="utf-8")
+
+    def test_shim_file_exists(self):
+        assert SHIM.is_file()
+
+    def test_dockerfile_copies_shim(self):
+        assert "COPY agt-deny-shim.py" in self._read()
+
+    def test_dockerfile_routes_denied_clis_to_shim(self):
+        content = self._read()
+        # The shim must be symlinked into both the real dirs and the pinned
+        # PATH dir so by-name and absolute-path calls are both logged.
+        assert "agt-deny-shim.py" in content
+        assert "/usr/local/sandbox-bin/$bin" in content
+        # The network/infra CLIs the issue calls out must be in the routed set.
+        import re
+
+        match = re.search(r'ARG\s+DENIED_LOGGED_BIN_NAMES\s*=\s*"([^"]+)"', content)
+        assert match, "Dockerfile must declare DENIED_LOGGED_BIN_NAMES"
+        routed = set(match.group(1).split())
+        assert {"az", "kubectl", "terraform", "curl"} <= routed
+
+    def test_shells_are_not_routed_to_python_shim(self):
+        # Shells stay execute-bit-stripped (stage 2); routing them to a Python
+        # shim would be pointless and risks an interpreter loop.
+        import re
+
+        content = self._read()
+        match = re.search(r'ARG\s+DENIED_LOGGED_BIN_NAMES\s*=\s*"([^"]+)"', content)
+        routed = set(match.group(1).split())
+        assert not ({"sh", "bash", "dash", "busybox"} & routed)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/agent-governance-python/agent-sandbox/tests/test_deny_shim.py
+++ b/agent-governance-python/agent-sandbox/tests/test_deny_shim.py
@@ -51,7 +51,8 @@ class TestDenyShim:
         assert record["binary"] == "kubectl"
         assert record["argv"] == ["get", "pods"]
         assert record["issue"] == 2662
-        assert record["ts"].endswith("Z")
+        # Audit records key on "timestamp" across AGT (compliance/flight_recorder/…).
+        assert record["timestamp"].endswith("Z")
 
     def test_emits_human_readable_line(self, tmp_path):
         result = _invoke_as(tmp_path, "terraform", "apply")
@@ -72,12 +73,45 @@ class TestDenyShim:
         assert record["binary"] == "az"
         assert record["argv"] == ["login"]
 
-    def test_unwritable_audit_log_does_not_crash(self, tmp_path):
-        # A bad log path must not turn a denial into a hard error.
+    def test_unwritable_audit_log_warns_but_does_not_crash(self, tmp_path):
+        # A bad log path must not turn a denial into a hard error, but the
+        # failure to record should be surfaced rather than swallowed.
         result = _invoke_as(
             tmp_path, "az", env={"AGT_DENIED_LOG": "/nonexistent-dir/x.log"}
         )
         assert result.returncode == DENY_EXIT_CODE
+        assert "could not write AGT_DENIED_LOG" in result.stderr
+
+    def test_audit_log_does_not_follow_symlink(self, tmp_path):
+        # A planted AGT_DENIED_LOG symlink must not redirect the append
+        # (O_NOFOLLOW). The symlink target stays untouched and the failure
+        # is surfaced on stderr.
+        target = tmp_path / "secret.txt"
+        target.write_text("original", encoding="utf-8")
+        link = tmp_path / "evil.log"
+        link.symlink_to(target)
+
+        result = _invoke_as(tmp_path, "az", env={"AGT_DENIED_LOG": str(link)})
+
+        assert result.returncode == DENY_EXIT_CODE
+        assert target.read_text(encoding="utf-8") == "original"
+        assert "could not write AGT_DENIED_LOG" in result.stderr
+
+    def test_main_with_empty_argv_reports_unknown(self):
+        # main([]) is reachable as a direct call; the argv[0] guard must hold.
+        import contextlib
+        import importlib.util
+        import io
+
+        spec = importlib.util.spec_from_file_location("agt_deny_shim", SHIM)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = module.main([])
+        assert rc == DENY_EXIT_CODE
+        assert json.loads(stderr.getvalue().splitlines()[0])["binary"] == "unknown"
 
 
 class TestDockerfileWiresShim:


### PR DESCRIPTION
## Summary

Option 2 of tracker #2662: convert *silently-blocked* denied commands in the hardened sandbox image into *logged* denials, so an agent's attempt to shell out to a dangerous CLI is recorded — not just refused.

Option 1 (the minimal-PATH image, #2713) already prevents denied network/infra CLIs, but a bare "command not found" / `EACCES` produces no AGT signal. The issue is explicit: *"detecting the attempt matters as much as preventing the outcome."*

## What changed

- **New `docker/agt-deny-shim.py`** — a stdlib-only Python logging shim. On invocation it writes a structured `command_denied` JSON record to stderr (captured in `SandboxResult.stderr`), optionally appends it to `$AGT_DENIED_LOG`, and exits `126` so the real command never runs.
- **`docker/Dockerfile.sandbox`** — a new stage routes the denied network/infra CLIs (`curl`, `wget`, `ssh`, `git`, `az`, `aws`, `gcloud`, `kubectl`, `terraform`, `helm`, `ansible`, `apt`, …) to the shim, installed **both** at each binary's real path (explicit-dir iteration, so absolute-path calls are caught) **and** under its name in the pinned PATH dir (so by-name calls are logged instead of failing silently). Extend via the `DENIED_LOGGED_BIN_NAMES` build-arg.
- **`README.md`** — documents the logging-deny behavior.
- **`tests/test_deny_shim.py`** — Docker-free tests.

## Design notes

- **Why Python, not a shell script:** the image strips the execute bit off every shell (`sh`, `bash`, …), so a shell shim could not run; `python3` is an allowed interpreter. Shells, interpreters, and encoders stay execute-bit-stripped — disabled but not logged; the network/infra tooling is what carries the compliance signal.
- **Fail-closed:** a missing/unwritable `$AGT_DENIED_LOG` never turns a denial into a hard error; the command is still denied.
- **Scope:** this is the image-level (option 2) layer. Option 4 (a Python runtime interception shim) was evaluated and dropped as substantially redundant with the existing static scanner (`code_scanner.py`), which already host-side blocks subprocess and process-spawning calls in sandboxed code. Option 3 (AppArmor) remains open on the tracker.

## Testing

`tests/test_deny_shim.py` — 10 tests covering the shim (exit 126, structured + human-readable records, `argv[0]`-derived binary name, audit-log append, unwritable-log resilience) and the Dockerfile wiring (parsed as text). Existing `TestMinimalPathSandboxImage` still passes (15 passed total).

Note: `Dockerfile.sandbox` is an opt-in image that is not built in CI (the provider falls back to `python:3.11-slim` when it is absent), so the image wiring is validated by inspection + the text-level Dockerfile tests, and the shim behavior by the Docker-free unit tests.

Refs #2662 (tracker — does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
