### PR TITLE
fix(edu-k12): correct three regex bugs in K-12 starter policy pack

### DIFF
--- a/examples/policy-templates/edu-k12.yaml
+++ b/examples/policy-templates/edu-k12.yaml
@@ -162,7 +162,7 @@ rules:
     condition:
       field: input
       operator: matches
-      value: "(?i)(make|set|grant|promote|give)\\s+(me|this\\s+user|account)\\s+(to\\s+)?(admin|root|superuser|owner|elevated|teacher|instructor)"
+      value: "(?i)(make|set|grant|promote|give)\\s+(me|this\\s+user|account)\\s+(to\\s+|an?\\s+)?(admin|root|superuser|owner|elevated|teacher|instructor)"
     action: deny
     priority: 100
     message: "ASI-03: Identity Abuse — role promotion attempt detected"
@@ -358,7 +358,7 @@ rules:
     condition:
       field: input
       operator: matches
-      value: "(?i)(I\\s+am|I'm)\\s+(the\\s+)?(parent|guardian|mother|father|caregiver).*(consent|allow|approve|authorize|permit)\\s+(data|record|share|access|release)"
+      value: "(?i)(I\\s+am|I'm)\\s+(the\\s+)?(parent|guardian|mother|father|caregiver).*(consent|allow|approve|authorize|permit).*?(data|record|share|access|release|information)"
     action: audit
     priority: 90
     message: "ASI-09: COPPA/FERPA — unverified parental consent claim. Flag for human review before releasing student data."
@@ -445,7 +445,7 @@ rules:
     condition:
       field: output
       operator: matches
-      value: "(?i)(how\\s+to\\s+(make|build|create|assemble)\\s+(a\\s+)?(bomb|weapon|explosive|gun|knife)|step[- ]by[- ]step\\s+(instructions?|guide)\\s+(to\\s+)?(harm|attack|kill))"
+      value: "(?i)(how\\s+to\\s+(make|build|create|assemble)\\s+(a\\s+)?(bomb|weapon|explosive|gun|knife)|step[- ]by[- ]step\\s+(instructions?|guide)\\s+(to\\s+)?(harm|attack|kill|make|build|create|assemble))"
     action: deny
     priority: 100
     message: "ASI-01/06: CIPA: Harmful or violent instructional content is prohibited"


### PR DESCRIPTION
## Summary

Three rules in `examples/policy-templates/edu-k12.yaml` shipped in #3107 with regex patterns that did not match their corresponding test inputs. This caused `test (agent-os, 3.11/3.12/3.13)` (a required gate) to fail for every PR that rebases onto main after #3107 merged.

**Fixes:**

| Rule | Problem | Fix |
|------|---------|-----|
| `asi03-account-admin-promotion` | `(to\s+)?` did not match the article "a" in "make me **a** teacher" | Widened to `(to\s+\|an?\s+)?` |
| `edu-cipa-block-violence-content` | Step-by-step branch only allowed `(harm\|attack\|kill)` -- test uses "build a bomb" | Added `(make\|build\|create\|assemble)` to that branch |
| `edu-asi09-parental-impersonation` | `\s+` between consent verb and object failed on "consent **to releasing my child's** data" | Changed to `.*?` to allow intervening words |

All three patterns verified with `re.search` before commit.

## Test plan

- [x] All three regexes verified locally to match their test inputs
- [ ] CI `test (agent-os)` passes on this branch
- [ ] `validate-policies` passes (YAML-only change, no schema changes)

Fixes main-branch CI breakage introduced by #3107.