### PR TITLE
fix(harness): fail closed on missing OPA decision + convert bare exceptions to RuntimeError

### DIFF
--- a/agent-governance-python/agt-policies/src/agt/_harness/opa_runner.py
+++ b/agent-governance-python/agt-policies/src/agt/_harness/opa_runner.py
@@ -119,7 +119,10 @@ def _resolve_path(snapshot: dict[str, Any], path: str) -> Any:
     elif path == "$snap" or path == "$":
         return snapshot
     else:
-        raise ValueError(f"unsupported policy_target path root: {path!r}")
+        # Unrecognised root (e.g. "x.tool_call" instead of "$snap.tool_call").
+        # Fail closed via RuntimeError per the documented contract rather than
+        # leaking a bare ValueError to run_scenario's two unguarded call sites.
+        raise RuntimeError(f"unsupported policy_target path root: {path!r}")
 
     obj: Any = snapshot
     parts: list[str] = []
@@ -137,7 +140,11 @@ def _resolve_path(snapshot: dict[str, Any], path: str) -> Any:
             if cur:
                 parts.append(cur)
                 cur = ""
-            j = rest.index("]", i)
+            j = rest.find("]", i)
+            if j == -1:
+                raise RuntimeError(
+                    f"malformed policy_target path {path!r}: unclosed '['"
+                )
             parts.append(rest[i : j + 1])
             i = j + 1
             continue
@@ -147,12 +154,83 @@ def _resolve_path(snapshot: dict[str, Any], path: str) -> Any:
         parts.append(cur)
 
     for part in parts:
-        if part.startswith("[") and part.endswith("]"):
-            idx = int(part[1:-1])
-            obj = obj[idx]
-        else:
-            obj = obj[part]
+        try:
+            if part.startswith("[") and part.endswith("]"):
+                obj = obj[int(part[1:-1])]
+            else:
+                obj = obj[part]
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"policy_target path {path!r} does not resolve against the snapshot"
+            ) from exc
     return obj
+
+
+# The verdict decisions the engine may return (SPECIFICATION.md §13/§14 and
+# ``agt.policies.result.Verdict``). Anything else is an anomaly.
+_VALID_DECISIONS = frozenset({"allow", "warn", "deny", "escalate", "transform"})
+
+
+def _decode_verdict(stdout: str) -> ScenarioResult:
+    """Decode ``opa eval --format json`` stdout into a :class:`ScenarioResult`.
+
+    Fails closed: malformed OPA output raises ``RuntimeError`` (per the
+    documented contract), and a verdict object that lacks a recognized
+    ``decision`` resolves to a ``deny`` rather than silently defaulting to
+    ``allow`` — a missing ``decision`` is an engine anomaly, and defaulting a
+    governance verdict to permit is exactly the wrong direction.
+    """
+    if not isinstance(stdout, str):
+        # ``run_scenario`` always passes ``proc.stdout`` (a str), but guard the
+        # contract so a None/bytes slip-through fails closed rather than raising
+        # a bare ``TypeError`` out of ``json.loads``.
+        raise RuntimeError(f"opa produced no decodable stdout: {stdout!r}")
+    try:
+        response = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"opa produced non-JSON output: {stdout[:200]!r}"
+        ) from exc
+
+    if not isinstance(response, dict):
+        # A top-level list/scalar (valid JSON, wrong shape) would otherwise
+        # raise AttributeError at response.get(...). Fail closed instead.
+        raise RuntimeError(
+            f"opa returned a non-object top-level response: {response!r}"
+        )
+
+    results = response.get("result") or []
+    if not results:
+        raise RuntimeError("opa eval produced no result")
+    expressions = results[0].get("expressions") or []
+    value = expressions[0].get("value") if expressions else None
+    if not isinstance(value, dict):
+        raise RuntimeError(f"opa returned non-object verdict: {value!r}")
+
+    decision = value.get("decision")
+    if decision not in _VALID_DECISIONS:
+        return ScenarioResult(
+            decision="deny",
+            reason="runtime_error:engine_invalid_verdict",
+            message=f"opa returned a verdict without a recognized decision: {value!r}",
+            raw=value,
+        )
+
+    labels = value.get("result_labels")
+    if labels is not None and not (
+        isinstance(labels, list) and all(isinstance(x, str) for x in labels)
+    ):
+        raise RuntimeError(f"opa returned non-list[str] result_labels: {labels!r}")
+
+    return ScenarioResult(
+        decision=decision,
+        reason=value.get("reason"),
+        message=value.get("message"),
+        transform=value.get("transform"),
+        evidence=value.get("evidence"),
+        result_labels=labels,
+        raw=value,
+    )
 
 
 def run_scenario(
@@ -182,7 +260,11 @@ def run_scenario(
 
     Raises:
         FileNotFoundError: When the OPA binary is not on PATH.
-        RuntimeError: When opa eval fails or produces no result.
+        RuntimeError: When opa eval fails, produces no/malformed result,
+            the intervention-point binding is malformed, or a
+            ``policy_target`` path does not resolve against the snapshot.
+            A verdict lacking a recognized ``decision`` is *not* raised —
+            it fails closed to a ``deny`` ScenarioResult.
     """
     if shutil.which("opa") is None:
         raise FileNotFoundError(
@@ -223,7 +305,13 @@ def run_scenario(
 
     tool: dict[str, Any] | None = None
     if intervention_point in {"pre_tool_call", "post_tool_call"}:
-        tool_name = _resolve_path(snapshot, ip_config["tool_name_from"])
+        tool_name_from = ip_config.get("tool_name_from")
+        if not isinstance(tool_name_from, str):
+            raise RuntimeError(
+                f"intervention point {intervention_point!r} binding is missing a "
+                "string 'tool_name_from'"
+            )
+        tool_name = _resolve_path(snapshot, tool_name_from)
         if not isinstance(tool_name, str):
             raise RuntimeError("tool_name_from did not resolve to a string")
         tool = _project_tool_from_manifest(manifest, tool_name)
@@ -260,18 +348,4 @@ def run_scenario(
     if proc.returncode != 0:
         raise RuntimeError(f"opa eval failed: {proc.stderr.strip()}")
 
-    response = json.loads(proc.stdout)
-    expressions = response.get("result", [{}])[0].get("expressions", [{}])
-    value = expressions[0].get("value") if expressions else None
-    if not isinstance(value, dict):
-        raise RuntimeError(f"opa returned non-object verdict: {value!r}")
-
-    return ScenarioResult(
-        decision=str(value.get("decision", "allow")),
-        reason=value.get("reason"),
-        message=value.get("message"),
-        transform=value.get("transform"),
-        evidence=value.get("evidence"),
-        result_labels=value.get("result_labels"),
-        raw=value,
-    )
+    return _decode_verdict(proc.stdout)

--- a/agent-governance-python/agt-policies/tests/test_opa_runner.py
+++ b/agent-governance-python/agt-policies/tests/test_opa_runner.py
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for the OPA scenario harness decode/resolve helpers.
+
+These pin the fail-closed contract of :func:`agt._harness.opa_runner`:
+a verdict without a recognized ``decision`` resolves to ``deny`` (not the
+old silent ``allow`` default), malformed OPA output raises ``RuntimeError``
+rather than ``IndexError``/``JSONDecodeError``, and an unresolvable
+``policy_target`` path raises a typed ``RuntimeError`` instead of a bare
+``KeyError``/``ValueError``. None of this needs the ``opa`` binary.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from agt._harness.opa_runner import _decode_verdict, _resolve_path
+
+
+def _opa_stdout(value: Any) -> str:
+    return json.dumps({"result": [{"expressions": [{"value": value}]}]})
+
+
+def test_decode_valid_decision() -> None:
+    result = _decode_verdict(_opa_stdout({"decision": "allow"}))
+    assert result.decision == "allow" and result.is_allow
+
+
+def test_decode_missing_decision_fails_closed() -> None:
+    result = _decode_verdict(_opa_stdout({"reason": "whatever"}))
+    assert result.decision == "deny"
+    assert result.reason == "runtime_error:engine_invalid_verdict"
+
+
+def test_decode_unrecognized_decision_fails_closed() -> None:
+    result = _decode_verdict(_opa_stdout({"decision": "permit"}))
+    assert result.decision == "deny"
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    ['{"result": []}', '{"result": [{"expressions": []}]}', "{}"],
+)
+def test_decode_no_usable_result_raises(stdout: str) -> None:
+    with pytest.raises(RuntimeError, match="no result|non-object"):
+        _decode_verdict(stdout)
+
+
+def test_decode_non_json_raises_runtime_error() -> None:
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        _decode_verdict("not json <<<")
+
+
+@pytest.mark.parametrize("stdout", ["[]", "5", '"a string"', "true", "null"])
+def test_decode_non_object_toplevel_fails_closed(stdout: str) -> None:
+    # Valid JSON that parses to a non-dict (list/scalar) must fail closed,
+    # not raise AttributeError at response.get(...).
+    with pytest.raises(RuntimeError, match="non-object top-level"):
+        _decode_verdict(stdout)
+
+
+@pytest.mark.parametrize("stdout", [None, b"{}"])
+def test_decode_non_string_stdout_fails_closed(stdout: object) -> None:
+    with pytest.raises(RuntimeError, match="no decodable stdout"):
+        _decode_verdict(stdout)  # type: ignore[arg-type]
+
+
+def test_decode_bad_result_labels_raises() -> None:
+    with pytest.raises(RuntimeError, match="result_labels"):
+        _decode_verdict(_opa_stdout({"decision": "allow", "result_labels": "nope"}))
+
+
+def test_decode_valid_result_labels_passthrough() -> None:
+    result = _decode_verdict(
+        _opa_stdout({"decision": "warn", "result_labels": ["a", "b"]})
+    )
+    assert result.result_labels == ["a", "b"]
+
+
+def test_resolve_path_valid() -> None:
+    snapshot = {"tool_call": {"args": ["x", "y"]}}
+    assert _resolve_path(snapshot, "$snap.tool_call.args[1]") == "y"
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["$snap.a.missing", "$snap.a[3]", "$snap.a[x]"],
+)
+def test_resolve_path_unresolvable_raises_runtime_error(path: str) -> None:
+    with pytest.raises(RuntimeError, match="does not resolve"):
+        _resolve_path({"a": [1]}, path)
+
+
+def test_resolve_path_unclosed_bracket_raises() -> None:
+    with pytest.raises(RuntimeError, match="unclosed"):
+        _resolve_path({"a": [1]}, "$snap.a[0")
+
+
+@pytest.mark.parametrize("path", ["bad_root.key", "x.tool_call", "tool_call"])
+def test_resolve_path_unsupported_root_raises_runtime_error(path: str) -> None:
+    with pytest.raises(RuntimeError, match="unsupported policy_target path root"):
+        _resolve_path({}, path)


### PR DESCRIPTION
Addresses the `_harness/opa_runner.py` findings from the robustness review #3137 (per @imran-siddique's request to track fixes as separate per-file PRs).

## Fail-open: missing `decision` defaulted to `allow`

`run_scenario` decoded the OPA verdict with
`str(value.get("decision", "allow"))`. A verdict object lacking a recognized
`decision` (a malformed/partial engine response) was silently treated as
`allow` — defaulting a governance verdict to *permit* is exactly the wrong
direction (ADR-0013). It now fails closed to a `deny` ScenarioResult
(`reason="runtime_error:engine_invalid_verdict"`).

## Bare exceptions that escaped the documented contract

`run_scenario` documents `Raises: RuntimeError`, but several paths leaked other
exception types that a `RuntimeError`-catching caller would not handle:

- `response.get("result", [{}])[0]` → **`IndexError`** when OPA returns an empty
  `result` list (a normal "no result" shape).
- `json.loads(proc.stdout)` → **`json.JSONDecodeError`** when OPA exits 0 with
  non-JSON stdout.
- `_resolve_path` → bare **`KeyError`/`IndexError`/`TypeError`/`ValueError`** on
  an unresolvable `policy_target` path (and `ValueError` on an unclosed `[`).
- `ip_config["tool_name_from"]` → bare **`KeyError`** when a tool intervention
  point omits the binding key.

All are now converted to `RuntimeError` with actionable messages, and
`result_labels` is validated as `list[str] | None` instead of stored as raw
`Any`.

## Refactor for testability

The verdict-decode logic is extracted into a pure `_decode_verdict(stdout)`
helper so the fail-closed behavior is unit-testable without spawning OPA.

## Tests

Adds `tests/test_opa_runner.py` (no `opa` binary required): missing/unrecognized
`decision` → `deny`; empty-result / non-JSON / non-object / bad-`result_labels`
→ `RuntimeError`; unresolvable / unclosed-bracket `policy_target` paths →
`RuntimeError`.

Verified locally against real OPA 0.70.0 (WSL):

```
platform linux -- Python 3.13.14, pytest-9.0.3
tests/test_opa_runner.py + tests/scenarios/ + tests/test_runtime.py
======================== 175 passed in 4.08s ========================
```

The full scenario suite exercises `run_scenario` end-to-end through real OPA, so
the happy path is confirmed unchanged.

Refs #3137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
