### PR TITLE
feat(go): add accumulated context governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **ACS artifact validation API** - added one bounded Rust-core validator for canonical manifest schema checks, typed ACS semantics, and OPA Rego parsing, exposed with the same structured result through Rust, Python, Node, and .NET. The `acs-generator` CLI now consumes this shared SDK surface.
+- **Go SDK context accumulation governance** - added workflow-scoped context envelopes, data classification labels, aggregation-rule evaluation with unknown-combination escalation, constrain-as-obligations policy mapping, and grow-only restriction inheritance for delegation parity with the Python implementation (#3084).
 
 ### Changed
 - **BREAKING: `acs-generator` is CLI-only in `0.4.0b0`.** Removed top-level library re-exports such as `GenerationEngine` and `FakeLanguageModel`. Reusable manifest and Rego validation now lives under `agent_control_specification.validation`; the Python SDK moves to `0.3.1b1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **ACS artifact validation API** - added one bounded Rust-core validator for canonical manifest schema checks, typed ACS semantics, and OPA Rego parsing, exposed with the same structured result through Rust, Python, Node, and .NET. The `acs-generator` CLI now consumes this shared SDK surface.
-- **Go SDK context accumulation governance** - added workflow-scoped context envelopes, data classification labels, aggregation-rule evaluation with unknown-combination escalation, constrain-as-obligations policy mapping, and grow-only restriction inheritance for delegation parity with the Python implementation (#3084).
+- **Go SDK context accumulation governance** - added workflow-scoped context envelopes, a data-classification sensitivity ladder, aggregation-rule evaluation with unknown-combination escalation, constrain-as-obligations policy mapping, grow-only restriction inheritance, and classified context-transition audit events for parity with the Python implementation (#3084).
 
 ### Changed
 - **BREAKING: `acs-generator` is CLI-only in `0.4.0b0`.** Removed top-level library re-exports such as `GenerationEngine` and `FakeLanguageModel`. Reusable manifest and Rego validation now lives under `agent_control_specification.validation`; the Python SDK moves to `0.3.1b1`.

--- a/agent-governance-golang/README.md
+++ b/agent-governance-golang/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/microsoft/agent-governance-toolkit/agent-governance-golang.svg)](https://pkg.go.dev/github.com/microsoft/agent-governance-toolkit/agent-governance-golang)
 
-Go module for the AgentMesh governance framework — identity, trust scoring, policy evaluation, tamper-evident audit logging, MCP security scanning, execution privilege rings, kill switches, agent lifecycle management, SLO tracking, shadow discovery, prompt defense, and native Go integrations.
+Go module for the AgentMesh governance framework — identity, trust scoring, policy evaluation, context accumulation governance, tamper-evident audit logging, MCP security scanning, execution privilege rings, kill switches, agent lifecycle management, SLO tracking, shadow discovery, prompt defense, and native Go integrations.
 
 ## Install
 
@@ -108,6 +108,22 @@ OPA/Rego and Cedar support with fail-closed evaluation paths.
 | `NewCedarBackend(options)` | Create a Cedar backend with CLI or built-in modes |
 | `OPAOptions` | Configure OPA URL, package/query, timeout, and Rego content |
 | `CedarOptions` | Configure Cedar policy content, entities, schema, and timeout |
+
+### Context Accumulation Governance (`context_governance.go`)
+
+Workflow-scoped context envelopes for accumulated labels, aggregate sensitivity, grow-only restrictions, unknown-combination escalation, and delegation inheritance.
+
+| Type / Function | Description |
+|---|---|
+| `NewContextEnvelope(envelopeID, workflowID)` | Create an empty workflow-scoped context envelope |
+| `FoldContext(env, labels, sensitivity)` | Return the next envelope version with labels folded and sensitivity raised |
+| `ApplyContextRestrictions(env, restrictions)` | Return the next envelope version with grow-only restrictions applied |
+| `EvaluateAggregation(env, ruleset, threshold)` | Apply organization-authored aggregation rules and escalate unknown combinations |
+| `AccumulateContext(env, labels, sensitivity, ruleset, threshold)` | Fold post-execution result labels and apply aggregation-derived restrictions |
+| `DecideNextContext(env, action, ruleset, threshold)` | Gate export, delegation, and memory writes against accumulated state |
+| `(*ContextDecision).PolicyDecision(hasObligationChannel)` | Collapse context outcomes onto the existing Go policy verdicts |
+| `MergeContextRestrictions(parent, childDeclared)` | Inherit parent restrictions across delegation boundaries |
+| `ContextEnvelopeReference(env)` | Project an envelope to an opaque id plus coarse sensitivity |
 
 ### Audit (`audit.go`)
 

--- a/agent-governance-golang/README.md
+++ b/agent-governance-golang/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/microsoft/agent-governance-toolkit/agent-governance-golang.svg)](https://pkg.go.dev/github.com/microsoft/agent-governance-toolkit/agent-governance-golang)
 
-Go module for the AgentMesh governance framework — identity, trust scoring, policy evaluation, tamper-evident audit logging, MCP security scanning, execution privilege rings, kill switches, agent lifecycle management, SLO tracking, shadow discovery, prompt defense, and native Go integrations.
+Go module for the AgentMesh governance framework — identity, trust scoring, policy evaluation, context accumulation governance, tamper-evident audit logging, MCP security scanning, execution privilege rings, kill switches, agent lifecycle management, SLO tracking, shadow discovery, prompt defense, and native Go integrations.
 
 ## Install
 
@@ -108,6 +108,22 @@ OPA/Rego and Cedar support with fail-closed evaluation paths.
 | `NewCedarlingDecision(options)` | Create a Cedar backend with CLI or built-in modes |
 | `OPAOptions` | Configure OPA URL, package/query, timeout, and Rego content |
 | `CedarOptions` | Configure Cedar policy content, entities, schema, and timeout |
+
+### Context Accumulation Governance (`context_governance.go`)
+
+Workflow-scoped context envelopes for accumulated labels, aggregate sensitivity, grow-only restrictions, unknown-combination escalation, and delegation inheritance.
+
+| Type / Function | Description |
+|---|---|
+| `NewContextEnvelope(envelopeID, workflowID)` | Create an empty workflow-scoped context envelope |
+| `FoldContext(env, labels, sensitivity)` | Return the next envelope version with labels folded and sensitivity raised |
+| `ApplyContextRestrictions(env, restrictions)` | Return the next envelope version with grow-only restrictions applied |
+| `EvaluateAggregation(env, ruleset, threshold)` | Apply organization-authored aggregation rules and escalate unknown combinations |
+| `AccumulateContext(env, labels, sensitivity, ruleset, threshold)` | Fold post-execution result labels and apply aggregation-derived restrictions |
+| `DecideNextContext(env, action, ruleset, threshold)` | Gate export, delegation, and memory writes against accumulated state |
+| `(*ContextDecision).PolicyDecision(hasObligationChannel)` | Collapse context outcomes onto the existing Go policy verdicts |
+| `MergeContextRestrictions(parent, childDeclared)` | Inherit parent restrictions across delegation boundaries |
+| `ContextEnvelopeReference(env)` | Project an envelope to an opaque id plus coarse sensitivity |
 
 ### Audit (`audit.go`)
 

--- a/agent-governance-golang/README.md
+++ b/agent-governance-golang/README.md
@@ -116,11 +116,11 @@ Workflow-scoped context envelopes for accumulated labels, aggregate sensitivity,
 | Type / Function | Description |
 |---|---|
 | `NewContextEnvelope(envelopeID, workflowID, createdAt)` | Create an empty workflow-scoped context envelope with a caller-supplied timestamp |
-| `FoldContext(env, labels, sensitivity)` | Return the next envelope version with labels folded and sensitivity raised |
+| `FoldContext(env, labels, sensitivity)` | Return the next envelope version with labels folded and sensitivity raised, or a validation error |
 | `ApplyContextRestrictions(env, restrictions)` | Return the next envelope version with grow-only restrictions applied |
-| `EvaluateAggregation(env, ruleset, threshold)` | Apply organization-authored aggregation rules and escalate unknown combinations |
-| `AccumulateContext(env, labels, sensitivity, ruleset, threshold)` | Fold post-execution result labels and apply aggregation-derived restrictions |
-| `DecideNextContext(env, action, ruleset, threshold)` | Gate export, delegation, and memory writes against accumulated state |
+| `EvaluateAggregation(env, ruleset, threshold)` | Validate and apply organization-authored aggregation rules, escalating unknown combinations |
+| `AccumulateContext(env, labels, sensitivity, ruleset, threshold)` | Fold post-execution result labels and apply aggregation-derived restrictions, or fail closed on invalid classifications or rules |
+| `DecideNextContext(env, action, ruleset, threshold)` | Gate export, delegation, and memory writes against accumulated state, or return a fail-closed decision with a validation error |
 | `(ContextDecision).PolicyDecision(hasObligationChannel)` | Collapse context outcomes onto the existing Go policy verdicts |
 | `MergeContextRestrictions(parent, childDeclared)` | Inherit parent restrictions across delegation boundaries |
 | `DelegateContext(parent, childID, childDeclared, createdAt)` | Construct a child envelope with inherited restrictions and a caller-supplied timestamp |

--- a/agent-governance-golang/README.md
+++ b/agent-governance-golang/README.md
@@ -109,21 +109,23 @@ OPA/Rego and Cedar support with fail-closed evaluation paths.
 | `OPAOptions` | Configure OPA URL, package/query, timeout, and Rego content |
 | `CedarOptions` | Configure Cedar policy content, entities, schema, and timeout |
 
-### Context Accumulation Governance (`context_governance.go`)
+### Context Accumulation Governance (`context_governance.go`, `context_audit.go`)
 
-Workflow-scoped context envelopes for accumulated labels, aggregate sensitivity, grow-only restrictions, unknown-combination escalation, and delegation inheritance.
+Workflow-scoped context envelopes for accumulated labels, aggregate sensitivity, grow-only restrictions, unknown-combination escalation, delegation inheritance, and classified transition events. `DelegateContext` is a Go convenience for constructing a child envelope from the cross-language `MergeContextRestrictions` contract.
 
 | Type / Function | Description |
 |---|---|
-| `NewContextEnvelope(envelopeID, workflowID)` | Create an empty workflow-scoped context envelope |
+| `NewContextEnvelope(envelopeID, workflowID, createdAt)` | Create an empty workflow-scoped context envelope with a caller-supplied timestamp |
 | `FoldContext(env, labels, sensitivity)` | Return the next envelope version with labels folded and sensitivity raised |
 | `ApplyContextRestrictions(env, restrictions)` | Return the next envelope version with grow-only restrictions applied |
 | `EvaluateAggregation(env, ruleset, threshold)` | Apply organization-authored aggregation rules and escalate unknown combinations |
 | `AccumulateContext(env, labels, sensitivity, ruleset, threshold)` | Fold post-execution result labels and apply aggregation-derived restrictions |
 | `DecideNextContext(env, action, ruleset, threshold)` | Gate export, delegation, and memory writes against accumulated state |
-| `(*ContextDecision).PolicyDecision(hasObligationChannel)` | Collapse context outcomes onto the existing Go policy verdicts |
+| `(ContextDecision).PolicyDecision(hasObligationChannel)` | Collapse context outcomes onto the existing Go policy verdicts |
 | `MergeContextRestrictions(parent, childDeclared)` | Inherit parent restrictions across delegation boundaries |
+| `DelegateContext(parent, childID, childDeclared, createdAt)` | Construct a child envelope with inherited restrictions and a caller-supplied timestamp |
 | `ContextEnvelopeReference(env)` | Project an envelope to an opaque id plus coarse sensitivity |
+| `ContextEventFor(eventType, agentID, before, after, rulesApplied)` | Build a classified audit event for an envelope transition |
 
 ### Audit (`audit.go`)
 

--- a/agent-governance-golang/packages/agentmesh/context_audit.go
+++ b/agent-governance-golang/packages/agentmesh/context_audit.go
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import "strings"
+
+// ContextEventType is the stable wire type for context-governance audit events.
+type ContextEventType string
+
+const (
+	// ContextEnvelopeCreated records creation of a context envelope.
+	ContextEnvelopeCreated ContextEventType = "CONTEXT_ENVELOPE_CREATED"
+	// ContextEnvelopeUpdated records a context envelope transition.
+	ContextEnvelopeUpdated ContextEventType = "CONTEXT_ENVELOPE_UPDATED"
+	// ContextAggregationElevated records an aggregation-driven sensitivity increase.
+	ContextAggregationElevated ContextEventType = "CONTEXT_AGGREGATION_ELEVATED"
+	// ContextDelegated records propagation of context into a child delegation.
+	ContextDelegated ContextEventType = "CONTEXT_DELEGATED"
+	// ContextRedacted records a redaction applied to governed context.
+	ContextRedacted ContextEventType = "CONTEXT_REDACTED"
+	// DerivedArtifactLabeled records classification of an artifact derived from context.
+	DerivedArtifactLabeled ContextEventType = "DERIVED_ARTIFACT_LABELED"
+)
+
+// ContextEvent records the governance-relevant delta between two envelope versions.
+// Its Classification is never lower than either envelope's aggregate sensitivity.
+type ContextEvent struct {
+	EventType           ContextEventType   `json:"event_type" yaml:"event_type"`
+	AgentID             string             `json:"agent_id" yaml:"agent_id"`
+	ContextEnvelopeID   string             `json:"context_envelope_id" yaml:"context_envelope_id"`
+	PreviousSensitivity DataClassification `json:"previous_sensitivity" yaml:"previous_sensitivity"`
+	NewSensitivity      DataClassification `json:"new_sensitivity" yaml:"new_sensitivity"`
+	LabelsAdded         []string           `json:"labels_added" yaml:"labels_added"`
+	RulesApplied        []string           `json:"rules_applied" yaml:"rules_applied"`
+	RestrictionsAdded   []string           `json:"restrictions_added" yaml:"restrictions_added"`
+	Classification      DataClassification `json:"classification" yaml:"classification"`
+}
+
+// ContextEventFor builds a deterministic event describing before -> after.
+func ContextEventFor(
+	eventType ContextEventType,
+	agentID string,
+	before ContextEnvelope,
+	after ContextEnvelope,
+	rulesApplied []string,
+) ContextEvent {
+	before = cloneContextEnvelope(before)
+	after = cloneContextEnvelope(after)
+
+	classification := before.AggregateSensitivity
+	if after.AggregateSensitivity > classification {
+		classification = after.AggregateSensitivity
+	}
+
+	return ContextEvent{
+		EventType:           eventType,
+		AgentID:             agentID,
+		ContextEnvelopeID:   after.EnvelopeID,
+		PreviousSensitivity: before.AggregateSensitivity,
+		NewSensitivity:      after.AggregateSensitivity,
+		LabelsAdded:         addedTokens(before.Labels, after.Labels),
+		RulesApplied:        cloneTokens(rulesApplied),
+		RestrictionsAdded:   addedTokens(before.Restrictions, after.Restrictions),
+		Classification:      classification,
+	}
+}
+
+func addedTokens(before []string, after []string) []string {
+	beforeSet := tokenSet(before)
+	added := make(map[string]bool)
+	for _, token := range after {
+		normalized := strings.TrimSpace(token)
+		if normalized != "" && !beforeSet[normalized] {
+			added[normalized] = true
+		}
+	}
+	return cloneTokens(sortedTokens(added))
+}

--- a/agent-governance-golang/packages/agentmesh/context_audit_test.go
+++ b/agent-governance-golang/packages/agentmesh/context_audit_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestContextEventForRecordsEnvelopeDelta(t *testing.T) {
+	before := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationConfidential,
+	}
+	after := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"financial", "pii"},
+		AggregateSensitivity: DataClassificationRestricted,
+		Restrictions:         []string{"no_external_export"},
+	}
+	rulesApplied := []string{"pii_financial_restricted"}
+
+	event := ContextEventFor(
+		ContextAggregationElevated,
+		"agent.customer-success",
+		before,
+		after,
+		rulesApplied,
+	)
+
+	if event.EventType != ContextAggregationElevated {
+		t.Fatalf("event type = %q, want %q", event.EventType, ContextAggregationElevated)
+	}
+	if event.ContextEnvelopeID != after.EnvelopeID {
+		t.Fatalf("context envelope id = %q, want %q", event.ContextEnvelopeID, after.EnvelopeID)
+	}
+	if event.PreviousSensitivity != DataClassificationConfidential {
+		t.Fatalf("previous sensitivity = %v, want confidential", event.PreviousSensitivity)
+	}
+	if event.NewSensitivity != DataClassificationRestricted {
+		t.Fatalf("new sensitivity = %v, want restricted", event.NewSensitivity)
+	}
+	if !reflect.DeepEqual(event.LabelsAdded, []string{"financial"}) {
+		t.Fatalf("labels added = %#v, want financial", event.LabelsAdded)
+	}
+	if !reflect.DeepEqual(event.RestrictionsAdded, []string{"no_external_export"}) {
+		t.Fatalf("restrictions added = %#v, want no_external_export", event.RestrictionsAdded)
+	}
+	if !reflect.DeepEqual(event.RulesApplied, rulesApplied) {
+		t.Fatalf("rules applied = %#v, want %#v", event.RulesApplied, rulesApplied)
+	}
+	if event.Classification != DataClassificationRestricted {
+		t.Fatalf("classification = %v, want restricted", event.Classification)
+	}
+
+	rulesApplied[0] = "mutated"
+	if event.RulesApplied[0] != "pii_financial_restricted" {
+		t.Fatalf("event rules were mutated through caller slice: %#v", event.RulesApplied)
+	}
+}
+
+func TestContextEventForKeepsHigherPreviousClassification(t *testing.T) {
+	before := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		AggregateSensitivity: DataClassificationRestricted,
+	}
+	after := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		AggregateSensitivity: DataClassificationInternal,
+	}
+
+	event := ContextEventFor(ContextEnvelopeUpdated, "agent-1", before, after, nil)
+
+	if event.Classification != DataClassificationRestricted {
+		t.Fatalf("classification = %v, want restricted", event.Classification)
+	}
+}
+
+func TestContextEventTypeWireValues(t *testing.T) {
+	got := []ContextEventType{
+		ContextEnvelopeCreated,
+		ContextEnvelopeUpdated,
+		ContextAggregationElevated,
+		ContextDelegated,
+		ContextRedacted,
+		DerivedArtifactLabeled,
+	}
+	want := []ContextEventType{
+		"CONTEXT_ENVELOPE_CREATED",
+		"CONTEXT_ENVELOPE_UPDATED",
+		"CONTEXT_AGGREGATION_ELEVATED",
+		"CONTEXT_DELEGATED",
+		"CONTEXT_REDACTED",
+		"DERIVED_ARTIFACT_LABELED",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("event wire values = %#v, want %#v", got, want)
+	}
+}
+
+func TestContextEventForSerializesEmptyDeltasAsArrays(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		AggregateSensitivity: DataClassificationInternal,
+	}
+	event := ContextEventFor(ContextEnvelopeUpdated, "agent-1", env, env, nil)
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+
+	var wire map[string]any
+	if err := json.Unmarshal(data, &wire); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	for _, field := range []string{"labels_added", "rules_applied", "restrictions_added"} {
+		values, ok := wire[field].([]any)
+		if !ok {
+			t.Fatalf("%s = %#v, want array", field, wire[field])
+		}
+		if len(values) != 0 {
+			t.Fatalf("%s = %#v, want empty array", field, values)
+		}
+	}
+}

--- a/agent-governance-golang/packages/agentmesh/context_governance.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance.go
@@ -1,0 +1,382 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// DataClassification is the shared sensitivity ladder for context governance.
+type DataClassification int
+
+const (
+	DataClassificationPublic DataClassification = iota
+	DataClassificationInternal
+	DataClassificationConfidential
+	DataClassificationRestricted
+	DataClassificationTopSecret
+)
+
+// String returns the stable wire spelling of the classification.
+func (dc DataClassification) String() string {
+	switch dc {
+	case DataClassificationPublic:
+		return "public"
+	case DataClassificationInternal:
+		return "internal"
+	case DataClassificationConfidential:
+		return "confidential"
+	case DataClassificationRestricted:
+		return "restricted"
+	case DataClassificationTopSecret:
+		return "top_secret"
+	default:
+		return "unknown"
+	}
+}
+
+// DataLabel describes classified data folded into a context envelope.
+type DataLabel struct {
+	Classification DataClassification `json:"classification" yaml:"classification"`
+	Categories     []string           `json:"categories,omitempty" yaml:"categories,omitempty"`
+	Owner          string             `json:"owner,omitempty" yaml:"owner,omitempty"`
+	RetentionDays  int                `json:"retention_days,omitempty" yaml:"retention_days,omitempty"`
+	Geography      string             `json:"geography,omitempty" yaml:"geography,omitempty"`
+}
+
+// ContextEnvelope is the accumulated governance state for one workflow.
+//
+// Treat envelopes as value objects: helpers in this file return a new envelope
+// with copied slices, monotonically increasing Version, grow-only Restrictions,
+// and a max-lattice AggregateSensitivity.
+type ContextEnvelope struct {
+	EnvelopeID           string             `json:"envelope_id" yaml:"envelope_id"`
+	WorkflowID           string             `json:"workflow_id" yaml:"workflow_id"`
+	Labels               []string           `json:"labels,omitempty" yaml:"labels,omitempty"`
+	AggregateSensitivity DataClassification `json:"aggregate_sensitivity" yaml:"aggregate_sensitivity"`
+	Restrictions         []string           `json:"restrictions,omitempty" yaml:"restrictions,omitempty"`
+	Version              int                `json:"version" yaml:"version"`
+	ParentEnvelopeID     string             `json:"parent_envelope_id,omitempty" yaml:"parent_envelope_id,omitempty"`
+	CreatedAt            string             `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+}
+
+// NewContextEnvelope creates an empty workflow-scoped context envelope.
+func NewContextEnvelope(envelopeID, workflowID string) ContextEnvelope {
+	return ContextEnvelope{
+		EnvelopeID:           envelopeID,
+		WorkflowID:           workflowID,
+		AggregateSensitivity: DataClassificationPublic,
+		CreatedAt:            time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// FoldContext returns the next envelope version after folding result labels.
+func FoldContext(env ContextEnvelope, newLabels []string, newSensitivity DataClassification) ContextEnvelope {
+	out := cloneContextEnvelope(env)
+	out.Labels = unionTokens(out.Labels, newLabels)
+	if newSensitivity > out.AggregateSensitivity {
+		out.AggregateSensitivity = newSensitivity
+	}
+	out.Version++
+	return out
+}
+
+// ApplyContextRestrictions returns the next envelope version with restrictions added.
+func ApplyContextRestrictions(env ContextEnvelope, restrictions []string) ContextEnvelope {
+	out := cloneContextEnvelope(env)
+	out.Restrictions = unionTokens(out.Restrictions, restrictions)
+	out.Version++
+	return out
+}
+
+// EnvelopeReference is the opaque cross-boundary projection of a ContextEnvelope.
+type EnvelopeReference struct {
+	EnvelopeID  string             `json:"envelope_id" yaml:"envelope_id"`
+	Sensitivity DataClassification `json:"sensitivity" yaml:"sensitivity"`
+}
+
+// ContextEnvelopeReference omits labels, restrictions, version lineage, and workflow details.
+func ContextEnvelopeReference(env ContextEnvelope) EnvelopeReference {
+	return EnvelopeReference{
+		EnvelopeID:  env.EnvelopeID,
+		Sensitivity: env.AggregateSensitivity,
+	}
+}
+
+// AggregationRule raises sensitivity and adds restrictions for a label combination.
+type AggregationRule struct {
+	Name             string             `json:"name" yaml:"name"`
+	AllLabels        []string           `json:"all_labels" yaml:"all_labels"`
+	SetsSensitivity  DataClassification `json:"sets_sensitivity" yaml:"sets_sensitivity"`
+	AddsRestrictions []string           `json:"adds_restrictions,omitempty" yaml:"adds_restrictions,omitempty"`
+}
+
+// AggregationRuleSet is an ordered collection of aggregation rules.
+type AggregationRuleSet struct {
+	Rules []AggregationRule `json:"rules" yaml:"rules"`
+}
+
+// AggregationResult is the outcome of evaluating an envelope against a rule set.
+type AggregationResult struct {
+	AggregateSensitivity DataClassification `json:"aggregate_sensitivity" yaml:"aggregate_sensitivity"`
+	Restrictions         []string           `json:"restrictions,omitempty" yaml:"restrictions,omitempty"`
+	Escalate             bool               `json:"escalate" yaml:"escalate"`
+	RulesApplied         []string           `json:"rules_applied,omitempty" yaml:"rules_applied,omitempty"`
+}
+
+// EvaluateAggregation applies matching rules and escalates unknown combinations at the threshold.
+func EvaluateAggregation(env ContextEnvelope, ruleset AggregationRuleSet, nCategoryThreshold int) AggregationResult {
+	env = cloneContextEnvelope(env)
+	sensitivity := env.AggregateSensitivity
+	restrictions := cloneTokens(env.Restrictions)
+	var applied []string
+
+	for _, rule := range ruleset.Rules {
+		ruleLabels := normalizeTokens(rule.AllLabels)
+		if containsAllTokens(env.Labels, ruleLabels) {
+			if rule.SetsSensitivity > sensitivity {
+				sensitivity = rule.SetsSensitivity
+			}
+			restrictions = unionTokens(restrictions, rule.AddsRestrictions)
+			applied = append(applied, strings.TrimSpace(rule.Name))
+		}
+	}
+
+	return AggregationResult{
+		AggregateSensitivity: sensitivity,
+		Restrictions:         restrictions,
+		Escalate:             len(applied) == 0 && len(env.Labels) >= nCategoryThreshold,
+		RulesApplied:         applied,
+	}
+}
+
+// ContextOutcome is the governance-level result of a context-aware decision.
+type ContextOutcome string
+
+const (
+	ContextOutcomeAllow     ContextOutcome = "allow"
+	ContextOutcomeConstrain ContextOutcome = "constrain"
+	ContextOutcomeDeny      ContextOutcome = "deny"
+	ContextOutcomeEscalate  ContextOutcome = "escalate"
+)
+
+// ContextObligation is one restriction the host must carry forward.
+type ContextObligation struct {
+	Key       string `json:"key" yaml:"key"`
+	Satisfied bool   `json:"satisfied" yaml:"satisfied"`
+}
+
+// ContextObligationSet carries obligations and labels from a constrained decision.
+type ContextObligationSet struct {
+	Obligations  []ContextObligation `json:"obligations,omitempty" yaml:"obligations,omitempty"`
+	ResultLabels []string            `json:"result_labels,omitempty" yaml:"result_labels,omitempty"`
+}
+
+// AllSatisfied reports whether every declared obligation is already satisfied.
+func (set ContextObligationSet) AllSatisfied() bool {
+	for _, obligation := range set.Obligations {
+		if !obligation.Satisfied {
+			return false
+		}
+	}
+	return true
+}
+
+// ContextDecision is a context-aware decision plus any obligations it carries.
+type ContextDecision struct {
+	Outcome              ContextOutcome       `json:"outcome" yaml:"outcome"`
+	Obligations          ContextObligationSet `json:"obligations" yaml:"obligations"`
+	AggregateSensitivity DataClassification   `json:"aggregate_sensitivity" yaml:"aggregate_sensitivity"`
+	Reason               string               `json:"reason,omitempty" yaml:"reason,omitempty"`
+}
+
+// AccumulateContext folds an action result into the envelope and reruns aggregation.
+func AccumulateContext(
+	env ContextEnvelope,
+	resultLabels []string,
+	resultSensitivity DataClassification,
+	ruleset AggregationRuleSet,
+	nCategoryThreshold int,
+) ContextEnvelope {
+	folded := FoldContext(env, resultLabels, resultSensitivity)
+	aggregation := EvaluateAggregation(folded, ruleset, nCategoryThreshold)
+	raised := cloneContextEnvelope(folded)
+	raised.AggregateSensitivity = aggregation.AggregateSensitivity
+	return ApplyContextRestrictions(raised, aggregation.Restrictions)
+}
+
+// DecideNextContext gates the next action using the default Restricted sensitivity floor.
+func DecideNextContext(
+	env ContextEnvelope,
+	action string,
+	ruleset AggregationRuleSet,
+	nCategoryThreshold int,
+) ContextDecision {
+	return DecideNextContextWithFloor(env, action, ruleset, nCategoryThreshold, DataClassificationRestricted)
+}
+
+// DecideNextContextWithFloor gates the next action against the accumulated envelope.
+func DecideNextContextWithFloor(
+	env ContextEnvelope,
+	action string,
+	ruleset AggregationRuleSet,
+	nCategoryThreshold int,
+	restrictedFloor DataClassification,
+) ContextDecision {
+	env = cloneContextEnvelope(env)
+	aggregation := EvaluateAggregation(env, ruleset, nCategoryThreshold)
+	if aggregation.Escalate {
+		return ContextDecision{
+			Outcome: ContextOutcomeEscalate,
+			Obligations: ContextObligationSet{
+				ResultLabels: cloneTokens(env.Labels),
+			},
+			AggregateSensitivity: aggregation.AggregateSensitivity,
+			Reason:               "aggregation threshold crossed with no governing rule",
+		}
+	}
+
+	gating := contextRestrictedActions[action]
+	restrictionPresent := gating != "" && tokenSet(env.Restrictions)[gating]
+	floorTriggered := gating != "" && aggregation.AggregateSensitivity >= restrictedFloor
+	if restrictionPresent || floorTriggered {
+		obligations := make([]ContextObligation, 0, len(env.Restrictions))
+		for _, restriction := range env.Restrictions {
+			obligations = append(obligations, ContextObligation{Key: restriction})
+		}
+
+		reason := "action " + action + " gated by sensitivity floor"
+		if restrictionPresent {
+			reason = "action " + action + " restricted by " + gating
+		}
+		return ContextDecision{
+			Outcome: ContextOutcomeConstrain,
+			Obligations: ContextObligationSet{
+				Obligations:  obligations,
+				ResultLabels: cloneTokens(env.Labels),
+			},
+			AggregateSensitivity: aggregation.AggregateSensitivity,
+			Reason:               reason,
+		}
+	}
+
+	return ContextDecision{
+		Outcome: ContextOutcomeAllow,
+		Obligations: ContextObligationSet{
+			ResultLabels: cloneTokens(env.Labels),
+		},
+		AggregateSensitivity: aggregation.AggregateSensitivity,
+	}
+}
+
+// PolicyDecision collapses a context-aware decision onto the existing policy verdicts.
+func (decision ContextDecision) PolicyDecision(hasObligationChannel bool) PolicyDecision {
+	switch decision.Outcome {
+	case ContextOutcomeAllow:
+		return Allow
+	case ContextOutcomeDeny:
+		return Deny
+	case ContextOutcomeEscalate:
+		return Review
+	case ContextOutcomeConstrain:
+		if hasObligationChannel {
+			return Allow
+		}
+		if len(decision.Obligations.Obligations) > 0 && decision.Obligations.AllSatisfied() {
+			return Allow
+		}
+		return Deny
+	default:
+		return Deny
+	}
+}
+
+// MergeContextRestrictions returns the child's effective grow-only restrictions.
+func MergeContextRestrictions(parent ContextEnvelope, childDeclared []string) []string {
+	return unionTokens(parent.Restrictions, childDeclared)
+}
+
+// DelegateContext creates a child envelope that inherits parent restrictions and sensitivity.
+func DelegateContext(parent ContextEnvelope, childEnvelopeID string, childDeclaredRestrictions []string) ContextEnvelope {
+	parent = cloneContextEnvelope(parent)
+	return ContextEnvelope{
+		EnvelopeID:           childEnvelopeID,
+		WorkflowID:           parent.WorkflowID,
+		Labels:               cloneTokens(parent.Labels),
+		AggregateSensitivity: parent.AggregateSensitivity,
+		Restrictions:         MergeContextRestrictions(parent, childDeclaredRestrictions),
+		ParentEnvelopeID:     parent.EnvelopeID,
+		CreatedAt:            time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+var contextRestrictedActions = map[string]string{
+	"export":       "no_external_export",
+	"delegate":     "no_external_delegation",
+	"memory_write": "no_memory_write",
+}
+
+func cloneContextEnvelope(env ContextEnvelope) ContextEnvelope {
+	out := env
+	out.Labels = normalizeTokens(env.Labels)
+	out.Restrictions = normalizeTokens(env.Restrictions)
+	return out
+}
+
+func cloneTokens(tokens []string) []string {
+	out := make([]string, len(tokens))
+	copy(out, tokens)
+	return out
+}
+
+func unionTokens(left []string, right []string) []string {
+	set := tokenSet(left)
+	for _, token := range right {
+		normalized := strings.TrimSpace(token)
+		if normalized != "" {
+			set[normalized] = true
+		}
+	}
+	return sortedTokens(set)
+}
+
+func normalizeTokens(tokens []string) []string {
+	set := tokenSet(tokens)
+	return sortedTokens(set)
+}
+
+func tokenSet(tokens []string) map[string]bool {
+	set := make(map[string]bool, len(tokens))
+	for _, token := range tokens {
+		normalized := strings.TrimSpace(token)
+		if normalized != "" {
+			set[normalized] = true
+		}
+	}
+	return set
+}
+
+func sortedTokens(set map[string]bool) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for token := range set {
+		out = append(out, token)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containsAllTokens(have []string, need []string) bool {
+	haveSet := tokenSet(have)
+	for _, token := range need {
+		if !haveSet[token] {
+			return false
+		}
+	}
+	return true
+}

--- a/agent-governance-golang/packages/agentmesh/context_governance.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance.go
@@ -275,10 +275,13 @@ func (decision ContextDecision) PolicyDecision(hasObligationChannel bool) Policy
 	case ContextOutcomeEscalate:
 		return Review
 	case ContextOutcomeConstrain:
+		if len(decision.Obligations.Obligations) == 0 {
+			return Deny
+		}
 		if hasObligationChannel {
 			return Allow
 		}
-		if len(decision.Obligations.Obligations) > 0 && decision.Obligations.AllSatisfied() {
+		if decision.Obligations.AllSatisfied() {
 			return Allow
 		}
 		return Deny

--- a/agent-governance-golang/packages/agentmesh/context_governance.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance.go
@@ -19,7 +19,7 @@ const (
 	DataClassificationTopSecret
 )
 
-// String returns the stable wire spelling of the classification.
+// String returns the lowercase display spelling of the classification.
 func (dc DataClassification) String() string {
 	switch dc {
 	case DataClassificationPublic:

--- a/agent-governance-golang/packages/agentmesh/context_governance.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance.go
@@ -6,7 +6,6 @@ package agentmesh
 import (
 	"sort"
 	"strings"
-	"time"
 )
 
 // DataClassification is the shared sensitivity ladder for context governance.
@@ -38,15 +37,6 @@ func (dc DataClassification) String() string {
 	}
 }
 
-// DataLabel describes classified data folded into a context envelope.
-type DataLabel struct {
-	Classification DataClassification `json:"classification" yaml:"classification"`
-	Categories     []string           `json:"categories,omitempty" yaml:"categories,omitempty"`
-	Owner          string             `json:"owner,omitempty" yaml:"owner,omitempty"`
-	RetentionDays  int                `json:"retention_days,omitempty" yaml:"retention_days,omitempty"`
-	Geography      string             `json:"geography,omitempty" yaml:"geography,omitempty"`
-}
-
 // ContextEnvelope is the accumulated governance state for one workflow.
 //
 // Treat envelopes as value objects: helpers in this file return a new envelope
@@ -64,12 +54,14 @@ type ContextEnvelope struct {
 }
 
 // NewContextEnvelope creates an empty workflow-scoped context envelope.
-func NewContextEnvelope(envelopeID, workflowID string) ContextEnvelope {
+// createdAt is caller-supplied so construction remains deterministic and free
+// of hidden clock access.
+func NewContextEnvelope(envelopeID, workflowID, createdAt string) ContextEnvelope {
 	return ContextEnvelope{
 		EnvelopeID:           envelopeID,
 		WorkflowID:           workflowID,
 		AggregateSensitivity: DataClassificationPublic,
-		CreatedAt:            time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:            createdAt,
 	}
 }
 
@@ -299,8 +291,16 @@ func MergeContextRestrictions(parent ContextEnvelope, childDeclared []string) []
 	return unionTokens(parent.Restrictions, childDeclared)
 }
 
-// DelegateContext creates a child envelope that inherits parent restrictions and sensitivity.
-func DelegateContext(parent ContextEnvelope, childEnvelopeID string, childDeclaredRestrictions []string) ContextEnvelope {
+// DelegateContext creates a child envelope that inherits parent restrictions
+// and sensitivity. It is a Go convenience over MergeContextRestrictions rather
+// than a direct Python or TypeScript API counterpart. createdAt is
+// caller-supplied so the helper stays deterministic.
+func DelegateContext(
+	parent ContextEnvelope,
+	childEnvelopeID string,
+	childDeclaredRestrictions []string,
+	createdAt string,
+) ContextEnvelope {
 	parent = cloneContextEnvelope(parent)
 	return ContextEnvelope{
 		EnvelopeID:           childEnvelopeID,
@@ -309,7 +309,7 @@ func DelegateContext(parent ContextEnvelope, childEnvelopeID string, childDeclar
 		AggregateSensitivity: parent.AggregateSensitivity,
 		Restrictions:         MergeContextRestrictions(parent, childDeclaredRestrictions),
 		ParentEnvelopeID:     parent.EnvelopeID,
-		CreatedAt:            time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:            createdAt,
 	}
 }
 

--- a/agent-governance-golang/packages/agentmesh/context_governance.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance.go
@@ -4,6 +4,7 @@
 package agentmesh
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -18,6 +19,12 @@ const (
 	DataClassificationRestricted
 	DataClassificationTopSecret
 )
+
+// Defined reports whether the classification is a member of the supported
+// sensitivity ladder.
+func (dc DataClassification) Defined() bool {
+	return dc >= DataClassificationPublic && dc <= DataClassificationTopSecret
+}
 
 // String returns the lowercase display spelling of the classification.
 func (dc DataClassification) String() string {
@@ -66,14 +73,28 @@ func NewContextEnvelope(envelopeID, workflowID, createdAt string) ContextEnvelop
 }
 
 // FoldContext returns the next envelope version after folding result labels.
-func FoldContext(env ContextEnvelope, newLabels []string, newSensitivity DataClassification) ContextEnvelope {
+// Undefined classifications return a validation error and a top-secret envelope.
+func FoldContext(
+	env ContextEnvelope,
+	newLabels []string,
+	newSensitivity DataClassification,
+) (ContextEnvelope, error) {
 	out := cloneContextEnvelope(env)
+	if err := validateDataClassification(
+		"envelope aggregate sensitivity",
+		out.AggregateSensitivity,
+	); err != nil {
+		return failClosedContextEnvelope(out), err
+	}
+	if err := validateDataClassification("new sensitivity", newSensitivity); err != nil {
+		return failClosedContextEnvelope(out), err
+	}
 	out.Labels = unionTokens(out.Labels, newLabels)
 	if newSensitivity > out.AggregateSensitivity {
 		out.AggregateSensitivity = newSensitivity
 	}
 	out.Version++
-	return out
+	return out, nil
 }
 
 // ApplyContextRestrictions returns the next envelope version with restrictions added.
@@ -120,8 +141,23 @@ type AggregationResult struct {
 }
 
 // EvaluateAggregation applies matching rules and escalates unknown combinations at the threshold.
-func EvaluateAggregation(env ContextEnvelope, ruleset AggregationRuleSet, nCategoryThreshold int) AggregationResult {
+// Invalid classifications or rules return a validation error and an escalating
+// top-secret result.
+func EvaluateAggregation(
+	env ContextEnvelope,
+	ruleset AggregationRuleSet,
+	nCategoryThreshold int,
+) (AggregationResult, error) {
 	env = cloneContextEnvelope(env)
+	if err := validateDataClassification(
+		"envelope aggregate sensitivity",
+		env.AggregateSensitivity,
+	); err != nil {
+		return failClosedAggregationResult(env), err
+	}
+	if err := validateAggregationRuleSet(ruleset); err != nil {
+		return failClosedAggregationResult(env), err
+	}
 	sensitivity := env.AggregateSensitivity
 	restrictions := cloneTokens(env.Restrictions)
 	var applied []string
@@ -142,7 +178,7 @@ func EvaluateAggregation(env ContextEnvelope, ruleset AggregationRuleSet, nCateg
 		Restrictions:         restrictions,
 		Escalate:             len(applied) == 0 && len(env.Labels) >= nCategoryThreshold,
 		RulesApplied:         applied,
-	}
+	}, nil
 }
 
 // ContextOutcome is the governance-level result of a context-aware decision.
@@ -186,18 +222,27 @@ type ContextDecision struct {
 }
 
 // AccumulateContext folds an action result into the envelope and reruns aggregation.
+// Invalid classifications or rules return a validation error and a top-secret envelope.
 func AccumulateContext(
 	env ContextEnvelope,
 	resultLabels []string,
 	resultSensitivity DataClassification,
 	ruleset AggregationRuleSet,
 	nCategoryThreshold int,
-) ContextEnvelope {
-	folded := FoldContext(env, resultLabels, resultSensitivity)
-	aggregation := EvaluateAggregation(folded, ruleset, nCategoryThreshold)
+) (ContextEnvelope, error) {
+	folded, err := FoldContext(env, resultLabels, resultSensitivity)
+	if err != nil {
+		return folded, err
+	}
+	aggregation, err := EvaluateAggregation(folded, ruleset, nCategoryThreshold)
+	if err != nil {
+		folded.AggregateSensitivity = aggregation.AggregateSensitivity
+		folded.Restrictions = unionTokens(folded.Restrictions, aggregation.Restrictions)
+		return folded, err
+	}
 	raised := cloneContextEnvelope(folded)
 	raised.AggregateSensitivity = aggregation.AggregateSensitivity
-	return ApplyContextRestrictions(raised, aggregation.Restrictions)
+	return ApplyContextRestrictions(raised, aggregation.Restrictions), nil
 }
 
 // DecideNextContext gates the next action using the default Restricted sensitivity floor.
@@ -206,20 +251,27 @@ func DecideNextContext(
 	action string,
 	ruleset AggregationRuleSet,
 	nCategoryThreshold int,
-) ContextDecision {
+) (ContextDecision, error) {
 	return DecideNextContextWithFloor(env, action, ruleset, nCategoryThreshold, DataClassificationRestricted)
 }
 
 // DecideNextContextWithFloor gates the next action against the accumulated envelope.
+// Invalid classifications or rules return a validation error and a deny decision.
 func DecideNextContextWithFloor(
 	env ContextEnvelope,
 	action string,
 	ruleset AggregationRuleSet,
 	nCategoryThreshold int,
 	restrictedFloor DataClassification,
-) ContextDecision {
+) (ContextDecision, error) {
 	env = cloneContextEnvelope(env)
-	aggregation := EvaluateAggregation(env, ruleset, nCategoryThreshold)
+	if err := validateDataClassification("restricted floor", restrictedFloor); err != nil {
+		return failClosedContextDecision(env, err), err
+	}
+	aggregation, err := EvaluateAggregation(env, ruleset, nCategoryThreshold)
+	if err != nil {
+		return failClosedContextDecision(env, err), err
+	}
 	if aggregation.Escalate {
 		return ContextDecision{
 			Outcome: ContextOutcomeEscalate,
@@ -228,7 +280,7 @@ func DecideNextContextWithFloor(
 			},
 			AggregateSensitivity: aggregation.AggregateSensitivity,
 			Reason:               "aggregation threshold crossed with no governing rule",
-		}
+		}, nil
 	}
 
 	gating := contextRestrictedActions[action]
@@ -253,7 +305,7 @@ func DecideNextContextWithFloor(
 			},
 			AggregateSensitivity: aggregation.AggregateSensitivity,
 			Reason:               reason,
-		}
+		}, nil
 	}
 
 	return ContextDecision{
@@ -262,7 +314,7 @@ func DecideNextContextWithFloor(
 			ResultLabels: cloneTokens(env.Labels),
 		},
 		AggregateSensitivity: aggregation.AggregateSensitivity,
-	}
+	}, nil
 }
 
 // PolicyDecision collapses a context-aware decision onto the existing policy verdicts.
@@ -383,4 +435,59 @@ func containsAllTokens(have []string, need []string) bool {
 		}
 	}
 	return true
+}
+
+func validateDataClassification(name string, classification DataClassification) error {
+	if classification.Defined() {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s must be a defined DataClassification value: %d",
+		name,
+		classification,
+	)
+}
+
+func validateAggregationRuleSet(ruleset AggregationRuleSet) error {
+	for index, rule := range ruleset.Rules {
+		if len(normalizeTokens(rule.AllLabels)) == 0 {
+			return fmt.Errorf(
+				"aggregation rule %d (%q) must require at least one label",
+				index,
+				strings.TrimSpace(rule.Name),
+			)
+		}
+		if err := validateDataClassification(
+			fmt.Sprintf("aggregation rule %d (%q) sensitivity", index, strings.TrimSpace(rule.Name)),
+			rule.SetsSensitivity,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func failClosedContextEnvelope(env ContextEnvelope) ContextEnvelope {
+	out := cloneContextEnvelope(env)
+	out.AggregateSensitivity = DataClassificationTopSecret
+	return out
+}
+
+func failClosedAggregationResult(env ContextEnvelope) AggregationResult {
+	return AggregationResult{
+		AggregateSensitivity: DataClassificationTopSecret,
+		Restrictions:         cloneTokens(env.Restrictions),
+		Escalate:             true,
+	}
+}
+
+func failClosedContextDecision(env ContextEnvelope, err error) ContextDecision {
+	return ContextDecision{
+		Outcome: ContextOutcomeDeny,
+		Obligations: ContextObligationSet{
+			ResultLabels: cloneTokens(env.Labels),
+		},
+		AggregateSensitivity: DataClassificationTopSecret,
+		Reason:               err.Error(),
+	}
 }

--- a/agent-governance-golang/packages/agentmesh/context_governance.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance.go
@@ -232,11 +232,12 @@ func DecideNextContextWithFloor(
 	}
 
 	gating := contextRestrictedActions[action]
-	restrictionPresent := gating != "" && tokenSet(env.Restrictions)[gating]
+	effectiveRestrictions := aggregation.Restrictions
+	restrictionPresent := gating != "" && tokenSet(effectiveRestrictions)[gating]
 	floorTriggered := gating != "" && aggregation.AggregateSensitivity >= restrictedFloor
 	if restrictionPresent || floorTriggered {
-		obligations := make([]ContextObligation, 0, len(env.Restrictions))
-		for _, restriction := range env.Restrictions {
+		obligations := make([]ContextObligation, 0, len(effectiveRestrictions))
+		for _, restriction := range effectiveRestrictions {
 			obligations = append(obligations, ContextObligation{Key: restriction})
 		}
 

--- a/agent-governance-golang/packages/agentmesh/context_governance_test.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package agentmesh
+
+import (
+	"reflect"
+	"testing"
+)
+
+var contextGovernanceRules = AggregationRuleSet{
+	Rules: []AggregationRule{
+		{
+			Name:             "pii_financial_restricted",
+			AllLabels:        []string{"pii", "financial"},
+			SetsSensitivity:  DataClassificationRestricted,
+			AddsRestrictions: []string{"no_external_export"},
+		},
+	},
+}
+
+func TestFoldContextJoinsLabelsAndRaisesSensitivity(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationInternal,
+	}
+
+	out := FoldContext(env, []string{"financial"}, DataClassificationConfidential)
+
+	if !reflect.DeepEqual(out.Labels, []string{"financial", "pii"}) {
+		t.Fatalf("labels = %#v, want financial+pii", out.Labels)
+	}
+	if out.AggregateSensitivity != DataClassificationConfidential {
+		t.Fatalf("aggregate sensitivity = %v, want confidential", out.AggregateSensitivity)
+	}
+	if out.Version != env.Version+1 {
+		t.Fatalf("version = %d, want %d", out.Version, env.Version+1)
+	}
+	if !reflect.DeepEqual(env.Labels, []string{"pii"}) {
+		t.Fatalf("original labels mutated: %#v", env.Labels)
+	}
+}
+
+func TestFoldContextIsIdempotentAndNeverLowersSensitivity(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationRestricted,
+	}
+
+	out := FoldContext(env, []string{"pii"}, DataClassificationPublic)
+
+	if !reflect.DeepEqual(out.Labels, []string{"pii"}) {
+		t.Fatalf("labels = %#v, want pii only", out.Labels)
+	}
+	if out.AggregateSensitivity != DataClassificationRestricted {
+		t.Fatalf("aggregate sensitivity = %v, want restricted", out.AggregateSensitivity)
+	}
+}
+
+func TestApplyContextRestrictionsIsGrowOnly(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:   "env-1",
+		WorkflowID:   "wf-1",
+		Restrictions: []string{"no_external_export"},
+	}
+
+	out := ApplyContextRestrictions(env, nil)
+	if !reflect.DeepEqual(out.Restrictions, []string{"no_external_export"}) {
+		t.Fatalf("restrictions = %#v, want original restriction", out.Restrictions)
+	}
+
+	out = ApplyContextRestrictions(out, []string{"no_memory_write"})
+	if !reflect.DeepEqual(out.Restrictions, []string{"no_external_export", "no_memory_write"}) {
+		t.Fatalf("restrictions = %#v, want both restrictions", out.Restrictions)
+	}
+}
+
+func TestContextEnvelopeReferenceOmitsEnvelopeContents(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii", "financial"},
+		AggregateSensitivity: DataClassificationRestricted,
+		Restrictions:         []string{"no_external_export"},
+		Version:              7,
+		ParentEnvelopeID:     "parent-1",
+	}
+
+	ref := ContextEnvelopeReference(env)
+
+	if ref.EnvelopeID != env.EnvelopeID {
+		t.Fatalf("envelope id = %q, want %q", ref.EnvelopeID, env.EnvelopeID)
+	}
+	if ref.Sensitivity != env.AggregateSensitivity {
+		t.Fatalf("sensitivity = %v, want %v", ref.Sensitivity, env.AggregateSensitivity)
+	}
+
+	refFields := reflect.TypeOf(ref)
+	if refFields.NumField() != 2 {
+		t.Fatalf("reference exposes %d fields, want 2", refFields.NumField())
+	}
+}
+
+func TestEvaluateAggregationRuleAndBackstop(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"financial", "pii"},
+		AggregateSensitivity: DataClassificationInternal,
+	}
+
+	result := EvaluateAggregation(env, contextGovernanceRules, 99)
+
+	if result.AggregateSensitivity != DataClassificationRestricted {
+		t.Fatalf("aggregate sensitivity = %v, want restricted", result.AggregateSensitivity)
+	}
+	if !reflect.DeepEqual(result.Restrictions, []string{"no_external_export"}) {
+		t.Fatalf("restrictions = %#v, want no_external_export", result.Restrictions)
+	}
+	if !reflect.DeepEqual(result.RulesApplied, []string{"pii_financial_restricted"}) {
+		t.Fatalf("rules applied = %#v, want pii_financial_restricted", result.RulesApplied)
+	}
+	if result.Escalate {
+		t.Fatal("escalate = true, want false for governed combination")
+	}
+
+	unknown := EvaluateAggregation(ContextEnvelope{
+		EnvelopeID:           "env-2",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"a", "b", "c"},
+		AggregateSensitivity: DataClassificationInternal,
+	}, contextGovernanceRules, 3)
+	if !unknown.Escalate {
+		t.Fatal("escalate = false, want true for unknown combination at threshold")
+	}
+}
+
+func TestAccumulateContextFoldsAndAppliesAggregationRestrictions(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationInternal,
+	}
+
+	out := AccumulateContext(env, []string{"financial"}, DataClassificationConfidential, contextGovernanceRules, 99)
+
+	if !reflect.DeepEqual(out.Labels, []string{"financial", "pii"}) {
+		t.Fatalf("labels = %#v, want financial+pii", out.Labels)
+	}
+	if out.AggregateSensitivity != DataClassificationRestricted {
+		t.Fatalf("aggregate sensitivity = %v, want restricted", out.AggregateSensitivity)
+	}
+	if !reflect.DeepEqual(out.Restrictions, []string{"no_external_export"}) {
+		t.Fatalf("restrictions = %#v, want no_external_export", out.Restrictions)
+	}
+	if out.Version != env.Version+2 {
+		t.Fatalf("version = %d, want %d", out.Version, env.Version+2)
+	}
+}
+
+func TestDecideNextContextGatesRestrictedActions(t *testing.T) {
+	env := AccumulateContext(ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationInternal,
+	}, []string{"financial"}, DataClassificationConfidential, contextGovernanceRules, 99)
+
+	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+
+	if decision.Outcome != ContextOutcomeConstrain {
+		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
+	}
+	if len(decision.Obligations.Obligations) != 1 || decision.Obligations.Obligations[0].Key != "no_external_export" {
+		t.Fatalf("obligations = %#v, want no_external_export", decision.Obligations.Obligations)
+	}
+	if decision.PolicyDecision(false) != Deny {
+		t.Fatalf("policy decision without channel = %q, want deny", decision.PolicyDecision(false))
+	}
+	if decision.PolicyDecision(true) != Allow {
+		t.Fatalf("policy decision with channel = %q, want allow", decision.PolicyDecision(true))
+	}
+}
+
+func TestDecideNextContextExplicitRestrictionGatesBelowFloor(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationConfidential,
+		Restrictions:         []string{"no_external_export"},
+	}
+
+	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	if decision.Outcome != ContextOutcomeConstrain {
+		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
+	}
+}
+
+func TestDecideNextContextFloorGatesFlowActionWithoutExplicitRestriction(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationRestricted,
+	}
+
+	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	if decision.Outcome != ContextOutcomeConstrain {
+		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
+	}
+	if len(decision.Obligations.Obligations) != 0 {
+		t.Fatalf("obligations = %#v, want none", decision.Obligations.Obligations)
+	}
+	if decision.PolicyDecision(false) != Deny {
+		t.Fatalf("policy decision = %q, want deny", decision.PolicyDecision(false))
+	}
+}
+
+func TestDecideNextContextEscalatesUnknownCombinations(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"a", "b", "c"},
+		AggregateSensitivity: DataClassificationInternal,
+	}
+
+	decision := DecideNextContext(env, "read", contextGovernanceRules, 3)
+
+	if decision.Outcome != ContextOutcomeEscalate {
+		t.Fatalf("outcome = %q, want escalate", decision.Outcome)
+	}
+	if decision.PolicyDecision(false) != Review {
+		t.Fatalf("policy decision = %q, want review", decision.PolicyDecision(false))
+	}
+}
+
+func TestConstrainWithoutObligationsFailsClosed(t *testing.T) {
+	decision := ContextDecision{
+		Outcome:              ContextOutcomeConstrain,
+		Obligations:          ContextObligationSet{},
+		AggregateSensitivity: DataClassificationRestricted,
+	}
+
+	if decision.PolicyDecision(false) != Deny {
+		t.Fatalf("policy decision = %q, want deny", decision.PolicyDecision(false))
+	}
+}
+
+func TestSatisfiedObligationAllowsWithoutChannel(t *testing.T) {
+	decision := ContextDecision{
+		Outcome: ContextOutcomeConstrain,
+		Obligations: ContextObligationSet{
+			Obligations: []ContextObligation{{Key: "no_external_export", Satisfied: true}},
+		},
+		AggregateSensitivity: DataClassificationRestricted,
+	}
+
+	if decision.PolicyDecision(false) != Allow {
+		t.Fatalf("policy decision = %q, want allow", decision.PolicyDecision(false))
+	}
+}
+
+func TestMergeContextRestrictionsAndDelegateContextInheritParentRestrictions(t *testing.T) {
+	parent := ContextEnvelope{
+		EnvelopeID:           "parent-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"pii"},
+		AggregateSensitivity: DataClassificationRestricted,
+		Restrictions:         []string{"no_external_export"},
+	}
+
+	merged := MergeContextRestrictions(parent, []string{"no_memory_write"})
+	if !reflect.DeepEqual(merged, []string{"no_external_export", "no_memory_write"}) {
+		t.Fatalf("merged restrictions = %#v, want parent+child restrictions", merged)
+	}
+
+	child := DelegateContext(parent, "child-1", []string{"no_memory_write"})
+	if child.ParentEnvelopeID != parent.EnvelopeID {
+		t.Fatalf("parent envelope id = %q, want %q", child.ParentEnvelopeID, parent.EnvelopeID)
+	}
+	if !reflect.DeepEqual(child.Restrictions, []string{"no_external_export", "no_memory_write"}) {
+		t.Fatalf("child restrictions = %#v, want inherited restrictions", child.Restrictions)
+	}
+	if child.AggregateSensitivity != parent.AggregateSensitivity {
+		t.Fatalf("child sensitivity = %v, want %v", child.AggregateSensitivity, parent.AggregateSensitivity)
+	}
+}

--- a/agent-governance-golang/packages/agentmesh/context_governance_test.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance_test.go
@@ -200,6 +200,28 @@ func TestDecideNextContextGatesRestrictedActions(t *testing.T) {
 	}
 }
 
+func TestDecideNextContextUsesAggregationDerivedRestrictions(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"financial", "pii"},
+		AggregateSensitivity: DataClassificationInternal,
+	}
+
+	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+
+	if decision.Outcome != ContextOutcomeConstrain {
+		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
+	}
+	if len(decision.Obligations.Obligations) != 1 ||
+		decision.Obligations.Obligations[0].Key != "no_external_export" {
+		t.Fatalf("obligations = %#v, want no_external_export", decision.Obligations.Obligations)
+	}
+	if decision.Reason != "action export restricted by no_external_export" {
+		t.Fatalf("reason = %q, want aggregation-derived restriction", decision.Reason)
+	}
+}
+
 func TestDecideNextContextExplicitRestrictionGatesBelowFloor(t *testing.T) {
 	env := ContextEnvelope{
 		EnvelopeID:           "env-1",

--- a/agent-governance-golang/packages/agentmesh/context_governance_test.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance_test.go
@@ -32,6 +32,26 @@ func TestNewContextEnvelopeUsesCallerSuppliedCreatedAt(t *testing.T) {
 	}
 }
 
+func TestDataClassificationDefinedRejectsOutOfRangeValues(t *testing.T) {
+	for _, classification := range []DataClassification{
+		DataClassificationPublic,
+		DataClassificationInternal,
+		DataClassificationConfidential,
+		DataClassificationRestricted,
+		DataClassificationTopSecret,
+	} {
+		if !classification.Defined() {
+			t.Fatalf("classification %d should be defined", classification)
+		}
+	}
+
+	for _, classification := range []DataClassification{-1, 5, 99} {
+		if classification.Defined() {
+			t.Fatalf("classification %d should be undefined", classification)
+		}
+	}
+}
+
 func TestFoldContextJoinsLabelsAndRaisesSensitivity(t *testing.T) {
 	env := ContextEnvelope{
 		EnvelopeID:           "env-1",
@@ -40,7 +60,10 @@ func TestFoldContextJoinsLabelsAndRaisesSensitivity(t *testing.T) {
 		AggregateSensitivity: DataClassificationInternal,
 	}
 
-	out := FoldContext(env, []string{"financial"}, DataClassificationConfidential)
+	out, err := FoldContext(env, []string{"financial"}, DataClassificationConfidential)
+	if err != nil {
+		t.Fatalf("fold context: %v", err)
+	}
 
 	if !reflect.DeepEqual(out.Labels, []string{"financial", "pii"}) {
 		t.Fatalf("labels = %#v, want financial+pii", out.Labels)
@@ -64,13 +87,54 @@ func TestFoldContextIsIdempotentAndNeverLowersSensitivity(t *testing.T) {
 		AggregateSensitivity: DataClassificationRestricted,
 	}
 
-	out := FoldContext(env, []string{"pii"}, DataClassificationPublic)
+	out, err := FoldContext(env, []string{"pii"}, DataClassificationPublic)
+	if err != nil {
+		t.Fatalf("fold context: %v", err)
+	}
 
 	if !reflect.DeepEqual(out.Labels, []string{"pii"}) {
 		t.Fatalf("labels = %#v, want pii only", out.Labels)
 	}
 	if out.AggregateSensitivity != DataClassificationRestricted {
 		t.Fatalf("aggregate sensitivity = %v, want restricted", out.AggregateSensitivity)
+	}
+}
+
+func TestFoldContextRejectsUndefinedClassifications(t *testing.T) {
+	tests := []struct {
+		name           string
+		envSensitivity DataClassification
+		newSensitivity DataClassification
+	}{
+		{
+			name:           "envelope",
+			envSensitivity: DataClassification(-1),
+			newSensitivity: DataClassificationPublic,
+		},
+		{
+			name:           "result",
+			envSensitivity: DataClassificationPublic,
+			newSensitivity: DataClassification(99),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := FoldContext(ContextEnvelope{
+				EnvelopeID:           "env-1",
+				WorkflowID:           "wf-1",
+				AggregateSensitivity: test.envSensitivity,
+			}, []string{"pii"}, test.newSensitivity)
+			if err == nil {
+				t.Fatal("fold context error = nil, want undefined-classification error")
+			}
+			if out.AggregateSensitivity != DataClassificationTopSecret {
+				t.Fatalf(
+					"fail-closed sensitivity = %v, want top_secret",
+					out.AggregateSensitivity,
+				)
+			}
+		})
 	}
 }
 
@@ -126,7 +190,10 @@ func TestEvaluateAggregationRuleAndBackstop(t *testing.T) {
 		AggregateSensitivity: DataClassificationInternal,
 	}
 
-	result := EvaluateAggregation(env, contextGovernanceRules, 99)
+	result, err := EvaluateAggregation(env, contextGovernanceRules, 99)
+	if err != nil {
+		t.Fatalf("evaluate aggregation: %v", err)
+	}
 
 	if result.AggregateSensitivity != DataClassificationRestricted {
 		t.Fatalf("aggregate sensitivity = %v, want restricted", result.AggregateSensitivity)
@@ -141,14 +208,80 @@ func TestEvaluateAggregationRuleAndBackstop(t *testing.T) {
 		t.Fatal("escalate = true, want false for governed combination")
 	}
 
-	unknown := EvaluateAggregation(ContextEnvelope{
+	unknown, err := EvaluateAggregation(ContextEnvelope{
 		EnvelopeID:           "env-2",
 		WorkflowID:           "wf-1",
 		Labels:               []string{"a", "b", "c"},
 		AggregateSensitivity: DataClassificationInternal,
 	}, contextGovernanceRules, 3)
+	if err != nil {
+		t.Fatalf("evaluate unknown aggregation: %v", err)
+	}
 	if !unknown.Escalate {
 		t.Fatal("escalate = false, want true for unknown combination at threshold")
+	}
+}
+
+func TestEvaluateAggregationRejectsInvalidClassificationsAndEmptyRules(t *testing.T) {
+	env := ContextEnvelope{
+		EnvelopeID:           "env-1",
+		WorkflowID:           "wf-1",
+		Labels:               []string{"a", "b", "c"},
+		AggregateSensitivity: DataClassificationInternal,
+	}
+	tests := []struct {
+		name    string
+		env     ContextEnvelope
+		ruleset AggregationRuleSet
+	}{
+		{
+			name: "undefined envelope classification",
+			env: ContextEnvelope{
+				EnvelopeID:           "env-invalid",
+				WorkflowID:           "wf-1",
+				AggregateSensitivity: DataClassification(-1),
+			},
+			ruleset: contextGovernanceRules,
+		},
+		{
+			name: "undefined rule classification",
+			env:  env,
+			ruleset: AggregationRuleSet{Rules: []AggregationRule{{
+				Name:            "invalid_classification",
+				AllLabels:       []string{"a"},
+				SetsSensitivity: DataClassification(99),
+			}}},
+		},
+		{
+			name: "empty rule labels",
+			env:  env,
+			ruleset: AggregationRuleSet{Rules: []AggregationRule{{
+				Name:            "matches_everything",
+				AllLabels:       []string{" "},
+				SetsSensitivity: DataClassificationRestricted,
+			}}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := EvaluateAggregation(test.env, test.ruleset, 3)
+			if err == nil {
+				t.Fatal("evaluate aggregation error = nil, want validation error")
+			}
+			if result.AggregateSensitivity != DataClassificationTopSecret {
+				t.Fatalf(
+					"fail-closed sensitivity = %v, want top_secret",
+					result.AggregateSensitivity,
+				)
+			}
+			if !result.Escalate {
+				t.Fatal("fail-closed escalate = false, want true")
+			}
+			if len(result.RulesApplied) != 0 {
+				t.Fatalf("rules applied = %#v, want none", result.RulesApplied)
+			}
+		})
 	}
 }
 
@@ -160,7 +293,16 @@ func TestAccumulateContextFoldsAndAppliesAggregationRestrictions(t *testing.T) {
 		AggregateSensitivity: DataClassificationInternal,
 	}
 
-	out := AccumulateContext(env, []string{"financial"}, DataClassificationConfidential, contextGovernanceRules, 99)
+	out, err := AccumulateContext(
+		env,
+		[]string{"financial"},
+		DataClassificationConfidential,
+		contextGovernanceRules,
+		99,
+	)
+	if err != nil {
+		t.Fatalf("accumulate context: %v", err)
+	}
 
 	if !reflect.DeepEqual(out.Labels, []string{"financial", "pii"}) {
 		t.Fatalf("labels = %#v, want financial+pii", out.Labels)
@@ -177,14 +319,20 @@ func TestAccumulateContextFoldsAndAppliesAggregationRestrictions(t *testing.T) {
 }
 
 func TestDecideNextContextGatesRestrictedActions(t *testing.T) {
-	env := AccumulateContext(ContextEnvelope{
+	env, err := AccumulateContext(ContextEnvelope{
 		EnvelopeID:           "env-1",
 		WorkflowID:           "wf-1",
 		Labels:               []string{"pii"},
 		AggregateSensitivity: DataClassificationInternal,
 	}, []string{"financial"}, DataClassificationConfidential, contextGovernanceRules, 99)
+	if err != nil {
+		t.Fatalf("accumulate context: %v", err)
+	}
 
-	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	decision, err := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	if err != nil {
+		t.Fatalf("decide next context: %v", err)
+	}
 
 	if decision.Outcome != ContextOutcomeConstrain {
 		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
@@ -208,7 +356,10 @@ func TestDecideNextContextUsesAggregationDerivedRestrictions(t *testing.T) {
 		AggregateSensitivity: DataClassificationInternal,
 	}
 
-	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	decision, err := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	if err != nil {
+		t.Fatalf("decide next context: %v", err)
+	}
 
 	if decision.Outcome != ContextOutcomeConstrain {
 		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
@@ -231,7 +382,10 @@ func TestDecideNextContextExplicitRestrictionGatesBelowFloor(t *testing.T) {
 		Restrictions:         []string{"no_external_export"},
 	}
 
-	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	decision, err := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	if err != nil {
+		t.Fatalf("decide next context: %v", err)
+	}
 	if decision.Outcome != ContextOutcomeConstrain {
 		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
 	}
@@ -245,7 +399,10 @@ func TestDecideNextContextFloorGatesFlowActionWithoutExplicitRestriction(t *test
 		AggregateSensitivity: DataClassificationRestricted,
 	}
 
-	decision := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	decision, err := DecideNextContext(env, "export", contextGovernanceRules, 99)
+	if err != nil {
+		t.Fatalf("decide next context: %v", err)
+	}
 	if decision.Outcome != ContextOutcomeConstrain {
 		t.Fatalf("outcome = %q, want constrain", decision.Outcome)
 	}
@@ -268,13 +425,48 @@ func TestDecideNextContextEscalatesUnknownCombinations(t *testing.T) {
 		AggregateSensitivity: DataClassificationInternal,
 	}
 
-	decision := DecideNextContext(env, "read", contextGovernanceRules, 3)
+	decision, err := DecideNextContext(env, "read", contextGovernanceRules, 3)
+	if err != nil {
+		t.Fatalf("decide next context: %v", err)
+	}
 
 	if decision.Outcome != ContextOutcomeEscalate {
 		t.Fatalf("outcome = %q, want escalate", decision.Outcome)
 	}
 	if decision.PolicyDecision(false) != Review {
 		t.Fatalf("policy decision = %q, want review", decision.PolicyDecision(false))
+	}
+}
+
+func TestDecideNextContextRejectsUndefinedRestrictedFloor(t *testing.T) {
+	decision, err := DecideNextContextWithFloor(
+		ContextEnvelope{
+			EnvelopeID:           "env-1",
+			WorkflowID:           "wf-1",
+			AggregateSensitivity: DataClassificationInternal,
+		},
+		"export",
+		contextGovernanceRules,
+		99,
+		DataClassification(-1),
+	)
+	if err == nil {
+		t.Fatal("decide next context error = nil, want invalid-floor error")
+	}
+	if decision.Outcome != ContextOutcomeDeny {
+		t.Fatalf("fail-closed outcome = %q, want deny", decision.Outcome)
+	}
+	if decision.AggregateSensitivity != DataClassificationTopSecret {
+		t.Fatalf(
+			"fail-closed sensitivity = %v, want top_secret",
+			decision.AggregateSensitivity,
+		)
+	}
+	if decision.PolicyDecision(true) != Deny {
+		t.Fatalf(
+			"fail-closed policy decision = %q, want deny",
+			decision.PolicyDecision(true),
+		)
 	}
 }
 

--- a/agent-governance-golang/packages/agentmesh/context_governance_test.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance_test.go
@@ -255,6 +255,9 @@ func TestDecideNextContextFloorGatesFlowActionWithoutExplicitRestriction(t *test
 	if decision.PolicyDecision(false) != Deny {
 		t.Fatalf("policy decision = %q, want deny", decision.PolicyDecision(false))
 	}
+	if decision.PolicyDecision(true) != Deny {
+		t.Fatalf("policy decision with empty obligation channel = %q, want deny", decision.PolicyDecision(true))
+	}
 }
 
 func TestDecideNextContextEscalatesUnknownCombinations(t *testing.T) {

--- a/agent-governance-golang/packages/agentmesh/context_governance_test.go
+++ b/agent-governance-golang/packages/agentmesh/context_governance_test.go
@@ -19,6 +19,19 @@ var contextGovernanceRules = AggregationRuleSet{
 	},
 }
 
+func TestNewContextEnvelopeUsesCallerSuppliedCreatedAt(t *testing.T) {
+	const createdAt = "2026-07-27T08:30:00Z"
+
+	env := NewContextEnvelope("env-1", "wf-1", createdAt)
+
+	if env.CreatedAt != createdAt {
+		t.Fatalf("created at = %q, want %q", env.CreatedAt, createdAt)
+	}
+	if env.AggregateSensitivity != DataClassificationPublic {
+		t.Fatalf("aggregate sensitivity = %v, want public", env.AggregateSensitivity)
+	}
+}
+
 func TestFoldContextJoinsLabelsAndRaisesSensitivity(t *testing.T) {
 	env := ContextEnvelope{
 		EnvelopeID:           "env-1",
@@ -280,7 +293,8 @@ func TestMergeContextRestrictionsAndDelegateContextInheritParentRestrictions(t *
 		t.Fatalf("merged restrictions = %#v, want parent+child restrictions", merged)
 	}
 
-	child := DelegateContext(parent, "child-1", []string{"no_memory_write"})
+	const childCreatedAt = "2026-07-27T08:31:00Z"
+	child := DelegateContext(parent, "child-1", []string{"no_memory_write"}, childCreatedAt)
 	if child.ParentEnvelopeID != parent.EnvelopeID {
 		t.Fatalf("parent envelope id = %q, want %q", child.ParentEnvelopeID, parent.EnvelopeID)
 	}
@@ -289,5 +303,8 @@ func TestMergeContextRestrictionsAndDelegateContextInheritParentRestrictions(t *
 	}
 	if child.AggregateSensitivity != parent.AggregateSensitivity {
 		t.Fatalf("child sensitivity = %v, want %v", child.AggregateSensitivity, parent.AggregateSensitivity)
+	}
+	if child.CreatedAt != childCreatedAt {
+		t.Fatalf("child created at = %q, want %q", child.CreatedAt, childCreatedAt)
 	}
 }


### PR DESCRIPTION
## Summary

- add Go `ContextEnvelope` and `DataClassification` primitives for accumulated context governance
- add aggregation rules, post-execution accumulation, next-action gating, obligations mapping, and delegation restriction inheritance
- add classified `ContextEvent` transitions with six stable cross-language wire event types
- keep envelope and delegation construction deterministic with caller-supplied timestamps
- document the Go-specific `DelegateContext` convenience API and add a changelog note for #3084

The unused `DataLabel` placeholder was removed instead of expanding this focused context-governance PR into a separate ABAC implementation.

## Validation

Validated with Go 1.25.9:

- `gofmt` on the changed Go files
- `go test ./packages/agentmesh`
- `go test ./...`
- `go vet ./...`
- repository changed-lines spell check

Part of #3084.
