### PR TITLE
fix(credential_redactor): add opt-in PII redaction and reconcile SSN pattern

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -252,6 +252,10 @@ class CredentialRedactor:
     ) -> dict[str, Any]:
         """Compatibility alias for dictionary redaction.
 
+        Kept for external API stability; there are no in-repo production callers
+        (callers use :meth:`redact_mapping` / :meth:`redact_data_structure`
+        directly). It threads ``redact_pii`` through for symmetry only.
+
         Args:
             mapping: Dictionary-like content to redact.
             redact_pii: When ``True``, also redact PII/CRI patterns. Defaults
@@ -265,6 +269,13 @@ class CredentialRedactor:
     @classmethod
     def redact_data_structure(cls, value: Any, *, redact_pii: bool = False) -> Any:
         """Recursively redact nested strings in dicts, lists, and tuples.
+
+        ``redact_pii`` defaults to ``False`` to preserve the historical
+        secrets-only behavior. The only production caller (the MCP gateway
+        audit path in ``mcp_gateway.py``) deliberately does not flip it: PII
+        scrubbing is an opt-in capability and ships wired to zero callers by
+        default, so audit logs retain their existing shape until a caller
+        explicitly opts in. See issue #3239.
 
         Args:
             value: Any Python value that may contain nested strings.

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -248,23 +248,17 @@ class CredentialRedactor:
 
     @classmethod
     def redact_dictionary(
-        cls, mapping: dict[str, Any] | None, *, redact_pii: bool = False
+        cls, mapping: dict[str, Any] | None
     ) -> dict[str, Any]:
         """Compatibility alias for dictionary redaction.
 
-        Kept for external API stability; there are no in-repo production callers
-        (callers use :meth:`redact_mapping` / :meth:`redact_data_structure`
-        directly). It threads ``redact_pii`` through for symmetry only.
-
         Args:
             mapping: Dictionary-like content to redact.
-            redact_pii: When ``True``, also redact PII/CRI patterns. Defaults
-                to ``False`` (secrets-only).
 
         Returns:
             The redacted mapping produced by :meth:`redact_mapping`.
         """
-        return cls.redact_mapping(mapping, redact_pii=redact_pii)
+        return cls.redact_mapping(mapping)
 
     @classmethod
     def redact_data_structure(cls, value: Any, *, redact_pii: bool = False) -> Any:

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -37,6 +37,11 @@ class CredentialRedactor:
     callers. The class operates on plain strings as well as nested dictionaries,
     lists, and tuples, replacing detected secret values with a stable
     placeholder.
+
+    By default :meth:`redact` and its helpers scrub only secret-like material
+    (:attr:`PATTERNS`). Personally identifiable information (:attr:`PII_PATTERNS`)
+    is detected by :meth:`find_pii_matches` and :meth:`contains_pii` but is
+    **not** removed unless ``redact_pii=True`` is passed to a redaction method.
     """
 
     # Python's stdlib ``re`` does not support per-pattern timeouts. These
@@ -115,8 +120,13 @@ class CredentialRedactor:
             ),
         ),
         CredentialPattern(
+            # Broadened to the canonical SSN form shared with
+            # ``integrations/base.py`` (dash/space/dot/none), which mirrors the
+            # YAML policy packs (see #2469 and #2594). Previously this only
+            # matched the dashed form, so ``123 45 6789`` / ``123.45.6789`` /
+            # ``123456789`` were detected by the integrations layer but not here.
             name="US SSN",
-            pattern=re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+            pattern=re.compile(r"\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b"),
         ),
         CredentialPattern(
             name="Credit card number",
@@ -172,15 +182,23 @@ class CredentialRedactor:
         return bool(cls.find_pii_matches(value))
 
     @classmethod
-    def redact(cls, value: str | None) -> str:
+    def redact(cls, value: str | None, *, redact_pii: bool = False) -> str:
         """Redact credential-like values from a string.
+
+        By default only secret-like material (API keys, tokens, private keys,
+        ...) is redacted. Pass ``redact_pii=True`` to additionally scrub
+        personally identifiable information (email, phone, SSN, credit card,
+        IPv4 address) detected by :attr:`PII_PATTERNS`.
 
         Args:
             value: String content that may contain credential-like material.
+            redact_pii: When ``True``, also redact PII/CRI patterns. Defaults
+                to ``False`` to preserve the historical secrets-only behavior.
 
         Returns:
-            A string with each detected credential replaced by
-            ``REDACTED_PLACEHOLDER``. Empty input returns an empty string.
+            A string with each detected credential (and, when ``redact_pii`` is
+            set, each PII value) replaced by ``REDACTED_PLACEHOLDER``. Empty
+            input returns an empty string.
         """
         if not value:
             return ""
@@ -193,18 +211,29 @@ class CredentialRedactor:
                 redaction_count += count
                 result = updated
 
+        if redact_pii:
+            for pii_pattern in cls.PII_PATTERNS:
+                updated, count = pii_pattern.pattern.subn(REDACTED_PLACEHOLDER, result)
+                if count:
+                    redaction_count += count
+                    result = updated
+
         if redaction_count:
             logger.info("Credential redaction applied to %s value(s)", redaction_count)
 
         return result
 
     @classmethod
-    def redact_mapping(cls, mapping: dict[str, Any] | None) -> dict[str, Any]:
+    def redact_mapping(
+        cls, mapping: dict[str, Any] | None, *, redact_pii: bool = False
+    ) -> dict[str, Any]:
         """Redact all nested values in a mapping.
 
         Args:
             mapping: A possibly nested mapping containing strings, lists,
                 tuples, or dictionaries.
+            redact_pii: When ``True``, also redact PII/CRI patterns in nested
+                strings. Defaults to ``False`` (secrets-only).
 
         Returns:
             A new mapping with nested strings redacted recursively. Empty input
@@ -212,39 +241,53 @@ class CredentialRedactor:
         """
         if not mapping:
             return {}
-        return {key: cls.redact_data_structure(value) for key, value in mapping.items()}
+        return {
+            key: cls.redact_data_structure(value, redact_pii=redact_pii)
+            for key, value in mapping.items()
+        }
 
     @classmethod
-    def redact_dictionary(cls, mapping: dict[str, Any] | None) -> dict[str, Any]:
+    def redact_dictionary(
+        cls, mapping: dict[str, Any] | None, *, redact_pii: bool = False
+    ) -> dict[str, Any]:
         """Compatibility alias for dictionary redaction.
 
         Args:
             mapping: Dictionary-like content to redact.
+            redact_pii: When ``True``, also redact PII/CRI patterns. Defaults
+                to ``False`` (secrets-only).
 
         Returns:
             The redacted mapping produced by :meth:`redact_mapping`.
         """
-        return cls.redact_mapping(mapping)
+        return cls.redact_mapping(mapping, redact_pii=redact_pii)
 
     @classmethod
-    def redact_data_structure(cls, value: Any) -> Any:
+    def redact_data_structure(cls, value: Any, *, redact_pii: bool = False) -> Any:
         """Recursively redact nested strings in dicts, lists, and tuples.
 
         Args:
             value: Any Python value that may contain nested strings.
+            redact_pii: When ``True``, also redact PII/CRI patterns in every
+                nested string. Defaults to ``False`` (secrets-only).
 
         Returns:
             A value of the same general shape with strings redacted in place of
             their original secret-bearing content.
         """
         if isinstance(value, str):
-            return cls.redact(value)
+            return cls.redact(value, redact_pii=redact_pii)
         if isinstance(value, dict):
-            return {key: cls.redact_data_structure(item) for key, item in value.items()}
+            return {
+                key: cls.redact_data_structure(item, redact_pii=redact_pii)
+                for key, item in value.items()
+            }
         if isinstance(value, list):
-            return [cls.redact_data_structure(item) for item in value]
+            return [cls.redact_data_structure(item, redact_pii=redact_pii) for item in value]
         if isinstance(value, tuple):
-            return tuple(cls.redact_data_structure(item) for item in value)
+            return tuple(
+                cls.redact_data_structure(item, redact_pii=redact_pii) for item in value
+            )
         return value
 
     @classmethod

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -8,7 +8,7 @@ import time
 
 import pytest
 
-from agent_os.credential_redactor import CredentialRedactor, REDACTED_PLACEHOLDER
+from agent_os.credential_redactor import REDACTED_PLACEHOLDER, CredentialRedactor
 
 
 def _fake_github_token(prefix: str) -> str:
@@ -180,3 +180,101 @@ def test_private_key_pattern_handles_adversarial_input_quickly():
 
     assert redacted == text
     assert elapsed < 1.0
+
+
+# ---------------------------------------------------------------------------
+# PII redaction — opt-in via ``redact_pii=True`` (see issue #3239).
+#
+# redact() is secrets-only by default; PII is detected by find_pii_matches() /
+# contains_pii() but not removed unless the caller opts in. These tests pin
+# both halves of that contract so the gap reported in #3239 cannot regress.
+# ---------------------------------------------------------------------------
+
+_PII_CASES = [
+    ("email user@example.com", "user@example.com"),
+    ("phone 415-555-0142", "415-555-0142"),
+    ("ssn 123-45-6789", "123-45-6789"),
+    ("card 4111111111111111", "4111111111111111"),
+    ("ip 10.0.0.1", "10.0.0.1"),
+]
+
+
+@pytest.mark.parametrize(("text", "fragment"), _PII_CASES)
+def test_default_redact_leaves_pii_untouched(text: str, fragment: str):
+    # Regression for #3239: by default redact() is secrets-only, so PII is
+    # detected but NOT removed.
+    assert CredentialRedactor.contains_pii(text) is True
+    assert CredentialRedactor.redact(text) == text
+    assert fragment in CredentialRedactor.redact(text)
+
+
+@pytest.mark.parametrize(("text", "fragment"), _PII_CASES)
+def test_redact_pii_scrubs_pii(text: str, fragment: str):
+    redacted = CredentialRedactor.redact(text, redact_pii=True)
+
+    assert REDACTED_PLACEHOLDER in redacted
+    assert fragment not in redacted
+
+
+@pytest.mark.parametrize(
+    "ssn",
+    ["123-45-6789", "123 45 6789", "123.45.6789", "123456789"],
+)
+def test_ssn_pattern_matches_all_separator_variants(ssn: str):
+    # The SSN pattern in PII_PATTERNS is reconciled with the canonical broadened
+    # form in integrations/base.py (dash/space/dot/none). See #3239.
+    matches = {match.matched_text for match in CredentialRedactor.find_pii_matches(ssn)}
+    assert ssn in matches
+    assert CredentialRedactor.redact(ssn, redact_pii=True) == REDACTED_PLACEHOLDER
+
+
+def test_redact_pii_still_redacts_secrets_too():
+    text = "key=sk-test_abcdefghijklmnopqrstuvwxyz email user@example.com"
+
+    redacted = CredentialRedactor.redact(text, redact_pii=True)
+
+    assert "sk-test_abcdefghijklmnopqrstuvwxyz" not in redacted
+    assert "user@example.com" not in redacted
+    assert redacted.count(REDACTED_PLACEHOLDER) >= 2
+
+
+def test_redact_pii_threads_through_nested_data_structure():
+    payload = {
+        "email": "user@example.com",
+        "nested": ["ssn 123-45-6789", {"ip": "10.0.0.1"}],
+        "safe": "hello",
+    }
+
+    redacted = CredentialRedactor.redact_data_structure(payload, redact_pii=True)
+
+    assert redacted["email"] == REDACTED_PLACEHOLDER
+    assert redacted["nested"][0] == f"ssn {REDACTED_PLACEHOLDER}"
+    assert redacted["nested"][1]["ip"] == REDACTED_PLACEHOLDER
+    assert redacted["safe"] == "hello"
+    # Default still leaves PII untouched in nested structures.
+    default_redacted = CredentialRedactor.redact_data_structure(payload)
+    assert default_redacted["email"] == "user@example.com"
+
+
+def test_redact_pii_threads_through_mapping_and_dictionary_alias():
+    payload = {"email": "user@example.com"}
+
+    assert (
+        CredentialRedactor.redact_mapping(payload, redact_pii=True)["email"]
+        == REDACTED_PLACEHOLDER
+    )
+    assert (
+        CredentialRedactor.redact_dictionary(payload, redact_pii=True)["email"]
+        == REDACTED_PLACEHOLDER
+    )
+    # Default remains secrets-only.
+    assert CredentialRedactor.redact_mapping(payload)["email"] == "user@example.com"
+
+
+def test_redact_pii_is_idempotent():
+    text = "email user@example.com ssn 123-45-6789"
+
+    once = CredentialRedactor.redact(text, redact_pii=True)
+    twice = CredentialRedactor.redact(once, redact_pii=True)
+
+    assert once == twice

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -228,6 +228,17 @@ def test_ssn_pattern_matches_all_separator_variants(ssn: str):
     assert CredentialRedactor.redact(ssn, redact_pii=True) == REDACTED_PLACEHOLDER
 
 
+def test_ssn_word_boundary_does_not_overmatch_longer_digit_runs():
+    # The no-separator SSN branch matches a bare 9-digit run. The \b anchors
+    # must keep it from over-matching longer numeric IDs (e.g. account numbers),
+    # which now surface through find_pii_matches()/contains_pii() callers such
+    # as mcp_response_scanner.py and stateless.py. A 12-digit run is longer
+    # than both SSN (9) and US phone (10/11 with optional leading 1), so no PII
+    # pattern should fire. (Review feedback on #3259.)
+    assert CredentialRedactor.contains_pii("acct 123456789012") is False
+    assert CredentialRedactor.find_pii_matches("acct 123456789012") == []
+
+
 def test_redact_pii_still_redacts_secrets_too():
     text = "key=sk-test_abcdefghijklmnopqrstuvwxyz email user@example.com"
 

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -267,15 +267,11 @@ def test_redact_pii_threads_through_nested_data_structure():
     assert default_redacted["email"] == "user@example.com"
 
 
-def test_redact_pii_threads_through_mapping_and_dictionary_alias():
+def test_redact_pii_threads_through_mapping():
     payload = {"email": "user@example.com"}
 
     assert (
         CredentialRedactor.redact_mapping(payload, redact_pii=True)["email"]
-        == REDACTED_PLACEHOLDER
-    )
-    assert (
-        CredentialRedactor.redact_dictionary(payload, redact_pii=True)["email"]
         == REDACTED_PLACEHOLDER
     )
     # Default remains secrets-only.


### PR DESCRIPTION
## Description

`CredentialRedactor.redact()` iterated only `PATTERNS` (secrets), so PII (email, phone, SSN, credit card, IPv4) detected by `find_pii_matches()` / `contains_pii()` was never removed — a docs-vs-behavior gap raised in #3239. The class docstring could lead callers to assume PII is scrubbed when persisting audit payloads.

- Add a keyword-only `redact_pii: bool = False` to `redact()`, `redact_data_structure()`, `redact_mapping()`, and `redact_dictionary()`; when `True`, `PII_PATTERNS` are also applied. Default behavior is unchanged (secrets-only), preserving the contract pinned by `test_pii_does_not_affect_credential_redact`.
- Reconcile the SSN pattern in `PII_PATTERNS` with the canonical broadened form in `integrations/base.py` (dash/space/dot/none); #2635 consolidated the integrations-layer SSN but this copy stayed divergent.
- Clarify the class/method docstrings so the secrets-only default (and the opt-in PII path) are unambiguous.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Package(s) Affected
- [x] agent-os-kernel

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest) — `pytest tests/test_credential_redactor.py tests/test_mcp_pii_and_response_gateway.py` → 91 passed (Windows, Python 3.13); `ruff check` clean on both files
- [x] I have updated documentation as needed
- [ ] I have signed the Microsoft CLA — pending; will sign via the CLA bot on this PR

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution

**Prior art / related projects:** The SSN pattern is reconciled with the canonical broadened form already established in `agent_os/integrations/base.py` (#2635, #2469, #2594) — same repo, no external prior art.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

## Related Issues
Refs #3239
