### PR TITLE
fix(typescript): honor configured sandbox timeout in executeCode

### DIFF
--- a/agent-governance-typescript/src/sandbox.ts
+++ b/agent-governance-typescript/src/sandbox.ts
@@ -131,6 +131,7 @@ function validateResourceName(value: string, label: string): void {
 export class DockerSandboxProvider implements SandboxProvider {
   private readonly image: string;
   private readonly containers = new Map<string, string>(); // sessionId -> containerId
+  private readonly configs = new Map<string, SandboxConfig>(); // sessionId -> config
 
   constructor(image: string = 'python:3.11-slim') {
     this.image = image;
@@ -189,6 +190,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         .trim();
 
       this.containers.set(sessionId, containerId);
+      this.configs.set(sessionId, cfg);
 
       return {
         agentId,
@@ -213,6 +215,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       throw new Error(`No active session '${sessionId}' for agent '${agentId}'`);
     }
 
+    const cfg = this.configs.get(sessionId) ?? defaultSandboxConfig();
     const executionId = randomUUID();
     const startTime = Date.now();
 
@@ -223,7 +226,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         `import base64; exec(base64.b64decode('${encoded}').decode())`,
       ];
 
-      execFile('docker', execArgs, { timeout: 60_000 }, (error, stdout, stderr) => {
+      execFile('docker', execArgs, { timeout: cfg.timeoutSeconds * 1000 }, (error, stdout, stderr) => {
         const durationSeconds = (Date.now() - startTime) / 1000.0;
         // Node's ExecException.code can be: a numeric exit code (child exited
         // non-zero), `null` (child killed by a signal — `error.signal` is set
@@ -275,6 +278,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       });
     } finally {
       this.containers.delete(sessionId);
+      this.configs.delete(sessionId);
     }
   }
 }

--- a/agent-governance-typescript/tests/sandbox-timeout.test.ts
+++ b/agent-governance-typescript/tests/sandbox-timeout.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+import { EventEmitter } from 'events';
+import * as childProcess from 'child_process';
+
+jest.mock('child_process');
+
+import { DockerSandboxProvider, defaultSandboxConfig } from '../src/sandbox';
+
+const mockedExecFileSync = childProcess.execFileSync as jest.Mock;
+const mockedExecFile = childProcess.execFile as unknown as jest.Mock;
+
+// Regression coverage for the timeout wiring. These run without Docker by
+// stubbing child_process: createSession's `docker run` returns a container id,
+// and executeCode's `docker exec` completes immediately so we can inspect the
+// options passed to it.
+describe('DockerSandboxProvider timeout enforcement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedExecFileSync.mockReturnValue(Buffer.from('container-abc123\n'));
+    mockedExecFile.mockImplementation((_cmd, _args, _options, cb) => {
+      cb(null, '', '');
+      return new EventEmitter();
+    });
+  });
+
+  it('passes the configured timeout to docker exec', async () => {
+    const provider = new DockerSandboxProvider();
+    const config = { ...defaultSandboxConfig(), timeoutSeconds: 2 };
+
+    const session = await provider.createSession('testAgent', config);
+    await provider.executeCode('testAgent', session.sessionId, 'print("hi")');
+
+    expect(mockedExecFile).toHaveBeenCalledTimes(1);
+    const options = mockedExecFile.mock.calls[0][2];
+    expect(options).toMatchObject({ timeout: 2000 });
+  });
+
+  it('falls back to the default 60s timeout when no config is given', async () => {
+    const provider = new DockerSandboxProvider();
+
+    const session = await provider.createSession('testAgent');
+    await provider.executeCode('testAgent', session.sessionId, 'print("hi")');
+
+    const options = mockedExecFile.mock.calls[0][2];
+    expect(options).toMatchObject({ timeout: 60_000 });
+  });
+});


### PR DESCRIPTION
## Description

`DockerSandboxProvider` lets callers pass a custom `SandboxConfig.timeoutSeconds`, but that value was silently ignored at execution time:

- `createSession()` applied the memory/CPU/network/env settings from the config but never stored the config object, so the per-session timeout was discarded after the container was created.
- `executeCode()` then ran the code with a hardcoded `{ timeout: 60_000 }`.

As a result, the sandbox's execution-time limit was always 60s regardless of configuration. A caller who set `timeoutSeconds: 2` got no enforcement below 60s, and a caller who set a larger value (e.g. 300) had work killed at 60s. Since the timeout is a sandbox containment control, this gave a false sense of control over how long agent-generated code can run.

### Fix

- Persist the resolved config per session in `createSession()` (a `sessionId -> SandboxConfig` map mirroring the existing `containers` map).
- Use `cfg.timeoutSeconds * 1000` for the `docker exec` timeout in `executeCode()`, falling back to `defaultSandboxConfig()` if a session somehow has no stored config.
- Drop the stored config in `destroySession()` so the new map does not leak.

The change is non-breaking: the public method signatures are unchanged, and the default config keeps the previous 60s behavior.

### Verification

- Added `tests/sandbox-timeout.test.ts`, which stubs `child_process` (no Docker needed) and asserts the configured timeout reaches `docker exec`. It fails against the old code (`expected 2000, received 60000`) and passes with the fix.
- Existing `sandbox` tests pass; `npm run build` and `npm run lint` are clean.
- Confirmed end-to-end against real Docker: with `timeoutSeconds: 2`, a `time.sleep(5)` snippet is now cut off at ~2s, whereas on `main` it ran the full ~5s and printed its output.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

Not applicable — this wires an existing `SandboxConfig` field through to execution; no external code or design was adapted.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

An AI coding assistant was used for drafting and test scaffolding. All output was reviewed and validated locally (unit test plus a live Docker reproduction) before submission.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Closes #3118
