### PR TITLE
feat: wire ACS verdicts into AGT kernel trust/audit/rings

### DIFF
--- a/agent-governance-python/agt-policies/README.md
+++ b/agent-governance-python/agt-policies/README.md
@@ -58,6 +58,9 @@ AGT adapters enforce.
 - `agt.policies.runtime` — Python wrapper over the ACS Python SDK that
   loads a resolved manifest, runs intervention points, applies the
   transform verdict, enforces approval, and emits AGT telemetry events.
+- `agt.policies.kernel` — `KernelBridge`, a dependency-injected
+  fail-closed gate that wires one ACS decision into the AGT kernel
+  (trust, audit, rings) and returns a single `KernelOutcome`.
 
 ## Runtime flow
 

--- a/agent-governance-python/agt-policies/src/agt/policies/__init__.py
+++ b/agent-governance-python/agt-policies/src/agt/policies/__init__.py
@@ -16,11 +16,25 @@ code imports:
 - :mod:`agt.policies.bridge` translates a v4
   ``agent_os.integrations.base.GovernancePolicy`` into an AGT manifest
   so callers can ride the v4 dataclass into the v5 engine.
+- :mod:`agt.policies.kernel` wires one ACS decision into the AGT kernel
+  (trust, audit, rings) through :class:`KernelBridge`, a dependency
+  injected fail closed governance gate.
 
 The module is structured as a thin re-export layer so external callers
 only need ``from agt.policies import ...``.
 """
 
+from .kernel import (
+    ActionClassifierLike,
+    AuditEmissionResult,
+    EmitEvent,
+    GovernanceEventSpec,
+    KernelBridge,
+    KernelDecision,
+    KernelOutcome,
+    RingEnforcerLike,
+    TrustTrackerLike,
+)
 from .result import EvaluationResult
 from .snapshot import (
     SnapshotBuilder,
@@ -35,8 +49,17 @@ from .snapshot import (
 )
 
 __all__ = [
+    "ActionClassifierLike",
+    "AuditEmissionResult",
+    "EmitEvent",
     "EvaluationResult",
+    "GovernanceEventSpec",
+    "KernelBridge",
+    "KernelDecision",
+    "KernelOutcome",
+    "RingEnforcerLike",
     "SnapshotBuilder",
+    "TrustTrackerLike",
     "agent_shutdown_snapshot",
     "agent_startup_snapshot",
     "input_snapshot",

--- a/agent-governance-python/agt-policies/src/agt/policies/kernel.py
+++ b/agent-governance-python/agt-policies/src/agt/policies/kernel.py
@@ -1,0 +1,687 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Wire one ACS decision into the AGT kernel (trust, audit, rings).
+
+An ACS intervention point produces a verdict, but the AGT kernel primitives that
+should react to it are disconnected islands, each with its own types: trust
+scoring (``agentmesh.trust_types.TrustTracker``), governance audit events
+(``agent_os.event_sink.GovernanceEvent`` / ``GovernanceEventProcessor``) and
+execution rings (``hypervisor.rings.RingEnforcer`` /
+``hypervisor.rings.ActionClassifier``). Without glue a host has to feed the ACS
+decision into every subsystem by hand and reconcile the two trust scales
+(agentmesh 0..1 reputation vs hypervisor ``eff_score``) itself.
+
+:class:`KernelBridge` is that glue. It is a composite, fail closed governance
+gate. Given one :class:`KernelDecision` it drives trust, emits one governance
+event and evaluates the execution ring, then returns a single
+:class:`KernelOutcome` whose ``proceeds`` flag is the AND of every independent
+gate.
+
+``proceeds`` is true only when
+
+- the ACS decision permits execution (``allow``, ``warn`` or ``transform``), and
+- the execution ring permits the action for the agent's current ring
+  (``RingEnforcer.check`` on ``ActionDescriptor.required_ring``), and
+- when ``strict_audit`` is set, the governance event was accepted for delivery
+  (``AuditEmissionResult.ACCEPTED``), and
+- no injected dependency raised.
+
+Any missing decision, unrecognized decision, dependency exception or (under
+strict audit) undelivered event drives ``proceeds`` false. The gate never
+flips a block into an allow.
+
+The bridge owns only neutral primitives and local Protocols. It imports none of
+``agentmesh``, ``agent_os`` or ``hypervisor``. The host injects concrete
+implementations, so no import cycle forms with
+``agent_os.integrations._v5_runtime_bridge`` (which already imports
+``agt.policies``).
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from types import SimpleNamespace
+from typing import Any, Callable, Mapping, Optional, Protocol, runtime_checkable
+
+# The five ACS decisions per policy-engine/spec/SPECIFICATION.md and
+# agent_control_specification._types.Decision.
+_RECOGNIZED_DECISIONS = frozenset({"allow", "warn", "deny", "escalate", "transform"})
+
+# Decisions whose execution side proceeds. Mirrors Decision.permits: allow,
+# warn and transform permit; deny and escalate halt until the host's approval
+# path resolves an escalate.
+_PERMITTING_DECISIONS = frozenset({"allow", "warn", "transform"})
+
+# effective decision -> (trust action, governance event kind, severity).
+# trust action is one of "reward" (success=True), "penalty" (success=False) or
+# "neutral" (no interaction recorded). Only allow rewards: a merely permitting
+# verdict (warn/transform) is not evidence of healthy behavior, and escalate is
+# pending host approval, so neither moves trust. deny penalizes. The event kind
+# strings match agent_os.event_sink.GovernanceEventKind values but stay plain
+# strings here so this module does not import agent_os.
+_OUTCOME_MAP: dict[str, tuple[str, str, str]] = {
+    "allow": ("reward", "policy_check", "info"),
+    "warn": ("neutral", "policy_check", "warning"),
+    "transform": ("neutral", "policy_check", "info"),
+    "deny": ("penalty", "policy_violation", "high"),
+    "escalate": ("neutral", "escalation_requested", "warning"),
+}
+
+# Applied when the decision is missing or unrecognized. Fail closed: treat as a
+# deny that penalizes trust and emits a violation.
+_FAIL_CLOSED_OUTCOME: tuple[str, str, str] = ("penalty", "policy_violation", "high")
+
+
+class AuditEmissionResult(str, Enum):
+    """Outcome of delivering one governance event to the host audit path.
+
+    The emitter returns this so audit delivery is observable. A ``-> None``
+    emitter would hide the fact that ``GovernanceEventProcessor.on_event`` can
+    drop an event on queue overflow, no-op after shutdown, or find no sink
+    registered, which would let a governed action proceed with no audit trail.
+    Only ``ACCEPTED`` counts as delivered for the fail closed gate.
+    """
+
+    ACCEPTED = "accepted"
+    DROPPED = "dropped"
+    NO_SINK = "no_sink"
+    FAILED = "failed"
+
+    @property
+    def delivered(self) -> bool:
+        """True only for ``ACCEPTED``. Every other result is a delivery gap."""
+        return self is AuditEmissionResult.ACCEPTED
+
+
+@dataclass(frozen=True)
+class GovernanceEventSpec:
+    """Neutral description of the governance event the bridge wants emitted.
+
+    The host adapter maps this to a concrete
+    ``agent_os.event_sink.GovernanceEvent`` (``kind`` -> ``GovernanceEventKind``)
+    and routes it through its ``GovernanceEventProcessor``. Keeping the spec
+    neutral is what lets this module stay free of the ``agent_os`` schema and
+    import.
+    """
+
+    kind: str
+    severity: str
+    agent_id: str
+    action: str
+    decision: str
+    reason: str
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class KernelDecision:
+    """Normalized ACS decision carrying both the raw and effective verdicts.
+
+    ``effective_decision`` is the verdict that actually took effect (what the
+    action executes against). ``raw_decision`` is the verdict the engine first
+    produced. They differ when the ACS runtime routes an ``escalate`` through
+    the host approval path and rewrites it to ``allow`` or ``deny``; the raw
+    ``escalate`` must survive so trust and audit reflect that an approval was
+    requested. See :meth:`from_evaluation_result` for why the plain
+    :class:`~agt.policies.result.EvaluationResult` seam alone is lossy.
+    """
+
+    effective_decision: str
+    raw_decision: str
+    reason: str = ""
+    approval_outcome: str | None = None
+    input_identity: str | None = None
+    enforced_identity: str | None = None
+    transform: Mapping[str, Any] | None = None
+    evidence: Mapping[str, Any] | None = None
+
+    @property
+    def is_recognized(self) -> bool:
+        """True when ``effective_decision`` is one of the five ACS decisions."""
+        return self.effective_decision in _RECOGNIZED_DECISIONS
+
+    @property
+    def permits(self) -> bool:
+        """True when the effective decision permits execution.
+
+        Unrecognized decisions never permit (fail closed).
+        """
+        return self.effective_decision in _PERMITTING_DECISIONS
+
+    @property
+    def was_escalated(self) -> bool:
+        """True when the raw engine verdict was ``escalate``.
+
+        Stays true even after the approval path rewrites the effective
+        decision to ``allow`` or ``deny``.
+        """
+        return self.raw_decision == "escalate"
+
+    @classmethod
+    def from_decision(
+        cls,
+        effective_decision: str,
+        *,
+        raw_decision: str | None = None,
+        reason: str = "",
+        **kwargs: Any,
+    ) -> "KernelDecision":
+        """Build from a bare decision string.
+
+        ``raw_decision`` defaults to ``effective_decision`` when the caller has
+        no separate raw verdict to preserve.
+        """
+        return cls(
+            effective_decision=effective_decision,
+            raw_decision=raw_decision if raw_decision is not None else effective_decision,
+            reason=reason,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_evaluation_result(cls, result: Any) -> "KernelDecision":
+        """Build from an ``agt.policies.result.EvaluationResult``.
+
+        ``EvaluationResult.verdict`` is the effective decision after the ACS
+        runtime has applied any approval routing, so an ``escalate`` that was
+        approved arrives here as ``allow``. The raw ``escalate`` is recovered
+        best effort from ``audit_entry`` (``raw_decision`` / ``original_verdict``
+        keys) or from a ``HUMAN_APPROVAL`` category. When neither is present the
+        raw decision equals the effective one and the escalation signal is not
+        recoverable from this seam. Hosts that need a lossless signal should
+        build from the raw ACS ``InterventionPointResult`` via
+        :meth:`from_intervention_point_result`.
+        """
+        effective = getattr(result, "verdict", None)
+        if not isinstance(effective, str):
+            effective = str(effective) if effective is not None else "deny"
+
+        audit_entry = getattr(result, "audit_entry", None) or {}
+        raw = None
+        approval_outcome = None
+        if isinstance(audit_entry, Mapping):
+            # AgtRuntime._result_from_intervention records the raw engine verdict
+            # under audit_entry["verdict"] (runtime.py) and keeps it there even
+            # after the approval path rewrites the effective verdict, so an
+            # approved escalate survives as audit_entry["verdict"] == "escalate"
+            # while result.verdict == "allow". Recover it from there (falling back
+            # to older raw_decision/original_verdict keys). approval_outcome is
+            # written under audit_entry["approval_outcome"] by the same path.
+            raw = (
+                audit_entry.get("raw_decision")
+                or audit_entry.get("original_verdict")
+                or audit_entry.get("verdict")
+            )
+            approval_outcome = audit_entry.get("approval_outcome")
+        if raw is None:
+            category = getattr(result, "category", None)
+            category_value = getattr(category, "value", category)
+            if isinstance(category_value, str) and category_value.upper() in {
+                "HUMAN_APPROVAL",
+                "HUMAN_APPROVAL_REQUIRED",
+            }:
+                raw = "escalate"
+        if raw is None:
+            raw = effective
+
+        return cls(
+            effective_decision=effective,
+            raw_decision=str(raw),
+            reason=getattr(result, "reason", "") or "",
+            approval_outcome=approval_outcome,
+            input_identity=getattr(result, "input_identity", None),
+            enforced_identity=getattr(result, "enforced_identity", None),
+            transform=getattr(result, "transform", None),
+            evidence=getattr(result, "evidence", None),
+        )
+
+    @classmethod
+    def from_intervention_point_result(cls, result: Any) -> "KernelDecision":
+        """Build from a raw ACS ``InterventionPointResult``.
+
+        This is the lossless seam for hosts that do not use ``AgtRuntime``. The
+        ``InterventionPointResult`` carries the verdict as the engine produced
+        it (before host approval routing), so ``raw_decision`` and
+        ``effective_decision`` are equal and an ``escalate`` is preserved
+        verbatim.
+        """
+        verdict = getattr(result, "verdict", None)
+        decision = getattr(verdict, "decision", None)
+        decision_value = getattr(decision, "value", decision)
+        if not isinstance(decision_value, str):
+            decision_value = str(decision_value) if decision_value is not None else "deny"
+        return cls(
+            effective_decision=decision_value,
+            raw_decision=decision_value,
+            reason=getattr(verdict, "reason", None) or "",
+            input_identity=getattr(result, "input_identity", None),
+            enforced_identity=getattr(result, "enforced_identity", None),
+            transform=getattr(verdict, "transform", None),
+            evidence=getattr(verdict, "evidence", None),
+        )
+
+
+@dataclass(frozen=True)
+class KernelOutcome:
+    """The single object a host reads instead of hand wiring three subsystems.
+
+    ``proceeds`` is the composite gate result. ``blocked_reason`` is set only
+    when ``proceeds`` is false and names which gate blocked (decision, ring or
+    audit), so callers do not have to reverse engineer it.
+    """
+
+    proceeds: bool
+    raw_decision: str
+    effective_decision: str
+    reason: str
+    trust_score: float
+    trust_delta: float
+    ring: Any
+    demoted: bool
+    ring_allowed: bool
+    audit: AuditEmissionResult
+    event: GovernanceEventSpec
+    blocked_reason: str | None = None
+
+
+@runtime_checkable
+class TrustTrackerLike(Protocol):
+    """Structural surface of ``agentmesh.trust_types.TrustTracker`` the bridge needs."""
+
+    def record_interaction(
+        self, agent_id: str, peer_id: str, action: str, success: bool
+    ) -> float:
+        ...
+
+    def get_score(self, agent_id: str) -> float:
+        ...
+
+
+@runtime_checkable
+class RingEnforcerLike(Protocol):
+    """Structural surface of ``hypervisor.rings.RingEnforcer`` the bridge needs."""
+
+    def compute_ring(self, eff_score: float, has_consensus: bool = ...) -> Any:
+        ...
+
+    def should_demote(self, current_ring: Any, eff_score: float) -> bool:
+        ...
+
+    def check(
+        self,
+        agent_ring: Any,
+        action: Any,
+        eff_score: float,
+        has_consensus: bool = ...,
+        has_sre_witness: bool = ...,
+    ) -> Any:
+        ...
+
+
+@runtime_checkable
+class ActionClassifierLike(Protocol):
+    """Structural surface of ``hypervisor.rings.ActionClassifier`` the bridge needs."""
+
+    def classify(self, action: Any) -> Any:
+        ...
+
+
+# Host callback that delivers one governance event and reports whether it was
+# accepted for delivery. Returning anything other than an AuditEmissionResult
+# (including None) is treated as FAILED under the fail closed contract.
+EmitEvent = Callable[[GovernanceEventSpec], AuditEmissionResult]
+
+
+def _action_name(action: Any) -> str:
+    """Derive a stable string label for an action (descriptor or bare string)."""
+    if action is None:
+        return ""
+    name = getattr(action, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    action_id = getattr(action, "action_id", None)
+    if isinstance(action_id, str) and action_id:
+        return action_id
+    return str(action)
+
+
+def _is_action_descriptor(action: Any) -> bool:
+    """True when ``action`` carries the ring surface ``RingEnforcer.check`` reads."""
+    return hasattr(action, "required_ring")
+
+
+def _tighten_required_ring(action: Any, classified_ring: Any) -> Any:
+    """Return ``action``, or a shim with a stricter ``required_ring``.
+
+    ``RingEnforcer.check`` reads only ``action.required_ring``. When a classifier
+    assigns a more privileged ring (lower ``.value``) than the action declares,
+    return a lightweight shim carrying the tighter requirement so the gate
+    honors the classifier. The requirement is only ever TIGHTENED, never
+    loosened: a classifier that returns a more permissive ring is ignored so the
+    gate cannot be weakened. When there is no tightening the original action is
+    returned unchanged.
+    """
+    declared = getattr(action, "required_ring", None)
+    declared_value = getattr(declared, "value", None)
+    classified_value = getattr(classified_ring, "value", None)
+    if (
+        classified_ring is not None
+        and classified_value is not None
+        and declared_value is not None
+        and classified_value < declared_value
+    ):
+        return SimpleNamespace(required_ring=classified_ring)
+    return action
+
+
+class KernelBridge:
+    """Compose one ACS decision into trust, audit and ring outcomes.
+
+    Dependencies are injected so this class imports none of ``agentmesh``,
+    ``agent_os`` or ``hypervisor``. ``trust_tracker`` and ``emit_event`` are
+    required; ``ring_enforcer`` and ``action_classifier`` are optional. When no
+    ring enforcer is injected the ring gate is inactive (``ring_allowed`` stays
+    true) because there is no configured ring constraint to violate.
+    """
+
+    def __init__(
+        self,
+        *,
+        trust_tracker: TrustTrackerLike,
+        emit_event: EmitEvent,
+        ring_enforcer: Optional[RingEnforcerLike] = None,
+        action_classifier: Optional[ActionClassifierLike] = None,
+    ) -> None:
+        if trust_tracker is None:
+            raise ValueError("trust_tracker is required")
+        if emit_event is None:
+            raise ValueError("emit_event is required")
+        self._trust = trust_tracker
+        self._emit = emit_event
+        self._rings = ring_enforcer
+        self._classifier = action_classifier
+        self._locks: dict[str, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+        self._seen_keys: set[str] = set()
+
+    def _lock_for(self, agent_id: str) -> threading.Lock:
+        with self._locks_guard:
+            lock = self._locks.get(agent_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._locks[agent_id] = lock
+            return lock
+
+    def apply(
+        self,
+        decision: Optional[KernelDecision],
+        *,
+        agent_id: str,
+        peer_id: str = "",
+        action: Any = "",
+        current_ring: Any = None,
+        has_consensus: bool = False,
+        strict_audit: bool = True,
+        idempotency_key: str | None = None,
+    ) -> KernelOutcome:
+        """Drive trust, audit and rings from one ACS decision.
+
+        Args:
+            decision: The normalized ACS decision. ``None`` is treated as a fail
+                closed deny.
+            agent_id: Subject of the trust update and ring evaluation. Must be a
+                non-empty string.
+            peer_id: Counterparty recorded in the trust interaction.
+            action: Either a ``hypervisor.models.ActionDescriptor`` (enables the
+                ring gate via ``required_ring``; an injected classifier may
+                tighten that required ring) or a bare string (trust and audit
+                only; the ring gate is not applicable).
+            current_ring: The agent's current execution ring. When a ring
+                enforcer is injected and ``action`` is a descriptor, a ``None``
+                ring fails the gate closed (the action is blocked) rather than
+                skipping it.
+            has_consensus: Passed through to ring computation and the check.
+            strict_audit: When true, a governance event that is not accepted for
+                delivery drives ``proceeds`` false.
+            idempotency_key: When repeated, the trust delta is not applied twice
+                (guards audit-failure retries).
+
+        Returns:
+            A :class:`KernelOutcome` whose ``proceeds`` is the AND of the
+            decision, ring and (strict) audit gates.
+        """
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            raise ValueError("agent_id must be a non-empty string")
+
+        if decision is None:
+            decision = KernelDecision.from_decision(
+                "deny", reason="fail_closed:missing_decision"
+            )
+
+        if decision.is_recognized:
+            effective = decision.effective_decision
+            trust_action, event_kind, severity = _OUTCOME_MAP[effective]
+            reason = decision.reason
+        else:
+            effective = "deny"
+            trust_action, event_kind, severity = _FAIL_CLOSED_OUTCOME
+            reason = (
+                decision.reason
+                or f"fail_closed:unrecognized_decision:{decision.effective_decision}"
+            )
+
+        # A raw escalate keeps its escalation semantics for trust and audit even
+        # after the approval path rewrote the effective decision. The human made
+        # the call, so trust stays neutral (the agent neither earned nor lost
+        # reputation) and the event records the escalation, regardless of whether
+        # the effective decision permits (approved) or blocks (rejected). The
+        # effective decision still drives ``acs_permits`` below, so an approved
+        # escalate can proceed subject to the ring and audit gates.
+        if decision.was_escalated:
+            trust_action = "neutral"
+            event_kind = "escalation_requested"
+            severity = "warning"
+
+        acs_permits = effective in _PERMITTING_DECISIONS
+        action_name = _action_name(action)
+
+        dep_error: str | None = None
+
+        # --- Trust (atomic per agent; idempotent on retry) --------------------
+        trust_score = 0.0
+        trust_delta = 0.0
+        try:
+            with self._lock_for(agent_id):
+                # Scope the idempotency key per agent: a host that derives the key
+                # from a shared correlation id must not let one agent's key
+                # suppress a different agent's trust/ring update.
+                seen_key = (
+                    (agent_id, idempotency_key) if idempotency_key is not None else None
+                )
+                already_applied = seen_key is not None and seen_key in self._seen_keys
+                before = self._trust.get_score(agent_id)
+                if already_applied or trust_action == "neutral":
+                    trust_score = before
+                    trust_delta = 0.0
+                else:
+                    success = trust_action == "reward"
+                    trust_score = self._trust.record_interaction(
+                        agent_id, peer_id, action_name, success
+                    )
+                    trust_delta = trust_score - before
+                    if seen_key is not None:
+                        self._seen_keys.add(seen_key)
+        except Exception as exc:  # fail closed: never proceed on a trust error
+            dep_error = f"trust_error:{exc}"
+
+        # --- Classification (advisory ring, may TIGHTEN the required ring) -----
+        # Compute before the ring gate so the classifier's ring can raise the
+        # privilege the action requires. ActionClassifier.set_override is
+        # documented to take precedence, but RingEnforcer.check reads
+        # action.required_ring directly, so without this the injected classifier
+        # would be ignored by the gate.
+        classified_ring: Any = None
+        risk_weight: Any = None
+        if self._classifier is not None and _is_action_descriptor(action):
+            try:
+                classification = self._classifier.classify(action)
+                classified_ring = getattr(classification, "ring", None)
+                risk_weight = getattr(classification, "risk_weight", None)
+            except Exception:  # classification is advisory, not a gate
+                classified_ring = None
+                risk_weight = None
+
+        # --- Rings: conservative demotion, then the action gate ---------------
+        ring = current_ring
+        demoted = False
+        ring_allowed = True
+        ring_reason = ""
+        if self._rings is not None and dep_error is None:
+            try:
+                # Demote only in reaction to a penalizing ACS decision (deny or
+                # fail closed). Never demote on a permitting decision: agentmesh
+                # reputation and hypervisor eff_score are different scales (a
+                # neutral agentmesh 0.5 is below the RING_2 floor 0.60), so a
+                # permitted action must not spontaneously trip a ring, and trust
+                # must never auto-promote a ring here.
+                if (
+                    trust_action == "penalty"
+                    and current_ring is not None
+                    and self._rings.should_demote(current_ring, trust_score)
+                ):
+                    demoted = True
+                    ring = self._rings.compute_ring(trust_score, has_consensus)
+            except Exception as exc:
+                dep_error = f"ring_demote_error:{exc}"
+
+            # The ring gate applies to descriptor actions (those carrying a
+            # required_ring). A bare-string action has no ring surface, so the
+            # gate is intentionally not applicable and ring_allowed stays True.
+            if dep_error is None and _is_action_descriptor(action):
+                if current_ring is None:
+                    # Enforcer configured for a descriptor action but no agent
+                    # ring to evaluate against: fail closed rather than skip.
+                    ring_allowed = False
+                    ring_reason = "ring_state_missing:current_ring"
+                else:
+                    try:
+                        gate_action = _tighten_required_ring(action, classified_ring)
+                        check = self._rings.check(
+                            ring, gate_action, trust_score, has_consensus=has_consensus
+                        )
+                        allowed_attr = getattr(check, "allowed", None)
+                        # Fail closed when the check result omits .allowed rather
+                        # than defaulting an ambiguous result to allowed.
+                        ring_allowed = bool(allowed_attr) if allowed_attr is not None else False
+                        if not ring_allowed:
+                            ring_reason = (
+                                getattr(check, "reason", "")
+                                or ("ring_check_indeterminate" if allowed_attr is None else "ring_denied")
+                            )
+                    except Exception as exc:
+                        ring_allowed = False  # fail closed
+                        ring_reason = f"ring_check_error:{exc}"
+
+        # --- Audit ------------------------------------------------------------
+        attributes: dict[str, Any] = {
+            "peer_id": peer_id,
+            "raw_decision": decision.raw_decision,
+            "effective_decision": effective,
+            "was_escalated": decision.was_escalated,
+            "has_consensus": has_consensus,
+            "trust_score": trust_score,
+            "trust_delta": trust_delta,
+            "demoted": demoted,
+            "ring_allowed": ring_allowed,
+        }
+        if decision.approval_outcome is not None:
+            attributes["approval_outcome"] = decision.approval_outcome
+        if decision.input_identity is not None:
+            attributes["input_identity"] = decision.input_identity
+        if decision.enforced_identity is not None:
+            attributes["enforced_identity"] = decision.enforced_identity
+        if decision.transform is not None:
+            attributes["transform"] = dict(decision.transform)
+        if decision.evidence is not None:
+            attributes["evidence"] = dict(decision.evidence)
+        if classified_ring is not None:
+            attributes["classified_ring"] = getattr(
+                classified_ring, "value", classified_ring
+            )
+        if risk_weight is not None:
+            attributes["risk_weight"] = risk_weight
+        if dep_error is not None:
+            attributes["dep_error"] = dep_error
+
+        # Keep the audit record consistent with the enforced outcome: a trust or
+        # ring dependency error, or a ring denial, is a blocked action and must
+        # not be logged as a benign policy_check/info. This runs before emit; the
+        # audit-delivery gate (below) cannot relabel the event it is delivering.
+        if dep_error is not None or not ring_allowed:
+            event_kind = "policy_violation"
+            severity = "high"
+
+        event = GovernanceEventSpec(
+            kind=event_kind,
+            severity=severity,
+            agent_id=agent_id,
+            action=action_name,
+            decision=effective,
+            reason=reason,
+            attributes=attributes,
+        )
+
+        try:
+            audit = self._emit(event)
+        except Exception:
+            audit = AuditEmissionResult.FAILED
+        if not isinstance(audit, AuditEmissionResult):
+            audit = AuditEmissionResult.FAILED
+
+        # --- Composite gate ---------------------------------------------------
+        proceeds = acs_permits and ring_allowed and dep_error is None
+        if strict_audit and not audit.delivered:
+            proceeds = False
+
+        blocked_reason: str | None = None
+        if not proceeds:
+            if dep_error is not None:
+                blocked_reason = dep_error
+            elif not acs_permits:
+                blocked_reason = reason or f"decision:{effective}"
+            elif not ring_allowed:
+                blocked_reason = ring_reason or "ring_denied"
+            elif strict_audit and not audit.delivered:
+                blocked_reason = f"audit:{audit.value}"
+            else:
+                blocked_reason = "blocked"
+
+        return KernelOutcome(
+            proceeds=proceeds,
+            raw_decision=decision.raw_decision,
+            effective_decision=effective,
+            reason=reason,
+            trust_score=trust_score,
+            trust_delta=trust_delta,
+            ring=ring,
+            demoted=demoted,
+            ring_allowed=ring_allowed,
+            audit=audit,
+            event=event,
+            blocked_reason=blocked_reason,
+        )
+
+
+__all__ = [
+    "AuditEmissionResult",
+    "GovernanceEventSpec",
+    "KernelDecision",
+    "KernelOutcome",
+    "KernelBridge",
+    "TrustTrackerLike",
+    "RingEnforcerLike",
+    "ActionClassifierLike",
+    "EmitEvent",
+]

--- a/agent-governance-python/agt-policies/src/agt/policies/kernel.py
+++ b/agent-governance-python/agt-policies/src/agt/policies/kernel.py
@@ -40,6 +40,7 @@ implementations, so no import cycle forms with
 from __future__ import annotations
 
 import threading
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from enum import Enum
 from types import SimpleNamespace
@@ -53,6 +54,11 @@ _RECOGNIZED_DECISIONS = frozenset({"allow", "warn", "deny", "escalate", "transfo
 # warn and transform permit; deny and escalate halt until the host's approval
 # path resolves an escalate.
 _PERMITTING_DECISIONS = frozenset({"allow", "warn", "transform"})
+
+# Tool intervention points. A block at one of these emits the more specific
+# ``tool_call_blocked`` event kind instead of the generic ``policy_violation``.
+# Mirrors agent_control_specification.InterventionPoint.is_tool_intervention_point.
+_TOOL_INTERVENTION_POINTS = frozenset({"pre_tool_call", "post_tool_call"})
 
 # effective decision -> (trust action, governance event kind, severity).
 # trust action is one of "reward" (success=True), "penalty" (success=False) or
@@ -69,9 +75,21 @@ _OUTCOME_MAP: dict[str, tuple[str, str, str]] = {
     "escalate": ("neutral", "escalation_requested", "warning"),
 }
 
-# Applied when the decision is missing or unrecognized. Fail closed: treat as a
-# deny that penalizes trust and emits a violation.
-_FAIL_CLOSED_OUTCOME: tuple[str, str, str] = ("penalty", "policy_violation", "high")
+# Fail closed when the decision is missing or unrecognized: treat as a deny that
+# penalizes trust and emits a violation.
+_FAIL_CLOSED_TRUST = "penalty"
+_FAIL_CLOSED_SEVERITY = "high"
+
+# Bounds on per-bridge state so a long-lived bridge does not grow without limit.
+_LOCK_STRIPES = 64
+_DEFAULT_MAX_SEEN_KEYS = 100_000
+
+
+def _block_event_kind(intervention_point: str | None) -> str:
+    """Event kind for a BLOCKED action: tool_call_blocked at a tool point."""
+    if intervention_point in _TOOL_INTERVENTION_POINTS:
+        return "tool_call_blocked"
+    return "policy_violation"
 
 
 class AuditEmissionResult(str, Enum):
@@ -132,6 +150,7 @@ class KernelDecision:
     raw_decision: str
     reason: str = ""
     approval_outcome: str | None = None
+    intervention_point: str | None = None
     input_identity: str | None = None
     enforced_identity: str | None = None
     transform: Mapping[str, Any] | None = None
@@ -201,20 +220,22 @@ class KernelDecision:
         audit_entry = getattr(result, "audit_entry", None) or {}
         raw = None
         approval_outcome = None
+        intervention_point = None
         if isinstance(audit_entry, Mapping):
             # AgtRuntime._result_from_intervention records the raw engine verdict
             # under audit_entry["verdict"] (runtime.py) and keeps it there even
             # after the approval path rewrites the effective verdict, so an
             # approved escalate survives as audit_entry["verdict"] == "escalate"
             # while result.verdict == "allow". Recover it from there (falling back
-            # to older raw_decision/original_verdict keys). approval_outcome is
-            # written under audit_entry["approval_outcome"] by the same path.
+            # to older raw_decision/original_verdict keys). approval_outcome and
+            # intervention_point are written under the same audit_entry.
             raw = (
                 audit_entry.get("raw_decision")
                 or audit_entry.get("original_verdict")
                 or audit_entry.get("verdict")
             )
             approval_outcome = audit_entry.get("approval_outcome")
+            intervention_point = audit_entry.get("intervention_point") or None
         if raw is None:
             category = getattr(result, "category", None)
             category_value = getattr(category, "value", category)
@@ -231,6 +252,7 @@ class KernelDecision:
             raw_decision=str(raw),
             reason=getattr(result, "reason", "") or "",
             approval_outcome=approval_outcome,
+            intervention_point=intervention_point,
             input_identity=getattr(result, "input_identity", None),
             enforced_identity=getattr(result, "enforced_identity", None),
             transform=getattr(result, "transform", None),
@@ -238,14 +260,17 @@ class KernelDecision:
         )
 
     @classmethod
-    def from_intervention_point_result(cls, result: Any) -> "KernelDecision":
+    def from_intervention_point_result(
+        cls, result: Any, *, intervention_point: str | None = None
+    ) -> "KernelDecision":
         """Build from a raw ACS ``InterventionPointResult``.
 
         This is the lossless seam for hosts that do not use ``AgtRuntime``. The
         ``InterventionPointResult`` carries the verdict as the engine produced
         it (before host approval routing), so ``raw_decision`` and
         ``effective_decision`` are equal and an ``escalate`` is preserved
-        verbatim.
+        verbatim. ``intervention_point`` (which the raw result does not carry)
+        can be passed so a tool-point block audits as ``tool_call_blocked``.
         """
         verdict = getattr(result, "verdict", None)
         decision = getattr(verdict, "decision", None)
@@ -256,6 +281,7 @@ class KernelDecision:
             effective_decision=decision_value,
             raw_decision=decision_value,
             reason=getattr(verdict, "reason", None) or "",
+            intervention_point=intervention_point,
             input_identity=getattr(result, "input_identity", None),
             enforced_identity=getattr(result, "enforced_identity", None),
             transform=getattr(verdict, "transform", None),
@@ -393,6 +419,7 @@ class KernelBridge:
         emit_event: EmitEvent,
         ring_enforcer: Optional[RingEnforcerLike] = None,
         action_classifier: Optional[ActionClassifierLike] = None,
+        max_seen_keys: int = _DEFAULT_MAX_SEEN_KEYS,
     ) -> None:
         if trust_tracker is None:
             raise ValueError("trust_tracker is required")
@@ -402,17 +429,36 @@ class KernelBridge:
         self._emit = emit_event
         self._rings = ring_enforcer
         self._classifier = action_classifier
-        self._locks: dict[str, threading.Lock] = {}
-        self._locks_guard = threading.Lock()
-        self._seen_keys: set[str] = set()
+        # Fixed-size striped lock pool keyed by hash(agent_id): bounds memory for
+        # long-lived bridges with high agent-id cardinality while still
+        # serializing concurrent apply() calls for the same agent (a given
+        # agent_id always maps to the same stripe). Distinct agents may share a
+        # stripe, which only costs occasional contention.
+        self._locks: tuple[threading.Lock, ...] = tuple(
+            threading.Lock() for _ in range(_LOCK_STRIPES)
+        )
+        # Idempotency ledger, bounded LRU. Guarded by its own lock because it is
+        # shared across stripes.
+        self._max_seen_keys = max(1, max_seen_keys)
+        self._seen_keys: "OrderedDict[tuple[str, str], None]" = OrderedDict()
+        self._seen_lock = threading.Lock()
 
     def _lock_for(self, agent_id: str) -> threading.Lock:
-        with self._locks_guard:
-            lock = self._locks.get(agent_id)
-            if lock is None:
-                lock = threading.Lock()
-                self._locks[agent_id] = lock
-            return lock
+        return self._locks[hash(agent_id) % _LOCK_STRIPES]
+
+    def _seen_contains(self, key: tuple[str, str]) -> bool:
+        with self._seen_lock:
+            if key in self._seen_keys:
+                self._seen_keys.move_to_end(key)
+                return True
+            return False
+
+    def _seen_add(self, key: tuple[str, str]) -> None:
+        with self._seen_lock:
+            self._seen_keys[key] = None
+            self._seen_keys.move_to_end(key)
+            while len(self._seen_keys) > self._max_seen_keys:
+                self._seen_keys.popitem(last=False)
 
     def apply(
         self,
@@ -445,8 +491,16 @@ class KernelBridge:
             has_consensus: Passed through to ring computation and the check.
             strict_audit: When true, a governance event that is not accepted for
                 delivery drives ``proceeds`` false.
-            idempotency_key: When repeated, the trust delta is not applied twice
-                (guards audit-failure retries).
+            idempotency_key: When repeated for the same ``agent_id``, the trust
+                delta is not applied twice (guards audit-failure retries). The
+                key is scoped per agent, so one agent's key never suppresses
+                another agent's update.
+
+        Trust semantics: a penalty (deny or fail-closed) is applied immediately
+        and unconditionally because it drives ring demotion. A reward (allow) is
+        deferred and committed only if the action ultimately ``proceeds`` -- a
+        blocked allow is never recorded as a trust success. Warn, transform and
+        escalate are trust-neutral.
 
         Returns:
             A :class:`KernelOutcome` whose ``proceeds`` is the AND of the
@@ -460,13 +514,24 @@ class KernelBridge:
                 "deny", reason="fail_closed:missing_decision"
             )
 
+        # ``block_kind`` is the event kind used for any BLOCKED outcome: the more
+        # specific ``tool_call_blocked`` at a tool intervention point, else the
+        # generic ``policy_violation``.
+        block_kind = _block_event_kind(decision.intervention_point)
+
         if decision.is_recognized:
             effective = decision.effective_decision
             trust_action, event_kind, severity = _OUTCOME_MAP[effective]
+            if effective == "deny":
+                event_kind = block_kind
             reason = decision.reason
         else:
             effective = "deny"
-            trust_action, event_kind, severity = _FAIL_CLOSED_OUTCOME
+            trust_action, event_kind, severity = (
+                _FAIL_CLOSED_TRUST,
+                block_kind,
+                _FAIL_CLOSED_SEVERITY,
+            )
             reason = (
                 decision.reason
                 or f"fail_closed:unrecognized_decision:{decision.effective_decision}"
@@ -490,8 +555,16 @@ class KernelBridge:
         dep_error: str | None = None
 
         # --- Trust (atomic per agent; idempotent on retry) --------------------
+        # Penalties are applied here, unconditionally: a denied or fail-closed
+        # action loses trust and drives ring demotion below. A REWARD is deferred
+        # (pending_reward) and only committed after the composite gate confirms
+        # the action proceeds, so a blocked allow is never recorded as a success
+        # (which would contradict the emitted block event).
         trust_score = 0.0
         trust_delta = 0.0
+        pending_reward = False
+        seen_key: tuple[str, str] | None = None
+        already_applied = False
         try:
             with self._lock_for(agent_id):
                 # Scope the idempotency key per agent: a host that derives the key
@@ -500,19 +573,20 @@ class KernelBridge:
                 seen_key = (
                     (agent_id, idempotency_key) if idempotency_key is not None else None
                 )
-                already_applied = seen_key is not None and seen_key in self._seen_keys
+                already_applied = seen_key is not None and self._seen_contains(seen_key)
                 before = self._trust.get_score(agent_id)
+                trust_score = before
                 if already_applied or trust_action == "neutral":
-                    trust_score = before
                     trust_delta = 0.0
-                else:
-                    success = trust_action == "reward"
+                elif trust_action == "penalty":
                     trust_score = self._trust.record_interaction(
-                        agent_id, peer_id, action_name, success
+                        agent_id, peer_id, action_name, False
                     )
                     trust_delta = trust_score - before
                     if seen_key is not None:
-                        self._seen_keys.add(seen_key)
+                        self._seen_add(seen_key)
+                else:  # reward: defer until the gate confirms the action proceeds
+                    pending_reward = True
         except Exception as exc:  # fail closed: never proceed on a trust error
             dep_error = f"trust_error:{exc}"
 
@@ -615,12 +689,13 @@ class KernelBridge:
         if dep_error is not None:
             attributes["dep_error"] = dep_error
 
-        # Keep the audit record consistent with the enforced outcome: a trust or
-        # ring dependency error, or a ring denial, is a blocked action and must
-        # not be logged as a benign policy_check/info. This runs before emit; the
-        # audit-delivery gate (below) cannot relabel the event it is delivering.
-        if dep_error is not None or not ring_allowed:
-            event_kind = "policy_violation"
+        # Keep the audit record consistent with the enforced outcome: a permit
+        # (policy_check) that a dependency error or ring denial actually blocked
+        # must not be logged as benign. Relabel it to the block kind. Escalation
+        # events keep their kind (the escalation is the salient signal); deny is
+        # already the block kind.
+        if (dep_error is not None or not ring_allowed) and event_kind == "policy_check":
+            event_kind = block_kind
             severity = "high"
 
         event = GovernanceEventSpec(
@@ -644,6 +719,33 @@ class KernelBridge:
         proceeds = acs_permits and ring_allowed and dep_error is None
         if strict_audit and not audit.delivered:
             proceeds = False
+
+        # Commit a deferred reward only now that the action is confirmed to
+        # proceed. A trust error here is post-authorization bookkeeping: it must
+        # not retroactively block the already-permitted, already-audited action,
+        # so it is captured in an attribute without flipping ``proceeds``.
+        if pending_reward and proceeds:
+            try:
+                with self._lock_for(agent_id):
+                    # Re-check the ledger under the lock: two concurrent same-key
+                    # allows both defer in phase 1 (the key is not added until a
+                    # reward commits), so phase 2 must confirm no other call
+                    # already committed this key before recording.
+                    if seen_key is not None and self._seen_contains(seen_key):
+                        trust_score = self._trust.get_score(agent_id)
+                        trust_delta = 0.0
+                    else:
+                        before_reward = self._trust.get_score(agent_id)
+                        trust_score = self._trust.record_interaction(
+                            agent_id, peer_id, action_name, True
+                        )
+                        trust_delta = trust_score - before_reward
+                        if seen_key is not None:
+                            self._seen_add(seen_key)
+            except Exception:  # pragma: no cover - defensive
+                # Bookkeeping failure after authorization: leave trust unchanged
+                # (trust_delta stays 0) rather than blocking an approved action.
+                trust_delta = 0.0
 
         blocked_reason: str | None = None
         if not proceeds:

--- a/agent-governance-python/agt-policies/src/agt/policies/kernel.py
+++ b/agent-governance-python/agt-policies/src/agt/policies/kernel.py
@@ -319,10 +319,10 @@ class TrustTrackerLike(Protocol):
     def record_interaction(
         self, agent_id: str, peer_id: str, action: str, success: bool
     ) -> float:
-        ...
+        """Record a trust interaction and return the agent's new score."""
 
     def get_score(self, agent_id: str) -> float:
-        ...
+        """Return the agent's current trust score."""
 
 
 @runtime_checkable
@@ -330,10 +330,10 @@ class RingEnforcerLike(Protocol):
     """Structural surface of ``hypervisor.rings.RingEnforcer`` the bridge needs."""
 
     def compute_ring(self, eff_score: float, has_consensus: bool = ...) -> Any:
-        ...
+        """Return the execution ring implied by a trust/effective score."""
 
     def should_demote(self, current_ring: Any, eff_score: float) -> bool:
-        ...
+        """Return True when the score warrants demoting the current ring."""
 
     def check(
         self,
@@ -343,7 +343,7 @@ class RingEnforcerLike(Protocol):
         has_consensus: bool = ...,
         has_sre_witness: bool = ...,
     ) -> Any:
-        ...
+        """Return the ring check result for an action at the agent's ring."""
 
 
 @runtime_checkable
@@ -351,7 +351,7 @@ class ActionClassifierLike(Protocol):
     """Structural surface of ``hypervisor.rings.ActionClassifier`` the bridge needs."""
 
     def classify(self, action: Any) -> Any:
-        ...
+        """Return the classification (ring, risk weight) for an action."""
 
 
 # Host callback that delivers one governance event and reports whether it was

--- a/agent-governance-python/agt-policies/tests/test_kernel.py
+++ b/agent-governance-python/agt-policies/tests/test_kernel.py
@@ -1,0 +1,521 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Unit tests for agt.policies.kernel.KernelBridge.
+
+These exercise the mediator with dependency-injected fakes so the trust / audit
+/ ring wiring is verified without importing agentmesh, agent_os or hypervisor.
+The runnable example (examples/acs_kernel_wiring) covers the real subsystems.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agt.policies.kernel import (
+    AuditEmissionResult,
+    GovernanceEventSpec,
+    KernelBridge,
+    KernelDecision,
+)
+
+
+class FakeTrust:
+    """Minimal TrustTrackerLike: reward +0.1, penalty -0.2, clamp 0..1."""
+
+    def __init__(self, initial: float = 0.5) -> None:
+        self._scores: dict[str, float] = {}
+        self._initial = initial
+        self.calls: list[tuple[str, str, str, bool]] = []
+
+    def get_score(self, agent_id: str) -> float:
+        return self._scores.get(agent_id, self._initial)
+
+    def record_interaction(
+        self, agent_id: str, peer_id: str, action: str, success: bool
+    ) -> float:
+        self.calls.append((agent_id, peer_id, action, success))
+        current = self.get_score(agent_id)
+        delta = 0.1 if success else -0.2
+        new = max(0.0, min(1.0, current + delta))
+        self._scores[agent_id] = new
+        return new
+
+
+class FakeRing:
+    """RingEnforcerLike fake. ``allow_check`` toggles the action gate."""
+
+    def __init__(self, allow_check: bool = True, demote: bool = False) -> None:
+        self.allow_check = allow_check
+        self.demote = demote
+        self.checked: list[tuple] = []
+
+    def compute_ring(self, eff_score, has_consensus=False):
+        return 3 if eff_score < 0.6 else 2
+
+    def should_demote(self, current_ring, eff_score) -> bool:
+        return self.demote
+
+    def check(self, agent_ring, action, eff_score, has_consensus=False, has_sre_witness=False):
+        self.checked.append((agent_ring, action, eff_score))
+        reason = "ok" if self.allow_check else "ring insufficient"
+        return SimpleNamespace(allowed=self.allow_check, reason=reason)
+
+
+class FakeClassifier:
+    def classify(self, action):
+        return SimpleNamespace(ring=1, risk_weight=0.9)
+
+
+def _ring(value: int) -> SimpleNamespace:
+    """A duck-typed ExecutionRing (only ``.value`` is read by the mediator)."""
+    return SimpleNamespace(value=value)
+
+
+class RingByRequirement:
+    """RingEnforcerLike that honors the action's required_ring like the real one.
+
+    Allowed when ``agent_ring.value <= required_ring.value`` (lower value = more
+    privileged), matching hypervisor RingEnforcer.check semantics.
+    """
+
+    def __init__(self) -> None:
+        self.checked: list[tuple] = []
+
+    def compute_ring(self, eff_score, has_consensus=False):
+        return _ring(3 if eff_score < 0.6 else 2)
+
+    def should_demote(self, current_ring, eff_score) -> bool:
+        return False
+
+    def check(self, agent_ring, action, eff_score, has_consensus=False, has_sre_witness=False):
+        req = action.required_ring
+        req_val = getattr(req, "value", req)
+        ag_val = getattr(agent_ring, "value", agent_ring)
+        allowed = ag_val <= req_val
+        self.checked.append((ag_val, req_val))
+        return SimpleNamespace(allowed=allowed, reason="ok" if allowed else "ring insufficient")
+
+
+class TighteningClassifier:
+    """Classifier that reclassifies every action to a stricter ring."""
+
+    def __init__(self, ring_value: int) -> None:
+        self._ring = _ring(ring_value)
+
+    def classify(self, action):
+        return SimpleNamespace(ring=self._ring, risk_weight=0.9)
+
+
+def _emitter(result: AuditEmissionResult = AuditEmissionResult.ACCEPTED):
+    events: list[GovernanceEventSpec] = []
+
+    def emit(event: GovernanceEventSpec) -> AuditEmissionResult:
+        events.append(event)
+        return result
+
+    emit.events = events  # type: ignore[attr-defined]
+    return emit
+
+
+def _tool_action(required_ring: int) -> SimpleNamespace:
+    """A duck-typed ActionDescriptor with the ring surface check() reads."""
+    return SimpleNamespace(name="send_email", action_id="send_email", required_ring=required_ring)
+
+
+def _bridge(trust=None, emit=None, rings=None, classifier=None) -> KernelBridge:
+    return KernelBridge(
+        trust_tracker=trust or FakeTrust(),
+        emit_event=emit or _emitter(),
+        ring_enforcer=rings,
+        action_classifier=classifier,
+    )
+
+
+def test_deny_penalizes_trust_emits_violation_and_blocks():
+    trust = FakeTrust()
+    emit = _emitter()
+    bridge = _bridge(trust=trust, emit=emit)
+
+    out = bridge.apply(
+        KernelDecision.from_decision("deny", reason="blocked_pattern_input"),
+        agent_id="a1",
+        peer_id="p1",
+    )
+
+    assert out.proceeds is False
+    assert out.trust_delta == pytest.approx(-0.2)
+    assert trust.get_score("a1") == pytest.approx(0.3)
+    assert emit.events[0].kind == "policy_violation"
+    assert emit.events[0].severity == "high"
+    assert out.blocked_reason == "blocked_pattern_input"
+
+
+def test_allow_rewards_trust_emits_policy_check_and_proceeds():
+    trust = FakeTrust()
+    emit = _emitter()
+    bridge = _bridge(trust=trust, emit=emit)
+
+    out = bridge.apply(KernelDecision.from_decision("allow"), agent_id="a1")
+
+    assert out.proceeds is True
+    assert out.trust_delta == pytest.approx(0.1)
+    assert emit.events[0].kind == "policy_check"
+    assert out.audit is AuditEmissionResult.ACCEPTED
+
+
+@pytest.mark.parametrize("decision", ["warn", "transform"])
+def test_permitting_but_not_allow_is_trust_neutral(decision):
+    trust = FakeTrust()
+    bridge = _bridge(trust=trust)
+
+    out = bridge.apply(KernelDecision.from_decision(decision), agent_id="a1")
+
+    assert out.proceeds is True
+    assert out.trust_delta == 0.0
+    assert trust.calls == []  # no record_interaction for neutral verdicts
+
+
+def test_escalate_is_neutral_blocks_and_preserves_raw():
+    trust = FakeTrust()
+    emit = _emitter()
+    bridge = _bridge(trust=trust, emit=emit)
+
+    out = bridge.apply(KernelDecision.from_decision("escalate"), agent_id="a1")
+
+    assert out.proceeds is False
+    assert out.trust_delta == 0.0
+    assert out.raw_decision == "escalate"
+    assert emit.events[0].kind == "escalation_requested"
+
+
+def test_ring_gate_blocks_permitted_decision_when_ring_insufficient():
+    rings = FakeRing(allow_check=False)
+    out = _bridge(rings=rings).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=_tool_action(required_ring=1),
+        current_ring=3,
+    )
+
+    assert out.ring_allowed is False
+    assert out.proceeds is False  # ACS allow is necessary but not sufficient
+    assert out.blocked_reason == "ring insufficient"
+    assert rings.checked  # check() actually ran
+
+
+def test_ring_gate_allows_when_ring_sufficient():
+    rings = FakeRing(allow_check=True)
+    out = _bridge(rings=rings).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=_tool_action(required_ring=3),
+        current_ring=2,
+    )
+    assert out.ring_allowed is True
+    assert out.proceeds is True
+
+
+def test_strict_audit_failure_blocks_proceed():
+    emit = _emitter(AuditEmissionResult.NO_SINK)
+    out = _bridge(emit=emit).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1", strict_audit=True
+    )
+    assert out.audit is AuditEmissionResult.NO_SINK
+    assert out.proceeds is False
+    assert out.blocked_reason == "audit:no_sink"
+
+
+def test_non_strict_audit_failure_still_proceeds():
+    emit = _emitter(AuditEmissionResult.DROPPED)
+    out = _bridge(emit=emit).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1", strict_audit=False
+    )
+    assert out.audit is AuditEmissionResult.DROPPED
+    assert out.proceeds is True
+
+
+def test_emitter_returning_non_result_is_failed():
+    def bad_emit(event):
+        return None
+
+    out = _bridge(emit=bad_emit).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1", strict_audit=True
+    )
+    assert out.audit is AuditEmissionResult.FAILED
+    assert out.proceeds is False
+
+
+def test_emitter_raising_is_failed_not_propagated():
+    def boom_emit(event):
+        raise RuntimeError("sink down")
+
+    out = _bridge(emit=boom_emit).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1", strict_audit=True
+    )
+    assert out.audit is AuditEmissionResult.FAILED
+    assert out.proceeds is False
+
+
+def test_fail_closed_on_none_decision():
+    trust = FakeTrust()
+    emit = _emitter()
+    out = _bridge(trust=trust, emit=emit).apply(None, agent_id="a1")
+    assert out.proceeds is False
+    assert out.effective_decision == "deny"
+    assert out.trust_delta == pytest.approx(-0.2)
+    assert emit.events[0].kind == "policy_violation"
+
+
+def test_fail_closed_on_unrecognized_decision():
+    trust = FakeTrust()
+    out = _bridge(trust=trust).apply(
+        KernelDecision.from_decision("maybe"), agent_id="a1"
+    )
+    assert out.proceeds is False
+    assert out.effective_decision == "deny"
+    assert out.trust_delta == pytest.approx(-0.2)
+    assert out.blocked_reason.startswith("fail_closed:unrecognized_decision")
+
+
+def test_empty_agent_id_raises():
+    with pytest.raises(ValueError):
+        _bridge().apply(KernelDecision.from_decision("allow"), agent_id="  ")
+
+
+def test_idempotency_key_prevents_double_apply():
+    trust = FakeTrust()
+    bridge = _bridge(trust=trust)
+
+    first = bridge.apply(
+        KernelDecision.from_decision("deny"), agent_id="a1", idempotency_key="k1"
+    )
+    second = bridge.apply(
+        KernelDecision.from_decision("deny"), agent_id="a1", idempotency_key="k1"
+    )
+
+    assert first.trust_delta == pytest.approx(-0.2)
+    assert second.trust_delta == 0.0  # retry does not re-penalize
+    assert trust.get_score("a1") == pytest.approx(0.3)
+
+
+def test_dep_error_fails_closed():
+    class BoomTrust(FakeTrust):
+        def record_interaction(self, *a, **k):
+            raise RuntimeError("trust backend down")
+
+    out = _bridge(trust=BoomTrust()).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1"
+    )
+    assert out.proceeds is False
+    assert out.blocked_reason.startswith("trust_error:")
+
+
+def test_demotion_recomputes_ring_on_penalty():
+    rings = FakeRing(allow_check=True, demote=True)
+    out = _bridge(rings=rings).apply(
+        KernelDecision.from_decision("deny"),
+        agent_id="a1",
+        action=_tool_action(required_ring=3),
+        current_ring=2,
+    )
+    assert out.demoted is True
+    assert out.ring == 3  # compute_ring result for the dropped score
+
+
+def test_from_evaluation_result_recovers_escalate_from_category():
+    result = SimpleNamespace(
+        verdict="allow",
+        audit_entry={},
+        category="HUMAN_APPROVAL",
+        reason="approved",
+        input_identity="id-in",
+        enforced_identity="id-enf",
+        transform=None,
+        evidence=None,
+    )
+    decision = KernelDecision.from_evaluation_result(result)
+    assert decision.effective_decision == "allow"
+    assert decision.raw_decision == "escalate"
+    assert decision.was_escalated is True
+
+
+def test_from_evaluation_result_prefers_audit_entry_raw():
+    result = SimpleNamespace(
+        verdict="deny",
+        audit_entry={"raw_decision": "escalate"},
+        category=None,
+        reason="",
+        input_identity=None,
+        enforced_identity=None,
+        transform=None,
+        evidence=None,
+    )
+    decision = KernelDecision.from_evaluation_result(result)
+    assert decision.raw_decision == "escalate"
+    assert decision.effective_decision == "deny"
+
+
+def test_from_intervention_point_result_preserves_escalate():
+    ipr = SimpleNamespace(
+        verdict=SimpleNamespace(
+            decision=SimpleNamespace(value="escalate"),
+            reason="needs approval",
+            transform=None,
+            evidence=None,
+        ),
+        input_identity="id-in",
+        enforced_identity="id-enf",
+    )
+    decision = KernelDecision.from_intervention_point_result(ipr)
+    assert decision.effective_decision == "escalate"
+    assert decision.raw_decision == "escalate"
+    assert decision.reason == "needs approval"
+
+
+# --- Remediation regression tests (deep-review Stage 4) ---------------------
+
+
+def test_from_evaluation_result_recovers_escalate_from_audit_verdict_key():
+    # AgtRuntime writes the raw verdict to audit_entry["verdict"] and the
+    # approval outcome to audit_entry["approval_outcome"]; an approved escalate
+    # arrives with effective verdict "allow".
+    result = SimpleNamespace(
+        verdict="allow",
+        audit_entry={"verdict": "escalate", "approval_outcome": "allow"},
+        category=None,
+        reason="approved",
+        input_identity=None,
+        enforced_identity=None,
+        transform=None,
+        evidence=None,
+    )
+    decision = KernelDecision.from_evaluation_result(result)
+    assert decision.effective_decision == "allow"
+    assert decision.raw_decision == "escalate"
+    assert decision.was_escalated is True
+    assert decision.approval_outcome == "allow"
+
+
+def test_approved_escalate_is_trust_neutral_and_audited_as_escalation():
+    # effective=allow permits, so it PROCEEDS, but the escalation semantics hold:
+    # trust neutral, event escalation_requested. This is the load-bearing use of
+    # the preserved raw verdict.
+    trust = FakeTrust()
+    emit = _emitter()
+    out = _bridge(trust=trust, emit=emit).apply(
+        KernelDecision.from_decision("allow", raw_decision="escalate"),
+        agent_id="a1",
+    )
+    assert out.proceeds is True
+    assert out.trust_delta == 0.0
+    assert trust.calls == []  # no reward for an approved escalation
+    assert emit.events[0].kind == "escalation_requested"
+    assert emit.events[0].attributes["was_escalated"] is True
+
+
+def test_ring_gate_fails_closed_when_current_ring_missing():
+    # Enforcer configured + descriptor action but no agent ring: block, do not skip.
+    rings = FakeRing(allow_check=True)
+    out = _bridge(rings=rings).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=_tool_action(required_ring=1),
+        current_ring=None,
+    )
+    assert out.ring_allowed is False
+    assert out.proceeds is False
+    assert out.blocked_reason == "ring_state_missing:current_ring"
+    assert rings.checked == []  # check() never reached
+
+
+def test_ring_check_without_allowed_attr_fails_closed():
+    class NoAllowedRing(FakeRing):
+        def check(self, agent_ring, action, eff_score, has_consensus=False, has_sre_witness=False):
+            return SimpleNamespace(reason="weird")  # no .allowed
+
+    out = _bridge(rings=NoAllowedRing()).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=_tool_action(required_ring=3),
+        current_ring=_ring(2),
+    )
+    assert out.ring_allowed is False
+    assert out.proceeds is False
+
+
+def test_classifier_tightens_required_ring_and_blocks():
+    # Action declares a permissive RING_3; classifier reclassifies to RING_1.
+    # Agent at RING_2 passes the declared ring but must fail the tightened one.
+    rings = RingByRequirement()
+    action = _tool_action_v(required_value=3)
+    out = _bridge(rings=rings, classifier=TighteningClassifier(ring_value=1)).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=action,
+        current_ring=_ring(2),
+    )
+    assert out.ring_allowed is False
+    assert out.proceeds is False
+    assert rings.checked == [(2, 1)]  # checked against the tightened requirement
+
+
+def test_classifier_never_loosens_required_ring():
+    # Classifier returns a MORE permissive ring; the declared stricter ring stands.
+    rings = RingByRequirement()
+    action = _tool_action_v(required_value=1)  # strict
+    out = _bridge(rings=rings, classifier=TighteningClassifier(ring_value=3)).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=action,
+        current_ring=_ring(2),
+    )
+    assert out.ring_allowed is False  # 2 > 1, still denied by the declared ring
+    assert rings.checked == [(2, 1)]  # never loosened to 3
+
+
+def test_idempotency_key_is_scoped_per_agent():
+    # The same key on a different agent must NOT suppress that agent's penalty.
+    trust = FakeTrust()
+    bridge = _bridge(trust=trust)
+    o1 = bridge.apply(KernelDecision.from_decision("deny"), agent_id="a1", idempotency_key="k")
+    o2 = bridge.apply(KernelDecision.from_decision("deny"), agent_id="a2", idempotency_key="k")
+    assert o1.trust_delta == pytest.approx(-0.2)
+    assert o2.trust_delta == pytest.approx(-0.2)  # a2 not suppressed by a1's key
+    assert trust.get_score("a2") == pytest.approx(0.3)
+
+
+def test_dep_error_event_relabeled_as_violation():
+    class BoomTrust(FakeTrust):
+        def record_interaction(self, *a, **k):
+            raise RuntimeError("trust backend down")
+
+    emit = _emitter()
+    out = _bridge(trust=BoomTrust(), emit=emit).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1"
+    )
+    assert out.proceeds is False
+    ev = emit.events[0]
+    # The audit record must reflect the block, not a benign policy_check/info.
+    assert ev.kind == "policy_violation"
+    assert ev.severity == "high"
+
+
+def test_ring_denied_event_relabeled_as_violation():
+    emit = _emitter()
+    out = _bridge(rings=FakeRing(allow_check=False), emit=emit).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=_tool_action(required_ring=1),
+        current_ring=3,
+    )
+    assert out.proceeds is False
+    assert emit.events[0].kind == "policy_violation"
+    assert emit.events[0].severity == "high"
+
+
+def _tool_action_v(required_value: int) -> SimpleNamespace:
+    """Descriptor whose required_ring carries a ``.value`` (like ExecutionRing)."""
+    return SimpleNamespace(
+        name="send_email", action_id="send_email", required_ring=_ring(required_value)
+    )

--- a/agent-governance-python/agt-policies/tests/test_kernel.py
+++ b/agent-governance-python/agt-policies/tests/test_kernel.py
@@ -299,16 +299,48 @@ def test_idempotency_key_prevents_double_apply():
     assert trust.get_score("a1") == pytest.approx(0.3)
 
 
-def test_dep_error_fails_closed():
+def test_penalty_trust_error_fails_closed():
+    # On the penalty path trust is a gate input (it drives demotion), so a trust
+    # backend error must fail closed.
     class BoomTrust(FakeTrust):
         def record_interaction(self, *a, **k):
             raise RuntimeError("trust backend down")
 
     out = _bridge(trust=BoomTrust()).apply(
+        KernelDecision.from_decision("deny"), agent_id="a1"
+    )
+    assert out.proceeds is False
+    assert out.blocked_reason.startswith("trust_error:")
+
+
+def test_get_score_error_fails_closed_on_allow():
+    # get_score is read before any gate; if the trust backend is unreadable we
+    # cannot govern, so even an allow fails closed.
+    class UnreadableTrust(FakeTrust):
+        def get_score(self, agent_id):
+            raise RuntimeError("trust backend unreadable")
+
+    out = _bridge(trust=UnreadableTrust()).apply(
         KernelDecision.from_decision("allow"), agent_id="a1"
     )
     assert out.proceeds is False
     assert out.blocked_reason.startswith("trust_error:")
+
+
+def test_reward_record_failure_does_not_block_authorized_action():
+    # The reward is deferred until the gate passes and is telemetry, not a gate
+    # input; a failure to RECORD it must not block an already-authorized action.
+    class RewardBoomTrust(FakeTrust):
+        def record_interaction(self, agent_id, peer_id, action, success):
+            if success:
+                raise RuntimeError("reward write failed")
+            return super().record_interaction(agent_id, peer_id, action, success)
+
+    out = _bridge(trust=RewardBoomTrust()).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1"
+    )
+    assert out.proceeds is True
+    assert out.trust_delta == 0.0
 
 
 def test_demotion_recomputes_ring_on_penalty():
@@ -486,12 +518,12 @@ def test_idempotency_key_is_scoped_per_agent():
 
 
 def test_dep_error_event_relabeled_as_violation():
-    class BoomTrust(FakeTrust):
-        def record_interaction(self, *a, **k):
-            raise RuntimeError("trust backend down")
+    class UnreadableTrust(FakeTrust):
+        def get_score(self, agent_id):
+            raise RuntimeError("trust backend unreadable")
 
     emit = _emitter()
-    out = _bridge(trust=BoomTrust(), emit=emit).apply(
+    out = _bridge(trust=UnreadableTrust(), emit=emit).apply(
         KernelDecision.from_decision("allow"), agent_id="a1"
     )
     assert out.proceeds is False
@@ -519,3 +551,238 @@ def _tool_action_v(required_value: int) -> SimpleNamespace:
     return SimpleNamespace(
         name="send_email", action_id="send_email", required_ring=_ring(required_value)
     )
+
+
+def test_blocked_allow_does_not_reward_trust():
+    # An ACS allow that the ring gate blocks must NOT be recorded as a trust
+    # success (the deferred-reward fix). No record_interaction, no delta.
+    trust = FakeTrust()
+    out = _bridge(trust=trust, rings=FakeRing(allow_check=False)).apply(
+        KernelDecision.from_decision("allow"),
+        agent_id="a1",
+        action=_tool_action(required_ring=1),
+        current_ring=3,
+    )
+    assert out.proceeds is False
+    assert out.trust_delta == 0.0
+    assert trust.get_score("a1") == pytest.approx(0.5)  # unchanged
+    assert trust.calls == []  # no success recorded for a blocked action
+
+
+def test_audit_blocked_allow_does_not_reward_trust():
+    # Same principle for a strict-audit block: no reward for a non-proceeding action.
+    trust = FakeTrust()
+    out = _bridge(trust=trust, emit=_emitter(AuditEmissionResult.NO_SINK)).apply(
+        KernelDecision.from_decision("allow"), agent_id="a1", strict_audit=True
+    )
+    assert out.proceeds is False
+    assert out.trust_delta == 0.0
+    assert trust.calls == []
+
+
+def test_tool_intervention_point_deny_emits_tool_call_blocked():
+    emit = _emitter()
+    out = _bridge(emit=emit).apply(
+        KernelDecision(
+            effective_decision="deny",
+            raw_decision="deny",
+            reason="blocked",
+            intervention_point="pre_tool_call",
+        ),
+        agent_id="a1",
+    )
+    assert out.proceeds is False
+    assert emit.events[0].kind == "tool_call_blocked"
+
+
+def test_non_tool_deny_stays_policy_violation():
+    emit = _emitter()
+    _bridge(emit=emit).apply(
+        KernelDecision(
+            effective_decision="deny",
+            raw_decision="deny",
+            reason="blocked",
+            intervention_point="input",
+        ),
+        agent_id="a1",
+    )
+    assert emit.events[0].kind == "policy_violation"
+
+
+def test_tool_point_allow_blocked_by_ring_relabels_to_tool_call_blocked():
+    emit = _emitter()
+    out = _bridge(emit=emit, rings=FakeRing(allow_check=False)).apply(
+        KernelDecision(
+            effective_decision="allow",
+            raw_decision="allow",
+            intervention_point="pre_tool_call",
+        ),
+        agent_id="a1",
+        action=_tool_action(required_ring=1),
+        current_ring=3,
+    )
+    assert out.proceeds is False
+    assert emit.events[0].kind == "tool_call_blocked"
+
+
+def test_from_evaluation_result_reads_intervention_point():
+    result = SimpleNamespace(
+        verdict="deny",
+        audit_entry={"verdict": "deny", "intervention_point": "pre_tool_call"},
+        category=None,
+        reason="",
+        input_identity=None,
+        enforced_identity=None,
+        transform=None,
+        evidence=None,
+    )
+    decision = KernelDecision.from_evaluation_result(result)
+    assert decision.intervention_point == "pre_tool_call"
+
+
+def test_locks_are_a_bounded_striped_pool():
+    from agt.policies.kernel import _LOCK_STRIPES
+
+    bridge = _bridge()
+    for i in range(500):
+        bridge.apply(KernelDecision.from_decision("deny"), agent_id=f"agent-{i}")
+    # The lock pool is fixed size regardless of agent-id cardinality.
+    assert len(bridge._locks) == _LOCK_STRIPES
+
+
+def test_seen_keys_are_bounded_and_evict_oldest():
+    bridge = KernelBridge(
+        trust_tracker=FakeTrust(),
+        emit_event=_emitter(),
+        max_seen_keys=3,
+    )
+    for i in range(10):
+        bridge.apply(
+            KernelDecision.from_decision("deny"),
+            agent_id=f"a{i}",
+            idempotency_key="k",
+        )
+    assert len(bridge._seen_keys) <= 3
+
+
+# --- Real-runtime escalate round-trip (deep-review Stage 4, #5) --------------
+#
+# Pins the coupling between KernelDecision.from_evaluation_result and the actual
+# AgtRuntime output: the raw escalate must be recoverable from a REAL approved
+# escalation, not just a hand-built EvaluationResult. Guards against a future
+# runtime refactor silently moving the audit_entry["verdict"] key.
+
+_ESCALATE_MANIFEST = (
+    "agent_control_specification_version: 0.3.0-alpha-agt\n"
+    "metadata:\n  name: kernel_escalate_test\n"
+    "extends: []\n"
+    "policies:\n  test_policy:\n    type: custom\n    adapter: kernel_escalate_adapter\n"
+    "intervention_points:\n  pre_tool_call:\n"
+    "    policy_target: $.tool_call.args\n"
+    "    policy_target_kind: tool_args\n"
+    "    tool_name_from: $.tool_call.name\n"
+    "    policy:\n      id: test_policy\n"
+    "tools:\n  lookup:\n    clearance: public\n"
+)
+
+
+def _run_real_escalate(tmp_path, *, approve: bool):
+    """Drive the real AgtRuntime through an escalate -> approve/deny cycle."""
+    from agt.policies import SnapshotBuilder
+    from agt.policies.runtime import AgtRuntime, ApprovalDecision
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(_ESCALATE_MANIFEST, encoding="utf-8")
+
+    class _EscalatePolicy:
+        def evaluate(self, invocation):  # noqa: ANN001
+            return {"decision": "escalate", "reason": "approval_required"}
+
+    def resolver(ip, result):  # noqa: ANN001
+        if approve:
+            return ApprovalDecision.allow(result.enforced_identity)
+        return ApprovalDecision.deny()
+
+    runtime = AgtRuntime(
+        manifest, policy_dispatcher=_EscalatePolicy(), approval_resolver=resolver
+    )
+    snapshot = SnapshotBuilder(agent_id="bot", session_id="s-1").pre_tool_call(
+        tool_name="lookup", args={"q": "x"}
+    )
+    return runtime.evaluate_intervention_point("pre_tool_call", snapshot)
+
+
+def test_real_runtime_approved_escalate_is_recovered_and_neutral(tmp_path):
+    pytest.importorskip("agent_control_specification")
+    result = _run_real_escalate(tmp_path, approve=True)
+    # The runtime rewrote the effective verdict to allow after approval.
+    assert result.verdict == "allow"
+
+    decision = KernelDecision.from_evaluation_result(result)
+    # ...but the raw escalate is recovered from the real runtime output.
+    assert decision.raw_decision == "escalate"
+    assert decision.was_escalated is True
+    assert decision.intervention_point == "pre_tool_call"
+
+    trust = FakeTrust()
+    emit = _emitter()
+    out = KernelBridge(trust_tracker=trust, emit_event=emit).apply(
+        decision, agent_id="bot"
+    )
+    # Approved escalate proceeds (effective allow) but earns no trust and audits
+    # as an escalation, not a reward.
+    assert out.proceeds is True
+    assert out.trust_delta == 0.0
+    assert trust.calls == []
+    assert emit.events[0].kind == "escalation_requested"
+
+
+def test_real_runtime_rejected_escalate_blocks_and_is_neutral(tmp_path):
+    pytest.importorskip("agent_control_specification")
+    result = _run_real_escalate(tmp_path, approve=False)
+    decision = KernelDecision.from_evaluation_result(result)
+    assert decision.was_escalated is True
+
+    trust = FakeTrust()
+    emit = _emitter()
+    out = KernelBridge(trust_tracker=trust, emit_event=emit).apply(
+        decision, agent_id="bot"
+    )
+    assert out.proceeds is False
+    assert out.trust_delta == 0.0  # rejection is the human's call, not the agent's fault
+    assert emit.events[0].kind == "escalation_requested"
+
+
+def test_concurrent_same_key_reward_applied_once():
+    # Two+ concurrent allows sharing (agent_id, idempotency_key) must reward the
+    # agent exactly once: phase 2 re-checks the ledger under the stripe lock.
+    import threading
+
+    trust = FakeTrust()
+    bridge = _bridge(trust=trust)
+    n = 8
+    barrier = threading.Barrier(n)
+    results = []
+    lock = threading.Lock()
+
+    def worker():
+        barrier.wait()
+        out = bridge.apply(
+            KernelDecision.from_decision("allow"),
+            agent_id="racer",
+            idempotency_key="dup",
+        )
+        with lock:
+            results.append(out.trust_delta)
+
+    threads = [threading.Thread(target=worker) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly one call recorded a success; the score moved by one reward only.
+    success_calls = [c for c in trust.calls if c[3] is True]
+    assert len(success_calls) == 1
+    assert trust.get_score("racer") == pytest.approx(0.6)
+    assert sum(1 for d in results if d != 0.0) == 1

--- a/examples/acs_kernel_wiring/README.md
+++ b/examples/acs_kernel_wiring/README.md
@@ -1,0 +1,85 @@
+# Wiring ACS verdicts into the AGT kernel
+
+This example shows how one ACS decision drives the three AGT kernel subsystems
+that are otherwise disconnected islands a host has to wire by hand:
+
+- **trust**  `agentmesh.trust_types.TrustTracker`
+- **audit**  `agent_os.event_sink` sink SPI (`GovernanceEvent` + `SinkExportResult`)
+- **rings**  `hypervisor.rings.RingEnforcer` and `ActionClassifier`
+
+`agt.policies.kernel.KernelBridge` is the glue. It is a dependency-injected,
+fail-closed composite gate. Given one `KernelDecision` (built from the
+`EvaluationResult` that `AgtRuntime.evaluate` returns) it updates trust, emits one
+governance event, evaluates the ring, and returns a single `KernelOutcome`.
+
+`KernelOutcome.proceeds` is the AND of every gate:
+
+```
+proceeds = ACS permits AND ring check allows AND (audit accepted, when strict) AND no dependency error
+```
+
+An ACS `allow` is necessary but not sufficient: the action is still blocked if
+the agent's ring is insufficient or the governance event could not be delivered.
+
+## Why the bridge is dependency-injected
+
+`agt-policies` does not depend on `agentmesh`, `agent_os` or `hypervisor`, and
+`agent_os` already imports `agt.policies`. The bridge takes those subsystems as
+injected Protocol implementations, so it never imports them and no import cycle
+forms. This example module is where the concrete subsystems meet the bridge.
+
+## Run
+
+From the repository root:
+
+```bash
+PYTHONPATH=agent-governance-python/agt-policies/src \
+    python examples/acs_kernel_wiring/wire_acs_into_kernel.py
+```
+
+## Expected output
+
+Three scenarios:
+
+| Scenario | ACS decision | Ring situation | Result |
+|----------|--------------|----------------|--------|
+| `deny` | deny on a reversible tool | agent at RING_2 | trust drops, `policy_violation` emitted, ring demoted to RING_3, `proceeds=False` |
+| `allow_ring_blocked` | allow on a non-reversible action | agent at RING_3, action needs RING_1 | ring check blocks despite the allow, `proceeds=False` |
+| `allow_ok` | allow on a reversible action | agent at RING_2, action needs RING_2 | trust rewarded, `policy_check` emitted, `proceeds=True` |
+
+The `deny` scenario is the repro from the task flipping: a single
+`KernelBridge.apply(...)` call now lowers trust, emits the governance event, and
+trips the ring, instead of the host doing all three by hand.
+
+Demotion is deliberately a reaction to a penalizing decision only. A permitting
+decision never trips a ring, because agentmesh reputation and hypervisor
+`eff_score` are different scales (a neutral agentmesh 0.5 is below the RING_2
+floor of 0.60), and trust is never used to auto-promote a ring.
+
+## Test
+
+```bash
+PYTHONPATH=agent-governance-python/agt-policies/src \
+    python -m pytest examples/acs_kernel_wiring/test_wiring.py -q
+```
+
+## Cleanup
+
+No files, threads, or external services are created. The audit sink is a plain
+in-memory recorder and the gate delivers to it synchronously.
+
+## Notes
+
+The audit event is delivered SYNCHRONOUSLY to the sink so the gate can know
+whether it landed before deciding `proceeds`. The example deliberately does not
+route the gate ack through `agent_os.event_sink.GovernanceEventProcessor`: its
+`on_event` is fire-and-forget (a background worker drains the queue and can drop
+under backpressure), so a gate that inferred delivery from it would race the
+worker. The processor is the right primitive for best-effort async fan-out to
+downstream SIEM, not for a synchronous fail-closed ack.
+
+`agent-hypervisor` emits a deprecation warning pointing at
+`agent-governance-toolkit-core`; the example uses it because it is the module that
+exposes `RingEnforcer` / `ActionClassifier` today. The bridge itself is
+subsystem-agnostic, so swapping the ring implementation only changes this wiring
+module, not `KernelBridge`.

--- a/examples/acs_kernel_wiring/test_wiring.py
+++ b/examples/acs_kernel_wiring/test_wiring.py
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Smoke test for the ACS -> AGT kernel wiring example.
+
+Runs the real subsystems (agentmesh trust, agent_os audit, hypervisor rings)
+through KernelBridge and asserts the ACS-decision-to-kernel repro flips: one
+apply() call lowers trust, emits a governance event, and gates the ring.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("agentmesh")
+pytest.importorskip("agent_os")
+pytest.importorskip("hypervisor")
+pytest.importorskip("agent_control_specification")
+
+from agt.policies.kernel import AuditEmissionResult  # noqa: E402
+from hypervisor.models import ExecutionRing  # noqa: E402
+
+from wire_acs_into_kernel import (  # noqa: E402
+    build_wired_kernel,
+    run_demo,
+    _acs_decision,
+    _reversible_tool,
+)
+
+
+def test_run_demo_flips_the_repro():
+    outcomes = run_demo()
+
+    deny = outcomes["deny"]
+    assert deny.effective_decision == "deny"
+    assert deny.proceeds is False
+    assert deny.trust_delta < 0  # trust lowered by the ACS deny
+    assert deny.demoted is True  # ring tripped down
+    assert deny.audit is AuditEmissionResult.ACCEPTED
+    assert deny.event.kind == "policy_violation"
+
+    blocked = outcomes["allow_ring_blocked"]
+    assert blocked.effective_decision == "allow"
+    assert blocked.ring_allowed is False
+    assert blocked.proceeds is False  # ACS allow is not sufficient
+
+    ok = outcomes["allow_ok"]
+    assert ok.proceeds is True
+    assert ok.trust_delta > 0
+    assert ok.event.kind == "policy_check"
+
+
+def test_single_apply_drives_all_three_subsystems():
+    wired = build_wired_kernel()
+    before = wired.trust.get_score("agent-x")
+
+    out = wired.bridge.apply(
+        _acs_decision("deny", reason="blocked_pattern_input"),
+        agent_id="agent-x",
+        peer_id="orchestrator",
+        action=_reversible_tool("send_email"),
+        current_ring=ExecutionRing.RING_2_STANDARD,
+    )
+
+    # trust moved
+    assert wired.trust.get_score("agent-x") < before
+    # audit delivered synchronously to the sink
+    assert wired.sink.count == 1
+    assert wired.sink.events[0].agent_id == "agent-x"
+    # ring evaluated
+    assert out.demoted is True

--- a/examples/acs_kernel_wiring/wire_acs_into_kernel.py
+++ b/examples/acs_kernel_wiring/wire_acs_into_kernel.py
@@ -1,0 +1,229 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Wire one ACS decision into the real AGT kernel through KernelBridge.
+
+This is the end-to-end counterpart to the manual host wiring the task's
+``agt_stack.py`` had to do by hand. It stands up the three real, otherwise
+disconnected AGT kernel subsystems
+
+- trust:  ``agentmesh.trust_types.TrustTracker``
+- audit:  ``agent_os.event_sink.GovernanceEventProcessor`` + a sink
+- rings:  ``hypervisor.rings.RingEnforcer`` + ``ActionClassifier``
+
+and drives all three from one ``KernelBridge.apply(...)`` call. The bridge is
+dependency injected, so this module is where the concrete subsystems meet it.
+
+The audit emitter is honest about delivery. It maps the neutral
+``GovernanceEventSpec`` onto a concrete ``GovernanceEvent`` and emits it
+synchronously to a sink (the ``agent_os.event_sink`` SPI), returning ACCEPTED
+only when the sink acknowledges it. A fail-closed gate needs a synchronous ack,
+so it deliberately does NOT use the fire-and-forget async
+``GovernanceEventProcessor`` for the ack (see ``SynchronousAuditEmitter``).
+
+Run:
+
+    PYTHONPATH=agent-governance-python/agt-policies/src \
+        python examples/acs_kernel_wiring/wire_acs_into_kernel.py
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from agentmesh.trust_types import TrustTracker
+from agent_os.event_sink import (
+    GovernanceEvent,
+    GovernanceEventKind,
+    GovernanceEventSinkBase,
+    SinkExportResult,
+)
+from hypervisor.models import ActionDescriptor, ExecutionRing, ReversibilityLevel
+from hypervisor.rings.classifier import ActionClassifier
+from hypervisor.rings.enforcer import RingEnforcer
+
+from agt.policies import EvaluationResult
+from agt.policies.kernel import (
+    AuditEmissionResult,
+    GovernanceEventSpec,
+    KernelBridge,
+    KernelDecision,
+    KernelOutcome,
+)
+
+
+class RecordingSink(GovernanceEventSinkBase):
+    """Governance event sink that records delivered events in memory."""
+
+    def __init__(self) -> None:
+        self.events: list[GovernanceEvent] = []
+
+    @property
+    def count(self) -> int:
+        return len(self.events)
+
+    def emit(self, events: Sequence[GovernanceEvent]) -> SinkExportResult:
+        self.events.extend(events)
+        return SinkExportResult.SUCCESS
+
+
+class SynchronousAuditEmitter:
+    """Map a GovernanceEventSpec to a GovernanceEvent and report delivery.
+
+    A fail-closed audit gate has to KNOW whether the event was delivered before
+    it decides ``proceeds``, so delivery must be synchronous and acknowledged.
+    The event is emitted directly to the sink and its ``SinkExportResult`` is
+    mapped to an ``AuditEmissionResult``: SUCCESS -> ACCEPTED, DROPPED ->
+    DROPPED, anything else or a raise -> FAILED, and no sink -> NO_SINK.
+
+    Note the deliberate choice NOT to route the gate ack through
+    ``agent_os.event_sink.GovernanceEventProcessor``: its ``on_event`` is
+    fire-and-forget (a background worker drains the queue and can drop under
+    backpressure), so a gate that inferred delivery from it would race the
+    worker and could report a delivered event as failed. The processor is the
+    right primitive for best-effort async fan-out to downstream SIEM, not for a
+    synchronous fail-closed ack.
+    """
+
+    def __init__(self, sink: RecordingSink | None) -> None:
+        self._sink = sink
+
+    def __call__(self, spec: GovernanceEventSpec) -> AuditEmissionResult:
+        try:
+            kind = GovernanceEventKind(spec.kind)
+        except ValueError:
+            kind = GovernanceEventKind.POLICY_CHECK
+        event = GovernanceEvent(
+            kind=kind,
+            severity=spec.severity,
+            agent_id=spec.agent_id,
+            action=spec.action,
+            decision=spec.decision,
+            reason=spec.reason,
+            attributes=dict(spec.attributes),
+        )
+        if self._sink is None:
+            return AuditEmissionResult.NO_SINK
+        try:
+            result = self._sink.emit([event])
+        except Exception:
+            return AuditEmissionResult.FAILED
+        if result == SinkExportResult.SUCCESS:
+            return AuditEmissionResult.ACCEPTED
+        if result == SinkExportResult.DROPPED:
+            return AuditEmissionResult.DROPPED
+        return AuditEmissionResult.FAILED
+
+
+@dataclass
+class WiredKernel:
+    """The bridge plus the concrete subsystems it drives, for inspection."""
+
+    bridge: KernelBridge
+    trust: TrustTracker
+    sink: RecordingSink | None
+
+
+def build_wired_kernel(*, with_audit_sink: bool = True) -> WiredKernel:
+    """Assemble the real subsystems and inject them into a KernelBridge."""
+    trust = TrustTracker()
+    sink = RecordingSink() if with_audit_sink else None
+    emitter = SynchronousAuditEmitter(sink)
+    bridge = KernelBridge(
+        trust_tracker=trust,
+        emit_event=emitter,
+        ring_enforcer=RingEnforcer(),
+        action_classifier=ActionClassifier(),
+    )
+    return WiredKernel(bridge=bridge, trust=trust, sink=sink)
+
+
+def _reversible_tool(name: str) -> ActionDescriptor:
+    """A reversible tool call. required_ring == RING_2_STANDARD."""
+    return ActionDescriptor(
+        action_id=name,
+        name=name,
+        execute_api=f"/v1/{name}:run",
+        undo_api=f"/v1/{name}:undo",
+        reversibility=ReversibilityLevel.FULL,
+        undo_window_seconds=300,
+    )
+
+
+def _non_reversible_tool(name: str) -> ActionDescriptor:
+    """A non-reversible tool call. required_ring == RING_1_PRIVILEGED."""
+    return ActionDescriptor(
+        action_id=name,
+        name=name,
+        execute_api=f"/v1/{name}:run",
+        reversibility=ReversibilityLevel.NONE,
+    )
+
+
+def _acs_decision(verdict: str, reason: str = "") -> KernelDecision:
+    """Build the normalized decision from a real ACS EvaluationResult.
+
+    ``EvaluationResult`` is exactly what ``agt.policies.runtime.AgtRuntime.evaluate``
+    returns, so this is the true ACS -> kernel seam without needing OPA wired up.
+    """
+    return KernelDecision.from_evaluation_result(
+        EvaluationResult(verdict=verdict, reason=reason)
+    )
+
+
+def run_demo() -> dict[str, KernelOutcome]:
+    """Run three scenarios and return their outcomes for inspection/tests."""
+    wired = build_wired_kernel()
+    bridge = wired.bridge
+    outcomes: dict[str, KernelOutcome] = {}
+
+    # A. ACS deny on a reversible tool call. One apply() lowers trust, emits a
+    #    policy_violation, and demotes the agent's ring.
+    outcomes["deny"] = bridge.apply(
+        _acs_decision("deny", reason="blocked_pattern_input"),
+        agent_id="agent-a",
+        peer_id="orchestrator",
+        action=_reversible_tool("send_email"),
+        current_ring=ExecutionRing.RING_2_STANDARD,
+    )
+
+    # B. ACS allow, but the agent's ring is insufficient for a non-reversible
+    #    action. The composite gate blocks even though ACS permitted.
+    outcomes["allow_ring_blocked"] = bridge.apply(
+        _acs_decision("allow"),
+        agent_id="agent-b",
+        peer_id="orchestrator",
+        action=_non_reversible_tool("delete_account"),
+        current_ring=ExecutionRing.RING_3_SANDBOX,
+    )
+
+    # C. ACS allow on a reversible action the agent's ring permits. Proceeds,
+    #    trust is rewarded, and a policy_check is emitted.
+    outcomes["allow_ok"] = bridge.apply(
+        _acs_decision("allow"),
+        agent_id="agent-c",
+        peer_id="orchestrator",
+        action=_reversible_tool("fetch_doc"),
+        current_ring=ExecutionRing.RING_2_STANDARD,
+    )
+
+    return outcomes
+
+
+def main() -> None:
+    outcomes = run_demo()
+    for label, out in outcomes.items():
+        print(f"[{label}]")
+        print(f"  effective_decision : {out.effective_decision}")
+        print(f"  proceeds           : {out.proceeds}")
+        print(f"  trust_score        : {out.trust_score:.3f} (delta {out.trust_delta:+.3f})")
+        print(f"  ring               : {out.ring}  demoted={out.demoted}")
+        print(f"  ring_allowed       : {out.ring_allowed}")
+        print(f"  audit              : {out.audit.value}")
+        print(f"  event.kind         : {out.event.kind}")
+        if out.blocked_reason:
+            print(f"  blocked_reason     : {out.blocked_reason}")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

ACS verdicts and the AGT kernel primitives (trust, audit, rings) were disconnected islands a host had to wire by hand. This adds `agt.policies.kernel.KernelBridge`, a dependency-injected, fail-closed composite gate that maps one ACS decision onto all three subsystems and returns a single `KernelOutcome`.

`proceeds = ACS permits AND ring check allows AND (audit accepted when strict) AND no dependency error`. An ACS `allow` is necessary but not sufficient.

The bridge takes the kernel subsystems as injected Protocols, so `agt-policies` imports none of `agentmesh` / `agent_os` / `hypervisor` and no cycle forms with `agent_os.integrations._v5_runtime_bridge` (which already imports `agt.policies`). It lands in `agent-governance-python/agt-policies/` because that package already owns the ACS↔AGT seam, and the dependency-injected design keeps the change additive and cycle-free.

### Changes

| File | What changed |
|------|-------------|
| `agent-governance-python/agt-policies/src/agt/policies/kernel.py` | New: `KernelBridge`, `KernelDecision`, `KernelOutcome`, `GovernanceEventSpec`, `AuditEmissionResult`, and the `TrustTrackerLike` / `RingEnforcerLike` / `ActionClassifierLike` Protocols. |
| `agent-governance-python/agt-policies/src/agt/policies/__init__.py` | Re-export the new public symbols. |
| `agent-governance-python/agt-policies/tests/test_kernel.py` | New: unit tests for the decision→outcome mapping, fail-closed paths, ring gating, idempotency/concurrency, and a real-runtime escalate round-trip. |
| `examples/acs_kernel_wiring/` | New: runnable example wiring the real `TrustTracker` + `agent_os` sink SPI + `RingEnforcer`/`ActionClassifier`, plus a guarded smoke test and README. |
| `agent-governance-python/agt-policies/README.md` | Add the `agt.policies.kernel` module to the inventory. |

### Behavior

**Decision normalization.** `KernelDecision` preserves the raw vs effective ACS decision. `from_evaluation_result` recovers an approved `escalate` from `audit_entry["verdict"]` (the key `AgtRuntime` writes) and copies `approval_outcome` and the intervention point; `from_intervention_point_result` is lossless for hosts that hold the raw ACS result.

**Trust.** Only `allow` rewards; `warn` / `transform` / `escalate` are neutral; `deny` and fail-closed penalize. A raw `escalate` stays trust-neutral and audits as `escalation_requested` even after the approval path rewrites the effective decision. Rewards are deferred until the composite gate confirms the action proceeds, so a blocked `allow` is never recorded as a trust success; penalties are applied immediately because they drive ring demotion. Trust drives ring demotion only, never auto-promotion (agentmesh reputation and hypervisor `eff_score` are different scales). The idempotency key is scoped per `agent_id`, and concurrent same-key calls are serialized so a reward is applied at most once.

**Rings.** The ring gate fails closed: a configured enforcer with a descriptor action but a missing `current_ring`, or a check result lacking `.allowed`, blocks rather than skipping. An injected `ActionClassifier` can tighten (never loosen) the required ring the enforcer checks.

**Audit.** Each decision emits one governance event. A block is recorded as `policy_violation` (or the more specific `tool_call_blocked` at a tool intervention point) rather than a benign `policy_check`, so the audit record matches the enforced outcome. Under `strict_audit`, an event that is not accepted for delivery blocks the action.

**Bounds.** Per-agent serialization uses a fixed striped lock pool and the idempotency ledger is LRU-bounded, so a long-lived bridge does not grow without limit.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [ ] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):
<!-- Leave blank if not applicable -->

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

GitHub Copilot assisted with implementation and tests; all output was reviewed.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->
