### PR TITLE
fix: reject policy fixtures without expectations

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/policy_test.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/policy_test.py
@@ -73,7 +73,7 @@ class ReplayReport:
 
     @property
     def ok(self) -> bool:
-        return self.failed == 0
+        return self.total > 0 and self.failed == 0
 
     @property
     def mismatches(self) -> list[FixtureResult]:
@@ -103,7 +103,7 @@ class ReplayReport:
         }
 
 
-def _load_fixtures(fixture_path: Path) -> list[dict[str, Any]]:
+def _load_fixtures(fixture_path: Path) -> list[Any]:
     """Load fixtures from a file or directory.
 
     Supports JSON and YAML. A single file may contain one fixture (object)
@@ -123,18 +123,20 @@ def _load_fixtures(fixture_path: Path) -> list[dict[str, Any]]:
     if not paths:
         raise FileNotFoundError(f"No fixture files found in {fixture_path}")
 
-    fixtures: list[dict[str, Any]] = []
+    fixtures: list[Any] = []
     for p in paths:
         raw = _load_file(p)
         if isinstance(raw, list):
             for item in raw:
-                item.setdefault("_source", str(p))
+                if isinstance(item, dict):
+                    item.setdefault("_source", str(p))
             fixtures.extend(raw)
         elif isinstance(raw, dict):
             # Check for YAML scenarios wrapper (tutorial compat)
             if "scenarios" in raw and isinstance(raw["scenarios"], list):
                 for item in raw["scenarios"]:
-                    item.setdefault("_source", str(p))
+                    if isinstance(item, dict):
+                        item.setdefault("_source", str(p))
                 fixtures.extend(raw["scenarios"])
             else:
                 raw.setdefault("_source", str(p))
@@ -155,20 +157,55 @@ def _load_file(path: Path) -> Any:
     return yaml.safe_load(text)
 
 
+def _validate_fixtures(fixtures: list[Any], fixture_path: Path) -> None:
+    """Reject fixture suites that cannot make a pass/fail assertion."""
+    if not fixtures:
+        raise ValueError(f"No fixtures found in {fixture_path}")
+
+    invalid: list[str] = []
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            invalid.append(
+                f"fixture entry in {str(fixture_path)!r} must be an object, "
+                f"got {type(fixture).__name__}"
+            )
+            continue
+
+        expected_verdict = fixture.get("expected_verdict") or fixture.get(
+            "expected_action"
+        )
+        expected_allowed = fixture.get("expected_allowed")
+        if expected_verdict or expected_allowed is not None:
+            continue
+
+        fixture_id = fixture.get("id") or fixture.get("name", "unnamed")
+        source = fixture.get("_source", str(fixture_path))
+        invalid.append(
+            f"fixture {fixture_id!r} in {source!r} must define expected_verdict, "
+            "expected_action, or expected_allowed"
+        )
+
+    if invalid:
+        details = "\n".join(f"- {message}" for message in invalid)
+        raise ValueError(f"Invalid policy test fixture(s):\n{details}")
+
+
 def replay(
     manifest_path: str | Path,
     fixture_path: str | Path,
 ) -> ReplayReport:
     """Replay fixtures against a native ACS manifest and return a report."""
-    from agent_control_specification import AgentControl, run_sync
-
     manifest_path = Path(manifest_path)
     fixture_path = Path(fixture_path)
     if not manifest_path.is_file():
         raise FileNotFoundError(f"Manifest path not found: {manifest_path}")
 
-    runtime = AgentControl.from_path(str(manifest_path))
     fixtures = _load_fixtures(fixture_path)
+    _validate_fixtures(fixtures, fixture_path)
+
+    from agent_control_specification import AgentControl, run_sync
+
+    runtime = AgentControl.from_path(str(manifest_path))
     report = ReplayReport()
 
     try:
@@ -182,12 +219,6 @@ def replay(
             expected_allowed = fixture.get("expected_allowed")
             source = fixture.get("_source", "")
             resolution_metadata = fixture.get("resolution_metadata")
-
-            if expected_verdict is None and expected_allowed is None:
-                logger.warning(
-                    "Fixture %r has no expected result — skipping", fixture_id
-                )
-                continue
 
             if (
                 isinstance(raw_input, dict)

--- a/tests/unit/test_policy_test.py
+++ b/tests/unit/test_policy_test.py
@@ -222,11 +222,94 @@ class TestReplay:
         report = replay(policy, fixture_dir)
         assert report.ok
 
+    def test_missing_expectation_raises(self, tmp_path: Path) -> None:
+        policy = _write_policy(tmp_path)
+        fixtures = _write_fixtures_json(
+            tmp_path,
+            [{"id": "missing-expectation", "input": {"action": "read"}}],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="fixture 'missing-expectation'.*must define expected_verdict",
+        ):
+            replay(policy, fixtures)
+
+    @pytest.mark.parametrize(
+        "expectation",
+        [
+            {"expected_verdict": None},
+            {"expected_action": None},
+            {"expected_allowed": None},
+            {"expected_verdict": ""},
+            {"expected_action": ""},
+        ],
+    )
+    def test_null_expectation_raises(
+        self, tmp_path: Path, expectation: dict[str, object]
+    ) -> None:
+        policy = _write_policy(tmp_path)
+        fixtures = _write_fixtures_json(
+            tmp_path,
+            [{"id": "null-expectation", "input": {"action": "read"}, **expectation}],
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="fixture 'null-expectation'.*must define expected_verdict",
+        ):
+            replay(policy, fixtures)
+
+    def test_empty_fixture_file_raises(self, tmp_path: Path) -> None:
+        policy = _write_policy(tmp_path)
+        fixtures = tmp_path / "fixtures.json"
+        fixtures.write_text("[]")
+
+        with pytest.raises(ValueError, match="No fixtures found"):
+            replay(policy, fixtures)
+
+    def test_malformed_fixture_in_mixed_suite_raises(self, tmp_path: Path) -> None:
+        policy = _write_policy(tmp_path)
+        fixtures = _write_fixtures_json(
+            tmp_path,
+            [
+                {
+                    "id": "valid",
+                    "input": {"action": "read"},
+                    "expected_verdict": "allow",
+                },
+                {"id": "malformed", "input": {"action": "write"}},
+            ],
+        )
+
+        with pytest.raises(ValueError, match="fixture 'malformed'"):
+            replay(policy, fixtures)
+
+    @pytest.mark.parametrize("invalid_fixture", ["not-an-object", 42, None])
+    def test_non_object_fixture_raises(
+        self, tmp_path: Path, invalid_fixture: object
+    ) -> None:
+        policy = _write_policy(tmp_path)
+        fixtures = tmp_path / "fixtures.json"
+        fixtures.write_text(json.dumps([invalid_fixture]))
+
+        with pytest.raises(
+            ValueError,
+            match=r"fixture entry .* must be an object",
+        ):
+            replay(policy, fixtures)
+
 
 # ── Report ─────────────────────────────────────────────────────────────
 
 
 class TestReplayReport:
+    def test_empty_report_is_not_successful(self) -> None:
+        report = ReplayReport()
+
+        assert report.total == 0
+        assert report.ok is False
+
     def test_to_dict(self) -> None:
         report = ReplayReport(
             results=[


### PR DESCRIPTION
## Description

Policy replay currently skips fixtures that define no expected outcome. A suite
containing only those fixtures therefore produces an empty report whose `ok`
property is true, allowing `agt test` to exit successfully without evaluating a
single assertion.

This change validates the complete fixture suite before evaluation and makes an
empty replay report unsuccessful by definition. Empty fixture files and
fixtures missing `expected_verdict`, `expected_action`, or `expected_allowed`
now produce actionable validation errors instead of disappearing from the
report.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected

- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Checklist

- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix works
- [x] All relevant new and existing tests pass (521 passed, 2 skipped)
- [x] Documentation is unchanged because the public fixture formats remain compatible
- [x] I have signed the Microsoft CLA

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] No external architectural pattern was adapted for this targeted validation fix

**Prior art / related projects:** None.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was submitted without my review
- [x] I have not used AI to generate review comments on others' PRs

Codex assisted with implementation and regression-test drafting. I reviewed the
specific two-file change in
[`patrickswedish/agent-governance-toolkit#1`](https://github.com/patrickswedish/agent-governance-toolkit/pull/1)
before merging it into my fork. The focused and package-level test suites and
Ruff checks were run locally.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] The AI tooling used has terms compatible with the MIT License

## Validation

- `pytest tests/unit/test_policy_test.py agent-governance-python/agent-compliance/tests -q`
  - 521 passed, 2 skipped
- `ruff check agent-governance-python/agent-compliance/src/agent_compliance/policy_test.py tests/unit/test_policy_test.py`
- `git diff --check`

## Related Issues

Fixes #3436