### PR TITLE
fix(hypervisor): wire up quarantine, causal attribution, and saga fan-out parsing

### DIFF
--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
@@ -103,9 +103,11 @@ class CausalAttributor:
         # weight, so "full liability to the direct cause" emerges naturally when no
         # other agent failed — there is no separate fallback branch.
         causal_raw: dict[str, float] = dict.fromkeys(agents, 0.0)
+        failed_on_chain = 0
         for agent_did, action in chain:
             if not action.get("success", True):
                 causal_raw[agent_did] += 1.0
+                failed_on_chain += 1
         if failure_agent_did in causal_raw:
             causal_raw[failure_agent_did] += self.DIRECT_CAUSE_BONUS
         causal_total = sum(causal_raw.values())
@@ -157,7 +159,7 @@ class CausalAttributor:
             saga_id=saga_id,
             session_id=session_id,
             attributions=attributions,
-            causal_chain_length=len(chain),
+            causal_chain_length=failed_on_chain,
             root_cause_agent=failure_agent_did,
         )
         self._history.append(result)

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
@@ -4,10 +4,14 @@
 """
 Fault attribution.
 
-Distributes saga-failure liability across the agents on the causal chain
-leading to the failure, weighted by failed actions and an optional caller
-``risk_weights`` policy. Falls back to full liability on the direct cause when
-no action graph or weights are available.
+Distributes saga-failure liability across the agents whose failed actions
+precede the declared failure step, plus a bonus for the direct cause. This is a
+deterministic heuristic (failed-action accounting), NOT a game-theoretic Shapley
+value: ``agent_actions`` carries no causal-graph edges or timestamps, so actions
+are ordered by ``step_id`` (treated as execution order) to decide which failures
+are upstream of the failure vs downstream cascade. An optional caller
+``risk_weights`` map overrides the heuristic only when it covers every
+participating agent.
 """
 
 from __future__ import annotations
@@ -70,13 +74,14 @@ class CausalAttributor:
     ) -> AttributionResult:
         """Attribute liability for a saga failure.
 
-        Walks ``agent_actions`` to the action that failed
-        (``failure_agent_did`` at ``failure_step_id``) and shares liability
-        across agents whose actions on that causal chain failed, plus a bonus
-        for the direct cause. If ``risk_weights`` keyed by agent DID are
-        provided, they override the causal split and distribute liability
-        normalized across the participating agents. With neither an action
-        graph nor matching weights, full liability goes to the direct cause.
+        Orders ``agent_actions`` by ``step_id`` and truncates at the failure
+        action (``failure_agent_did`` at ``failure_step_id``); each FAILED action
+        on that prefix earns weight, plus a ``DIRECT_CAUSE_BONUS`` for the direct
+        cause, normalized to sum 1.0. Downstream (post-failure-step) actions are
+        excluded as cascade. ``risk_weights`` override the heuristic ONLY when the
+        map covers every participating agent (so a partial map cannot silently
+        exonerate a failed agent); otherwise it is ignored and the causal split is
+        used. The result is independent of ``agent_actions`` key/insertion order.
         """
         agents = list(agent_actions.keys())
 
@@ -94,6 +99,9 @@ class CausalAttributor:
         chain = self._causal_chain(agent_actions, failure_step_id, failure_agent_did)
 
         # Causal contribution: failed actions on the chain, plus direct-cause bonus.
+        # When the direct cause participates, the bonus guarantees it positive
+        # weight, so "full liability to the direct cause" emerges naturally when no
+        # other agent failed — there is no separate fallback branch.
         causal_raw: dict[str, float] = dict.fromkeys(agents, 0.0)
         for agent_did, action in chain:
             if not action.get("success", True):
@@ -105,21 +113,25 @@ class CausalAttributor:
             a: (causal_raw[a] / causal_total if causal_total else 0.0) for a in agents
         }
 
-        use_weights = risk_weights is not None and any(
-            risk_weights.get(a, 0.0) > 0.0 for a in agents
-        )
-        if use_weights:
-            weight_raw = {a: max(0.0, risk_weights.get(a, 0.0)) for a in agents}
+        # risk_weights override only if they cover EVERY participating agent and
+        # carry positive mass; a partial map falls through to the causal split.
+        weight_total = 0.0
+        full_coverage = risk_weights is not None and all(a in risk_weights for a in agents)
+        if full_coverage:
+            weight_raw = {a: max(0.0, risk_weights[a]) for a in agents}
             weight_total = sum(weight_raw.values())
+
+        if full_coverage and weight_total > 0:
             liability = {a: weight_raw[a] / weight_total for a in agents}
             mode = "risk-weighted"
         elif causal_total > 0:
             liability = dict(causal_contribution)
             mode = "causal-chain"
         else:
-            # Fallback: no failed actions on the chain and no weights.
-            liability = {a: (1.0 if a == failure_agent_did else 0.0) for a in agents}
-            mode = "direct-cause-fallback"
+            # No participating agent is identifiable as a cause (direct cause
+            # absent and nothing failed on the chain): attribute nothing.
+            liability = dict.fromkeys(agents, 0.0)
+            mode = "no-attribution"
 
         attributions = []
         for agent_did in agents:
@@ -157,34 +169,44 @@ class CausalAttributor:
         failure_step_id: str,
         failure_agent_did: str,
     ) -> list[tuple[str, dict]]:
-        """Flatten actions in iteration order and truncate at the failure action.
+        """Order actions by ``step_id`` and truncate at the failure action.
 
-        The chain is every action up to and including the failure (matched by
-        ``failure_agent_did`` + ``failure_step_id``, falling back to the first
-        action with ``failure_step_id``). Post-failure actions are cascade
-        effects, not causes, so they are excluded. If the failure action is not
-        found, the whole flattened list is treated as the chain.
+        ``agent_actions`` has no timestamps, so ``step_id`` is the only available
+        ordering signal and is treated as execution order. Flattened actions are
+        sorted by ``(step_id, original_index)`` — a STABLE, insertion-order
+        INDEPENDENT order — then truncated at the failure action (exact
+        ``failure_agent_did`` + ``failure_step_id`` match preferred, else the first
+        action carrying ``failure_step_id``). Actions sorting after the failure are
+        downstream cascade and excluded. If the failure step is not found, the
+        whole ordered list is the chain.
+
+        NOTE: this assumes ``step_id`` values sort into execution order. Callers
+        whose step ids do not encode order should pass risk_weights instead.
         """
         flat: list[tuple[str, dict]] = [
             (agent_did, action)
             for agent_did, actions in agent_actions.items()
             for action in actions
         ]
+        ordered = sorted(
+            enumerate(flat), key=lambda item: (str(item[1][1].get("step_id", "")), item[0])
+        )
+        ordered_flat = [pair for _, pair in ordered]
 
         fail_idx = None
-        for idx, (agent_did, action) in enumerate(flat):
+        for idx, (agent_did, action) in enumerate(ordered_flat):
             if agent_did == failure_agent_did and action.get("step_id") == failure_step_id:
                 fail_idx = idx
                 break
         if fail_idx is None:
-            for idx, (_, action) in enumerate(flat):
+            for idx, (_, action) in enumerate(ordered_flat):
                 if action.get("step_id") == failure_step_id:
                     fail_idx = idx
                     break
 
         if fail_idx is None:
-            return flat
-        return flat[: fail_idx + 1]
+            return ordered_flat
+        return ordered_flat[: fail_idx + 1]
 
     @property
     def attribution_history(self) -> list[AttributionResult]:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/attribution.py
@@ -2,10 +2,12 @@
 # Licensed under the MIT License.
 # Public Preview — basic implementation
 """
-Fault Logging — stub implementation.
+Fault attribution.
 
-Public Preview: assigns full liability to the direct-cause agent.
-No causal chain analysis.
+Distributes saga-failure liability across the agents on the causal chain
+leading to the failure, weighted by failed actions and an optional caller
+``risk_weights`` policy. Falls back to full liability on the direct cause when
+no action graph or weights are available.
 """
 
 from __future__ import annotations
@@ -50,7 +52,9 @@ class AttributionResult:
 
 
 class CausalAttributor:
-    """Simple fault attribution — assigns liability to the direct cause agent."""
+    """Distributes fault liability across the causal chain of a saga failure."""
+
+    DIRECT_CAUSE_BONUS = 1.0
 
     def __init__(self) -> None:
         self._history: list[AttributionResult] = []
@@ -64,26 +68,123 @@ class CausalAttributor:
         failure_agent_did: str,
         risk_weights: dict[str, float] | None = None,
     ) -> AttributionResult:
-        """Assign full liability to the direct-cause agent."""
+        """Attribute liability for a saga failure.
+
+        Walks ``agent_actions`` to the action that failed
+        (``failure_agent_did`` at ``failure_step_id``) and shares liability
+        across agents whose actions on that causal chain failed, plus a bonus
+        for the direct cause. If ``risk_weights`` keyed by agent DID are
+        provided, they override the causal split and distribute liability
+        normalized across the participating agents. With neither an action
+        graph nor matching weights, full liability goes to the direct cause.
+        """
+        agents = list(agent_actions.keys())
+
+        if not agents:
+            result = AttributionResult(
+                saga_id=saga_id,
+                session_id=session_id,
+                attributions=[],
+                causal_chain_length=0,
+                root_cause_agent=failure_agent_did,
+            )
+            self._history.append(result)
+            return result
+
+        chain = self._causal_chain(agent_actions, failure_step_id, failure_agent_did)
+
+        # Causal contribution: failed actions on the chain, plus direct-cause bonus.
+        causal_raw: dict[str, float] = dict.fromkeys(agents, 0.0)
+        for agent_did, action in chain:
+            if not action.get("success", True):
+                causal_raw[agent_did] += 1.0
+        if failure_agent_did in causal_raw:
+            causal_raw[failure_agent_did] += self.DIRECT_CAUSE_BONUS
+        causal_total = sum(causal_raw.values())
+        causal_contribution = {
+            a: (causal_raw[a] / causal_total if causal_total else 0.0) for a in agents
+        }
+
+        use_weights = risk_weights is not None and any(
+            risk_weights.get(a, 0.0) > 0.0 for a in agents
+        )
+        if use_weights:
+            weight_raw = {a: max(0.0, risk_weights.get(a, 0.0)) for a in agents}
+            weight_total = sum(weight_raw.values())
+            liability = {a: weight_raw[a] / weight_total for a in agents}
+            mode = "risk-weighted"
+        elif causal_total > 0:
+            liability = dict(causal_contribution)
+            mode = "causal-chain"
+        else:
+            # Fallback: no failed actions on the chain and no weights.
+            liability = {a: (1.0 if a == failure_agent_did else 0.0) for a in agents}
+            mode = "direct-cause-fallback"
+
         attributions = []
-        for agent_did in agent_actions:
+        for agent_did in agents:
+            is_direct = agent_did == failure_agent_did
+            score = liability[agent_did]
+            if is_direct:
+                reason = f"Direct cause ({mode})"
+            elif score > 0:
+                reason = f"Causal contributor ({mode})"
+            else:
+                reason = "No causal contribution"
             attributions.append(
                 FaultAttribution(
                     agent_did=agent_did,
-                    liability_score=1.0 if agent_did == failure_agent_did else 0.0,
-                    causal_contribution=1.0 if agent_did == failure_agent_did else 0.0,
-                    is_direct_cause=(agent_did == failure_agent_did),
-                    reason="Direct cause" if agent_did == failure_agent_did else "",
+                    liability_score=score,
+                    causal_contribution=causal_contribution[agent_did],
+                    is_direct_cause=is_direct,
+                    reason=reason,
                 )
             )
+
         result = AttributionResult(
             saga_id=saga_id,
             session_id=session_id,
             attributions=attributions,
+            causal_chain_length=len(chain),
             root_cause_agent=failure_agent_did,
         )
         self._history.append(result)
         return result
+
+    @staticmethod
+    def _causal_chain(
+        agent_actions: dict[str, list[dict]],
+        failure_step_id: str,
+        failure_agent_did: str,
+    ) -> list[tuple[str, dict]]:
+        """Flatten actions in iteration order and truncate at the failure action.
+
+        The chain is every action up to and including the failure (matched by
+        ``failure_agent_did`` + ``failure_step_id``, falling back to the first
+        action with ``failure_step_id``). Post-failure actions are cascade
+        effects, not causes, so they are excluded. If the failure action is not
+        found, the whole flattened list is treated as the chain.
+        """
+        flat: list[tuple[str, dict]] = [
+            (agent_did, action)
+            for agent_did, actions in agent_actions.items()
+            for action in actions
+        ]
+
+        fail_idx = None
+        for idx, (agent_did, action) in enumerate(flat):
+            if agent_did == failure_agent_did and action.get("step_id") == failure_step_id:
+                fail_idx = idx
+                break
+        if fail_idx is None:
+            for idx, (_, action) in enumerate(flat):
+                if action.get("step_id") == failure_step_id:
+                    fail_idx = idx
+                    break
+
+        if fail_idx is None:
+            return flat
+        return flat[: fail_idx + 1]
 
     @property
     def attribution_history(self) -> list[AttributionResult]:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
@@ -75,10 +75,16 @@ class QuarantineManager:
         forensic_data: dict | None = None,
     ) -> QuarantineRecord:
         """Quarantine an agent for ``duration_seconds`` (default
-        ``DEFAULT_QUARANTINE_SECONDS``). The record is active and enforced
-        until it expires or is released."""
-        dur = duration_seconds if duration_seconds is not None else self.DEFAULT_QUARANTINE_SECONDS
+        ``DEFAULT_QUARANTINE_SECONDS``). The record is active and enforced until
+        it expires or is released. Any prior active record for the same
+        ``(agent_did, session_id)`` is superseded, so an agent has at most one
+        active quarantine per session (history is retained)."""
         now = datetime.now(UTC)
+        prior = self._find_active(agent_did, session_id)
+        if prior is not None:
+            prior.is_active = False
+            prior.released_at = now
+        dur = duration_seconds if duration_seconds is not None else self.DEFAULT_QUARANTINE_SECONDS
         record = QuarantineRecord(
             agent_did=agent_did,
             session_id=session_id,

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
@@ -93,14 +93,27 @@ class QuarantineManager:
         return record
 
     def release(self, agent_did: str, session_id: str) -> QuarantineRecord | None:
-        """Release an active quarantine early. Returns the released record,
-        or None if the agent is not currently quarantined."""
-        record = self._find_active(agent_did, session_id, include_expired=True)
-        if record is None:
+        """Release the agent's active quarantine(s) early. Clears EVERY active,
+        unexpired record for (agent_did, session_id) so ``is_quarantined`` is
+        False afterward even if the agent was quarantined more than once. Already
+        expired records are left for ``tick`` (releasing them here would stamp a
+        late ``released_at`` and overstate ``duration_seconds``). Returns the most
+        recently entered released record, or None if none were active."""
+        now = datetime.now(UTC)
+        released = [
+            record
+            for record in self._quarantines.values()
+            if record.agent_did == agent_did
+            and record.session_id == session_id
+            and record.is_active
+            and not record.is_expired
+        ]
+        if not released:
             return None
-        record.is_active = False
-        record.released_at = datetime.now(UTC)
-        return record
+        for record in released:
+            record.is_active = False
+            record.released_at = now
+        return max(released, key=lambda r: r.entered_at)
 
     def is_quarantined(self, agent_did: str, session_id: str) -> bool:
         """True if the agent has an active, unexpired quarantine for the session."""
@@ -122,15 +135,13 @@ class QuarantineManager:
                 expired.append(record)
         return expired
 
-    def _find_active(
-        self, agent_did: str, session_id: str, include_expired: bool = False
-    ) -> QuarantineRecord | None:
+    def _find_active(self, agent_did: str, session_id: str) -> QuarantineRecord | None:
         for record in self._quarantines.values():
             if (
                 record.agent_did == agent_did
                 and record.session_id == session_id
                 and record.is_active
-                and (include_expired or not record.is_expired)
+                and not record.is_expired
             ):
                 return record
         return None

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/liability/quarantine.py
@@ -2,16 +2,18 @@
 # Licensed under the MIT License.
 # Public Preview — basic implementation
 """
-Quarantine Manager — stub implementation.
+Quarantine Manager.
 
-Public Preview: quarantine is not enforced. Calls return safe defaults.
+Records quarantined agents in-memory, enforces them via ``is_quarantined``,
+expires them based on ``expires_at``, and supports manual release. State is
+process-local (not persisted across restarts).
 """
 
 from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 
 
@@ -55,7 +57,7 @@ class QuarantineRecord:
 
 class QuarantineManager:
     """
-    Quarantine stub (Public Preview: no quarantine enforcement).
+    Records and enforces agent quarantines (process-local, in-memory).
     """
 
     DEFAULT_QUARANTINE_SECONDS = 300
@@ -72,30 +74,66 @@ class QuarantineManager:
         duration_seconds: int | None = None,
         forensic_data: dict | None = None,
     ) -> QuarantineRecord:
-        """Log a quarantine request (Public Preview: no enforcement)."""
+        """Quarantine an agent for ``duration_seconds`` (default
+        ``DEFAULT_QUARANTINE_SECONDS``). The record is active and enforced
+        until it expires or is released."""
+        dur = duration_seconds if duration_seconds is not None else self.DEFAULT_QUARANTINE_SECONDS
+        now = datetime.now(UTC)
         record = QuarantineRecord(
             agent_did=agent_did,
             session_id=session_id,
             reason=reason,
             details=details,
-            is_active=False,
+            entered_at=now,
+            expires_at=now + timedelta(seconds=dur),
+            is_active=True,
+            forensic_data=forensic_data or {},
         )
         self._quarantines[record.quarantine_id] = record
         return record
 
     def release(self, agent_did: str, session_id: str) -> QuarantineRecord | None:
-        """No-op in Public Preview."""
-        return None
+        """Release an active quarantine early. Returns the released record,
+        or None if the agent is not currently quarantined."""
+        record = self._find_active(agent_did, session_id, include_expired=True)
+        if record is None:
+            return None
+        record.is_active = False
+        record.released_at = datetime.now(UTC)
+        return record
 
     def is_quarantined(self, agent_did: str, session_id: str) -> bool:
-        """Always False in Public Preview."""
-        return False
+        """True if the agent has an active, unexpired quarantine for the session."""
+        return self._find_active(agent_did, session_id) is not None
 
     def get_active_quarantine(self, agent_did: str, session_id: str) -> QuarantineRecord | None:
-        return None
+        return self._find_active(agent_did, session_id)
 
     def tick(self) -> list[QuarantineRecord]:
-        return []
+        """Expire any active records whose ``expires_at`` has passed. Returns
+        the records that were expired by this call."""
+        expired: list[QuarantineRecord] = []
+        now = datetime.now(UTC)
+        for record in self._quarantines.values():
+            if record.is_active and record.is_expired:
+                record.is_active = False
+                if record.released_at is None:
+                    record.released_at = record.expires_at or now
+                expired.append(record)
+        return expired
+
+    def _find_active(
+        self, agent_did: str, session_id: str, include_expired: bool = False
+    ) -> QuarantineRecord | None:
+        for record in self._quarantines.values():
+            if (
+                record.agent_did == agent_did
+                and record.session_id == session_id
+                and record.is_active
+                and (include_expired or not record.is_expired)
+            ):
+                return record
+        return None
 
     def get_history(
         self, agent_did: str | None = None, session_id: str | None = None
@@ -110,8 +148,8 @@ class QuarantineManager:
 
     @property
     def active_quarantines(self) -> list[QuarantineRecord]:
-        return []
+        return [r for r in self._quarantines.values() if r.is_active and not r.is_expired]
 
     @property
     def quarantine_count(self) -> int:
-        return 0
+        return len(self.active_quarantines)

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/dsl.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/dsl.py
@@ -5,8 +5,9 @@
 Declarative Saga DSL.
 
 Parses step definitions and fan-out groups (with their declared policy and
-validated branch references). Execution of fan-out groups remains sequential;
-``sequential_steps`` still returns all steps.
+validated branch references) into a ``SagaDefinition``. ``fan_out_step_ids`` and
+``sequential_steps`` expose which steps run in parallel; fan-out groups are
+executed by ``FanOutOrchestrator``, which enforces the declared policy.
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ class SagaDSLStep:
 
 @dataclass
 class SagaDSLFanOut:
-    """A fan-out group (Public Preview: ignored during execution)."""
+    """A fan-out group: branches that run in parallel under ``policy``."""
 
     policy: FanOutPolicy = FanOutPolicy.ALL_MUST_SUCCEED
     branch_step_ids: list[str] = field(default_factory=list)
@@ -59,19 +60,23 @@ class SagaDefinition:
 
     @property
     def fan_out_step_ids(self) -> set[str]:
-        return set()
+        """Step IDs that belong to any fan-out group (run in parallel)."""
+        ids: set[str] = set()
+        for fan_out in self.fan_outs:
+            ids.update(fan_out.branch_step_ids)
+        return ids
 
     @property
     def sequential_steps(self) -> list[SagaDSLStep]:
-        """All steps are sequential in Public Preview."""
-        return list(self.steps)
+        """Steps that are not part of any fan-out group."""
+        parallel = self.fan_out_step_ids
+        return [s for s in self.steps if s.id not in parallel]
 
 
 class SagaDSLParser:
     """
-    Parses saga definitions from dict.
-
-    Public Preview: fan-out groups are parsed but ignored during execution.
+    Parses saga definitions from a dict into a ``SagaDefinition``, including
+    fan-out groups with their declared policy and validated branch step IDs.
     """
 
     def __init__(self, *, schema_validation: bool = False) -> None:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/dsl.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/dsl.py
@@ -107,10 +107,10 @@ class SagaDSLParser:
             step_ids.add(step.id)
             steps.append(step)
 
-        fan_outs = [
-            self._parse_fan_out(raw_fan_out, step_ids)
-            for raw_fan_out in definition.get("fan_out", [])
-        ]
+        raw_fan_outs = definition.get("fan_out", [])
+        if not isinstance(raw_fan_outs, list):
+            raise SagaDSLError("'fan_out' must be a list of fan-out groups")
+        fan_outs = [self._parse_fan_out(raw_fan_out, step_ids) for raw_fan_out in raw_fan_outs]
 
         return SagaDefinition(
             name=name,
@@ -147,8 +147,18 @@ class SagaDSLParser:
 
     def _parse_fan_out(self, raw: dict, valid_step_ids: set[str]) -> SagaDSLFanOut:
         """Parse a fan-out group, honoring its declared ``policy`` and
-        validating each branch against the parsed step IDs."""
+        validating each branch against the parsed step IDs.
+
+        Raises ``SagaDSLError`` (not a raw ``AttributeError``/``TypeError``) on
+        malformed input, since ``parse`` runs with ``schema_validation=False`` by
+        default and so cannot rely on the JSON schema to reject bad shapes.
+        """
+        if not isinstance(raw, dict):
+            raise SagaDSLError(f"Each fan-out group must be an object, got {type(raw).__name__}")
+
         branches = raw.get("branches", [])
+        if not isinstance(branches, list):
+            raise SagaDSLError("Fan-out 'branches' must be a list of step IDs")
         for branch_id in branches:
             if branch_id not in valid_step_ids:
                 raise SagaDSLError(

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/dsl.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/dsl.py
@@ -2,10 +2,11 @@
 # Licensed under the MIT License.
 # Public Preview — basic implementation
 """
-Declarative Saga DSL — stub implementation.
+Declarative Saga DSL.
 
-Public Preview: DSL parsing is retained for basic step definitions only.
-Fan-out groups in DSL are ignored (sequential execution only).
+Parses step definitions and fan-out groups (with their declared policy and
+validated branch references). Execution of fan-out groups remains sequential;
+``sequential_steps`` still returns all steps.
 """
 
 from __future__ import annotations
@@ -106,12 +107,17 @@ class SagaDSLParser:
             step_ids.add(step.id)
             steps.append(step)
 
+        fan_outs = [
+            self._parse_fan_out(raw_fan_out, step_ids)
+            for raw_fan_out in definition.get("fan_out", [])
+        ]
+
         return SagaDefinition(
             name=name,
             session_id=session_id,
             saga_id=definition.get("saga_id", f"saga:{uuid.uuid4().hex[:8]}"),
             steps=steps,
-            fan_outs=[],
+            fan_outs=fan_outs,
             metadata=definition.get("metadata", {}),
         )
 
@@ -140,11 +146,25 @@ class SagaDSLParser:
         )
 
     def _parse_fan_out(self, raw: dict, valid_step_ids: set[str]) -> SagaDSLFanOut:
-        """Parse fan-out definition (Public Preview: retained for API compat)."""
-        return SagaDSLFanOut(
-            policy=FanOutPolicy.ALL_MUST_SUCCEED,
-            branch_step_ids=raw.get("branches", []),
-        )
+        """Parse a fan-out group, honoring its declared ``policy`` and
+        validating each branch against the parsed step IDs."""
+        branches = raw.get("branches", [])
+        for branch_id in branches:
+            if branch_id not in valid_step_ids:
+                raise SagaDSLError(
+                    f"Fan-out branch references unknown step '{branch_id}'"
+                )
+
+        policy_raw = raw.get("policy")
+        if policy_raw is None:
+            policy = FanOutPolicy.ALL_MUST_SUCCEED
+        else:
+            try:
+                policy = FanOutPolicy(policy_raw)
+            except ValueError as exc:
+                raise SagaDSLError(f"Invalid fan-out policy: '{policy_raw}'") from exc
+
+        return SagaDSLFanOut(policy=policy, branch_step_ids=list(branches))
 
     def to_saga_steps(self, definition: SagaDefinition) -> list[SagaStep]:
         """Convert a SagaDefinition into SagaStep objects."""

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/fan_out.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/fan_out.py
@@ -2,10 +2,12 @@
 # Licensed under the MIT License.
 # Public Preview — basic implementation
 """
-Parallel Saga Fan-Out — stub implementation.
+Parallel Saga Fan-Out.
 
-Public Preview: only sequential ALL_MUST_SUCCEED execution.
-Fan-out groups execute branches one at a time.
+Executes a group of saga branches and resolves it against the group's
+``FanOutPolicy`` (ALL / MAJORITY / ANY must succeed). Branches are run
+sequentially but execution stops as soon as the policy outcome is decided
+(e.g. ANY stops on the first success, ALL on the first failure).
 """
 
 from __future__ import annotations
@@ -58,12 +60,41 @@ class FanOutGroup:
         return len(self.branches)
 
     def check_policy(self) -> bool:
-        """Public Preview: only ALL_MUST_SUCCEED is enforced."""
-        return self.success_count == self.total_branches
+        """True if the branch outcomes satisfy this group's policy.
+
+        ALL: every branch succeeded (vacuously true with no branches).
+        MAJORITY: a strict majority of branches succeeded.
+        ANY: at least one branch succeeded.
+        """
+        total = self.total_branches
+        if self.policy == FanOutPolicy.ALL_MUST_SUCCEED:
+            return self.success_count == total
+        if self.policy == FanOutPolicy.MAJORITY_MUST_SUCCEED:
+            return self.success_count * 2 > total
+        if self.policy == FanOutPolicy.ANY_MUST_SUCCEED:
+            return self.success_count >= 1
+        return False
+
+    def is_decided(self) -> bool:
+        """True once the resolved branches already determine ``check_policy``,
+        so remaining branches need not run.
+
+        ALL is decided on the first failure; ANY on the first success; MAJORITY
+        once a majority has succeeded or become unreachable.
+        """
+        total = self.total_branches
+        succ, fail = self.success_count, self.failure_count
+        if self.policy == FanOutPolicy.ALL_MUST_SUCCEED:
+            return fail >= 1
+        if self.policy == FanOutPolicy.ANY_MUST_SUCCEED:
+            return succ >= 1
+        if self.policy == FanOutPolicy.MAJORITY_MUST_SUCCEED:
+            return succ * 2 > total or fail * 2 >= total
+        return False
 
 
 class FanOutOrchestrator:
-    """Fan-out stub (Public Preview: sequential execution, ALL_MUST_SUCCEED only)."""
+    """Runs fan-out branches and resolves the group against its ``FanOutPolicy``."""
 
     def __init__(self) -> None:
         self._groups: dict[str, FanOutGroup] = {}
@@ -71,7 +102,7 @@ class FanOutOrchestrator:
     def create_group(
         self, saga_id: str, policy: FanOutPolicy = FanOutPolicy.ALL_MUST_SUCCEED
     ) -> FanOutGroup:
-        group = FanOutGroup(saga_id=saga_id, policy=FanOutPolicy.ALL_MUST_SUCCEED)
+        group = FanOutGroup(saga_id=saga_id, policy=policy)
         self._groups[group.group_id] = group
         return group
 
@@ -87,7 +118,13 @@ class FanOutOrchestrator:
         executors: dict[str, Callable[..., Any]],
         timeout_seconds: int = 300,
     ) -> FanOutGroup:
-        """Execute branches sequentially (Public Preview)."""
+        """Run branches until the group's policy outcome is decided.
+
+        Branches run one at a time; after each resolves, execution stops early
+        if ``is_decided`` (the policy can no longer change). Unrun branches stay
+        PENDING. On an unsatisfied policy, every succeeded branch is queued for
+        compensation.
+        """
         group = self._get_group(group_id)
 
         for branch in group.branches:
@@ -109,7 +146,8 @@ class FanOutOrchestrator:
                 branch.error = str(e)
                 branch.step.error = str(e)
                 branch.step.transition(StepState.FAILED)
-                break  # ALL_MUST_SUCCEED: stop on first failure
+            if group.is_decided():
+                break
 
         group.policy_satisfied = group.check_policy()
         group.resolved = True

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
@@ -330,7 +330,21 @@ class TestCausalAttributionDistribution:
         assert result.get_liability("c") == 0.0
         assert result.causal_chain_length == 1
 
-    def test_causal_chain_length_reflects_chain(self):
+    def test_causal_chain_length_counts_failures(self):
+        """causal_chain_length is the number of FAILED actions on the chain (the
+        causal contributors), not the count of all preceding actions."""
+        attributor = CausalAttributor()
+        actions = {
+            "a": [{"action_id": "a1", "step_id": "s1", "success": False}],
+            "b": [{"action_id": "b1", "step_id": "s2", "success": False}],
+            "c": [{"action_id": "c1", "step_id": "s3", "success": True}],
+        }
+        # Chain is s1, s2 (up to the failure at s2); both a and b failed -> 2.
+        result = attributor.attribute("saga-1", "sess-1", actions, "s2", "b")
+        assert result.causal_chain_length == 2
+
+    def test_causal_chain_length_ignores_successful_prep(self):
+        """Successful pre-failure actions do not inflate causal_chain_length."""
         attributor = CausalAttributor()
         actions = {
             "a": [{"action_id": "a1", "step_id": "s1", "success": True}],
@@ -338,8 +352,8 @@ class TestCausalAttributionDistribution:
             "c": [{"action_id": "c1", "step_id": "s3", "success": True}],
         }
         result = attributor.attribute("saga-1", "sess-1", actions, "s2", "b")
-        # Chain is s1, s2 (up to and including the failure); s3 is excluded.
-        assert result.causal_chain_length == 2
+        # Only b failed on the chain -> 1, even though s1 precedes it.
+        assert result.causal_chain_length == 1
 
     def test_attribution_is_insertion_order_independent(self):
         """Regression: liability must not depend on agent_actions dict order.
@@ -471,16 +485,20 @@ class TestQuarantineEnforcement:
         )
         assert record.forensic_data == {"score": 0.9}
 
-    def test_release_clears_all_stacked_quarantines(self):
-        """Regression: re-quarantining the same (agent, session) creates two
-        active records; a single release() must clear ALL of them so the agent
-        is definitively no longer quarantined."""
+    def test_requarantine_supersedes_prior_active(self):
+        """Re-quarantining the same (agent, session) supersedes the prior active
+        record, so there is at most one active quarantine per key; history is
+        retained, and a single release() fully clears it."""
         mgr = QuarantineManager()
-        mgr.quarantine("a1", "s1", QuarantineReason.MANUAL)
-        mgr.quarantine("a1", "s1", QuarantineReason.RING_BREACH)
-        assert mgr.quarantine_count == 2
+        first = mgr.quarantine("a1", "s1", QuarantineReason.MANUAL)
+        second = mgr.quarantine("a1", "s1", QuarantineReason.RING_BREACH)
+        assert mgr.quarantine_count == 1
+        assert not first.is_active
+        assert second.is_active
+        assert mgr.get_active_quarantine("a1", "s1") is second
+        assert len(mgr.get_history(agent_did="a1")) == 2  # both retained
         released = mgr.release("a1", "s1")
-        assert released is not None
+        assert released is second
         assert not mgr.is_quarantined("a1", "s1")
         assert mgr.quarantine_count == 0
 

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 """Tests for Shapley-value fault attribution, quarantine, and liability ledger."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from hypervisor.liability.attribution import (
@@ -255,3 +257,152 @@ class TestLiabilityLedger:
         assert profile.quarantine_count == 0
         assert profile.risk_score == 0.0
         assert profile.recommendation == "admit"
+
+
+# ── Causal Attribution Distribution (BUG 2 fix) ─────────────────
+
+
+class TestCausalAttributionDistribution:
+    def test_risk_weights_distribute_liability(self):
+        """risk_weights keyed by agent DID override the causal split and are
+        normalized across participants (no longer 100% to the direct cause)."""
+        attributor = CausalAttributor()
+        actions = {
+            "did:a": [{"action_id": "act1", "step_id": "s1", "success": True}],
+            "did:b": [{"action_id": "act2", "step_id": "s2", "success": False}],
+        }
+        result = attributor.attribute(
+            "saga-1",
+            "sess-1",
+            actions,
+            failure_step_id="s2",
+            failure_agent_did="did:b",
+            risk_weights={"did:a": 0.5, "did:b": 0.5},
+        )
+        assert abs(result.get_liability("did:a") - 0.5) < 1e-9
+        assert abs(result.get_liability("did:b") - 0.5) < 1e-9
+
+    def test_risk_weights_proportional(self):
+        attributor = CausalAttributor()
+        actions = {
+            "did:a": [{"action_id": "act1", "step_id": "s1", "success": False}],
+            "did:b": [{"action_id": "act2", "step_id": "s2", "success": False}],
+        }
+        result = attributor.attribute(
+            "saga-1",
+            "sess-1",
+            actions,
+            failure_step_id="s2",
+            failure_agent_did="did:b",
+            risk_weights={"did:a": 3.0, "did:b": 1.0},
+        )
+        assert abs(result.get_liability("did:a") - 0.75) < 1e-9
+        assert abs(result.get_liability("did:b") - 0.25) < 1e-9
+
+    def test_multiple_failed_agents_share_liability(self):
+        """Without weights, two failed agents on the chain share liability;
+        the direct cause keeps the larger share but not 100%."""
+        attributor = CausalAttributor()
+        actions = {
+            "agent-a": [{"action_id": "act1", "step_id": "s1", "success": False}],
+            "agent-b": [{"action_id": "act2", "step_id": "s2", "success": False}],
+        }
+        result = attributor.attribute("saga-1", "sess-1", actions, "s2", "agent-b")
+        a = result.get_liability("agent-a")
+        b = result.get_liability("agent-b")
+        assert a > 0.0
+        assert b > a
+        assert b < 1.0
+        assert abs((a + b) - 1.0) < 1e-9
+
+    def test_post_failure_cascade_excluded(self):
+        """Agents that fail after the root failure are cascade effects, not
+        causes, so the direct cause gets full liability."""
+        attributor = CausalAttributor()
+        actions = {
+            "a": [{"action_id": "a1", "step_id": "s1", "success": False}],
+            "b": [{"action_id": "b1", "step_id": "s2", "success": False}],
+            "c": [{"action_id": "c1", "step_id": "s3", "success": False}],
+        }
+        result = attributor.attribute("saga-1", "sess-1", actions, "s1", "a")
+        assert result.get_liability("a") == 1.0
+        assert result.get_liability("b") == 0.0
+        assert result.get_liability("c") == 0.0
+        assert result.causal_chain_length == 1
+
+    def test_causal_chain_length_reflects_chain(self):
+        attributor = CausalAttributor()
+        actions = {
+            "a": [{"action_id": "a1", "step_id": "s1", "success": True}],
+            "b": [{"action_id": "b1", "step_id": "s2", "success": False}],
+            "c": [{"action_id": "c1", "step_id": "s3", "success": True}],
+        }
+        result = attributor.attribute("saga-1", "sess-1", actions, "s2", "b")
+        # Chain is s1, s2 (up to and including the failure); s3 is excluded.
+        assert result.causal_chain_length == 2
+
+
+# ── Quarantine Enforcement (BUG 1 fix) ──────────────────────────
+
+
+class TestQuarantineEnforcement:
+    def test_quarantine_is_recorded_and_enforced(self):
+        mgr = QuarantineManager()
+        record = mgr.quarantine("did:bad", "s", QuarantineReason.RING_BREACH)
+        assert record.is_active
+        assert mgr.is_quarantined("did:bad", "s")
+        assert mgr.quarantine_count == 1
+        assert record in mgr.active_quarantines
+        assert mgr.get_active_quarantine("did:bad", "s") is record
+
+    def test_unrelated_agent_not_quarantined(self):
+        mgr = QuarantineManager()
+        mgr.quarantine("did:bad", "s", QuarantineReason.MANUAL)
+        assert not mgr.is_quarantined("did:other", "s")
+        assert not mgr.is_quarantined("did:bad", "other-session")
+
+    def test_release_clears_quarantine(self):
+        mgr = QuarantineManager()
+        mgr.quarantine("a1", "s1", QuarantineReason.MANUAL)
+        released = mgr.release("a1", "s1")
+        assert released is not None
+        assert not released.is_active
+        assert released.released_at is not None
+        assert not mgr.is_quarantined("a1", "s1")
+        assert mgr.quarantine_count == 0
+
+    def test_release_unknown_returns_none(self):
+        mgr = QuarantineManager()
+        assert mgr.release("nobody", "s1") is None
+
+    def test_default_expiry_applied(self):
+        mgr = QuarantineManager()
+        record = mgr.quarantine("a1", "s1", QuarantineReason.MANUAL)
+        assert record.expires_at is not None
+        delta = (record.expires_at - record.entered_at).total_seconds()
+        assert abs(delta - QuarantineManager.DEFAULT_QUARANTINE_SECONDS) < 1.0
+
+    def test_custom_duration(self):
+        mgr = QuarantineManager()
+        record = mgr.quarantine("a1", "s1", QuarantineReason.MANUAL, duration_seconds=42)
+        delta = (record.expires_at - record.entered_at).total_seconds()
+        assert abs(delta - 42) < 1.0
+
+    def test_tick_expires_quarantine(self):
+        mgr = QuarantineManager()
+        record = mgr.quarantine("a1", "s1", QuarantineReason.MANUAL, duration_seconds=100)
+        assert mgr.is_quarantined("a1", "s1")
+        record.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        # Expiry is observed lazily before tick...
+        assert not mgr.is_quarantined("a1", "s1")
+        expired = mgr.tick()
+        assert record in expired
+        assert not record.is_active
+        assert mgr.quarantine_count == 0
+
+    def test_forensic_data_persisted(self):
+        mgr = QuarantineManager()
+        record = mgr.quarantine(
+            "a1", "s1", QuarantineReason.CASCADE_SLASH, forensic_data={"score": 0.9}
+        )
+        assert record.forensic_data == {"score": 0.9}

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_liability_improvements.py
@@ -341,6 +341,70 @@ class TestCausalAttributionDistribution:
         # Chain is s1, s2 (up to and including the failure); s3 is excluded.
         assert result.causal_chain_length == 2
 
+    def test_attribution_is_insertion_order_independent(self):
+        """Regression: liability must not depend on agent_actions dict order.
+        Same facts (a failed at s1, b failed at s2, failure at b) inserted in
+        both orders must give identical scores."""
+        ab = {
+            "a": [{"action_id": "a1", "step_id": "s1", "success": False}],
+            "b": [{"action_id": "b1", "step_id": "s2", "success": False}],
+        }
+        ba = {
+            "b": [{"action_id": "b1", "step_id": "s2", "success": False}],
+            "a": [{"action_id": "a1", "step_id": "s1", "success": False}],
+        }
+        ra = CausalAttributor().attribute("sg", "ss", ab, "s2", "b")
+        rb = CausalAttributor().attribute("sg", "ss", ba, "s2", "b")
+        assert ra.get_liability("a") == rb.get_liability("a")
+        assert ra.get_liability("b") == rb.get_liability("b")
+        assert ra.causal_chain_length == rb.causal_chain_length
+
+    def test_post_failure_action_of_multiaction_agent_excluded(self):
+        """Regression: an agent that succeeds upstream then fails AFTER the root
+        failure step is a cascade victim, not a cause. Ordering by step_id must
+        exclude its post-failure action."""
+        actions = {
+            # a: ok at s1, then fails at s3 (after b's root failure at s2)
+            "a": [
+                {"action_id": "a1", "step_id": "s1", "success": True},
+                {"action_id": "a3", "step_id": "s3", "success": False},
+            ],
+            "b": [{"action_id": "b2", "step_id": "s2", "success": False}],
+        }
+        result = CausalAttributor().attribute("sg", "ss", actions, "s2", "b")
+        assert result.get_liability("a") == 0.0
+        assert result.get_liability("b") == 1.0
+
+    def test_partial_risk_weights_fall_back_to_causal(self):
+        """Regression: a partial risk_weights map (not covering every agent) must
+        NOT silently zero the omitted failed agents. It falls back to the causal
+        split instead of treating the partial map as a complete override."""
+        actions = {
+            "a": [{"action_id": "a1", "step_id": "s1", "success": False}],
+            "b": [{"action_id": "b1", "step_id": "s2", "success": False}],
+            "c": [{"action_id": "c1", "step_id": "s3", "success": False}],
+        }
+        # Only 'a' is weighted; b and c are omitted.
+        result = CausalAttributor().attribute(
+            "sg", "ss", actions, "s3", "c", risk_weights={"a": 1.0}
+        )
+        # c (direct cause) and b (upstream failure) must retain liability.
+        assert result.get_liability("c") > 0.0
+        assert result.get_liability("b") > 0.0
+
+    def test_full_risk_weights_override_causal(self):
+        """Full-coverage weights override the causal split (BUGS.md contract):
+        a gets 0.5 even though its action succeeded (causal contribution 0)."""
+        actions = {
+            "a": [{"action_id": "a1", "step_id": "s1", "success": True}],
+            "b": [{"action_id": "b1", "step_id": "s2", "success": False}],
+        }
+        result = CausalAttributor().attribute(
+            "sg", "ss", actions, "s2", "b", risk_weights={"a": 0.5, "b": 0.5}
+        )
+        assert abs(result.get_liability("a") - 0.5) < 1e-9
+        assert abs(result.get_liability("b") - 0.5) < 1e-9
+
 
 # ── Quarantine Enforcement (BUG 1 fix) ──────────────────────────
 
@@ -406,3 +470,28 @@ class TestQuarantineEnforcement:
             "a1", "s1", QuarantineReason.CASCADE_SLASH, forensic_data={"score": 0.9}
         )
         assert record.forensic_data == {"score": 0.9}
+
+    def test_release_clears_all_stacked_quarantines(self):
+        """Regression: re-quarantining the same (agent, session) creates two
+        active records; a single release() must clear ALL of them so the agent
+        is definitively no longer quarantined."""
+        mgr = QuarantineManager()
+        mgr.quarantine("a1", "s1", QuarantineReason.MANUAL)
+        mgr.quarantine("a1", "s1", QuarantineReason.RING_BREACH)
+        assert mgr.quarantine_count == 2
+        released = mgr.release("a1", "s1")
+        assert released is not None
+        assert not mgr.is_quarantined("a1", "s1")
+        assert mgr.quarantine_count == 0
+
+    def test_release_does_not_touch_expired_records(self):
+        """Regression: release() must not 'release' an already-expired record
+        (is_quarantined already reports False); doing so would stamp a late
+        released_at and overstate duration_seconds vs tick()'s expires_at clamp."""
+        mgr = QuarantineManager()
+        record = mgr.quarantine("a1", "s1", QuarantineReason.MANUAL, duration_seconds=100)
+        record.entered_at = datetime.now(UTC) - timedelta(seconds=50)
+        record.expires_at = datetime.now(UTC) - timedelta(seconds=10)
+        assert not mgr.is_quarantined("a1", "s1")
+        assert mgr.release("a1", "s1") is None
+        assert record.released_at is None

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_saga_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_saga_improvements.py
@@ -71,13 +71,68 @@ class TestFanOut:
         assert result.failure_count == 1
         assert len(result.compensation_needed) > 0
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     async def test_majority_policy_succeeds(self, steps):
-        pass
+        """MAJORITY_MUST_SUCCEED is satisfied when a strict majority succeed.
+        With 3 branches, 2 successes resolve the group (the 3rd need not run)."""
+        fan = FanOutOrchestrator()
+        group = fan.create_group("saga-1", FanOutPolicy.MAJORITY_MUST_SUCCEED)
+        for s in steps:
+            fan.add_branch(group.group_id, s)
 
-    @pytest.mark.skip("Feature not available in Public Preview")
+        async def ok():
+            return "ok"
+
+        async def fail():
+            raise ValueError("nope")
+
+        # s1 ok, s2 ok -> majority (2/3) reached; s3 (would fail) is not needed.
+        executors = {"s1": ok, "s2": ok, "s3": fail}
+        result = await fan.execute(group.group_id, executors)
+        assert result.policy == FanOutPolicy.MAJORITY_MUST_SUCCEED
+        assert result.policy_satisfied
+        assert result.success_count == 2
+        assert len(result.compensation_needed) == 0
+
+    async def test_majority_policy_fails(self, steps):
+        """MAJORITY is not satisfied when a majority cannot be reached."""
+        fan = FanOutOrchestrator()
+        group = fan.create_group("saga-1", FanOutPolicy.MAJORITY_MUST_SUCCEED)
+        for s in steps:
+            fan.add_branch(group.group_id, s)
+
+        async def ok():
+            return "ok"
+
+        async def fail():
+            raise ValueError("nope")
+
+        # s1 ok, s2 fail, s3 fail -> only 1/3, majority impossible.
+        executors = {"s1": ok, "s2": fail, "s3": fail}
+        result = await fan.execute(group.group_id, executors)
+        assert not result.policy_satisfied
+        assert result.success_count == 1
+
     async def test_any_policy_succeeds(self, steps):
-        pass
+        """ANY_MUST_SUCCEED is satisfied by the first success; later branches
+        need not run, and no compensation is required."""
+        fan = FanOutOrchestrator()
+        group = fan.create_group("saga-1", FanOutPolicy.ANY_MUST_SUCCEED)
+        for s in steps:
+            fan.add_branch(group.group_id, s)
+
+        async def ok():
+            return "ok"
+
+        async def fail():
+            raise ValueError("nope")
+
+        # s1 fails, s2 succeeds -> ANY satisfied; s3 not needed.
+        executors = {"s1": fail, "s2": ok, "s3": fail}
+        result = await fan.execute(group.group_id, executors)
+        assert result.policy == FanOutPolicy.ANY_MUST_SUCCEED
+        assert result.policy_satisfied
+        assert result.success_count == 1
+        assert len(result.compensation_needed) == 0
 
     async def test_all_fail_any_policy(self, steps):
         fan = FanOutOrchestrator()
@@ -98,9 +153,15 @@ class TestFanOut:
         # With 0 branches, 0 == 0 is True for ALL_MUST_SUCCEED (vacuously true)
         assert group.check_policy()
 
-    @pytest.mark.skip("Feature not available in Public Preview")
     def test_group_check_policy_any_empty(self):
-        pass
+        # ANY_MUST_SUCCEED with no branches: nothing succeeded -> not satisfied.
+        group = FanOutGroup(policy=FanOutPolicy.ANY_MUST_SUCCEED)
+        assert not group.check_policy()
+
+    def test_create_group_honors_policy(self):
+        fan = FanOutOrchestrator()
+        group = fan.create_group("saga-1", FanOutPolicy.MAJORITY_MUST_SUCCEED)
+        assert group.policy == FanOutPolicy.MAJORITY_MUST_SUCCEED
 
     def test_active_groups(self, steps):
         fan = FanOutOrchestrator()
@@ -291,8 +352,9 @@ class TestSagaDSL:
                 "fan_out": [{"policy": "all_must_succeed", "branches": ["par1", "par2"]}],
             }
         )
-        # Public Preview: all steps are sequential (fan_out ignored)
-        assert len(defn.sequential_steps) == 3
+        # par1/par2 are fan-out branches; only seq1 is sequential.
+        assert defn.fan_out_step_ids == {"par1", "par2"}
+        assert [s.id for s in defn.sequential_steps] == ["seq1"]
 
 
 # ── DSL Fan-Out Parsing (BUG 3 fix) ─────────────────────────────

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_saga_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_saga_improvements.py
@@ -293,3 +293,71 @@ class TestSagaDSL:
         )
         # Public Preview: all steps are sequential (fan_out ignored)
         assert len(defn.sequential_steps) == 3
+
+
+# ── DSL Fan-Out Parsing (BUG 3 fix) ─────────────────────────────
+
+
+class TestSagaDSLFanOutParsing:
+    def _defn(self, fan_out):
+        return {
+            "name": "x",
+            "session_id": "s1",
+            "steps": [
+                {"id": "seq1", "action_id": "a", "agent": "x"},
+                {"id": "par1", "action_id": "b", "agent": "y"},
+                {"id": "par2", "action_id": "c", "agent": "z"},
+            ],
+            "fan_out": fan_out,
+        }
+
+    def test_fan_out_round_trips_with_policy(self):
+        parser = SagaDSLParser()
+        defn = parser.parse(
+            self._defn([{"policy": "any_must_succeed", "branches": ["par1", "par2"]}])
+        )
+        assert len(defn.fan_outs) == 1
+        fo = defn.fan_outs[0]
+        assert fo.policy == FanOutPolicy.ANY_MUST_SUCCEED
+        assert fo.branch_step_ids == ["par1", "par2"]
+
+    def test_fan_out_default_policy(self):
+        parser = SagaDSLParser()
+        defn = parser.parse(self._defn([{"branches": ["par1", "par2"]}]))
+        assert defn.fan_outs[0].policy == FanOutPolicy.ALL_MUST_SUCCEED
+
+    def test_multiple_fan_out_groups(self):
+        parser = SagaDSLParser()
+        defn = parser.parse(
+            self._defn(
+                [
+                    {"policy": "majority_must_succeed", "branches": ["par1"]},
+                    {"policy": "all_must_succeed", "branches": ["par2"]},
+                ]
+            )
+        )
+        assert [fo.policy for fo in defn.fan_outs] == [
+            FanOutPolicy.MAJORITY_MUST_SUCCEED,
+            FanOutPolicy.ALL_MUST_SUCCEED,
+        ]
+
+    def test_fan_out_invalid_branch_raises(self):
+        parser = SagaDSLParser()
+        with pytest.raises(SagaDSLError, match="unknown step 'ghost'"):
+            parser.parse(self._defn([{"policy": "all_must_succeed", "branches": ["ghost"]}]))
+
+    def test_fan_out_invalid_policy_raises(self):
+        parser = SagaDSLParser()
+        with pytest.raises(SagaDSLError, match="Invalid fan-out policy"):
+            parser.parse(self._defn([{"policy": "best_effort", "branches": ["par1"]}]))
+
+    def test_no_fan_out_key_yields_empty(self):
+        parser = SagaDSLParser()
+        defn = parser.parse(
+            {
+                "name": "x",
+                "session_id": "s1",
+                "steps": [{"id": "s1", "action_id": "a", "agent": "x"}],
+            }
+        )
+        assert defn.fan_outs == []

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_saga_improvements.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_saga_improvements.py
@@ -361,3 +361,20 @@ class TestSagaDSLFanOutParsing:
             }
         )
         assert defn.fan_outs == []
+
+    @pytest.mark.parametrize(
+        "bad_fan_out",
+        [
+            "notalist",
+            [123],
+            [None],
+            [{"branches": 123}],
+            [{"branches": "par1"}],
+        ],
+    )
+    def test_malformed_fan_out_raises_typed_error(self, bad_fan_out):
+        """Regression: with schema_validation off (default), malformed fan_out
+        input must raise SagaDSLError, not a raw AttributeError/TypeError."""
+        parser = SagaDSLParser()
+        with pytest.raises(SagaDSLError):
+            parser.parse(self._defn(bad_fan_out))


### PR DESCRIPTION
## Summary

Wires up three pieces of declared but inert logic in the `agent-hypervisor` package so they do what their API shape implies instead of returning silent no-ops, then hardens the attribution and quarantine fixes and makes the saga fan-out capability enforce its declared policy end to end.

## Problem

Several capabilities under `agent-governance-python/agent-hypervisor/src/hypervisor/` existed (or were declared) but did nothing at runtime, behind "Public Preview" docstrings while exposing a working-looking API.

| Area | Symptom |
|------|---------|
| `QuarantineManager.quarantine` | Stored a record with `is_active=False`; `is_quarantined`/`active_quarantines`/`quarantine_count`/`release`/`tick` were hardcoded to `False`/`[]`/`0`/`None`, so a quarantine was never recorded or enforced. |
| `CausalAttributor.attribute` | Hardcoded `liability_score=1.0` to the direct cause and `0.0` to everyone else, ignoring `agent_actions` and `risk_weights`; `causal_chain_length` was always `0`. |
| `SagaDSLParser.parse` | Hardcoded `fan_outs=[]` and never read `definition["fan_out"]`; `_parse_fan_out` was dead code that also hardcoded `policy=ALL_MUST_SUCCEED`. |
| `FanOutOrchestrator` | `create_group` ignored its `policy` arg, `check_policy` only implemented `ALL_MUST_SUCCEED`, and `execute` always broke on the first failure, so a declared `ANY`/`MAJORITY` policy was parsed and then silently run as `ALL`. |

A deep multi-lens code review of the first fix then found two reproduced blockers in the new attribution code (non-deterministic ordering, and partial `risk_weights` silently zeroing failed agents) plus several dead-capability follow-ups, all addressed here.

## Changes

| File | What changed |
|------|-------------|
| `liability/quarantine.py` | `quarantine()` persists an active, time-bounded record and supersedes any prior active record for the same `(agent, session)` (at most one active per key, history retained). All query methods reflect it; `tick()` expires records; `release()` clears the active record and skips already-expired ones to keep `duration_seconds` consistent. |
| `liability/attribution.py` | `attribute()` orders `agent_actions` by `step_id` (deterministic, insertion-order independent) and truncates at the failure step, distributing liability over failed actions plus a direct-cause bonus. `risk_weights` override only when they cover every participating agent, else a partial map falls back to the causal split. `causal_chain_length` now counts failed actions on the chain. Removed an unreachable fallback branch. Documented as a heuristic, not a Shapley value. |
| `saga/dsl.py` | `parse()` reads `definition["fan_out"]`, validating branch step IDs and honoring the declared `FanOutPolicy`. `fan_out_step_ids`/`sequential_steps` now expose which steps run in parallel. Malformed `fan_out` input raises typed `SagaDSLError` instead of leaking `AttributeError`/`TypeError`. |
| `saga/fan_out.py` | `create_group` honors its `policy`; `check_policy` implements ALL / MAJORITY / ANY; `execute` stops once the policy outcome is decided (ALL on first failure, ANY on first success, MAJORITY once reached or unreachable) and queues succeeded branches for compensation when the policy is not satisfied. |
| `tests/unit/test_liability_improvements.py` | New `TestCausalAttributionDistribution` and `TestQuarantineEnforcement` plus regressions for order independence, multi-action cascade exclusion, partial vs full `risk_weights`, failed-action chain length, and re-quarantine supersede. |
| `tests/unit/test_saga_improvements.py` | New `TestSagaDSLFanOutParsing`, a malformed-input regression, and un-skipped MAJORITY/ANY policy tests. |

## Testing

- Full `agent-hypervisor` suite via `pytest tests/ -q`: 841 passed, 57 skipped.
- Validated in a clean `pip install -e ".[dev]"` venv matching the CI install.
- Lint: `ruff check src/ --select E,F,W --ignore E501` passes (the CI gate); broader pyproject ruff (E,F,I,W,B,C4,UP) passes on changed files.
- Fan-out policies verified end to end: ANY 1/3 succeeds, ANY 0/3 fails, MAJORITY 2/3 succeeds, MAJORITY 1/3 fails, ALL 3/3 succeeds, ALL 2/3 fails.
- Review repros re-run after remediation: ordering is deterministic across dict insertion order, a multi-action agent's post-failure action is excluded, partial `risk_weights` no longer zero a failed agent, full `risk_weights` still override, re-quarantine supersedes, and malformed `fan_out` raises `SagaDSLError`.
