### PR TITLE
feat(rust): add accumulated context governance

### DIFF
--- a/agent-governance-rust/agentmesh/README.md
+++ b/agent-governance-rust/agentmesh/README.md
@@ -400,6 +400,7 @@ let rules = [AggregationRule::new(
     ["pii", "financial"],
     DataClassification::Restricted,
 )
+.expect("aggregation rules require labels")
 .with_restrictions(["no_external_export"])];
 
 let envelope = ContextEnvelope::new("env-1", "workflow-1");

--- a/agent-governance-rust/agentmesh/README.md
+++ b/agent-governance-rust/agentmesh/README.md
@@ -383,10 +383,11 @@ YAML-based policy engine with four-way decisions (allow / deny / requires-approv
 | `engine.load_from_file(path)` | Load rules from a YAML file |
 | `engine.evaluate(action, context)` | Evaluate an action against loaded policy |
 
-### Accumulated Context (`context.rs`)
+### Accumulated Context (`context.rs`, `context_audit.rs`)
 
 Workflow-scoped governance that folds actual result labels after execution, then gates later
-actions against the accumulated sensitivity and restrictions.
+actions against the accumulated sensitivity and restrictions. Transition audit events record
+only the envelope delta and carry the higher of the before/after sensitivity classifications.
 
 ```rust
 use agentmesh::context::{

--- a/agent-governance-rust/agentmesh/README.md
+++ b/agent-governance-rust/agentmesh/README.md
@@ -383,6 +383,46 @@ YAML-based policy engine with four-way decisions (allow / deny / requires-approv
 | `engine.load_from_file(path)` | Load rules from a YAML file |
 | `engine.evaluate(action, context)` | Evaluate an action against loaded policy |
 
+### Accumulated Context (`context.rs`)
+
+Workflow-scoped governance that folds actual result labels after execution, then gates later
+actions against the accumulated sensitivity and restrictions.
+
+```rust
+use agentmesh::context::{
+    accumulate, decide_next, to_policy_decision, AggregationRule, ContextEnvelope,
+};
+use agentmesh::{DataClassification, PolicyDecision};
+
+let rules = [AggregationRule::new(
+    "customer_profile",
+    ["pii", "financial"],
+    DataClassification::Restricted,
+)
+.with_restrictions(["no_external_export"])];
+
+let envelope = ContextEnvelope::new("env-1", "workflow-1");
+let envelope = accumulate(
+    &envelope,
+    ["pii", "financial"],
+    DataClassification::Confidential,
+    &rules,
+    3,
+);
+let decision = decide_next(
+    &envelope,
+    "export",
+    &rules,
+    3,
+    DataClassification::Restricted,
+);
+
+assert!(matches!(
+    to_policy_decision(&decision, false),
+    PolicyDecision::Deny(_)
+));
+```
+
 ### Trust (`trust.rs`)
 
 Integer trust scoring (0–1000) across five tiers with optional JSON persistence.

--- a/agent-governance-rust/agentmesh/src/context.rs
+++ b/agent-governance-rust/agentmesh/src/context.rs
@@ -289,8 +289,8 @@ pub fn decide_next(
         "memory_write" => Some("no_memory_write"),
         _ => None,
     };
-    let restriction_present =
-        gating_restriction.is_some_and(|restriction| envelope.restrictions.contains(restriction));
+    let restriction_present = gating_restriction
+        .is_some_and(|restriction| aggregation.restrictions.contains(restriction));
     let floor_triggered =
         gating_restriction.is_some() && aggregation.aggregate_sensitivity >= restricted_floor;
 
@@ -306,7 +306,7 @@ pub fn decide_next(
         return ContextDecision {
             outcome: ContextOutcome::Constrain,
             obligations: ObligationSet {
-                obligations: envelope
+                obligations: aggregation
                     .restrictions
                     .iter()
                     .map(|restriction| Obligation {
@@ -511,6 +511,32 @@ mod tests {
         let floor_decision =
             decide_next(&floor, "delegate", &[], 99, DataClassification::Restricted);
         assert_eq!(floor_decision.outcome, ContextOutcome::Constrain);
+    }
+
+    #[test]
+    fn rule_implied_restrictions_gate_without_prior_accumulation() {
+        let rules = [aggregation_rule()];
+        let envelope = ContextEnvelope::new("env-1", "workflow-1")
+            .fold(["pii", "financial"], DataClassification::Internal);
+
+        assert!(envelope.restrictions().is_empty());
+
+        let decision = decide_next(
+            &envelope,
+            "export",
+            &rules,
+            3,
+            DataClassification::TopSecret,
+        );
+
+        assert_eq!(decision.outcome, ContextOutcome::Constrain);
+        assert_eq!(
+            decision.obligations.obligations,
+            vec![Obligation {
+                key: "no_external_export".to_string(),
+                satisfied: false,
+            }]
+        );
     }
 
     #[test]

--- a/agent-governance-rust/agentmesh/src/context.rs
+++ b/agent-governance-rust/agentmesh/src/context.rs
@@ -297,11 +297,11 @@ pub fn decide_next(
     if restriction_present || floor_triggered {
         let reason = if restriction_present {
             format!(
-                "action {action:?} restricted by {:?}",
+                "action '{action}' restricted by '{}'",
                 gating_restriction.expect("restriction checked above")
             )
         } else {
-            format!("action {action:?} gated by sensitivity floor")
+            format!("action '{action}' gated by sensitivity floor")
         };
         return ContextDecision {
             outcome: ContextOutcome::Constrain,

--- a/agent-governance-rust/agentmesh/src/context.rs
+++ b/agent-governance-rust/agentmesh/src/context.rs
@@ -1,0 +1,565 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Accumulated context governance for multi-step agent workflows.
+//!
+//! The semantic contract follows the Python implementation introduced in
+//! <https://github.com/microsoft/agent-governance-toolkit/pull/2800>.
+
+use crate::governance_support::DataClassification;
+use crate::types::PolicyDecision;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// Immutable, versioned governance state accumulated by a workflow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextEnvelope {
+    envelope_id: String,
+    workflow_id: String,
+    labels: BTreeSet<String>,
+    aggregate_sensitivity: DataClassification,
+    restrictions: BTreeSet<String>,
+    version: u64,
+    parent_envelope_id: Option<String>,
+    created_at: String,
+}
+
+impl ContextEnvelope {
+    /// Create an empty public envelope.
+    pub fn new(envelope_id: impl Into<String>, workflow_id: impl Into<String>) -> Self {
+        Self {
+            envelope_id: envelope_id.into(),
+            workflow_id: workflow_id.into(),
+            labels: BTreeSet::new(),
+            aggregate_sensitivity: DataClassification::Public,
+            restrictions: BTreeSet::new(),
+            version: 0,
+            parent_envelope_id: None,
+            created_at: String::new(),
+        }
+    }
+
+    /// Record the parent envelope for a delegated workflow.
+    pub fn with_parent_envelope_id(mut self, parent_envelope_id: impl Into<String>) -> Self {
+        self.parent_envelope_id = Some(parent_envelope_id.into());
+        self
+    }
+
+    /// Attach a caller-supplied timestamp without reading the wall clock.
+    pub fn with_created_at(mut self, created_at: impl Into<String>) -> Self {
+        self.created_at = created_at.into();
+        self
+    }
+
+    pub fn envelope_id(&self) -> &str {
+        &self.envelope_id
+    }
+
+    pub fn workflow_id(&self) -> &str {
+        &self.workflow_id
+    }
+
+    pub fn labels(&self) -> &BTreeSet<String> {
+        &self.labels
+    }
+
+    pub fn aggregate_sensitivity(&self) -> DataClassification {
+        self.aggregate_sensitivity
+    }
+
+    pub fn restrictions(&self) -> &BTreeSet<String> {
+        &self.restrictions
+    }
+
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    pub fn parent_envelope_id(&self) -> Option<&str> {
+        self.parent_envelope_id.as_deref()
+    }
+
+    pub fn created_at(&self) -> &str {
+        &self.created_at
+    }
+
+    /// Return the next envelope after joining actual result labels and sensitivity.
+    pub fn fold<I, S>(&self, new_labels: I, new_sensitivity: DataClassification) -> ContextEnvelope
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut next = self.clone();
+        next.labels.extend(new_labels.into_iter().map(Into::into));
+        next.aggregate_sensitivity = next.aggregate_sensitivity.max(new_sensitivity);
+        next.version = next
+            .version
+            .checked_add(1)
+            .expect("context envelope version overflow");
+        next
+    }
+
+    /// Return the next envelope after adding restrictions.
+    pub fn apply_restrictions<I, S>(&self, restrictions: I) -> ContextEnvelope
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut next = self.clone();
+        next.restrictions
+            .extend(restrictions.into_iter().map(Into::into));
+        next.version = next
+            .version
+            .checked_add(1)
+            .expect("context envelope version overflow");
+        next
+    }
+
+    /// Project the envelope onto the only value intended to cross a trust boundary.
+    pub fn reference(&self) -> EnvelopeReference {
+        EnvelopeReference {
+            envelope_id: self.envelope_id.clone(),
+            sensitivity: self.aggregate_sensitivity,
+        }
+    }
+}
+
+/// Opaque cross-boundary handle that does not expose envelope contents.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvelopeReference {
+    pub envelope_id: String,
+    pub sensitivity: DataClassification,
+}
+
+/// Organization-authored rule over a combination of accumulated labels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregationRule {
+    pub name: String,
+    pub all_labels: BTreeSet<String>,
+    pub sets_sensitivity: DataClassification,
+    pub adds_restrictions: BTreeSet<String>,
+}
+
+impl AggregationRule {
+    pub fn new<I, S>(
+        name: impl Into<String>,
+        all_labels: I,
+        sets_sensitivity: DataClassification,
+    ) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            name: name.into(),
+            all_labels: all_labels.into_iter().map(Into::into).collect(),
+            sets_sensitivity,
+            adds_restrictions: BTreeSet::new(),
+        }
+    }
+
+    pub fn with_restrictions<I, S>(mut self, restrictions: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.adds_restrictions = restrictions.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+/// Result of evaluating an envelope against aggregation rules.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregationResult {
+    pub aggregate_sensitivity: DataClassification,
+    pub restrictions: BTreeSet<String>,
+    pub escalate: bool,
+    pub rules_applied: Vec<String>,
+}
+
+/// Apply matching rules and escalate unknown combinations at the configured threshold.
+pub fn evaluate_aggregation(
+    envelope: &ContextEnvelope,
+    rules: &[AggregationRule],
+    category_threshold: usize,
+) -> AggregationResult {
+    let mut aggregate_sensitivity = envelope.aggregate_sensitivity;
+    let mut restrictions = envelope.restrictions.clone();
+    let mut rules_applied = Vec::new();
+
+    for rule in rules {
+        if rule.all_labels.is_subset(&envelope.labels) {
+            aggregate_sensitivity = aggregate_sensitivity.max(rule.sets_sensitivity);
+            restrictions.extend(rule.adds_restrictions.iter().cloned());
+            rules_applied.push(rule.name.clone());
+        }
+    }
+
+    AggregationResult {
+        aggregate_sensitivity,
+        restrictions,
+        escalate: rules_applied.is_empty() && envelope.labels.len() >= category_threshold,
+        rules_applied,
+    }
+}
+
+/// A restriction the host must enforce before an action proceeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Obligation {
+    pub key: String,
+    pub satisfied: bool,
+}
+
+/// Obligations and labels carried by a constrained outcome.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObligationSet {
+    pub obligations: Vec<Obligation>,
+    pub result_labels: BTreeSet<String>,
+}
+
+impl ObligationSet {
+    pub fn all_satisfied(&self) -> bool {
+        self.obligations
+            .iter()
+            .all(|obligation| obligation.satisfied)
+    }
+}
+
+/// Context-aware governance outcome before mapping to the SDK policy surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextOutcome {
+    Allow,
+    Constrain,
+    Deny,
+    Escalate,
+}
+
+/// Context-aware decision and any obligations it carries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextDecision {
+    pub outcome: ContextOutcome,
+    pub obligations: ObligationSet,
+    pub aggregate_sensitivity: DataClassification,
+    pub reason: String,
+}
+
+/// Fold an action's actual result into an envelope and re-run aggregation.
+pub fn accumulate<I, S>(
+    envelope: &ContextEnvelope,
+    result_labels: I,
+    result_sensitivity: DataClassification,
+    rules: &[AggregationRule],
+    category_threshold: usize,
+) -> ContextEnvelope
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut folded = envelope.fold(result_labels, result_sensitivity);
+    let aggregation = evaluate_aggregation(&folded, rules, category_threshold);
+    folded.aggregate_sensitivity = aggregation.aggregate_sensitivity;
+    folded.apply_restrictions(aggregation.restrictions)
+}
+
+/// Gate a flow-bearing action against already accumulated context.
+pub fn decide_next(
+    envelope: &ContextEnvelope,
+    action: &str,
+    rules: &[AggregationRule],
+    category_threshold: usize,
+    restricted_floor: DataClassification,
+) -> ContextDecision {
+    let aggregation = evaluate_aggregation(envelope, rules, category_threshold);
+
+    if aggregation.escalate {
+        return ContextDecision {
+            outcome: ContextOutcome::Escalate,
+            obligations: ObligationSet {
+                result_labels: envelope.labels.clone(),
+                ..ObligationSet::default()
+            },
+            aggregate_sensitivity: aggregation.aggregate_sensitivity,
+            reason: "aggregation threshold crossed with no governing rule".to_string(),
+        };
+    }
+
+    let gating_restriction = match action {
+        "export" => Some("no_external_export"),
+        "delegate" => Some("no_external_delegation"),
+        "memory_write" => Some("no_memory_write"),
+        _ => None,
+    };
+    let restriction_present =
+        gating_restriction.is_some_and(|restriction| envelope.restrictions.contains(restriction));
+    let floor_triggered =
+        gating_restriction.is_some() && aggregation.aggregate_sensitivity >= restricted_floor;
+
+    if restriction_present || floor_triggered {
+        let reason = if restriction_present {
+            format!(
+                "action {action:?} restricted by {:?}",
+                gating_restriction.expect("restriction checked above")
+            )
+        } else {
+            format!("action {action:?} gated by sensitivity floor")
+        };
+        return ContextDecision {
+            outcome: ContextOutcome::Constrain,
+            obligations: ObligationSet {
+                obligations: envelope
+                    .restrictions
+                    .iter()
+                    .map(|restriction| Obligation {
+                        key: restriction.clone(),
+                        satisfied: false,
+                    })
+                    .collect(),
+                result_labels: envelope.labels.clone(),
+            },
+            aggregate_sensitivity: aggregation.aggregate_sensitivity,
+            reason,
+        };
+    }
+
+    ContextDecision {
+        outcome: ContextOutcome::Allow,
+        obligations: ObligationSet {
+            result_labels: envelope.labels.clone(),
+            ..ObligationSet::default()
+        },
+        aggregate_sensitivity: aggregation.aggregate_sensitivity,
+        reason: String::new(),
+    }
+}
+
+/// Map a context outcome to the SDK policy decision without failing open.
+pub fn to_policy_decision(
+    decision: &ContextDecision,
+    has_obligation_channel: bool,
+) -> PolicyDecision {
+    match decision.outcome {
+        ContextOutcome::Allow => PolicyDecision::Allow,
+        ContextOutcome::Deny => PolicyDecision::Deny(reason_or(
+            &decision.reason,
+            "accumulated context denied the action",
+        )),
+        ContextOutcome::Escalate => PolicyDecision::RequiresApproval(reason_or(
+            &decision.reason,
+            "accumulated context requires review",
+        )),
+        ContextOutcome::Constrain
+            if has_obligation_channel
+                || (!decision.obligations.obligations.is_empty()
+                    && decision.obligations.all_satisfied()) =>
+        {
+            PolicyDecision::Allow
+        }
+        ContextOutcome::Constrain => PolicyDecision::Deny(reason_or(
+            &decision.reason,
+            "context obligations cannot be enforced",
+        )),
+    }
+}
+
+/// Inherit every parent restriction while allowing a child to add more.
+pub fn merge_restrictions<I, S>(parent: &ContextEnvelope, child_declared: I) -> BTreeSet<String>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut restrictions = parent.restrictions.clone();
+    restrictions.extend(child_declared.into_iter().map(Into::into));
+    restrictions
+}
+
+fn reason_or(reason: &str, fallback: &str) -> String {
+    if reason.is_empty() {
+        fallback.to_string()
+    } else {
+        reason.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn aggregation_rule() -> AggregationRule {
+        AggregationRule::new(
+            "pii_financial_restricted",
+            ["pii", "financial"],
+            DataClassification::Restricted,
+        )
+        .with_restrictions(["no_external_export"])
+    }
+
+    #[test]
+    fn envelope_join_is_immutable_commutative_and_grow_only() {
+        let original = ContextEnvelope::new("env-1", "workflow-1")
+            .with_parent_envelope_id("parent-1")
+            .with_created_at("2026-07-28T00:00:00Z");
+        let first = original
+            .fold(["pii"], DataClassification::Internal)
+            .fold(["financial"], DataClassification::Confidential);
+        let reversed = original
+            .fold(["financial"], DataClassification::Confidential)
+            .fold(["pii"], DataClassification::Internal);
+
+        assert!(original.labels().is_empty());
+        assert_eq!(first.labels(), reversed.labels());
+        assert_eq!(
+            first.aggregate_sensitivity(),
+            reversed.aggregate_sensitivity()
+        );
+        assert_eq!(
+            first
+                .fold(["pii"], DataClassification::Public)
+                .aggregate_sensitivity(),
+            DataClassification::Confidential
+        );
+
+        let restricted = first
+            .apply_restrictions(["no_external_export"])
+            .apply_restrictions(std::iter::empty::<&str>());
+        assert!(restricted.restrictions().contains("no_external_export"));
+        assert_eq!(restricted.version(), 4);
+        assert_eq!(restricted.parent_envelope_id(), Some("parent-1"));
+    }
+
+    #[test]
+    fn envelope_reference_does_not_serialize_context_contents() {
+        let reference = ContextEnvelope::new("env-1", "workflow-1")
+            .fold(["pii"], DataClassification::TopSecret)
+            .apply_restrictions(["no_external_export"])
+            .reference();
+        let value = serde_json::to_value(reference).expect("reference should serialize");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "envelope_id": "env-1",
+                "sensitivity": "top_secret"
+            })
+        );
+    }
+
+    #[test]
+    fn aggregation_applies_rules_and_escalates_unknown_combinations() {
+        let rules = [aggregation_rule()];
+        let governed = ContextEnvelope::new("env-1", "workflow-1")
+            .fold(["pii", "financial"], DataClassification::Internal);
+        let result = evaluate_aggregation(&governed, &rules, 3);
+
+        assert_eq!(result.aggregate_sensitivity, DataClassification::Restricted);
+        assert!(result.restrictions.contains("no_external_export"));
+        assert_eq!(result.rules_applied, ["pii_financial_restricted"]);
+        assert!(!result.escalate);
+
+        let unknown = ContextEnvelope::new("env-2", "workflow-1").fold(
+            ["pii", "behavioral", "location"],
+            DataClassification::Internal,
+        );
+        assert!(evaluate_aggregation(&unknown, &rules, 3).escalate);
+    }
+
+    #[test]
+    fn accumulation_uses_actual_results_and_gates_the_next_action() {
+        let rules = [aggregation_rule()];
+        let envelope =
+            ContextEnvelope::new("env-1", "workflow-1").fold(["pii"], DataClassification::Internal);
+        let accumulated = accumulate(
+            &envelope,
+            ["financial"],
+            DataClassification::Confidential,
+            &rules,
+            3,
+        );
+
+        assert!(accumulated.labels().contains("financial"));
+        assert_eq!(
+            accumulated.aggregate_sensitivity(),
+            DataClassification::Restricted
+        );
+        assert!(accumulated.restrictions().contains("no_external_export"));
+
+        let decision = decide_next(
+            &accumulated,
+            "export",
+            &rules,
+            3,
+            DataClassification::Restricted,
+        );
+        assert_eq!(decision.outcome, ContextOutcome::Constrain);
+        assert!(matches!(
+            to_policy_decision(&decision, false),
+            PolicyDecision::Deny(_)
+        ));
+        assert_eq!(to_policy_decision(&decision, true), PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn restrictions_and_sensitivity_floor_gate_independently() {
+        let explicit = ContextEnvelope::new("env-1", "workflow-1")
+            .fold(["pii"], DataClassification::Confidential)
+            .apply_restrictions(["no_external_export"]);
+        let explicit_decision =
+            decide_next(&explicit, "export", &[], 99, DataClassification::Restricted);
+        assert_eq!(explicit_decision.outcome, ContextOutcome::Constrain);
+
+        let floor = ContextEnvelope::new("env-2", "workflow-1")
+            .fold(["pii"], DataClassification::Restricted);
+        let floor_decision =
+            decide_next(&floor, "delegate", &[], 99, DataClassification::Restricted);
+        assert_eq!(floor_decision.outcome, ContextOutcome::Constrain);
+    }
+
+    #[test]
+    fn escalation_maps_to_a_non_allowing_review_decision() {
+        let envelope = ContextEnvelope::new("env-1", "workflow-1").fold(
+            ["pii", "financial", "location"],
+            DataClassification::Internal,
+        );
+        let decision = decide_next(&envelope, "read", &[], 3, DataClassification::Restricted);
+
+        assert_eq!(decision.outcome, ContextOutcome::Escalate);
+        assert!(matches!(
+            to_policy_decision(&decision, false),
+            PolicyDecision::RequiresApproval(_)
+        ));
+    }
+
+    #[test]
+    fn constrain_without_a_channel_only_allows_satisfied_obligations() {
+        let mut decision = ContextDecision {
+            outcome: ContextOutcome::Constrain,
+            obligations: ObligationSet::default(),
+            aggregate_sensitivity: DataClassification::Restricted,
+            reason: "restricted".to_string(),
+        };
+        assert!(matches!(
+            to_policy_decision(&decision, false),
+            PolicyDecision::Deny(_)
+        ));
+
+        decision.obligations.obligations.push(Obligation {
+            key: "no_external_export".to_string(),
+            satisfied: true,
+        });
+        assert_eq!(to_policy_decision(&decision, false), PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn delegation_restrictions_are_a_grow_only_union() {
+        let parent =
+            ContextEnvelope::new("parent", "workflow-1").apply_restrictions(["no_external_export"]);
+        let child_restrictions = merge_restrictions(&parent, ["no_memory_write"]);
+
+        assert_eq!(
+            child_restrictions,
+            BTreeSet::from([
+                "no_external_export".to_string(),
+                "no_memory_write".to_string()
+            ])
+        );
+    }
+}

--- a/agent-governance-rust/agentmesh/src/context.rs
+++ b/agent-governance-rust/agentmesh/src/context.rs
@@ -134,10 +134,10 @@ pub struct EnvelopeReference {
 /// Organization-authored rule over a combination of accumulated labels.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AggregationRule {
-    pub name: String,
-    pub all_labels: BTreeSet<String>,
-    pub sets_sensitivity: DataClassification,
-    pub adds_restrictions: BTreeSet<String>,
+    name: String,
+    all_labels: BTreeSet<String>,
+    sets_sensitivity: DataClassification,
+    adds_restrictions: BTreeSet<String>,
 }
 
 impl AggregationRule {
@@ -145,17 +145,25 @@ impl AggregationRule {
         name: impl Into<String>,
         all_labels: I,
         sets_sensitivity: DataClassification,
-    ) -> Self
+    ) -> Result<Self, String>
     where
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
-        Self {
-            name: name.into(),
-            all_labels: all_labels.into_iter().map(Into::into).collect(),
+        let name = name.into();
+        let all_labels: BTreeSet<String> = all_labels.into_iter().map(Into::into).collect();
+        if all_labels.is_empty() {
+            return Err(format!(
+                "aggregation rule '{name}' must have a non-empty all_labels set"
+            ));
+        }
+
+        Ok(Self {
+            name,
+            all_labels,
             sets_sensitivity,
             adds_restrictions: BTreeSet::new(),
-        }
+        })
     }
 
     pub fn with_restrictions<I, S>(mut self, restrictions: I) -> Self
@@ -198,7 +206,9 @@ pub fn evaluate_aggregation(
     AggregationResult {
         aggregate_sensitivity,
         restrictions,
-        escalate: rules_applied.is_empty() && envelope.labels.len() >= category_threshold,
+        escalate: rules_applied.is_empty()
+            && !envelope.labels.is_empty()
+            && envelope.labels.len() >= category_threshold,
         rules_applied,
     }
 }
@@ -390,6 +400,7 @@ mod tests {
             ["pii", "financial"],
             DataClassification::Restricted,
         )
+        .expect("fixture rule has labels")
         .with_restrictions(["no_external_export"])
     }
 
@@ -460,6 +471,28 @@ mod tests {
             DataClassification::Internal,
         );
         assert!(evaluate_aggregation(&unknown, &rules, 3).escalate);
+    }
+
+    #[test]
+    fn empty_aggregation_rule_labels_are_rejected() {
+        let error = AggregationRule::new(
+            "empty_rule",
+            std::iter::empty::<&str>(),
+            DataClassification::TopSecret,
+        )
+        .expect_err("empty rules must not match every envelope");
+
+        assert_eq!(
+            error.to_string(),
+            "aggregation rule 'empty_rule' must have a non-empty all_labels set"
+        );
+    }
+
+    #[test]
+    fn empty_envelope_does_not_escalate_at_zero_threshold() {
+        let envelope = ContextEnvelope::new("env-1", "workflow-1");
+
+        assert!(!evaluate_aggregation(&envelope, &[], 0).escalate);
     }
 
     #[test]

--- a/agent-governance-rust/agentmesh/src/context_audit.rs
+++ b/agent-governance-rust/agentmesh/src/context_audit.rs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Classified audit events for context-envelope transitions.
+//!
+//! The wire values and event shape follow the Python implementation introduced
+//! in <https://github.com/microsoft/agent-governance-toolkit/pull/2800>.
+
+use crate::context::ContextEnvelope;
+use crate::governance_support::DataClassification;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+pub const CONTEXT_ENVELOPE_CREATED: &str = "CONTEXT_ENVELOPE_CREATED";
+pub const CONTEXT_ENVELOPE_UPDATED: &str = "CONTEXT_ENVELOPE_UPDATED";
+pub const CONTEXT_AGGREGATION_ELEVATED: &str = "CONTEXT_AGGREGATION_ELEVATED";
+pub const CONTEXT_DELEGATED: &str = "CONTEXT_DELEGATED";
+pub const CONTEXT_REDACTED: &str = "CONTEXT_REDACTED";
+pub const DERIVED_ARTIFACT_LABELED: &str = "DERIVED_ARTIFACT_LABELED";
+
+/// Governance-relevant delta between two context-envelope versions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextEvent {
+    pub event_type: String,
+    pub agent_id: String,
+    pub context_envelope_id: String,
+    pub previous_sensitivity: DataClassification,
+    pub new_sensitivity: DataClassification,
+    pub labels_added: BTreeSet<String>,
+    pub rules_applied: Vec<String>,
+    pub restrictions_added: BTreeSet<String>,
+    pub classification: DataClassification,
+}
+
+/// Build an event whose classification is never below either envelope.
+pub fn context_event<I, S>(
+    event_type: impl Into<String>,
+    agent_id: impl Into<String>,
+    before: &ContextEnvelope,
+    after: &ContextEnvelope,
+    rules_applied: I,
+) -> ContextEvent
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    ContextEvent {
+        event_type: event_type.into(),
+        agent_id: agent_id.into(),
+        context_envelope_id: after.envelope_id().to_string(),
+        previous_sensitivity: before.aggregate_sensitivity(),
+        new_sensitivity: after.aggregate_sensitivity(),
+        labels_added: after
+            .labels()
+            .difference(before.labels())
+            .cloned()
+            .collect(),
+        rules_applied: rules_applied.into_iter().map(Into::into).collect(),
+        restrictions_added: after
+            .restrictions()
+            .difference(before.restrictions())
+            .cloned()
+            .collect(),
+        classification: before
+            .aggregate_sensitivity()
+            .max(after.aggregate_sensitivity()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_event_records_delta_and_classification_floor() {
+        let before = ContextEnvelope::new("env-1", "workflow-1")
+            .fold(["pii"], DataClassification::Confidential);
+        let after = before
+            .fold(["financial"], DataClassification::Restricted)
+            .apply_restrictions(["no_external_export"]);
+        let event = context_event(
+            CONTEXT_AGGREGATION_ELEVATED,
+            "agent.customer-success",
+            &before,
+            &after,
+            ["pii_financial_restricted"],
+        );
+
+        assert_eq!(event.previous_sensitivity, DataClassification::Confidential);
+        assert_eq!(event.new_sensitivity, DataClassification::Restricted);
+        assert_eq!(
+            event.labels_added,
+            BTreeSet::from(["financial".to_string()])
+        );
+        assert_eq!(
+            event.restrictions_added,
+            BTreeSet::from(["no_external_export".to_string()])
+        );
+        assert_eq!(event.rules_applied, ["pii_financial_restricted"]);
+        assert_eq!(event.classification, DataClassification::Restricted);
+        assert_eq!(
+            serde_json::to_value(&event)
+                .expect("context event should serialize")
+                .get("event_type"),
+            Some(&serde_json::json!("CONTEXT_AGGREGATION_ELEVATED"))
+        );
+    }
+
+    #[test]
+    fn wire_values_and_higher_previous_classification_are_preserved() {
+        assert_eq!(
+            [
+                CONTEXT_ENVELOPE_CREATED,
+                CONTEXT_ENVELOPE_UPDATED,
+                CONTEXT_AGGREGATION_ELEVATED,
+                CONTEXT_DELEGATED,
+                CONTEXT_REDACTED,
+                DERIVED_ARTIFACT_LABELED,
+            ],
+            [
+                "CONTEXT_ENVELOPE_CREATED",
+                "CONTEXT_ENVELOPE_UPDATED",
+                "CONTEXT_AGGREGATION_ELEVATED",
+                "CONTEXT_DELEGATED",
+                "CONTEXT_REDACTED",
+                "DERIVED_ARTIFACT_LABELED",
+            ]
+        );
+
+        let before = ContextEnvelope::new("env-1", "workflow-1")
+            .fold(std::iter::empty::<&str>(), DataClassification::Restricted);
+        let after = ContextEnvelope::new("env-1", "workflow-1")
+            .fold(std::iter::empty::<&str>(), DataClassification::Internal);
+        let event = context_event(
+            CONTEXT_ENVELOPE_UPDATED,
+            "agent-1",
+            &before,
+            &after,
+            std::iter::empty::<&str>(),
+        );
+
+        assert_eq!(event.classification, DataClassification::Restricted);
+    }
+}

--- a/agent-governance-rust/agentmesh/src/governance_support.rs
+++ b/agent-governance-rust/agentmesh/src/governance_support.rs
@@ -1538,13 +1538,14 @@ pub enum PolicyCategory {
     Spend,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum DataClassification {
     Public,
     Internal,
     Confidential,
     Restricted,
+    TopSecret,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -21,6 +21,7 @@
 #![cfg_attr(test, allow(deprecated))]
 
 pub mod audit;
+pub mod context;
 pub mod control_support;
 pub mod credential_vault;
 pub mod governance_support;

--- a/agent-governance-rust/agentmesh/src/lib.rs
+++ b/agent-governance-rust/agentmesh/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod audit;
 pub mod context;
+pub mod context_audit;
 pub mod control_support;
 pub mod credential_vault;
 pub mod governance_support;


### PR DESCRIPTION
## Description  Adds the remaining Rust SDK slice of accumulated-context governance tracked by #3084.  - reuses the existing `DataClassification` type, completing its ordered ladder with `TopSecret` - adds an immutable, versioned `ContextEnvelope` with max-lattice sensitivity and grow-only restrictions - evaluates organization-authored label combinations and escalates unknown combinations at a configurable threshold - folds actual post-execution result labels, then gates later exports, delegations, and memory writes - inherits parent restrictions across delegation boundaries - gates actions and builds obligations from the rule-augmented restriction set, then maps constrained outcomes onto the existing Rust `PolicyDecision` surface without failing open - exposes an opaque `EnvelopeReference` containing only the envelope ID and aggregate sensitivity - emits classified context-transition audit events with exact cross-SDK wire values and delta-only payloads  The current Rust policy surface does not carry `result_labels`, despite the older issue text. This API therefore accepts actual labels explicitly after execution rather than guessing an action's output labels in advance.  Labels remain deterministic organization-authored category tokens backed by `BTreeSet<String>`. This avoids adding an unused parallel `DataLabel`/ABAC surface. No new dependencies are introduced.  Compatibility note: adding `TopSecret` extends a public Rust enum, so downstream exhaustive matches must add an arm. Existing discriminants do not change.  ## Type of Change - [ ] Bug fix (non-breaking change that fixes an issue) - [ ] New feature (non-breaking change that adds functionality) - [x] Breaking change (fix or feature that would cause existing functionality to change) - [x] Documentation update - [ ] Maintenance (dependency updates, CI/CD, refactoring) - [ ] Security fix  ## Package(s) Affected - [x] agent-mesh (`agent-governance-rust/agentmesh`) - [ ] agent-os-kernel - [ ] agent-runtime - [ ] agent-sre - [ ] agent-governance - [ ] docs / root  ## Verification  - `cargo test --release --workspace` — 524 passed, 0 failed - `cargo build --release --workspace` - `cargo clippy --release -p agentmesh --lib --no-deps -- -A deprecated` — no new warnings - `rustfmt --edition 2021 --check agentmesh/src/context.rs agentmesh/src/context_audit.rs` - `git diff --check`  ## Checklist - [x] My code follows the project style guidelines (Rustfmt and Clippy; Ruff is not applicable) - [x] I have added tests that prove my feature works - [x] All new and existing tests pass - [x] I have updated documentation as needed - [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)  ## Attribution & Prior Art - [x] This contribution does not contain code copied or derived from other projects without attribution - [x] Any external projects that inspired this design are credited in code comments or documentation - [x] If this PR implements functionality similar to an existing open-source project, I have listed it below  **Prior art / related projects:**  This is a Rust semantic-parity implementation of the in-repository Python context and audit design merged in #2800. The module documentation credits that source directly. No external project code was used.  ## AI Assistance - [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered - [x] I have run tests and verification appropriate for this change - [x] No part of this PR was autonomously submitted by an AI agent without my review - [x] I have not used AI to generate review comments on others' PRs  Codex assisted with implementation and test drafting. I reviewed the complete diff and validation results before submission.  ## IP, Patents, and Licensing - [x] This contribution does not implement patent-pending or patent-encumbered techniques - [x] This contribution does not require an NDA or licensing agreement to understand or use - [x] Any AI tools used have terms compatible with the MIT License  ## Related Issues  Part of #3084.