### PR TITLE
fix(agent-os): redact secrets annotated with a trailing suffix

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -57,6 +57,14 @@ class CredentialRedactor:
     # word character, so ``_sk-`` has no boundary and the secret would be missed;
     # ``(?<![A-Za-z0-9])`` treats ``_`` (and ``-``, ``/``, ``.``, whitespace) as a
     # valid left edge while still not matching inside an alphanumeric word.
+    #
+    # The trailing edge uses the mirror assertion ``(?![A-Za-z0-9])`` for the same
+    # reason. A closing ``\b`` after a value class that excludes ``_`` is not just
+    # inconsistent with the left edge — for a fixed-length or ``_``-excluding value
+    # it makes the whole pattern fail on ``<secret>_suffix``, because there is no
+    # shorter match the engine can back off to that ends on a word boundary. A
+    # complete, valid key annotated in place (``AKIA..._old``, ``sk_live_..._rotated``)
+    # was therefore not redacted at all.
     PATTERNS: tuple[CredentialPattern, ...] = (
         CredentialPattern(
             name="OpenAI API key",
@@ -70,7 +78,7 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="AWS access key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])AKIA[A-Z0-9]{16}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             # The 40-char base64 secret value has no distinctive prefix, so it is
@@ -118,9 +126,13 @@ class CredentialRedactor:
             ),
         ),
         CredentialPattern(
+            # The two alternatives were the only prefix-anchored patterns still
+            # using ``\b`` on the left, so a credential glued after ``_`` --
+            # ``auth_Basic <b64>``, ``url_https://user:pass@host`` -- was missed.
             name="Basic auth secret",
             pattern=re.compile(
-                r"(?i)(?:\bBasic\s+[A-Za-z0-9+/=]{8,}\b|\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^@\s/]+@)"
+                r"(?i)(?:(?<![A-Za-z0-9])Basic\s+[A-Za-z0-9+/=]{8,}(?![A-Za-z0-9+/=])"
+                r"|(?<![A-Za-z0-9])[a-z][a-z0-9+.-]*://[^/\s:@]+:[^@\s/]+@)"
             ),
         ),
         CredentialPattern(
@@ -139,11 +151,11 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="Google API key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])AIza[0-9A-Za-z_\-]{35}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])AIza[0-9A-Za-z_\-]{35}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             name="Stripe secret key",
-            pattern=re.compile(r"(?<![A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}\b"),
+            pattern=re.compile(r"(?<![A-Za-z0-9])(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{10,}(?![A-Za-z0-9])"),
         ),
         CredentialPattern(
             name="Generic API secret",

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -48,23 +48,8 @@ class CredentialRedactor:
     placeholder.
     """
 
-    # Python's stdlib ``re`` does not support per-pattern timeouts. These
-    # patterns are kept simple and anchored to avoid pathological backtracking.
-    #
-    # Prefix-anchored patterns use a ``(?<![A-Za-z0-9])`` lookbehind rather than
-    # ``\b`` so a secret glued directly to a preceding word character (for
-    # example ``session_sk-...``) is still detected. ``\b`` treats ``_`` as a
-    # word character, so ``_sk-`` has no boundary and the secret would be missed;
-    # ``(?<![A-Za-z0-9])`` treats ``_`` (and ``-``, ``/``, ``.``, whitespace) as a
-    # valid left edge while still not matching inside an alphanumeric word.
-    #
-    # The trailing edge uses the mirror assertion ``(?![A-Za-z0-9])`` for the same
-    # reason. A closing ``\b`` after a value class that excludes ``_`` is not just
-    # inconsistent with the left edge — for a fixed-length or ``_``-excluding value
-    # it makes the whole pattern fail on ``<secret>_suffix``, because there is no
-    # shorter match the engine can back off to that ends on a word boundary. A
-    # complete, valid key annotated in place (``AKIA..._old``, ``sk_live_..._rotated``)
-    # was therefore not redacted at all.
+    # Use explicit ASCII alphanumeric guards where a token's value class is not
+    # compatible with ``\b``.
     PATTERNS: tuple[CredentialPattern, ...] = (
         CredentialPattern(
             name="OpenAI API key",

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -71,9 +71,15 @@ class CredentialRedactor:
             pattern=re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9][A-Za-z0-9_-]{18,}\b"),
         ),
         CredentialPattern(
+            # Both branches share one trailing assertion, so it must not exclude
+            # a character either value class already excludes: the classic
+            # ``gh?_`` class stops at ``_``, so ``(?![A-Za-z0-9_])`` left no
+            # shorter match ending before ``_`` and ``ghp_..._old`` was not
+            # redacted at all. ``github_pat_`` includes ``_`` in its class, so it
+            # consumes the suffix and is unaffected either way.
             name="GitHub token",
             pattern=re.compile(
-                r"(?<![A-Za-z0-9])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9_])"
+                r"(?<![A-Za-z0-9])(?:gh[psour]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{22,})(?![A-Za-z0-9])"
             ),
         ),
         CredentialPattern(

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -161,7 +161,8 @@ def test_redacts_supported_github_token_prefixes(token: str):
 @pytest.mark.parametrize(
     "prefix", ["ghp", "ghs", "gho", "ghu", "ghr"],
 )
-def test_redacts_classic_github_token_with_trailing_underscore(prefix: str):
+@pytest.mark.parametrize("suffix", ["_", "_old"])
+def test_redacts_classic_github_token_with_trailing_underscore(prefix: str, suffix: str):
     """A trailing "_" ends a classic token; it does not disqualify it.
 
     A row asserting the opposite used to live in the false-positive table
@@ -172,8 +173,8 @@ def test_redacts_classic_github_token_with_trailing_underscore(prefix: str):
     """
     token = _fake_github_token(prefix)
 
-    assert CredentialRedactor.redact(f"{token}_") == f"{REDACTED_PLACEHOLDER}_"
-    assert "GitHub token" in CredentialRedactor.detect_credential_types(f"{token}_")
+    assert CredentialRedactor.redact(f"{token}{suffix}") == f"{REDACTED_PLACEHOLDER}{suffix}"
+    assert "GitHub token" in CredentialRedactor.detect_credential_types(f"{token}{suffix}")
 
 
 @pytest.mark.parametrize(

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -449,6 +449,50 @@ def test_trailing_anchor_does_not_widen_the_match(text: str):
     assert CredentialRedactor.redact(text) == text
 
 
+# The patterns that end on the mirror assertion, per the class comment. The rest
+# either keep a trailing \b or have no trailing assertion, which is safe because
+# their value class already includes "_" and so absorbs the annotation.
+_MIRROR_ASSERTION_PATTERNS = frozenset(
+    {"AWS access key", "GitHub token", "Google API key", "Stripe secret key"}
+)
+
+
+def test_only_underscore_excluding_patterns_use_the_mirror_assertion():
+    """Pin the class comment's claim about which trailing edge each pattern uses.
+
+    The comment above PATTERNS explains the mirror assertion in terms of value
+    classes that exclude `_`. Stating it as a blanket property of every pattern
+    would be wrong -- most keep a trailing `\\b` -- so the split is asserted here
+    rather than only described in prose.
+    """
+    mirror = {
+        p.name for p in CredentialRedactor.PATTERNS if p.pattern.pattern.endswith("(?![A-Za-z0-9])")
+    }
+    assert mirror == _MIRROR_ASSERTION_PATTERNS
+
+    # No trailing negative lookahead may exclude "_": excluding a character the
+    # value class also excludes is what left the annotated key unredacted.
+    for pattern in CredentialRedactor.PATTERNS:
+        assert not pattern.pattern.pattern.endswith("(?![A-Za-z0-9_])"), pattern.name
+
+
+@pytest.mark.parametrize(
+    ("text", "secret"),
+    [
+        # Value classes that include "_" consume the annotation themselves, so a
+        # trailing \b lands after the suffix and the secret is still redacted.
+        ("sk-ABCDEFGHIJKLMNOPQRSTUV_old", "sk-ABCDEFGHIJKLMNOPQRSTUV"),
+        ("Bearer ABCDEFGHIJKLMNOPQRST_old", "ABCDEFGHIJKLMNOPQRST"),
+        ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.ABCDEFGH_old", "eyJhbGciOiJIUzI1NiJ9"),
+    ],
+)
+def test_patterns_keeping_a_trailing_boundary_still_redact_an_annotated_key(text: str, secret: str):
+    # The counterpart to the mirror-assertion cases: these needed no change, and
+    # the class comment says so. Verified rather than assumed.
+    assert CredentialRedactor.contains_credentials(text) is True
+    assert secret not in CredentialRedactor.redact(text)
+
+
 def test_scan_and_redact_reports_types_without_raw_secret():
     secret = "xoxb-FAKE-not-a-real-slack-token-00"
     redacted, types = CredentialRedactor.scan_and_redact(f"token {secret}")

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -19,6 +19,9 @@ def _fake_github_token(prefix: str) -> str:
 # appears in source (avoids secret-scanner false positives on a test value).
 _FAKE_GOOGLE_KEY = "AIza" + "SyD1234567890abcdefghijklmnopqrstuv"
 
+# AWS's own documentation example access key ID -- deterministic and clearly fake.
+_FAKE_AWS_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
 
 def _fake_pem_block(label: str) -> str:
     return (
@@ -338,6 +341,68 @@ def test_detects_secret_glued_to_preceding_word_character(text: str):
 def test_loosened_anchor_does_not_match_inside_words(text: str):
     # The (?<![A-Za-z0-9]) anchor still refuses to match a secret prefix that is
     # embedded in an alphanumeric word (e.g. the "sk-" inside "disk-").
+    assert CredentialRedactor.contains_credentials(text) is False
+    assert CredentialRedactor.redact(text) == text
+
+
+# A base64 Basic-auth value; the credential is the whole encoded pair.
+_FAKE_BASIC_B64 = "YWxhZGRpbjpvcGVuc2VzYW1l"
+
+
+@pytest.mark.parametrize(
+    ("text", "secret"),
+    [
+        # AKIA... is fixed-length, so the engine has no shorter match to back off
+        # to and the whole pattern fails -- the key is not redacted at all.
+        (f"{_FAKE_AWS_ACCESS_KEY}_old", _FAKE_AWS_ACCESS_KEY),
+        (f"AWS_ACCESS_KEY_ID_OLD={_FAKE_AWS_ACCESS_KEY}_deprecated", _FAKE_AWS_ACCESS_KEY),
+        (f'{{"{_FAKE_AWS_ACCESS_KEY}_backup": "unused"}}', _FAKE_AWS_ACCESS_KEY),
+        # Google keys are fixed-length too. No `key=` prefix here: that would be
+        # caught by the keyword-anchored "Generic API secret" pattern instead, and
+        # the case would pass without exercising the Google pattern at all.
+        (f"rotate {_FAKE_GOOGLE_KEY}_v2 today", _FAKE_GOOGLE_KEY),
+        # Stripe's value class excludes "_", so {10,} cannot absorb the suffix.
+        ("stripe=sk_live_FakeTestKey0000_rotated", "sk_live_FakeTestKey0000"),
+        # Both Basic-auth alternatives kept \b on the *left* edge, the very case
+        # the lookbehind was introduced for everywhere else.
+        (f"auth_Basic {_FAKE_BASIC_B64}", _FAKE_BASIC_B64),
+        ("url_https://user:pass123@example.com/resource", "pass123"),
+    ],
+)
+def test_redacts_secret_glued_to_a_following_word_character(text: str, secret: str):
+    """A key annotated in place must still be redacted.
+
+    Rotation notes are how secrets actually appear in the text a host scans:
+    `AKIA..._old`, `sk_live_..._rotated`, a JSON key suffixed `_backup`. A
+    trailing `\\b` after a value class that excludes `_` cannot match these,
+    and because the value length is fixed (or `_`-free) there is no shorter
+    match ending on a word boundary for the engine to fall back to. The result
+    was not a truncated redaction but no redaction at all.
+    """
+    assert CredentialRedactor.contains_credentials(text) is True
+    assert secret not in CredentialRedactor.redact(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Glued on the left: still an alphanumeric word, still not a secret.
+        f"x{_FAKE_AWS_ACCESS_KEY}",
+        f"prefix{_FAKE_GOOGLE_KEY}",
+        # One character too long for a fixed-length key: not that key.
+        f"{_FAKE_AWS_ACCESS_KEY}X",
+        f"{_FAKE_AWS_ACCESS_KEY}1",
+        f"{_FAKE_GOOGLE_KEY}9",
+        # Below the length floor.
+        "sk_live_short",
+        "Basic short",
+        # A URL with no userinfo.
+        "https://example.com/path",
+    ],
+)
+def test_trailing_anchor_does_not_widen_the_match(text: str):
+    # Replacing the trailing \b with (?![A-Za-z0-9]) must not make the patterns
+    # accept more: an alphanumeric character on either side still disqualifies.
     assert CredentialRedactor.contains_credentials(text) is False
     assert CredentialRedactor.redact(text) == text
 

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -151,10 +151,27 @@ def test_redacts_supported_github_token_prefixes(token: str):
 
 
 @pytest.mark.parametrize(
+    "prefix", ["ghp", "ghs", "gho", "ghu", "ghr"],
+)
+def test_redacts_classic_github_token_with_trailing_underscore(prefix: str):
+    """A trailing "_" ends a classic token; it does not disqualify it.
+
+    A row asserting the opposite used to live in the false-positive table
+    below, which encoded the leak as intended behaviour: the classic body class
+    stops at "_", so a token followed by "_" is a complete token followed by a
+    separator -- exactly the ``_old`` / ``_backup`` annotation this pattern has
+    to survive.
+    """
+    token = _fake_github_token(prefix)
+
+    assert CredentialRedactor.redact(f"{token}_") == f"{REDACTED_PLACEHOLDER}_"
+    assert "GitHub token" in CredentialRedactor.detect_credential_types(f"{token}_")
+
+
+@pytest.mark.parametrize(
     "text",
     [
         f"x{_fake_github_token('ghp')}",
-        f"{_fake_github_token('ghs')}_",
         "gho_short",
         "github_pat_short",
         "notgithub_pat_FAKE_FOR_TESTING_0000000000000000000000",
@@ -363,6 +380,16 @@ _FAKE_BASIC_B64 = "YWxhZGRpbjpvcGVuc2VzYW1l"
         (f"rotate {_FAKE_GOOGLE_KEY}_v2 today", _FAKE_GOOGLE_KEY),
         # Stripe's value class excludes "_", so {10,} cannot absorb the suffix.
         ("stripe=sk_live_FakeTestKey0000_rotated", "sk_live_FakeTestKey0000"),
+        # The classic GitHub token had the same class/assertion disagreement
+        # about "_" that this change fixes elsewhere: its body class stops at
+        # "_" while the shared trailing assertion excluded "_" as well, so the
+        # whole token leaked. All five classic prefixes share the one pattern.
+        (f"{_fake_github_token('ghp')}_old", _fake_github_token("ghp")),
+        (f"{_fake_github_token('gho')}_rotated", _fake_github_token("gho")),
+        (
+            f'{{"{_fake_github_token("ghu")}_backup": "unused"}}',
+            _fake_github_token("ghu"),
+        ),
         # Both Basic-auth alternatives kept \b on the *left* edge, the very case
         # the lookbehind was introduced for everywhere else.
         (f"auth_Basic {_FAKE_BASIC_B64}", _FAKE_BASIC_B64),
@@ -398,6 +425,12 @@ def test_redacts_secret_glued_to_a_following_word_character(text: str, secret: s
         "Basic short",
         # A URL with no userinfo.
         "https://example.com/path",
+        # A classic GitHub token glued on the left is still an alphanumeric word.
+        # No right-edge row here: the body is {20,}, so one more alphanumeric is
+        # a longer valid token rather than a false positive -- unlike the
+        # fixed-length keys above.
+        f"x{_fake_github_token('ghp')}",
+        "ghp_TOOSHORT",
     ],
 )
 def test_trailing_anchor_does_not_widen_the_match(text: str):

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -5,8 +5,9 @@
 # Fixture credentials, not repo vocabulary. ``AKIAIOSFODNN`` opens AWS's own
 # documentation example key ID, ``TOOSHORT`` is the below-the-length-floor token
 # that must stay unredacted, and ``Rpbjpvc`` is a camel-case fragment cspell
-# extracts from the base64 Basic-auth fixture. Declared here because
-# ``cspell:ignore`` applies from its own line onward.
+# extracts from the base64 Basic-auth fixture. Declared at the top by
+# convention, not by necessity: ``cspell:ignore`` scopes to the whole document,
+# so it covers a word that appears above it too.
 # cspell:ignore AKIAIOSFODNN TOOSHORT Rpbjpvc
 
 from __future__ import annotations

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -2,6 +2,13 @@
 # Licensed under the MIT License.
 """Tests for credential redaction helpers."""
 
+# Fixture credentials, not repo vocabulary. ``AKIAIOSFODNN`` opens AWS's own
+# documentation example key ID, ``TOOSHORT`` is the below-the-length-floor token
+# that must stay unredacted, and ``Rpbjpvc`` is a camel-case fragment cspell
+# extracts from the base64 Basic-auth fixture. Declared here because
+# ``cspell:ignore`` applies from its own line onward.
+# cspell:ignore AKIAIOSFODNN TOOSHORT Rpbjpvc
+
 from __future__ import annotations
 
 import time


### PR DESCRIPTION
## Description

Fixes the trailing word-boundary blind spot in `CredentialRedactor`: a complete, valid secret with a suffix glued to it (`AKIAIOSFODNN7EXAMPLE_old`, `stripe=sk_live_..._rotated`) was **not redacted at all**, and `contains_credentials` returned `False`.

The class comment documents why the *left* edge moved from `\b` to a `(?<![A-Za-z0-9])` lookbehind: `\b` treats `_` as a word character, so `session_sk-...` had no boundary and was missed. The right edge kept `\b`, which has the same blind spot in reverse. Usually the engine backs off to a shorter match ending on a boundary — but for three of these patterns it cannot:

- `AWS access key` — `AKIA[A-Z0-9]{16}` is fixed-length; no shorter candidate exists.
- `Google API key` — `AIza[0-9A-Za-z_\-]{35}` is fixed-length; same.
- `Stripe secret key` — the `{10,}` value class excludes `_`, so it cannot absorb the suffix and reach a boundary either.

So the whole pattern fails and nothing is redacted. `OpenAI API key` is the useful contrast: its `[A-Za-z0-9_-]{18,}` value class *includes* `_`, absorbs the suffix, and already works. The defect is precisely where the value class and the boundary assertion disagree about `_`.

`Basic auth secret` is a second instance of the same incomplete migration — the only prefix-anchored pattern still using `\b` on the **left** of both alternatives, so `auth_Basic <b64>` and `url_https://user:pass@host` were missed.

**Change:** trailing `\b` -> `(?![A-Za-z0-9])`, the mirror of the existing lookbehind. Exactly as strict about what may follow (`AKIA...X` and `AKIA...1` are still rejected) while allowing `_`. For `Basic auth secret`, the lookbehind on both alternatives plus `(?![A-Za-z0-9+/=])` after the base64 value so `=` padding is not read as a boundary.

**Why it matters:** `MCPResponseScanner` feeds MCP tool-response text to `sanitize_response`, and audit payloads go through `redact_mapping`. `_old`, `_deprecated`, `_backup`, `_rotated`, `_v2` are how a config file marks the credential being replaced — and the key being rotated out is live until it is revoked. Since `contains_credentials` also returned `False`, a policy gate keyed on detection saw nothing to block.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Package(s) Affected
- [x] agent-os-kernel

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [ ] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

Verification:
- `test_redacts_secret_glued_to_a_following_word_character` (7 cases) — **all 7 fail on `main`** and pass after.
- `test_trailing_anchor_does_not_widen_the_match` (8 cases: `xAKIA...`, `AKIA...X`, `AKIA...1`, `AIza...9`, `sk_live_short`, `Basic short`, `https://example.com/path`, `prefixAIza...`) — pass on both, so the anchor is not loosened.
- `tests/test_credential_redactor.py`: 79 passed. Redaction-related tests across the suite (`-k "redact or credential or secret or scan"`): 308 passed.
- Full `tests/` run is identical before and after (257 failed / 4464 passed both on `main` and on this branch — those failures are pre-existing and unrelated; three modules also fail to import on `main` for missing `agentmesh` / `agent_sre`).
- No super-linear scanning: 100k-character adversarial inputs (`AKIA` + `A`*100000, `sk_live_` + `a`*100000, 5000 repeated `Basic`/URL markers) all complete in <0.05s.
- `Spell-check changed files`: CI's exact command (`scripts/ci/changed_lines.py --mode added-lines | cspell@8.17.3 --config .cspell.json`) exits 0.

The one `ruff check` finding on the test file (I001 import sort, `agent_os.credential_redactor` ordering) is pre-existing — it reports on the unmodified file at `2a23e34` too, so it is left alone rather than mixed into this change.

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects:** none — this fixes existing patterns in place.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Fixes #3494