### PR TITLE
docs: clarify Python quickstart install extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ AGT does not try to win that fight inside the prompt. Every tool call, message s
 pip install agent-governance-toolkit[full]
 ```
 
+Use the `[full]` extra for the quick-start imports below. The base
+`agent-governance-toolkit` wheel installs the compliance CLI only; the governance
+modules live in the consolidated core distribution. The `agentmesh` quick-start
+import remains the current wrapper API. The `agent_os` `PolicyEvaluator` example
+below is legacy compatibility: importing `agent_os` currently emits a
+`DeprecationWarning` because the old `agent-os-kernel` distribution is deprecated.
+Use `agent-governance-toolkit-core` (or the `[full]` extra that includes it) as
+the replacement distribution, and prefer the AGT 5 `agt-policies`/ACS APIs for
+new policy-engine host code.
+
 For Claude Code, add AGT as a plugin marketplace and install the governance plugin:
 
 ```text

--- a/agent-governance-python/README.md
+++ b/agent-governance-python/README.md
@@ -9,15 +9,26 @@ Python to publish multiple focused distributions instead of a single monolithic 
 
 ## Installing
 
-The recommended install for most users is the meta-package, which pulls in the core runtime and lets you add framework integrations as extras:
+The base meta-package installs the compliance CLI. Add an extra when you need
+the governance runtime, framework integrations, or the full Python stack:
 
 ```
+# Compliance CLI only
 pip install agent-governance-toolkit
+
+# Framework integrations
 pip install agent-governance-toolkit[langchain]
 pip install agent-governance-toolkit[crewai]
 pip install agent-governance-toolkit[openai-agents]
+
+# Full Python governance stack, including agentmesh and legacy agent_os compatibility
 pip install agent-governance-toolkit[full]
 ```
+
+`agent_os` is the legacy compatibility import from the old `agent-os-kernel`
+surface. It currently emits a `DeprecationWarning`; use
+`agent-governance-toolkit-core` (or the `[full]` extra) as the replacement
+distribution, and prefer `agt-policies`/ACS APIs for new policy-engine host code.
 
 If you only need a specific component, each package can also be installed on its own. See the package listing below for names.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,6 +8,16 @@ Get from zero to governed AI agents in under 5 minutes.
 pip install agent-governance-toolkit[full]
 ```
 
+Use the `[full]` extra for these examples. The base `agent-governance-toolkit`
+wheel installs the compliance CLI only; the governance modules shown below come
+from the consolidated core distribution. The `agentmesh` examples remain the
+current wrapper API. The advanced `agent_os.policies` example is legacy
+compatibility: importing `agent_os` currently emits a `DeprecationWarning`
+because the old `agent-os-kernel` distribution is deprecated. Use
+`agent-governance-toolkit-core` (or the `[full]` extra that includes it) as the
+replacement distribution, and prefer the AGT 5 `agt-policies`/ACS APIs for new
+policy-engine host code.
+
 !!! info "Other languages"
     **TypeScript:** `npm install @microsoft/agent-governance-sdk` ·
     **.NET:** `dotnet add package Microsoft.AgentGovernance` ·


### PR DESCRIPTION
## Summary

Refs #3253.

- clarify that the quick-start governance imports require `agent-governance-toolkit[full]`
- document that the base `agent-governance-toolkit` wheel installs the compliance CLI only
- clarify that the v4.1 package consolidation renamed distributions, not the public `agentmesh` / `agent_os` Python import paths
- update the Python package overview so the base install is separated from framework/full extras

## Validation

- reproduced `pip install agent-governance-toolkit` v4.1.0 missing `agentmesh` / `agent_os` imports
- reproduced `pip install agent-governance-toolkit[full]` v4.1.0 importing `agentmesh.governance` and `agent_os.policies`
- Codex independent review: passed with no blockers or suggestions after follow-up wording update
- `python scripts/docs/check_links.py README.md docs/quickstart.md agent-governance-python/README.md`
- `python scripts/docs/check_links.py`
- `python scripts/docs/check_frontmatter.py` (warn mode; exits 0 with existing missing-frontmatter warnings)
- `git diff --check`
- added-line secret scan: 0 findings
- CRLF scan: no CRLF in changed files
