### PR TITLE
fix(ci): bump build-go toolchain to 1.25 to match go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1088,7 +1088,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.22"
+          go-version: "1.25"
       - name: Build
         working-directory: agent-governance-golang
         run: go build ./...


### PR DESCRIPTION
## Summary

The `build-go` job in `ci.yml` pins `actions/setup-go` to `go-version: "1.22"`, but `agent-governance-golang/go.mod` declares `go 1.25`. With `GOTOOLCHAIN=local` (the default for `actions/setup-go`), that fails outright:

```
go: go.mod requires go >= 1.25 (running go 1.22.12; GOTOOLCHAIN=local)
```

This job only runs on push when Go files change, or unconditionally on the daily `schedule` trigger, so the mismatch stayed latent until the scheduled run exercised it (run [29898140033](https://github.com/microsoft/agent-governance-toolkit/actions/runs/29898140033), 2026-07-22).

## Fix

Bump the pinned `go-version` in the `build-go` job from `"1.22"` to `"1.25"` to match `go.mod`.

## Test plan

- Extracted `agent-governance-golang` from live `main` and ran `go build ./...` locally with a `go1.25`+ toolchain: builds clean.
- Confirmed the only diff introduced is the single `go-version` line.
