### PR TITLE
feat(dotnet): add approval chain parity

### DIFF
--- a/agent-governance-dotnet/README.md
+++ b/agent-governance-dotnet/README.md
@@ -172,6 +172,84 @@ engine.LoadCedar(
         """);
 ```
 
+### Action-Bound Approval Chains
+
+`require_approval` decisions can be routed through the ADR-0030 approval protocol. The protocol binds approval to the exact agent, subject, operation, target, parameters, policy version, and chain version. It persists pending requests, records hash-linked entries, fails closed on timeout or malformed responses, and revalidates and consumes a terminal allow immediately before execution.
+
+```csharp
+using AgentGovernance.Approvals;
+
+var store = new InMemoryApprovalStore();
+var audit = new InMemoryApprovalAuditSink();
+var chain = new ApprovalChain
+{
+    ChainId = "production-writes",
+    Version = "3",
+    Stages = new[]
+    {
+        new ApprovalStage
+        {
+            StageIndex = 0,
+            AllowedIdentities = new[] { "did:web:example.com:users:alice" }
+        }
+    }
+};
+var coordinator = new ApprovalCoordinator(
+    chain,
+    store,
+    new ApprovalCoordinatorOptions
+    {
+        PolicyRuleId = "production-db-writes",
+        PolicyVersion = "2026.07.17",
+        RequestTtl = TimeSpan.FromMinutes(10),
+        AuditSink = audit
+    });
+
+var binding = new ActionBinding
+{
+    Operation = "tool.invoke",
+    AgentId = "did:agent:123",
+    SubjectId = "user-456",
+    Target = new ActionTarget
+    {
+        ToolName = "sql_execute",
+        ToolSchemaVersion = "2",
+        Resource = "prod-db"
+    },
+    Parameters = new Dictionary<string, object?>
+    {
+        ["statement"] = "UPDATE accounts SET status = ? WHERE id = ?",
+        ["values"] = new object[] { "closed", 42 }
+    }
+};
+
+var opened = coordinator.OpenRequest(binding);
+
+// Call SubmitEntry only after the caller has authenticated this principal.
+coordinator.SubmitEntry(
+    opened.Request.ApprovalRequestId,
+    stageIndex: 0,
+    new ApprovalVote
+    {
+        ApproverKind = ApproverKind.Human,
+        ApproverIdentity = "did:web:example.com:users:alice",
+        IdentityAssurance = "oidc",
+        Decision = ApprovalEntryDecision.Allow,
+        ReasonCode = "reviewed-production-change"
+    });
+
+var execution = coordinator.ValidateForExecution(
+    opened.Request.ApprovalRequestId,
+    binding);
+
+if (!execution.Allowed)
+{
+    throw new InvalidOperationException(execution.ReasonCode);
+}
+```
+
+For remote workflows, attach a `WebhookApprover` to an `ApprovalStage`. Its versioned payload carries the request and action digests, policy and chain versions, and expiry. Approve responses are accepted only when a supplied `WebhookResponseVerifier` returns an identity established through authenticated transport or a verified assertion. LLM entries are advisory and cannot authorize or deny execution. A chain with no required non-advisory stage fails closed with `no_required_approval_stage`; this intentionally avoids the vacuous-allow behavior in the current Python implementation and matches the safer Go parity behavior.
+
 ### Rate Limiting
 
 Sliding window rate limiter integrated into the policy engine:

--- a/agent-governance-dotnet/README.md
+++ b/agent-governance-dotnet/README.md
@@ -222,7 +222,7 @@ In this example, accumulation raises the envelope to `Restricted`, adds `no_exte
 
 ### Action-Bound Approval Chains
 
-`require_approval` decisions can be routed through the ADR-0030 approval protocol. The protocol binds approval to the exact agent, subject, operation, target, parameters, policy version, and chain version. It persists pending requests, records hash-linked entries, fails closed on timeout or malformed responses, and revalidates and consumes a terminal allow immediately before execution.
+`require_approval` decisions can be routed through the ADR-0030 approval protocol. The protocol binds approval to the exact agent, subject, operation, target, parameters, policy version, and chain version. It persists pending requests, records hash-linked entries, fails closed on timeout or malformed responses, and revalidates and consumes a terminal allow immediately before execution. The entry chain uses plain SHA-256 without a secret key for tamper evidence inside a trusted store boundary. It is not a MAC or signature, so a writer with direct store access can recompute the chain.
 
 ```csharp
 using AgentGovernance.Approvals;
@@ -296,7 +296,7 @@ if (!execution.Allowed)
 }
 ```
 
-For remote workflows, attach a `WebhookApprover` to an `ApprovalStage`. Its versioned payload carries the request and action digests, policy and chain versions, and expiry. Approve responses are accepted only when a supplied `WebhookResponseVerifier` returns an identity established through authenticated transport or a verified assertion. LLM entries are advisory and cannot authorize or deny execution. A chain with no required non-advisory stage fails closed with `no_required_approval_stage`; this intentionally avoids the vacuous-allow behavior in the current Python implementation and matches the safer Go parity behavior.
+For remote workflows, attach a `WebhookApprover` to an `ApprovalStage`. Its versioned payload carries the request and action digests, policy and chain versions, and expiry. Approve responses are accepted only when a supplied `WebhookResponseVerifier` returns an identity established through authenticated transport or a verified assertion. The default HTTP client rejects redirects and pins each connection to request-time DNS results after rejecting loopback, link-local, private, and reserved addresses. A caller-supplied `HttpClient` receives the same request-time address check, but its handler remains responsible for pinning the validated destination when it connects. LLM entries are optional advisory stages and cannot authorize or deny execution. A chain with no required non-advisory stage fails closed with `no_required_approval_stage`; this intentionally avoids the vacuous-allow behavior in the current Python implementation and matches the safer Go parity behavior. `ResolveAsync` consumes an allowed approval before returning, so callers should use its `Execution` result rather than validating the same request again.
 
 ### Rate Limiting
 

--- a/agent-governance-dotnet/README.md
+++ b/agent-governance-dotnet/README.md
@@ -220,6 +220,84 @@ var auditEvent = ContextEvent.Create(
 
 In this example, accumulation raises the envelope to `Restricted`, adds `no_external_export`, and increments the version twice. The export decision is `Constrain`; a caller without an obligation channel should fail closed and deny the action. Unknown combinations produce `Escalate` and should enter the existing stop-and-review flow. Envelope and audit timestamps are never read from the wall clock by this API.
 
+### Action-Bound Approval Chains
+
+`require_approval` decisions can be routed through the ADR-0030 approval protocol. The protocol binds approval to the exact agent, subject, operation, target, parameters, policy version, and chain version. It persists pending requests, records hash-linked entries, fails closed on timeout or malformed responses, and revalidates and consumes a terminal allow immediately before execution.
+
+```csharp
+using AgentGovernance.Approvals;
+
+var store = new InMemoryApprovalStore();
+var audit = new InMemoryApprovalAuditSink();
+var chain = new ApprovalChain
+{
+    ChainId = "production-writes",
+    Version = "3",
+    Stages = new[]
+    {
+        new ApprovalStage
+        {
+            StageIndex = 0,
+            AllowedIdentities = new[] { "did:web:example.com:users:alice" }
+        }
+    }
+};
+var coordinator = new ApprovalCoordinator(
+    chain,
+    store,
+    new ApprovalCoordinatorOptions
+    {
+        PolicyRuleId = "production-db-writes",
+        PolicyVersion = "2026.07.17",
+        RequestTtl = TimeSpan.FromMinutes(10),
+        AuditSink = audit
+    });
+
+var binding = new ActionBinding
+{
+    Operation = "tool.invoke",
+    AgentId = "did:agent:123",
+    SubjectId = "user-456",
+    Target = new ActionTarget
+    {
+        ToolName = "sql_execute",
+        ToolSchemaVersion = "2",
+        Resource = "prod-db"
+    },
+    Parameters = new Dictionary<string, object?>
+    {
+        ["statement"] = "UPDATE accounts SET status = ? WHERE id = ?",
+        ["values"] = new object[] { "closed", 42 }
+    }
+};
+
+var opened = coordinator.OpenRequest(binding);
+
+// Call SubmitEntry only after the caller has authenticated this principal.
+coordinator.SubmitEntry(
+    opened.Request.ApprovalRequestId,
+    stageIndex: 0,
+    new ApprovalVote
+    {
+        ApproverKind = ApproverKind.Human,
+        ApproverIdentity = "did:web:example.com:users:alice",
+        IdentityAssurance = "oidc",
+        Decision = ApprovalEntryDecision.Allow,
+        ReasonCode = "reviewed-production-change"
+    });
+
+var execution = coordinator.ValidateForExecution(
+    opened.Request.ApprovalRequestId,
+    binding);
+
+if (!execution.Allowed)
+{
+    throw new InvalidOperationException(execution.ReasonCode);
+}
+```
+
+For remote workflows, attach a `WebhookApprover` to an `ApprovalStage`. Its versioned payload carries the request and action digests, policy and chain versions, and expiry. Approve responses are accepted only when a supplied `WebhookResponseVerifier` returns an identity established through authenticated transport or a verified assertion. LLM entries are advisory and cannot authorize or deny execution. A chain with no required non-advisory stage fails closed with `no_required_approval_stage`; this intentionally avoids the vacuous-allow behavior in the current Python implementation and matches the safer Go parity behavior.
+
 ### Rate Limiting
 
 Sliding window rate limiter integrated into the policy engine:

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalAudit.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalAudit.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AgentGovernance.Approvals;
+
+/// <summary>Lifecycle events emitted by the approval protocol.</summary>
+public enum ApprovalAuditEventType
+{
+    /// <summary>A policy decision suspended execution.</summary>
+    PolicyDecision,
+
+    /// <summary>An approval request was opened.</summary>
+    ApprovalRequested,
+
+    /// <summary>An approval chain entry was appended.</summary>
+    ApprovalChainEntry,
+
+    /// <summary>An approval request reached a terminal resolution.</summary>
+    ApprovalResolved,
+
+    /// <summary>An approval request expired.</summary>
+    ApprovalExpired,
+
+    /// <summary>An approval request was cancelled.</summary>
+    ApprovalCancelled,
+
+    /// <summary>An allow resolution was consumed.</summary>
+    ApprovalConsumed,
+
+    /// <summary>Execution was released after successful validation.</summary>
+    ExecutionAllowed,
+
+    /// <summary>Execution was denied during validation.</summary>
+    ExecutionDenied
+}
+
+/// <summary>A structured, linked approval audit record.</summary>
+public sealed record ApprovalAuditEvent
+{
+    /// <summary>The audit event type.</summary>
+    public required ApprovalAuditEventType Type { get; init; }
+
+    /// <summary>The UTC event time.</summary>
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>The acting agent identifier.</summary>
+    public string? AgentId { get; init; }
+
+    /// <summary>The linked policy decision identifier.</summary>
+    public string? PolicyDecisionId { get; init; }
+
+    /// <summary>The linked approval request identifier.</summary>
+    public string? ApprovalRequestId { get; init; }
+
+    /// <summary>The linked approval resolution identifier.</summary>
+    public string? ApprovalResolutionId { get; init; }
+
+    /// <summary>The linked approval chain entry identifier.</summary>
+    public string? ChainEntryId { get; init; }
+
+    /// <summary>The bound action digest.</summary>
+    public string? ActionDigest { get; init; }
+
+    /// <summary>The bound policy version.</summary>
+    public string? PolicyVersion { get; init; }
+
+    /// <summary>The bound approval chain version.</summary>
+    public string? ApprovalChainVersion { get; init; }
+
+    /// <summary>The machine-readable event reason.</summary>
+    public string? ReasonCode { get; init; }
+}
+
+/// <summary>Receives structured approval protocol audit records.</summary>
+public interface IApprovalAuditSink
+{
+    /// <summary>Persists one approval audit record.</summary>
+    void Write(ApprovalAuditEvent auditEvent);
+}
+
+/// <summary>A thread-safe in-memory approval audit sink for tests and local embedding.</summary>
+public sealed class InMemoryApprovalAuditSink : IApprovalAuditSink
+{
+    private readonly object _sync = new();
+    private readonly List<ApprovalAuditEvent> _events = new();
+
+    /// <inheritdoc />
+    public void Write(ApprovalAuditEvent auditEvent)
+    {
+        ArgumentNullException.ThrowIfNull(auditEvent);
+        lock (_sync)
+        {
+            _events.Add(auditEvent);
+        }
+    }
+
+    /// <summary>Returns an immutable snapshot of recorded events.</summary>
+    public IReadOnlyList<ApprovalAuditEvent> GetEvents()
+    {
+        lock (_sync)
+        {
+            return _events.ToList().AsReadOnly();
+        }
+    }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalCoordinator.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalCoordinator.cs
@@ -1,0 +1,832 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using AgentGovernance.Policy;
+
+namespace AgentGovernance.Approvals;
+
+/// <summary>Machine-readable execution-time validation reasons.</summary>
+public static class ApprovalReasonCodes
+{
+    /// <summary>The approval is valid for execution.</summary>
+    public const string Approved = "approved";
+
+    /// <summary>The request could not be found.</summary>
+    public const string RequestNotFound = "approval_request_not_found";
+
+    /// <summary>The request has not reached a terminal resolution.</summary>
+    public const string NotResolved = "approval_not_resolved";
+
+    /// <summary>The request is still pending.</summary>
+    public const string Pending = "approval_pending";
+
+    /// <summary>The request was denied.</summary>
+    public const string Denied = "approval_denied";
+
+    /// <summary>The request expired.</summary>
+    public const string Expired = "approval_expired";
+
+    /// <summary>The request was cancelled.</summary>
+    public const string Cancelled = "approval_cancelled";
+
+    /// <summary>The one-time approval was already consumed.</summary>
+    public const string Consumed = "approval_consumed";
+
+    /// <summary>The action differs from the approved action.</summary>
+    public const string ActionDigestMismatch = "action_digest_mismatch";
+
+    /// <summary>The policy version differs from the approved version.</summary>
+    public const string PolicyVersionMismatch = "policy_version_mismatch";
+
+    /// <summary>The approval chain identifier differs from the approved chain.</summary>
+    public const string ChainIdMismatch = "approval_chain_id_mismatch";
+
+    /// <summary>The approval chain version differs from the approved version.</summary>
+    public const string ChainVersionMismatch = "approval_chain_version_mismatch";
+
+    /// <summary>The entry hash chain or authority checks failed.</summary>
+    public const string ChainTampered = "approval_chain_tampered";
+
+    /// <summary>Required approval stages are incomplete.</summary>
+    public const string ChainIncomplete = "approval_chain_incomplete";
+
+    /// <summary>No required non-advisory stage exists.</summary>
+    public const string NoRequiredStage = "no_required_approval_stage";
+
+    /// <summary>An unexpected validation error occurred.</summary>
+    public const string InternalError = "approval_internal_error";
+}
+
+/// <summary>Configures an <see cref="ApprovalCoordinator"/>.</summary>
+public sealed record ApprovalCoordinatorOptions
+{
+    /// <summary>The default policy rule identifier.</summary>
+    public string PolicyRuleId { get; init; } = "unspecified";
+
+    /// <summary>The active policy version.</summary>
+    public string PolicyVersion { get; init; } = "unspecified";
+
+    /// <summary>The lifetime of a newly opened approval request.</summary>
+    public TimeSpan RequestTtl { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>The maximum wait for each approval transport.</summary>
+    public TimeSpan StageTimeout { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>An optional clock for deterministic tests.</summary>
+    public Func<DateTimeOffset> Clock { get; init; } = static () => DateTimeOffset.UtcNow;
+
+    /// <summary>An optional structured audit sink.</summary>
+    public IApprovalAuditSink? AuditSink { get; init; }
+}
+
+/// <summary>
+/// Creates, advances, resolves, and execution-validates action-bound approval requests.
+/// Every ambiguous or unexpected path fails closed.
+/// </summary>
+public sealed class ApprovalCoordinator
+{
+    private readonly ApprovalChain _chain;
+    private readonly IApprovalStore _store;
+    private readonly ApprovalCoordinatorOptions _options;
+    private readonly ConcurrentDictionary<string, object> _requestLocks = new(StringComparer.Ordinal);
+
+    /// <summary>Creates a coordinator for one versioned approval chain.</summary>
+    public ApprovalCoordinator(
+        ApprovalChain chain,
+        IApprovalStore? store = null,
+        ApprovalCoordinatorOptions? options = null)
+    {
+        _chain = chain ?? throw new ArgumentNullException(nameof(chain));
+        _store = store ?? new InMemoryApprovalStore();
+        _options = options ?? new ApprovalCoordinatorOptions();
+        ValidateConfiguration();
+    }
+
+    /// <summary>Opens a durable approval request without collecting votes.</summary>
+    public ApprovalResult OpenRequest(ActionBinding binding, string? policyRuleId = null)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        binding.Validate();
+
+        var now = _options.Clock().ToUniversalTime();
+        var actionDigest = binding.Digest();
+        var policyDecision = new ApprovalPolicyDecisionRecord
+        {
+            ActionDigest = actionDigest,
+            PolicyRuleId = string.IsNullOrWhiteSpace(policyRuleId) ? _options.PolicyRuleId : policyRuleId,
+            PolicyVersion = _options.PolicyVersion,
+            ApprovalChainId = _chain.ChainId,
+            ApprovalChainVersion = _chain.Version,
+            DecidedAt = now
+        };
+        var request = new ApprovalRequest
+        {
+            PolicyDecisionId = policyDecision.PolicyDecisionId,
+            ActionDigest = actionDigest,
+            AgentId = binding.AgentId,
+            SubjectId = binding.SubjectId,
+            Operation = binding.Operation,
+            TargetResource = binding.Target.Resource,
+            PolicyVersion = _options.PolicyVersion,
+            ApprovalChainId = _chain.ChainId,
+            ApprovalChainVersion = _chain.Version,
+            RequestedAt = now,
+            ExpiresAt = now.Add(_options.RequestTtl),
+            Status = ApprovalStatus.Pending,
+            FailClosedOnTimeout = true
+        };
+
+        _store.SaveRequest(policyDecision, request);
+        Emit(ApprovalAuditEventType.PolicyDecision, policyDecision, request);
+        Emit(ApprovalAuditEventType.ApprovalRequested, policyDecision, request);
+        return BuildResult(policyDecision, request);
+    }
+
+    /// <summary>
+    /// Opens a request from an existing <c>require_approval</c> policy decision.
+    /// </summary>
+    /// <exception cref="ApprovalProtocolException">The decision is not <c>require_approval</c>.</exception>
+    public ApprovalResult OpenRequest(PolicyDecision policyDecision, ActionBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(policyDecision);
+        EnsureRequiresApproval(policyDecision);
+        return OpenRequest(binding, policyDecision.MatchedRule);
+    }
+
+    /// <summary>Appends an authenticated entry and resolves the request when the chain is complete.</summary>
+    public ApprovalResult SubmitEntry(string approvalRequestId, int stageIndex, ApprovalVote vote)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(approvalRequestId);
+        ArgumentNullException.ThrowIfNull(vote);
+
+        lock (RequestLock(approvalRequestId))
+        {
+            var (policyDecision, request) = LoadRequest(approvalRequestId);
+            var entries = _store.GetEntries(approvalRequestId);
+
+            if (!string.IsNullOrWhiteSpace(vote.ChainEntryId))
+            {
+                var existing = entries.FirstOrDefault(entry =>
+                    string.Equals(entry.ChainEntryId, vote.ChainEntryId, StringComparison.Ordinal));
+                if (existing is not null)
+                {
+                    return BuildResult(policyDecision, request);
+                }
+            }
+
+            if (request.Status != ApprovalStatus.Pending)
+            {
+                throw new ApprovalProtocolException(
+                    $"Approval request '{approvalRequestId}' is {ApprovalNames.Value(request.Status)}.");
+            }
+
+            if (_options.Clock().ToUniversalTime() >= request.ExpiresAt)
+            {
+                return ResolveLocked(policyDecision, request, ApprovalOutcome.Expired, ApprovalReasonCodes.Expired);
+            }
+
+            var stage = _chain.FindStage(stageIndex) ??
+                throw new ApprovalProtocolException($"Unknown approval stage '{stageIndex}'.");
+            var isAdvisory = stage.IsAdvisory || vote.ApproverKind == ApproverKind.LlmAdvisory;
+            if (!isAdvisory && !stage.Authorizes(vote.ApproverIdentity, vote.Roles))
+            {
+                throw new ApprovalProtocolException(
+                    $"Identity '{vote.ApproverIdentity}' is not permitted for approval stage {stageIndex}.");
+            }
+
+            if (!isAdvisory && entries.Any(entry =>
+                    entry.StageIndex == stageIndex && entry.ApproverKind != ApproverKind.LlmAdvisory))
+            {
+                throw new ApprovalProtocolException(
+                    $"Approval stage {stageIndex} already has a non-advisory decision.");
+            }
+
+            var effectiveKind = isAdvisory ? ApproverKind.LlmAdvisory : vote.ApproverKind;
+            var entry = new ApprovalChainEntry
+            {
+                ApprovalRequestId = approvalRequestId,
+                ChainEntryId = string.IsNullOrWhiteSpace(vote.ChainEntryId)
+                    ? ApprovalIds.New("ace")
+                    : vote.ChainEntryId,
+                StageIndex = stageIndex,
+                ApproverKind = effectiveKind,
+                ApproverIdentity = vote.ApproverIdentity,
+                IdentityAssurance = vote.IdentityAssurance,
+                Decision = vote.Decision,
+                ReasonCode = string.IsNullOrWhiteSpace(vote.ReasonCode)
+                    ? ApprovalNames.Value(vote.Decision)
+                    : vote.ReasonCode,
+                Roles = vote.Roles.OrderBy(role => role, StringComparer.Ordinal).ToArray(),
+                InputDigest = request.InputDigest(),
+                PreviousEntryDigest = entries.LastOrDefault()?.EntryDigest,
+                DecidedAt = _options.Clock().ToUniversalTime()
+            }.Seal();
+
+            _store.AppendEntry(entry);
+            Emit(
+                ApprovalAuditEventType.ApprovalChainEntry,
+                policyDecision,
+                request,
+                chainEntry: entry,
+                reasonCode: entry.ReasonCode);
+
+            if (isAdvisory)
+            {
+                return BuildResult(policyDecision, request);
+            }
+
+            if (entry.Decision == ApprovalEntryDecision.Deny)
+            {
+                return ResolveLocked(policyDecision, request, ApprovalOutcome.Deny, entry.ReasonCode);
+            }
+
+            var updatedEntries = _store.GetEntries(approvalRequestId);
+            return RequiredStagesSatisfied(updatedEntries)
+                ? ResolveLocked(policyDecision, request, ApprovalOutcome.Allow, ApprovalReasonCodes.Approved)
+                : BuildResult(policyDecision, request);
+        }
+    }
+
+    /// <summary>Runs all required stages, then validates and consumes a terminal allow.</summary>
+    public Task<ApprovalResult> ResolveAsync(
+        ActionBinding binding,
+        CancellationToken cancellationToken = default) =>
+        ResolveCoreAsync(binding, null, cancellationToken);
+
+    /// <summary>Routes an existing <c>require_approval</c> decision through this chain.</summary>
+    public Task<ApprovalResult> ResolveAsync(
+        PolicyDecision policyDecision,
+        ActionBinding binding,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(policyDecision);
+        EnsureRequiresApproval(policyDecision);
+        return ResolveCoreAsync(binding, policyDecision.MatchedRule, cancellationToken);
+    }
+
+    /// <summary>Revalidates and atomically consumes an allowed approval before execution.</summary>
+    public ApprovalExecutionDecision ValidateForExecution(
+        string approvalRequestId,
+        ActionBinding binding) =>
+        ValidateForExecutionCore(approvalRequestId, binding, consume: true);
+
+    /// <summary>Revalidates an allowed approval without consuming it.</summary>
+    public ApprovalExecutionDecision CheckForExecution(
+        string approvalRequestId,
+        ActionBinding binding) =>
+        ValidateForExecutionCore(approvalRequestId, binding, consume: false);
+
+    /// <summary>Cancels a pending request and records a terminal deny.</summary>
+    public ApprovalResult CancelRequest(string approvalRequestId, string reasonCode = ApprovalReasonCodes.Cancelled)
+    {
+        lock (RequestLock(approvalRequestId))
+        {
+            var (policyDecision, request) = LoadRequest(approvalRequestId);
+            if (request.Status != ApprovalStatus.Pending)
+            {
+                throw new ApprovalProtocolException(
+                    $"Approval request '{approvalRequestId}' is {ApprovalNames.Value(request.Status)}.");
+            }
+
+            return ResolveLocked(policyDecision, request, ApprovalOutcome.Cancelled, reasonCode);
+        }
+    }
+
+    /// <summary>Returns the current persisted state for an approval request.</summary>
+    public ApprovalResult GetResult(string approvalRequestId)
+    {
+        var (policyDecision, request) = LoadRequest(approvalRequestId);
+        return BuildResult(policyDecision, request);
+    }
+
+    private async Task<ApprovalResult> ResolveCoreAsync(
+        ActionBinding binding,
+        string? policyRuleId,
+        CancellationToken cancellationToken)
+    {
+        var result = OpenRequest(binding, policyRuleId);
+        var requiredNonAdvisorySeen = false;
+
+        foreach (var stage in _chain.Stages.OrderBy(stage => stage.StageIndex))
+        {
+            if (!stage.Required)
+            {
+                continue;
+            }
+
+            if (!stage.IsAdvisory)
+            {
+                requiredNonAdvisorySeen = true;
+            }
+
+            if (_options.Clock().ToUniversalTime() >= result.Request.ExpiresAt)
+            {
+                return ResolveSystemDeny(
+                    result.Request.ApprovalRequestId,
+                    stage.StageIndex,
+                    ApprovalOutcome.Expired,
+                    ApprovalReasonCodes.Expired);
+            }
+
+            if (stage.Transport is null)
+            {
+                return ResolveSystemDeny(
+                    result.Request.ApprovalRequestId,
+                    stage.StageIndex,
+                    ApprovalOutcome.Deny,
+                    "missing_approval_transport");
+            }
+
+            ApprovalVote vote;
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(_options.StageTimeout);
+            try
+            {
+                vote = await stage.Transport.RequestApprovalAsync(result.Request, timeout.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (ApprovalTransportProtocolException exception)
+            {
+                return ResolveSystemDeny(
+                    result.Request.ApprovalRequestId,
+                    stage.StageIndex,
+                    ApprovalOutcome.Deny,
+                    exception.ReasonCode);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                return ResolveSystemDeny(
+                    result.Request.ApprovalRequestId,
+                    stage.StageIndex,
+                    ApprovalOutcome.Deny,
+                    "approval_timeout");
+            }
+            catch (OperationCanceledException)
+            {
+                return ResolveSystemDeny(
+                    result.Request.ApprovalRequestId,
+                    stage.StageIndex,
+                    ApprovalOutcome.Cancelled,
+                    ApprovalReasonCodes.Cancelled);
+            }
+            catch (Exception)
+            {
+                return ResolveSystemDeny(
+                    result.Request.ApprovalRequestId,
+                    stage.StageIndex,
+                    ApprovalOutcome.Deny,
+                    "approval_transport_error");
+            }
+
+            result = SubmitEntry(result.Request.ApprovalRequestId, stage.StageIndex, vote);
+            if (result.Resolution is null)
+            {
+                continue;
+            }
+
+            if (result.Resolution.Outcome != ApprovalOutcome.Allow)
+            {
+                return result;
+            }
+
+            var execution = ValidateForExecution(result.Request.ApprovalRequestId, binding);
+            return GetResult(result.Request.ApprovalRequestId) with { Execution = execution };
+        }
+
+        return !requiredNonAdvisorySeen
+            ? ResolveSystemDeny(
+                result.Request.ApprovalRequestId,
+                0,
+                ApprovalOutcome.Deny,
+                ApprovalReasonCodes.NoRequiredStage)
+            : ResolveSystemDeny(
+                result.Request.ApprovalRequestId,
+                0,
+                ApprovalOutcome.Deny,
+                ApprovalReasonCodes.ChainIncomplete);
+    }
+
+    private ApprovalExecutionDecision ValidateForExecutionCore(
+        string approvalRequestId,
+        ActionBinding binding,
+        bool consume)
+    {
+        try
+        {
+            binding.Validate();
+            var currentDigest = binding.Digest();
+
+            lock (RequestLock(approvalRequestId))
+            {
+                var (policyDecision, request) = LoadRequest(approvalRequestId);
+                if (request.Status == ApprovalStatus.Consumed)
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.Consumed);
+                }
+
+                if (request.Status == ApprovalStatus.Cancelled)
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.Cancelled);
+                }
+
+                if (_options.Clock().ToUniversalTime() >= request.ExpiresAt)
+                {
+                    if (request.Status == ApprovalStatus.Pending)
+                    {
+                        _ = ResolveLocked(policyDecision, request, ApprovalOutcome.Expired, ApprovalReasonCodes.Expired);
+                    }
+                    else
+                    {
+                        _store.TryUpdateStatus(approvalRequestId, ApprovalStatus.Expired, out request);
+                        Emit(
+                            ApprovalAuditEventType.ApprovalExpired,
+                            policyDecision,
+                            request,
+                            reasonCode: ApprovalReasonCodes.Expired);
+                    }
+
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.Expired);
+                }
+
+                if (!_store.TryGetResolution(approvalRequestId, out var resolution))
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.NotResolved);
+                }
+
+                if (resolution.Outcome != ApprovalOutcome.Allow || request.Status != ApprovalStatus.Allowed)
+                {
+                    return DenyExecution(
+                        policyDecision,
+                        request,
+                        string.IsNullOrWhiteSpace(resolution.ReasonCode)
+                            ? StatusReason(request.Status)
+                            : resolution.ReasonCode,
+                        resolution);
+                }
+
+                if (!string.Equals(currentDigest, request.ActionDigest, StringComparison.Ordinal) ||
+                    !string.Equals(resolution.ActionDigest, request.ActionDigest, StringComparison.Ordinal))
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.ActionDigestMismatch, resolution);
+                }
+
+                if (!string.Equals(_options.PolicyVersion, request.PolicyVersion, StringComparison.Ordinal) ||
+                    !string.Equals(resolution.PolicyVersion, request.PolicyVersion, StringComparison.Ordinal))
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.PolicyVersionMismatch, resolution);
+                }
+
+                if (!string.Equals(_chain.ChainId, request.ApprovalChainId, StringComparison.Ordinal))
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.ChainIdMismatch, resolution);
+                }
+
+                if (!string.Equals(_chain.Version, request.ApprovalChainVersion, StringComparison.Ordinal) ||
+                    !string.Equals(resolution.ApprovalChainVersion, request.ApprovalChainVersion, StringComparison.Ordinal))
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.ChainVersionMismatch, resolution);
+                }
+
+                var entries = _store.GetEntries(approvalRequestId);
+                var integrityReason = VerifyEntryChain(request, resolution, entries);
+                if (integrityReason is not null)
+                {
+                    return DenyExecution(policyDecision, request, integrityReason, resolution);
+                }
+
+                if (consume && !_store.TryConsume(approvalRequestId, out request))
+                {
+                    return DenyExecution(policyDecision, request, ApprovalReasonCodes.Consumed, resolution);
+                }
+
+                var decision = new ApprovalExecutionDecision
+                {
+                    ApprovalRequestId = approvalRequestId,
+                    Allowed = true,
+                    ReasonCode = ApprovalReasonCodes.Approved,
+                    Consumed = consume
+                };
+                if (consume)
+                {
+                    Emit(
+                        ApprovalAuditEventType.ApprovalConsumed,
+                        policyDecision,
+                        request,
+                        resolution,
+                        reasonCode: ApprovalReasonCodes.Approved);
+                }
+
+                Emit(
+                    ApprovalAuditEventType.ExecutionAllowed,
+                    policyDecision,
+                    request,
+                    resolution,
+                    reasonCode: ApprovalReasonCodes.Approved);
+                return decision;
+            }
+        }
+        catch (Exception)
+        {
+            return new ApprovalExecutionDecision
+            {
+                ApprovalRequestId = approvalRequestId,
+                Allowed = false,
+                ReasonCode = ApprovalReasonCodes.InternalError
+            };
+        }
+    }
+
+    private ApprovalResult ResolveSystemDeny(
+        string approvalRequestId,
+        int stageIndex,
+        ApprovalOutcome outcome,
+        string reasonCode)
+    {
+        lock (RequestLock(approvalRequestId))
+        {
+            var (policyDecision, request) = LoadRequest(approvalRequestId);
+            if (request.Status != ApprovalStatus.Pending)
+            {
+                return BuildResult(policyDecision, request);
+            }
+
+            var entries = _store.GetEntries(approvalRequestId);
+            var systemEntry = new ApprovalChainEntry
+            {
+                ApprovalRequestId = approvalRequestId,
+                StageIndex = stageIndex,
+                ApproverKind = ApproverKind.Service,
+                ApproverIdentity = "system:approval-coordinator",
+                IdentityAssurance = "system",
+                Decision = ApprovalEntryDecision.Deny,
+                ReasonCode = reasonCode,
+                InputDigest = request.InputDigest(),
+                PreviousEntryDigest = entries.LastOrDefault()?.EntryDigest,
+                DecidedAt = _options.Clock().ToUniversalTime()
+            }.Seal();
+            _store.AppendEntry(systemEntry);
+            Emit(
+                ApprovalAuditEventType.ApprovalChainEntry,
+                policyDecision,
+                request,
+                chainEntry: systemEntry,
+                reasonCode: reasonCode);
+            return ResolveLocked(policyDecision, request, outcome, reasonCode);
+        }
+    }
+
+    private ApprovalResult ResolveLocked(
+        ApprovalPolicyDecisionRecord policyDecision,
+        ApprovalRequest request,
+        ApprovalOutcome outcome,
+        string reasonCode)
+    {
+        if (request.Status != ApprovalStatus.Pending)
+        {
+            return BuildResult(policyDecision, request);
+        }
+
+        var entries = _store.GetEntries(request.ApprovalRequestId);
+        var resolution = new ApprovalResolution
+        {
+            ApprovalRequestId = request.ApprovalRequestId,
+            Outcome = outcome,
+            ActionDigest = request.ActionDigest,
+            PolicyVersion = request.PolicyVersion,
+            ApprovalChainVersion = request.ApprovalChainVersion,
+            FinalEntryDigest = entries.LastOrDefault()?.EntryDigest,
+            ResolvedAt = _options.Clock().ToUniversalTime(),
+            ReasonCode = reasonCode
+        };
+        _store.SaveResolution(resolution);
+        _store.TryUpdateStatus(request.ApprovalRequestId, StatusForOutcome(outcome), out request);
+        Emit(
+            ApprovalAuditEventType.ApprovalResolved,
+            policyDecision,
+            request,
+            resolution,
+            reasonCode: reasonCode);
+
+        if (outcome == ApprovalOutcome.Expired)
+        {
+            Emit(
+                ApprovalAuditEventType.ApprovalExpired,
+                policyDecision,
+                request,
+                resolution,
+                reasonCode: reasonCode);
+        }
+        else if (outcome == ApprovalOutcome.Cancelled)
+        {
+            Emit(
+                ApprovalAuditEventType.ApprovalCancelled,
+                policyDecision,
+                request,
+                resolution,
+                reasonCode: reasonCode);
+        }
+
+        return BuildResult(policyDecision, request);
+    }
+
+    private string? VerifyEntryChain(
+        ApprovalRequest request,
+        ApprovalResolution resolution,
+        IReadOnlyList<ApprovalChainEntry> entries)
+    {
+        if (entries.Count == 0)
+        {
+            return ApprovalReasonCodes.ChainTampered;
+        }
+
+        var inputDigest = request.InputDigest();
+        string? previous = null;
+        foreach (var entry in entries)
+        {
+            if (!string.Equals(entry.ApprovalRequestId, request.ApprovalRequestId, StringComparison.Ordinal) ||
+                !string.Equals(entry.InputDigest, inputDigest, StringComparison.Ordinal) ||
+                !string.Equals(entry.PreviousEntryDigest, previous, StringComparison.Ordinal) ||
+                !entry.VerifyDigest())
+            {
+                return ApprovalReasonCodes.ChainTampered;
+            }
+
+            if (entry.ApproverKind != ApproverKind.LlmAdvisory)
+            {
+                var stage = _chain.FindStage(entry.StageIndex);
+                var isSystemDeny = entry.ApproverIdentity == "system:approval-coordinator" &&
+                    entry.Decision == ApprovalEntryDecision.Deny;
+                if (stage is null || (!isSystemDeny && !stage.Authorizes(entry.ApproverIdentity, entry.Roles)))
+                {
+                    return ApprovalReasonCodes.ChainTampered;
+                }
+            }
+
+            previous = entry.EntryDigest;
+        }
+
+        if (!string.Equals(resolution.FinalEntryDigest, previous, StringComparison.Ordinal))
+        {
+            return ApprovalReasonCodes.ChainTampered;
+        }
+
+        return RequiredStagesSatisfied(entries) ? null : ApprovalReasonCodes.ChainIncomplete;
+    }
+
+    private bool RequiredStagesSatisfied(IReadOnlyList<ApprovalChainEntry> entries)
+    {
+        var required = _chain.Stages
+            .Where(stage => stage.Required && !stage.IsAdvisory)
+            .Select(stage => stage.StageIndex)
+            .ToHashSet();
+        if (required.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var entry in entries)
+        {
+            if (entry.ApproverKind != ApproverKind.LlmAdvisory &&
+                entry.Decision == ApprovalEntryDecision.Allow)
+            {
+                required.Remove(entry.StageIndex);
+            }
+        }
+
+        return required.Count == 0;
+    }
+
+    private ApprovalExecutionDecision DenyExecution(
+        ApprovalPolicyDecisionRecord policyDecision,
+        ApprovalRequest request,
+        string reasonCode,
+        ApprovalResolution? resolution = null)
+    {
+        Emit(
+            ApprovalAuditEventType.ExecutionDenied,
+            policyDecision,
+            request,
+            resolution,
+            reasonCode: reasonCode);
+        return new ApprovalExecutionDecision
+        {
+            ApprovalRequestId = request.ApprovalRequestId,
+            Allowed = false,
+            ReasonCode = reasonCode
+        };
+    }
+
+    private ApprovalResult BuildResult(
+        ApprovalPolicyDecisionRecord policyDecision,
+        ApprovalRequest request)
+    {
+        _store.TryGetRequest(request.ApprovalRequestId, out policyDecision, out request);
+        _store.TryGetResolution(request.ApprovalRequestId, out var resolution);
+        return new ApprovalResult
+        {
+            PolicyDecision = policyDecision,
+            Request = request,
+            Entries = _store.GetEntries(request.ApprovalRequestId),
+            Resolution = resolution
+        };
+    }
+
+    private (ApprovalPolicyDecisionRecord PolicyDecision, ApprovalRequest Request) LoadRequest(
+        string approvalRequestId)
+    {
+        if (!_store.TryGetRequest(approvalRequestId, out var policyDecision, out var request))
+        {
+            throw new ApprovalProtocolException($"Unknown approval request '{approvalRequestId}'.");
+        }
+
+        return (policyDecision, request);
+    }
+
+    private object RequestLock(string approvalRequestId) =>
+        _requestLocks.GetOrAdd(approvalRequestId, static _ => new object());
+
+    private void ValidateConfiguration()
+    {
+        if (string.IsNullOrWhiteSpace(_chain.ChainId) || string.IsNullOrWhiteSpace(_chain.Version))
+        {
+            throw new ApprovalProtocolException("Approval chain id and version are required.");
+        }
+
+        if (_chain.Stages.Count == 0)
+        {
+            throw new ApprovalProtocolException("Approval chain must contain at least one stage.");
+        }
+
+        if (_chain.Stages.Select(stage => stage.StageIndex).Distinct().Count() != _chain.Stages.Count)
+        {
+            throw new ApprovalProtocolException("Approval stage indexes must be unique.");
+        }
+
+        if (_options.RequestTtl <= TimeSpan.Zero || _options.StageTimeout <= TimeSpan.Zero)
+        {
+            throw new ApprovalProtocolException("Approval TTL and stage timeout must be positive.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.PolicyVersion))
+        {
+            throw new ApprovalProtocolException("Policy version is required.");
+        }
+    }
+
+    private static void EnsureRequiresApproval(PolicyDecision policyDecision)
+    {
+        var normalized = policyDecision.Action
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .ToLowerInvariant();
+        if (normalized != "requireapproval")
+        {
+            throw new ApprovalProtocolException("Only require_approval decisions enter an approval chain.");
+        }
+    }
+
+    private static ApprovalStatus StatusForOutcome(ApprovalOutcome outcome) => outcome switch
+    {
+        ApprovalOutcome.Allow => ApprovalStatus.Allowed,
+        ApprovalOutcome.Deny => ApprovalStatus.Denied,
+        ApprovalOutcome.Expired => ApprovalStatus.Expired,
+        ApprovalOutcome.Cancelled => ApprovalStatus.Cancelled,
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome))
+    };
+
+    private static string StatusReason(ApprovalStatus status) => status switch
+    {
+        ApprovalStatus.Pending => ApprovalReasonCodes.Pending,
+        ApprovalStatus.Allowed => ApprovalReasonCodes.Approved,
+        ApprovalStatus.Denied => ApprovalReasonCodes.Denied,
+        ApprovalStatus.Expired => ApprovalReasonCodes.Expired,
+        ApprovalStatus.Cancelled => ApprovalReasonCodes.Cancelled,
+        ApprovalStatus.Consumed => ApprovalReasonCodes.Consumed,
+        _ => ApprovalReasonCodes.InternalError
+    };
+
+    private void Emit(
+        ApprovalAuditEventType type,
+        ApprovalPolicyDecisionRecord policyDecision,
+        ApprovalRequest request,
+        ApprovalResolution? resolution = null,
+        ApprovalChainEntry? chainEntry = null,
+        string? reasonCode = null)
+    {
+        _options.AuditSink?.Write(new ApprovalAuditEvent
+        {
+            Type = type,
+            Timestamp = _options.Clock().ToUniversalTime(),
+            AgentId = request.AgentId,
+            PolicyDecisionId = policyDecision.PolicyDecisionId,
+            ApprovalRequestId = request.ApprovalRequestId,
+            ApprovalResolutionId = resolution?.ApprovalResolutionId,
+            ChainEntryId = chainEntry?.ChainEntryId,
+            ActionDigest = request.ActionDigest,
+            PolicyVersion = request.PolicyVersion,
+            ApprovalChainVersion = request.ApprovalChainVersion,
+            ReasonCode = reasonCode
+        });
+    }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalCoordinator.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalCoordinator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Concurrent;
 using AgentGovernance.Policy;
 
 namespace AgentGovernance.Approvals;
@@ -86,10 +85,11 @@ public sealed record ApprovalCoordinatorOptions
 /// </summary>
 public sealed class ApprovalCoordinator
 {
+    private const int RequestLockStripeCount = 64;
     private readonly ApprovalChain _chain;
     private readonly IApprovalStore _store;
     private readonly ApprovalCoordinatorOptions _options;
-    private readonly ConcurrentDictionary<string, object> _requestLocks = new(StringComparer.Ordinal);
+    private readonly object[] _requestLocks = CreateRequestLocks();
 
     /// <summary>Creates a coordinator for one versioned approval chain.</summary>
     public ApprovalCoordinator(
@@ -188,7 +188,13 @@ public sealed class ApprovalCoordinator
 
             var stage = _chain.FindStage(stageIndex) ??
                 throw new ApprovalProtocolException($"Unknown approval stage '{stageIndex}'.");
-            var isAdvisory = stage.IsAdvisory || vote.ApproverKind == ApproverKind.LlmAdvisory;
+            if (!stage.IsAdvisory && vote.ApproverKind == ApproverKind.LlmAdvisory)
+            {
+                throw new ApprovalProtocolException(
+                    $"LLM advisory vote is not valid for non-advisory approval stage {stageIndex}.");
+            }
+
+            var isAdvisory = stage.IsAdvisory;
             if (!isAdvisory && !stage.Authorizes(vote.ApproverIdentity, vote.Roles))
             {
                 throw new ApprovalProtocolException(
@@ -277,7 +283,7 @@ public sealed class ApprovalCoordinator
         ActionBinding binding) =>
         ValidateForExecutionCore(approvalRequestId, binding, consume: false);
 
-    /// <summary>Cancels a pending request and records a terminal deny.</summary>
+    /// <summary>Cancels a pending request and records a terminal cancellation.</summary>
     public ApprovalResult CancelRequest(string approvalRequestId, string reasonCode = ApprovalReasonCodes.Cancelled)
     {
         lock (RequestLock(approvalRequestId))
@@ -528,6 +534,7 @@ public sealed class ApprovalCoordinator
         }
         catch (Exception)
         {
+            TryEmitInternalExecutionDenied(approvalRequestId);
             return new ApprovalExecutionDecision
             {
                 ApprovalRequestId = approvalRequestId,
@@ -743,8 +750,51 @@ public sealed class ApprovalCoordinator
         return (policyDecision, request);
     }
 
-    private object RequestLock(string approvalRequestId) =>
-        _requestLocks.GetOrAdd(approvalRequestId, static _ => new object());
+    private object RequestLock(string approvalRequestId)
+    {
+        var index = (int)((uint)StringComparer.Ordinal.GetHashCode(approvalRequestId) %
+            (uint)_requestLocks.Length);
+        return _requestLocks[index];
+    }
+
+    private static object[] CreateRequestLocks()
+    {
+        var locks = new object[RequestLockStripeCount];
+        for (var index = 0; index < locks.Length; index++)
+        {
+            locks[index] = new object();
+        }
+
+        return locks;
+    }
+
+    private void TryEmitInternalExecutionDenied(string approvalRequestId)
+    {
+        try
+        {
+            if (!_store.TryGetRequest(approvalRequestId, out var policyDecision, out var request))
+            {
+                return;
+            }
+
+            ApprovalResolution? resolution = null;
+            if (_store.TryGetResolution(approvalRequestId, out var storedResolution))
+            {
+                resolution = storedResolution;
+            }
+
+            Emit(
+                ApprovalAuditEventType.ExecutionDenied,
+                policyDecision,
+                request,
+                resolution,
+                reasonCode: ApprovalReasonCodes.InternalError);
+        }
+        catch (Exception)
+        {
+            // Audit emission must not turn a fail-closed validation result into an exception.
+        }
+    }
 
     private void ValidateConfiguration()
     {

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalCoordinator.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalCoordinator.cs
@@ -385,7 +385,19 @@ public sealed class ApprovalCoordinator
                     "approval_transport_error");
             }
 
-            result = SubmitEntry(result.Request.ApprovalRequestId, stage.StageIndex, vote);
+            try
+            {
+                result = SubmitEntry(result.Request.ApprovalRequestId, stage.StageIndex, vote);
+            }
+            catch (ApprovalProtocolException)
+            {
+                return ResolveSystemDeny(
+                    result.Request.ApprovalRequestId,
+                    stage.StageIndex,
+                    ApprovalOutcome.Deny,
+                    "invalid_approval_vote");
+            }
+
             if (result.Resolution is null)
             {
                 continue;
@@ -400,15 +412,16 @@ public sealed class ApprovalCoordinator
             return GetResult(result.Request.ApprovalRequestId) with { Execution = execution };
         }
 
+        var fallbackStageIndex = _chain.Stages.Min(stage => stage.StageIndex);
         return !requiredNonAdvisorySeen
             ? ResolveSystemDeny(
                 result.Request.ApprovalRequestId,
-                0,
+                fallbackStageIndex,
                 ApprovalOutcome.Deny,
                 ApprovalReasonCodes.NoRequiredStage)
             : ResolveSystemDeny(
                 result.Request.ApprovalRequestId,
-                0,
+                fallbackStageIndex,
                 ApprovalOutcome.Deny,
                 ApprovalReasonCodes.ChainIncomplete);
     }
@@ -659,12 +672,23 @@ public sealed class ApprovalCoordinator
                 return ApprovalReasonCodes.ChainTampered;
             }
 
-            if (entry.ApproverKind != ApproverKind.LlmAdvisory)
+            var stage = _chain.FindStage(entry.StageIndex);
+            if (stage is null)
             {
-                var stage = _chain.FindStage(entry.StageIndex);
+                return ApprovalReasonCodes.ChainTampered;
+            }
+
+            var isAdvisoryEntry = entry.ApproverKind == ApproverKind.LlmAdvisory;
+            if (isAdvisoryEntry != stage.IsAdvisory)
+            {
+                return ApprovalReasonCodes.ChainTampered;
+            }
+
+            if (!isAdvisoryEntry)
+            {
                 var isSystemDeny = entry.ApproverIdentity == "system:approval-coordinator" &&
                     entry.Decision == ApprovalEntryDecision.Deny;
-                if (stage is null || (!isSystemDeny && !stage.Authorizes(entry.ApproverIdentity, entry.Roles)))
+                if (!isSystemDeny && !stage.Authorizes(entry.ApproverIdentity, entry.Roles))
                 {
                     return ApprovalReasonCodes.ChainTampered;
                 }
@@ -811,6 +835,11 @@ public sealed class ApprovalCoordinator
         if (_chain.Stages.Select(stage => stage.StageIndex).Distinct().Count() != _chain.Stages.Count)
         {
             throw new ApprovalProtocolException("Approval stage indexes must be unique.");
+        }
+
+        if (_chain.Stages.Any(stage => stage.Required && stage.IsAdvisory))
+        {
+            throw new ApprovalProtocolException("LLM advisory stages cannot be required.");
         }
 
         if (_options.RequestTtl <= TimeSpan.Zero || _options.StageTimeout <= TimeSpan.Zero)

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalDigest.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalDigest.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Cryptography;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace AgentGovernance.Approvals;
+
+/// <summary>
+/// Produces deterministic RFC 8785-style JSON and SHA-256 digests for approval records.
+/// Object members are ordered by UTF-16 code unit using ordinal string ordering.
+/// </summary>
+public static class ApprovalDigest
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    private static readonly JsonWriterOptions WriterOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        Indented = false,
+        SkipValidation = false
+    };
+
+    /// <summary>Returns the deterministic UTF-8 JSON representation of a value.</summary>
+    /// <param name="value">A JSON-serializable value.</param>
+    /// <returns>The canonical UTF-8 bytes.</returns>
+    /// <exception cref="ApprovalProtocolException">The value cannot be represented safely.</exception>
+    public static byte[] Canonicalize(object? value)
+    {
+        try
+        {
+            var element = value is JsonElement jsonElement
+                ? jsonElement.Clone()
+                : JsonSerializer.SerializeToElement(value, SerializerOptions);
+
+            using var buffer = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(buffer, WriterOptions))
+            {
+                WriteElement(writer, element);
+            }
+
+            return buffer.ToArray();
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException or ArgumentException)
+        {
+            throw new ApprovalProtocolException("Value cannot be canonicalized as JSON.", exception);
+        }
+    }
+
+    /// <summary>Returns a lowercase <c>sha256:</c>-prefixed digest of a canonical value.</summary>
+    /// <param name="value">A JSON-serializable value.</param>
+    public static string Sha256(object? value)
+    {
+        var digest = SHA256.HashData(Canonicalize(value));
+        return $"sha256:{Convert.ToHexString(digest).ToLowerInvariant()}";
+    }
+
+    private static void WriteElement(Utf8JsonWriter writer, JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                WriteObject(writer, element);
+                break;
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (var item in element.EnumerateArray())
+                {
+                    WriteElement(writer, item);
+                }
+
+                writer.WriteEndArray();
+                break;
+            case JsonValueKind.String:
+                writer.WriteStringValue(element.GetString());
+                break;
+            case JsonValueKind.Number:
+                WriteNumber(writer, element);
+                break;
+            case JsonValueKind.True:
+                writer.WriteBooleanValue(true);
+                break;
+            case JsonValueKind.False:
+                writer.WriteBooleanValue(false);
+                break;
+            case JsonValueKind.Null:
+                writer.WriteNullValue();
+                break;
+            default:
+                throw new ApprovalProtocolException($"Unsupported JSON value kind '{element.ValueKind}'.");
+        }
+    }
+
+    private static void WriteObject(Utf8JsonWriter writer, JsonElement element)
+    {
+        var properties = element.EnumerateObject().ToList();
+        if (properties.Select(property => property.Name).Distinct(StringComparer.Ordinal).Count() != properties.Count)
+        {
+            throw new ApprovalProtocolException("Canonical JSON objects cannot contain duplicate property names.");
+        }
+
+        properties.Sort((left, right) => StringComparer.Ordinal.Compare(left.Name, right.Name));
+        writer.WriteStartObject();
+        foreach (var property in properties)
+        {
+            writer.WritePropertyName(property.Name);
+            WriteElement(writer, property.Value);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteNumber(Utf8JsonWriter writer, JsonElement element)
+    {
+        if (element.TryGetInt64(out var signed))
+        {
+            writer.WriteNumberValue(signed);
+            return;
+        }
+
+        if (element.TryGetUInt64(out var unsigned))
+        {
+            writer.WriteNumberValue(unsigned);
+            return;
+        }
+
+        if (element.TryGetDecimal(out var decimalValue))
+        {
+            if (decimalValue == decimal.Truncate(decimalValue) &&
+                decimalValue >= long.MinValue &&
+                decimalValue <= long.MaxValue)
+            {
+                writer.WriteNumberValue(decimal.ToInt64(decimalValue));
+            }
+            else
+            {
+                writer.WriteNumberValue(decimalValue);
+            }
+
+            return;
+        }
+
+        var doubleValue = element.GetDouble();
+        if (!double.IsFinite(doubleValue))
+        {
+            throw new ApprovalProtocolException("NaN and Infinity cannot be canonicalized.");
+        }
+
+        writer.WriteNumberValue(doubleValue == 0d ? 0d : doubleValue);
+    }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalModels.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalModels.cs
@@ -1,0 +1,533 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AgentGovernance.Policy;
+
+namespace AgentGovernance.Approvals;
+
+/// <summary>Constants shared by the action-bound approval protocol.</summary>
+public static class ApprovalProtocol
+{
+    /// <summary>The protocol and action-binding schema version.</summary>
+    public const string SchemaVersion = "1.0";
+}
+
+/// <summary>The lifecycle state of an approval request.</summary>
+public enum ApprovalStatus
+{
+    /// <summary>The request is waiting for approval entries.</summary>
+    Pending,
+
+    /// <summary>The required approval stages have allowed the request.</summary>
+    Allowed,
+
+    /// <summary>An approval stage denied the request.</summary>
+    Denied,
+
+    /// <summary>The request expired before execution.</summary>
+    Expired,
+
+    /// <summary>The request was explicitly cancelled.</summary>
+    Cancelled,
+
+    /// <summary>The one-time approval was consumed at execution.</summary>
+    Consumed
+}
+
+/// <summary>Classifies the principal recorded on an approval entry.</summary>
+public enum ApproverKind
+{
+    /// <summary>An authenticated human approver.</summary>
+    Human,
+
+    /// <summary>An authenticated service approver.</summary>
+    Service,
+
+    /// <summary>An advisory LLM output that cannot authorize or deny execution.</summary>
+    LlmAdvisory
+}
+
+/// <summary>An individual approval entry decision.</summary>
+public enum ApprovalEntryDecision
+{
+    /// <summary>The approver allows the stage.</summary>
+    Allow,
+
+    /// <summary>The approver denies the request.</summary>
+    Deny
+}
+
+/// <summary>The terminal outcome of an approval request.</summary>
+public enum ApprovalOutcome
+{
+    /// <summary>All required stages allowed the request.</summary>
+    Allow,
+
+    /// <summary>An authenticated stage denied the request.</summary>
+    Deny,
+
+    /// <summary>The request expired.</summary>
+    Expired,
+
+    /// <summary>The request was cancelled.</summary>
+    Cancelled
+}
+
+/// <summary>Identifies the tool or resource targeted by an action.</summary>
+public sealed record ActionTarget
+{
+    /// <summary>The tool name.</summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>The version of the tool input schema.</summary>
+    public required string ToolSchemaVersion { get; init; }
+
+    /// <summary>The optional resource targeted by the action.</summary>
+    public string? Resource { get; init; }
+
+    internal IReadOnlyDictionary<string, object?> ToCanonical() =>
+        new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["tool_name"] = ToolName,
+            ["tool_schema_version"] = ToolSchemaVersion,
+            ["resource"] = Resource
+        };
+}
+
+/// <summary>
+/// Captures the exact executable request authorized by an approval.
+/// Changing the agent, subject, operation, target, or parameters changes the digest.
+/// </summary>
+public sealed record ActionBinding
+{
+    private const int MaxStringLength = 4096;
+
+    /// <summary>The action-binding schema version.</summary>
+    public string SchemaVersion { get; init; } = ApprovalProtocol.SchemaVersion;
+
+    /// <summary>The operation kind, such as <c>tool.invoke</c>.</summary>
+    public required string Operation { get; init; }
+
+    /// <summary>The acting agent identifier.</summary>
+    public required string AgentId { get; init; }
+
+    /// <summary>The represented subject, when applicable.</summary>
+    public string? SubjectId { get; init; }
+
+    /// <summary>The target tool and resource.</summary>
+    public required ActionTarget Target { get; init; }
+
+    /// <summary>The exact parameters that will be executed.</summary>
+    public IReadOnlyDictionary<string, object?> Parameters { get; init; } =
+        new Dictionary<string, object?>(StringComparer.Ordinal);
+
+    /// <summary>Validates required fields and canonical parameter support.</summary>
+    /// <exception cref="ApprovalProtocolException">The binding is malformed or cannot be canonicalized.</exception>
+    public void Validate()
+    {
+        if (!string.Equals(SchemaVersion, ApprovalProtocol.SchemaVersion, StringComparison.Ordinal))
+        {
+            throw new ApprovalProtocolException($"Unsupported action-binding schema version '{SchemaVersion}'.");
+        }
+
+        ValidateString(nameof(Operation), Operation, required: true);
+        ValidateString(nameof(AgentId), AgentId, required: true);
+        ValidateString(nameof(SubjectId), SubjectId, required: false);
+        ArgumentNullException.ThrowIfNull(Target);
+        ValidateString(nameof(Target.ToolName), Target.ToolName, required: true);
+        ValidateString(nameof(Target.ToolSchemaVersion), Target.ToolSchemaVersion, required: true);
+        ValidateString(nameof(Target.Resource), Target.Resource, required: false);
+
+        try
+        {
+            _ = ApprovalDigest.Canonicalize(Parameters);
+        }
+        catch (Exception exception) when (exception is not ApprovalProtocolException)
+        {
+            throw new ApprovalProtocolException("Action parameters cannot be canonicalized.", exception);
+        }
+    }
+
+    /// <summary>Returns the SHA-256-prefixed canonical digest for this binding.</summary>
+    public string Digest()
+    {
+        Validate();
+        return ApprovalDigest.Sha256(ToCanonical());
+    }
+
+    internal IReadOnlyDictionary<string, object?> ToCanonical() =>
+        new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["schema_version"] = SchemaVersion,
+            ["operation"] = Operation,
+            ["agent_id"] = AgentId,
+            ["subject_id"] = SubjectId,
+            ["target"] = Target.ToCanonical(),
+            ["parameters"] = Parameters
+        };
+
+    private static void ValidateString(string field, string? value, bool required)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            if (required)
+            {
+                throw new ApprovalProtocolException($"{field} is required.");
+            }
+
+            return;
+        }
+
+        if (value.Contains('\0', StringComparison.Ordinal))
+        {
+            throw new ApprovalProtocolException($"{field} must not contain NUL characters.");
+        }
+
+        if (value.Length > MaxStringLength)
+        {
+            throw new ApprovalProtocolException($"{field} exceeds {MaxStringLength} characters.");
+        }
+    }
+}
+
+/// <summary>The policy decision that suspended execution pending approval.</summary>
+public sealed record ApprovalPolicyDecisionRecord
+{
+    /// <summary>The unique policy decision identifier.</summary>
+    public string PolicyDecisionId { get; init; } = ApprovalIds.New("pd");
+
+    /// <summary>The explicit policy action.</summary>
+    public PolicyAction Verdict { get; init; } = PolicyAction.RequireApproval;
+
+    /// <summary>The digest of the exact action under review.</summary>
+    public required string ActionDigest { get; init; }
+
+    /// <summary>The matched policy rule identifier.</summary>
+    public required string PolicyRuleId { get; init; }
+
+    /// <summary>The active policy version.</summary>
+    public required string PolicyVersion { get; init; }
+
+    /// <summary>The configured approval chain identifier.</summary>
+    public required string ApprovalChainId { get; init; }
+
+    /// <summary>The immutable approval chain version.</summary>
+    public required string ApprovalChainVersion { get; init; }
+
+    /// <summary>The UTC decision time.</summary>
+    public DateTimeOffset DecidedAt { get; init; } = DateTimeOffset.UtcNow;
+}
+
+/// <summary>A pending approval request bound to one action digest.</summary>
+public sealed record ApprovalRequest
+{
+    /// <summary>The unique approval request identifier.</summary>
+    public string ApprovalRequestId { get; init; } = ApprovalIds.New("ar");
+
+    /// <summary>The policy decision that created this request.</summary>
+    public required string PolicyDecisionId { get; init; }
+
+    /// <summary>The digest of the exact action under review.</summary>
+    public required string ActionDigest { get; init; }
+
+    /// <summary>The acting agent identifier.</summary>
+    public required string AgentId { get; init; }
+
+    /// <summary>The represented subject, when applicable.</summary>
+    public string? SubjectId { get; init; }
+
+    /// <summary>The operation kind.</summary>
+    public required string Operation { get; init; }
+
+    /// <summary>The target resource, when applicable.</summary>
+    public string? TargetResource { get; init; }
+
+    /// <summary>The policy version bound to the request.</summary>
+    public required string PolicyVersion { get; init; }
+
+    /// <summary>The approval chain identifier.</summary>
+    public required string ApprovalChainId { get; init; }
+
+    /// <summary>The approval chain version bound to the request.</summary>
+    public required string ApprovalChainVersion { get; init; }
+
+    /// <summary>The UTC request creation time.</summary>
+    public DateTimeOffset RequestedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>The UTC expiry time.</summary>
+    public required DateTimeOffset ExpiresAt { get; init; }
+
+    /// <summary>The current request lifecycle status.</summary>
+    public ApprovalStatus Status { get; init; } = ApprovalStatus.Pending;
+
+    /// <summary>Whether timeout must fail closed. This protocol always sets it to <c>true</c>.</summary>
+    public bool FailClosedOnTimeout { get; init; } = true;
+
+    /// <summary>Returns the request fields presented to an approver.</summary>
+    public IReadOnlyDictionary<string, object?> PresentedCanonical() =>
+        new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["approval_request_id"] = ApprovalRequestId,
+            ["policy_decision_id"] = PolicyDecisionId,
+            ["action_digest"] = ActionDigest,
+            ["agent_id"] = AgentId,
+            ["subject_id"] = SubjectId,
+            ["operation"] = Operation,
+            ["target_resource"] = TargetResource,
+            ["policy_version"] = PolicyVersion,
+            ["approval_chain_id"] = ApprovalChainId,
+            ["approval_chain_version"] = ApprovalChainVersion,
+            ["expires_at"] = ExpiresAt.UtcDateTime.ToString("O", System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+    /// <summary>Returns the digest of the exact request presentation.</summary>
+    public string InputDigest() => ApprovalDigest.Sha256(PresentedCanonical());
+}
+
+/// <summary>A transport-normalized approver decision.</summary>
+public sealed record ApprovalVote
+{
+    /// <summary>The approver kind.</summary>
+    public ApproverKind ApproverKind { get; init; } = ApproverKind.Service;
+
+    /// <summary>The verified approver identity.</summary>
+    public required string ApproverIdentity { get; init; }
+
+    /// <summary>The assurance mechanism used to verify the identity.</summary>
+    public required string IdentityAssurance { get; init; }
+
+    /// <summary>The allow or deny decision.</summary>
+    public required ApprovalEntryDecision Decision { get; init; }
+
+    /// <summary>A machine-readable reason code.</summary>
+    public string ReasonCode { get; init; } = string.Empty;
+
+    /// <summary>The verified roles carried by the approver identity.</summary>
+    public IReadOnlyList<string> Roles { get; init; } = Array.Empty<string>();
+
+    /// <summary>An optional caller-supplied idempotency identifier.</summary>
+    public string? ChainEntryId { get; init; }
+}
+
+/// <summary>One append-only, digest-linked approval decision.</summary>
+public sealed record ApprovalChainEntry
+{
+    /// <summary>The owning approval request identifier.</summary>
+    public required string ApprovalRequestId { get; init; }
+
+    /// <summary>The idempotent chain entry identifier.</summary>
+    public string ChainEntryId { get; init; } = ApprovalIds.New("ace");
+
+    /// <summary>The approval stage index.</summary>
+    public required int StageIndex { get; init; }
+
+    /// <summary>The approver kind.</summary>
+    public required ApproverKind ApproverKind { get; init; }
+
+    /// <summary>The verified approver identity.</summary>
+    public required string ApproverIdentity { get; init; }
+
+    /// <summary>The identity assurance mechanism.</summary>
+    public required string IdentityAssurance { get; init; }
+
+    /// <summary>The allow or deny entry decision.</summary>
+    public required ApprovalEntryDecision Decision { get; init; }
+
+    /// <summary>The reason code supplied with the decision.</summary>
+    public string ReasonCode { get; init; } = string.Empty;
+
+    /// <summary>The verified roles used for stage authorization.</summary>
+    public IReadOnlyList<string> Roles { get; init; } = Array.Empty<string>();
+
+    /// <summary>The digest of the request presentation reviewed by the approver.</summary>
+    public required string InputDigest { get; init; }
+
+    /// <summary>The previous approval entry digest, or <c>null</c> for the first entry.</summary>
+    public string? PreviousEntryDigest { get; init; }
+
+    /// <summary>The digest of this complete entry excluding this property.</summary>
+    public string? EntryDigest { get; init; }
+
+    /// <summary>The UTC decision time.</summary>
+    public DateTimeOffset DecidedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Returns a copy with its tamper-evident digest populated.</summary>
+    public ApprovalChainEntry Seal() => this with { EntryDigest = ComputeDigest() };
+
+    /// <summary>Returns whether the stored entry digest matches the entry contents.</summary>
+    public bool VerifyDigest() =>
+        EntryDigest is not null &&
+        string.Equals(EntryDigest, ComputeDigest(), StringComparison.Ordinal);
+
+    internal string ComputeDigest() => ApprovalDigest.Sha256(CanonicalWithoutDigest());
+
+    internal IReadOnlyDictionary<string, object?> CanonicalWithoutDigest() =>
+        new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["approval_request_id"] = ApprovalRequestId,
+            ["chain_entry_id"] = ChainEntryId,
+            ["stage_index"] = StageIndex,
+            ["approver_kind"] = ApprovalNames.Value(ApproverKind),
+            ["approver_identity"] = ApproverIdentity,
+            ["identity_assurance"] = IdentityAssurance,
+            ["decision"] = ApprovalNames.Value(Decision),
+            ["reason_code"] = ReasonCode,
+            ["roles"] = Roles,
+            ["input_digest"] = InputDigest,
+            ["previous_entry_digest"] = PreviousEntryDigest,
+            ["decided_at"] = DecidedAt.UtcDateTime.ToString("O", System.Globalization.CultureInfo.InvariantCulture)
+        };
+}
+
+/// <summary>The terminal resolution of an approval request.</summary>
+public sealed record ApprovalResolution
+{
+    /// <summary>The unique resolution identifier.</summary>
+    public string ApprovalResolutionId { get; init; } = ApprovalIds.New("apr");
+
+    /// <summary>The resolved approval request identifier.</summary>
+    public required string ApprovalRequestId { get; init; }
+
+    /// <summary>The terminal outcome.</summary>
+    public required ApprovalOutcome Outcome { get; init; }
+
+    /// <summary>The approved action digest.</summary>
+    public required string ActionDigest { get; init; }
+
+    /// <summary>The approved policy version.</summary>
+    public required string PolicyVersion { get; init; }
+
+    /// <summary>The approved chain version.</summary>
+    public required string ApprovalChainVersion { get; init; }
+
+    /// <summary>The digest of the final approval chain entry.</summary>
+    public string? FinalEntryDigest { get; init; }
+
+    /// <summary>The UTC resolution time.</summary>
+    public DateTimeOffset ResolvedAt { get; init; } = DateTimeOffset.UtcNow;
+
+    /// <summary>The machine-readable resolution reason.</summary>
+    public string ReasonCode { get; init; } = string.Empty;
+}
+
+/// <summary>The result of execution-time approval validation.</summary>
+public sealed record ApprovalExecutionDecision
+{
+    /// <summary>The approval request identifier.</summary>
+    public required string ApprovalRequestId { get; init; }
+
+    /// <summary>Whether execution may proceed.</summary>
+    public required bool Allowed { get; init; }
+
+    /// <summary>The machine-readable validation reason.</summary>
+    public required string ReasonCode { get; init; }
+
+    /// <summary>Whether validation atomically consumed the approval.</summary>
+    public bool Consumed { get; init; }
+}
+
+/// <summary>One ordered stage of a versioned approval chain.</summary>
+public sealed record ApprovalStage
+{
+    /// <summary>The unique stage index within the chain.</summary>
+    public required int StageIndex { get; init; }
+
+    /// <summary>The expected approver kind.</summary>
+    public ApproverKind ApproverKind { get; init; } = ApproverKind.Human;
+
+    /// <summary>The identities permitted to satisfy this stage.</summary>
+    public IReadOnlyCollection<string> AllowedIdentities { get; init; } = Array.Empty<string>();
+
+    /// <summary>The verified roles permitted to satisfy this stage.</summary>
+    public IReadOnlyCollection<string> AllowedRoles { get; init; } = Array.Empty<string>();
+
+    /// <summary>Whether this stage is required for a terminal allow.</summary>
+    public bool Required { get; init; } = true;
+
+    /// <summary>The transport used by automatic chain execution.</summary>
+    public IApprovalTransport? Transport { get; init; }
+
+    internal bool IsAdvisory => ApproverKind == ApproverKind.LlmAdvisory;
+
+    internal bool Authorizes(string identity, IEnumerable<string> roles) =>
+        AllowedIdentities.Contains(identity, StringComparer.Ordinal) ||
+        roles.Any(role => AllowedRoles.Contains(role, StringComparer.Ordinal));
+}
+
+/// <summary>A versioned, immutable approval-chain configuration.</summary>
+public sealed record ApprovalChain
+{
+    /// <summary>The chain identifier.</summary>
+    public required string ChainId { get; init; }
+
+    /// <summary>The immutable chain version.</summary>
+    public required string Version { get; init; }
+
+    /// <summary>The configured approval stages.</summary>
+    public required IReadOnlyList<ApprovalStage> Stages { get; init; }
+
+    internal ApprovalStage? FindStage(int stageIndex) =>
+        Stages.FirstOrDefault(stage => stage.StageIndex == stageIndex);
+}
+
+/// <summary>The complete persisted approval state for one request.</summary>
+public sealed record ApprovalResult
+{
+    /// <summary>The policy decision that suspended execution.</summary>
+    public required ApprovalPolicyDecisionRecord PolicyDecision { get; init; }
+
+    /// <summary>The approval request.</summary>
+    public required ApprovalRequest Request { get; init; }
+
+    /// <summary>The append-only approval entries.</summary>
+    public IReadOnlyList<ApprovalChainEntry> Entries { get; init; } = Array.Empty<ApprovalChainEntry>();
+
+    /// <summary>The terminal resolution, when resolved.</summary>
+    public ApprovalResolution? Resolution { get; init; }
+
+    /// <summary>The execution-time validation result, when attempted.</summary>
+    public ApprovalExecutionDecision? Execution { get; init; }
+}
+
+internal static class ApprovalIds
+{
+    internal static string New(string prefix) => $"{prefix}_{Guid.NewGuid():N}";
+}
+
+internal static class ApprovalNames
+{
+    internal static string Value(ApprovalStatus value) => value switch
+    {
+        ApprovalStatus.Pending => "pending",
+        ApprovalStatus.Allowed => "allowed",
+        ApprovalStatus.Denied => "denied",
+        ApprovalStatus.Expired => "expired",
+        ApprovalStatus.Cancelled => "cancelled",
+        ApprovalStatus.Consumed => "consumed",
+        _ => throw new ArgumentOutOfRangeException(nameof(value))
+    };
+
+    internal static string Value(ApproverKind value) => value switch
+    {
+        ApproverKind.Human => "human",
+        ApproverKind.Service => "service",
+        ApproverKind.LlmAdvisory => "llm_advisory",
+        _ => throw new ArgumentOutOfRangeException(nameof(value))
+    };
+
+    internal static string Value(ApprovalEntryDecision value) => value switch
+    {
+        ApprovalEntryDecision.Allow => "allow",
+        ApprovalEntryDecision.Deny => "deny",
+        _ => throw new ArgumentOutOfRangeException(nameof(value))
+    };
+
+    internal static string Value(ApprovalOutcome value) => value switch
+    {
+        ApprovalOutcome.Allow => "allow",
+        ApprovalOutcome.Deny => "deny",
+        ApprovalOutcome.Expired => "expired",
+        ApprovalOutcome.Cancelled => "cancelled",
+        _ => throw new ArgumentOutOfRangeException(nameof(value))
+    };
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalModels.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalModels.cs
@@ -351,7 +351,10 @@ public sealed record ApprovalChainEntry
     /// <summary>The UTC decision time.</summary>
     public DateTimeOffset DecidedAt { get; init; } = DateTimeOffset.UtcNow;
 
-    /// <summary>Returns a copy with its tamper-evident digest populated.</summary>
+    /// <summary>
+    /// Returns a copy with its tamper-evident SHA-256 digest populated without a secret key.
+    /// This detects changes outside the trusted store boundary but does not authenticate a store writer.
+    /// </summary>
     public ApprovalChainEntry Seal() => this with { EntryDigest = ComputeDigest() };
 
     /// <summary>Returns whether the stored entry digest matches the entry contents.</summary>

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalStore.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalStore.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AgentGovernance.Approvals;
+
+/// <summary>Persistence contract for approval requests, entries, and resolutions.</summary>
+public interface IApprovalStore
+{
+    /// <summary>Persists a new policy decision and approval request.</summary>
+    void SaveRequest(ApprovalPolicyDecisionRecord policyDecision, ApprovalRequest request);
+
+    /// <summary>Attempts to load a policy decision and approval request.</summary>
+    bool TryGetRequest(
+        string approvalRequestId,
+        out ApprovalPolicyDecisionRecord policyDecision,
+        out ApprovalRequest request);
+
+    /// <summary>Updates a request lifecycle status.</summary>
+    bool TryUpdateStatus(string approvalRequestId, ApprovalStatus status, out ApprovalRequest request);
+
+    /// <summary>Appends one tamper-evident approval entry.</summary>
+    void AppendEntry(ApprovalChainEntry entry);
+
+    /// <summary>Returns entries in append order.</summary>
+    IReadOnlyList<ApprovalChainEntry> GetEntries(string approvalRequestId);
+
+    /// <summary>Persists the terminal resolution for a request.</summary>
+    void SaveResolution(ApprovalResolution resolution);
+
+    /// <summary>Attempts to load the terminal resolution for a request.</summary>
+    bool TryGetResolution(string approvalRequestId, out ApprovalResolution resolution);
+
+    /// <summary>
+    /// Atomically marks an allowed request as consumed. Returns <c>true</c> exactly once.
+    /// </summary>
+    bool TryConsume(string approvalRequestId, out ApprovalRequest request);
+}
+
+/// <summary>A thread-safe process-local reference implementation of <see cref="IApprovalStore"/>.</summary>
+public sealed class InMemoryApprovalStore : IApprovalStore
+{
+    private readonly object _sync = new();
+    private readonly Dictionary<string, StoreRecord> _records = new(StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public void SaveRequest(ApprovalPolicyDecisionRecord policyDecision, ApprovalRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(policyDecision);
+        ArgumentNullException.ThrowIfNull(request);
+
+        lock (_sync)
+        {
+            if (_records.ContainsKey(request.ApprovalRequestId))
+            {
+                throw new ApprovalProtocolException(
+                    $"Approval request '{request.ApprovalRequestId}' already exists.");
+            }
+
+            _records.Add(request.ApprovalRequestId, new StoreRecord(policyDecision, request));
+        }
+    }
+
+    /// <inheritdoc />
+    public bool TryGetRequest(
+        string approvalRequestId,
+        out ApprovalPolicyDecisionRecord policyDecision,
+        out ApprovalRequest request)
+    {
+        lock (_sync)
+        {
+            if (_records.TryGetValue(approvalRequestId, out var record))
+            {
+                policyDecision = record.PolicyDecision;
+                request = record.Request;
+                return true;
+            }
+        }
+
+        policyDecision = null!;
+        request = null!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryUpdateStatus(string approvalRequestId, ApprovalStatus status, out ApprovalRequest request)
+    {
+        lock (_sync)
+        {
+            if (!_records.TryGetValue(approvalRequestId, out var record))
+            {
+                request = null!;
+                return false;
+            }
+
+            record.Request = record.Request with { Status = status };
+            request = record.Request;
+            return true;
+        }
+    }
+
+    /// <inheritdoc />
+    public void AppendEntry(ApprovalChainEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        lock (_sync)
+        {
+            if (!_records.TryGetValue(entry.ApprovalRequestId, out var record))
+            {
+                throw new ApprovalProtocolException(
+                    $"Unknown approval request '{entry.ApprovalRequestId}'.");
+            }
+
+            record.Entries.Add(CopyEntry(entry));
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ApprovalChainEntry> GetEntries(string approvalRequestId)
+    {
+        lock (_sync)
+        {
+            return _records.TryGetValue(approvalRequestId, out var record)
+                ? record.Entries.Select(CopyEntry).ToList().AsReadOnly()
+                : Array.Empty<ApprovalChainEntry>();
+        }
+    }
+
+    /// <inheritdoc />
+    public void SaveResolution(ApprovalResolution resolution)
+    {
+        ArgumentNullException.ThrowIfNull(resolution);
+
+        lock (_sync)
+        {
+            if (!_records.TryGetValue(resolution.ApprovalRequestId, out var record))
+            {
+                throw new ApprovalProtocolException(
+                    $"Unknown approval request '{resolution.ApprovalRequestId}'.");
+            }
+
+            record.Resolution = resolution;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool TryGetResolution(string approvalRequestId, out ApprovalResolution resolution)
+    {
+        lock (_sync)
+        {
+            if (_records.TryGetValue(approvalRequestId, out var record) && record.Resolution is not null)
+            {
+                resolution = record.Resolution;
+                return true;
+            }
+        }
+
+        resolution = null!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryConsume(string approvalRequestId, out ApprovalRequest request)
+    {
+        lock (_sync)
+        {
+            if (!_records.TryGetValue(approvalRequestId, out var record))
+            {
+                request = null!;
+                return false;
+            }
+
+            if (record.Request.Status != ApprovalStatus.Allowed)
+            {
+                request = record.Request;
+                return false;
+            }
+
+            record.Request = record.Request with { Status = ApprovalStatus.Consumed };
+            request = record.Request;
+            return true;
+        }
+    }
+
+    private static ApprovalChainEntry CopyEntry(ApprovalChainEntry entry) =>
+        entry with { Roles = entry.Roles.ToArray() };
+
+    private sealed class StoreRecord
+    {
+        internal StoreRecord(ApprovalPolicyDecisionRecord policyDecision, ApprovalRequest request)
+        {
+            PolicyDecision = policyDecision;
+            Request = request;
+        }
+
+        internal ApprovalPolicyDecisionRecord PolicyDecision { get; }
+
+        internal ApprovalRequest Request { get; set; }
+
+        internal List<ApprovalChainEntry> Entries { get; } = new();
+
+        internal ApprovalResolution? Resolution { get; set; }
+    }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalTransport.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalTransport.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+
+namespace AgentGovernance.Approvals;
+
+/// <summary>Requests an approval vote from an external workflow.</summary>
+public interface IApprovalTransport
+{
+    /// <summary>Requests one approval vote for the supplied action-bound request.</summary>
+    Task<ApprovalVote> RequestApprovalAsync(
+        ApprovalRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>An approval protocol configuration or lifecycle error.</summary>
+public class ApprovalProtocolException : Exception
+{
+    /// <summary>Creates an approval protocol exception.</summary>
+    public ApprovalProtocolException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Creates an approval protocol exception with an inner exception.</summary>
+    public ApprovalProtocolException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+/// <summary>A fail-closed webhook response validation error.</summary>
+public sealed class ApprovalTransportProtocolException : ApprovalProtocolException
+{
+    /// <summary>Creates a transport protocol exception with a machine-readable reason.</summary>
+    public ApprovalTransportProtocolException(string reasonCode)
+        : base($"Approval transport protocol failure: {reasonCode}.")
+    {
+        ReasonCode = reasonCode;
+    }
+
+    /// <summary>The machine-readable reason code.</summary>
+    public string ReasonCode { get; }
+}
+
+/// <summary>A principal and roles verified independently of a webhook response body assertion.</summary>
+public sealed record WebhookVerifiedIdentity
+{
+    /// <summary>The verified principal identifier.</summary>
+    public required string Identity { get; init; }
+
+    /// <summary>The verification assurance mechanism.</summary>
+    public required string Assurance { get; init; }
+
+    /// <summary>The roles bound to the verified principal.</summary>
+    public IReadOnlyList<string> Roles { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>Verifies the authenticated principal behind a webhook approval response.</summary>
+/// <param name="body">The parsed response body.</param>
+/// <param name="request">The approval request being answered.</param>
+/// <returns>A verified identity, or <c>null</c> when identity cannot be established.</returns>
+public delegate WebhookVerifiedIdentity? WebhookResponseVerifier(
+    JsonElement body,
+    ApprovalRequest request);

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalTransport.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/ApprovalTransport.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net;
 using System.Text.Json;
 
 namespace AgentGovernance.Approvals;
@@ -64,3 +65,11 @@ public sealed record WebhookVerifiedIdentity
 public delegate WebhookVerifiedIdentity? WebhookResponseVerifier(
     JsonElement body,
     ApprovalRequest request);
+
+/// <summary>Resolves a webhook host immediately before an outbound connection.</summary>
+/// <param name="host">The webhook DNS host name.</param>
+/// <param name="cancellationToken">Cancels address resolution.</param>
+/// <returns>All addresses currently published for the host.</returns>
+public delegate Task<IPAddress[]> WebhookAddressResolver(
+    string host,
+    CancellationToken cancellationToken);

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace AgentGovernance.Approvals;
+
+/// <summary>
+/// Sends versioned, action-bound approval requests to an HTTP endpoint.
+/// Approve responses require an independently verified principal and matching request binding.
+/// </summary>
+public sealed class WebhookApprover : IApprovalTransport, IDisposable
+{
+    private static readonly HashSet<string> BlockedHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "169.254.169.254",
+        "fd00:ec2::254",
+        "metadata.google.internal"
+    };
+
+    private readonly Uri _endpoint;
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsClient;
+    private readonly IReadOnlyDictionary<string, string> _headers;
+    private readonly WebhookResponseVerifier? _responseVerifier;
+
+    /// <summary>Creates a versioned webhook approval transport.</summary>
+    /// <param name="endpoint">The HTTP or HTTPS approval endpoint.</param>
+    /// <param name="httpClient">An optional caller-owned HTTP client.</param>
+    /// <param name="headers">Optional authentication or routing headers.</param>
+    /// <param name="responseVerifier">Verifies the principal behind approve responses.</param>
+    public WebhookApprover(
+        Uri endpoint,
+        HttpClient? httpClient = null,
+        IReadOnlyDictionary<string, string>? headers = null,
+        WebhookResponseVerifier? responseVerifier = null)
+    {
+        ValidateEndpoint(endpoint);
+        _endpoint = endpoint;
+        _httpClient = httpClient ?? new HttpClient();
+        _ownsClient = httpClient is null;
+        _headers = headers is null
+            ? new Dictionary<string, string>(StringComparer.Ordinal)
+            : new Dictionary<string, string>(headers, StringComparer.Ordinal);
+        _responseVerifier = responseVerifier;
+    }
+
+    /// <summary>Builds the versioned request payload required by ADR-0030.</summary>
+    public static IReadOnlyDictionary<string, object?> BuildRequestPayload(ApprovalRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["schema_version"] = ApprovalProtocol.SchemaVersion,
+            ["type"] = "approval_request",
+            ["input_digest"] = request.InputDigest()
+        };
+
+        foreach (var field in request.PresentedCanonical())
+        {
+            payload[field.Key] = field.Value;
+        }
+
+        return payload;
+    }
+
+    /// <inheritdoc />
+    public async Task<ApprovalVote> RequestApprovalAsync(
+        ApprovalRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, _endpoint)
+        {
+            Content = JsonContent.Create(BuildRequestPayload(request))
+        };
+        foreach (var header in _headers)
+        {
+            if (!message.Headers.TryAddWithoutValidation(header.Key, header.Value))
+            {
+                message.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        using var response = await _httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        using var document = await JsonDocument.ParseAsync(
+            responseStream,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return ParseResponse(document.RootElement, request, _responseVerifier);
+    }
+
+    /// <summary>Releases an internally created HTTP client.</summary>
+    public void Dispose()
+    {
+        if (_ownsClient)
+        {
+            _httpClient.Dispose();
+        }
+    }
+
+    internal static ApprovalVote ParseResponse(
+        JsonElement body,
+        ApprovalRequest request,
+        WebhookResponseVerifier? responseVerifier)
+    {
+        if (body.ValueKind != JsonValueKind.Object)
+        {
+            throw new ApprovalTransportProtocolException("malformed_webhook_response");
+        }
+
+        if (!Matches(body, "approval_request_id", request.ApprovalRequestId))
+        {
+            throw new ApprovalTransportProtocolException("approval_request_id_mismatch");
+        }
+
+        if (!Matches(body, "action_digest", request.ActionDigest))
+        {
+            throw new ApprovalTransportProtocolException("action_digest_mismatch");
+        }
+
+        var approved = ReadDecision(body);
+        var reason = ReadString(body, "reason") ?? (approved ? "approved" : "denied_by_webhook");
+        var chainEntryId = ReadString(body, "chain_entry_id");
+
+        if (!approved)
+        {
+            return new ApprovalVote
+            {
+                ApproverKind = ReadApproverKind(body),
+                ApproverIdentity = ReadString(body, "approver") ?? "webhook",
+                IdentityAssurance = ReadString(body, "identity_assurance") ?? "webhook",
+                Decision = ApprovalEntryDecision.Deny,
+                ReasonCode = reason,
+                ChainEntryId = chainEntryId
+            };
+        }
+
+        WebhookVerifiedIdentity? verifiedIdentity;
+        try
+        {
+            verifiedIdentity = responseVerifier?.Invoke(body, request);
+        }
+        catch (Exception exception)
+        {
+            throw new ApprovalTransportProtocolException(
+                $"identity_verification_error:{exception.GetType().Name}");
+        }
+
+        if (verifiedIdentity is null || string.IsNullOrWhiteSpace(verifiedIdentity.Identity))
+        {
+            throw new ApprovalTransportProtocolException("unverified_approver_identity");
+        }
+
+        return new ApprovalVote
+        {
+            ApproverKind = ReadApproverKind(body),
+            ApproverIdentity = verifiedIdentity.Identity,
+            IdentityAssurance = verifiedIdentity.Assurance,
+            Decision = ApprovalEntryDecision.Allow,
+            ReasonCode = reason,
+            Roles = verifiedIdentity.Roles.ToArray(),
+            ChainEntryId = chainEntryId
+        };
+    }
+
+    private static void ValidateEndpoint(Uri endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        if (!endpoint.IsAbsoluteUri ||
+            (endpoint.Scheme != Uri.UriSchemeHttp && endpoint.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("Approval webhook endpoint must use HTTP or HTTPS.", nameof(endpoint));
+        }
+
+        var normalizedHost = endpoint.Host.Trim('[', ']');
+        if (BlockedHosts.Contains(normalizedHost))
+        {
+            throw new ArgumentException("Approval webhook endpoint host is blocked.", nameof(endpoint));
+        }
+
+        if (IPAddress.TryParse(normalizedHost, out var address) && IsLinkLocal(address))
+        {
+            throw new ArgumentException("Approval webhook endpoint host is blocked.", nameof(endpoint));
+        }
+    }
+
+    private static bool IsLinkLocal(IPAddress address)
+    {
+        if (address.IsIPv6LinkLocal)
+        {
+            return true;
+        }
+
+        var bytes = address.GetAddressBytes();
+        return bytes.Length == 4 && bytes[0] == 169 && bytes[1] == 254;
+    }
+
+    private static bool Matches(JsonElement body, string propertyName, string expected) =>
+        body.TryGetProperty(propertyName, out var property) &&
+        property.ValueKind == JsonValueKind.String &&
+        string.Equals(property.GetString(), expected, StringComparison.Ordinal);
+
+    private static bool ReadDecision(JsonElement body)
+    {
+        if (body.TryGetProperty("approved", out var approved) &&
+            approved.ValueKind is JsonValueKind.True or JsonValueKind.False)
+        {
+            return approved.GetBoolean();
+        }
+
+        var decision = ReadString(body, "decision")?.ToLowerInvariant();
+        return decision switch
+        {
+            "allow" or "approve" or "approved" => true,
+            "deny" or "denied" or "reject" or "rejected" => false,
+            _ => throw new ApprovalTransportProtocolException("missing_or_malformed_decision")
+        };
+    }
+
+    private static ApproverKind ReadApproverKind(JsonElement body) =>
+        ReadString(body, "approver_kind")?.ToLowerInvariant() switch
+        {
+            "human" => ApproverKind.Human,
+            "llm_advisory" => ApproverKind.LlmAdvisory,
+            _ => ApproverKind.Service
+        };
+
+    private static string? ReadString(JsonElement body, string propertyName) =>
+        body.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
@@ -153,7 +153,9 @@ public sealed class WebhookApprover : IApprovalTransport, IDisposable
                 $"identity_verification_error:{exception.GetType().Name}");
         }
 
-        if (verifiedIdentity is null || string.IsNullOrWhiteSpace(verifiedIdentity.Identity))
+        if (verifiedIdentity is null ||
+            string.IsNullOrWhiteSpace(verifiedIdentity.Identity) ||
+            string.IsNullOrWhiteSpace(verifiedIdentity.Assurance))
         {
             throw new ApprovalTransportProtocolException("unverified_approver_identity");
         }
@@ -165,7 +167,7 @@ public sealed class WebhookApprover : IApprovalTransport, IDisposable
             IdentityAssurance = verifiedIdentity.Assurance,
             Decision = ApprovalEntryDecision.Allow,
             ReasonCode = reason,
-            Roles = verifiedIdentity.Roles.ToArray(),
+            Roles = verifiedIdentity.Roles?.ToArray() ?? Array.Empty<string>(),
             ChainEntryId = chainEntryId
         };
     }

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
@@ -39,7 +39,10 @@ public sealed class WebhookApprover : IApprovalTransport, IDisposable
     {
         ValidateEndpoint(endpoint);
         _endpoint = endpoint;
-        _httpClient = httpClient ?? new HttpClient();
+        _httpClient = httpClient ?? new HttpClient(new HttpClientHandler
+        {
+            AllowAutoRedirect = false
+        });
         _ownsClient = httpClient is null;
         _headers = headers is null
             ? new Dictionary<string, string>(StringComparer.Ordinal)

--- a/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Approvals/WebhookApprover.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using System.Net.Http.Json;
+using System.Net.Sockets;
 using System.Text.Json;
 
 namespace AgentGovernance.Approvals;
@@ -17,6 +18,7 @@ public sealed class WebhookApprover : IApprovalTransport, IDisposable
     {
         "169.254.169.254",
         "fd00:ec2::254",
+        "metadata.google",
         "metadata.google.internal"
     };
 
@@ -25,24 +27,27 @@ public sealed class WebhookApprover : IApprovalTransport, IDisposable
     private readonly bool _ownsClient;
     private readonly IReadOnlyDictionary<string, string> _headers;
     private readonly WebhookResponseVerifier? _responseVerifier;
+    private readonly WebhookAddressResolver _addressResolver;
 
     /// <summary>Creates a versioned webhook approval transport.</summary>
     /// <param name="endpoint">The HTTP or HTTPS approval endpoint.</param>
     /// <param name="httpClient">An optional caller-owned HTTP client.</param>
     /// <param name="headers">Optional authentication or routing headers.</param>
     /// <param name="responseVerifier">Verifies the principal behind approve responses.</param>
+    /// <param name="addressResolver">
+    /// Optional DNS resolver for service discovery or testing. Every returned address is still validated.
+    /// </param>
     public WebhookApprover(
         Uri endpoint,
         HttpClient? httpClient = null,
         IReadOnlyDictionary<string, string>? headers = null,
-        WebhookResponseVerifier? responseVerifier = null)
+        WebhookResponseVerifier? responseVerifier = null,
+        WebhookAddressResolver? addressResolver = null)
     {
         ValidateEndpoint(endpoint);
         _endpoint = endpoint;
-        _httpClient = httpClient ?? new HttpClient(new HttpClientHandler
-        {
-            AllowAutoRedirect = false
-        });
+        _addressResolver = addressResolver ?? Dns.GetHostAddressesAsync;
+        _httpClient = httpClient ?? CreateHttpClient(_addressResolver);
         _ownsClient = httpClient is null;
         _headers = headers is null
             ? new Dictionary<string, string>(StringComparer.Ordinal)
@@ -75,6 +80,14 @@ public sealed class WebhookApprover : IApprovalTransport, IDisposable
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
+
+        if (!_ownsClient)
+        {
+            _ = await ResolveAllowedAddressesAsync(
+                _endpoint.DnsSafeHost,
+                _addressResolver,
+                cancellationToken).ConfigureAwait(false);
+        }
 
         using var message = new HttpRequestMessage(HttpMethod.Post, _endpoint)
         {
@@ -184,27 +197,151 @@ public sealed class WebhookApprover : IApprovalTransport, IDisposable
             throw new ArgumentException("Approval webhook endpoint must use HTTP or HTTPS.", nameof(endpoint));
         }
 
-        var normalizedHost = endpoint.Host.Trim('[', ']');
-        if (BlockedHosts.Contains(normalizedHost))
+        var normalizedHost = endpoint.IdnHost.Trim('[', ']').TrimEnd('.');
+        if (IsBlockedHostName(normalizedHost))
         {
             throw new ArgumentException("Approval webhook endpoint host is blocked.", nameof(endpoint));
         }
 
-        if (IPAddress.TryParse(normalizedHost, out var address) && IsLinkLocal(address))
+        if (IPAddress.TryParse(normalizedHost, out var address) && IsBlockedAddress(address))
         {
             throw new ArgumentException("Approval webhook endpoint host is blocked.", nameof(endpoint));
         }
     }
 
-    private static bool IsLinkLocal(IPAddress address)
+    private static HttpClient CreateHttpClient(WebhookAddressResolver addressResolver)
     {
-        if (address.IsIPv6LinkLocal)
+        var handler = new SocketsHttpHandler
         {
-            return true;
+            AllowAutoRedirect = false,
+            UseProxy = false,
+            ConnectCallback = async (context, cancellationToken) =>
+            {
+                var addresses = await ResolveAllowedAddressesAsync(
+                    context.DnsEndPoint.Host,
+                    addressResolver,
+                    cancellationToken).ConfigureAwait(false);
+                Exception? lastException = null;
+                foreach (var address in addresses)
+                {
+                    var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                    try
+                    {
+                        await socket.ConnectAsync(
+                            new IPEndPoint(address, context.DnsEndPoint.Port),
+                            cancellationToken).ConfigureAwait(false);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch (SocketException exception)
+                    {
+                        socket.Dispose();
+                        lastException = exception;
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                }
+
+                throw new HttpRequestException("No resolved webhook address accepted the connection.", lastException);
+            }
+        };
+        return new HttpClient(handler);
+    }
+
+    private static async Task<IPAddress[]> ResolveAllowedAddressesAsync(
+        string host,
+        WebhookAddressResolver addressResolver,
+        CancellationToken cancellationToken)
+    {
+        if (IPAddress.TryParse(host.Trim('[', ']'), out var literalAddress))
+        {
+            return IsBlockedAddress(literalAddress)
+                ? throw new ApprovalTransportProtocolException("blocked_webhook_endpoint")
+                : new[] { NormalizeAddress(literalAddress) };
         }
 
-        var bytes = address.GetAddressBytes();
-        return bytes.Length == 4 && bytes[0] == 169 && bytes[1] == 254;
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await addressResolver(host, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new ApprovalTransportProtocolException("webhook_endpoint_resolution_failed");
+        }
+
+        if (addresses is null || addresses.Length == 0)
+        {
+            throw new ApprovalTransportProtocolException("webhook_endpoint_resolution_failed");
+        }
+
+        if (addresses.Any(IsBlockedAddress))
+        {
+            throw new ApprovalTransportProtocolException("blocked_webhook_endpoint");
+        }
+
+        return addresses.Select(NormalizeAddress).Distinct().ToArray();
+    }
+
+    private static bool IsBlockedHostName(string host) =>
+        string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+        host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase) ||
+        BlockedHosts.Any(blocked =>
+            string.Equals(host, blocked, StringComparison.OrdinalIgnoreCase) ||
+            host.EndsWith($".{blocked}", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsBlockedAddress(IPAddress address)
+    {
+        address = NormalizeAddress(address);
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var bytes = address.GetAddressBytes();
+            return bytes[0] is 0 or 10 or 127 ||
+                (bytes[0] == 100 && bytes[1] is >= 64 and <= 127) ||
+                (bytes[0] == 169 && bytes[1] == 254) ||
+                (bytes[0] == 172 && bytes[1] is >= 16 and <= 31) ||
+                (bytes[0] == 192 && bytes[1] is 0 or 2 or 168) ||
+                (bytes[0] == 192 && bytes[1] == 88 && bytes[2] == 99) ||
+                (bytes[0] == 198 && bytes[1] is 18 or 19) ||
+                (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100) ||
+                (bytes[0] == 203 && bytes[1] == 0 && bytes[2] == 113) ||
+                bytes[0] >= 224;
+        }
+
+        var ipv6 = address.GetAddressBytes();
+        return IPAddress.IsLoopback(address) ||
+            address.Equals(IPAddress.IPv6Any) ||
+            address.IsIPv6LinkLocal ||
+            address.IsIPv6SiteLocal ||
+            address.IsIPv6Multicast ||
+            (ipv6[0] & 0xfe) == 0xfc ||
+            (ipv6[0] == 0x20 && ipv6[1] == 0x01 && ipv6[2] == 0x0d && ipv6[3] == 0xb8);
+    }
+
+    private static IPAddress NormalizeAddress(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+        {
+            return address.MapToIPv4();
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            var bytes = address.GetAddressBytes();
+            if (bytes.Take(12).All(value => value == 0) &&
+                (bytes[12] != 0 || bytes[13] != 0 || bytes[14] != 0 || bytes[15] > 1))
+            {
+                return new IPAddress(bytes[^4..]);
+            }
+        }
+
+        return address;
     }
 
     private static bool Matches(JsonElement body, string propertyName, string expected) =>

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
@@ -1,0 +1,609 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AgentGovernance.Approvals;
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public sealed class ApprovalProtocolTests
+{
+    [Fact]
+    public void Canonicalize_SortsKeysAndDoesNotEscapeHtml()
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["b"] = "<&>",
+            ["a"] = 1
+        };
+
+        var canonical = Encoding.UTF8.GetString(ApprovalDigest.Canonicalize(value));
+
+        Assert.Equal("{\"a\":1,\"b\":\"<&>\"}", canonical);
+    }
+
+    [Fact]
+    public void ActionBinding_DigestIsStableAndActionSensitive()
+    {
+        var first = Binding(new Dictionary<string, object?> { ["amount"] = 42, ["currency"] = "EUR" });
+        var reordered = Binding(new Dictionary<string, object?> { ["currency"] = "EUR", ["amount"] = 42 });
+        var changed = Binding(new Dictionary<string, object?> { ["amount"] = 43, ["currency"] = "EUR" });
+
+        Assert.Equal(first.Digest(), reordered.Digest());
+        Assert.NotEqual(first.Digest(), changed.Digest());
+        Assert.StartsWith("sha256:", first.Digest(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OpenRequest_RejectsMalformedBinding()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var binding = Binding() with { Operation = " " };
+
+        Assert.Throws<ApprovalProtocolException>(() => coordinator.OpenRequest(binding));
+    }
+
+    [Fact]
+    public void OpenRequest_RoutesRequireApprovalPolicyDecision()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var decision = new PolicyDecision
+        {
+            Allowed = false,
+            Action = "requireapproval",
+            MatchedRule = "production-write",
+            Reason = "approval required"
+        };
+
+        var result = coordinator.OpenRequest(decision, Binding());
+
+        Assert.Equal("production-write", result.PolicyDecision.PolicyRuleId);
+        Assert.Equal(PolicyAction.RequireApproval, result.PolicyDecision.Verdict);
+        Assert.Equal(ApprovalStatus.Pending, result.Request.Status);
+    }
+
+    [Fact]
+    public void OpenRequest_RejectsNonApprovalPolicyDecision()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var decision = new PolicyDecision
+        {
+            Allowed = true,
+            Action = "allow",
+            Reason = "allowed"
+        };
+
+        Assert.Throws<ApprovalProtocolException>(() => coordinator.OpenRequest(decision, Binding()));
+    }
+
+    [Fact]
+    public void SubmitEntry_AllowsOnlyAfterEveryRequiredStage()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice"), Stage(1, "bob")));
+        var opened = coordinator.OpenRequest(Binding());
+
+        var afterFirst = coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+        Assert.Null(afterFirst.Resolution);
+        Assert.Equal(ApprovalStatus.Pending, afterFirst.Request.Status);
+
+        var afterSecond = coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 1, Vote("bob"));
+        Assert.Equal(ApprovalOutcome.Allow, afterSecond.Resolution?.Outcome);
+        Assert.Equal(ApprovalStatus.Allowed, afterSecond.Request.Status);
+    }
+
+    [Fact]
+    public void SubmitEntry_DenyShortCircuitsChain()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice"), Stage(1, "bob")));
+        var opened = coordinator.OpenRequest(Binding());
+
+        var result = coordinator.SubmitEntry(
+            opened.Request.ApprovalRequestId,
+            0,
+            Vote("alice", ApprovalEntryDecision.Deny, "risk_rejected"));
+
+        Assert.Equal(ApprovalOutcome.Deny, result.Resolution?.Outcome);
+        Assert.Equal("risk_rejected", result.Resolution?.ReasonCode);
+        Assert.Equal(ApprovalStatus.Denied, result.Request.Status);
+    }
+
+    [Fact]
+    public void SubmitEntry_LlmAdvisoryCannotAllowOrDeny()
+    {
+        var advisory = Stage(0, "model") with { ApproverKind = ApproverKind.LlmAdvisory };
+        var coordinator = Coordinator(Chain(advisory, Stage(1, "alice")));
+        var opened = coordinator.OpenRequest(Binding());
+
+        var afterAdvisory = coordinator.SubmitEntry(
+            opened.Request.ApprovalRequestId,
+            0,
+            Vote("model", ApprovalEntryDecision.Deny) with { ApproverKind = ApproverKind.LlmAdvisory });
+
+        Assert.Null(afterAdvisory.Resolution);
+        Assert.Equal(ApprovalStatus.Pending, afterAdvisory.Request.Status);
+
+        var allowed = coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 1, Vote("alice"));
+        Assert.Equal(ApprovalOutcome.Allow, allowed.Resolution?.Outcome);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoRequiredNonAdvisoryStageFailsClosed()
+    {
+        var advisory = Stage(0, "model") with
+        {
+            ApproverKind = ApproverKind.LlmAdvisory,
+            Transport = new DelegateTransport((_, _) => Task.FromResult(
+                Vote("model") with { ApproverKind = ApproverKind.LlmAdvisory }))
+        };
+        var coordinator = Coordinator(Chain(advisory));
+
+        var result = await coordinator.ResolveAsync(Binding());
+
+        Assert.Equal(ApprovalOutcome.Deny, result.Resolution?.Outcome);
+        Assert.Equal(ApprovalReasonCodes.NoRequiredStage, result.Resolution?.ReasonCode);
+        Assert.False(result.Execution?.Allowed ?? false);
+    }
+
+    [Theory]
+    [InlineData(ApprovalEntryDecision.Allow)]
+    [InlineData(ApprovalEntryDecision.Deny)]
+    public void SubmitEntry_UnauthorizedDecisionLeavesRequestPending(ApprovalEntryDecision decision)
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var opened = coordinator.OpenRequest(Binding());
+
+        Assert.Throws<ApprovalProtocolException>(() => coordinator.SubmitEntry(
+            opened.Request.ApprovalRequestId,
+            0,
+            Vote("mallory", decision)));
+
+        Assert.Equal(ApprovalStatus.Pending, coordinator.GetResult(opened.Request.ApprovalRequestId).Request.Status);
+        Assert.Empty(coordinator.GetResult(opened.Request.ApprovalRequestId).Entries);
+    }
+
+    [Fact]
+    public void SubmitEntry_CallerIdIsIdempotentBeforeAndAfterResolution()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice"), Stage(1, "bob")));
+        var opened = coordinator.OpenRequest(Binding());
+        var vote = Vote("alice") with { ChainEntryId = "ace_retry" };
+
+        coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, vote);
+        var retriedPending = coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, vote);
+        Assert.Single(retriedPending.Entries);
+
+        coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 1, Vote("bob"));
+        var retriedResolved = coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, vote);
+        Assert.Equal(2, retriedResolved.Entries.Count);
+        Assert.Equal(ApprovalStatus.Allowed, retriedResolved.Request.Status);
+    }
+
+    [Fact]
+    public void SubmitEntry_RejectsConflictingDecisionForSatisfiedStage()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice"), Stage(1, "bob")));
+        var opened = coordinator.OpenRequest(Binding());
+        coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+
+        Assert.Throws<ApprovalProtocolException>(() => coordinator.SubmitEntry(
+            opened.Request.ApprovalRequestId,
+            0,
+            Vote("alice", ApprovalEntryDecision.Deny)));
+    }
+
+    [Fact]
+    public void ValidateForExecution_BindsActionAndConsumesOnce()
+    {
+        var binding = Binding();
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var opened = coordinator.OpenRequest(binding);
+        coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+
+        var mismatch = coordinator.ValidateForExecution(
+            opened.Request.ApprovalRequestId,
+            binding with { Parameters = new Dictionary<string, object?> { ["amount"] = 99 } });
+        var allowed = coordinator.ValidateForExecution(opened.Request.ApprovalRequestId, binding);
+        var replay = coordinator.ValidateForExecution(opened.Request.ApprovalRequestId, binding);
+
+        Assert.False(mismatch.Allowed);
+        Assert.Equal(ApprovalReasonCodes.ActionDigestMismatch, mismatch.ReasonCode);
+        Assert.True(allowed.Allowed);
+        Assert.True(allowed.Consumed);
+        Assert.False(replay.Allowed);
+        Assert.Equal(ApprovalReasonCodes.Consumed, replay.ReasonCode);
+    }
+
+    [Fact]
+    public void ValidateForExecution_RejectsPolicyAndChainVersionChanges()
+    {
+        var store = new InMemoryApprovalStore();
+        var binding = Binding();
+        var original = Coordinator(Chain(Stage(0, "alice")), store: store, policyVersion: "policy-v1");
+        var opened = original.OpenRequest(binding);
+        original.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+
+        var changedPolicy = Coordinator(Chain(Stage(0, "alice")), store: store, policyVersion: "policy-v2");
+        var policyDecision = changedPolicy.CheckForExecution(opened.Request.ApprovalRequestId, binding);
+
+        var changedChain = Coordinator(
+            Chain(Stage(0, "alice")) with { Version = "chain-v2" },
+            store: store,
+            policyVersion: "policy-v1");
+        var chainDecision = changedChain.CheckForExecution(opened.Request.ApprovalRequestId, binding);
+
+        Assert.Equal(ApprovalReasonCodes.PolicyVersionMismatch, policyDecision.ReasonCode);
+        Assert.Equal(ApprovalReasonCodes.ChainVersionMismatch, chainDecision.ReasonCode);
+    }
+
+    [Fact]
+    public void ValidateForExecution_DetectsAppendedTamperEntry()
+    {
+        var store = new InMemoryApprovalStore();
+        var binding = Binding();
+        var coordinator = Coordinator(Chain(Stage(0, "alice")), store: store);
+        var opened = coordinator.OpenRequest(binding);
+        var allowed = coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+        var last = Assert.Single(allowed.Entries);
+        store.AppendEntry(new ApprovalChainEntry
+        {
+            ApprovalRequestId = opened.Request.ApprovalRequestId,
+            StageIndex = 0,
+            ApproverKind = ApproverKind.LlmAdvisory,
+            ApproverIdentity = "model",
+            IdentityAssurance = "advisory",
+            Decision = ApprovalEntryDecision.Allow,
+            InputDigest = opened.Request.InputDigest(),
+            PreviousEntryDigest = last.EntryDigest
+        }.Seal());
+
+        var decision = coordinator.CheckForExecution(opened.Request.ApprovalRequestId, binding);
+
+        Assert.False(decision.Allowed);
+        Assert.Equal(ApprovalReasonCodes.ChainTampered, decision.ReasonCode);
+    }
+
+    [Fact]
+    public void ValidateForExecution_ConcurrentConsumeAllowsExactlyOnce()
+    {
+        var binding = Binding();
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var opened = coordinator.OpenRequest(binding);
+        coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+        var decisions = new ApprovalExecutionDecision[24];
+
+        Parallel.For(0, decisions.Length, index =>
+        {
+            decisions[index] = coordinator.ValidateForExecution(opened.Request.ApprovalRequestId, binding);
+        });
+
+        Assert.Single(decisions, decision => decision.Allowed);
+        Assert.Equal(23, decisions.Count(decision => decision.ReasonCode == ApprovalReasonCodes.Consumed));
+    }
+
+    [Fact]
+    public void ValidateForExecution_ApprovalExpiresAfterAllow()
+    {
+        var now = DateTimeOffset.Parse("2026-07-17T12:00:00Z");
+        var coordinator = Coordinator(
+            Chain(Stage(0, "alice")),
+            clock: () => now,
+            ttl: TimeSpan.FromMinutes(1));
+        var binding = Binding();
+        var opened = coordinator.OpenRequest(binding);
+        coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+        now = now.AddMinutes(2);
+
+        var decision = coordinator.ValidateForExecution(opened.Request.ApprovalRequestId, binding);
+
+        Assert.False(decision.Allowed);
+        Assert.Equal(ApprovalReasonCodes.Expired, decision.ReasonCode);
+    }
+
+    [Fact]
+    public void CancelRequest_IsTerminalAndCannotExecute()
+    {
+        var binding = Binding();
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var opened = coordinator.OpenRequest(binding);
+
+        var cancelled = coordinator.CancelRequest(opened.Request.ApprovalRequestId, "operator_cancelled");
+        var decision = coordinator.ValidateForExecution(opened.Request.ApprovalRequestId, binding);
+
+        Assert.Equal(ApprovalOutcome.Cancelled, cancelled.Resolution?.Outcome);
+        Assert.Equal(ApprovalStatus.Cancelled, cancelled.Request.Status);
+        Assert.Equal(ApprovalReasonCodes.Cancelled, decision.ReasonCode);
+    }
+
+    [Fact]
+    public void AuditEvents_LinkPolicyRequestEntryResolutionAndConsumption()
+    {
+        var sink = new InMemoryApprovalAuditSink();
+        var binding = Binding();
+        var coordinator = Coordinator(Chain(Stage(0, "alice")), auditSink: sink);
+        var opened = coordinator.OpenRequest(binding);
+        coordinator.SubmitEntry(opened.Request.ApprovalRequestId, 0, Vote("alice"));
+        coordinator.ValidateForExecution(opened.Request.ApprovalRequestId, binding);
+
+        var events = sink.GetEvents();
+        Assert.Contains(events, item => item.Type == ApprovalAuditEventType.PolicyDecision);
+        Assert.Contains(events, item => item.Type == ApprovalAuditEventType.ApprovalRequested);
+        Assert.Contains(events, item => item.Type == ApprovalAuditEventType.ApprovalChainEntry);
+        Assert.Contains(events, item => item.Type == ApprovalAuditEventType.ApprovalResolved);
+        Assert.Contains(events, item => item.Type == ApprovalAuditEventType.ApprovalConsumed);
+        Assert.Contains(events, item => item.Type == ApprovalAuditEventType.ExecutionAllowed);
+        Assert.All(events, item => Assert.Equal(opened.Request.ApprovalRequestId, item.ApprovalRequestId));
+        Assert.All(events, item => Assert.Equal(opened.PolicyDecision.PolicyDecisionId, item.PolicyDecisionId));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_TimeoutFailsClosedAndRecordsDeny()
+    {
+        var stage = Stage(0, "alice") with
+        {
+            Transport = new DelegateTransport(async (_, cancellationToken) =>
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return Vote("alice");
+            })
+        };
+        var coordinator = Coordinator(Chain(stage), timeout: TimeSpan.FromMilliseconds(20));
+
+        var result = await coordinator.ResolveAsync(Binding());
+
+        Assert.Equal(ApprovalOutcome.Deny, result.Resolution?.Outcome);
+        Assert.Equal("approval_timeout", result.Resolution?.ReasonCode);
+        Assert.Equal(ApprovalStatus.Denied, result.Request.Status);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_TransportFailureFailsClosed()
+    {
+        var stage = Stage(0, "alice") with
+        {
+            Transport = new DelegateTransport((_, _) =>
+                Task.FromException<ApprovalVote>(new HttpRequestException("offline")))
+        };
+        var coordinator = Coordinator(Chain(stage));
+
+        var result = await coordinator.ResolveAsync(Binding());
+
+        Assert.Equal(ApprovalOutcome.Deny, result.Resolution?.Outcome);
+        Assert.Equal("approval_transport_error", result.Resolution?.ReasonCode);
+    }
+
+    private static ActionBinding Binding(IReadOnlyDictionary<string, object?>? parameters = null) => new()
+    {
+        Operation = "tool.invoke",
+        AgentId = "did:agent:123",
+        SubjectId = "user-456",
+        Target = new ActionTarget
+        {
+            ToolName = "payments.transfer",
+            ToolSchemaVersion = "1",
+            Resource = "account-42"
+        },
+        Parameters = parameters ?? new Dictionary<string, object?> { ["amount"] = 42 }
+    };
+
+    private static ApprovalStage Stage(int index, string identity) => new()
+    {
+        StageIndex = index,
+        AllowedIdentities = new[] { identity }
+    };
+
+    private static ApprovalChain Chain(params ApprovalStage[] stages) => new()
+    {
+        ChainId = "high-risk-tools",
+        Version = "chain-v1",
+        Stages = stages
+    };
+
+    private static ApprovalVote Vote(
+        string identity,
+        ApprovalEntryDecision decision = ApprovalEntryDecision.Allow,
+        string reason = "reviewed") => new()
+        {
+            ApproverKind = ApproverKind.Human,
+            ApproverIdentity = identity,
+            IdentityAssurance = "oidc",
+            Decision = decision,
+            ReasonCode = reason
+        };
+
+    private static ApprovalCoordinator Coordinator(
+        ApprovalChain chain,
+        IApprovalStore? store = null,
+        string policyVersion = "policy-v1",
+        Func<DateTimeOffset>? clock = null,
+        TimeSpan? ttl = null,
+        TimeSpan? timeout = null,
+        IApprovalAuditSink? auditSink = null) =>
+        new(
+            chain,
+            store,
+            new ApprovalCoordinatorOptions
+            {
+                PolicyRuleId = "production-write",
+                PolicyVersion = policyVersion,
+                Clock = clock ?? (() => DateTimeOffset.UtcNow),
+                RequestTtl = ttl ?? TimeSpan.FromMinutes(5),
+                StageTimeout = timeout ?? TimeSpan.FromMinutes(5),
+                AuditSink = auditSink
+            });
+
+    private sealed class DelegateTransport : IApprovalTransport
+    {
+        private readonly Func<ApprovalRequest, CancellationToken, Task<ApprovalVote>> _handler;
+
+        internal DelegateTransport(Func<ApprovalRequest, CancellationToken, Task<ApprovalVote>> handler)
+        {
+            _handler = handler;
+        }
+
+        public Task<ApprovalVote> RequestApprovalAsync(
+            ApprovalRequest request,
+            CancellationToken cancellationToken = default) =>
+            _handler(request, cancellationToken);
+    }
+}
+
+public sealed class WebhookApproverTests
+{
+    [Fact]
+    public void BuildRequestPayload_CarriesVersionAndActionBinding()
+    {
+        var request = OpenRequest();
+
+        var payload = WebhookApprover.BuildRequestPayload(request);
+
+        Assert.Equal("1.0", payload["schema_version"]);
+        Assert.Equal("approval_request", payload["type"]);
+        Assert.Equal(request.ApprovalRequestId, payload["approval_request_id"]);
+        Assert.Equal(request.PolicyDecisionId, payload["policy_decision_id"]);
+        Assert.Equal(request.ActionDigest, payload["action_digest"]);
+        Assert.Equal(request.PolicyVersion, payload["policy_version"]);
+        Assert.Equal(request.ApprovalChainVersion, payload["approval_chain_version"]);
+        Assert.Equal(request.InputDigest(), payload["input_digest"]);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_VerifiedApproveReturnsBoundIdentity()
+    {
+        var request = OpenRequest();
+        using var client = ClientFor(request, approved: true);
+        using var approver = new WebhookApprover(
+            new Uri("https://approvals.example/v1"),
+            client,
+            responseVerifier: (_, _) => new WebhookVerifiedIdentity
+            {
+                Identity = "did:web:example.com:alice",
+                Assurance = "oidc",
+                Roles = new[] { "security" }
+            });
+
+        var vote = await approver.RequestApprovalAsync(request);
+
+        Assert.Equal(ApprovalEntryDecision.Allow, vote.Decision);
+        Assert.Equal("did:web:example.com:alice", vote.ApproverIdentity);
+        Assert.Equal("oidc", vote.IdentityAssurance);
+        Assert.Contains("security", vote.Roles);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_UnverifiedApproveFailsClosed()
+    {
+        var request = OpenRequest();
+        using var client = ClientFor(request, approved: true);
+        using var approver = new WebhookApprover(new Uri("https://approvals.example/v1"), client);
+
+        var error = await Assert.ThrowsAsync<ApprovalTransportProtocolException>(
+            () => approver.RequestApprovalAsync(request));
+
+        Assert.Equal("unverified_approver_identity", error.ReasonCode);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_BindingMismatchFailsClosed()
+    {
+        var request = OpenRequest();
+        using var client = new HttpClient(new StubHandler((_, _) => JsonResponse(new
+        {
+            approval_request_id = request.ApprovalRequestId,
+            action_digest = "sha256:wrong",
+            approved = true
+        })));
+        using var approver = new WebhookApprover(new Uri("https://approvals.example/v1"), client);
+
+        var error = await Assert.ThrowsAsync<ApprovalTransportProtocolException>(
+            () => approver.RequestApprovalAsync(request));
+
+        Assert.Equal("action_digest_mismatch", error.ReasonCode);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_DenyDoesNotTrustBodyIdentityForAllow()
+    {
+        var request = OpenRequest();
+        using var client = ClientFor(request, approved: false);
+        using var approver = new WebhookApprover(new Uri("https://approvals.example/v1"), client);
+
+        var vote = await approver.RequestApprovalAsync(request);
+
+        Assert.Equal(ApprovalEntryDecision.Deny, vote.Decision);
+        Assert.Equal("webhook-user", vote.ApproverIdentity);
+    }
+
+    [Fact]
+    public void Constructor_BlocksMetadataEndpoints()
+    {
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://169.254.169.254/latest/meta-data")));
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://169.254.1.2/approval")));
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://[fd00:ec2::254]/latest/meta-data")));
+    }
+
+    private static ApprovalRequest OpenRequest()
+    {
+        var coordinator = new ApprovalCoordinator(
+            new ApprovalChain
+            {
+                ChainId = "high-risk-tools",
+                Version = "chain-v1",
+                Stages = new[]
+                {
+                    new ApprovalStage
+                    {
+                        StageIndex = 0,
+                        AllowedIdentities = new[] { "did:web:example.com:alice" }
+                    }
+                }
+            },
+            options: new ApprovalCoordinatorOptions { PolicyVersion = "policy-v1" });
+        return coordinator.OpenRequest(new ActionBinding
+        {
+            Operation = "tool.invoke",
+            AgentId = "did:agent:123",
+            Target = new ActionTarget
+            {
+                ToolName = "payments.transfer",
+                ToolSchemaVersion = "1"
+            }
+        }).Request;
+    }
+
+    private static HttpClient ClientFor(ApprovalRequest request, bool approved) =>
+        new(new StubHandler((_, _) => JsonResponse(new
+        {
+            approval_request_id = request.ApprovalRequestId,
+            action_digest = request.ActionDigest,
+            approved,
+            approver = "webhook-user",
+            reason = approved ? "reviewed" : "rejected"
+        })));
+
+    private static HttpResponseMessage JsonResponse(object body) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+    };
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> _handler;
+
+        internal StubHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(_handler(request, cancellationToken));
+    }
+}

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
@@ -131,6 +131,23 @@ public sealed class ApprovalProtocolTests
     }
 
     [Fact]
+    public void SubmitEntry_RejectsAdvisoryVoteForNonAdvisoryStage()
+    {
+        var coordinator = Coordinator(Chain(Stage(0, "alice")));
+        var opened = coordinator.OpenRequest(Binding());
+        var advisoryVote = Vote("model") with { ApproverKind = ApproverKind.LlmAdvisory };
+
+        Assert.Throws<ApprovalProtocolException>(() => coordinator.SubmitEntry(
+            opened.Request.ApprovalRequestId,
+            0,
+            advisoryVote));
+
+        var result = coordinator.GetResult(opened.Request.ApprovalRequestId);
+        Assert.Equal(ApprovalStatus.Pending, result.Request.Status);
+        Assert.Empty(result.Entries);
+    }
+
+    [Fact]
     public async Task ResolveAsync_NoRequiredNonAdvisoryStageFailsClosed()
     {
         var advisory = Stage(0, "model") with
@@ -340,6 +357,26 @@ public sealed class ApprovalProtocolTests
     }
 
     [Fact]
+    public void ValidateForExecution_InternalErrorEmitsExecutionDeniedForKnownRequest()
+    {
+        var sink = new InMemoryApprovalAuditSink();
+        var coordinator = Coordinator(Chain(Stage(0, "alice")), auditSink: sink);
+        var opened = coordinator.OpenRequest(Binding());
+
+        var decision = coordinator.CheckForExecution(
+            opened.Request.ApprovalRequestId,
+            Binding() with { Target = null! });
+
+        Assert.False(decision.Allowed);
+        Assert.Equal(ApprovalReasonCodes.InternalError, decision.ReasonCode);
+        var denied = Assert.Single(
+            sink.GetEvents(),
+            item => item.Type == ApprovalAuditEventType.ExecutionDenied);
+        Assert.Equal(ApprovalReasonCodes.InternalError, denied.ReasonCode);
+        Assert.Equal(opened.Request.ApprovalRequestId, denied.ApprovalRequestId);
+    }
+
+    [Fact]
     public async Task ResolveAsync_TimeoutFailsClosedAndRecordsDeny()
     {
         var stage = Stage(0, "alice") with
@@ -491,6 +528,46 @@ public sealed class WebhookApproverTests
         Assert.Equal("did:web:example.com:alice", vote.ApproverIdentity);
         Assert.Equal("oidc", vote.IdentityAssurance);
         Assert.Contains("security", vote.Roles);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_VerifiedApproveWithNullRolesUsesEmptyRoles()
+    {
+        var request = OpenRequest();
+        using var client = ClientFor(request, approved: true);
+        using var approver = new WebhookApprover(
+            new Uri("https://approvals.example/v1"),
+            client,
+            responseVerifier: (_, _) => new WebhookVerifiedIdentity
+            {
+                Identity = "did:web:example.com:alice",
+                Assurance = "oidc",
+                Roles = null!
+            });
+
+        var vote = await approver.RequestApprovalAsync(request);
+
+        Assert.Empty(vote.Roles);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_BlankVerifiedAssuranceFailsClosed()
+    {
+        var request = OpenRequest();
+        using var client = ClientFor(request, approved: true);
+        using var approver = new WebhookApprover(
+            new Uri("https://approvals.example/v1"),
+            client,
+            responseVerifier: (_, _) => new WebhookVerifiedIdentity
+            {
+                Identity = "did:web:example.com:alice",
+                Assurance = " "
+            });
+
+        var error = await Assert.ThrowsAsync<ApprovalTransportProtocolException>(
+            () => approver.RequestApprovalAsync(request));
+
+        Assert.Equal("unverified_approver_identity", error.ReasonCode);
     }
 
     [Fact]

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
@@ -114,7 +114,11 @@ public sealed class ApprovalProtocolTests
     [Fact]
     public void SubmitEntry_LlmAdvisoryCannotAllowOrDeny()
     {
-        var advisory = Stage(0, "model") with { ApproverKind = ApproverKind.LlmAdvisory };
+        var advisory = Stage(0, "model") with
+        {
+            ApproverKind = ApproverKind.LlmAdvisory,
+            Required = false
+        };
         var coordinator = Coordinator(Chain(advisory, Stage(1, "alice")));
         var opened = coordinator.OpenRequest(Binding());
 
@@ -148,11 +152,22 @@ public sealed class ApprovalProtocolTests
     }
 
     [Fact]
+    public void Constructor_RejectsRequiredLlmAdvisoryStage()
+    {
+        var advisory = Stage(0, "model") with { ApproverKind = ApproverKind.LlmAdvisory };
+
+        var error = Assert.Throws<ApprovalProtocolException>(() => Coordinator(Chain(advisory)));
+
+        Assert.Contains("cannot be required", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ResolveAsync_NoRequiredNonAdvisoryStageFailsClosed()
     {
-        var advisory = Stage(0, "model") with
+        var advisory = Stage(7, "model") with
         {
             ApproverKind = ApproverKind.LlmAdvisory,
+            Required = false,
             Transport = new DelegateTransport((_, _) => Task.FromResult(
                 Vote("model") with { ApproverKind = ApproverKind.LlmAdvisory }))
         };
@@ -163,6 +178,7 @@ public sealed class ApprovalProtocolTests
         Assert.Equal(ApprovalOutcome.Deny, result.Resolution?.Outcome);
         Assert.Equal(ApprovalReasonCodes.NoRequiredStage, result.Resolution?.ReasonCode);
         Assert.False(result.Execution?.Allowed ?? false);
+        Assert.Equal(7, Assert.Single(result.Entries).StageIndex);
     }
 
     [Theory]
@@ -256,8 +272,10 @@ public sealed class ApprovalProtocolTests
         Assert.Equal(ApprovalReasonCodes.ChainVersionMismatch, chainDecision.ReasonCode);
     }
 
-    [Fact]
-    public void ValidateForExecution_DetectsAppendedTamperEntry()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(999)]
+    public void ValidateForExecution_DetectsAppendedAdvisoryAtInvalidStage(int stageIndex)
     {
         var store = new InMemoryApprovalStore();
         var binding = Binding();
@@ -268,7 +286,7 @@ public sealed class ApprovalProtocolTests
         store.AppendEntry(new ApprovalChainEntry
         {
             ApprovalRequestId = opened.Request.ApprovalRequestId,
-            StageIndex = 0,
+            StageIndex = stageIndex,
             ApproverKind = ApproverKind.LlmAdvisory,
             ApproverIdentity = "model",
             IdentityAssurance = "advisory",
@@ -412,6 +430,23 @@ public sealed class ApprovalProtocolTests
         Assert.Equal("approval_transport_error", result.Resolution?.ReasonCode);
     }
 
+    [Fact]
+    public async Task ResolveAsync_InvalidTransportVoteFailsClosed()
+    {
+        var stage = Stage(4, "alice") with
+        {
+            Transport = new DelegateTransport((_, _) => Task.FromResult(Vote("mallory")))
+        };
+        var coordinator = Coordinator(Chain(stage));
+
+        var result = await coordinator.ResolveAsync(Binding());
+
+        Assert.Equal(ApprovalOutcome.Deny, result.Resolution?.Outcome);
+        Assert.Equal("invalid_approval_vote", result.Resolution?.ReasonCode);
+        Assert.Equal(ApprovalStatus.Denied, result.Request.Status);
+        Assert.Equal(4, Assert.Single(result.Entries).StageIndex);
+    }
+
     private static ActionBinding Binding(IReadOnlyDictionary<string, object?>? parameters = null) => new()
     {
         Operation = "tool.invoke",
@@ -520,7 +555,8 @@ public sealed class WebhookApproverTests
                 Identity = "did:web:example.com:alice",
                 Assurance = "oidc",
                 Roles = new[] { "security" }
-            });
+            },
+            addressResolver: ResolvePublicEndpoint);
 
         var vote = await approver.RequestApprovalAsync(request);
 
@@ -543,7 +579,8 @@ public sealed class WebhookApproverTests
                 Identity = "did:web:example.com:alice",
                 Assurance = "oidc",
                 Roles = null!
-            });
+            },
+            addressResolver: ResolvePublicEndpoint);
 
         var vote = await approver.RequestApprovalAsync(request);
 
@@ -562,7 +599,8 @@ public sealed class WebhookApproverTests
             {
                 Identity = "did:web:example.com:alice",
                 Assurance = " "
-            });
+            },
+            addressResolver: ResolvePublicEndpoint);
 
         var error = await Assert.ThrowsAsync<ApprovalTransportProtocolException>(
             () => approver.RequestApprovalAsync(request));
@@ -575,7 +613,10 @@ public sealed class WebhookApproverTests
     {
         var request = OpenRequest();
         using var client = ClientFor(request, approved: true);
-        using var approver = new WebhookApprover(new Uri("https://approvals.example/v1"), client);
+        using var approver = new WebhookApprover(
+            new Uri("https://approvals.example/v1"),
+            client,
+            addressResolver: ResolvePublicEndpoint);
 
         var error = await Assert.ThrowsAsync<ApprovalTransportProtocolException>(
             () => approver.RequestApprovalAsync(request));
@@ -593,7 +634,10 @@ public sealed class WebhookApproverTests
             action_digest = "sha256:wrong",
             approved = true
         })));
-        using var approver = new WebhookApprover(new Uri("https://approvals.example/v1"), client);
+        using var approver = new WebhookApprover(
+            new Uri("https://approvals.example/v1"),
+            client,
+            addressResolver: ResolvePublicEndpoint);
 
         var error = await Assert.ThrowsAsync<ApprovalTransportProtocolException>(
             () => approver.RequestApprovalAsync(request));
@@ -602,61 +646,38 @@ public sealed class WebhookApproverTests
     }
 
     [Fact]
-    public async Task RequestApprovalAsync_DefaultClientDoesNotFollowRedirects()
+    public async Task RequestApprovalAsync_RevalidatesDnsAndBlocksRebinding()
     {
         var request = OpenRequest();
-        var port = GetFreePort();
-        var baseUrl = $"http://127.0.0.1:{port}";
-        using var listener = new HttpListener();
-        listener.Prefixes.Add($"{baseUrl}/");
-        listener.Start();
-        var redirectedRequests = 0;
-        var serverTask = Task.Run(async () =>
+        var sent = 0;
+        var resolutions = 0;
+        using var client = new HttpClient(new StubHandler((_, _) =>
         {
-            try
+            Interlocked.Increment(ref sent);
+            return JsonResponse(new
             {
-                while (listener.IsListening)
-                {
-                    var context = await listener.GetContextAsync().ConfigureAwait(false);
-                    if (context.Request.Url?.AbsolutePath == "/start")
-                    {
-                        context.Response.StatusCode = (int)HttpStatusCode.Found;
-                        context.Response.RedirectLocation = $"{baseUrl}/target";
-                    }
-                    else
-                    {
-                        Interlocked.Increment(ref redirectedRequests);
-                        context.Response.StatusCode = (int)HttpStatusCode.OK;
-                    }
+                approval_request_id = request.ApprovalRequestId,
+                action_digest = request.ActionDigest,
+                approved = false
+            });
+        }));
+        using var approver = new WebhookApprover(
+            new Uri("https://approvals.example/v1"),
+            client,
+            addressResolver: (_, _) => Task.FromResult(
+                Interlocked.Increment(ref resolutions) == 1
+                    ? new[] { IPAddress.Parse("93.184.216.34") }
+                    : new[] { IPAddress.Loopback }));
 
-                    context.Response.Close();
-                }
-            }
-            catch (HttpListenerException)
-            {
-                // Listener shutdown ends the test server.
-            }
-            catch (ObjectDisposedException)
-            {
-                // Listener shutdown ends the test server.
-            }
-        });
+        var firstVote = await approver.RequestApprovalAsync(request);
 
-        try
-        {
-            using var approver = new WebhookApprover(new Uri($"{baseUrl}/start"));
+        var error = await Assert.ThrowsAsync<ApprovalTransportProtocolException>(
+            () => approver.RequestApprovalAsync(request));
 
-            await Assert.ThrowsAsync<HttpRequestException>(
-                () => approver.RequestApprovalAsync(request));
-
-            Assert.Equal(0, Volatile.Read(ref redirectedRequests));
-        }
-        finally
-        {
-            listener.Stop();
-            listener.Close();
-            await serverTask.WaitAsync(TimeSpan.FromSeconds(5));
-        }
+        Assert.Equal(ApprovalEntryDecision.Deny, firstVote.Decision);
+        Assert.Equal("blocked_webhook_endpoint", error.ReasonCode);
+        Assert.Equal(2, resolutions);
+        Assert.Equal(1, sent);
     }
 
     [Fact]
@@ -664,7 +685,10 @@ public sealed class WebhookApproverTests
     {
         var request = OpenRequest();
         using var client = ClientFor(request, approved: false);
-        using var approver = new WebhookApprover(new Uri("https://approvals.example/v1"), client);
+        using var approver = new WebhookApprover(
+            new Uri("https://approvals.example/v1"),
+            client,
+            addressResolver: ResolvePublicEndpoint);
 
         var vote = await approver.RequestApprovalAsync(request);
 
@@ -673,14 +697,26 @@ public sealed class WebhookApproverTests
     }
 
     [Fact]
-    public void Constructor_BlocksMetadataEndpoints()
+    public void Constructor_BlocksLocalPrivateAndMetadataEndpoints()
     {
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://localhost/approval")));
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://127.0.0.1/approval")));
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://10.0.0.1/approval")));
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://172.16.0.1/approval")));
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://192.168.0.1/approval")));
         Assert.Throws<ArgumentException>(() => new WebhookApprover(
             new Uri("http://169.254.169.254/latest/meta-data")));
         Assert.Throws<ArgumentException>(() => new WebhookApprover(
             new Uri("http://169.254.1.2/approval")));
         Assert.Throws<ArgumentException>(() => new WebhookApprover(
             new Uri("http://[fd00:ec2::254]/latest/meta-data")));
+        Assert.Throws<ArgumentException>(() => new WebhookApprover(
+            new Uri("http://[::ffff:127.0.0.1]/approval")));
     }
 
     private static ApprovalRequest OpenRequest()
@@ -727,13 +763,12 @@ public sealed class WebhookApproverTests
         Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
     };
 
-    private static int GetFreePort()
+    private static Task<IPAddress[]> ResolvePublicEndpoint(
+        string _,
+        CancellationToken cancellationToken)
     {
-        using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(new[] { IPAddress.Parse("93.184.216.34") });
     }
 
     private sealed class StubHandler : HttpMessageHandler

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/ApprovalProtocolTests.cs
@@ -602,6 +602,64 @@ public sealed class WebhookApproverTests
     }
 
     [Fact]
+    public async Task RequestApprovalAsync_DefaultClientDoesNotFollowRedirects()
+    {
+        var request = OpenRequest();
+        var port = GetFreePort();
+        var baseUrl = $"http://127.0.0.1:{port}";
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"{baseUrl}/");
+        listener.Start();
+        var redirectedRequests = 0;
+        var serverTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (listener.IsListening)
+                {
+                    var context = await listener.GetContextAsync().ConfigureAwait(false);
+                    if (context.Request.Url?.AbsolutePath == "/start")
+                    {
+                        context.Response.StatusCode = (int)HttpStatusCode.Found;
+                        context.Response.RedirectLocation = $"{baseUrl}/target";
+                    }
+                    else
+                    {
+                        Interlocked.Increment(ref redirectedRequests);
+                        context.Response.StatusCode = (int)HttpStatusCode.OK;
+                    }
+
+                    context.Response.Close();
+                }
+            }
+            catch (HttpListenerException)
+            {
+                // Listener shutdown ends the test server.
+            }
+            catch (ObjectDisposedException)
+            {
+                // Listener shutdown ends the test server.
+            }
+        });
+
+        try
+        {
+            using var approver = new WebhookApprover(new Uri($"{baseUrl}/start"));
+
+            await Assert.ThrowsAsync<HttpRequestException>(
+                () => approver.RequestApprovalAsync(request));
+
+            Assert.Equal(0, Volatile.Read(ref redirectedRequests));
+        }
+        finally
+        {
+            listener.Stop();
+            listener.Close();
+            await serverTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Fact]
     public async Task RequestApprovalAsync_DenyDoesNotTrustBodyIdentityForAllow()
     {
         var request = OpenRequest();
@@ -668,6 +726,15 @@ public sealed class WebhookApproverTests
     {
         Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
     };
+
+    private static int GetFreePort()
+    {
+        using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
 
     private sealed class StubHandler : HttpMessageHandler
     {


### PR DESCRIPTION
## Description

Adds the .NET language-parity slice for action-bound `require_approval` approval chains tracked in #3083.

The new `AgentGovernance.Approvals` surface provides:

- deterministic action binding and SHA-256 digests
- a durable store contract with a thread-safe in-memory implementation
- ordered, versioned approval chains with deny short-circuiting
- advisory LLM entries that cannot authorize or deny execution
- fail-closed timeout, cancellation, malformed response, and transport-error handling
- linked, tamper-evident approval entries and structured audit events
- execution-time action, policy, chain, integrity, expiry, and one-time-consume checks
- a versioned webhook transport with bound-response validation, independently verified approve identities, and metadata endpoint blocking

The zero-required-non-advisory-stage path intentionally denies with `no_required_approval_stage`. This avoids the current Python vacuous-allow behavior and matches the safer Go parity implementation in #3242. The behavior is documented in the .NET README and covered by regression tests.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected

- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

Scope: `agent-governance-dotnet/` only.

## Checklist

- [x] My code follows the project style guidelines (`ruff` is not applicable; scoped `dotnet format --verify-no-changes` passed)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`dotnet test AgentGovernance.sln`)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

Additional validation:

- `dotnet format AgentGovernance.sln --no-restore --verify-no-changes --include src/AgentGovernance/Approvals tests/AgentGovernance.Tests/ApprovalProtocolTests.cs`
- `dotnet build AgentGovernance.sln` succeeds
- `dotnet test AgentGovernance.sln` passes 806 tests

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**:

- ADR-0030 in this repository
- the existing Python approval protocol in this repository
- TypeScript parity PR #3200
- Go parity PR #3242

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

OpenAI Codex assisted with implementation, regression tests, and validation. The draft remains open for contributor and maintainer review.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Part of #3083.
