### PR TITLE
fix(agent-os): enforce output intervention-point verdicts in anthropic and autogen adapters

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -957,3 +957,6 @@ asdict
 # --- Docker / BuildKit toolchain terms ---
 moby
 buildkit
+
+# discarded-verdict census (tests/test_transform_never_dropped.py)
+DISCARDABLE

--- a/agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py
@@ -354,7 +354,9 @@ class _GovernedMessages:
         # replacement, so that path blocks as well.
         allowed, reason = self._kernel.post_execute(self._ctx, response)
         if not allowed:
-            raise PolicyViolationError(f"Response blocked by policy: {reason}")
+            raise PolicyViolationError(
+                f"Response blocked by policy: {reason or 'denied by output policy'}"
+            )
 
         return response
 
@@ -562,7 +564,9 @@ class GovernanceMessageHook:
         # replacement, so that path blocks as well.
         allowed, reason = self._kernel.post_execute(self._ctx, response)
         if not allowed:
-            raise PolicyViolationError(f"Response blocked by policy: {reason}")
+            raise PolicyViolationError(
+                f"Response blocked by policy: {reason or 'denied by output policy'}"
+            )
 
         return response
 

--- a/agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py
@@ -348,8 +348,13 @@ class _GovernedMessages:
                         # land, so proceeding would run the original.
                         raise tool_result.to_policy_violation(PolicyViolationError) from exc
 
-        # Post-execute bookkeeping
-        self._kernel.post_execute(self._ctx, response)
+        # Output mediation: a deny here must stop the response being
+        # disclosed to the caller. ``post_execute`` reports a transform as
+        # refused because this two-value contract cannot carry the
+        # replacement, so that path blocks as well.
+        allowed, reason = self._kernel.post_execute(self._ctx, response)
+        if not allowed:
+            raise PolicyViolationError(f"Response blocked by policy: {reason}")
 
         return response
 
@@ -551,8 +556,13 @@ class GovernanceMessageHook:
                         # land, so proceeding would run the original.
                         raise tool_result.to_policy_violation(PolicyViolationError) from exc
 
-        # Record host completion after output mediation.
-        self._kernel.post_execute(self._ctx, response)
+        # Output mediation: a deny here must stop the response being
+        # disclosed to the caller. ``post_execute`` reports a transform as
+        # refused because this two-value contract cannot carry the
+        # replacement, so that path blocks as well.
+        allowed, reason = self._kernel.post_execute(self._ctx, response)
+        if not allowed:
+            raise PolicyViolationError(f"Response blocked by policy: {reason}")
 
         return response
 

--- a/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
@@ -634,7 +634,13 @@ class AutoGenKernel(BaseIntegration):
                     return None
                 raise
 
-            kernel.post_execute(ctx, result)
+            valid, reason = kernel.post_execute(ctx, result)
+            if not valid:
+                logger.info(
+                    "Policy DENY (post_execute) on initiate_chat for %s: %s",
+                    agent_id, reason,
+                )
+                raise PolicyViolationError(reason)
             return result
 
         agent.initiate_chat = governed_initiate_chat
@@ -738,7 +744,13 @@ class AutoGenKernel(BaseIntegration):
                     return None
                 raise
 
-            kernel.post_execute(ctx, result)
+            valid, reason = kernel.post_execute(ctx, result)
+            if not valid:
+                logger.info(
+                    "Policy DENY (post_execute) on receive for %s: %s",
+                    agent_id, reason,
+                )
+                raise PolicyViolationError(reason)
             return result
 
         agent.receive = governed_receive

--- a/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py
@@ -640,7 +640,7 @@ class AutoGenKernel(BaseIntegration):
                     "Policy DENY (post_execute) on initiate_chat for %s: %s",
                     agent_id, reason,
                 )
-                raise PolicyViolationError(reason)
+                raise PolicyViolationError(reason or "denied by output policy")
             return result
 
         agent.initiate_chat = governed_initiate_chat
@@ -750,7 +750,7 @@ class AutoGenKernel(BaseIntegration):
                     "Policy DENY (post_execute) on receive for %s: %s",
                     agent_id, reason,
                 )
-                raise PolicyViolationError(reason)
+                raise PolicyViolationError(reason or "denied by output policy")
             return result
 
         agent.receive = governed_receive

--- a/agent-governance-python/agent-os/tests/test_adapter_interception.py
+++ b/agent-governance-python/agent-os/tests/test_adapter_interception.py
@@ -272,3 +272,189 @@ async def test_autogen_on_send_drops_pii_even_when_policy_allows(
     result = await handler.on_send(message)
 
     assert result is DropMessage
+
+
+# ── Output verdict enforcement at the post_execute seam ───────────────
+#
+# Four adapter call sites evaluated the output intervention point via
+# ``kernel.post_execute(...)`` and discarded the returned (allowed, reason)
+# tuple, so an output deny still disclosed the response and an output
+# transform was silently dropped. These tests pin the fixed behaviour on
+# the surfaces a caller actually drives: the deprecated Anthropic wrap
+# proxy, the recommended Anthropic message hook, and the AutoGen legacy
+# ``govern()`` patches for ``initiate_chat`` and ``receive``.
+
+from agent_os.exceptions import PolicyViolationError  # noqa: E402
+
+_SECRET = "SECRET-TOKEN-XYZ-99"
+
+
+class _PerPointRuntime(_StubRuntime):
+    """A stub runtime that answers per intervention point, allowing elsewhere."""
+
+    def __init__(self, overrides: dict[str, PolicyEvaluation]) -> None:
+        super().__init__(_allow())
+        self._overrides = overrides
+
+    def evaluate(
+        self, intervention_point: str, snapshot: dict[str, Any]
+    ) -> PolicyEvaluation:
+        name = getattr(intervention_point, "value", str(intervention_point))
+        self.calls.append((name, snapshot))
+        result = self._overrides.get(name, self._result)
+        return result.model_copy(update={"intervention_point": name})
+
+
+def _output_transform() -> PolicyEvaluation:
+    return PolicyEvaluation(
+        verdict="transform",
+        reason_code="redact",
+        transform=TransformResult(path="output.content", value="[redacted]"),
+    )
+
+
+class _AnthropicResponse:
+    """A minimal Anthropic-shaped response carrying a secret payload."""
+
+    def __init__(self, text: str) -> None:
+        self.id = "msg-1"
+        self.content: list[Any] = []
+        self.usage = None
+        self._text = text
+
+    def __str__(self) -> str:
+        return self._text
+
+
+def _anthropic_client(text: str) -> MagicMock:
+    client = MagicMock()
+    client.messages.create.return_value = _AnthropicResponse(text)
+    return client
+
+
+def test_anthropic_wrap_blocks_denied_output() -> None:
+    """The governed proxy must not disclose a response the output point denies."""
+    kernel = AnthropicKernel(runtime=_PerPointRuntime({"output": _deny()}))
+    governed = kernel.wrap(_anthropic_client(_SECRET))
+
+    with pytest.raises(PolicyViolationError) as excinfo:
+        governed.messages.create(
+            model="m", messages=[{"role": "user", "content": "hi"}]
+        )
+
+    assert _SECRET not in str(excinfo.value)
+    assert "blocked by policy" in str(excinfo.value)
+
+
+def test_anthropic_hook_create_blocks_denied_output() -> None:
+    """The message hook must not disclose a response the output point denies."""
+    kernel = AnthropicKernel(runtime=_PerPointRuntime({"output": _deny()}))
+    hook = kernel.as_message_hook()
+
+    with pytest.raises(PolicyViolationError) as excinfo:
+        hook.create(
+            _anthropic_client(_SECRET),
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert _SECRET not in str(excinfo.value)
+    assert "blocked by policy" in str(excinfo.value)
+
+
+def test_anthropic_hook_refuses_output_transform_it_cannot_apply() -> None:
+    """``post_execute`` answers with a tuple, so it has nowhere to carry the
+    replacement; the response must be refused rather than forwarded as-is."""
+    kernel = AnthropicKernel(
+        runtime=_PerPointRuntime({"output": _output_transform()})
+    )
+    hook = kernel.as_message_hook()
+
+    with pytest.raises(PolicyViolationError) as excinfo:
+        hook.create(
+            _anthropic_client(_SECRET),
+            model="m",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert _SECRET not in str(excinfo.value)
+    assert "transform_not_applicable" in str(excinfo.value)
+
+
+class _ChattyAgent:
+    """Minimal AutoGen-shaped agent whose calls return a fixed reply."""
+
+    def __init__(self, reply: str, name: str = "agent-1") -> None:
+        self.name = name
+        self._reply = reply
+
+    def initiate_chat(self, recipient: Any, message: Any = None, **kwargs: Any) -> Any:
+        return self._reply
+
+    def generate_reply(self, messages: Any = None, sender: Any = None, **kwargs: Any) -> Any:
+        return self._reply
+
+    def receive(self, message: Any, sender: Any, **kwargs: Any) -> Any:
+        return self._reply
+
+
+def test_autogen_initiate_chat_blocks_denied_output() -> None:
+    """A denied chat result raises instead of being returned to the caller."""
+    kernel = AutoGenKernel(runtime=_PerPointRuntime({"output": _deny()}))
+    agent = _ChattyAgent(_SECRET)
+    kernel.govern(agent)
+
+    with pytest.raises(PolicyViolationError) as excinfo:
+        agent.initiate_chat(_named("peer"), message="hello")
+
+    assert _SECRET not in str(excinfo.value)
+
+
+def test_autogen_receive_blocks_denied_output() -> None:
+    """A denied receive result raises instead of being returned to the caller."""
+    kernel = AutoGenKernel(runtime=_PerPointRuntime({"output": _deny()}))
+    agent = _ChattyAgent(_SECRET)
+    kernel.govern(agent)
+
+    with pytest.raises(PolicyViolationError) as excinfo:
+        agent.receive("hello", _named("peer"))
+
+    assert _SECRET not in str(excinfo.value)
+
+
+def test_autogen_initiate_chat_refuses_output_transform_it_cannot_apply() -> None:
+    """``post_execute`` cannot carry the replacement, so the result is refused."""
+    kernel = AutoGenKernel(
+        runtime=_PerPointRuntime({"output": _output_transform()})
+    )
+    agent = _ChattyAgent(_SECRET)
+    kernel.govern(agent)
+
+    with pytest.raises(PolicyViolationError) as excinfo:
+        agent.initiate_chat(_named("peer"), message="hello")
+
+    assert _SECRET not in str(excinfo.value)
+    assert "transform_not_applicable" in str(excinfo.value)
+
+
+def test_autogen_allowed_output_is_returned_unchanged() -> None:
+    """The consumed verdict must not turn allows into blocks."""
+    kernel = AutoGenKernel(runtime=_PerPointRuntime({}))
+    agent = _ChattyAgent("all good")
+    kernel.govern(agent)
+
+    assert agent.initiate_chat(_named("peer"), message="hello") == "all good"
+    assert agent.receive("hello", _named("peer")) == "all good"
+
+
+def test_anthropic_allowed_output_is_returned_unchanged() -> None:
+    """The consumed verdict must not turn allows into blocks."""
+    kernel = AnthropicKernel(runtime=_PerPointRuntime({}))
+    hook = kernel.as_message_hook()
+    client = _anthropic_client("all good")
+
+    response = hook.create(
+        client, model="m", messages=[{"role": "user", "content": "hi"}]
+    )
+
+    assert str(response) == "all good"

--- a/agent-governance-python/agent-os/tests/test_adapter_interception.py
+++ b/agent-governance-python/agent-os/tests/test_adapter_interception.py
@@ -13,7 +13,7 @@ here rather than assumed.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -458,3 +458,34 @@ def test_anthropic_allowed_output_is_returned_unchanged() -> None:
     )
 
     assert str(response) == "all good"
+
+
+def test_autogen_output_deny_without_reason_gets_public_message() -> None:
+    """A deny whose reason is None must not surface "None" to callers."""
+    kernel = AutoGenKernel(runtime=_PerPointRuntime({"output": _deny()}))
+    agent = _ChattyAgent(_SECRET)
+    kernel.govern(agent)
+
+    with patch.object(kernel, "post_execute", return_value=(False, None)):
+        with pytest.raises(PolicyViolationError) as excinfo:
+            agent.initiate_chat(_named("peer"), message="hello")
+
+    assert "None" not in str(excinfo.value)
+    assert "denied by output policy" in str(excinfo.value)
+
+
+def test_anthropic_hook_output_deny_without_reason_gets_public_message() -> None:
+    """The anthropic hook path must also normalize a None deny reason."""
+    kernel = AnthropicKernel(runtime=_PerPointRuntime({"output": _deny()}))
+    hook = kernel.as_message_hook()
+
+    with patch.object(kernel, "post_execute", return_value=(False, None)):
+        with pytest.raises(PolicyViolationError) as excinfo:
+            hook.create(
+                _anthropic_client(_SECRET),
+                model="m",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    assert "None" not in str(excinfo.value)
+    assert "denied by output policy" in str(excinfo.value)

--- a/agent-governance-python/agent-os/tests/test_transform_never_dropped.py
+++ b/agent-governance-python/agent-os/tests/test_transform_never_dropped.py
@@ -741,3 +741,91 @@ def test_a_target_that_takes_no_write_is_not_passed_over():
         "forwarded with no exception raised: " + ", ".join(skipped) + ". "
         "Refuse on the other branch, or track whether the write landed."
     )
+
+
+# ── census 5: a verdict that is never read is a verdict that never ran ────
+
+
+DISCARDABLE = EVAL_METHODS | {"pre_execute", "post_execute"}
+
+
+def _discarded_verdicts_in(tree: ast.AST, label: str) -> list[str]:
+    """Evaluation calls in *tree* whose verdict is discarded outright.
+
+    The four censuses above judge how a consumer handles the verdict it
+    holds. This catches the consumer that never holds one: the call sits as
+    a bare expression statement (or its result is assigned to ``_``), so the
+    ``(allowed, reason)`` tuple or result object is built and thrown away. A
+    deny then blocks nothing and a transform is never applied — the action
+    already ran, and the caller forwards its result as if it had been
+    permitted. Four adapter output sites shipped exactly this shape, as
+    ``kernel.post_execute(ctx, response)`` on a statement line, so an output
+    deny still disclosed the response.
+
+    ``pre_execute``/``post_execute`` are included alongside the evaluate_*
+    seams: they are the tuple-contract fronts for ``evaluate_input`` and
+    ``evaluate_output``, and every one of the live drops went through them.
+    """
+    found = []
+    for node in ast.walk(tree):
+        call = None
+        if isinstance(node, ast.Expr):
+            call = node.value
+        elif isinstance(node, ast.Assign) and all(
+            isinstance(t, ast.Name) and t.id == "_" for t in node.targets
+        ):
+            call = node.value
+        if isinstance(call, ast.Await):
+            call = call.value
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        name = (
+            func.attr
+            if isinstance(func, ast.Attribute)
+            else func.id if isinstance(func, ast.Name) else None
+        )
+        if name in DISCARDABLE:
+            found.append(f"{label}:{node.lineno} {name}")
+    return found
+
+
+def _discarded_verdicts() -> list[str]:
+    found = []
+    for path in sorted(SRC.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if not any(m in text for m in DISCARDABLE):
+            continue
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:  # pragma: no cover - the repo does not ship these
+            continue
+        found.extend(_discarded_verdicts_in(tree, str(path.relative_to(SRC))))
+    return found
+
+
+def test_the_fifth_census_recognises_a_discarded_verdict():
+    """Guard against the matcher silently matching nothing and passing vacuously."""
+    snippet = ast.parse(
+        "def f(kernel, ctx, response):\n"
+        "    kernel.post_execute(ctx, response)\n"
+        "    _ = kernel.evaluate_output(ctx, content=response)\n"
+        "    return response\n"
+        "async def g(kernel, ctx, body):\n"
+        "    await kernel.pre_execute(ctx, body)\n"
+    )
+
+    hits = _discarded_verdicts_in(snippet, "snippet.py")
+
+    assert len(hits) == 3, hits
+
+
+def test_no_evaluation_verdict_is_discarded():
+    dropped = _discarded_verdicts()
+
+    assert not dropped, (
+        "these evaluate a policy and discard the verdict, so a deny blocks "
+        "nothing and a transform is never applied while the caller forwards "
+        "the result as permitted: " + ", ".join(dropped) + ". Consume the "
+        "verdict: block on deny and apply or refuse a transform."
+    )

--- a/agent-governance-python/agent-os/tests/test_transform_never_dropped.py
+++ b/agent-governance-python/agent-os/tests/test_transform_never_dropped.py
@@ -804,7 +804,7 @@ def _discarded_verdicts() -> list[str]:
     return found
 
 
-def test_the_fifth_census_recognises_a_discarded_verdict():
+def test_the_fifth_census_recognizes_a_discarded_verdict():
     """Guard against the matcher silently matching nothing and passing vacuously."""
     snippet = ast.parse(
         "def f(kernel, ctx, response):\n"

--- a/agent-governance-python/agt-policies/tests/scenarios/test_anthropic_adapter_scenarios.py
+++ b/agent-governance-python/agt-policies/tests/scenarios/test_anthropic_adapter_scenarios.py
@@ -57,6 +57,11 @@ intervention_points:
     tool_name_from: $.tool_call.name
     policy:
       id: scenario_policy
+  output:
+    policy_target: $.response.content
+    policy_target_kind: assistant_output
+    policy:
+      id: scenario_policy
 tools:
   web_search:
     clearance: public
@@ -117,7 +122,13 @@ def test_hook_create_allow_path_forwards_to_anthropic(tmp_path: Path) -> None:
     """An ``allow`` verdict lets Anthropic see the original message content."""
     from agent_os.integrations.anthropic_adapter import AnthropicKernel
 
-    runtime, policy = _build_runtime(tmp_path, [{"decision": "allow"}])
+    runtime, policy = _build_runtime(
+        tmp_path,
+        [
+            {"decision": "allow"},  # input
+            {"decision": "allow"},  # output (post-execute)
+        ],
+    )
     kernel = AnthropicKernel(runtime=runtime)
     hook = kernel.as_message_hook()
     client = _make_client()
@@ -129,7 +140,8 @@ def test_hook_create_allow_path_forwards_to_anthropic(tmp_path: Path) -> None:
         messages=[{"role": "user", "content": "Hello, Claude"}],
     )
 
-    assert len(policy.invocations) == 1
+    # The manifest binds input and output, so the hook evaluates both.
+    assert len(policy.invocations) == 2
     client.messages.create.assert_called_once()
     sent = client.messages.create.call_args.kwargs
     assert sent["messages"][0]["content"] == "Hello, Claude"
@@ -182,7 +194,8 @@ def test_hook_create_transform_path_redacts_outbound_message(tmp_path: Path) -> 
                     "path": "$policy_target",
                     "value": "Customer SSN is [REDACTED]",
                 },
-            }
+            },
+            {"decision": "allow"},  # output (post-execute)
         ],
     )
     kernel = AnthropicKernel(runtime=runtime)
@@ -214,7 +227,10 @@ def test_hook_create_escalate_with_approving_resolver_forwards(tmp_path: Path) -
 
     runtime, _policy = _build_runtime(
         tmp_path,
-        [{"decision": "escalate", "reason": "human_approval_required"}],
+        [
+            {"decision": "escalate", "reason": "human_approval_required"},
+            {"decision": "allow"},  # output (post-execute)
+        ],
         approval_resolver=resolver,
     )
     kernel = AnthropicKernel(runtime=runtime)


### PR DESCRIPTION
## Description

Follow-up to the #3444 stack merge. A probe against `main` at that merge confirmed that four adapter call sites evaluate the `output` intervention point via `kernel.post_execute(ctx, ...)` and discard the returned `(allowed, reason)` tuple, so an output `deny` still discloses the model response to the caller and an output `transform` is never applied:

- `agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py` — `_GovernedMessages.create` (deprecated `GovernedAnthropicClient` wrap path)
- `agent-governance-python/agent-os/src/agent_os/integrations/anthropic_adapter.py` — `GovernanceMessageHook.create` (recommended hook path)
- `agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py` — `governed_initiate_chat`
- `agent-governance-python/agent-os/src/agent_os/integrations/autogen_adapter.py` — `governed_receive`

**Probe evidence:** with a runtime that allows `input` and denies `output`, all four surfaces returned the response containing the secret payload to the caller instead of blocking it; the sibling adapters (bedrock, mistral, gemini, openai) blocked as expected.

**Fix:** each site now consumes the verdict the way the sibling adapters already do (`bedrock_adapter.py`, `mistral_adapter.py`, `gemini_adapter.py`, `openai_adapter.py` `_poll_run`): a deny raises `PolicyViolationError` with the public reason before the response is returned. A transform — which the two-value `post_execute` contract deliberately reports as refused (`transform_not_applicable`) — now blocks as well instead of forwarding the un-rewritten output. The AutoGen `initiate_chat`/`receive` sites raise, matching their own pre-execute deny convention (their `generate_reply` sibling keeps its `[BLOCKED: ...]` string convention and was already enforcing).

**Tests added** (`tests/test_adapter_interception.py`):
- output-deny for the Anthropic hook (`hook.create`) and the wrap path, asserting the secret string never reaches the caller and the deny surfaces as `PolicyViolationError`
- output-deny for AutoGen `initiate_chat` and `receive`, same assertions
- unappliable-output-transform refusal per adapter (`transform_not_applicable`), since the tuple contract cannot carry a replacement
- allowed-path parity tests so consuming the verdict does not turn allows into blocks

**Census extension** (`tests/test_transform_never_dropped.py`): a fifth census AST-walks `src/agent_os` and fails on any `evaluate_*`/`pre_execute`/`post_execute` call whose result is discarded (bare expression statement or assignment to `_`) — the discarded-verdict class this bug belongs to — plus a self-test proving the matcher recognises the pattern. The whole tree passes it after the fixes.

**Tracked separately:** Bedrock streaming (the output policy currently sees the `_GovernedEventStream` wrapper repr rather than the streamed content) and transform write-verification.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [x] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues
Follows up #3444.
