### PR TITLE
fix: align PolicyInterceptor check ordering with pre_execute_check

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -859,10 +859,10 @@ class PolicyInterceptor:
     Default interceptor that enforces GovernancePolicy rules.
 
     Checks:
+    - Call count within limits
     - Human approval requirement (require_human_approval)
     - Tool is in allowed_tools (if specified)
     - Arguments don't contain blocked patterns
-    - Call count within limits
     """
 
     def __init__(
@@ -882,6 +882,14 @@ class PolicyInterceptor:
             deny_max_tool_calls,
             deny_not_allowed_tool,
         )
+
+        # Check call count
+        if self.context and self.context.call_count >= self.policy.max_tool_calls:
+            result = deny_max_tool_calls(self.policy.max_tool_calls, self.context.call_count)
+            return ToolCallResult(
+                allowed=False,
+                reason=result.reason,
+            )
 
         # Check human approval requirement
         if self.policy.require_human_approval:
@@ -904,14 +912,6 @@ class PolicyInterceptor:
         matched = self.policy.matches_pattern(args_str)
         if matched:
             result = deny_blocked_pattern_tool(matched[0])
-            return ToolCallResult(
-                allowed=False,
-                reason=result.reason,
-            )
-
-        # Check call count
-        if self.context and self.context.call_count >= self.policy.max_tool_calls:
-            result = deny_max_tool_calls(self.policy.max_tool_calls, self.context.call_count)
             return ToolCallResult(
                 allowed=False,
                 reason=result.reason,


### PR DESCRIPTION
Replaces closed [PR #3266](https://github.com/microsoft/agent-governance-toolkit/pull/3266). The head branch was deleted and recreated to resolve a token scope issue.

---

## Summary

Aligns the check ordering in `PolicyInterceptor.intercept()` to match `pre_execute_check`.

**Before:** human-approval → allowlist → blocked-patterns → call-count  
**After:** call-count → human-approval → allowlist → blocked-patterns

This matches the order used by `pre_execute_check` (which already checks call count first). The change avoids running allowlist/blocked-patterns evaluation when the call is already over the `max_tool_calls` budget.

## Related Issue

Closes #3238

## Changes

- `agent-governance-python/agent-os/src/agent_os/integrations/base.py`: Moved call count check to the top of `PolicyInterceptor.intercept()`, before human approval, allowed tools, and blocked pattern checks.
- Updated class docstring to reflect new check order.

## Verification

All PolicyInterceptor-related tests pass on Python 3.13:

```
$ cd agent-governance-python/agent-os
$ python3 -m pytest tests/test_spec_adapter_contract_conformance.py -k PolicyInterceptor -v
13 passed

$ python3 -m pytest tests/test_spec_policy_engine_conformance.py -v
69 passed

$ python3 -m pytest tests/test_safety_critical.py -k PolicyInterceptor -v
10 passed (PolicyInterceptor tests)
```

## Notes

- Minimal diff: 1 file, only reordering within the same method
- No behavioral change in enforcement — every check still runs, just in a different order
- No security impact