### PR TITLE
refactor(cedarling-governed): gate write on token device claim

### DIFF
--- a/examples/cedarling-governed/README.md
+++ b/examples/cedarling-governed/README.md
@@ -79,15 +79,17 @@ Expected output of `multi_issuer_example.py`:
          reason : Cedarling: allowed (multi-issuer)
 [DENY ] admin agent on personal mobile writes config → write on infra-config (device=mobile)
          reason : Cedarling: denied (multi-issuer)
+[DENY ] admin agent on an unidentified device writes config → write on infra-config (device=tablet)
+         reason : Cedarling: denied (multi-issuer)
 [ALLOW] admin agent on personal mobile reads config → read_data on infra-config (device=mobile)
          reason : Cedarling: allowed (multi-issuer)
 [DENY ] operator agent on managed laptop writes config → write on infra-config (device=laptop)
          reason : Cedarling: denied (multi-issuer)
 ```
 
-The first two requests carry the *same admin token* and differ only in the
-device context — write follows the capability, so a weaker device drops it. The
-fourth request shows the role gate: an operator token never writes. Policies in
+The first three requests carry admin tokens with different device-posture
+claims and write follows the capability, so only the insecure devices are denied.
+The fifth request shows the role gate: an operator token never writes. Policies in
 [`policy-stores/multi-issuer/`](policy-stores/multi-issuer):
 
 ```

--- a/examples/cedarling-governed/README.md
+++ b/examples/cedarling-governed/README.md
@@ -1,41 +1,51 @@
 # Cedarling Governed Agent
 
-Authorization for autonomous agents with [Cedarling](https://docs.jans.io/stable/cedarling),
-plugged into AGT's `PolicyEvaluator` as an external policy backend (no changes
-to AGT core). Cedarling evaluates Cedar policies **in-process** against a local
-policy store.
+This example demonstrates how you can perform authorization for autonomous agents with [Cedarling](https://docs.jans.io/stable/cedarling),
+plugged into AGT's `PolicyEvaluator` as an external policy backend. This does not introduce any changes
+to the AGT core.
 
-Two examples, one per authorization mode:
+Cedarling evaluates Cedar policies **in-process** against a local [Cedar policy](https://cedarpolicy.com/) store.
 
-| Example | Mode | Identity comes from | Demonstrates |
-|---------|------|---------------------|--------------|
-| [`unsigned_example.py`](unsigned_example.py) | `unsigned` | the request dict (`agent_id` + `principal_attributes`) | role-based access control |
-| [`multi_issuer_example.py`](multi_issuer_example.py) | `multi-issuer` | verified JWTs from trusted issuers | capability-based authorization |
+This document offers two runnable examples. 
+
+| Demonstrates | Identity comes from | Cedarling mode | Example |
+|--------------|---------------------|------|---------|
+| Role-based access control | Authorization request data | `unsigned` | [`unsigned_example.py`](unsigned_example.py) |
+| Token-based authorization | Verified JWTs from trusted issuers | `multi-issuer` | [`multi_issuer_example.py`](multi_issuer_example.py) |
+
+## Install requirements
 
 ```bash
 pip install -r requirements.txt
-# cedarling-agentmesh is not yet on PyPI; install it from source:
-pip install -e ../../agent-governance-python/agentmesh-integrations/cedarling-agentmesh
-python unsigned_example.py
-python multi_issuer_example.py
 ```
 
 `cedarling-python` (pulled in by `requirements.txt`) evaluates the policies
-in-process against the bundled stores in [`policy-stores/`](policy-stores). The
-`cedarling_agentmesh` backend is installed separately from source per the step
-above.
+in-process against the bundled stores in [`policy-stores/`](policy-stores).
 
----
+## Role-based access control (Unsigned mode)
 
-## Unsigned authorization (role-based)
+[`unsigned_example.py`](unsigned_example.py) implements typical RBAC authorization. This uses Cedarling's [unsigned mode of authorization](https://docs.jans.io/head/cedarling/reference/cedarling-authz/#unsigned-authorization-authorize_unsigned). In this case, the principal entity and it's attributes are provided by the application itself when it sends the request for authorization. 
 
-For internal services, background jobs, and test harnesses there is often no
-token. In unsigned mode the principal's identity and attributes come straight
-from the request dict — `agent_id` becomes the principal, `principal_attributes`
-(e.g. `{"role": "admin"}`) populate its entity attributes — and policies check
-those attributes.
+In our example, the request supplied data 
 
-Expected output of `unsigned_example.py`:
+- `agent_id` becomes the principal
+- `principal_attributes`(e.g. `{"role": "admin"}`) populate its entity attributes 
+
+[Policies used in this example](policy-stores/unsigned) are built to check the above attributes.
+These policies effectively does the following:
+
+```
+allow-read   : permit Read/ReadData when principal.role == "admin"
+forbid-write : forbid Write        when principal.role == "auditor"
+```
+
+Use command below to run the example:
+
+```bash
+python unsigned_example.py
+```
+
+Expected output:
 
 ```
 [ALLOW] agent-analyst (role=admin) → read_data on reports
@@ -48,31 +58,41 @@ Expected output of `unsigned_example.py`:
          reason : Cedarling: denied (unsigned)
 ```
 
-The full decision spread: an explicit `permit`, two default denials, and an
-explicit `forbid`. Policies in [`policy-stores/unsigned/`](policy-stores/unsigned):
+## Token-based authorization (Multi-issuer mode)
 
+
+This example demonstrates how you can implement [token-based](https://docs.jans.io/stable/cedarling/#proof-based-authorization-token-based-access-control-tbac) 
+or token-based access control.
+
+### Policies
+
+In this example, users from the operations team are requesting authorization to read/update the infrastructure configuration. They may use their secure corporate devices or personal insecure devices to authenticate and perform the action.
+
+[Policies](policy-stores/multi-issuer) are designed to consider a combination of user claims(role) and contextual data(device information) to `allow` or `deny` the authorization. Both of these inputs are extracted from the tokens.
+
+| User role |      Device info | Action | Result |
+|-----------|------------------|--------|--------|
+| admin     | secure laptop    | write  | allow  |
+| admin     | personal mobile  | write  | deny   |
+| admin     | personal mobile  | read   | allow  |
+| operator  | secure laptop    | write  | deny   |
+
+### Tokens to carry the context
+
+Role and device data is extracted from the access token claims. Policies reason over the claims that the issuers have published in the token. Plus, the request context.
+Refer to [TBAC](https://docs.jans.io/stable/cedarling/#proof-based-authorization-token-based-access-control-tbac) principles to understand the benefits.
+ 
+This mode is called "Multi-issuer" mode because the policy store can be configured to trust tokens issued by several issuers. 
+
+### Run the example
+
+Use command below to run the example:
+
+```bash
+python multi_issuer_example.py
 ```
-allow-read   : permit Read/ReadData when principal.role == "admin"
-forbid-write : forbid Write        when principal.role == "auditor"
-```
 
----
-
-## Multi-issuer authorization (capability-based)
-
-The differentiator: a capability is the combination of **verified JWT claims**
-and the **request context**, not a role the caller asserts about itself.
-
-In the example an operations agent manages infrastructure config. Whether it may
-*write* depends on two things together: a `role` claim carried by a verified
-access token, and the device posture passed as request context. An admin agent
-on a managed laptop may write; the *same admin token* presented from an insecure
-device (a personal mobile) may not — the capability is revoked by context.
-Reading is allowed from any device, and a non-admin token never writes.
-"Multi-issuer" because the store may trust several issuers; policies reason over
-the claims they vouch for plus the request context.
-
-Expected output of `multi_issuer_example.py`:
+Expected output:
 
 ```
 [ALLOW] admin agent on managed laptop writes config → write on infra-config (device=laptop)
@@ -87,26 +107,32 @@ Expected output of `multi_issuer_example.py`:
          reason : Cedarling: denied (multi-issuer)
 ```
 
-The first three requests carry admin tokens with different device-posture
-claims and write follows the capability, so only the insecure devices are denied.
-The fifth request shows the role gate: an operator token never writes. Policies in
-[`policy-stores/multi-issuer/`](policy-stores/multi-issuer):
+For the above output, the requests carried admin access tokens with device information in its 
+claims. Based on this information, the second and third requests are denied as coming from an unmanaged 
+device. The fifth request shows the role gate: an operator token never writes. 
+
+See the complete policies at [`policy-stores/multi-issuer/`](policy-stores/multi-issuer). 
+These policies effectively implement the following:
 
 ```
 allow-admin-read  : permit Read/ReadData when token role == "admin"
 allow-admin-write : permit Write when token role == "admin" AND device != "mobile"
 ```
 
-> The demo forges its own JWTs and runs with signature/status validation
-> disabled so the claims are readable and no IdP is needed. In production these
+> Note:
+> In absence of an IDP, this demo forges its own JWTs and runs with signature/status validation
+> disabled so the claims are readable. In production these
 > tokens come from your identity provider — keep both validations **on**.
 
 ### Adding more issuers
 
-The store trusts one issuer; "multi-issuer" means it can trust several. Drop
-another file in `policy-stores/multi-issuer/trusted-issuers/`, add its
-`<issuer>_access_token` field to the `Context` type in `schema.cedarschema`, and
-pass that token alongside the others in the per-request `tokens` dict:
+The store used in this example trusts one issuer. 
+
+Follow the steps below to add additional issuers:
+
+- Drop another file in `policy-stores/multi-issuer/trusted-issuers/`
+- Add its `<issuer>_access_token` field to the `Context` type in `schema.cedarschema`
+- Pass that token alongside the others in the per-request `tokens` dictionary
 
 ```python
 decision = evaluator.evaluate({
@@ -119,12 +145,10 @@ decision = evaluator.evaluate({
 })
 ```
 
----
-
 ## What both examples show
 
-- `CedarlingBackend` registered with `PolicyEvaluator.add_backend()` — zero
-  modifications to `agent-os-kernel`.
+- `CedarlingBackend` registered with `PolicyEvaluator.add_backend()` without modifying
+  the `agent-os-kernel`
 - In-process Cedar evaluation against a real local policy store.
 - The aggregated `PolicyDecision` — `allowed`, `action`, `reason`, plus the
   deciding `backend` and `evaluation_ms` on its `audit_entry`. (The backend's
@@ -134,15 +158,15 @@ decision = evaluator.evaluate({
 
 ## How a request maps to Cedar
 
-The backend translates each AGT request dict into a Cedar authorization query:
+The backend translates each AGT request parameters into a Cedar authorization query:
 
 | AGT request key        | Cedar field                                                      |
 |------------------------|------------------------------------------------------------------|
 | `agent_id`             | `principal` entity id (`AGT::Agent`) — unsigned only             |
 | `tool_name`            | `action` — snake_case → PascalCase (`read_data` → `ReadData`)    |
 | `resource`             | `resource` entity id (`AGT::Resource`)                           |
-| `principal_attributes` | principal entity attributes — **unsigned only**                  |
-| `tokens`               | JWTs keyed by Cedar entity type — **multi-issuer only**          |
+| `principal_attributes` | principal entity attributes — **unsigned mode only**                  |
+| `tokens`               | JWTs keyed by Cedar entity type — **multi-issuer mode only**          |
 | any other key          | Cedar `context` attribute (also spread onto the resource entity) |
 
 The `AGT::` prefix comes from the `namespace="AGT"` argument, which matches the

--- a/examples/cedarling-governed/README.md
+++ b/examples/cedarling-governed/README.md
@@ -70,12 +70,12 @@ In this example, users from the operations team are requesting authorization to 
 
 [Policies](policy-stores/multi-issuer) are designed to consider a combination of user claims(role) and contextual data(device information) to `allow` or `deny` the authorization. Both of these inputs are extracted from the tokens.
 
-| User role |      Device info | Action | Result |
-|-----------|------------------|--------|--------|
-| admin     | secure laptop    | write  | allow  |
-| admin     | personal mobile  | write  | deny   |
-| admin     | personal mobile  | read   | allow  |
-| operator  | secure laptop    | write  | deny   |
+| User role | Device info         | Action | Result |
+| --------- | ------------------- | ------ | ------ |
+| admin     | secure laptop       | write  | allow  |
+| admin     | unidentified device | write  | deny   |
+| admin     | personal mobile     | read   | allow  |
+| operator  | secure laptop       | write  | deny   |
 
 ### Tokens to carry the context
 
@@ -116,7 +116,7 @@ These policies effectively implement the following:
 
 ```
 allow-admin-read  : permit Read/ReadData when token role == "admin"
-allow-admin-write : permit Write when token role == "admin" AND device != "mobile"
+allow-admin-write : permit Write when token role == "admin" AND device in {"laptop", "workstation"}
 ```
 
 > Note:

--- a/examples/cedarling-governed/README.md
+++ b/examples/cedarling-governed/README.md
@@ -110,7 +110,6 @@ pass that token alongside the others in the per-request `tokens` dict:
 decision = evaluator.evaluate({
     "tool_name": "write",
     "resource": "infra-config",
-    "device": "laptop",
     "tokens": {
         "AGT::Access_Token": "<jwt-from-issuer-a>",
         # "AGT::Id_Token":   "<jwt-from-issuer-b>",
@@ -162,7 +161,7 @@ policy-stores/
 │       └── forbid-write.cedar
 └── multi-issuer/
     ├── metadata.json
-    ├── schema.cedarschema           # adds Access_Token entity + Context (tokens + device)
+    ├── schema.cedarschema           # Access_Token entity carries role + device claims as tags
     ├── trusted-issuers/
     │   └── janssen.json             # the IdP whose tokens are trusted
     └── policies/

--- a/examples/cedarling-governed/multi_issuer_example.py
+++ b/examples/cedarling-governed/multi_issuer_example.py
@@ -85,7 +85,7 @@ def _mint_access_token(*, subject: str, role: str, device: str) -> str:
         "token_type": "Bearer",
         "scope": ["openid", "profile"],
         "role": role,
-        "device": device,
+        "device": device.strip().lower(),
         "iat": now,
         "exp": now + 3600,
         "jti": f"jti-{subject}-{device}",
@@ -96,6 +96,7 @@ def _mint_access_token(*, subject: str, role: str, device: str) -> str:
 
 ADMIN_LAPTOP_TOKEN = _mint_access_token(subject="agent-ops", role="admin", device="laptop")
 ADMIN_MOBILE_TOKEN = _mint_access_token(subject="agent-ops", role="admin", device="mobile")
+ADMIN_TABLET_TOKEN = _mint_access_token(subject="agent-ops", role="admin", device="tablet")
 # Operator token: same trusted issuer, but not admin — no write capability.
 OPERATOR_TOKEN = _mint_access_token(subject="agent-helpdesk", role="operator", device="laptop")
 
@@ -167,6 +168,15 @@ test_cases = [
             "tool_name": "write",
             "resource": "infra-config",
             "tokens": {ACCESS_TOKEN_TYPE: ADMIN_MOBILE_TOKEN},
+        },
+    },
+    {
+        "label": "admin agent on an unidentified device writes config",
+        "device": "tablet",
+        "request": {
+            "tool_name": "write",
+            "resource": "infra-config",
+            "tokens": {ACCESS_TOKEN_TYPE: ADMIN_TABLET_TOKEN},
         },
     },
     # same mobile admin token reading -> read isn't device-gated -> ALLOW

--- a/examples/cedarling-governed/multi_issuer_example.py
+++ b/examples/cedarling-governed/multi_issuer_example.py
@@ -3,23 +3,24 @@
 """Capability-based authorization for autonomous agents with Cedarling + AGT.
 
 An operations agent manages infrastructure config. Whether it may *write* is a
-capability that depends on two things together:
+capability that depends on two claims a trusted issuer stamped into its access
+token:
 
-  - **who it is** — a ``role`` claim carried by a verified access token, and
-  - **how it connected** — the device posture, passed as request context.
+  - **who it is**: a ``role`` claim, and
+  - **how it connected**: a ``device`` claim describing the device posture.
 
-An admin agent on a managed laptop may write. The *same admin token* presented
-from an insecure device (a personal mobile) may not — the capability is revoked
-by context. Reading is allowed from any device. A non-admin token never writes.
+An admin token issued on a managed laptop may write. The same admin role on a
+different device (a personal mobile) may not: the capability is revoked by the
+weaker device. Reading is allowed from any device. A non-admin token never writes.
 
-Nothing in the request can assert the role: it comes only from a token a trusted
-issuer vouched for. That verified claim, combined with the request context, is
-the capability — this is what sets Cedarling apart from role-based access
-control, where the caller asserts its own role.
+Nothing in the request asserts these facts: they come only from claims a trusted
+issuer vouched for. That bundle of verified claims is the capability, this is
+what sets Cedarling apart from role-based access control, where the caller
+asserts its own role.
 
 This is Cedarling's *multi-issuer* authorization mode: tokens may come from one
 or more trusted issuers declared in the policy store, and policies reason over
-the claims those issuers vouch for plus the request context.
+the claims those issuers vouch for.
 
 Run:
     pip install -r requirements.txt
@@ -67,8 +68,8 @@ ACCESS_TOKEN_TYPE = "AGT::Access_Token"
 # match the trusted issuer's configuration endpoint host (test.jans.org).
 
 
-def _mint_access_token(*, subject: str, role: str) -> str:
-    """Build an unsigned demo JWT carrying a ``role`` capability claim."""
+def _mint_access_token(*, subject: str, role: str, device: str) -> str:
+    """Build an unsigned demo JWT carrying ``role`` and ``device`` claims."""
 
     def b64(obj: dict) -> str:
         raw = json.dumps(obj, separators=(",", ":")).encode()
@@ -84,18 +85,19 @@ def _mint_access_token(*, subject: str, role: str) -> str:
         "token_type": "Bearer",
         "scope": ["openid", "profile"],
         "role": role,
+        "device": device,
         "iat": now,
         "exp": now + 3600,
-        "jti": f"jti-{subject}",
+        "jti": f"jti-{subject}-{device}",
     }
     # Signature is irrelevant (validation disabled for the demo).
     return f"{b64(header)}.{b64(payload)}.demo-signature"
 
 
-# Admin token grants the write capability — gated on device posture below.
-ADMIN_TOKEN = _mint_access_token(subject="agent-ops", role="admin")
+ADMIN_LAPTOP_TOKEN = _mint_access_token(subject="agent-ops", role="admin", device="laptop")
+ADMIN_MOBILE_TOKEN = _mint_access_token(subject="agent-ops", role="admin", device="mobile")
 # Operator token: same trusted issuer, but not admin — no write capability.
-OPERATOR_TOKEN = _mint_access_token(subject="agent-helpdesk", role="operator")
+OPERATOR_TOKEN = _mint_access_token(subject="agent-helpdesk", role="operator", device="laptop")
 
 
 # ---------------------------------------------------------------------------
@@ -136,54 +138,54 @@ evaluator.add_backend(backend)
 #   tool_name -> action  (snake_case -> PascalCase, e.g. read_data -> ReadData)
 #   resource  -> resource id (AGT::Resource)
 #   tokens    -> JWTs, keyed by the Cedar entity type they map to
-#   device    -> extra context attribute (the connecting device posture)
 #
-# Cedarling validates each token against the trusted issuer, exposes its claims
-# as context.tokens.janssen_access_token, and evaluates the policies in
-# policy-stores/multi-issuer/policies/ against those claims plus the context:
+# Every non-reserved JWT claim (here role and device) is exposed to policies as a
+# tag on context.tokens.janssen_access_token. Cedarling validates each token
+# against the trusted issuer, then evaluates the policies in
+# policy-stores/multi-issuer/policies/ against those claims:
 #   allow-admin-read  : permit Read/ReadData when the token role is "admin"
 #   allow-admin-write : permit Write when the token role is "admin" AND the
-#                       request device is not "mobile" (insecure)
+#                       token device claim is not "mobile" (insecure)
 # Anything not permitted is denied by default.
 
 test_cases = [
-    # admin on a managed laptop -> role + secure device -> ALLOW
+    # admin token issued on a managed laptop -> role + secure device -> ALLOW
     {
         "label": "admin agent on managed laptop writes config",
+        "device": "laptop",
         "request": {
             "tool_name": "write",
             "resource": "infra-config",
-            "device": "laptop",
-            "tokens": {ACCESS_TOKEN_TYPE: ADMIN_TOKEN},
+            "tokens": {ACCESS_TOKEN_TYPE: ADMIN_LAPTOP_TOKEN},
         },
     },
-    # admin on a personal mobile -> right role, insecure device -> DENY
+    # admin token issued on a personal mobile -> right role, insecure device -> DENY
     {
         "label": "admin agent on personal mobile writes config",
+        "device": "mobile",
         "request": {
             "tool_name": "write",
             "resource": "infra-config",
-            "device": "mobile",
-            "tokens": {ACCESS_TOKEN_TYPE: ADMIN_TOKEN},
+            "tokens": {ACCESS_TOKEN_TYPE: ADMIN_MOBILE_TOKEN},
         },
     },
-    # admin reading from that same mobile -> read isn't device-gated -> ALLOW
+    # same mobile admin token reading -> read isn't device-gated -> ALLOW
     {
         "label": "admin agent on personal mobile reads config",
+        "device": "mobile",
         "request": {
             "tool_name": "read_data",
             "resource": "infra-config",
-            "device": "mobile",
-            "tokens": {ACCESS_TOKEN_TYPE: ADMIN_TOKEN},
+            "tokens": {ACCESS_TOKEN_TYPE: ADMIN_MOBILE_TOKEN},
         },
     },
-    # operator on a managed laptop -> not admin -> DENY (default deny)
+    # operator token on a managed laptop -> not admin -> DENY (default deny)
     {
         "label": "operator agent on managed laptop writes config",
+        "device": "laptop",
         "request": {
             "tool_name": "write",
             "resource": "infra-config",
-            "device": "laptop",
             "tokens": {ACCESS_TOKEN_TYPE: OPERATOR_TOKEN},
         },
     },
@@ -200,7 +202,7 @@ for case in test_cases:
     status = "ALLOW" if decision.allowed else "DENY "
     print(
         f"[{status}] {case['label']} → "
-        f"{request['tool_name']} on {request['resource']} (device={request['device']})"
+        f"{request['tool_name']} on {request['resource']} (device={case['device']})"
     )
     print(f"         reason : {decision.reason}")
     print(f"         backend: {audit['backend']}  timing: {audit['evaluation_ms']:.2f}ms")

--- a/examples/cedarling-governed/multi_issuer_example.py
+++ b/examples/cedarling-governed/multi_issuer_example.py
@@ -88,7 +88,7 @@ def _mint_access_token(*, subject: str, role: str, device: str) -> str:
         "device": device.strip().lower(),
         "iat": now,
         "exp": now + 3600,
-        "jti": f"jti-{subject}-{device}",
+        "jti": f"jti-{subject}-{device.strip().lower()}",
     }
     # Signature is irrelevant (validation disabled for the demo).
     return f"{b64(header)}.{b64(payload)}.demo-signature"

--- a/examples/cedarling-governed/multi_issuer_example.py
+++ b/examples/cedarling-governed/multi_issuer_example.py
@@ -146,7 +146,7 @@ evaluator.add_backend(backend)
 # policy-stores/multi-issuer/policies/ against those claims:
 #   allow-admin-read  : permit Read/ReadData when the token role is "admin"
 #   allow-admin-write : permit Write when the token role is "admin" AND the
-#                       token device claim is not "mobile" (insecure)
+#                       token device claim is in the {"laptop", "workstation"} allowlist
 # Anything not permitted is denied by default.
 
 test_cases = [

--- a/examples/cedarling-governed/policy-stores/multi-issuer/policies/allow-admin-write.cedar
+++ b/examples/cedarling-governed/policy-stores/multi-issuer/policies/allow-admin-write.cedar
@@ -8,5 +8,8 @@ permit(
     context.tokens.janssen_access_token.hasTag("role") &&
     context.tokens.janssen_access_token.getTag("role").contains("admin") &&
     context.tokens.janssen_access_token.hasTag("device") &&
-    !context.tokens.janssen_access_token.getTag("device").contains("mobile")
+    ["laptop", "workstation"].containsAll(
+        context.tokens.janssen_access_token.getTag("device")
+    ) &&
+    !context.tokens.janssen_access_token.getTag("device").isEmpty()
 };

--- a/examples/cedarling-governed/policy-stores/multi-issuer/policies/allow-admin-write.cedar
+++ b/examples/cedarling-governed/policy-stores/multi-issuer/policies/allow-admin-write.cedar
@@ -7,6 +7,6 @@ permit(
     context has tokens.janssen_access_token &&
     context.tokens.janssen_access_token.hasTag("role") &&
     context.tokens.janssen_access_token.getTag("role").contains("admin") &&
-    context has device &&
-    context.device != "mobile"
+    context.tokens.janssen_access_token.hasTag("device") &&
+    !context.tokens.janssen_access_token.getTag("device").contains("mobile")
 };

--- a/examples/cedarling-governed/policy-stores/multi-issuer/schema.cedarschema
+++ b/examples/cedarling-governed/policy-stores/multi-issuer/schema.cedarschema
@@ -1,9 +1,7 @@
 namespace AGT {
   type Url = {"host": String, "path": String, "protocol": String};
   entity Agent = {};
-  entity Resource = {
-    device?: String,
-  };
+  entity Resource = {};
   entity Access_Token = {
     sub?: String,
     iss?: Janssen::TrustedIssuer,
@@ -31,7 +29,6 @@ namespace Janssen {
   entity TrustedIssuer = {"issuer_entity_id": AGT::Url};
 }
 type Context = {
-  device?: String,
   tokens: {
     janssen_access_token?: AGT::Access_Token,
     total_token_count: Long


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes in this PR -->

Moves the device posture attribute from untrusted request context (context.device) into the access token as a verified issuer-signed claim to show Cedarling's capability based authorization.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
<!-- REQUIRED for new features, integrations, or architectural patterns -->
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
<!-- Example: "Sandboxing approach inspired by https://github.com/example/project (Apache-2.0)" -->
<!-- Leave blank if not applicable -->

## AI Assistance
<!-- See CONTRIBUTING.md "AI-Assisted Contributions" for full policy -->
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [ ] I have run tests and verification appropriate for this change
- [ ] No part of this PR was autonomously submitted by an AI agent without my review
- [ ] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
<!-- Example: "GitHub Copilot for boilerplate, Codex for test generation — all output reviewed" -->
<!-- Leave blank if AI was not used or was only used for minor assistance -->

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
