### PR TITLE
chore(rust): upgrade ed25519-dalek 2.x -> 3.x and rand 0.8 -> 0.10 (fixes #3355)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -101,7 +101,12 @@
     "pwsh",
     "notlike",
     "sdists",
-    "shellcheck"
+    "shellcheck",
+    "chacha",
+    "chacha20",
+    "getrandom",
+    "spki",
+    "zerocopy"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/.cspell.json
+++ b/.cspell.json
@@ -106,7 +106,11 @@
     "chacha20",
     "getrandom",
     "spki",
-    "zerocopy"
+    "zerocopy",
+    "rngs",
+    "keygen",
+    "csprng",
+    "CSPRNG"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/agent-governance-rust/Cargo.lock
+++ b/agent-governance-rust/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -63,7 +63,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "ureq",
  "url",
 ]
@@ -89,7 +89,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
 ]
@@ -104,7 +104,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
 ]
@@ -261,12 +261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,13 +335,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -370,9 +364,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -455,6 +449,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,12 +535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,9 +589,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -615,15 +614,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.3",
  "fiat-crypto",
+ "rand_core",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -675,16 +675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,14 +701,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.6"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -729,25 +729,24 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
- "serde",
- "sha2",
+ "rand_core",
+ "sha2 0.11.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -766,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "ena"
@@ -781,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -827,15 +826,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -875,12 +874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,27 +894,27 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -966,16 +959,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "rand_core",
 ]
 
 [[package]]
@@ -992,15 +983,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1026,7 +1008,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1145,12 +1127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,9 +1193,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iso8601"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+checksum = "74a0559b45528cf0732d911524974977a5749f477d7dd99652830ffdaf53c4d1"
 dependencies = [
  "nom",
 ]
@@ -1250,13 +1226,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1334,12 +1309,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1682,16 +1651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "polyval"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,15 +1675,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "precomputed-hash"
@@ -1774,16 +1724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,32 +1765,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1870,22 +1791,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1978,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -1993,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -2046,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2125,7 +2046,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -2165,7 +2086,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2174,7 +2106,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -2186,11 +2118,11 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -2232,16 +2164,6 @@ name = "spin"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2326,7 +2248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2369,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2389,9 +2311,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2590,27 +2512,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2621,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2631,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2644,45 +2557,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -2691,14 +2570,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2855,97 +2734,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.119",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/agent-governance-rust/Cargo.toml
+++ b/agent-governance-rust/Cargo.toml
@@ -18,10 +18,10 @@ base64 = "=0.23.1"
 cedar-policy = "=4.12.0"
 clap = { version = "=4.6.5", features = ["derive"] }
 predicates = "=3.1.4"
-ed25519-dalek = { version = "=2.2.0", features = ["rand_core"] }
+ed25519-dalek = { version = "=3.0.0", features = ["rand_core"] }
 hmac = "=0.12.1"
 opentelemetry = { version = "=0.32.0", default-features = false, features = ["trace"] }
-rand = "=0.8.6"
+rand = "=0.10.2"
 regex = "=1.13.1"
 regorus = { version = "=0.11.0", default-features = false, features = ["regex"] }
 serde = { version = "=1.0.229", features = ["derive"] }

--- a/agent-governance-rust/agentmesh-mcp/src/mcp/clock.rs
+++ b/agent-governance-rust/agentmesh-mcp/src/mcp/clock.rs
@@ -4,7 +4,7 @@
 //! Clock and nonce seams for deterministic security testing.
 
 use crate::mcp::error::McpError;
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{distr::Alphanumeric, RngExt};
 use std::collections::VecDeque;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
@@ -71,7 +71,7 @@ pub struct SystemNonceGenerator;
 
 impl NonceGenerator for SystemNonceGenerator {
     fn generate(&self) -> Result<String, McpError> {
-        let nonce = rand::thread_rng()
+        let nonce = rand::rng()
             .sample_iter(&Alphanumeric)
             .take(32)
             .map(char::from)

--- a/agent-governance-rust/agentmesh/src/credential_vault.rs
+++ b/agent-governance-rust/agentmesh/src/credential_vault.rs
@@ -23,7 +23,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use hmac::{Hmac, Mac};
-use rand::RngCore;
+use rand::Rng;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -280,7 +280,7 @@ impl CredentialVault {
     #[must_use]
     pub fn generate_key() -> [u8; KEY_LENGTH] {
         let mut k = [0u8; KEY_LENGTH];
-        rand::thread_rng().fill_bytes(&mut k);
+        rand::rng().fill_bytes(&mut k);
         k
     }
 
@@ -546,7 +546,7 @@ impl Default for CredentialVault {
 fn encrypt(key: &[u8; KEY_LENGTH], plaintext: &[u8]) -> Result<Vec<u8>, CredentialError> {
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
     let mut nonce_bytes = [0u8; NONCE_LENGTH];
-    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    rand::rng().fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
     let ct = cipher
         .encrypt(nonce, plaintext)

--- a/agent-governance-rust/agentmesh/src/credential_vault.rs
+++ b/agent-governance-rust/agentmesh/src/credential_vault.rs
@@ -23,6 +23,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use hmac::{Hmac, Mac};
+use rand::rand_core::UnwrapErr;
+use rand::rngs::SysRng;
 use rand::Rng;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -276,11 +278,11 @@ impl CredentialVault {
         Ok(vault)
     }
 
-    /// Generate a fresh AES-256-GCM key (32 random bytes).
+    /// Generate a fresh AES-256-GCM key (32 random bytes) from OS entropy.
     #[must_use]
     pub fn generate_key() -> [u8; KEY_LENGTH] {
         let mut k = [0u8; KEY_LENGTH];
-        rand::rng().fill_bytes(&mut k);
+        UnwrapErr(SysRng).fill_bytes(&mut k);
         k
     }
 

--- a/agent-governance-rust/agentmesh/src/identity.rs
+++ b/agent-governance-rust/agentmesh/src/identity.rs
@@ -4,7 +4,6 @@
 //! Ed25519-based agent identity with DID support.
 
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
-use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 
 /// Maximum delegation depth to prevent Sybil attacks via infinite chains.
@@ -29,7 +28,7 @@ pub struct AgentIdentity {
 impl AgentIdentity {
     /// Generate a new Ed25519-based identity for the given agent.
     pub fn generate(agent_id: &str, capabilities: Vec<String>) -> Result<Self, IdentityError> {
-        let signing_key = SigningKey::generate(&mut OsRng);
+        let signing_key = SigningKey::generate(&mut rand::rng());
         let public_key = signing_key.verifying_key();
         Ok(Self {
             did: format!("did:agentmesh:{}", agent_id),
@@ -77,7 +76,7 @@ impl AgentIdentity {
             }
         }
 
-        let signing_key = SigningKey::generate(&mut OsRng);
+        let signing_key = SigningKey::generate(&mut rand::rng());
         let public_key = signing_key.verifying_key();
 
         Ok(Self {

--- a/agent-governance-rust/agentmesh/src/identity.rs
+++ b/agent-governance-rust/agentmesh/src/identity.rs
@@ -4,6 +4,8 @@
 //! Ed25519-based agent identity with DID support.
 
 use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
+use rand::rand_core::UnwrapErr;
+use rand::rngs::SysRng;
 use serde::{Deserialize, Serialize};
 
 /// Maximum delegation depth to prevent Sybil attacks via infinite chains.
@@ -28,7 +30,8 @@ pub struct AgentIdentity {
 impl AgentIdentity {
     /// Generate a new Ed25519-based identity for the given agent.
     pub fn generate(agent_id: &str, capabilities: Vec<String>) -> Result<Self, IdentityError> {
-        let signing_key = SigningKey::generate(&mut rand::rng());
+        // OS entropy per the ed25519-dalek 3 documented pattern for key generation.
+        let signing_key = SigningKey::generate(&mut UnwrapErr(SysRng));
         let public_key = signing_key.verifying_key();
         Ok(Self {
             did: format!("did:agentmesh:{}", agent_id),
@@ -76,7 +79,7 @@ impl AgentIdentity {
             }
         }
 
-        let signing_key = SigningKey::generate(&mut rand::rng());
+        let signing_key = SigningKey::generate(&mut UnwrapErr(SysRng));
         let public_key = signing_key.verifying_key();
 
         Ok(Self {
@@ -213,6 +216,24 @@ mod tests {
         let id1 = AgentIdentity::generate("agent-a", vec![]).unwrap();
         let id2 = AgentIdentity::generate("agent-b", vec![]).unwrap();
         assert_ne!(id1.public_key.to_bytes(), id2.public_key.to_bytes());
+    }
+
+    #[test]
+    fn test_os_entropy_keygen_distinct_and_usable() {
+        // Keys come from OS entropy (UnwrapErr(SysRng)); two generations must
+        // yield distinct keys and each must produce verifiable signatures.
+        let id1 = AgentIdentity::generate("entropy-a", vec![]).unwrap();
+        let id2 = AgentIdentity::generate("entropy-b", vec![]).unwrap();
+        assert_ne!(id1.public_key.to_bytes(), id2.public_key.to_bytes());
+
+        let data = b"os entropy round trip";
+        let sig1 = id1.sign(data);
+        let sig2 = id2.sign(data);
+        assert!(id1.verify(data, &sig1));
+        assert!(id2.verify(data, &sig2));
+        // Cross-verification must fail: the keys are independent.
+        assert!(!id1.verify(data, &sig2));
+        assert!(!id2.verify(data, &sig1));
     }
 
     #[test]

--- a/agent-governance-rust/agentmesh/src/identity_support.rs
+++ b/agent-governance-rust/agentmesh/src/identity_support.rs
@@ -7,7 +7,6 @@ use crate::identity::{AgentIdentity, IdentityError, PublicIdentity, MAX_DELEGATI
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use ed25519_dalek::SigningKey;
-use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -170,7 +169,7 @@ impl Credential {
         // effectively never" — semantically the same as what the caller
         // appears to have asked for — without invoking arithmetic UB.
         let expires_at_secs = issued_at_secs.saturating_add(ttl_seconds.max(1));
-        let signing_key = SigningKey::generate(&mut OsRng);
+        let signing_key = SigningKey::generate(&mut rand::rng());
         let token = URL_SAFE_NO_PAD.encode(signing_key.to_bytes());
         Self {
             credential_id: format!("cred_{:016x}", rand::random::<u64>()),
@@ -1052,7 +1051,7 @@ impl KeyRotationManager {
                 previous_public_key: identity.public_key.to_bytes().to_vec(),
                 rotated_at_secs: unix_secs_now(),
             });
-        let signing_key = SigningKey::generate(&mut OsRng);
+        let signing_key = SigningKey::generate(&mut rand::rng());
         let public_key = signing_key.verifying_key();
         AgentIdentity {
             did: identity.did.clone(),

--- a/agent-governance-rust/agentmesh/src/identity_support.rs
+++ b/agent-governance-rust/agentmesh/src/identity_support.rs
@@ -7,6 +7,8 @@ use crate::identity::{AgentIdentity, IdentityError, PublicIdentity, MAX_DELEGATI
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use ed25519_dalek::SigningKey;
+use rand::rand_core::UnwrapErr;
+use rand::rngs::SysRng;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -169,7 +171,8 @@ impl Credential {
         // effectively never" — semantically the same as what the caller
         // appears to have asked for — without invoking arithmetic UB.
         let expires_at_secs = issued_at_secs.saturating_add(ttl_seconds.max(1));
-        let signing_key = SigningKey::generate(&mut rand::rng());
+        // OS entropy per the ed25519-dalek 3 documented pattern for key generation.
+        let signing_key = SigningKey::generate(&mut UnwrapErr(SysRng));
         let token = URL_SAFE_NO_PAD.encode(signing_key.to_bytes());
         Self {
             credential_id: format!("cred_{:016x}", rand::random::<u64>()),
@@ -1051,7 +1054,7 @@ impl KeyRotationManager {
                 previous_public_key: identity.public_key.to_bytes().to_vec(),
                 rotated_at_secs: unix_secs_now(),
             });
-        let signing_key = SigningKey::generate(&mut rand::rng());
+        let signing_key = SigningKey::generate(&mut UnwrapErr(SysRng));
         let public_key = signing_key.verifying_key();
         AgentIdentity {
             did: identity.did.clone(),

--- a/agent-governance-rust/agentmesh/tests/credential_vault.rs
+++ b/agent-governance-rust/agentmesh/tests/credential_vault.rs
@@ -324,6 +324,17 @@ fn rotation_does_not_require_prompt_changes() {
 }
 
 #[test]
+fn generate_key_distinct_per_call() {
+    // Vault keys come from OS entropy; two generations must differ and not be
+    // all zero.
+    let k1 = CredentialVault::generate_key();
+    let k2 = CredentialVault::generate_key();
+    assert_ne!(k1, k2);
+    assert_ne!(k1, [0u8; 32]);
+    assert_ne!(k2, [0u8; 32]);
+}
+
+#[test]
 fn encrypted_persistence_round_trip() {
     let key = CredentialVault::generate_key();
     let dir = tempfile::tempdir().unwrap();

--- a/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
+++ b/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
@@ -64,18 +64,26 @@ Two secondary security properties do improve:
 - Collapsing duplicate `rand_core` majors (0.6.4 + 0.10.1 -> 0.10.1) removes
   the possibility of two RNG stacks with different entropy sources being linked
   into one binary. `getrandom` retains three versions; see the table note above.
-- `OsRng` was removed in `rand` 0.10. Call sites move to `rand::rng()`
-  (`ThreadRng`), which is an infallible `CryptoRng`. `SigningKey::generate`
-  requires an infallible `CryptoRng`, so `SysRng` (which is only
-  `TryCryptoRng`) is deliberately not used. Key generation therefore keeps a
-  cryptographically secure, non-failing entropy source. `ThreadRng` differs
-  from `OsRng` in one respect worth documenting: it is a thread-local
-  ChaCha12 CSPRNG that reseeds from the OS per 64 KiB of output and is not
-  fork-safe (a child process that forks without exec inherits the parent's RNG
-  state). No code in this workspace calls `fork` directly and neither Tokio
-  nor the test harness uses a forking process model, so this property does not
-  affect the workspace today. If a forking process model is introduced later,
-  the RNG call sites will need to be revisited.
+- `OsRng` was removed in `rand` 0.10, but OS entropy is still available as
+  `rand::rngs::SysRng` (a re-export of `getrandom::SysRng`). Key generation
+  now draws directly from OS entropy via
+  `rand_core::UnwrapErr(rand::rngs::SysRng)`, which is exactly the pattern the
+  `ed25519-dalek` 3.0.0 `SigningKey::generate` documentation shows
+  (`let mut csprng = UnwrapErr(SysRng); SigningKey::generate(&mut csprng)`).
+  `SysRng` is `TryCryptoRng` with the OS as its only entropy source; the
+  `UnwrapErr` adapter makes it the infallible `CryptoRng` that
+  `SigningKey::generate` requires (an OS entropy failure panics rather than
+  yielding a weak key). The key generation call sites are
+  `AgentIdentity::generate`, `AgentIdentity::delegate`, `Credential::issue`,
+  `KeyRotationManager::rotate` (Ed25519 signing keys) and
+  `CredentialVault::generate_key` (AES-256-GCM key). Thread rng
+  (`rand::rng()`, a thread-local ChaCha12 CSPRNG reseeded from the OS per
+  64 KiB of output) remains only in non-key-material paths: the AES-GCM
+  nonce in `credential_vault.rs`, generated identifiers
+  (`credential_id`, `link_id`, `chain_id`, `incident_id`, `violation_id`,
+  `report_id`, `grant_id`, `challenge_id`, sandbox execution ids), the
+  attestation challenge nonce in `trust_support.rs`, and the MCP clock
+  nonce in `agentmesh-mcp`.
 
 Signature verification behaviour is unchanged; the existing signature-reject
 tests continue to refuse both forged and replayed signatures.
@@ -91,7 +99,8 @@ source-compatible. All edits in this change are the `rand` 0.9/0.10 reshuffle:
 - `thread_rng()` -> `rng()`
 - the `Rng` extension trait -> `RngExt`
 - the `RngCore` core trait -> `Rng`
-- `OsRng` (removed) -> `rand::rng()`
+- `OsRng` (removed) -> `UnwrapErr(SysRng)` in key generation,
+  `rand::rng()` in non-key-material paths
 
 These are mechanical renames the compiler catches exhaustively; there is no
 silent behavioural drift available to them.

--- a/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
+++ b/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
@@ -1,0 +1,98 @@
+---
+title: ed25519-dalek 3.x and rand 0.10 coordinated upgrade
+last_reviewed: 2026-07-27
+owner: chopmob-cloud
+---
+
+# ed25519-dalek 3.x and rand 0.10 coordinated upgrade
+
+Covers the `agent-governance-rust` workspace lockfile change in the PR that
+resolves #3355.
+
+## Which Dependencies Changed And Why
+
+Two direct, exactly-pinned dependencies move together:
+
+- `ed25519-dalek` `=2.2.0` -> `=3.0.0`
+- `rand` `=0.8.6` -> `=0.10.2`
+
+They cannot move independently. `ed25519-dalek` 3 is built on `rand_core` 0.9+,
+which `rand` 0.10 provides; `rand` 0.8 provides `rand_core` 0.6. Dependabot's
+one-at-a-time bumps (#3269, #3271) each leave the workspace unbuildable for
+this reason, which is why this is a single coordinated change.
+
+Transitive effects in `agent-governance-rust/Cargo.lock`:
+
+| Package | Before | After |
+|---|---|---|
+| `curve25519-dalek` | 4.1.3 | 5.0.0 |
+| `ed25519` | 2.2.3 | 3.0.0 |
+| `signature` | 2.2.0 | 3.0.0 |
+| `fiat-crypto` | 0.2.9 | 0.3.0 |
+| `rand_core` | 0.6.4 + 0.10.1 | 0.10.1 |
+| `getrandom` | 0.2.17 + 0.4.2 | 0.4.2 |
+| `chacha20` | absent | 0.10.1 |
+| `rand_chacha`, `ppv-lite86` | 0.3.1, 0.2.21 | removed |
+| `zerocopy`, `zerocopy-derive` | 0.8.48 | removed |
+| `wasi` | 0.11.1 | removed |
+| `pkcs8`, `spki`, `der`, `const-oid`, `base64ct` | present | removed |
+| `digest` | 0.10.7 | 0.10.7 + 0.11.3 |
+| `sha2` | 0.10.9 | 0.10.9 + 0.11.0 |
+
+Two results are worth calling out. The duplicate `rand_core` and `getrandom`
+majors collapse to one version each, so the workspace no longer links two
+independent RNG cores. Against that, `digest` and `sha2` each gain a second
+major, because the dalek 3 stack has moved to the 0.11 line while other
+workspace crates remain on 0.10. That duplication is a known consequence of
+this upgrade rather than an oversight, and it resolves once the remaining
+consumers move to `sha2` 0.11.
+
+The PKCS#8 encoding chain (`pkcs8`, `spki`, `der`, `const-oid`, `base64ct`)
+drops out because `ed25519-dalek` 3 no longer pulls it in by default. This
+workspace does not use PKCS#8 key encoding, so nothing depended on it.
+
+## Security Advisory Relevance
+
+No CVE or RustSec advisory is being remediated here. The pinned prior versions
+`ed25519-dalek` 2.2.0 and `rand` 0.8.6 carry no advisory known to the author at
+the time of writing, and this upgrade is driven by version-compatibility and
+maintenance, not by a published vulnerability.
+
+Two secondary security properties do improve:
+
+- Collapsing duplicate `rand_core` and `getrandom` majors removes the
+  possibility of two RNG stacks with different entropy sources being linked
+  into one binary.
+- `OsRng` was removed in `rand` 0.10. Call sites move to `rand::rng()`
+  (`ThreadRng`), which is an infallible `CryptoRng`. `SigningKey::generate`
+  requires an infallible `CryptoRng`, so `SysRng` — which is only
+  `TryCryptoRng` — is deliberately not used. Key generation therefore keeps a
+  cryptographically secure, non-failing entropy source.
+
+Signature verification behaviour is unchanged; the existing signature-reject
+tests continue to refuse both forged and replayed signatures.
+
+## Breaking Change Risk Assessment
+
+Risk is moderate and contained to this workspace, with no public API change.
+
+The `ed25519-dalek` 2 -> 3 signing and verifying surface used here is
+source-compatible. All edits in this change are the `rand` 0.9/0.10 reshuffle:
+
+- `distributions` -> `distr`
+- `thread_rng()` -> `rng()`
+- the `Rng` extension trait -> `RngExt`
+- the `RngCore` core trait -> `Rng`
+- `OsRng` (removed) -> `rand::rng()`
+
+These are mechanical renames the compiler catches exhaustively; there is no
+silent behavioural drift available to them.
+
+Verification: `cargo build`, `cargo test` and `cargo clippy` are green, with
+514 tests passing — identical to the pre-upgrade baseline, with no tests
+skipped or removed.
+
+The residual risk is the `digest`/`sha2` major duplication noted above. It
+increases compiled size and means two hash implementations are linked, but both
+are versions of the same audited crate and neither is reachable from the other's
+call sites.

--- a/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
+++ b/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
@@ -29,7 +29,7 @@ Transitive effects in `agent-governance-rust/Cargo.lock`:
 | `signature` | 2.2.0 | 3.0.0 |
 | `fiat-crypto` | 0.2.9 | 0.3.0 |
 | `rand_core` | 0.6.4 + 0.10.1 | 0.10.1 |
-| `getrandom` | 0.2.17 + 0.4.2 | 0.4.2 |
+| `getrandom` | 0.2.17 + 0.3.4 + 0.4.2 | 0.2.17 + 0.3.4 + 0.4.3 |
 | `chacha20` | absent | 0.10.1 |
 | `rand_chacha`, `ppv-lite86` | 0.3.1, 0.2.21 | removed |
 | `zerocopy`, `zerocopy-derive` | 0.8.48 | removed |
@@ -38,9 +38,11 @@ Transitive effects in `agent-governance-rust/Cargo.lock`:
 | `digest` | 0.10.7 | 0.10.7 + 0.11.3 |
 | `sha2` | 0.10.9 | 0.10.9 + 0.11.0 |
 
-Two results are worth calling out. The duplicate `rand_core` and `getrandom`
-majors collapse to one version each, so the workspace no longer links two
-independent RNG cores. Against that, `digest` and `sha2` each gain a second
+One result is worth calling out. The duplicate `rand_core` majors collapse
+from two versions (0.6.4 + 0.10.1) to one (0.10.1), so the workspace no
+longer links two independent RNG cores. `getrandom` stays at three versions
+(0.2.17 + 0.3.4 + 0.4.3); 0.3.4 was already present on `main` before this PR
+and is not introduced by this upgrade. Against that, `digest` and `sha2` each gain a second
 major, because the dalek 3 stack has moved to the 0.11 line while other
 workspace crates remain on 0.10. That duplication is a known consequence of
 this upgrade rather than an oversight, and it resolves once the remaining
@@ -59,9 +61,9 @@ maintenance, not by a published vulnerability.
 
 Two secondary security properties do improve:
 
-- Collapsing duplicate `rand_core` and `getrandom` majors removes the
-  possibility of two RNG stacks with different entropy sources being linked
-  into one binary.
+- Collapsing duplicate `rand_core` majors (0.6.4 + 0.10.1 -> 0.10.1) removes
+  the possibility of two RNG stacks with different entropy sources being linked
+  into one binary. `getrandom` retains three versions; see the table note above.
 - `OsRng` was removed in `rand` 0.10. Call sites move to `rand::rng()`
   (`ThreadRng`), which is an infallible `CryptoRng`. `SigningKey::generate`
   requires an infallible `CryptoRng`, so `SysRng` (which is only

--- a/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
+++ b/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
@@ -105,9 +105,11 @@ source-compatible. All edits in this change are the `rand` 0.9/0.10 reshuffle:
 These are mechanical renames the compiler catches exhaustively; there is no
 silent behavioural drift available to them.
 
-Verification: `cargo build`, `cargo test` and `cargo clippy` are green, with
-514 tests passing, identical to the pre-upgrade baseline, with no tests
-skipped or removed.
+Verification: `cargo build`, `cargo test` and `cargo clippy` are green. The
+pre-upgrade baseline was 514 tests passing; this change adds tests on top of
+that baseline (including two key-generation tests covering the
+`UnwrapErr(SysRng)` path), and the full workspace suite passes with 0
+failures, with no pre-existing tests skipped or removed.
 
 The residual risk is the `digest`/`sha2` major duplication noted above. It
 increases compiled size and means two hash implementations are linked, but both

--- a/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
+++ b/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
@@ -1,7 +1,6 @@
 ---
 title: ed25519-dalek 3.x and rand 0.10 coordinated upgrade
 last_reviewed: 2026-07-27
-owner: chopmob-cloud
 ---
 
 # ed25519-dalek 3.x and rand 0.10 coordinated upgrade
@@ -18,7 +17,7 @@ Two direct, exactly-pinned dependencies move together:
 
 They cannot move independently. `ed25519-dalek` 3 is built on `rand_core` 0.9+,
 which `rand` 0.10 provides; `rand` 0.8 provides `rand_core` 0.6. Dependabot's
-one-at-a-time bumps (#3269, #3271) each leave the workspace unbuildable for
+one-at-a-time bumps (#3269, #3271) each leave the workspace unable to build for
 this reason, which is why this is a single coordinated change.
 
 Transitive effects in `agent-governance-rust/Cargo.lock`:
@@ -65,8 +64,8 @@ Two secondary security properties do improve:
   into one binary.
 - `OsRng` was removed in `rand` 0.10. Call sites move to `rand::rng()`
   (`ThreadRng`), which is an infallible `CryptoRng`. `SigningKey::generate`
-  requires an infallible `CryptoRng`, so `SysRng` — which is only
-  `TryCryptoRng` — is deliberately not used. Key generation therefore keeps a
+  requires an infallible `CryptoRng`, so `SysRng` (which is only
+  `TryCryptoRng`) is deliberately not used. Key generation therefore keeps a
   cryptographically secure, non-failing entropy source.
 
 Signature verification behaviour is unchanged; the existing signature-reject
@@ -89,7 +88,7 @@ These are mechanical renames the compiler catches exhaustively; there is no
 silent behavioural drift available to them.
 
 Verification: `cargo build`, `cargo test` and `cargo clippy` are green, with
-514 tests passing — identical to the pre-upgrade baseline, with no tests
+514 tests passing, identical to the pre-upgrade baseline, with no tests
 skipped or removed.
 
 The residual risk is the `digest`/`sha2` major duplication noted above. It

--- a/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
+++ b/docs/dependency-audits/2026-07-27-ed25519-dalek-3-rand-0.10.md
@@ -66,7 +66,14 @@ Two secondary security properties do improve:
   (`ThreadRng`), which is an infallible `CryptoRng`. `SigningKey::generate`
   requires an infallible `CryptoRng`, so `SysRng` (which is only
   `TryCryptoRng`) is deliberately not used. Key generation therefore keeps a
-  cryptographically secure, non-failing entropy source.
+  cryptographically secure, non-failing entropy source. `ThreadRng` differs
+  from `OsRng` in one respect worth documenting: it is a thread-local
+  ChaCha12 CSPRNG that reseeds from the OS per 64 KiB of output and is not
+  fork-safe (a child process that forks without exec inherits the parent's RNG
+  state). No code in this workspace calls `fork` directly and neither Tokio
+  nor the test harness uses a forking process model, so this property does not
+  affect the workspace today. If a forking process model is introduced later,
+  the RNG call sites will need to be revisited.
 
 Signature verification behaviour is unchanged; the existing signature-reject
 tests continue to refuse both forged and replayed signatures.


### PR DESCRIPTION
## Summary

Upgrades `ed25519-dalek` `2.2.0 -> 3.0.0` and `rand` `0.8.6 -> 0.10.2` across the `agent-governance-rust` workspace, as requested in #3355.

Dependabot #3269 (dalek 3) and #3271 (rand 0.10) each failed `build-rust` because they bump one crate at a time. The two must move **together**: `ed25519-dalek` 3 rides `rand_core` 0.9, which `rand` 0.10 provides, so bumping either alone leaves a `rand_core` version mismatch. This is a single coordinated PR.

## What actually changed

Bumping both together showed that the `ed25519-dalek` 2 -> 3 signing/verifying surface used in this crate is **source-compatible** (`SigningKey::generate`, `Signature::from_bytes`, `VerifyingKey::from_bytes`, `Signer`/`Verifier`). All the real edits are the `rand` 0.9/0.10 trait and module reshuffle:

- `rand::distributions` -> `rand::distr` (`clock.rs`)
- `rand::thread_rng()` -> `rand::rng()` in non-key-material paths (`clock.rs`, the AES-GCM nonce in `credential_vault.rs`)
- the old `Rng` extension trait (providing `sample_iter`) is now `RngExt` (`clock.rs`)
- the old `RngCore` core trait (providing `fill_bytes`) is now named `Rng` (`credential_vault.rs`)
- `rand::rngs::OsRng` was removed; key generation now uses `UnwrapErr(SysRng)` (`identity.rs`, `identity_support.rs`, `credential_vault.rs`), see below

### Note on key-generation RNG

`SigningKey::generate` in `ed25519-dalek` 3 requires an **infallible** `CryptoRng` (`pub fn generate<R: CryptoRng + ?Sized>(csprng: &mut R)`). The documented pattern in the `ed25519-dalek` 3.0.0 `SigningKey::generate` docs is OS entropy through the `UnwrapErr` adapter: `let mut csprng = UnwrapErr(SysRng); SigningKey::generate(&mut csprng)`. `SysRng` (the `getrandom` 0.4 system source re-exported by `rand` 0.10 as `rand::rngs::SysRng`) implements the fallible `TryCryptoRng`, and `rand_core`'s `UnwrapErr` wrapper turns it into an infallible `CryptoRng` via the blanket impl, satisfying the bound directly from OS entropy with no new dependency and no lockfile change.

Every key-material path draws from `UnwrapErr(SysRng)`: `AgentIdentity::generate`/`delegate`, `Credential::issue`, `KeyRotationManager::rotate`, and the vault's AES-256-GCM `CredentialVault::generate_key`. Thread RNG (`rand::rng()`) remains only where key material is not involved (the AES-GCM nonce, generated identifiers, the attestation challenge nonce, and the MCP clock nonce). This draws long-lived key material straight from the OS CSPRNG and removes the thread-local reseed and fork-safety caveats from the keygen path. The dependency-audit doc records the split.

## Validation

`agent-governance-rust`, from a green baseline:

| | baseline (2.2.0 / 0.8.6) | this PR (3.0.0 / 0.10.2) |
|---|---|---|
| `cargo build --workspace` | clean | clean, no new warnings |
| `cargo test --workspace --locked` | 514 pass, 0 fail | **518 pass, 0 fail** (Linux) |
| `cargo clippy --workspace --all-targets` | 9 warnings | 9 warnings (0 new) |

The PR adds two keygen tests (distinct usable keys with cross-verification rejection; distinct non-zero vault keys), which is the +4 delta over the 514 baseline together with the branch's earlier additions. The suite still includes the signature-**rejection** tests (`trust::test_verify_peer_rejects_mismatched_claimed_peer`, `trust::test_verify_peer_rejects_signature_not_created_by_peer`, `mcp::signing::tests::rejects_replayed_messages`), so verification still refuses forged and replayed signatures, not merely accepts valid ones.

Fixes #3355.
