### PR TITLE
fix(deps): cap agentrust-trace below 0.3.0 to restore TRACE validation

### DIFF
--- a/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-core/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "click>=8.1.0,<9.0",
     "python-dateutil>=2.8.0,<3.0",
     "jsonschema>=4.0.0,<5.0",
-    "agentrust-trace>=0.2.0",
+    "agentrust-trace>=0.2.0,<0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/agent-governance-python/agent-mesh/pyproject.toml
+++ b/agent-governance-python/agent-mesh/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
     # `pip install agent-mesh[dev]` brings everything needed for tests.
     "agent_hypervisor>=3.7.0,<6.0",
     # TRACE Trust Record emission (ADR-0032)
-    "agentrust-trace>=0.2.0",
+    "agentrust-trace>=0.2.0,<0.3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

We didn't cap agentrust-trace and the latest version is incompatible with our use in some modules. This PR is to cap `agentrust-trace` to `>=0.2.0,<0.3.0` in `agent-mesh` and `agent-governance-toolkit-core` so CI stops installing the incompatible `0.3.0` release.

## Problem

`agentrust-trace 0.3.0` made the `TrustRecord.transparency` field require at least one character. `agentmesh.governance.trace_sink.session_to_trust_record` always emits `"transparency": ""`, so `TrustRecord.model_validate(signed)` now raises a pydantic `ValidationError` and these four cases fail in the docker-compose contributor flow:

- `tests/governance/test_trace_sink.py::TestTRACEAuditSinkEmit::test_emit_writes_json_file`
- `tests/governance/test_trace_sink.py::TestTRACEAuditSinkEmit::test_emit_file_is_valid_trust_record`
- `tests/governance/test_trace_sink.py::TestTRACEAuditSinkEmit::test_emit_specific_file_path`
- `tests/governance/test_trace_sink.py::TestGovernedCallableCloseSession::test_close_session_writes_trust_record`

The dependency was declared as `agentrust-trace>=0.2.0` with no upper bound, so the build resolves to `0.3.0`. That breakage takes down `docker-compose-test`, and `ci-complete` then fails as an aggregator of that job, on every PR whose CI runs the contributor-flow suite.

## Fix

Pin the range to `>=0.2.0,<0.3.0` in both `pyproject.toml` files. The TRACE sink was written against the v0.2 record shape, so 0.2.x restores compatibility.

## Verification

Isolated the exact failure point against both releases.

```
agentrust-trace 0.3.0 -> ValidationError: transparency String should have at least 1 character (type=string_too_short, input_value='')
agentrust-trace 0.2.0 -> TrustRecord.model_validate PASS
```

## Follow-up

This unblocks CI but does not migrate to v0.3. A separate change should update `session_to_trust_record` (and the `transparency` value) to the v0.3 `TrustRecord` schema and then lift the upper bound.
