### PR TITLE
fix(codeowners): add @imran-siddique to *.md reviewer line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,4 +21,4 @@
 # Documentation
 /docs/                       @imran-siddique @MohammadHaroonAbuomar
 /site/                       @imran-siddique @MohammadHaroonAbuomar
-*.md                         @microsoft/agent-governance-toolkit @MohammadHaroonAbuomar
+*.md                         @microsoft/agent-governance-toolkit @MohammadHaroonAbuomar @imran-siddique


### PR DESCRIPTION
## Summary

The `*.md` CODEOWNERS override shadowed the default `*` line, so `@imran-siddique` approvals were not counted for PRs touching markdown files. This left maintainer-approved PRs stuck on `REVIEW_REQUIRED` (e.g. #3013, #2994, #2973, #2766).

The fix is one character: add `@imran-siddique` to the `*.md` line, consistent with how every other path rule in this file already includes both maintainers.

## Test plan
- [ ] After merge, re-run the policy gate check on #3013, #2994, #2973, #2766 — all should flip to APPROVED and auto-merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)