### PR TITLE
feat: add external evaluator handoff example

### DIFF
--- a/docs/dependency-audits/2026-09-03-external-evaluator-handoff.md
+++ b/docs/dependency-audits/2026-09-03-external-evaluator-handoff.md
@@ -1,0 +1,44 @@
+---
+title: External Evaluator Handoff Example Dependencies
+last_reviewed: 2026-09-03
+owner: agt-maintainers
+---
+
+# External Evaluator Handoff Example Dependencies
+
+## Which Dependencies Changed And Why
+
+The new `examples/external-evaluator-handoff/requirements.txt` declares two
+bounded dependencies for the standalone example:
+
+- `agent-governance-toolkit-core>=5.0.0,<6.0` supplies the existing
+  `DecisionBOM` model and the public `sha256_jcs` digest helper. The v5 floor is
+  required so the example does not teach direct use of a raw cryptographic
+  primitive outside the SDK boundary.
+- `pytest>=8.0.0,<10.0` is used only to run the example's local regression
+  tests. It is not imported by the runnable example.
+
+These dependencies are isolated to the example and do not change any AGT
+package or repository-wide runtime dependency.
+
+## Security Advisory Relevance
+
+This change is not a security-advisory remediation and does not add a new
+cryptographic implementation. Content digests are delegated to AGT's existing
+public SDK helper. `pytest` is test-only, and the repository's dependency
+review and vulnerability checks remain authoritative for the resolved graph.
+
+## Breaking Change Risk Assessment
+
+**Risk: low and example-local.** The example requires AGT core v5 because the
+public digest helper is part of that supported surface. Users pinned to AGT
+core v4 cannot run this example without upgrading, but no existing package,
+API, policy, or runtime behavior is changed. The upper bounds keep resolution
+within the currently supported major versions.
+
+## Validation And Rollback
+
+Validation covers the example test suite, formatting and lint checks, strict
+JSON output, documentation links, and the repository dependency and
+unauthorized-crypto gates. Rollback consists of removing the standalone
+example and this audit record; no production data or migration is involved.

--- a/examples/external-evaluator-handoff/README.md
+++ b/examples/external-evaluator-handoff/README.md
@@ -83,13 +83,16 @@ and the permanent authority boundary.
 - Decision BOM fields can contain policy, context, or trace data. The exporter
   therefore includes no optional fields unless their exact names are
   allowlisted by the caller.
+- Allowlisted values are normalized into detached strict-JSON copies. Mutating
+  a constructed request therefore does not mutate the source Decision BOM.
 - The sample uses synthetic identifiers and values. Review tenant, privacy,
   retention, and cross-border requirements before exporting real records.
 - `source_completeness` describes Decision BOM reconstruction coverage. It does
   not prove that an event was correct, authorized, or complete in the real
   world.
-- A content hash identifies the request bytes; it is not a signature,
-  attestation, or proof of truth.
+- A content hash identifies the canonical payload bytes before `request_id` is
+  added, so the identifier itself is excluded from its hash input. The hash is
+  not a signature, attestation, or proof of truth.
 
 ## Prior art and interoperability intent
 

--- a/examples/external-evaluator-handoff/README.md
+++ b/examples/external-evaluator-handoff/README.md
@@ -1,0 +1,99 @@
+# External Evaluator Handoff
+
+> Status: experimental, community-driven example
+
+This example converts one or more AGT Decision BOMs into a deterministic,
+strict-JSON request for a downstream evaluator. It demonstrates an
+interface-first boundary: AGT remains the runtime governance and observation
+source, while an external system may perform post-execution fitness,
+adaptation, stability, or other longitudinal evaluation.
+
+The example is deliberately offline. It does not call an external service,
+change an AGT policy decision, authorize an action, mutate an audit record, or
+turn an evaluation result into a governance decision.
+
+## Why this boundary exists
+
+Runtime governance and post-execution evaluation answer different questions:
+
+- AGT answers whether an action was allowed, which policy applied, and what
+  governance signals were observed.
+- A downstream evaluator may compare multiple observed decisions over time and
+  produce a reviewable assessment.
+- That assessment is input to a separate review process. It is not permission
+  and does not override AGT.
+
+The handoff builds on AGT's existing
+[`DecisionBOM`](../../agent-governance-python/agent-mesh/src/agentmesh/governance/decision_bom.py)
+instead of introducing a second audit or policy model.
+
+## Prerequisites
+
+- Python 3.11+
+- No API keys or network service required at runtime
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r examples/external-evaluator-handoff/requirements.txt
+```
+
+## Run
+
+From the repository root:
+
+```bash
+python examples/external-evaluator-handoff/external_evaluator_handoff.py
+```
+
+The script prints one synthetic request. Its shape contains:
+
+- a content-derived `request_id`;
+- source Decision BOM observations;
+- only explicitly allowlisted extra fields;
+- fixed read-only and zero-authority declarations.
+
+Example boundary:
+
+```json
+{
+  "authority_boundary": {
+    "evaluation_result_is_governance_decision": false,
+    "execution_authorized": false,
+    "policy_decision_overridden": false,
+    "read_only": true,
+    "source_records_mutated": false
+  }
+}
+```
+
+## Test
+
+```bash
+PYTHONPATH=agent-governance-python/agent-mesh/src \
+  pytest -q examples/external-evaluator-handoff/test_external_evaluator_handoff.py
+```
+
+The tests cover deterministic output, exact field allowlisting, source
+immutability, timezone rejection, empty-input rejection, strict JSON values,
+and the permanent authority boundary.
+
+## Data and security notes
+
+- Decision BOM fields can contain policy, context, or trace data. The exporter
+  therefore includes no optional fields unless their exact names are
+  allowlisted by the caller.
+- The sample uses synthetic identifiers and values. Review tenant, privacy,
+  retention, and cross-border requirements before exporting real records.
+- `source_completeness` describes Decision BOM reconstruction coverage. It does
+  not prove that an event was correct, authorized, or complete in the real
+  world.
+- A content hash identifies the request bytes; it is not a signature,
+  attestation, or proof of truth.
+
+## Prior art and interoperability intent
+
+The interface boundary was informed by SAEE's Evolution Intelligence Layer:
+`https://github.com/joy7758/SAEE`. No SAEE source code, engine implementation,
+or runtime dependency is included. The request is framework-neutral so other
+external evaluators can consume the same observation boundary.

--- a/examples/external-evaluator-handoff/README.md
+++ b/examples/external-evaluator-handoff/README.md
@@ -1,5 +1,7 @@
 # External Evaluator Handoff
 
+<!-- cspell:ignore SAEE -->
+
 > Status: experimental, community-driven example
 
 This example converts one or more AGT Decision BOMs into a deterministic,
@@ -90,9 +92,10 @@ and the permanent authority boundary.
 - `source_completeness` describes Decision BOM reconstruction coverage. It does
   not prove that an event was correct, authorized, or complete in the real
   world.
-- A content hash identifies the canonical payload bytes before `request_id` is
-  added, so the identifier itself is excluded from its hash input. The hash is
-  not a signature, attestation, or proof of truth.
+- A content hash generated through AGT's public `sha256_jcs` SDK helper
+  identifies the canonical payload bytes before `request_id` is added, so the
+  identifier itself is excluded from its hash input. The hash is not a
+  signature, attestation, or proof of truth.
 
 ## Prior art and interoperability intent
 

--- a/examples/external-evaluator-handoff/external_evaluator_handoff.py
+++ b/examples/external-evaluator-handoff/external_evaluator_handoff.py
@@ -31,7 +31,14 @@ def _utc_timestamp(value: datetime) -> str:
 def _export_field(field: BOMField) -> dict[str, Any]:
     """Export one explicitly allowlisted BOM field with fail-closed JSON checks."""
     try:
-        json.dumps(field.value, allow_nan=False)
+        serialized_value = json.dumps(
+            field.value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        exported_value = json.loads(serialized_value)
     except (TypeError, ValueError) as exc:
         raise ValueError(
             f"field {field.name!r} is not strict-JSON serializable"
@@ -40,7 +47,7 @@ def _export_field(field: BOMField) -> dict[str, Any]:
     return {
         "name": field.name,
         "category": field.category.value,
-        "value": field.value,
+        "value": exported_value,
         "source": field.source,
         "confidence": field.confidence,
         "inferred": field.inferred,

--- a/examples/external-evaluator-handoff/external_evaluator_handoff.py
+++ b/examples/external-evaluator-handoff/external_evaluator_handoff.py
@@ -1,0 +1,170 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Export AGT Decision BOMs to a read-only external-evaluation request.
+
+This example deliberately stops at the interoperability boundary.  It does not
+call an evaluator, mutate AGT records, or turn an evaluation result into a
+governance decision.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Collection, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+from agentmesh.governance.decision_bom import BOMField, BOMFieldCategory, DecisionBOM
+
+
+SCHEMA_VERSION = "0.1"
+
+
+def _utc_timestamp(value: datetime) -> str:
+    """Return an RFC 3339 UTC timestamp, rejecting timezone-free values."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamps must include a timezone")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _export_field(field: BOMField) -> dict[str, Any]:
+    """Export one explicitly allowlisted BOM field with fail-closed JSON checks."""
+    try:
+        json.dumps(field.value, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"field {field.name!r} is not strict-JSON serializable"
+        ) from exc
+
+    return {
+        "name": field.name,
+        "category": field.category.value,
+        "value": field.value,
+        "source": field.source,
+        "confidence": field.confidence,
+        "inferred": field.inferred,
+    }
+
+
+def build_external_evaluation_request(
+    decisions: Sequence[DecisionBOM],
+    *,
+    generated_at: datetime,
+    allowed_field_names: Collection[str] = (),
+) -> dict[str, Any]:
+    """Build a deterministic, offline request for a downstream evaluator.
+
+    Args:
+        decisions: Reconstructed AGT decisions to expose as observations.
+        generated_at: Time at which this handoff request was created.  Callers
+            must pass a timezone-aware value so replays are unambiguous.
+        allowed_field_names: Exact Decision BOM field names permitted to cross
+            the boundary.  The default is empty to avoid exporting arbitrary
+            policy, context, or trace data by accident.
+
+    Returns:
+        A strict-JSON-compatible dictionary.  Its authority boundary is
+        intentionally fixed: the downstream evaluator receives observations
+        but cannot authorize actions, override policy, or mutate source records.
+
+    Raises:
+        ValueError: If no decisions are provided, timestamps are timezone-free,
+            or an allowlisted value is not strict-JSON serializable.
+    """
+    if not decisions:
+        raise ValueError("at least one Decision BOM is required")
+
+    generated_at_utc = _utc_timestamp(generated_at)
+    allowlist = frozenset(allowed_field_names)
+    observations: list[dict[str, Any]] = []
+
+    for decision in decisions:
+        fields = [
+            _export_field(field) for field in decision.fields if field.name in allowlist
+        ]
+        observations.append(
+            {
+                "decision_id": decision.decision_id,
+                "observed_at": _utc_timestamp(decision.timestamp),
+                "agent_id": decision.agent_id,
+                "action_requested": decision.action_requested,
+                "governance_outcome": decision.outcome,
+                "source_completeness": decision.completeness_score,
+                "sources_queried": list(decision.sources_queried),
+                "fields": fields,
+            }
+        )
+
+    request: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "purpose": "post_execution_external_evaluation",
+        "generated_at": generated_at_utc,
+        "source": {
+            "system": "agent-governance-toolkit",
+            "representation": "decision_bom",
+            "decision_count": len(observations),
+        },
+        "observations": observations,
+        "authority_boundary": {
+            "read_only": True,
+            "source_records_mutated": False,
+            "execution_authorized": False,
+            "policy_decision_overridden": False,
+            "evaluation_result_is_governance_decision": False,
+        },
+    }
+
+    canonical = json.dumps(
+        request,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    request["request_id"] = f"eval_{hashlib.sha256(canonical).hexdigest()}"
+    return request
+
+
+def _sample_decisions(now: datetime) -> list[DecisionBOM]:
+    """Create synthetic Decision BOMs for the runnable example."""
+    return [
+        DecisionBOM(
+            decision_id="decision-001",
+            timestamp=now,
+            agent_id="did:mesh:synthetic-agent",
+            action_requested="read_inventory",
+            outcome="allow",
+            fields=[
+                BOMField(
+                    name="latency_ms",
+                    category=BOMFieldCategory.OUTCOME,
+                    value=42,
+                    source="synthetic_trace",
+                ),
+                BOMField(
+                    name="internal_policy_context",
+                    category=BOMFieldCategory.POLICY,
+                    value={"rule": "allow-read"},
+                    source="synthetic_policy",
+                ),
+            ],
+            sources_queried=["audit", "policy", "trace"],
+            completeness_score=0.8,
+        )
+    ]
+
+
+def main() -> None:
+    """Print one synthetic, offline evaluation handoff request."""
+    now = datetime.now(timezone.utc)
+    request = build_external_evaluation_request(
+        _sample_decisions(now),
+        generated_at=now,
+        allowed_field_names={"latency_ms"},
+    )
+    print(json.dumps(request, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/external-evaluator-handoff/external_evaluator_handoff.py
+++ b/examples/external-evaluator-handoff/external_evaluator_handoff.py
@@ -9,15 +9,16 @@ governance decision.
 
 from __future__ import annotations
 
-import hashlib
 import json
 from collections.abc import Collection, Sequence
 from datetime import datetime, timezone
 from typing import Any
 
+from agentmesh.governance.approval_protocol import sha256_jcs
 from agentmesh.governance.decision_bom import BOMField, BOMFieldCategory, DecisionBOM
 
 
+# cspell:ignore utcoffset
 SCHEMA_VERSION = "0.1"
 
 
@@ -40,9 +41,7 @@ def _export_field(field: BOMField) -> dict[str, Any]:
         )
         exported_value = json.loads(serialized_value)
     except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"field {field.name!r} is not strict-JSON serializable"
-        ) from exc
+        raise ValueError(f"field {field.name!r} is not strict-JSON serializable") from exc
 
     return {
         "name": field.name,
@@ -87,9 +86,7 @@ def build_external_evaluation_request(
     observations: list[dict[str, Any]] = []
 
     for decision in decisions:
-        fields = [
-            _export_field(field) for field in decision.fields if field.name in allowlist
-        ]
+        fields = [_export_field(field) for field in decision.fields if field.name in allowlist]
         observations.append(
             {
                 "decision_id": decision.decision_id,
@@ -122,14 +119,8 @@ def build_external_evaluation_request(
         },
     }
 
-    canonical = json.dumps(
-        request,
-        allow_nan=False,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
-    request["request_id"] = f"eval_{hashlib.sha256(canonical).hexdigest()}"
+    digest = sha256_jcs(request)
+    request["request_id"] = f"eval_{digest.removeprefix('sha256:')}"
     return request
 
 

--- a/examples/external-evaluator-handoff/requirements.txt
+++ b/examples/external-evaluator-handoff/requirements.txt
@@ -1,0 +1,2 @@
+agent-governance-toolkit-core>=4.1.0,<6.0
+pytest>=9.1.1,<10.0

--- a/examples/external-evaluator-handoff/requirements.txt
+++ b/examples/external-evaluator-handoff/requirements.txt
@@ -1,2 +1,2 @@
 agent-governance-toolkit-core>=4.1.0,<6.0
-pytest>=9.1.1,<10.0
+pytest>=8.0.0,<10.0

--- a/examples/external-evaluator-handoff/requirements.txt
+++ b/examples/external-evaluator-handoff/requirements.txt
@@ -1,2 +1,2 @@
-agent-governance-toolkit-core>=4.1.0,<6.0
+agent-governance-toolkit-core>=5.0.0,<6.0
 pytest>=8.0.0,<10.0

--- a/examples/external-evaluator-handoff/test_external_evaluator_handoff.py
+++ b/examples/external-evaluator-handoff/test_external_evaluator_handoff.py
@@ -15,7 +15,8 @@ from agentmesh.governance.decision_bom import BOMField, BOMFieldCategory, Decisi
 
 MODULE_PATH = Path(__file__).with_name("external_evaluator_handoff.py")
 SPEC = importlib.util.spec_from_file_location("external_evaluator_handoff", MODULE_PATH)
-assert SPEC and SPEC.loader
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"could not load external evaluator handoff from {MODULE_PATH}")
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
 
@@ -92,6 +93,22 @@ def test_handoff_exports_no_optional_fields_by_default() -> None:
     )
 
     assert request["observations"][0]["fields"] == []
+
+
+def test_handoff_detaches_mutable_allowlisted_values_from_source() -> None:
+    decision = _decision(value={"nested": ["original"]})
+    request = MODULE.build_external_evaluation_request(
+        [decision],
+        generated_at=datetime(2026, 7, 22, 12, 1, tzinfo=timezone.utc),
+        allowed_field_names={"latency_ms"},
+    )
+
+    exported_value = request["observations"][0]["fields"][0]["value"]
+    exported_value["nested"].append("request-only")
+    assert decision.fields[0].value == {"nested": ["original"]}
+
+    decision.fields[0].value["nested"].append("source-only")
+    assert exported_value == {"nested": ["original", "request-only"]}
 
 
 def test_handoff_rejects_empty_decision_set() -> None:

--- a/examples/external-evaluator-handoff/test_external_evaluator_handoff.py
+++ b/examples/external-evaluator-handoff/test_external_evaluator_handoff.py
@@ -1,0 +1,119 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for the external evaluator handoff example."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from agentmesh.governance.decision_bom import BOMField, BOMFieldCategory, DecisionBOM
+
+
+MODULE_PATH = Path(__file__).with_name("external_evaluator_handoff.py")
+SPEC = importlib.util.spec_from_file_location("external_evaluator_handoff", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def _decision(*, value: object = 42) -> DecisionBOM:
+    observed_at = datetime(2026, 7, 22, 12, 0, tzinfo=timezone.utc)
+    return DecisionBOM(
+        decision_id="decision-001",
+        timestamp=observed_at,
+        agent_id="did:mesh:synthetic-agent",
+        action_requested="read_inventory",
+        outcome="allow",
+        fields=[
+            BOMField(
+                name="latency_ms",
+                category=BOMFieldCategory.OUTCOME,
+                value=value,
+                source="synthetic_trace",
+            ),
+            BOMField(
+                name="private_context",
+                category=BOMFieldCategory.CONTEXT,
+                value="must-not-cross-by-default",
+                source="synthetic_context",
+            ),
+        ],
+        sources_queried=["audit", "trace"],
+        completeness_score=0.8,
+    )
+
+
+def test_handoff_is_deterministic_allowlisted_and_read_only() -> None:
+    decision = _decision()
+    original = copy.deepcopy(decision.to_dict())
+    generated_at = datetime(2026, 7, 22, 12, 1, tzinfo=timezone.utc)
+
+    first = MODULE.build_external_evaluation_request(
+        [decision],
+        generated_at=generated_at,
+        allowed_field_names={"latency_ms"},
+    )
+    second = MODULE.build_external_evaluation_request(
+        [decision],
+        generated_at=generated_at,
+        allowed_field_names={"latency_ms"},
+    )
+
+    assert first == second
+    assert decision.to_dict() == original
+    assert first["request_id"].startswith("eval_")
+    assert first["observations"][0]["fields"] == [
+        {
+            "name": "latency_ms",
+            "category": "outcome",
+            "value": 42,
+            "source": "synthetic_trace",
+            "confidence": 1.0,
+            "inferred": False,
+        }
+    ]
+    assert first["authority_boundary"] == {
+        "read_only": True,
+        "source_records_mutated": False,
+        "execution_authorized": False,
+        "policy_decision_overridden": False,
+        "evaluation_result_is_governance_decision": False,
+    }
+
+
+def test_handoff_exports_no_optional_fields_by_default() -> None:
+    request = MODULE.build_external_evaluation_request(
+        [_decision()],
+        generated_at=datetime(2026, 7, 22, 12, 1, tzinfo=timezone.utc),
+    )
+
+    assert request["observations"][0]["fields"] == []
+
+
+def test_handoff_rejects_empty_decision_set() -> None:
+    with pytest.raises(ValueError, match="at least one Decision BOM"):
+        MODULE.build_external_evaluation_request(
+            [],
+            generated_at=datetime(2026, 7, 22, 12, 1, tzinfo=timezone.utc),
+        )
+
+
+def test_handoff_rejects_timezone_free_timestamps() -> None:
+    with pytest.raises(ValueError, match="timestamps must include a timezone"):
+        MODULE.build_external_evaluation_request(
+            [_decision()],
+            generated_at=datetime(2026, 7, 22, 12, 1),
+        )
+
+
+def test_handoff_rejects_non_json_allowlisted_values() -> None:
+    with pytest.raises(ValueError, match="not strict-JSON serializable"):
+        MODULE.build_external_evaluation_request(
+            [_decision(value=object())],
+            generated_at=datetime(2026, 7, 22, 12, 1, tzinfo=timezone.utc),
+            allowed_field_names={"latency_ms"},
+        )

--- a/examples/external-evaluator-handoff/test_external_evaluator_handoff.py
+++ b/examples/external-evaluator-handoff/test_external_evaluator_handoff.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from agentmesh.governance.approval_protocol import sha256_jcs
 from agentmesh.governance.decision_bom import BOMField, BOMFieldCategory, DecisionBOM
 
 
@@ -84,6 +85,20 @@ def test_handoff_is_deterministic_allowlisted_and_read_only() -> None:
         "policy_decision_overridden": False,
         "evaluation_result_is_governance_decision": False,
     }
+
+
+def test_request_id_uses_the_public_sdk_digest() -> None:
+    request = MODULE.build_external_evaluation_request(
+        [_decision()],
+        generated_at=datetime(2026, 7, 22, 12, 1, tzinfo=timezone.utc),
+        allowed_field_names={"latency_ms"},
+    )
+
+    payload = copy.deepcopy(request)
+    request_id = payload.pop("request_id")
+    expected_digest = sha256_jcs(payload).removeprefix("sha256:")
+
+    assert request_id == f"eval_{expected_digest}"
 
 
 def test_handoff_exports_no_optional_fields_by_default() -> None:


### PR DESCRIPTION
## Description

This PR adds an experimental, community-driven example that converts AGT
`DecisionBOM` observations into a deterministic, strict-JSON request for an
external post-execution evaluator.

The boundary remains intentionally narrow:

- AGT remains the runtime governance and observation source.
- Optional BOM fields cross the boundary only through an exact caller-provided
  allowlist; the default exports none.
- The handoff is read-only and cannot authorize execution, override policy,
  mutate source records, or turn an evaluator result into a governance
  decision.
- The sample is offline and uses only synthetic data.
- The deterministic identifier uses AGT's public `sha256_jcs` SDK helper, not a
  raw cryptographic primitive.

This provides an integration-first interoperability surface without adding an
external evaluator, a second audit model, or a new runtime dependency to AGT
core.

### Maintainer-review update

This branch is rebased onto current `main` and addresses the three requested
repository gates:

- replaces direct `hashlib` use with the public `sha256_jcs` SDK API and adds a
  regression test for the identifier binding;
- adds file-local cspell directives for `SAEE` and `utcoffset`;
- adds the required dependency audit under `docs/dependency-audits/`.

The standalone requirements now use
`agent-governance-toolkit-core>=5.0.0,<6.0`, because the public digest helper is
part of the v5 supported surface.

### Relationship to existing merged work

This PR continues an existing upstream interoperability path rather than
introducing a parallel evidence model:

- [#1319](https://github.com/microsoft/agent-governance-toolkit/pull/1319)
  documented the boundary between AGT runtime evidence and downstream external
  operation-accountability profiles.
- [#1370](https://github.com/microsoft/agent-governance-toolkit/pull/1370) added
  the merged AuditEntry / AuditService accountability export and EEOAP mapping
  example.
- This PR starts from reconstructed Decision BOM observations and emits a
  generic post-execution evaluator request. It complements #1370: #1370 exports
  operation-accountability records, while this example hands decision
  observations to a separate longitudinal evaluator.

### User and developer impact

The implementation is limited to `examples/external-evaluator-handoff/`, with
one repository-required record under `docs/dependency-audits/`. It does not
change a published API, core runtime behavior, policy enforcement, or existing
package dependencies. Developers can run the example locally and adapt the
request at an explicit external-evaluator boundary.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Maintenance (dependency audit and review fixes)
- [ ] Security fix

## Package(s) Affected

- [ ] agent-os-kernel
- [x] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

## Checklist

- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

The full monorepo test matrix was not run locally. The scoped checks below pass;
the repository CI remains authoritative for the full matrix.

## Validation

- PyPI `agent-governance-toolkit-core>=5.0.0,<6.0`: example tests — 7 passed
- current `agent-mesh` source: example tests — 7 passed
- Ruff E/F/W lint and Ruff format check — passed
- runnable example plus strict JSON output validation — passed
- `python -m compileall -q examples/external-evaluator-handoff` — passed
- README and dependency-audit link checks — 0 broken links
- strict dependency-audit frontmatter check — 0 findings
- cspell 8.17.3 on changed lines — passed
- No Unauthorized Crypto — passed
- Dependency Audit Trail — passed
- No Stubs/TODOs — passed
- Security Audit Required — passed
- No Unauthenticated Registration — passed
- `git diff --check` — passed

The consolidated package emits existing deprecation warnings for legacy Python
import namespaces; this example does not introduce those warnings.

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**:

- [SAEE](https://github.com/joy7758/SAEE) informed the separation between
  runtime governance and longitudinal external evaluation. No SAEE source code,
  engine implementation, or runtime dependency is included.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

Codex assisted with implementation, tests, documentation, validation, and the
PR update under the contributor's direction. The contributor reviewed the
original candidate and explicitly authorized this maintainer-requested update.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues and Merged Work

- Discussion: [#1314](https://github.com/microsoft/agent-governance-toolkit/issues/1314)
- Merged documentation boundary: [#1319](https://github.com/microsoft/agent-governance-toolkit/pull/1319)
- Merged AuditEntry accountability export: [#1370](https://github.com/microsoft/agent-governance-toolkit/pull/1370)
