### PR TITLE
feat(sandbox): add agt-sandbox AppArmor profile for command-denylist enforcement

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -616,6 +616,7 @@ myorg
 mypod
 mypy
 nacl
+nagt
 namelist
 nameof
 namespacing

--- a/agent-governance-python/agent-sandbox/docker/apparmor/agt-sandbox
+++ b/agent-governance-python/agent-sandbox/docker/apparmor/agt-sandbox
@@ -1,0 +1,133 @@
+# AGT sandbox AppArmor profile — option 3 of the command-denylist stack (#3068).
+#
+# Relationship to the other enforcement layers:
+#   Option 1 (Dockerfile.sandbox): minimal PATH — dangerous CLIs are unreachable
+#     via name lookup.
+#   Option 2 (agt-deny-shim.py): logging shim — by-name and absolute-path
+#     invocations are logged as structured `command_denied` events.
+#   Option 3 (this file): kernel-level exec enforcement — exec of the listed
+#     binaries is denied even when a caller reconstructs the binary path or
+#     copies one to a writable directory. Note: in-process network access
+#     (e.g. Python urllib, requests) is not blocked by this profile; the
+#     network, allow at the top is intentionally broad to match docker-default.
+#     This profile enforces exec-level denylist only, not full network isolation.
+#
+# Installation (one-time, requires root):
+#   sudo apparmor_parser -r -W /path/to/agt-sandbox
+#
+# DockerSandboxProvider detects the profile via /sys/kernel/security/apparmor/profiles
+# and applies it automatically. Hosts without AppArmor (e.g. macOS / Docker Desktop)
+# fall back to docker-default transparently.
+#
+# Verified on Ubuntu 22.04 with AppArmor 3.0.4 and Docker 24.
+#
+# Profile structure mirrors docker-default (moby/moby) so updates to docker-default
+# can be ported here. Our additions are the AGT-specific `deny` blocks below.
+
+#include <tunables/global>
+
+profile agt-sandbox flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network,
+  capability,
+  file,
+  umount,
+
+  # /proc hardening — identical to docker-default
+  deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wklx,
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/mem rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/kcore rwklx,
+  deny @{PROC}/kmsg rwklx,
+
+  # /sys hardening — identical to docker-default
+  deny mount,
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+  # Signal handling — identical to docker-default
+  signal (receive) peer=unconfined,
+  signal (send,receive) peer=@{profile_name},
+
+  # ptrace within same profile — identical to docker-default
+  ptrace (read,trace) peer=@{profile_name},
+
+  # ------------------------------------------------------------------
+  # AGT-specific: deny execution of dangerous network and infra CLIs.
+  #
+  # AppArmor deny rules are processed before allow rules regardless of
+  # rule order, so these override the broad `file,` allow above.
+  #
+  # mrx (mmap-with-execute + read + exec) is used instead of x alone so
+  # that ld.so-based invocations (/lib/ld-linux.so.2 /usr/bin/curl) are
+  # also blocked. The copy-and-exec vector (cp /usr/bin/curl /tmp/c) is
+  # closed by the writable-directory exec denies further below.
+  #
+  # Keep this list in sync with DENIED_LOGGED_BIN_NAMES in Dockerfile.sandbox
+  # so all three enforcement layers cover the same binary set.
+  # ------------------------------------------------------------------
+
+  # Network exfiltration tools
+  deny /usr/bin/curl    mrx,
+  deny /usr/bin/wget    mrx,
+  deny /usr/bin/nc      mrx,
+  deny /usr/bin/netcat  mrx,
+  deny /usr/bin/ncat    mrx,
+  deny /usr/bin/socat   mrx,
+  deny /bin/nc          mrx,
+
+  # Remote access / file transfer
+  deny /usr/bin/ssh     mrx,
+  deny /usr/bin/scp     mrx,
+  deny /usr/bin/sftp    mrx,
+  deny /usr/bin/rsync   mrx,
+  deny /usr/bin/telnet  mrx,
+  deny /usr/bin/ftp     mrx,
+  deny /usr/bin/tftp    mrx,
+
+  # Version control (can exfiltrate or fetch code)
+  deny /usr/bin/git     mrx,
+
+  # Cloud provider CLIs
+  deny /usr/bin/az           mrx,
+  deny /usr/local/bin/az     mrx,
+  deny /usr/bin/aws          mrx,
+  deny /usr/local/bin/aws    mrx,
+  deny /usr/bin/gcloud       mrx,
+  deny /usr/local/bin/gcloud mrx,
+
+  # Infrastructure orchestration CLIs
+  deny /usr/bin/kubectl        mrx,
+  deny /usr/local/bin/kubectl  mrx,
+  deny /usr/bin/terraform      mrx,
+  deny /usr/local/bin/terraform mrx,
+  deny /usr/bin/helm           mrx,
+  deny /usr/local/bin/helm     mrx,
+  deny /usr/bin/ansible        mrx,
+  deny /usr/local/bin/ansible  mrx,
+
+  # Package managers (prevent in-container software installation)
+  deny /usr/bin/apt      mrx,
+  deny /usr/bin/apt-get  mrx,
+  deny /usr/bin/dpkg     mrx,
+  deny /usr/bin/dnf      mrx,
+  deny /usr/bin/yum      mrx,
+  deny /usr/bin/apk      mrx,
+
+  # Deny exec from writable directories to block copy-and-exec attacks.
+  # An attacker copying a denied binary to /tmp or /workspace cannot
+  # execute it from there. mx (not mrx): r would also deny read of these
+  # tmpfs-backed dirs (/workspace is the container working_dir + tmpfs
+  # mount, /tmp is tmpfs under read_only_fs=True — see provider.py),
+  # which kills the sandbox outright wherever the profile enforces. m
+  # alone already closes the ld.so PROT_EXEC-mmap vector.
+  deny /tmp/**       mx,
+  deny /workspace/** mx,
+}

--- a/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
+++ b/agent-governance-python/agent-sandbox/src/agent_sandbox/docker_provider/provider.py
@@ -141,6 +141,40 @@ def has_iptables() -> bool:
     return shutil.which("iptables") is not None
 
 
+def _apparmor_profile_loaded(name: str) -> bool:
+    """Return ``True`` if the named AppArmor profile is loaded on this host.
+
+    Reads ``/sys/kernel/security/apparmor/profiles`` which lists one loaded
+    profile per line in the form ``<name> (enforce|complain)``.  Returns
+    ``False`` on any OS error (e.g. the file doesn't exist on macOS / Docker
+    Desktop hosts where AppArmor is not available).
+    """
+    try:
+        with open("/sys/kernel/security/apparmor/profiles") as fh:
+            for line in fh:
+                parts = line.split()
+                if len(parts) >= 2 and parts[0] == name and parts[1] == "(enforce)":
+                    return True
+    except OSError:
+        pass
+    return False
+
+
+_fallback_apparmor_warned = False
+
+
+def _fallback_apparmor_profile() -> str:
+    global _fallback_apparmor_warned
+    if not _fallback_apparmor_warned:
+        logger.warning(
+            "agt-sandbox AppArmor profile not loaded in enforce mode; "
+            "falling back to docker-default. Run "
+            "'sudo apparmor_parser -r -W agt-sandbox' to enable kernel-level enforcement."
+        )
+        _fallback_apparmor_warned = True
+    return "docker-default"
+
+
 class DockerSandboxProvider(SandboxProvider):
     """``SandboxProvider`` backed by hardened Docker containers.
 
@@ -169,6 +203,10 @@ class DockerSandboxProvider(SandboxProvider):
     # Legacy fallback used when the hardened image is not on the local
     # daemon. Kept stable so existing deployments do not break.
     _LEGACY_DEFAULT_IMAGE: str = "python:3.11-slim"
+
+    # Custom AppArmor profile (docker/apparmor/agt-sandbox). Applied when
+    # loaded on the host; falls back to docker-default otherwise.
+    _APPARMOR_PROFILE_NAME: str = "agt-sandbox"
 
     def __init__(
         self,
@@ -1077,10 +1115,21 @@ class DockerSandboxProvider(SandboxProvider):
             # have customized the Docker daemon defaults to weaker policies
             # do not silently weaken the sandbox. `default` resolves to
             # Docker's built-in profile on hosts that ship one.
+            #
+            # Prefer the custom agt-sandbox AppArmor profile (option 3 of
+            # the command-denylist stack, #3068) when it is loaded on the
+            # host. Fall back to docker-default on hosts where AppArmor is
+            # unavailable (e.g. macOS / Docker Desktop) or the profile has
+            # not yet been installed via `apparmor_parser -r -W agt-sandbox`.
             "security_opt": [
                 "no-new-privileges",
                 "seccomp=default",
-                "apparmor=docker-default",
+                "apparmor="
+                + (
+                    self._APPARMOR_PROFILE_NAME
+                    if _apparmor_profile_loaded(self._APPARMOR_PROFILE_NAME)
+                    else _fallback_apparmor_profile()
+                ),
             ],
             "cap_drop": ["ALL"],
             "user": "65534:65534",

--- a/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
+++ b/agent-governance-python/agent-sandbox/tests/test_docker_sandbox.py
@@ -1543,4 +1543,126 @@ class TestDefaultImageSelection:
 
     def test_hardened_image_tag_documented(self):
         from agent_sandbox.docker_provider.provider import DockerSandboxProvider
-        assert DockerSandboxProvider.HARDENED_IMAGE_TAG == 'agt-sandbox/python-minimal-path:3.11'
+        assert DockerSandboxProvider.HARDENED_IMAGE_TAG == "agt-sandbox/python-minimal-path:3.11"
+
+
+# =========================================================================
+# Section 24: AppArmor profile selection (#3068)
+# =========================================================================
+
+
+class TestAppArmorProfileLoaded:
+    """Unit tests for the _apparmor_profile_loaded helper."""
+
+    def _patch_apparmor_profiles(self, tmp_path, content):
+        """Return a context manager that redirects the AppArmor profiles read."""
+        import builtins
+        profiles = tmp_path / "profiles"
+        profiles.write_text(content)
+        _real_open = builtins.open
+
+        def _fake_open(path, *a, **kw):
+            if path == "/sys/kernel/security/apparmor/profiles":
+                return _real_open(str(profiles), *a, **kw)
+            return _real_open(path, *a, **kw)
+
+        return patch("builtins.open", side_effect=_fake_open)
+
+    def test_returns_true_when_profile_present(self, tmp_path):
+        from agent_sandbox.docker_provider.provider import _apparmor_profile_loaded
+
+        content = "docker-default (enforce)\nagt-sandbox (enforce)\npython3 (complain)\n"
+        with self._patch_apparmor_profiles(tmp_path, content):
+            assert _apparmor_profile_loaded("agt-sandbox") is True
+
+    def test_returns_false_when_profile_absent(self, tmp_path):
+        from agent_sandbox.docker_provider.provider import _apparmor_profile_loaded
+
+        with self._patch_apparmor_profiles(tmp_path, "docker-default (enforce)\n"):
+            assert _apparmor_profile_loaded("agt-sandbox") is False
+
+    def test_returns_false_on_oserror(self):
+        from agent_sandbox.docker_provider.provider import _apparmor_profile_loaded
+
+        with patch("builtins.open", side_effect=OSError("no apparmor")):
+            assert _apparmor_profile_loaded("agt-sandbox") is False
+
+    def test_no_partial_name_match(self, tmp_path):
+        from agent_sandbox.docker_provider.provider import _apparmor_profile_loaded
+
+        with self._patch_apparmor_profiles(tmp_path, "agt-sandbox-extra (enforce)\n"):
+            assert _apparmor_profile_loaded("agt-sandbox") is False
+
+    def test_returns_false_when_profile_in_complain_mode(self, tmp_path):
+        from agent_sandbox.docker_provider.provider import _apparmor_profile_loaded
+
+        with self._patch_apparmor_profiles(tmp_path, "agt-sandbox (complain)\n"):
+            assert _apparmor_profile_loaded("agt-sandbox") is False
+
+    def test_returns_false_when_mode_token_missing(self, tmp_path):
+        from agent_sandbox.docker_provider.provider import _apparmor_profile_loaded
+
+        with self._patch_apparmor_profiles(tmp_path, "agt-sandbox\n"):
+            assert _apparmor_profile_loaded("agt-sandbox") is False
+
+
+class TestAppArmorProfileSelection:
+    """_create_container picks agt-sandbox when loaded, docker-default otherwise."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_fallback_warning_throttle(self):
+        from agent_sandbox.docker_provider import provider as provider_module
+
+        provider_module._fallback_apparmor_warned = False
+        yield
+        provider_module._fallback_apparmor_warned = False
+
+    def _make_raw_provider(self):
+        with patch(
+            "agent_sandbox.docker_provider.provider.DockerSandboxProvider.__init__",
+            return_value=None,
+        ):
+            p = DockerSandboxProvider.__new__(DockerSandboxProvider)
+            p._image = "python:3.11-slim"
+            p._runtime = IsolationRuntime.RUNC
+            client = MagicMock()
+            client.images.get.return_value = MagicMock()
+            client.containers.run.return_value = MagicMock()
+            p._client = client
+            return p, client
+
+    def test_uses_agt_sandbox_when_profile_loaded(self):
+        p, client = self._make_raw_provider()
+        with patch(
+            "agent_sandbox.docker_provider.provider._apparmor_profile_loaded",
+            return_value=True,
+        ):
+            p._create_container("a1", "s1", SandboxConfig())
+        kw = client.containers.run.call_args[1]
+        assert "apparmor=agt-sandbox" in kw["security_opt"]
+        assert not any(o == "apparmor=docker-default" for o in kw["security_opt"])
+
+    def test_falls_back_to_docker_default_when_profile_not_loaded(self):
+        p, client = self._make_raw_provider()
+        with patch(
+            "agent_sandbox.docker_provider.provider._apparmor_profile_loaded",
+            return_value=False,
+        ):
+            p._create_container("a1", "s1", SandboxConfig())
+        kw = client.containers.run.call_args[1]
+        assert "apparmor=docker-default" in kw["security_opt"]
+        assert not any(o == "apparmor=agt-sandbox" for o in kw["security_opt"])
+
+    def test_fallback_emits_warning(self, caplog):
+        import logging
+        p, _ = self._make_raw_provider()
+        with patch(
+            "agent_sandbox.docker_provider.provider._apparmor_profile_loaded",
+            return_value=False,
+        ):
+            with caplog.at_level(logging.WARNING, logger="agent_sandbox.docker_provider.provider"):
+                p._create_container("a1", "s1", SandboxConfig())
+        assert any("agt-sandbox" in r.message and "falling back" in r.message for r in caplog.records)
+
+    def test_apparmor_profile_name_constant(self):
+        assert DockerSandboxProvider._APPARMOR_PROFILE_NAME == "agt-sandbox"


### PR DESCRIPTION
Closes #3068.

## Summary

- Adds `docker/apparmor/agt-sandbox` — a custom AppArmor profile that denies exec of dangerous network, cloud, and infra CLIs at the kernel level (option 3 of the command-denylist stack from #2662)
- `DockerSandboxProvider` probes `/sys/kernel/security/apparmor/profiles` at container creation and applies `agt-sandbox` when loaded, falling back to `docker-default` on hosts where AppArmor is unavailable (macOS / Docker Desktop)
- Adds `_apparmor_profile_loaded()` helper and `_APPARMOR_PROFILE_NAME` class constant

## Relationship to other layers

| Layer | Mechanism | Issue |
|-------|-----------|-------|
| Option 1 | Minimal-PATH hardened image — CLIs unreachable by name | #2713 ✅ |
| Option 2 | Logging shim — by-name and absolute-path attempts logged | #3019 ✅ |
| Option 3 | AppArmor profile — kernel-level exec deny, fires even on bind-mounted binaries | **this PR** |

## Test plan

- [x] `TestAppArmorProfileLoaded` — 6 tests: profile present/absent/OSError/no-partial-match/complain-mode/missing-mode-token
- [x] `TestAppArmorProfileSelection` — 4 tests: custom profile used when loaded, fallback to docker-default, fallback warning emitted, constant value
- [x] Existing `TestContainerCreationHardening::test_hardening_flags` and `TestHardeningAdditions::test_security_opt_includes_seccomp_and_apparmor` still pass (fallback path, no AppArmor on macOS CI)
- [x] Full `test_docker_sandbox.py` suite: 229 passed

## Install the profile (one-time, requires root on the Docker host)

```bash
sudo apparmor_parser -r -W agent-governance-python/agent-sandbox/docker/apparmor/agt-sandbox
```
