### PR TITLE
examples: add Terraform governed-agent infrastructure for AWS and Azure

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -152,3 +152,10 @@ Nanvix
 reqwest
 requireapproval
 uncallable
+myagent
+myagentprodsa
+passwordless
+appconfig
+appconfiguration
+boto
+hostnames

--- a/examples/terraform-aws/README.md
+++ b/examples/terraform-aws/README.md
@@ -1,0 +1,131 @@
+# Governed Agent Infrastructure — AWS Example
+
+Terraform example that provisions the complete AWS infrastructure required to run
+AGT-governed agents in production. All AGT governance config values are stored as
+SSM parameters so agents read them at runtime — no governance config is baked into
+container images.
+
+## What Gets Provisioned
+
+| Resource | Purpose |
+|---|---|
+| VPC + private/public subnets + NAT | Agents run in private subnets with no inbound access |
+| Security group (egress-only) | HTTPS-out only; blocks all inbound |
+| KMS key (auto-rotating) | Signs Ed25519 governance receipts; encrypts audit logs |
+| S3 bucket | Immutable audit log storage with lifecycle tiers and TLS enforcement |
+| IAM role + instance profile | Least-privilege access to SSM, S3, Secrets Manager, KMS, CloudWatch |
+| Secrets Manager secret | Holds the Ed25519 signing key PEM |
+| SSM parameters | All `AGT_*` governance config values agents read at startup |
+| CloudWatch Log Group | Structured governance event ingestion |
+
+## Quick Start
+
+```bash
+cd examples/terraform-aws
+terraform init
+terraform plan -var="project=myagent"
+terraform apply -var="project=myagent"
+```
+
+## Governance Config Variables
+
+All variables mirror `GovernanceConfig` in `agent-runtime/deploy.py` and the
+`AGT_*` env vars injected by `DockerDeployer` / `KubernetesDeployer`.
+
+| Variable | Default | `AGT_*` env var |
+|---|---|---|
+| `trust_level` | `standard` | `AGT_TRUST_LEVEL` |
+| `max_tool_calls` | `100` | `AGT_MAX_TOOL_CALLS` |
+| `rate_limit_rpm` | `60` | `AGT_RATE_LIMIT_RPM` |
+| `audit_enabled` | `true` | `AGT_AUDIT_ENABLED` |
+| `kill_switch_enabled` | `true` | `AGT_KILL_SWITCH` |
+| `retention_days` | `180` | `AGT_RETENTION_DAYS` |
+
+`trust_level` accepts: `unclassified`, `basic`, `standard`, `elevated`, `critical` —
+matching the `GovernanceTier` enum in `github_enterprise.py`.
+
+## Example: Production Deployment
+
+```hcl
+module "governed_agent" {
+  source = "../../infra/terraform/modules/governed-agent-aws"
+
+  project     = "customer-support-agent"
+  environment = "prod"
+
+  trust_level         = "elevated"
+  max_tool_calls      = 50
+  rate_limit_rpm      = 30
+  retention_days      = 365
+  kill_switch_enabled = true
+
+  tags = {
+    team    = "ai-platform"
+    contact = "ai-platform@example.com"
+  }
+}
+```
+
+## How Agents Read Config at Runtime
+
+Agents fetch governance config from SSM at startup:
+
+```bash
+# List all AGT parameters for this deployment
+aws ssm get-parameters-by-path \
+  --path "/myagent-prod/agt/" \
+  --region us-east-1
+```
+
+In Python (e.g., inside a `DockerDeployer` entrypoint):
+
+```python
+import boto3
+
+ssm = boto3.client("ssm", region_name="us-east-1")
+params = ssm.get_parameters_by_path(Path="/myagent-prod/agt/", WithDecryption=False)
+
+config = {p["Name"].split("/")[-1]: p["Value"] for p in params["Parameters"]}
+# config["trust-level"]        → "elevated"
+# config["max-tool-calls"]     → "50"
+# config["audit-enabled"]      → "true"
+# config["audit-bucket"]       → "myagent-prod-audit-a1b2c3d4"
+```
+
+## Populating the Ed25519 Signing Key
+
+The Secrets Manager secret is created as a placeholder. Populate it via your CI
+pipeline or a one-time bootstrap script after `terraform apply`:
+
+```bash
+# Generate a key (requires PyNaCl or cryptography)
+python -c "
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
+key = Ed25519PrivateKey.generate()
+print(key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode())
+" > signing_key.pem
+
+# Upload to Secrets Manager
+aws secretsmanager put-secret-value \
+  --secret-id "myagent-prod/agt/signing-key" \
+  --secret-string file://signing_key.pem
+
+rm signing_key.pem  # never store the PEM on disk in production
+```
+
+## Known Limitations
+
+- `AGT_POLICY_PATH` (the Cedar/YAML policy file) is a runtime container mount and
+  is not provisioned here. A follow-up could add an S3 prefix for policy file
+  storage and wire its path into SSM.
+- No ECS task definition or Kubernetes manifest is included — this example
+  provisions the supporting infrastructure; the compute layer is left to the caller.
+
+## Requirements
+
+| Tool | Version |
+|---|---|
+| Terraform / OpenTofu | >= 1.5.0 |
+| AWS provider | >= 5.0 |
+| AWS CLI | >= 2.x (for runtime config reads) |

--- a/examples/terraform-aws/main.tf
+++ b/examples/terraform-aws/main.tf
@@ -1,0 +1,473 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Example: governed agent infrastructure on AWS
+#
+# Provisions all AWS resources required to run AGT-governed agents in production:
+#   - VPC with private subnets (agents) and public subnets (NAT gateways)
+#   - Egress-only security group for agent workloads (HTTPS only, no inbound)
+#   - KMS key (auto-rotating) for Ed25519 receipt signing and audit log encryption
+#   - S3 bucket with versioning, KMS encryption, lifecycle tiers, and TLS enforcement
+#   - IAM role + instance profile with least-privilege permissions
+#   - Secrets Manager secret for the Ed25519 signing key PEM
+#   - SSM parameters for all AGT_* governance config values agents read at runtime
+#   - CloudWatch Log Group for structured governance events
+#
+# Usage:
+#   cd examples/terraform-aws
+#   terraform init
+#   terraform plan -var="project=myagent"
+#   terraform apply -var="project=myagent"
+#
+# Agents read governance config from SSM at runtime:
+#   aws ssm get-parameters-by-path --path "/<project>-<env>/agt/"
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+
+  common_tags = merge(var.tags, {
+    "agt:project"     = var.project
+    "agt:environment" = var.environment
+    "agt:trust-level" = var.trust_level
+    "agt:managed-by"  = "terraform"
+  })
+}
+
+# ── Data sources ──────────────────────────────────────────────────────────────
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# ── VPC ───────────────────────────────────────────────────────────────────────
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-vpc" })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.common_tags, { Name = "${local.name_prefix}-igw" })
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = merge(local.common_tags, {
+    Name                              = "${local.name_prefix}-private-${count.index + 1}"
+    "kubernetes.io/role/internal-elb" = "1"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = false
+
+  tags = merge(local.common_tags, {
+    Name                     = "${local.name_prefix}-public-${count.index + 1}"
+    "kubernetes.io/role/elb" = "1"
+  })
+}
+
+resource "aws_eip" "nat" {
+  count  = length(var.public_subnet_cidrs)
+  domain = "vpc"
+  tags   = merge(local.common_tags, { Name = "${local.name_prefix}-nat-eip-${count.index + 1}" })
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = length(var.public_subnet_cidrs)
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+  tags          = merge(local.common_tags, { Name = "${local.name_prefix}-nat-${count.index + 1}" })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-public-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = length(var.private_subnet_cidrs)
+  vpc_id = aws_vpc.this.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this[count.index].id
+  }
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-private-rt-${count.index + 1}" })
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.private_subnet_cidrs)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}
+
+# ── Security group for agent workloads (egress-only) ─────────────────────────
+
+resource "aws_security_group" "agents" {
+  name        = "${local.name_prefix}-agents"
+  description = "Governed agent workloads — HTTPS egress only, no inbound."
+  vpc_id      = aws_vpc.this.id
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "HTTPS egress for LLM API calls"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.vpc_cidr]
+    description = "Intra-VPC traffic"
+  }
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-agents-sg" })
+}
+
+# ── KMS key for receipt signing and audit log encryption ─────────────────────
+
+resource "aws_kms_key" "receipt_signing" {
+  description             = "AGT governance receipt signing key for ${local.name_prefix}"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  rotation_period_in_days = var.receipt_signing_key_rotation_days
+  multi_region            = false
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowAgentRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.agent.arn
+        }
+        Action = [
+          "kms:GenerateDataKeyPair",
+          "kms:Sign",
+          "kms:Verify",
+          "kms:DescribeKey",
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-receipt-signing" })
+}
+
+resource "aws_kms_alias" "receipt_signing" {
+  name          = "alias/${local.name_prefix}-receipt-signing"
+  target_key_id = aws_kms_key.receipt_signing.key_id
+}
+
+# ── S3 audit log bucket ───────────────────────────────────────────────────────
+
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket" "audit_logs" {
+  bucket        = "${local.name_prefix}-audit-${random_id.bucket_suffix.hex}"
+  force_destroy = var.environment != "prod"
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-audit-logs" })
+}
+
+resource "aws_s3_bucket_versioning" "audit_logs" {
+  bucket = aws_s3_bucket.audit_logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "audit_logs" {
+  bucket = aws_s3_bucket.audit_logs.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.receipt_signing.arn
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "audit_logs" {
+  bucket = aws_s3_bucket.audit_logs.id
+
+  rule {
+    id     = "audit-retention"
+    status = "Enabled"
+
+    filter {}
+
+    transition {
+      days          = 90
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 180
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = var.retention_days
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "audit_logs" {
+  bucket                  = aws_s3_bucket.audit_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "audit_logs" {
+  bucket     = aws_s3_bucket.audit_logs.id
+  depends_on = [aws_s3_bucket_public_access_block.audit_logs]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.audit_logs.arn,
+          "${aws_s3_bucket.audit_logs.arn}/*",
+        ]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      },
+      {
+        Sid    = "AllowAgentRole"
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_role.agent.arn
+        }
+        Action   = ["s3:PutObject", "s3:GetObject"]
+        Resource = "${aws_s3_bucket.audit_logs.arn}/*"
+      }
+    ]
+  })
+}
+
+# ── IAM role for agent workloads ──────────────────────────────────────────────
+
+data "aws_iam_policy_document" "agent_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com", "ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "agent" {
+  name               = "${local.name_prefix}-agent-role"
+  assume_role_policy = data.aws_iam_policy_document.agent_assume_role.json
+  tags               = local.common_tags
+}
+
+data "aws_iam_policy_document" "agent_permissions" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+    ]
+    resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${local.name_prefix}/agt/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject", "s3:GetObject"]
+    resources = ["${aws_s3_bucket.audit_logs.arn}/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.signing_key.arn]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKeyPair",
+      "kms:Sign",
+      "kms:Verify",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [aws_kms_key.receipt_signing.arn]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.governance.arn}:*"]
+  }
+}
+
+resource "aws_iam_policy" "agent" {
+  name        = "${local.name_prefix}-agent-policy"
+  description = "Least-privilege AGT governance permissions for agent workloads."
+  policy      = data.aws_iam_policy_document.agent_permissions.json
+  tags        = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "agent" {
+  role       = aws_iam_role.agent.name
+  policy_arn = aws_iam_policy.agent.arn
+}
+
+resource "aws_iam_instance_profile" "agent" {
+  name = "${local.name_prefix}-agent-profile"
+  role = aws_iam_role.agent.name
+  tags = local.common_tags
+}
+
+# ── Secrets Manager — Ed25519 signing key ────────────────────────────────────
+
+resource "aws_secretsmanager_secret" "signing_key" {
+  name                    = "${local.name_prefix}/agt/signing-key"
+  description             = "Ed25519 private key PEM for AGT governance receipt signing."
+  recovery_window_in_days = var.environment == "prod" ? 30 : 7
+  kms_key_id              = aws_kms_key.receipt_signing.arn
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-signing-key" })
+}
+
+# ── SSM parameters — AGT governance config ────────────────────────────────────
+# Mirrors GovernanceConfig fields from agent-runtime/deploy.py.
+# Agents read these at startup instead of relying on baked-in env vars.
+
+resource "aws_ssm_parameter" "trust_level" {
+  name  = "/${local.name_prefix}/agt/trust-level"
+  type  = "String"
+  value = var.trust_level
+  tags  = local.common_tags
+}
+
+resource "aws_ssm_parameter" "max_tool_calls" {
+  name  = "/${local.name_prefix}/agt/max-tool-calls"
+  type  = "String"
+  value = tostring(var.max_tool_calls)
+  tags  = local.common_tags
+}
+
+resource "aws_ssm_parameter" "rate_limit_rpm" {
+  name  = "/${local.name_prefix}/agt/rate-limit-rpm"
+  type  = "String"
+  value = tostring(var.rate_limit_rpm)
+  tags  = local.common_tags
+}
+
+resource "aws_ssm_parameter" "audit_enabled" {
+  name  = "/${local.name_prefix}/agt/audit-enabled"
+  type  = "String"
+  value = tostring(var.audit_enabled)
+  tags  = local.common_tags
+}
+
+resource "aws_ssm_parameter" "kill_switch_enabled" {
+  name  = "/${local.name_prefix}/agt/kill-switch-enabled"
+  type  = "String"
+  value = tostring(var.kill_switch_enabled)
+  tags  = local.common_tags
+}
+
+resource "aws_ssm_parameter" "audit_bucket" {
+  name  = "/${local.name_prefix}/agt/audit-bucket"
+  type  = "String"
+  value = aws_s3_bucket.audit_logs.bucket
+  tags  = local.common_tags
+}
+
+# ── CloudWatch Log Group for governance events ────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "governance" {
+  name              = "/agt/${local.name_prefix}/governance"
+  retention_in_days = min(var.retention_days, 365)
+  kms_key_id        = aws_kms_key.receipt_signing.arn
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-governance-logs" })
+}

--- a/examples/terraform-aws/outputs.tf
+++ b/examples/terraform-aws/outputs.tf
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+output "vpc_id" {
+  description = "ID of the agent governance VPC."
+  value       = aws_vpc.this.id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets where agent workloads run."
+  value       = aws_subnet.private[*].id
+}
+
+output "agent_security_group_id" {
+  description = "Security group ID for agent workloads (egress-only)."
+  value       = aws_security_group.agents.id
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for receipt signing and audit log encryption."
+  value       = aws_kms_key.receipt_signing.arn
+}
+
+output "kms_key_alias" {
+  description = "Alias of the KMS receipt signing key."
+  value       = aws_kms_alias.receipt_signing.name
+}
+
+output "audit_log_bucket" {
+  description = "Name of the S3 bucket storing governance audit logs."
+  value       = aws_s3_bucket.audit_logs.bucket
+}
+
+output "audit_log_bucket_arn" {
+  description = "ARN of the audit log S3 bucket."
+  value       = aws_s3_bucket.audit_logs.arn
+}
+
+output "signing_key_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the Ed25519 signing key PEM."
+  value       = aws_secretsmanager_secret.signing_key.arn
+}
+
+output "agent_iam_role_arn" {
+  description = "ARN of the IAM role for agent ECS tasks / EC2 instances."
+  value       = aws_iam_role.agent.arn
+}
+
+output "agent_instance_profile_arn" {
+  description = "ARN of the EC2 instance profile for agent workloads."
+  value       = aws_iam_instance_profile.agent.arn
+}
+
+output "cloudwatch_log_group" {
+  description = "Name of the CloudWatch Log Group for governance events."
+  value       = aws_cloudwatch_log_group.governance.name
+}
+
+output "ssm_parameter_prefix" {
+  description = "SSM parameter path prefix. Agents read AGT_* config from <prefix>/<param>."
+  value       = "/${var.project}-${var.environment}/agt"
+}

--- a/examples/terraform-aws/test_terraform_aws.py
+++ b/examples/terraform-aws/test_terraform_aws.py
@@ -1,0 +1,399 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Structural tests for examples/terraform-aws.
+
+Validates HCL structure, required resources, variable definitions, output
+declarations, and AGT governance config correctness without running
+terraform apply or requiring cloud credentials.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import hcl2
+import pytest
+
+EXAMPLE_DIR = Path(__file__).parent
+
+# ── HCL fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def main_tf() -> dict:
+    with open(EXAMPLE_DIR / "main.tf") as f:
+        return hcl2.load(f)
+
+
+@pytest.fixture(scope="module")
+def variables_tf() -> dict:
+    with open(EXAMPLE_DIR / "variables.tf") as f:
+        return hcl2.load(f)
+
+
+@pytest.fixture(scope="module")
+def outputs_tf() -> dict:
+    with open(EXAMPLE_DIR / "outputs.tf") as f:
+        return hcl2.load(f)
+
+
+# ── File existence ────────────────────────────────────────────────────────────
+
+
+class TestFilesExist:
+    def test_main_tf_exists(self):
+        assert (EXAMPLE_DIR / "main.tf").exists()
+
+    def test_variables_tf_exists(self):
+        assert (EXAMPLE_DIR / "variables.tf").exists()
+
+    def test_outputs_tf_exists(self):
+        assert (EXAMPLE_DIR / "outputs.tf").exists()
+
+    def test_readme_exists(self):
+        assert (EXAMPLE_DIR / "README.md").exists()
+
+
+# ── Terraform block ───────────────────────────────────────────────────────────
+
+
+class TestTerraformBlock:
+    def test_required_version_present(self, main_tf):
+        tf_blocks = main_tf.get("terraform", [])
+        assert tf_blocks, "terraform block missing from main.tf"
+        block = tf_blocks[0]
+        assert "required_version" in block, "required_version missing from terraform block"
+
+    def test_required_version_is_1_5_or_higher(self, main_tf):
+        version_constraint = main_tf["terraform"][0]["required_version"]
+        assert "1.5" in version_constraint or "1.6" in version_constraint or ">=" in version_constraint
+
+    def test_aws_provider_declared(self, main_tf):
+        providers = main_tf.get("terraform", [{}])[0].get("required_providers", [{}])[0]
+        assert "aws" in providers, "aws provider missing from required_providers"
+
+    def test_random_provider_declared(self, main_tf):
+        providers = main_tf.get("terraform", [{}])[0].get("required_providers", [{}])[0]
+        assert "random" in providers, "random provider missing from required_providers"
+
+    def test_aws_provider_version_constraint(self, main_tf):
+        providers = main_tf["terraform"][0]["required_providers"][0]
+        aws_version = providers["aws"].get("version", "")
+        assert ">= 5.0" in aws_version or "~> 5" in aws_version, (
+            f"aws provider version constraint should pin to >= 5.0, got: {aws_version}"
+        )
+
+
+# ── Required AWS resources ────────────────────────────────────────────────────
+
+
+class TestRequiredResources:
+    def _resource_names(self, main_tf: dict, resource_type: str) -> list[str]:
+        # hcl2 wraps resource type keys in quotes: '"aws_vpc"'
+        key = f'"{resource_type}"'
+        names = []
+        for block in main_tf.get("resource", []):
+            if key in block:
+                names.extend(block[key].keys())
+        return names
+
+    def test_vpc_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_vpc"), "aws_vpc resource missing"
+
+    def test_private_subnets_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_subnet"), "aws_subnet resources missing"
+
+    def test_nat_gateway_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_nat_gateway"), "aws_nat_gateway missing — agents need outbound access"
+
+    def test_security_group_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_security_group"), "aws_security_group missing"
+
+    def test_kms_key_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_kms_key"), "aws_kms_key missing — required for receipt signing"
+
+    def test_s3_bucket_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_s3_bucket"), "aws_s3_bucket missing — required for audit logs"
+
+    def test_iam_role_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_iam_role"), "aws_iam_role missing — agents need least-privilege role"
+
+    def test_iam_policy_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_iam_policy"), "aws_iam_policy missing"
+
+    def test_secrets_manager_secret_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_secretsmanager_secret"), (
+            "aws_secretsmanager_secret missing — required for Ed25519 signing key"
+        )
+
+    def test_cloudwatch_log_group_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_cloudwatch_log_group"), (
+            "aws_cloudwatch_log_group missing — required for governance events"
+        )
+
+    def test_instance_profile_present(self, main_tf):
+        assert self._resource_names(main_tf, "aws_iam_instance_profile"), "aws_iam_instance_profile missing"
+
+
+# ── SSM parameters — AGT governance config ───────────────────────────────────
+
+
+class TestSSMParameters:
+    """All AGT_* governance config values must be stored as SSM parameters."""
+
+    EXPECTED_PARAMS = {
+        "trust_level",
+        "max_tool_calls",
+        "rate_limit_rpm",
+        "audit_enabled",
+        "kill_switch_enabled",
+        "audit_bucket",
+    }
+
+    def _ssm_param_names(self, main_tf: dict) -> set[str]:
+        names = set()
+        for block in main_tf.get("resource", []):
+            if '"aws_ssm_parameter"' in block:
+                names.update(k.strip('"') for k in block['"aws_ssm_parameter"'].keys())
+        return names
+
+    def test_all_agt_params_present(self, main_tf):
+        found = self._ssm_param_names(main_tf)
+        missing = self.EXPECTED_PARAMS - found
+        assert not missing, f"SSM parameters missing for AGT config keys: {missing}"
+
+    def test_trust_level_param_present(self, main_tf):
+        assert "trust_level" in self._ssm_param_names(main_tf)
+
+    def test_max_tool_calls_param_present(self, main_tf):
+        assert "max_tool_calls" in self._ssm_param_names(main_tf)
+
+    def test_audit_enabled_param_present(self, main_tf):
+        assert "audit_enabled" in self._ssm_param_names(main_tf)
+
+    def test_kill_switch_param_present(self, main_tf):
+        assert "kill_switch_enabled" in self._ssm_param_names(main_tf)
+
+    def test_audit_bucket_param_present(self, main_tf):
+        assert "audit_bucket" in self._ssm_param_names(main_tf)
+
+
+# ── S3 security hardening ─────────────────────────────────────────────────────
+
+
+class TestS3Security:
+    def test_public_access_block_present(self, main_tf):
+        found = any(
+            '"aws_s3_bucket_public_access_block"' in block
+            for block in main_tf.get("resource", [])
+        )
+        assert found, "aws_s3_bucket_public_access_block missing — S3 bucket must block public access"
+
+    def test_bucket_versioning_present(self, main_tf):
+        found = any(
+            '"aws_s3_bucket_versioning"' in block
+            for block in main_tf.get("resource", [])
+        )
+        assert found, "aws_s3_bucket_versioning missing — audit logs must be versioned"
+
+    def test_bucket_encryption_present(self, main_tf):
+        found = any(
+            '"aws_s3_bucket_server_side_encryption_configuration"' in block
+            for block in main_tf.get("resource", [])
+        )
+        assert found, "S3 server-side encryption missing — audit logs must be KMS-encrypted"
+
+    def test_bucket_lifecycle_present(self, main_tf):
+        found = any(
+            '"aws_s3_bucket_lifecycle_configuration"' in block
+            for block in main_tf.get("resource", [])
+        )
+        assert found, "S3 lifecycle configuration missing — audit log retention tiers required"
+
+    def test_bucket_policy_present(self, main_tf):
+        found = any(
+            '"aws_s3_bucket_policy"' in block
+            for block in main_tf.get("resource", [])
+        )
+        assert found, "aws_s3_bucket_policy missing — TLS enforcement policy required"
+
+    def test_tls_deny_in_bucket_policy(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "DenyInsecureTransport" in raw or "aws:SecureTransport" in raw, (
+            "Bucket policy must deny non-TLS access (aws:SecureTransport = false)"
+        )
+
+
+# ── KMS key hardening ─────────────────────────────────────────────────────────
+
+
+class TestKMSSecurity:
+    def test_kms_key_rotation_enabled(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"aws_kms_key"' in block:
+                for _name, config in block['"aws_kms_key"'].items():
+                    assert config.get("enable_key_rotation") is True, (
+                        "KMS key must have enable_key_rotation = true"
+                    )
+
+    def test_kms_alias_present(self, main_tf):
+        found = any('"aws_kms_alias"' in block for block in main_tf.get("resource", []))
+        assert found, "aws_kms_alias missing — KMS key should have a human-readable alias"
+
+    def test_kms_deletion_window_set(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"aws_kms_key"' in block:
+                for _name, config in block['"aws_kms_key"'].items():
+                    assert "deletion_window_in_days" in config, (
+                        "deletion_window_in_days must be set on KMS key"
+                    )
+
+
+# ── Security group — egress-only ──────────────────────────────────────────────
+
+
+class TestSecurityGroup:
+    def test_https_egress_rule_present(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "443" in raw, "Security group must allow HTTPS (port 443) egress"
+
+    def test_no_inbound_allow_all(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        # Fail if there is an ingress rule with cidr 0.0.0.0/0
+        assert 'ingress' not in raw or '0.0.0.0/0' not in raw.split('ingress')[1].split('egress')[0], (
+            "Security group must not allow inbound traffic from 0.0.0.0/0"
+        )
+
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+
+
+class TestVariables:
+    EXPECTED_VARS = {
+        "project",
+        "environment",
+        "aws_region",
+        "trust_level",
+        "max_tool_calls",
+        "rate_limit_rpm",
+        "audit_enabled",
+        "kill_switch_enabled",
+        "retention_days",
+        "vpc_cidr",
+        "private_subnet_cidrs",
+        "public_subnet_cidrs",
+        "tags",
+    }
+
+    def _var_names(self, variables_tf: dict) -> set[str]:
+        # hcl2 wraps variable names in quotes: '"project"'
+        return {k.strip('"') for block in variables_tf.get("variable", []) for k in block}
+
+    def test_all_required_vars_declared(self, variables_tf):
+        declared = self._var_names(variables_tf)
+        missing = self.EXPECTED_VARS - declared
+        assert not missing, f"Variables missing from variables.tf: {missing}"
+
+    def test_trust_level_has_validation(self, variables_tf):
+        raw = (EXAMPLE_DIR / "variables.tf").read_text()
+        assert "trust_level" in raw
+        assert "validation" in raw, "trust_level must have a validation block"
+        assert "unclassified" in raw, "trust_level validation must include all GovernanceTier values"
+        assert "critical" in raw
+
+    def test_project_has_validation(self, variables_tf):
+        raw = (EXAMPLE_DIR / "variables.tf").read_text()
+        assert "validation" in raw, "project variable must have a validation block"
+
+    def test_retention_days_has_validation(self, variables_tf):
+        raw = (EXAMPLE_DIR / "variables.tf").read_text()
+        assert "retention_days" in raw
+        assert "180" in raw, "retention_days must enforce a minimum of 180 days"
+
+    def test_environment_default_is_dev(self, variables_tf):
+        for block in variables_tf.get("variable", []):
+            if '"environment"' in block:
+                default = str(block['"environment"'].get("default", "")).strip('"')
+                assert default == "dev", f"environment default should be 'dev', got {default!r}"
+
+    def test_trust_level_default_is_standard(self, variables_tf):
+        for block in variables_tf.get("variable", []):
+            if '"trust_level"' in block:
+                default = str(block['"trust_level"'].get("default", "")).strip('"')
+                assert default == "standard", f"trust_level default should be 'standard', got {default!r}"
+
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+
+class TestOutputs:
+    EXPECTED_OUTPUTS = {
+        "vpc_id",
+        "private_subnet_ids",
+        "agent_security_group_id",
+        "kms_key_arn",
+        "audit_log_bucket",
+        "signing_key_secret_arn",
+        "agent_iam_role_arn",
+        "cloudwatch_log_group",
+        "ssm_parameter_prefix",
+    }
+
+    def _output_names(self, outputs_tf: dict) -> set[str]:
+        return {k.strip('"') for block in outputs_tf.get("output", []) for k in block}
+
+    def test_all_required_outputs_declared(self, outputs_tf):
+        declared = self._output_names(outputs_tf)
+        missing = self.EXPECTED_OUTPUTS - declared
+        assert not missing, f"Outputs missing from outputs.tf: {missing}"
+
+    def test_kms_key_arn_output_present(self, outputs_tf):
+        assert "kms_key_arn" in self._output_names(outputs_tf)
+
+    def test_audit_bucket_output_present(self, outputs_tf):
+        assert "audit_log_bucket" in self._output_names(outputs_tf)
+
+    def test_ssm_prefix_output_present(self, outputs_tf):
+        assert "ssm_parameter_prefix" in self._output_names(outputs_tf), (
+            "ssm_parameter_prefix output required so callers know where to read AGT config"
+        )
+
+    def test_agent_role_arn_output_present(self, outputs_tf):
+        assert "agent_iam_role_arn" in self._output_names(outputs_tf)
+
+
+# ── README content ────────────────────────────────────────────────────────────
+
+
+class TestREADME:
+    @pytest.fixture(scope="class")
+    def readme(self) -> str:
+        return (EXAMPLE_DIR / "README.md").read_text()
+
+    def test_quick_start_section_present(self, readme):
+        assert "Quick Start" in readme or "quick start" in readme.lower()
+
+    def test_terraform_init_command_present(self, readme):
+        assert "terraform init" in readme
+
+    def test_governance_config_table_present(self, readme):
+        assert "AGT_TRUST_LEVEL" in readme
+        assert "AGT_MAX_TOOL_CALLS" in readme
+        assert "AGT_AUDIT_ENABLED" in readme
+
+    def test_signing_key_bootstrap_documented(self, readme):
+        assert "signing" in readme.lower() and ("bootstrap" in readme.lower() or "populate" in readme.lower()), (
+            "README must document how to populate the Ed25519 signing key after apply"
+        )
+
+    def test_known_limitations_documented(self, readme):
+        assert "limitation" in readme.lower() or "Known" in readme, (
+            "README must document known limitations (e.g. AGT_POLICY_PATH not provisioned)"
+        )
+
+    def test_ssm_runtime_config_reading_documented(self, readme):
+        assert "ssm" in readme.lower() or "SSM" in readme, (
+            "README must show how agents read AGT config from SSM at runtime"
+        )

--- a/examples/terraform-aws/variables.tf
+++ b/examples/terraform-aws/variables.tf
@@ -1,0 +1,113 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+variable "project" {
+  description = "Project name used as a prefix for all resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{3,24}$", var.project))
+    error_message = "project must be 3-24 lowercase alphanumeric characters or hyphens."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment: dev, staging, or prod."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region for all resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+# ── Governance config (mirrors GovernanceConfig in agent-runtime/deploy.py) ──
+
+variable "trust_level" {
+  description = "AGT trust tier injected into agent containers via AGT_TRUST_LEVEL."
+  type        = string
+  default     = "standard"
+
+  validation {
+    condition     = contains(["unclassified", "basic", "standard", "elevated", "critical"], var.trust_level)
+    error_message = "trust_level must be one of: unclassified, basic, standard, elevated, critical."
+  }
+}
+
+variable "max_tool_calls" {
+  description = "Maximum tool calls per agent session (AGT_MAX_TOOL_CALLS)."
+  type        = number
+  default     = 100
+}
+
+variable "rate_limit_rpm" {
+  description = "Agent request rate cap in requests per minute (AGT_RATE_LIMIT_RPM)."
+  type        = number
+  default     = 60
+}
+
+variable "audit_enabled" {
+  description = "Whether to enable AGT audit logging (AGT_AUDIT_ENABLED)."
+  type        = bool
+  default     = true
+}
+
+variable "kill_switch_enabled" {
+  description = "Whether to enable the AGT kill switch (AGT_KILL_SWITCH)."
+  type        = bool
+  default     = true
+}
+
+variable "retention_days" {
+  description = "Days to retain audit logs in S3 (AGT_RETENTION_DAYS). Must be >= 180."
+  type        = number
+  default     = 180
+
+  validation {
+    condition     = var.retention_days >= 180
+    error_message = "retention_days must be at least 180 for compliance."
+  }
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+variable "vpc_cidr" {
+  description = "CIDR block for the agent governance VPC."
+  type        = string
+  default     = "10.10.0.0/16"
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets (one per AZ). Agent workloads run here."
+  type        = list(string)
+  default     = ["10.10.1.0/24", "10.10.2.0/24"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets hosting NAT gateways."
+  type        = list(string)
+  default     = ["10.10.101.0/24", "10.10.102.0/24"]
+}
+
+# ── Receipt signing ───────────────────────────────────────────────────────────
+
+variable "receipt_signing_key_rotation_days" {
+  description = "Automatic KMS key rotation period in days for governance receipt signing."
+  type        = number
+  default     = 365
+}
+
+# ── Tags ──────────────────────────────────────────────────────────────────────
+
+variable "tags" {
+  description = "Additional tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/terraform-azure/README.md
+++ b/examples/terraform-azure/README.md
@@ -1,0 +1,151 @@
+# Governed Agent Infrastructure — Azure Example
+
+Terraform example that provisions the complete Azure infrastructure required to run
+AGT-governed agents in production. All AGT governance config values are stored in
+App Configuration so agents read them at runtime — no governance config is baked
+into container images.
+
+## What Gets Provisioned
+
+| Resource | Purpose |
+|---|---|
+| Resource Group | Container for all governed agent resources |
+| VNet + private subnet + NSG | Agents run in private subnet; all inbound denied |
+| User-Assigned Managed Identity | Passwordless agent authentication — no credentials in images |
+| Key Vault (Premium) | Stores the Ed25519 signing key; purge-protected in prod |
+| Storage Account + Blob container | Immutable audit log storage with lifecycle tiers and TLS-only |
+| App Configuration | All `AGT_*` governance config values agents read at startup |
+| Log Analytics Workspace | Governance event ingestion and retention |
+
+## Quick Start
+
+```bash
+cd examples/terraform-azure
+az login
+terraform init
+terraform plan -var="project=myagent"
+terraform apply -var="project=myagent"
+```
+
+## Governance Config Variables
+
+All variables mirror `GovernanceConfig` in `agent-runtime/deploy.py` and the
+`AGT_*` env vars injected by `DockerDeployer` / `KubernetesDeployer`.
+
+| Variable | Default | `AGT_*` env var |
+|---|---|---|
+| `trust_level` | `standard` | `AGT_TRUST_LEVEL` |
+| `max_tool_calls` | `100` | `AGT_MAX_TOOL_CALLS` |
+| `rate_limit_rpm` | `60` | `AGT_RATE_LIMIT_RPM` |
+| `audit_enabled` | `true` | `AGT_AUDIT_ENABLED` |
+| `kill_switch_enabled` | `true` | `AGT_KILL_SWITCH` |
+| `retention_days` | `180` | `AGT_RETENTION_DAYS` |
+
+`trust_level` accepts: `unclassified`, `basic`, `standard`, `elevated`, `critical` —
+matching the `GovernanceTier` enum in `github_enterprise.py`.
+
+## Example: Production Deployment
+
+```hcl
+module "governed_agent" {
+  source = "../../infra/terraform/modules/governed-agent-azure"
+
+  project     = "customer-support-agent"
+  environment = "prod"
+  location    = "eastus"
+
+  trust_level         = "elevated"
+  max_tool_calls      = 50
+  rate_limit_rpm      = 30
+  retention_days      = 365
+  kill_switch_enabled = true
+
+  tags = {
+    team    = "ai-platform"
+    contact = "ai-platform@example.com"
+  }
+}
+```
+
+## How Agents Read Config at Runtime
+
+Agents fetch governance config from App Configuration at startup:
+
+```bash
+# List all AGT keys for this environment
+az appconfig kv list \
+  --name myagent-prod-appconfig \
+  --label prod
+```
+
+In Python (e.g., inside a `DockerDeployer` entrypoint):
+
+```python
+from azure.appconfiguration import AzureAppConfigurationClient
+from azure.identity import ManagedIdentityCredential
+
+credential = ManagedIdentityCredential(client_id="<managed-identity-client-id>")
+client = AzureAppConfigurationClient(
+    base_url="https://myagent-prod-appconfig.azconfig.io",
+    credential=credential,
+)
+
+settings = {s.key: s.value for s in client.list_configuration_settings(label_filter="prod")}
+# settings["agt:trust-level"]        → "elevated"
+# settings["agt:max-tool-calls"]     → "50"
+# settings["agt:audit-enabled"]      → "true"
+# settings["agt:audit-container"]    → "myagentprodsa123456/agt-audit-logs"
+```
+
+## Populating the Ed25519 Signing Key
+
+The Key Vault secret is created with a placeholder value. Populate it after
+`terraform apply` via your CI pipeline or a bootstrap script:
+
+```bash
+# Generate a key (requires cryptography library)
+python -c "
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
+key = Ed25519PrivateKey.generate()
+print(key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode())
+" > signing_key.pem
+
+# Upload to Key Vault
+az keyvault secret set \
+  --vault-name <keyvault-name> \
+  --name agt-signing-key \
+  --file signing_key.pem
+
+rm signing_key.pem  # never store the PEM on disk in production
+```
+
+The `ignore_changes = [value]` lifecycle rule on the Key Vault secret ensures
+subsequent `terraform apply` runs do not overwrite the real key with the placeholder.
+
+## Prod vs Dev Differences
+
+This example adjusts several settings automatically based on `environment`:
+
+| Setting | `dev` | `prod` |
+|---|---|---|
+| Key Vault purge protection | Disabled | Enabled |
+| Key Vault soft-delete retention | 7 days | 90 days |
+| Storage replication | LRS | GRS |
+| App Configuration SKU | free | standard |
+
+## Known Limitations
+
+- `AGT_POLICY_PATH` (the Cedar/YAML policy file) is a runtime container mount and
+  is not provisioned here. A follow-up could add a Blob prefix for policy file
+  storage and wire its path into App Configuration.
+- No AKS Helm chart or Container Apps definition is included — this example
+  provisions the supporting infrastructure; the compute layer is left to the caller.
+
+## Requirements
+
+| Tool | Version |
+|---|---|
+| Terraform / OpenTofu | >= 1.5.0 |
+| AzureRM provider | >= 3.85 |
+| Azure CLI | >= 2.x (for `az login` and runtime config reads) |

--- a/examples/terraform-azure/main.tf
+++ b/examples/terraform-azure/main.tf
@@ -1,0 +1,334 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# cspell:ignore appconfig appconfiguration passwordless myagent myagentprodsa
+#
+# Example: governed agent infrastructure on Azure
+#
+# Provisions all Azure resources required to run AGT-governed agents in production:
+#   - Resource Group, VNet, private subnet with service endpoints, NSG (deny-all inbound)
+#   - User-Assigned Managed Identity for passwordless agent authentication
+#   - Key Vault (Premium, purge-protected in prod) for the Ed25519 signing key
+#   - Storage Account + Blob container with lifecycle tiers and TLS enforcement
+#   - App Configuration store for all AGT_* governance config values
+#   - Log Analytics Workspace for governance event ingestion and retention
+#
+# Usage:
+#   cd examples/terraform-azure
+#   az login
+#   terraform init
+#   terraform plan -var="project=myagent"
+#   terraform apply -var="project=myagent"
+#
+# Agents read governance config from App Configuration at runtime:
+#   az appconfig kv list --name <appconfig-name> --label <environment>
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.85, < 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = false
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  name_prefix         = "${var.project}-${var.environment}"
+  resource_group_name = var.resource_group_name != "" ? var.resource_group_name : "${local.name_prefix}-rg"
+
+  common_tags = merge(var.tags, {
+    "agt-project"     = var.project
+    "agt-environment" = var.environment
+    "agt-trust-level" = var.trust_level
+    "agt-managed-by"  = "terraform"
+  })
+}
+
+# ── Resource Group ────────────────────────────────────────────────────────────
+
+resource "azurerm_resource_group" "this" {
+  name     = local.resource_group_name
+  location = var.location
+  tags     = local.common_tags
+}
+
+# ── VNet, subnet, and NSG ─────────────────────────────────────────────────────
+
+resource "azurerm_virtual_network" "this" {
+  name                = "${local.name_prefix}-vnet"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  address_space       = var.vnet_address_space
+  tags                = local.common_tags
+}
+
+resource "azurerm_subnet" "agents" {
+  name                 = "${local.name_prefix}-agents"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [var.private_subnet_prefix]
+
+  service_endpoints = [
+    "Microsoft.KeyVault",
+    "Microsoft.Storage",
+    "Microsoft.CognitiveServices",
+  ]
+}
+
+resource "azurerm_network_security_group" "agents" {
+  name                = "${local.name_prefix}-agents-nsg"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  security_rule {
+    name                       = "DenyAllInbound"
+    priority                   = 4096
+    direction                  = "Inbound"
+    access                     = "Deny"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "AllowHttpsOutbound"
+    priority                   = 100
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = var.private_subnet_prefix
+    destination_address_prefix = "Internet"
+  }
+
+  tags = local.common_tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "agents" {
+  subnet_id                 = azurerm_subnet.agents.id
+  network_security_group_id = azurerm_network_security_group.agents.id
+}
+
+# ── User-Assigned Managed Identity ───────────────────────────────────────────
+
+resource "azurerm_user_assigned_identity" "agent" {
+  name                = "${local.name_prefix}-agent-identity"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.common_tags
+}
+
+# ── Key Vault for Ed25519 signing key ─────────────────────────────────────────
+
+resource "random_string" "kv_suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+resource "azurerm_key_vault" "this" {
+  name                       = "${substr(local.name_prefix, 0, 16)}kv${random_string.kv_suffix.result}"
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  purge_protection_enabled   = var.environment == "prod"
+  soft_delete_retention_days = var.environment == "prod" ? 90 : 7
+  enable_rbac_authorization  = true
+
+  network_acls {
+    default_action             = "Deny"
+    bypass                     = "AzureServices"
+    virtual_network_subnet_ids = [azurerm_subnet.agents.id]
+  }
+
+  tags = local.common_tags
+}
+
+resource "azurerm_role_assignment" "agent_kv_secrets" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.agent.principal_id
+}
+
+resource "azurerm_role_assignment" "agent_kv_crypto" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Crypto User"
+  principal_id         = azurerm_user_assigned_identity.agent.principal_id
+}
+
+# Placeholder secret — populate via CI bootstrap or key rotation script.
+resource "azurerm_key_vault_secret" "signing_key" {
+  name         = "agt-signing-key"
+  value        = "PLACEHOLDER-replace-with-Ed25519-PEM-via-CI-or-bootstrap-script"
+  key_vault_id = azurerm_key_vault.this.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = local.common_tags
+}
+
+# ── Storage Account for immutable audit logs ──────────────────────────────────
+
+resource "random_string" "sa_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_storage_account" "audit_logs" {
+  name                            = "${substr(replace(local.name_prefix, "-", ""), 0, 16)}${random_string.sa_suffix.result}"
+  resource_group_name             = azurerm_resource_group.this.name
+  location                        = azurerm_resource_group.this.location
+  account_tier                    = "Standard"
+  account_replication_type        = var.environment == "prod" ? "GRS" : "LRS"
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  https_traffic_only_enabled      = true
+
+  blob_properties {
+    versioning_enabled = true
+
+    delete_retention_policy {
+      days = 30
+    }
+
+    container_delete_retention_policy {
+      days = 30
+    }
+  }
+
+  network_rules {
+    default_action             = "Deny"
+    bypass                     = ["AzureServices"]
+    virtual_network_subnet_ids = [azurerm_subnet.agents.id]
+  }
+
+  tags = local.common_tags
+}
+
+resource "azurerm_storage_container" "audit_logs" {
+  name                  = "agt-audit-logs"
+  storage_account_id    = azurerm_storage_account.audit_logs.id
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_management_policy" "audit_logs" {
+  storage_account_id = azurerm_storage_account.audit_logs.id
+
+  rule {
+    name    = "audit-retention"
+    enabled = true
+
+    filters {
+      blob_types   = ["blockBlob"]
+      prefix_match = ["agt-audit-logs/"]
+    }
+
+    actions {
+      base_blob {
+        tier_to_cool_after_days_since_modification_greater_than    = 90
+        tier_to_archive_after_days_since_modification_greater_than = 180
+        delete_after_days_since_modification_greater_than          = var.retention_days
+      }
+    }
+  }
+}
+
+resource "azurerm_role_assignment" "agent_storage" {
+  scope                = azurerm_storage_account.audit_logs.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.agent.principal_id
+}
+
+# ── App Configuration — AGT governance parameters ────────────────────────────
+# Mirrors SSM parameters on AWS. Agents read these at startup so governance
+# config is version-controlled and not baked into container images.
+
+resource "azurerm_app_configuration" "governance" {
+  name                = "${local.name_prefix}-appconfig"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  sku                 = var.environment == "prod" ? "standard" : "free"
+  tags                = local.common_tags
+}
+
+resource "azurerm_role_assignment" "agent_appconfig" {
+  scope                = azurerm_app_configuration.governance.id
+  role_definition_name = "App Configuration Data Reader"
+  principal_id         = azurerm_user_assigned_identity.agent.principal_id
+}
+
+resource "azurerm_app_configuration_key" "trust_level" {
+  configuration_store_id = azurerm_app_configuration.governance.id
+  key                    = "agt:trust-level"
+  value                  = var.trust_level
+  label                  = var.environment
+}
+
+resource "azurerm_app_configuration_key" "max_tool_calls" {
+  configuration_store_id = azurerm_app_configuration.governance.id
+  key                    = "agt:max-tool-calls"
+  value                  = tostring(var.max_tool_calls)
+  label                  = var.environment
+}
+
+resource "azurerm_app_configuration_key" "rate_limit_rpm" {
+  configuration_store_id = azurerm_app_configuration.governance.id
+  key                    = "agt:rate-limit-rpm"
+  value                  = tostring(var.rate_limit_rpm)
+  label                  = var.environment
+}
+
+resource "azurerm_app_configuration_key" "audit_enabled" {
+  configuration_store_id = azurerm_app_configuration.governance.id
+  key                    = "agt:audit-enabled"
+  value                  = tostring(var.audit_enabled)
+  label                  = var.environment
+}
+
+resource "azurerm_app_configuration_key" "kill_switch_enabled" {
+  configuration_store_id = azurerm_app_configuration.governance.id
+  key                    = "agt:kill-switch-enabled"
+  value                  = tostring(var.kill_switch_enabled)
+  label                  = var.environment
+}
+
+resource "azurerm_app_configuration_key" "audit_container" {
+  configuration_store_id = azurerm_app_configuration.governance.id
+  key                    = "agt:audit-container"
+  value                  = "${azurerm_storage_account.audit_logs.name}/${azurerm_storage_container.audit_logs.name}"
+  label                  = var.environment
+}
+
+# ── Log Analytics Workspace for governance events ─────────────────────────────
+
+resource "azurerm_log_analytics_workspace" "governance" {
+  name                = "${local.name_prefix}-governance-logs"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "PerGB2018"
+  retention_in_days   = min(var.retention_days, 730)
+  tags                = local.common_tags
+}

--- a/examples/terraform-azure/outputs.tf
+++ b/examples/terraform-azure/outputs.tf
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+output "resource_group_name" {
+  description = "Name of the Azure resource group."
+  value       = azurerm_resource_group.this.name
+}
+
+output "vnet_id" {
+  description = "ID of the agent governance VNet."
+  value       = azurerm_virtual_network.this.id
+}
+
+output "agent_subnet_id" {
+  description = "ID of the private subnet where agent workloads run."
+  value       = azurerm_subnet.agents.id
+}
+
+output "managed_identity_id" {
+  description = "Resource ID of the user-assigned managed identity for agent workloads."
+  value       = azurerm_user_assigned_identity.agent.id
+}
+
+output "managed_identity_client_id" {
+  description = "Client ID of the managed identity — set as AZURE_CLIENT_ID in agent containers."
+  value       = azurerm_user_assigned_identity.agent.client_id
+}
+
+output "key_vault_uri" {
+  description = "URI of the Key Vault holding the Ed25519 signing key."
+  value       = azurerm_key_vault.this.vault_uri
+}
+
+output "key_vault_id" {
+  description = "Resource ID of the Key Vault."
+  value       = azurerm_key_vault.this.id
+}
+
+output "signing_key_secret_id" {
+  description = "Key Vault secret ID for the Ed25519 governance receipt signing key."
+  value       = azurerm_key_vault_secret.signing_key.id
+}
+
+output "audit_storage_account_name" {
+  description = "Name of the Storage Account for governance audit logs."
+  value       = azurerm_storage_account.audit_logs.name
+}
+
+output "audit_container_name" {
+  description = "Name of the Blob container for governance audit logs."
+  value       = azurerm_storage_container.audit_logs.name
+}
+
+output "app_configuration_endpoint" {
+  description = "Endpoint of the App Configuration store. Agents read AGT_* config from here."
+  value       = azurerm_app_configuration.governance.endpoint
+}
+
+output "log_analytics_workspace_id" {
+  description = "Resource ID of the Log Analytics workspace for governance events."
+  value       = azurerm_log_analytics_workspace.governance.id
+}

--- a/examples/terraform-azure/test_terraform_azure.py
+++ b/examples/terraform-azure/test_terraform_azure.py
@@ -1,0 +1,512 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Structural tests for examples/terraform-azure.
+
+Validates HCL structure, required resources, variable definitions, output
+declarations, and AGT governance config correctness without running
+terraform apply or requiring Azure credentials.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import hcl2
+import pytest
+
+EXAMPLE_DIR = Path(__file__).parent
+
+# ── HCL fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def main_tf() -> dict:
+    with open(EXAMPLE_DIR / "main.tf") as f:
+        return hcl2.load(f)
+
+
+@pytest.fixture(scope="module")
+def variables_tf() -> dict:
+    with open(EXAMPLE_DIR / "variables.tf") as f:
+        return hcl2.load(f)
+
+
+@pytest.fixture(scope="module")
+def outputs_tf() -> dict:
+    with open(EXAMPLE_DIR / "outputs.tf") as f:
+        return hcl2.load(f)
+
+
+# ── File existence ────────────────────────────────────────────────────────────
+
+
+class TestFilesExist:
+    def test_main_tf_exists(self):
+        assert (EXAMPLE_DIR / "main.tf").exists()
+
+    def test_variables_tf_exists(self):
+        assert (EXAMPLE_DIR / "variables.tf").exists()
+
+    def test_outputs_tf_exists(self):
+        assert (EXAMPLE_DIR / "outputs.tf").exists()
+
+    def test_readme_exists(self):
+        assert (EXAMPLE_DIR / "README.md").exists()
+
+
+# ── Terraform block ───────────────────────────────────────────────────────────
+
+
+class TestTerraformBlock:
+    def test_required_version_present(self, main_tf):
+        tf_blocks = main_tf.get("terraform", [])
+        assert tf_blocks, "terraform block missing from main.tf"
+        assert "required_version" in tf_blocks[0], "required_version missing from terraform block"
+
+    def test_azurerm_provider_declared(self, main_tf):
+        providers = main_tf.get("terraform", [{}])[0].get("required_providers", [{}])[0]
+        assert "azurerm" in providers, "azurerm provider missing from required_providers"
+
+    def test_random_provider_declared(self, main_tf):
+        providers = main_tf.get("terraform", [{}])[0].get("required_providers", [{}])[0]
+        assert "random" in providers, "random provider missing from required_providers"
+
+    def test_azurerm_provider_version_constraint(self, main_tf):
+        providers = main_tf["terraform"][0]["required_providers"][0]
+        version = providers["azurerm"].get("version", "")
+        assert ">= 3.85" in version or "~> 3" in version or ">= 4" in version, (
+            f"azurerm provider version constraint too loose: {version}"
+        )
+
+    def test_azurerm_provider_features_block_present(self, main_tf):
+        providers = main_tf.get("provider", [])
+        azurerm_providers = [p for p in providers if '"azurerm"' in p]
+        assert azurerm_providers, "azurerm provider block missing (needs features {})"
+
+
+# ── Required Azure resources ──────────────────────────────────────────────────
+
+
+class TestRequiredResources:
+    def _resource_names(self, main_tf: dict, resource_type: str) -> list[str]:
+        key = f'"{resource_type}"'
+        names = []
+        for block in main_tf.get("resource", []):
+            if key in block:
+                names.extend(block[key].keys())
+        return names
+
+    def test_resource_group_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_resource_group"), (
+            "azurerm_resource_group missing"
+        )
+
+    def test_vnet_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_virtual_network"), (
+            "azurerm_virtual_network missing"
+        )
+
+    def test_subnet_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_subnet"), (
+            "azurerm_subnet missing — agents need a private subnet"
+        )
+
+    def test_nsg_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_network_security_group"), (
+            "azurerm_network_security_group missing"
+        )
+
+    def test_managed_identity_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_user_assigned_identity"), (
+            "azurerm_user_assigned_identity missing — agents must use passwordless auth"
+        )
+
+    def test_key_vault_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_key_vault"), (
+            "azurerm_key_vault missing — required for Ed25519 signing key"
+        )
+
+    def test_key_vault_secret_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_key_vault_secret"), (
+            "azurerm_key_vault_secret missing — Ed25519 signing key must be stored"
+        )
+
+    def test_storage_account_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_storage_account"), (
+            "azurerm_storage_account missing — required for audit logs"
+        )
+
+    def test_storage_container_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_storage_container"), (
+            "azurerm_storage_container missing — audit log container required"
+        )
+
+    def test_storage_lifecycle_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_storage_management_policy"), (
+            "azurerm_storage_management_policy missing — audit log lifecycle tiers required"
+        )
+
+    def test_app_configuration_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_app_configuration"), (
+            "azurerm_app_configuration missing — required for AGT_* governance config"
+        )
+
+    def test_log_analytics_workspace_present(self, main_tf):
+        assert self._resource_names(main_tf, "azurerm_log_analytics_workspace"), (
+            "azurerm_log_analytics_workspace missing — required for governance events"
+        )
+
+
+# ── App Configuration keys — AGT governance config ───────────────────────────
+
+
+class TestAppConfigurationKeys:
+    """All AGT_* governance config values must be stored as App Configuration keys."""
+
+    EXPECTED_KEYS = {
+        "trust_level",
+        "max_tool_calls",
+        "rate_limit_rpm",
+        "audit_enabled",
+        "kill_switch_enabled",
+        "audit_container",
+    }
+
+    def _appconfig_key_names(self, main_tf: dict) -> set[str]:
+        names = set()
+        for block in main_tf.get("resource", []):
+            if '"azurerm_app_configuration_key"' in block:
+                names.update(k.strip('"') for k in block['"azurerm_app_configuration_key"'].keys())
+        return names
+
+    def test_all_agt_keys_present(self, main_tf):
+        found = self._appconfig_key_names(main_tf)
+        missing = self.EXPECTED_KEYS - found
+        assert not missing, f"App Configuration keys missing for AGT config: {missing}"
+
+    def test_trust_level_key_present(self, main_tf):
+        assert "trust_level" in self._appconfig_key_names(main_tf)
+
+    def test_max_tool_calls_key_present(self, main_tf):
+        assert "max_tool_calls" in self._appconfig_key_names(main_tf)
+
+    def test_audit_enabled_key_present(self, main_tf):
+        assert "audit_enabled" in self._appconfig_key_names(main_tf)
+
+    def test_kill_switch_key_present(self, main_tf):
+        assert "kill_switch_enabled" in self._appconfig_key_names(main_tf)
+
+    def test_audit_container_key_present(self, main_tf):
+        assert "audit_container" in self._appconfig_key_names(main_tf)
+
+    def test_keys_have_environment_label(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "var.environment" in raw or "${var.environment}" in raw, (
+            "App Configuration keys must be labelled with var.environment"
+        )
+
+
+# ── Key Vault security hardening ──────────────────────────────────────────────
+
+
+class TestKeyVaultSecurity:
+    def test_key_vault_uses_premium_sku(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"azurerm_key_vault"' in block:
+                for _name, config in block['"azurerm_key_vault"'].items():
+                    sku = str(config.get("sku_name", "")).strip('"')
+                    assert sku == "premium", (
+                        "Key Vault must use 'premium' SKU to support HSM-backed keys"
+                    )
+
+    def test_key_vault_rbac_enabled(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"azurerm_key_vault"' in block:
+                for _name, config in block['"azurerm_key_vault"'].items():
+                    assert config.get("enable_rbac_authorization") is True, (
+                        "Key Vault must use RBAC authorization (not legacy access policies)"
+                    )
+
+    def test_key_vault_network_acls_deny_default(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "default_action" in raw and "Deny" in raw, (
+            "Key Vault network_acls must set default_action = Deny"
+        )
+
+    def test_key_vault_purge_protection_prod_conditional(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "purge_protection_enabled" in raw, (
+            "Key Vault must set purge_protection_enabled (true in prod)"
+        )
+        assert 'var.environment == "prod"' in raw or "var.environment ==" in raw, (
+            "purge_protection_enabled should be conditional on environment == prod"
+        )
+
+    def test_signing_key_secret_has_ignore_changes(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "ignore_changes" in raw, (
+            "Key Vault signing key secret must have lifecycle ignore_changes = [value] "
+            "so terraform apply does not overwrite a real key with the placeholder"
+        )
+
+    def test_role_assignments_for_managed_identity(self, main_tf):
+        role_assignments = []
+        for block in main_tf.get("resource", []):
+            if '"azurerm_role_assignment"' in block:
+                role_assignments.extend(k.strip('"') for k in block['"azurerm_role_assignment"'].keys())
+        kv_assignments = [r for r in role_assignments if "kv" in r]
+        assert kv_assignments, (
+            "No Key Vault role assignments found for managed identity"
+        )
+
+
+# ── Storage security hardening ────────────────────────────────────────────────
+
+
+class TestStorageSecurity:
+    def test_tls_only_enforced(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"azurerm_storage_account"' in block:
+                for _name, config in block['"azurerm_storage_account"'].items():
+                    assert config.get("https_traffic_only_enabled") is True, (
+                        "Storage account must enforce HTTPS-only traffic"
+                    )
+
+    def test_min_tls_version_set(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"azurerm_storage_account"' in block:
+                for _name, config in block['"azurerm_storage_account"'].items():
+                    tls = str(config.get("min_tls_version", "")).strip('"')
+                    assert tls == "TLS1_2", (
+                        f"min_tls_version must be TLS1_2, got {tls!r}"
+                    )
+
+    def test_public_access_blocked(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"azurerm_storage_account"' in block:
+                for _name, config in block['"azurerm_storage_account"'].items():
+                    assert config.get("allow_nested_items_to_be_public") is False, (
+                        "Storage account must block public access to blobs"
+                    )
+
+    def test_blob_versioning_enabled(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "versioning_enabled" in raw, (
+            "Blob versioning must be enabled on audit log storage"
+        )
+
+    def test_grs_replication_in_prod(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "GRS" in raw, (
+            "Storage account must use GRS replication in prod for durability"
+        )
+        assert 'var.environment == "prod"' in raw or "var.environment ==" in raw, (
+            "GRS replication should be conditional on environment == prod"
+        )
+
+    def test_container_access_is_private(self, main_tf):
+        for block in main_tf.get("resource", []):
+            if '"azurerm_storage_container"' in block:
+                for _name, config in block['"azurerm_storage_container"'].items():
+                    access = str(config.get("container_access_type", "")).strip('"')
+                    assert access == "private", (
+                        f"Audit log container must be private, got {access!r}"
+                    )
+
+
+# ── NSG — deny-all inbound ────────────────────────────────────────────────────
+
+
+class TestNSGRules:
+    def test_deny_all_inbound_rule_present(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "DenyAllInbound" in raw, (
+            "NSG must have a DenyAllInbound rule — agent subnets must block all inbound"
+        )
+
+    def test_https_outbound_rule_present(self, main_tf):
+        raw = (EXAMPLE_DIR / "main.tf").read_text()
+        assert "AllowHttpsOutbound" in raw or "443" in raw, (
+            "NSG must allow HTTPS outbound (port 443) for LLM API calls"
+        )
+
+    def test_subnet_nsg_association_present(self, main_tf):
+        found = any(
+            '"azurerm_subnet_network_security_group_association"' in block
+            for block in main_tf.get("resource", [])
+        )
+        assert found, (
+            "azurerm_subnet_network_security_group_association missing — NSG must be attached to subnet"
+        )
+
+
+# ── Managed Identity RBAC ─────────────────────────────────────────────────────
+
+
+class TestManagedIdentityRBAC:
+    def _role_assignment_names(self, main_tf: dict) -> list[str]:
+        names = []
+        for block in main_tf.get("resource", []):
+            if '"azurerm_role_assignment"' in block:
+                names.extend(k.strip('"') for k in block['"azurerm_role_assignment"'].keys())
+        return names
+
+    def test_storage_role_assignment_present(self, main_tf):
+        names = self._role_assignment_names(main_tf)
+        storage_assignments = [n for n in names if "storage" in n]
+        assert storage_assignments, (
+            "No storage role assignment found — managed identity needs access to write audit logs"
+        )
+
+    def test_appconfig_role_assignment_present(self, main_tf):
+        names = self._role_assignment_names(main_tf)
+        appconfig_assignments = [n for n in names if "appconfig" in n]
+        assert appconfig_assignments, (
+            "No App Configuration role assignment — managed identity needs to read AGT config"
+        )
+
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+
+
+class TestVariables:
+    EXPECTED_VARS = {
+        "project",
+        "environment",
+        "location",
+        "resource_group_name",
+        "trust_level",
+        "max_tool_calls",
+        "rate_limit_rpm",
+        "audit_enabled",
+        "kill_switch_enabled",
+        "retention_days",
+        "vnet_address_space",
+        "private_subnet_prefix",
+        "tags",
+    }
+
+    def _var_names(self, variables_tf: dict) -> set[str]:
+        return {k.strip('"') for block in variables_tf.get("variable", []) for k in block}
+
+    def test_all_required_vars_declared(self, variables_tf):
+        declared = self._var_names(variables_tf)
+        missing = self.EXPECTED_VARS - declared
+        assert not missing, f"Variables missing from variables.tf: {missing}"
+
+    def test_trust_level_has_validation(self, variables_tf):
+        raw = (EXAMPLE_DIR / "variables.tf").read_text()
+        assert "validation" in raw, "trust_level must have a validation block"
+        assert "unclassified" in raw and "critical" in raw, (
+            "trust_level validation must list all GovernanceTier values"
+        )
+
+    def test_retention_days_minimum_enforced(self, variables_tf):
+        raw = (EXAMPLE_DIR / "variables.tf").read_text()
+        assert "retention_days" in raw
+        assert "180" in raw, "retention_days must enforce a minimum of 180 days"
+
+    def test_environment_default_is_dev(self, variables_tf):
+        for block in variables_tf.get("variable", []):
+            if '"environment"' in block:
+                default = str(block['"environment"'].get("default", "")).strip('"')
+                assert default == "dev"
+
+    def test_trust_level_default_is_standard(self, variables_tf):
+        for block in variables_tf.get("variable", []):
+            if '"trust_level"' in block:
+                default = str(block['"trust_level"'].get("default", "")).strip('"')
+                assert default == "standard"
+
+    def test_location_default_set(self, variables_tf):
+        for block in variables_tf.get("variable", []):
+            if '"location"' in block:
+                default = str(block['"location"'].get("default", "")).strip('"')
+                assert default, "location must have a default value"
+
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+
+class TestOutputs:
+    EXPECTED_OUTPUTS = {
+        "resource_group_name",
+        "vnet_id",
+        "agent_subnet_id",
+        "managed_identity_id",
+        "managed_identity_client_id",
+        "key_vault_uri",
+        "signing_key_secret_id",
+        "audit_storage_account_name",
+        "audit_container_name",
+        "app_configuration_endpoint",
+        "log_analytics_workspace_id",
+    }
+
+    def _output_names(self, outputs_tf: dict) -> set[str]:
+        return {k.strip('"') for block in outputs_tf.get("output", []) for k in block}
+
+    def test_all_required_outputs_declared(self, outputs_tf):
+        declared = self._output_names(outputs_tf)
+        missing = self.EXPECTED_OUTPUTS - declared
+        assert not missing, f"Outputs missing from outputs.tf: {missing}"
+
+    def test_managed_identity_client_id_output_present(self, outputs_tf):
+        assert "managed_identity_client_id" in self._output_names(outputs_tf), (
+            "managed_identity_client_id output required — agents need AZURE_CLIENT_ID"
+        )
+
+    def test_app_config_endpoint_output_present(self, outputs_tf):
+        assert "app_configuration_endpoint" in self._output_names(outputs_tf), (
+            "app_configuration_endpoint output required so agents know where to read AGT config"
+        )
+
+    def test_key_vault_uri_output_present(self, outputs_tf):
+        assert "key_vault_uri" in self._output_names(outputs_tf)
+
+
+# ── README content ────────────────────────────────────────────────────────────
+
+
+class TestREADME:
+    @pytest.fixture(scope="class")
+    def readme(self) -> str:
+        return (EXAMPLE_DIR / "README.md").read_text()
+
+    def test_quick_start_section_present(self, readme):
+        assert "Quick Start" in readme or "quick start" in readme.lower()
+
+    def test_az_login_documented(self, readme):
+        assert "az login" in readme, "README must document az login step"
+
+    def test_terraform_init_command_present(self, readme):
+        assert "terraform init" in readme
+
+    def test_governance_config_table_present(self, readme):
+        assert "AGT_TRUST_LEVEL" in readme
+        assert "AGT_MAX_TOOL_CALLS" in readme
+        assert "AGT_AUDIT_ENABLED" in readme
+
+    def test_prod_vs_dev_differences_documented(self, readme):
+        assert "prod" in readme.lower() and "dev" in readme.lower(), (
+            "README must document prod vs dev differences (GRS, purge protection, etc.)"
+        )
+
+    def test_signing_key_bootstrap_documented(self, readme):
+        assert "signing" in readme.lower() and ("bootstrap" in readme.lower() or "populate" in readme.lower()), (
+            "README must document how to populate the Ed25519 signing key"
+        )
+
+    def test_app_configuration_runtime_reading_documented(self, readme):
+        assert "appconfig" in readme.lower() or "App Configuration" in readme, (
+            "README must show how agents read AGT config from App Configuration at runtime"
+        )
+
+    def test_ignore_changes_lifecycle_explained(self, readme):
+        assert "ignore_changes" in readme, (
+            "README must explain the ignore_changes lifecycle rule on the signing key secret"
+        )
+
+    def test_known_limitations_documented(self, readme):
+        assert "limitation" in readme.lower() or "Known" in readme

--- a/examples/terraform-azure/variables.tf
+++ b/examples/terraform-azure/variables.tf
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+variable "project" {
+  description = "Project name used as a prefix for all resource names."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{3,24}$", var.project))
+    error_message = "project must be 3-24 lowercase alphanumeric characters or hyphens."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment: dev, staging, or prod."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "location" {
+  description = "Azure region for all resources."
+  type        = string
+  default     = "eastus"
+}
+
+variable "resource_group_name" {
+  description = "Name of the Azure resource group. Defaults to <project>-<environment>-rg."
+  type        = string
+  default     = ""
+}
+
+# ── Governance config (mirrors GovernanceConfig in agent-runtime/deploy.py) ──
+
+variable "trust_level" {
+  description = "AGT trust tier stored in App Configuration and injected as AGT_TRUST_LEVEL."
+  type        = string
+  default     = "standard"
+
+  validation {
+    condition     = contains(["unclassified", "basic", "standard", "elevated", "critical"], var.trust_level)
+    error_message = "trust_level must be one of: unclassified, basic, standard, elevated, critical."
+  }
+}
+
+variable "max_tool_calls" {
+  description = "Maximum tool calls per agent session (AGT_MAX_TOOL_CALLS)."
+  type        = number
+  default     = 100
+}
+
+variable "rate_limit_rpm" {
+  description = "Agent request rate cap in requests per minute (AGT_RATE_LIMIT_RPM)."
+  type        = number
+  default     = 60
+}
+
+variable "audit_enabled" {
+  description = "Whether to enable AGT audit logging (AGT_AUDIT_ENABLED)."
+  type        = bool
+  default     = true
+}
+
+variable "kill_switch_enabled" {
+  description = "Whether to enable the AGT kill switch (AGT_KILL_SWITCH)."
+  type        = bool
+  default     = true
+}
+
+variable "retention_days" {
+  description = "Days to retain audit logs in Blob Storage (AGT_RETENTION_DAYS). Must be >= 180."
+  type        = number
+  default     = 180
+
+  validation {
+    condition     = var.retention_days >= 180
+    error_message = "retention_days must be at least 180 for compliance."
+  }
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+variable "vnet_address_space" {
+  description = "Address space for the agent governance VNet."
+  type        = list(string)
+  default     = ["10.20.0.0/16"]
+}
+
+variable "private_subnet_prefix" {
+  description = "Address prefix for the private subnet where agent workloads run."
+  type        = string
+  default     = "10.20.1.0/24"
+}
+
+# ── Tags ──────────────────────────────────────────────────────────────────────
+
+variable "tags" {
+  description = "Additional tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary

- Adds `examples/terraform-aws/`: self-contained Terraform example provisioning VPC, KMS key (auto-rotating), S3 audit log bucket, IAM role + instance profile, Secrets Manager secret (Ed25519 signing key), SSM parameters for all `AGT_*` governance config values, and CloudWatch Log Group
- Adds `examples/terraform-azure/`: self-contained Terraform example provisioning VNet + NSG (deny-all inbound), User-Assigned Managed Identity, Key Vault (Premium, purge-protected in prod), Storage Account + Blob container, App Configuration store for all `AGT_*` governance config values, and Log Analytics Workspace
- All governance config variables (`trust_level`, `max_tool_calls`, `rate_limit_rpm`, `audit_enabled`, `kill_switch_enabled`, `retention_days`) mirror `GovernanceConfig` in `agent-runtime/deploy.py` and the `AGT_*` env vars injected by `DockerDeployer` / `KubernetesDeployer`
- 118 structural tests (`test_terraform_aws.py`, `test_terraform_azure.py`) validate HCL structure, required resources, security hardening, SSM/App Configuration key coverage, and README completeness — no cloud credentials required

## Test plan

- [ ] `python -m pytest examples/terraform-aws/test_terraform_aws.py examples/terraform-azure/test_terraform_azure.py -v` → 118 passed
- [ ] Review `examples/terraform-aws/README.md` and `examples/terraform-azure/README.md` for accuracy
- [ ] Optionally run `terraform init && terraform plan -var="project=myagent"` in either directory with valid cloud credentials

Closes #2770