### PR TITLE
docs: clarify [full] install and secrets-only redact() behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,16 @@ AGT does not try to win that fight inside the prompt. Every tool call, message s
 
 **Prerequisites:** Python 3.10+
 
+> **Install note:** The base wheel (`pip install agent-governance-toolkit`) ships
+> a minimal surface. For the Quick Start imports below (`agentmesh.governance`,
+> policy evaluation helpers), install the full extra:
+>
+> ```bash
+> pip install "agent-governance-toolkit[full]"
+> ```
+
 ```bash
-pip install agent-governance-toolkit[full]
+pip install "agent-governance-toolkit[full]"
 ```
 
 For Claude Code, add AGT as a plugin marketplace and install the governance plugin:
@@ -113,6 +121,9 @@ Or use the full `PolicyEvaluator` API for programmatic control:
 <summary><b>PolicyEvaluator example</b></summary>
 
 ```python
+# Prefer agentmesh.governance for new code (see docs/package-consolidation/MIGRATION.md).
+# agent_os.policies still works via the compatibility surface but may emit
+# DeprecationWarning when the underlying agent-os-kernel path is used.
 from agent_os.policies import (
     PolicyEvaluator, PolicyDocument, PolicyRule,
     PolicyCondition, PolicyAction, PolicyOperator, PolicyDefaults

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -230,20 +230,24 @@ class CredentialRedactor:
 
     @classmethod
     def redact(cls, value: str | None) -> str:
-        """Redact credential-like values from a string.
+        """Redact **secret/credential** patterns from a string (not general PII).
 
         Redaction is driven by the exact spans that :meth:`find_matches`
-        reports, so redaction removes precisely what detection finds. This is
-        deliberately not a sequential ``subn`` over the patterns: applying
-        patterns to a progressively mutated string lets an earlier greedy
-        pattern consume the anchor keyword of a later one, which would remove
-        less than detection reported and leave a secret in place.
+        reports (``PATTERNS`` only: tokens, keys, connection strings, etc.).
+        PII patterns (email, phone, SSN, …) are available via
+        :meth:`find_pii_matches` / :meth:`contains_pii` for **detection** but
+        are **not** removed by this method. Callers that need PII scrubbing must
+        handle ``PII_PATTERNS`` separately.
+
+        Span-based redaction (rather than sequential ``subn``) avoids an earlier
+        greedy pattern consuming the anchor of a later one and leaving a secret
+        in place.
 
         Args:
             value: String content that may contain credential-like material.
 
         Returns:
-            A string with each detected credential replaced by
+            A string with each detected **secret** replaced by
             ``REDACTED_PLACEHOLDER``. Empty input returns an empty string.
         """
         if not value:


### PR DESCRIPTION
## Summary
Addresses two good-first-issue docs bugs:

### #3253 — Quick Start install path
- Document that `agentmesh.governance` requires `pip install "agent-governance-toolkit[full]"`
- Note that the base wheel alone raises `ModuleNotFoundError` for those imports
- Clarify that `agent_os.policies` is a compatibility path (see package consolidation migration)

### #3239 — credential_redactor.redact()
- Docstring now states `redact()` covers **secrets/credentials only** (`PATTERNS`)
- Points callers to `find_pii_matches` / `contains_pii` for PII detection (not scrubbed by `redact()`)

Closes #3253
Closes #3239
