### PR TITLE
fix(agent-os): apply the require_tls gate to the configured server URL

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
@@ -178,12 +178,9 @@ class McpAuthPolicy:
         entry = self._servers.get(server_name)
         if entry:
             if auth_method in entry.allowed_auth_methods:
-                # TLS check: parse the URL's scheme rather than testing
-                # for the literal "http://" prefix. Previously, a URL
-                # using `ftp://`, `ws://`, `gopher://`, or no scheme at
-                # all bypassed the require_tls gate because none of
-                # them start with "http://" — only `https://` and
-                # `wss://` represent actual TLS-secured transports.
+                # TLS check: the scheme is parsed and matched against the
+                # allowlist below, so only `https://` and `wss://` count as
+                # TLS-secured transports.
                 #
                 # The URL to check falls back to the one registered on the
                 # entry. `url` defaults to "" and the gate used to be skipped

--- a/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
@@ -129,6 +129,12 @@ class McpAuthPolicy:
         connection will be encrypted -- so a TLS requirement cannot be
         considered satisfied. Callers decide whether to invoke this at all for
         an empty URL.
+
+        The returned string never embeds the URL itself. It reaches
+        ``AuthCheckResult.reason``, which audit backends promote to attributes
+        (``otel_audit_backend`` maps it to ``agt.audit.reason``), and a server
+        URL can carry a token in its userinfo or query string. The scheme is
+        the only part needed to explain the decision, and it is not secret.
         """
         try:
             scheme = urlparse(url).scheme.lower()
@@ -136,9 +142,9 @@ class McpAuthPolicy:
             scheme = ""
         if scheme in TLS_SCHEMES:
             return None
-        if not scheme:
-            return f"URL {url!r} has no scheme, so TLS cannot be verified"
         allowlist = ", ".join(sorted(TLS_SCHEMES))
+        if not scheme:
+            return f"the URL has no scheme, so TLS cannot be verified (need {allowlist})"
         return f"URL scheme {scheme!r} is not in the TLS allowlist ({allowlist})"
 
     def check(self, server_name: str, auth_method: str, url: str = "") -> AuthCheckResult:

--- a/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
@@ -43,6 +43,9 @@ logger = logging.getLogger(__name__)
 # Supported auth methods (aligns with 2026 MCP roadmap)
 VALID_AUTH_METHODS = {"oauth2", "mtls", "api_key", "bearer", "none"}
 
+# Only these URL schemes represent an actual TLS-secured transport.
+TLS_SCHEMES = frozenset({"https", "wss"})
+
 
 @dataclass
 class McpServerEntry:
@@ -112,13 +115,42 @@ class McpAuthPolicy:
         """Remove a server from the allowlist."""
         return self._servers.pop(name, None) is not None
 
+    @staticmethod
+    def _tls_violation(url: str) -> str | None:
+        """Return why *url* is not TLS-secured, or ``None`` if it is.
+
+        Scheme-based rather than prefix-based: ``ftp://``, ``ws://`` and a URL
+        with no scheme at all are all non-TLS, and only ``https``/``wss`` are
+        actual TLS transports.
+
+        A non-empty URL with **no scheme** is a violation rather than a pass. It
+        is the shape a bare host or a glob pattern takes (``mcp.internal``,
+        ``*.internal/finance``), and there is no way to tell from it whether the
+        connection will be encrypted -- so a TLS requirement cannot be
+        considered satisfied. Callers decide whether to invoke this at all for
+        an empty URL.
+        """
+        try:
+            scheme = urlparse(url).scheme.lower()
+        except (ValueError, AttributeError):
+            scheme = ""
+        if scheme in TLS_SCHEMES:
+            return None
+        if not scheme:
+            return f"URL {url!r} has no scheme, so TLS cannot be verified"
+        allowlist = ", ".join(sorted(TLS_SCHEMES))
+        return f"URL scheme {scheme!r} is not in the TLS allowlist ({allowlist})"
+
     def check(self, server_name: str, auth_method: str, url: str = "") -> AuthCheckResult:
         """Check if an auth method is allowed for the given MCP server.
 
         Args:
             server_name: Name of the MCP server.
             auth_method: Authentication method being used.
-            url: Server URL (for logging/audit).
+            url: Server URL for the connection being checked. When omitted, the
+                URL registered on the matching :class:`McpServerEntry` is used
+                instead, so a server configured with a plaintext URL is blocked
+                whether or not the caller repeats that URL here.
 
         Returns:
             AuthCheckResult indicating whether the connection is allowed.
@@ -152,20 +184,28 @@ class McpAuthPolicy:
                 # all bypassed the require_tls gate because none of
                 # them start with "http://" — only `https://` and
                 # `wss://` represent actual TLS-secured transports.
-                if entry.require_tls and url:
-                    try:
-                        scheme = urlparse(url).scheme.lower()
-                    except (ValueError, AttributeError):
-                        scheme = ""
-                    if scheme not in {"https", "wss"}:
+                #
+                # The URL to check falls back to the one registered on the
+                # entry. `url` defaults to "" and the gate used to be skipped
+                # entirely when it was falsy, so a server configured with a
+                # plaintext URL and require_tls=True was allowed by any caller
+                # that did not repeat the URL -- including every caller on the
+                # from_yaml path, where the URL lives in config and the call
+                # site has no reason to pass it again.
+                #
+                # When neither the caller nor the entry supplies a URL there is
+                # nothing to evaluate, and the gate stays skipped as before.
+                # Denying that case would be a separate policy decision about
+                # every server registered without a URL, not this fix.
+                effective_url = url or entry.url
+                if entry.require_tls and effective_url:
+                    violation = self._tls_violation(effective_url)
+                    if violation is not None:
                         return AuthCheckResult(
                             allowed=False,
                             server_name=server_name,
                             auth_method=auth_method,
-                            reason=(
-                                f"Server '{server_name}' requires TLS but URL scheme "
-                                f"{scheme!r} is not in the TLS allowlist (https, wss)"
-                            ),
+                            reason=f"Server '{server_name}' requires TLS but {violation}",
                         )
                 return AuthCheckResult(
                     allowed=True,

--- a/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
@@ -107,6 +107,88 @@ class TestMcpAuthPolicy:
         assert len(result.reason) > 0
 
 
+class TestTlsGateUsesTheConfiguredUrl:
+    """``require_tls`` must hold for the URL the server is registered with.
+
+    The gate only ran when the *caller* passed a ``url``, which defaults to
+    ``""``. So a server configured with a plaintext URL and ``require_tls=True``
+    was allowed by any caller that did not repeat that URL -- including every
+    caller on the ``from_yaml`` path, where the URL lives in config and the call
+    site has no reason to pass it again.
+    """
+
+    @staticmethod
+    def _policy(url: str, **kwargs: object) -> McpAuthPolicy:
+        return McpAuthPolicy(
+            servers=[
+                McpServerEntry(name="finance", url=url, allowed_auth_methods=["mtls"], **kwargs),
+            ]
+        )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://mcp.internal/finance",
+            "ws://mcp.internal/finance",
+            "ftp://mcp.internal/finance",
+            "gopher://mcp.internal",
+            # No scheme: the shape a bare host or a glob pattern takes. Nothing
+            # here says the transport is encrypted, so TLS is not satisfied.
+            "mcp.internal/finance",
+            "*.internal/finance",
+        ],
+    )
+    def test_plaintext_configured_url_is_denied_without_a_caller_url(self, url: str) -> None:
+        result = self._policy(url).check("finance", auth_method="mtls")
+        assert result.allowed is False
+        assert "requires TLS" in result.reason
+
+    @pytest.mark.parametrize("url", ["https://mcp.internal/finance", "wss://mcp.internal/ws"])
+    def test_tls_configured_url_is_allowed(self, url: str) -> None:
+        assert self._policy(url).check("finance", auth_method="mtls").allowed is True
+
+    def test_scheme_case_is_ignored(self) -> None:
+        assert self._policy("HTTPS://MCP.INTERNAL").check("finance", auth_method="mtls").allowed
+
+    def test_caller_url_still_wins_over_the_configured_one(self) -> None:
+        # The caller knows the URL actually being dialed; a plaintext dial
+        # against an https-registered server must still be blocked.
+        policy = self._policy("https://mcp.internal/finance")
+        assert policy.check("finance", auth_method="mtls").allowed is True
+        assert (
+            policy.check("finance", auth_method="mtls", url="http://mcp.internal/finance").allowed
+            is False
+        )
+
+    def test_no_url_anywhere_leaves_the_gate_skipped(self) -> None:
+        # Unchanged behaviour: with no URL from either source there is nothing
+        # to evaluate. Denying this would be a separate policy decision about
+        # every server registered without a URL.
+        assert self._policy("").check("finance", auth_method="mtls").allowed is True
+
+    def test_require_tls_false_allows_plaintext(self) -> None:
+        policy = self._policy("http://mcp.internal/finance", require_tls=False)
+        assert policy.check("finance", auth_method="mtls").allowed is True
+
+    def test_auth_method_denial_is_not_masked_by_the_tls_gate(self) -> None:
+        # A method outside the allowlist must still be reported as such, not as
+        # a TLS problem — the allowlist check comes first.
+        result = self._policy("http://mcp.internal/finance").check("finance", auth_method="oauth2")
+        assert result.allowed is False
+        assert "not allowed for server" in result.reason
+
+    def test_yaml_configured_plaintext_server_is_denied(self) -> None:
+        policy = McpAuthPolicy.from_yaml("""
+mcp_auth_policy:
+  servers:
+    - name: finance-tools
+      url: http://mcp.internal/finance
+      allowed_auth_methods: [mtls]
+      require_tls: true
+""")
+        assert policy.check("finance-tools", auth_method="mtls").allowed is False
+
+
 class TestFromYaml:
     def test_parse_yaml(self):
         policy = McpAuthPolicy.from_yaml("""

--- a/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
@@ -143,6 +143,24 @@ class TestTlsGateUsesTheConfiguredUrl:
         assert not result.allowed
         assert "requires TLS" in result.reason
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://user:s3cret@mcp.internal/finance",
+            "http://mcp.internal/finance?access_token=s3cret",
+            # No scheme, so the whole string would have been echoed verbatim.
+            "mcp.internal/finance?access_token=s3cret",
+        ],
+    )
+    def test_denial_reason_does_not_echo_the_url(self, url: str) -> None:
+        # `reason` is promoted to audit attributes (otel_audit_backend maps it
+        # to agt.audit.reason), and a server URL can carry a token in its
+        # userinfo or query string. The scheme alone explains the decision.
+        result = self._policy(url).check("finance", auth_method="mtls")
+        assert not result.allowed
+        assert "s3cret" not in result.reason
+        assert url not in result.reason
+
     @pytest.mark.parametrize("url", ["https://mcp.internal/finance", "wss://mcp.internal/ws"])
     def test_tls_configured_url_is_allowed(self, url: str) -> None:
         assert self._policy(url).check("finance", auth_method="mtls").allowed

--- a/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_auth_enforcement.py
@@ -140,12 +140,12 @@ class TestTlsGateUsesTheConfiguredUrl:
     )
     def test_plaintext_configured_url_is_denied_without_a_caller_url(self, url: str) -> None:
         result = self._policy(url).check("finance", auth_method="mtls")
-        assert result.allowed is False
+        assert not result.allowed
         assert "requires TLS" in result.reason
 
     @pytest.mark.parametrize("url", ["https://mcp.internal/finance", "wss://mcp.internal/ws"])
     def test_tls_configured_url_is_allowed(self, url: str) -> None:
-        assert self._policy(url).check("finance", auth_method="mtls").allowed is True
+        assert self._policy(url).check("finance", auth_method="mtls").allowed
 
     def test_scheme_case_is_ignored(self) -> None:
         assert self._policy("HTTPS://MCP.INTERNAL").check("finance", auth_method="mtls").allowed
@@ -154,27 +154,26 @@ class TestTlsGateUsesTheConfiguredUrl:
         # The caller knows the URL actually being dialed; a plaintext dial
         # against an https-registered server must still be blocked.
         policy = self._policy("https://mcp.internal/finance")
-        assert policy.check("finance", auth_method="mtls").allowed is True
-        assert (
-            policy.check("finance", auth_method="mtls", url="http://mcp.internal/finance").allowed
-            is False
-        )
+        assert policy.check("finance", auth_method="mtls").allowed
+        assert not policy.check(
+            "finance", auth_method="mtls", url="http://mcp.internal/finance"
+        ).allowed
 
     def test_no_url_anywhere_leaves_the_gate_skipped(self) -> None:
         # Unchanged behaviour: with no URL from either source there is nothing
         # to evaluate. Denying this would be a separate policy decision about
         # every server registered without a URL.
-        assert self._policy("").check("finance", auth_method="mtls").allowed is True
+        assert self._policy("").check("finance", auth_method="mtls").allowed
 
     def test_require_tls_false_allows_plaintext(self) -> None:
         policy = self._policy("http://mcp.internal/finance", require_tls=False)
-        assert policy.check("finance", auth_method="mtls").allowed is True
+        assert policy.check("finance", auth_method="mtls").allowed
 
     def test_auth_method_denial_is_not_masked_by_the_tls_gate(self) -> None:
         # A method outside the allowlist must still be reported as such, not as
         # a TLS problem — the allowlist check comes first.
         result = self._policy("http://mcp.internal/finance").check("finance", auth_method="oauth2")
-        assert result.allowed is False
+        assert not result.allowed
         assert "not allowed for server" in result.reason
 
     def test_yaml_configured_plaintext_server_is_denied(self) -> None:
@@ -186,7 +185,7 @@ mcp_auth_policy:
       allowed_auth_methods: [mtls]
       require_tls: true
 """)
-        assert policy.check("finance-tools", auth_method="mtls").allowed is False
+        assert not policy.check("finance-tools", auth_method="mtls").allowed
 
 
 class TestFromYaml:


### PR DESCRIPTION
Fixes #3511

### What was wrong

`McpAuthPolicy.check` enforced `require_tls` only against the URL the **caller** passed. That parameter defaults to `""` and the gate was skipped entirely when it was falsy, so `entry.url` — written by both constructors and by `from_yaml`, documented on `McpServerEntry` and in `docs/specs/MCP-SECURITY-GATEWAY-1.0.md` §10.3 — was never read by any code path.

```python
policy = McpAuthPolicy(servers=[McpServerEntry(
    name="finance", url="http://mcp.internal/finance",
    allowed_auth_methods=["mtls"], require_tls=True)])

policy.check("finance", "mtls").allowed                             # -> True
policy.check("finance", "mtls", url="http://mcp.internal/finance")  # -> False
```

Both calls describe the same connection to the same server under the same policy, and they disagree. Which one fires depended on whether the caller redundantly restated configuration the policy object already held.

The `from_yaml` path always took the permissive branch, since that is exactly the deployment shape where the URL lives in config and the call site has no reason to pass it again:

```yaml
mcp_auth_policy:
  servers:
    - name: finance-tools
      url: http://mcp.internal/finance
      allowed_auth_methods: [mtls]
      require_tls: true
```

```python
McpAuthPolicy.from_yaml(cfg).check("finance-tools", auth_method="mtls").allowed
# -> True
```

`from_yaml` parses `url` into the entry and nothing reads it back. A configuration that says `require_tls: true` and points at `http://` is the misconfiguration this check exists to catch, and the check stayed silent.

### What changed

**`effective_url = url or entry.url`.** The caller-supplied URL keeps priority, since it describes the connection actually being dialed and may legitimately differ from the registered pattern — a plaintext dial against an `https`-registered server is still blocked.

**With no URL from either source, the gate stays skipped**, exactly as before. Denying every server registered without a URL would be a separate policy decision about existing configurations, not part of fixing this one, so it is deliberately out of scope.

**Scheme inspection moves into `_tls_violation`**, and `TLS_SCHEMES` becomes a module constant. A non-empty URL with no scheme — the shape a bare host or the documented glob pattern takes (`mcp.internal`, `*.internal/finance`) — was already denied by `"" not in {"https","wss"}`, but only as a by-product of set membership, reported as `scheme '' is not in the TLS allowlist`. It is now denied deliberately, with `URL 'mcp.internal' has no scheme, so TLS cannot be verified`, and covered by a test. This matters more than it did before: the change makes that path reachable from **configured** URLs for the first time.

### Compatibility

Strictly more denials, and only in the case the guard was written to reject: a server whose configured URL is not TLS while `require_tls` is True. Every combination that was allowed for a legitimate reason still is — `require_tls=False`, an `https`/`wss` configured URL, no URL anywhere, and unknown servers on the default path (which has no TLS gate at all, unchanged here).

`min_tls_version` is stored, documented, and specified (§10.6 step 5) but read by no code path. That is unimplemented functionality rather than a guard that misreports, so it is noted in #3511 and left for its own issue rather than folded in here.

### Verification

- `tests/test_mcp_auth_enforcement.py`: **31 passed**. With the source file stashed: **7 failed / 24 passed** — every new assertion fails on `main`.
- Full `tests/` suite (`-p no:randomly --continue-on-collection-errors`): **4478 passed / 257 failed** against base **4464 / 257** — exactly +14, the new test count, **no new failures**.
- `tests/test_spec_mcp_gateway_conformance.py` cannot be collected on `main` (pre-existing `ModuleNotFoundError: agent_sre`, one of three such modules), so its S10.1–S10.11 assertions were replayed by hand against the patched module — **all still hold**, including S10.7 (`http://` caller URL denied) and S10.11 (`add_server` with no URL still allowed).
- `ruff check`: **4 findings, identical to base** (`UP037` in the source, `I001` + two `F401` in the test file — all pre-existing). `ruff format --diff`: the remaining reformat suggestions are all on lines this PR does not touch, matching base exactly.
- `cspell` on all 133 added lines: clean.

### Tests added

`TestTlsGateUsesTheConfiguredUrl` — 8 methods / 14 cases:

- plaintext configured URL denied with no caller URL, over `http`, `ws`, `ftp`, `gopher`, and two scheme-less forms
- `https` and `wss` configured URLs allowed; scheme case ignored
- a caller URL still overrides the configured one in the restrictive direction
- no URL anywhere leaves the gate skipped (pins the deliberately-unchanged case)
- `require_tls=False` still allows plaintext
- an out-of-allowlist auth method is still reported as an allowlist failure, not masked as a TLS one — the ordering matters for the error a user sees
- the `from_yaml` path, which is where this fails in practice

### Checklist

- [x] Tests added that fail without the fix and pass with it
- [x] `ruff check` / `ruff format` state unchanged relative to base
- [x] No new failures in the full test suite
