### PR TITLE
fix(python): fail closed on zero-required-stages approval chains (#3438)

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_protocol/coordinator.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_protocol/coordinator.py
@@ -158,6 +158,7 @@ class ApprovalCoordinator:
             fail_closed_on_timeout=fail_closed_on_timeout,
         )
         self.store.save_request(request)
+        self._maybe_resolve(request, chain)
         return decision, request
 
     # -- advancing the chain ------------------------------------------------
@@ -248,10 +249,15 @@ class ApprovalCoordinator:
                 return
 
         # Allow is terminal only once every required stage has an allow.
+        # A chain with zero required stages is misconfigured and must fail closed (deny).
+        required = {s.stage_index for s in chain.stages if s.required}
+        if not required:
+            self._resolve(request, Outcome.DENY, None)
+            return
+
         allowed_stages = {
             e.stage_index for e in entries if e.decision == EntryDecision.ALLOW
         }
-        required = {s.stage_index for s in chain.stages if s.required}
         if required.issubset(allowed_stages):
             final_digest = entries[-1].entry_digest if entries else None
             self._resolve(request, Outcome.ALLOW, final_digest)

--- a/agent-governance-python/agent-mesh/tests/test_approval_protocol.py
+++ b/agent-governance-python/agent-mesh/tests/test_approval_protocol.py
@@ -16,6 +16,7 @@ from agentmesh.governance.approval_protocol import (
     ApproverKind,
     EntryDecision,
     InMemoryApprovalStore,
+    Outcome,
     ReasonCode,
     canonicalize,
     sha256_jcs,
@@ -512,3 +513,31 @@ class TestChainIntegrity:
         )
         assert first is second
         assert len(coord.store.get_entries(request.approval_request_id)) == 1
+
+    def test_zero_required_stages_denies(self):
+        chain = ApprovalChain(
+            chain_id="zero-required",
+            version="1",
+            stages=(
+                ApprovalStage(0, allowed_identities=frozenset({ALICE}), required=False),
+            ),
+        )
+        coord = make_coordinator(chain)
+        binding = make_binding()
+        _, request = coord.open_request(
+            binding,
+            policy_rule_id="r",
+            policy_version="v1",
+            chain_id=chain.chain_id,
+            ttl_seconds=600,
+        )
+        verdict = coord.validate_for_execution(
+            request.approval_request_id,
+            current_action_digest=binding.digest(),
+            current_policy_version="v1",
+            current_chain_version=chain.version,
+        )
+        assert not verdict.allowed
+        resolution = coord.store.get_resolution(request.approval_request_id)
+        assert resolution is not None
+        assert resolution.outcome == Outcome.DENY


### PR DESCRIPTION
### Linked Issue
Fixes #3438

### Observed Failure
In the Python SDK implementation of `ApprovalCoordinator._maybe_resolve` (`agent-governance-python/agent-mesh/src/agentmesh/governance/approval_protocol/coordinator.py`), when an `ApprovalChain` had zero required stages (`required` set was empty), `required.issubset(allowed_stages)` evaluated to `True`.
This caused misconfigured approval chains with 0 required stages to automatically resolve to `Outcome.ALLOW`.

By contrast, the Go and TypeScript SDK implementations explicitly deny requests when `required_stages` is empty (fail-closed security posture).

### Root Cause
`_maybe_resolve` checked `required.issubset(allowed_stages)` without checking if `required` was empty (`not required`), leading Python to allow requests for chains without required stages instead of failing closed.

### Implementation
- Added a `not required` guard in `ApprovalCoordinator._maybe_resolve`: when `required` is empty (zero required stages), `_maybe_resolve` calls `self._resolve(request, Outcome.DENY, None)` to fail closed immediately.
- Updated `open_request` to invoke `self._maybe_resolve(request, chain)` so zero-required-stage chains resolve to `DENY` upon request initialization.

### Regression Coverage
Added unit test `test_zero_required_stages_denies` in `agent-governance-python/agent-mesh/tests/test_approval_protocol.py` verifying that an approval chain with 0 required stages resolves to `Outcome.DENY` and rejects execution validation.

### Exact Validation Commands & Results
- `PYTHONPATH=... python3 -m pytest agent-governance-python/agent-mesh/tests/test_approval_protocol.py` -> 26 passed
- `PYTHONPATH=... python3 -m pytest agent-governance-python/agent-mesh/tests/test_approval_*.py` -> 61 passed
- `git diff --check` -> Passed cleanly

### Cross-SDK Parity Impact
Aligns Python `ApprovalCoordinator` behavior with Go (#3242) and TypeScript (#3200) SDKs.

### Unrelated Changes
No unrelated changes were included.