### PR TITLE
feat(dotnet): add accumulated context governance parity

### DIFF
--- a/agent-governance-dotnet/README.md
+++ b/agent-governance-dotnet/README.md
@@ -172,6 +172,54 @@ engine.LoadCedar(
         """);
 ```
 
+### Accumulated Context Governance
+
+`AgentGovernance.Context` carries immutable, versioned governance state across tool calls and delegation boundaries. Labels and restrictions only grow, sensitivity is the maximum classification seen so far, declared aggregation rules run in order, and an unknown label combination escalates once it reaches the configured threshold.
+
+```csharp
+using AgentGovernance.Context;
+
+var rules = new AggregationRuleSet(
+[
+    new AggregationRule(
+        "pii_financial_restricted",
+        ["pii", "financial"],
+        DataClassification.Restricted,
+        ["no_external_export"])
+]);
+
+var before = new ContextEnvelope(
+    "env-42",
+    "workflow-7",
+    labels: ["pii"],
+    aggregateSensitivity: DataClassification.Internal,
+    createdAt: new DateTimeOffset(2026, 7, 27, 5, 0, 0, TimeSpan.Zero));
+
+var after = ContextGovernance.Accumulate(
+    before,
+    resultLabels: ["financial"],
+    resultSensitivity: DataClassification.Confidential,
+    rules,
+    categoryThreshold: 3);
+
+var decision = ContextGovernance.DecideNext(
+    after,
+    action: "export",
+    rules,
+    categoryThreshold: 3);
+
+var policyAction = decision.ToPolicyAction(hasObligationChannel: false);
+var aggregation = rules.Evaluate(after, categoryThreshold: 3);
+var auditEvent = ContextEvent.Create(
+    ContextEventTypes.AggregationElevated,
+    "did:mesh:analyst-001",
+    before,
+    after,
+    aggregation.RulesApplied);
+```
+
+In this example, accumulation raises the envelope to `Restricted`, adds `no_external_export`, and increments the version twice. The export decision is `Constrain`; without an obligation channel its policy action is `Deny`. Unknown combinations produce `Escalate`, which maps to the existing stop-and-review `RequireApproval` policy action. Envelope and audit timestamps are never read from the wall clock by this API.
+
 ### Rate Limiting
 
 Sliding window rate limiter integrated into the policy engine:

--- a/agent-governance-dotnet/README.md
+++ b/agent-governance-dotnet/README.md
@@ -208,7 +208,7 @@ var decision = ContextGovernance.DecideNext(
     rules,
     categoryThreshold: 3);
 
-var policyAction = decision.ToPolicyAction(hasObligationChannel: false);
+var decisionOutcome = decision.Outcome;
 var aggregation = rules.Evaluate(after, categoryThreshold: 3);
 var auditEvent = ContextEvent.Create(
     ContextEventTypes.AggregationElevated,
@@ -218,7 +218,7 @@ var auditEvent = ContextEvent.Create(
     aggregation.RulesApplied);
 ```
 
-In this example, accumulation raises the envelope to `Restricted`, adds `no_external_export`, and increments the version twice. The export decision is `Constrain`; without an obligation channel its policy action is `Deny`. Unknown combinations produce `Escalate`, which maps to the existing stop-and-review `RequireApproval` policy action. Envelope and audit timestamps are never read from the wall clock by this API.
+In this example, accumulation raises the envelope to `Restricted`, adds `no_external_export`, and increments the version twice. The export decision is `Constrain`; a caller without an obligation channel should fail closed and deny the action. Unknown combinations produce `Escalate` and should enter the existing stop-and-review flow. Envelope and audit timestamps are never read from the wall clock by this API.
 
 ### Rate Limiting
 

--- a/agent-governance-dotnet/src/AgentGovernance/Context/ContextAggregation.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Context/ContextAggregation.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+
+namespace AgentGovernance.Context;
+
+/// <summary>
+/// Organization-authored rule over a combination of accumulated labels.
+/// </summary>
+public sealed class AggregationRule
+{
+    /// <summary>Creates an immutable aggregation rule.</summary>
+    public AggregationRule(
+        string name,
+        IEnumerable<string> allLabels,
+        DataClassification setsSensitivity,
+        IEnumerable<string>? addsRestrictions = null)
+    {
+        Name = ContextTokens.Identifier(name, nameof(name));
+        AllLabels = ContextTokens.Snapshot(allLabels, nameof(allLabels));
+        SetsSensitivity = DataClassificationGuard.Defined(
+            setsSensitivity,
+            nameof(setsSensitivity));
+        AddsRestrictions = ContextTokens.SnapshotOptional(
+            addsRestrictions,
+            nameof(addsRestrictions));
+    }
+
+    /// <summary>Stable rule name.</summary>
+    public string Name { get; }
+
+    /// <summary>Labels that must all be present for this rule to match.</summary>
+    public IReadOnlySet<string> AllLabels { get; }
+
+    /// <summary>Minimum sensitivity applied by this rule.</summary>
+    public DataClassification SetsSensitivity { get; }
+
+    /// <summary>Restrictions added by this rule.</summary>
+    public IReadOnlySet<string> AddsRestrictions { get; }
+}
+
+/// <summary>
+/// Ordered immutable collection of aggregation rules.
+/// </summary>
+public sealed class AggregationRuleSet
+{
+    /// <summary>Creates a rule set in declared evaluation order.</summary>
+    public AggregationRuleSet(IEnumerable<AggregationRule>? rules = null)
+    {
+        var snapshot = rules?.ToArray() ?? [];
+        if (snapshot.Any(static rule => rule is null))
+        {
+            throw new ArgumentException("Rules cannot contain null values.", nameof(rules));
+        }
+
+        Rules = new ReadOnlyCollection<AggregationRule>(snapshot);
+    }
+
+    /// <summary>Rules in deterministic evaluation order.</summary>
+    public IReadOnlyList<AggregationRule> Rules { get; }
+
+    /// <summary>
+    /// Applies known rules and escalates unknown combinations at the threshold.
+    /// </summary>
+    public AggregationResult Evaluate(
+        ContextEnvelope envelope,
+        int categoryThreshold)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        if (categoryThreshold < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(categoryThreshold),
+                categoryThreshold,
+                "Category threshold must be positive.");
+        }
+
+        var sensitivity = envelope.AggregateSensitivity;
+        var restrictions = new HashSet<string>(
+            envelope.Restrictions,
+            StringComparer.Ordinal);
+        var applied = new List<string>();
+
+        foreach (var rule in Rules)
+        {
+            if (!rule.AllLabels.IsSubsetOf(envelope.Labels))
+            {
+                continue;
+            }
+
+            sensitivity = DataClassificationGuard.Maximum(
+                sensitivity,
+                rule.SetsSensitivity);
+            restrictions.UnionWith(rule.AddsRestrictions);
+            applied.Add(rule.Name);
+        }
+
+        return new AggregationResult(
+            sensitivity,
+            restrictions,
+            escalate: applied.Count == 0 && envelope.Labels.Count >= categoryThreshold,
+            applied);
+    }
+}
+
+/// <summary>
+/// Result of evaluating an envelope against aggregation rules.
+/// </summary>
+public sealed class AggregationResult
+{
+    internal AggregationResult(
+        DataClassification aggregateSensitivity,
+        IEnumerable<string> restrictions,
+        bool escalate,
+        IEnumerable<string> rulesApplied)
+    {
+        AggregateSensitivity = DataClassificationGuard.Defined(
+            aggregateSensitivity,
+            nameof(aggregateSensitivity));
+        Restrictions = ContextTokens.Snapshot(restrictions, nameof(restrictions));
+        Escalate = escalate;
+        RulesApplied = new ReadOnlyCollection<string>(rulesApplied.ToArray());
+    }
+
+    /// <summary>Resulting maximum sensitivity.</summary>
+    public DataClassification AggregateSensitivity { get; }
+
+    /// <summary>Resulting grow-only restrictions.</summary>
+    public IReadOnlySet<string> Restrictions { get; }
+
+    /// <summary>Whether the unknown-combination backstop requires review.</summary>
+    public bool Escalate { get; }
+
+    /// <summary>Names of matching rules in evaluation order.</summary>
+    public IReadOnlyList<string> RulesApplied { get; }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Context/ContextDecision.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Context/ContextDecision.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using AgentGovernance.Policy;
+
+namespace AgentGovernance.Context;
+
+/// <summary>
+/// Governance-level outcome of a context-aware decision.
+/// </summary>
+public enum ContextOutcome
+{
+    /// <summary>Allow the action.</summary>
+    Allow,
+
+    /// <summary>Allow only with enforceable obligations.</summary>
+    Constrain,
+
+    /// <summary>Deny the action.</summary>
+    Deny,
+
+    /// <summary>Stop and require review.</summary>
+    Escalate
+}
+
+/// <summary>
+/// One restriction obligation carried by a constrained decision.
+/// </summary>
+public sealed class Obligation
+{
+    /// <summary>Creates an immutable obligation.</summary>
+    public Obligation(string key, bool satisfied = false)
+    {
+        Key = ContextTokens.Identifier(key, nameof(key));
+        Satisfied = satisfied;
+    }
+
+    /// <summary>Restriction key to enforce.</summary>
+    public string Key { get; }
+
+    /// <summary>Whether the obligation has already been satisfied.</summary>
+    public bool Satisfied { get; }
+}
+
+/// <summary>
+/// Immutable obligations and result labels carried by a decision.
+/// </summary>
+public sealed class ObligationSet
+{
+    /// <summary>Creates an immutable obligation set.</summary>
+    public ObligationSet(
+        IEnumerable<Obligation>? obligations = null,
+        IEnumerable<string>? resultLabels = null)
+    {
+        var snapshot = obligations?.ToArray() ?? [];
+        if (snapshot.Any(static obligation => obligation is null))
+        {
+            throw new ArgumentException(
+                "Obligations cannot contain null values.",
+                nameof(obligations));
+        }
+
+        Obligations = new ReadOnlyCollection<Obligation>(snapshot);
+        ResultLabels = ContextTokens.SnapshotOptional(
+            resultLabels,
+            nameof(resultLabels));
+    }
+
+    /// <summary>Declared obligations in deterministic order.</summary>
+    public IReadOnlyList<Obligation> Obligations { get; }
+
+    /// <summary>Labels produced by the governed action.</summary>
+    public IReadOnlySet<string> ResultLabels { get; }
+
+    /// <summary>Whether every declared obligation is satisfied.</summary>
+    public bool AllSatisfied => Obligations.All(static obligation => obligation.Satisfied);
+}
+
+/// <summary>
+/// Context-aware decision and the obligations it carries.
+/// </summary>
+public sealed class ContextDecision
+{
+    /// <summary>Creates an immutable context decision.</summary>
+    public ContextDecision(
+        ContextOutcome outcome,
+        ObligationSet obligations,
+        DataClassification aggregateSensitivity,
+        string reason = "")
+    {
+        if (!Enum.IsDefined(outcome))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(outcome),
+                outcome,
+                "Outcome must be a defined ContextOutcome value.");
+        }
+
+        ArgumentNullException.ThrowIfNull(obligations);
+        ArgumentNullException.ThrowIfNull(reason);
+
+        Outcome = outcome;
+        Obligations = obligations;
+        AggregateSensitivity = DataClassificationGuard.Defined(
+            aggregateSensitivity,
+            nameof(aggregateSensitivity));
+        Reason = reason;
+    }
+
+    /// <summary>Governance-level outcome.</summary>
+    public ContextOutcome Outcome { get; }
+
+    /// <summary>Obligations carried by this decision.</summary>
+    public ObligationSet Obligations { get; }
+
+    /// <summary>Accumulated sensitivity at decision time.</summary>
+    public DataClassification AggregateSensitivity { get; }
+
+    /// <summary>Human-readable decision reason.</summary>
+    public string Reason { get; }
+
+    /// <summary>
+    /// Maps this decision to the existing policy action surface.
+    /// </summary>
+    public PolicyAction ToPolicyAction(bool hasObligationChannel) =>
+        Outcome switch
+        {
+            ContextOutcome.Allow => PolicyAction.Allow,
+            ContextOutcome.Deny => PolicyAction.Deny,
+            ContextOutcome.Escalate => PolicyAction.RequireApproval,
+            ContextOutcome.Constrain when hasObligationChannel => PolicyAction.Allow,
+            ContextOutcome.Constrain
+                when Obligations.Obligations.Count > 0 && Obligations.AllSatisfied =>
+                PolicyAction.Allow,
+            _ => PolicyAction.Deny
+        };
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Context/ContextEnvelope.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Context/ContextEnvelope.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Frozen;
+
+namespace AgentGovernance.Context;
+
+/// <summary>
+/// Immutable, versioned accumulated governance state for one workflow.
+/// </summary>
+public sealed class ContextEnvelope
+{
+    /// <summary>
+    /// Creates an immutable context envelope from caller-supplied state.
+    /// </summary>
+    public ContextEnvelope(
+        string envelopeId,
+        string workflowId,
+        IEnumerable<string>? labels = null,
+        DataClassification aggregateSensitivity = DataClassification.Public,
+        IEnumerable<string>? restrictions = null,
+        int version = 0,
+        string? parentEnvelopeId = null,
+        DateTimeOffset? createdAt = null)
+    {
+        EnvelopeId = ContextTokens.Identifier(envelopeId, nameof(envelopeId));
+        WorkflowId = ContextTokens.Identifier(workflowId, nameof(workflowId));
+        Labels = ContextTokens.SnapshotOptional(labels, nameof(labels));
+        AggregateSensitivity = DataClassificationGuard.Defined(
+            aggregateSensitivity,
+            nameof(aggregateSensitivity));
+        Restrictions = ContextTokens.SnapshotOptional(restrictions, nameof(restrictions));
+
+        if (version < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(version),
+                version,
+                "Envelope version cannot be negative.");
+        }
+
+        Version = version;
+        ParentEnvelopeId = parentEnvelopeId is null
+            ? null
+            : ContextTokens.Identifier(parentEnvelopeId, nameof(parentEnvelopeId));
+        CreatedAt = createdAt;
+    }
+
+    /// <summary>Stable identifier for this envelope lineage.</summary>
+    public string EnvelopeId { get; }
+
+    /// <summary>Workflow correlation identifier.</summary>
+    public string WorkflowId { get; }
+
+    /// <summary>Accumulated organization-authored labels.</summary>
+    public IReadOnlySet<string> Labels { get; }
+
+    /// <summary>Running maximum sensitivity.</summary>
+    public DataClassification AggregateSensitivity { get; }
+
+    /// <summary>Grow-only restriction tokens.</summary>
+    public IReadOnlySet<string> Restrictions { get; }
+
+    /// <summary>Monotonic envelope version.</summary>
+    public int Version { get; }
+
+    /// <summary>Parent envelope identifier for delegated context.</summary>
+    public string? ParentEnvelopeId { get; }
+
+    /// <summary>Optional timestamp supplied by the caller.</summary>
+    public DateTimeOffset? CreatedAt { get; }
+
+    /// <summary>
+    /// Returns the next version after joining labels and sensitivity.
+    /// </summary>
+    public ContextEnvelope Fold(
+        IEnumerable<string> newLabels,
+        DataClassification newSensitivity)
+    {
+        var nextLabels = ContextTokens.Union(
+            Labels,
+            newLabels,
+            nameof(newLabels));
+
+        return Copy(
+            labels: nextLabels,
+            aggregateSensitivity: DataClassificationGuard.Maximum(
+                AggregateSensitivity,
+                DataClassificationGuard.Defined(newSensitivity, nameof(newSensitivity))),
+            version: checked(Version + 1));
+    }
+
+    /// <summary>
+    /// Returns the next version after adding grow-only restrictions.
+    /// </summary>
+    public ContextEnvelope ApplyRestrictions(IEnumerable<string> restrictions)
+    {
+        var nextRestrictions = ContextTokens.Union(
+            Restrictions,
+            restrictions,
+            nameof(restrictions));
+
+        return Copy(
+            restrictions: nextRestrictions,
+            version: checked(Version + 1));
+    }
+
+    /// <summary>
+    /// Projects this envelope onto its opaque cross-boundary reference.
+    /// </summary>
+    public EnvelopeReference ToReference() =>
+        new(EnvelopeId, AggregateSensitivity);
+
+    internal ContextEnvelope WithAggregateSensitivity(DataClassification sensitivity) =>
+        Copy(aggregateSensitivity: sensitivity);
+
+    private ContextEnvelope Copy(
+        IEnumerable<string>? labels = null,
+        DataClassification? aggregateSensitivity = null,
+        IEnumerable<string>? restrictions = null,
+        int? version = null) =>
+        new(
+            EnvelopeId,
+            WorkflowId,
+            labels ?? Labels,
+            aggregateSensitivity ?? AggregateSensitivity,
+            restrictions ?? Restrictions,
+            version ?? Version,
+            ParentEnvelopeId,
+            CreatedAt);
+}
+
+internal static class ContextTokens
+{
+    private static readonly IReadOnlySet<string> Empty =
+        Array.Empty<string>().ToFrozenSet(StringComparer.Ordinal);
+
+    internal static string Identifier(string value, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+        if (!string.Equals(value, value.Trim(), StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "Value cannot contain leading or trailing whitespace.",
+                parameterName);
+        }
+
+        return value;
+    }
+
+    internal static IReadOnlySet<string> SnapshotOptional(
+        IEnumerable<string>? tokens,
+        string parameterName) =>
+        tokens is null ? Empty : Snapshot(tokens, parameterName);
+
+    internal static IReadOnlySet<string> Snapshot(
+        IEnumerable<string> tokens,
+        string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(tokens, parameterName);
+
+        var snapshot = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var token in tokens)
+        {
+            snapshot.Add(Identifier(token, parameterName));
+        }
+
+        return snapshot.ToFrozenSet(StringComparer.Ordinal);
+    }
+
+    internal static IReadOnlySet<string> Union(
+        IEnumerable<string> existing,
+        IEnumerable<string> added,
+        string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(added, parameterName);
+        return Snapshot(existing.Concat(added), parameterName);
+    }
+}
+
+/// <summary>
+/// Opaque cross-boundary reference to accumulated governance context.
+/// </summary>
+public sealed class EnvelopeReference
+{
+    /// <summary>Creates an opaque envelope reference.</summary>
+    public EnvelopeReference(
+        string envelopeId,
+        DataClassification sensitivity)
+    {
+        EnvelopeId = ContextTokens.Identifier(envelopeId, nameof(envelopeId));
+        Sensitivity = DataClassificationGuard.Defined(
+            sensitivity,
+            nameof(sensitivity));
+    }
+
+    /// <summary>Opaque envelope lineage identifier.</summary>
+    public string EnvelopeId { get; }
+
+    /// <summary>Coarse sensitivity tier used to select a policy path.</summary>
+    public DataClassification Sensitivity { get; }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Context/ContextEvent.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Context/ContextEvent.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+
+namespace AgentGovernance.Context;
+
+/// <summary>
+/// Stable event-type vocabulary for accumulated context transitions.
+/// </summary>
+public static class ContextEventTypes
+{
+    /// <summary>A context envelope was created.</summary>
+    public const string EnvelopeCreated = "CONTEXT_ENVELOPE_CREATED";
+
+    /// <summary>A context envelope was updated.</summary>
+    public const string EnvelopeUpdated = "CONTEXT_ENVELOPE_UPDATED";
+
+    /// <summary>Aggregation elevated context sensitivity or restrictions.</summary>
+    public const string AggregationElevated = "CONTEXT_AGGREGATION_ELEVATED";
+
+    /// <summary>Context crossed a delegation boundary.</summary>
+    public const string Delegated = "CONTEXT_DELEGATED";
+
+    /// <summary>Context content was redacted.</summary>
+    public const string Redacted = "CONTEXT_REDACTED";
+
+    /// <summary>A derived artifact received labels.</summary>
+    public const string DerivedArtifactLabeled = "DERIVED_ARTIFACT_LABELED";
+}
+
+/// <summary>
+/// Immutable audit event describing one envelope transition.
+/// </summary>
+public sealed class ContextEvent
+{
+    private ContextEvent(
+        string eventType,
+        string agentId,
+        string contextEnvelopeId,
+        DataClassification previousSensitivity,
+        DataClassification newSensitivity,
+        IEnumerable<string> labelsAdded,
+        IEnumerable<string> rulesApplied,
+        IEnumerable<string> restrictionsAdded,
+        DataClassification classification)
+    {
+        EventType = eventType;
+        AgentId = agentId;
+        ContextEnvelopeId = contextEnvelopeId;
+        PreviousSensitivity = previousSensitivity;
+        NewSensitivity = newSensitivity;
+        LabelsAdded = ContextTokens.Snapshot(labelsAdded, nameof(labelsAdded));
+        RulesApplied = SnapshotRules(rulesApplied);
+        RestrictionsAdded = ContextTokens.Snapshot(
+            restrictionsAdded,
+            nameof(restrictionsAdded));
+        Classification = classification;
+    }
+
+    /// <summary>Stable event type.</summary>
+    public string EventType { get; }
+
+    /// <summary>Agent responsible for the transition.</summary>
+    public string AgentId { get; }
+
+    /// <summary>Identifier of the resulting envelope.</summary>
+    public string ContextEnvelopeId { get; }
+
+    /// <summary>Sensitivity before the transition.</summary>
+    public DataClassification PreviousSensitivity { get; }
+
+    /// <summary>Sensitivity after the transition.</summary>
+    public DataClassification NewSensitivity { get; }
+
+    /// <summary>Labels added by the transition.</summary>
+    public IReadOnlySet<string> LabelsAdded { get; }
+
+    /// <summary>Applied rules in caller-supplied order.</summary>
+    public IReadOnlyList<string> RulesApplied { get; }
+
+    /// <summary>Restrictions added by the transition.</summary>
+    public IReadOnlySet<string> RestrictionsAdded { get; }
+
+    /// <summary>Classification floor protecting this event.</summary>
+    public DataClassification Classification { get; }
+
+    /// <summary>
+    /// Creates a deterministic event from an envelope transition.
+    /// </summary>
+    public static ContextEvent Create(
+        string eventType,
+        string agentId,
+        ContextEnvelope before,
+        ContextEnvelope after,
+        IEnumerable<string>? rulesApplied = null)
+    {
+        ContextTokens.Identifier(eventType, nameof(eventType));
+        ContextTokens.Identifier(agentId, nameof(agentId));
+        ArgumentNullException.ThrowIfNull(before);
+        ArgumentNullException.ThrowIfNull(after);
+
+        return new ContextEvent(
+            eventType,
+            agentId,
+            after.EnvelopeId,
+            before.AggregateSensitivity,
+            after.AggregateSensitivity,
+            after.Labels.Except(before.Labels, StringComparer.Ordinal),
+            rulesApplied ?? [],
+            after.Restrictions.Except(
+                before.Restrictions,
+                StringComparer.Ordinal),
+            DataClassificationGuard.Maximum(
+                before.AggregateSensitivity,
+                after.AggregateSensitivity));
+    }
+
+    private static IReadOnlyList<string> SnapshotRules(
+        IEnumerable<string> rulesApplied)
+    {
+        ArgumentNullException.ThrowIfNull(rulesApplied);
+        var snapshot = rulesApplied
+            .Select(static rule => ContextTokens.Identifier(rule, nameof(rulesApplied)))
+            .ToArray();
+        return new ReadOnlyCollection<string>(snapshot);
+    }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Context/ContextGovernance.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Context/ContextGovernance.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AgentGovernance.Context;
+
+/// <summary>
+/// Pure operations over accumulated governance context.
+/// </summary>
+public static class ContextGovernance
+{
+    private static readonly IReadOnlyDictionary<string, string> RestrictedActions =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["export"] = "no_external_export",
+            ["delegate"] = "no_external_delegation",
+            ["memory_write"] = "no_memory_write"
+        };
+
+    /// <summary>
+    /// Folds an action's actual result into an envelope and reapplies aggregation.
+    /// </summary>
+    public static ContextEnvelope Accumulate(
+        ContextEnvelope envelope,
+        IEnumerable<string> resultLabels,
+        DataClassification resultSensitivity,
+        AggregationRuleSet ruleSet,
+        int categoryThreshold)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(ruleSet);
+
+        var folded = envelope.Fold(resultLabels, resultSensitivity);
+        var aggregation = ruleSet.Evaluate(folded, categoryThreshold);
+        var raised = folded.WithAggregateSensitivity(
+            aggregation.AggregateSensitivity);
+
+        return raised.ApplyRestrictions(aggregation.Restrictions);
+    }
+
+    /// <summary>
+    /// Gates an action against an already-accumulated envelope.
+    /// </summary>
+    public static ContextDecision DecideNext(
+        ContextEnvelope envelope,
+        string action,
+        AggregationRuleSet ruleSet,
+        int categoryThreshold,
+        DataClassification restrictedFloor = DataClassification.Restricted)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(ruleSet);
+        ContextTokens.Identifier(action, nameof(action));
+        DataClassificationGuard.Defined(restrictedFloor, nameof(restrictedFloor));
+
+        var aggregation = ruleSet.Evaluate(envelope, categoryThreshold);
+        if (aggregation.Escalate)
+        {
+            return new ContextDecision(
+                ContextOutcome.Escalate,
+                new ObligationSet(resultLabels: envelope.Labels),
+                aggregation.AggregateSensitivity,
+                "aggregation threshold crossed with no governing rule");
+        }
+
+        RestrictedActions.TryGetValue(action, out var gatingRestriction);
+        var restrictionPresent = gatingRestriction is not null
+            && envelope.Restrictions.Contains(gatingRestriction);
+        var floorTriggered = gatingRestriction is not null
+            && aggregation.AggregateSensitivity >= restrictedFloor;
+
+        if (restrictionPresent || floorTriggered)
+        {
+            var obligations = envelope.Restrictions
+                .Order(StringComparer.Ordinal)
+                .Select(static restriction => new Obligation(restriction));
+            var reason = restrictionPresent
+                ? $"action '{action}' restricted by '{gatingRestriction}'"
+                : $"action '{action}' gated by sensitivity floor";
+
+            return new ContextDecision(
+                ContextOutcome.Constrain,
+                new ObligationSet(obligations, envelope.Labels),
+                aggregation.AggregateSensitivity,
+                reason);
+        }
+
+        return new ContextDecision(
+            ContextOutcome.Allow,
+            new ObligationSet(resultLabels: envelope.Labels),
+            aggregation.AggregateSensitivity);
+    }
+
+    /// <summary>
+    /// Returns the grow-only union of parent and child-declared restrictions.
+    /// </summary>
+    public static IReadOnlySet<string> MergeRestrictions(
+        ContextEnvelope parent,
+        IEnumerable<string> childDeclared)
+    {
+        ArgumentNullException.ThrowIfNull(parent);
+        return ContextTokens.Union(
+            parent.Restrictions,
+            childDeclared,
+            nameof(childDeclared));
+    }
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Context/DataClassification.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Context/DataClassification.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AgentGovernance.Context;
+
+/// <summary>
+/// Ordered sensitivity levels for accumulated governance context.
+/// </summary>
+public enum DataClassification
+{
+    /// <summary>Public data.</summary>
+    Public = 0,
+
+    /// <summary>Internal data.</summary>
+    Internal = 1,
+
+    /// <summary>Confidential data.</summary>
+    Confidential = 2,
+
+    /// <summary>Restricted data.</summary>
+    Restricted = 3,
+
+    /// <summary>Top-secret data.</summary>
+    TopSecret = 4
+}
+
+internal static class DataClassificationGuard
+{
+    internal static DataClassification Defined(
+        DataClassification classification,
+        string parameterName)
+    {
+        if (!Enum.IsDefined(classification))
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                classification,
+                "Classification must be a defined DataClassification value.");
+        }
+
+        return classification;
+    }
+
+    internal static DataClassification Maximum(
+        DataClassification left,
+        DataClassification right) =>
+        (DataClassification)Math.Max(
+            (int)Defined(left, nameof(left)),
+            (int)Defined(right, nameof(right)));
+}

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/AccumulatedContextAuditTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/AccumulatedContextAuditTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AgentGovernance.Context;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public sealed class AccumulatedContextAuditTests
+{
+    [Fact]
+    public void EnvelopeReference_ExposesOnlyOpaqueIdAndSensitivity()
+    {
+        var envelope = Envelope(
+            "env-after",
+            labels: ["pii", "financial"],
+            sensitivity: DataClassification.Restricted,
+            restrictions: ["no_external_export"],
+            version: 7);
+
+        var reference = envelope.ToReference();
+
+        Assert.Equal("env-after", reference.EnvelopeId);
+        Assert.Equal(DataClassification.Restricted, reference.Sensitivity);
+        Assert.Equal(
+            ["EnvelopeId", "Sensitivity"],
+            typeof(EnvelopeReference)
+                .GetProperties()
+                .Select(static property => property.Name)
+                .Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Create_BuildsExactDeterministicTransitionDelta()
+    {
+        var before = Envelope(
+            "env-before",
+            labels: ["pii"],
+            sensitivity: DataClassification.Confidential,
+            restrictions: ["retain_audit"],
+            version: 2);
+        var after = Envelope(
+            "env-after",
+            labels: ["pii", "financial"],
+            sensitivity: DataClassification.Restricted,
+            restrictions: ["retain_audit", "no_external_export"],
+            version: 4);
+        var rules = new List<string>
+        {
+            "pii_financial_restricted",
+            "financial_export_control"
+        };
+
+        var auditEvent = ContextEvent.Create(
+            ContextEventTypes.AggregationElevated,
+            "did:mesh:agent-1",
+            before,
+            after,
+            rules);
+        rules.Clear();
+
+        Assert.Equal(
+            ContextEventTypes.AggregationElevated,
+            auditEvent.EventType);
+        Assert.Equal("did:mesh:agent-1", auditEvent.AgentId);
+        Assert.Equal("env-after", auditEvent.ContextEnvelopeId);
+        Assert.Equal(
+            DataClassification.Confidential,
+            auditEvent.PreviousSensitivity);
+        Assert.Equal(
+            DataClassification.Restricted,
+            auditEvent.NewSensitivity);
+        Assert.True(auditEvent.LabelsAdded.SetEquals(["financial"]));
+        Assert.Equal(
+            ["pii_financial_restricted", "financial_export_control"],
+            auditEvent.RulesApplied);
+        Assert.True(
+            auditEvent.RestrictionsAdded.SetEquals(["no_external_export"]));
+        Assert.Equal(DataClassification.Restricted, auditEvent.Classification);
+        Assert.DoesNotContain(
+            typeof(ContextEvent).GetProperties(),
+            static property => property.Name.Contains(
+                "Time",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Create_UsesMaximumSensitivityAsEventClassification()
+    {
+        var auditEvent = ContextEvent.Create(
+            ContextEventTypes.Redacted,
+            "did:mesh:agent-1",
+            Envelope(
+                "env-before",
+                sensitivity: DataClassification.TopSecret),
+            Envelope(
+                "env-after",
+                sensitivity: DataClassification.Internal));
+
+        Assert.Equal(DataClassification.TopSecret, auditEvent.Classification);
+        Assert.Equal(DataClassification.Internal, auditEvent.NewSensitivity);
+    }
+
+    [Fact]
+    public void ContextEventTypes_MatchStablePythonVocabulary()
+    {
+        Assert.Equal("CONTEXT_ENVELOPE_CREATED", ContextEventTypes.EnvelopeCreated);
+        Assert.Equal("CONTEXT_ENVELOPE_UPDATED", ContextEventTypes.EnvelopeUpdated);
+        Assert.Equal("CONTEXT_AGGREGATION_ELEVATED", ContextEventTypes.AggregationElevated);
+        Assert.Equal("CONTEXT_DELEGATED", ContextEventTypes.Delegated);
+        Assert.Equal("CONTEXT_REDACTED", ContextEventTypes.Redacted);
+        Assert.Equal("DERIVED_ARTIFACT_LABELED", ContextEventTypes.DerivedArtifactLabeled);
+    }
+
+    [Fact]
+    public void Create_RejectsMalformedAuditIdentityAndRules()
+    {
+        var envelope = Envelope("env-1");
+
+        Assert.Throws<ArgumentException>(
+            () => ContextEvent.Create("", "did:mesh:agent-1", envelope, envelope));
+        Assert.Throws<ArgumentException>(
+            () => ContextEvent.Create(
+                ContextEventTypes.EnvelopeUpdated,
+                " ",
+                envelope,
+                envelope));
+        Assert.Throws<ArgumentException>(
+            () => ContextEvent.Create(
+                ContextEventTypes.EnvelopeUpdated,
+                "did:mesh:agent-1",
+                envelope,
+                envelope,
+                [""]));
+    }
+
+    private static ContextEnvelope Envelope(
+        string envelopeId,
+        IEnumerable<string>? labels = null,
+        DataClassification sensitivity = DataClassification.Public,
+        IEnumerable<string>? restrictions = null,
+        int version = 0) =>
+        new(
+            envelopeId,
+            "workflow-audit",
+            labels,
+            sensitivity,
+            restrictions,
+            version,
+            createdAt: new DateTimeOffset(2026, 7, 27, 5, 0, 0, TimeSpan.Zero));
+}

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/AccumulatedContextDecisionTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/AccumulatedContextDecisionTests.cs
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AgentGovernance.Context;
+using AgentGovernance.Policy;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public sealed class AccumulatedContextDecisionTests
+{
+    [Fact]
+    public void DecideNext_EscalatesUnknownCombinationAndMapsToReview()
+    {
+        var envelope = Envelope(labels: ["a", "b", "c"]);
+
+        var decision = ContextGovernance.DecideNext(
+            envelope,
+            "read",
+            Rules(),
+            categoryThreshold: 3);
+
+        Assert.Equal(ContextOutcome.Escalate, decision.Outcome);
+        Assert.True(decision.Obligations.ResultLabels.SetEquals(["a", "b", "c"]));
+        Assert.Empty(decision.Obligations.Obligations);
+        Assert.Equal(
+            "aggregation threshold crossed with no governing rule",
+            decision.Reason);
+        Assert.Equal(PolicyAction.RequireApproval, decision.ToPolicyAction(false));
+    }
+
+    [Theory]
+    [InlineData("export", "no_external_export")]
+    [InlineData("delegate", "no_external_delegation")]
+    [InlineData("memory_write", "no_memory_write")]
+    public void DecideNext_ExplicitRestrictionConstrainsBelowFloor(
+        string action,
+        string restriction)
+    {
+        var envelope = Envelope(
+            labels: ["pii"],
+            sensitivity: DataClassification.Confidential,
+            restrictions: [restriction, "retain_audit"]);
+
+        var decision = ContextGovernance.DecideNext(
+            envelope,
+            action,
+            Rules(),
+            categoryThreshold: 99);
+
+        Assert.Equal(ContextOutcome.Constrain, decision.Outcome);
+        Assert.Equal(
+            new[] { "retain_audit", restriction }.Order(StringComparer.Ordinal),
+            decision.Obligations.Obligations.Select(static obligation => obligation.Key));
+        Assert.All(
+            decision.Obligations.Obligations,
+            static obligation => Assert.False(obligation.Satisfied));
+        Assert.Equal(PolicyAction.Deny, decision.ToPolicyAction(false));
+        Assert.Equal(PolicyAction.Allow, decision.ToPolicyAction(true));
+    }
+
+    [Fact]
+    public void DecideNext_SensitivityFloorConstrainsFlowActionWithoutRestriction()
+    {
+        var decision = ContextGovernance.DecideNext(
+            Envelope(
+                labels: ["pii"],
+                sensitivity: DataClassification.Restricted),
+            "export",
+            Rules(),
+            categoryThreshold: 99);
+
+        Assert.Equal(ContextOutcome.Constrain, decision.Outcome);
+        Assert.Empty(decision.Obligations.Obligations);
+        Assert.Equal(
+            "action 'export' gated by sensitivity floor",
+            decision.Reason);
+        Assert.Equal(PolicyAction.Deny, decision.ToPolicyAction(false));
+        Assert.Equal(PolicyAction.Allow, decision.ToPolicyAction(true));
+    }
+
+    [Fact]
+    public void DecideNext_AllowsSupportedUnrestrictedAction()
+    {
+        var decision = ContextGovernance.DecideNext(
+            Envelope(labels: ["pii"]),
+            "read",
+            Rules(),
+            categoryThreshold: 99);
+
+        Assert.Equal(ContextOutcome.Allow, decision.Outcome);
+        Assert.True(decision.Obligations.ResultLabels.SetEquals(["pii"]));
+        Assert.Equal(PolicyAction.Allow, decision.ToPolicyAction(false));
+    }
+
+    [Fact]
+    public void ToPolicyAction_EnforcesObligationsAndFailsClosed()
+    {
+        var satisfied = Decision(
+            ContextOutcome.Constrain,
+            new ObligationSet([new Obligation("retain_audit", satisfied: true)]));
+        var unsatisfied = Decision(
+            ContextOutcome.Constrain,
+            new ObligationSet([new Obligation("retain_audit")]));
+        var empty = Decision(ContextOutcome.Constrain, new ObligationSet());
+        var denied = Decision(ContextOutcome.Deny, new ObligationSet());
+
+        Assert.Equal(PolicyAction.Allow, satisfied.ToPolicyAction(false));
+        Assert.Equal(PolicyAction.Deny, unsatisfied.ToPolicyAction(false));
+        Assert.Equal(PolicyAction.Deny, empty.ToPolicyAction(false));
+        Assert.Equal(PolicyAction.Deny, denied.ToPolicyAction(true));
+    }
+
+    [Fact]
+    public void DecisionModels_RejectMalformedOrUnsupportedState()
+    {
+        Assert.Throws<ArgumentException>(() => new Obligation(""));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Decision((ContextOutcome)99, new ObligationSet()));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Decision(
+                ContextOutcome.Allow,
+                new ObligationSet(),
+                (DataClassification)99));
+        Assert.Throws<ArgumentException>(
+            () => ContextGovernance.DecideNext(
+                Envelope(),
+                " ",
+                Rules(),
+                categoryThreshold: 99));
+    }
+
+    private static ContextDecision Decision(
+        ContextOutcome outcome,
+        ObligationSet obligations,
+        DataClassification sensitivity = DataClassification.Restricted) =>
+        new(outcome, obligations, sensitivity);
+
+    private static AggregationRuleSet Rules() =>
+        new(
+        [
+            new AggregationRule(
+                "pii_financial_restricted",
+                ["pii", "financial"],
+                DataClassification.Restricted,
+                ["no_external_export"])
+        ]);
+
+    private static ContextEnvelope Envelope(
+        IEnumerable<string>? labels = null,
+        DataClassification sensitivity = DataClassification.Internal,
+        IEnumerable<string>? restrictions = null) =>
+        new(
+            "env-decision",
+            "workflow-decision",
+            labels,
+            sensitivity,
+            restrictions,
+            createdAt: new DateTimeOffset(2026, 7, 27, 5, 0, 0, TimeSpan.Zero));
+}
+
+public sealed class AccumulatedContextDelegationTests
+{
+    [Fact]
+    public void MergeRestrictions_InheritsParentAndAddsChildRestrictions()
+    {
+        var parent = new ContextEnvelope(
+            "parent-1",
+            "workflow-1",
+            restrictions: ["no_external_export"]);
+
+        var child = ContextGovernance.MergeRestrictions(
+            parent,
+            ["no_memory_write"]);
+        var grandchild = ContextGovernance.MergeRestrictions(
+            new ContextEnvelope(
+                "child-1",
+                "workflow-1",
+                restrictions: child,
+                parentEnvelopeId: parent.EnvelopeId),
+            ["retain_audit"]);
+
+        Assert.True(child.SetEquals(["no_external_export", "no_memory_write"]));
+        Assert.True(
+            grandchild.SetEquals(
+                ["no_external_export", "no_memory_write", "retain_audit"]));
+        Assert.True(parent.Restrictions.SetEquals(["no_external_export"]));
+    }
+
+    [Fact]
+    public void MergeRestrictions_CannotDropParentRestrictions()
+    {
+        var parent = new ContextEnvelope(
+            "parent-1",
+            "workflow-1",
+            restrictions: ["no_external_export", "no_memory_write"]);
+
+        var effective = ContextGovernance.MergeRestrictions(parent, []);
+
+        Assert.True(
+            effective.SetEquals(
+                ["no_external_export", "no_memory_write"]));
+    }
+
+    [Fact]
+    public void MergeRestrictions_RejectsMalformedChildToken()
+    {
+        var parent = new ContextEnvelope("parent-1", "workflow-1");
+
+        Assert.Throws<ArgumentException>(
+            () => ContextGovernance.MergeRestrictions(parent, [""]));
+    }
+}

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/AccumulatedContextStateTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/AccumulatedContextStateTests.cs
@@ -1,0 +1,334 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using AgentGovernance.Context;
+using Xunit;
+
+namespace AgentGovernance.Tests;
+
+public sealed class AccumulatedContextClassificationTests
+{
+    [Fact]
+    public void DataClassification_UsesStableOrderedVocabulary()
+    {
+        Assert.Collection(
+            Enum.GetValues<DataClassification>(),
+            value => Assert.Equal((DataClassification.Public, 0), (value, (int)value)),
+            value => Assert.Equal((DataClassification.Internal, 1), (value, (int)value)),
+            value => Assert.Equal((DataClassification.Confidential, 2), (value, (int)value)),
+            value => Assert.Equal((DataClassification.Restricted, 3), (value, (int)value)),
+            value => Assert.Equal((DataClassification.TopSecret, 4), (value, (int)value)));
+    }
+
+    [Fact]
+    public void ContextEnvelope_RejectsUndefinedClassification()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ContextEnvelope(
+                "env-1",
+                "workflow-1",
+                aggregateSensitivity: (DataClassification)99));
+    }
+}
+
+public sealed class AccumulatedContextEnvelopeTests
+{
+    private static readonly DateTimeOffset CreatedAt =
+        new(2026, 7, 27, 5, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Constructor_SnapshotsInputsAndPreservesCallerTimestamp()
+    {
+        var labels = new HashSet<string>(StringComparer.Ordinal) { "pii" };
+        var restrictions = new HashSet<string>(StringComparer.Ordinal) { "no_memory_write" };
+
+        var envelope = new ContextEnvelope(
+            "env-1",
+            "workflow-1",
+            labels,
+            DataClassification.Internal,
+            restrictions,
+            version: 7,
+            parentEnvelopeId: "parent-1",
+            createdAt: CreatedAt);
+
+        labels.Add("financial");
+        restrictions.Add("no_external_export");
+
+        Assert.Equal("env-1", envelope.EnvelopeId);
+        Assert.Equal("workflow-1", envelope.WorkflowId);
+        Assert.True(envelope.Labels.SetEquals(["pii"]));
+        Assert.Equal(DataClassification.Internal, envelope.AggregateSensitivity);
+        Assert.True(envelope.Restrictions.SetEquals(["no_memory_write"]));
+        Assert.Equal(7, envelope.Version);
+        Assert.Equal("parent-1", envelope.ParentEnvelopeId);
+        Assert.Equal(CreatedAt, envelope.CreatedAt);
+    }
+
+    [Fact]
+    public void Fold_UnionsLabelsRaisesSensitivityAndIncrementsVersionWithoutMutation()
+    {
+        var original = Envelope(
+            labels: ["pii"],
+            sensitivity: DataClassification.Internal,
+            restrictions: ["no_memory_write"],
+            version: 2);
+
+        var folded = original.Fold(
+            ["financial"],
+            DataClassification.Confidential);
+
+        Assert.NotSame(original, folded);
+        Assert.True(folded.Labels.SetEquals(["pii", "financial"]));
+        Assert.Equal(DataClassification.Confidential, folded.AggregateSensitivity);
+        Assert.True(folded.Restrictions.SetEquals(["no_memory_write"]));
+        Assert.Equal(3, folded.Version);
+        Assert.True(original.Labels.SetEquals(["pii"]));
+        Assert.Equal(DataClassification.Internal, original.AggregateSensitivity);
+        Assert.Equal(2, original.Version);
+    }
+
+    [Fact]
+    public void Fold_IsIdempotentCommutativeAndNeverLowersSensitivity()
+    {
+        var original = Envelope(
+            labels: ["pii"],
+            sensitivity: DataClassification.Restricted);
+
+        var leftThenRight = original
+            .Fold(["financial"], DataClassification.Public)
+            .Fold(["behavioral", "pii"], DataClassification.Confidential);
+        var rightThenLeft = original
+            .Fold(["behavioral", "pii"], DataClassification.Confidential)
+            .Fold(["financial"], DataClassification.Public);
+
+        Assert.True(leftThenRight.Labels.SetEquals(rightThenLeft.Labels));
+        Assert.Equal(DataClassification.Restricted, leftThenRight.AggregateSensitivity);
+        Assert.Equal(leftThenRight.AggregateSensitivity, rightThenLeft.AggregateSensitivity);
+    }
+
+    [Fact]
+    public void ApplyRestrictions_IsGrowOnlyAndIncrementsVersion()
+    {
+        var original = Envelope(
+            restrictions: ["no_external_export"],
+            version: 4);
+
+        var unchangedSet = original.ApplyRestrictions([]);
+        var grown = unchangedSet.ApplyRestrictions(["no_memory_write"]);
+
+        Assert.True(unchangedSet.Restrictions.SetEquals(["no_external_export"]));
+        Assert.Equal(5, unchangedSet.Version);
+        Assert.True(grown.Restrictions.SetEquals(["no_external_export", "no_memory_write"]));
+        Assert.Equal(6, grown.Version);
+        Assert.True(original.Restrictions.SetEquals(["no_external_export"]));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(" pii")]
+    [InlineData("pii ")]
+    public void Constructor_RejectsMalformedLabels(string label)
+    {
+        Assert.Throws<ArgumentException>(
+            () => Envelope(labels: [label]));
+    }
+
+    [Fact]
+    public void Constructor_RejectsMalformedIdentityAndVersion()
+    {
+        Assert.Throws<ArgumentException>(() => new ContextEnvelope("", "workflow-1"));
+        Assert.Throws<ArgumentException>(() => new ContextEnvelope("env-1", " "));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ContextEnvelope("env-1", "workflow-1", version: -1));
+    }
+
+    [Fact]
+    public void Fold_RejectsMalformedLabelsAndUndefinedClassification()
+    {
+        var envelope = Envelope();
+
+        Assert.Throws<ArgumentException>(
+            () => envelope.Fold([""], DataClassification.Public));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => envelope.Fold(["pii"], (DataClassification)(-1)));
+    }
+
+    private static ContextEnvelope Envelope(
+        IEnumerable<string>? labels = null,
+        DataClassification sensitivity = DataClassification.Public,
+        IEnumerable<string>? restrictions = null,
+        int version = 0) =>
+        new(
+            "env-1",
+            "workflow-1",
+            labels,
+            sensitivity,
+            restrictions,
+            version,
+            createdAt: CreatedAt);
+}
+
+public sealed class AccumulatedContextAggregationTests
+{
+    [Fact]
+    public void Evaluate_AppliesEveryKnownRuleInDeclaredOrder()
+    {
+        var rules = new[]
+        {
+            new AggregationRule(
+                "pii_financial_restricted",
+                ["pii", "financial"],
+                DataClassification.Restricted,
+                ["no_external_export"]),
+            new AggregationRule(
+                "financial_behavioral_top_secret",
+                ["financial", "behavioral"],
+                DataClassification.TopSecret,
+                ["no_memory_write"])
+        };
+        var ruleSet = new AggregationRuleSet(rules);
+        var envelope = Envelope(
+            labels: ["pii", "financial", "behavioral"],
+            sensitivity: DataClassification.Confidential,
+            restrictions: ["retain_audit"]);
+
+        var result = ruleSet.Evaluate(envelope, categoryThreshold: 99);
+
+        Assert.Equal(DataClassification.TopSecret, result.AggregateSensitivity);
+        Assert.True(
+            result.Restrictions.SetEquals(
+                ["retain_audit", "no_external_export", "no_memory_write"]));
+        Assert.Equal(
+            ["pii_financial_restricted", "financial_behavioral_top_secret"],
+            result.RulesApplied);
+        Assert.False(result.Escalate);
+    }
+
+    [Fact]
+    public void Evaluate_PreservesCurrentSensitivityWhenNoRuleMatches()
+    {
+        var result = Rules().Evaluate(
+            Envelope(
+                labels: ["pii", "behavioral"],
+                sensitivity: DataClassification.Confidential),
+            categoryThreshold: 99);
+
+        Assert.Equal(DataClassification.Confidential, result.AggregateSensitivity);
+        Assert.Empty(result.RulesApplied);
+        Assert.False(result.Escalate);
+    }
+
+    [Fact]
+    public void Evaluate_EscalatesUnknownCombinationAtThresholdOnlyWhenNoRuleMatches()
+    {
+        var unknown = Rules().Evaluate(
+            Envelope(labels: ["a", "b", "c"]),
+            categoryThreshold: 3);
+        var known = Rules().Evaluate(
+            Envelope(labels: ["pii", "financial", "behavioral"]),
+            categoryThreshold: 3);
+
+        Assert.True(unknown.Escalate);
+        Assert.False(known.Escalate);
+    }
+
+    [Fact]
+    public void Accumulate_FoldsActualResultAndAppliesAggregationAsTwoVersions()
+    {
+        var original = Envelope(
+            labels: ["pii"],
+            sensitivity: DataClassification.Internal,
+            version: 4);
+
+        var accumulated = ContextGovernance.Accumulate(
+            original,
+            ["financial"],
+            DataClassification.Confidential,
+            Rules(),
+            categoryThreshold: 99);
+
+        Assert.True(accumulated.Labels.SetEquals(["pii", "financial"]));
+        Assert.Equal(DataClassification.Restricted, accumulated.AggregateSensitivity);
+        Assert.True(accumulated.Restrictions.SetEquals(["no_external_export"]));
+        Assert.Equal(6, accumulated.Version);
+        Assert.True(original.Labels.SetEquals(["pii"]));
+        Assert.Equal(DataClassification.Internal, original.AggregateSensitivity);
+        Assert.Empty(original.Restrictions);
+        Assert.Equal(4, original.Version);
+    }
+
+    [Fact]
+    public void AggregationModels_SnapshotMutableInputs()
+    {
+        var labels = new HashSet<string>(StringComparer.Ordinal) { "pii" };
+        var restrictions = new HashSet<string>(StringComparer.Ordinal) { "retain_audit" };
+        var mutableRules = new List<AggregationRule>
+        {
+            new(
+                "pii_internal",
+                labels,
+                DataClassification.Internal,
+                restrictions)
+        };
+
+        var ruleSet = new AggregationRuleSet(mutableRules);
+        labels.Add("financial");
+        restrictions.Add("no_external_export");
+        mutableRules.Clear();
+
+        var result = ruleSet.Evaluate(
+            Envelope(labels: ["pii"]),
+            categoryThreshold: 99);
+
+        Assert.Equal(["pii_internal"], result.RulesApplied);
+        Assert.True(result.Restrictions.SetEquals(["retain_audit"]));
+    }
+
+    [Fact]
+    public void Aggregation_RejectsMalformedRulesAndThresholds()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new AggregationRule(
+                "",
+                ["pii"],
+                DataClassification.Restricted));
+        Assert.Throws<ArgumentException>(
+            () => new AggregationRule(
+                "bad-label",
+                [" "],
+                DataClassification.Restricted));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new AggregationRule(
+                "bad-classification",
+                ["pii"],
+                (DataClassification)99));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Rules().Evaluate(Envelope(), categoryThreshold: 0));
+    }
+
+    private static AggregationRuleSet Rules() =>
+        new(
+        [
+            new AggregationRule(
+                "pii_financial_restricted",
+                ["pii", "financial"],
+                DataClassification.Restricted,
+                ["no_external_export"])
+        ]);
+
+    private static ContextEnvelope Envelope(
+        IEnumerable<string>? labels = null,
+        DataClassification sensitivity = DataClassification.Internal,
+        IEnumerable<string>? restrictions = null,
+        int version = 0) =>
+        new(
+            "env-aggregation",
+            "workflow-aggregation",
+            labels,
+            sensitivity,
+            restrictions,
+            version,
+            createdAt: new DateTimeOffset(2026, 7, 27, 5, 0, 0, TimeSpan.Zero));
+}


### PR DESCRIPTION
## Description

Adds the remaining .NET SDK slice of accumulated-context governance parity tracked by #3084.

- introduces the ordered `DataClassification` lattice and immutable, versioned `ContextEnvelope`
- applies deterministic aggregation rules with an unknown-combination escalation backstop
- accumulates post-execution labels and sensitivity while keeping restrictions grow-only
- inherits parent restrictions across delegation boundaries
- maps allow/constrain/deny/escalate outcomes onto the existing .NET `PolicyAction` surface without failing open
- emits classified context-transition audit events and opaque envelope references
- documents the shipped API and adds 34 focused parity tests

### Design notes

- The Python implementation from #2800 is the semantic reference; .NET naming and immutable collection types are idiomatic adaptations.
- `Escalate` maps to `PolicyAction.RequireApproval`, the existing .NET stop-and-review action. That action is non-allowing until approval is resolved.
- Timestamps remain caller-supplied; policy evaluation does not read the wall clock.
- This focused accumulated-context slice deliberately does not export a standalone `DataLabel`/ABAC surface. Context labels are validated organization-authored category tokens, and an unconsumed exported `DataLabel` was already identified as a parity blocker during review of the Go slice.
- No new dependencies are introduced.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [ ] docs / root

## Verification

- `dotnet format AgentGovernance.sln --no-restore --verify-no-changes --include <changed C# files>`
- focused accumulated-context tests: **34 passed, 0 failed, 0 skipped**
- full Dockerized .NET gate on the official .NET 8 ARM64 SDK image: **812 passed, 0 failed, 0 skipped**
- build: **0 errors**, no new compiler warnings
- `git diff --check`
- independent blocker review against the Python contract: **PASS**, no blockers

## Checklist
- [x] My code follows the project style guidelines (`dotnet format --verify-no-changes`; Ruff is not applicable to this .NET-only change)
- [x] I have added tests that prove my feature works
- [x] All new and existing tests pass (`dotnet test`; pytest is not applicable to this .NET-only change)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

Semantic parity port of the in-repository Python accumulated-context implementation merged in #2800 and tracked for other AGT SDKs in #3084. No external project code was used.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

LazyCodex/OmO and Codex assisted with the implementation and an independent blocker review. The complete diff, Python semantic contract, public API decisions, and test evidence were reviewed before submission; formatting, build, focused tests, and the full .NET suite were rerun independently.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Refs #3084
