### PR TITLE
feat(agent-mesh): legacy ApprovalHandler to protocol compatibility adapter (ADR-0030 step 3)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_bridge.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_bridge.py
@@ -1,0 +1,109 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Compatibility bridge from legacy approval handlers to the ADR-0030 protocol.
+
+Step 3 of the ADR-0030 migration. The action-bound approval protocol
+(:mod:`.approval_protocol`) is asynchronous and durable, but the existing
+:class:`~agentmesh.governance.approval.ApprovalHandler` implementations
+(callback, console, webhook, auto-reject) are synchronous: a handler is asked
+for a decision and returns one inline.
+
+:class:`LegacyHandlerAdapter` wraps such a handler so its vote becomes one
+authenticated entry on a protocol approval chain: it asks the handler, maps the
+``approved`` / ``approver`` / ``reason`` result onto a single
+:meth:`~.approval_protocol.ApprovalCoordinator.submit_entry` call, and reports
+the outcome. This keeps existing handlers working inside the protocol without
+each integration (govern, Agent OS escalation, MCP gateway, framework adapters)
+reimplementing the same mapping.
+
+This module is allowed to depend on both the legacy ``approval`` module and the
+``approval_protocol`` foundation; the foundation never depends back on it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .approval import ApprovalDecision, ApprovalHandler, ApprovalRequest
+from .approval_protocol import (
+    ApprovalChainEntry,
+    ApprovalCoordinator,
+    ApprovalProtocolError,
+    ApproverKind,
+    EntryDecision,
+)
+from .approval_protocol import ApprovalRequest as ProtocolApprovalRequest
+
+__all__ = ["AdapterResult", "LegacyHandlerAdapter"]
+
+
+@dataclass
+class AdapterResult:
+    """Outcome of bridging one handler vote into a protocol chain entry.
+
+    Attributes:
+        approval: The legacy handler's decision (always present).
+        entry: The submitted chain entry, or ``None`` if it was rejected.
+        error: Fail-closed reason when ``entry`` is ``None`` (e.g. the approver
+            identity is not permitted by the stage, or the request has expired).
+    """
+
+    approval: ApprovalDecision
+    entry: Optional[ApprovalChainEntry]
+    error: Optional[str]
+
+    @property
+    def submitted(self) -> bool:
+        return self.entry is not None
+
+
+class LegacyHandlerAdapter:
+    """Drives one protocol chain entry from a legacy ``ApprovalHandler`` vote."""
+
+    def __init__(
+        self,
+        handler: ApprovalHandler,
+        *,
+        approver_kind: ApproverKind = ApproverKind.HUMAN,
+        identity_assurance: str = "approval-handler",
+    ) -> None:
+        self._handler = handler
+        self._approver_kind = approver_kind
+        self._identity_assurance = identity_assurance
+
+    def collect(
+        self,
+        coordinator: ApprovalCoordinator,
+        request: ProtocolApprovalRequest,
+        legacy_request: ApprovalRequest,
+        *,
+        stage_index: int = 0,
+    ) -> AdapterResult:
+        """Ask the handler and submit its vote as a chain entry.
+
+        Fail-closed: any :class:`ApprovalProtocolError` from ``submit_entry``
+        (unpermitted identity, expired request, unknown stage) yields an
+        :class:`AdapterResult` with ``entry=None`` and a populated ``error``
+        rather than propagating, so callers can deny without special-casing.
+        """
+        approval = self._handler.request_approval(legacy_request)
+        try:
+            entry = coordinator.submit_entry(
+                request.approval_request_id,
+                stage_index=stage_index,
+                approver_kind=self._approver_kind,
+                approver_identity=approval.approver or "unknown",
+                identity_assurance=self._identity_assurance,
+                decision=(
+                    EntryDecision.ALLOW if approval.approved else EntryDecision.DENY
+                ),
+                reason_code=approval.reason or "",
+            )
+        except ApprovalProtocolError as exc:
+            return AdapterResult(
+                approval=approval,
+                entry=None,
+                error=f"approval entry rejected: {exc}",
+            )
+        return AdapterResult(approval=approval, entry=entry, error=None)

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
@@ -28,14 +28,8 @@ from .policy import Policy, PolicyDecision, PolicyEngine
 from .audit import AuditLog
 from .approval import ApprovalHandler, ApprovalRequest, AutoRejectApproval
 from .advisory import AdvisoryCheck, AdvisoryDecision
-from .approval_protocol import (
-    ActionBinding,
-    ActionTarget,
-    ApprovalCoordinator,
-    ApprovalProtocolError,
-    ApproverKind,
-    EntryDecision,
-)
+from .approval_protocol import ActionBinding, ActionTarget, ApprovalCoordinator
+from .approval_bridge import LegacyHandlerAdapter
 
 if TYPE_CHECKING:
     from hypervisor.models import ExecutionRing
@@ -418,9 +412,13 @@ class GovernedCallable:
         )
 
         # The legacy handler is the synchronous source of the approver's vote;
-        # its result becomes one authenticated chain entry at stage 0.
+        # the adapter turns that vote into one authenticated chain entry at
+        # stage 0, fail-closed on an unpermitted identity or expired request.
         handler = self._config.approval_handler or AutoRejectApproval()
-        approval = handler.request_approval(
+        adapter = LegacyHandlerAdapter(handler)
+        result = adapter.collect(
+            coordinator,
+            request,
             ApprovalRequest(
                 action=context.get("action", {}).get("type", "unknown"),
                 rule_name=decision.matched_rule or "",
@@ -428,27 +426,12 @@ class GovernedCallable:
                 agent_id=self._config.agent_id,
                 context=context,
                 approvers=decision.approvers,
-            )
+            ),
         )
+        approval = result.approval
 
         verdict = None
-        fail_reason: Optional[str] = None
-        try:
-            coordinator.submit_entry(
-                request.approval_request_id,
-                stage_index=0,
-                approver_kind=ApproverKind.HUMAN,
-                approver_identity=approval.approver or "unknown",
-                identity_assurance="approval-handler",
-                decision=(
-                    EntryDecision.ALLOW if approval.approved else EntryDecision.DENY
-                ),
-                reason_code=approval.reason or "",
-            )
-        except ApprovalProtocolError as exc:
-            # Unpermitted identity, expired request, etc. Fail closed.
-            fail_reason = f"approval entry rejected: {exc}"
-        else:
+        if result.submitted:
             verdict = coordinator.validate_for_execution(
                 request.approval_request_id,
                 current_action_digest=binding.digest(),
@@ -457,7 +440,7 @@ class GovernedCallable:
             )
 
         allowed = bool(verdict and verdict.allowed)
-        reason_code = verdict.reason_code if verdict is not None else fail_reason
+        reason_code = verdict.reason_code if verdict is not None else result.error
 
         # Audit linkage: tie the entry to the protocol record ids and the action
         # digest (ADR-0030 section 7); reuse the AuditEntry assurance fields.

--- a/agent-governance-python/agent-mesh/tests/test_approval_bridge.py
+++ b/agent-governance-python/agent-mesh/tests/test_approval_bridge.py
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the legacy-handler -> protocol compatibility bridge (ADR-0030 step 3)."""
+
+from agentmesh.governance.approval import (
+    ApprovalDecision,
+    ApprovalRequest,
+    CallbackApproval,
+)
+from agentmesh.governance.approval_bridge import AdapterResult, LegacyHandlerAdapter
+from agentmesh.governance.approval_protocol import (
+    ActionBinding,
+    ActionTarget,
+    ApprovalChain,
+    ApprovalCoordinator,
+    ApprovalStage,
+    ApproverKind,
+    EntryDecision,
+    InMemoryApprovalStore,
+    Outcome,
+)
+
+ALICE = "alice"
+
+
+def _coord(identities=frozenset({ALICE})):
+    chain = ApprovalChain("c", "1", (ApprovalStage(0, allowed_identities=identities),))
+    return ApprovalCoordinator(InMemoryApprovalStore(), {chain.chain_id: chain})
+
+
+def _binding():
+    return ActionBinding(
+        operation="tool.invoke", agent_id="a", target=ActionTarget("t", "1")
+    )
+
+
+def _open(coord, ttl_seconds=300):
+    _, request = coord.open_request(
+        _binding(),
+        policy_rule_id="r",
+        policy_version="v1",
+        chain_id="c",
+        ttl_seconds=ttl_seconds,
+    )
+    return request
+
+
+def _legacy_request():
+    return ApprovalRequest(action="transfer", rule_name="r", policy_name="p", agent_id="a")
+
+
+def _handler(approved=True, approver=ALICE, reason="ok"):
+    return CallbackApproval(
+        lambda req: ApprovalDecision(approved=approved, approver=approver, reason=reason)
+    )
+
+
+class TestLegacyHandlerAdapter:
+    def test_approve_submits_allow_entry_and_resolves(self):
+        coord = _coord()
+        request = _open(coord)
+        result = LegacyHandlerAdapter(_handler(approved=True)).collect(
+            coord, request, _legacy_request()
+        )
+        assert isinstance(result, AdapterResult)
+        assert result.submitted and result.entry is not None
+        assert result.error is None
+        assert result.entry.decision == EntryDecision.ALLOW
+        assert result.entry.approver_identity == ALICE
+        resolution = coord.store.get_resolution(request.approval_request_id)
+        assert resolution is not None and resolution.outcome == Outcome.ALLOW
+
+    def test_reject_submits_deny_entry(self):
+        coord = _coord()
+        request = _open(coord)
+        result = LegacyHandlerAdapter(_handler(approved=False)).collect(
+            coord, request, _legacy_request()
+        )
+        assert result.submitted
+        assert result.entry.decision == EntryDecision.DENY
+        resolution = coord.store.get_resolution(request.approval_request_id)
+        assert resolution is not None and resolution.outcome == Outcome.DENY
+
+    def test_unpermitted_identity_fails_closed(self):
+        coord = _coord()
+        request = _open(coord)
+        result = LegacyHandlerAdapter(_handler(approver="mallory")).collect(
+            coord, request, _legacy_request()
+        )
+        assert not result.submitted
+        assert result.entry is None
+        assert result.error and "rejected" in result.error
+        # The handler's vote is still reported even though it was not recorded.
+        assert result.approval.approver == "mallory"
+
+    def test_expired_request_fails_closed(self):
+        coord = _coord()
+        request = _open(coord, ttl_seconds=0)
+        result = LegacyHandlerAdapter(_handler()).collect(
+            coord, request, _legacy_request()
+        )
+        assert not result.submitted
+        assert result.error
+
+    def test_reason_and_approver_propagate(self):
+        coord = _coord()
+        request = _open(coord)
+        result = LegacyHandlerAdapter(_handler(reason="looks-ok")).collect(
+            coord, request, _legacy_request()
+        )
+        assert result.entry.reason_code == "looks-ok"
+        assert result.approval.reason == "looks-ok"
+
+    def test_custom_kind_and_assurance(self):
+        coord = _coord()
+        request = _open(coord)
+        adapter = LegacyHandlerAdapter(
+            _handler(), approver_kind=ApproverKind.SERVICE, identity_assurance="mtls"
+        )
+        result = adapter.collect(coord, request, _legacy_request())
+        assert result.entry.approver_kind == ApproverKind.SERVICE
+        assert result.entry.identity_assurance == "mtls"


### PR DESCRIPTION
## Summary

Step 3 of the ADR-0030 migration: a reusable compatibility adapter so existing synchronous `ApprovalHandler` implementations (callback, console, webhook, auto-reject) drive the action-bound approval protocol.

Step 2 (#3076) bridged the legacy handler into the coordinator inline inside `govern()`. This PR extracts that into `governance/approval_bridge.py`, so every approval path (Agent OS escalation, MCP gateway, framework adapters) can reuse one handler-to-protocol mapping instead of reimplementing it.

## What changed

- New `governance/approval_bridge.py`:
  - `LegacyHandlerAdapter(handler, *, approver_kind=HUMAN, identity_assurance="approval-handler")`.
  - `.collect(coordinator, request, legacy_request, *, stage_index=0) -> AdapterResult`: asks the handler, maps `approved` / `approver` / `reason` onto one `submit_entry`, fail-closed on `ApprovalProtocolError` (unpermitted identity, expired request, unknown stage).
  - `AdapterResult(approval, entry, error)` with a `.submitted` convenience.
- `govern.py`: the `require_approval` coordinator path now uses the adapter; behavior is unchanged (net -17 lines there).
- The `approval_protocol` foundation package is untouched and never depends on the bridge.

## Tests

`tests/test_approval_bridge.py` (6 tests): approve submits an ALLOW entry and resolves allow; reject submits DENY; an unpermitted identity fails closed (`entry=None`, error set, vote still reported); an expired request fails closed; reason and approver propagate; custom approver kind and assurance. Existing govern coordinator and approval suites still pass (85 total).

## Scope

Single-stage via the synchronous handler, same as step 2. Multi-stage orchestration and async / webhook transport remain steps 4 and beyond.

Refs #2478. ADR-0030 step 3.
