### PR TITLE
fix(agent-os): reject supervisors registered above the deterministic trust root

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -61,11 +61,26 @@ class SupervisorHierarchy:
         """Check hierarchy rules and return a list of violations (empty = valid).
 
         Rules:
+        - No supervisor may sit above the root: levels MUST NOT be negative.
         - Level 0 MUST exist and MUST be deterministic (not an LLM agent).
         - Middle levels (1–N) may be agent-based.
         - Each level present must have at least one supervisor.
         """
         violations: list[str] = []
+
+        # Checked before anything else: level 0 is the root, so a negative level
+        # places a supervisor *above* the deterministic authority. The
+        # determinism rule below only inspects supervisors whose level is exactly
+        # 0, and the gap scan only walks ``range(1, max_level + 1)``, so a
+        # negative level was invisible to both — an agent registered at level -1
+        # produced no violations at all while ranking ahead of the trust root in
+        # ``get_authority_chain``.
+        for s in self._supervisors:
+            if s.level < 0:
+                violations.append(
+                    f"Supervisor '{s.name}' has negative level {s.level}; level 0 is the "
+                    "root and nothing may sit above it"
+                )
 
         level_0 = [s for s in self._supervisors if s.level == 0]
         if not level_0:

--- a/agent-governance-python/agent-os/src/agent_os/trust_root.py
+++ b/agent-governance-python/agent-os/src/agent_os/trust_root.py
@@ -71,7 +71,26 @@ class TrustRoot:
         is_agent = supervisor_config.get("is_agent", True)
         if level is None or not supervisor_config.get("name"):
             return False
-        return not (level == 0 and is_agent)
+
+        # The level must be a real integer before it can be compared against the
+        # root. ``"0" == 0`` is False in Python, so a string level skipped the
+        # determinism check below entirely rather than failing it. ``bool`` is a
+        # subclass of ``int`` and ``False == 0``, so it is excluded explicitly
+        # instead of being read as the root level.
+        if isinstance(level, bool) or not isinstance(level, int):
+            return False
+
+        # Level 0 is the root; higher levels are closer to workers. A negative
+        # level would sit *above* the deterministic root, which is the one place
+        # in the hierarchy that must not be occupied by an agent.
+        if level < 0:
+            return False
+
+        # Root level must be deterministic — not an LLM agent
+        if level == 0 and is_agent:
+            return False
+
+        return True
 
     def is_deterministic(self) -> bool:
         """The authority delegates only to the deterministic ACS runtime."""

--- a/agent-governance-python/agent-os/tests/test_trust_root.py
+++ b/agent-governance-python/agent-os/tests/test_trust_root.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 """Tests for the native-runtime trust authority and supervisor hierarchy."""
 from __future__ import annotations
+import pytest
 from agent_control_specification import Decision, InterventionPointResult, Verdict
 from agent_os.supervisor import SupervisorHierarchy
 from agent_os.trust_root import TrustRoot
@@ -41,3 +42,70 @@ def test_supervisor_hierarchy_escalates_to_native_trust_root() -> None:
     assert hierarchy.validate_hierarchy() == []
     assert hierarchy.escalate({'tool': 'read_file', 'arguments': {}}, from_level=1).allowed
     assert not hierarchy.escalate({'tool': 'delete_file', 'arguments': {}}, from_level=1).allowed
+
+@pytest.mark.parametrize('level', [-1, -2, -100])
+@pytest.mark.parametrize('is_agent', [True, False])
+def test_negative_supervisor_level_is_rejected(level: int, is_agent: bool) -> None:
+    """Level 0 is the root, so a negative level sits *above* it.
+
+    The rule was a single exact comparison, ``if level == 0 and is_agent``, which
+    every negative level passes -- placing a supervisor ahead of the
+    deterministic authority, which is the one position the rule exists to
+    protect. Rejected regardless of ``is_agent``: being deterministic does not
+    make the position valid, because there is nothing above the root to
+    supervise.
+    """
+    assert _root().validate_supervisor({'name': 'above-root', 'level': level, 'is_agent': is_agent}) is False
+
+@pytest.mark.parametrize('level', ['0', '1', 0.0, 1.5, [0], True, False])
+def test_non_integer_supervisor_level_is_rejected(level: object) -> None:
+    """A level that is not a real ``int`` skipped the determinism check.
+
+    ``"0" == 0`` is False in Python, so a string level -- exactly what a config
+    loader that skips coercion produces -- was never compared against the root
+    at all rather than failing the comparison. ``bool`` is covered here too: it
+    is an ``int`` subclass whose ``False == 0``, so a bool level would otherwise
+    be read as the root level.
+    """
+    assert _root().validate_supervisor({'name': 'sup', 'level': level, 'is_agent': True}) is False
+
+@pytest.mark.parametrize(('level', 'is_agent', 'expected'), [(0, False, True), (0, True, False), (1, True, True), (9, True, True)])
+def test_accepted_supervisor_levels_are_unchanged(level: int, is_agent: bool, expected: bool) -> None:
+    assert _root().validate_supervisor({'name': 'sup', 'level': level, 'is_agent': is_agent}) is expected
+
+def _hierarchy_with(name: str, level: int, is_agent: bool) -> SupervisorHierarchy:
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('trust-root', level=0, is_agent=False)
+    hierarchy.register_supervisor('safety-agent', level=1, is_agent=True)
+    hierarchy.register_supervisor(name, level=level, is_agent=is_agent)
+    return hierarchy
+
+def test_agent_registered_above_the_root_is_reported() -> None:
+    """``validate_hierarchy`` had no check that could see a negative level.
+
+    The determinism rule only inspects supervisors whose level is exactly 0, and
+    the gap scan only walks ``range(1, max_level + 1)``. An LLM agent at level -1
+    therefore produced an empty violation list -- the documented "valid" signal.
+    """
+    violations = _hierarchy_with('above-root', -1, True).validate_hierarchy()
+    assert violations != []
+    assert any('above-root' in v and '-1' in v for v in violations)
+
+def test_deterministic_supervisor_above_the_root_is_also_reported() -> None:
+    assert _hierarchy_with('above-root', -1, False).validate_hierarchy() != []
+
+def test_negative_level_outranks_the_root_in_the_authority_chain() -> None:
+    """Why a violation is the right response rather than a warning.
+
+    The chain is ordered by level, so a negative level lands last -- the
+    position the docstring reserves for the trust root as final authority.
+    """
+    assert _hierarchy_with('above-root', -1, True).get_authority_chain({})[-1] == 'above-root'
+
+@pytest.mark.parametrize('level', [-1, -7])
+def test_negative_level_is_reported_even_without_a_level_0(level: int) -> None:
+    # The gap scan walks range(1, max_level + 1), which is empty when the highest
+    # level is negative, so nothing else would fire here either.
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('only', level=level, is_agent=True)
+    assert any('negative level' in v for v in hierarchy.validate_hierarchy())


### PR DESCRIPTION
Fixes #3509

### What was wrong

The level-0 determinism rule was enforced by a single exact comparison, `if level == 0 and is_agent`, in both `TrustRoot.validate_supervisor` and `SupervisorHierarchy.validate_hierarchy`. Anything not equal to `0` passed — including every **negative** level, which places an LLM agent *above* the deterministic trust root, and every **non-integer** level, because `"0" == 0` is `False` in Python.

`validate_hierarchy` had no check that could see a negative level at all. The determinism loop only inspects supervisors whose level is exactly `0`, and the gap scan walks `range(1, max_level + 1)`, which never covers negatives. So:

```python
h = SupervisorHierarchy(trust_root=root)
h.register_supervisor("trust-root", level=0, is_agent=False)
h.register_supervisor("safety-agent", level=1, is_agent=True)
h.register_supervisor("evil-agent", level=-1, is_agent=True)

h.validate_hierarchy()          # -> []   <- the documented "valid" signal
h.get_authority_chain({})[-1]   # -> 'evil-agent'
```

An empty violation list is the API's "valid" answer (`docs/api-reference.md`), while the agent occupies the slot the docstring reserves for the trust root as final authority. That contradicts the invariant `docs/owasp-agentic-top10-mapping.md` states under ASI10:

> **TrustRoot** — a deterministic (non-LLM) policy authority **at the top of the supervisor hierarchy** that cannot be prompt-injected.

### What changed

**`trust_root.py` — `validate_supervisor`**

- `level` must be a real `int`. `bool` is excluded explicitly: it is an `int` subclass and `False == 0`, so a bool level would otherwise be read as the root level.
- `level < 0` is rejected before the determinism check, regardless of `is_agent`. There is no configuration under which a supervisor above the root is meaningful, so even a deterministic one there is a misconfiguration — this is not a case where an opt-out applies.

**`supervisor.py` — `validate_hierarchy`**

- A violation is emitted for every supervisor with a negative level, checked **before** the level-0 rules so the message names the supervisor that is actually there rather than the root that is missing. With a lone supervisor at level -1 the old code reported only `Level 0 (root) has no registered supervisor`, which points at the wrong thing.

Behaviour table (`is_agent=True` unless noted):

| `level` | before | after |
| --- | --- | --- |
| `-1` / `-100` | `True` | `False` |
| `-1`, `is_agent=False` | `True` | `False` |
| `"0"` / `"1"` / `1.5` / `[0]` | `True` | `False` |
| `True` | `True` | `False` |
| `0` | `False` | `False` |
| `0`, `is_agent=False` | `True` | `True` |
| `1` .. `N` | `True` | `True` |

One previously accepted configuration does change: `level=0.0` with `is_agent=False` was accepted by `validate_supervisor` on main and is now rejected, since `isinstance(level, int)` excludes floats. It cost nothing, because no float level could be consumed downstream anyway -- the gap scan computes `range(1, max_level + 1)`, which raises `TypeError` on a float. Pinned in `test_float_level_never_reached_a_working_hierarchy`. Otherwise unchanged: level 0 deterministic, and agent-based supervisors at levels 1..N.

### Compatibility

`validate_supervisor` becomes stricter, so a caller that today passes `level` as a string and relies on `True` will start getting `False`. That is the defect being fixed — a governance check returning "acceptable" for the input it exists to reject — and there are no in-repo callers passing a non-`int` level. `register_supervisor` is annotated `level: int` already, so the hierarchy side is a pure addition of a missing violation.

### Verification

- `tests/test_trust_root.py`: **44 passed**. With the two source files stashed, the same file is **15 failed / 29 passed** — every new assertion fails on `main` and passes with the fix.
- Full `tests/` suite (`-p no:randomly --continue-on-collection-errors`): **4488 passed / 257 failed**, against **4464 / 257** on base — exactly +24, the new test count, with **no new failures**. (The 257 pre-existing failures and 3 collection errors are unrelated: modules importing `agentmesh` / `agent_sre`.)
- `ruff check` and `ruff format --check` on the three touched files: **identical to base** (base already reports `I001` + `F401` in the test file and would reformat `trust_root.py`; this branch reports the same and nothing more).
- `cspell` on all 147 added lines: clean.

### Tests added

`TestValidateSupervisorLevelInvariant` (4 methods / 16 cases) — negative levels rejected regardless of `is_agent`; non-integer levels rejected; `bool` levels rejected with the reason stated; and a table asserting the four previously valid combinations still behave the same.

`TestNegativeLevelIsAViolation` (5 methods / 6 cases) — an agent above the root is reported; a *deterministic* supervisor above the root is also reported; the authority-chain consequence is pinned so the reason the violation matters is testable, not just asserted in a comment; a negative level is reported even with no level 0 present, where the gap scan is empty; and a valid 0/1 hierarchy still returns `[]`.

### Checklist

- [x] Tests added that fail without the fix and pass with it
- [x] `ruff check` / `ruff format --check` state unchanged relative to base
- [x] No new failures in the full test suite
