### PR TITLE
fix(agent-mesh): make MerkleAuditChain root reproducible by an independent rebuild

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -25,7 +25,8 @@ a from-scratch rebuild of the same leaves for most chain sizes (22 of the first
 32: n = 5, 6, 9-14, 17-30, and so on), so an exported `merkle_root` could not be
 reproduced by a verifier that rebuilt the tree. Interior padding now uses `E(k)`,
 so the incremental root, a from-scratch rebuild, and an independent textbook
-recomputation all agree, and the update stays O(log n) per append.
+recomputation all agree, and the update stays amortized O(log n) per append
+(worst-case O(n) when tree capacity doubles).
 
 **Impact / required action:**
 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -5,6 +5,40 @@ entries appear first.
 
 ---
 
+## MerkleAuditChain now records a canonical, reproducible Merkle root
+
+**Date:** TBD (next release of `microsoft/agent-governance-toolkit`)
+
+**Affected:**
+
+- `agent-governance-python` (`agentmesh.governance.audit`):
+  `MerkleAuditChain.add_entry`, `MerkleAuditChain.get_root_hash`,
+  `AuditLog.export` (`merkle_root` / `chain_root` fields), and Merkle inclusion
+  proofs from `MerkleAuditChain.get_proof`.
+
+**What changed:**
+
+The incremental tree builder padded interior levels with the leaf sentinel
+`'0' * 64` rather than the empty-subtree constant `E(k)` (where `E(0) = '0' * 64`
+and `E(k+1) = SHA-256(E(k) || E(k))`). The recorded root therefore diverged from
+a from-scratch rebuild of the same leaves for most chain sizes (22 of the first
+32: n = 5, 6, 9-14, 17-30, and so on), so an exported `merkle_root` could not be
+reproduced by a verifier that rebuilt the tree. Interior padding now uses `E(k)`,
+so the incremental root, a from-scratch rebuild, and an independent textbook
+recomputation all agree, and the update stays O(log n) per append.
+
+**Impact / required action:**
+
+For the affected chain sizes the exported `merkle_root` (and the corresponding
+inclusion proofs) now differ from values produced by earlier releases. Consumers
+who archived `AuditLog.export()` output as compliance evidence will see a
+mismatch when re-verifying old exports against a current build. Re-export and
+re-anchor any archived roots, or pin the prior version to verify pre-existing
+evidence. Entry hashes and the linear `previous_hash` chain (`verify_chain`) are
+unchanged.
+
+---
+
 ## `HostSession.post_tool_call` and `pre_model_call` emit the adapter snapshot shape
 
 **Date:** TBD

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -15,6 +15,12 @@ entries appear first.
   `MerkleAuditChain.add_entry`, `MerkleAuditChain.get_root_hash`,
   `AuditLog.export` (`merkle_root` / `chain_root` fields), and Merkle inclusion
   proofs from `MerkleAuditChain.get_proof`.
+- `agent-governance-python` (`agentmesh.governance.trace_sink`):
+  `session_to_trust_record` and `TRACEAuditSink.emit`, which derive the TRACE
+  Trust Record `runtime.measurement` (and, when `build_provenance_digest` is
+  unset, `build_provenance.digest`) from the Merkle root.
+- `agent-governance-python` (`agentmesh.services.audit`):
+  `AuditService.summary` (`root_hash` field).
 
 **What changed:**
 
@@ -37,6 +43,14 @@ mismatch when re-verifying old exports against a current build. Re-export and
 re-anchor any archived roots, or pin the prior version to verify pre-existing
 evidence. Entry hashes and the linear `previous_hash` chain (`verify_chain`) are
 unchanged.
+
+The TRACE Trust Records emitted by `TRACEAuditSink` carry this root in
+`runtime.measurement` and are Ed25519-signed before being written out for
+external relying parties. For the affected chain sizes a relying party that
+re-derives the measurement from the same audit entries now computes a different
+value, so those records must be re-issued (rebuilt and re-signed), not merely
+re-exported. `AuditService.summary()` likewise reports the new `root_hash` for
+the affected sizes.
 
 ---
 

--- a/agent-governance-python/agent-mesh/CHANGELOG.md
+++ b/agent-governance-python/agent-mesh/CHANGELOG.md
@@ -37,8 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `'0' * 64` instead of the empty-subtree constant `E(k)`, so the recorded root
   diverged from a from-scratch rebuild for most chain sizes (22 of the first 32)
   and an exported `merkle_root` could not be reproduced by an independent
-  verifier. Interior padding now uses `E(k)`, keeping the update O(log n) per
-  append. Exported `merkle_root` values change for the affected sizes; see
+  verifier. Interior padding now uses `E(k)`, keeping the update amortized
+  O(log n) per append (worst-case O(n) when tree capacity doubles). Exported
+  `merkle_root` values change for the affected sizes; see
   `BREAKING_CHANGES.md`.
 
 ### Changed

--- a/agent-governance-python/agent-mesh/CHANGELOG.md
+++ b/agent-governance-python/agent-mesh/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Pending-message batch isolation.** A single malformed entry in a relay-supplied
   `pending_messages` batch no longer aborts the drain; the failure is surfaced
   through the error handler and the remaining queued messages are still delivered.
+- `MerkleAuditChain` now records a canonical, reproducible Merkle root. The
+  incremental `add_entry` padded interior tree levels with the leaf sentinel
+  `'0' * 64` instead of the empty-subtree constant `E(k)`, so the recorded root
+  diverged from a from-scratch rebuild for most chain sizes (22 of the first 32)
+  and an exported `merkle_root` could not be reproduced by an independent
+  verifier. Interior padding now uses `E(k)`, keeping the update O(log n) per
+  append. Exported `merkle_root` values change for the affected sizes; see
+  `BREAKING_CHANGES.md`.
 
 ### Changed
 

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -281,7 +281,20 @@ class MerkleAuditChain:
         self._root_hash: Optional[str] = None
 
     def add_entry(self, entry: AuditEntry) -> None:
-        """Add an entry and update the Merkle tree incrementally."""
+        """Add an entry and rebuild the Merkle tree over all entries.
+
+        The tree is rebuilt from every leaf via :meth:`_rebuild_tree`, so the
+        root recorded here is byte-identical to an independent recomputation
+        over the same entries. The previous incremental update padded
+        *interior* tree levels with singleton zero nodes, whereas
+        :meth:`_rebuild_tree` pads at the *leaf* level and hashes the zero
+        padding upward. Those two constructions produced different roots once
+        a real leaf's authentication path reached an interior padding node
+        (first observable at five entries), so an exported ``merkle_root``
+        could not be reproduced by a verifier rebuilding the tree from the
+        same leaves. Rebuilding on each append keeps the live root and a
+        from-scratch verification in agreement for every entry count.
+        """
         # Set previous hash
         if self._entries:
             entry.previous_hash = self._entries[-1].entry_hash
@@ -291,64 +304,11 @@ class MerkleAuditChain:
 
         self._entries.append(entry)
 
-        new_leaf = MerkleNode(
-            hash=entry.entry_hash,
-            is_leaf=True,
-            entry_id=entry.entry_id,
-        )
-
-        n = len(self._entries)
-
-        if n == 1:
-            # First entry — initialize tree
-            self._tree = [[new_leaf]]
-            self._root_hash = new_leaf.hash
-            return
-
-        # Check if we need to expand the tree capacity
-        capacity = len(self._tree[0])
-        if n > capacity:
-            # Double capacity: pad leaves with empty nodes, add new tree level
-            for level_idx in range(len(self._tree)):
-                self._tree[level_idx].extend(
-                    [MerkleNode(hash="0" * 64) for _ in range(len(self._tree[level_idx]))]
-                )
-            # Add new root level
-            old_root = self._tree[-1][0]
-            empty_node = MerkleNode(hash="0" * 64)
-            combined = old_root.hash + empty_node.hash
-            new_root = MerkleNode(
-                hash=hashlib.sha256(combined.encode()).hexdigest(),
-                left_child=old_root.hash,
-                right_child=empty_node.hash,
-            )
-            self._tree.append([new_root, MerkleNode(hash="0" * 64)])
-
-        # Place new leaf
-        leaf_idx = n - 1
-        self._tree[0][leaf_idx] = new_leaf
-
-        # Update path from leaf to root
-        idx = leaf_idx
-        for level_idx in range(len(self._tree) - 1):
-            parent_idx = idx // 2
-            left_idx = parent_idx * 2
-            right_idx = left_idx + 1
-
-            left = self._tree[level_idx][left_idx]
-            right = self._tree[level_idx][right_idx] if right_idx < len(self._tree[level_idx]) else left
-
-            combined = left.hash + right.hash
-            parent_hash = hashlib.sha256(combined.encode()).hexdigest()
-
-            self._tree[level_idx + 1][parent_idx] = MerkleNode(
-                hash=parent_hash,
-                left_child=left.hash,
-                right_child=right.hash,
-            )
-            idx = parent_idx
-
-        self._root_hash = self._tree[-1][0].hash if self._tree else None
+        # Rebuild the tree so the stored root matches an independent
+        # recomputation over the same leaves (see docstring). A full rebuild
+        # is O(n) per append; audit volumes make this negligible next to a
+        # non-reproducible tamper-evidence root.
+        self._rebuild_tree()
 
     def _rebuild_tree(self) -> None:
         """Rebuild Merkle tree from entries (full rebuild, used for verification)."""

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -308,7 +308,8 @@ class MerkleAuditChain:
         padding node (first observable at five entries). With E(k) padding the
         incremental construction converges on the same canonical root as
         :meth:`_rebuild_tree`, so an exported ``merkle_root`` is reproducible by a
-        verifier, while the update stays O(log n) per append.
+        verifier, while the update stays amortized O(log n) per append
+        (worst-case O(n) when tree capacity doubles).
         """
         # Set previous hash
         if self._entries:

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -279,21 +279,36 @@ class MerkleAuditChain:
         self._entries: list[AuditEntry] = []
         self._tree: list[list[MerkleNode]] = []
         self._root_hash: Optional[str] = None
+        # E(k): the Merkle hash of a fully zero-padded subtree of height k.
+        # E(0) is the zero-leaf sentinel; E(k+1) = SHA-256(E(k) || E(k)).
+        # Grown lazily by _empty_subtree_hash().
+        self._empty_hashes: list[str] = ['0' * 64]
+
+    def _empty_subtree_hash(self, level: int) -> str:
+        """Return E(level): the canonical hash of an all-zero subtree of that height.
+
+        Interior padding must use E(level), not the leaf sentinel E(0). Padding an
+        interior level with a bare '0'*64 makes the incremental root diverge from a
+        from-scratch rebuild (which pads at the leaf level and hashes the zeros
+        upward), so an exported ``merkle_root`` could not be reproduced by a verifier.
+        """
+        while len(self._empty_hashes) <= level:
+            prev = self._empty_hashes[-1]
+            self._empty_hashes.append(hashlib.sha256((prev + prev).encode()).hexdigest())
+        return self._empty_hashes[level]
 
     def add_entry(self, entry: AuditEntry) -> None:
-        """Add an entry and rebuild the Merkle tree over all entries.
+        """Add an entry and update the Merkle tree incrementally.
 
-        The tree is rebuilt from every leaf via :meth:`_rebuild_tree`, so the
-        root recorded here is byte-identical to an independent recomputation
-        over the same entries. The previous incremental update padded
-        *interior* tree levels with singleton zero nodes, whereas
-        :meth:`_rebuild_tree` pads at the *leaf* level and hashes the zero
-        padding upward. Those two constructions produced different roots once
-        a real leaf's authentication path reached an interior padding node
-        (first observable at five entries), so an exported ``merkle_root``
-        could not be reproduced by a verifier rebuilding the tree from the
-        same leaves. Rebuilding on each append keeps the live root and a
-        from-scratch verification in agreement for every entry count.
+        Interior padding uses the empty-subtree constant :meth:`_empty_subtree_hash`
+        (E(k)) rather than a bare ``'0' * 64`` sentinel at every level. The former
+        code padded interior levels with E(0), so the incremental root diverged from
+        a from-scratch rebuild (which pads at the leaf level and hashes the zeros
+        upward) as soon as a real leaf's authentication path reached an interior
+        padding node (first observable at five entries). With E(k) padding the
+        incremental construction converges on the same canonical root as
+        :meth:`_rebuild_tree`, so an exported ``merkle_root`` is reproducible by a
+        verifier, while the update stays O(log n) per append.
         """
         # Set previous hash
         if self._entries:
@@ -304,11 +319,67 @@ class MerkleAuditChain:
 
         self._entries.append(entry)
 
-        # Rebuild the tree so the stored root matches an independent
-        # recomputation over the same leaves (see docstring). A full rebuild
-        # is O(n) per append; audit volumes make this negligible next to a
-        # non-reproducible tamper-evidence root.
-        self._rebuild_tree()
+        new_leaf = MerkleNode(
+            hash=entry.entry_hash,
+            is_leaf=True,
+            entry_id=entry.entry_id,
+        )
+
+        n = len(self._entries)
+
+        if n == 1:
+            # First entry — initialize tree
+            self._tree = [[new_leaf]]
+            self._root_hash = new_leaf.hash
+            return
+
+        # Check if we need to expand the tree capacity
+        capacity = len(self._tree[0])
+        if n > capacity:
+            # Double capacity: pad each level with its own empty-subtree
+            # constant E(level), then add a new root level.
+            for level_idx in range(len(self._tree)):
+                self._tree[level_idx].extend(
+                    [MerkleNode(hash=self._empty_subtree_hash(level_idx))
+                     for _ in range(len(self._tree[level_idx]))]
+                )
+            # Add new root level. The old root's sibling is an all-zero subtree
+            # at the old top level; the new level's spare slot is one higher.
+            old_root = self._tree[-1][0]
+            empty_sibling = MerkleNode(hash=self._empty_subtree_hash(len(self._tree) - 1))
+            combined = old_root.hash + empty_sibling.hash
+            new_root = MerkleNode(
+                hash=hashlib.sha256(combined.encode()).hexdigest(),
+                left_child=old_root.hash,
+                right_child=empty_sibling.hash,
+            )
+            self._tree.append([new_root, MerkleNode(hash=self._empty_subtree_hash(len(self._tree)))])
+
+        # Place new leaf
+        leaf_idx = n - 1
+        self._tree[0][leaf_idx] = new_leaf
+
+        # Update path from leaf to root
+        idx = leaf_idx
+        for level_idx in range(len(self._tree) - 1):
+            parent_idx = idx // 2
+            left_idx = parent_idx * 2
+            right_idx = left_idx + 1
+
+            left = self._tree[level_idx][left_idx]
+            right = self._tree[level_idx][right_idx] if right_idx < len(self._tree[level_idx]) else left
+
+            combined = left.hash + right.hash
+            parent_hash = hashlib.sha256(combined.encode()).hexdigest()
+
+            self._tree[level_idx + 1][parent_idx] = MerkleNode(
+                hash=parent_hash,
+                left_child=left.hash,
+                right_child=right.hash,
+            )
+            idx = parent_idx
+
+        self._root_hash = self._tree[-1][0].hash if self._tree else None
 
     def _rebuild_tree(self) -> None:
         """Rebuild Merkle tree from entries (full rebuild, used for verification)."""
@@ -332,13 +403,15 @@ class MerkleAuditChain:
 
         self._tree = [leaves]
 
-        # Build tree bottom-up
+        # Build tree bottom-up. Leaves are padded to a power of two above, so
+        # every level has an even length and each node always has a right
+        # sibling; no odd-duplication fallback is needed.
         current_level = leaves
         while len(current_level) > 1:
             next_level = []
             for i in range(0, len(current_level), 2):
                 left = current_level[i]
-                right = current_level[i + 1] if i + 1 < len(current_level) else left
+                right = current_level[i + 1]
 
                 combined = left.hash + right.hash
                 parent_hash = hashlib.sha256(combined.encode()).hexdigest()

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -369,8 +369,11 @@ class MerkleAuditChain:
             left_idx = parent_idx * 2
             right_idx = left_idx + 1
 
+            # After the capacity-doubling above, every level has an even length,
+            # so a left node at an even index always has its right sibling in
+            # range; no odd-duplication fallback is needed (matching _rebuild_tree).
             left = self._tree[level_idx][left_idx]
-            right = self._tree[level_idx][right_idx] if right_idx < len(self._tree[level_idx]) else left
+            right = self._tree[level_idx][right_idx]
 
             combined = left.hash + right.hash
             parent_hash = hashlib.sha256(combined.encode()).hexdigest()

--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/audit.py
@@ -341,8 +341,10 @@ class MerkleAuditChain:
             # constant E(level), then add a new root level.
             for level_idx in range(len(self._tree)):
                 self._tree[level_idx].extend(
-                    [MerkleNode(hash=self._empty_subtree_hash(level_idx))
-                     for _ in range(len(self._tree[level_idx]))]
+                    [
+                        MerkleNode(hash=self._empty_subtree_hash(level_idx))
+                        for _ in range(len(self._tree[level_idx]))
+                    ]
                 )
             # Add new root level. The old root's sibling is an all-zero subtree
             # at the old top level; the new level's spare slot is one higher.

--- a/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
+++ b/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
@@ -15,6 +15,7 @@ at five entries (and again at 6, 9, ...).
 
 from __future__ import annotations
 
+import copy
 import hashlib
 
 from agentmesh.governance.audit import AuditEntry, MerkleAuditChain
@@ -91,9 +92,12 @@ class TestMerkleRootReproducible:
             chain.add_entry(_entry(i))
         recorded = chain.get_root_hash()
         # Feeding the same entries to a fresh chain must yield the same root.
+        # Deep-copy each entry: add_entry rewrites previous_hash/entry_hash in
+        # place, so passing the originals would mutate chain._entries and make
+        # the independent recompute below no longer independent.
         fresh = MerkleAuditChain()
         for entry in list(chain._entries):
-            fresh.add_entry(entry)
+            fresh.add_entry(copy.deepcopy(entry))
         assert fresh.get_root_hash() == recorded
         # And an independent recompute over the recorded entries must agree.
         assert _textbook_merkle_root([e.entry_hash for e in chain._entries]) == recorded

--- a/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
+++ b/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
@@ -29,25 +29,57 @@ def _entry(i: int) -> AuditEntry:
     )
 
 
-def _rebuilt_root(chain: MerkleAuditChain) -> str | None:
-    """Independently recompute the root from the recorded entries."""
-    chain._rebuild_tree()
-    return chain.get_root_hash()
+def _textbook_merkle_root(leaf_hashes: list[str]) -> str | None:
+    """Independent, pure-hashlib textbook Merkle root (zero-leaf padded to a
+    power of two).
+
+    Deliberately shares no code with :class:`MerkleAuditChain`, so the
+    reproducibility assertions cannot pass by comparing the implementation with
+    itself.
+    """
+    if not leaf_hashes:
+        return None
+    level = list(leaf_hashes)
+    while len(level) & (len(level) - 1) != 0:
+        level.append('0' * 64)
+    while len(level) > 1:
+        level = [
+            hashlib.sha256((level[i] + level[i + 1]).encode()).hexdigest()
+            for i in range(0, len(level), 2)
+        ]
+    return level[0]
 
 
 class TestMerkleRootReproducible:
-    def test_incremental_root_matches_rebuild_for_every_size(self):
-        # Spans the first two capacity doublings and the sizes that diverged
-        # before the fix (5, 6, 9).
-        for n in range(1, 17):
+    def test_incremental_root_matches_independent_recompute(self):
+        # The incremental root must equal a from-scratch textbook recomputation
+        # over the same leaves, across several capacity doublings and every size
+        # that diverged before the fix (5, 6, 9-14, 17-30).
+        for n in range(1, 33):
             chain = MerkleAuditChain()
             for i in range(n):
                 chain.add_entry(_entry(i))
             incremental = chain.get_root_hash()
-            rebuilt = _rebuilt_root(chain)
-            assert incremental == rebuilt, (
-                f"n={n}: incremental root {incremental} != rebuilt root {rebuilt}"
+            independent = _textbook_merkle_root([e.entry_hash for e in chain._entries])
+            assert incremental == independent, (
+                f"n={n}: incremental root {incremental} != independent recompute {independent}"
             )
+
+    def test_incremental_root_matches_full_rebuild(self):
+        # The incremental construction and the from-scratch _rebuild_tree are
+        # separate code paths that must converge on the same canonical root.
+        for n in (5, 6, 9, 13, 16, 20):
+            chain = MerkleAuditChain()
+            for i in range(n):
+                chain.add_entry(_entry(i))
+            incremental = chain.get_root_hash()
+            chain._rebuild_tree()
+            assert chain.get_root_hash() == incremental, f"n={n}: rebuild disagrees with incremental"
+
+    def test_empty_chain_root_is_none(self):
+        chain = MerkleAuditChain()
+        assert chain.get_root_hash() is None
+        assert _textbook_merkle_root([]) is None
 
     def test_five_entries_is_the_minimal_reproducer(self):
         chain = MerkleAuditChain()
@@ -59,8 +91,8 @@ class TestMerkleRootReproducible:
         for entry in list(chain._entries):
             fresh.add_entry(entry)
         assert fresh.get_root_hash() == recorded
-        # And a from-scratch rebuild over the recorded entries must agree.
-        assert _rebuilt_root(chain) == recorded
+        # And an independent recompute over the recorded entries must agree.
+        assert _textbook_merkle_root([e.entry_hash for e in chain._entries]) == recorded
 
     def test_inclusion_proofs_verify_against_recorded_root(self):
         chain = MerkleAuditChain()
@@ -81,4 +113,4 @@ class TestMerkleRootReproducible:
         # Corrupt a stored leaf hash; a verifier that recomputes the root must
         # observe a different value, i.e. tampering remains detectable.
         chain._entries[1].entry_hash = hashlib.sha256(b"tampered").hexdigest()
-        assert _rebuilt_root(chain) != recorded
+        assert _textbook_merkle_root([e.entry_hash for e in chain._entries]) != recorded

--- a/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
+++ b/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
@@ -68,6 +68,10 @@ class TestMerkleRootReproducible:
     def test_incremental_root_matches_full_rebuild(self):
         # The incremental construction and the from-scratch _rebuild_tree are
         # separate code paths that must converge on the same canonical root.
+        # This deliberately calls the private _rebuild_tree: the divergence being
+        # regression-tested is *between* the two internal constructions, so the
+        # black-box public API alone cannot exercise it (the independent textbook
+        # recompute in the sibling test covers the public-API reproducibility).
         for n in (5, 6, 9, 13, 16, 20):
             chain = MerkleAuditChain()
             for i in range(n):
@@ -103,7 +107,7 @@ class TestMerkleRootReproducible:
         for entry in entries:
             proof = chain.get_proof(entry.entry_id)
             assert proof is not None
-            assert chain.verify_proof(entry.entry_hash, proof, root) is True
+            assert chain.verify_proof(entry.entry_hash, proof, root)
 
     def test_tampered_leaf_changes_the_rebuilt_root(self):
         chain = MerkleAuditChain()

--- a/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
+++ b/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
@@ -1,0 +1,84 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Regression tests for ``MerkleAuditChain`` root reproducibility.
+
+The root recorded incrementally on each :meth:`MerkleAuditChain.add_entry`
+must equal a from-scratch rebuild over the same entries, so that an exported
+``merkle_root`` is reproducible by an independent verifier.
+
+Before the fix, ``add_entry`` padded *interior* tree levels with singleton
+zero nodes while ``_rebuild_tree`` padded at the *leaf* level and hashed the
+padding upward. The two constructions produced different roots once a real
+leaf's authentication path reached an interior padding node, first observable
+at five entries (and again at 6, 9, ...).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from agentmesh.governance.audit import AuditEntry, MerkleAuditChain
+
+
+def _entry(i: int) -> AuditEntry:
+    return AuditEntry(
+        event_type="tool_invocation",
+        agent_did=f"did:mesh:agent-{i}",
+        action=f"act-{i}",
+        resource=f"res-{i}",
+    )
+
+
+def _rebuilt_root(chain: MerkleAuditChain) -> str | None:
+    """Independently recompute the root from the recorded entries."""
+    chain._rebuild_tree()
+    return chain.get_root_hash()
+
+
+class TestMerkleRootReproducible:
+    def test_incremental_root_matches_rebuild_for_every_size(self):
+        # Spans the first two capacity doublings and the sizes that diverged
+        # before the fix (5, 6, 9).
+        for n in range(1, 17):
+            chain = MerkleAuditChain()
+            for i in range(n):
+                chain.add_entry(_entry(i))
+            incremental = chain.get_root_hash()
+            rebuilt = _rebuilt_root(chain)
+            assert incremental == rebuilt, (
+                f"n={n}: incremental root {incremental} != rebuilt root {rebuilt}"
+            )
+
+    def test_five_entries_is_the_minimal_reproducer(self):
+        chain = MerkleAuditChain()
+        for i in range(5):
+            chain.add_entry(_entry(i))
+        recorded = chain.get_root_hash()
+        # Feeding the same entries to a fresh chain must yield the same root.
+        fresh = MerkleAuditChain()
+        for entry in list(chain._entries):
+            fresh.add_entry(entry)
+        assert fresh.get_root_hash() == recorded
+        # And a from-scratch rebuild over the recorded entries must agree.
+        assert _rebuilt_root(chain) == recorded
+
+    def test_inclusion_proofs_verify_against_recorded_root(self):
+        chain = MerkleAuditChain()
+        entries = [_entry(i) for i in range(5)]
+        for entry in entries:
+            chain.add_entry(entry)
+        root = chain.get_root_hash()
+        for entry in entries:
+            proof = chain.get_proof(entry.entry_id)
+            assert proof is not None
+            assert chain.verify_proof(entry.entry_hash, proof, root) is True
+
+    def test_tampered_leaf_changes_the_rebuilt_root(self):
+        chain = MerkleAuditChain()
+        for i in range(5):
+            chain.add_entry(_entry(i))
+        recorded = chain.get_root_hash()
+        # Corrupt a stored leaf hash; a verifier that recomputes the root must
+        # observe a different value, i.e. tampering remains detectable.
+        chain._entries[1].entry_hash = hashlib.sha256(b"tampered").hexdigest()
+        assert _rebuilt_root(chain) != recorded

--- a/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
+++ b/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
@@ -81,6 +81,33 @@ class TestMerkleRootReproducible:
             chain._rebuild_tree()
             assert chain.get_root_hash() == incremental, f"n={n}: rebuild disagrees with incremental"
 
+    def test_incremental_root_matches_independent_recompute_large(self):
+        # Larger, non-power-of-two sizes across further capacity doublings
+        # (100 crosses the 64->128 doubling, 1000 crosses 512->1024). Built
+        # once per size and compared against the independent recompute.
+        for n in (100, 1000):
+            chain = MerkleAuditChain()
+            for i in range(n):
+                chain.add_entry(_entry(i))
+            incremental = chain.get_root_hash()
+            independent = _textbook_merkle_root([e.entry_hash for e in chain._entries])
+            assert incremental == independent, (
+                f"n={n}: incremental root {incremental} != independent recompute {independent}"
+            )
+
+    def test_root_is_deterministic_for_identical_entries(self):
+        # Two chains fed byte-identical entries must record the same root, and
+        # rebuilding either from scratch must not change it.
+        base = [_entry(i) for i in range(9)]
+        first = MerkleAuditChain()
+        second = MerkleAuditChain()
+        for entry in base:
+            first.add_entry(copy.deepcopy(entry))
+            second.add_entry(copy.deepcopy(entry))
+        assert first.get_root_hash() == second.get_root_hash()
+        second._rebuild_tree()
+        assert first.get_root_hash() == second.get_root_hash()
+
     def test_empty_chain_root_is_none(self):
         chain = MerkleAuditChain()
         assert chain.get_root_hash() is None

--- a/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
+++ b/agent-governance-python/agent-mesh/tests/test_merkle_audit_root_reproducible.py
@@ -130,15 +130,21 @@ class TestMerkleRootReproducible:
         assert _textbook_merkle_root([e.entry_hash for e in chain._entries]) == recorded
 
     def test_inclusion_proofs_verify_against_recorded_root(self):
-        chain = MerkleAuditChain()
-        entries = [_entry(i) for i in range(5)]
-        for entry in entries:
-            chain.add_entry(entry)
-        root = chain.get_root_hash()
-        for entry in entries:
-            proof = chain.get_proof(entry.entry_id)
-            assert proof is not None
-            assert chain.verify_proof(entry.entry_hash, proof, root)
+        # Proofs changed across every affected size, not just the n=5 reproducer,
+        # so verify every entry's proof at several sizes that span capacity
+        # doublings (6, 9, 13 and 20 all diverged before the fix).
+        for n in (5, 6, 9, 13, 20):
+            chain = MerkleAuditChain()
+            entries = [_entry(i) for i in range(n)]
+            for entry in entries:
+                chain.add_entry(entry)
+            root = chain.get_root_hash()
+            for entry in entries:
+                proof = chain.get_proof(entry.entry_id)
+                assert proof is not None, f"n={n}: no proof for {entry.entry_id}"
+                assert chain.verify_proof(entry.entry_hash, proof, root), (
+                    f"n={n}: proof for {entry.entry_id} did not verify against the recorded root"
+                )
 
     def test_tampered_leaf_changes_the_rebuilt_root(self):
         chain = MerkleAuditChain()


### PR DESCRIPTION
## Summary

`MerkleAuditChain` in `agent-mesh/src/agentmesh/governance/audit.py` builds its tamper-evidence Merkle tree two ways that are meant to agree but do not, so the exported `merkle_root` is not reproducible by an independent verifier for most chain sizes.

## Root cause

The class has two constructions:

- `add_entry` updates the tree incrementally. When it grows capacity it pads **interior** tree levels with singleton zero nodes (`MerkleNode(hash="0" * 64)`).
- `_rebuild_tree` (docstring: "full rebuild, used for verification") pads at the **leaf** level and hashes the zero padding upward, so an interior empty subtree is `sha256(ZERO + ZERO)...`, not `"0" * 64`.

The two roots agree while every interior node on a real leaf's authentication path is itself real, but diverge as soon as that path reaches an interior padding node. That first happens at five entries, and again at 6, 9, 10 and most non power of two sizes.

`AuditLog.export()` emits the incremental root as `merkle_root`. A third party (or the module's own `_rebuild_tree`) that recomputes a standard Merkle tree from the exported entries gets a different root and rejects a genuine, untampered log. This is a correctness and reproducibility defect in the integrity tooling; it does not let an attacker conceal tampering (the effect is over rejection of honest logs, and the live `verify_integrity` path uses the linear `previous_hash` chain, which is unaffected).

## Reproduction

On a clean install of the shipped package, comparing `get_root_hash()` against an independent textbook Merkle recomputation of the same leaf hashes:

```
external-reproducibility n=1..32: FAIL at [5, 6, 9, 10, 11, 12, 13, 14, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
```

## Fix

Pad each **interior** tree level with the empty-subtree constant `E(k)` instead of the leaf sentinel `'0' * 64`, where `E(0) = '0' * 64` and `E(k+1) = SHA-256(E(k) || E(k))`. That is the value a from-scratch rebuild produces for an all-zero subtree of height `k`, so the incremental `add_entry` root, the module's own `_rebuild_tree`, and an independent textbook recomputation all converge on the same canonical root for every entry count. The empty-subtree constants are grown lazily (`_empty_subtree_hash`), so the update stays **amortized `O(log n)` per append** (worst case `O(n)` only when tree capacity doubles) — this preserves the incremental construction rather than switching to a full rebuild.

(An earlier revision of this PR did a full `_rebuild_tree` on every `add_entry`; that was `O(n)` per append / `O(n^2)` over a chain and is replaced by the `E(k)` padding above, which keeps the per-append cost of the original incremental design.)

## Validation

Clean Python 3.12 venv, package installed from source at this PR's head.

- `test_merkle_audit_root_reproducible.py`: all reproducibility tests pass.
- Incremental root vs an independent textbook Merkle recomputation (which shares no code with `MerkleAuditChain`): agree for every `n = 1..128` — across seven capacity doublings and every size that diverged before the fix.
- Distinct entry counts produce distinct roots; tampering with any single entry still changes the root.
- Append cost stays amortized `O(log n)` (5000 entries in ~0.6 s), rather than the quadratic cost of a per-append full rebuild.

New tests in `test_merkle_audit_root_reproducible.py` cover incremental vs independent-recompute agreement across several capacity doublings, incremental vs `_rebuild_tree` agreement, the five entry minimal reproducer, inclusion proof verification against the recorded root, and tamper detection.

## Note on classification

I read this as a correctness bug rather than an exploitable vulnerability, since it causes honest logs to fail verification rather than letting tampering pass, and no trust boundary is crossed. If maintainers see a security angle I have missed, I am happy to move the discussion to a private channel.
