### PR TITLE
ci: set dependabot commit-message prefix on all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+# Every ecosystem sets commit-message.prefix so dependabot emits titles in the
+# repo's conventional-commit style ("chore(deps): bump X ..."). Without it,
+# some ecosystems generate "Bump X ..." with a capitalized subject, which fails
+# the pr-title check (subjectPattern ^(?![A-Z]).+$). This was previously set on
+# nuget only; extending it to all ecosystems keeps their auto-generated titles
+# passing the same gate.
 updates:
   # All Python packages under agent-governance-python/, covered by a single
   # multi-directory entry. A separate per-directory entry for any of these
@@ -31,6 +37,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     groups:
       python-dev-tooling:
         patterns:
@@ -47,6 +56,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   - package-ecosystem: "npm"
     directory: "/agent-governance-python/agent-os/extensions/copilot"
@@ -55,6 +67,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   - package-ecosystem: "npm"
     directory: "/agent-governance-copilot-cli"
@@ -63,6 +78,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   - package-ecosystem: "npm"
     directory: "/agent-governance-claude-code"
@@ -71,6 +89,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   - package-ecosystem: "npm"
     directory: "/agent-governance-typescript"
@@ -79,6 +100,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   - package-ecosystem: "npm"
     directory: "/agent-governance-antigravity-cli"
@@ -87,6 +111,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   # .NET
   - package-ecosystem: "nuget"
@@ -111,6 +138,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   # Go
   - package-ecosystem: "gomod"
@@ -120,6 +150,9 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   # Docker
   - package-ecosystem: "docker"
@@ -129,6 +162,9 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -138,3 +174,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"


### PR DESCRIPTION
## Problem

The `PR Title Check` (`amannn/action-semantic-pull-request` with `subjectPattern: ^(?![A-Z]).+$`) rejects titles whose subject starts with a capital letter. Dependabot emits `chore(deps): Bump X from A to B` (capital "Bump") for ecosystems that do not have `commit-message.prefix` set, so those PRs fail the gate. This currently blocks the entire open dependabot backlog (~21 PRs) on this one check.

`nuget` already worked around this by setting `commit-message.prefix` (with a comment explaining exactly this). The other ecosystems were never given the same setting.

## Fix

Extend `commit-message.prefix: "chore(deps)"` / `prefix-development: "chore(deps-dev)"` to every ecosystem entry (pip, all npm dirs, cargo, gomod, docker, github-actions). Dependabot then generates lowercase `chore(deps): bump X ...` titles that pass the check. Purely a title-format change; it does not alter what gets updated. Diff is additive (39 insertions), YAML validated.

## Follow-up

This fixes titles going forward. The ~21 already-open dependabot PRs keep their current titles until dependabot regenerates them, so they need either a one-line title edit or `@dependabot recreate` to pick up the compliant format.

cc @MohammadHaroonAbuomar @liamcrumm for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)