### PR TITLE
feat(agent-mesh): versioned action-bound webhook approval contract (ADR-0030 step 4)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_webhook.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_webhook.py
@@ -1,0 +1,172 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Versioned, action-bound webhook approval contract (ADR-0030 step 4, section 5).
+
+The legacy :class:`~agentmesh.governance.approval.WebhookApproval` sends a thin
+payload with no request id, action digest, policy/chain version, or expiry, and
+it trusts an ``approver`` string supplied in the response body. ADR-0030 section
+5 supersedes that: a webhook is a transport, not an approver identity type, and
+the contract must carry the binding and refuse body-supplied identities that are
+not backed by a verified assertion.
+
+This module provides that contract against the merged protocol foundation:
+
+* :func:`build_webhook_request` builds the schema-versioned, action-bound
+  request payload from a protocol :class:`ApprovalRequest`;
+* :func:`parse_webhook_response` validates the response echoes the binding and
+  only honours an approve when the approver identity is verified;
+* :class:`VersionedWebhookApproval` is the protocol-native transport. It takes
+  the protocol request (the legacy ``ApprovalHandler.request_approval``
+  signature is too thin to carry the action digest), POSTs the payload with
+  caller-supplied auth headers, and fails closed on timeout, transport error,
+  malformed response, or binding mismatch.
+
+It depends only on the protocol foundation and the legacy ``ApprovalDecision``
+result type; it does not modify ``govern`` or the foundation package. Wiring the
+transport into the govern/bridge flow is a separate follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, Optional
+
+from .advisory import _validate_webhook_url
+from .approval import ApprovalDecision
+from .approval_protocol import ApprovalRequest
+
+logger = logging.getLogger(__name__)
+
+WEBHOOK_SCHEMA_VERSION = "1.0"
+
+# A verifier maps (response_body, request) to the verified approver principal,
+# or None when the identity cannot be trusted. It is the single extension point
+# for "bound to authenticated transport or a verified identity assertion".
+ResponseVerifier = Callable[[dict, ApprovalRequest], Optional[str]]
+Transport = Callable[[str, bytes, dict, float], dict]
+
+
+def build_webhook_request(
+    request: ApprovalRequest, *, schema_version: str = WEBHOOK_SCHEMA_VERSION
+) -> dict[str, Any]:
+    """Build the versioned, action-bound webhook request payload.
+
+    Carries the ADR-0030 section 5 required fields (request id, policy decision
+    id, action digest, policy version, chain version, expiry) by reusing the
+    protocol request's canonical presentation, plus the schema version and the
+    input digest the approver is asked to attest to.
+    """
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "type": "approval_request",
+        "input_digest": request.input_digest(),
+    }
+    payload.update(request.presented_canonical())
+    return payload
+
+
+def _deny(reason: str, *, approver: str = "webhook:rejected") -> ApprovalDecision:
+    return ApprovalDecision(approved=False, approver=approver, reason=reason)
+
+
+def parse_webhook_response(
+    body: Any,
+    *,
+    request: ApprovalRequest,
+    response_verifier: Optional[ResponseVerifier] = None,
+) -> ApprovalDecision:
+    """Validate a webhook response and map it to an :class:`ApprovalDecision`.
+
+    Fail-closed: the response must echo ``approval_request_id`` and
+    ``action_digest`` from the request, and an approve is honoured only when the
+    approver identity is verified by ``response_verifier``. A deny is always
+    honoured (denying is the safe direction). Anything malformed denies.
+    """
+    if not isinstance(body, dict):
+        return _deny("malformed webhook response")
+
+    if body.get("approval_request_id") != request.approval_request_id:
+        return _deny("approval_request_id mismatch", approver="webhook:binding-mismatch")
+    if body.get("action_digest") != request.action_digest:
+        return _deny("action_digest mismatch", approver="webhook:binding-mismatch")
+
+    approved = body.get("approved")
+    if approved is None and "decision" in body:
+        approved = body.get("decision") == "allow"
+    if not isinstance(approved, bool):
+        return _deny("missing or malformed 'approved' field")
+
+    reason = str(body.get("reason", ""))
+
+    if not approved:
+        return ApprovalDecision(
+            approved=False,
+            approver=str(body.get("approver") or "webhook"),
+            reason=reason or "denied by webhook",
+        )
+
+    # Approve path: a body-supplied identity is only trusted when verified.
+    principal: Optional[str] = None
+    if response_verifier is not None:
+        try:
+            principal = response_verifier(body, request)
+        except Exception as exc:  # a misbehaving verifier must not allow
+            return _deny(f"identity verification error: {exc}")
+    if not principal:
+        return _deny("approve rejected: unverified approver identity")
+
+    return ApprovalDecision(approved=True, approver=str(principal), reason=reason)
+
+
+class VersionedWebhookApproval:
+    """Protocol-native versioned webhook approval transport (ADR-0030 section 5).
+
+    Args:
+        url: Webhook endpoint (validated against the SSRF guard).
+        timeout_seconds: Max time to wait for the response. Default 300.
+        headers: Outbound headers, e.g. a bearer token or HMAC for
+            authenticating the remote service.
+        response_verifier: Verifies the approver identity in the response and
+            returns the trusted principal, or None to deny the approve.
+        transport: Optional injected ``(url, data, headers, timeout) -> dict``
+            for testing; defaults to a urllib POST.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout_seconds: float = 300.0,
+        headers: Optional[dict[str, str]] = None,
+        response_verifier: Optional[ResponseVerifier] = None,
+        transport: Optional[Transport] = None,
+    ) -> None:
+        _validate_webhook_url(url)
+        self._url = url
+        self._timeout = timeout_seconds
+        self._headers = dict(headers or {})
+        self._response_verifier = response_verifier
+        self._transport = transport
+
+    def request_decision(self, request: ApprovalRequest) -> ApprovalDecision:
+        """POST the versioned payload and return the validated decision."""
+        data = json.dumps(build_webhook_request(request)).encode("utf-8")
+        headers = {"Content-Type": "application/json", **self._headers}
+        post = self._transport or self._http_post
+        try:
+            body = post(self._url, data, headers, self._timeout)
+        except Exception as exc:  # timeout, transport, auth, decode
+            logger.error("versioned webhook approval error: %s", exc)
+            return _deny(f"webhook error: {exc}", approver="system:webhook-error")
+        return parse_webhook_response(
+            body, request=request, response_verifier=self._response_verifier
+        )
+
+    @staticmethod
+    def _http_post(url: str, data: bytes, headers: dict, timeout: float) -> dict:
+        import urllib.request
+
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8"))

--- a/agent-governance-python/agent-mesh/tests/test_approval_webhook.py
+++ b/agent-governance-python/agent-mesh/tests/test_approval_webhook.py
@@ -1,0 +1,163 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the versioned, action-bound webhook approval contract (ADR-0030 step 4)."""
+
+import json
+from datetime import timedelta
+
+import pytest
+
+from agentmesh.governance.approval_protocol import ApprovalRequest, utcnow
+from agentmesh.governance.approval_webhook import (
+    WEBHOOK_SCHEMA_VERSION,
+    VersionedWebhookApproval,
+    build_webhook_request,
+    parse_webhook_response,
+)
+
+
+def _request():
+    return ApprovalRequest(
+        policy_decision_id="pd_1",
+        action_digest="sha256:abc123",
+        agent_id="agent-1",
+        operation="tool.invoke",
+        policy_version="2026.06.17",
+        approval_chain_id="high-risk",
+        approval_chain_version="3",
+        expires_at=utcnow() + timedelta(seconds=300),
+        subject_id="user-1",
+        target_resource="prod-db",
+    )
+
+
+def _verifier(body, request):
+    # Trust the body-supplied approver only when a valid assertion accompanies it.
+    return body.get("approver") if body.get("identity_assertion") == "valid" else None
+
+
+def _ok_response(request, **overrides):
+    body = {
+        "approval_request_id": request.approval_request_id,
+        "action_digest": request.action_digest,
+        "approved": True,
+        "approver": "alice",
+        "identity_assertion": "valid",
+        "reason": "reviewed",
+    }
+    body.update(overrides)
+    return body
+
+
+class TestBuildWebhookRequest:
+    def test_payload_carries_binding_and_versions(self):
+        request = _request()
+        payload = build_webhook_request(request)
+        assert payload["schema_version"] == WEBHOOK_SCHEMA_VERSION
+        assert payload["type"] == "approval_request"
+        assert payload["approval_request_id"] == request.approval_request_id
+        assert payload["action_digest"] == "sha256:abc123"
+        assert payload["policy_version"] == "2026.06.17"
+        assert payload["approval_chain_version"] == "3"
+        assert payload["input_digest"].startswith("sha256:")
+        assert "expires_at" in payload
+
+
+class TestParseWebhookResponse:
+    def test_verified_approve(self):
+        request = _request()
+        decision = parse_webhook_response(
+            _ok_response(request), request=request, response_verifier=_verifier
+        )
+        assert decision.approved
+        assert decision.approver == "alice"
+
+    def test_request_id_mismatch_denies(self):
+        request = _request()
+        decision = parse_webhook_response(
+            _ok_response(request, approval_request_id="ar_other"),
+            request=request,
+            response_verifier=_verifier,
+        )
+        assert not decision.approved
+        assert decision.approver == "webhook:binding-mismatch"
+
+    def test_action_digest_mismatch_denies(self):
+        request = _request()
+        decision = parse_webhook_response(
+            _ok_response(request, action_digest="sha256:tampered"),
+            request=request,
+            response_verifier=_verifier,
+        )
+        assert not decision.approved
+        assert decision.approver == "webhook:binding-mismatch"
+
+    def test_approve_without_verifier_denies(self):
+        request = _request()
+        decision = parse_webhook_response(_ok_response(request), request=request)
+        assert not decision.approved
+        assert "unverified" in decision.reason
+
+    def test_approve_with_unverifiable_identity_denies(self):
+        request = _request()
+        decision = parse_webhook_response(
+            _ok_response(request, identity_assertion="forged"),
+            request=request,
+            response_verifier=_verifier,
+        )
+        assert not decision.approved
+
+    def test_explicit_deny_needs_no_verifier(self):
+        request = _request()
+        decision = parse_webhook_response(
+            _ok_response(request, approved=False, approver="bob", reason="too risky"),
+            request=request,
+        )
+        assert not decision.approved
+        assert decision.reason == "too risky"
+
+    def test_malformed_denies(self):
+        request = _request()
+        assert not parse_webhook_response("nope", request=request).approved
+        assert not parse_webhook_response(
+            {"approval_request_id": request.approval_request_id,
+             "action_digest": request.action_digest},
+            request=request,
+        ).approved  # missing 'approved'
+
+
+class TestVersionedWebhookApproval:
+    def test_request_decision_posts_versioned_payload(self):
+        request = _request()
+        captured = {}
+
+        def fake_transport(url, data, headers, timeout):
+            captured["url"] = url
+            captured["payload"] = json.loads(data.decode("utf-8"))
+            captured["headers"] = headers
+            return _ok_response(request)
+
+        wh = VersionedWebhookApproval(
+            "https://example.com/approve",
+            headers={"Authorization": "Bearer t"},
+            response_verifier=_verifier,
+            transport=fake_transport,
+        )
+        decision = wh.request_decision(request)
+        assert decision.approved and decision.approver == "alice"
+        assert captured["payload"]["action_digest"] == "sha256:abc123"
+        assert captured["payload"]["schema_version"] == WEBHOOK_SCHEMA_VERSION
+        assert captured["headers"]["Authorization"] == "Bearer t"
+
+    def test_transport_error_fails_closed(self):
+        def boom(url, data, headers, timeout):
+            raise TimeoutError("timed out")
+
+        wh = VersionedWebhookApproval("https://example.com/a", transport=boom)
+        decision = wh.request_decision(_request())
+        assert not decision.approved
+        assert "webhook error" in decision.reason
+
+    def test_bad_url_rejected(self):
+        with pytest.raises(ValueError):
+            VersionedWebhookApproval("ftp://evil/approve")


### PR DESCRIPTION
## Summary

Step 4 of the ADR-0030 migration (section 5): a versioned, action-bound webhook approval contract.

The legacy `WebhookApproval` ([approval.py](https://github.com/microsoft/agent-governance-toolkit/blob/main/agent-governance-python/agent-mesh/src/agentmesh/governance/approval.py)) sends a thin payload with no request id, action digest, policy/chain version, or expiry, and trusts an `approver` string supplied in the response body. ADR-0030 section 5 supersedes that: a webhook is a transport, not an approver identity type, and the contract must carry the binding and refuse body-supplied identities that are not backed by a verified assertion.

## What changed

New `governance/approval_webhook.py` (additive):

- `build_webhook_request(request, *, schema_version="1.0")`: schema-versioned, action-bound payload carrying the request id, policy decision id, action digest, policy version, chain version, and expiry (reuses the protocol request's `presented_canonical()`), plus the `input_digest`.
- `parse_webhook_response(body, *, request, response_verifier=None)`: the response must echo `approval_request_id` and `action_digest` (binding mismatch denies); an approve is honoured only when the approver identity is verified by `response_verifier`; a deny is always honoured; anything malformed denies.
- `VersionedWebhookApproval`: the protocol-native transport (it takes the protocol `ApprovalRequest`, because the legacy `ApprovalHandler.request_approval` signature is too thin to carry the action digest). POSTs with caller-supplied auth headers, reuses the existing `_validate_webhook_url` SSRF guard, and fails closed on timeout, transport error, malformed response, or binding mismatch. HTTP is injectable for tests.

## Scope

- Standalone and additive: no changes to `govern`, to the legacy `WebhookApproval` (kept as the "old payload behind a legacy adapter" the ADR allows), or to the `approval_protocol` foundation.
- Independent of the step-3 PR (#3096): different files, so the two can review and merge in any order. Wiring the transport into the govern/bridge flow is a follow-up.
- Auth depth (first cut): outbound auth via caller-supplied headers; inbound trust requires the response to echo the binding plus a verified principal via `response_verifier`, denying otherwise. Mutual TLS or a built-in signature scheme is later hardening.

## Tests

`tests/test_approval_webhook.py` (11 tests, no network): payload field coverage; verified approve; request-id and action-digest mismatch deny; approve without a verifier denies; approve with an unverifiable identity denies; explicit deny needs no verifier; malformed denies; transport posts the versioned payload with auth headers; transport error fails closed; bad URL rejected.

Refs #2478. ADR-0030 step 4.
