### PR TITLE
fix(agent-os): consistent credential detection and redaction

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,6 +11,15 @@
     }
   ],
   "words": [
+    "subn",
+    "redactable",
+    "accountkey",
+    "sharedaccesssignature",
+    "xoxa",
+    "xoxp",
+    "xoxr",
+    "xoxs",
+    "xapp",
     "Microbenchmarks",
     "isin",
     "tolist",

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -24,10 +24,19 @@ class CredentialPattern:
 
 @dataclass(frozen=True)
 class CredentialMatch:
-    """A credential-like value detected in text."""
+    """A credential-like value detected in text.
+
+    ``start`` and ``end`` are the character offsets of the match within the
+    scanned string (``-1`` when unknown). They let callers reason about
+    overlapping spans (for example, suppressing a PII match that falls inside a
+    credential match) without re-scanning. ``matched_text`` holds the raw value
+    and must never be logged or echoed to callers.
+    """
 
     name: str
     matched_text: str
+    start: int = -1
+    end: int = -1
 
 
 class CredentialRedactor:
@@ -41,20 +50,38 @@ class CredentialRedactor:
 
     # Python's stdlib ``re`` does not support per-pattern timeouts. These
     # patterns are kept simple and anchored to avoid pathological backtracking.
+    #
+    # Prefix-anchored patterns use a ``(?<![A-Za-z0-9])`` lookbehind rather than
+    # ``\b`` so a secret glued directly to a preceding word character (for
+    # example ``session_sk-...``) is still detected. ``\b`` treats ``_`` as a
+    # word character, so ``_sk-`` has no boundary and the secret would be missed;
+    # ``(?<![A-Za-z0-9])`` treats ``_`` (and ``-``, ``/``, ``.``, whitespace) as a
+    # valid left edge while still not matching inside an alphanumeric word.
     PATTERNS: tuple[CredentialPattern, ...] = (
         CredentialPattern(
             name="OpenAI API key",
-            pattern=re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]{18,}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9][A-Za-z0-9_-]{18,}\b"),
         ),
         CredentialPattern(
             name="GitHub token",
             pattern=re.compile(
-                r"(?<![A-Za-z0-9_])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9_])"
+                r"(?<![A-Za-z0-9])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9_])"
             ),
         ),
         CredentialPattern(
             name="AWS access key",
-            pattern=re.compile(r"\bAKIA[A-Z0-9]{16}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}\b"),
+        ),
+        CredentialPattern(
+            # The 40-char base64 secret value has no distinctive prefix, so it is
+            # anchored to the assignment keyword to avoid matching arbitrary
+            # base64 blobs. The generic "secret" pattern misses it because
+            # "secret" inside "aws_secret_access_key" has no word boundary.
+            name="AWS secret access key",
+            pattern=re.compile(
+                r"(?i)aws[_ -]?secret[_ -]?access[_ -]?key"
+                r"[\"']?\s*[:=]\s*[\"']?[A-Za-z0-9/+=]{40,}"
+            ),
         ),
         CredentialPattern(
             name="Azure key",
@@ -63,8 +90,18 @@ class CredentialRedactor:
             ),
         ),
         CredentialPattern(
+            # Azure Storage SAS token. The "sig" query parameter carries the
+            # secret HMAC signature (base64(HMAC-SHA256) = 44 chars, longer when
+            # URL-encoded). Matching the sig value directly is order-independent
+            # (SAS params are not ordered) and single-pass. The 43-char floor is
+            # far above an incidental short "sig=" query value, so it stands in
+            # for a context anchor without the false positives.
+            name="Azure SAS token",
+            pattern=re.compile(r"(?i)(?<![A-Za-z0-9])sig=[A-Za-z0-9%/+=_.~-]{43,}"),
+        ),
+        CredentialPattern(
             name="Bearer token",
-            pattern=re.compile(r"\bBearer\s+[A-Za-z0-9._\-+/=]{16,}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])Bearer\s+[A-Za-z0-9._\-+/=]{16,}\b"),
         ),
         CredentialPattern(
             name="PEM private key",
@@ -77,7 +114,7 @@ class CredentialRedactor:
         CredentialPattern(
             name="Connection string secret",
             pattern=re.compile(
-                r"(?i)\b(?:password|pwd|accountkey|sharedaccesssignature)\s*=\s*[^;\s]{4,}"
+                r"(?i)(?<![A-Za-z0-9])(?:password|pwd|accountkey|sharedaccesssignature)\s*=\s*[^;\s]{4,}"
             ),
         ),
         CredentialPattern(
@@ -88,12 +125,30 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="JWT",
-            pattern=re.compile(r"\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9._-]{6,}\.[A-Za-z0-9._-]{6,}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9._-]{6,}\.[A-Za-z0-9._-]{6,}\b"),
+        ),
+        CredentialPattern(
+            # Covers bot/user/legacy tokens (xoxb/xoxa/xoxp/xoxr/xoxs) and
+            # app-level tokens (xapp-). No trailing \b: the "-" in the value
+            # class lets a word boundary backtrack and redact only a prefix,
+            # leaking the token's final secret segment. The value class already
+            # bounds the match, so greedy consumption stops at the first
+            # non-token character.
+            name="Slack token",
+            pattern=re.compile(r"(?<![A-Za-z0-9])(?:xox[baprs]|xapp)-[A-Za-z0-9-]{10,}"),
+        ),
+        CredentialPattern(
+            name="Google API key",
+            pattern=re.compile(r"(?<![A-Za-z0-9])AIza[0-9A-Za-z_\-]{35}\b"),
+        ),
+        CredentialPattern(
+            name="Stripe secret key",
+            pattern=re.compile(r"(?<![A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}\b"),
         ),
         CredentialPattern(
             name="Generic API secret",
             pattern=re.compile(
-                r"(?i)\b(?:api[_-]?key|client[_-]?secret|secret|token)\b\s*[:=]\s*['\"]?[^\s'\";]{6,}"
+                r"(?i)(?<![A-Za-z0-9])(?:api[_-]?key|client[_-]?secret|secret|token)\b\s*[:=]\s*['\"]?[^\s'\";]{6,}"
             ),
         ),
     )
@@ -155,6 +210,8 @@ class CredentialRedactor:
                     CredentialMatch(
                         name=pii_pattern.name,
                         matched_text=match.group(0),
+                        start=match.start(),
+                        end=match.end(),
                     )
                 )
         return matches
@@ -175,6 +232,13 @@ class CredentialRedactor:
     def redact(cls, value: str | None) -> str:
         """Redact credential-like values from a string.
 
+        Redaction is driven by the exact spans that :meth:`find_matches`
+        reports, so redaction removes precisely what detection finds. This is
+        deliberately not a sequential ``subn`` over the patterns: applying
+        patterns to a progressively mutated string lets an earlier greedy
+        pattern consume the anchor keyword of a later one, which would remove
+        less than detection reported and leave a secret in place.
+
         Args:
             value: String content that may contain credential-like material.
 
@@ -185,18 +249,55 @@ class CredentialRedactor:
         if not value:
             return ""
 
-        result = value
-        redaction_count = 0
-        for credential_pattern in cls.PATTERNS:
-            updated, count = credential_pattern.pattern.subn(REDACTED_PLACEHOLDER, result)
-            if count:
-                redaction_count += count
-                result = updated
+        spans = sorted(
+            (match.start, match.end)
+            for match in cls.find_matches(value)
+            if match.start >= 0 and match.end > match.start
+        )
+        if not spans:
+            return value
 
-        if redaction_count:
-            logger.info("Credential redaction applied to %s value(s)", redaction_count)
+        merged: list[list[int]] = []
+        for start, end in spans:
+            if merged and start < merged[-1][1]:
+                merged[-1][1] = max(merged[-1][1], end)
+            else:
+                merged.append([start, end])
 
-        return result
+        pieces: list[str] = []
+        cursor = 0
+        for start, end in merged:
+            pieces.append(value[cursor:start])
+            pieces.append(REDACTED_PLACEHOLDER)
+            cursor = end
+        pieces.append(value[cursor:])
+
+        logger.info("Credential redaction applied to %s span(s)", len(merged))
+        return "".join(pieces)
+
+    @classmethod
+    def scan_and_redact(cls, value: str | None) -> tuple[str, list[str]]:
+        """Detect and redact credentials in a single, consistent operation.
+
+        This is the one call a host should use to clean text before returning it
+        to a model: it both removes credential-like material and reports which
+        credential *types* were present. Redaction is driven by the same
+        :meth:`find_matches` spans used for detection, so a type reported here is
+        always removed from ``redacted_text``.
+
+        Args:
+            value: String content that may contain credential-like material.
+
+        Returns:
+            A tuple of ``(redacted_text, credential_type_names)``. The names are
+            de-duplicated pattern labels (for example ``"Slack token"``) and
+            contain no raw secret material, so the result is safe to log. Empty
+            input returns ``("", [])``.
+        """
+        if not value:
+            return "", []
+        type_names = cls.detect_credential_types(value)
+        return cls.redact(value), type_names
 
     @classmethod
     def redact_mapping(cls, mapping: dict[str, Any] | None) -> dict[str, Any]:
@@ -293,6 +394,8 @@ class CredentialRedactor:
                     CredentialMatch(
                         name=credential_pattern.name,
                         matched_text=match.group(0),
+                        start=match.start(),
+                        end=match.end(),
                     )
                 )
         return matches

--- a/agent-governance-python/agent-os/src/agent_os/mcp_gateway.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_gateway.py
@@ -277,7 +277,8 @@ class MCPGateway:
         applies the gateway's ``response_policy``:
 
         - **BLOCK**: deny the response if any threat is found.
-        - **SANITIZE**: strip injection tags but block credential/PII leaks.
+        - **SANITIZE**: strip injection tags and redact credentials; block PII
+          and exfiltration leaks (which cannot be safely removed).
         - **LOG**: allow the response but record all threats in the audit log.
 
         Args:
@@ -340,10 +341,11 @@ class MCPGateway:
                 action="logged",
             )
         elif self._response_policy == ResponsePolicy.SANITIZE:
-            # Sanitize strips injection tags only. Credential and PII leaks
-            # are still blocked because sanitize_response cannot safely
-            # remove arbitrary secret/PII spans from prose.
-            hard_block_categories = {"credential_leak", "pii_leak", "data_exfiltration"}
+            # Sanitize strips injection tags and redacts credentials. PII and
+            # exfiltration URLs cannot be safely removed from prose, so they are
+            # still hard-blocked. Credential leaks are no longer a hard block:
+            # sanitize_response now redacts them.
+            hard_block_categories = {"pii_leak", "data_exfiltration"}
             has_hard_block = any(
                 t.category in hard_block_categories for t in scan_result.threats
             )
@@ -357,14 +359,27 @@ class MCPGateway:
                     action="blocked",
                 )
             else:
-                sanitized, _ = self._response_scanner.sanitize_response(text, tool_name)
-                decision = MCPResponseDecision(
-                    allowed=True,
-                    reason=f"Response sanitized — {len(scan_result.threats)} threat(s) stripped",
-                    content=sanitized,
-                    threats=threat_dicts,
-                    action="sanitized",
-                )
+                sanitized, removed = self._response_scanner.sanitize_response(text, tool_name)
+                # Fail closed if sanitization errored or left a credential behind,
+                # so relaxing the credential hard-block above can never leak.
+                sanitize_failed = any(t.category == "error" for t in removed)
+                residual_credential = CredentialRedactor.contains_credentials(sanitized)
+                if sanitize_failed or residual_credential:
+                    decision = MCPResponseDecision(
+                        allowed=False,
+                        reason="Response blocked — sanitization incomplete (fail closed)",
+                        content=None,
+                        threats=threat_dicts,
+                        action="blocked",
+                    )
+                else:
+                    decision = MCPResponseDecision(
+                        allowed=True,
+                        reason=f"Response sanitized — {len(scan_result.threats)} threat(s) stripped",
+                        content=sanitized,
+                        threats=threat_dicts,
+                        action="sanitized",
+                    )
         else:
             # BLOCK (default)
             categories = {t.category for t in scan_result.threats}

--- a/agent-governance-python/agent-os/src/agent_os/mcp_response_scanner.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_response_scanner.py
@@ -8,7 +8,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 
-from agent_os.credential_redactor import CredentialRedactor
+from agent_os.credential_redactor import CredentialMatch, CredentialRedactor
 
 logger = logging.getLogger(__name__)
 
@@ -118,8 +118,11 @@ class MCPResponseScanner:
                     description="Imperative instruction detected in tool response.",
                 )
             )
-            threats.extend(self._scan_credential_leaks(response_content))
-            threats.extend(self._scan_pii_leaks(response_content))
+            credential_matches = self._deduplicate_credential_matches(
+                CredentialRedactor.find_matches(response_content)
+            )
+            threats.extend(self._credential_threats(credential_matches, action="detected"))
+            threats.extend(self._scan_pii_leaks(response_content, credential_matches))
             threats.extend(self._scan_exfiltration_urls(response_content))
 
             if not threats:
@@ -143,25 +146,37 @@ class MCPResponseScanner:
         response_content: str | None,
         tool_name: str = "unknown",
     ) -> tuple[str, list[MCPResponseThreat]]:
-        """Strip instruction tags from tool output and report stripped threats.
+        """Strip instruction tags and redact credentials from tool output.
+
+        This makes the returned content safe from prompt-injection tags and
+        credential leakage in one pass, so a host does not have to stitch the
+        scanner and :class:`CredentialRedactor` together by hand.
+
+        Note: this removes instruction tags and *credentials* only. It does
+        **not** remove PII (email, phone, SSN, credit card, IP); those are
+        reported by :meth:`scan_response` and must be handled by policy. Do not
+        treat sanitized output as PII-safe.
 
         Args:
             response_content: Raw tool output to sanitize.
             tool_name: Human-readable tool name for reporting.
 
         Returns:
-            A tuple of ``(sanitized_content, stripped_threats)``. On failure the
-            method returns an empty string and a fail-closed error finding.
+            A tuple of ``(sanitized_content, removed_threats)`` where
+            ``removed_threats`` lists the instruction tags stripped and the
+            credential types redacted (by type name, never the raw secret). On
+            failure the method returns an empty string and a fail-closed error
+            finding.
         """
         try:
             if not response_content:
                 return "", []
 
             sanitized = response_content
-            stripped: list[MCPResponseThreat] = []
+            removed: list[MCPResponseThreat] = []
             for pattern in _INSTRUCTION_TAG_PATTERNS:
                 for match in pattern.finditer(sanitized):
-                    stripped.append(
+                    removed.append(
                         MCPResponseThreat(
                             category="instruction_injection",
                             description="Instruction tag stripped from tool response.",
@@ -170,7 +185,16 @@ class MCPResponseScanner:
                     )
                 sanitized = pattern.sub("", sanitized)
 
-            return sanitized, stripped
+            credential_matches = self._deduplicate_credential_matches(
+                CredentialRedactor.find_matches(sanitized)
+            )
+            if credential_matches:
+                sanitized = CredentialRedactor.redact(sanitized)
+                removed.extend(
+                    self._credential_threats(credential_matches, action="redacted")
+                )
+
+            return sanitized, removed
         except Exception:
             logger.error("MCP response sanitization failed closed", exc_info=True)
             return "", [
@@ -203,23 +227,75 @@ class MCPResponseScanner:
         return threats
 
     @staticmethod
-    def _scan_credential_leaks(content: str) -> list[MCPResponseThreat]:
-        threats: list[MCPResponseThreat] = []
-        for credential_match in CredentialRedactor.find_matches(content):
-            threats.append(
-                MCPResponseThreat(
-                    category="credential_leak",
-                    description=f"{credential_match.name} detected in tool response.",
-                    matched_pattern=credential_match.name,
-                    details={"credential_type": credential_match.name},
-                )
+    def _deduplicate_credential_matches(
+        matches: list[CredentialMatch],
+    ) -> list[CredentialMatch]:
+        """Drop credential matches whose span is strictly inside a larger match.
+
+        A single secret can match both a specific and a generic pattern (for
+        example ``api_key=AIza...`` matches "Google API key" and "Generic API
+        secret"). Keeping only the widest span per region avoids emitting
+        duplicate ``credential_leak`` findings for one secret. Matches with equal
+        spans or unknown offsets are all retained.
+        """
+        kept: list[CredentialMatch] = []
+        for index, match in enumerate(matches):
+            if match.start < 0:
+                kept.append(match)
+                continue
+            match_size = match.end - match.start
+            contained = any(
+                other_index != index
+                and other.start >= 0
+                and other.start <= match.start
+                and match.end <= other.end
+                and (other.end - other.start) > match_size
+                for other_index, other in enumerate(matches)
             )
-        return threats
+            if not contained:
+                kept.append(match)
+        return kept
 
     @staticmethod
-    def _scan_pii_leaks(content: str) -> list[MCPResponseThreat]:
+    def _credential_threats(
+        matches: list[CredentialMatch], *, action: str
+    ) -> list[MCPResponseThreat]:
+        """Build credential threats from matches, exposing only the type name.
+
+        ``action`` is "detected" (scan) or "redacted" (sanitize). The raw
+        matched secret value is never placed in the threat.
+        """
+        return [
+            MCPResponseThreat(
+                category="credential_leak",
+                description=f"{match.name} {action} in tool response.",
+                matched_pattern=match.name,
+                details={"credential_type": match.name},
+            )
+            for match in matches
+        ]
+
+    @staticmethod
+    def _scan_pii_leaks(
+        content: str,
+        credential_matches: list[CredentialMatch] | None = None,
+    ) -> list[MCPResponseThreat]:
+        credential_spans = [
+            (match.start, match.end)
+            for match in (credential_matches or [])
+            if match.start >= 0
+        ]
         threats: list[MCPResponseThreat] = []
         for pii_match in CredentialRedactor.find_pii_matches(content):
+            # Suppress PII that falls entirely inside a credential match: digit
+            # runs in tokens such as Google "AIza..." keys otherwise register as
+            # a false "US phone number" and would wrongly hard-block a secret
+            # that is actually redactable.
+            if pii_match.start >= 0 and any(
+                start <= pii_match.start and pii_match.end <= end
+                for start, end in credential_spans
+            ):
+                continue
             threats.append(
                 MCPResponseThreat(
                     category="pii_leak",

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -15,6 +15,11 @@ def _fake_github_token(prefix: str) -> str:
     return f"{prefix}_FAKEFORTESTING000000000000000000"
 
 
+# Fake Google API key built by concatenation so the contiguous literal never
+# appears in source (avoids secret-scanner false positives on a test value).
+_FAKE_GOOGLE_KEY = "AIza" + "SyD1234567890abcdefghijklmnopqrstuv"
+
+
 def _fake_pem_block(label: str) -> str:
     return (
         f"-----BEGIN {label}-----\n"
@@ -180,3 +185,174 @@ def test_private_key_pattern_handles_adversarial_input_quickly():
 
     assert redacted == text
     assert elapsed < 1.0
+
+
+# AWS's own documentation example secret — deterministic and clearly fake.
+_FAKE_AWS_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+# Realistic-length clearly-fake Azure SAS signature. Real Azure sig values are
+# base64(HMAC-SHA256) = 44 chars (longer URL-encoded); the detector requires
+# this realistic floor so short incidental "sig=" params are not flagged.
+_FAKE_SAS_SIG = "abcDEF0123ghiJKL4567mnoPQR89stuVWX%2Fyz01%3D2345"
+
+
+@pytest.mark.parametrize(
+    ("input_text", "expected_type"),
+    [
+        (f"aws_secret_access_key = {_FAKE_AWS_SECRET}", "AWS secret access key"),
+        (f"aws-secret-access-key: {_FAKE_AWS_SECRET}", "AWS secret access key"),
+        (f'"AWS Secret Access Key":"{_FAKE_AWS_SECRET}"', "AWS secret access key"),
+        (
+            "https://a.blob.core.windows.net/c/b?sv=2021-08-06&ss=b&srt=o"
+            f"&sp=rwd&se=2025-01-01T00:00:00Z&sig={_FAKE_SAS_SIG}",
+            "Azure SAS token",
+        ),
+        (
+            # SAS query parameters are not ordered; sig may appear before sv.
+            f"https://a.blob.core.windows.net/c/b?sig={_FAKE_SAS_SIG}"
+            "&sv=2021-08-06&sp=r",
+            "Azure SAS token",
+        ),
+        ("xoxb-FAKE-not-a-real-slack-token-00", "Slack token"),
+        ("xapp-FAKE-not-a-real-slack-token-00", "Slack token"),
+        (_FAKE_GOOGLE_KEY, "Google API key"),
+        ("stripe=sk_live_FakeTestKey0000", "Stripe secret key"),
+        ("rk_test_FakeTestKey0000", "Stripe secret key"),
+    ],
+)
+def test_detects_and_redacts_newly_covered_secret_classes(input_text: str, expected_type: str):
+    redacted = CredentialRedactor.redact(input_text)
+    detected = CredentialRedactor.detect_credential_types(input_text)
+
+    assert REDACTED_PLACEHOLDER in redacted
+    assert expected_type in detected
+    assert CredentialRedactor.contains_credentials(input_text) is True
+
+
+def test_aws_secret_value_is_fully_removed():
+    text = f"aws_secret_access_key = {_FAKE_AWS_SECRET}"
+
+    assert _FAKE_AWS_SECRET not in CredentialRedactor.redact(text)
+
+
+def test_azure_sas_signature_is_removed():
+    url = (
+        "https://a.blob.core.windows.net/c/b?sv=2021-08-06&ss=b&srt=o"
+        f"&sp=rwd&se=2025-01-01T00:00:00Z&sig={_FAKE_SAS_SIG}"
+    )
+
+    redacted = CredentialRedactor.redact(url)
+
+    assert "sig=" not in redacted
+    assert _FAKE_SAS_SIG not in redacted
+    # The non-secret base path survives.
+    assert redacted.startswith("https://a.blob.core.windows.net/c/b?")
+
+
+def test_azure_sas_detected_regardless_of_parameter_order():
+    # SAS query parameters are order-independent; a token with sig before sv
+    # must still be detected and redacted (regression: an sv-anchored pattern
+    # missed this and the signature leaked).
+    url = (
+        f"https://a.blob.core.windows.net/c/b?sig={_FAKE_SAS_SIG}"
+        "&sv=2021-08-06&sp=r"
+    )
+
+    assert CredentialRedactor.contains_credentials(url) is True
+    assert _FAKE_SAS_SIG not in CredentialRedactor.redact(url)
+
+
+def test_azure_sas_pattern_has_no_quadratic_backtracking():
+    # Repeated non-matching markers must not trigger super-linear scanning
+    # (regression: a lazy cross-parameter gap scanned to end from each marker).
+    text = "&".join(["sv=2021-08-06"] * 5000)
+
+    start = time.perf_counter()
+    CredentialRedactor.redact(text)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 1.0
+
+
+def test_slack_token_fully_redacted_when_followed_by_word_char():
+    # Regression: the "-" in the token class let a trailing word boundary
+    # backtrack and redact only a prefix, leaking the final secret segment.
+    secret_tail = "abcdefghijklmnopqrstuvwx"
+    text = f"slack=xoxb-111111111111-222222222222-{secret_tail}_rotated"
+
+    redacted = CredentialRedactor.redact(text)
+
+    assert secret_tail not in redacted
+
+
+def test_bare_sig_query_param_without_sas_context_is_not_flagged():
+    # A short "sig=" that is not an Azure SAS token must not false-positive.
+    text = "https://example.com/callback?sig=abcdefghijklmnopqrstuvwxyz123456"
+
+    assert CredentialRedactor.contains_credentials(text) is False
+    assert CredentialRedactor.redact(text) == text
+
+
+def test_detection_and_redaction_agree_on_adjacent_anchored_secrets():
+    # Regression: sequential subn on a mutating string let the greedy OpenAI
+    # pattern consume the "aws_secret_access_key" anchor of a following pattern,
+    # so redaction removed less than detection reported and the secret survived.
+    secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    text = "sk-abcDEF012345678901234567890-aws_secret_access_key=" + secret
+
+    detected = CredentialRedactor.detect_credential_types(text)
+    redacted = CredentialRedactor.redact(text)
+
+    assert "AWS secret access key" in detected
+    assert secret not in redacted
+    assert CredentialRedactor.contains_credentials(redacted) is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "session_sk-abcdefghijklmnopqrstuvwx0123",
+        "prefix_ghp_FAKEFORTESTING000000000000000000",
+        "x_xoxb-FAKE-not-a-real-slack-token",
+        "svc_" + _FAKE_GOOGLE_KEY,
+        "env_sk_live_FakeTestKey0000",
+        "db_password=Hunter2xyz",
+    ],
+)
+def test_detects_secret_glued_to_preceding_word_character(text: str):
+    # Regression: a leading \b treats "_" as a word character, so a secret glued
+    # directly after "_" was missed. The (?<![A-Za-z0-9]) anchor detects it.
+    assert CredentialRedactor.contains_credentials(text) is True
+    assert REDACTED_PLACEHOLDER in CredentialRedactor.redact(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "basketball-court-schedule-1234567",
+        "the disk-usage-report is ready",
+        "a risky-business-plan draft",
+        "the tokenizer=fast setting is nice",
+    ],
+)
+def test_loosened_anchor_does_not_match_inside_words(text: str):
+    # The (?<![A-Za-z0-9]) anchor still refuses to match a secret prefix that is
+    # embedded in an alphanumeric word (e.g. the "sk-" inside "disk-").
+    assert CredentialRedactor.contains_credentials(text) is False
+    assert CredentialRedactor.redact(text) == text
+
+
+def test_scan_and_redact_reports_types_without_raw_secret():
+    secret = "xoxb-FAKE-not-a-real-slack-token-00"
+    redacted, types = CredentialRedactor.scan_and_redact(f"token {secret}")
+
+    assert REDACTED_PLACEHOLDER in redacted
+    assert secret not in redacted
+    assert types == ["Slack token"]
+    # The returned metadata must never carry the raw secret value.
+    assert all(secret not in name for name in types)
+
+
+def test_scan_and_redact_empty_input():
+    assert CredentialRedactor.scan_and_redact(None) == ("", [])
+    assert CredentialRedactor.scan_and_redact("") == ("", [])

--- a/agent-governance-python/agent-os/tests/test_mcp_pii_and_response_gateway.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_pii_and_response_gateway.py
@@ -4,8 +4,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from agent_os.credential_redactor import CredentialRedactor
 from agent_os.integrations.base import GovernancePolicy
 from agent_os.mcp_gateway import (
@@ -15,6 +13,10 @@ from agent_os.mcp_gateway import (
 )
 from agent_os.mcp_protocols import InMemoryAuditSink
 from agent_os.mcp_response_scanner import MCPResponseScanner
+
+# Fake Google API key built by concatenation so the contiguous literal never
+# appears in source (avoids secret-scanner false positives on a test value).
+_FAKE_GOOGLE_KEY = "AIza" + "SyD1234567890abcdefghijklmnopqrstuv"
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -201,7 +203,7 @@ class TestGatewayResponseBlock:
 
 
 class TestGatewayResponseSanitize:
-    """ResponsePolicy.SANITIZE: strip injection tags, block credential/PII."""
+    """ResponsePolicy.SANITIZE: strip injection tags, redact credentials, block PII/exfil."""
 
     def test_injection_tags_stripped(self):
         gw = _make_gateway(response_policy=ResponsePolicy.SANITIZE)
@@ -220,13 +222,51 @@ class TestGatewayResponseSanitize:
         assert decision.allowed is False
         assert "cannot be sanitized" in decision.reason
 
-    def test_credential_still_blocked_in_sanitize_mode(self):
+    def test_credential_redacted_in_sanitize_mode(self):
         gw = _make_gateway(response_policy=ResponsePolicy.SANITIZE)
-        decision = gw.intercept_tool_response(
-            "a1", "tool", "sk-test_abcdefghijklmnopqrstuvwxyz"
-        )
-        assert decision.allowed is False
-        assert "credential_leak" in decision.reason
+        secret = "sk-test_abcdefghijklmnopqrstuvwxyz"
+        decision = gw.intercept_tool_response("a1", "tool", secret)
+        assert decision.allowed is True
+        assert decision.action == "sanitized"
+        assert secret not in (decision.content or "")
+        assert "[REDACTED]" in (decision.content or "")
+
+    def test_google_key_redacted_not_pii_blocked_in_sanitize_mode(self):
+        # Google keys contain digit runs that used to register as a false
+        # "US phone number" PII match and wrongly hard-block a redactable secret.
+        gw = _make_gateway(response_policy=ResponsePolicy.SANITIZE)
+        secret = _FAKE_GOOGLE_KEY
+        decision = gw.intercept_tool_response("a1", "tool", secret)
+        assert decision.allowed is True
+        assert decision.action == "sanitized"
+        assert secret not in (decision.content or "")
+
+    def test_slack_token_redacted_in_sanitize_mode(self):
+        gw = _make_gateway(response_policy=ResponsePolicy.SANITIZE)
+        secret = "xoxb-FAKE-not-a-real-slack-token-00"
+        decision = gw.intercept_tool_response("a1", "tool", secret)
+        assert decision.allowed is True
+        assert decision.action == "sanitized"
+        assert secret not in (decision.content or "")
+
+    def test_adjacent_anchored_secret_not_leaked_in_sanitize_mode(self):
+        # End-to-end regression: a greedy pattern must not consume a following
+        # pattern's anchor and let the secret pass the fail-closed re-check.
+        gw = _make_gateway(response_policy=ResponsePolicy.SANITIZE)
+        secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        text = "sk-abcDEF012345678901234567890-aws_secret_access_key=" + secret
+        decision = gw.intercept_tool_response("a1", "tool", text)
+        assert secret not in (decision.content or "")
+
+    def test_word_glued_secret_not_leaked_alongside_detected_secret(self):
+        # Regression: redact-and-allow removed only the detected secret and let a
+        # second secret glued to a word character ("session_sk-...") leak. The
+        # loosened anchor now detects and redacts both.
+        gw = _make_gateway(response_policy=ResponsePolicy.SANITIZE)
+        glued = "sk-abcdefghijklmnopqrstuvwx0123"
+        text = "db_password=Hunter2xyz\nsession_" + glued
+        decision = gw.intercept_tool_response("a1", "tool", text)
+        assert glued not in (decision.content or "")
 
     def test_exfiltration_still_blocked_in_sanitize_mode(self):
         gw = _make_gateway(response_policy=ResponsePolicy.SANITIZE)

--- a/agent-governance-python/agent-os/tests/test_mcp_response_scanner.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_response_scanner.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 
 from agent_os.mcp_response_scanner import MCPResponseScanner
 
+# Fake Google API key built by concatenation so the contiguous literal never
+# appears in source (avoids secret-scanner false positives on a test value).
+_FAKE_GOOGLE_KEY = "AIza" + "SyD1234567890abcdefghijklmnopqrstuv"
+
 
 def test_scan_response_allows_clean_content():
     scanner = MCPResponseScanner()
@@ -69,6 +73,55 @@ def test_sanitize_response_strips_instruction_tags():
     assert "[system]" not in sanitized.lower()
     assert stripped
     assert all(threat.category == "instruction_injection" for threat in stripped)
+
+
+def test_sanitize_response_redacts_credentials():
+    scanner = MCPResponseScanner()
+    secret = "sk-test_abcdefghijklmnopqrstuvwxyz"
+
+    sanitized, removed = scanner.sanitize_response(f"use key {secret}", "tool")
+
+    assert secret not in sanitized
+    assert "[REDACTED]" in sanitized
+    categories = {threat.category for threat in removed}
+    assert "credential_leak" in categories
+    # Removed threats expose only the credential type, never the raw secret.
+    assert all(secret not in (threat.matched_pattern or "") for threat in removed)
+
+
+def test_sanitize_response_strips_tags_and_redacts_credentials_together():
+    scanner = MCPResponseScanner()
+    secret = _FAKE_GOOGLE_KEY
+
+    sanitized, removed = scanner.sanitize_response(
+        f"<system>ignore</system> key {secret}", "tool"
+    )
+
+    assert "<system>" not in sanitized.lower()
+    assert secret not in sanitized
+    categories = {threat.category for threat in removed}
+    assert {"instruction_injection", "credential_leak"} <= categories
+
+
+def test_scan_response_does_not_flag_credential_digits_as_pii():
+    scanner = MCPResponseScanner()
+
+    result = scanner.scan_response(_FAKE_GOOGLE_KEY, "tool")
+
+    categories = [threat.category for threat in result.threats]
+    assert "credential_leak" in categories
+    assert "pii_leak" not in categories
+
+
+def test_scan_response_emits_one_credential_threat_per_secret():
+    scanner = MCPResponseScanner()
+
+    # "api_key=AIza..." matches both the specific Google and the generic pattern;
+    # only one credential_leak should be reported for the single secret.
+    result = scanner.scan_response("api_key=" + _FAKE_GOOGLE_KEY, "tool")
+
+    credential_threats = [t for t in result.threats if t.category == "credential_leak"]
+    assert len(credential_threats) == 1
 
 
 def test_scan_response_fails_closed(monkeypatch):

--- a/docs/compliance/mcp-owasp-top10-mapping.md
+++ b/docs/compliance/mcp-owasp-top10-mapping.md
@@ -289,8 +289,8 @@ result = proxy.route(target="mcp://random-server.external", tool_call={...})
 
 **Mitigation:** The **MCP Response Scanner** inspects all tool outputs for sensitive data before they enter agent context. **CredentialRedactor** strips credentials, and VFS policies enforce per-agent context boundaries.
 
-- **MCP Response Scanner** — fail-closed inspection of tool outputs; blocks responses containing credentials, PII, or injection payloads
-- **CredentialRedactor** — strips API keys, tokens, PEM blocks, and connection strings from all MCP responses
+- **MCP Response Scanner** — fail-closed inspection of tool outputs; blocks responses containing PII or injection payloads and redacts credential values under the sanitize policy
+- **CredentialRedactor** — strips API keys, tokens, PEM blocks, connection strings, AWS secret keys, Azure SAS tokens, and Slack/Google/Stripe tokens from all MCP responses
 - **VFS Context Isolation** — per-agent memory boundaries prevent cross-agent context leakage
 - **Scoped Sessions** — `MCPSessionAuthenticator` binds context to specific agent sessions with TTL expiry
 - **PII Detection** — identifies and redacts sensitive personal data in tool responses

--- a/docs/security/audits/2026-07-02-agent-os-credential-redaction.md
+++ b/docs/security/audits/2026-07-02-agent-os-credential-redaction.md
@@ -1,0 +1,75 @@
+# 2026-07-02 — Agent-OS Credential Detection and Redaction
+
+PR: [microsoft/agent-governance-toolkit#3248](https://github.com/microsoft/agent-governance-toolkit/pull/3248)
+
+## What changed and why
+
+`agent_os` had two components that handled secrets in tool output and disagreed
+with each other. `MCPResponseScanner.scan_response` flagged credential threats,
+but `MCPResponseScanner.sanitize_response` only stripped instruction tags and
+returned the secrets intact. `CredentialRedactor` missed several common secret
+formats that the scanner still reported, so detection and redaction produced
+different verdicts on the same input. This PR makes credential handling
+internally consistent.
+
+- `CredentialRedactor.redact` is now driven by the exact spans that
+  `find_matches` reports, instead of applying each pattern sequentially to a
+  progressively mutated string. The old approach let an earlier greedy pattern
+  consume the anchor keyword of a later pattern, so redaction removed less than
+  detection reported and left a secret in place.
+- New credential patterns cover the AWS secret access key, Azure Storage SAS
+  token, and Slack, Google, and Stripe tokens.
+- Prefix-anchored patterns use a `(?<![A-Za-z0-9])` left anchor instead of `\b`,
+  so a secret glued to a preceding word character (for example `session_sk-...`)
+  is detected. Under redact-and-allow this matters because a secret the scanner
+  cannot see would otherwise be returned when it co-occurs with a detected one.
+- `MCPResponseScanner.sanitize_response` strips instruction tags and redacts
+  credential values, returning the removed credential type names rather than the
+  raw secret.
+- `MCPGateway` under `ResponsePolicy.SANITIZE` now redacts credential leaks and
+  allows the cleaned response, matching the behavior required by
+  `docs/specs/MCP-SECURITY-GATEWAY-1.0.md` section 21.3. PII and exfiltration
+  URLs are still blocked because they cannot be safely removed from prose.
+
+## Threat model impact
+
+This change strengthens the response data-loss boundary and does not introduce a
+new external attack surface. It touches only detection and redaction of secrets
+in tool output.
+
+| Dimension | Direction |
+|---|---|
+| Detection and redaction consistency | **Strengthened.** Redaction now removes exactly the spans detection reports, so a credential the scanner flags can no longer survive `sanitize_response`. |
+| Secret coverage | **Strengthened.** AWS secret keys, Azure SAS tokens, and Slack, Google, and Stripe tokens are now detected and redacted. |
+| SANITIZE behavior | **Changed.** Credential-bearing responses are returned redacted rather than hard-blocked. A fail-closed guard re-checks the redacted output and blocks if a credential remains, so relaxing the hard block cannot leak a detected secret. |
+| Denial-of-service | **Strengthened.** The Azure SAS pattern matches the signature value directly instead of a lazy cross-parameter span that scanned to end from each marker, removing a super-linear backtracking path on untrusted input. |
+| Secret gluing | **Strengthened.** Prefix-anchored patterns use a `(?<![A-Za-z0-9])` left anchor instead of a word boundary, so a secret joined directly to a preceding word character (for example `session_sk-...`) is now detected and redacted. Previously such a secret was missed, and under redact-and-allow it could leak when it co-occurred with a separately detected credential. |
+| Log and audit exposure | **Unchanged.** Threats and the new `scan_and_redact` API expose only credential type names, never raw secret values; `redact` logs a span count only. |
+| PII handling | **Unchanged.** PII is still detected and hard-blocked; PII matches that fall inside a credential span are suppressed so a secret is not double-reported. |
+
+### Known limitations
+
+Two narrow, pre-existing behaviors remain out of scope for this change and are
+tracked as follow-ups. Both reproduce identically on the base branch.
+
+- Tag stripping can join fragments into PII or an exfiltration URL with no
+  post-sanitize re-scan of those categories.
+- A secret glued to a following alphanumeric run of a fixed-length identifier
+  (for example an AWS access key id immediately followed by more letters) can
+  still evade detection; the left-edge case (`session_sk-...`) is fixed here.
+
+## Test coverage
+
+- `tests/test_credential_redactor.py` covers each new secret class, full removal
+  of the AWS secret value, order-independent Azure SAS detection, redaction of a
+  Slack token followed by a word character, the absence of super-linear
+  backtracking on repeated SAS markers, detection and redaction agreeing on
+  adjacent anchored secrets, detection of secrets glued to a preceding word
+  character, and the loosened anchor still refusing matches inside words.
+- `tests/test_mcp_response_scanner.py` covers `sanitize_response` removing
+  credentials, combined tag stripping and redaction, PII suppression inside a
+  credential span, and one credential finding per secret.
+- `tests/test_mcp_pii_and_response_gateway.py` covers the `SANITIZE` policy
+  redacting and allowing credential leaks, still blocking PII and exfiltration,
+  not leaking an adjacent anchored secret, and not leaking a word-glued secret
+  that co-occurs with a detected one.

--- a/docs/tutorials/07-mcp-security-gateway.md
+++ b/docs/tutorials/07-mcp-security-gateway.md
@@ -1096,7 +1096,7 @@ Response scanning is built into `MCPGateway`. Choose a `ResponsePolicy`:
 | Policy | Behaviour |
 |--------|-----------|
 | `BLOCK` (default) | Deny the response if any threat is found |
-| `SANITIZE` | Strip injection tags; still block credential/PII leaks |
+| `SANITIZE` | Strip injection tags and redact credentials; block PII/exfiltration leaks |
 | `LOG` | Allow the response through but record all threats |
 
 ```python
@@ -1158,15 +1158,17 @@ The response scanner detects these PII/CRI categories via `CredentialRedactor`:
 | Credit card number | `4111 1111 1111 1111`, `4111-1111-1111-1111` |
 | IPv4 address | `10.0.0.1`, `192.168.1.100` |
 
-In addition, the scanner detects credentials (API keys, tokens, JWTs,
-connection strings) and prompt injection patterns (instruction tags,
+In addition, the scanner detects credentials (API keys, bearer tokens, JWTs,
+connection strings, AWS access and secret keys, Azure SAS tokens, and
+Slack/Google/Stripe tokens) and prompt injection patterns (instruction tags,
 imperative overrides, exfiltration URLs).
 
 ### Sanitize Mode: Category-Aware
 
-`SANITIZE` mode strips injection tags from responses but **still blocks**
-credential leaks, PII leaks, and exfiltration URLs. These categories cannot
-be safely removed from prose without data loss:
+`SANITIZE` mode strips injection tags and redacts credential values in place,
+then allows the cleaned response through. PII leaks and exfiltration URLs are
+still blocked, because they cannot be safely removed from prose without data
+loss:
 
 ```python
 gateway = MCPGateway(policy, response_policy=ResponsePolicy.SANITIZE)
@@ -1179,6 +1181,15 @@ decision = gateway.intercept_tool_response(
 print(decision.allowed)  # True
 print(decision.action)   # "sanitized"
 print(decision.content)  # " Here are your results."
+
+# Credential values are redacted, response allowed
+decision = gateway.intercept_tool_response(
+    "bot", "tool",
+    "Your key is sk-abcdefghijklmnopqrstuvwxyz012345.",
+)
+print(decision.allowed)  # True
+print(decision.action)   # "sanitized"
+print(decision.content)  # "Your key is [REDACTED]."
 
 # PII leaks are still blocked
 decision = gateway.intercept_tool_response(


### PR DESCRIPTION
## Description

Make credential detection and redaction in `agent_os` internally consistent. `CredentialRedactor` becomes the single detect and redact core, and `MCPResponseScanner.sanitize_response` now actually redacts credentials instead of only stripping instruction tags.

### Problem

The two components disagreed and the sanitize path leaked secrets. Reproduced before the change:

| # | Defect | Before |
|---|--------|--------|
| 1 | `sanitize_response` leaves secrets in place | `scan_response` flags 5 threats; `sanitize_response` returns the text unchanged |
| 2 | AWS secret access key missed | `redact()` returns the 40-char secret unchanged |
| 3 | Azure Storage SAS token missed | blob URL with `sig=` passes `redact()` and `scan_response` unchanged |
| 4 | Slack/Google/Stripe missed by redactor | `contains_credentials` is `False` for `xoxb-`, `AIza...`, `sk_live_` |
| 5 | No single detect and redact API | integrators must stitch two components together and still hit gaps |

### Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agent-os/src/agent_os/credential_redactor.py` | `redact()` is span-driven from `find_matches` so detection and redaction cannot disagree; prefix patterns use a `(?<![A-Za-z0-9])` left anchor so `_`-glued secrets are caught; added AWS secret key, Azure SAS, Slack (incl. `xapp-`), Google, Stripe patterns; new `scan_and_redact` returns type names only, never the raw secret; `CredentialMatch` gains additive `start`/`end` offsets |
| `agent-governance-python/agent-os/src/agent_os/mcp_response_scanner.py` | `sanitize_response` strips tags AND redacts credentials; PII matches inside a credential span are suppressed; overlapping credential matches dedupe to one finding per secret |
| `agent-governance-python/agent-os/src/agent_os/mcp_gateway.py` | `SANITIZE` policy redacts and allows credential leaks (conforms to spec `MCP-SECURITY-GATEWAY-1.0` section 21.3) and fails closed if sanitization is incomplete; PII and exfiltration URLs stay blocked |
| `agent-governance-python/agent-os/tests/*` | Regression tests for each secret class, span-driven redaction, PII suppression, dedup, the gateway behavior change, and word-glued secret detection |
| `docs/tutorials/07-mcp-security-gateway.md`, `docs/compliance/mcp-owasp-top10-mapping.md` | Update the `SANITIZE` behavior and credential coverage to match the shipped code |
| `docs/security/audits/2026-07-02-agent-os-credential-redaction.md` | Security audit doc required by the capability-path CI gate |

### Design notes

- `redact()` is span-driven, not a sequential `subn` over the patterns. Applying patterns to a progressively mutated string let an earlier greedy pattern (OpenAI `sk-`) consume the anchor keyword of a later pattern (`aws_secret_access_key`), which removed less than detection reported and left the secret in place. Driving redaction from the detected spans makes the detection and redaction agree invariant structurally true.
- The Azure SAS pattern matches the `sig` value directly (order-independent, single pass) instead of a `sv=...&sig=` span, which both missed reordered tokens and had super-linear backtracking on repeated markers.
- Prefix patterns use a `(?<![A-Za-z0-9])` left anchor instead of `\b`, so a secret glued to a preceding word character (`session_sk-...`) is detected. Without it, redact and allow could return an undetected secret that co-occurs with a detected one; the anchor closes that gap.
- `SANITIZE` returning redacted and allowed content is a behavior change from the previous hard-block. It brings the gateway into conformance with spec section 21.3, which already required this.

### Known limitations (follow-ups, pre-existing)

These reproduce identically on `main` and are outside the credential detect and redact scope of this change:

- Tag-stripping can join fragments into PII or an exfiltration URL (`user@<tag>example.com`) with no post-sanitize re-scan of those categories.
- A secret glued to a following alphanumeric run of a fixed-length id (for example an AWS access-key id immediately followed by more letters) can still evade detection. The left-edge case (`session_sk-...`) is fixed in this PR.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [x] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
None. Original implementation against the existing `agent_os` components and the `MCP-SECURITY-GATEWAY-1.0` spec.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:
<!-- Leave blank if AI was not used or was only used for minor assistance -->
Copilot leveraged in development

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
