### PR TITLE
fix(red-team): unify attack verdict and exit code on --threshold

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
@@ -48,6 +48,18 @@ def _get_adversarial():
         }
     except ImportError:
         return None
+
+
+def _meets_threshold(result: Any, threshold: float) -> bool:
+    """Return whether a playbook result meets the configured resilience threshold.
+
+    The CLI pass criterion is the user-supplied ``--threshold`` (default 70),
+    which may differ from ``PlaybookResult.passed`` — a fixed 70.0 baseline
+    baked into ``agent_sre.chaos.adversarial``. Driving both the printed
+    verdict and the process exit code from this single criterion keeps them in
+    sync, so CI never exits 0 while printing FAIL (or vice versa). See #3237.
+    """
+    return result.resilience_score >= threshold
 
 
 @click.group("red-team")
@@ -314,7 +326,7 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
             "target": target,
             "experiment_id": experiment.experiment_id,
             "playbooks_run": len(results),
-            "overall_passed": all(r.passed for r in results),
+            "overall_passed": all(_meets_threshold(r, threshold) for r in results),
             "results": [
                 {
                     "playbook_id": r.playbook.playbook_id,
@@ -342,28 +354,27 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
         click.echo(f"  Target: {target}")
         click.echo(f"  Experiment: {experiment.experiment_id}\n")
 
-        overall_pass = True
+        overall_pass = all(_meets_threshold(r, threshold) for r in results)
         for r in results:
-            icon = "+" if r.passed else "!"
+            playbook_pass = _meets_threshold(r, threshold)
+            icon = "+" if playbook_pass else "!"
             click.echo(f"  [{icon}] {r.playbook.name}")
             click.echo(f"      Score: {r.resilience_score}/100  ", nl=False)
-            click.echo(f"{'PASS' if r.passed else 'FAIL'}")
+            click.echo(f"{'PASS' if playbook_pass else 'FAIL'}")
 
             for step, result, passed in r.step_results:
                 step_icon = "+" if passed else "x"
                 click.echo(f"        [{step_icon}] {step.name}: {result.value}")
 
             click.echo()
-            if not r.passed:
-                overall_pass = False
 
         click.echo(f"  {'─'*56}")
         total = len(results)
-        passed_count = sum(1 for r in results if r.passed)
+        passed_count = sum(1 for r in results if _meets_threshold(r, threshold))
         click.echo(f"  Results: {passed_count}/{total} playbooks passed")
         click.echo(f"  Overall: {'PASS' if overall_pass else 'FAIL'}\n")
 
-    if not all(r.resilience_score >= threshold for r in results):
+    if not all(_meets_threshold(r, threshold) for r in results):
         raise SystemExit(1)
 
 

--- a/agent-governance-python/agent-compliance/tests/test_red_team_cli.py
+++ b/agent-governance-python/agent-compliance/tests/test_red_team_cli.py
@@ -322,8 +322,20 @@ class TestRedTeamAttackThreshold:
         )
 
     def _patch(self, monkeypatch, results):
-        monkeypatch.setattr(
-            "agent_compliance.cli.red_team._get_adversarial",
+        # Patch the `attack` command callback's own __globals__ instead of the
+        # dotted module path. `tests/test_init_imports.py` force-reimports
+        # agent_compliance (dropping every `agent_compliance.*` entry from
+        # sys.modules), which can leave several distinct `red_team` module
+        # objects alive in memory. When that happens, monkeypatching
+        # "agent_compliance.cli.red_team._get_adversarial" patches whichever
+        # module object is current in sys.modules at patch time — which may not
+        # be the one whose `attack` function the click `cli` tree actually
+        # invokes, so the stub is silently bypassed and the real agent_sre
+        # adversarial runner executes. Patching the callback's globals hits the
+        # exact namespace that runs. See #3237.
+        attack_fn = cli.commands["red-team"].commands["attack"].callback
+        monkeypatch.setitem(
+            attack_fn.__globals__, "_get_adversarial",
             lambda: self._fake_adversarial(results),
         )
 

--- a/agent-governance-python/agent-compliance/tests/test_red_team_cli.py
+++ b/agent-governance-python/agent-compliance/tests/test_red_team_cli.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import json
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
-import click
 import pytest
 from click.testing import CliRunner
 
@@ -286,3 +286,96 @@ class TestHelperFunctions:
         prompt_results = {"test.txt": {"grade": "A", "score": 95, "missing": []}}
         recs = _generate_recommendations(prompt_results, None)
         assert any("passed" in r.lower() for r in recs)
+
+
+class TestRedTeamAttackThreshold:
+    """Regression for #3237: overall verdict and exit code must share one criterion.
+
+    ``PlaybookResult.passed`` is a fixed 70.0 baseline baked into
+    ``agent_sre``, while ``--threshold`` is caller-controlled. Before the fix
+    the printed/JSON verdict used ``r.passed`` but the exit code used
+    ``r.resilience_score >= threshold``, so CI could exit 0 while printing
+    FAIL (or vice versa) whenever ``--threshold`` differed from 70.
+    """
+
+    @staticmethod
+    def _fake_adversarial(results):
+        """Stand in for ``_get_adversarial()`` with fixed playbook results."""
+        fake_experiment = mock.MagicMock(experiment_id="exp-test")
+        return {
+            "BUILTIN_PLAYBOOKS": [r.playbook for r in results],
+            "AdversarialRunner": lambda experiment: mock.MagicMock(
+                run_all=lambda playbooks: results
+            ),
+            "ChaosExperiment": mock.MagicMock(return_value=fake_experiment),
+            "Fault": mock.MagicMock(),
+            "FaultType": mock.MagicMock(),
+        }
+
+    @staticmethod
+    def _result(score, passed, name="Test Playbook", playbook_id="pb-1"):
+        return SimpleNamespace(
+            resilience_score=score,
+            passed=passed,
+            playbook=SimpleNamespace(name=name, playbook_id=playbook_id),
+            step_results=[],
+        )
+
+    def _patch(self, monkeypatch, results):
+        monkeypatch.setattr(
+            "agent_compliance.cli.red_team._get_adversarial",
+            lambda: self._fake_adversarial(results),
+        )
+
+    def test_threshold_above_baseline_shows_fail_and_exits_nonzero(self, runner, monkeypatch):
+        # score=75 -> passed=True on the 70 baseline, but below --threshold 90.
+        # Before fix: verdict printed PASS while exit code was 1.
+        self._patch(monkeypatch, [self._result(75.0, passed=True)])
+        res = runner.invoke(cli, ["red-team", "attack", "--threshold", "90"])
+
+        assert res.exit_code == 1
+        assert "Overall: FAIL" in res.output
+
+    def test_threshold_below_baseline_shows_pass_and_exits_zero(self, runner, monkeypatch):
+        # score=60 -> passed=False on the 70 baseline, but meets --threshold 50.
+        # Before fix: verdict printed FAIL while exit code was 0.
+        self._patch(monkeypatch, [self._result(60.0, passed=False)])
+        res = runner.invoke(cli, ["red-team", "attack", "--threshold", "50"])
+
+        assert res.exit_code == 0
+        assert "Overall: PASS" in res.output
+
+    def test_json_overall_passed_uses_threshold_not_baseline(self, runner, monkeypatch):
+        self._patch(monkeypatch, [self._result(75.0, passed=True)])
+        res = runner.invoke(cli, ["red-team", "attack", "--threshold", "90", "--json"])
+
+        assert res.exit_code == 1
+        data = json.loads(res.output)
+        assert data["overall_passed"] is False
+        # Per-playbook `passed` retains the agent-sre baseline semantics.
+        assert data["results"][0]["passed"] is True
+
+    def test_default_threshold_matches_baseline_behavior(self, runner, monkeypatch):
+        self._patch(monkeypatch, [self._result(80.0, passed=True)])
+        res = runner.invoke(cli, ["red-team", "attack"])
+
+        assert res.exit_code == 0
+        assert "Overall: PASS" in res.output
+
+    def test_score_equal_to_threshold_passes(self, runner, monkeypatch):
+        self._patch(monkeypatch, [self._result(90.0, passed=True)])
+        res = runner.invoke(cli, ["red-team", "attack", "--threshold", "90"])
+
+        assert res.exit_code == 0
+        assert "Overall: PASS" in res.output
+
+    def test_multiple_playbooks_one_below_threshold_fails(self, runner, monkeypatch):
+        results = [
+            self._result(95.0, passed=True, name="Strong"),
+            self._result(75.0, passed=True, name="Weak"),
+        ]
+        self._patch(monkeypatch, results)
+        res = runner.invoke(cli, ["red-team", "attack", "--threshold", "90"])
+
+        assert res.exit_code == 1
+        assert "Overall: FAIL" in res.output


### PR DESCRIPTION
## Description

The `attack` command's printed/JSON verdict used `PlaybookResult.passed` — a fixed 70.0 baseline baked into `agent_sre.chaos.adversarial` — but its exit code used `r.resilience_score >= threshold`, where `--threshold` is caller-controlled (default 70). Whenever `--threshold` differed from 70 the verdict and exit code diverged: CI could exit 0 while printing FAIL, or exit 1 while printing PASS — an unreliable gate (#3237).

- Add a `_meets_threshold(result, threshold)` helper and drive the JSON `overall_passed`, the text `Overall: PASS/FAIL` verdict, and the process exit code all from it, so they share a single criterion.
- Per-playbook `r.passed` (the agent-sre 70.0 baseline) is left intact in both text and JSON output; it carries independent "meets baseline" information and changing it would mean redefining an `agent_sre` field.
- Default `--threshold 70` behavior is unchanged (`r.passed` equals `score >= 70` there).

The `report` subcommand uses the same `r.passed` baseline but has no `--threshold` option and no score-based exit code, so it is unaffected and intentionally out of scope.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Package(s) Affected
- [x] agent-governance

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest) — `pytest tests/test_red_team_cli.py::TestRedTeamAttackThreshold` → 6 passed; `ruff check` clean on both files. (The pre-existing `test_list_playbooks_text` requires `agent-sre` installed and exercises the `else` branch locally; it passes on CI where `agent-sre` is installed.)
- [x] I have updated documentation as needed (helper docstring)
- [x] I have signed the Microsoft CLA — already signed via PR #3259

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution

**Prior art / related projects:** None external — the fix is internal to this repo's CLI; the threshold semantics come from the existing `--threshold` option.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use

## Related Issues
Refs #3237
