### PR TITLE
fix(resolution): validate rule priority + harden parent-deny immutability against unsat bias

### DIFF
--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/merge.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/merge.py
@@ -241,25 +241,55 @@ def _condition_unsatisfiable(condition: Any) -> bool:
     return parts is not None and parts[1] == "in" and condition.get("value") == []
 
 
-def _conditions_disjoint(left: Any, right: Any) -> bool:
-    if _condition_unsatisfiable(left) or _condition_unsatisfiable(right):
+def _conditions_disjoint(
+    left: Any, right: Any, *, ignore_left_unsatisfiable: bool = False
+) -> bool:
+    # ``ignore_left_unsatisfiable`` is set on the deny-immutability path so a
+    # (possibly false-positive) "left is unsatisfiable" classification can never
+    # declare a parent deny harmless and silently neutralise it — that would be
+    # a fail-open against the deny-immutability invariant (ADR-0014). The right
+    # (child) side's unsatisfiability is still safe to short-circuit on: an
+    # unsatisfiable child allow never fires, so it overrides nothing.
+    if not ignore_left_unsatisfiable and _condition_unsatisfiable(left):
+        return True
+    if _condition_unsatisfiable(right):
         return True
     if not isinstance(left, dict) or not isinstance(right, dict):
         return False
 
     left_or = _compound_items(left, "or")
     if left_or is not None:
-        return all(_conditions_disjoint(item, right) for item in left_or)
+        return all(
+            _conditions_disjoint(
+                item, right, ignore_left_unsatisfiable=ignore_left_unsatisfiable
+            )
+            for item in left_or
+        )
     right_or = _compound_items(right, "or")
     if right_or is not None:
-        return all(_conditions_disjoint(left, item) for item in right_or)
+        return all(
+            _conditions_disjoint(
+                left, item, ignore_left_unsatisfiable=ignore_left_unsatisfiable
+            )
+            for item in right_or
+        )
 
     left_and = _compound_items(left, "and")
     if left_and is not None:
-        return any(_conditions_disjoint(item, right) for item in left_and)
+        return any(
+            _conditions_disjoint(
+                item, right, ignore_left_unsatisfiable=ignore_left_unsatisfiable
+            )
+            for item in left_and
+        )
     right_and = _compound_items(right, "and")
     if right_and is not None:
-        return any(_conditions_disjoint(left, item) for item in right_and)
+        return any(
+            _conditions_disjoint(
+                left, item, ignore_left_unsatisfiable=ignore_left_unsatisfiable
+            )
+            for item in right_and
+        )
 
     if "not" in left or "not" in right:
         return False
@@ -270,7 +300,12 @@ def _conditions_disjoint(left: Any, right: Any) -> bool:
 def _conditions_overlap(parent_condition: Any, child_condition: Any) -> bool:
     if _condition_key(parent_condition) == _condition_key(child_condition):
         return True
-    return not _conditions_disjoint(parent_condition, child_condition)
+    # Deny-immutability check: bias toward "overlap" (i.e. protect the parent
+    # deny). Drop the protection only for disjointness provable WITHOUT assuming
+    # the parent (left) deny condition is unsatisfiable.
+    return not _conditions_disjoint(
+        parent_condition, child_condition, ignore_left_unsatisfiable=True
+    )
 
 
 def merge_documents(documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -303,6 +338,16 @@ def merge_documents(documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
             if not isinstance(rule, dict) or "name" not in rule:
                 raise ResolutionError.invalid_governance(
                     f"rule at level {level} is missing name"
+                )
+            # ``priority`` feeds ``sorted(key=...)`` below; an explicit
+            # ``priority: null`` (None) or a typo (``priority: high``) would
+            # raise a bare ``TypeError`` comparing against ints, escaping the
+            # ResolutionError contract. Validate it as numeric up front.
+            priority = rule.get("priority", 0)
+            if isinstance(priority, bool) or not isinstance(priority, (int, float)):
+                raise ResolutionError.invalid_governance(
+                    f"rule {rule.get('name')!r} at level {level} has non-numeric "
+                    f"priority {priority!r}"
                 )
 
     if len(documents) == 1:

--- a/agent-governance-python/agt-policies/tests/test_merge_deny.py
+++ b/agent-governance-python/agt-policies/tests/test_merge_deny.py
@@ -1,0 +1,131 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for agt.manifest_resolution.merge robustness fixes.
+
+Covers the non-numeric ``priority`` TypeError fix and pins the deny-immutability
+(ADR-0014) behavior across the ``_conditions_disjoint`` refactor that stops the
+unsatisfiability heuristic from neutralising a parent deny.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agt.manifest_resolution.errors import ResolutionError
+from agt.manifest_resolution.merge import _conditions_overlap, merge_documents
+
+
+def _doc(rules: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"rules": rules}
+
+
+# ── priority validation (TypeError fix) ────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", [None, "high", True])
+def test_non_numeric_priority_raises_resolution_error(bad: Any) -> None:
+    with pytest.raises(ResolutionError):
+        merge_documents([_doc([{"name": "r", "action": "allow", "priority": bad}])])
+
+
+def test_valid_priority_sorts_descending() -> None:
+    out = merge_documents(
+        [_doc([
+            {"name": "lo", "action": "allow", "priority": 1},
+            {"name": "hi", "action": "allow", "priority": 5},
+            {"name": "mid", "action": "allow", "priority": 3.5},
+        ])]
+    )
+    assert [r["name"] for r in out] == ["hi", "mid", "lo"]
+
+
+def test_absent_priority_defaults_to_zero() -> None:
+    out = merge_documents(
+        [_doc([
+            {"name": "explicit", "action": "allow", "priority": 2},
+            {"name": "default", "action": "allow"},  # -> 0
+        ])]
+    )
+    assert [r["name"] for r in out] == ["explicit", "default"]
+
+
+# ── deny immutability (ADR-0014) ───────────────────────────────────────────
+
+
+def test_child_allow_overlapping_parent_deny_is_dropped() -> None:
+    parent = _doc([{
+        "name": "deny-shell", "action": "deny",
+        "condition": {"field": "tool", "operator": "eq", "value": "shell"},
+    }])
+    child = _doc([{
+        "name": "allow-shell", "action": "allow", "priority": 100,
+        "condition": {"field": "tool", "operator": "eq", "value": "shell"},
+    }])
+    names = [r["name"] for r in merge_documents([parent, child])]
+    assert "deny-shell" in names
+    assert "allow-shell" not in names
+
+
+def test_disjoint_child_allow_survives() -> None:
+    parent = _doc([{
+        "name": "deny-shell", "action": "deny",
+        "condition": {"field": "tool", "operator": "eq", "value": "shell"},
+    }])
+    child = _doc([{
+        "name": "allow-python", "action": "allow", "priority": 1,
+        "condition": {"field": "tool", "operator": "eq", "value": "python"},
+    }])
+    names = [r["name"] for r in merge_documents([parent, child])]
+    assert "allow-python" in names
+
+
+def test_satisfiable_compound_parent_deny_still_protects() -> None:
+    # A satisfiable AND-condition parent deny must not be classified away; a
+    # child allow overlapping its scope is dropped (immutability holds).
+    parent = _doc([{
+        "name": "deny-admin-delete", "action": "deny",
+        "condition": {"and": [
+            {"field": "role", "operator": "eq", "value": "admin"},
+            {"field": "action", "operator": "eq", "value": "delete"},
+        ]},
+    }])
+    child = _doc([{
+        "name": "allow-admin", "action": "allow", "priority": 100,
+        "condition": {"field": "role", "operator": "eq", "value": "admin"},
+    }])
+    names = [r["name"] for r in merge_documents([parent, child])]
+    assert "allow-admin" not in names
+
+
+def test_unsat_classified_parent_deny_still_protects_overlapping_child() -> None:
+    # RED on main, GREEN here. The parent deny's condition is classified
+    # unsatisfiable by `_condition_unsatisfiable` (the empty-`in` conjunct),
+    # yet it still overlaps the child via its other conjunct (`tool == shell`).
+    # On main, `_conditions_disjoint` short-circuits on the parent's
+    # unsatisfiability, declares the deny disjoint, and the child allow
+    # survives — neutralising the parent deny (fail-open, ADR-0014). The fix
+    # ignores the parent's unsatisfiability on the deny path, so the overlap is
+    # detected and the child allow is dropped.
+    parent = _doc([{
+        "name": "deny-shell", "action": "deny",
+        "condition": {"and": [
+            {"field": "x", "operator": "in", "value": []},
+            {"field": "tool", "operator": "eq", "value": "shell"},
+        ]},
+    }])
+    child = _doc([{
+        "name": "allow-shell", "action": "allow", "priority": 100,
+        "condition": {"field": "tool", "operator": "eq", "value": "shell"},
+    }])
+    names = [r["name"] for r in merge_documents([parent, child])]
+    assert "deny-shell" in names
+    assert "allow-shell" not in names
+
+
+def test_conditions_overlap_identical_conditions() -> None:
+    # Sanity guard for the `_condition_key` fast-path (non-identical-dict cases
+    # are covered by the merge_documents tests above).
+    cond = {"field": "tool", "operator": "eq", "value": "shell"}
+    assert _conditions_overlap(dict(cond), dict(cond)) is True


### PR DESCRIPTION
Addresses the `manifest_resolution/merge.py` findings from the robustness review #3137 (per @imran-siddique's request to track fixes as separate per-file PRs).

## Unhandled `TypeError` on non-numeric `priority`

`merge_documents` sorts with `key=lambda r: r.get("priority", 0)`. `.get(...,
0)` only substitutes `0` when the key is **absent** — an explicit `priority:
null` (→ `None`) or a typo (`priority: high` → `str`) reaches the sort and
raises a bare `TypeError` comparing against ints. That is not a `ResolutionError`,
so it escapes the documented contract and may surface as a crash instead of a
fail-closed deny (ADR-0013).

**Fix:** validate `priority` as numeric (non-bool `int`/`float`) in the upfront
rule-validation loop and raise `ResolutionError.invalid_governance` otherwise.

## Deny-immutability hardening (ADR-0014)

`_conditions_disjoint` short-circuits to "disjoint" when **either** side is
classified unsatisfiable. Because the parent **deny** condition is the `left`
operand on the deny-immutability path, a false positive in the unsatisfiability
heuristic would declare the parent deny disjoint from a child `allow`, so
`_conditions_overlap` returns `False` and the child allow is kept — silently
neutralising a parent deny.

**Fix:** `_conditions_overlap` (used only by the deny-immutability check) now
passes `ignore_left_unsatisfiable=True`, so the parent (left) side's
unsatisfiability classification can never establish "no overlap". The child
(right) side's unsatisfiability is still honored (an unsatisfiable child allow
never fires, so it overrides nothing).

### Honest scope note

`_condition_unsatisfiable` looks sound today (its `and`/`or`/`in []` cases all
classify only genuinely-unsatisfiable conditions, and a genuinely-unsatisfiable
deny is inert), so I could not exhibit a concrete exploitable fail-open — the
empty-`or` repro from the review is an inert deny, not a true neutralisation.
This change is therefore **defensive hardening**: it removes the structural
dependence of a security-critical check on the heuristic being false-positive
free. For sound classifications it is behavior-preserving and only ever more
conservative (stronger deny immutability), as the regression tests confirm.
Happy to drop it if maintainers prefer to keep merge semantics untouched.

## Tests

Adds `tests/test_merge_deny.py`: non-numeric `priority` → `ResolutionError`,
priority sort ordering, and deny-immutability behavior (overlapping child allow
dropped, disjoint child allow survives, satisfiable compound parent deny still
protects).

Verified locally against real OPA 0.70.0 (WSL):

```
platform linux -- Python 3.13.14, pytest-9.0.3
tests/test_merge_deny.py + tests/test_manifest_resolution.py + tests/scenarios/
======================== 195 passed in 3.53s ========================
```

Refs #3137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
