### PR TITLE
feat(trace): add TRACE v0.2 trust record data model and session mapping (#3086)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -842,3 +842,10 @@ geofencing
 geofence
 geomatch
 YYMMDDGSSSCAZ
+
+# --- TRACE / identity-chain / advisory terms ---
+agentrust
+contextvars
+miyannishar
+GHSA
+ghsa

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
@@ -107,6 +107,12 @@ from .protocol_facets import (
     extract_protocol_facets,
     default_registry,
 )
+from .trace_model import (
+    TraceModelConfig,
+    TraceSession,
+    TrustRecord,
+    session_to_trust_record,
+)
 
 __all__ = [
     # High-level wrapper (issue #1372)
@@ -223,5 +229,10 @@ __all__ = [
     "FacetRegistry",
     "extract_protocol_facets",
     "default_registry",
+    # TRACE v0.2 Trust Record model (ADR-0032, issue #3086)
+    "TraceModelConfig",
+    "TraceSession",
+    "TrustRecord",
+    "session_to_trust_record",
 ]
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
@@ -17,6 +17,7 @@ Or wrap an entire callable (agent, tool, function):
 from __future__ import annotations
 
 import functools
+import hashlib
 import logging
 import os
 import re
@@ -161,19 +162,29 @@ class GovernedCallable:
 
         # Load policy
         policy = config.policy
+        _bundle_bytes: bytes = b""
         if isinstance(policy, str):
             if os.path.isfile(policy):
+                with open(policy, "rb") as _f:
+                    _bundle_bytes = _f.read()
                 loaded = self._engine.load_yaml_file(policy)
             else:
+                _bundle_bytes = policy.encode("utf-8")
                 loaded = self._engine.load_yaml(policy)
         elif isinstance(policy, Policy):
             loaded = policy
             self._engine.load_policy(loaded)
+            _bundle_bytes = loaded.to_yaml().encode("utf-8") if hasattr(loaded, "to_yaml") else b""
         else:
             raise TypeError(
                 f"policy must be a file path, YAML string, or Policy object, "
                 f"got {type(policy).__name__}"
             )
+
+        # Hash of policy bundle bytes at load time — consumed by TRACEAuditSink (ADR-0032).
+        self._policy_bundle_hash: str = (
+            "sha256:" + hashlib.sha256(_bundle_bytes).hexdigest() if _bundle_bytes else ""
+        )
 
         # Ensure the policy applies to our agent_id. If no agents are
         # specified, default to wildcard so govern() works out of the box.

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/trace_model.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/trace_model.py
@@ -1,0 +1,114 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""TRACE v0.2 Trust Record data model and session mapping (ADR-0032, step 1/5)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from .audit import AuditEntry
+
+
+_DENY_OUTCOMES = frozenset({"denied"})
+_DENY_EVENT_TYPES = frozenset({"policy_violation", "tool_blocked"})
+
+
+@dataclass
+class TraceModelConfig:
+    """Config-injected values for TRACE Trust Record fields."""
+
+    model: dict
+    runtime: dict
+    enforcement_mode: str
+    build_provenance: dict
+    verifier: str
+    eat_profile: str = "tag:agentrust.io,2026:trace-v0.1"
+
+
+@dataclass
+class TraceSession:
+    """Bundle of per-session data needed to produce a TRACE Trust Record."""
+
+    agent_did: str
+    audit_entries: list[AuditEntry]
+    data_class: str
+    policy_bundle_hash: Optional[str] = None
+
+
+@dataclass
+class TrustRecord:
+    """TRACE v0.2 Trust Record (ADR-0032)."""
+
+    eat_profile: str
+    iat: int
+    subject: str
+    model: dict
+    runtime: dict
+    policy: dict
+    data_class: str
+    build_provenance: dict
+    appraisal: dict
+    transparency: str
+    tool_transcript: dict
+
+
+def _jcs_hash(entries: list[AuditEntry]) -> str:
+    """Return 'sha256:<hex>' of RFC 8785 JCS-canonical JSON of the entry list."""
+    serialized = [json.loads(e.model_dump_json()) for e in entries]
+    canonical = json.dumps(
+        serialized, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def session_to_trust_record(session: TraceSession, config: TraceModelConfig) -> dict:
+    """Map a closed AGT session to a TRACE v0.2 Trust Record payload dict."""
+    entries = session.audit_entries
+
+    iat = 0
+    if entries:
+        latest = max(entries, key=lambda e: e.timestamp)
+        iat = int(latest.timestamp.timestamp())
+
+    has_deny = any(
+        e.outcome in _DENY_OUTCOMES or e.event_type in _DENY_EVENT_TYPES
+        for e in entries
+    )
+    appraisal_status = "contraindicated" if has_deny else "affirming"
+
+    call_count = sum(1 for e in entries if e.event_type == "tool_invocation")
+
+    record = TrustRecord(
+        eat_profile=config.eat_profile,
+        iat=iat,
+        subject=session.agent_did,
+        model=config.model,
+        runtime=config.runtime,
+        policy={
+            "bundle_hash": session.policy_bundle_hash or "",
+            "enforcement_mode": config.enforcement_mode,
+        },
+        data_class=session.data_class,
+        build_provenance=config.build_provenance,
+        appraisal={"status": appraisal_status, "verifier": config.verifier},
+        transparency="",
+        tool_transcript={"hash": _jcs_hash(entries), "call_count": call_count},
+    )
+
+    return {
+        "eat_profile": record.eat_profile,
+        "iat": record.iat,
+        "subject": record.subject,
+        "model": record.model,
+        "runtime": record.runtime,
+        "policy": record.policy,
+        "data_class": record.data_class,
+        "build_provenance": record.build_provenance,
+        "appraisal": record.appraisal,
+        "transparency": record.transparency,
+        "tool_transcript": record.tool_transcript,
+    }

--- a/agent-governance-python/agent-mesh/tests/governance/test_trace_model.py
+++ b/agent-governance-python/agent-mesh/tests/governance/test_trace_model.py
@@ -1,0 +1,148 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for TRACE v0.2 Trust Record model and session mapping."""
+
+from __future__ import annotations
+
+from agentmesh.governance.audit import AuditEntry
+from agentmesh.governance.trace_model import (
+    TraceModelConfig,
+    TraceSession,
+    session_to_trust_record,
+)
+
+_ZEROS = "0" * 64
+
+_CONFIG = TraceModelConfig(
+    model={
+        "provider": "anthropic",
+        "model_id": "claude-opus-4",
+        "version": "1.0",
+        "weights_digest": f"sha256:{_ZEROS}",
+    },
+    runtime={"platform": "software-only", "measurement": f"sha256:{_ZEROS}"},
+    enforcement_mode="enforce",
+    build_provenance={
+        "slsa_level": 2,
+        "builder": "github-actions",
+        "digest": f"sha256:{_ZEROS}",
+    },
+    verifier="https://verifier.agentrust.io",
+)
+
+
+def _entry(**kwargs) -> AuditEntry:
+    defaults = {
+        "event_type": "tool_invocation",
+        "agent_did": "did:mesh:test-agent",
+        "action": "read_file",
+    }
+    defaults.update(kwargs)
+    return AuditEntry(**defaults)
+
+
+class TestSessionToTrustRecord:
+    def test_golden_path_fields_present(self):
+        session = TraceSession(
+            agent_did="did:mesh:spiffe://cluster/ns/default/sa/agent-1",
+            audit_entries=[_entry()],
+            data_class="public",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+
+        assert record["eat_profile"] == "tag:agentrust.io,2026:trace-v0.1"
+        assert record["subject"] == "did:mesh:spiffe://cluster/ns/default/sa/agent-1"
+        assert record["data_class"] == "public"
+        assert isinstance(record["iat"], int) and record["iat"] > 0
+        assert record["transparency"] == ""
+        assert record["appraisal"]["status"] == "affirming"
+        assert record["appraisal"]["verifier"] == "https://verifier.agentrust.io"
+        assert record["tool_transcript"]["call_count"] == 1
+        assert record["tool_transcript"]["hash"].startswith("sha256:")
+
+    def test_affirming_when_no_denials(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[_entry(), _entry(event_type="session_start", action="start")],
+            data_class="public",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["appraisal"]["status"] == "affirming"
+
+    def test_contraindicated_on_denied_outcome(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[_entry(outcome="denied")],
+            data_class="confidential",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["appraisal"]["status"] == "contraindicated"
+
+    def test_contraindicated_on_tool_blocked(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[_entry(event_type="tool_blocked")],
+            data_class="public",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["appraisal"]["status"] == "contraindicated"
+
+    def test_contraindicated_on_policy_violation(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[_entry(event_type="policy_violation")],
+            data_class="public",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["appraisal"]["status"] == "contraindicated"
+
+    def test_call_count_only_counts_tool_invocations(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[
+                _entry(event_type="tool_invocation"),
+                _entry(event_type="tool_invocation"),
+                _entry(event_type="session_start", action="start"),
+                _entry(event_type="policy_check", action="check"),
+            ],
+            data_class="public",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["tool_transcript"]["call_count"] == 2
+
+    def test_policy_bundle_hash_forwarded(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[_entry()],
+            data_class="public",
+            policy_bundle_hash="deadbeef1234",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["policy"]["bundle_hash"] == "deadbeef1234"
+
+    def test_missing_policy_bundle_hash_defaults_to_empty(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[_entry()],
+            data_class="public",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["policy"]["bundle_hash"] == ""
+
+    def test_empty_entries_iat_is_zero(self):
+        session = TraceSession(
+            agent_did="did:mesh:test",
+            audit_entries=[],
+            data_class="public",
+        )
+        record = session_to_trust_record(session, _CONFIG)
+        assert record["iat"] == 0
+        assert record["appraisal"]["status"] == "affirming"
+        assert record["tool_transcript"]["call_count"] == 0
+
+    def test_transcript_hash_is_deterministic(self):
+        entries = [_entry(entry_id="fixed-id-1"), _entry(entry_id="fixed-id-2")]
+        session = TraceSession(agent_did="did:mesh:test", audit_entries=entries, data_class="public")
+        r1 = session_to_trust_record(session, _CONFIG)
+        r2 = session_to_trust_record(session, _CONFIG)
+        assert r1["tool_transcript"]["hash"] == r2["tool_transcript"]["hash"]

--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -865,9 +865,15 @@ class PolicyInterceptor:
     - Call count within limits
     """
 
-    def __init__(self, policy: GovernancePolicy, context: ExecutionContext | None = None):
+    def __init__(
+        self,
+        policy: GovernancePolicy,
+        context: ExecutionContext | None = None,
+        policy_bundle_hash: str | None = None,
+    ):
         self.policy = policy
         self.context = context
+        self.policy_bundle_hash = policy_bundle_hash
 
     def intercept(self, request: ToolCallRequest) -> ToolCallResult:
         from agent_os.policies.decision_factory import (


### PR DESCRIPTION
## Summary

Implements the data model layer for TRACE v0.2 Trust Records (ADR-0032, step 1 of 5). No signing, sinks, or wire transport yet -- those land in steps 2-5.

- **`trace_model.py`** -- `TraceModelConfig`, `TraceSession`, `TrustRecord` dataclasses + `session_to_trust_record()` mapping function
- **`appraisal.status`** -- set to `"contraindicated"` when any entry has `outcome=="denied"` or `event_type in {"policy_violation", "tool_blocked"}`; `"affirming"` otherwise
- **`tool_transcript.hash`** -- RFC 8785 JCS-canonical JSON hash per TRACE spec (`sha256:` prefix)
- **`PolicyInterceptor`** -- optional `policy_bundle_hash` param stored at load time; sink reads it at session close
- **`GovernedCallable`** -- computes `_policy_bundle_hash` from raw bundle bytes at policy load time
- **`governance/__init__.py`** -- exports the four new public symbols

## Acceptance criteria

- [x] `TrustRecord` dataclass with all 11 required TRACE v0.2 fields
- [x] `session_to_trust_record(session, config) -> dict` mapping function
- [x] `PolicyInterceptor` stores `policy_bundle_hash` at load time
- [x] `subject` derived from `session.agent_did` (e.g. `did:mesh:spiffe://...`) -- no SPIFFE config needed (ADR-0032 v0.2)
- [x] Unit tests: golden-path mapping, deny decision sets `appraisal.status = "contraindicated"`, call_count counts only `tool_invocation` entries, transcript hash is deterministic

## Test plan

- [ ] `pytest agent-governance-python/agent-mesh/tests/governance/test_trace_model.py -v` passes (10 test cases)
- [ ] No regressions in existing governance tests

## References

- ADR-0032
- Closes #3086
- Next: #3087 (signing step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)