### PR TITLE
feat(agent-mesh): wire versioned webhook transport into govern (ADR-0030)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_bridge.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_bridge.py
@@ -23,7 +23,7 @@ This module is allowed to depend on both the legacy ``approval`` module and the
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
 from .approval import ApprovalDecision, ApprovalHandler, ApprovalRequest
 from .approval_protocol import (
@@ -35,7 +35,28 @@ from .approval_protocol import (
 )
 from .approval_protocol import ApprovalRequest as ProtocolApprovalRequest
 
-__all__ = ["AdapterResult", "LegacyHandlerAdapter"]
+__all__ = [
+    "AdapterResult",
+    "ApprovalTransport",
+    "LegacyHandlerAdapter",
+    "submit_vote",
+]
+
+
+@runtime_checkable
+class ApprovalTransport(Protocol):
+    """A protocol-native approval source.
+
+    Unlike a legacy :class:`~agentmesh.governance.approval.ApprovalHandler`
+    (which only receives the thin legacy request), a transport is handed the
+    full protocol :class:`ApprovalRequest` so it can present the action digest,
+    versions, and expiry to the approver. :class:`VersionedWebhookApproval`
+    satisfies this.
+    """
+
+    def request_decision(
+        self, request: ProtocolApprovalRequest
+    ) -> ApprovalDecision: ...
 
 
 @dataclass
@@ -56,6 +77,42 @@ class AdapterResult:
     @property
     def submitted(self) -> bool:
         return self.entry is not None
+
+
+def submit_vote(
+    coordinator: ApprovalCoordinator,
+    request: ProtocolApprovalRequest,
+    approval: ApprovalDecision,
+    *,
+    approver_kind: ApproverKind = ApproverKind.HUMAN,
+    identity_assurance: str = "approval-handler",
+    stage_index: int = 0,
+) -> AdapterResult:
+    """Record an already-obtained approver vote as one protocol chain entry.
+
+    Shared by every vote source (legacy handler, webhook transport, ...).
+    Fail-closed: any :class:`ApprovalProtocolError` from ``submit_entry``
+    (unpermitted identity, expired request, unknown stage) yields an
+    :class:`AdapterResult` with ``entry=None`` and a populated ``error`` rather
+    than propagating, so callers can deny without special-casing.
+    """
+    try:
+        entry = coordinator.submit_entry(
+            request.approval_request_id,
+            stage_index=stage_index,
+            approver_kind=approver_kind,
+            approver_identity=approval.approver or "unknown",
+            identity_assurance=identity_assurance,
+            decision=(
+                EntryDecision.ALLOW if approval.approved else EntryDecision.DENY
+            ),
+            reason_code=approval.reason or "",
+        )
+    except ApprovalProtocolError as exc:
+        return AdapterResult(
+            approval=approval, entry=None, error=f"approval entry rejected: {exc}"
+        )
+    return AdapterResult(approval=approval, entry=entry, error=None)
 
 
 class LegacyHandlerAdapter:
@@ -88,22 +145,11 @@ class LegacyHandlerAdapter:
         rather than propagating, so callers can deny without special-casing.
         """
         approval = self._handler.request_approval(legacy_request)
-        try:
-            entry = coordinator.submit_entry(
-                request.approval_request_id,
-                stage_index=stage_index,
-                approver_kind=self._approver_kind,
-                approver_identity=approval.approver or "unknown",
-                identity_assurance=self._identity_assurance,
-                decision=(
-                    EntryDecision.ALLOW if approval.approved else EntryDecision.DENY
-                ),
-                reason_code=approval.reason or "",
-            )
-        except ApprovalProtocolError as exc:
-            return AdapterResult(
-                approval=approval,
-                entry=None,
-                error=f"approval entry rejected: {exc}",
-            )
-        return AdapterResult(approval=approval, entry=entry, error=None)
+        return submit_vote(
+            coordinator,
+            request,
+            approval,
+            approver_kind=self._approver_kind,
+            identity_assurance=self._identity_assurance,
+            stage_index=stage_index,
+        )

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/govern.py
@@ -32,7 +32,7 @@ from .trace_sink import TraceConfig, TRACEAuditSink
 from .approval import ApprovalHandler, ApprovalRequest, AutoRejectApproval
 from .advisory import AdvisoryCheck, AdvisoryDecision
 from .approval_protocol import ActionBinding, ActionTarget, ApprovalCoordinator
-from .approval_bridge import LegacyHandlerAdapter
+from .approval_bridge import ApprovalTransport, LegacyHandlerAdapter, submit_vote
 
 if TYPE_CHECKING:
     from hypervisor.models import ExecutionRing
@@ -131,6 +131,10 @@ class GovernanceConfig:
     approval_coordinator: Optional[ApprovalCoordinator] = None
     approval_chain_id: Optional[str] = None
     approval_ttl_seconds: float = 300.0
+    # Optional protocol-native approval source (e.g. VersionedWebhookApproval).
+    # When set, it receives the full protocol request (action digest, versions,
+    # expiry) instead of the legacy handler. Requires a coordinator + chain.
+    approval_transport: Optional[ApprovalTransport] = None
     trace: Optional[TraceConfig] = None
 
 
@@ -450,23 +454,33 @@ class GovernedCallable:
             ttl_seconds=self._config.approval_ttl_seconds,
         )
 
-        # The legacy handler is the synchronous source of the approver's vote;
-        # the adapter turns that vote into one authenticated chain entry at
-        # stage 0, fail-closed on an unpermitted identity or expired request.
-        handler = self._config.approval_handler or AutoRejectApproval()
-        adapter = LegacyHandlerAdapter(handler)
-        result = adapter.collect(
-            coordinator,
-            request,
-            ApprovalRequest(
-                action=context.get("action", {}).get("type", "unknown"),
-                rule_name=decision.matched_rule or "",
-                policy_name=decision.policy_name or "",
-                agent_id=self._config.agent_id,
-                context=context,
-                approvers=decision.approvers,
-            ),
-        )
+        # Obtain the approver's vote and record it as one authenticated chain
+        # entry at stage 0 (fail-closed on an unpermitted identity or expired
+        # request). A configured protocol-native transport receives the full
+        # request (action digest, versions, expiry); otherwise the legacy
+        # handler is bridged via the thin legacy request.
+        transport = self._config.approval_transport
+        if transport is not None:
+            result = submit_vote(
+                coordinator,
+                request,
+                transport.request_decision(request),
+                identity_assurance="webhook",
+            )
+        else:
+            handler = self._config.approval_handler or AutoRejectApproval()
+            result = LegacyHandlerAdapter(handler).collect(
+                coordinator,
+                request,
+                ApprovalRequest(
+                    action=context.get("action", {}).get("type", "unknown"),
+                    rule_name=decision.matched_rule or "",
+                    policy_name=decision.policy_name or "",
+                    agent_id=self._config.agent_id,
+                    context=context,
+                    approvers=decision.approvers,
+                ),
+            )
         approval = result.approval
 
         verdict = None
@@ -662,6 +676,7 @@ def govern(
     approval_coordinator: Optional[ApprovalCoordinator] = None,
     approval_chain_id: Optional[str] = None,
     approval_ttl_seconds: float = 300.0,
+    approval_transport: Optional[ApprovalTransport] = None,
     trace: Optional[TraceConfig] = None,
 ) -> GovernedCallable:
     """Wrap any callable with AGT governance — 2-line integration.
@@ -703,6 +718,7 @@ def govern(
         approval_coordinator=approval_coordinator,
         approval_chain_id=approval_chain_id,
         approval_ttl_seconds=approval_ttl_seconds,
+        approval_transport=approval_transport,
         trace=trace,
     )
     return GovernedCallable(fn, config)

--- a/agent-governance-python/agent-mesh/tests/test_webhook_transport_wiring.py
+++ b/agent-governance-python/agent-mesh/tests/test_webhook_transport_wiring.py
@@ -1,0 +1,158 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Wiring the versioned webhook transport into govern via the coordinator (ADR-0030)."""
+
+import json
+
+import pytest
+
+from agentmesh.governance.approval import ApprovalDecision
+from agentmesh.governance.approval_bridge import ApprovalTransport, submit_vote
+from agentmesh.governance.approval_protocol import (
+    ActionBinding,
+    ActionTarget,
+    ApprovalChain,
+    ApprovalCoordinator,
+    ApprovalStage,
+    EntryDecision,
+    InMemoryApprovalStore,
+)
+from agentmesh.governance.approval_webhook import VersionedWebhookApproval
+from agentmesh.governance.govern import GovernanceDenied, govern
+
+ALICE = "alice"
+
+REQUIRE_APPROVAL_POLICY = """
+apiVersion: governance.toolkit/v1
+name: webhook-approval-test
+agents: ["*"]
+default_action: allow
+rules:
+  - name: approve-transfer
+    condition: "action.type == 'transfer'"
+    action: require_approval
+    priority: 100
+"""
+
+
+def _coord(identities=frozenset({ALICE})):
+    chain = ApprovalChain(
+        "default", "1", (ApprovalStage(0, allowed_identities=identities),)
+    )
+    return ApprovalCoordinator(InMemoryApprovalStore(), {chain.chain_id: chain})
+
+
+def _binding():
+    return ActionBinding(
+        operation="tool.invoke", agent_id="a", target=ActionTarget("t", "1")
+    )
+
+
+def _open(coord):
+    _, request = coord.open_request(
+        _binding(),
+        policy_rule_id="r",
+        policy_version="v1",
+        chain_id="default",
+        ttl_seconds=300,
+    )
+    return request
+
+
+def _transfer(**kwargs):
+    return "transfer-done"
+
+
+def _verifier(body, request):
+    return body.get("approver") if body.get("identity_assertion") == "valid" else None
+
+
+def _echo_transport(approved=True, approver=ALICE, assertion="valid", capture=None):
+    def transport(url, data, headers, timeout):
+        payload = json.loads(data.decode("utf-8"))
+        if capture is not None:
+            capture["payload"] = payload
+        return {
+            "approval_request_id": payload["approval_request_id"],
+            "action_digest": payload["action_digest"],
+            "approved": approved,
+            "approver": approver,
+            "identity_assertion": assertion,
+        }
+
+    return transport
+
+
+def _webhook(transport, verifier=_verifier):
+    return VersionedWebhookApproval(
+        "https://example.com/approve", response_verifier=verifier, transport=transport
+    )
+
+
+def _governed(coord, webhook):
+    return govern(
+        _transfer,
+        policy=REQUIRE_APPROVAL_POLICY,
+        approval_coordinator=coord,
+        approval_chain_id="default",
+        approval_transport=webhook,
+    )
+
+
+class TestSubmitVote:
+    def test_approve_records_allow_entry(self):
+        coord = _coord()
+        request = _open(coord)
+        result = submit_vote(
+            coord, request, ApprovalDecision(approved=True, approver=ALICE, reason="ok")
+        )
+        assert result.submitted and result.entry.decision == EntryDecision.ALLOW
+        assert result.error is None
+
+    def test_unpermitted_identity_fails_closed(self):
+        coord = _coord()
+        request = _open(coord)
+        result = submit_vote(
+            coord, request, ApprovalDecision(approved=True, approver="mallory")
+        )
+        assert not result.submitted and result.error
+
+    def test_versioned_webhook_satisfies_transport_protocol(self):
+        assert isinstance(_webhook(_echo_transport()), ApprovalTransport)
+
+
+class TestGovernWebhookTransport:
+    def test_approve_runs_tool_and_webhook_receives_binding(self):
+        capture = {}
+        g = _governed(_coord(), _webhook(_echo_transport(capture=capture)))
+        assert g(action="transfer", amount=100) == "transfer-done"
+        # The webhook payload carried the action binding and versioned envelope.
+        assert capture["payload"]["action_digest"].startswith("sha256:")
+        assert capture["payload"]["schema_version"] == "1.0"
+        assert capture["payload"]["policy_version"]
+
+    def test_deny_is_denied(self):
+        g = _governed(_coord(), _webhook(_echo_transport(approved=False)))
+        with pytest.raises(GovernanceDenied):
+            g(action="transfer", amount=100)
+
+    def test_unverified_identity_is_denied(self):
+        g = _governed(_coord(), _webhook(_echo_transport(assertion="forged")))
+        with pytest.raises(GovernanceDenied):
+            g(action="transfer", amount=100)
+
+    def test_binding_mismatch_is_denied(self):
+        # A webhook that echoes the wrong action digest must not release.
+        def tamper(url, data, headers, timeout):
+            payload = json.loads(data.decode("utf-8"))
+            return {
+                "approval_request_id": payload["approval_request_id"],
+                "action_digest": "sha256:tampered",
+                "approved": True,
+                "approver": ALICE,
+                "identity_assertion": "valid",
+            }
+
+        g = _governed(_coord(), _webhook(tamper))
+        with pytest.raises(GovernanceDenied):
+            g(action="transfer", amount=100)


### PR DESCRIPTION
## Summary

Follow-up that ties ADR-0030 steps 3 (#3096) and 4 (#3097) together: route the merged `VersionedWebhookApproval` transport through `govern()`'s `require_approval` coordinator path, so the webhook receives the full protocol request (action digest, policy and chain version, expiry) rather than the thin legacy request.

## What changed

- `approval_bridge.py`:
  - Extract the chain-entry submission out of `LegacyHandlerAdapter.collect` into a shared `submit_vote(coordinator, request, approval, ...)` helper (fail-closed on `ApprovalProtocolError`). `collect` now delegates to it; behavior is identical.
  - Add an `ApprovalTransport` protocol (`request_decision(request) -> ApprovalDecision`) that `VersionedWebhookApproval` structurally satisfies.
- `govern.py`:
  - New optional `approval_transport` on `GovernanceConfig` / `govern()`. When set, the `require_approval` coordinator path takes the vote from the transport (handed the full protocol request) instead of the legacy handler, records it via `submit_vote`, and revalidates before execution.
  - The legacy handler path is unchanged when no transport is configured.

## Fail-closed

Unverified webhook identity, action-digest binding mismatch, an explicit deny, and an expired request all deny.

## Tests

`tests/test_webhook_transport_wiring.py`: `submit_vote` approve and unpermitted-identity paths; `VersionedWebhookApproval` satisfies `ApprovalTransport`; through `govern` an approve runs the tool and the webhook payload carries the action digest and versioned envelope; deny, unverified identity, and binding mismatch each deny. Existing bridge, govern coordinator, webhook, and govern suites still pass (63 total).

Refs #2478. Connects ADR-0030 steps 3 and 4.
