### PR TITLE
fix(amb): replace deprecated Pydantic json_encoders with field_serializer

### DIFF
--- a/agent-governance-python/agent-os/modules/amb/amb_core/cloudevents.py
+++ b/agent-governance-python/agent-os/modules/amb/amb_core/cloudevents.py
@@ -23,7 +23,7 @@ Example:
 
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Union
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import BaseModel, Field, field_validator, ConfigDict, field_serializer
 import json
 import uuid
 
@@ -134,11 +134,18 @@ class CloudEvent(BaseModel):
     )
     
     model_config = ConfigDict(
-        json_encoders={
-            datetime: lambda v: v.isoformat() if v else None
-        },
         extra="allow",  # Allow additional extension attributes
     )
+
+    @field_serializer('time', when_used='json')
+    def _serialize_time(self, value: Optional[datetime]) -> Optional[str]:
+        """Serialize event time to an ISO 8601 string in JSON output.
+
+        Replaces the deprecated Pydantic v1 ``json_encoders`` config. Scoped to
+        ``when_used='json'`` so ``model_dump()`` (Python mode) keeps the native
+        ``datetime`` object, matching the previous behaviour.
+        """
+        return value.isoformat() if value else None
     
     @field_validator('specversion')
     @classmethod

--- a/agent-governance-python/agent-os/modules/amb/amb_core/models.py
+++ b/agent-governance-python/agent-os/modules/amb/amb_core/models.py
@@ -5,7 +5,7 @@
 from enum import Enum, IntEnum
 from typing import Any, Dict, Optional
 from datetime import datetime, timezone
-from pydantic import BaseModel, Field, ConfigDict, field_validator
+from pydantic import BaseModel, Field, ConfigDict, field_validator, field_serializer
 
 
 class MessagePriority(IntEnum):
@@ -84,11 +84,18 @@ class Message(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     
     model_config = ConfigDict(
-        json_encoders={
-            datetime: lambda v: v.isoformat()
-        },
         populate_by_name=True,  # Allow both 'ttl' and 'ttl_seconds'
     )
+
+    @field_serializer('timestamp', when_used='json')
+    def _serialize_timestamp(self, value: datetime) -> str:
+        """Serialize timestamp to an ISO 8601 string in JSON output.
+
+        Replaces the deprecated Pydantic v1 ``json_encoders`` config. Scoped to
+        ``when_used='json'`` so ``model_dump()`` (Python mode) keeps the native
+        ``datetime`` object, matching the previous behaviour.
+        """
+        return value.isoformat()
     
     @field_validator('priority', mode='before')
     @classmethod


### PR DESCRIPTION
## Summary

We had to pin a pydantic version because we're using a now deprecated json encoder from an earlier version. This PR is to replace the deprecated Pydantic v1 `json_encoders` ConfigDict option in `amb_core.Message` and `amb_core.CloudEvent` with `@field_serializer(..., when_used='json')`. This silences the `PydanticDeprecatedSince20: json_encoders is deprecated` warning emitted on every `import agentmesh` and takes the code off Pydantic's v3 removal path, with no change to serialized output.

## Problem

Importing `agentmesh` emits `PydanticDeprecatedSince20: json_encoders is deprecated`. The warning is reachable through `agentmesh.governance.conflict_resolution` (a backward-compat shim) which imports `agent_os`, which imports `amb_core`. The traceback (with `PydanticDeprecatedSince20` promoted to an error) terminates in `amb_core/models.py`. `agentmesh` itself contains no `json_encoders`; `amb_core` is the true source. It works today because the repo pins `pydantic<3`, but it is a maintenance landmine and adds import-time noise.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agent-os/modules/amb/amb_core/models.py` | Drop `json_encoders` from `Message.model_config`; add `@field_serializer('timestamp', when_used='json')` returning `value.isoformat()` |
| `agent-governance-python/agent-os/modules/amb/amb_core/cloudevents.py` | Drop `json_encoders` from `CloudEvent.model_config`; add `@field_serializer('time', when_used='json')` returning `value.isoformat() if value else None` |

### Why `field_serializer` and not just deleting `json_encoders`

Pydantic v2's default datetime serializer emits UTC as `...Z`, but the old `.isoformat()` encoder emits `...+00:00`. Simply deleting the encoder would silently change the serialized `timestamp`/`time` of every AMB Message and CloudEvent on the wire. The field serializer reproduces `+00:00` exactly. `when_used='json'` preserves the other half of the old semantics: `model_dump()` / `to_dict()` (Python mode) still return native `datetime` objects.

## Testing

- All 103 amb tests pass: `pytest tests/` run with `-W error::pydantic.PydanticDeprecatedSince20` (so any residual `json_encoders` in exercised paths would fail the run).
- Behavior equivalence verified by before/after capture:
  - `Message.timestamp` and `CloudEvent.time` still emit `2023-01-02T03:04:05.123456+00:00`.
  - Nested datetimes inside `payload`/`data` dicts still emit `...Z` (the type-based encoder never covered these).
  - `CloudEvent(time=None)` still emits `"time":null`.
  - `model_dump()` still returns native `datetime` objects.
- End-to-end: importing `agentmesh` with the patched `amb_core` yields 0 `json_encoders` warnings (previously fired twice).

### Out of scope

`CloudEventBatch.to_json` raises `TypeError` when a `datetime` is nested inside `data`; reproduced on unpatched `main`, so it is pre-existing and unrelated.
