### PR TITLE
fix(ci): add tzdata, pyatr, nono-py to dep-confusion allowlist

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -62,7 +62,9 @@
     "forgeable",
     "unstarred",
     "getcode",
-    "datetimes"
+    "datetimes",
+    "tzdata",
+    "pyatr"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -156,6 +156,12 @@ REGISTERED_PACKAGES = {
     "autogen-agentchat", "autogen_agentchat",
     "autogen-core", "autogen_core", "autogen-ext", "autogen_ext",
     "agentdojo",
+    # IANA timezone database for Python (real PyPI package, optional dep for Windows tz support)
+    "tzdata",
+    # AGT Audit Trail Record library (real PyPI package, pre-1.0; used in acs-atr-annotator example)
+    "pyatr",
+    # OS-native (Landlock / Seatbelt) capability sandbox (real PyPI package, Alpha; agt-sandbox[nono])
+    "nono-py", "nono_py",
     # With extras (base name is what matters)
 }
 


### PR DESCRIPTION
Three PyPI packages flagged by `dep-confusion-scan` after recent merges to main.

| Package | Introduced by | Reason |
|---------|---------------|--------|
| `tzdata` | Pre-existing | IANA timezone database; Windows tz support in agent-os |
| `pyatr` | #3025 (ATR annotator example) | AGT audit trail record library |
| `nono-py` | #3029 (NonoSandboxProvider) | OS-native Landlock/Seatbelt sandbox bindings |

All three are real, registered PyPI packages. Adding them to `REGISTERED_PACKAGES` unblocks `dep-confusion-scan` on main.

No other changes.