### PR TITLE
docs: add embodied action governance profile

### DIFF
--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,3 +1,9 @@
+---
+title: Known Limitations and Design Boundaries
+last_reviewed: 2026-06-25
+owner: agt-maintainers
+---
+
 # Known Limitations & Design Boundaries
 
 > **Transparency is a feature.** This document describes what AGT does *not* do
@@ -262,35 +268,50 @@ dashboard shows "governed" status, but no rules are enforced.
 ## 10. Physical AI and Embodied Agent Governance
 
 AGT governs **software agents** that call tools via APIs, MCP, or inter-agent
-protocols. It does **not** provide governance primitives specific to **physical
-agents** (robots, drones, autonomous vehicles, industrial actuators).
+protocols. It can govern an embodied agent's software request before that
+request reaches a robot, drone, lab device, building system, or industrial
+controller. It is **not** a robot safety controller, real-time planner,
+functional-safety system, or proof of physical execution.
 
 **What this means in practice:**
 
 - ✅ AGT can govern the *software decision layer* of a robotic agent (e.g.,
   blocking an API call to arm a mechanism)
+- ✅ AGT can require action-bound approval for high-risk embodied requests when
+  paired with [ADR-0030](adr/0030-action-bound-approval-protocol.md)
+- ❌ AGT does **not** prove that a downstream controller accepted, safely
+  executed, or completed the physical action
 - ❌ AGT does **not** provide hardware kill switches, force-limiting, or actuator
   safety interlocks
 - ❌ AGT does **not** model physical world state, collision boundaries, or
   safety zones
+- ❌ AGT does **not** replace safety PLCs, robot controllers, emergency stops,
+  certification evidence, or domain-specific runtime monitors
 - ❌ AGT does **not** address latency requirements for real-time control loops
   (typically <10ms) — policy evaluation at <0.1ms is fast enough, but the
   full governance stack (identity, trust, audit) may not be
 
 **Example gap:** A warehouse robot governed by AGT has its `move_to_location`
 call approved by policy, but the target location is occupied by a human. AGT
-has no spatial awareness to detect this.
+has no spatial awareness to detect this. The AGT decision proves only that the
+software request was governed; the downstream safety layer must reject,
+constrain, or stop unsafe motion.
 
 **Mitigations available today:**
 - Use AGT's policy engine for the *decision layer* — blocking unsafe commands
   before they reach the actuator layer
-- Combine AGT with domain-specific robot safety frameworks (e.g., ROS 2 Safety
-  Controller, ISO 10218 / ISO 15066 compliance layers)
-- Use **execution rings** to isolate physical actuator calls in Ring 0 with
-  human-in-the-loop approval
+- Combine AGT with domain-specific robot safety frameworks, certified
+  controllers, safety PLCs, interlocks, and emergency stops
+- Use action-bound approval for high-risk physical requests and fail closed when
+  current controller or safety-state evidence is missing
+- Use AGT audit and trace records as software governance evidence, not as proof
+  of physical outcome
+- Use the draft [embodied action governance boundary profile](proposals/EMBODIED-ACTION-GOVERNANCE-PROFILE.md)
+  when documenting decision-layer policies for physical systems
 
-**Status:** Physical AI governance is out of scope for AGT's current roadmap.
-We welcome community contributions exploring this space.
+**Status:** Physical safety and real-time physical control remain out of scope
+for AGT's current roadmap. The embodied action profile is a community-facing
+documentation and policy-example path for decision-layer governance only.
 
 ## 11. Streaming Data and Real-Time Assurance
 

--- a/docs/proposals/EMBODIED-ACTION-GOVERNANCE-PROFILE.md
+++ b/docs/proposals/EMBODIED-ACTION-GOVERNANCE-PROFILE.md
@@ -1,0 +1,155 @@
+---
+title: Embodied Action Governance Boundary Profile
+last_reviewed: 2026-06-25
+owner: agt-maintainers
+---
+
+# Proposal: Embodied Action Governance Boundary Profile
+
+**Status:** Draft
+**Type:** Docs and policy profile
+**Scope:** Software decision-layer governance for embodied action requests
+
+**Related ADRs and docs:**
+
+- [ADR-0030: Action-bound approval protocol](../adr/0030-action-bound-approval-protocol.md)
+- [ADR-0032: AGT emits TRACE v0.1 trust records](../adr/0032-agt-emits-trace-v01-trust-records.md)
+- [ADR-0009: RFC 9334 RATS architecture alignment](../adr/0009-rfc-9334-rats-architecture-alignment.md)
+- [ADR-0010: TEE keystore and SEV-SNP attestation](../adr/0010-tee-keystore-sevsnp-attestation.md)
+- [ADR-0017: Merkle chain for audit tamper evidence](../adr/0017-merkle-chain-for-audit-tamper-evidence.md)
+- [ADR-0024: RL training governance with violation penalties](../adr/0024-rl-training-governance-with-violation-penalties.md)
+- [Known limitations and design boundaries](../LIMITATIONS.md)
+- [Sample policy fixture](../../examples/policies/embodied-action-governance.yaml)
+
+## Summary
+
+This proposal defines a small boundary profile for agents that request actions
+with possible physical effects, such as robot motion, drone navigation, lab
+automation, building controls, or industrial actuator changes.
+
+The profile reuses existing AGT concepts: policy evaluation, action-bound
+approval, audit logs, and software trace records. It does not introduce a robot
+safety controller, hardware attestation requirement, ROS integration, or proof
+that the physical world changed as intended.
+
+## Problem
+
+Embodied agents can turn an allowed software action into a physical request. A
+policy decision like "allow `robot.move`" is useful, but it is not the same as
+"the motion is physically safe" or "the controller executed the motion
+successfully."
+
+AGT needs a clear contribution path for this domain that helps users govern
+software decisions while preserving the boundary stated in
+[physical AI limitations](../LIMITATIONS.md#10-physical-ai-and-embodied-agent-governance):
+physical safety remains the job of downstream controllers, safety PLCs,
+interlocks, emergency stops, certified runtime monitors, and domain-specific
+validation.
+
+## Non-goals
+
+- Certify functional safety or conformity with robotics, aviation, medical, or
+  industrial-control standards.
+- Replace robot controllers, safety PLCs, motion planners, collision monitors,
+  emergency stops, force limits, or hardware interlocks.
+- Prove physical completion, physical non-harm, or world-state correctness after
+  an action executes.
+- Make AGT a hard real-time control loop.
+- Require TEEs, hardware roots of trust, or a specific downstream controller.
+- Add first-party ROS, ROS 2, Isaac, PLC, or drone SDK adapters in this proposal.
+
+## Boundary Model
+
+| Layer | AGT can help with | AGT does not prove |
+|-------|-------------------|--------------------|
+| Policy decision | Whether the agent is authorized to request a named physical action under declared context | That the action is physically safe |
+| Action-bound approval | Whether an exact action digest was approved before execution | That the approver certified the physical outcome |
+| Audit and trace records | That AGT observed and recorded the request, decision, and selected context | That a downstream controller executed or completed the action |
+| Tamper-evident logs | That local audit entries were chained and alteration is detectable | That the entire chain was externally anchored or impossible to replace |
+| Downstream controller | External evidence can be referenced or required by policy | AGT itself does not create controller-level safety evidence |
+
+## Suggested Action Context
+
+The profile treats embodied requests as ordinary governed actions with extra
+context. These keys are illustrative, not a committed runtime schema:
+
+```yaml
+physical_action:
+  embodiment_id: "cell-7-arm-a"
+  controller_id: "safety-plc-3"
+  operation: "bounded_motion"
+  workspace: "assembly-cell-7"
+  target_ref: "bin-slot-12"
+  max_speed_mps: 0.25
+  max_force_n: 35
+  human_proximity: "unknown"
+  reversibility: "reversible"
+  safety_state_token_ref: "controller-state-2026-06-25T11:40:00Z"
+  outcome_evidence_required: true
+```
+
+Deployments can map these fields into the existing policy context passed to the
+policy evaluator. High-risk deployments should fail closed when required safety
+state is missing or stale.
+
+## Risk Tiers
+
+| Tier | Examples | Suggested AGT treatment |
+|------|----------|-------------------------|
+| Observation only | Read robot state, read sensor state, query controller status | Allow or audit, subject to normal data access policy |
+| Simulation and planning | Validate a trajectory in simulation, generate a plan without actuation | Allow or audit when clearly separated from live controllers |
+| Bounded actuation | Move within a validated workspace, set a low-risk actuator state | Require explicit allowlist, current context, audit, and downstream safety gate |
+| Human-proximate or contact action | Gripper close, robot move near people, drone navigation, lab dispensing | Use `require_approval` with action-bound approval and fail closed on missing safety state |
+| Irreversible or critical action | Disable interlock, release emergency stop, force PLC output, bypass controller | Deny by default; allow only outside AGT through certified operational procedures |
+
+## Mapping To Existing AGT Decisions
+
+- Use [ADR-0030](../adr/0030-action-bound-approval-protocol.md) for high-risk
+  embodied actions. `require_approval` is a suspended decision until a terminal
+  approval is bound to the exact action.
+- Use [ADR-0032](../adr/0032-agt-emits-trace-v01-trust-records.md) as the
+  software trace baseline. Treat hardware-backed or controller-issued evidence
+  as external evidence, not as something AGT itself guarantees.
+- Use [ADR-0009](../adr/0009-rfc-9334-rats-architecture-alignment.md) and
+  [ADR-0010](../adr/0010-tee-keystore-sevsnp-attestation.md) when a deployment
+  needs attested controller or enclave claims. This profile does not make those
+  mandatory.
+- Use [ADR-0017](../adr/0017-merkle-chain-for-audit-tamper-evidence.md) for
+  tamper-evident local audit chains, while preserving the limitation that local
+  chains are not the same as externally anchored evidence.
+- Use [ADR-0024](../adr/0024-rl-training-governance-with-violation-penalties.md)
+  for training-time or reinforcement-learning governance concerns. Runtime
+  physical safety still belongs to the downstream safety layer.
+
+## Example Policy
+
+The sample fixture in
+[examples/policies/embodied-action-governance.yaml](../../examples/policies/embodied-action-governance.yaml)
+shows a deny-by-default policy profile with:
+
+- hard blocks for safety bypass language and direct interlock override actions
+- `require_approval` for human-proximate or actuator-changing actions
+- audit-only treatment for physical state reads
+- allowlisted simulation-only planning actions
+
+The fixture is intentionally generic. It should be copied, reviewed, and mapped
+to deployment-specific controller actions before use.
+
+## Integration Path
+
+1. Document the boundary profile and keep it aligned with the limitations page.
+2. Maintain generic policy fixtures for action names and risk tiers.
+3. Add optional examples that pass physical-action context into existing policy
+   evaluation APIs without adding new AGT runtime dependencies.
+4. Defer ROS, PLC, drone, cMCP, hardware-attestation, or controller-specific
+   adapters until maintainers approve a concrete integration surface.
+
+## Acceptance Criteria
+
+- The limitations page states that AGT can govern embodied action requests but
+  does not provide physical safety, real-time control, or outcome proof.
+- The sample policy fixture is discoverable from `examples/policies/README.md`.
+- The profile maps to existing ADRs instead of introducing a parallel approval,
+  trace, or attestation model.
+- The proposal avoids claims that AGT certifies physical execution or replaces
+  domain safety systems.

--- a/docs/proposals/EMBODIED-ACTION-GOVERNANCE-PROFILE.md
+++ b/docs/proposals/EMBODIED-ACTION-GOVERNANCE-PROFILE.md
@@ -121,6 +121,22 @@ state is missing or stale.
   for training-time or reinforcement-learning governance concerns. Runtime
   physical safety still belongs to the downstream safety layer.
 
+## Future Evidence Integration
+
+This profile can provide the decision-layer inputs for external evidence
+systems without making AGT responsible for controller verification. A deployment
+can record the AGT decision, action digest, policy version, approval status, and
+selected physical-action context, then bind those fields to downstream
+controller receipts in a separate evidence layer.
+
+Such an evidence layer could prove that a controller or gateway issued a signed
+receipt for the same action request AGT evaluated. That binding would complement
+AGT audit records, but it would remain outside this proposal unless a future
+integration explicitly defines the verifier, receipt schema, trust anchors, and
+failure behavior. In particular, controller receipts still would not prove
+physical completion, physical non-harm, or sensor truth unless those claims are
+separately validated by the downstream safety system.
+
 ## Example Policy
 
 The sample fixture in

--- a/examples/policies/README.md
+++ b/examples/policies/README.md
@@ -4,6 +4,10 @@ Sample YAML governance policy files for AgentMesh.
 
 Each file in this directory is a self-contained policy configuration that demonstrates how to express a particular class of security or compliance control using the policy engine. They are intended as starting points — review and adapt them for your environment before deploying to production.
 
+Notable profiles:
+
+- [`embodied-action-governance.yaml`](embodied-action-governance.yaml) - decision-layer controls for embodied or physical action requests.
+
 ## Using this directory
 
 1. **Browse** the `.yaml` files to find a scenario close to what you need. Each file opens with a comment block describing what it covers and any caveats.

--- a/examples/policies/README.md
+++ b/examples/policies/README.md
@@ -4,9 +4,24 @@ Sample YAML governance policy files for AgentMesh.
 
 Each file in this directory is a self-contained policy configuration that demonstrates how to express a particular class of security or compliance control using the policy engine. They are intended as starting points — review and adapt them for your environment before deploying to production.
 
-Notable profiles:
+## Policies
 
-- [`embodied-action-governance.yaml`](embodied-action-governance.yaml) - decision-layer controls for embodied or physical action requests.
+| File | Description |
+|------|-------------|
+| [`adk-governance.yaml`](adk-governance.yaml) | Tool restrictions and delegation controls for Google ADK agents. |
+| [`atr-community-rules.yaml`](atr-community-rules.yaml) | Community governance rules for agent trust and review workflows. |
+| [`cli-security-rules.yaml`](cli-security-rules.yaml) | Blocks dangerous shell and CLI patterns. |
+| [`conversation-guardian.yaml`](conversation-guardian.yaml) | Content safety rules for conversational agents. |
+| [`embodied-action-governance.yaml`](embodied-action-governance.yaml) | Decision-layer controls for embodied or physical action requests. |
+| [`lotl_prevention_policy.yaml`](lotl_prevention_policy.yaml) | Controls for limiting living-off-the-land style tool abuse. |
+| [`mcp-security.yaml`](mcp-security.yaml) | Security controls for MCP tool usage. |
+| [`pii-detection.yaml`](pii-detection.yaml) | Detects and blocks personally identifiable information. |
+| [`prompt-injection-safety.yaml`](prompt-injection-safety.yaml) | Guards against prompt injection attacks. |
+| [`sandbox-safety.yaml`](sandbox-safety.yaml) | Restrictions for sandboxed agent execution. |
+| [`semantic-policy.yaml`](semantic-policy.yaml) | Semantic similarity-based policy enforcement. |
+| [`sql-readonly.yaml`](sql-readonly.yaml) | Restricts agents to read-only SQL operations. |
+| [`sql-safety.yaml`](sql-safety.yaml) | Blocks destructive SQL patterns. |
+| [`sql-strict.yaml`](sql-strict.yaml) | Strict SQL allowlist for production databases. |
 
 ## Using this directory
 

--- a/examples/policies/embodied-action-governance.yaml
+++ b/examples/policies/embodied-action-governance.yaml
@@ -1,0 +1,77 @@
+# Embodied Action Governance - Sample Configuration
+#
+# IMPORTANT: This is a SAMPLE configuration provided as a starting point.
+# Review, customize, and extend these rules for your deployment before use.
+#
+# This sample governs software action requests before they reach downstream
+# physical controllers. It is not a functional-safety system and does not
+# verify that a physical action was accepted, safely executed, or completed.
+
+version: "1.0"
+name: embodied-action-governance
+description: >
+  Sample governance rules for AI agents that request physically consequential
+  actions such as robot motion, drone navigation, lab automation, building
+  controls, or industrial actuator commands.
+
+disclaimer: >
+  This sample only governs the software action request before it reaches a
+  downstream controller. It does not replace safety PLCs, certified robot
+  controllers, emergency stops, interlocks, runtime monitors, or functional
+  safety reviews.
+
+metadata:
+  related_proposal: docs/proposals/EMBODIED-ACTION-GOVERNANCE-PROFILE.md
+  boundary: decision-layer-only
+
+rules:
+  - name: block-safety-control-bypass
+    condition:
+      field: input
+      operator: matches
+      value: "(?i)(bypass|skip|disable|override).*(safety|interlock|emergency.?stop|controller|human.?approval|approval)"
+    action: deny
+    priority: 100
+    message: "Embodied action request attempts to bypass a safety or approval control"
+
+  - name: block-direct-interlock-control
+    condition:
+      field: action
+      operator: matches
+      value: "^(robot\\.release_emergency_stop|robot\\.override_safety|controller\\.disable_interlock|plc\\.force_output)$"
+    action: deny
+    priority: 100
+    message: "Direct safety interlock override is outside AGT policy authorization"
+
+  - name: require-approval-for-human-proximate-actuation
+    condition:
+      field: action
+      operator: matches
+      value: "^(robot\\.move|robot\\.set_pose|robot\\.gripper\\.close|drone\\.navigate|plc\\.write_output|lab_robot\\.dispense)$"
+    action: require_approval
+    approvers:
+      - safety-operator
+    priority: 90
+    message: "Human-proximate or actuator-changing action requires action-bound approval and downstream safety checks"
+
+  - name: audit-physical-state-reads
+    condition:
+      field: action
+      operator: matches
+      value: "^(robot\\.read_state|cell\\.read_safety_state|sensor\\.read_|controller\\.get_status)$"
+    action: audit
+    priority: 50
+    message: "Physical state read is allowed with audit trail"
+
+  - name: allow-decision-layer-simulation
+    condition:
+      field: action
+      operator: matches
+      value: "^(simulator\\.plan_motion|simulator\\.validate_trajectory)$"
+    action: allow
+    priority: 40
+    message: "Simulation-only planning action is allowed"
+
+defaults:
+  action: deny
+  max_tool_calls: 10

--- a/examples/policies/embodied-action-governance.yaml
+++ b/examples/policies/embodied-action-governance.yaml
@@ -58,7 +58,7 @@ rules:
     condition:
       field: action
       operator: matches
-      value: "^(robot\\.read_state|cell\\.read_safety_state|sensor\\.read_|controller\\.get_status)$"
+      value: "^(robot\\.read_state|cell\\.read_safety_state|sensor\\.read_\\w+|controller\\.get_status)$"
     action: audit
     priority: 50
     message: "Physical state read is allowed with audit trail"


### PR DESCRIPTION
## Summary

- Add a draft embodied action governance boundary profile for physical-action requests.
- Clarify the physical AI limitation so AGT is framed as decision-layer governance, not physical safety or outcome proof.
- Add a deny-by-default sample policy fixture for embodied action requests and link it from the policy examples README.

## Why

This gives contributors a scoped way to discuss embodied AI governance in AGT while preserving the project boundary: downstream controllers, safety PLCs, interlocks, emergency stops, certified runtime monitors, and domain-specific validation remain responsible for physical safety.

## Validation

- `python3 scripts/docs/check_links.py`
- `python3 scripts/docs/check_frontmatter.py` (warn-only; existing repo-wide frontmatter backlog remains)
- `python3 scripts/docs/check_links.py docs/LIMITATIONS.md docs/proposals/EMBODIED-ACTION-GOVERNANCE-PROFILE.md examples/policies/README.md`
- YAML parse check for `examples/policies/embodied-action-governance.yaml`
- `git diff --cached --check`