### PR TITLE
fix(typescript): fail closed and add null-safety validation to McpSecurityScanner

### DIFF
--- a/agent-governance-typescript/src/mcp.ts
+++ b/agent-governance-typescript/src/mcp.ts
@@ -31,8 +31,8 @@ export interface McpScanResult {
 
 /** Minimal MCP tool definition accepted by the scanner. */
 export interface McpToolDefinition {
-  name: string;
-  description: string;
+  name?: string;
+  description?: string;
   parameters?: Record<string, unknown>;
 }
 
@@ -148,24 +148,40 @@ const SEVERITY_WEIGHT: Record<McpThreat['severity'], number> = {
 export class McpSecurityScanner {
   /** Scan a single tool definition. */
   scan(toolDefinition: McpToolDefinition): McpScanResult {
-    const threats: McpThreat[] = [];
+    const toolName = toolDefinition?.name ?? 'unknown';
+    try {
+      const threats: McpThreat[] = [];
 
-    this.detectToolPoisoning(toolDefinition, threats);
-    this.detectTyposquatting(toolDefinition, threats);
-    this.detectHiddenInstructions(toolDefinition, threats);
-    this.detectRugPull(toolDefinition, threats);
+      this.detectToolPoisoning(toolDefinition, threats);
+      this.detectTyposquatting(toolDefinition, threats);
+      this.detectHiddenInstructions(toolDefinition, threats);
+      this.detectRugPull(toolDefinition, threats);
 
-    const risk_score = Math.min(
-      100,
-      threats.reduce((sum, t) => sum + SEVERITY_WEIGHT[t.severity], 0),
-    );
+      const risk_score = Math.min(
+        100,
+        threats.reduce((sum, t) => sum + SEVERITY_WEIGHT[t.severity], 0),
+      );
 
-    return {
-      tool_name: toolDefinition.name,
-      threats,
-      risk_score,
-      safe: threats.length === 0,
-    };
+      return {
+        tool_name: toolName,
+        threats,
+        risk_score,
+        safe: threats.length === 0,
+      };
+    } catch (err) {
+      return {
+        tool_name: toolName,
+        threats: [
+          {
+            type: McpThreatType.ToolPoisoning,
+            severity: 'critical',
+            description: `Scan error — fail closed: ${err instanceof Error ? err.message : String(err)}`,
+          },
+        ],
+        risk_score: 100,
+        safe: false,
+      };
+    }
   }
 
   /** Scan multiple tool definitions. */
@@ -176,7 +192,7 @@ export class McpSecurityScanner {
   // ── Private detection methods ──
 
   private detectToolPoisoning(tool: McpToolDefinition, threats: McpThreat[]): void {
-    const text = tool.description;
+    const text = tool?.description ?? '';
     for (const pattern of POISONING_PATTERNS) {
       const match = pattern.exec(text);
       if (match) {
@@ -211,7 +227,9 @@ export class McpSecurityScanner {
   }
 
   private detectTyposquatting(tool: McpToolDefinition, threats: McpThreat[]): void {
-    const name = tool.name.toLowerCase();
+    const name = (tool?.name ?? '').toLowerCase();
+    if (!name) return;
+
     for (const known of KNOWN_TOOL_NAMES) {
       if (name === known) continue; // exact match is fine
       const dist = levenshtein(name, known);
@@ -222,12 +240,13 @@ export class McpSecurityScanner {
           description: `Tool name "${tool.name}" is suspiciously similar to known tool "${known}" (edit distance ${dist})`,
           evidence: known,
         });
+        break; // stop after first typosquatting match to prevent duplicate threat inflation
       }
     }
   }
 
   private detectHiddenInstructions(tool: McpToolDefinition, threats: McpThreat[]): void {
-    const text = tool.description;
+    const text = tool?.description ?? '';
 
     // Zero-width characters
     for (const zwc of ZERO_WIDTH_CHARS) {
@@ -257,7 +276,7 @@ export class McpSecurityScanner {
   }
 
   private detectRugPull(tool: McpToolDefinition, threats: McpThreat[]): void {
-    const text = tool.description;
+    const text = tool?.description ?? '';
     if (text.length <= RUG_PULL_DESCRIPTION_LENGTH) return;
 
     let instructionMatches = 0;

--- a/agent-governance-typescript/tests/mcp.test.ts
+++ b/agent-governance-typescript/tests/mcp.test.ts
@@ -212,4 +212,54 @@ describe('McpSecurityScanner', () => {
       expect(result.risk_score).toBeGreaterThan(0);
     });
   });
+
+  // ── Edge cases and Fail-Closed ──
+
+  describe('null safety and fail-closed handling', () => {
+    it('handles tool definition with missing description without throwing', () => {
+      const tool: McpToolDefinition = {
+        name: 'read_file',
+      };
+      const result = scanner.scan(tool);
+      expect(result.safe).toBe(true);
+      expect(result.tool_name).toBe('read_file');
+    });
+
+    it('handles tool definition with missing name without throwing', () => {
+      const tool: McpToolDefinition = {
+        description: 'Reads a file.',
+      };
+      const result = scanner.scan(tool);
+      expect(result.safe).toBe(true);
+      expect(result.tool_name).toBe('unknown');
+    });
+
+    it('fails closed when scan method encounters an unexpected exception', () => {
+      const tool: McpToolDefinition = {
+        name: 'test_tool',
+        description: 'Test description',
+      };
+      // Force an error in internal detector
+      jest.spyOn(scanner as any, 'detectToolPoisoning').mockImplementation(() => {
+        throw new Error('Unexpected memory error');
+      });
+
+      const result = scanner.scan(tool);
+      expect(result.safe).toBe(false);
+      expect(result.risk_score).toBe(100);
+      expect(result.threats).toHaveLength(1);
+      expect(result.threats[0].severity).toBe('critical');
+      expect(result.threats[0].description).toContain('Scan error — fail closed');
+    });
+
+    it('emits at most one typosquatting threat per tool', () => {
+      const tool: McpToolDefinition = {
+        name: 'serch', // dist 1 from search, dist 2 from fetch
+        description: 'Web search tool',
+      };
+      const result = scanner.scan(tool);
+      const typosquats = result.threats.filter((t) => t.type === McpThreatType.Typosquatting);
+      expect(typosquats).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
## Problem and Affected Boundary

In `@microsoft/agent-governance-sdk` (`agent-governance-typescript/`), `McpSecurityScanner` screens Model Context Protocol (MCP) tool definitions for security threats (tool poisoning, typosquatting, hidden instructions, rug pulls). When processing untrusted tool definitions from external MCP tool servers, definitions missing expected string properties (e.g. `description` or `name` omitted or `null`) or malformed structures caused `McpSecurityScanner.scan()` to crash with unhandled `TypeError` exceptions (such as `Cannot read properties of undefined (reading 'includes')` or `Cannot read properties of undefined (reading 'toLowerCase')`).

Furthermore, unlike the Python `MCPSecurityScanner` (which catches unexpected scan exceptions and fails closed with a `CRITICAL` threat finding), the TypeScript implementation lacked a fail-closed error boundary. Additionally, `detectTyposquatting` did not break after finding a match, causing a tool name matching multiple known tools within edit distance 2 to emit duplicate threat findings and artificially inflate the risk score.

## Reproduction

1. Pass an untrusted tool definition missing a `description` or `name` to `McpSecurityScanner.scan()`:
```typescript
const scanner = new McpSecurityScanner();
scanner.scan({ name: 'my_tool' } as any); // Throws TypeError: Cannot read properties of undefined (reading 'includes')
```

## Expected vs Actual Behavior

- **Expected**: `McpSecurityScanner.scan()` safely handles missing/null property fields without throwing runtime exceptions. If an unexpected error occurs during scanning, it fails closed returning `safe = false`, `risk_score = 100`, and a critical threat finding.
- **Actual**: `McpSecurityScanner.scan()` threw an unhandled `TypeError`, crashing host process / agent gateway routines.

## Root Cause

1. `McpToolDefinition` required non-optional `name` and `description` strings, but internal private detection methods (`detectToolPoisoning`, `detectTyposquatting`, `detectHiddenInstructions`, `detectRugPull`) directly accessed `tool.description` and `tool.name` without null-coalescing or fallback checks.
2. `scan()` executed detection steps without a try-catch error boundary.
3. `detectTyposquatting` did not exit the loop after recording a typosquatting match.

## Implementation

- Updated `McpToolDefinition` interface to make `name` and `description` optional (`name?: string; description?: string;`).
- Wrapped `McpSecurityScanner.scan()` in a try-catch fail-closed block that catches unexpected errors and returns a fail-closed result (`safe: false`, `risk_score: 100`, critical `ToolPoisoning` threat).
- Added string sanitization (`tool?.name ?? ''`, `tool?.description ?? ''`) in all private detection methods.
- Added a `break` after the first typosquatting match in `detectTyposquatting`.

## Regression Coverage

Added 4 unit tests in `agent-governance-typescript/tests/mcp.test.ts`:
- `handles tool definition with missing description without throwing`
- `handles tool definition with missing name without throwing`
- `fails closed when scan method encounters an unexpected exception`
- `emits at most one typosquatting threat per tool`

## Exact Validation Commands and Results

```bash
cd agent-governance-typescript
npm test        # PASS: 37 test suites, 564 tests passed
npm run build   # PASS: tsc clean
npm run lint    # PASS: eslint clean
git diff --check # PASS: clean
```

## Compatibility Considerations

Backward compatible. Non-breaking bug fix for `McpSecurityScanner` in TypeScript SDK.

## Security Disclosure Assessment

Ordinary correctness and robustness defense-in-depth bug fix in scanner exception handling and null validation. Does not expose or exploit a remote vulnerability.

## Confirmation

No unrelated files, formatting changes, or lockfile churn are included.