### PR TITLE
fix: remove unsafe classifier cache and honor falsy ring/risk overrides

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
@@ -13,6 +13,10 @@ from dataclasses import dataclass
 
 from hypervisor.models import ActionDescriptor, ExecutionRing, ReversibilityLevel
 
+# A classification is fully determined by these four fields, so they form the
+# cache key. See ActionClassifier.classify for why action_id alone is unsafe.
+_CacheKey = tuple[str, ExecutionRing, float, ReversibilityLevel]
+
 
 @dataclass
 class ClassificationResult:
@@ -36,17 +40,54 @@ class ActionClassifier:
     - Read-only operations → Ring 3
     """
 
+    # The cache is keyed on the full classification fingerprint rather than on
+    # action_id alone. action_id is not unique to a behaviour: distinct actions
+    # (e.g. a read-only fetch and a destructive admin op) can legitimately share
+    # a stable tool id. Keying on the fields that fully determine the result
+    # guarantees a cache hit only when the produced classification is identical,
+    # so a privilege escalation can never be masked by a stale low-risk entry.
     def __init__(self) -> None:
-        self._cache: dict[str, ClassificationResult] = {}
+        self._cache: dict[_CacheKey, ClassificationResult] = {}
         self._overrides: dict[str, ClassificationResult] = {}
 
+    @staticmethod
+    def _cache_key(action: ActionDescriptor) -> _CacheKey:
+        """Build the fingerprint that fully determines an action's classification."""
+        return (
+            action.action_id,
+            action.required_ring,
+            action.risk_weight,
+            action.reversibility,
+        )
+
+    def _cached_for_id(self, action_id: str) -> ClassificationResult | None:
+        """Return the most recently cached result for ``action_id``, if any.
+
+        Used by overrides, which are keyed on action_id rather than on the full
+        fingerprint. When multiple attribute variants share an id, the latest is
+        returned.
+        """
+        latest: ClassificationResult | None = None
+        for result in self._cache.values():
+            if result.action_id == action_id:
+                latest = result
+        return latest
+
     def classify(self, action: ActionDescriptor) -> ClassificationResult:
-        """Classify an action and cache the result."""
+        """Classify an action and cache the result.
+
+        The cache key is the action's classification fingerprint, not its
+        action_id, so two actions sharing an id but differing in privilege are
+        classified independently. Callers do not need to call ``clear_cache()``
+        to avoid stale results after an action's attributes change.
+        """
         if action.action_id in self._overrides:
             return self._overrides[action.action_id]
 
-        if action.action_id in self._cache:
-            return self._cache[action.action_id]
+        key = self._cache_key(action)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
 
         result = ClassificationResult(
             action_id=action.action_id,
@@ -54,7 +95,7 @@ class ActionClassifier:
             risk_weight=action.risk_weight,
             reversibility=action.reversibility,
         )
-        self._cache[action.action_id] = result
+        self._cache[key] = result
         return result
 
     def set_override(
@@ -64,7 +105,7 @@ class ActionClassifier:
         risk_weight: float | None = None,
     ) -> None:
         """Set a session-level override for action classification."""
-        existing = self._cache.get(action_id)
+        existing = self._cached_for_id(action_id)
         self._overrides[action_id] = ClassificationResult(
             action_id=action_id,
             ring=ring or (existing.ring if existing else ExecutionRing.RING_3_SANDBOX),
@@ -74,5 +115,10 @@ class ActionClassifier:
         )
 
     def clear_cache(self) -> None:
-        """Clear classification cache (e.g., on manifest update)."""
+        """Clear the classification cache.
+
+        No longer required for correctness: results are keyed on the action's
+        classification fingerprint, so changed attributes produce a new entry
+        automatically. Use this only to bound memory (e.g. on manifest reload).
+        """
         self._cache.clear()

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
@@ -13,10 +13,6 @@ from dataclasses import dataclass
 
 from hypervisor.models import ActionDescriptor, ExecutionRing, ReversibilityLevel
 
-# A classification is fully determined by these four fields, so they form the
-# cache key. See ActionClassifier.classify for why action_id alone is unsafe.
-_CacheKey = tuple[str, ExecutionRing, float, ReversibilityLevel]
-
 
 @dataclass
 class ClassificationResult:
@@ -38,67 +34,36 @@ class ActionClassifier:
     - No Undo_API + destructive → non-reversible → Ring 1 minimum
     - Config/admin operations → Ring 0
     - Read-only operations → Ring 3
+
+    Classification is a pure function of the action's attributes, so results
+    are not cached. action_id is not unique to a behaviour: distinct actions
+    (e.g. a read-only fetch and a destructive admin op) can legitimately share
+    a stable tool id, so caching on it risked leaking one action's
+    ring/risk_weight label to a different action that reused its id. Computing
+    the result on each call removes that hazard; session-level overrides are
+    the only retained state.
     """
 
-    # The cache is keyed on the full classification fingerprint rather than on
-    # action_id alone. action_id is not unique to a behaviour: distinct actions
-    # (e.g. a read-only fetch and a destructive admin op) can legitimately share
-    # a stable tool id. Keying on the fields that fully determine the result
-    # guarantees a cache hit only when the produced classification is identical,
-    # so one action's ring/risk_weight label can never leak to a different action
-    # that happens to reuse its id (e.g. a destructive op inheriting a prior
-    # read-only RING_3_SANDBOX/0.2 entry, or the reverse).
     def __init__(self) -> None:
-        self._cache: dict[_CacheKey, ClassificationResult] = {}
         self._overrides: dict[str, ClassificationResult] = {}
 
-    @staticmethod
-    def _cache_key(action: ActionDescriptor) -> _CacheKey:
-        """Build the fingerprint that fully determines an action's classification."""
-        return (
-            action.action_id,
-            action.required_ring,
-            action.risk_weight,
-            action.reversibility,
-        )
-
-    def _cached_for_id(self, action_id: str) -> ClassificationResult | None:
-        """Return the most recently cached result for ``action_id``, if any.
-
-        Used by overrides, which are keyed on action_id rather than on the full
-        fingerprint. When multiple attribute variants share an id, the latest is
-        returned.
-        """
-        latest: ClassificationResult | None = None
-        for result in self._cache.values():
-            if result.action_id == action_id:
-                latest = result
-        return latest
-
     def classify(self, action: ActionDescriptor) -> ClassificationResult:
-        """Classify an action and cache the result.
+        """Classify an action.
 
-        The cache key is the action's classification fingerprint, not its
-        action_id, so two actions sharing an id but differing in privilege are
-        classified independently. Callers do not need to call ``clear_cache()``
-        to avoid stale results after an action's attributes change.
+        A session-level override for the action's id takes precedence;
+        otherwise the result is computed directly from the action's
+        attributes. Two actions sharing an id but differing in privilege are
+        classified independently.
         """
         if action.action_id in self._overrides:
             return self._overrides[action.action_id]
 
-        key = self._cache_key(action)
-        cached = self._cache.get(key)
-        if cached is not None:
-            return cached
-
-        result = ClassificationResult(
+        return ClassificationResult(
             action_id=action.action_id,
             ring=action.required_ring,
             risk_weight=action.risk_weight,
             reversibility=action.reversibility,
         )
-        self._cache[key] = result
-        return result
 
     def set_override(
         self,
@@ -108,35 +73,19 @@ class ActionClassifier:
     ) -> None:
         """Set a session-level override for action classification.
 
-        The override is keyed on ``action_id`` and takes precedence over the
-        fingerprint cache, so it applies to EVERY action sharing this id
-        regardless of attributes. Unspecified ``ring``/``risk_weight`` inherit
-        from the most recent cached classification of this id (or
-        RING_3_SANDBOX/0.5 if none); when an id has multiple privilege variants
-        that inherited value is necessarily one of them. Pass both ``ring`` and
-        ``risk_weight`` to pin a precise result rather than inherit.
+        The override is keyed on ``action_id`` and takes precedence over
+        attribute-based classification, so it applies to EVERY action sharing
+        this id. Unspecified ``ring``/``risk_weight`` fall back to
+        RING_3_SANDBOX/0.5 and ``reversibility`` is always ``NONE``; pass both
+        ``ring`` and ``risk_weight`` to pin a precise result.
         """
-        existing = self._cached_for_id(action_id)
         self._overrides[action_id] = ClassificationResult(
             action_id=action_id,
             # Guard with `is not None`, not `or`: ExecutionRing.RING_0_ROOT == 0
             # and risk_weight 0.0 are falsy, so `x or default` would silently
             # drop a deliberate Ring 0 / zero-risk pin back to the default.
-            ring=ring if ring is not None else (existing.ring if existing else ExecutionRing.RING_3_SANDBOX),
-            risk_weight=(
-                risk_weight
-                if risk_weight is not None
-                else (existing.risk_weight if existing else 0.5)
-            ),
-            reversibility=existing.reversibility if existing else ReversibilityLevel.NONE,
+            ring=ring if ring is not None else ExecutionRing.RING_3_SANDBOX,
+            risk_weight=risk_weight if risk_weight is not None else 0.5,
+            reversibility=ReversibilityLevel.NONE,
             confidence=0.9,  # overrides have slightly lower confidence
         )
-
-    def clear_cache(self) -> None:
-        """Clear the classification cache.
-
-        No longer required for correctness: results are keyed on the action's
-        classification fingerprint, so changed attributes produce a new entry
-        automatically. Use this only to bound memory (e.g. on manifest reload).
-        """
-        self._cache.clear()

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
@@ -45,7 +45,9 @@ class ActionClassifier:
     # (e.g. a read-only fetch and a destructive admin op) can legitimately share
     # a stable tool id. Keying on the fields that fully determine the result
     # guarantees a cache hit only when the produced classification is identical,
-    # so a privilege escalation can never be masked by a stale low-risk entry.
+    # so one action's ring/risk_weight label can never leak to a different action
+    # that happens to reuse its id (e.g. a destructive op inheriting a prior
+    # read-only RING_3_SANDBOX/0.2 entry, or the reverse).
     def __init__(self) -> None:
         self._cache: dict[_CacheKey, ClassificationResult] = {}
         self._overrides: dict[str, ClassificationResult] = {}
@@ -108,8 +110,15 @@ class ActionClassifier:
         existing = self._cached_for_id(action_id)
         self._overrides[action_id] = ClassificationResult(
             action_id=action_id,
-            ring=ring or (existing.ring if existing else ExecutionRing.RING_3_SANDBOX),
-            risk_weight=risk_weight or (existing.risk_weight if existing else 0.5),
+            # Guard with `is not None`, not `or`: ExecutionRing.RING_0_ROOT == 0
+            # and risk_weight 0.0 are falsy, so `x or default` would silently
+            # drop a deliberate Ring 0 / zero-risk pin back to the default.
+            ring=ring if ring is not None else (existing.ring if existing else ExecutionRing.RING_3_SANDBOX),
+            risk_weight=(
+                risk_weight
+                if risk_weight is not None
+                else (existing.risk_weight if existing else 0.5)
+            ),
             reversibility=existing.reversibility if existing else ReversibilityLevel.NONE,
             confidence=0.9,  # overrides have slightly lower confidence
         )

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py
@@ -106,7 +106,16 @@ class ActionClassifier:
         ring: ExecutionRing | None = None,
         risk_weight: float | None = None,
     ) -> None:
-        """Set a session-level override for action classification."""
+        """Set a session-level override for action classification.
+
+        The override is keyed on ``action_id`` and takes precedence over the
+        fingerprint cache, so it applies to EVERY action sharing this id
+        regardless of attributes. Unspecified ``ring``/``risk_weight`` inherit
+        from the most recent cached classification of this id (or
+        RING_3_SANDBOX/0.5 if none); when an id has multiple privilege variants
+        that inherited value is necessarily one of them. Pass both ``ring`` and
+        ``risk_weight`` to pin a precise result rather than inherit.
+        """
         existing = self._cached_for_id(action_id)
         self._overrides[action_id] = ClassificationResult(
             action_id=action_id,

--- a/agent-governance-python/agent-hypervisor/tests/test_classifier.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_classifier.py
@@ -34,7 +34,6 @@ class TestClassificationResult:
 class TestActionClassifier:
     def test_init(self):
         classifier = ActionClassifier()
-        assert classifier._cache == {}
         assert classifier._overrides == {}
 
     def test_classify_read_only(self):
@@ -85,17 +84,19 @@ class TestActionClassifier:
         result = classifier.classify(action)
         assert result.ring == ExecutionRing.RING_2_STANDARD
 
-    def test_classify_caches_result(self):
+    def test_classify_is_deterministic(self):
         classifier = ActionClassifier()
         action = ActionDescriptor(
-            action_id="act-cache",
-            name="Cached",
+            action_id="act-stable",
+            name="Stable",
             execute_api="/api/x",
             is_read_only=True,
         )
         r1 = classifier.classify(action)
         r2 = classifier.classify(action)
-        assert r1 is r2
+        # Classification is a pure function of the action's attributes, so
+        # repeated calls produce equal results (no cached state required).
+        assert r1 == r2
 
     def test_classify_shared_id_does_not_mask_privilege_escalation(self):
         """Two actions sharing an action_id but differing in privilege must be
@@ -149,8 +150,6 @@ class TestActionClassifier:
             execute_api="/api/t",
             is_read_only=True,
         )
-        # Classify first to populate cache
-        classifier.classify(action)
         classifier.set_override(
             "overridden",
             ring=ExecutionRing.RING_1_PRIVILEGED,
@@ -161,7 +160,7 @@ class TestActionClassifier:
         assert result.risk_weight == 0.9
         assert result.confidence == 0.9
 
-    def test_set_override_without_cache(self):
+    def test_set_override_for_unclassified_action(self):
         classifier = ActionClassifier()
         classifier.set_override("unknown-action", ring=ExecutionRing.RING_1_PRIVILEGED)
         action = ActionDescriptor(
@@ -202,26 +201,7 @@ class TestActionClassifier:
         )
         assert classifier.classify(action).risk_weight == 0.0
 
-    def test_clear_cache(self):
-        classifier = ActionClassifier()
-        action = ActionDescriptor(
-            action_id="cached-act",
-            name="X",
-            execute_api="/api/x",
-            is_read_only=True,
-        )
-        classifier.classify(action)
-        assert any(key[0] == "cached-act" for key in classifier._cache)
-        classifier.clear_cache()
-        assert classifier._cache == {}
-
-    def test_clear_cache_does_not_clear_overrides(self):
-        classifier = ActionClassifier()
-        classifier.set_override("act-o", ring=ExecutionRing.RING_0_ROOT)
-        classifier.clear_cache()
-        assert "act-o" in classifier._overrides
-
-    def test_override_takes_precedence_over_cache(self):
+    def test_override_takes_precedence_over_classification(self):
         classifier = ActionClassifier()
         action = ActionDescriptor(
             action_id="act-p",
@@ -229,7 +209,6 @@ class TestActionClassifier:
             execute_api="/api/x",
             is_read_only=True,
         )
-        classifier.classify(action)
         classifier.set_override("act-p", ring=ExecutionRing.RING_1_PRIVILEGED, risk_weight=1.0)
         result = classifier.classify(action)
         assert result.ring == ExecutionRing.RING_1_PRIVILEGED

--- a/agent-governance-python/agent-hypervisor/tests/test_classifier.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_classifier.py
@@ -97,6 +97,39 @@ class TestActionClassifier:
         r2 = classifier.classify(action)
         assert r1 is r2
 
+    def test_classify_shared_id_does_not_mask_privilege_escalation(self):
+        """Two actions sharing an action_id but differing in privilege must be
+        classified independently. Regression for the cache keying on action_id
+        alone, which let an admin/destructive action inherit a prior read-only
+        RING_3_SANDBOX result for the same id.
+        """
+        classifier = ActionClassifier()
+        read_only = ActionDescriptor(
+            action_id="same",
+            name="Read",
+            execute_api="/api/read",
+            reversibility=ReversibilityLevel.FULL,
+            is_read_only=True,
+        )
+        admin = ActionDescriptor(
+            action_id="same",
+            name="Admin",
+            execute_api="/api/admin",
+            is_admin=True,
+        )
+
+        read_result = classifier.classify(read_only)
+        admin_result = classifier.classify(admin)
+
+        assert read_result.ring == ExecutionRing.RING_3_SANDBOX
+        assert read_result.risk_weight == ReversibilityLevel.FULL.default_risk_weight
+        # The admin action is NOT served the cached low-risk entry.
+        assert admin_result.ring == ExecutionRing.RING_0_ROOT
+        assert admin_result.risk_weight == ReversibilityLevel.NONE.default_risk_weight
+        # Re-classifying either action still returns its own correct entry.
+        assert classifier.classify(read_only).ring == ExecutionRing.RING_3_SANDBOX
+        assert classifier.classify(admin).ring == ExecutionRing.RING_0_ROOT
+
     def test_classify_risk_weight_from_reversibility(self):
         classifier = ActionClassifier()
         action = ActionDescriptor(
@@ -149,7 +182,7 @@ class TestActionClassifier:
             is_read_only=True,
         )
         classifier.classify(action)
-        assert "cached-act" in classifier._cache
+        assert any(key[0] == "cached-act" for key in classifier._cache)
         classifier.clear_cache()
         assert classifier._cache == {}
 

--- a/agent-governance-python/agent-hypervisor/tests/test_classifier.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_classifier.py
@@ -173,6 +173,35 @@ class TestActionClassifier:
         assert result.ring == ExecutionRing.RING_1_PRIVILEGED
         assert result.confidence == 0.9
 
+    def test_set_override_to_ring_zero_is_respected(self):
+        """RING_0_ROOT == 0 is falsy; the override must still pin Ring 0 instead
+        of falling through to the RING_3_SANDBOX default. Pinning the MOST
+        privileged ring silently downgrading to the LEAST is a security bug.
+        """
+        classifier = ActionClassifier()
+        classifier.set_override("danger", ring=ExecutionRing.RING_0_ROOT)
+        action = ActionDescriptor(
+            action_id="danger",
+            name="Danger",
+            execute_api="/api/danger",
+            is_read_only=True,
+        )
+        assert classifier.classify(action).ring == ExecutionRing.RING_0_ROOT
+
+    def test_set_override_risk_weight_zero_is_respected(self):
+        """risk_weight 0.0 is falsy but must be honoured, not coerced to 0.5."""
+        classifier = ActionClassifier()
+        classifier.set_override(
+            "safe", ring=ExecutionRing.RING_3_SANDBOX, risk_weight=0.0
+        )
+        action = ActionDescriptor(
+            action_id="safe",
+            name="Safe",
+            execute_api="/api/safe",
+            is_read_only=True,
+        )
+        assert classifier.classify(action).risk_weight == 0.0
+
     def test_clear_cache(self):
         classifier = ActionClassifier()
         action = ActionDescriptor(

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_rings.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_rings.py
@@ -114,16 +114,16 @@ class TestActionClassifier:
         assert result.ring == ExecutionRing.RING_1_PRIVILEGED
         assert result.risk_weight == 0.95
 
-    def test_cache_hit(self):
+    def test_classify_is_deterministic(self):
         action = ActionDescriptor(
-            action_id="cached",
-            name="Cached",
-            execute_api="/cached",
+            action_id="stable",
+            name="Stable",
+            execute_api="/stable",
             reversibility=ReversibilityLevel.PARTIAL,
         )
         r1 = self.classifier.classify(action)
         r2 = self.classifier.classify(action)
-        assert r1 is r2  # same object from cache
+        assert r1 == r2  # pure function of attributes; no cached state
 
     def test_override(self):
         action = ActionDescriptor(


### PR DESCRIPTION
## Summary

`ActionClassifier` had two bugs. (1) It memoized ring classifications keyed only on `action_id`, but an `action_id` is stable per tool and not unique per behaviour, so two different actions sharing an id collapsed to one cache entry and the second inherited the first's `ring`/`risk_weight` label (e.g. a destructive `is_admin` op served a prior read-only `RING_3_SANDBOX/0.2` entry, or the reverse). (2) `set_override` used `or`-style defaults, which silently dropped a deliberate Ring 0 / zero-risk pin because both are falsy.

This PR removes the cache entirely (rather than re-keying it) and fixes the falsy-default override.

## Problem

- `classify()` cached on `action.action_id` alone. Classify a read-only action (id `"same"`), then an admin action with the **same** id, and the second returned the cached `RING_3_SANDBOX/0.2` instead of `RING_0_ROOT/0.95`. Reproduced against `main`.
- `set_override()` used `ring or default` / `risk_weight or default`. Because `ExecutionRing.RING_0_ROOT == 0` and `0.0` are falsy, an operator pinning an action to Ring 0 (most scrutiny) or risk `0.0` silently got the `RING_3_SANDBOX` / `0.5` default. Reproduced.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agent-hypervisor/src/hypervisor/rings/classifier.py` | Remove the cache entirely (`_cache`, `_cache_key`, `_cached_for_id`, the `_CacheKey` alias, and the public `clear_cache()`). `classify()` is now a pure function of the action's attributes, so the action_id collision cannot occur by construction. Fix `set_override` to guard defaults with `is not None` (respect Ring 0 / risk 0.0); unspecified `ring`/`risk_weight` fall back to `RING_3_SANDBOX`/`0.5` and `reversibility` is always `NONE`. |
| `agent-governance-python/agent-hypervisor/tests/test_classifier.py` | Keep `test_classify_shared_id_does_not_mask_privilege_escalation`, `test_set_override_to_ring_zero_is_respected`, `test_set_override_risk_weight_zero_is_respected`. Convert the cache-identity test to a value-equality determinism check; remove the `clear_cache` tests. |
| `agent-governance-python/agent-hypervisor/tests/unit/test_rings.py` | Convert `test_cache_hit` (identity assertion) to a determinism check. |

### Why remove rather than re-key

After keying the cache on the full classification fingerprint `(action_id, required_ring, risk_weight, reversibility)`, the cached value carried those same four fields, so a hit only saved one dataclass allocation while the dict grew unbounded per distinct tuple. Removal is the simpler fix, eliminates the collision by construction, and drops the insertion-order-dependent `set_override` inherit path. `clear_cache()`/`set_override` have no production callers (only tests), and `classify()` is not on this package's own enforcement path.

This single source file is force-included verbatim into both the `agent-hypervisor` and `agent-governance-toolkit-core` wheels, so one edit fixes both packages. No public method signatures change (only the no-longer-needed `clear_cache()` is removed).

## Scope / reachability note

`ActionClassifier` is exported public API (`hypervisor.__all__`) and is constructed on the `Hypervisor` core, but `classify()` is **not** currently called by this package's own enforcement path (core uses `ring_enforcer.compute_ring(eff_score)`). This is therefore a correctness fix for the exported classifier API and external consumers, not a fix to a live internal escalation. `RING_3_SANDBOX` is the least-privileged ring, so internal enforcement would fail closed on an under-ringed action; the real risk is a wrong ring/risk label feeding downstream trust/elevation scoring.

## Testing

- `tests/test_classifier.py` + `tests/unit/test_rings.py`: 25 passed.
- Full hypervisor suite (`PYTHONPATH=src python -m pytest tests/ -q`): 806 passed, 60 skipped.
- `ruff check --select E,F,W --ignore E501` on the changed files: clean.
- Regression confirmed: the shared-id test fails on `main` (admin -> `RING_3_SANDBOX/0.2`) and passes on this branch. The falsy-zero repro returns `RING_0_ROOT` after the fix (was `RING_3_SANDBOX`).

Tests run with `PYTHONPATH=src` because the installed wheel is a stale build artifact that would otherwise shadow the edited source.
