### PR TITLE
fix(docs): replace expired Discord invite with non-expiring link

### DIFF
--- a/.github/linters/markdown-link-check.json
+++ b/.github/linters/markdown-link-check.json
@@ -52,7 +52,7 @@
     { "pattern": "genai\\.owasp\\.org" },
     { "pattern": "learn\\.microsoft\\.com" },
     { "pattern": "microsoft\\.com/en-us/security/blog" },
-    { "pattern": "dcbadge\\.limes\\.pink/api/server/7aVPCcVh" },
+    { "pattern": "dcbadge\\.limes\\.pink/api/server/TxMRqY3pFr" },
     { "pattern": "agent-governance-python/agent-lightning/pull" },
     { "pattern": "azure-container-apps/blob" },
     { "pattern": "^(?!https?://|mailto:|#)" }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 </p>
 
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
-[![Discord](https://dcbadge.limes.pink/api/server/7aVPCcVh?style=flat)](https://discord.gg/7aVPCcVh)
+[![Discord](https://dcbadge.limes.pink/api/server/TxMRqY3pFr?style=flat)](https://discord.gg/TxMRqY3pFr)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/agent-governance-toolkit?label=PyPI)](https://pypi.org/project/agent-governance-toolkit/)
 [![npm](https://img.shields.io/npm/v/%40microsoft/agent-governance-sdk?label=npm)](https://www.npmjs.com/package/@microsoft/agent-governance-sdk)
@@ -413,7 +413,7 @@ See [Known Limitations](docs/LIMITATIONS.md) for honest design boundaries and re
 
 ## Contributing
 
-[Contributing Guide](CONTRIBUTING.md) · [Community](docs/COMMUNITY.md) · [Discord](https://discord.gg/7aVPCcVh) · [Security Policy](SECURITY.md) · [Changelog](CHANGELOG.md)
+[Contributing Guide](CONTRIBUTING.md) · [Community](docs/COMMUNITY.md) · [Discord](https://discord.gg/TxMRqY3pFr) · [Security Policy](SECURITY.md) · [Changelog](CHANGELOG.md)
 
 **Using AGT?** Add your organization to [ADOPTERS.md](docs/ADOPTERS.md).
 

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -22,7 +22,7 @@
 </p>
 
 [![CI](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/microsoft/agent-governance-toolkit/actions/workflows/ci.yml)
-[![Discord](https://dcbadge.limes.pink/api/server/7aVPCcVh?style=flat)](https://discord.gg/7aVPCcVh)
+[![Discord](https://dcbadge.limes.pink/api/server/TxMRqY3pFr?style=flat)](https://discord.gg/TxMRqY3pFr)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
 [![PyPI version](https://img.shields.io/pypi/v/agent-governance-toolkit?label=PyPI)](https://pypi.org/project/agent-governance-toolkit/)
 [![npm](https://img.shields.io/npm/v/%40microsoft/agent-governance-sdk?label=npm)](https://www.npmjs.com/package/@microsoft/agent-governance-sdk)
@@ -397,7 +397,7 @@ AGT는 OS 커널 레벨이 아닌 애플리케이션 미들웨어 레이어에�
 
 ## 기여하기 (Contributing)
 
-[기여 가이드](../../CONTRIBUTING.md) · [커뮤니티](../../docs/COMMUNITY.md) · [Discord](https://discord.gg/7aVPCcVh) · [보안 정책](../../SECURITY.md) · [변경 이력](../../CHANGELOG.md)
+[기여 가이드](../../CONTRIBUTING.md) · [커뮤니티](../../docs/COMMUNITY.md) · [Discord](https://discord.gg/TxMRqY3pFr) · [보안 정책](../../SECURITY.md) · [변경 이력](../../CHANGELOG.md)
 
 **AGT를 사용 중이신가요?** [ADOPTERS.md](../../docs/ADOPTERS.md)에 귀하의 조직을 추가해 주세요.
 


### PR DESCRIPTION
## What

The Discord invite advertised in the README has expired. This replaces it with a non-expiring one.

## Why

The current code `7aVPCcVh` no longer resolves:

```
GET https://discord.com/api/v10/invites/7aVPCcVh
{"message": "Invite is expired.", "code": 50270}
```

The badge is broken for the same reason: `https://dcbadge.limes.pink/api/server/7aVPCcVh?style=flat` returns HTTP 400, so the README renders a dead badge alongside a dead link.

The replacement resolves to the project guild and does not expire:

| | |
|---|---|
| guild | Agent Governance Toolkit (`1509995837638447104`) |
| `expires_at` | `null` |
| badge URL | HTTP 200 |

## Scope

Five occurrences across three files:

- `README.md` (badge and Contributing footer)
- `docs/i18n/README.ko.md` (same two places; the only translated README carrying the link)
- `.github/linters/markdown-link-check.json` — the ignore pattern was keyed to the old invite code. Updating the badge without it would leave a stale exception and start link-checking the new URL. Updated rather than removed, to preserve the original intent.

The ja, zh-CN, and zh-TW READMEs do not carry a Discord link and are untouched. No other content changes.
