### PR TITLE
docs: add AARM Extended and ATF compliance to README

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -1,3 +1,5 @@
+AARM
+ATF
 AAIF
 abprs
 abspath

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/microsoft/agent-governance-toolkit/badge)](https://scorecard.dev/viewer/?uri=github.com/microsoft/agent-governance-toolkit)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12085/badge)](https://www.bestpractices.dev/projects/12085)
 [![OWASP Agentic Top 10](https://img.shields.io/badge/OWASP_Agentic_Top_10-10%2F10_Covered-blue)](docs/compliance/owasp-agentic-top10-architecture.md)
+[![AARM Extended](https://img.shields.io/badge/AARM-Extended_(R1–R9)-brightgreen)](https://aarm.dev/builders/agent-governance-toolkit-microsoft)
+[![ATF](https://img.shields.io/badge/ATF-All_5_Elements-brightgreen)](https://agentictrustframework.ai/ecosystem)
 
 > [!IMPORTANT]
 > **Public Preview** -- production-quality public preview releases. May have breaking changes before GA.
@@ -362,6 +364,8 @@ Every major component has a formal RFC 2119 specification with conformance tests
 | [NIST AI RMF 1.0](docs/compliance/nist-ai-rmf-alignment.md) | Full GOVERN, MAP, MEASURE, MANAGE alignment |
 | [EU AI Act](docs/compliance/) | Compliance mapping with automated evidence |
 | [SOC 2](docs/compliance/soc2-mapping.md) | Control mapping with audit trail export |
+| [AARM Extended](https://aarm.dev/builders/agent-governance-toolkit-microsoft) | All R1–R9 requirements satisfied; verified Jun 14, 2026 |
+| [ATF](https://agentictrustframework.ai/ecosystem) | All five elements mapped: Agent Mesh (identity), Agent OS (policy), Agent Compliance (governance), Agent Runtime (sandboxing), Agent SRE (incident response) |
 
 ---
 
@@ -391,7 +395,7 @@ See [Known Limitations](docs/LIMITATIONS.md) for honest design boundaries and re
 | **Architecture** | [System Design](docs/ARCHITECTURE.md) · [Threat Model](docs/security/threat-model.md) · [ADRs](docs/adr/) (29) |
 | **Specifications** | [All Specs](docs/specs/) (10 formal specs, 992 conformance tests) |
 | **API Reference** | [Agent OS](agent-governance-python/agent-os/README.md) · [AgentMesh](agent-governance-python/agent-mesh/README.md) · [Agent SRE](agent-governance-python/agent-sre/README.md) |
-| **Compliance** | [OWASP](docs/compliance/owasp-agentic-top10-architecture.md) · [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [SOC 2](docs/compliance/soc2-mapping.md) |
+| **Compliance** | [OWASP](docs/compliance/owasp-agentic-top10-architecture.md) · [EU AI Act](docs/compliance/) · [NIST AI RMF](docs/compliance/nist-ai-rmf-alignment.md) · [SOC 2](docs/compliance/soc2-mapping.md) · [AARM Extended](https://aarm.dev/builders/agent-governance-toolkit-microsoft) · [ATF](https://agentictrustframework.ai/ecosystem) |
 | **Deployment** | [Azure](docs/deployment/README.md) · [AWS](docs/deployment/README.md) · [GCP](docs/deployment/README.md) · [Docker Compose](docs/deployment/README.md) |
 | **Extensions** | [VS Code](agent-governance-typescript/agent-os-vscode/) · [Framework Integrations](agent-governance-python/agentmesh-integrations/) |
 


### PR DESCRIPTION
AGT is listed on both registries — adding the references.

**AARM** ([aarm.dev/builders/agent-governance-toolkit-microsoft](https://aarm.dev/builders/agent-governance-toolkit-microsoft)): AARM Extended conformance, all R1–R9 requirements satisfied, verified June 14, 2026.

**ATF** ([agentictrustframework.ai/ecosystem](https://agentictrustframework.ai/ecosystem)): all five ATF elements mapped — Agent Mesh (identity), Agent OS (policy enforcement), Agent Compliance (governance verification), Agent Runtime (sandboxing), Agent SRE (incident response).

Changes: two badges, two rows in the Standards Compliance table, two links in the Documentation compliance row.