### PR TITLE
feat(hypervisor): implement liability engine logic (not yet runtime-wired)

### DIFF
--- a/agent-governance-python/agent-hypervisor/docs/joint-liability-guide.md
+++ b/agent-governance-python/agent-hypervisor/docs/joint-liability-guide.md
@@ -1,6 +1,5 @@
 # Understanding Joint Liability for AI Agents
 
-> **Edition:** Public Preview APIs only.
 > Module path: `src/hypervisor/liability/`
 
 ## Table of Contents
@@ -83,9 +82,9 @@ The `VouchingEngine` enforces several safeguards (configurable via class constan
 - **Default bond percentage** (`DEFAULT_BOND_PCT = 0.20`): 20% of the voucher's σ is bonded by default.
 - **Maximum exposure** (`DEFAULT_MAX_EXPOSURE = 0.80`): A voucher cannot bond more than 80% of its σ across all active vouches.
 
-> **Public Preview note:** The Public Preview approves all vouch requests
-> and does not enforce bonding. The API surface is identical — constraints are
-> enforced in the full edition.
+These constraints are enforced: `vouch()` raises `VouchingError` on self-sponsorship, a
+voucher σ below `MIN_VOUCHER_SCORE`, a sponsorship that would create a cycle in the session's
+liability graph, or a bond that would exceed the voucher's maximum exposure.
 
 ## The Effective Score Formula
 
@@ -122,9 +121,9 @@ eff = engine.compute_eff_score(
 )
 ```
 
-> **Public Preview note:** `compute_eff_score` returns the vouchee's own
-> score (`vouchee_sigma`) without the voucher boost. The formula above is
-> applied in the full edition.
+> **Multiple vouchers:** when several agents sponsor the same vouchee, their bonds add
+> up — `compute_eff_score` returns `σ_L + ω × Σ(bonded_amount)` over all active vouchers,
+> capped at 1.0.
 
 ## Slashing: What Happens When an Agent Misbehaves
 
@@ -154,7 +153,7 @@ result = slasher.slash(
 
 print(result.slash_id)              # "penalize:<uuid>"
 print(result.vouchee_sigma_before)  # 0.72
-print(result.vouchee_sigma_after)   # Reduced (full edition)
+print(result.vouchee_sigma_after)   # 0.0 — vouchee blacklisted
 print(result.voucher_clips)         # List of VoucherClip records
 print(result.reason)                # "behavioral_drift"
 ```
@@ -166,9 +165,10 @@ print(result.reason)                # "behavioral_drift"
 | `MAX_CASCADE_DEPTH` | 2 | Maximum depth for cascade penalties |
 | `SIGMA_FLOOR` | 0.05 | Minimum σ — an agent is never penalized below this |
 
-> **Public Preview note:** `slash` logs the penalty event but does not
-> reduce any scores. `vouchee_sigma_after` equals `vouchee_sigma_before` and
-> `voucher_clips` is empty.
+A slash blacklists the offending vouchee (σ → 0.0) and clips each active voucher's score to
+`max(SIGMA_FLOOR, σ × (1 - ω))`, mutating the supplied `agent_scores` map in place. The penalty
+cascades up the liability graph to vouchers-of-vouchers, bounded by `MAX_CASCADE_DEPTH`. Vouchers
+absent from `agent_scores` are skipped (their score is unknown to the caller).
 
 ## Cascade Effects
 
@@ -240,7 +240,7 @@ ledger.record(
 # Query history
 history = ledger.get_agent_history("did:mesh:agent-b")
 profile = ledger.compute_risk_profile("did:mesh:agent-b")
-print(profile.recommendation)  # "admit" (Public Preview always admits)
+print(profile.recommendation)  # "admit" | "probation" | "deny" (risk-based)
 ```
 
 Ledger entry types include:
@@ -384,7 +384,7 @@ print(f"Has cycle: {matrix.has_cycle()}")  # False
 | `LedgerEntryType` | `liability.ledger` | Enum of event types recorded in the ledger |
 | `AgentRiskProfile` | `liability.ledger` | Risk profile computed from an agent's history |
 | `CausalAttributor` | `liability.attribution` | Assigns fault to the direct-cause agent |
-| `QuarantineManager` | `liability.quarantine` | Manages agent quarantine (no-op in community) |
+| `QuarantineManager` | `liability.quarantine` | Enforces time-bounded agent quarantine |
 
 ---
 

--- a/agent-governance-python/agent-hypervisor/docs/joint-liability-guide.md
+++ b/agent-governance-python/agent-hypervisor/docs/joint-liability-guide.md
@@ -101,24 +101,29 @@ Where:
 |--------|---------|
 | **σ\_L** | The vouchee's own reputation score (low-trust agent) |
 | **ω** | Risk weight — how much of the voucher's bond translates to trust (0.0–1.0) |
-| **σ\_H** | The voucher's bonded reputation amount (high-trust agent's stake) |
+| **σ\_H** | The voucher's **bonded** amount = ``voucher_sigma × bond_pct`` (not the voucher's full σ) |
 
 This formula lets a new agent with low reputation (σ\_L = 0.30) participate
-meaningfully when backed by a trusted agent (σ\_H = 0.85, ω = 0.5):
+meaningfully when backed by a trusted agent. If the voucher's σ is 0.85 and it
+bonds the default 20% (`bond_pct = 0.20`), then σ\_H = 0.85 × 0.20 = 0.17, so
+with ω = 0.5:
 
 ```
-σ_eff = 0.30 + (0.5 × 0.85) = 0.725
+σ_eff = 0.30 + (0.5 × 0.17) = 0.385
 ```
 
-The `compute_eff_score` method computes this:
+The `compute_eff_score` method computes this (using the bonds recorded by
+`vouch`):
 
 ```python
+engine.vouch("did:mesh:voucher", "did:mesh:agent-b", "session-123", 0.85, bond_pct=0.20)
 eff = engine.compute_eff_score(
     vouchee_did="did:mesh:agent-b",
     session_id="session-123",
     vouchee_sigma=0.30,    # σ_L
     risk_weight=0.5,       # ω
 )
+# eff == 0.385
 ```
 
 > **Multiple vouchers:** when several agents sponsor the same vouchee, their bonds add

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/audit/commitment.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/audit/commitment.py
@@ -1,17 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Hash Commitment — stub implementation.
+Hash Commitment — local commitment store with optional external anchoring.
 
-Public Preview: stores commitments in-memory only.
-No blockchain anchoring.
+Stores each session's audit hash-chain root as a verifiable commitment. By
+default commitments are anchored locally (in-memory). Supplying an
+``anchor_backend`` (any object exposing ``anchor(record) -> str``) records an
+external anchor reference (e.g. a transaction id) for each commitment.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Protocol
 
 
 @dataclass
@@ -27,16 +29,26 @@ class CommitmentRecord:
     committed_to: str = "local"
 
 
+class AnchorBackend(Protocol):
+    """External anchoring backend (e.g. a ledger or notary service)."""
+
+    def anchor(self, record: CommitmentRecord) -> str: ...
+
+
 class CommitmentEngine:
     """
-    Simple in-memory commitment store.
+    Verifiable commitment store for session audit roots.
 
-    Public Preview: stores commitments locally, no external anchoring.
+    Without an anchor backend this is a real local commitment ledger:
+    ``commit`` stores a root and ``verify`` checks a presented root against it.
+    With an anchor backend, each commitment also carries an external anchor
+    reference.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, anchor_backend: AnchorBackend | None = None) -> None:
         self._commitments: dict[str, CommitmentRecord] = {}
         self._batch_queue: list[CommitmentRecord] = []
+        self._anchor_backend = anchor_backend
 
     def commit(
         self,
@@ -45,13 +57,16 @@ class CommitmentEngine:
         participant_dids: list[str],
         delta_count: int,
     ) -> CommitmentRecord:
-        """Commit a session's Summary Hash."""
+        """Commit a session's Summary Hash, anchoring externally if configured."""
         record = CommitmentRecord(
             session_id=session_id,
             hash_chain_root=hash_chain_root,
             participant_dids=participant_dids,
             delta_count=delta_count,
         )
+        if self._anchor_backend is not None:
+            record.blockchain_tx_id = self._anchor_backend.anchor(record)
+            record.committed_to = "external"
         self._commitments[session_id] = record
         return record
 
@@ -63,12 +78,17 @@ class CommitmentEngine:
         return record.hash_chain_root == expected_root
 
     def queue_for_batch(self, record: CommitmentRecord) -> None:
-        """Queue a commitment (Public Preview: no-op)."""
+        """Queue a commitment for deferred (batched) anchoring."""
         self._batch_queue.append(record)
 
     def flush_batch(self) -> list[CommitmentRecord]:
-        """Flush the batch queue."""
+        """Flush the batch queue, anchoring each queued record if a backend is set."""
         batch = list(self._batch_queue)
+        if self._anchor_backend is not None:
+            for record in batch:
+                if record.blockchain_tx_id is None:
+                    record.blockchain_tx_id = self._anchor_backend.anchor(record)
+                    record.committed_to = "external"
         self._batch_queue.clear()
         return batch
 

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/audit/gc.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/audit/gc.py
@@ -1,17 +1,18 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Ephemeral Session Data Garbage Collection — stub implementation.
+Ephemeral Session Data Garbage Collection.
 
-Public Preview: GC is a no-op. Data is retained in-memory for
-session lifetime only.
+At session teardown the GC purges sensitive ephemeral state (VFS file contents,
+snapshots, caches) so it is not retained in memory, while preserving the
+tamper-evident delta hash chain required for audit. Delta retention is governed
+by :class:`RetentionPolicy`.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 
@@ -50,7 +51,7 @@ class RetentionPolicy:
 
 class EphemeralGC:
     """
-    GC stub (Public Preview: logs collection requests, no actual purge).
+    Purges ephemeral session data while retaining the audit hash chain.
     """
 
     def __init__(self, policy: RetentionPolicy | None = None) -> None:
@@ -70,17 +71,34 @@ class EphemeralGC:
         estimated_cache_bytes: int = 0,
         estimated_delta_bytes: int = 0,
     ) -> GCResult:
-        """Log a GC request (Public Preview: no actual purge)."""
+        """Purge the session's ephemeral data; retain the delta hash chain.
+
+        When a ``vfs`` object is supplied its contents/snapshots/permissions are
+        irreversibly cleared (see :meth:`SessionVFS.purge`) and the purged counts
+        reflect what was actually dropped. The ``*_count``/``*_bytes`` arguments
+        are storage-accounting estimates used only for reporting savings.
+        """
+        purged_files = vfs_file_count
+        purged_caches = cache_count
+        if vfs is not None and hasattr(vfs, "purge"):
+            purged_files, purged_caches = vfs.purge()
+
+        retained_delta_count = delta_count
+        if delta_engine is not None and hasattr(delta_engine, "turn_count"):
+            retained_delta_count = delta_engine.turn_count
+
+        storage_before = estimated_vfs_bytes + estimated_cache_bytes + estimated_delta_bytes
+        # Only the retained delta hash chain survives; VFS + caches are purged.
+        storage_after = estimated_delta_bytes
+
         result = GCResult(
             session_id=session_id,
-            retained_deltas=delta_count,
+            retained_deltas=retained_delta_count,
             retained_hash=True,
-            purged_vfs_files=0,
-            purged_caches=0,
-            storage_before_bytes=estimated_vfs_bytes
-            + estimated_cache_bytes
-            + estimated_delta_bytes,
-            storage_after_bytes=estimated_vfs_bytes + estimated_cache_bytes + estimated_delta_bytes,
+            purged_vfs_files=purged_files,
+            purged_caches=purged_caches,
+            storage_before_bytes=storage_before,
+            storage_after_bytes=storage_after,
         )
         self._gc_history.append(result)
         self._purged_sessions.add(session_id)
@@ -90,7 +108,9 @@ class EphemeralGC:
         return session_id in self._purged_sessions
 
     def should_expire_deltas(self, delta_timestamp: datetime) -> bool:
-        return False
+        """True if a delta is older than the policy's delta retention window."""
+        cutoff = datetime.now(UTC) - timedelta(days=self.policy.delta_retention_days)
+        return delta_timestamp < cutoff
 
     @property
     def history(self) -> list[GCResult]:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/__init__.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/__init__.py
@@ -1,11 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Liability Matrix — simple event log for sponsor→sponsored agent relationships.
+Liability Matrix — directed graph of sponsor -> sponsored agent bonds.
 
-Public Preview: graph operations are retained for API compatibility
-but sponsorship/penalty/quarantine are stubs.
+Tracks bonded relationships within a session and provides exposure,
+cascade-path, and cycle-detection queries used by the slashing engine.
 """
 
 from __future__ import annotations

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
@@ -1,11 +1,10 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Fault Logging — stub implementation.
+Fault Attribution — assigns saga-failure liability to the direct-cause agent.
 
-Public Preview: assigns full liability to the direct-cause agent.
-No causal chain analysis.
+Assigns full liability (1.0) to the agent whose action failed the saga and 0.0
+to the others, recording an auditable :class:`AttributionResult` per failure.
 """
 
 from __future__ import annotations

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/ledger.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/ledger.py
@@ -1,15 +1,16 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Liability Ledger — simple append-only fault log.
+Liability Ledger — append-only fault log with risk scoring and admission.
 
-Public Preview: records fault events as (agent, type, timestamp, details).
-No risk scoring, no admission decisions.
+Records liability events per agent and derives a saturating risk score from the
+severity of negative events (slashes, quarantines, faults), discounted by clean
+sessions. The score drives an admission recommendation: admit / probation / deny.
 """
 
 from __future__ import annotations
 
+import math
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -46,7 +47,7 @@ class LedgerEntry:
 
 @dataclass
 class AgentRiskProfile:
-    """Risk profile for an agent (Public Preview: always admits)."""
+    """Risk profile derived from an agent's liability history."""
 
     agent_did: str
     total_entries: int = 0
@@ -60,14 +61,24 @@ class AgentRiskProfile:
 
 class LiabilityLedger:
     """
-    Simple append-only fault log.
-
-    Public Preview: records events for audit trail only.
-    No risk scoring or admission logic.
+    Append-only fault log with risk scoring and admission decisions.
     """
 
     PROBATION_THRESHOLD = 0.3
     DENY_THRESHOLD = 0.6
+
+    # Negative event types and the severity assumed when an entry is recorded
+    # without an explicit severity.
+    _NEGATIVE_DEFAULT_SEVERITY = {
+        LedgerEntryType.SLASH_RECEIVED: 0.6,
+        LedgerEntryType.SLASH_CASCADED: 0.4,
+        LedgerEntryType.QUARANTINE_ENTERED: 0.5,
+        LedgerEntryType.FAULT_ATTRIBUTED: 0.5,
+    }
+    # Each clean session offsets this much accumulated negative severity.
+    _REDEMPTION_PER_CLEAN = 0.1
+    # Larger -> risk saturates more slowly with accumulated severity.
+    _RISK_SCALE = 2.0
 
     def __init__(self) -> None:
         self._entries: list[LedgerEntry] = []
@@ -100,17 +111,65 @@ class LiabilityLedger:
         return list(self._by_agent.get(agent_did, []))
 
     def compute_risk_profile(self, agent_did: str) -> AgentRiskProfile:
-        """Return a basic risk profile (Public Preview: always admits)."""
+        """Derive a risk profile from the agent's recorded history.
+
+        ``risk_score = 1 - exp(-raw / RISK_SCALE)`` where
+        ``raw = max(0, Σ negative-severity - REDEMPTION_PER_CLEAN * clean_sessions)``.
+        """
         entries = self.get_agent_history(agent_did)
+
+        slash_count = 0
+        quarantine_count = 0
+        clean_count = 0
+        neg_severities: list[float] = []
+
+        for e in entries:
+            if e.entry_type in (
+                LedgerEntryType.SLASH_RECEIVED,
+                LedgerEntryType.SLASH_CASCADED,
+            ):
+                slash_count += 1
+            if e.entry_type == LedgerEntryType.QUARANTINE_ENTERED:
+                quarantine_count += 1
+            if e.entry_type == LedgerEntryType.CLEAN_SESSION:
+                clean_count += 1
+            if e.entry_type in self._NEGATIVE_DEFAULT_SEVERITY:
+                default = self._NEGATIVE_DEFAULT_SEVERITY[e.entry_type]
+                neg_severities.append(e.severity if e.severity > 0 else default)
+
+        neg_sum = sum(neg_severities)
+        fault_avg = (neg_sum / len(neg_severities)) if neg_severities else 0.0
+        raw = max(0.0, neg_sum - self._REDEMPTION_PER_CLEAN * clean_count)
+        risk_score = 1.0 - math.exp(-raw / self._RISK_SCALE)
+
+        if risk_score >= self.DENY_THRESHOLD:
+            recommendation = "deny"
+        elif risk_score >= self.PROBATION_THRESHOLD:
+            recommendation = "probation"
+        else:
+            recommendation = "admit"
+
         return AgentRiskProfile(
             agent_did=agent_did,
             total_entries=len(entries),
-            recommendation="admit",
+            slash_count=slash_count,
+            quarantine_count=quarantine_count,
+            clean_session_count=clean_count,
+            fault_score_avg=fault_avg,
+            risk_score=risk_score,
+            recommendation=recommendation,
         )
 
     def should_admit(self, agent_did: str) -> tuple[bool, str]:
-        """Always admits in Public Preview."""
-        return True, "admit"
+        """Admission decision. Denies only agents whose risk crosses DENY_THRESHOLD.
+
+        Returns ``(admitted, reason)`` where reason is the recommendation:
+        ``"admit"``, ``"probation"`` (admitted, flagged), or ``"deny"``.
+        """
+        profile = self.compute_risk_profile(agent_did)
+        if profile.recommendation == "deny":
+            return False, "deny"
+        return True, profile.recommendation
 
     @property
     def total_entries(self) -> int:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
@@ -1,17 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Quarantine Manager — stub implementation.
+Quarantine Manager — isolates agents for a bounded duration.
 
-Public Preview: quarantine is not enforced. Calls return safe defaults.
+A quarantine is an active, time-bounded record. ``is_quarantined`` and
+``get_active_quarantine`` honour expiry, ``release`` lifts it early, and
+``tick`` expires lapsed records. Re-quarantining an already-isolated agent
+supersedes the prior record (escalation).
 """
 
 from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 
 
@@ -55,7 +57,7 @@ class QuarantineRecord:
 
 class QuarantineManager:
     """
-    Quarantine stub (Public Preview: no quarantine enforcement).
+    Enforces time-bounded agent quarantine within sessions.
     """
 
     DEFAULT_QUARANTINE_SECONDS = 300
@@ -72,30 +74,67 @@ class QuarantineManager:
         duration_seconds: int | None = None,
         forensic_data: dict | None = None,
     ) -> QuarantineRecord:
-        """Log a quarantine request (Public Preview: no enforcement)."""
+        """Quarantine an agent for ``duration_seconds`` (default 300s).
+
+        If the agent already has an active quarantine in this session, that
+        record is released first so only the newest (escalated) record is active.
+        """
+        existing = self.get_active_quarantine(agent_did, session_id)
+        if existing is not None:
+            existing.is_active = False
+            existing.released_at = datetime.now(UTC)
+
+        now = datetime.now(UTC)
+        seconds = self.DEFAULT_QUARANTINE_SECONDS if duration_seconds is None else duration_seconds
         record = QuarantineRecord(
             agent_did=agent_did,
             session_id=session_id,
             reason=reason,
             details=details,
-            is_active=False,
+            entered_at=now,
+            expires_at=now + timedelta(seconds=seconds),
+            is_active=True,
+            forensic_data=forensic_data or {},
         )
         self._quarantines[record.quarantine_id] = record
         return record
 
     def release(self, agent_did: str, session_id: str) -> QuarantineRecord | None:
-        """No-op in Public Preview."""
-        return None
+        """Release an agent's active quarantine early. Returns the record, or None."""
+        record = self.get_active_quarantine(agent_did, session_id)
+        if record is None:
+            return None
+        record.is_active = False
+        record.released_at = datetime.now(UTC)
+        return record
 
     def is_quarantined(self, agent_did: str, session_id: str) -> bool:
-        """Always False in Public Preview."""
-        return False
+        """True if the agent has an active, unexpired quarantine in the session."""
+        return self.get_active_quarantine(agent_did, session_id) is not None
 
     def get_active_quarantine(self, agent_did: str, session_id: str) -> QuarantineRecord | None:
+        """Return the agent's active, unexpired quarantine, expiring lapsed ones lazily."""
+        for record in self._quarantines.values():
+            if record.agent_did != agent_did or record.session_id != session_id:
+                continue
+            if not record.is_active:
+                continue
+            if record.is_expired:
+                record.is_active = False
+                record.released_at = record.expires_at
+                continue
+            return record
         return None
 
     def tick(self) -> list[QuarantineRecord]:
-        return []
+        """Expire all lapsed active quarantines. Returns the records just expired."""
+        expired: list[QuarantineRecord] = []
+        for record in self._quarantines.values():
+            if record.is_active and record.is_expired:
+                record.is_active = False
+                record.released_at = record.expires_at
+                expired.append(record)
+        return expired
 
     def get_history(
         self, agent_did: str | None = None, session_id: str | None = None
@@ -110,8 +149,8 @@ class QuarantineManager:
 
     @property
     def active_quarantines(self) -> list[QuarantineRecord]:
-        return []
+        return [r for r in self._quarantines.values() if r.is_active and not r.is_expired]
 
     @property
     def quarantine_count(self) -> int:
-        return 0
+        return len(self.active_quarantines)

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/slashing.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/slashing.py
@@ -1,10 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Collateral Penalty Engine — stub implementation.
+Collateral Penalty Engine — slashes misbehaving agents and their sponsors.
 
-Public Preview: penalty is not enforced. Penalty calls are logged only.
+A slash blacklists the offending vouchee (sigma -> 0) and clips every active
+voucher's collateral (``sigma * (1 - omega)``, floored at ``SIGMA_FLOOR``). The
+penalty cascades up the liability graph to vouchers-of-vouchers, bounded by
+``MAX_CASCADE_DEPTH``.
 """
 
 from __future__ import annotations
@@ -12,6 +14,8 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+
+from hypervisor.liability.vouching import VouchingEngine
 
 
 @dataclass
@@ -42,13 +46,14 @@ class VoucherClip:
 
 class SlashingEngine:
     """
-    Penalty stub (Public Preview: logs penalty events, no penalties applied).
+    Penalty engine: blacklists offenders and clips their sponsors' collateral.
     """
 
     MAX_CASCADE_DEPTH = 2
     SIGMA_FLOOR = 0.05
 
-    def __init__(self, vouching_engine: object) -> None:
+    def __init__(self, vouching_engine: VouchingEngine) -> None:
+        self._vouching = vouching_engine
         self._slash_history: list[SlashResult] = []
 
     def slash(
@@ -61,19 +66,79 @@ class SlashingEngine:
         agent_scores: dict[str, float],
         cascade_depth: int = 0,
     ) -> SlashResult:
-        """Log a penalty event (Public Preview: no penalties applied)."""
+        """Blacklist the vouchee and clip its (transitive) vouchers' collateral.
+
+        Args:
+            agent_scores: live score map, mutated in place. The vouchee is set to
+                ``0.0``; each clipped voucher is reduced to
+                ``max(SIGMA_FLOOR, sigma * (1 - risk_weight))``. Vouchers absent
+                from this map are skipped (their score is unknown to the caller).
+        """
+        agent_scores[vouchee_did] = 0.0
+
+        clips: list[VoucherClip] = []
+        visited: set[str] = {vouchee_did}
+        reached = self._clip_chain(
+            vouchee_did, session_id, risk_weight, agent_scores, clips, visited, cascade_depth + 1
+        )
+
         result = SlashResult(
             slash_id=f"penalize:{uuid.uuid4()}",
             vouchee_did=vouchee_did,
             vouchee_sigma_before=vouchee_sigma,
-            vouchee_sigma_after=vouchee_sigma,
-            voucher_clips=[],
+            vouchee_sigma_after=0.0,
+            voucher_clips=clips,
             reason=reason,
             session_id=session_id,
-            cascade_depth=0,
+            cascade_depth=max(0, reached),
         )
         self._slash_history.append(result)
         return result
+
+    def _clip_chain(
+        self,
+        vouchee_did: str,
+        session_id: str,
+        risk_weight: float,
+        agent_scores: dict[str, float],
+        clips: list[VoucherClip],
+        visited: set[str],
+        depth: int,
+    ) -> int:
+        """Clip the direct vouchers of ``vouchee_did`` and cascade upward.
+
+        Returns the deepest cascade level that applied a clip.
+        """
+        if depth > self.MAX_CASCADE_DEPTH:
+            return depth - 1
+
+        reached = depth - 1
+        for record in self._vouching.get_vouchers_for(vouchee_did, session_id):
+            voucher = record.voucher_did
+            if voucher in visited or voucher not in agent_scores:
+                continue
+            visited.add(voucher)
+
+            sigma_before = agent_scores[voucher]
+            sigma_after = max(self.SIGMA_FLOOR, sigma_before * (1.0 - risk_weight))
+            agent_scores[voucher] = sigma_after
+            clips.append(
+                VoucherClip(
+                    voucher_did=voucher,
+                    sigma_before=sigma_before,
+                    sigma_after=sigma_after,
+                    risk_weight=risk_weight,
+                    vouch_id=record.vouch_id,
+                )
+            )
+            reached = max(reached, depth)
+            reached = max(
+                reached,
+                self._clip_chain(
+                    voucher, session_id, risk_weight, agent_scores, clips, visited, depth + 1
+                ),
+            )
+        return reached
 
     @property
     def history(self) -> list[SlashResult]:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/slashing.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/slashing.py
@@ -71,15 +71,19 @@ class SlashingEngine:
         Args:
             agent_scores: live score map, mutated in place. The vouchee is set to
                 ``0.0``; each clipped voucher is reduced to
-                ``max(SIGMA_FLOOR, sigma * (1 - risk_weight))``. Vouchers absent
-                from this map are skipped (their score is unknown to the caller).
+                ``max(SIGMA_FLOOR, sigma * (1 - risk_weight))``. ``risk_weight`` is
+                clamped to ``[0, 1]`` so a penalty can never increase a score. A
+                voucher absent from this map is not scored (its sigma is unknown to
+                the caller) but the cascade still propagates THROUGH it to any known
+                upstream guarantors.
         """
+        omega = min(1.0, max(0.0, risk_weight))
         agent_scores[vouchee_did] = 0.0
 
         clips: list[VoucherClip] = []
         visited: set[str] = {vouchee_did}
         reached = self._clip_chain(
-            vouchee_did, session_id, risk_weight, agent_scores, clips, visited, cascade_depth + 1
+            vouchee_did, session_id, omega, agent_scores, clips, visited, cascade_depth + 1
         )
 
         result = SlashResult(
@@ -115,23 +119,27 @@ class SlashingEngine:
         reached = depth - 1
         for record in self._vouching.get_vouchers_for(vouchee_did, session_id):
             voucher = record.voucher_did
-            if voucher in visited or voucher not in agent_scores:
+            if voucher in visited:
                 continue
             visited.add(voucher)
 
-            sigma_before = agent_scores[voucher]
-            sigma_after = max(self.SIGMA_FLOOR, sigma_before * (1.0 - risk_weight))
-            agent_scores[voucher] = sigma_after
-            clips.append(
-                VoucherClip(
-                    voucher_did=voucher,
-                    sigma_before=sigma_before,
-                    sigma_after=sigma_after,
-                    risk_weight=risk_weight,
-                    vouch_id=record.vouch_id,
+            # A voucher whose score the caller does not track cannot be clipped,
+            # but the cascade must still flow through it to known upstream sponsors.
+            if voucher in agent_scores:
+                sigma_before = agent_scores[voucher]
+                sigma_after = max(self.SIGMA_FLOOR, sigma_before * (1.0 - risk_weight))
+                agent_scores[voucher] = sigma_after
+                clips.append(
+                    VoucherClip(
+                        voucher_did=voucher,
+                        sigma_before=sigma_before,
+                        sigma_after=sigma_after,
+                        risk_weight=risk_weight,
+                        vouch_id=record.vouch_id,
+                    )
                 )
-            )
-            reached = max(reached, depth)
+                reached = max(reached, depth)
+
             reached = max(
                 reached,
                 self._clip_chain(

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/vouching.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/vouching.py
@@ -1,10 +1,13 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Sponsorship Protocol — stub implementation.
+Sponsorship Protocol — joint-liability bonding between agents.
 
-Public Preview: sponsorship is not enforced. All requests are approved.
+A voucher stakes (bonds) a fraction of its reputation (sigma) to sponsor a
+vouchee into a session. Bonds boost the vouchee's effective score and are the
+collateral clipped by the :mod:`~hypervisor.liability.slashing` engine when the
+vouchee misbehaves. Bonding is enforced: self-vouching, under-qualified
+vouchers, cycles, and over-exposure are rejected.
 """
 
 from __future__ import annotations
@@ -45,7 +48,10 @@ class VouchRecord:
 
 class VouchingEngine:
     """
-    Sponsorship stub (Public Preview: approves all, no bonding).
+    Joint-liability sponsorship engine.
+
+    Enforces voucher qualification, acyclicity, and per-voucher exposure
+    limits, and computes a vouchee's effective score from active bonds.
     """
 
     SCORE_SCALE = VOUCHING_SCORE_SCALE
@@ -71,14 +77,43 @@ class VouchingEngine:
         bond_pct: float | None = None,
         expiry: datetime | None = None,
     ) -> VouchRecord:
-        """Create a sponsorship record (Public Preview: always succeeds, no bonding)."""
+        """Create a sponsorship bond, staking ``bond_pct`` of the voucher's sigma.
+
+        Raises:
+            VouchingError: if the voucher sponsors itself, has a sigma below
+                ``MIN_VOUCHER_SCORE``, would create a cycle in the session's
+                liability graph, or would exceed its maximum bonded exposure.
+        """
+        if voucher_did == vouchee_did:
+            raise VouchingError("Cannot sponsor for yourself")
+        if voucher_sigma < self.MIN_VOUCHER_SCORE:
+            raise VouchingError(
+                f"Voucher sigma {voucher_sigma:.3f} is below minimum {self.MIN_VOUCHER_SCORE:.2f}"
+            )
+        if self._creates_cycle(voucher_did, vouchee_did, session_id):
+            raise VouchingError(
+                f"Circular sponsorship: {vouchee_did} already sponsors {voucher_did}"
+            )
+
+        pct = self.DEFAULT_BOND_PCT if bond_pct is None else bond_pct
+        bonded_amount = voucher_sigma * pct
+
+        max_bondable = self.max_exposure * voucher_sigma
+        projected = self.get_total_exposure(voucher_did, session_id) + bonded_amount
+        if projected > max_bondable + 1e-9:
+            raise VouchingError(
+                f"Bond {bonded_amount:.3f} would exceed max exposure "
+                f"{max_bondable:.3f} for {voucher_did}"
+            )
+
         record = VouchRecord(
             vouch_id=f"sponsor:{uuid.uuid4()}",
             voucher_did=voucher_did,
             vouchee_did=vouchee_did,
             session_id=session_id,
-            bonded_sigma_pct=0.0,
-            bonded_amount=0.0,
+            bonded_sigma_pct=pct,
+            bonded_amount=bonded_amount,
+            expiry=expiry,
         )
         self._vouches[record.vouch_id] = record
         return record
@@ -90,8 +125,15 @@ class VouchingEngine:
         vouchee_sigma: float,
         risk_weight: float,
     ) -> float:
-        """Return sponsored agent's own score (Public Preview: no sponsor boost)."""
-        return vouchee_sigma
+        """Effective score: ``sigma_L + omega * sum(bonded_amount)``, capped at 1.0.
+
+        ``sigma_L`` is the vouchee's own score, ``omega`` the risk weight, and the
+        sum runs over the bonds of all active vouchers for the vouchee.
+        """
+        bonded_total = sum(
+            v.bonded_amount for v in self._active_vouches_for(vouchee_did, session_id)
+        )
+        return min(1.0, vouchee_sigma + risk_weight * bonded_total)
 
     def get_vouchers_for(self, agent_did: str, session_id: str) -> list[VouchRecord]:
         """Get all sponsors for an agent in a session."""
@@ -102,8 +144,12 @@ class VouchingEngine:
         ]
 
     def get_total_exposure(self, voucher_did: str, session_id: str) -> float:
-        """Always zero in Public Preview."""
-        return 0.0
+        """Total sigma a voucher has bonded across all its active vouches in a session."""
+        return sum(
+            v.bonded_amount
+            for v in self._vouches.values()
+            if v.voucher_did == voucher_did and v.session_id == session_id and v.is_active
+        )
 
     def release_bond(self, vouch_id: str) -> None:
         """Release a sponsorship bond."""
@@ -127,6 +173,28 @@ class VouchingEngine:
         return self.get_vouchers_for(agent_did, session_id)
 
     def _creates_cycle(self, voucher_did: str, vouchee_did: str, session_id: str) -> bool:
+        """True if adding ``voucher_did -> vouchee_did`` would close a cycle.
+
+        Walks the existing active sponsor graph (edges point voucher -> vouchee)
+        looking for a path from ``vouchee_did`` back to ``voucher_did``.
+        """
+        if voucher_did == vouchee_did:
+            return True
+        adjacency: dict[str, list[str]] = {}
+        for v in self._vouches.values():
+            if v.session_id == session_id and v.is_active:
+                adjacency.setdefault(v.voucher_did, []).append(v.vouchee_did)
+
+        stack = [vouchee_did]
+        seen: set[str] = set()
+        while stack:
+            node = stack.pop()
+            if node == voucher_did:
+                return True
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(adjacency.get(node, ()))
         return False
 
 

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/vouching.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/vouching.py
@@ -50,8 +50,8 @@ class VouchingEngine:
     """
     Joint-liability sponsorship engine.
 
-    Enforces voucher qualification, acyclicity, and per-voucher exposure
-    limits, and computes a vouchee's effective score from active bonds.
+    Enforces voucher qualification, cycle-free sponsorship, and per-voucher
+    exposure limits, and computes a vouchee's effective score from active bonds.
     """
 
     SCORE_SCALE = VOUCHING_SCORE_SCALE
@@ -61,7 +61,9 @@ class VouchingEngine:
 
     def __init__(self, max_exposure: float | None = None) -> None:
         self._vouches: dict[str, VouchRecord] = {}
-        self.max_exposure = max_exposure or self.DEFAULT_MAX_EXPOSURE
+        self.max_exposure = (
+            self.DEFAULT_MAX_EXPOSURE if max_exposure is None else max_exposure
+        )
 
     @property
     def vouch_count(self) -> int:
@@ -81,8 +83,9 @@ class VouchingEngine:
 
         Raises:
             VouchingError: if the voucher sponsors itself, has a sigma below
-                ``MIN_VOUCHER_SCORE``, would create a cycle in the session's
-                liability graph, or would exceed its maximum bonded exposure.
+                ``MIN_VOUCHER_SCORE``, supplies a ``bond_pct`` outside ``[0, 1]``,
+                would create a cycle in the session's liability graph, or would
+                exceed its maximum bonded exposure.
         """
         if voucher_did == vouchee_did:
             raise VouchingError("Cannot sponsor for yourself")
@@ -90,12 +93,16 @@ class VouchingEngine:
             raise VouchingError(
                 f"Voucher sigma {voucher_sigma:.3f} is below minimum {self.MIN_VOUCHER_SCORE:.2f}"
             )
+
+        pct = self.DEFAULT_BOND_PCT if bond_pct is None else bond_pct
+        if not 0.0 <= pct <= 1.0:
+            raise VouchingError(f"bond_pct {pct} must be within [0, 1]")
+
         if self._creates_cycle(voucher_did, vouchee_did, session_id):
             raise VouchingError(
                 f"Circular sponsorship: {vouchee_did} already sponsors {voucher_did}"
             )
 
-        pct = self.DEFAULT_BOND_PCT if bond_pct is None else bond_pct
         bonded_amount = voucher_sigma * pct
 
         max_bondable = self.max_exposure * voucher_sigma
@@ -127,28 +134,36 @@ class VouchingEngine:
     ) -> float:
         """Effective score: ``sigma_L + omega * sum(bonded_amount)``, capped at 1.0.
 
-        ``sigma_L`` is the vouchee's own score, ``omega`` the risk weight, and the
-        sum runs over the bonds of all active vouchers for the vouchee.
+        ``sigma_L`` is the vouchee's own score, ``omega`` the risk weight
+        (clamped to ``[0, 1]``), and the sum runs over the bonds of all active,
+        unexpired vouchers for the vouchee.
         """
+        omega = min(1.0, max(0.0, risk_weight))
         bonded_total = sum(
             v.bonded_amount for v in self._active_vouches_for(vouchee_did, session_id)
         )
-        return min(1.0, vouchee_sigma + risk_weight * bonded_total)
+        return min(1.0, vouchee_sigma + omega * bonded_total)
 
     def get_vouchers_for(self, agent_did: str, session_id: str) -> list[VouchRecord]:
-        """Get all sponsors for an agent in a session."""
+        """Get all active, unexpired sponsors for an agent in a session."""
         return [
             v
             for v in self._vouches.values()
-            if v.vouchee_did == agent_did and v.session_id == session_id and v.is_active
+            if v.vouchee_did == agent_did
+            and v.session_id == session_id
+            and v.is_active
+            and not v.is_expired
         ]
 
     def get_total_exposure(self, voucher_did: str, session_id: str) -> float:
-        """Total sigma a voucher has bonded across all its active vouches in a session."""
+        """Total sigma a voucher has bonded across its active, unexpired vouches in a session."""
         return sum(
             v.bonded_amount
             for v in self._vouches.values()
-            if v.voucher_did == voucher_did and v.session_id == session_id and v.is_active
+            if v.voucher_did == voucher_did
+            and v.session_id == session_id
+            and v.is_active
+            and not v.is_expired
         )
 
     def release_bond(self, vouch_id: str) -> None:
@@ -182,7 +197,7 @@ class VouchingEngine:
             return True
         adjacency: dict[str, list[str]] = {}
         for v in self._vouches.values():
-            if v.session_id == session_id and v.is_active:
+            if v.session_id == session_id and v.is_active and not v.is_expired:
                 adjacency.setdefault(v.voucher_did, []).append(v.vouchee_did)
 
         stack = [vouchee_did]

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/session/sso.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/session/sso.py
@@ -167,6 +167,27 @@ class SessionVFS:
     def snapshot_count(self) -> int:
         return len(self._snapshots)
 
+    def purge(self) -> tuple[int, int]:
+        """Irreversibly drop all session data held in memory.
+
+        Clears file contents, snapshots (which hold copied file contents), and
+        path permissions, then records a terminal ``delete`` edit covering the
+        namespace. Used by :class:`~hypervisor.audit.gc.EphemeralGC` at session
+        teardown so sensitive session data is not retained.
+
+        Returns:
+            ``(files_purged, snapshots_purged)``.
+        """
+        files_purged = len(self._files)
+        snapshots_purged = len(self._snapshots)
+        self._files.clear()
+        self._snapshots.clear()
+        self._permissions.clear()
+        self._edit_log.append(
+            VFSEdit(path=self.namespace, operation="delete", agent_did="system:gc")
+        )
+        return files_purged, snapshots_purged
+
     def _resolve(self, path: str) -> str:
         if path.startswith(self.namespace):
             return path

--- a/agent-governance-python/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
+++ b/agent-governance-python/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
@@ -168,11 +168,10 @@ class TestVouchingSlashingIntegration:
         eff_score = self.hv.vouching.compute_eff_score(
             "did:mesh:low", self.session_id, 0.4, risk_weight=0.5
         )
-        # Public Preview: no sponsor boost, eff_score = vouchee_sigma
-        assert eff_score == 0.4
+        # bonded_amount = 0.9 * 0.3 = 0.27; eff = 0.4 + 0.5 * 0.27 = 0.535
+        assert eff_score == pytest.approx(0.535)
         assert eff_score <= 1.0
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_max_exposure_prevents_over_bonding(self):
         """Agent cannot bond more than max_exposure of their σ."""
         # Default max_exposure = 0.80
@@ -184,16 +183,17 @@ class TestVouchingSlashingIntegration:
             )
 
     def test_slash_cascades_to_voucher(self):
-        """Public Preview: penalty logs but doesn't apply penalties."""
+        """Slashing blacklists the vouchee and clips its voucher's collateral."""
         self.hv.vouching.vouch("did:mesh:high", "did:mesh:low", self.session_id, 0.9, bond_pct=0.3)
         agent_scores = {"did:mesh:high": 0.9, "did:mesh:low": 0.5}
         result = self.hv.slashing.slash(
             "did:mesh:low", self.session_id, 0.5, 0.5, "policy_violation", agent_scores
         )
-        # Public Preview: no penalties applied
-        assert agent_scores["did:mesh:low"] == 0.5  # unchanged
-        assert agent_scores["did:mesh:high"] == 0.9  # unchanged
-        assert len(result.voucher_clips) == 0
+        # Vouchee blacklisted; voucher clipped 0.9 * (1 - 0.5) = 0.45
+        assert agent_scores["did:mesh:low"] == 0.0
+        assert agent_scores["did:mesh:high"] == pytest.approx(0.45)
+        assert len(result.voucher_clips) == 1
+        assert result.vouchee_sigma_after == 0.0
 
     def test_release_bonds_on_session_terminate(self):
         self.hv.vouching.vouch("did:mesh:high", "did:mesh:low", self.session_id, 0.9)
@@ -462,6 +462,8 @@ class TestGCIntegration:
         # GC should have purged VFS
         assert self.hv.gc.is_purged(sid)
         assert len(self.hv.gc.history) == 1
+        # Sensitive session contents are actually dropped from memory.
+        assert session.sso.vfs.file_count == 0
 
     def test_gc_tracks_purged_sessions(self):
         gc = self.hv.gc

--- a/agent-governance-python/agent-hypervisor/tests/integration/test_scenarios.py
+++ b/agent-governance-python/agent-hypervisor/tests/integration/test_scenarios.py
@@ -489,7 +489,6 @@ class TestVoucherCascadeWithNexus:
         )
         self.nexus = NexusAdapter(scorer=self.nexus_engine)
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     async def test_voucher_cascade_with_nexus_penalty(self):
         """Sponsor → penalize → sponsor clipped → both reported to Nexus."""
         # Create session

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
@@ -98,30 +98,46 @@ class TestCommitmentEngine:
 
 
 class TestEphemeralGC:
-    def test_collect(self):
+    def test_collect_purges_vfs(self):
+        from hypervisor.session.sso import SessionVFS
+
+        vfs = SessionVFS("session:1")
+        vfs.write("/secret.txt", "sensitive", agent_did="did:a")
+        vfs.write("/notes.txt", "more", agent_did="did:a")
+        vfs.create_snapshot()
+        assert vfs.file_count == 2
+
         gc = EphemeralGC()
         result = gc.collect(
             session_id="session:1",
-            vfs_file_count=100,
-            cache_count=50,
+            vfs=vfs,
             delta_count=20,
             estimated_vfs_bytes=1_000_000,
             estimated_cache_bytes=500_000,
             estimated_delta_bytes=50_000,
         )
-        # Public preview: no actual purge, data retained
-        assert result.purged_vfs_files == 0
+        # Sensitive session data is actually purged from memory.
+        assert vfs.file_count == 0
+        assert vfs.snapshot_count == 0
+        assert result.purged_vfs_files == 2
+        assert result.purged_caches == 1
+        # Delta hash chain is retained for audit; VFS + caches are reclaimed.
         assert result.retained_deltas == 20
-        # No savings since nothing is purged
-        assert result.storage_saved_bytes == 0
-        assert result.savings_pct == 0
+        assert result.retained_hash is True
+        assert result.storage_saved_bytes == 1_500_000
+        assert result.savings_pct > 0
 
-    def test_retention_policy(self):
+    def test_collect_without_vfs_marks_purged(self):
+        gc = EphemeralGC()
+        result = gc.collect(session_id="session:2")
+        assert gc.is_purged("session:2")
+        assert result.retained_hash is True
+
+    def test_retention_policy_expires_old_deltas(self):
         from datetime import datetime, timedelta
 
         gc = EphemeralGC(RetentionPolicy(delta_retention_days=30))
         old = datetime.now(UTC) - timedelta(days=31)
-        # Public preview: never expires deltas
-        assert not gc.should_expire_deltas(old)
+        assert gc.should_expire_deltas(old)
         recent = datetime.now(UTC) - timedelta(days=1)
         assert not gc.should_expire_deltas(recent)

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
@@ -123,7 +123,7 @@ class TestEphemeralGC:
         assert result.purged_caches == 1
         # Delta hash chain is retained for audit; VFS + caches are reclaimed.
         assert result.retained_deltas == 20
-        assert result.retained_hash is True
+        assert result.retained_hash
         assert result.storage_saved_bytes == 1_500_000
         assert result.savings_pct > 0
 
@@ -131,7 +131,7 @@ class TestEphemeralGC:
         gc = EphemeralGC()
         result = gc.collect(session_id="session:2")
         assert gc.is_purged("session:2")
-        assert result.retained_hash is True
+        assert result.retained_hash
 
     def test_retention_policy_expires_old_deltas(self):
         from datetime import datetime, timedelta

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_liability.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_liability.py
@@ -38,51 +38,51 @@ class TestVouchingEngine:
         assert record.voucher_did == "did:mesh:high"
         assert record.vouchee_did == "did:mesh:low"
         assert record.is_active
-        assert record.bonded_sigma_pct == 0.0  # Public Preview: no bonding
-        assert record.bonded_amount == 0.0  # Public Preview: no bonding
+        # Default bond is DEFAULT_BOND_PCT (0.20) of the voucher's sigma.
+        assert record.bonded_sigma_pct == pytest.approx(0.20)
+        assert record.bonded_amount == pytest.approx(0.16)
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_cannot_vouch_for_self(self):
         with pytest.raises(VouchingError, match="Cannot sponsor for yourself"):
             self.engine.vouch("did:mesh:a", "did:mesh:a", self.session, 0.8)
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_low_score_cannot_vouch(self):
         with pytest.raises(VouchingError, match="below minimum"):
             self.engine.vouch("did:mesh:low", "did:mesh:other", self.session, 0.3)
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_circular_vouching_rejected(self):
         self.engine.vouch("did:mesh:a", "did:mesh:b", self.session, 0.8)
         with pytest.raises(VouchingError, match="Circular"):
             self.engine.vouch("did:mesh:b", "did:mesh:a", self.session, 0.7)
 
     def test_eff_score_formula(self):
-        """Public Preview: eff_score = sponsored agent's own score (no sponsor boost)."""
+        """eff_score = vouchee_sigma + risk_weight * bonded_amount."""
         self.engine.vouch("did:mesh:high", "did:mesh:low", self.session, 0.9, bond_pct=0.5)
+        # bonded_amount = 0.9 * 0.5 = 0.45
         eff_score = self.engine.compute_eff_score(
             vouchee_did="did:mesh:low",
             session_id=self.session,
             vouchee_sigma=0.3,
             risk_weight=0.2,
         )
-        assert abs(eff_score - 0.3) < 1e-9  # Returns vouchee_sigma directly
+        # 0.3 + 0.2 * 0.45 = 0.39
+        assert abs(eff_score - 0.39) < 1e-9
 
     def test_eff_score_capped_at_1(self):
         self.engine.vouch("did:mesh:high", "did:mesh:low", self.session, 0.9, bond_pct=0.8)
         eff_score = self.engine.compute_eff_score(
             "did:mesh:low", self.session, 0.8, risk_weight=1.0
         )
-        assert eff_score <= 1.0
+        assert eff_score == pytest.approx(1.0)
 
     def test_multiple_vouchers(self):
         self.engine.vouch("did:mesh:a", "did:mesh:low", self.session, 0.8, bond_pct=0.5)
         self.engine.vouch("did:mesh:b", "did:mesh:low", self.session, 0.6, bond_pct=0.5)
-        # Public Preview: eff_score = vouchee_sigma (no boost)
+        # bonded amounts: 0.40 + 0.30 = 0.70; eff = 0.1 + 0.5 * 0.70 = 0.45
         eff_score = self.engine.compute_eff_score(
             "did:mesh:low", self.session, 0.1, risk_weight=0.5
         )
-        assert abs(eff_score - 0.1) < 1e-9
+        assert abs(eff_score - 0.45) < 1e-9
 
     def test_release_session_bonds(self):
         self.engine.vouch("did:mesh:a", "did:mesh:b", self.session, 0.8)
@@ -95,7 +95,15 @@ class TestVouchingEngine:
         self.engine.vouch("did:mesh:a", "did:mesh:b", self.session, 0.8, bond_pct=0.3)
         self.engine.vouch("did:mesh:a", "did:mesh:c", self.session, 0.8, bond_pct=0.2)
         exposure = self.engine.get_total_exposure("did:mesh:a", self.session)
-        assert exposure == 0.0  # Public Preview: no bonding
+        # 0.8*0.3 + 0.8*0.2 = 0.24 + 0.16 = 0.40
+        assert exposure == pytest.approx(0.40)
+
+    def test_max_exposure_rejects_over_bonding(self):
+        """A voucher cannot bond more than max_exposure * sigma across vouches."""
+        # Default max_exposure = 0.80; cap for sigma 0.9 is 0.72.
+        self.engine.vouch("did:mesh:high", "did:mesh:a", self.session, 0.9, bond_pct=0.5)
+        with pytest.raises(VouchingError, match="exceed max exposure"):
+            self.engine.vouch("did:mesh:high", "did:mesh:b", self.session, 0.9, bond_pct=0.5)
 
 
 class TestLiabilityMatrix:

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_liability.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_liability.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 """Tests for the sponsorship & bonding engine and liability matrix."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from hypervisor.liability import LiabilityMatrix
@@ -104,6 +106,31 @@ class TestVouchingEngine:
         self.engine.vouch("did:mesh:high", "did:mesh:a", self.session, 0.9, bond_pct=0.5)
         with pytest.raises(VouchingError, match="exceed max exposure"):
             self.engine.vouch("did:mesh:high", "did:mesh:b", self.session, 0.9, bond_pct=0.5)
+
+    def test_max_exposure_zero_forbids_all_bonding(self):
+        """max_exposure=0.0 means no bonding (must not be clobbered to the default)."""
+        engine = VouchingEngine(max_exposure=0.0)
+        assert engine.max_exposure == 0.0
+        with pytest.raises(VouchingError, match="exceed max exposure"):
+            engine.vouch("did:mesh:high", "did:mesh:low", self.session, 0.9, bond_pct=0.2)
+
+    @pytest.mark.parametrize("bad_pct", [-0.1, 1.5, -10.0])
+    def test_invalid_bond_pct_rejected(self, bad_pct):
+        """bond_pct outside [0,1] is rejected (negatives would invert exposure)."""
+        with pytest.raises(VouchingError, match=r"bond_pct .* must be within"):
+            self.engine.vouch("did:mesh:high", "did:mesh:low", self.session, 0.9, bond_pct=bad_pct)
+
+    def test_expired_vouch_excluded(self):
+        """An expired bond grants no trust, no exposure, and is not an active sponsor."""
+        past = datetime.now(UTC) - timedelta(seconds=5)
+        self.engine.vouch(
+            "did:mesh:high", "did:mesh:low", self.session, 0.9, bond_pct=0.5, expiry=past
+        )
+        assert self.engine.get_vouchers_for("did:mesh:low", self.session) == []
+        assert self.engine.get_total_exposure("did:mesh:high", self.session) == 0.0
+        # No boost: eff_score collapses to the vouchee's own sigma.
+        eff = self.engine.compute_eff_score("did:mesh:low", self.session, 0.3, risk_weight=1.0)
+        assert eff == pytest.approx(0.3)
 
 
 class TestLiabilityMatrix:

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 """Tests for Shapley-value fault attribution, quarantine, and liability ledger."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from hypervisor.liability.attribution import (
@@ -125,29 +127,62 @@ class TestCausalAttribution:
 
 
 class TestQuarantine:
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_quarantine_agent(self):
-        pass
+        mgr = QuarantineManager()
+        record = mgr.quarantine("a1", "s1", QuarantineReason.RING_BREACH, details="breach")
+        assert mgr.is_quarantined("a1", "s1")
+        assert mgr.get_active_quarantine("a1", "s1") is record
+        assert record.reason == QuarantineReason.RING_BREACH
+        # Isolation is scoped to the session it was issued in.
+        assert not mgr.is_quarantined("a1", "other-session")
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_release_quarantine(self):
-        pass
+        mgr = QuarantineManager()
+        mgr.quarantine("a1", "s1", QuarantineReason.MANUAL)
+        released = mgr.release("a1", "s1")
+        assert released is not None
+        assert released.released_at is not None
+        assert not mgr.is_quarantined("a1", "s1")
+        # Releasing again is a no-op.
+        assert mgr.release("a1", "s1") is None
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_quarantine_escalation(self):
-        pass
+        mgr = QuarantineManager()
+        mgr.quarantine("a1", "s1", QuarantineReason.RATE_LIMIT_EXCEEDED)
+        mgr.quarantine("a1", "s1", QuarantineReason.LIABILITY_VIOLATION)
+        # Re-quarantine supersedes the prior record: only one active, newest reason.
+        assert mgr.quarantine_count == 1
+        active = mgr.get_active_quarantine("a1", "s1")
+        assert active.reason == QuarantineReason.LIABILITY_VIOLATION
+        assert len(mgr.get_history(agent_did="a1")) == 2
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_quarantine_with_forensic_data(self):
-        pass
+        mgr = QuarantineManager()
+        forensic = {"drift_score": 0.82, "action_id": "send-email"}
+        record = mgr.quarantine(
+            "a1", "s1", QuarantineReason.BEHAVIORAL_DRIFT, forensic_data=forensic
+        )
+        assert record.forensic_data == forensic
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_tick_expires_quarantines(self):
-        pass
+        mgr = QuarantineManager()
+        record = mgr.quarantine("a1", "s1", QuarantineReason.MANUAL, duration_seconds=300)
+        assert mgr.is_quarantined("a1", "s1")
+        # Force the record past its expiry, then tick.
+        record.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        expired = mgr.tick()
+        assert record in expired
+        assert not mgr.is_quarantined("a1", "s1")
+        assert mgr.quarantine_count == 0
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_active_quarantines_property(self):
-        pass
+        mgr = QuarantineManager()
+        mgr.quarantine("a1", "s1", QuarantineReason.MANUAL)
+        mgr.quarantine("a2", "s1", QuarantineReason.MANUAL)
+        assert mgr.quarantine_count == 2
+        assert {r.agent_did for r in mgr.active_quarantines} == {"a1", "a2"}
+        mgr.release("a1", "s1")
+        assert mgr.quarantine_count == 1
 
     def test_quarantine_history(self):
         mgr = QuarantineManager()
@@ -207,18 +242,20 @@ class TestLiabilityLedger:
         for i in range(5):
             ledger.record("a1", LedgerEntryType.SLASH_RECEIVED, f"s{i}", severity=0.9)
         profile = ledger.compute_risk_profile("a1")
-        # Public Preview: no risk scoring, always admits
-        assert profile.risk_score == 0.0
-        assert profile.recommendation == "admit"
+        assert profile.slash_count == 5
+        assert profile.risk_score > ledger.DENY_THRESHOLD
+        assert profile.recommendation == "deny"
 
     def test_risk_profile_probation(self):
         ledger = LiabilityLedger()
+        # Two moderate slashes accumulate into the probation band.
         ledger.record("a1", LedgerEntryType.SLASH_RECEIVED, "s1", severity=0.7)
-        ledger.record("a1", LedgerEntryType.CLEAN_SESSION, "s2")
-        ledger.record("a1", LedgerEntryType.CLEAN_SESSION, "s3")
-
+        ledger.record("a1", LedgerEntryType.SLASH_RECEIVED, "s2", severity=0.7)
         profile = ledger.compute_risk_profile("a1")
-        assert profile.recommendation in ("admit", "probation")
+        assert profile.recommendation == "probation"
+        admitted, reason = ledger.should_admit("a1")
+        assert admitted  # probation is admitted-but-flagged
+        assert reason == "probation"
 
     def test_should_admit_clean(self):
         ledger = LiabilityLedger()
@@ -232,9 +269,8 @@ class TestLiabilityLedger:
             ledger.record("a1", LedgerEntryType.SLASH_RECEIVED, f"s{i}", severity=0.9)
 
         admitted, reason = ledger.should_admit("a1")
-        # Public Preview: always admits
-        assert admitted
-        assert reason == "admit"
+        assert not admitted
+        assert reason == "deny"
 
     def test_unknown_agent_admitted(self):
         ledger = LiabilityLedger()
@@ -251,7 +287,5 @@ class TestLiabilityLedger:
         ledger = LiabilityLedger()
         ledger.record("a1", LedgerEntryType.QUARANTINE_ENTERED, "s1", severity=0.5)
         profile = ledger.compute_risk_profile("a1")
-        # Public Preview: no risk scoring, always admits
-        assert profile.quarantine_count == 0
-        assert profile.risk_score == 0.0
-        assert profile.recommendation == "admit"
+        assert profile.quarantine_count == 1
+        assert profile.risk_score > 0.0

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_slashing.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_slashing.py
@@ -14,7 +14,6 @@ class TestSlashingEngine:
         self.slashing = SlashingEngine(self.vouching)
         self.session = "session:test-penalize"
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_vouchee_blacklisted(self):
         """Sponsored agent σ → 0 on violation."""
         scores = {"did:mesh:bad": 0.7, "did:mesh:good": 0.9}
@@ -32,7 +31,6 @@ class TestSlashingEngine:
         assert scores["did:mesh:bad"] == 0.0
         assert result.vouchee_sigma_after == 0.0
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_voucher_collateral_clip(self):
         """σ_new = σ_old × (1 - ω)"""
         scores = {"did:mesh:bad": 0.5, "did:mesh:sponsor": 0.9}
@@ -70,7 +68,6 @@ class TestSlashingEngine:
 
         assert scores["did:mesh:sponsor"] >= SlashingEngine.SIGMA_FLOOR
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_multiple_vouchers_all_clipped(self):
         """All sponsors for a sponsored agent get clipped."""
         scores = {"did:mesh:bad": 0.4, "did:mesh:v1": 0.8, "did:mesh:v2": 0.7}

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_slashing.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_slashing.py
@@ -87,3 +87,38 @@ class TestSlashingEngine:
         # v1: 0.8 * (1-0.3) = 0.56, v2: 0.7 * (1-0.3) = 0.49
         assert abs(scores["did:mesh:v1"] - 0.56) < 1e-9
         assert abs(scores["did:mesh:v2"] - 0.49) < 1e-9
+
+    def test_negative_risk_weight_cannot_reward_voucher(self):
+        """A penalty must never increase a score; risk_weight is clamped to [0,1]."""
+        scores = {"did:mesh:bad": 0.5, "did:mesh:sponsor": 0.9}
+        self.vouching.vouch("did:mesh:sponsor", "did:mesh:bad", self.session, 0.9)
+        self.slashing.slash(
+            vouchee_did="did:mesh:bad",
+            session_id=self.session,
+            vouchee_sigma=0.5,
+            risk_weight=-1.0,  # would reward (×2) if unclamped
+            reason="x",
+            agent_scores=scores,
+        )
+        assert scores["did:mesh:sponsor"] <= 0.9
+
+    def test_cascade_flows_through_untracked_intermediate(self):
+        """A voucher missing from agent_scores must not block the cascade upstream.
+
+        A → B → C: slashing C must still clip A (known) even though B is not in
+        agent_scores.
+        """
+        self.vouching.vouch("did:mesh:A", "did:mesh:B", self.session, 0.9)
+        self.vouching.vouch("did:mesh:B", "did:mesh:C", self.session, 0.9)
+        scores = {"did:mesh:C": 0.5, "did:mesh:A": 0.8}  # B intentionally absent
+        result = self.slashing.slash(
+            vouchee_did="did:mesh:C",
+            session_id=self.session,
+            vouchee_sigma=0.5,
+            risk_weight=0.5,
+            reason="x",
+            agent_scores=scores,
+        )
+        clipped = {c.voucher_did for c in result.voucher_clips}
+        assert clipped == {"did:mesh:A"}  # B skipped (untracked), A reached
+        assert scores["did:mesh:A"] == pytest.approx(0.4)  # 0.8 * (1-0.5)

--- a/docs/tutorials/12-liability-and-attribution.md
+++ b/docs/tutorials/12-liability-and-attribution.md
@@ -217,9 +217,9 @@ eff_score = engine.compute_eff_score(
 print(f"Effective score: {eff_score}")
 ```
 
-> **Public Preview:** In the Public Preview, `compute_eff_score` returns
-> the vouchee's own sigma directly — sponsor boost is an enterprise feature.
-> The vouching graph is still tracked for auditing and liability analysis.
+> **Multiple vouchers:** when several agents sponsor the same vouchee, `compute_eff_score`
+> sums their bonds — it returns `σ_L + ω × Σ(bonded_amount)` over all active vouchers, capped
+> at 1.0. The vouching graph is also tracked for auditing and liability analysis.
 
 ### 5.4 Exposure Tracking
 
@@ -332,9 +332,9 @@ for clip in result.voucher_clips:
     print(f"  Vouch ID: {clip.vouch_id}")
 ```
 
-> **Public Preview:** In the Public Preview, slashing is logged but
-> scores are not actually modified. The `SlashResult` records are still created
-> for auditing. Enterprise editions enforce real score deductions.
+> **Score mutation:** `slash()` mutates the supplied `agent_scores` map in place — the
+> vouchee is set to `0.0` and each active voucher is clipped to `max(SIGMA_FLOOR, σ × (1 - ω))`.
+> The `SlashResult` and its `VoucherClip` records capture the before/after values for auditing.
 
 ### 6.4 Cascade Depth
 
@@ -623,9 +623,9 @@ if active:
     print(f"Duration: {active.duration_seconds}s")
 ```
 
-> **Public Preview:** In the Public Preview, `is_quarantined()` always
-> returns `False` and `active_quarantines` is always empty. Quarantine records
-> are still created for auditing. Enterprise editions enforce actual isolation.
+> **Expiry:** `is_quarantined()` and `get_active_quarantine()` honour each record's
+> `expires_at`; lapsed records are expired lazily on read and in bulk via `tick()`. A record
+> stays active until it expires or is released.
 
 ### 9.4 Releasing from Quarantine
 
@@ -780,9 +780,9 @@ print(f"Admit: {should_admit}")  # True/False
 print(f"Reason: {reason}")       # "admit" / "probation" / "deny"
 ```
 
-> **Public Preview:** `should_admit()` always returns `(True, "admit")`.
-> The risk profile is still computed for visibility. Enterprise editions enforce
-> admission gates.
+> **Admission gate:** `should_admit()` denies an agent only when its risk score crosses
+> `DENY_THRESHOLD`. It returns `(False, "deny")` for denied agents and `(True, reason)`
+> otherwise, where `reason` is `"admit"` or `"probation"` (admitted but flagged).
 
 ### 10.6 Thresholds
 


### PR DESCRIPTION
## Summary

Replaces the no-op stub bodies in the `hypervisor` liability/accountability engines with real, tested logic (bonding, slashing, risk-based admission, quarantine, GC purge, commitment). The engine methods now do what their signatures and docstrings claim when called, instead of accepting parameters and returning hardcoded safe values.

NOTE: pr in draft, considering whether to remove this entirely

## Problem

Every method in the liability pillar accepted meaningful parameters and silently ignored them, using "Public Preview" in docstrings as the justification for returning success-shaped values:

- `VouchingEngine.vouch` hardcoded `bonded_amount=0.0`; `get_total_exposure` returned `0.0`; `compute_eff_score` returned the vouchee score unchanged.
- `SlashingEngine.slash` returned `vouchee_sigma_after == vouchee_sigma_before` with empty clips. No penalty applied.
- `LiabilityLedger.should_admit` returned `(True, "admit")` even after many maximum-severity faults.
- `QuarantineManager` returned safe defaults; `EphemeralGC.collect` purged nothing, so sensitive session data was retained in memory (a data-retention/privacy issue).

The API shape lied. A host wiring bonding/slashing/quarantine/admission for security got zero enforcement and zero error signal. The tests that asserted real behavior were skipped with `@pytest.mark.skip("...Public Preview")`, and the assertions that ran were edited to ratify the stub, so CI was green over non-functional code.

## Changes

| File | What changed |
|------|-------------|
| `liability/vouching.py` | Real bonding (`bonded_amount = voucher_sigma * bond_pct`); reject self-vouch, voucher sigma below `MIN_VOUCHER_SCORE`, cycles, and over-`max_exposure`; validate `bond_pct` in `[0,1]`; `compute_eff_score = sigma_L + clamp(omega) * sum(active bonds)` capped at 1.0; active queries now also exclude expired bonds |
| `liability/slashing.py` | Blacklist vouchee to `0.0`; clip each active voucher to `max(SIGMA_FLOOR, sigma * (1 - omega))`; cascade up the liability graph to `MAX_CASCADE_DEPTH`; cascade flows THROUGH a voucher missing from `agent_scores` to reach known upstream guarantors; `risk_weight` clamped to `[0,1]` |
| `liability/ledger.py` | Saturating risk score from negative-event severity discounted by clean sessions; `should_admit` denies above `DENY_THRESHOLD` (admit / probation / deny) |
| `liability/quarantine.py` | Active, time-bounded records with expiry, release, `tick`, and single-active escalation |
| `audit/gc.py` + `session/sso.py` | `EphemeralGC.collect` performs a real purge via new `SessionVFS.purge()` (clears file contents, snapshots, permissions) while retaining the content-free delta hash chain for audit |
| `audit/commitment.py` | Documented as a real local commitment store with an optional external `anchor_backend` hook |
| `liability/attribution.py`, `liability/__init__.py` | Docstring corrections only (the attributor was already a real direct-cause implementation) |
| tests (unit + integration) | Un-skipped/rewrote 14 enforcement tests; added regressions for expiry exclusion, weight bounds, `max_exposure=0`, and cascade-through-untracked-voucher |
| docs (guide + tutorial 12) | Document the shipped behavior; corrected a worked example that claimed `eff = 0.725` (full sigma) where the code yields `0.385` (bonded amount) |

## Reachability / open decision (please read before merging)

A multi-lens deep review (correctness, domain-semantics, fit, scope, fidelity; dual-model) found that most of this pillar is not reached by any production call path, and this is pre-existing (this PR does not touch `core.py` or `api/`):

- No `Hypervisor()` instance wires a `policy_check` adapter, so `SlashingEngine.slash` is never invoked in `src/`; and `core.verify_behavior` mutates a throwaway `agent_scores` dict that is never written back to participants.
- `LiabilityLedger` and `QuarantineManager` are never instantiated in `src/`; `compute_eff_score` has no caller, so bonds never influence any trust/ring decision.
- Reached and genuinely improved: `VouchingEngine.vouch` and `get_total_exposure` (via the `/sponsor` API), and `gc.collect`, `commitment.commit`, `release_session_bonds` (via `terminate_session`). The GC purge is a real privacy fix, verified by a live heap-grep that no session plaintext survives.

`agent-hypervisor` is also a deprecated package. So this PR honestly makes the engines correct, but the question of whether to (a) wire enforcement into the live runtime, (b) remove the unwired engines, or (c) keep them with an explicit "runtime does not invoke this" note is a security-model decision for a maintainer. Opening as DRAFT for that reason. Two latent design risks if (a) is chosen later: clean-session whitewashing of the risk score, and sponsor-stacking of `compute_eff_score`.

## Testing

- `pytest tests/` (from the package): 828 passed, 46 skipped (baseline `main`: 805 passed, 60 skipped). Net 14 enforcement tests un-skipped plus regressions, no regressions.
- Ruff CI gate `ruff check src/ --select E,F,W --ignore E501`: clean.
- Spell-check gate (cspell on added lines): clean.
- Docs relative-link check: 0 new broken.
- MIT license headers present on all changed source files; commits are DCO signed-off.
