### PR TITLE
docs: fix python setup instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,14 @@ python -m venv .venv
 source .venv/bin/activate        # Linux/macOS
 # .venv\Scripts\activate         # Windows
 
+# Install the core package from the local source to avoid dependency conflicts
+# (Required for all local development to ensure you test against local core changes)
+pip install --no-cache-dir --no-deps -e agent-governance-toolkit-core
+
 # Install the package you are working on in editable mode
-pip install -e agent-os/[dev]       # Policy engine
-pip install -e agent-mesh/[dev]     # Identity/trust layer
-pip install -e agent-compliance/[dev]  # Compliance tooling
+pip install -e "agent-os[dev]"       # Policy engine
+pip install -e "agent-mesh[dev]"     # Identity/trust layer
+pip install -e "agent-compliance[dev]"  # Compliance tooling
 
 # Run tests for that package
 cd agent-os && pytest
@@ -293,17 +297,20 @@ git clone https://github.com/microsoft/agent-governance-toolkit.git
 cd agent-governance-toolkit
 
 # Install in development mode
+# Install the core package from the local source to avoid dependency conflicts
+pip install --no-cache-dir --no-deps -e "agent-governance-python/agent-governance-toolkit-core"
+
 pip install -e "agent-governance-python/agent-primitives[dev]"
 pip install -e "agent-governance-python/agent-mcp-governance[dev]"
-pip install -e "agent-os[dev]"
-pip install -e "agent-mesh[dev]"
-pip install -e "agent-runtime[dev]"
-pip install -e "agent-sre[dev]"
-pip install -e "agent-compliance[dev]"
-pip install -e "agent-marketplace[dev]"  # installs agentmesh-marketplace
-pip install -e "agent-lightning[dev]"
-pip install -e "agent-hypervisor[dev]"
-pip install -e "agentmesh-integrations[dev]"
+pip install -e "agent-governance-python/agent-os[dev]"
+pip install -e "agent-governance-python/agent-mesh[dev]"
+pip install -e "agent-governance-python/agent-runtime[dev]"
+pip install -e "agent-governance-python/agent-sre[dev]"
+pip install -e "agent-governance-python/agent-compliance[dev]"
+pip install -e "agent-governance-python/agent-marketplace[dev]"  # installs agentmesh-marketplace
+pip install -e "agent-governance-python/agent-lightning[dev]"
+pip install -e "agent-governance-python/agent-hypervisor[dev]"
+pip install -e "agent-governance-python/agentmesh-integrations[dev]"
 
 # Restore the standalone .NET SDK when working in that path
 dotnet restore agent-governance-dotnet/AgentGovernance.sln

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ AGT does not try to win that fight inside the prompt. Every tool call, message s
 **Prerequisites:** Python 3.10+
 
 ```bash
-pip install agent-governance-toolkit[full]
+pip install "agent-governance-toolkit[full]"
 ```
 
 Use the `[full]` extra for the quick-start imports below. The base
@@ -266,7 +266,7 @@ Every layer is optional. Start with `govern()` and add layers as your risk profi
 
 | Language | Package | Command |
 |----------|---------|---------|
-| **Python** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | `pip install agent-governance-toolkit[full]` |
+| **Python** | [`agent-governance-toolkit`](https://pypi.org/project/agent-governance-toolkit/) | `pip install "agent-governance-toolkit[full]"` |
 | **TypeScript** | [`@microsoft/agent-governance-sdk`](agent-governance-typescript/) | `npm install @microsoft/agent-governance-sdk` |
 | **Copilot CLI** | [`@microsoft/agent-governance-copilot-cli`](agent-governance-copilot-cli/) | `npx @microsoft/agent-governance-copilot-cli install` |
 | **Claude Code** | [`@microsoft/agent-governance-claude-code`](agent-governance-claude-code/) | `claude --plugin-dir ./agent-governance-claude-code` |


### PR DESCRIPTION
Fixes #3414 by quoting package names to prevent glob expansion errors in Zsh, and explicitly installing the core package locally first to resolve cryptography dependency conflicts.