### PR TITLE
fix(agent-os): deep-copy context before storing as context_snapshot

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
@@ -217,7 +217,7 @@ class PolicyEvaluator:
                     "policy": None,
                     "rule": None,
                     "action": "deny",
-                    "context_snapshot": context,
+                    "context_snapshot": copy.deepcopy(context),
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                     "error": True,
                 },

--- a/agent-governance-python/agent-os/src/agent_os/policies/shared.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/shared.py
@@ -10,6 +10,7 @@ YAML serialization and a bridge to the existing PolicyDocument format.
 
 from __future__ import annotations
 
+import copy
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -189,7 +190,7 @@ class SharedPolicyEvaluator:
                     audit={
                         "rule_id": rule.id,
                         "action": rule.action,
-                        "context_snapshot": context,
+                        "context_snapshot": copy.deepcopy(context),
                         "timestamp": datetime.now(timezone.utc).isoformat(),
                     },
                 )


### PR DESCRIPTION
## Summary

Two locations stored the raw `context` reference instead of a defensive copy, breaking `test_flat_yaml_match_isolated_from_top_level_mutation`:

```
AssertionError: assert {'extra': 'original', 'tool_name': 'x'} is not {'extra': 'original', 'tool_name': 'x'}
```

- `policies/shared.py` — introduced by #2766 (dynamic conditions merge); also needed `import copy`
- `policies/evaluator.py` line 222 — pre-existing latent bug in the fail-closed except block (all other `context_snapshot` assignments in that file already used `copy.deepcopy`)

## Changes
- `shared.py`: add `import copy`, change `context` → `copy.deepcopy(context)`
- `evaluator.py`: change `context` → `copy.deepcopy(context)` in fail-closed path

## Test plan
- [ ] `test (agent-os, 3.11/3.12/3.13)` passes on CI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)