### PR TITLE
fix(red-team): align report verdict and process exit code criteria (Fixes #3237)

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
@@ -304,7 +304,7 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
     experiment.start()
 
     runner = AdversarialRunner(experiment)
-    results = runner.run_all(selected)
+    results = runner.run_all(selected, threshold=threshold)
 
     experiment.complete()
 
@@ -363,7 +363,7 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
         click.echo(f"  Results: {passed_count}/{total} playbooks passed")
         click.echo(f"  Overall: {'PASS' if overall_pass else 'FAIL'}\n")
 
-    if not all(r.resilience_score >= threshold for r in results):
+    if not all(r.passed for r in results):
         raise SystemExit(1)
 
 

--- a/agent-governance-python/agent-compliance/tests/test_red_team_cli.py
+++ b/agent-governance-python/agent-compliance/tests/test_red_team_cli.py
@@ -198,6 +198,16 @@ class TestRedTeamAttack:
         if "agent-sre" not in (result.output or ""):
             assert result.exit_code == 1
 
+    def test_attack_threshold_consistency(self, runner: CliRunner):
+        """Verify report verdict and exit code are consistent when using custom threshold."""
+        result = runner.invoke(cli, ["red-team", "attack", "--threshold", "100.0", "--json"])
+        if result.exit_code in (0, 1) and "target" in (result.output or ""):
+            data = json.loads(result.output)
+            if data["overall_passed"]:
+                assert result.exit_code == 0
+            else:
+                assert result.exit_code == 1
+
 
 class TestRedTeamReport:
     """Tests for agt red-team report."""

--- a/agent-governance-python/agent-sre/src/agent_sre/chaos/adversarial.py
+++ b/agent-governance-python/agent-sre/src/agent_sre/chaos/adversarial.py
@@ -108,7 +108,9 @@ class AdversarialRunner:
             return AttackResult.BLOCKED
         return AttackResult.BYPASSED
 
-    def run_playbook(self, playbook: AdversarialPlaybook) -> PlaybookResult:
+    def run_playbook(
+        self, playbook: AdversarialPlaybook, threshold: float = 70.0
+    ) -> PlaybookResult:
         """Execute all steps in a playbook and score the results."""
         step_results: list[tuple[PlaybookStep, AttackResult, bool]] = []
         blocked_count = 0
@@ -122,7 +124,7 @@ class AdversarialRunner:
 
         total = len(playbook.steps)
         resilience_score = (blocked_count / total * 100.0) if total > 0 else 0.0
-        overall_passed = resilience_score >= 70.0
+        overall_passed = resilience_score >= threshold
 
         return PlaybookResult(
             playbook=playbook,
@@ -131,9 +133,11 @@ class AdversarialRunner:
             passed=overall_passed,
         )
 
-    def run_all(self, playbooks: list[AdversarialPlaybook]) -> list[PlaybookResult]:
+    def run_all(
+        self, playbooks: list[AdversarialPlaybook], threshold: float = 70.0
+    ) -> list[PlaybookResult]:
         """Run all provided playbooks and return their results."""
-        return [self.run_playbook(pb) for pb in playbooks]
+        return [self.run_playbook(pb, threshold=threshold) for pb in playbooks]
 
 
 # ---------------------------------------------------------------------------

--- a/agent-governance-python/agent-sre/tests/unit/test_adversarial_chaos.py
+++ b/agent-governance-python/agent-sre/tests/unit/test_adversarial_chaos.py
@@ -257,15 +257,33 @@ class TestAdversarialRunner:
         assert all(r.resilience_score == 100.0 for r in results)
 
     def test_runner_custom_threshold(self) -> None:
+        """Validate resilience threshold evaluation including edge case values."""
         exp = self._make_experiment([
             Fault.prompt_injection("target"),
         ])
         runner = AdversarialRunner(exp)
         pb = BUILTIN_PLAYBOOKS[1]  # privilege-escalation: partial defense (1/3 blocked, score 33.3)
+
+        # Standard custom thresholds
         res_low = runner.run_playbook(pb, threshold=30.0)
         assert res_low.passed is True
+
         res_high = runner.run_playbook(pb, threshold=50.0)
         assert res_high.passed is False
+
+        # Edge case threshold values: zero, negative numbers, and values exceeding 100
+        res_zero = runner.run_playbook(pb, threshold=0.0)
+        assert res_zero.passed is True
+
+        res_neg = runner.run_playbook(pb, threshold=-10.0)
+        assert res_neg.passed is True
+
+        res_extreme = runner.run_playbook(pb, threshold=150.0)
+        assert res_extreme.passed is False
+
+        # Verify run_all propagates custom threshold to all playbooks
+        results = runner.run_all([pb], threshold=50.0)
+        assert results[0].passed is False
 
 
 # ---------------------------------------------------------------------------

--- a/agent-governance-python/agent-sre/tests/unit/test_adversarial_chaos.py
+++ b/agent-governance-python/agent-sre/tests/unit/test_adversarial_chaos.py
@@ -256,6 +256,17 @@ class TestAdversarialRunner:
         assert all(r.passed for r in results)
         assert all(r.resilience_score == 100.0 for r in results)
 
+    def test_runner_custom_threshold(self) -> None:
+        exp = self._make_experiment([
+            Fault.prompt_injection("target"),
+        ])
+        runner = AdversarialRunner(exp)
+        pb = BUILTIN_PLAYBOOKS[1]  # privilege-escalation: partial defense (1/3 blocked, score 33.3)
+        res_low = runner.run_playbook(pb, threshold=30.0)
+        assert res_low.passed is True
+        res_high = runner.run_playbook(pb, threshold=50.0)
+        assert res_high.passed is False
+
 
 # ---------------------------------------------------------------------------
 # PlaybookResult scoring


### PR DESCRIPTION
### Summary
Fixes #3237.

In `agent_compliance/cli/red_team.py` (`agt red-team attack`), the printed/JSON report verdict and `overall_passed` were derived from each playbook's `r.passed`, while the process exit code checked `all(r.resilience_score >= threshold for r in results)`. This could lead to a divergence where the report prints `PASS` but CI exits 1 (or vice versa when `--threshold` is customized).

### Fix
1. Updated `AdversarialRunner.run_playbook` and `run_all` in `agent_sre/chaos/adversarial.py` to accept a `threshold` parameter (default `70.0`), deriving `r.passed` via `resilience_score >= threshold`.
2. Passed the CLI `threshold` into `runner.run_all(selected, threshold=threshold)` in `red_team.py`.
3. Aligned the process exit code check to `all(r.passed for r in results)` so that both report output and process exit code are driven by the exact same criterion.
4. Added unit tests covering custom thresholds and CLI verdict/exit code consistency.

### Testing
Ran unit tests with `pytest` in `agent-compliance` and `agent-sre`. All 23 tests pass cleanly.