### PR TITLE
docs: clarify AGT CLI installation for CI environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,17 @@ Every layer is optional. Start with `govern()` and add layers as your risk profi
 
 ## Install
 
+### Quick CI Install
+
+To make the `agt` CLI available in CI environments, install the top-level Python meta-package:
+
+```bash
+pip install "agent-governance-toolkit>=4.1"
+agt verify --evidence agt-evidence.json
+```
+
+The `agt` CLI is distributed as part of `agent-governance-toolkit`. Internal repository directories (for example, `agent-governance-python/agent-compliance`) and internal package names (for example, `agent-governance-toolkit-compliance`) are not published independently on PyPI.
+
 | Language | Package | Command |
 |----------|---------|---------|
 | **Python** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Every layer is optional. Start with `govern()` and add layers as your risk profi
 To make the `agt` CLI available in CI environments, install the top-level Python meta-package:
 
 ```bash
-pip install "agent-governance-toolkit>=4.1"
+pip install "agent-governance-toolkit>=5.0"
 agt verify --evidence agt-evidence.json
 ```
 

--- a/agent-governance-python/agent-compliance/README.md
+++ b/agent-governance-python/agent-compliance/README.md
@@ -71,7 +71,7 @@ pip install agent-governance-toolkit[full]
 > Install with:
 >
 > ```bash
-> pip install "agent-governance-toolkit>=4.1"
+> pip install "agent-governance-toolkit>=5.0"
 > ```
 >
 > Do **not** install using the repository subdirectory name (`agent-compliance`) or the internal package name (`agent-governance-toolkit-compliance`), as those are not published independently on PyPI.

--- a/agent-governance-python/agent-compliance/README.md
+++ b/agent-governance-python/agent-compliance/README.md
@@ -65,6 +65,17 @@ pip install agent-governance-toolkit[full]
 
 ## Quick Start
 
+> [!NOTE]
+> This package is distributed as part of the `agent-governance-toolkit` meta-package on PyPI.
+>
+> Install with:
+>
+> ```bash
+> pip install "agent-governance-toolkit>=4.1"
+> ```
+>
+> Do **not** install using the repository subdirectory name (`agent-compliance`) or the internal package name (`agent-governance-toolkit-compliance`), as those are not published independently on PyPI.
+
 ```python
 import asyncio
 from agent_os import StatelessKernel, ExecutionContext


### PR DESCRIPTION
## Description

Adds explicit documentation for installing the `agt` CLI in CI environments.

This change clarifies that the CLI is distributed through the `agent-governance-toolkit` meta-package on PyPI and that internal repository directories (`agent-compliance`) and internal package names (`agent-governance-toolkit-compliance`) are not published independently.

It also adds a minimal CI example:

```bash
pip install "agent-governance-toolkit>=4.1"
agt verify --evidence agt-evidence.json
```

## Type of Change

* [x] Documentation update

## Package(s) Affected

* [x] agent-governance
* [x] docs / root

## Checklist

* [ ] My code follows the project style guidelines (ruff check)
* [ ] I have added tests that prove my fix/feature works
* [ ] All new and existing tests pass (pytest)
* [x] I have updated documentation as needed
* [x] I have signed the Microsoft CLA

## Attribution & Prior Art

* [x] This contribution does not contain code copied or derived from other projects without attribution
* [x] Any external projects that inspired this design are credited in code comments or documentation
* [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

N/A

## AI Assistance

* [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
* [x] I have run tests and verification appropriate for this change
* [x] No part of this PR was autonomously submitted by an AI agent without my review
* [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

ChatGPT was used for guidance and wording suggestions. All changes were reviewed and verified before submission.

## IP, Patents, and Licensing

* [x] This contribution does not implement patent-pending or patent-encumbered techniques
* [x] This contribution does not require an NDA or licensing agreement to understand or use
* [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Closes #3192
