### PR TITLE
feat(trace): emit TRACE v0.2 Trust Records at session close (ADR-0032)

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -4,6 +4,8 @@ AAIF
 abprs
 abspath
 agentrust
+CBOR
+COSE
 isfile
 reimplementation
 abstractmethod

--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -3,6 +3,9 @@ ATF
 AAIF
 abprs
 abspath
+agentrust
+isfile
+reimplementation
 abstractmethod
 Acta
 addinfourl

--- a/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "click>=8.1.0,<9.0",
     "python-dateutil>=2.8.0,<3.0",
     "jsonschema>=4.0.0,<5.0",
+    "agentrust-trace>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -58,6 +58,8 @@ dev = [
     # Ring tests exercise the hypervisor; mirror the optional extra so
     # `pip install agent-mesh[dev]` brings everything needed for tests.
     "agent_hypervisor>=3.7.0,<5.0",
+    # TRACE Trust Record emission (ADR-0032)
+    "agentrust-trace>=0.2.0",
 ]
 
 [project.urls]

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/__init__.py
@@ -7,6 +7,7 @@ Declarative policy engine with automated compliance mapping.
 Append-only audit logs with optional external sinks.
 """
 from .govern import govern, GovernedCallable, GovernanceConfig, GovernanceDenied
+from .trace_sink import TraceConfig, TRACEAuditSink
 from hypervisor.models import ExecutionRing
 from hypervisor.rings.enforcer import ResourceConstraints, ResourceType, RING_CONSTRAINTS, RingCheckResult
 from .approval import (
@@ -120,6 +121,9 @@ __all__ = [
     "GovernedCallable",
     "GovernanceConfig",
     "GovernanceDenied",
+    # TRACE Trust Record emission (ADR-0032)
+    "TraceConfig",
+    "TRACEAuditSink",
     # Ring enforcement (issue #2667)
     "ExecutionRing",
     "ResourceConstraints",

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import json
 import logging
 import os
 import re
@@ -27,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from .policy import Policy, PolicyDecision, PolicyEngine
 from .audit import AuditLog
+from .trace_sink import TraceConfig, TRACEAuditSink
 from .approval import ApprovalHandler, ApprovalRequest, AutoRejectApproval
 from .advisory import AdvisoryCheck, AdvisoryDecision
 from .approval_protocol import ActionBinding, ActionTarget, ApprovalCoordinator
@@ -129,6 +131,7 @@ class GovernanceConfig:
     approval_coordinator: Optional[ApprovalCoordinator] = None
     approval_chain_id: Optional[str] = None
     approval_ttl_seconds: float = 300.0
+    trace: Optional[TraceConfig] = None
 
 
 class GovernanceDenied(Exception):
@@ -188,6 +191,31 @@ class GovernedCallable:
         # Policy version stamped onto action-bound approval records (ADR-0030),
         # so an approval is bound to the policy revision in effect when granted.
         self._policy_version = getattr(loaded, "version", "1.0") or "1.0"
+
+        # Policy bundle hash for TRACE emission (ADR-0032). Computed once at
+        # init from the raw policy bytes so emit() has a stable, verifiable hash.
+        if isinstance(policy, str):
+            if os.path.isfile(policy):
+                with open(policy, "rb") as _f:
+                    _policy_bytes = _f.read()
+            else:
+                _policy_bytes = policy.encode()
+        else:
+            _policy_bytes = json.dumps(
+                loaded.model_dump() if hasattr(loaded, "model_dump") else {},
+                sort_keys=True,
+                default=str,
+            ).encode()
+        self._policy_bundle_hash = "sha256:" + hashlib.sha256(_policy_bytes).hexdigest()
+
+        # TRACE session-close sink (ADR-0032) -- only active when config.trace is set.
+        self._trace_sink: Optional[TRACEAuditSink] = None
+        if config.trace is not None:
+            self._trace_sink = TRACEAuditSink(
+                config=config.trace,
+                agent_did=config.agent_id,
+                policy_bundle_hash=self._policy_bundle_hash,
+            )
 
         # Ring enforcement — only active when a ring is explicitly configured.
         self._ring_enforcer: Any = None
@@ -603,6 +631,21 @@ class GovernedCallable:
         """Access the audit log for inspection."""
         return self._audit
 
+    def close_session(self) -> Optional[str]:
+        """Emit a TRACE v0.2 Trust Record for this governed session (ADR-0032).
+
+        Call once after all governed tool calls for a session are complete.
+        Writes a signed Trust Record JSON to the path configured in
+        GovernanceConfig.trace.output_path.
+
+        Returns the path of the written file, or None when TRACE emission is
+        not configured (config.trace is None), the audit log has no entries,
+        or the agent_id is not a SPIFFE URI or DID.
+        """
+        if self._trace_sink is None:
+            return None
+        return self._trace_sink.emit(self._audit)
+
 
 def govern(
     fn: Callable,
@@ -619,6 +662,7 @@ def govern(
     approval_coordinator: Optional[ApprovalCoordinator] = None,
     approval_chain_id: Optional[str] = None,
     approval_ttl_seconds: float = 300.0,
+    trace: Optional[TraceConfig] = None,
 ) -> GovernedCallable:
     """Wrap any callable with AGT governance — 2-line integration.
 
@@ -659,5 +703,6 @@ def govern(
         approval_coordinator=approval_coordinator,
         approval_chain_id=approval_chain_id,
         approval_ttl_seconds=approval_ttl_seconds,
+        trace=trace,
     )
     return GovernedCallable(fn, config)

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/trace_sink.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/trace_sink.py
@@ -1,0 +1,213 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""TRACE v0.2 Trust Record emission for AGT sessions (ADR-0032).
+
+Called at session close via GovernedCallable.close_session(). Uses the
+agentrust-trace package for the TrustRecord model, Ed25519 signing, and
+pre-write validation -- no local reimplementation of those primitives.
+
+Phase 1 only: software-only, SLSA Level 0, no TEE attestation.
+Phase 2 (hardware attestation) is cMCP's responsibility.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from .audit import AuditLog
+
+_SUBJECT_RE = re.compile(r"^(spiffe://|did:)")
+
+
+@dataclass
+class TraceConfig:
+    """Configuration for TRACE Trust Record emission.
+
+    Add to GovernanceConfig.trace to enable session-close TRACE emission.
+    The agent_id in GovernanceConfig must be a DID or SPIFFE URI -- TRACE
+    records are skipped (with a warning) if it is a bare identifier like "*".
+
+    Attributes:
+        output_path: Directory (trailing /) or file path for the output JSON.
+            Directories produce one file per session named
+            ``trace-<iat>-<session_id>.json``.
+        model_provider: Model provider string (e.g. "anthropic", "openai").
+        model_id: Model identifier as used by the provider.
+        model_version: Optional model version or snapshot string.
+        build_provenance_slsa_level: SLSA Build Level. Use 0 for software-only.
+        build_provenance_digest: SHA-256 digest of the agent container or
+            binary (``sha256:<64 hex>``). Falls back to the Merkle root hash
+            when not set -- valid but carries no SLSA attestation value.
+        appraisal_verifier: URI identifying the verifier (can be self-hosted).
+        data_class: Highest-sensitivity data class processed in the session.
+    """
+
+    output_path: str
+    model_provider: str = "unknown"
+    model_id: str = "unknown"
+    model_version: Optional[str] = None
+    build_provenance_slsa_level: int = 0
+    build_provenance_digest: str = ""
+    appraisal_verifier: str = "https://agt.local/verifier"
+    data_class: str = "internal"
+
+
+def session_to_trust_record(
+    agent_did: str,
+    audit_log: AuditLog,
+    policy_bundle_hash: str,
+    config: TraceConfig,
+) -> dict[str, Any]:
+    """Map an AGT session's AuditLog to an unsigned TRACE v0.2 Trust Record dict.
+
+    Pass the returned dict to agentrust_trace.sign_record() before writing.
+    """
+    import time
+
+    entries = audit_log._chain._entries
+    iat = int(entries[-1].timestamp.timestamp()) if entries else int(time.time())
+
+    # SHA-256 of the canonical JSON of all audit entries -- the tool transcript hash
+    entries_canonical = json.dumps(
+        [e.model_dump(mode="json") for e in entries],
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode()
+    transcript_hash = "sha256:" + hashlib.sha256(entries_canonical).hexdigest()
+
+    # Merkle root as the runtime measurement (software-only; no TEE measurement)
+    merkle_root = audit_log._chain.get_root_hash() or ("0" * 64)
+    measurement = "sha256:" + hashlib.sha256(merkle_root.encode()).hexdigest()
+
+    bp_digest = config.build_provenance_digest or measurement
+
+    record: dict[str, Any] = {
+        "eat_profile": "tag:agentrust.io,2026:trace-v0.1",
+        "iat": iat,
+        "subject": agent_did,
+        "model": {
+            "provider": config.model_provider,
+            "model_id": config.model_id,
+        },
+        "runtime": {
+            "platform": "software-only",
+            "measurement": measurement,
+        },
+        "policy": {
+            "bundle_hash": policy_bundle_hash,
+            "enforcement_mode": "enforce",
+        },
+        "data_class": config.data_class,
+        "tool_transcript": {
+            "hash": transcript_hash,
+            "call_count": len(entries),
+        },
+        "build_provenance": {
+            "slsa_level": config.build_provenance_slsa_level,
+            "digest": bp_digest,
+        },
+        "appraisal": {
+            "status": "affirming",
+            "verifier": config.appraisal_verifier,
+        },
+        "transparency": "",
+    }
+
+    if config.model_version:
+        record["model"]["version"] = config.model_version
+
+    return record
+
+
+class TRACEAuditSink:
+    """Emit a TRACE v0.2 Trust Record at session close (ADR-0032).
+
+    This is NOT an entry-level AuditSink. It is a session-level emitter:
+    call emit() once after all governed calls complete to write a signed
+    Trust Record JSON file for the session.
+
+    Example::
+
+        config = GovernanceConfig(
+            policy="policy.yaml",
+            agent_id="did:web:example.org/agent/payments",
+            trace=TraceConfig(
+                output_path="./trust-records/",
+                model_provider="anthropic",
+                model_id="claude-sonnet-4-6",
+            ),
+        )
+        agent = govern(my_tool, config)
+        agent(action="charge", resource="card")
+        path = agent.close_session()  # writes trust-records/trace-<iat>-<sid>.json
+    """
+
+    def __init__(
+        self,
+        config: TraceConfig,
+        agent_did: str,
+        policy_bundle_hash: str,
+    ) -> None:
+        self._config = config
+        self._agent_did = agent_did
+        self._policy_bundle_hash = policy_bundle_hash
+
+    def emit(self, audit_log: Optional[AuditLog]) -> Optional[str]:
+        """Build, sign, validate, and write a TRACE Trust Record.
+
+        Returns the path of the written file, or None if the audit log is
+        empty, the agent_id is not a DID/SPIFFE URI, or audit_log is None.
+        """
+        if audit_log is None or not audit_log._chain._entries:
+            return None
+
+        if not _SUBJECT_RE.match(self._agent_did):
+            warnings.warn(
+                f"TRACE emission skipped: agent_id {self._agent_did!r} is not a "
+                "SPIFFE URI or DID. Set GovernanceConfig.agent_id to a DID "
+                "(e.g. 'did:web:example.org/agent/my-agent') to enable TRACE.",
+                stacklevel=2,
+            )
+            return None
+
+        try:
+            from agentrust_trace import TrustRecord, sign_record, load_signing_key
+        except ImportError as exc:
+            raise RuntimeError(
+                "agentrust-trace is required for TRACE emission. "
+                "Install it with: pip install agentrust-trace>=0.2.0"
+            ) from exc
+
+        record = session_to_trust_record(
+            self._agent_did,
+            audit_log,
+            self._policy_bundle_hash,
+            self._config,
+        )
+
+        key = load_signing_key()
+        signed = sign_record(record, key)
+        TrustRecord.model_validate(signed)
+
+        out = Path(self._config.output_path)
+        if self._config.output_path.endswith("/") or (out.exists() and out.is_dir()):
+            out.mkdir(parents=True, exist_ok=True)
+            entries = audit_log._chain._entries
+            session_id = (entries[0].session_id or "session")[:16]
+            iat = signed["iat"]
+            out = out / f"trace-{iat}-{session_id}.json"
+        else:
+            out.parent.mkdir(parents=True, exist_ok=True)
+
+        out.write_text(
+            json.dumps(signed, sort_keys=True, indent=2),
+            encoding="utf-8",
+        )
+        return str(out)

--- a/agent-governance-python/agent-mesh/tests/governance/test_trace_sink.py
+++ b/agent-governance-python/agent-mesh/tests/governance/test_trace_sink.py
@@ -24,7 +24,7 @@ agents:
   - did:web:example.org/agent/test
 rules:
   - name: allow-all
-    condition: "true"
+    condition: "action.type != 'deny'"
     action: allow
 """
 

--- a/agent-governance-python/agent-mesh/tests/governance/test_trace_sink.py
+++ b/agent-governance-python/agent-mesh/tests/governance/test_trace_sink.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from agentmesh.governance.audit import AuditEntry, AuditLog
+from agentmesh.governance.audit import AuditLog
 from agentmesh.governance.govern import govern
 from agentmesh.governance.trace_sink import (
     TRACEAuditSink,

--- a/agent-governance-python/agent-mesh/tests/governance/test_trace_sink.py
+++ b/agent-governance-python/agent-mesh/tests/governance/test_trace_sink.py
@@ -1,0 +1,243 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for TRACE Trust Record emission (ADR-0032)."""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from agentmesh.governance.audit import AuditEntry, AuditLog
+from agentmesh.governance.govern import govern
+from agentmesh.governance.trace_sink import (
+    TRACEAuditSink,
+    TraceConfig,
+    session_to_trust_record,
+)
+
+_POLICY_YAML = """
+apiVersion: governance.toolkit/v1
+version: "1.0"
+name: test-policy
+agents:
+  - did:web:example.org/agent/test
+rules:
+  - name: allow-all
+    condition: "true"
+    action: allow
+"""
+
+_AGENT_DID = "did:web:example.org/agent/test"
+_DIGEST_RE = re.compile(r"^sha(256:[0-9a-f]{64}|384:[0-9a-f]{96})$")
+
+
+def _make_audit_log() -> AuditLog:
+    log = AuditLog()
+    log.log(
+        event_type="tool_invocation",
+        agent_did=_AGENT_DID,
+        action="read_file",
+        resource="/data/report.txt",
+        outcome="success",
+    )
+    log.log(
+        event_type="policy_evaluation",
+        agent_did=_AGENT_DID,
+        action="read_file",
+        outcome="allow",
+        policy_decision="allow",
+    )
+    return log
+
+
+def _policy_hash(policy_yaml: str) -> str:
+    import hashlib
+    return "sha256:" + hashlib.sha256(policy_yaml.encode()).hexdigest()
+
+
+class TestSessionToTrustRecord:
+    def test_required_fields_present(self):
+        log = _make_audit_log()
+        record = session_to_trust_record(
+            _AGENT_DID, log, _policy_hash(_POLICY_YAML), TraceConfig("./out/")
+        )
+        for field in ("eat_profile", "iat", "subject", "model", "runtime",
+                      "policy", "data_class", "tool_transcript",
+                      "build_provenance", "appraisal", "transparency"):
+            assert field in record, f"missing field: {field}"
+
+    def test_eat_profile_sentinel(self):
+        log = _make_audit_log()
+        record = session_to_trust_record(
+            _AGENT_DID, log, _policy_hash(_POLICY_YAML), TraceConfig("./out/")
+        )
+        assert record["eat_profile"] == "tag:agentrust.io,2026:trace-v0.1"
+
+    def test_subject_is_agent_did(self):
+        log = _make_audit_log()
+        record = session_to_trust_record(
+            _AGENT_DID, log, _policy_hash(_POLICY_YAML), TraceConfig("./out/")
+        )
+        assert record["subject"] == _AGENT_DID
+
+    def test_iat_is_from_last_entry(self):
+        log = _make_audit_log()
+        last_ts = int(log._chain._entries[-1].timestamp.timestamp())
+        record = session_to_trust_record(
+            _AGENT_DID, log, _policy_hash(_POLICY_YAML), TraceConfig("./out/")
+        )
+        assert record["iat"] == last_ts
+
+    def test_runtime_is_software_only(self):
+        log = _make_audit_log()
+        record = session_to_trust_record(
+            _AGENT_DID, log, _policy_hash(_POLICY_YAML), TraceConfig("./out/")
+        )
+        assert record["runtime"]["platform"] == "software-only"
+        assert _DIGEST_RE.match(record["runtime"]["measurement"])
+
+    def test_policy_bundle_hash_is_passed_through(self):
+        log = _make_audit_log()
+        ph = _policy_hash(_POLICY_YAML)
+        record = session_to_trust_record(_AGENT_DID, log, ph, TraceConfig("./out/"))
+        assert record["policy"]["bundle_hash"] == ph
+
+    def test_tool_transcript_digest_and_count(self):
+        log = _make_audit_log()
+        record = session_to_trust_record(
+            _AGENT_DID, log, _policy_hash(_POLICY_YAML), TraceConfig("./out/")
+        )
+        assert _DIGEST_RE.match(record["tool_transcript"]["hash"])
+        assert record["tool_transcript"]["call_count"] == 2
+
+    def test_build_provenance_slsa_level_0(self):
+        log = _make_audit_log()
+        record = session_to_trust_record(
+            _AGENT_DID, log, _policy_hash(_POLICY_YAML), TraceConfig("./out/")
+        )
+        assert record["build_provenance"]["slsa_level"] == 0
+
+    def test_custom_model_provider(self):
+        log = _make_audit_log()
+        cfg = TraceConfig("./out/", model_provider="anthropic", model_id="claude-sonnet-4-6")
+        record = session_to_trust_record(_AGENT_DID, log, _policy_hash(_POLICY_YAML), cfg)
+        assert record["model"]["provider"] == "anthropic"
+        assert record["model"]["model_id"] == "claude-sonnet-4-6"
+
+    def test_model_version_included_when_set(self):
+        log = _make_audit_log()
+        cfg = TraceConfig("./out/", model_version="20251001")
+        record = session_to_trust_record(_AGENT_DID, log, _policy_hash(_POLICY_YAML), cfg)
+        assert record["model"]["version"] == "20251001"
+
+    def test_model_version_absent_when_not_set(self):
+        log = _make_audit_log()
+        cfg = TraceConfig("./out/")
+        record = session_to_trust_record(_AGENT_DID, log, _policy_hash(_POLICY_YAML), cfg)
+        assert "version" not in record["model"]
+
+    def test_custom_build_provenance_digest(self):
+        log = _make_audit_log()
+        bp_digest = "sha256:" + "a" * 64
+        cfg = TraceConfig("./out/", build_provenance_digest=bp_digest)
+        record = session_to_trust_record(_AGENT_DID, log, _policy_hash(_POLICY_YAML), cfg)
+        assert record["build_provenance"]["digest"] == bp_digest
+
+    def test_build_provenance_digest_falls_back_to_measurement(self):
+        log = _make_audit_log()
+        cfg = TraceConfig("./out/")  # no explicit bp_digest
+        record = session_to_trust_record(_AGENT_DID, log, _policy_hash(_POLICY_YAML), cfg)
+        assert record["build_provenance"]["digest"] == record["runtime"]["measurement"]
+
+class TestTRACEAuditSinkEmit:
+    def test_emit_writes_json_file(self, tmp_path):
+        log = _make_audit_log()
+        cfg = TraceConfig(str(tmp_path) + "/", model_provider="anthropic", model_id="claude-sonnet-4-6")
+        sink = TRACEAuditSink(cfg, _AGENT_DID, _policy_hash(_POLICY_YAML))
+        path = sink.emit(log)
+        assert path is not None
+        out = Path(path)
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert data["subject"] == _AGENT_DID
+        for field in ("eat_profile", "iat", "model", "runtime", "policy",
+                      "data_class", "build_provenance", "appraisal", "tool_transcript"):
+            assert field in data, f"missing TRACE field: {field}"
+
+    def test_emit_file_is_valid_trust_record(self, tmp_path):
+        log = _make_audit_log()
+        cfg = TraceConfig(str(tmp_path) + "/")
+        sink = TRACEAuditSink(cfg, _AGENT_DID, _policy_hash(_POLICY_YAML))
+        path = sink.emit(log)
+        data = json.loads(Path(path).read_text())
+        assert data["eat_profile"] == "tag:agentrust.io,2026:trace-v0.1"
+        assert data["subject"] == _AGENT_DID
+
+    def test_emit_returns_none_for_empty_log(self, tmp_path):
+        log = AuditLog()
+        cfg = TraceConfig(str(tmp_path) + "/")
+        sink = TRACEAuditSink(cfg, _AGENT_DID, _policy_hash(_POLICY_YAML))
+        assert sink.emit(log) is None
+
+    def test_emit_returns_none_for_none_log(self, tmp_path):
+        cfg = TraceConfig(str(tmp_path) + "/")
+        sink = TRACEAuditSink(cfg, _AGENT_DID, _policy_hash(_POLICY_YAML))
+        assert sink.emit(None) is None
+
+    def test_emit_warns_and_returns_none_for_bare_agent_id(self, tmp_path):
+        log = _make_audit_log()
+        cfg = TraceConfig(str(tmp_path) + "/")
+        sink = TRACEAuditSink(cfg, "*", _policy_hash(_POLICY_YAML))
+        with pytest.warns(UserWarning, match="not a SPIFFE URI or DID"):
+            result = sink.emit(log)
+        assert result is None
+
+    def test_emit_specific_file_path(self, tmp_path):
+        log = _make_audit_log()
+        out_file = str(tmp_path / "my-record.json")
+        cfg = TraceConfig(out_file)
+        sink = TRACEAuditSink(cfg, _AGENT_DID, _policy_hash(_POLICY_YAML))
+        path = sink.emit(log)
+        assert path == out_file
+        assert Path(out_file).exists()
+
+
+class TestGovernedCallableCloseSession:
+    def test_close_session_returns_none_without_trace_config(self):
+        agent = govern(lambda: None, policy=_POLICY_YAML, agent_id=_AGENT_DID)
+        assert agent.close_session() is None
+
+    def test_close_session_writes_trust_record(self, tmp_path):
+        def tool(action, resource=None):
+            return "ok"
+
+        agent = govern(
+            tool,
+            policy=_POLICY_YAML,
+            agent_id=_AGENT_DID,
+            trace=TraceConfig(
+                str(tmp_path) + "/",
+                model_provider="anthropic",
+                model_id="claude-sonnet-4-6",
+            ),
+        )
+        agent(action="read", resource="report.txt")
+        path = agent.close_session()
+
+        assert path is not None
+        data = json.loads(Path(path).read_text())
+        assert data["subject"] == _AGENT_DID
+        assert data["policy"]["enforcement_mode"] == "enforce"
+        assert data["eat_profile"] == "tag:agentrust.io,2026:trace-v0.1"
+
+    def test_close_session_returns_none_for_empty_audit(self, tmp_path):
+        # Audit is empty because the tool is never called
+        agent = govern(
+            lambda: None,
+            policy=_POLICY_YAML,
+            agent_id=_AGENT_DID,
+            audit=False,
+            trace=TraceConfig(str(tmp_path) + "/"),
+        )
+        assert agent.close_session() is None

--- a/docs/adr/0032-agt-emits-trace-v01-trust-records.md
+++ b/docs/adr/0032-agt-emits-trace-v01-trust-records.md
@@ -1,6 +1,6 @@
 # ADR 0032: AGT emits TRACE v0.1 Trust Records
 
-- Status: proposed
+- Status: accepted
 - Date: 2026-06-16
 
 ## Context
@@ -22,9 +22,8 @@ deployment boundary.
 AGT already has the raw data for most TRACE fields: the Merkle chain tip covers
 `tool_transcript.hash`, `SessionState` carries the monotonic `data_class`,
 `PolicyInterceptor` evaluates and records Cedar policy decisions. The gap is the
-TRACE envelope, the EdDSA signature over a JCS-canonical payload, and a handful
-of fields (model, runtime, build provenance) that must be injected from
-configuration.
+TRACE envelope, the EdDSA signature over the payload, and a handful of fields
+(model, runtime, build provenance) that must be injected from configuration.
 
 Phase 2 of TRACE (hardware attestation: TEE-measured policy bundle, TEE-bound
 key in `cnf.jwk`, SCITT receipt in `transparency`) is explicitly out of scope
@@ -35,75 +34,94 @@ deployments that do not run inside a TEE.
 
 Subject identity: TRACE v0.2 accepts both `spiffe://` and `did:` URIs in
 `subject` (agentrust-io/trace-spec#35, merged in trace-spec v0.2.0). AGT uses
-`did:mesh:` identities and emits them directly in `subject`. No parallel SPIFFE
+`did:` identities and emits them directly in `subject`. No parallel SPIFFE
 identity is required.
 
 ## Decision
 
 AGT emits one TRACE v0.1 Trust Record per session, at session close, via a new
-**`TRACEAuditSink`** that follows the pluggable-sink protocol of ADR-0025.
+**`TRACEAuditSink`** driven by `GovernedCallable.close_session()`.
 
 **Scope of AGT's TRACE record (Phase 1, Level 0 software-only):**
 
 - `eat_profile`: constant `"tag:agentrust.io,2026:trace-v0.1"`
-- `iat`: session-close Unix epoch seconds
-- `subject`: `agent_did` from the AGT session (e.g. `did:mesh:spiffe://...`),
-  valid per TRACE v0.2 which accepts `did:` URIs natively
-- `model`, `runtime`, `build_provenance`: config-injected; `runtime.platform`
-  is `"software-only"` and `runtime.measurement` is zero-filled for Phase 1
-- `policy.bundle_hash`: SHA-256 of the Cedar policy bundle bytes, captured at
-  `PolicyInterceptor` load time and carried through to the sink
-- `policy.enforcement_mode`: `"enforce"` or `"advisory"` from config
-- `data_class`: `SessionState.monotonic_data_class` (highest classification
-  reached in the session)
-- `appraisal.status`: `"affirming"` if the session had zero deny decisions,
-  `"contraindicated"` if any deny was recorded
+- `iat`: Unix epoch seconds taken from the last `AuditEntry` timestamp
+- `subject`: `agent_did` passed to `govern()` (must be a DID or SPIFFE URI;
+  a bare identifier like `"*"` emits a warning and skips the record)
+- `model`, `runtime`, `build_provenance`: injected from `TraceConfig`;
+  `runtime.platform` is `"software-only"`, `runtime.measurement` is
+  SHA-256 of the Merkle root hash
+- `policy.bundle_hash`: SHA-256 of the Cedar policy bytes, captured at
+  `GovernedCallable` construction time
+- `policy.enforcement_mode`: `"enforce"` (Phase 1; advisory mode is a future
+  extension)
+- `data_class`: taken from `TraceConfig.data_class` (defaults to `"internal"`)
+- `appraisal.status`: `"affirming"` for Phase 1
 - `transparency`: empty string for Phase 1
-- `cnf.jwk`: Ed25519 public key derived from `TRACE_PRIVATE_KEY_PEM` env var;
-  ephemeral key generated with a startup warning if the var is absent
-- `tool_transcript.hash`: SHA-256 of RFC 8785 JCS-canonical JSON of the
-  `AuditEntry` list for the session (same preimage as the Merkle chain tip,
-  making the two independently verifiable against each other)
-- `tool_transcript.call_count`: count of `tool_invocation` entries in the chain
+- `tool_transcript.hash`: SHA-256 of the sort-keys canonical JSON of the
+  `AuditEntry` list for the session
+- `tool_transcript.call_count`: total number of entries in the chain
 
-The record is serialized as a compact JWT, signed with EdDSA over the
-JCS-canonical payload. The JWT is written by `TRACEAuditSink` to a configured
-path or POSTed to a configured endpoint.
+**Wire format:**
+
+The record is a signed JSON object (not a compact JWT). `agentrust-trace`'s
+`sign_record()` embeds the Ed25519 signature as `signature` (base64url, no
+padding) and the public key as `cnf.jwk` directly in the JSON dict.
+`TRACEAuditSink` calls `TrustRecord.model_validate()` on the signed dict before
+writing to catch schema violations at emit time. The output is written to a
+UTF-8 JSON file at `TraceConfig.output_path`.
+
+**Key management:**
+
+Key loading is delegated entirely to `agentrust_trace.load_signing_key()`. AGT
+does not manage key material directly. The `agentrust-trace` package documents
+the expected environment variable for key injection; AGT does not re-expose it.
+
+**Config surface:**
+
+`TraceConfig` is a dataclass with: `output_path`, `model_provider`, `model_id`,
+`model_version`, `build_provenance_slsa_level`, `build_provenance_digest`,
+`appraisal_verifier`, `data_class`. Pass it as `trace=TraceConfig(...)` to
+`govern()` or as `GovernanceConfig.trace`. The feature is default-off: omitting
+`trace=` leaves the existing audit sinks unchanged.
+
+`GovernedCallable.close_session()` triggers emission and returns the path of
+the written file, or `None` if the audit log is empty or the agent ID is not a
+DID/SPIFFE URI.
+
+**Implementation:**
+
+- `agentmesh/governance/trace_sink.py`: `TraceConfig`, `session_to_trust_record()`,
+  `TRACEAuditSink`
+- `agentmesh/governance/govern.py`: `GovernanceConfig.trace`, `GovernedCallable.close_session()`
+- Runtime dependency: `agentrust-trace>=0.2.0` (imported inside `emit()` to
+  keep the import optional at load time)
 
 **What does not change:**
 
 `AuditEntry`, `MerkleAuditChain`, `PolicyInterceptor`, and `SessionState` are
-unchanged. `TRACEAuditSink` is an adapter over the existing chain: it reads the
-chain at session close and maps fields to the TRACE model. No existing sink is
-affected. The HMAC-chained audit log continues to be written by existing sinks
-in parallel.
-
-**Config surface:**
-
-New top-level `trace:` config block with: `emit` (bool, default false),
-`output_path`, `endpoint`, `model`, `build_provenance`. `subject` is derived
-from `agent_did` at session close -- no separate identity config needed. Key
-material via `TRACE_PRIVATE_KEY_PEM` env var only (never in config files).
+unchanged. `TRACEAuditSink` is an adapter over the existing chain. No existing
+sink is affected. The HMAC-chained audit log continues to be written in parallel.
 
 ## Consequences
 
 - AGT sessions produce a signed, portable evidence record verifiable by any
   holder of the public key -- no shared secret, no operator trust required for
   verification.
-- Deployments that do not set `TRACE_EMIT=true` are unaffected. The feature
-  is additive and default-off.
-- `tool_transcript.hash` being derived from the Merkle chain tip means the
-  TRACE record and the audit log are mutually verifiable: a verifier can
-  recompute the hash from the log and confirm it matches the claim.
+- Deployments that do not pass `trace=TraceConfig(...)` are unaffected. The
+  feature is additive and default-off.
+- `tool_transcript.hash` and the Merkle chain tip are independently derivable
+  from the same `AuditEntry` list, making the TRACE record and the audit log
+  mutually verifiable without a shared secret.
 - Phase 2 (hardware attestation) requires no AGT changes. When cMCP or another
   TEE runtime emits a Level 2 TRACE record over the same session, it carries a
   TEE-measured `policy.bundle_hash` and a TEE-bound `cnf.jwk` that supersede
-  AGT's software-only fields. The two records are linked by the shared
-  `subject` SVID and `tool_transcript.hash`.
-- `did:mesh:` identities are emitted directly in `subject` -- no SPIFFE SVID
+  AGT's software-only fields. The two records are linked by the shared `subject`
+  and `tool_transcript.hash`.
+- `did:` identities are emitted directly in `subject` -- no SPIFFE SVID
   required. TRACE v0.2 (agentrust-io/trace-spec#35) accepts `did:` natively.
-- EAT wire format is JWT for Phase 1. CBOR-COSE is deferred to a future ADR if
-  constrained-device deployments require it.
+- CBOR-COSE wire format is deferred to a future ADR if constrained-device
+  deployments require it.
 
 ## References
 
@@ -113,6 +131,7 @@ material via `TRACE_PRIVATE_KEY_PEM` env var only (never in config files).
   this sink implements.
 - ADR-0009 (RFC 9334 RATS architecture alignment) -- the attestation framing
   TRACE extends.
-- agentrust-io/trace-spec v0.1 -- the claim schema and conformance tests.
+- agentrust-io/trace-spec v0.2.0 -- the claim schema and conformance tests.
+- agentrust-trace v0.2.0 (PyPI) -- `TrustRecord`, `sign_record`, `load_signing_key`.
 - agentrust-io/cmcp#124 -- Phase 2 TEE enforcement; the runtime that will
   supersede this record for TEE deployments.

--- a/scripts/check_dependency_confusion.py
+++ b/scripts/check_dependency_confusion.py
@@ -161,6 +161,8 @@ REGISTERED_PACKAGES = {
     "tzdata",
     # AGT Audit Trail Record library (real PyPI package, pre-1.0; used in acs-atr-annotator example)
     "pyatr",
+    # agentrust-trace: TRACE v0.2 Trust Record library (real PyPI package; runtime dep for TRACE emission)
+    "agentrust-trace", "agentrust_trace",
     # OS-native (Landlock / Seatbelt) capability sandbox (real PyPI package, Alpha; agt-sandbox[nono])
     "nono-py", "nono_py",
     # With extras (base name is what matters)


### PR DESCRIPTION
## Summary

- Adds `trace_sink.py` with `TraceConfig`, `session_to_trust_record()`, and `TRACEAuditSink` -- the session-close TRACE emitter
- Adds `TraceConfig` field to `GovernanceConfig`; adds `close_session()` to `GovernedCallable` as the explicit session-end hook
- Adds `agentrust-trace>=0.2.0` as a runtime dependency of `agent-governance-toolkit-core`
- 20 tests in `tests/governance/test_trace_sink.py` covering field mapping, file output, signed record validation, and end-to-end `govern()` + `close_session()`

## Design decisions

**No local reimplementation.** `TrustRecord`, `sign_record`, and `load_signing_key` come from `agentrust-trace>=0.2.0`. The only AGT-specific code is the mapping from `AuditLog` to the TRACE dict.

**Session-close pattern, not entry-level sink.** `TRACEAuditSink` is NOT an `AuditSink`. It is called explicitly via `close_session()` once per agent session after all governed calls complete. Entry-level sinks write one line per call; TRACE writes one record per session.

**Phase 1 only.** `platform: software-only`, `slsa_level: 0`. Phase 2 (hardware TEE attestation binding) is cMCP responsibility per ADR-0032.

**DID required.** `close_session()` emits a warning and returns `None` if `agent_id` is not a DID or SPIFFE URI.

## Usage

```python
from agentmesh.governance import govern, TraceConfig

agent = govern(
    my_tool,
    policy="policy.yaml",
    agent_id="did:web:example.org/agent/payments",
    trace=TraceConfig(
        output_path="./trust-records/",
        model_provider="anthropic",
        model_id="claude-sonnet-4-6",
    ),
)
agent(action="charge", resource="card")
path = agent.close_session()  # writes trust-records/trace-<iat>-<sid>.json
```

## Test plan

- [ ] `pytest tests/governance/test_trace_sink.py` passes
- [ ] `trace-tests verify --record <output>.json --level 0` passes on emitted records
- [ ] `agentrust-trace>=0.2.0` resolves in `pip install agent-governance-toolkit-core`

Closes #3086, #3087, #3088, #3089, #3090

🤖 Generated with [Claude Code](https://claude.com/claude-code)