### PR TITLE
fix(ci): stop skipping npm test in build-npm due to pipefail SIGPIPE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1052,7 +1052,10 @@ jobs:
         shell: bash
         run: |
           if node -e "const fs=require('node:fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); process.exit(pkg.scripts && pkg.scripts.test ? 0 : 1)"; then
-            if find . -type f \( -name "*.test.ts" -o -name "*.spec.ts" -o -name "*.test.tsx" -o -name "*.spec.tsx" -o -name "*.test.js" -o -name "*.spec.js" -o -name "*.test.mjs" -o -name "*.spec.mjs" -o -name "*.test.cjs" -o -name "*.spec.cjs" \) | grep -q .; then
+            # `-print -quit` makes find exit cleanly after the first match. Without it,
+            # under `bash -o pipefail` the early-exit of `grep -q` SIGPIPEs find (exit 141)
+            # and the pipeline is treated as false, so npm test was being skipped.
+            if find . -type f \( -name "*.test.ts" -o -name "*.spec.ts" -o -name "*.test.tsx" -o -name "*.spec.tsx" -o -name "*.test.js" -o -name "*.spec.js" -o -name "*.test.mjs" -o -name "*.spec.mjs" -o -name "*.test.cjs" -o -name "*.spec.cjs" \) -print -quit | grep -q .; then
               npm test
             else
               echo "No test files found"


### PR DESCRIPTION
## Problem

The `Test ${{ matrix.name }}` step in the `build-npm` job detects test files with `find ... | grep -q .`. GitHub Actions runs `shell: bash` with `-eo pipefail`. When `grep -q` matches it exits immediately and closes the pipe; `find` receives SIGPIPE on its next write and exits 141. Under `pipefail` the pipeline status is the failed `find`, so the `if` is false, the job logs `No test files found`, and reports green without running `npm test`.

The TypeScript test suite has not been running in CI for any matrix package that has more than one matching test file. Found while reviewing #3151, where the CI log showed `No test files found` for `agent-governance-typescript` despite the package having tests.

## Change

Add `-print -quit` to the `find` so it prints the first match and exits cleanly (status 0), making the pipeline 0|0 and restoring the `npm test` path. Single occurrence in the file. Inline comment added explaining the pipefail interaction.

## Verification

```bash
set -o pipefail
# before: exits 141 when >1 file matches
find agent-governance-typescript -name '*.test.ts' | grep -q .; echo $?
# after: exits 0
find agent-governance-typescript -name '*.test.ts' -print -quit | grep -q .; echo $?
```

Blocks the next release; CI green on TS packages is currently not test evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)