### PR TITLE
fix(escalation): record votes in approve/deny; fix quorum always evaluating to 0

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/escalation.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/escalation.py
@@ -166,8 +166,15 @@ class InMemoryApprovalQueue(ApprovalBackend):
     def approve(self, request_id: str, approver: str = "") -> bool:
         with self._lock:
             req = self._requests.get(request_id)
-            if req is None or req.decision != EscalationDecision.PENDING:
+            if req is None:
                 return False
+            if not approver.strip():
+                return False
+            if any(a == approver for a, _, _ in req.votes):
+                return False
+            req.votes.append((approver, "ALLOW", datetime.now(timezone.utc)))
+            if req.decision != EscalationDecision.PENDING:
+                return True
             req.decision = EscalationDecision.ALLOW
             req.resolved_by = approver
             req.resolved_at = datetime.now(timezone.utc)
@@ -179,8 +186,15 @@ class InMemoryApprovalQueue(ApprovalBackend):
     def deny(self, request_id: str, approver: str = "") -> bool:
         with self._lock:
             req = self._requests.get(request_id)
-            if req is None or req.decision != EscalationDecision.PENDING:
+            if req is None:
                 return False
+            if not approver.strip():
+                return False
+            if any(a == approver for a, _, _ in req.votes):
+                return False
+            req.votes.append((approver, "DENY", datetime.now(timezone.utc)))
+            if req.decision != EscalationDecision.PENDING:
+                return True
             req.decision = EscalationDecision.DENY
             req.resolved_by = approver
             req.resolved_at = datetime.now(timezone.utc)

--- a/agent-governance-python/agent-os/tests/test_escalation.py
+++ b/agent-governance-python/agent-os/tests/test_escalation.py
@@ -17,6 +17,7 @@ from agent_os.integrations.escalation import (
     EscalationRequest,
     EscalationResult,
     InMemoryApprovalQueue,
+    QuorumConfig,
 )
 
 
@@ -74,16 +75,50 @@ class TestInMemoryApprovalQueue:
         retrieved = queue.get_decision(req.request_id)
         assert retrieved.decision == EscalationDecision.DENY
 
-    def test_double_approve_fails(self):
+    def test_double_approve_same_approver_rejected(self):
         queue = InMemoryApprovalQueue()
         req = EscalationRequest(agent_id="a1", action="x", reason="r")
         queue.submit(req)
-        assert queue.approve(req.request_id) is True
-        assert queue.approve(req.request_id) is False  # Already resolved
+        assert queue.approve(req.request_id, approver="admin") is True
+        assert queue.approve(req.request_id, approver="admin") is False  # duplicate vote
+
+    def test_second_approver_vote_recorded(self):
+        queue = InMemoryApprovalQueue()
+        req = EscalationRequest(agent_id="a1", action="x", reason="r")
+        queue.submit(req)
+        assert queue.approve(req.request_id, approver="admin-a") is True
+        assert queue.approve(req.request_id, approver="admin-b") is True
+        retrieved = queue.get_decision(req.request_id)
+        assert len(retrieved.votes) == 2
+        approvers = [a for a, _, _ in retrieved.votes]
+        assert "admin-a" in approvers
+        assert "admin-b" in approvers
+
+    def test_votes_recorded_on_approve(self):
+        queue = InMemoryApprovalQueue()
+        req = EscalationRequest(agent_id="a1", action="x", reason="r")
+        queue.submit(req)
+        queue.approve(req.request_id, approver="reviewer-1")
+        retrieved = queue.get_decision(req.request_id)
+        assert len(retrieved.votes) == 1
+        approver, verdict, _ = retrieved.votes[0]
+        assert approver == "reviewer-1"
+        assert verdict == "ALLOW"
+
+    def test_votes_recorded_on_deny(self):
+        queue = InMemoryApprovalQueue()
+        req = EscalationRequest(agent_id="a1", action="x", reason="r")
+        queue.submit(req)
+        queue.deny(req.request_id, approver="sec-team")
+        retrieved = queue.get_decision(req.request_id)
+        assert len(retrieved.votes) == 1
+        approver, verdict, _ = retrieved.votes[0]
+        assert approver == "sec-team"
+        assert verdict == "DENY"
 
     def test_approve_nonexistent(self):
         queue = InMemoryApprovalQueue()
-        assert queue.approve("nonexistent") is False
+        assert queue.approve("nonexistent", approver="admin") is False
 
     def test_list_pending(self):
         queue = InMemoryApprovalQueue()
@@ -91,7 +126,7 @@ class TestInMemoryApprovalQueue:
         r2 = EscalationRequest(agent_id="a2", action="y", reason="s")
         queue.submit(r1)
         queue.submit(r2)
-        queue.approve(r1.request_id)
+        queue.approve(r1.request_id, approver="admin")
         pending = queue.list_pending()
         assert len(pending) == 1
         assert pending[0].request_id == r2.request_id
@@ -133,7 +168,7 @@ class TestEscalationHandler:
 
         def approve():
             time.sleep(0.1)
-            queue.approve(request.request_id)
+            queue.approve(request.request_id, approver="admin")
 
         t = threading.Thread(target=approve)
         t.start()
@@ -246,3 +281,72 @@ class TestEscalationRequest:
         )
         assert req.agent_id == "a1"
         assert req.action == "deploy"
+
+
+class TestQuorumResolution:
+    def test_quorum_met_resolves_allow(self):
+        queue = InMemoryApprovalQueue()
+        handler = EscalationHandler(
+            backend=queue,
+            timeout_seconds=5,
+            quorum=QuorumConfig(required_approvals=1, total_approvers=1),
+        )
+        request = handler.escalate("agent-1", "action", "reason")
+
+        def approve():
+            time.sleep(0.05)
+            queue.approve(request.request_id, approver="reviewer-1")
+
+        t = threading.Thread(target=approve)
+        t.start()
+        decision = handler.resolve(request.request_id)
+        t.join()
+        assert decision == EscalationDecision.ALLOW
+
+    def test_quorum_not_met_times_out(self):
+        queue = InMemoryApprovalQueue()
+        handler = EscalationHandler(
+            backend=queue,
+            timeout_seconds=0.2,
+            default_action=DefaultTimeoutAction.DENY,
+            quorum=QuorumConfig(required_approvals=2, total_approvers=3),
+        )
+        request = handler.escalate("agent-1", "action", "reason")
+        queue.approve(request.request_id, approver="reviewer-1")
+        decision = handler.resolve(request.request_id)
+        assert decision == EscalationDecision.DENY
+
+    def test_duplicate_approver_does_not_satisfy_quorum(self):
+        queue = InMemoryApprovalQueue()
+        handler = EscalationHandler(
+            backend=queue,
+            timeout_seconds=0.2,
+            default_action=DefaultTimeoutAction.DENY,
+            quorum=QuorumConfig(required_approvals=2, total_approvers=3),
+        )
+        request = handler.escalate("agent-1", "action", "reason")
+        queue.approve(request.request_id, approver="reviewer-1")
+        result = queue.approve(request.request_id, approver="reviewer-1")
+        assert result is False
+        retrieved = queue.get_decision(request.request_id)
+        assert len(retrieved.votes) == 1
+
+    def test_empty_approver_rejected_on_approve(self):
+        queue = InMemoryApprovalQueue()
+        req = EscalationRequest(agent_id="a1", action="x", reason="r")
+        queue.submit(req)
+        assert queue.approve(req.request_id) is False
+        assert queue.approve(req.request_id, approver="") is False
+        assert queue.approve(req.request_id, approver="   ") is False
+        retrieved = queue.get_decision(req.request_id)
+        assert len(retrieved.votes) == 0
+
+    def test_empty_approver_rejected_on_deny(self):
+        queue = InMemoryApprovalQueue()
+        req = EscalationRequest(agent_id="a1", action="x", reason="r")
+        queue.submit(req)
+        assert queue.deny(req.request_id) is False
+        assert queue.deny(req.request_id, approver="") is False
+        assert queue.deny(req.request_id, approver="   ") is False
+        retrieved = queue.get_decision(req.request_id)
+        assert len(retrieved.votes) == 0

--- a/agent-governance-python/agent-os/tests/test_security_hardening.py
+++ b/agent-governance-python/agent-os/tests/test_security_hardening.py
@@ -457,9 +457,6 @@ class TestQuorumApproval:
         request = handler.escalate("agent-1", "deploy", "needs review")
         # One approval — not enough for quorum of 2
         queue.approve(request.request_id, approver="admin1")
-        # Manually add vote tracking
-        req = queue.get_decision(request.request_id)
-        req.votes.append(("admin1", "ALLOW", req.resolved_at))
         decision = handler.resolve(request.request_id)
         # With only 1 vote and quorum=2, should timeout-deny
         assert decision == EscalationDecision.DENY
@@ -474,9 +471,7 @@ class TestQuorumApproval:
         )
         request = handler.escalate("agent-1", "deploy", "needs review")
         queue.approve(request.request_id, approver="admin1")
-        req = queue.get_decision(request.request_id)
-        req.votes.append(("admin1", "ALLOW", req.resolved_at))
-        req.votes.append(("admin2", "ALLOW", req.resolved_at))
+        queue.approve(request.request_id, approver="admin2")
         decision = handler.resolve(request.request_id)
         assert decision == EscalationDecision.ALLOW
 
@@ -490,8 +485,6 @@ class TestQuorumApproval:
         )
         request = handler.escalate("agent-1", "deploy", "needs review")
         queue.deny(request.request_id, approver="sec-team")
-        req = queue.get_decision(request.request_id)
-        req.votes.append(("sec-team", "DENY", req.resolved_at))
         decision = handler.resolve(request.request_id)
         assert decision == EscalationDecision.DENY
 


### PR DESCRIPTION
## Summary

- `InMemoryApprovalQueue.approve()` and `deny()` were setting `req.decision` and `req.resolved_by` but never appending to `req.votes`
- `EscalationHandler.resolve()` evaluates quorum by summing `req.votes` -- with an always-empty list the count was 0, resetting a correctly-resolved decision back to `PENDING` and falling through to the timeout default
- Fix: append the vote tuple `(approver, verdict, timestamp)` to `req.votes` before any decision logic; deduplicate by approver so a single reviewer cannot satisfy quorum multiple times

Fixes #3126

## Changes

**`agent-governance-python/agent-os/src/agent_os/integrations/escalation.py`**
- `approve()`: append `(approver, "ALLOW", datetime.now(...))` to `req.votes` before setting decision; skip duplicate votes from the same approver; allow additional votes to be recorded after decision is already final
- `deny()`: same pattern for `"DENY"` verdict

**`agent-governance-python/agent-os/tests/test_escalation.py`**
- Renamed `test_double_approve_fails` to `test_double_approve_same_approver_rejected` (clarifies the dedup semantics, not "already resolved")
- Added `test_second_approver_vote_recorded` -- second approver's vote appended, both visible in `req.votes`
- Added `test_votes_recorded_on_approve` / `test_votes_recorded_on_deny` -- assert `votes` list populated with correct approver and verdict
- Added `TestQuorumResolution` class: quorum met resolves ALLOW, quorum not met times out to DENY, duplicate approver vote rejected and does not satisfy quorum

## Test plan

- [ ] All 26 escalation tests pass (`pytest tests/test_escalation.py`)
- [ ] `test_quorum_met_resolves_allow`: quorum=1, single approver, resolves ALLOW
- [ ] `test_quorum_not_met_times_out`: quorum=2, 1 approver, times out to DENY
- [ ] `test_duplicate_approver_does_not_satisfy_quorum`: second call from same approver returns False, `votes` list length stays at 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)