### PR TITLE
feat(examples): add East Africa policy packs (Uganda DPPA, Tanzania PDPA, Ethiopia PDP)

### DIFF
--- a/examples/policies/african-regulatory/README.md
+++ b/examples/policies/african-regulatory/README.md
@@ -1,8 +1,8 @@
 # African Regulatory Policy Pack
 
-Agent-OS governance policies for AI agents operating in Nigeria, Kenya, and
-South Africa — plus five universal agent safety controls aligned to the OWASP
-Agentic AI Top 10.
+Agent-OS governance policies for AI agents operating in Nigeria, Kenya, South
+Africa, Uganda, Tanzania, and Ethiopia — plus five universal agent safety
+controls aligned to the OWASP Agentic AI Top 10.
 
 Maintained by the [agt-policies-nigeria](https://github.com/kingztech2019/agt-policies-nigeria)
 open-source project. Contributions welcome.
@@ -22,6 +22,9 @@ open-source project. Contributions welcome.
 │      nfiu-aml-str  pos-geofencing                                   │
 │  KE: kenya-dpa                                                      │
 │  ZA: popia-south-africa                                             │
+│  UG: uganda-dppa                                                    │
+│  TZ: tanzania-pdpa                                                  │
+│  ET: ethiopia-pdp                                                   │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -55,13 +58,16 @@ are selected per jurisdiction.
 | `pos-geofencing.yaml` | CBN Agent Banking Guidelines 2020 | 🇳🇬 NG |
 | `kenya-dpa.yaml` | Kenya Data Protection Act 2019 | 🇰🇪 KE |
 | `popia-south-africa.yaml` | POPIA Act 4 of 2013 | 🇿🇦 ZA |
+| `uganda-dppa.yaml` | Uganda Data Protection and Privacy Act 2019 | 🇺🇬 UG |
+| `tanzania-pdpa.yaml` | Tanzania Personal Data Protection Act 2022 | 🇹🇿 TZ |
+| `ethiopia-pdp.yaml` | Ethiopia Proclamation 958/2016 + draft PDPP *(draft)* | 🇪🇹 ET |
 
 ---
 
 ## Rego Reference Implementations
 
 The `rego/` subdirectory contains [OPA](https://www.openpolicyagent.org/) Rego
-implementations of all 12 policies, plus a jurisdiction router.
+implementations of all 15 policies, plus a jurisdiction router.
 
 > **⚠️ Important:** The `.rego` files are **reference implementations only**.
 > They are **not loaded by the Agent-OS Python runtime**, which uses the YAML
@@ -79,7 +85,7 @@ To run the Rego policies with OPA:
 curl -L -o /tmp/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
 chmod +x /tmp/opa
 
-# Run all tests (306 tests)
+# Run all tests (384 tests)
 /tmp/opa test rego/ -v
 
 # Evaluate a single policy

--- a/examples/policies/african-regulatory/ethiopia-pdp.yaml
+++ b/examples/policies/african-regulatory/ethiopia-pdp.yaml
@@ -1,41 +1,40 @@
 # agt-policies-africa
 # Ethiopia Personal Data Protection — Governance Policy
 #
-# Regulatory reference: Ethiopia Personal Data Protection Proclamation (forthcoming)
-#                       Ethiopia Computer Crime Proclamation No. 958/2016 (interim)
-#                       Ethiopia Electronic Transactions Proclamation No. 1205/2020
-# Enforcing authority: Ethiopian Communications Authority (ECA) /
-#                      Ministry of Innovation and Technology (MInT)
+# Regulatory reference: Ethiopia Personal Data Protection Proclamation No. 1321/2024
+#                       (Enacted July 24, 2024 — Federal Negarit Gazette)
+#                       Ethiopia Computer Crime Proclamation No. 958/2016
+#                       (retained for unauthorised access controls)
+# Enforcing authority: Ethiopian Communications Authority (ECA)
 #
-# ⚠️  NOTE ON REGULATORY STATUS: Ethiopia's dedicated Personal Data Protection
-# Proclamation is in active development. This policy pack is based on:
-# (a) Existing obligations under Proclamation No. 958/2016 and No. 1205/2020
-# (b) The principles in the draft Personal Data Protection Proclamation
-# (c) Continental AI governance principles from the African Union Framework
-# Update this pack when the dedicated Proclamation is enacted and gazetted.
+# Key obligations covered:
+#   Art. 9   — Sensitive personal data (health, biometric, genetic, ethnic, religious)
+#   Art. 18  — Principle of data transfer (adequacy requirement)
+#   Art. 20  — Conditions for cross-border transfer (consent, necessity, safeguards)
+#   Art. 22  — Data sovereignty (critical data must remain in-country)
+#   Art. 43  — Breach notification to ECA within 72 hours
+#   Art. 46  — Record of processing operations (audit trail)
+#   Art. 52  — Accountability (controller demonstrates compliance)
+#   Proc. 958/2016 — Unauthorised access to computer systems is a criminal offence
 #
 # ⚠️  This is a community-maintained governance starter policy.
 # It is NOT a certified legal compliance instrument. Organisations must
 # perform their own compliance assessments with qualified advisors.
-#
-# Key obligations covered:
-#   Computer Crime Proclamation No. 958/2016 — unauthorised data access controls
-#   Electronic Transactions Proclamation No. 1205/2020 — data handling in e-transactions
-#   Draft PDPP — cross-border transfers, sensitive data, accountability, breach notification
+# Verify thresholds and adequacy lists against current ECA guidance.
 
 version: "1.0"
 name: ethiopia-pdp
 description: >
   Ethiopia data protection governance policy for AI agents processing Ethiopian
-  personal data. Based on Computer Crime Proclamation No. 958/2016, Electronic
-  Transactions Proclamation No. 1205/2020, and the draft Personal Data Protection
-  Proclamation. Covers cross-border restrictions, sensitive data controls, and
-  accountability. Update when dedicated PDPP is enacted.
+  personal data. Based on Personal Data Protection Proclamation No. 1321/2024
+  (enacted July 24, 2024) and Computer Crime Proclamation No. 958/2016.
+  Covers cross-border restrictions (Art. 18-20), sensitive data controls (Art. 9),
+  breach notification (Art. 43), data sovereignty (Art. 22), and accountability (Art. 52).
 
 rules:
 
   # =========================================================================
-  # Breach Notification — Obligation exists under ECA oversight
+  # Breach Notification — Art. 43: 72 hours to ECA after becoming aware
   # AI agents must not suppress breach alerts or delay incident reporting.
   # =========================================================================
 
@@ -46,12 +45,13 @@ rules:
       value: "(?i)(don'?t\\s+(report|notify|disclose)|hide\\s+(the\\s+)?(breach|incident)|suppress\\s+(alert|notification)|delay\\s+(breach|incident)\\s+report)"
     action: deny
     priority: 1
-    message: "Ethiopia: Agent cannot suppress breach notifications — ECA incident reporting obligation applies"
+    message: "Ethiopia PDPP 1321/2024 Art. 43: Agent cannot suppress breach notifications — ECA must be notified within 72 hours of awareness"
 
   # =========================================================================
-  # Sensitive Personal Data
-  # Ethiopia's draft PDPP and AU AI Framework treat health, biometric,
-  # ethnic, political, religious, and financial data as sensitive.
+  # Sensitive Personal Data — Art. 9
+  # Prohibited categories: health, genetic, biometric, ethnic origin, political
+  # opinions, religious beliefs, trade union membership, sexual orientation,
+  # criminal offences, communication data.
   # =========================================================================
 
   - name: ethiopia-health-data-in-output
@@ -61,7 +61,7 @@ rules:
       value: "(?i)(medical\\s+record|health\\s+(condition|status|data)|HIV|genetic\\s+(data|test)|mental\\s+health|disability|prescription)"
     action: escalate
     priority: 1
-    message: "Ethiopia draft PDPP: Health/medical sensitive data detected — requires explicit consent or documented legal basis"
+    message: "Ethiopia PDPP 1321/2024 Art. 9: Health/genetic sensitive data detected — requires explicit consent or documented lawful condition"
 
   - name: ethiopia-special-category-data
     condition:
@@ -70,7 +70,7 @@ rules:
       value: "(?i)(ethnic\\s+origin|tribe|political\\s+opinion|religious\\s+belief|trade\\s+union|sexual\\s+orientation|criminal\\s+conviction)"
     action: escalate
     priority: 1
-    message: "Ethiopia draft PDPP: Special category personal data detected — requires explicit consent or lawful processing condition"
+    message: "Ethiopia PDPP 1321/2024 Art. 9: Special category personal data detected — requires explicit consent or lawful processing condition"
 
   - name: ethiopia-biometric-data
     condition:
@@ -79,13 +79,13 @@ rules:
       value: "(?i)(fingerprint|facial\\s+recognition|retina|iris\\s+scan|voice\\s+print|biometric\\s+(template|hash|data))"
     action: deny
     priority: 1
-    message: "Ethiopia draft PDPP: Biometric data detected — must not be transmitted without documented lawful basis and ECA notification"
+    message: "Ethiopia PDPP 1321/2024 Art. 9: Biometric data detected — must not be transmitted without documented lawful basis and ECA notification"
 
   # =========================================================================
-  # Cross-Border Data Transfers
-  # Ethiopia's draft PDPP requires adequacy or binding contractual safeguards
-  # before personal data leaves Ethiopia. Cross-border transfers are a high
-  # priority for ECA enforcement under the AU AI governance framework.
+  # Cross-Border Data Transfers — Art. 18, 19, 20, 22
+  # Art. 18: Transfer requires adequate protection in destination jurisdiction
+  # Art. 20: Without adequacy: explicit consent, necessity, or public interest
+  # Art. 22: Data sovereignty — critical data must remain in-country
   # =========================================================================
 
   - name: ethiopia-cross-border-language-in-output
@@ -95,7 +95,7 @@ rules:
       value: "(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\\s+ethiopia|cross.?border|international\\s+transfer|offshore)"
     action: escalate
     priority: 1
-    message: "Ethiopia draft PDPP: Cross-border data transfer detected — requires adequacy verification before proceeding"
+    message: "Ethiopia PDPP 1321/2024 Art. 18: Cross-border data transfer language detected — requires ECA adequacy verification before proceeding"
 
   - name: ethiopia-cross-border-action
     condition:
@@ -104,12 +104,12 @@ rules:
       value: "send_to_external|export_data|upload_to_cloud|forward_to|relay_data|sync_to_remote"
     action: escalate
     priority: 2
-    message: "Ethiopia draft PDPP: Cross-border data transfer action requires adequacy check — ECA approval may be required"
+    message: "Ethiopia PDPP 1321/2024 Art. 20: Cross-border data transfer action requires adequacy check or documented derogation (Art. 20)"
 
   # =========================================================================
   # Unauthorised Data Access — Computer Crime Proclamation No. 958/2016
-  # Unauthorised access to personal data and systems is a criminal offence.
-  # AI agents must not facilitate or obscure unauthorised access.
+  # Unauthorised access to computer systems and personal data is a criminal
+  # offence under 958/2016. AI agents must not facilitate or obscure it.
   # =========================================================================
 
   - name: ethiopia-unauthorised-access-signal
@@ -119,10 +119,10 @@ rules:
       value: "(?i)(unauthori[sz]ed\\s+(access|login|entry)|bypass(ing)?\\s+(auth|security|login)|circumvent(ing)?\\s+(access|control))"
     action: deny
     priority: 1
-    message: "Ethiopia Proclamation 958/2016: Unauthorised system access signal detected — blocked. This may constitute a criminal offence."
+    message: "Ethiopia Proclamation 958/2016: Unauthorised system access signal detected — blocked. This constitutes a criminal offence."
 
   # =========================================================================
-  # Data Minimisation
+  # Data Minimisation / Data Sovereignty — Art. 22
   # =========================================================================
 
   - name: ethiopia-bulk-data-export
@@ -132,12 +132,13 @@ rules:
       value: "bulk_export|export_all|dump_database|download_all_records|full_table_export|batch_download_pii"
     action: escalate
     priority: 2
-    message: "Ethiopia draft PDPP: Bulk personal data export — data minimisation principle requires documented lawful basis"
+    message: "Ethiopia PDPP 1321/2024 Art. 22: Bulk personal data export — data sovereignty principle requires documented lawful basis and DPO review"
 
   # =========================================================================
-  # Ethiopian National ID — Fayda Number
+  # Ethiopian National ID — Fayda/MOSIP Number
   # Ethiopia's digital identity system (Fayda/MOSIP) issues national IDs.
-  # Exposure of Fayda IDs in agent output constitutes a data breach.
+  # Exposure of Fayda IDs in agent output constitutes a data breach (Art. 43).
+  # Note: Fayda falls under Art. 2 "identifier" definition in Proclamation 1321/2024.
   # =========================================================================
 
   - name: ethiopia-fayda-id-in-output
@@ -147,12 +148,12 @@ rules:
       value: "(?i)(fayda\\s+(id|number|no)|ethiopia\\s+(national\\s+)?id|mosip\\s+id)[\\s:=]{0,5}[0-9]{10,16}"
     action: deny
     priority: 1
-    message: "Ethiopia: Fayda/National ID number detected in agent output — blocked to prevent identity exposure"
+    message: "Ethiopia PDPP 1321/2024 Art. 43: Fayda/National ID number detected in agent output — blocked to prevent identity data breach"
 
   # =========================================================================
-  # Accountability / Audit Trail
-  # ECA and the draft PDPP require data controllers to maintain records of
-  # processing activities accessible to the supervisory authority on request.
+  # Accountability / Audit Trail — Art. 46, Art. 52
+  # Art. 46: Controllers must maintain records of processing operations
+  # Art. 52: Accountability — controller must demonstrate compliance to ECA
   # =========================================================================
 
   - name: ethiopia-pii-access-audit
@@ -162,7 +163,7 @@ rules:
       value: "read_user|get_customer|lookup_account|fetch_profile|query_personal|access_pii"
     action: audit
     priority: 3
-    message: "Ethiopia draft PDPP: Personal data access logged — ECA accountability audit trail requirement"
+    message: "Ethiopia PDPP 1321/2024 Art. 46/52: Personal data access logged — ECA record of processing operations and accountability requirement"
 
   - name: ethiopia-pii-modification-audit
     condition:
@@ -171,4 +172,4 @@ rules:
       value: "update_user|modify_profile|patch_account|edit_customer|change_personal"
     action: audit
     priority: 3
-    message: "Ethiopia draft PDPP: Personal data modification logged — ECA accountability audit trail requirement"
+    message: "Ethiopia PDPP 1321/2024 Art. 46/52: Personal data modification logged — ECA record of processing operations and accountability requirement"

--- a/examples/policies/african-regulatory/ethiopia-pdp.yaml
+++ b/examples/policies/african-regulatory/ethiopia-pdp.yaml
@@ -1,0 +1,174 @@
+# agt-policies-africa
+# Ethiopia Personal Data Protection — Governance Policy
+#
+# Regulatory reference: Ethiopia Personal Data Protection Proclamation (forthcoming)
+#                       Ethiopia Computer Crime Proclamation No. 958/2016 (interim)
+#                       Ethiopia Electronic Transactions Proclamation No. 1205/2020
+# Enforcing authority: Ethiopian Communications Authority (ECA) /
+#                      Ministry of Innovation and Technology (MInT)
+#
+# ⚠️  NOTE ON REGULATORY STATUS: Ethiopia's dedicated Personal Data Protection
+# Proclamation is in active development. This policy pack is based on:
+# (a) Existing obligations under Proclamation No. 958/2016 and No. 1205/2020
+# (b) The principles in the draft Personal Data Protection Proclamation
+# (c) Continental AI governance principles from the African Union Framework
+# Update this pack when the dedicated Proclamation is enacted and gazetted.
+#
+# ⚠️  This is a community-maintained governance starter policy.
+# It is NOT a certified legal compliance instrument. Organisations must
+# perform their own compliance assessments with qualified advisors.
+#
+# Key obligations covered:
+#   Computer Crime Proclamation No. 958/2016 — unauthorised data access controls
+#   Electronic Transactions Proclamation No. 1205/2020 — data handling in e-transactions
+#   Draft PDPP — cross-border transfers, sensitive data, accountability, breach notification
+
+version: "1.0"
+name: ethiopia-pdp
+description: >
+  Ethiopia data protection governance policy for AI agents processing Ethiopian
+  personal data. Based on Computer Crime Proclamation No. 958/2016, Electronic
+  Transactions Proclamation No. 1205/2020, and the draft Personal Data Protection
+  Proclamation. Covers cross-border restrictions, sensitive data controls, and
+  accountability. Update when dedicated PDPP is enacted.
+
+rules:
+
+  # =========================================================================
+  # Breach Notification — Obligation exists under ECA oversight
+  # AI agents must not suppress breach alerts or delay incident reporting.
+  # =========================================================================
+
+  - name: ethiopia-breach-suppression
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(don'?t\\s+(report|notify|disclose)|hide\\s+(the\\s+)?(breach|incident)|suppress\\s+(alert|notification)|delay\\s+(breach|incident)\\s+report)"
+    action: deny
+    priority: 1
+    message: "Ethiopia: Agent cannot suppress breach notifications — ECA incident reporting obligation applies"
+
+  # =========================================================================
+  # Sensitive Personal Data
+  # Ethiopia's draft PDPP and AU AI Framework treat health, biometric,
+  # ethnic, political, religious, and financial data as sensitive.
+  # =========================================================================
+
+  - name: ethiopia-health-data-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(medical\\s+record|health\\s+(condition|status|data)|HIV|genetic\\s+(data|test)|mental\\s+health|disability|prescription)"
+    action: escalate
+    priority: 1
+    message: "Ethiopia draft PDPP: Health/medical sensitive data detected — requires explicit consent or documented legal basis"
+
+  - name: ethiopia-special-category-data
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(ethnic\\s+origin|tribe|political\\s+opinion|religious\\s+belief|trade\\s+union|sexual\\s+orientation|criminal\\s+conviction)"
+    action: escalate
+    priority: 1
+    message: "Ethiopia draft PDPP: Special category personal data detected — requires explicit consent or lawful processing condition"
+
+  - name: ethiopia-biometric-data
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(fingerprint|facial\\s+recognition|retina|iris\\s+scan|voice\\s+print|biometric\\s+(template|hash|data))"
+    action: deny
+    priority: 1
+    message: "Ethiopia draft PDPP: Biometric data detected — must not be transmitted without documented lawful basis and ECA notification"
+
+  # =========================================================================
+  # Cross-Border Data Transfers
+  # Ethiopia's draft PDPP requires adequacy or binding contractual safeguards
+  # before personal data leaves Ethiopia. Cross-border transfers are a high
+  # priority for ECA enforcement under the AU AI governance framework.
+  # =========================================================================
+
+  - name: ethiopia-cross-border-language-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\\s+ethiopia|cross.?border|international\\s+transfer|offshore)"
+    action: escalate
+    priority: 1
+    message: "Ethiopia draft PDPP: Cross-border data transfer detected — requires adequacy verification before proceeding"
+
+  - name: ethiopia-cross-border-action
+    condition:
+      field: action
+      operator: matches
+      value: "send_to_external|export_data|upload_to_cloud|forward_to|relay_data|sync_to_remote"
+    action: escalate
+    priority: 2
+    message: "Ethiopia draft PDPP: Cross-border data transfer action requires adequacy check — ECA approval may be required"
+
+  # =========================================================================
+  # Unauthorised Data Access — Computer Crime Proclamation No. 958/2016
+  # Unauthorised access to personal data and systems is a criminal offence.
+  # AI agents must not facilitate or obscure unauthorised access.
+  # =========================================================================
+
+  - name: ethiopia-unauthorised-access-signal
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(unauthori[sz]ed\\s+(access|login|entry)|bypass(ing)?\\s+(auth|security|login)|circumvent(ing)?\\s+(access|control))"
+    action: deny
+    priority: 1
+    message: "Ethiopia Proclamation 958/2016: Unauthorised system access signal detected — blocked. This may constitute a criminal offence."
+
+  # =========================================================================
+  # Data Minimisation
+  # =========================================================================
+
+  - name: ethiopia-bulk-data-export
+    condition:
+      field: action
+      operator: matches
+      value: "bulk_export|export_all|dump_database|download_all_records|full_table_export|batch_download_pii"
+    action: escalate
+    priority: 2
+    message: "Ethiopia draft PDPP: Bulk personal data export — data minimisation principle requires documented lawful basis"
+
+  # =========================================================================
+  # Ethiopian National ID — Fayda Number
+  # Ethiopia's digital identity system (Fayda/MOSIP) issues national IDs.
+  # Exposure of Fayda IDs in agent output constitutes a data breach.
+  # =========================================================================
+
+  - name: ethiopia-fayda-id-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(fayda\\s+(id|number|no)|ethiopia\\s+(national\\s+)?id|mosip\\s+id)[\\s:=]{0,5}[0-9]{10,16}"
+    action: deny
+    priority: 1
+    message: "Ethiopia: Fayda/National ID number detected in agent output — blocked to prevent identity exposure"
+
+  # =========================================================================
+  # Accountability / Audit Trail
+  # ECA and the draft PDPP require data controllers to maintain records of
+  # processing activities accessible to the supervisory authority on request.
+  # =========================================================================
+
+  - name: ethiopia-pii-access-audit
+    condition:
+      field: action
+      operator: matches
+      value: "read_user|get_customer|lookup_account|fetch_profile|query_personal|access_pii"
+    action: audit
+    priority: 3
+    message: "Ethiopia draft PDPP: Personal data access logged — ECA accountability audit trail requirement"
+
+  - name: ethiopia-pii-modification-audit
+    condition:
+      field: action
+      operator: matches
+      value: "update_user|modify_profile|patch_account|edit_customer|change_personal"
+    action: audit
+    priority: 3
+    message: "Ethiopia draft PDPP: Personal data modification logged — ECA accountability audit trail requirement"

--- a/examples/policies/african-regulatory/rego/ethiopia-pdp.rego
+++ b/examples/policies/african-regulatory/rego/ethiopia-pdp.rego
@@ -1,10 +1,20 @@
 # agt-policies-africa
 # Ethiopia Personal Data Protection — Data Protection Policy (Rego)
 #
-# Regulatory reference: Computer Crime Proclamation No. 958/2016 (interim)
-#                       Electronic Transactions Proclamation No. 1205/2020
-#                       Ethiopia Personal Data Protection Proclamation (forthcoming)
-# Enforcing authority: Ethiopian Communications Authority (ECA) / MInT
+# Regulatory reference: Ethiopia Personal Data Protection Proclamation No. 1321/2024
+#                       (Enacted July 24, 2024 — Federal Negarit Gazette)
+#                       Ethiopia Computer Crime Proclamation No. 958/2016
+# Enforcing authority: Ethiopian Communications Authority (ECA)
+#
+# Key articles:
+#   Art. 9   — Sensitive personal data (health, biometric, genetic, ethnic, religious)
+#   Art. 18  — Principle of data transfer (adequacy requirement)
+#   Art. 20  — Conditions for cross-border transfer
+#   Art. 22  — Data sovereignty (critical data must remain in-country)
+#   Art. 43  — Breach notification to ECA within 72 hours
+#   Art. 46  — Record of processing operations
+#   Art. 52  — Accountability
+#   Proc. 958/2016 — Unauthorised access criminal offence
 #
 # Input schema expected:
 #   {
@@ -43,37 +53,37 @@ bulk_export_actions := {
 
 # ── Deny rules ────────────────────────────────────────────────────
 
-# ECA oversight: Block breach suppression
+# Art. 43: Block breach suppression — ECA must be notified within 72 hours
 deny contains msg if {
 	regex.match(`(?i)(don'?t\s+(report|notify|disclose)|hide\s+(the\s+)?(breach|incident)|suppress\s+(alert|notification)|delay\s+(breach|incident)\s+report)`, input.output)
-	msg := "Ethiopia: Agent cannot suppress breach notifications — ECA incident reporting obligation applies"
+	msg := "Ethiopia PDPP 1321/2024 Art. 43: Agent cannot suppress breach notifications — ECA must be notified within 72 hours of awareness"
 }
 
-# Draft PDPP: Block biometric data transmission
+# Art. 9: Block biometric data transmission
 deny contains msg if {
 	regex.match(`(?i)(fingerprint|facial\s+recognition|retina|iris\s+scan|voice\s+print|biometric\s+(template|hash|data))`, input.output)
-	msg := "Ethiopia draft PDPP: Biometric data detected — must not be transmitted without documented lawful basis and ECA notification"
+	msg := "Ethiopia PDPP 1321/2024 Art. 9: Biometric data detected — must not be transmitted without documented lawful basis and ECA notification"
 }
 
-# Draft PDPP: Block cross-border transfer to non-permitted region
+# Art. 18/19: Block cross-border transfer to non-permitted region
 deny contains msg if {
 	input.action in transfer_actions
 	input.params.destination_region != null
 	not input.params.destination_region in permitted_regions
 	msg := sprintf(
-		"Ethiopia draft PDPP: Cross-border transfer to '%v' blocked — region not in ECA adequacy-approved list",
+		"Ethiopia PDPP 1321/2024 Art. 18: Cross-border transfer to '%v' blocked — region not in ECA adequacy-approved list",
 		[input.params.destination_region],
 	)
 }
 
-# Draft PDPP: Block transfer to non-ET country without consent
+# Art. 20: Block transfer to non-ET country without documented consent or adequacy
 deny contains msg if {
 	input.action in transfer_actions
 	input.params.destination_country != null
 	input.params.destination_country != "ET"
 	not input.context.consent_documented == true
 	msg := sprintf(
-		"Ethiopia draft PDPP: Transfer to country '%v' blocked — no documented consent or adequacy basis on file",
+		"Ethiopia PDPP 1321/2024 Art. 20: Transfer to '%v' blocked — no documented consent or adequacy basis on file",
 		[input.params.destination_country],
 	)
 }
@@ -81,82 +91,83 @@ deny contains msg if {
 # Proclamation 958/2016: Block unauthorised access signals
 deny contains msg if {
 	regex.match(`(?i)(unauthori[sz]ed\s+(access|login|entry)|bypass(ing)?\s+(auth|security|login)|circumvent(ing)?\s+(access|control))`, input.output)
-	msg := "Ethiopia Proclamation 958/2016: Unauthorised system access signal detected — blocked. This may constitute a criminal offence."
+	msg := "Ethiopia Proclamation 958/2016: Unauthorised system access signal detected — blocked. This constitutes a criminal offence."
 }
 
-# Draft PDPP: Block Fayda/national ID in output
+# Art. 43: Block Fayda/national ID in output (identity data breach)
+# Fayda falls under Art. 2 "identifier" definition in Proclamation 1321/2024
 deny contains msg if {
 	regex.match(`(?i)(fayda\s+(id|number|no)|ethiopia\s+(national\s+)?id|mosip\s+id)[\s:=]{0,5}[0-9]{10,16}`, input.output)
-	msg := "Ethiopia: Fayda/National ID number detected in agent output — blocked to prevent identity exposure"
+	msg := "Ethiopia PDPP 1321/2024 Art. 43: Fayda/National ID number detected in agent output — blocked to prevent identity data breach"
 }
 
-# Draft PDPP: Block large record exports
+# Art. 22: Block large record exports — data sovereignty
 deny contains msg if {
 	input.action in transfer_actions
 	input.params.record_count > 1000
 	msg := sprintf(
-		"Ethiopia draft PDPP: Export of %v records is disproportionate — requires Data Protection Officer review",
+		"Ethiopia PDPP 1321/2024 Art. 22: Export of %v records is disproportionate — requires Data Protection Officer review and ECA notification",
 		[input.params.record_count],
 	)
 }
 
 # ── Escalate rules ────────────────────────────────────────────────
 
-# Draft PDPP: Health/medical data
+# Art. 9: Health/genetic sensitive data
 escalate contains msg if {
 	regex.match(`(?i)(medical\s+record|health\s+(condition|status|data)|HIV|genetic\s+(data|test)|mental\s+health|disability|prescription)`, input.output)
-	msg := "Ethiopia draft PDPP: Health/medical sensitive data detected — requires explicit consent or documented legal basis"
+	msg := "Ethiopia PDPP 1321/2024 Art. 9: Health/genetic sensitive data detected — requires explicit consent or documented lawful condition"
 }
 
-# Draft PDPP: Special category data
+# Art. 9: Special category data (ethnic, religious, political, trade union)
 escalate contains msg if {
 	regex.match(`(?i)(ethnic\s+origin|tribe|political\s+opinion|religious\s+belief|trade\s+union|sexual\s+orientation|criminal\s+conviction)`, input.output)
-	msg := "Ethiopia draft PDPP: Special category personal data detected — requires explicit consent or lawful processing condition"
+	msg := "Ethiopia PDPP 1321/2024 Art. 9: Special category personal data detected — requires explicit consent or lawful processing condition"
 }
 
-# Draft PDPP: Cross-border language
+# Art. 18: Cross-border language in agent output
 escalate contains msg if {
 	regex.match(`(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\s+ethiopia|cross.?border|international\s+transfer|offshore)`, input.output)
-	msg := "Ethiopia draft PDPP: Cross-border data transfer language detected — requires ECA adequacy verification"
+	msg := "Ethiopia PDPP 1321/2024 Art. 18: Cross-border data transfer language detected — requires ECA adequacy verification"
 }
 
-# Draft PDPP: Transfer with missing destination metadata
+# Art. 20: Transfer action with missing destination metadata
 escalate contains msg if {
 	input.action in transfer_actions
 	not input.params.destination_region
 	not input.params.destination_country
-	msg := "Ethiopia draft PDPP: Cross-border transfer with no destination metadata — cannot verify adequacy, requires human review"
+	msg := "Ethiopia PDPP 1321/2024 Art. 20: Cross-border transfer with no destination metadata — cannot verify adequacy, requires human review"
 }
 
-# Draft PDPP: Moderate record exports
+# Art. 22: Moderate record exports — data sovereignty
 escalate contains msg if {
 	input.action in transfer_actions
 	input.params.record_count > 100
 	input.params.record_count <= 1000
 	msg := sprintf(
-		"Ethiopia draft PDPP: Export of %v records requires Data Protection Officer approval",
+		"Ethiopia PDPP 1321/2024 Art. 22: Export of %v records requires Data Protection Officer approval",
 		[input.params.record_count],
 	)
 }
 
-# Draft PDPP: Bulk export actions
+# Art. 22: Bulk export actions
 escalate contains msg if {
 	input.action in bulk_export_actions
-	msg := "Ethiopia draft PDPP: Bulk personal data export requires documented lawful basis and ECA notification"
+	msg := "Ethiopia PDPP 1321/2024 Art. 22: Bulk personal data export requires documented lawful basis and ECA notification"
 }
 
-# ── Audit rules ───────────────────────────────────────────────────
+# ── Audit rules — Art. 46 / Art. 52 ─────────────────────────────
 
 audit contains msg if {
 	pii_actions := {"read_user", "get_customer", "lookup_account", "fetch_profile", "query_personal", "access_pii"}
 	input.action in pii_actions
-	msg := "Ethiopia draft PDPP: Personal data access logged — ECA accountability audit trail requirement"
+	msg := "Ethiopia PDPP 1321/2024 Art. 46/52: Personal data access logged — record of processing operations and accountability requirement"
 }
 
 audit contains msg if {
 	pii_update_actions := {"update_user", "modify_profile", "patch_account", "edit_customer", "change_personal"}
 	input.action in pii_update_actions
-	msg := "Ethiopia draft PDPP: Personal data modification logged — ECA accountability audit trail requirement"
+	msg := "Ethiopia PDPP 1321/2024 Art. 46/52: Personal data modification logged — record of processing operations and accountability requirement"
 }
 
 # ── Decision summary ─────────────────────────────────────────────

--- a/examples/policies/african-regulatory/rego/ethiopia-pdp.rego
+++ b/examples/policies/african-regulatory/rego/ethiopia-pdp.rego
@@ -1,0 +1,180 @@
+# agt-policies-africa
+# Ethiopia Personal Data Protection — Data Protection Policy (Rego)
+#
+# Regulatory reference: Computer Crime Proclamation No. 958/2016 (interim)
+#                       Electronic Transactions Proclamation No. 1205/2020
+#                       Ethiopia Personal Data Protection Proclamation (forthcoming)
+# Enforcing authority: Ethiopian Communications Authority (ECA) / MInT
+#
+# Input schema expected:
+#   {
+#     "action":  "export_data",
+#     "params":  {
+#       "destination_region": "us-east-1",
+#       "destination_country": "US",
+#       "record_count": 500
+#     },
+#     "output":  "agent output text",
+#     "context": { "consent_documented": false, "legal_basis": "" }
+#   }
+
+package agt_policies_africa.ethiopia_pdp
+
+import rego.v1
+
+# ── Permitted regions (Ethiopia-hosted or adequacy-approved) ──────
+permitted_regions := {
+	"af-south-1", # AWS Africa (Cape Town) — nearest available
+	"af-east-1",  # East Africa region placeholder
+	"ethiopia",
+	"ET",
+	"et",
+}
+
+transfer_actions := {
+	"send_to_external", "export_data", "upload_to_cloud",
+	"forward_to", "relay_data", "sync_to_remote",
+}
+
+bulk_export_actions := {
+	"bulk_export", "export_all", "download_all_records",
+	"dump_database", "full_table_export", "batch_download_pii",
+}
+
+# ── Deny rules ────────────────────────────────────────────────────
+
+# ECA oversight: Block breach suppression
+deny contains msg if {
+	regex.match(`(?i)(don'?t\s+(report|notify|disclose)|hide\s+(the\s+)?(breach|incident)|suppress\s+(alert|notification)|delay\s+(breach|incident)\s+report)`, input.output)
+	msg := "Ethiopia: Agent cannot suppress breach notifications — ECA incident reporting obligation applies"
+}
+
+# Draft PDPP: Block biometric data transmission
+deny contains msg if {
+	regex.match(`(?i)(fingerprint|facial\s+recognition|retina|iris\s+scan|voice\s+print|biometric\s+(template|hash|data))`, input.output)
+	msg := "Ethiopia draft PDPP: Biometric data detected — must not be transmitted without documented lawful basis and ECA notification"
+}
+
+# Draft PDPP: Block cross-border transfer to non-permitted region
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.destination_region != null
+	not input.params.destination_region in permitted_regions
+	msg := sprintf(
+		"Ethiopia draft PDPP: Cross-border transfer to '%v' blocked — region not in ECA adequacy-approved list",
+		[input.params.destination_region],
+	)
+}
+
+# Draft PDPP: Block transfer to non-ET country without consent
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.destination_country != null
+	input.params.destination_country != "ET"
+	not input.context.consent_documented == true
+	msg := sprintf(
+		"Ethiopia draft PDPP: Transfer to country '%v' blocked — no documented consent or adequacy basis on file",
+		[input.params.destination_country],
+	)
+}
+
+# Proclamation 958/2016: Block unauthorised access signals
+deny contains msg if {
+	regex.match(`(?i)(unauthori[sz]ed\s+(access|login|entry)|bypass(ing)?\s+(auth|security|login)|circumvent(ing)?\s+(access|control))`, input.output)
+	msg := "Ethiopia Proclamation 958/2016: Unauthorised system access signal detected — blocked. This may constitute a criminal offence."
+}
+
+# Draft PDPP: Block Fayda/national ID in output
+deny contains msg if {
+	regex.match(`(?i)(fayda\s+(id|number|no)|ethiopia\s+(national\s+)?id|mosip\s+id)[\s:=]{0,5}[0-9]{10,16}`, input.output)
+	msg := "Ethiopia: Fayda/National ID number detected in agent output — blocked to prevent identity exposure"
+}
+
+# Draft PDPP: Block large record exports
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.record_count > 1000
+	msg := sprintf(
+		"Ethiopia draft PDPP: Export of %v records is disproportionate — requires Data Protection Officer review",
+		[input.params.record_count],
+	)
+}
+
+# ── Escalate rules ────────────────────────────────────────────────
+
+# Draft PDPP: Health/medical data
+escalate contains msg if {
+	regex.match(`(?i)(medical\s+record|health\s+(condition|status|data)|HIV|genetic\s+(data|test)|mental\s+health|disability|prescription)`, input.output)
+	msg := "Ethiopia draft PDPP: Health/medical sensitive data detected — requires explicit consent or documented legal basis"
+}
+
+# Draft PDPP: Special category data
+escalate contains msg if {
+	regex.match(`(?i)(ethnic\s+origin|tribe|political\s+opinion|religious\s+belief|trade\s+union|sexual\s+orientation|criminal\s+conviction)`, input.output)
+	msg := "Ethiopia draft PDPP: Special category personal data detected — requires explicit consent or lawful processing condition"
+}
+
+# Draft PDPP: Cross-border language
+escalate contains msg if {
+	regex.match(`(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\s+ethiopia|cross.?border|international\s+transfer|offshore)`, input.output)
+	msg := "Ethiopia draft PDPP: Cross-border data transfer language detected — requires ECA adequacy verification"
+}
+
+# Draft PDPP: Transfer with missing destination metadata
+escalate contains msg if {
+	input.action in transfer_actions
+	not input.params.destination_region
+	not input.params.destination_country
+	msg := "Ethiopia draft PDPP: Cross-border transfer with no destination metadata — cannot verify adequacy, requires human review"
+}
+
+# Draft PDPP: Moderate record exports
+escalate contains msg if {
+	input.action in transfer_actions
+	input.params.record_count > 100
+	input.params.record_count <= 1000
+	msg := sprintf(
+		"Ethiopia draft PDPP: Export of %v records requires Data Protection Officer approval",
+		[input.params.record_count],
+	)
+}
+
+# Draft PDPP: Bulk export actions
+escalate contains msg if {
+	input.action in bulk_export_actions
+	msg := "Ethiopia draft PDPP: Bulk personal data export requires documented lawful basis and ECA notification"
+}
+
+# ── Audit rules ───────────────────────────────────────────────────
+
+audit contains msg if {
+	pii_actions := {"read_user", "get_customer", "lookup_account", "fetch_profile", "query_personal", "access_pii"}
+	input.action in pii_actions
+	msg := "Ethiopia draft PDPP: Personal data access logged — ECA accountability audit trail requirement"
+}
+
+audit contains msg if {
+	pii_update_actions := {"update_user", "modify_profile", "patch_account", "edit_customer", "change_personal"}
+	input.action in pii_update_actions
+	msg := "Ethiopia draft PDPP: Personal data modification logged — ECA accountability audit trail requirement"
+}
+
+# ── Decision summary ─────────────────────────────────────────────
+decision := "deny" if count(deny) > 0
+
+decision := "escalate" if {
+	count(deny) == 0
+	count(escalate) > 0
+}
+
+decision := "audit" if {
+	count(deny) == 0
+	count(escalate) == 0
+	count(audit) > 0
+}
+
+decision := "allow" if {
+	count(deny) == 0
+	count(escalate) == 0
+	count(audit) == 0
+}

--- a/examples/policies/african-regulatory/rego/jurisdiction-router.rego
+++ b/examples/policies/african-regulatory/rego/jurisdiction-router.rego
@@ -47,6 +47,9 @@ jurisdiction_policies := {
 	"NG": {"cbn", "bvn_nin", "ndpa", "nfiu"},
 	"KE": {"kdpa"},
 	"ZA": {"popia"},
+	"UG": {"uganda_dppa"},
+	"TZ": {"tanzania_pdpa"},
+	"ET": {"ethiopia_pdp"},
 }
 
 # ── Policy pack → OPA query path ─────────────────────────────────
@@ -58,6 +61,9 @@ policy_queries := {
 	"nfiu": "data.agt_policies_nigeria.nfiu.decision",
 	"kdpa": "data.agt_policies_africa.kdpa.decision",
 	"popia": "data.agt_policies_africa.popia.decision",
+	"uganda_dppa": "data.agt_policies_africa.uganda_dppa.decision",
+	"tanzania_pdpa": "data.agt_policies_africa.tanzania_pdpa.decision",
+	"ethiopia_pdp": "data.agt_policies_africa.ethiopia_pdp.decision",
 	"prompt_injection": "data.agt_policies_agent.prompt_injection.decision",
 	"pii_leakage": "data.agt_policies_agent.pii_leakage.decision",
 	"tool_permissions": "data.agt_policies_agent.tool_permissions.decision",

--- a/examples/policies/african-regulatory/rego/tanzania-pdpa.rego
+++ b/examples/policies/african-regulatory/rego/tanzania-pdpa.rego
@@ -1,0 +1,178 @@
+# agt-policies-africa
+# Tanzania Personal Data Protection Act 2022 — Data Protection Policy (Rego)
+#
+# Regulatory reference: Tanzania Personal Data Protection Act 2022
+# Enforcing authority: Personal Data Protection Commission (PDPC)
+#
+# Input schema expected:
+#   {
+#     "action":  "export_data",
+#     "params":  {
+#       "destination_region": "us-east-1",
+#       "destination_country": "US",
+#       "record_count": 500
+#     },
+#     "output":  "agent output text",
+#     "context": { "consent_documented": false, "legal_basis": "" }
+#   }
+
+package agt_policies_africa.tanzania_pdpa
+
+import rego.v1
+
+# ── Permitted regions (Tanzania-hosted or adequacy-approved) ──────
+permitted_regions := {
+	"af-south-1", # AWS Africa (Cape Town) — nearest available
+	"af-east-1",  # East Africa region placeholder
+	"tanzania",
+	"TZ",
+	"tz",
+}
+
+transfer_actions := {
+	"send_to_external", "export_data", "upload_to_cloud",
+	"forward_to", "relay_data", "sync_to_remote",
+}
+
+bulk_export_actions := {
+	"bulk_export", "export_all", "download_all_records",
+	"dump_database", "full_table_export", "batch_download_pii",
+}
+
+# ── Deny rules ────────────────────────────────────────────────────
+
+# PDPA s.28: Block breach suppression
+deny contains msg if {
+	regex.match(`(?i)(don'?t\s+(report|notify|disclose)|hide\s+(the\s+)?(breach|incident)|suppress\s+(alert|notification)|delay\s+(breach|incident)\s+report)`, input.output)
+	msg := "Tanzania PDPA s.28: Agent cannot suppress breach notifications — 72-hour PDPC reporting obligation applies"
+}
+
+# PDPA s.17: Block biometric data transmission
+deny contains msg if {
+	regex.match(`(?i)(fingerprint|facial\s+recognition|retina|iris\s+scan|voice\s+print|biometric\s+(template|hash|data))`, input.output)
+	msg := "Tanzania PDPA s.17: Biometric data detected — must not be transmitted without documented lawful basis"
+}
+
+# PDPA s.13: Block transfer to non-permitted region
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.destination_region != null
+	not input.params.destination_region in permitted_regions
+	msg := sprintf(
+		"Tanzania PDPA s.13: Cross-border transfer to '%v' blocked — region not in PDPC adequacy-approved list",
+		[input.params.destination_region],
+	)
+}
+
+# PDPA s.13: Block transfer to non-TZ country without consent
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.destination_country != null
+	input.params.destination_country != "TZ"
+	not input.context.consent_documented == true
+	msg := sprintf(
+		"Tanzania PDPA s.13: Transfer to country '%v' blocked — no documented consent or adequacy basis on file",
+		[input.params.destination_country],
+	)
+}
+
+# PDPA s.8: Block processing without consent
+deny contains msg if {
+	regex.match(`(?i)(process(ing)?|shar(ing)?|us(ing)?).{0,30}(without\s+consent|no\s+consent|bypass.{0,10}consent)`, input.output)
+	msg := "Tanzania PDPA s.8: Data processing without lawful basis is prohibited — valid consent or documented legal basis required"
+}
+
+# PDPA: Block NIDA national ID in output
+deny contains msg if {
+	regex.match(`(?i)(nida\s+(number|no|#)|national\s+id|tanzania\s+id)[\s:=]{0,5}[0-9]{20}`, input.output)
+	msg := "Tanzania PDPA: NIDA national ID number detected in agent output — blocked to prevent identity exposure"
+}
+
+# PDPA s.30: Block large record exports (>1000 records)
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.record_count > 1000
+	msg := sprintf(
+		"Tanzania PDPA s.30: Export of %v records is disproportionate — requires Data Protection Officer review",
+		[input.params.record_count],
+	)
+}
+
+# ── Escalate rules ────────────────────────────────────────────────
+
+# PDPA s.17: Health/medical data
+escalate contains msg if {
+	regex.match(`(?i)(medical\s+record|health\s+(condition|status|data)|HIV|genetic\s+(data|test)|mental\s+health|disability|prescription)`, input.output)
+	msg := "Tanzania PDPA s.17: Health/medical special category data detected — requires explicit consent or documented legal basis"
+}
+
+# PDPA s.17: Special category data
+escalate contains msg if {
+	regex.match(`(?i)(ethnic\s+origin|race|tribe|political\s+opinion|religious\s+belief|trade\s+union|sexual\s+orientation|criminal\s+conviction)`, input.output)
+	msg := "Tanzania PDPA s.17: Special category personal data detected — explicit consent or lawful processing condition required"
+}
+
+# PDPA s.13: Cross-border language in output
+escalate contains msg if {
+	regex.match(`(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\s+tanzania|cross.?border|international\s+transfer|offshore)`, input.output)
+	msg := "Tanzania PDPA s.13: Cross-border data transfer language detected — requires PDPC adequacy verification"
+}
+
+# PDPA s.13: Transfer with missing destination metadata
+escalate contains msg if {
+	input.action in transfer_actions
+	not input.params.destination_region
+	not input.params.destination_country
+	msg := "Tanzania PDPA s.13: Cross-border transfer with no destination metadata — cannot verify adequacy, requires human review"
+}
+
+# PDPA s.30: Moderate record exports
+escalate contains msg if {
+	input.action in transfer_actions
+	input.params.record_count > 100
+	input.params.record_count <= 1000
+	msg := sprintf(
+		"Tanzania PDPA s.30: Export of %v records requires Data Protection Officer approval",
+		[input.params.record_count],
+	)
+}
+
+# PDPA s.30: Bulk export actions
+escalate contains msg if {
+	input.action in bulk_export_actions
+	msg := "Tanzania PDPA s.30: Bulk personal data export requires documented lawful basis and DPO approval"
+}
+
+# ── Audit rules ───────────────────────────────────────────────────
+
+audit contains msg if {
+	pii_actions := {"read_user", "get_customer", "lookup_account", "fetch_profile", "query_personal", "access_pii"}
+	input.action in pii_actions
+	msg := "Tanzania PDPA s.25: Personal data access logged — PDPC accountability audit trail requirement"
+}
+
+audit contains msg if {
+	pii_update_actions := {"update_user", "modify_profile", "patch_account", "edit_customer", "change_personal"}
+	input.action in pii_update_actions
+	msg := "Tanzania PDPA s.25: Personal data modification logged — PDPC accountability audit trail requirement"
+}
+
+# ── Decision summary ─────────────────────────────────────────────
+decision := "deny" if count(deny) > 0
+
+decision := "escalate" if {
+	count(deny) == 0
+	count(escalate) > 0
+}
+
+decision := "audit" if {
+	count(deny) == 0
+	count(escalate) == 0
+	count(audit) > 0
+}
+
+decision := "allow" if {
+	count(deny) == 0
+	count(escalate) == 0
+	count(audit) == 0
+}

--- a/examples/policies/african-regulatory/rego/uganda-dppa.rego
+++ b/examples/policies/african-regulatory/rego/uganda-dppa.rego
@@ -1,0 +1,183 @@
+# agt-policies-africa
+# Uganda Data Protection and Privacy Act 2019 — Data Protection Policy (Rego)
+#
+# Regulatory reference: Uganda Data Protection and Privacy Act 2019 (DPPA)
+# Enforcing authority: Personal Data Protection Office (PDPO) / NITA-U
+#
+# Input schema expected:
+#   {
+#     "action":  "export_data",
+#     "params":  {
+#       "destination_region": "us-east-1",
+#       "destination_country": "US",
+#       "record_count": 500
+#     },
+#     "output":  "agent output text",
+#     "context": { "consent_documented": false, "legal_basis": "" }
+#   }
+
+package agt_policies_africa.uganda_dppa
+
+import rego.v1
+
+# ── Permitted regions (Uganda-hosted or adequacy-approved) ────────
+# Update this list following Uganda PDPO adequacy determinations.
+permitted_regions := {
+	"af-south-1", # AWS Africa (Cape Town) — nearest available
+	"af-east-1",  # East Africa region placeholder
+	"uganda",
+	"UG",
+	"ug",
+}
+
+# Cross-border transfer actions
+transfer_actions := {
+	"send_to_external", "export_data", "upload_to_cloud",
+	"forward_to", "relay_data", "sync_to_remote",
+}
+
+# Bulk export actions (DPPA s.4(e) — data minimisation)
+bulk_export_actions := {
+	"bulk_export", "export_all", "download_all_records",
+	"dump_database", "full_table_export", "batch_download_pii",
+}
+
+# ── Deny rules ────────────────────────────────────────────────────
+
+# DPPA s.22: Block breach suppression
+deny contains msg if {
+	regex.match(`(?i)(don'?t\s+(report|notify|disclose)|hide\s+(the\s+)?(breach|incident)|suppress\s+(alert|notification)|delay\s+(breach|incident)\s+report)`, input.output)
+	msg := "Uganda DPPA s.22: Agent cannot suppress breach notifications — 72-hour PDPO reporting obligation applies"
+}
+
+# DPPA s.13: Block biometric data transmission
+deny contains msg if {
+	regex.match(`(?i)(fingerprint|facial\s+recognition|retina|iris\s+scan|voice\s+print|biometric\s+(template|hash|data))`, input.output)
+	msg := "Uganda DPPA s.13: Biometric data detected — must not be transmitted without documented lawful basis"
+}
+
+# DPPA s.19: Block transfer to non-permitted region
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.destination_region != null
+	not input.params.destination_region in permitted_regions
+	msg := sprintf(
+		"Uganda DPPA s.19: Cross-border transfer to '%v' blocked — region not in PDPO adequacy-approved list",
+		[input.params.destination_region],
+	)
+}
+
+# DPPA s.19: Block transfer to non-UG country without consent
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.destination_country != null
+	input.params.destination_country != "UG"
+	not input.context.consent_documented == true
+	msg := sprintf(
+		"Uganda DPPA s.19: Transfer to country '%v' blocked — no documented consent or adequacy basis on file",
+		[input.params.destination_country],
+	)
+}
+
+# DPPA: Block National ID (NIRA) in output
+deny contains msg if {
+	regex.match(`(?i)(national\s+id|nira\s+number|uganda\s+id)[\s:=]{0,5}[A-Z]{2}[0-9]{9,12}`, input.output)
+	msg := "Uganda DPPA: National ID number (NIRA) detected in agent output — blocked to prevent identity exposure"
+}
+
+# DPPA s.4: Block large record exports (>1000 records)
+deny contains msg if {
+	input.action in transfer_actions
+	input.params.record_count > 1000
+	msg := sprintf(
+		"Uganda DPPA s.4(e): Export of %v records is disproportionate — requires Data Protection Officer review",
+		[input.params.record_count],
+	)
+}
+
+# ── Escalate rules ────────────────────────────────────────────────
+
+# DPPA s.13: Health/medical data requires approval
+escalate contains msg if {
+	regex.match(`(?i)(medical\s+record|health\s+(condition|status|data)|HIV|genetic\s+(data|test)|mental\s+health|disability|prescription)`, input.output)
+	msg := "Uganda DPPA s.13: Health/medical sensitive personal data detected — requires explicit consent or documented legal basis"
+}
+
+# DPPA s.13: Special category data requires approval
+escalate contains msg if {
+	regex.match(`(?i)(ethnic\s+origin|tribe|political\s+opinion|religious\s+belief|trade\s+union|sexual\s+orientation|criminal\s+conviction)`, input.output)
+	msg := "Uganda DPPA s.13: Special category personal data detected — explicit consent or lawful condition required"
+}
+
+# DPPA s.13: Financial data requires approval
+escalate contains msg if {
+	regex.match(`(?i)(bank\s+account\s+number|account\s+balance|credit\s+score|loan\s+status|financial\s+(record|data|history))`, input.output)
+	msg := "Uganda DPPA s.13: Financial personal data detected — requires documented lawful basis"
+}
+
+# DPPA s.19: Cross-border language in output
+escalate contains msg if {
+	regex.match(`(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\s+uganda|cross.?border|international\s+transfer|offshore)`, input.output)
+	msg := "Uganda DPPA s.19: Cross-border data transfer language detected — requires PDPO adequacy verification"
+}
+
+# DPPA s.19: Transfer with missing destination metadata
+escalate contains msg if {
+	input.action in transfer_actions
+	not input.params.destination_region
+	not input.params.destination_country
+	msg := "Uganda DPPA s.19: Cross-border transfer with no destination metadata — cannot verify adequacy, requires human review"
+}
+
+# DPPA s.4(e): Moderate record exports (100–1000 records)
+escalate contains msg if {
+	input.action in transfer_actions
+	input.params.record_count > 100
+	input.params.record_count <= 1000
+	msg := sprintf(
+		"Uganda DPPA s.4(e): Export of %v records requires Data Protection Officer approval",
+		[input.params.record_count],
+	)
+}
+
+# DPPA s.4(e): Bulk export actions
+escalate contains msg if {
+	input.action in bulk_export_actions
+	msg := "Uganda DPPA s.4(e): Bulk personal data export requires documented lawful basis and DPO approval"
+}
+
+# ── Audit rules ───────────────────────────────────────────────────
+
+# DPPA s.25: All personal data access must be logged
+audit contains msg if {
+	pii_actions := {"read_user", "get_customer", "lookup_account", "fetch_profile", "query_personal", "access_pii"}
+	input.action in pii_actions
+	msg := "Uganda DPPA s.25: Personal data access logged — PDPO accountability audit trail requirement"
+}
+
+# DPPA s.25: All personal data modifications must be logged
+audit contains msg if {
+	pii_update_actions := {"update_user", "modify_profile", "patch_account", "edit_customer", "change_personal"}
+	input.action in pii_update_actions
+	msg := "Uganda DPPA s.25: Personal data modification logged — PDPO accountability audit trail requirement"
+}
+
+# ── Decision summary ─────────────────────────────────────────────
+decision := "deny" if count(deny) > 0
+
+decision := "escalate" if {
+	count(deny) == 0
+	count(escalate) > 0
+}
+
+decision := "audit" if {
+	count(deny) == 0
+	count(escalate) == 0
+	count(audit) > 0
+}
+
+decision := "allow" if {
+	count(deny) == 0
+	count(escalate) == 0
+	count(audit) == 0
+}

--- a/examples/policies/african-regulatory/tanzania-pdpa.yaml
+++ b/examples/policies/african-regulatory/tanzania-pdpa.yaml
@@ -1,0 +1,165 @@
+# agt-policies-africa
+# Tanzania Personal Data Protection Act 2022 — Data Protection Policy
+#
+# Regulatory reference: Tanzania Personal Data Protection Act 2022 (PDPA)
+# Enforcing authority: Personal Data Protection Commission (PDPC)
+#
+# ⚠️  IMPORTANT: This is a community-maintained governance starter policy.
+# It is NOT a certified legal compliance instrument. Organisations must
+# perform their own compliance assessments with qualified advisors before
+# deploying in regulated environments.
+#
+# Key obligations enforced:
+#   s.8   — Data processing principles (lawfulness, minimisation, accuracy)
+#   s.13  — Cross-border data transfer restrictions (adequacy required)
+#   s.17  — Special categories of personal data
+#   s.25  — Data controller accountability / audit trail
+#   s.28  — Data breach notification (72 hours to PDPC)
+#   s.30  — Data minimisation — collect only what is necessary
+
+version: "1.0"
+name: tanzania-pdpa
+description: >
+  Tanzania Personal Data Protection Act 2022 compliance policy for AI agents
+  processing Tanzanian personal data. Enforces cross-border transfer restrictions,
+  special category data controls, breach notification obligations, and PDPC
+  accountability requirements.
+
+rules:
+
+  # =========================================================================
+  # Tanzania PDPA s.28 — Breach Notification (72 hours to PDPC)
+  # Data controllers must notify the PDPC within 72 hours of a breach.
+  # AI agents must never suppress or delay this obligation.
+  # =========================================================================
+
+  - name: tanzania-breach-suppression
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(don'?t\\s+(report|notify|disclose)|hide\\s+(the\\s+)?(breach|incident)|suppress\\s+(alert|notification)|delay\\s+(breach|incident)\\s+report)"
+    action: deny
+    priority: 1
+    message: "Tanzania PDPA s.28: Agent cannot suppress breach notifications — 72-hour PDPC reporting obligation applies"
+
+  # =========================================================================
+  # Tanzania PDPA s.17 — Special Categories of Personal Data
+  # Processing of health, genetic, biometric, racial/ethnic origin, political
+  # opinions, religious beliefs, trade union membership, sexual orientation,
+  # and criminal record data requires explicit lawful basis.
+  # =========================================================================
+
+  - name: tanzania-health-data-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(medical\\s+record|health\\s+(condition|status|data)|HIV|genetic\\s+(data|test)|mental\\s+health|disability|prescription)"
+    action: escalate
+    priority: 1
+    message: "Tanzania PDPA s.17: Health/medical special category data detected — requires explicit consent or documented legal basis"
+
+  - name: tanzania-special-category-data
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(ethnic\\s+origin|race|tribe|political\\s+opinion|religious\\s+belief|trade\\s+union|sexual\\s+orientation|criminal\\s+conviction)"
+    action: escalate
+    priority: 1
+    message: "Tanzania PDPA s.17: Special category personal data detected — explicit consent or lawful processing condition required"
+
+  - name: tanzania-biometric-data
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(fingerprint|facial\\s+recognition|retina|iris\\s+scan|voice\\s+print|biometric\\s+(template|hash|data))"
+    action: deny
+    priority: 1
+    message: "Tanzania PDPA s.17: Biometric data detected — must not be transmitted by AI agents without documented lawful basis"
+
+  # =========================================================================
+  # Tanzania PDPA s.13 — Cross-Border Data Transfers
+  # Personal data may only be transferred out of Tanzania where the destination
+  # country provides an equivalent level of data protection. PDPC approval
+  # required for transfers to countries without adequacy determination.
+  # =========================================================================
+
+  - name: tanzania-cross-border-language-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\\s+tanzania|cross.?border|international\\s+transfer|offshore)"
+    action: escalate
+    priority: 1
+    message: "Tanzania PDPA s.13: Cross-border data transfer detected — requires PDPC adequacy verification before proceeding"
+
+  - name: tanzania-cross-border-action
+    condition:
+      field: action
+      operator: matches
+      value: "send_to_external|export_data|upload_to_cloud|forward_to|relay_data|sync_to_remote"
+    action: escalate
+    priority: 2
+    message: "Tanzania PDPA s.13: Cross-border data transfer action requires adequacy check — destination must provide equivalent protection"
+
+  # =========================================================================
+  # Tanzania PDPA s.30 — Data Minimisation
+  # =========================================================================
+
+  - name: tanzania-bulk-data-export
+    condition:
+      field: action
+      operator: matches
+      value: "bulk_export|export_all|dump_database|download_all_records|full_table_export|batch_download_pii"
+    action: escalate
+    priority: 2
+    message: "Tanzania PDPA s.30: Bulk personal data export — data minimisation requires DPO approval and documented lawful basis"
+
+  # =========================================================================
+  # Tanzania National ID — NIDA Number
+  # Tanzania National ID numbers (NIDA) are 20-digit identifiers. Exposure
+  # in agent output is a personal data breach under Tanzania PDPA.
+  # =========================================================================
+
+  - name: tanzania-nida-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(nida\\s+(number|no|#)|national\\s+id|tanzania\\s+id)[\\s:=]{0,5}[0-9]{20}"
+    action: deny
+    priority: 1
+    message: "Tanzania PDPA: NIDA national ID number detected in agent output — blocked to prevent identity exposure"
+
+  # =========================================================================
+  # Tanzania PDPA s.8 — Consent and Processing Without Lawful Basis
+  # =========================================================================
+
+  - name: tanzania-processing-without-consent
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(process(ing)?|shar(ing)?|us(ing)?).{0,30}(without\\s+consent|no\\s+consent|bypass.{0,10}consent|skip.{0,10}consent)"
+    action: deny
+    priority: 1
+    message: "Tanzania PDPA s.8: Data processing without lawful basis is prohibited — valid consent or documented legal basis required"
+
+  # =========================================================================
+  # Tanzania PDPA s.25 — Accountability / Audit Trail
+  # =========================================================================
+
+  - name: tanzania-pii-access-audit
+    condition:
+      field: action
+      operator: matches
+      value: "read_user|get_customer|lookup_account|fetch_profile|query_personal|access_pii"
+    action: audit
+    priority: 3
+    message: "Tanzania PDPA s.25: Personal data access logged — PDPC accountability audit trail requirement"
+
+  - name: tanzania-pii-modification-audit
+    condition:
+      field: action
+      operator: matches
+      value: "update_user|modify_profile|patch_account|edit_customer|change_personal"
+    action: audit
+    priority: 3
+    message: "Tanzania PDPA s.25: Personal data modification logged — PDPC accountability audit trail requirement"

--- a/examples/policies/african-regulatory/uganda-dppa.yaml
+++ b/examples/policies/african-regulatory/uganda-dppa.yaml
@@ -1,0 +1,164 @@
+# agt-policies-africa
+# Uganda Data Protection and Privacy Act 2019 — Data Protection Policy
+#
+# Regulatory reference: Uganda Data Protection and Privacy Act 2019 (DPPA)
+# Enforcing authority: Personal Data Protection Office (PDPO) / NITA-U
+#
+# ⚠️  IMPORTANT: This is a community-maintained governance starter policy.
+# It is NOT a certified legal compliance instrument. Organisations must
+# perform their own compliance assessments with qualified advisors before
+# deploying in regulated environments.
+#
+# Key obligations enforced:
+#   s.4   — Data protection principles (lawfulness, minimisation, accuracy)
+#   s.13  — Conditions for processing sensitive personal data
+#   s.19  — Cross-border data transfer restrictions (adequacy required)
+#   s.22  — Data breach notification obligation (72 hours to PDPO)
+#   s.25  — Accountability of data controllers / audit trail
+
+version: "1.0"
+name: uganda-dppa
+description: >
+  Uganda Data Protection and Privacy Act 2019 compliance policy for AI agents
+  processing Ugandan personal data. Enforces cross-border transfer restrictions,
+  sensitive personal data handling, breach notification obligations, and
+  accountability requirements.
+
+rules:
+
+  # =========================================================================
+  # Uganda DPPA s.22 — Breach Notification (72 hours to PDPO)
+  # Data controllers must notify the PDPO within 72 hours of becoming aware
+  # of a personal data breach. AI agents must never suppress this obligation.
+  # =========================================================================
+
+  - name: uganda-breach-suppression
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(don'?t\\s+(report|notify|disclose)|hide\\s+(the\\s+)?(breach|incident)|suppress\\s+(alert|notification)|delay\\s+(breach|incident)\\s+report)"
+    action: deny
+    priority: 1
+    message: "Uganda DPPA s.22: Agent cannot suppress breach notifications — 72-hour PDPO reporting obligation applies"
+
+  # =========================================================================
+  # Uganda DPPA s.13 — Sensitive Personal Data
+  # Processing of health data, biometric data, ethnic origin, political
+  # opinions, religious beliefs, trade union membership, sexual life, genetic
+  # data, and financial information requires a documented lawful basis.
+  # =========================================================================
+
+  - name: uganda-health-data-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(medical\\s+record|health\\s+(condition|status|data)|HIV|genetic\\s+(data|test)|mental\\s+health|disability|prescription)"
+    action: escalate
+    priority: 1
+    message: "Uganda DPPA s.13: Health/medical sensitive personal data detected — requires explicit consent or documented legal basis"
+
+  - name: uganda-special-category-data
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(ethnic\\s+origin|tribe|political\\s+opinion|religious\\s+belief|trade\\s+union|sexual\\s+orientation|criminal\\s+conviction)"
+    action: escalate
+    priority: 1
+    message: "Uganda DPPA s.13: Special category personal data detected — explicit consent or lawful condition required"
+
+  - name: uganda-biometric-data
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(fingerprint|facial\\s+recognition|retina|iris\\s+scan|voice\\s+print|biometric\\s+(template|hash|data))"
+    action: deny
+    priority: 1
+    message: "Uganda DPPA s.13: Biometric data detected — must not be transmitted by AI agents without documented lawful basis"
+
+  - name: uganda-financial-data-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(bank\\s+account\\s+number|account\\s+balance|credit\\s+score|loan\\s+status|financial\\s+(record|data|history))"
+    action: escalate
+    priority: 1
+    message: "Uganda DPPA s.13: Financial personal data detected — requires documented lawful basis and data subject notification"
+
+  # =========================================================================
+  # Uganda DPPA s.19 — Cross-Border Data Transfers
+  # Personal data may only be transferred outside Uganda where the destination
+  # country ensures adequate data protection. Transfers to inadequate
+  # destinations require explicit consent and PDPO notification.
+  # =========================================================================
+
+  - name: uganda-cross-border-language-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(send(ing)?|transfer(ring)?|export(ing)?).{0,60}(outside\\s+uganda|cross.?border|international\\s+transfer|offshore)"
+    action: escalate
+    priority: 1
+    message: "Uganda DPPA s.19: Cross-border data transfer detected — requires PDPO adequacy verification before proceeding"
+
+  - name: uganda-cross-border-action
+    condition:
+      field: action
+      operator: matches
+      value: "send_to_external|export_data|upload_to_cloud|forward_to|relay_data|sync_to_remote"
+    action: escalate
+    priority: 2
+    message: "Uganda DPPA s.19: Cross-border data transfer action requires adequacy check — destination must provide equivalent protection"
+
+  # =========================================================================
+  # Uganda DPPA s.4(e) — Data Minimisation
+  # Only collect and process data that is adequate, relevant, and limited
+  # to what is necessary for the stated purpose.
+  # =========================================================================
+
+  - name: uganda-bulk-data-export
+    condition:
+      field: action
+      operator: matches
+      value: "bulk_export|export_all|dump_database|download_all_records|full_table_export|batch_download_pii"
+    action: escalate
+    priority: 2
+    message: "Uganda DPPA s.4(e): Bulk personal data export — data minimisation principle requires DPO approval and documented legal basis"
+
+  # =========================================================================
+  # Uganda National ID — NIRA-Issued Identification Numbers
+  # Uganda National ID numbers issued by NIRA are personally identifying.
+  # Exposure in agent output constitutes a data breach under Uganda DPPA.
+  # =========================================================================
+
+  - name: uganda-national-id-in-output
+    condition:
+      field: output
+      operator: matches
+      value: "(?i)(national\\s+id|nira\\s+number|uganda\\s+id)[\\s:=]{0,5}[A-Z]{2}[0-9]{9,12}"
+    action: deny
+    priority: 1
+    message: "Uganda DPPA: National ID number (NIRA) detected in agent output — blocked to prevent identity exposure"
+
+  # =========================================================================
+  # Uganda DPPA s.25 — Accountability / Audit Trail
+  # Data controllers must demonstrate compliance with data protection
+  # principles. All AI agent access to personal data must be logged.
+  # =========================================================================
+
+  - name: uganda-pii-access-audit
+    condition:
+      field: action
+      operator: matches
+      value: "read_user|get_customer|lookup_account|fetch_profile|query_personal|access_pii"
+    action: audit
+    priority: 3
+    message: "Uganda DPPA s.25: Personal data access logged — PDPO accountability audit trail requirement"
+
+  - name: uganda-pii-modification-audit
+    condition:
+      field: action
+      operator: matches
+      value: "update_user|modify_profile|patch_account|edit_customer|change_personal"
+    action: audit
+    priority: 3
+    message: "Uganda DPPA s.25: Personal data modification logged — PDPO accountability audit trail requirement"


### PR DESCRIPTION
## Description
Follow-up to #3077 (merged). Adds three East African data protection policy packs to `examples/policies/african-regulatory/`, extending the jurisdiction router to cover Uganda, Tanzania, and Ethiopia. Each pack ships both YAML and OPA Rego formats with full test coverage.

Extends the African regulatory policy pack with three new jurisdictions:

- **Uganda Data Protection and Privacy Act 2019 (UG)** — NIRA national ID blocking, biometric deny, PDPO breach notification, financial data escalation, special category data (s.4, s.13, s.19, s.22, s.25)
- **Tanzania Personal Data Protection Act 2022 (TZ)** — NIDA 20-digit national ID blocking, PDPC breach notification, consent enforcement, biometric deny (s.8, s.13, s.17, s.25, s.28)
- **Ethiopia Personal Data Protection Proclamation No. 1321/2024 (ET)** — enacted July 24, 2024. Fayda/MOSIP ID blocking (Art. 2), sensitive data controls (Art. 9), cross-border transfer adequacy checks (Art. 18–20), data sovereignty (Art. 22), 72-hour ECA breach notification (Art. 43), accountability audit trail (Art. 46/52). Computer Crime Proclamation 958/2016 retained for unauthorised access detection.

Also updates:
- `rego/jurisdiction-router.rego`: UG, TZ, ET added to `jurisdiction_policies` and `policy_queries`
- `README.md`: coverage table, architecture diagram, and test count (306 → 384)

Jurisdiction coverage: NG, KE, ZA → **NG, KE, ZA, UG, TZ, ET**
Total OPA tests: 306 → **384**

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

None of the above — changes are confined to `examples/policies/african-regulatory/` (YAML policy files, Rego reference implementations, jurisdiction router, README).

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects:**
Policy files are maintained in [kingztech2019/agt-policies-nigeria](https://github.com/kingztech2019/agt-policies-nigeria) (MIT), the source repository for this policy pack. OPA Rego patterns follow the same conventions established in #3077.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

Claude Code was used to assist with Rego rule authoring and test generation. All policy rules were reviewed against the cited regulatory sources — including verification that Ethiopia's Personal Data Protection Proclamation No. 1321/2024 was enacted and gazetted on July 24, 2024. All 384 OPA tests were run and verified locally before submission.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
Extends #3077 — African regulatory policy pack (NDPA, CBN, POPIA, Kenya DPA)
