### PR TITLE
feat(engine-api): add capability-metadata library for AGT Studio

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -58,6 +58,7 @@
     "javascripts",
     "tabindex",
     "dampenable",
+    "dunder",
     "forgeable",
     "unstarred",
     "getcode",

--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Engine API capability-metadata library for AGT Studio.
+
+This package is the reusable substrate that lets an Engine API adapter declare
+each endpoint's three capability flags inline and emit them as the
+``x-capability-flags`` OpenAPI extension. It is library-only: it exposes no HTTP
+routes. The FastAPI reference adapter (issue #3) imports this package to wire its
+routes.
+
+See ``docs/studio/engine-api-contract.md`` section 5 (Capability Metadata) and
+section 6 (Read-only Invariant) for the normative specification.
+
+Public surface:
+
+* :class:`CapabilityFlags` - frozen Pydantic model of the three flags that
+  enforces the read-only invariant at construction time.
+* :func:`capability_flags` - decorator that validates and attaches flags to an
+  endpoint callable under :data:`CAPABILITY_FLAGS_ATTR` (``__capability_flags__``).
+* :func:`inject_capability_extension` - injects ``x-capability-flags`` into a
+  FastAPI app's generated OpenAPI document.
+* :func:`derive_studio_client_allowlist` - derives the sorted read-only client
+  allowlist from a generated OpenAPI document.
+* :data:`CAPABILITY_EXTENSION_KEY` - the OpenAPI extension key (``x-capability-flags``).
+* :data:`CAPABILITY_FLAGS_ATTR` - the endpoint attribute name (``__capability_flags__``).
+"""
+
+from __future__ import annotations
+
+from agentmesh.engine_api.capabilities import (
+    CAPABILITY_FLAGS_ATTR,
+    CapabilityFlags,
+    capability_flags,
+)
+from agentmesh.engine_api.openapi import (
+    CAPABILITY_EXTENSION_KEY,
+    derive_studio_client_allowlist,
+    inject_capability_extension,
+)
+
+__all__ = [
+    "CAPABILITY_EXTENSION_KEY",
+    "CAPABILITY_FLAGS_ATTR",
+    "CapabilityFlags",
+    "capability_flags",
+    "derive_studio_client_allowlist",
+    "inject_capability_extension",
+]

--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/capabilities.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/capabilities.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Capability metadata model and decorator for the AGT Studio Engine API.
+
+This module implements the capability-flag substrate defined in
+``docs/studio/engine-api-contract.md`` section 5 (Capability Metadata) and
+section 6 (Read-only Invariant).
+
+Every Engine API endpoint carries three boolean capability flags:
+
+* ``runtime_mutating`` - the operation persists a change to engine state.
+* ``user_intent_required`` - the operation MUST only be invoked from an explicit
+  user gesture (button click, confirm dialog), never speculatively.
+* ``read_only_surface`` - the operation is safe to expose on a read-only Studio
+  surface. An endpoint is read-only if and only if ``runtime_mutating`` is false.
+
+The read-only invariant (``read_only_surface == (not runtime_mutating)``) is
+enforced at :class:`CapabilityFlags` construction time, so the iff rule cannot
+be forged. Any violating construction raises :class:`ValueError`.
+
+The :func:`capability_flags` decorator validates the flags and attaches the
+resulting :class:`CapabilityFlags` instance to the wrapped callable under the
+attribute named by :data:`CAPABILITY_FLAGS_ATTR` (``__capability_flags__``).
+The OpenAPI hook in :mod:`agentmesh.engine_api.openapi` reads that attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+#: Name of the attribute that :func:`capability_flags` attaches to a decorated
+#: callable. A dunder name is used so it does not collide with user attributes.
+CAPABILITY_FLAGS_ATTR = "__capability_flags__"
+
+F = TypeVar("F", bound=Callable[..., object])
+
+
+class CapabilityFlags(BaseModel):
+    """The three authoritative capability flags for an Engine API operation.
+
+    The model is frozen: once constructed, the flags cannot be mutated. This
+    keeps the validated read-only invariant intact for the lifetime of the
+    instance.
+
+    Raises:
+        ValueError: if ``read_only_surface != (not runtime_mutating)``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    runtime_mutating: bool
+    user_intent_required: bool
+    read_only_surface: bool
+
+    @model_validator(mode="after")
+    def _enforce_read_only_invariant(self) -> "CapabilityFlags":
+        expected_read_only = not self.runtime_mutating
+        if self.read_only_surface != expected_read_only:
+            raise ValueError(
+                "read-only invariant violated: read_only_surface must equal "
+                "(not runtime_mutating). Got read_only_surface="
+                f"{self.read_only_surface!r} with runtime_mutating="
+                f"{self.runtime_mutating!r}; expected read_only_surface="
+                f"{expected_read_only!r}."
+            )
+        return self
+
+
+def capability_flags(
+    *,
+    runtime_mutating: bool,
+    user_intent_required: bool,
+    read_only_surface: bool,
+) -> Callable[[F], F]:
+    """Attach validated :class:`CapabilityFlags` to a callable.
+
+    The flags are validated through :class:`CapabilityFlags`, so the read-only
+    invariant is enforced at decoration time: decorating with an inconsistent
+    combination raises :class:`ValueError` immediately, before any server
+    starts. The validated instance is stored on the callable under
+    :data:`CAPABILITY_FLAGS_ATTR`.
+
+    Usage::
+
+        @capability_flags(
+            runtime_mutating=False,
+            user_intent_required=False,
+            read_only_surface=True,
+        )
+        async def get_health(): ...
+
+    Args:
+        runtime_mutating: Whether the operation persists engine state changes.
+        user_intent_required: Whether the operation requires an explicit user
+            gesture.
+        read_only_surface: Whether the operation is safe on a read-only surface.
+            Must equal ``not runtime_mutating``.
+
+    Returns:
+        A decorator that attaches the flags and returns the original callable.
+
+    Raises:
+        ValueError: if the flag combination violates the read-only invariant.
+    """
+    flags = CapabilityFlags(
+        runtime_mutating=runtime_mutating,
+        user_intent_required=user_intent_required,
+        read_only_surface=read_only_surface,
+    )
+
+    def decorator(fn: F) -> F:
+        setattr(fn, CAPABILITY_FLAGS_ATTR, flags)
+        return fn
+
+    return decorator

--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/openapi.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/openapi.py
@@ -1,0 +1,143 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+OpenAPI integration for Engine API capability metadata.
+
+This module provides two functions:
+
+* :func:`inject_capability_extension` walks a FastAPI app's routes, reads the
+  :class:`~agentmesh.engine_api.capabilities.CapabilityFlags` attached by the
+  :func:`~agentmesh.engine_api.capabilities.capability_flags` decorator, and
+  writes them into the generated OpenAPI document as the ``x-capability-flags``
+  extension on each operation object. The shape matches
+  ``docs/studio/openapi.yaml``.
+
+* :func:`derive_studio_client_allowlist` reads a generated OpenAPI document and
+  returns the sorted list of ``operationId`` values whose
+  ``x-capability-flags.runtime_mutating`` is ``false``. This is the function the
+  Epic 1d CI invariant test calls to machine-derive the read-only Studio client
+  allowlist (no hand-maintained route list).
+
+**Hook timing.** :func:`inject_capability_extension` overrides ``app.openapi``
+with a wrapper that generates the schema via the app's existing generator and
+then injects the extension. It is safe to call once, after all routes are
+registered and before serving. The generated schema is cached on
+``app.openapi_schema`` by FastAPI, so injection happens on first access.
+
+**Failure mode.** If a route is included in the OpenAPI schema as an operation
+but its endpoint carries no attached flags, :func:`inject_capability_extension`
+raises :class:`ValueError`. Failing loudly here makes it impossible to ship a
+Studio surface with an unknown-flag endpoint.
+
+FastAPI is imported lazily inside :func:`inject_capability_extension` so this
+package imposes no hard import-time dependency on FastAPI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentmesh.engine_api.capabilities import CAPABILITY_FLAGS_ATTR, CapabilityFlags
+
+#: HTTP methods that correspond to OpenAPI operation objects within a path item.
+_OPENAPI_OPERATION_METHODS = frozenset(
+    {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+)
+
+#: The OpenAPI extension key under which the three capability flags are emitted.
+CAPABILITY_EXTENSION_KEY = "x-capability-flags"
+
+
+def inject_capability_extension(app: Any) -> None:
+    """Wire capability-flag emission into a FastAPI app's OpenAPI generation.
+
+    Overrides ``app.openapi`` so the generated document carries an
+    ``x-capability-flags`` object (with ``runtime_mutating``,
+    ``user_intent_required``, and ``read_only_surface``) on every operation
+    whose endpoint was decorated with
+    :func:`~agentmesh.engine_api.capabilities.capability_flags`.
+
+    Args:
+        app: A ``fastapi.FastAPI`` instance with its routes already registered.
+
+    Raises:
+        ValueError: when the schema is generated and an operation present in the
+            OpenAPI document has no attached capability flags.
+    """
+    from fastapi.routing import APIRoute
+
+    original_openapi = app.openapi
+
+    def openapi_with_capabilities() -> dict[str, Any]:
+        schema = original_openapi()
+        paths: dict[str, Any] = schema.get("paths", {})
+
+        for route in app.routes:
+            if not isinstance(route, APIRoute):
+                continue
+            if not route.include_in_schema:
+                continue
+
+            path_item = paths.get(route.path)
+            if path_item is None:
+                continue
+
+            flags: CapabilityFlags | None = getattr(route.endpoint, CAPABILITY_FLAGS_ATTR, None)
+
+            for method in route.methods:
+                operation = path_item.get(method.lower())
+                if operation is None:
+                    continue
+                if flags is None:
+                    raise ValueError(
+                        "missing capability flags for operation "
+                        f"{method.upper()} {route.path!r} (endpoint "
+                        f"{route.endpoint.__name__!r}). Decorate the endpoint "
+                        "with @capability_flags(...) before calling "
+                        "inject_capability_extension()."
+                    )
+                operation[CAPABILITY_EXTENSION_KEY] = flags.model_dump()
+
+        app.openapi_schema = schema
+        return schema
+
+    app.openapi = openapi_with_capabilities
+
+
+def derive_studio_client_allowlist(openapi_doc: dict[str, Any]) -> list[str]:
+    """Return the sorted read-only Studio client allowlist from an OpenAPI doc.
+
+    Iterates over every operation in the document and keeps the ``operationId``
+    of each operation whose ``x-capability-flags.runtime_mutating`` is ``false``.
+    By the read-only invariant this is exactly the set of read-only operations.
+
+    Args:
+        openapi_doc: A generated OpenAPI document (as produced by
+            :func:`inject_capability_extension`).
+
+    Returns:
+        ``operationId`` values in deterministic ascending sorted order. An
+        operation without an ``x-capability-flags`` object, without an
+        ``operationId``, or with ``runtime_mutating: true`` is excluded.
+    """
+    allowlist: list[str] = []
+
+    paths: dict[str, Any] = openapi_doc.get("paths", {})
+    for path_item in paths.values():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            if method.lower() not in _OPENAPI_OPERATION_METHODS:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            flags = operation.get(CAPABILITY_EXTENSION_KEY)
+            if not isinstance(flags, dict):
+                continue
+            operation_id = operation.get("operationId")
+            if not operation_id:
+                continue
+            if flags.get("runtime_mutating") is False:
+                allowlist.append(operation_id)
+
+    return sorted(allowlist)

--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/openapi.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/openapi.py
@@ -137,7 +137,8 @@ def derive_studio_client_allowlist(openapi_doc: dict[str, Any]) -> list[str]:
             operation_id = operation.get("operationId")
             if not operation_id:
                 continue
-            if flags.get("runtime_mutating") is False:
+            runtime_mutating = flags.get("runtime_mutating")
+            if isinstance(runtime_mutating, bool) and not runtime_mutating:
                 allowlist.append(operation_id)
 
     return sorted(allowlist)

--- a/agent-governance-python/agent-mesh/tests/engine_api/__init__.py
+++ b/agent-governance-python/agent-mesh/tests/engine_api/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the agentmesh.engine_api capability-metadata library."""

--- a/agent-governance-python/agent-mesh/tests/engine_api/test_capabilities.py
+++ b/agent-governance-python/agent-mesh/tests/engine_api/test_capabilities.py
@@ -1,0 +1,204 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for CapabilityFlags, the capability_flags decorator, and allowlist derivation."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentmesh.engine_api import (
+    CAPABILITY_EXTENSION_KEY,
+    CAPABILITY_FLAGS_ATTR,
+    CapabilityFlags,
+    capability_flags,
+    derive_studio_client_allowlist,
+)
+
+# The 12 read-only operations from docs/studio/engine-api-contract.md section 5.2
+# (the implemented HTTP operations) plus the single mutating operation.
+_READ_ONLY_OPERATION_IDS = [
+    "getHealth",
+    "listPolicies",
+    "getPolicy",
+    "validatePolicy",
+    "testPolicy",
+    "getAuditLog",
+    "getTrustScores",
+    "getTrustGraph",
+    "listAgents",
+    "listDecisions",
+    "getVersions",
+    "getEvents",
+]
+
+
+def _read_only_flags() -> dict[str, bool]:
+    return {
+        "runtime_mutating": False,
+        "user_intent_required": False,
+        "read_only_surface": True,
+    }
+
+
+def _mutating_flags() -> dict[str, bool]:
+    return {
+        "runtime_mutating": True,
+        "user_intent_required": True,
+        "read_only_surface": False,
+    }
+
+
+class TestCapabilityFlags:
+    def test_valid_read_only_combination(self):
+        flags = CapabilityFlags(**_read_only_flags())
+        assert flags.runtime_mutating is False
+        assert flags.user_intent_required is False
+        assert flags.read_only_surface is True
+
+    def test_valid_mutating_combination(self):
+        flags = CapabilityFlags(**_mutating_flags())
+        assert flags.runtime_mutating is True
+        assert flags.user_intent_required is True
+        assert flags.read_only_surface is False
+
+    def test_mutating_endpoint_may_skip_user_intent(self):
+        # The invariant only couples read_only_surface and runtime_mutating;
+        # user_intent_required is independent.
+        flags = CapabilityFlags(
+            runtime_mutating=True,
+            user_intent_required=False,
+            read_only_surface=False,
+        )
+        assert flags.read_only_surface is False
+
+    def test_invariant_rejects_mutating_marked_read_only(self):
+        with pytest.raises(ValueError, match="read-only invariant violated"):
+            CapabilityFlags(
+                runtime_mutating=True,
+                user_intent_required=True,
+                read_only_surface=True,
+            )
+
+    def test_invariant_rejects_non_mutating_not_read_only(self):
+        with pytest.raises(ValueError, match="read-only invariant violated"):
+            CapabilityFlags(
+                runtime_mutating=False,
+                user_intent_required=False,
+                read_only_surface=False,
+            )
+
+    def test_model_is_frozen(self):
+        flags = CapabilityFlags(**_read_only_flags())
+        with pytest.raises(Exception):
+            flags.runtime_mutating = True
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValueError):
+            CapabilityFlags(
+                runtime_mutating=False,
+                user_intent_required=False,
+                read_only_surface=True,
+                unexpected=True,
+            )
+
+
+class TestCapabilityFlagsDecorator:
+    def test_attaches_validated_flags(self):
+        @capability_flags(
+            runtime_mutating=False,
+            user_intent_required=False,
+            read_only_surface=True,
+        )
+        def endpoint():
+            return "ok"
+
+        attached = getattr(endpoint, CAPABILITY_FLAGS_ATTR)
+        assert isinstance(attached, CapabilityFlags)
+        assert attached.runtime_mutating is False
+        assert attached.read_only_surface is True
+
+    def test_returns_original_callable(self):
+        def endpoint():
+            return "ok"
+
+        decorated = capability_flags(
+            runtime_mutating=False,
+            user_intent_required=False,
+            read_only_surface=True,
+        )(endpoint)
+
+        assert decorated is endpoint
+        assert decorated() == "ok"
+
+    def test_decoration_raises_on_invariant_violation(self):
+        with pytest.raises(ValueError, match="read-only invariant violated"):
+
+            @capability_flags(
+                runtime_mutating=True,
+                user_intent_required=True,
+                read_only_surface=True,
+            )
+            def endpoint():
+                return "ok"
+
+
+class TestDeriveStudioClientAllowlist:
+    def _build_doc(self) -> dict:
+        paths: dict = {}
+        # 12 read-only GET/POST operations.
+        for index, operation_id in enumerate(_READ_ONLY_OPERATION_IDS):
+            paths[f"/api/v1/op{index}"] = {
+                "get": {
+                    "operationId": operation_id,
+                    CAPABILITY_EXTENSION_KEY: _read_only_flags(),
+                }
+            }
+        # 1 mutating operation that must be excluded.
+        paths["/api/v1/policy/save"] = {
+            "post": {
+                "operationId": "policy_save",
+                CAPABILITY_EXTENSION_KEY: _mutating_flags(),
+            }
+        }
+        return {"openapi": "3.1.0", "paths": paths}
+
+    def test_returns_twelve_read_only_operation_ids(self):
+        allowlist = derive_studio_client_allowlist(self._build_doc())
+        assert len(allowlist) == 12
+
+    def test_excludes_policy_save(self):
+        allowlist = derive_studio_client_allowlist(self._build_doc())
+        assert "policy_save" not in allowlist
+        assert set(allowlist) == set(_READ_ONLY_OPERATION_IDS)
+
+    def test_output_is_sorted(self):
+        allowlist = derive_studio_client_allowlist(self._build_doc())
+        assert allowlist == sorted(allowlist)
+
+    def test_empty_document_returns_empty_list(self):
+        assert derive_studio_client_allowlist({"paths": {}}) == []
+
+    def test_operations_without_flags_are_ignored(self):
+        doc = {
+            "paths": {
+                "/api/v1/health": {
+                    "get": {"operationId": "getHealth", CAPABILITY_EXTENSION_KEY: _read_only_flags()}
+                },
+                "/api/v1/undocumented": {"get": {"operationId": "noFlags"}},
+            }
+        }
+        assert derive_studio_client_allowlist(doc) == ["getHealth"]
+
+    def test_non_operation_keys_are_ignored(self):
+        doc = {
+            "paths": {
+                "/api/v1/policies": {
+                    "parameters": [{"name": "page"}],
+                    "get": {
+                        "operationId": "listPolicies",
+                        CAPABILITY_EXTENSION_KEY: _read_only_flags(),
+                    },
+                }
+            }
+        }
+        assert derive_studio_client_allowlist(doc) == ["listPolicies"]

--- a/agent-governance-python/agent-mesh/tests/engine_api/test_capabilities.py
+++ b/agent-governance-python/agent-mesh/tests/engine_api/test_capabilities.py
@@ -51,15 +51,15 @@ def _mutating_flags() -> dict[str, bool]:
 class TestCapabilityFlags:
     def test_valid_read_only_combination(self):
         flags = CapabilityFlags(**_read_only_flags())
-        assert flags.runtime_mutating is False
-        assert flags.user_intent_required is False
-        assert flags.read_only_surface is True
+        assert not flags.runtime_mutating
+        assert not flags.user_intent_required
+        assert flags.read_only_surface
 
     def test_valid_mutating_combination(self):
         flags = CapabilityFlags(**_mutating_flags())
-        assert flags.runtime_mutating is True
-        assert flags.user_intent_required is True
-        assert flags.read_only_surface is False
+        assert flags.runtime_mutating
+        assert flags.user_intent_required
+        assert not flags.read_only_surface
 
     def test_mutating_endpoint_may_skip_user_intent(self):
         # The invariant only couples read_only_surface and runtime_mutating;
@@ -69,7 +69,7 @@ class TestCapabilityFlags:
             user_intent_required=False,
             read_only_surface=False,
         )
-        assert flags.read_only_surface is False
+        assert not flags.read_only_surface
 
     def test_invariant_rejects_mutating_marked_read_only(self):
         with pytest.raises(ValueError, match="read-only invariant violated"):
@@ -114,8 +114,8 @@ class TestCapabilityFlagsDecorator:
 
         attached = getattr(endpoint, CAPABILITY_FLAGS_ATTR)
         assert isinstance(attached, CapabilityFlags)
-        assert attached.runtime_mutating is False
-        assert attached.read_only_surface is True
+        assert not attached.runtime_mutating
+        assert attached.read_only_surface
 
     def test_returns_original_callable(self):
         def endpoint():

--- a/agent-governance-python/agent-mesh/tests/engine_api/test_openapi.py
+++ b/agent-governance-python/agent-mesh/tests/engine_api/test_openapi.py
@@ -1,0 +1,123 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for inject_capability_extension OpenAPI emission against a FastAPI app."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+
+from agentmesh.engine_api import (  # noqa: E402
+    CAPABILITY_EXTENSION_KEY,
+    capability_flags,
+    derive_studio_client_allowlist,
+    inject_capability_extension,
+)
+
+
+def _build_studio_app() -> FastAPI:
+    """A FastAPI app mirroring the spec: 12 read-only ops + 1 mutating save."""
+    app = FastAPI(title="AGT Studio Engine API", version="1.0.0")
+
+    @app.get("/api/v1/health", operation_id="getHealth")
+    @capability_flags(
+        runtime_mutating=False, user_intent_required=False, read_only_surface=True
+    )
+    async def get_health():
+        return {"status": "ok"}
+
+    @app.get("/api/v1/policies", operation_id="listPolicies")
+    @capability_flags(
+        runtime_mutating=False, user_intent_required=False, read_only_surface=True
+    )
+    async def list_policies():
+        return []
+
+    @app.post("/api/v1/policy/save", operation_id="policy_save")
+    @capability_flags(
+        runtime_mutating=True, user_intent_required=True, read_only_surface=False
+    )
+    async def save_policy():
+        return {"saved": True}
+
+    return app
+
+
+class TestInjectCapabilityExtension:
+    def test_emits_extension_on_every_operation(self):
+        app = _build_studio_app()
+        inject_capability_extension(app)
+        schema = app.openapi()
+
+        health_op = schema["paths"]["/api/v1/health"]["get"]
+        assert health_op[CAPABILITY_EXTENSION_KEY] == {
+            "runtime_mutating": False,
+            "user_intent_required": False,
+            "read_only_surface": True,
+        }
+
+        save_op = schema["paths"]["/api/v1/policy/save"]["post"]
+        assert save_op[CAPABILITY_EXTENSION_KEY] == {
+            "runtime_mutating": True,
+            "user_intent_required": True,
+            "read_only_surface": False,
+        }
+
+    def test_extension_has_all_three_fields(self):
+        app = _build_studio_app()
+        inject_capability_extension(app)
+        schema = app.openapi()
+
+        for path_item in schema["paths"].values():
+            for operation in path_item.values():
+                flags = operation[CAPABILITY_EXTENSION_KEY]
+                assert set(flags) == {
+                    "runtime_mutating",
+                    "user_intent_required",
+                    "read_only_surface",
+                }
+
+    def test_shape_matches_openapi_yaml(self):
+        # docs/studio/openapi.yaml emits x-capability-flags as a mapping of three
+        # booleans on the operation object. Confirm we produce the same shape.
+        app = _build_studio_app()
+        inject_capability_extension(app)
+        schema = app.openapi()
+
+        flags = schema["paths"]["/api/v1/policies"]["get"][CAPABILITY_EXTENSION_KEY]
+        assert flags == {
+            "runtime_mutating": False,
+            "user_intent_required": False,
+            "read_only_surface": True,
+        }
+
+    def test_idempotent_across_repeated_calls(self):
+        app = _build_studio_app()
+        inject_capability_extension(app)
+        first = app.openapi()
+        second = app.openapi()
+        assert first == second
+
+    def test_raises_when_decorated_route_missing_flags(self):
+        app = FastAPI(title="t", version="1.0.0")
+
+        @app.get("/api/v1/unflagged", operation_id="unflagged")
+        async def unflagged():
+            return {}
+
+        inject_capability_extension(app)
+        with pytest.raises(ValueError, match="missing capability flags"):
+            app.openapi()
+
+
+class TestEndToEndAllowlist:
+    def test_allowlist_from_generated_schema(self):
+        app = _build_studio_app()
+        inject_capability_extension(app)
+        schema = app.openapi()
+
+        allowlist = derive_studio_client_allowlist(schema)
+        assert allowlist == ["getHealth", "listPolicies"]
+        assert "policy_save" not in allowlist


### PR DESCRIPTION
## Summary

Adds a small, reusable `agentmesh.engine_api` library that implements the capability-metadata substrate from the Engine API contract, so the future FastAPI reference adapter (issue #3) can declare each endpoint's three flags inline and emit them as the `x-capability-flags` OpenAPI extension. Library-only and purely additive: no HTTP routes are exposed and no existing source is modified.

## Problem

The Studio contract (`docs/studio/engine-api-contract.md` sections 5 and 6) defines three per-endpoint capability flags and a read-only invariant, but there was no Python mechanism to declare them, emit them into the generated OpenAPI document, or machine-derive the read-only Studio client allowlist. Without this, the allowlist would be hand-maintained and the read-only rule would be unenforceable by CI (Epic 1d).

## Changes

| File | What changed |
|------|-------------|
| `src/agentmesh/engine_api/capabilities.py` | New `CapabilityFlags` Pydantic v2 model (frozen, three booleans) that enforces the read-only invariant `read_only_surface == (not runtime_mutating)` at construction, raising a clear `ValueError`; plus the `capability_flags(...)` decorator that validates and attaches flags under `__capability_flags__`. |
| `src/agentmesh/engine_api/openapi.py` | `inject_capability_extension(app)` overrides `app.openapi` to write `x-capability-flags` onto each operation and raises if a schema operation has no attached flags (fail loudly); `derive_studio_client_allowlist(openapi_doc)` returns sorted `operationId`s where `runtime_mutating == false`. FastAPI is lazy-imported. |
| `src/agentmesh/engine_api/__init__.py` | Public exports and package docstring documenting the attribute name and hook timing. |
| `tests/engine_api/test_capabilities.py` | Covers valid/invariant-violation flag construction, frozen model, decorator attachment and error path, and allowlist derivation (sorted output, `policy_save` exclusion, 12-of-13 fixture). |
| `tests/engine_api/test_openapi.py` | Builds a FastAPI app, asserts emission shape matches `openapi.yaml`, idempotency, the missing-flags raise, and end-to-end allowlist derivation. |
| `tests/engine_api/__init__.py` | Test package marker. |

### Design decisions

- Attribute name is `__capability_flags__` (dunder, exported as `CAPABILITY_FLAGS_ATTR`).
- The model is frozen, so validated flags cannot be mutated post-construction.
- Pydantic v2, matching the rest of agent-mesh.
- FastAPI is not added to runtime dependencies: the agent-mesh `pyproject.toml` is a deprecation stub whose runtime deps only carry the `-core` redirect, and `fastapi` is already in the `[dev]` extra used by CI. The OpenAPI hook lazy-imports FastAPI instead.

## Testing

- `python -m ruff check --select E,F,W --ignore E501 .../engine_api .../tests/engine_api` passes.
- `python -m pytest tests/engine_api` passes (22 passed).
- Verified the change is additive only (two new directories; no existing files modified).

Closes #3026