### PR TITLE
fix: fail closed on missing negative rule fields

### DIFF
--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
@@ -229,7 +229,17 @@ def _render_rego(rules: list[dict[str, Any]]) -> str:
         message = str(rule.get("message", ""))
 
         accessor = _rego_field_accessor(field)
-        op_clause = _rego_op_clause(operator, accessor, value) if accessor is not None else None
+        match_missing_negative = action == "deny"
+        op_clause = (
+            _rego_op_clause(
+                operator,
+                accessor,
+                value,
+                match_missing_negative=match_missing_negative,
+            )
+            if accessor is not None
+            else None
+        )
         if op_clause is None:
             # Unsupported operators or invalid field paths MUST fail
             # closed. Render an always-matching deny rule so evaluation
@@ -318,7 +328,13 @@ def _rego_field_accessor(field: str) -> str | None:
     return expr
 
 
-def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
+def _rego_op_clause(
+    operator: str,
+    accessor: str,
+    value: Any,
+    *,
+    match_missing_negative: bool = False,
+) -> Optional[str]:
     """Render the body of a `_match[i]` rule for a given operator.
 
     Returns None for unsupported operators; the caller turns the rule into a fail-closed deny.
@@ -328,9 +344,12 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "eq":
         return f"{indent}{accessor} == {literal}"
     if operator == "ne":
-        # Missing fields intentionally satisfy negative conditions so deny
-        # rules fail closed when callers omit allowlist-bound fields.
-        return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
+        if match_missing_negative:
+            # Deny rules fail closed on missing negative fields per ACS §5.2;
+            # allow rules keep the null guard so they cannot short-circuit
+            # lower-priority deny rules.
+            return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
+        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"
     if operator == "lt":
@@ -342,9 +361,12 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "in":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v in {literal}"
     if operator == "not_in":
-        # Missing fields intentionally satisfy negative conditions so deny
-        # rules fail closed when callers omit allowlist-bound fields.
-        return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
+        if match_missing_negative:
+            # Deny rules fail closed on missing negative fields per ACS §5.2;
+            # allow rules keep the null guard so they cannot short-circuit
+            # lower-priority deny rules.
+            return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
+        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}not _v in {literal}"
     if operator == "exists":
         return f"{indent}{accessor} != null"
     if operator == "contains":

--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
@@ -328,6 +328,8 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "eq":
         return f"{indent}{accessor} == {literal}"
     if operator == "ne":
+        # Missing fields intentionally satisfy negative conditions so deny
+        # rules fail closed when callers omit allowlist-bound fields.
         return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"
@@ -340,6 +342,8 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "in":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v in {literal}"
     if operator == "not_in":
+        # Missing fields intentionally satisfy negative conditions so deny
+        # rules fail closed when callers omit allowlist-bound fields.
         return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
     if operator == "exists":
         return f"{indent}{accessor} != null"

--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
@@ -328,7 +328,7 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "eq":
         return f"{indent}{accessor} == {literal}"
     if operator == "ne":
-        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v != {literal}"
+        return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"
     if operator == "lt":
@@ -340,7 +340,7 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "in":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v in {literal}"
     if operator == "not_in":
-        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}not _v in {literal}"
+        return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
     if operator == "exists":
         return f"{indent}{accessor} != null"
     if operator == "contains":

--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
@@ -353,10 +353,9 @@ def _rego_op_clause(
         return f"{indent}{accessor} == {literal}"
     if operator == "ne":
         if match_missing_negative:
-            # Deny rules fail closed on missing negative fields per ACS §5.2;
-            # allow rules keep the null guard so they cannot short-circuit
-            # lower-priority deny rules.
-            return f"{indent}not {accessor} == {literal}"
+            # Deny rules fail closed on absent negative fields; allow rules keep
+            # the null guard so they cannot short-circuit lower-priority deny rules.
+            return f"{indent}not ({accessor} == {literal})"
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"
@@ -370,11 +369,10 @@ def _rego_op_clause(
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v in {literal}"
     if operator == "not_in":
         if match_missing_negative:
-            # Deny rules fail closed on missing negative fields per ACS §5.2;
-            # allow rules keep the null guard so they cannot short-circuit
-            # lower-priority deny rules.
-            return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
-        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}not _v in {literal}"
+            # Deny rules fail closed on absent negative fields; allow rules keep
+            # the null guard so they cannot short-circuit lower-priority deny rules.
+            return f"{indent}_v := {accessor}\n{indent}not (_v in {literal})"
+        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}not (_v in {literal})"
     if operator == "exists":
         return f"{indent}{accessor} != null"
     if operator == "contains":

--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
@@ -337,6 +337,14 @@ def _rego_op_clause(
 ) -> Optional[str]:
     """Render the body of a `_match[i]` rule for a given operator.
 
+    Args:
+        operator: Normalized AGT condition operator.
+        accessor: Rego expression that reads the condition field.
+        value: Expected condition value.
+        match_missing_negative: When true, missing fields satisfy negative
+            operators so deny rules fail closed. Allow rules leave this false
+            so they cannot mask a lower-priority deny rule.
+
     Returns None for unsupported operators; the caller turns the rule into a fail-closed deny.
     """
     literal = json.dumps(value)

--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
@@ -356,7 +356,7 @@ def _rego_op_clause(
             # Deny rules fail closed on missing negative fields per ACS §5.2;
             # allow rules keep the null guard so they cannot short-circuit
             # lower-priority deny rules.
-            return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
+            return f"{indent}not {accessor} == {literal}"
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"

--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/merge.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/merge.py
@@ -70,6 +70,9 @@ def _accepts_value(operator: str, expected: Any, value: Any) -> bool:
     try:
         if operator == "eq":
             return value == expected
+        # This merge-time overlap helper treats missing values as non-matches.
+        # Runtime missing-field fail-closed behavior is deny-only and rendered
+        # in build.py, so allow rules cannot mask lower-priority deny rules.
         if operator == "ne":
             return value is not None and value != expected
         if operator == "gt":

--- a/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
@@ -169,21 +169,40 @@ def _value_at(sample: dict, field: str) -> object:
     return current
 
 
-def _condition_matches(condition: object, sample: dict) -> bool:
+def _condition_matches(
+    condition: object,
+    sample: dict,
+    *,
+    match_missing_negative: bool = False,
+) -> bool:
     if not isinstance(condition, dict):
         return False
     if "and" in condition:
         items = condition["and"]
         return isinstance(items, list) and all(
-            _condition_matches(item, sample) for item in items
+            _condition_matches(
+                item,
+                sample,
+                match_missing_negative=match_missing_negative,
+            )
+            for item in items
         )
     if "or" in condition:
         items = condition["or"]
         return isinstance(items, list) and any(
-            _condition_matches(item, sample) for item in items
+            _condition_matches(
+                item,
+                sample,
+                match_missing_negative=match_missing_negative,
+            )
+            for item in items
         )
     if "not" in condition:
-        return not _condition_matches(condition["not"], sample)
+        return not _condition_matches(
+            condition["not"],
+            sample,
+            match_missing_negative=match_missing_negative,
+        )
 
     field = condition.get("field")
     operator = condition.get("operator")
@@ -195,8 +214,12 @@ def _condition_matches(condition: object, sample: dict) -> bool:
         if operator == "exists":
             return actual is not None
         if operator == "ne":
+            if actual is None:
+                return match_missing_negative
             return actual != expected
         if operator == "not_in":
+            if actual is None:
+                return match_missing_negative and isinstance(expected, list)
             return isinstance(expected, list) and actual not in expected
         if actual is None:
             return False
@@ -968,7 +991,7 @@ def test_resolve_renders_operator_vocabulary(
         ("not_in", ["eastus", "westus"], "not _v in"),
     ],
 )
-def test_resolve_negative_operators_match_missing_fields(
+def test_resolve_deny_negative_operators_match_missing_fields(
     tmp_path: Path, operator: str, value: object, rego_snippet: str
 ) -> None:
     root = tmp_path
@@ -995,9 +1018,53 @@ def test_resolve_negative_operators_match_missing_fields(
     bundle = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
     rego = (bundle / "agt_legacy.rego").read_text(encoding="utf-8")
 
-    assert _condition_matches(condition, {"tool_call": {"name": "exec"}})
+    assert _condition_matches(
+        condition,
+        {"tool_call": {"name": "exec"}},
+        match_missing_negative=True,
+    )
     assert rego_snippet in rego
     assert "_v != null" not in rego
+    assert "runtime_error:manifest_invalid" not in rego
+
+
+@pytest.mark.parametrize(
+    ("operator", "value", "rego_snippet"),
+    [
+        ("ne", "sha256:registered", '_v != "sha256:registered"'),
+        ("not_in", ["eastus", "westus"], "not _v in"),
+    ],
+)
+def test_resolve_allow_negative_operators_do_not_match_missing_fields(
+    tmp_path: Path, operator: str, value: object, rego_snippet: str
+) -> None:
+    root = tmp_path
+    condition = {
+        "field": "tool_call.content_hash",
+        "operator": operator,
+        "value": value,
+    }
+    _write(
+        root / "governance.yaml",
+        {
+            "rules": [
+                _rule_with_condition(
+                    f"allow-missing-{operator}",
+                    "allow",
+                    condition,
+                )
+            ],
+            "intervention_points": _legacy_binding(),
+        },
+    )
+
+    manifest = resolve_manifest(root, root)
+    bundle = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
+    rego = (bundle / "agt_legacy.rego").read_text(encoding="utf-8")
+
+    assert not _condition_matches(condition, {"tool_call": {"name": "exec"}})
+    assert rego_snippet in rego
+    assert "_v != null" in rego
     assert "runtime_error:manifest_invalid" not in rego
 
 

--- a/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
@@ -970,7 +970,7 @@ def test_resolve_fails_closed_when_legacy_rules_unbound(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("operator", "value", "expected_snippet"),
     [
-        ("not_in", ["secret", "token"], "not _v in"),
+        ("not_in", ["secret", "token"], "not (_v in"),
         ("startswith", "sec", "startswith(_v"),
         ("endswith", "ret", "endswith(_v"),
         ("exists", None, "!= null"),
@@ -1004,18 +1004,22 @@ def test_resolve_renders_operator_vocabulary(
 
 
 @pytest.mark.parametrize(
-    ("operator", "value", "rego_snippet"),
+    ("operator", "field", "value", "rego_snippet"),
     [
-        ("ne", "sha256:registered", "not object.get("),
-        ("not_in", ["eastus", "westus"], "not _v in"),
+        ("ne", "tool_call.content_hash", "sha256:registered", "not (object.get("),
+        ("not_in", "tool_call.region", ["region-a", "region-b"], "not (_v in"),
     ],
 )
 def test_resolve_deny_negative_operators_match_missing_fields(
-    tmp_path: Path, operator: str, value: object, rego_snippet: str
+    tmp_path: Path,
+    operator: str,
+    field: str,
+    value: object,
+    rego_snippet: str,
 ) -> None:
     root = tmp_path
     condition = {
-        "field": "tool_call.content_hash",
+        "field": field,
         "operator": operator,
         "value": value,
     }
@@ -1024,7 +1028,7 @@ def test_resolve_deny_negative_operators_match_missing_fields(
         {
             "rules": [
                 _rule_with_condition(
-                    f"deny-missing-{operator}",
+                    f"deny-missing-{operator.replace('_', '-')}",
                     "deny",
                     condition,
                 )
@@ -1047,22 +1051,33 @@ def test_resolve_deny_negative_operators_match_missing_fields(
     assert "runtime_error:manifest_invalid" not in rego
 
 
-def test_resolve_deny_ne_missing_field_denies_with_generated_rego(
+@pytest.mark.parametrize(
+    ("operator", "field", "value"),
+    [
+        ("ne", "tool_call.content_hash", "sha256:registered"),
+        ("not_in", "tool_call.region", ["region-a", "region-b"]),
+    ],
+)
+def test_resolve_deny_negative_missing_field_denies_with_generated_rego(
     tmp_path: Path,
+    operator: str,
+    field: str,
+    value: object,
 ) -> None:
     opa = _require_opa()
     root = tmp_path
+    rule_name = f"deny-missing-{operator.replace('_', '-')}"
     _write(
         root / "governance.yaml",
         {
             "rules": [
                 _rule_with_condition(
-                    "deny-missing-ne",
+                    rule_name,
                     "deny",
                     {
-                        "field": "tool_call.content_hash",
-                        "operator": "ne",
-                        "value": "sha256:registered",
+                        "field": field,
+                        "operator": operator,
+                        "value": value,
                     },
                 )
             ],
@@ -1097,22 +1112,26 @@ def test_resolve_deny_ne_missing_field_denies_with_generated_rego(
     verdict = payload["result"][0]["expressions"][0]["value"]
 
     assert verdict["decision"] == "deny"
-    assert verdict["reason"] == "deny-missing-ne"
+    assert verdict["reason"] == rule_name
 
 
 @pytest.mark.parametrize(
-    ("operator", "value", "rego_snippet"),
+    ("operator", "field", "value", "rego_snippet"),
     [
-        ("ne", "sha256:registered", '_v != "sha256:registered"'),
-        ("not_in", ["eastus", "westus"], "not _v in"),
+        ("ne", "tool_call.content_hash", "sha256:registered", '_v != "sha256:registered"'),
+        ("not_in", "tool_call.region", ["region-a", "region-b"], "not (_v in"),
     ],
 )
 def test_resolve_allow_negative_operators_do_not_match_missing_fields(
-    tmp_path: Path, operator: str, value: object, rego_snippet: str
+    tmp_path: Path,
+    operator: str,
+    field: str,
+    value: object,
+    rego_snippet: str,
 ) -> None:
     root = tmp_path
     condition = {
-        "field": "tool_call.content_hash",
+        "field": field,
         "operator": operator,
         "value": value,
     }
@@ -1153,12 +1172,12 @@ def test_condition_matches_propagates_missing_negative_mode_to_compounds() -> No
                     {
                         "field": "tool_call.region",
                         "operator": "not_in",
-                        "value": ["eastus"],
+                        "value": ["region-a"],
                     },
                     {
                         "field": "tool_call.region",
                         "operator": "eq",
-                        "value": "westus",
+                        "value": "region-b",
                     },
                 ]
             },
@@ -1175,7 +1194,7 @@ def test_condition_matches_propagates_missing_negative_mode_to_compounds() -> No
     [
         ("eq", "sha256:registered", '== "sha256:registered"'),
         ("gt", 10, "_v != null"),
-        ("in", ["eastus", "westus"], "_v != null"),
+        ("in", ["region-a", "region-b"], "_v != null"),
     ],
 )
 def test_resolve_positive_operators_do_not_match_missing_fields(

--- a/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
@@ -1001,6 +1001,46 @@ def test_resolve_negative_operators_match_missing_fields(
     assert "runtime_error:manifest_invalid" not in rego
 
 
+@pytest.mark.parametrize(
+    ("operator", "value", "expected_snippet"),
+    [
+        ("eq", "sha256:registered", '== "sha256:registered"'),
+        ("gt", 10, "_v != null"),
+        ("in", ["eastus", "westus"], "_v != null"),
+    ],
+)
+def test_resolve_positive_operators_do_not_match_missing_fields(
+    tmp_path: Path, operator: str, value: object, expected_snippet: str
+) -> None:
+    root = tmp_path
+    condition = {
+        "field": "tool_call.content_hash",
+        "operator": operator,
+        "value": value,
+    }
+    _write(
+        root / "governance.yaml",
+        {
+            "rules": [
+                _rule_with_condition(
+                    f"deny-missing-{operator}",
+                    "deny",
+                    condition,
+                )
+            ],
+            "intervention_points": _legacy_binding(),
+        },
+    )
+
+    manifest = resolve_manifest(root, root)
+    bundle = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
+    rego = (bundle / "agt_legacy.rego").read_text(encoding="utf-8")
+
+    assert not _condition_matches(condition, {"tool_call": {"name": "exec"}})
+    assert expected_snippet in rego
+    assert "runtime_error:manifest_invalid" not in rego
+
+
 def test_resolve_explicit_bundle_dir(tmp_path: Path) -> None:
     root = tmp_path / "ws"
     root.mkdir()

--- a/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
@@ -194,12 +194,14 @@ def _condition_matches(condition: object, sample: dict) -> bool:
     try:
         if operator == "exists":
             return actual is not None
+        if operator == "ne":
+            return actual != expected
+        if operator == "not_in":
+            return isinstance(expected, list) and actual not in expected
         if actual is None:
             return False
         if operator == "eq":
             return actual == expected
-        if operator == "ne":
-            return actual != expected
         if operator == "gt":
             return actual > expected
         if operator == "gte":
@@ -210,8 +212,6 @@ def _condition_matches(condition: object, sample: dict) -> bool:
             return actual <= expected
         if operator == "in":
             return isinstance(expected, list) and actual in expected
-        if operator == "not_in":
-            return isinstance(expected, list) and actual not in expected
         if operator == "contains":
             return expected in actual
         if operator == "startswith":
@@ -958,6 +958,46 @@ def test_resolve_renders_operator_vocabulary(
     rego = (bundle / "agt_legacy.rego").read_text(encoding="utf-8")
 
     assert expected_snippet in rego
+    assert "runtime_error:manifest_invalid" not in rego
+
+
+@pytest.mark.parametrize(
+    ("operator", "value", "rego_snippet"),
+    [
+        ("ne", "sha256:registered", '_v != "sha256:registered"'),
+        ("not_in", ["eastus", "westus"], "not _v in"),
+    ],
+)
+def test_resolve_negative_operators_match_missing_fields(
+    tmp_path: Path, operator: str, value: object, rego_snippet: str
+) -> None:
+    root = tmp_path
+    condition = {
+        "field": "tool_call.content_hash",
+        "operator": operator,
+        "value": value,
+    }
+    _write(
+        root / "governance.yaml",
+        {
+            "rules": [
+                _rule_with_condition(
+                    f"deny-missing-{operator}",
+                    "deny",
+                    condition,
+                )
+            ],
+            "intervention_points": _legacy_binding(),
+        },
+    )
+
+    manifest = resolve_manifest(root, root)
+    bundle = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
+    rego = (bundle / "agt_legacy.rego").read_text(encoding="utf-8")
+
+    assert _condition_matches(condition, {"tool_call": {"name": "exec"}})
+    assert rego_snippet in rego
+    assert "_v != null" not in rego
     assert "runtime_error:manifest_invalid" not in rego
 
 

--- a/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
@@ -175,6 +175,11 @@ def _condition_matches(
     *,
     match_missing_negative: bool = False,
 ) -> bool:
+    """Evaluate a condition with the same missing-field mode as rendered Rego.
+
+    ``match_missing_negative`` mirrors deny-rule rendering: missing fields
+    satisfy ``ne`` and ``not_in`` only when deny rules must fail closed.
+    """
     if not isinstance(condition, dict):
         return False
     if "and" in condition:
@@ -1066,6 +1071,36 @@ def test_resolve_allow_negative_operators_do_not_match_missing_fields(
     assert rego_snippet in rego
     assert "_v != null" in rego
     assert "runtime_error:manifest_invalid" not in rego
+
+
+def test_condition_matches_propagates_missing_negative_mode_to_compounds() -> None:
+    condition = {
+        "and": [
+            {
+                "field": "tool_call.content_hash",
+                "operator": "ne",
+                "value": "sha256:registered",
+            },
+            {
+                "or": [
+                    {
+                        "field": "tool_call.region",
+                        "operator": "not_in",
+                        "value": ["eastus"],
+                    },
+                    {
+                        "field": "tool_call.region",
+                        "operator": "eq",
+                        "value": "westus",
+                    },
+                ]
+            },
+        ]
+    }
+    sample = {"tool_call": {"name": "exec"}}
+
+    assert _condition_matches(condition, sample, match_missing_negative=True)
+    assert not _condition_matches(condition, sample)
 
 
 @pytest.mark.parametrize(

--- a/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_manifest_resolution.py
@@ -9,8 +9,11 @@ resolution reasons in ``policy-engine/spec/SPECIFICATION.md`` §16.
 
 from __future__ import annotations
 
+import json
 import random
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -25,6 +28,17 @@ from agt.manifest_resolution import (
     resolve_manifest,
 )
 from agt.manifest_resolution.merge import merge_top_level_section
+
+
+def _require_opa() -> str:
+    opa = shutil.which("opa")
+    if opa is None:
+        candidate = Path.home() / ".local" / "bin" / "opa"
+        if candidate.is_file():
+            opa = str(candidate)
+    if opa is None:
+        pytest.skip("opa binary required for Rego evaluation")
+    return opa
 
 
 # ── discover_policies ────────────────────────────────────────────────
@@ -992,7 +1006,7 @@ def test_resolve_renders_operator_vocabulary(
 @pytest.mark.parametrize(
     ("operator", "value", "rego_snippet"),
     [
-        ("ne", "sha256:registered", '_v != "sha256:registered"'),
+        ("ne", "sha256:registered", "not object.get("),
         ("not_in", ["eastus", "westus"], "not _v in"),
     ],
 )
@@ -1031,6 +1045,59 @@ def test_resolve_deny_negative_operators_match_missing_fields(
     assert rego_snippet in rego
     assert "_v != null" not in rego
     assert "runtime_error:manifest_invalid" not in rego
+
+
+def test_resolve_deny_ne_missing_field_denies_with_generated_rego(
+    tmp_path: Path,
+) -> None:
+    opa = _require_opa()
+    root = tmp_path
+    _write(
+        root / "governance.yaml",
+        {
+            "rules": [
+                _rule_with_condition(
+                    "deny-missing-ne",
+                    "deny",
+                    {
+                        "field": "tool_call.content_hash",
+                        "operator": "ne",
+                        "value": "sha256:registered",
+                    },
+                )
+            ],
+            "intervention_points": _legacy_binding(),
+        },
+    )
+
+    manifest = resolve_manifest(root, root)
+    bundle = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
+    input_path = tmp_path / "input.json"
+    input_path.write_text(
+        json.dumps({"snapshot": {"tool_call": {"name": "exec"}}}),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            opa,
+            "eval",
+            "--format=json",
+            "--data",
+            str(bundle / "agt_legacy.rego"),
+            "--input",
+            str(input_path),
+            "data.agt.legacy.verdict",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    verdict = payload["result"][0]["expressions"][0]["value"]
+
+    assert verdict["decision"] == "deny"
+    assert verdict["reason"] == "deny-missing-ne"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Treat missing fields as matching declarative `ne` and `not_in` conditions only for deny rules, so deny rules fail closed on omission.
- Keep allow rules and positive operators guarded on missing fields so they cannot short-circuit lower-priority deny rules.
- Make the deny-only missing-field behavior explicit in code comments as intended ACS section 5.2 fail-closed behavior.
- Document why the static merge-time overlap helper keeps missing values as non-matches.
- Add regression coverage for deny and allow negative operators, positive operators, compound missing-field conditions, and generated Rego verdicts for missing-field `ne` and `not_in` cases.

Fixes #3297.

## Review follow-up

- The review concern about allow-rule `ne` / `not_in` semantics is handled by gating missing-field matching on `action == "deny"`.
- Allow rules retain the null guard and do not match missing fields, so they cannot mask lower-priority deny rules.
- `merge.py` remains a static overlap helper and intentionally treats missing values as non-matches; runtime fail-closed behavior is applied only during deny-rule Rego rendering.

## Validation

- `cd agent-governance-python/agt-policies && uv run --no-project --with pytest --with pyyaml --with pydantic --with "agent-control-specification>=0.3.1b0,<0.4.0" --with-editable . pytest tests/test_manifest_resolution.py -q`
- `cd agent-governance-python/agt-policies && uv run --no-project --with pytest --with pyyaml --with pydantic --with "agent-control-specification>=0.3.1b0,<0.4.0" --with-editable . pytest tests -q --tb=short`
- `git diff --check origin/main...HEAD`
