### PR TITLE
fix(agent-os): strip all invisible characters in conversation guardian normalization

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
@@ -98,6 +98,11 @@ _HOMOGLYPH_MAP: dict[str, str] = {
 #
 # The result of this function is only ever matched against, never shown to a
 # user or stored, so stripping is always preferable to preserving.
+#
+# Deleting them is not sufficient on its own, though: deletion closes the gap
+# between two adjacent keywords and destroys the ``\b`` the patterns need, so
+# ``normalize_variants`` also produces a space-substituted variant and the
+# detectors match against both. See its docstring.
 _INVISIBLE_RANGES: tuple[tuple[int, int], ...] = (
     (0x00AD, 0x00AD),  # soft hyphen
     (0x034F, 0x034F),  # combining grapheme joiner
@@ -133,21 +138,16 @@ _INVISIBLE_CHARS = re.compile(
 )
 
 
-def normalize_text(text: str) -> str:
-    """Normalize text to defeat common evasion techniques.
+def _normalize(text: str, invisible_becomes: str) -> str:
+    """Normalize *text*, replacing invisible characters with *invisible_becomes*.
 
-    Handles: unicode homoglyphs, leetspeak, invisible characters (every
-    range in ``_INVISIBLE_RANGES``, not only the zero-width ones),
-    excessive whitespace, combining diacritics, fullwidth characters.
-
-    The return value is intended for matching only. It is lossy by design --
-    invisible characters are dropped rather than preserved -- so it must not be
-    stored or displayed in place of the original text.
+    Every step other than that replacement is shared by both variants; see
+    ``normalize_variants`` for why there are two.
     """
-    # Strip invisible characters (see _INVISIBLE_RANGES). This has to run before
-    # the compatibility decomposition below, which does not remove them, and one
-    # of them mid-word is enough to defeat every word-anchored pattern here.
-    text = _INVISIBLE_CHARS.sub("", text)
+    # Handle invisible characters (see _INVISIBLE_RANGES) before the
+    # compatibility decomposition below, which does not remove them, and one of
+    # them mid-word is enough to defeat every word-anchored pattern here.
+    text = _INVISIBLE_CHARS.sub(invisible_becomes, text)
 
     # NFKD decomposition (handles fullwidth, compatibility chars)
     text = unicodedata.normalize("NFKD", text)
@@ -165,6 +165,50 @@ def normalize_text(text: str) -> str:
     text = re.sub(r"\s+", " ", text).strip()
 
     return text
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text to defeat common evasion techniques.
+
+    Handles: unicode homoglyphs, leetspeak, invisible characters (every
+    range in ``_INVISIBLE_RANGES``, not only the zero-width ones),
+    excessive whitespace, combining diacritics, fullwidth characters.
+
+    The return value is intended for matching only. It is lossy by design --
+    invisible characters are dropped rather than preserved -- so it must not be
+    stored or displayed in place of the original text.
+
+    Deletion alone cannot resist both placements of an invisible character, so
+    the detectors do not use this function on its own; they match against every
+    variant from ``normalize_variants``, of which this is the first.
+    """
+    return _normalize(text, "")
+
+
+def normalize_variants(text: str) -> tuple[str, ...]:
+    """Return the normalized forms a pattern must be matched against.
+
+    Deleting an invisible character and replacing it with a space each defeat
+    one placement and create the other:
+
+    - *inside* a keyword, deletion restores the word (``priv​ilege`` ->
+      ``privilege``) while a space breaks it in two;
+    - *between* two keywords, deletion glues them and destroys the ``\\b`` the
+      patterns are anchored on (``privileges​impersonate`` ->
+      ``privilegesimpersonate``, so ``\\bimpersonat\\w*`` no longer matches),
+      while a space separates them.
+
+    Neither is the safe default, so both are produced and a pattern matching
+    any variant counts. That is fail-closed in the direction this module needs:
+    an evasion attempt is scored, and the cost is that a keyword an author
+    genuinely split with an invisible character is scored too.
+
+    The raw text is not included -- callers match it separately, since a
+    pattern may legitimately depend on characters normalization removes.
+    """
+    deleted = _normalize(text, "")
+    spaced = _normalize(text, " ")
+    return (deleted,) if spaced == deleted else (deleted, spaced)
 
 
 # ── Enums ────────────────────────────────────────────────────────────
@@ -401,18 +445,19 @@ class EscalationClassifier:
     def score_message(self, text: str) -> tuple[float, list[str]]:
         """Score a single message for escalation patterns.
 
-        Matches against both original and normalized text to catch
-        evasion while preserving regular detection.
+        Matches against the original text and every variant from
+        ``normalize_variants`` to catch evasion while preserving regular
+        detection.
 
         Returns:
             Tuple of (score in [0, 1], list of matched pattern descriptions).
         """
-        normalized = normalize_text(text)
+        candidates = (text, *normalize_variants(text))
         total = 0.0
         matched: list[str] = []
         for weight, patterns in _ESCALATION_PATTERNS:
             for pattern in patterns:
-                if pattern.search(text) or pattern.search(normalized):
+                if any(pattern.search(candidate) for candidate in candidates):
                     total += weight
                     matched.append(pattern.pattern)
         return min(total, 1.0), matched
@@ -539,18 +584,19 @@ class OffensiveIntentDetector:
     def score_message(self, text: str) -> tuple[float, list[str]]:
         """Score a message for offensive intent patterns.
 
-        Matches against both original and normalized text to catch
-        evasion while preserving regular detection.
+        Matches against the original text and every variant from
+        ``normalize_variants`` to catch evasion while preserving regular
+        detection.
 
         Returns:
             Tuple of (score in [0, 1], list of matched pattern descriptions).
         """
-        normalized = normalize_text(text)
+        candidates = (text, *normalize_variants(text))
         total = 0.0
         matched: list[str] = []
         for weight, patterns in _OFFENSIVE_PATTERNS:
             for pattern in patterns:
-                if pattern.search(text) or pattern.search(normalized):
+                if any(pattern.search(candidate) for candidate in candidates):
                     total += weight
                     matched.append(pattern.pattern)
         return min(total, 1.0), matched
@@ -1014,4 +1060,5 @@ __all__ = [
     "TranscriptEntry",
     "load_conversation_guardian_config",
     "normalize_text",
+    "normalize_variants",
 ]

--- a/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
@@ -80,14 +80,60 @@ _HOMOGLYPH_MAP: dict[str, str] = {
 }
 
 
+# Inclusive code point ranges of characters that render as nothing but still
+# split a word for a regex engine.
+#
+# Enumerating a handful of zero-width code points is not enough: any invisible
+# character inserted mid-word defeats every ``\b``-anchored pattern in this
+# module equally, so the set has to be defined by the property that makes them
+# usable for evasion rather than by the few that came to mind.
+#
+# These are Unicode's Default_Ignorable_Code_Point ranges -- which is what
+# "renders as nothing" means normatively -- plus the invisible Hangul filler
+# letters. ``unicodedata`` does not expose that property, so the ranges are
+# spelled out. Note they do not share one category: U+FE0F (variation selector)
+# and U+034F (combining grapheme joiner) are Mn, U+3164 (Hangul filler) is Lo,
+# and U+2065 is unassigned, so no single category test finds them all.
+#
+# The result of this function is only ever matched against, never shown to a
+# user or stored, so stripping is always preferable to preserving.
+_INVISIBLE_RANGES: tuple[tuple[int, int], ...] = (
+    (0x00AD, 0x00AD),  # soft hyphen
+    (0x034F, 0x034F),  # combining grapheme joiner
+    (0x061C, 0x061C),  # arabic letter mark
+    (0x115F, 0x1160),  # hangul filler letters
+    (0x17B4, 0x17B5),  # khmer inherent vowels
+    (0x180B, 0x180F),  # mongolian variation selectors, vowel separator
+    (0x200B, 0x200F),  # zero width space and joiners, directional marks
+    (0x202A, 0x202E),  # directional embedding and override
+    (0x2060, 0x206F),  # word joiner, invisible operators, deprecated formats
+    (0x3164, 0x3164),  # hangul filler
+    (0xFE00, 0xFE0F),  # variation selectors
+    (0xFEFF, 0xFEFF),  # zero width no-break space
+    (0xFFA0, 0xFFA0),  # half width hangul filler
+    (0xFFF0, 0xFFF8),  # unassigned, reserved as invisible
+    (0x1BCA0, 0x1BCA3),  # shorthand format controls
+    (0xE0000, 0xE0FFF),  # tag characters, variation selectors supplement
+)
+
+# Built from the ranges rather than written as one literal so the code points
+# stay readable -- spelled out, the class is a run of characters that show up as
+# nothing in an editor. None of them need escaping inside a character class.
+_INVISIBLE_CHARS = re.compile(
+    "[" + "".join(f"{chr(low)}-{chr(high)}" for low, high in _INVISIBLE_RANGES) + "]"
+)
+
+
 def normalize_text(text: str) -> str:
     """Normalize text to defeat common evasion techniques.
 
     Handles: unicode homoglyphs, leetspeak, zero-width characters,
     excessive whitespace, combining diacritics, fullwidth characters.
     """
-    # Strip zero-width characters
-    text = re.sub(r"[\u200b\u200c\u200d\u2060\ufeff]", "", text)
+    # Strip invisible characters (see _INVISIBLE_RANGES). This has to run before
+    # the compatibility decomposition below, which does not remove them, and one
+    # of them mid-word is enough to defeat every word-anchored pattern here.
+    text = _INVISIBLE_CHARS.sub("", text)
 
     # NFKD decomposition (handles fullwidth, compatibility chars)
     text = unicodedata.normalize("NFKD", text)

--- a/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
@@ -121,6 +121,7 @@ _INVISIBLE_RANGES: tuple[tuple[int, int], ...] = (
     # after this exception so the two do not drift apart.
     (0xFFF9, 0xFFFB),  # interlinear annotation anchor, separator, terminator
     (0x1BCA0, 0x1BCA3),  # shorthand format controls
+    (0x1D173, 0x1D17A),  # musical symbol beam and phrase controls
     (0xE0000, 0xE0FFF),  # tag characters, variation selectors supplement
 )
 

--- a/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/conversation_guardian.py
@@ -90,7 +90,8 @@ _HOMOGLYPH_MAP: dict[str, str] = {
 #
 # These are Unicode's Default_Ignorable_Code_Point ranges -- which is what
 # "renders as nothing" means normatively -- plus the invisible Hangul filler
-# letters. ``unicodedata`` does not expose that property, so the ranges are
+# letters and the interlinear annotation characters (see below).
+# ``unicodedata`` does not expose that property, so the ranges are
 # spelled out. Note they do not share one category: U+FE0F (variation selector)
 # and U+034F (combining grapheme joiner) are Mn, U+3164 (Hangul filler) is Lo,
 # and U+2065 is unassigned, so no single category test finds them all.
@@ -112,6 +113,13 @@ _INVISIBLE_RANGES: tuple[tuple[int, int], ...] = (
     (0xFEFF, 0xFEFF),  # zero width no-break space
     (0xFFA0, 0xFFA0),  # half width hangul filler
     (0xFFF0, 0xFFF8),  # unassigned, reserved as invisible
+    # U+FFF9..FFFB (interlinear annotation) are *not* Default_Ignorable, so they
+    # fall outside the property this list is otherwise derived from. They are
+    # included anyway: Unicode says they should not be exchanged in plain text
+    # and most renderers show nothing for them, so mid-keyword they evade every
+    # pattern here exactly like the ranges above. The test for them is named
+    # after this exception so the two do not drift apart.
+    (0xFFF9, 0xFFFB),  # interlinear annotation anchor, separator, terminator
     (0x1BCA0, 0x1BCA3),  # shorthand format controls
     (0xE0000, 0xE0FFF),  # tag characters, variation selectors supplement
 )
@@ -127,8 +135,13 @@ _INVISIBLE_CHARS = re.compile(
 def normalize_text(text: str) -> str:
     """Normalize text to defeat common evasion techniques.
 
-    Handles: unicode homoglyphs, leetspeak, zero-width characters,
+    Handles: unicode homoglyphs, leetspeak, invisible characters (every
+    range in ``_INVISIBLE_RANGES``, not only the zero-width ones),
     excessive whitespace, combining diacritics, fullwidth characters.
+
+    The return value is intended for matching only. It is lossy by design --
+    invisible characters are dropped rather than preserved -- so it must not be
+    stored or displayed in place of the original text.
     """
     # Strip invisible characters (see _INVISIBLE_RANGES). This has to run before
     # the compatibility decomposition below, which does not remove them, and one

--- a/agent-governance-python/agent-os/tests/test_conversation_guardian.py
+++ b/agent-governance-python/agent-os/tests/test_conversation_guardian.py
@@ -605,20 +605,25 @@ class TestEvasionResistance:
     # words, which the whitespace collapse already handled -- the mid-word case
     # was never covered.) One per Unicode category involved, since no single
     # category test finds them all: Cf, Mn, Lo and unassigned are represented.
+    #
+    # Written as escape sequences, never as the characters themselves: pasted
+    # literally they are indistinguishable from an empty string in a diff, in a
+    # review, and in an editor, and a tool that trims "trailing whitespace"
+    # could silently delete one and turn a test green for the wrong reason.
     @pytest.mark.parametrize(
         ("name", "char"),
         [
-            ("soft hyphen", "­"),
-            ("combining grapheme joiner", "͏"),
-            ("arabic letter mark", "؜"),
-            ("mongolian vowel separator", "᠎"),
-            ("left-to-right mark", "‎"),
-            ("right-to-left isolate", "⁧"),
-            ("invisible plus", "⁤"),
-            ("unassigned invisible", "⁥"),
-            ("hangul filler", "ㅤ"),
-            ("variation selector 16", "️"),
-            ("zero width no-break space", "﻿"),
+            ("soft hyphen", "\u00ad"),
+            ("combining grapheme joiner", "\u034f"),
+            ("arabic letter mark", "\u061c"),
+            ("mongolian vowel separator", "\u180e"),
+            ("left-to-right mark", "\u200e"),
+            ("right-to-left isolate", "\u2067"),
+            ("invisible plus", "\u2064"),
+            ("unassigned invisible", "\u2065"),
+            ("hangul filler", "\u3164"),
+            ("variation selector 16", "\ufe0f"),
+            ("zero width no-break space", "\ufeff"),
             ("tag latin small letter a", "\U000e0061"),
         ],
     )
@@ -626,7 +631,26 @@ class TestEvasionResistance:
         assert normalize_text(_hidden("urgent", char)) == "urgent", name
 
     @pytest.mark.parametrize(
-        "char", ["­", "‎", "️", "ㅤ", "͏"]
+        ("name", "char"),
+        [
+            ("interlinear annotation anchor", "\ufff9"),
+            ("interlinear annotation separator", "\ufffa"),
+            ("interlinear annotation terminator", "\ufffb"),
+        ],
+    )
+    def test_non_default_ignorable_invisibles_are_also_stripped(self, name: str, char: str):
+        """U+FFF9..FFFB are the one group here that is not Default_Ignorable.
+
+        Every other range in ``_INVISIBLE_RANGES`` is derived from that
+        property. These three are not, so a future reader deriving the list
+        purely from Default_Ignorable would drop them -- and they evade just as
+        well, since Unicode says they should not be exchanged in plain text and
+        renderers show nothing for them.
+        """
+        assert normalize_text(_hidden("urgent", char)) == "urgent", name
+
+    @pytest.mark.parametrize(
+        "char", ["\u00ad", "\u200e", "\ufe0f", "\u3164", "\u034f", "\ufff9"]
     )
     def test_invisible_chars_do_not_evade_escalation_scoring(self, char: str):
         # An invisible character in each keyword took the score from 0.80 to
@@ -639,7 +663,7 @@ class TestEvasionResistance:
 
         assert c.score_message(evaded)[0] == c.score_message(clean)[0]
 
-    @pytest.mark.parametrize("char", ["­", "‎", "️"])
+    @pytest.mark.parametrize("char", ["\u00ad", "\u200e", "\ufe0f", "\ufffb"])
     def test_invisible_chars_do_not_evade_offensive_scoring(self, char: str):
         d = OffensiveIntentDetector()
         words = ["exfiltrate", "the", "data", "escalate", "privileges", "impersonate"]
@@ -652,7 +676,7 @@ class TestEvasionResistance:
         # End to end: the same message went from critical/quarantine to
         # none/none with one soft hyphen per keyword.
         words = ["exfiltrate", "the", "data", "escalate", "privileges", "impersonate"]
-        content = " ".join(_hidden(word, "­") for word in words)
+        content = " ".join(_hidden(word, "\u00ad") for word in words)
         guardian = ConversationGuardian()
 
         alert = guardian.analyze_message("c1", "a", "b", content)

--- a/agent-governance-python/agent-os/tests/test_conversation_guardian.py
+++ b/agent-governance-python/agent-os/tests/test_conversation_guardian.py
@@ -530,7 +530,10 @@ class TestEdgeCases:
 # Evasion Resistance
 # =============================================================================
 
-from agent_os.integrations.conversation_guardian import normalize_text
+from agent_os.integrations.conversation_guardian import (
+    _INVISIBLE_RANGES,
+    normalize_text,
+)
 
 
 def _hidden(word: str, char: str) -> str:
@@ -624,11 +627,48 @@ class TestEvasionResistance:
             ("hangul filler", "\u3164"),
             ("variation selector 16", "\ufe0f"),
             ("zero width no-break space", "\ufeff"),
+            ("musical symbol begin beam", "\U0001d173"),
+            ("musical symbol end phrase", "\U0001d17a"),
             ("tag latin small letter a", "\U000e0061"),
         ],
     )
     def test_invisible_char_inside_keyword_is_stripped(self, name: str, char: str):
         assert normalize_text(_hidden("urgent", char)) == "urgent", name
+
+    def test_every_default_ignorable_range_is_covered(self):
+        """The table must cover the property its comment claims it is built from.
+
+        U+1D173..1D17A (musical symbol beam/phrase controls) were missing while
+        the neighbouring supplementary-plane ranges U+1BCA0..1BCA3 and
+        U+E0000..E0FFF were present, so the omission read as deliberate rather
+        than as a gap. Checking the property instead of a hand-picked sample
+        means the next range added to Default_Ignorable is caught here rather
+        than by whoever finds the evasion.
+
+        ``unicodedata`` does not expose Default_Ignorable_Code_Point, so the
+        expected set is spelled out from the Unicode data file (DerivedCoreProper
+        ties.txt). Ranges the module adds *beyond* the property -- the
+        interlinear annotation characters -- are intentionally not listed here;
+        this asserts coverage, not equality.
+        """
+        default_ignorable = (
+            (0x00AD, 0x00AD), (0x034F, 0x034F), (0x061C, 0x061C),
+            (0x115F, 0x1160), (0x17B4, 0x17B5), (0x180B, 0x180F),
+            (0x200B, 0x200F), (0x202A, 0x202E), (0x2060, 0x206F),
+            (0x3164, 0x3164), (0xFE00, 0xFE0F), (0xFEFF, 0xFEFF),
+            (0xFFA0, 0xFFA0), (0xFFF0, 0xFFF8), (0x1BCA0, 0x1BCA3),
+            (0x1D173, 0x1D17A), (0xE0000, 0xE0FFF),
+        )
+        covered = {
+            cp for start, end in _INVISIBLE_RANGES for cp in range(start, end + 1)
+        }
+        missing = [
+            f"U+{cp:04X}"
+            for start, end in default_ignorable
+            for cp in range(start, end + 1)
+            if cp not in covered
+        ]
+        assert missing == [], f"Default_Ignorable code points not stripped: {missing}"
 
     @pytest.mark.parametrize(
         ("name", "char"),

--- a/agent-governance-python/agent-os/tests/test_conversation_guardian.py
+++ b/agent-governance-python/agent-os/tests/test_conversation_guardian.py
@@ -641,15 +641,20 @@ class TestEvasionResistance:
         U+1D173..1D17A (musical symbol beam/phrase controls) were missing while
         the neighbouring supplementary-plane ranges U+1BCA0..1BCA3 and
         U+E0000..E0FFF were present, so the omission read as deliberate rather
-        than as a gap. Checking the property instead of a hand-picked sample
-        means the next range added to Default_Ignorable is caught here rather
-        than by whoever finds the evasion.
+        than as a gap. Asserting against the whole property rather than a
+        hand-picked sample of it means a range dropped from ``_INVISIBLE_RANGES``
+        fails here instead of being found by whoever uses it to evade the
+        keyword scan.
 
-        ``unicodedata`` does not expose Default_Ignorable_Code_Point, so the
-        expected set is spelled out from the Unicode data file (DerivedCoreProper
-        ties.txt). Ranges the module adds *beyond* the property -- the
-        interlinear annotation characters -- are intentionally not listed here;
-        this asserts coverage, not equality.
+        ``unicodedata`` does not expose Default_Ignorable_Code_Point, so this is
+        a snapshot of the property, transcribed from Unicode's
+        ``DerivedCoreProperties.txt``. It is not read from Unicode data at run
+        time, so a range Unicode *adds* to the property in a future version has
+        to be added to the snapshot by hand -- update both together.
+
+        Ranges the module covers *beyond* the property -- the interlinear
+        annotation characters -- are intentionally not listed: this asserts
+        coverage, not equality.
         """
         default_ignorable = (
             (0x00AD, 0x00AD), (0x034F, 0x034F), (0x061C, 0x061C),

--- a/agent-governance-python/agent-os/tests/test_conversation_guardian.py
+++ b/agent-governance-python/agent-os/tests/test_conversation_guardian.py
@@ -533,6 +533,7 @@ class TestEdgeCases:
 from agent_os.integrations.conversation_guardian import (
     _INVISIBLE_RANGES,
     normalize_text,
+    normalize_variants,
 )
 
 
@@ -746,6 +747,110 @@ class TestEvasionResistance:
         # The strip must not eat real content: every character above is visible
         # and has to survive, including the ones adjacent to stripped ranges.
         assert normalize_text(text).strip()
+
+
+class TestInvisibleCharactersBetweenKeywords:
+    """An invisible character *between* two keywords must not hide either one.
+
+    Deleting it glues the keywords together and destroys the ``\\b`` the patterns
+    are anchored on, which is the mirror image of the mid-word case: deletion is
+    what rescues that one. Neither placement can be handled by one variant, so
+    the detectors match against a space-substituted variant as well.
+
+    This was already true on main for the five characters it stripped -- a zero
+    width space between two leetspeak keywords scores 0.35 there instead of 0.70
+    -- so widening the stripped set widened an existing weakness. Both are fixed
+    here, which is why the parametrisations below cover a previously-stripped
+    character alongside the newly-covered ones.
+    """
+
+    # Leetspeak is part of every case on purpose. The detectors match the raw
+    # text as well as the normalized variants, and an invisible character is a
+    # non-word character, so in *plain* text the raw match still fires across
+    # the glue. Only when some other evasion (here leetspeak) forces the match
+    # to depend on a normalized variant does the gluing actually hide anything.
+    @pytest.mark.parametrize(
+        ("name", "char"),
+        [
+            ("zero width space (stripped on main too)", "\u200b"),
+            ("soft hyphen", "\u00ad"),
+            ("variation selector 16", "\ufe0f"),
+            ("hangul filler", "\u3164"),
+            ("interlinear annotation anchor", "\ufff9"),
+            ("musical symbol begin beam", "\U0001d173"),
+        ],
+    )
+    def test_glue_does_not_hide_an_offensive_keyword(self, name: str, char: str):
+        # "3scalate privileg3s<char>imp3rsonate": deletion yields
+        # "...privilegesimpersonate", where \bimpersonat\w* cannot match, so the
+        # score fell from 0.70 to 0.35 -- one keyword silently lost.
+        d = OffensiveIntentDetector()
+        clean = "3scalate privileg3s imp3rsonate"
+        glued = f"3scalate privileg3s{char}imp3rsonate"
+
+        assert d.score_message(glued)[0] == d.score_message(clean)[0], name
+
+    @pytest.mark.parametrize(
+        ("name", "char"),
+        [
+            ("zero width space (stripped on main too)", "\u200b"),
+            ("soft hyphen", "\u00ad"),
+            ("variation selector 16", "\ufe0f"),
+            ("interlinear annotation terminator", "\ufffb"),
+        ],
+    )
+    def test_glue_does_not_hide_an_escalation_keyword(self, name: str, char: str):
+        # "y0u must<char>n0 excuses" -> "you mustno excuses" under deletion, which
+        # matches neither \byou\s+must\b nor \bno\s+excuses\b: 0.50 -> 0.00.
+        c = EscalationClassifier()
+        clean = "y0u must n0 excuses"
+        glued = f"y0u must{char}n0 excuses"
+
+        assert c.score_message(glued)[0] == c.score_message(clean)[0], name
+
+    def test_glue_and_mid_word_evasion_are_both_caught_in_one_message(self):
+        """The two placements in the same message, which needs both variants.
+
+        ``privileg3s<char>imp3rsonate`` is only scored via the space-substituted
+        variant and ``3xf1ltr4te`` with a character inside it only via the
+        deleted variant, so a message using both is the case that fails if
+        either variant is dropped.
+        """
+        d = OffensiveIntentDetector()
+        clean = "3xf1ltr4te data 3scalate privileg3s imp3rsonate"
+        # Concatenated rather than interpolated: a backslash escape inside an
+        # f-string expression is a syntax error before Python 3.12, and this
+        # package supports 3.11.
+        evaded = _hidden("3xf1ltr4te", "\u00ad") + " data 3scalate privileg3s\ufe0fimp3rsonate"
+
+        assert d.score_message(evaded)[0] == d.score_message(clean)[0]
+
+    def test_guardian_still_pauses_on_a_glued_message(self):
+        # End to end, at the composite level: this message recommends "pause" on
+        # main and produced no action at all once the character was stripped.
+        guardian = ConversationGuardian()
+
+        alert = guardian.analyze_message("c1", "a", "b", "3scalate privileg3s\ufe0fimp3rsonate")
+
+        assert alert.offensive_score == pytest.approx(0.70)
+        assert alert.action is AlertAction.PAUSE
+
+    def test_variants_are_deduplicated_when_there_is_nothing_invisible(self):
+        # Ordinary text produces one variant, not two identical ones, so the
+        # common case does no extra matching work.
+        assert normalize_variants("you must comply") == ("you must comply",)
+
+    def test_variants_are_the_deleted_and_spaced_forms(self):
+        assert normalize_variants("privileg3s\ufe0fimp3rsonate") == (
+            "privilegesimpersonate",
+            "privileges impersonate",
+        )
+
+    def test_normalize_text_is_still_the_deleting_variant(self):
+        # normalize_text is exported and used elsewhere; splitting the variants
+        # out must not change what it returns.
+        assert normalize_text(_hidden("urgent", "\ufe0f")) == "urgent"
+        assert normalize_text("privileg3s\ufe0fimp3rsonate") == "privilegesimpersonate"
 
 
 # =============================================================================

--- a/agent-governance-python/agent-os/tests/test_conversation_guardian.py
+++ b/agent-governance-python/agent-os/tests/test_conversation_guardian.py
@@ -533,6 +533,19 @@ class TestEdgeCases:
 from agent_os.integrations.conversation_guardian import normalize_text
 
 
+def _hidden(word: str, char: str) -> str:
+    """Return *word* with *char* inserted in the middle of it.
+
+    The character goes inside the word, which is where it defeats a word-anchored
+    pattern. Inserted at runtime rather than written into the literals so the
+    source keeps whole, readable words.
+    """
+    if len(word) < 2:
+        return word
+    middle = len(word) // 2
+    return word[:middle] + char + word[middle:]
+
+
 class TestEvasionResistance:
     """Tests that pattern detection resists common evasion techniques."""
 
@@ -584,6 +597,86 @@ class TestEvasionResistance:
         d = OffensiveIntentDetector()
         score, _ = d.score_message("3xpl0it the vulner4bility")
         assert score > 0.0
+
+    # Invisible characters that render as nothing but still split a word for the
+    # regex engine. Only the five zero-width ones were stripped, so any of these
+    # placed *inside* a keyword defeated every pattern in the module.
+    # (`test_zero_width_characters` above puts its zero width space *between*
+    # words, which the whitespace collapse already handled -- the mid-word case
+    # was never covered.) One per Unicode category involved, since no single
+    # category test finds them all: Cf, Mn, Lo and unassigned are represented.
+    @pytest.mark.parametrize(
+        ("name", "char"),
+        [
+            ("soft hyphen", "­"),
+            ("combining grapheme joiner", "͏"),
+            ("arabic letter mark", "؜"),
+            ("mongolian vowel separator", "᠎"),
+            ("left-to-right mark", "‎"),
+            ("right-to-left isolate", "⁧"),
+            ("invisible plus", "⁤"),
+            ("unassigned invisible", "⁥"),
+            ("hangul filler", "ㅤ"),
+            ("variation selector 16", "️"),
+            ("zero width no-break space", "﻿"),
+            ("tag latin small letter a", "\U000e0061"),
+        ],
+    )
+    def test_invisible_char_inside_keyword_is_stripped(self, name: str, char: str):
+        assert normalize_text(_hidden("urgent", char)) == "urgent", name
+
+    @pytest.mark.parametrize(
+        "char", ["­", "‎", "️", "ㅤ", "͏"]
+    )
+    def test_invisible_chars_do_not_evade_escalation_scoring(self, char: str):
+        # An invisible character in each keyword took the score from 0.80 to
+        # 0.00 -- past the 0.6 threshold in the wrong direction, so a message
+        # that should quarantine produced no alert at all.
+        c = EscalationClassifier()
+        words = ["urgent", "you", "must", "comply", "immediately", "no", "excuses"]
+        clean = " ".join(words)
+        evaded = " ".join(_hidden(word, char) for word in words)
+
+        assert c.score_message(evaded)[0] == c.score_message(clean)[0]
+
+    @pytest.mark.parametrize("char", ["­", "‎", "️"])
+    def test_invisible_chars_do_not_evade_offensive_scoring(self, char: str):
+        d = OffensiveIntentDetector()
+        words = ["exfiltrate", "the", "data", "escalate", "privileges", "impersonate"]
+        clean = " ".join(words)
+        evaded = " ".join(_hidden(word, char) for word in words)
+
+        assert d.score_message(evaded)[0] == d.score_message(clean)[0]
+
+    def test_invisible_chars_do_not_evade_the_guardian(self):
+        # End to end: the same message went from critical/quarantine to
+        # none/none with one soft hyphen per keyword.
+        words = ["exfiltrate", "the", "data", "escalate", "privileges", "impersonate"]
+        content = " ".join(_hidden(word, "­") for word in words)
+        guardian = ConversationGuardian()
+
+        alert = guardian.analyze_message("c1", "a", "b", content)
+
+        assert alert.severity is AlertSeverity.CRITICAL
+        assert alert.action is AlertAction.QUARANTINE
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "hello world",
+            "the API returned 200 OK",
+            "naïve café",  # visible diacritics
+            "中文测试",  # CJK
+            "ok \U0001f44d\U0001f3fd done",  # emoji with a skin tone modifier
+            "\U0001f1fa\U0001f1f8 usa",  # regional indicator pair
+            "한국어 test",  # hangul syllables, not the fillers
+            "start \u05e9\u05dc\u05d5\u05dd end",  # right-to-left script
+        ],
+    )
+    def test_stripping_does_not_empty_ordinary_text(self, text: str):
+        # The strip must not eat real content: every character above is visible
+        # and has to survive, including the ones adjacent to stripped ranges.
+        assert normalize_text(text).strip()
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #3500

### What

`normalize_text` stripped five zero-width code points, so any other invisible character placed *inside* a keyword split the word for every ``-anchored pattern in the module and defeated detection entirely.

| message | `EscalationClassifier` | `OffensiveIntentDetector` | `analyze_message` |
| --- | --- | --- | --- |
| clean | 0.80 | 1.00 | `critical` / `quarantine` |
| one soft hyphen per keyword | **0.00** | **0.00** | **`none` / `none`** |

The thresholds are 0.6 and 0.5, so the evaded message produces no alert at all. The characters are invisible in an editor or log viewer, so an operator reading the transcript sees the plain offensive text while the guardian reports nothing.

### Why the existing steps missed it

- NFKD does not remove any of these characters.
- The combining-diacritic strip does not help either: `unicodedata.combining()` returns `0` for U+FE0F and U+034F even though both are category `Mn`.
- No single category test works. The usable characters span `Cf` (U+00AD), `Mn` (U+034F, U+FE0F), `Lo` (U+3164) and unassigned (U+2065).
- `test_zero_width_characters` puts its zero-width space *between* words, where the whitespace collapse already handles it — the mid-word case was never covered.

### How

Replace the five-character class with Unicode's `Default_Ignorable_Code_Point` ranges plus the invisible Hangul filler letters, and strip before the compatibility decomposition. The set is defined by the property that makes these characters usable for evasion rather than by the few that came to mind. `unicodedata` does not expose the property, so the ranges are spelled out as an integer table and the character class is built from it — written out as literals, the class is a run of characters that show up as nothing in an editor.

`normalize_text` output is only ever matched against, never returned to a caller or stored, so stripping is safe rather than lossy here.

### Tests

29 new cases in `TestEvasionResistance`:

- 12 invisible characters, one per Unicode category involved, each inserted mid-keyword.
- Score-parity checks for `EscalationClassifier` and `OffensiveIntentDetector`: the evaded message must score exactly what the clean one scores.
- An end-to-end guardian check asserting `critical` / `quarantine`.
- 8 no-false-positive cases: visible diacritics, CJK, an emoji with a skin-tone modifier, a regional indicator pair, Hangul syllables (as opposed to the fillers) and right-to-left script all survive.

Verified: `tests/test_conversation_guardian.py` 108 passed with the fix, 20 failed / 88 passed on the unpatched source. Full `tests/` run 257 failed / 4493 passed against 257 / 4464 on the base commit — the same 257 pre-existing failures and exactly the 29 new tests, no new failures. `ruff check` diagnostics identical to base apart from clearing one pre-existing unused-import warning.

### Checklist

- [x] I have read the [contributing guidelines](https://github.com/microsoft/agent-governance-toolkit/blob/main/CONTRIBUTING.md)
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
