### PR TITLE
fix(trust): populate TrustRecord timestamp in record_interaction

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/trust_types.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/trust_types.py
@@ -9,6 +9,7 @@ Import from here instead of duplicating in each integration package.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -103,6 +104,7 @@ class TrustTracker:
             action=action,
             success=success,
             trust_delta=delta,
+            timestamp=datetime.now(timezone.utc).isoformat(),
         ))
         return new_score
 

--- a/agent-governance-python/agent-mesh/tests/test_trust_types.py
+++ b/agent-governance-python/agent-mesh/tests/test_trust_types.py
@@ -167,7 +167,7 @@ class TestTrustTracker:
 
     def test_recorded_interactions_have_iso_timestamps(self) -> None:
         # BUG-4 regression: record_interaction must populate timestamp
-        # so history is orderable, decayable, and time-boundable.
+        # so history can be ordered, decayed over time, and time-bounded.
         tracker = TrustTracker()
         tracker.record_interaction("a1", "a2", "task1", success=True)
         tracker.record_interaction("a1", "a3", "task2", success=False)

--- a/agent-governance-python/agent-mesh/tests/test_trust_types.py
+++ b/agent-governance-python/agent-mesh/tests/test_trust_types.py
@@ -3,6 +3,8 @@
 """Tests for shared trust and identity types (agentmesh.trust_types)."""
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 
 from agentmesh.trust_types import (
@@ -162,6 +164,20 @@ class TestTrustTracker:
         a1_history = tracker.get_history("a1")
         assert len(a1_history) == 2
         assert all(r.agent_id == "a1" for r in a1_history)
+
+    def test_recorded_interactions_have_iso_timestamps(self) -> None:
+        # BUG-4 regression: record_interaction must populate timestamp
+        # so history is orderable, decayable, and time-boundable.
+        tracker = TrustTracker()
+        tracker.record_interaction("a1", "a2", "task1", success=True)
+        tracker.record_interaction("a1", "a3", "task2", success=False)
+        tracker.record_interaction("a1", "a4", "task3", success=True)
+        timestamps = [r.timestamp for r in tracker.get_history("a1")]
+        # No empty timestamps, and each parses as ISO-8601.
+        assert all(ts for ts in timestamps)
+        parsed = [datetime.fromisoformat(ts) for ts in timestamps]
+        # Recorded in order, so timestamps are non-decreasing.
+        assert parsed == sorted(parsed)
 
     def test_reset(self) -> None:
         tracker = TrustTracker(initial_score=0.5, reward=0.1)


### PR DESCRIPTION
## Summary

Populate `TrustRecord.timestamp` when `TrustTracker.record_interaction()` appends to history, so trust history is orderable, decayable, and time-boundable.

## Problem

`record_interaction()` constructed each `TrustRecord` without setting `timestamp`, so it fell back to the dataclass default `""`. Every record returned by `get_history()` had `timestamp == ""`. That quietly breaks anything temporal: interactions cannot be ordered, time-based trust decay has no clock, and an audit cannot be time-bounded ("what did this agent do in the last hour?"). The trust system could not reason about time using its own history.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agent-mesh/src/agentmesh/trust_types.py` | Set `timestamp=datetime.now(timezone.utc).isoformat()` when building the `TrustRecord` in `record_interaction`. |
| `agent-governance-python/agent-mesh/tests/test_trust_types.py` | Regression test: recorded interactions have non-empty, ISO-parseable, non-decreasing timestamps. |

The `TrustRecord` dataclass default stays `""`, so directly constructed records are unchanged (the existing `test_defaults` assertion still holds). Only the tracker-recorded path now carries a real timestamp.

## Testing

- Repro: three `record_interaction` calls previously yielded `['', '', '']`; now yield ISO-8601 UTC timestamps.
- `pytest tests/test_trust_types.py tests/test_trust_decay.py tests/test_trust.py` -> 99 passed.
- CI lint `ruff check --select E,F,W --ignore E501` on changed files: clean.
