### PR TITLE
fix: purge ephemeral session data in EphemeralGC without rewriting the audit chain

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/audit/delta.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/audit/delta.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -110,32 +109,6 @@ class DeltaEngine:
         if not self._deltas:
             return None
         return self._deltas[-1].delta_hash
-
-    def prune_expired(self, is_expired: Callable[[datetime], bool]) -> int:
-        """Remove deltas whose timestamp is expired and re-anchor the chain.
-
-        ``is_expired(timestamp)`` decides per-delta expiry (typically a
-        retention-policy check). Retained deltas are re-linked into a fresh
-        valid chain — the new head's ``parent_hash`` is set to ``None`` and
-        every retained ``delta_hash`` is recomputed in order — so
-        :meth:`verify_chain` continues to pass after pruning. Returns the
-        number of deltas removed.
-
-        Note: re-anchoring changes the live chain root. Callers that need the
-        pre-prune root for liability (e.g. commitment anchoring) must capture
-        it before calling this.
-        """
-        retained = [d for d in self._deltas if not is_expired(d.timestamp)]
-        removed = len(self._deltas) - len(retained)
-        if removed == 0:
-            return 0
-        parent_hash: str | None = None
-        for delta in retained:
-            delta.parent_hash = parent_hash
-            delta.compute_hash()
-            parent_hash = delta.delta_hash
-        self._deltas = retained
-        return removed
 
     def verify_chain(self) -> tuple[bool, str | None]:
         """Verify full chain integrity: hash correctness and parent linkage."""

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/audit/delta.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/audit/delta.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -109,6 +110,32 @@ class DeltaEngine:
         if not self._deltas:
             return None
         return self._deltas[-1].delta_hash
+
+    def prune_expired(self, is_expired: Callable[[datetime], bool]) -> int:
+        """Remove deltas whose timestamp is expired and re-anchor the chain.
+
+        ``is_expired(timestamp)`` decides per-delta expiry (typically a
+        retention-policy check). Retained deltas are re-linked into a fresh
+        valid chain — the new head's ``parent_hash`` is set to ``None`` and
+        every retained ``delta_hash`` is recomputed in order — so
+        :meth:`verify_chain` continues to pass after pruning. Returns the
+        number of deltas removed.
+
+        Note: re-anchoring changes the live chain root. Callers that need the
+        pre-prune root for liability (e.g. commitment anchoring) must capture
+        it before calling this.
+        """
+        retained = [d for d in self._deltas if not is_expired(d.timestamp)]
+        removed = len(self._deltas) - len(retained)
+        if removed == 0:
+            return 0
+        parent_hash: str | None = None
+        for delta in retained:
+            delta.parent_hash = parent_hash
+            delta.compute_hash()
+            parent_hash = delta.delta_hash
+        self._deltas = retained
+        return removed
 
     def verify_chain(self) -> tuple[bool, str | None]:
         """Verify full chain integrity: hash correctness and parent linkage."""

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/audit/gc.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/audit/gc.py
@@ -3,11 +3,13 @@
 """
 Ephemeral Session Data Garbage Collection.
 
-Purges ephemeral session state (VFS files, cached snapshots) on collection
-and expires audit deltas that fall outside the configured retention window.
+Purges ephemeral session state (VFS files, cached snapshots) on collection.
 The reported ``GCResult`` and ``is_purged`` flag reflect what was actually
-removed — a host that calls :meth:`EphemeralGC.collect` to delete sensitive
-session data can trust the confirmation.
+removed — when a host hands ``collect`` a live VFS, ``is_purged`` is True only
+once that VFS is empty, so the confirmation can be trusted for the data it was
+given. The tamper-evident audit ``delta`` chain is durable forensic evidence
+and is retained intact; ``should_expire_deltas`` only judges, per policy,
+whether a delta falls outside the retention window.
 """
 
 from __future__ import annotations
@@ -52,7 +54,8 @@ class RetentionPolicy:
 
 class EphemeralGC:
     """
-    Purges ephemeral session data and expires audit deltas per retention policy.
+    Purges ephemeral session data (VFS files and cached snapshots) while
+    preserving the durable tamper-evident audit chain.
     """
 
     def __init__(self, policy: RetentionPolicy | None = None) -> None:
@@ -73,16 +76,20 @@ class EphemeralGC:
         estimated_delta_bytes: int = 0,
         gc_agent_did: str = "did:agt:hypervisor:gc",
     ) -> GCResult:
-        """Purge ephemeral session data and expire out-of-retention deltas.
+        """Purge ephemeral session data; preserve the durable audit chain.
 
         When a real ``vfs`` is supplied its files and cached snapshots are
-        physically removed; when a real ``delta_engine`` is supplied, deltas
-        older than ``policy.delta_retention_days`` are pruned. The
-        ``estimated_*`` / ``*_count`` parameters are only used for storage
-        accounting when the corresponding live object is absent — they never
-        cause the result to report a purge that did not happen.
+        physically removed. The audit ``delta_engine`` is the tamper-evident
+        forensic log (``policy.hash_retention == "permanent"``) and is
+        deliberately NOT mutated here: rewriting it to "expire" entries would
+        break the committed hash-chain root and let deletions go undetected,
+        so the chain is retained intact and ``should_expire_deltas`` is exposed
+        only as a retention-policy predicate for callers that archive the log
+        out of band. The ``estimated_*`` / ``*_count`` parameters are only used
+        for storage accounting when the corresponding live object is absent —
+        they never cause the result to report a purge that did not happen.
         """
-        # --- VFS files + cached snapshots ---
+        # --- VFS files + cached snapshots (the ephemeral, sensitive data) ---
         if vfs is not None:
             vfs_bytes_before = self._vfs_storage_bytes(vfs)
             purged_vfs_files, purged_caches = vfs.purge_all(gc_agent_did)
@@ -90,35 +97,22 @@ class EphemeralGC:
             vfs_fully_purged = vfs.file_count == 0
         else:
             # No live handle: nothing is physically removed, so report no
-            # purge (reporting vfs_file_count here would be a lie).
+            # purge and do not claim the session was purged.
             vfs_bytes_before = estimated_vfs_bytes
             vfs_bytes_after = estimated_vfs_bytes
             purged_vfs_files = 0
             purged_caches = 0
-            vfs_fully_purged = True
+            vfs_fully_purged = False
 
-        # --- audit deltas (retain within window, expire the rest) ---
+        # --- audit deltas: retained intact (durable tamper-evident evidence) ---
         if delta_engine is not None:
-            total_deltas = len(delta_engine.deltas)
-            delta_engine.prune_expired(self.should_expire_deltas)
             retained_deltas = len(delta_engine.deltas)
         else:
-            total_deltas = delta_count
             retained_deltas = delta_count
+        delta_bytes_after = estimated_delta_bytes
 
-        if total_deltas > 0:
-            delta_bytes_before = estimated_delta_bytes
-            delta_bytes_after = round(estimated_delta_bytes * retained_deltas / total_deltas)
-        else:
-            delta_bytes_before = estimated_delta_bytes
-            delta_bytes_after = estimated_delta_bytes
-
-        # Caches are physically purged only via the live VFS snapshots above;
-        # estimated_cache_bytes is reclaimed proportionally to that purge.
-        if purged_caches > 0 or vfs is None:
-            cache_bytes_after = estimated_cache_bytes if vfs is None else 0
-        else:
-            cache_bytes_after = estimated_cache_bytes
+        # Caches (VFS snapshots) are reclaimed only via the live purge above.
+        cache_bytes_after = 0 if purged_caches > 0 else estimated_cache_bytes
 
         result = GCResult(
             session_id=session_id,
@@ -126,12 +120,14 @@ class EphemeralGC:
             retained_hash=self.policy.hash_retention == "permanent",
             purged_vfs_files=purged_vfs_files,
             purged_caches=purged_caches,
-            storage_before_bytes=vfs_bytes_before + estimated_cache_bytes + delta_bytes_before,
+            storage_before_bytes=vfs_bytes_before + estimated_cache_bytes + estimated_delta_bytes,
             storage_after_bytes=vfs_bytes_after + cache_bytes_after + delta_bytes_after,
         )
         self._gc_history.append(result)
 
-        # Honest flag: mark purged only when no live retained data remains.
+        # Honest flag: mark purged only with positive evidence of removal —
+        # a live vfs was supplied AND is empty afterwards. With no vfs handle
+        # the GC inspected nothing and must not claim the session was purged.
         if vfs_fully_purged:
             self._purged_sessions.add(session_id)
         return result

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/audit/gc.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/audit/gc.py
@@ -1,17 +1,19 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-# Public Preview — basic implementation
 """
-Ephemeral Session Data Garbage Collection — stub implementation.
+Ephemeral Session Data Garbage Collection.
 
-Public Preview: GC is a no-op. Data is retained in-memory for
-session lifetime only.
+Purges ephemeral session state (VFS files, cached snapshots) on collection
+and expires audit deltas that fall outside the configured retention window.
+The reported ``GCResult`` and ``is_purged`` flag reflect what was actually
+removed — a host that calls :meth:`EphemeralGC.collect` to delete sensitive
+session data can trust the confirmation.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 
@@ -50,7 +52,7 @@ class RetentionPolicy:
 
 class EphemeralGC:
     """
-    GC stub (Public Preview: logs collection requests, no actual purge).
+    Purges ephemeral session data and expires audit deltas per retention policy.
     """
 
     def __init__(self, policy: RetentionPolicy | None = None) -> None:
@@ -69,28 +71,97 @@ class EphemeralGC:
         estimated_vfs_bytes: int = 0,
         estimated_cache_bytes: int = 0,
         estimated_delta_bytes: int = 0,
+        gc_agent_did: str = "did:agt:hypervisor:gc",
     ) -> GCResult:
-        """Log a GC request (Public Preview: no actual purge)."""
+        """Purge ephemeral session data and expire out-of-retention deltas.
+
+        When a real ``vfs`` is supplied its files and cached snapshots are
+        physically removed; when a real ``delta_engine`` is supplied, deltas
+        older than ``policy.delta_retention_days`` are pruned. The
+        ``estimated_*`` / ``*_count`` parameters are only used for storage
+        accounting when the corresponding live object is absent — they never
+        cause the result to report a purge that did not happen.
+        """
+        # --- VFS files + cached snapshots ---
+        if vfs is not None:
+            vfs_bytes_before = self._vfs_storage_bytes(vfs)
+            purged_vfs_files, purged_caches = vfs.purge_all(gc_agent_did)
+            vfs_bytes_after = 0 if vfs.file_count == 0 else self._vfs_storage_bytes(vfs)
+            vfs_fully_purged = vfs.file_count == 0
+        else:
+            # No live handle: nothing is physically removed, so report no
+            # purge (reporting vfs_file_count here would be a lie).
+            vfs_bytes_before = estimated_vfs_bytes
+            vfs_bytes_after = estimated_vfs_bytes
+            purged_vfs_files = 0
+            purged_caches = 0
+            vfs_fully_purged = True
+
+        # --- audit deltas (retain within window, expire the rest) ---
+        if delta_engine is not None:
+            total_deltas = len(delta_engine.deltas)
+            delta_engine.prune_expired(self.should_expire_deltas)
+            retained_deltas = len(delta_engine.deltas)
+        else:
+            total_deltas = delta_count
+            retained_deltas = delta_count
+
+        if total_deltas > 0:
+            delta_bytes_before = estimated_delta_bytes
+            delta_bytes_after = round(estimated_delta_bytes * retained_deltas / total_deltas)
+        else:
+            delta_bytes_before = estimated_delta_bytes
+            delta_bytes_after = estimated_delta_bytes
+
+        # Caches are physically purged only via the live VFS snapshots above;
+        # estimated_cache_bytes is reclaimed proportionally to that purge.
+        if purged_caches > 0 or vfs is None:
+            cache_bytes_after = estimated_cache_bytes if vfs is None else 0
+        else:
+            cache_bytes_after = estimated_cache_bytes
+
         result = GCResult(
             session_id=session_id,
-            retained_deltas=delta_count,
-            retained_hash=True,
-            purged_vfs_files=0,
-            purged_caches=0,
-            storage_before_bytes=estimated_vfs_bytes
-            + estimated_cache_bytes
-            + estimated_delta_bytes,
-            storage_after_bytes=estimated_vfs_bytes + estimated_cache_bytes + estimated_delta_bytes,
+            retained_deltas=retained_deltas,
+            retained_hash=self.policy.hash_retention == "permanent",
+            purged_vfs_files=purged_vfs_files,
+            purged_caches=purged_caches,
+            storage_before_bytes=vfs_bytes_before + estimated_cache_bytes + delta_bytes_before,
+            storage_after_bytes=vfs_bytes_after + cache_bytes_after + delta_bytes_after,
         )
         self._gc_history.append(result)
-        self._purged_sessions.add(session_id)
+
+        # Honest flag: mark purged only when no live retained data remains.
+        if vfs_fully_purged:
+            self._purged_sessions.add(session_id)
         return result
+
+    @staticmethod
+    def _vfs_storage_bytes(vfs: Any) -> int:
+        """Sum UTF-8 byte sizes of all files via the VFS public API."""
+        total = 0
+        for path in vfs.list_files():
+            content = vfs.read(path)
+            if content is not None:
+                total += len(content.encode("utf-8"))
+        return total
 
     def is_purged(self, session_id: str) -> bool:
         return session_id in self._purged_sessions
 
     def should_expire_deltas(self, delta_timestamp: datetime) -> bool:
-        return False
+        """Return True if a delta at ``delta_timestamp`` is outside retention.
+
+        Compares the timestamp against ``policy.delta_retention_days``. A
+        non-positive retention window means "retain nothing" (everything
+        expires); deltas exactly at the cutoff are retained.
+        """
+        retention_days = self.policy.delta_retention_days
+        cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+        ts = delta_timestamp
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        return ts < cutoff
 
     @property
     def history(self) -> list[GCResult]:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/session/sso.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/session/sso.py
@@ -91,6 +91,30 @@ class SessionVFS:
         prefix = self.namespace
         return [p.removeprefix(prefix) for p in self._files if p.startswith(prefix)]
 
+    def purge_all(self, agent_did: str = "did:agt:hypervisor:gc") -> tuple[int, int]:
+        """Forcibly purge all ephemeral session data.
+
+        Clears files, path permissions, and cached snapshots. Unlike
+        :meth:`delete`, this bypasses per-path permission checks: garbage
+        collection is a system-level reclaim of the entire session and must
+        not be blocked by an agent-scoped permission entry. Snapshots are
+        cleared too — they hold full copies of file state recoverable via
+        :meth:`restore_snapshot`, so leaving them behind would retain the
+        very data the purge is meant to remove.
+
+        Returns:
+            ``(files_purged, snapshots_purged)``.
+        """
+        files_purged = len(self._files)
+        snapshots_purged = len(self._snapshots)
+        self._files.clear()
+        self._permissions.clear()
+        self._snapshots.clear()
+        self._edit_log.append(
+            VFSEdit(path=self.namespace, operation="delete", agent_did=agent_did)
+        )
+        return files_purged, snapshots_purged
+
     def set_permissions(self, path: str, allowed_agents: set[str], agent_did: str) -> VFSEdit:
         """Set path-level permissions."""
         full_path = self._resolve(path)

--- a/agent-governance-python/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
+++ b/agent-governance-python/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
@@ -464,9 +464,14 @@ class TestGCIntegration:
         assert len(self.hv.gc.history) == 1
 
     def test_gc_tracks_purged_sessions(self):
+        from hypervisor.session.sso import SessionVFS
+
         gc = self.hv.gc
-        gc.collect(session_id="s1")
-        gc.collect(session_id="s2")
+        # GC marks a session purged only with positive evidence of removal, so
+        # hand it a real (empty) VFS per session — mirrors core._cleanup_session,
+        # which always passes the live VFS.
+        gc.collect(session_id="s1", vfs=SessionVFS("s1"))
+        gc.collect(session_id="s2", vfs=SessionVFS("s2"))
         assert gc.purged_session_count == 2
         assert gc.is_purged("s1")
         assert gc.is_purged("s2")

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
@@ -139,24 +139,27 @@ class TestEphemeralGC:
         assert result.storage_saved_bytes > 0
         assert gc.is_purged("s") is True
 
-    def test_collect_expires_old_deltas_keeps_fresh(self):
-        # A real delta_engine: deltas outside the window are pruned, fresh
-        # ones retained, and the retained chain stays verifiable.
+    def test_collect_preserves_audit_chain_intact(self):
+        # BUG-fix regression guard: collect() must NOT rewrite the tamper-evident
+        # delta chain. Even under a zero-day retention window (every delta is
+        # outside retention per should_expire_deltas), the chain is retained
+        # unchanged and its committed root stays reproducible.
         engine = DeltaEngine("s")
         engine.capture("did:a", [VFSChange(path="/old.txt", operation="add")])
         engine.capture("did:a", [VFSChange(path="/fresh.txt", operation="add")])
-        # Age the first delta past the 30-day window.
-        engine._deltas[0].timestamp = datetime.now(UTC) - timedelta(days=40)
+        committed_root = engine.compute_hash_chain_root()
 
-        gc = EphemeralGC(RetentionPolicy(delta_retention_days=30))
+        gc = EphemeralGC(RetentionPolicy(delta_retention_days=0))
+        assert gc.should_expire_deltas(engine.deltas[0].timestamp)  # outside retention
         result = gc.collect(session_id="s", delta_engine=engine)
 
-        assert result.retained_deltas == 1
-        assert len(engine.deltas) == 1
-        assert engine.deltas[0].changes[0].path.endswith("fresh.txt")
+        # Chain untouched: same length, still verifiable, same root.
+        assert len(engine.deltas) == 2
+        assert result.retained_deltas == 2
         valid, error = engine.verify_chain()
-        assert valid is True
-        assert error is None
+        assert valid is True and error is None
+        assert engine.compute_hash_chain_root() == committed_root
+        assert result.retained_hash is True
 
     def test_retention_policy_expires_outside_window(self):
         gc = EphemeralGC(RetentionPolicy(delta_retention_days=30))
@@ -164,3 +167,12 @@ class TestEphemeralGC:
         assert gc.should_expire_deltas(old)
         recent = datetime.now(UTC) - timedelta(days=1)
         assert not gc.should_expire_deltas(recent)
+
+    def test_collect_without_vfs_does_not_claim_purged(self):
+        # Honest flag guard: with no live VFS handle, GC inspected nothing and
+        # must not report the session as purged.
+        gc = EphemeralGC()
+        result = gc.collect(session_id="s1", vfs_file_count=3, estimated_vfs_bytes=999)
+        assert result.purged_vfs_files == 0
+        assert gc.is_purged("s1") is False
+        assert gc.purged_session_count == 0

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_audit.py
@@ -2,11 +2,12 @@
 # Licensed under the MIT License.
 """Tests for delta audit engine and commitment."""
 
-from datetime import UTC
+from datetime import UTC, datetime, timedelta
 
 from hypervisor.audit.commitment import CommitmentEngine
 from hypervisor.audit.delta import DeltaEngine, VFSChange
 from hypervisor.audit.gc import EphemeralGC, RetentionPolicy
+from hypervisor.session.sso import SessionVFS
 
 
 class TestDeltaEngine:
@@ -98,7 +99,9 @@ class TestCommitmentEngine:
 
 
 class TestEphemeralGC:
-    def test_collect(self):
+    def test_collect_accounting_only_without_live_handles(self):
+        # With no live vfs/delta_engine, collect cannot physically purge, so
+        # it must not claim it did: 0 files purged, all deltas retained.
         gc = EphemeralGC()
         result = gc.collect(
             session_id="session:1",
@@ -109,19 +112,55 @@ class TestEphemeralGC:
             estimated_cache_bytes=500_000,
             estimated_delta_bytes=50_000,
         )
-        # Public preview: no actual purge, data retained
         assert result.purged_vfs_files == 0
         assert result.retained_deltas == 20
-        # No savings since nothing is purged
         assert result.storage_saved_bytes == 0
         assert result.savings_pct == 0
 
-    def test_retention_policy(self):
-        from datetime import datetime, timedelta
+    def test_collect_purges_live_vfs_and_confirms(self):
+        # BUG 1 regression: a real VFS must actually be emptied and is_purged
+        # must reflect reality (not lie while data is still readable).
+        vfs = SessionVFS("s")
+        vfs.write("/a.txt", "data1", agent_did="did:a")
+        vfs.write("/b.txt", "data2", agent_did="did:a")
+        snap = vfs.create_snapshot()
+        assert vfs.file_count == 2
+
+        gc = EphemeralGC()
+        result = gc.collect(session_id="s", vfs=vfs)
+
+        assert vfs.file_count == 0
+        assert vfs.read("/a.txt") is None
+        assert vfs.read("/b.txt") is None
+        assert result.purged_vfs_files == 2
+        # Cached snapshot (a recoverable copy of the data) is purged too.
+        assert result.purged_caches == 1
+        assert snap not in vfs.list_snapshots()
+        assert result.storage_saved_bytes > 0
+        assert gc.is_purged("s") is True
+
+    def test_collect_expires_old_deltas_keeps_fresh(self):
+        # A real delta_engine: deltas outside the window are pruned, fresh
+        # ones retained, and the retained chain stays verifiable.
+        engine = DeltaEngine("s")
+        engine.capture("did:a", [VFSChange(path="/old.txt", operation="add")])
+        engine.capture("did:a", [VFSChange(path="/fresh.txt", operation="add")])
+        # Age the first delta past the 30-day window.
+        engine._deltas[0].timestamp = datetime.now(UTC) - timedelta(days=40)
 
         gc = EphemeralGC(RetentionPolicy(delta_retention_days=30))
+        result = gc.collect(session_id="s", delta_engine=engine)
+
+        assert result.retained_deltas == 1
+        assert len(engine.deltas) == 1
+        assert engine.deltas[0].changes[0].path.endswith("fresh.txt")
+        valid, error = engine.verify_chain()
+        assert valid is True
+        assert error is None
+
+    def test_retention_policy_expires_outside_window(self):
+        gc = EphemeralGC(RetentionPolicy(delta_retention_days=30))
         old = datetime.now(UTC) - timedelta(days=31)
-        # Public preview: never expires deltas
-        assert not gc.should_expire_deltas(old)
+        assert gc.should_expire_deltas(old)
         recent = datetime.now(UTC) - timedelta(days=1)
         assert not gc.should_expire_deltas(recent)


### PR DESCRIPTION
## Summary

Fix two coupled data-retention bugs in the agent-hypervisor `EphemeralGC` so it actually purges ephemeral session data and reports deletion truthfully, while preserving the tamper-evident audit chain.

## Problem

`BUGS.md` describes two bugs in `agent-governance-python/agent-hypervisor/src/hypervisor/audit/gc.py`.

- **BUG 2 (root cause)** `should_expire_deltas(delta_timestamp)` returned `False` unconditionally, so the retention window was never applied and `delta_timestamp` was a dead parameter.
- **BUG 1** `collect()` returned `is_purged=True` while leaving the VFS fully intact and readable, so a host calling `collect()` to delete ephemeral session data and checking `is_purged()` got a false confirmation while PII, prompts, and secrets stayed readable. A lying status flag is worse than a pure no-op.

A context-first multi-lens review of the first fix attempt caught a second, more serious defect that the green test suite missed (see Design note below), corrected in the follow-up commit.

## Changes

| File | What changed |
|------|-------------|
| `src/hypervisor/audit/gc.py` | `should_expire_deltas` now compares `delta_timestamp` against `policy.delta_retention_days`. `collect()` physically purges a live VFS (files and cached snapshots) and reports `purged_vfs_files` / `purged_caches` / `storage_saved_bytes` from real removal. `is_purged` is set only with positive evidence of removal (a live VFS was supplied and is empty afterwards), so the flag cannot lie. The durable audit delta chain is retained intact and is never rewritten. |
| `src/hypervisor/session/sso.py` | New `SessionVFS.purge_all()` force-clears files, permissions, and cached snapshots (snapshots are recoverable copies of file state, surfaced as `purged_caches`). It bypasses per-path permission checks as a system-level reclaim. |
| `tests/unit/test_audit.py` | Corrected the retention assertion (an old delta is judged expired, a fresh one is not). Added guards for live-VFS purge, audit-chain preservation, and the honest `is_purged` flag. |
| `tests/integration/test_hypervisor_e2e.py` | The session-tracking test passes a real per-session VFS, mirroring the only real caller `core._cleanup_session`. |

## Testing

- `cd agent-governance-python/agent-hypervisor && pytest tests/ -q` gives 808 passed, 60 skipped.
- `ruff check src/ --select E,F,W --ignore E501` is clean (CI-exact lint).
- No dependency or lockfile changes, so the supply-chain and lockfile gates are not triggered.
