### PR TITLE
fix(agent-os): deepcopy context in YAML-match audit entry

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
+++ b/agent-governance-python/agent-os/src/agent_os/policies/evaluator.py
@@ -250,7 +250,7 @@ class PolicyEvaluator:
                         "policy": doc.name,
                         "rule": rule.name,
                         "action": rule.action.value,
-                        "context_snapshot": context,
+                        "context_snapshot": copy.deepcopy(context),
                         "timestamp": datetime.now(timezone.utc).isoformat(),
                     }
                     if rule.dynamic_condition is not None:


### PR DESCRIPTION
## Summary

- YAML-match branch of `_evaluate_flat()` set `context_snapshot` to the live `context` reference rather than a copy
- Every other branch (`backend error`, `backend success`, `default action`, `exception`) already called `copy.deepcopy(context)` — this one was missed when #3023 landed
- Post-evaluation mutations to `context` were visible inside the audit record, violating the isolation invariant

## Test

`TestContextSnapshotIsolation::test_flat_yaml_match_isolated_from_top_level_mutation` in `tests/test_folder_governance.py` was failing on all three Python versions. This commit makes it pass.

## Checklist

- [x] One-line change, no behavior impact beyond isolation correctness
- [x] Existing test coverage
- [x] `--signoff` for DCO

🤖 Generated with [Claude Code](https://claude.com/claude-code)