### PR TITLE
fix(capability): reject narrow grants satisfying broad capability checks

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
@@ -118,8 +118,6 @@ class CapabilityGrant(BaseModel):
             # "read" matching "readwrite:secret". Require the granted
             # capability to be a colon-delimited prefix of the requested one.
             pass
-        elif self.capability == requested:
-            pass
         else:
             # Fall back to component matching. parse_capability raises
             # ValueError on inputs that don't contain a colon (e.g.
@@ -365,7 +363,27 @@ class CapabilityRegistry:
 
         if require_grantor_capability:
             grantor_scope = self._scopes.get(from_agent)
-            if grantor_scope is None or not grantor_scope.has_capability(capability):
+            if grantor_scope is None:
+                raise PermissionError(
+                    f"Grantor {from_agent} does not hold capability {capability!r}"
+                )
+            if resource_ids:
+                # The grant is resource-scoped, so the grantor must hold the
+                # capability for each requested resource. Checking without a
+                # resource_id would wrongly reject a grantor whose own grant
+                # is scoped to exactly these resources (the unscoped
+                # has_capability() now fails closed on resource-scoped grants).
+                missing = [
+                    r
+                    for r in resource_ids
+                    if not grantor_scope.has_capability(capability, resource_id=r)
+                ]
+                if missing:
+                    raise PermissionError(
+                        f"Grantor {from_agent} does not hold capability "
+                        f"{capability!r} for resources {missing}"
+                    )
+            elif not grantor_scope.has_capability(capability):
                 raise PermissionError(
                     f"Grantor {from_agent} does not hold capability {capability!r}"
                 )

--- a/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py
@@ -134,13 +134,24 @@ class CapabilityGrant(BaseModel):
                 return False
             if self.resource != "*" and self.resource != req_resource:
                 return False
-            if req_qualifier and self.qualifier:
-                if self.qualifier != "*" and self.qualifier != req_qualifier:
+            if self.qualifier is not None and self.qualifier != "*":
+                # This grant is scoped to a specific qualifier, so it
+                # only satisfies a request for that exact qualifier. A
+                # request that omits the qualifier (req_qualifier is
+                # None) is broader than the grant and must NOT be
+                # authorized by it. Otherwise a narrow grant (e.g.
+                # "write:database:table_users") would satisfy a broad
+                # check (e.g. "write:database"), a privilege escalation.
+                if req_qualifier != self.qualifier:
                     return False
 
-        # Check resource ID if scoped
-        if self.resource_ids and resource_id:
-            if resource_id not in self.resource_ids:
+        # Check resource ID scope. A grant restricted to specific
+        # resource_ids must not satisfy a check that omits resource_id
+        # (broader than the grant) nor one naming a resource outside the
+        # set. Only an unrestricted grant (empty resource_ids) matches
+        # regardless of resource_id.
+        if self.resource_ids:
+            if resource_id is None or resource_id not in self.resource_ids:
                 return False
 
         return True

--- a/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
+++ b/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
@@ -1311,6 +1311,39 @@ class TestCapabilityRegistry:
         assert reg.check("did:mesh:1", "read:db", resource_id="r2") is False
         assert reg.check("did:mesh:1", "read:db") is False
 
+    def test_resource_scoped_grantor_can_delegate_own_scope(self):
+        # A grantor whose own grant is scoped to ["r1"] must be able to
+        # sub-delegate read:db on ["r1"], but not on a resource it does
+        # not hold, and not as an unscoped grant.
+        reg = CapabilityRegistry()
+        reg.grant("read:db", "did:mesh:grantor", "did:mesh:admin", resource_ids=["r1"])
+
+        delegated = reg.grant(
+            "read:db",
+            "did:mesh:child",
+            "did:mesh:grantor",
+            resource_ids=["r1"],
+            require_grantor_capability=True,
+        )
+        assert delegated.resource_ids == ["r1"]
+
+        with pytest.raises(PermissionError):
+            reg.grant(
+                "read:db",
+                "did:mesh:child",
+                "did:mesh:grantor",
+                resource_ids=["r2"],
+                require_grantor_capability=True,
+            )
+
+        with pytest.raises(PermissionError):
+            reg.grant(
+                "read:db",
+                "did:mesh:child",
+                "did:mesh:grantor",
+                require_grantor_capability=True,
+            )
+
 
 # ---------------------------------------------------------------------------
 # trust/handshake.py

--- a/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
+++ b/agent-governance-python/agent-mesh/tests/test_coverage_boost.py
@@ -1151,6 +1151,32 @@ class TestCapabilityGrant:
         assert g.matches("read:data", resource_id="res1") is True
         assert g.matches("read:data", resource_id="res2") is False
 
+    def test_matches_narrow_qualifier_does_not_satisfy_broad_check(self):
+        # BUG-2 regression: a grant scoped to a qualifier must NOT
+        # satisfy a check that omits the qualifier (privilege escalation).
+        g = CapabilityGrant.create(
+            "write:database:table_users", "did:mesh:1", "did:mesh:0"
+        )
+        assert g.matches("write:database:table_users") is True
+        assert g.matches("write:database") is False
+
+    def test_matches_broad_grant_satisfies_narrow_qualifier_check(self):
+        # The correct direction is preserved: a broad grant DOES satisfy
+        # a narrower (more qualified) check.
+        g = CapabilityGrant.create("write:database", "did:mesh:1", "did:mesh:0")
+        assert g.matches("write:database") is True
+        assert g.matches("write:database:table_users") is True
+
+    def test_matches_resource_scoped_requires_resource_id(self):
+        # BUG-2 regression: a resource-scoped grant must NOT satisfy a
+        # check that omits resource_id (the scope is otherwise ignored).
+        g = CapabilityGrant.create(
+            "read:db", "did:mesh:1", "did:mesh:0", resource_ids=["r1"]
+        )
+        assert g.matches("read:db", resource_id="r1") is True
+        assert g.matches("read:db", resource_id="r2") is False
+        assert g.matches("read:db") is False
+
     def test_revoke(self):
         g = CapabilityGrant.create("read:data", "did:mesh:1", "did:mesh:0")
         g.revoke()
@@ -1266,6 +1292,24 @@ class TestCapabilityRegistry:
         reg.grant("read:data", "did:mesh:2", "did:mesh:0")
         agents = reg.get_agents_with_capability("read:data")
         assert len(agents) == 2
+
+    def test_check_narrow_qualifier_grant_rejects_broad_request(self):
+        # BUG-2 regression (privilege escalation): an agent granted
+        # write to one table must NOT pass a check for the whole
+        # database.
+        reg = CapabilityRegistry()
+        reg.grant("write:database:table_users", "did:mesh:1", "did:mesh:0")
+        assert reg.check("did:mesh:1", "write:database:table_users") is True
+        assert reg.check("did:mesh:1", "write:database") is False
+
+    def test_check_resource_scoped_grant_rejects_unscoped_request(self):
+        # BUG-2 regression: a grant scoped to resource_ids must NOT be
+        # authorized when the checker omits the resource_id.
+        reg = CapabilityRegistry()
+        reg.grant("read:db", "did:mesh:1", "did:mesh:0", resource_ids=["r1"])
+        assert reg.check("did:mesh:1", "read:db", resource_id="r1") is True
+        assert reg.check("did:mesh:1", "read:db", resource_id="r2") is False
+        assert reg.check("did:mesh:1", "read:db") is False
 
 
 # ---------------------------------------------------------------------------

--- a/docs/security/audits/2026-06-25-capability-scope-tightening.md
+++ b/docs/security/audits/2026-06-25-capability-scope-tightening.md
@@ -1,0 +1,98 @@
+# 2026-06-25 - Capability scope tightening (qualifier and resource_id)
+
+PR: microsoft/agent-governance-toolkit#3176
+
+## What changed and why
+
+`CapabilityGrant.matches()` in
+`agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py` is the
+authorization predicate behind `CapabilityRegistry.check()` (the decision a
+policy enforcement point calls) and `CapabilityScope.has_capability()`.
+Capabilities are strings of the form `action:resource[:qualifier]`, optionally
+narrowed by a grant's `resource_ids` list.
+
+Two clauses under-restricted authorization by treating a value the *checker*
+omitted as "match any", so a narrow grant satisfied a broader check (a privilege
+escalation):
+
+```python
+# before — qualifier only compared when BOTH sides had one
+if req_qualifier and self.qualifier:
+    if self.qualifier != "*" and self.qualifier != req_qualifier:
+        return False
+
+# before — resource scope only checked when the caller passed a resource_id
+if self.resource_ids and resource_id:
+    if resource_id not in self.resource_ids:
+        return False
+```
+
+After the fix:
+
+```python
+# a grant scoped to a specific (non-"*") qualifier requires the request to
+# name that exact qualifier; omitting it is broader than the grant
+if self.qualifier is not None and self.qualifier != "*":
+    if req_qualifier != self.qualifier:
+        return False
+
+# a grant restricted to resource_ids is denied unless the request names an
+# in-scope resource; omitting resource_id is broader than the grant
+if self.resource_ids:
+    if resource_id is None or resource_id not in self.resource_ids:
+        return False
+```
+
+Concretely: `grant("write:database:table_users")` no longer satisfies
+`check("write:database")`, and `grant("read:db", resource_ids=["r1"])` no longer
+satisfies `check("read:db")` with no `resource_id`. The dangerous part was that
+the simplest, coarsest call (the natural `check(agent, "write:database")` before
+allowing a write to any table) was the insecure one.
+
+## Threat model impact
+
+This is a **least-privilege tightening** of an authorization decision. It only
+removes permissive matches; it never grants a new match. Per the AgentMesh
+boundary "Never weaken trust thresholds — only tighten", the direction is
+correct.
+
+| Dimension | Direction |
+|---|---|
+| Authorization (escalation) | **Strengthened.** Closes the narrow-grant-satisfies-broad-check escalation for the qualifier and `resource_ids` dimensions. |
+| Correct broad→narrow direction | **Preserved.** A broad grant (`write:database`) still satisfies a narrower check (`write:database:table_users`) via the existing colon-boundary prefix branch. |
+| Fail-closed behavior | **Preserved/extended.** Malformed requests still fail closed; an omitted qualifier/resource_id is now treated as broader-than-grant and denied rather than silently allowed. |
+| Delegation guard (`grant(require_grantor_capability=True)`) | **Strengthened.** A grantor whose grant is scoped to `resource_ids` can no longer use an unscoped `has_capability()` to delegate a broader (unscoped) capability. The grant request model mints only unscoped grants, so the prior behavior was itself a scope-escalation; the new behavior fails closed. |
+| Discovery (`get_agents_with_capability`, `filter_capabilities`) | **More restrictive (intended).** A resource-scoped grant no longer counts as holding the unscoped capability in these unscoped queries. No production caller relied on the old behavior. |
+| New attack surface | **None.** No new inputs, network exposure, secrets, or trust decisions; signature of `matches()`/`check()` unchanged. |
+| Backward compatibility | A caller that relied on the permissive behavior (e.g. probing `has_capability` without a `resource_id` for a resource-scoped grant) now receives `False`. This is the intended security fix; such callers must pass the qualifier/`resource_id` explicitly. |
+
+### Known residual (out of scope, tracked separately)
+
+`CapabilityGrant.parse_capability()` truncates capabilities to three components,
+dropping everything after the second colon, so a 4+ segment grant such as
+`write:database:table_users:row_1` still escalates to its parent and siblings.
+This reproduces identically on `main` and is **not** introduced by this change;
+it lives in the parser, not the matcher. Tracked in
+microsoft/agent-governance-toolkit#3180. A correct fix changes the capability
+data model and warrants its own audited change.
+
+## Test coverage
+
+Added to `agent-governance-python/agent-mesh/tests/test_coverage_boost.py`
+(`TestCapabilityGrant` and `TestCapabilityRegistry`):
+
+| Test | Purpose |
+|---|---|
+| `test_matches_narrow_qualifier_does_not_satisfy_broad_check` | A qualifier-scoped grant matches its exact capability but NOT the unqualified parent. |
+| `test_matches_broad_grant_satisfies_narrow_qualifier_check` | The correct broad→narrow direction is preserved. |
+| `test_matches_resource_scoped_requires_resource_id` | A `resource_ids`-scoped grant matches only with an in-scope `resource_id`; omitted/out-of-scope are denied. |
+| `test_check_narrow_qualifier_grant_rejects_broad_request` | Registry-level: an agent granted write to one table fails a check for the whole database. |
+| `test_check_resource_scoped_grant_rejects_unscoped_request` | Registry-level: a resource-scoped grant is denied when the check omits `resource_id`. |
+
+These regression tests fail on `main` and pass on this branch. The existing
+capability, negative-security, and spec-conformance suites (380 + 62 tests)
+continue to pass, and the change was reviewed by a multi-lens deep code review
+(dual-model correctness, domain-semantics over a 192-case authorization truth
+table, and fit/scope/fidelity gate runs) with no reproduced blockers introduced.
+The spec at `docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md` §8.5 was updated to
+document the tightened, fail-closed scoping rules.

--- a/docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md
+++ b/docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md
@@ -821,11 +821,19 @@ The `matches()` method MUST evaluate capability matching in order:
    matches. This prevents `read` from matching `readwrite:secret`.
 4. **Component matching fallback:** Parse both capability strings and
    compare action, resource, and qualifier independently. Wildcard
-   `*` in any component matches any value. Malformed requests (no
-   colon) MUST fail closed (return false).
-5. **Resource ID scoping:** If `resource_ids` is non-empty and a
-   `resource_id` is provided, the requested resource ID MUST be
-   present in the grant's `resource_ids`.
+   `*` in any component matches any value. A grant scoped to a
+   specific (non-`*`) qualifier MUST only match a request that names
+   that exact qualifier; a request that omits the qualifier is broader
+   than the grant and MUST NOT match it (otherwise a narrow grant such
+   as `write:database:table_users` would satisfy a broad check such as
+   `write:database`). Malformed requests (no colon) MUST fail closed
+   (return false).
+5. **Resource ID scoping:** If `resource_ids` is non-empty, the grant
+   only matches a request that provides a `resource_id` present in the
+   grant's `resource_ids`. A request that omits `resource_id` is
+   broader than the grant and MUST fail closed (return false). A grant
+   with empty `resource_ids` is unscoped and matches regardless of the
+   requested `resource_id`.
 
 **[Pure Specification]**
 


### PR DESCRIPTION
## Summary

Fix a privilege-escalation under-restriction in `CapabilityGrant.matches()` (`agentmesh/trust/capability.py`): a check that omitted the qualifier or `resource_id` was treated as match-any, so a narrow grant satisfied a broad authorization check.

## Problem

`CapabilityRegistry.check()` is the decision a policy enforcement point calls. It delegates to `CapabilityScope.has_capability()` → `CapabilityGrant.matches()`. Two clauses in `matches()` only enforced scope when the *caller* supplied it:

- Qualifier: `if req_qualifier and self.qualifier:` compared qualifiers only when both were present. A grant for `write:database:table_users` therefore satisfied a check for `write:database`.
- Resource scope: `if self.resource_ids and resource_id:` skipped the scope check whenever the caller passed no `resource_id`. A grant scoped to `resource_ids=["r1"]` therefore satisfied `check(agent, "read:db")` with no resource.

The dangerous part is that the simplest, coarsest call (`check(agent, "write:database")` before allowing a write to any table) was the insecure one, silently authorized by a grant meant for a single table.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agent-mesh/src/agentmesh/trust/capability.py` | A grant with a specific (non-`*`) qualifier now requires the request to name that exact qualifier; a grant restricted to `resource_ids` is denied unless the check names an in-scope resource. Also removed an unreachable exact-match branch and made the `require_grantor_capability` delegation check per-resource. |
| `agent-governance-python/agent-mesh/tests/test_coverage_boost.py` | Grant- and registry-level regression tests for both bug scenarios, the preserved correct direction, and resource-scoped delegation. |
| `docs/specs/AGENTMESH-TRUST-COORDINATION-1.0.md` | Updated section 8.5 to document the tightened, fail-closed qualifier and resource-ID scoping rules. |
| `docs/security/audits/2026-06-25-capability-scope-tightening.md` | New security audit doc (required by the security-audit CI gate for `trust/` changes). |

## Behavior

The correct direction is unchanged: a broad grant still satisfies a narrower check (`write:database` grant satisfies `write:database:table_users`). Only the wrong direction (narrow grant satisfying a broad check) is now denied. Intended conservative side effect: a resource-scoped grant no longer satisfies unscoped queries (`has_capability`/`get_agents_with_capability`/`filter_capabilities`) that omit `resource_id`.

## Testing

- New regression tests fail on `main`, pass here.
- `pytest tests/test_coverage_boost.py tests/test_negative_security.py tests/test_spec_mesh_trust_conformance.py` -> 380 passed, no regressions.
- CI lint `ruff check --select E,F,W --ignore E501` on changed files: clean (the one pre-existing `F841` at `test_coverage_boost.py:1636` is on `main` and outside this change).

