### PR TITLE
fix(iatp): declare cryptography as a runtime dependency

### DIFF
--- a/agent-governance-python/agent-os/modules/iatp/pyproject.toml
+++ b/agent-governance-python/agent-os/modules/iatp/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "python-dateutil>=2.8.2,<3.0",
     "agentmesh-primitives>=4.1.0,<5.0",
     "click>=8.0.0,<9.0",
+    "cryptography>=42.0.0,<50.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

#3133 (`6d92588a`) made `iatp/attestation.py:_verify_signature` fail closed (return `False`) when the `cryptography` library is not importable. The library is not declared in this package's runtime dependencies, so a default `pip install agent-governance-toolkit-trust-protocol` rejects every signed attestation when `verify_signature=True`.

## Change

Add `cryptography>=42.0.0,<50.0` to `[project].dependencies` in `agent-os/modules/iatp/pyproject.toml`. Lower bound matches the floor used by agent-mesh; upper bound matches the repo-wide ceiling from #3070.

## Verification

`iatp/tests/test_ed25519_attestation.py::test_verification_fails_closed_without_crypto_library` (added in #3133) covers the fail-closed path; with this dependency declared, the normal verification path is reachable on a default install.

Blocks the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)