### PR TITLE
refactor(v4-removal)!: move the Rust SDK onto ACS v5 manifests

### DIFF
--- a/agent-governance-rust/Cargo.lock
+++ b/agent-governance-rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,13 +44,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent_control_specification"
+version = "0.3.1-beta.0"
+dependencies = [
+ "agent_control_specification_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "agent_control_specification_core"
+version = "0.3.1-beta.0"
+dependencies = [
+ "base64 0.22.1",
+ "cedar-policy",
+ "jsonschema",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "ureq",
+ "url",
+]
+
+[[package]]
 name = "agentmesh"
 version = "5.0.0"
 dependencies = [
  "aes-gcm",
+ "agent_control_specification",
  "agentmesh-mcp",
  "assert_cmd",
- "base64",
+ "base64 0.22.1",
  "cedar-policy",
  "clap",
  "ed25519-dalek",
@@ -66,7 +98,7 @@ dependencies = [
 name = "agentmesh-mcp"
 version = "5.0.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hmac",
  "rand",
  "regex",
@@ -75,6 +107,20 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -131,7 +177,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -142,20 +188,20 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
 dependencies = [
  "object",
 ]
@@ -192,9 +238,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -210,12 +262,27 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -225,9 +292,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -249,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -279,21 +346,27 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -370,15 +443,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -428,7 +501,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -483,6 +556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -548,7 +630,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -571,7 +653,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -582,7 +664,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -601,7 +683,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -620,6 +701,17 @@ dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -662,14 +754,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "ena"
@@ -682,22 +774,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -713,7 +805,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
 ]
 
 [[package]]
@@ -741,6 +843,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +874,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +903,24 @@ name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -790,8 +939,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -802,7 +965,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
@@ -834,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -893,6 +1056,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1148,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -917,12 +1183,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -943,6 +1209,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,12 +1234,42 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64 0.21.7",
+ "bytecount",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -983,7 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
 dependencies = [
  "ascii-canvas",
- "bit-set",
+ "bit-set 0.8.0",
  "ena",
  "itertools",
  "lalrpop-util",
@@ -1022,9 +1327,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linked-hash-map"
@@ -1051,6 +1356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -1085,7 +1396,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1099,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miette"
@@ -1123,7 +1434,17 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1131,6 +1452,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nonempty"
@@ -1148,20 +1478,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
+name = "num"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.2.1"
+name = "num-cmp"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1169,6 +1528,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1239,13 +1619,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -1288,6 +1674,15 @@ dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
  "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1359,14 +1754,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1383,12 +1778,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1458,7 +1859,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1508,6 +1909,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-literal-escaper"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,14 +1947,49 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1619,7 +2069,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1628,7 +2078,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -1642,12 +2092,12 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -1665,7 +2115,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1674,7 +2124,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -1704,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -1718,16 +2168,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
+name = "simd-adler32"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smol_str"
@@ -1741,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"
@@ -1756,6 +2218,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "stacker"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,7 +2233,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1794,9 +2262,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1805,13 +2273,24 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1824,7 +2303,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1833,7 +2312,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1859,17 +2338,16 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1879,25 +2357,35 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
+name = "tinystr"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1986,10 +2474,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2024,11 +2564,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2037,14 +2577,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2055,9 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2065,22 +2605,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2102,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2115,8 +2655,26 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2125,7 +2683,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2149,7 +2707,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2160,7 +2718,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2189,12 +2747,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -2204,6 +2835,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -2224,9 +2861,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2242,7 +2879,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2255,7 +2892,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2274,7 +2911,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -2285,33 +2922,116 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.48"
+name = "writeable"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/agent-governance-rust/Cargo.toml
+++ b/agent-governance-rust/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/microsoft/agent-governance-toolkit"
 rust-version = "1.89"
 
 [workspace.dependencies]
+agent_control_specification = { path = "../policy-engine/sdk/rust", version = "0.3.1-beta.0" }
 agentmesh-mcp = { path = "agentmesh-mcp", version = "5.0.0" }
 aes-gcm = "=0.11.0"
 assert_cmd = "=2.2.2"

--- a/agent-governance-rust/agentmesh/Cargo.toml
+++ b/agent-governance-rust/agentmesh/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/bin/agt/main.rs"
 required-features = ["cli"]
 
 [dependencies]
+agent_control_specification.workspace = true
 agentmesh-mcp.workspace = true
 aes-gcm.workspace = true
 base64.workspace = true

--- a/agent-governance-rust/agentmesh/MIGRATION_V5.md
+++ b/agent-governance-rust/agentmesh/MIGRATION_V5.md
@@ -1,0 +1,84 @@
+# Rust framework policy migration
+
+`FrameworkGovernanceAdapter` now consumes native Agent Control Specification
+objects. The removed local framework policy and pattern types are not
+translated at runtime.
+
+```rust
+use agentmesh::{
+    AgentControl, FrameworkGovernanceAdapter, FrameworkKind, Manifest,
+};
+
+let manifest = Manifest::from_path("manifest.yaml")?;
+let control = AgentControl::from_manifest(manifest)?;
+let adapter = FrameworkGovernanceAdapter::new(
+    FrameworkKind::Tower,
+    MyHook,
+    control,
+);
+```
+
+Move tool catalogs, intervention-point bindings, budgets, approval rules, and
+content policies into the manifest. Keep framework-only drift and checkpoint
+settings in `FrameworkHostConfig`.
+
+Legacy-shaped YAML is rejected with `runtime_error:manifest_invalid`. The Rust
+SDK does not guess at or partially translate removed fields.
+
+## Budgets are host-reported
+
+`FrameworkGovernanceAdapter` counts tool calls itself and tracks elapsed time
+from construction, but it mediates requests without ever seeing a model
+response, so it cannot observe tokens or cost on its own.
+
+Call `record_usage` after each model call, or manifest budget rules keyed on
+`token_count` or `cost_usd` will evaluate against zero and never fire:
+
+```rust
+let adapter = FrameworkGovernanceAdapter::new(FrameworkKind::Actix, hook, control);
+// ... after a model call returns usage ...
+adapter.record_usage(response.total_tokens, response.cost_usd);
+```
+
+`tool_call_count` and `elapsed_seconds` need no host involvement.
+
+## Removed: `FrameworkExecutionResult::matched_patterns`
+
+The field carried the regex rule ids matched by the v4 pattern engine. ACS
+returns a verdict with a reason rather than a match list, so the field had no
+source and would have returned an empty vector on every call. It is removed
+rather than left in place, so code that read it fails to compile instead of
+silently seeing no matches. Read `decision` and the emitted `events` instead.
+
+## `with_host_config` returns `Result`
+
+It previously panicked on a `FrameworkHostConfig` outside the valid range. It
+now returns `RuntimeError::ManifestInvalid`. `new` is unchanged and stays
+infallible, because the default config is valid by construction.
+
+## A manifest must bind every point the adapter evaluates
+
+The runtime denies an intervention point the manifest does not declare
+(`runtime_error:intervention_point_unknown` becomes a `Deny`). Failing closed is
+the right default, but it makes a minimal first manifest look broken: the
+adapter evaluates `input` on every `execute()` and `pre_tool_call` on every tool
+call, so a manifest binding only one of them denies everything on the other path
+with no obvious cause.
+
+Bind both:
+
+```yaml
+intervention_points:
+  input:
+    policy_target: $.input.body
+    policy:
+      id: your_policy
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    tool_name_from: $.tool_call.name
+    policy:
+      id: your_policy
+```
+
+If a deny appears with `intervention_point_unknown` in the reason, the manifest
+is missing the point rather than the policy rejecting the request.

--- a/agent-governance-rust/agentmesh/src/integration_support.rs
+++ b/agent-governance-rust/agentmesh/src/integration_support.rs
@@ -3,10 +3,14 @@
 
 //! Lightweight integration, discovery, and prompt-defense helpers for embedding governance.
 
+use agent_control_specification::{
+    AgentControl, Decision, EnforcementMode, InterventionPoint, Manifest, RuntimeError,
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::Instant;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -57,143 +61,34 @@ fn token_jaccard_distance(left: &str, right: &str) -> f64 {
     1.0 - (intersection / union.max(1.0))
 }
 
-fn glob_to_regex(pattern: &str) -> String {
-    let mut regex = String::from("^");
-    for ch in pattern.chars() {
-        match ch {
-            '*' => regex.push_str(".*"),
-            '?' => regex.push('.'),
-            '.' | '+' | '(' | ')' | '[' | ']' | '{' | '}' | '^' | '$' | '|' | '\\' => {
-                regex.push('\\');
-                regex.push(ch);
-            }
-            _ => regex.push(ch),
-        }
-    }
-    regex.push('$');
-    regex
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PatternType {
-    Substring,
-    Regex,
-    Glob,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GovernancePattern {
-    pub pattern: String,
-    pub pattern_type: PatternType,
-}
-
-impl GovernancePattern {
-    pub fn substring(pattern: &str) -> Self {
-        Self {
-            pattern: pattern.to_string(),
-            pattern_type: PatternType::Substring,
-        }
-    }
-
-    pub fn regex(pattern: &str) -> Self {
-        Self {
-            pattern: pattern.to_string(),
-            pattern_type: PatternType::Regex,
-        }
-    }
-
-    pub fn glob(pattern: &str) -> Self {
-        Self {
-            pattern: pattern.to_string(),
-            pattern_type: PatternType::Glob,
-        }
-    }
-
-    pub fn matches(&self, text: &str) -> bool {
-        match self.pattern_type {
-            PatternType::Substring => text
-                .to_ascii_lowercase()
-                .contains(&self.pattern.to_ascii_lowercase()),
-            PatternType::Regex => crate::regex_cache::compiled_regex(&self.pattern)
-                .map(|regex| regex.is_match(text))
-                .unwrap_or(false),
-            PatternType::Glob => crate::regex_cache::compiled_regex(&glob_to_regex(&self.pattern))
-                .map(|regex| regex.is_match(text))
-                .unwrap_or(false),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GovernancePolicy {
-    pub name: String,
-    pub max_tool_calls: usize,
-    pub allowed_tools: Vec<String>,
-    pub blocked_patterns: Vec<GovernancePattern>,
-    pub require_human_approval: bool,
-    pub confidence_threshold: f64,
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct FrameworkHostConfig {
     pub drift_threshold: f64,
     pub checkpoint_frequency: usize,
 }
 
-impl GovernancePolicy {
-    pub fn validate(&self) -> Result<(), String> {
-        if self.max_tool_calls == 0 {
-            return Err("max_tool_calls must be greater than zero".to_string());
-        }
-        if !(0.0..=1.0).contains(&self.confidence_threshold) {
-            return Err("confidence_threshold must be between 0.0 and 1.0".to_string());
-        }
-        if !(0.0..=1.0).contains(&self.drift_threshold) {
-            return Err("drift_threshold must be between 0.0 and 1.0".to_string());
-        }
-        if self.checkpoint_frequency == 0 {
-            return Err("checkpoint_frequency must be greater than zero".to_string());
-        }
-        Ok(())
-    }
-
-    pub fn detect_conflicts(&self) -> Vec<String> {
-        let mut warnings = Vec::new();
-        if self.max_tool_calls == 0 && !self.allowed_tools.is_empty() {
-            warnings
-                .push("allowed_tools is non-empty but max_tool_calls blocks all calls".to_string());
-        }
-        if self.confidence_threshold == 0.0 {
-            warnings.push("confidence_threshold is 0.0, disabling confidence review".to_string());
-        }
-        warnings
-    }
-
-    pub fn allows_tool(&self, tool_name: Option<&str>) -> bool {
-        match tool_name {
-            None => true,
-            Some(tool) => self.allowed_tools.iter().any(|allowed| allowed == tool),
-        }
-    }
-
-    pub fn matches_payload(&self, payload: &str) -> Vec<String> {
-        self.blocked_patterns
-            .iter()
-            .filter(|pattern| pattern.matches(payload))
-            .map(|pattern| pattern.pattern.clone())
-            .collect()
-    }
-}
-
-impl Default for GovernancePolicy {
+impl Default for FrameworkHostConfig {
     fn default() -> Self {
         Self {
-            name: "default".to_string(),
-            max_tool_calls: 10,
-            allowed_tools: Vec::new(),
-            blocked_patterns: Vec::new(),
-            require_human_approval: false,
-            confidence_threshold: 0.8,
             drift_threshold: 0.15,
             checkpoint_frequency: 5,
         }
+    }
+}
+
+impl FrameworkHostConfig {
+    pub fn validate(self) -> Result<Self, RuntimeError> {
+        if !(0.0..=1.0).contains(&self.drift_threshold) {
+            return Err(RuntimeError::ManifestInvalid(
+                "framework host drift_threshold must be between 0.0 and 1.0".to_string(),
+            ));
+        }
+        if self.checkpoint_frequency == 0 {
+            return Err(RuntimeError::ManifestInvalid(
+                "framework host checkpoint_frequency must be greater than zero".to_string(),
+            ));
+        }
+        Ok(self)
     }
 }
 
@@ -299,7 +194,7 @@ pub enum FrameworkKind {
 pub struct FrameworkExecutionResult {
     pub decision: ExecutionResponse,
     pub requires_human_approval: bool,
-    pub matched_patterns: Vec<String>,
+    pub effective_payload: Option<String>,
     pub events: Vec<GovernanceEvent>,
 }
 
@@ -313,24 +208,97 @@ pub struct ResponseGovernanceAssessment {
 pub struct FrameworkGovernanceAdapter<H: GovernanceHook> {
     pub framework: FrameworkKind,
     middleware: GovernanceMiddleware<H>,
-    policy: GovernancePolicy,
+    control: AgentControl,
+    host_config: FrameworkHostConfig,
     event_log: Mutex<VecDeque<GovernanceEvent>>,
     tool_call_count: Mutex<usize>,
+    /// Usage the host reports via [`FrameworkGovernanceAdapter::record_usage`].
+    /// The adapter never sees model responses, so a host that wants manifest
+    /// budget rules on tokens or cost to fire has to feed these in.
+    token_count: Mutex<u64>,
+    cost_usd: Mutex<f64>,
+    started_at: Instant,
 }
 
 impl<H: GovernanceHook> FrameworkGovernanceAdapter<H> {
-    pub fn new(framework: FrameworkKind, hook: H) -> Self {
-        Self::with_policy(framework, hook, GovernancePolicy::default())
+    pub fn new(framework: FrameworkKind, hook: H, control: AgentControl) -> Self {
+        // The default config is valid by construction (0.15 is inside 0.0..=1.0
+        // and 5 is non-zero), so this path cannot fail and stays infallible.
+        Self::from_validated_config(framework, hook, control, FrameworkHostConfig::default())
     }
 
-    pub fn with_policy(framework: FrameworkKind, hook: H, policy: GovernancePolicy) -> Self {
+    /// Build an adapter from a caller-supplied host config.
+    ///
+    /// Returns [`RuntimeError::ManifestInvalid`] when the config is out of
+    /// range rather than panicking, so a host can surface the error.
+    pub fn with_host_config(
+        framework: FrameworkKind,
+        hook: H,
+        control: AgentControl,
+        host_config: FrameworkHostConfig,
+    ) -> Result<Self, RuntimeError> {
+        Ok(Self::from_validated_config(
+            framework,
+            hook,
+            control,
+            host_config.validate()?,
+        ))
+    }
+
+    /// Record model usage so manifest budget rules can see it.
+    ///
+    /// The adapter mediates requests but never observes model responses, so
+    /// token and cost budgets stay at zero unless the host reports usage here
+    /// after each model call. Elapsed time is tracked from construction.
+    pub fn record_usage(&self, tokens: u64, cost_usd: f64) {
+        *self
+            .token_count
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) += tokens;
+        *self.cost_usd.lock().unwrap_or_else(|e| e.into_inner()) += cost_usd;
+    }
+
+    fn from_validated_config(
+        framework: FrameworkKind,
+        hook: H,
+        control: AgentControl,
+        host_config: FrameworkHostConfig,
+    ) -> Self {
         Self {
             framework,
             middleware: GovernanceMiddleware::new(hook),
-            policy,
+            control,
+            host_config,
             event_log: Mutex::new(VecDeque::new()),
             tool_call_count: Mutex::new(0),
+            token_count: Mutex::new(0),
+            cost_usd: Mutex::new(0.0),
+            started_at: Instant::now(),
         }
+    }
+
+    pub fn from_manifest(
+        framework: FrameworkKind,
+        hook: H,
+        manifest: Manifest,
+    ) -> Result<Self, RuntimeError> {
+        Ok(Self::new(
+            framework,
+            hook,
+            AgentControl::from_manifest(manifest)?,
+        ))
+    }
+
+    pub fn from_path(
+        framework: FrameworkKind,
+        hook: H,
+        manifest_path: impl AsRef<Path>,
+    ) -> Result<Self, RuntimeError> {
+        Ok(Self::new(
+            framework,
+            hook,
+            AgentControl::from_path(manifest_path)?,
+        ))
     }
 
     pub fn execute(&self, actor: &str, action: &str, payload: Option<&str>) -> ExecutionResponse {
@@ -346,16 +314,16 @@ impl<H: GovernanceHook> FrameworkGovernanceAdapter<H> {
         .decision
     }
 
-    pub fn for_tower(hook: H, policy: GovernancePolicy) -> Self {
-        Self::with_policy(FrameworkKind::Tower, hook, policy)
+    pub fn for_tower(hook: H, control: AgentControl) -> Self {
+        Self::new(FrameworkKind::Tower, hook, control)
     }
 
-    pub fn for_axum(hook: H, policy: GovernancePolicy) -> Self {
-        Self::with_policy(FrameworkKind::Axum, hook, policy)
+    pub fn for_axum(hook: H, control: AgentControl) -> Self {
+        Self::new(FrameworkKind::Axum, hook, control)
     }
 
-    pub fn for_actix(hook: H, policy: GovernancePolicy) -> Self {
-        Self::with_policy(FrameworkKind::Actix, hook, policy)
+    pub fn for_actix(hook: H, control: AgentControl) -> Self {
+        Self::new(FrameworkKind::Actix, hook, control)
     }
 
     pub fn evaluate_request(
@@ -364,88 +332,118 @@ impl<H: GovernanceHook> FrameworkGovernanceAdapter<H> {
         tool_name: Option<&str>,
         confidence: Option<f64>,
     ) -> FrameworkExecutionResult {
+        let tool_call_count = *self
+            .tool_call_count
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let token_count = *self.token_count.lock().unwrap_or_else(|e| e.into_inner());
+        let cost_usd = *self.cost_usd.lock().unwrap_or_else(|e| e.into_inner());
+        let elapsed_seconds = self.started_at.elapsed().as_secs_f64();
         let mut events = vec![self.emit_event(
             GovernanceEventType::PolicyCheck,
             &request.actor,
             &request.action,
-            format!("policy '{}' evaluated request", self.policy.name),
+            "ACS evaluated request".to_string(),
         )];
-
-        let matched_patterns = request
-            .payload
-            .as_deref()
-            .map(|payload| self.policy.matches_payload(payload))
-            .unwrap_or_default();
-        if !matched_patterns.is_empty() {
+        let (intervention_point, snapshot) = match tool_name {
+            Some(tool) => (
+                InterventionPoint::PreToolCall,
+                serde_json::json!({
+                    "envelope": {
+                        "agent": {"id": request.actor},
+                        "session": {"id": format!("rust-framework-{}", request.actor)},
+                        "intervention_point": "pre_tool_call",
+                        "budgets": {
+                            "tool_call_count": tool_call_count,
+                            "token_count": token_count,
+                            "elapsed_seconds": elapsed_seconds,
+                            "cost_usd": cost_usd
+                        }
+                    },
+                    "tool_call": {
+                        "name": tool,
+                        "args": {"payload": request.payload, "confidence": confidence},
+                        "id": format!("{}-{}", request.actor, tool_call_count + 1)
+                    }
+                }),
+            ),
+            None => (
+                InterventionPoint::Input,
+                serde_json::json!({
+                    "envelope": {
+                        "agent": {"id": request.actor},
+                        "session": {"id": format!("rust-framework-{}", request.actor)},
+                        "intervention_point": "input",
+                        "budgets": {
+                            "tool_call_count": tool_call_count,
+                            "token_count": token_count,
+                            "elapsed_seconds": elapsed_seconds,
+                            "cost_usd": cost_usd
+                        }
+                    },
+                    "input": {
+                        "body": request.payload,
+                        "source": "host",
+                        "headers": {}
+                    }
+                }),
+            ),
+        };
+        let evaluation = self.control.evaluate_intervention_point(
+            intervention_point,
+            snapshot,
+            EnforcementMode::Enforce,
+        );
+        let requires_human_approval = evaluation.verdict.decision == Decision::Escalate;
+        if !evaluation.verdict.decision.permits() {
+            let reason = evaluation
+                .verdict
+                .reason
+                .clone()
+                .unwrap_or_else(|| "policy denied request".to_string());
             events.push(self.emit_event(
-                GovernanceEventType::PolicyViolation,
-                &request.actor,
-                &request.action,
-                format!(
-                    "blocked payload patterns matched: {}",
-                    matched_patterns.join(", ")
-                ),
-            ));
-            return FrameworkExecutionResult {
-                decision: ExecutionResponse {
-                    allowed: false,
-                    reason: Some("blocked by governance policy patterns".to_string()),
+                if tool_name.is_some() {
+                    GovernanceEventType::ToolCallBlocked
+                } else {
+                    GovernanceEventType::PolicyViolation
                 },
-                requires_human_approval: false,
-                matched_patterns,
-                events,
-            };
-        }
-
-        if !self.policy.allows_tool(tool_name) {
-            events.push(self.emit_event(
-                GovernanceEventType::ToolCallBlocked,
                 &request.actor,
                 &request.action,
-                format!("tool '{}' is not permitted", tool_name.unwrap_or("<none>")),
+                reason.clone(),
             ));
             return FrameworkExecutionResult {
                 decision: ExecutionResponse {
                     allowed: false,
-                    reason: Some("tool is not allowed by governance policy".to_string()),
-                },
-                requires_human_approval: false,
-                matched_patterns,
-                events,
-            };
-        }
-
-        let requires_human_approval = self.policy.require_human_approval
-            || confidence
-                .map(|score| score < self.policy.confidence_threshold)
-                .unwrap_or(false);
-        if requires_human_approval {
-            events.push(self.emit_event(
-                GovernanceEventType::PolicyViolation,
-                &request.actor,
-                &request.action,
-                "request requires human approval".to_string(),
-            ));
-            return FrameworkExecutionResult {
-                decision: ExecutionResponse {
-                    allowed: false,
-                    reason: Some("request requires human approval".to_string()),
+                    reason: Some(reason),
                 },
                 requires_human_approval,
-                matched_patterns,
+                effective_payload: None,
                 events,
             };
         }
 
-        let hook_decision = self.middleware.execute(&request);
-        let checkpoint = self.record_tool_call(&request.actor, &request.action);
-        if let Some(event) = checkpoint {
-            events.push(event);
+        let effective_payload = evaluation
+            .transformed_policy_target
+            .as_ref()
+            .map(|value| match value {
+                serde_json::Value::String(text) => text.clone(),
+                other => other.to_string(),
+            })
+            .or_else(|| request.payload.clone());
+        let effective_request = ExecutionRequest {
+            payload: effective_payload.clone(),
+            ..request.clone()
+        };
+        let hook_decision = self.middleware.execute(&effective_request);
+        if tool_name.is_some() {
+            if let Some(event) = self.record_tool_call(&request.actor, &request.action) {
+                events.push(event);
+            }
         }
         FrameworkExecutionResult {
             decision: hook_decision,
             requires_human_approval: false,
-            matched_patterns,
+            effective_payload,
             events,
         }
     }
@@ -460,7 +458,8 @@ impl<H: GovernanceHook> FrameworkGovernanceAdapter<H> {
         let prompt_defense = PromptDefenseEvaluator::evaluate_report(response_body);
         let mut events = Vec::new();
         let drift = baseline.map(|baseline| {
-            let drift = DriftResult::compare(baseline, response_body, self.policy.drift_threshold);
+            let drift =
+                DriftResult::compare(baseline, response_body, self.host_config.drift_threshold);
             if drift.exceeded {
                 events.push(self.emit_event(
                     GovernanceEventType::DriftDetected,
@@ -515,14 +514,16 @@ impl<H: GovernanceHook> FrameworkGovernanceAdapter<H> {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         *tool_call_count += 1;
-        (*tool_call_count % self.policy.checkpoint_frequency == 0).then(|| {
-            self.emit_event(
-                GovernanceEventType::CheckpointCreated,
-                actor,
-                action,
-                format!("checkpoint created after {} tool calls", tool_call_count),
-            )
-        })
+        (*tool_call_count)
+            .is_multiple_of(self.host_config.checkpoint_frequency)
+            .then(|| {
+                self.emit_event(
+                    GovernanceEventType::CheckpointCreated,
+                    actor,
+                    action,
+                    format!("checkpoint created after {} tool calls", tool_call_count),
+                )
+            })
     }
 }
 
@@ -1374,6 +1375,8 @@ impl DiscoveryScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_control_specification::{PolicyDispatcher, PreparedPolicyInvocation};
+    use std::sync::Arc;
     use tempfile::tempdir;
 
     struct DemoHook;
@@ -1394,6 +1397,137 @@ mod tests {
         }
     }
 
+    /// Captures the snapshot each evaluation receives so tests can assert on
+    /// the budget block the adapter sends to the runtime.
+    #[derive(Clone, Default)]
+    struct CapturingPolicy {
+        seen: Arc<Mutex<Vec<serde_json::Value>>>,
+    }
+
+    impl PolicyDispatcher for CapturingPolicy {
+        fn evaluate(
+            &self,
+            invocation: &PreparedPolicyInvocation,
+        ) -> Result<serde_json::Value, RuntimeError> {
+            self.seen
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(serde_json::to_value(invocation).unwrap_or_default());
+            Ok(serde_json::json!({"decision": "allow", "reason": null}))
+        }
+    }
+
+    struct StaticPolicy {
+        decision: &'static str,
+        reason: Option<&'static str>,
+        transform: Option<&'static str>,
+    }
+
+    impl PolicyDispatcher for StaticPolicy {
+        fn evaluate(
+            &self,
+            _invocation: &PreparedPolicyInvocation,
+        ) -> Result<serde_json::Value, RuntimeError> {
+            let mut output = serde_json::json!({
+                "decision": self.decision,
+                "reason": self.reason,
+            });
+            if let Some(value) = self.transform {
+                output["transform"] = serde_json::json!({
+                    "path": "$policy_target",
+                    "value": value,
+                });
+            }
+            Ok(output)
+        }
+    }
+
+    fn control(decision: &'static str, reason: Option<&'static str>) -> AgentControl {
+        let manifest = Manifest::from_yaml_str(
+            r#"
+agent_control_specification_version: 0.3.1-beta
+policies:
+  integration:
+    type: custom
+    adapter: integration_test
+intervention_points:
+  input:
+    policy_target: $.input.body
+    policy:
+      id: integration
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    tool_name_from: $.tool_call.name
+    policy:
+      id: integration
+tools:
+  read_file:
+    clearance: public
+"#,
+        )
+        .unwrap();
+        AgentControl::from_manifest_with_dispatchers(
+            manifest,
+            None,
+            Some(Arc::new(StaticPolicy {
+                decision,
+                reason,
+                transform: None,
+            })),
+        )
+        .unwrap()
+    }
+
+    fn capturing_control(policy: CapturingPolicy) -> AgentControl {
+        let manifest = Manifest::from_yaml_str(
+            r#"
+agent_control_specification_version: 0.3.1-beta
+policies:
+  integration:
+    type: custom
+    adapter: integration_test
+intervention_points:
+  input:
+    policy_target: $.input.body
+    policy:
+      id: integration
+tools:
+  read_file:
+    clearance: public
+"#,
+        )
+        .unwrap();
+        AgentControl::from_manifest_with_dispatchers(manifest, None, Some(Arc::new(policy))).unwrap()
+    }
+
+    fn transform_control(value: &'static str) -> AgentControl {
+        let manifest = Manifest::from_yaml_str(
+            r#"
+agent_control_specification_version: 0.3.1-beta
+policies:
+  integration:
+    type: custom
+    adapter: integration_test
+intervention_points:
+  input:
+    policy_target: $.input.body
+    policy:
+      id: integration
+"#,
+        )
+        .unwrap();
+        AgentControl::from_manifest_with_dispatchers(
+            manifest,
+            None,
+            Some(Arc::new(StaticPolicy {
+                decision: "transform",
+                reason: Some("redacted"),
+                transform: Some(value),
+            })),
+        )
+        .unwrap()
+    }
+
     #[test]
     fn middleware_invokes_hook() {
         let middleware = GovernanceMiddleware::new(DemoHook);
@@ -1407,44 +1541,36 @@ mod tests {
 
     #[test]
     fn framework_adapter_executes_requests() {
-        let adapter = FrameworkGovernanceAdapter::new(FrameworkKind::Tower, DemoHook);
+        let adapter =
+            FrameworkGovernanceAdapter::new(FrameworkKind::Tower, DemoHook, control("allow", None));
         let result = adapter.execute("agent", "data.read", None);
         assert!(result.allowed);
     }
 
     #[test]
-    fn governance_policy_blocks_payload_and_tools() {
-        let policy = GovernancePolicy {
-            allowed_tools: vec!["read_file".into()],
-            blocked_patterns: vec![
-                GovernancePattern::substring("password"),
-                GovernancePattern::regex(r"rm\s+-rf"),
-            ],
-            ..GovernancePolicy::default()
-        };
-        let adapter =
-            FrameworkGovernanceAdapter::with_policy(FrameworkKind::Axum, DemoHook, policy);
+    fn framework_adapter_surfaces_acs_denial() {
+        let adapter = FrameworkGovernanceAdapter::new(
+            FrameworkKind::Axum,
+            DemoHook,
+            control("deny", Some("blocked_payload")),
+        );
         let result = adapter.evaluate_request(
             ExecutionRequest {
                 actor: "agent".into(),
                 action: "tools.call".into(),
                 payload: Some("contains password".into()),
             },
-            Some("write_file"),
+            Some("read_file"),
             Some(0.95),
         );
         assert!(!result.decision.allowed);
-        assert!(!result.matched_patterns.is_empty());
+        assert_eq!(result.decision.reason.as_deref(), Some("blocked_payload"));
     }
 
     #[test]
-    fn framework_adapter_requires_review_for_low_confidence() {
-        let policy = GovernancePolicy {
-            confidence_threshold: 0.9,
-            allowed_tools: vec!["read_file".into()],
-            ..GovernancePolicy::default()
-        };
-        let adapter = FrameworkGovernanceAdapter::for_tower(DemoHook, policy);
+    fn framework_adapter_requires_review_for_escalate() {
+        let adapter =
+            FrameworkGovernanceAdapter::for_tower(DemoHook, control("escalate", Some("review")));
         let result = adapter.evaluate_request(
             ExecutionRequest {
                 actor: "agent".into(),
@@ -1459,31 +1585,55 @@ mod tests {
     }
 
     #[test]
-    fn framework_adapter_denies_tools_without_explicit_allowlist() {
-        let adapter = FrameworkGovernanceAdapter::for_tower(DemoHook, GovernancePolicy::default());
+    fn framework_adapter_applies_acs_transform_to_hook_payload() {
+        let adapter = FrameworkGovernanceAdapter::new(
+            FrameworkKind::Tower,
+            DemoHook,
+            transform_control("safe"),
+        );
         let result = adapter.evaluate_request(
             ExecutionRequest {
                 actor: "agent".into(),
-                action: "tools.call".into(),
-                payload: None,
+                action: "data.read".into(),
+                payload: Some("secret".into()),
             },
-            Some("read_file"),
-            Some(0.95),
+            None,
+            None,
         );
-        assert!(!result.decision.allowed);
-        assert_eq!(
-            result.decision.reason.as_deref(),
-            Some("tool is not allowed by governance policy")
-        );
+        assert!(result.decision.allowed);
+        assert_eq!(result.effective_payload.as_deref(), Some("safe"));
+    }
+
+    #[test]
+    fn legacy_governance_shape_is_rejected_as_manifest_invalid() {
+        let error = Manifest::from_yaml_str(
+            r#"
+name: legacy
+max_tool_calls: 10
+allowed_tools: [read_file]
+blocked_patterns: [password]
+"#,
+        )
+        .unwrap_err();
+        assert_eq!(error.reason(), "runtime_error:manifest_invalid");
+        assert!(error
+            .detail()
+            .contains("agent_control_specification_version"));
     }
 
     #[test]
     fn framework_adapter_assesses_response_drift() {
-        let policy = GovernancePolicy {
+        let host_config = FrameworkHostConfig {
             drift_threshold: 0.10,
-            ..GovernancePolicy::default()
+            ..FrameworkHostConfig::default()
         };
-        let adapter = FrameworkGovernanceAdapter::for_actix(DemoHook, policy);
+        let adapter = FrameworkGovernanceAdapter::with_host_config(
+            FrameworkKind::Actix,
+            DemoHook,
+            control("allow", None),
+            host_config,
+        )
+        .expect("valid host config");
         let assessment = adapter.assess_response(
             "agent",
             "respond",
@@ -1721,8 +1871,7 @@ mod tests {
     #[test]
     fn token_jaccard_distance_increases_with_drift() {
         // Quarter-overlap should score around 0.6–0.7 distance — well
-        // above the typical 0.10–0.15 drift threshold used in
-        // GovernancePolicy::default().
+        // above the typical 0.10–0.15 host drift threshold.
         let dist = token_jaccard_distance("alpha beta gamma delta", "alpha epsilon zeta theta");
         assert!(dist > 0.5, "expected drift > 0.5, got {dist}");
         assert!(dist < 1.0, "expected drift < 1.0, got {dist}");
@@ -1743,5 +1892,39 @@ mod tests {
         let drift = DriftResult::compare("same text here", "same text here", 0.1);
         assert!(!drift.exceeded);
         assert!(drift.score.abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn recorded_usage_reaches_the_budget_block_the_runtime_sees() {
+        let policy = CapturingPolicy::default();
+        let adapter = FrameworkGovernanceAdapter::new(
+            FrameworkKind::Tower,
+            DemoHook,
+            capturing_control(policy.clone()),
+        );
+
+        adapter.record_usage(1200, 0.25);
+        adapter.record_usage(34, 0.05);
+
+        let _ = adapter.evaluate_request(
+            ExecutionRequest {
+                actor: "agent".into(),
+                action: "data.read".into(),
+                payload: Some("hello".into()),
+            },
+            None,
+            None,
+        );
+
+        let seen = policy.seen.lock().unwrap_or_else(|e| e.into_inner());
+        let text = serde_json::to_string(&*seen).unwrap();
+        assert!(
+            text.contains("1234"),
+            "accumulated token_count missing from snapshot: {text}"
+        );
+        assert!(
+            !text.contains("\"token_count\":0"),
+            "token_count still hard-coded to zero: {text}"
+        );
     }
 }

--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -58,6 +58,8 @@ pub mod trust;
 pub mod trust_support;
 pub mod types;
 
+pub use agent_control_specification::{AgentControl, Manifest};
+
 pub use agentmesh_mcp::mcp::*;
 pub use audit::AuditLogger;
 pub use control_support::{
@@ -93,11 +95,10 @@ pub use integration_support::{
     DiscoveryInventorySummary, DiscoveryReconciler, DiscoveryRecord, DiscoveryRiskAssessment,
     DiscoveryRiskLevel, DiscoveryRiskScorer, DiscoveryScanResult, DiscoveryScanner,
     DiscoveryStatus, DriftResult, ExecutionRequest, ExecutionResponse, FrameworkAdapter,
-    FrameworkExecutionResult, FrameworkGovernanceAdapter, FrameworkKind, FrameworkResponse,
-    GovernanceEvent, GovernanceEventType, GovernanceHook, GovernanceMiddleware, GovernancePattern,
-    GovernancePolicy, PatternType, ProcessSnapshot, PromptDefenseEvaluator, PromptDefenseFinding,
-    PromptDefenseReport, PromptRiskLevel, RegisteredAgent, ResponseGovernanceAssessment,
-    ShadowAgent,
+    FrameworkExecutionResult, FrameworkGovernanceAdapter, FrameworkHostConfig, FrameworkKind,
+    FrameworkResponse, GovernanceEvent, GovernanceEventType, GovernanceHook, GovernanceMiddleware,
+    ProcessSnapshot, PromptDefenseEvaluator, PromptDefenseFinding, PromptDefenseReport,
+    PromptRiskLevel, RegisteredAgent, ResponseGovernanceAssessment, ShadowAgent,
 };
 pub use lifecycle::{LifecycleEvent, LifecycleManager, LifecycleState};
 pub use policy::{PolicyEngine, PolicyError};

--- a/docs/dependency-audits/2026-07-27-rust-acs-dependency.md
+++ b/docs/dependency-audits/2026-07-27-rust-acs-dependency.md
@@ -1,0 +1,66 @@
+---
+title: Rust agentmesh crate takes the ACS workspace dependency
+last_reviewed: 2026-07-27
+owner: liamcrumm
+---
+
+# Rust agentmesh crate takes the ACS workspace dependency
+
+## Which Dependencies Changed And Why
+
+No third-party crate was added or upgraded. `agent-governance-rust/Cargo.lock`
+gains `agent_control_specification` because the `agentmesh` crate now evaluates
+policy through the ACS engine instead of the vendored v4 path.
+
+The dependency is a path entry pointing at `policy-engine/sdk/rust` inside this
+repository, so it resolves to the workspace source rather than a registry
+release. The lockfile was regenerated with `cargo generate-lockfile --offline`
+and checked with `cargo metadata --offline --locked`, which fails if the
+committed lockfile disagrees with the manifests.
+
+## Security Advisory Relevance
+
+No CVE or RustSec advisory is addressed.
+
+The direct dependency added to `agentmesh` is first-party and MIT licensed, and
+it is the same engine the Python and TypeScript surfaces evaluate against, so
+the three stop being able to disagree about a policy outcome.
+
+It is not free of transitive cost. `Cargo.lock` gains 66 package entries: the
+two first-party crates (`agent_control_specification`,
+`agent_control_specification_core`) and **64 third-party crates that were not
+previously in the workspace graph**, pulled in by the engine's manifest
+validation and its unicode handling:
+
+`adler2`, `ahash`, `bytecount`, `crc32fast`, `displaydoc`, `fancy-regex`, `flate2`, `form_urlencoded`, `fraction`, `futures-task`, `futures-util`, `icu_collections`, `icu_locale_core`, `icu_normalizer`, `icu_normalizer_data`, `icu_properties`, `icu_properties_data`, `icu_provider`, `idna`, `idna_adapter`, `iso8601`, `jsonschema`, `litemap`, `miniz_oxide`, `nom`, `num`, `num-cmp`, `num-complex`, `num-iter`, `num-rational`, `percent-encoding`, `potential_utf`, `ring`, `rustls`, `rustls-pki-types`, `rustls-webpki`, `simd-adler32`, `slab`, `stable_deref_trait`, `synstructure`, `tinystr`, `untrusted`, `ureq`, `url`, `utf8_iter`, `uuid`, `webpki-roots`, `windows-targets`, `windows_aarch64_gnullvm`, `windows_aarch64_msvc`, `windows_i686_gnu`, `windows_i686_gnullvm`, `windows_i686_msvc`, `windows_x86_64_gnu`, `windows_x86_64_gnullvm`, `windows_x86_64_msvc`, `writeable`, `yoke`, `yoke-derive`, `zerofrom`, `zerofrom-derive`, `zerotrie`, `zerovec`, `zerovec-derive`
+
+Two clusters account for nearly all of it.
+
+**Manifest validation.** `jsonschema` brings `fancy-regex`, `fraction`, `num*`,
+`referencing`, and the `icu_*` unicode tables through `idna`/`url`.
+
+**An HTTP and TLS stack, which matters more.** `ureq`, `rustls`, `ring`, and
+`webpki-roots` are all new to this graph. They arrive because the ACS Rust SDK
+pins its core features to include `openai_moderation`, `perspective`,
+`llama_guard`, `lakera_guard`, and `auto`, and because `Manifest::from_url`
+exists. `agentmesh` cannot opt out: the feature set is fixed inside the SDK
+crate, not selected by the consumer.
+
+Nothing in `agentmesh` calls a remote annotator or `from_url`, so no egress is
+added by this change in practice. The capability is now linked in, though, and
+for a governance library that is worth stating plainly rather than describing
+the change as pulling nothing new. Narrowing the SDK's feature set so hosts can
+build without the network stack is a follow-up on the ACS crate, not on this
+PR.
+
+`cargo deny` and `cargo audit` coverage should be confirmed against the new set
+before release.
+
+## Breaking Change Risk Assessment
+
+Low. A path dependency inside the workspace changes no published version
+constraint for downstream crates, and `cargo check --offline --workspace`
+compiles with the crate's four pre-existing warnings unchanged.
+
+The user-visible breaking change is the removal of the v4 policy language
+itself, which `BREAKING_CHANGES.md` covers.

--- a/scripts/v4_ratchet_baseline.json
+++ b/scripts/v4_ratchet_baseline.json
@@ -1,10 +1,9 @@
 {
-  "grand_total": 655,
+  "grand_total": 628,
   "package_totals": {
     "CHANGELOG.md": 2,
     "agent-governance-golang/examples": 1,
     "agent-governance-python/agt-policies": 28,
-    "agent-governance-rust/agentmesh": 27,
     "docs/ERROR_HANDLING.md": 3,
     "docs/FAQ.md": 3,
     "docs/LIMITATIONS.md": 1,
@@ -60,14 +59,6 @@
     "agent-governance-python/agt-policies/tests/test_manifest_resolution.py": {
       "discover_policies": 7,
       "import:agt.manifest_resolution": 2
-    },
-    "agent-governance-rust/agentmesh/src/integration_support.rs": {
-      "GovernancePolicy": 17,
-      "PatternType": 8
-    },
-    "agent-governance-rust/agentmesh/src/lib.rs": {
-      "GovernancePolicy": 1,
-      "PatternType": 1
     },
     "docs/ERROR_HANDLING.md": {
       "PolicyDocument": 3
@@ -488,8 +479,8 @@
       "resolution_root": 2
     },
     "scripts/v4_ratchet_baseline.json": {
-      "GovernancePolicy": 73,
-      "PolicyDocument": 60,
+      "GovernancePolicy": 35,
+      "PolicyDocument": 41,
       "v4_policy_document_file": 1
     }
   },


### PR DESCRIPTION
## Summary

Moves the Rust `agentmesh` crate onto ACS v5 manifests so it evaluates policy through the same engine as the Python runtime. PR 2 of 4 in the v4 policy-language removal.

## Problem

The Rust SDK still built policy input in the v4 shape and evaluated it with a vendored copy of the old logic. That meant a policy could behave differently in Rust than in Python, and the crate had no way to consume the ACS manifests that the rest of the toolkit now produces.

## Changes

| File | What changed |
|------|-------------|
| `agent-governance-rust/agentmesh/Cargo.toml` | Depends on the `agent_control_specification` workspace crate. |
| `agent-governance-rust/Cargo.toml`, `Cargo.lock` | Declares the ACS path dependency and regenerates the lockfile. |
| `agent-governance-rust/agentmesh/src/lib.rs`, `integration_support.rs` | Policy evaluation goes through ACS instead of the v4 code path. |
| `agent-governance-rust/agentmesh/MIGRATION_V5.md` | Migration notes for crate consumers. |
| `docs/dependency-audits/2026-07-27-rust-acs-dependency.md` | Dependency audit for the lockfile change. |
| `scripts/v4_ratchet_baseline.json` | Regenerated, as every PR in this stack must. |

| `integration_support.rs` | `with_host_config` returns `Result` instead of panicking on an out-of-range config. `new` stays infallible because the default is valid by construction. |
| `integration_support.rs` | Removes `FrameworkExecutionResult::matched_patterns`. ACS returns a verdict and reason rather than a match list, so the field had no source and returned an empty vector on every call. Removing it gives callers a compile error instead of silently no matches. |
| `integration_support.rs` | Budgets are no longer hard-coded to zero. Elapsed time is tracked from construction and `record_usage` lets a host report tokens and cost, which is the only place that data exists. Without it, manifest budget rules on tokens or cost never fired. |
| `MIGRATION_V5.md` | Documents all three. |

## Testing

- `cargo check --offline --workspace`: compiles, with the crate's four pre-existing warnings unchanged
- `cargo metadata --offline --locked`: the committed lockfile matches the manifests
- `scripts/check_v4_ratchet.py`: passes, marker count drops from 656 to 629
- `scripts/tests/test_check_v4_ratchet.py`: 35 passed

## Stack

Based on the Python runtime PR. Merges cleanly once that lands, without a branch update.

