### PR TITLE
fix(agt-policies): ne/not_in fail open on missing fields, bypassing deny rules

### DIFF
--- a/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py
@@ -328,7 +328,10 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "eq":
         return f"{indent}{accessor} == {literal}"
     if operator == "ne":
-        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v != {literal}"
+        # No `_v != null` guard: a missing field (accessor -> null) IS
+        # "not equal" to any non-null value, so it must satisfy a deny
+        # rule built on `ne` rather than fail the rule body (#3297).
+        return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
     if operator == "gt":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v > {literal}"
     if operator == "lt":
@@ -340,7 +343,10 @@ def _rego_op_clause(operator: str, accessor: str, value: Any) -> Optional[str]:
     if operator == "in":
         return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}_v in {literal}"
     if operator == "not_in":
-        return f"{indent}_v := {accessor}\n{indent}_v != null\n{indent}not _v in {literal}"
+        # Same reasoning as `ne`: a missing field is not a member of the
+        # set, so it must satisfy `not_in` rather than fail closed on
+        # the null guard (#3297).
+        return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
     if operator == "exists":
         return f"{indent}{accessor} != null"
     if operator == "contains":

--- a/agent-governance-python/agt-policies/tests/scenarios/test_egress_content_hash_escalation_scenarios.py
+++ b/agent-governance-python/agt-policies/tests/scenarios/test_egress_content_hash_escalation_scenarios.py
@@ -238,3 +238,102 @@ def test_tampered_content_hash_denied(tmp_path: Path) -> None:
     )
     assert result.is_deny
     assert result.reason == "deny_unknown_tool_hash"
+
+
+def test_missing_content_hash_denied(tmp_path: Path) -> None:
+    """A call that omits content_hash entirely must not bypass the `ne`
+    gate. Omission is trivial for a caller to do and must not be
+    treated as an implicit match (#3297)."""
+    snap = pre_tool_call_snapshot(
+        agent_id="coder",
+        tool_name="execute_code",
+        args={"code": "print('hello')"},
+    )
+    result = run_scenario(
+        workspace_root=tmp_path,
+        governance_yaml={"governance.yaml": _content_hash_governance()},
+        intervention_point="pre_tool_call",
+        snapshot=snap,
+    )
+    assert result.is_deny
+    assert result.reason == "deny_unknown_tool_hash"
+
+
+# ── Region allowlist (not_in) ───────────────────────────────────────
+
+
+def _region_allowlist_governance() -> dict:
+    """Deny calls whose declared region falls outside the allowlist. A
+    call that omits region entirely must not bypass the gate."""
+    return {
+        "rules": [
+            {
+                "name": "deny_region_not_allowlisted",
+                "condition": {
+                    "field": "tool_call.args.region",
+                    "operator": "not_in",
+                    "value": ["us-east", "us-west"],
+                },
+                "action": "deny",
+                "priority": 100,
+                "message": "region is not on the allowlist",
+            }
+        ],
+        "tools": {"transfer_data": {"clearance": "restricted"}},
+        "intervention_points": {
+            "pre_tool_call": {
+                "policy_target": "$.tool_call.args",
+                "policy_target_kind": "tool_args",
+                "tool_name_from": "$.tool_call.name",
+                "policy": {"id": "agt_legacy_rules"},
+            }
+        },
+    }
+
+
+def test_region_in_allowlist_passes(tmp_path: Path) -> None:
+    snap = pre_tool_call_snapshot(
+        agent_id="etl",
+        tool_name="transfer_data",
+        args={"region": "us-east"},
+    )
+    result = run_scenario(
+        workspace_root=tmp_path,
+        governance_yaml={"governance.yaml": _region_allowlist_governance()},
+        intervention_point="pre_tool_call",
+        snapshot=snap,
+    )
+    assert result.is_allow
+
+
+def test_region_outside_allowlist_denied(tmp_path: Path) -> None:
+    snap = pre_tool_call_snapshot(
+        agent_id="etl",
+        tool_name="transfer_data",
+        args={"region": "eu-west"},
+    )
+    result = run_scenario(
+        workspace_root=tmp_path,
+        governance_yaml={"governance.yaml": _region_allowlist_governance()},
+        intervention_point="pre_tool_call",
+        snapshot=snap,
+    )
+    assert result.is_deny
+    assert result.reason == "deny_region_not_allowlisted"
+
+
+def test_region_missing_denied(tmp_path: Path) -> None:
+    """Omitting region entirely must not bypass the not_in gate (#3297)."""
+    snap = pre_tool_call_snapshot(
+        agent_id="etl",
+        tool_name="transfer_data",
+        args={},
+    )
+    result = run_scenario(
+        workspace_root=tmp_path,
+        governance_yaml={"governance.yaml": _region_allowlist_governance()},
+        intervention_point="pre_tool_call",
+        snapshot=snap,
+    )
+    assert result.is_deny
+    assert result.reason == "deny_region_not_allowlisted"


### PR DESCRIPTION
## Summary

Fixes #3297.

`_rego_op_clause` in `agent-governance-python/agt-policies/src/agt/manifest_resolution/build.py` guarded every comparison operator with `_v != null` before evaluating the operator. That guard is correct for **positive** operators (`eq`, `gt`, `in`, ...) — a missing field shouldn't satisfy a positive assertion. But the same guard was applied uniformly to the **negative** operators `ne` and `not_in`, which inverts the intended safety: when the referenced field is absent, `_v != null` itself is false, so the rule body never matches and evaluation falls through to `default verdict := allow`.

Concretely, a deny rule like:

```
deny if tool_call.content_hash ne "sha256:REGISTERED"
```

intended to block calls with an unregistered (or missing) content hash, was **bypassed entirely by omitting `content_hash`** — trivial for a caller to do.

## Fix

Dropped the `_v != null` guard for `ne` and `not_in` only (2 lines changed). Rego's native `!=` and `not ... in` already treat `null` correctly once the guard is removed — no restructuring of the accessor or matcher needed:

```python
if operator == "ne":
    return f"{indent}_v := {accessor}\n{indent}_v != {literal}"
...
if operator == "not_in":
    return f"{indent}_v := {accessor}\n{indent}not _v in {literal}"
```

All other operators (`eq`, `gt`, `lt`, `gte`, `lte`, `in`, `exists`, `contains`, `startswith`, `endswith`, `matches`/`regex`) are untouched.

## Tests

Added to `tests/scenarios/test_egress_content_hash_escalation_scenarios.py`, run through the real OPA-backed scenario harness (`agt._harness.opa_runner.run_scenario`), not string-matching on generated Rego source:

- `test_missing_content_hash_denied` — the exact `content_hash ne` example from #3297
- A new `not_in` region-allowlist fixture with `test_region_in_allowlist_passes`, `test_region_outside_allowlist_denied`, and `test_region_missing_denied`

Watched both missing-field tests fail red (`decision: allow`) against the unmodified code, then pass green after the fix.

## Verification

```
$ PYTHONPATH=src python -m pytest tests/ -q
122 passed, 8 pre-existing failures (Windows symlink privilege, cp1252 console
encoding, OPA 1.18 vs. stock-Rego-library version mismatch), 20 skipped
```

Confirmed via `git stash` that the 8 failures are identical (same tests, same errors) on unmodified `upstream/main` — none are introduced by this change. Also independently reproduced the issue's exact `opa eval` repro command against `_render_rego` output to confirm the fix.

## Test plan

- [x] New regression tests fail on pre-fix code, pass on post-fix code
- [x] Full `agt-policies` suite has no new failures vs. baseline
- [x] `ruff check` clean on changed files
- [x] Manually reran the issue's OPA repro script against the fixed renderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)