### PR TITLE
fix(red-team): drive verdict and exit code from single overall_pass criterion

### DIFF
--- a/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
+++ b/agent-governance-python/agent-compliance/src/agent_compliance/cli/red_team.py
@@ -308,13 +308,15 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
 
     experiment.complete()
 
+    overall_pass = all(r.passed for r in results)
+
     # Format output
     if output_json:
         data = {
             "target": target,
             "experiment_id": experiment.experiment_id,
             "playbooks_run": len(results),
-            "overall_passed": all(r.passed for r in results),
+            "overall_passed": overall_pass,
             "results": [
                 {
                     "playbook_id": r.playbook.playbook_id,
@@ -342,7 +344,6 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
         click.echo(f"  Target: {target}")
         click.echo(f"  Experiment: {experiment.experiment_id}\n")
 
-        overall_pass = True
         for r in results:
             icon = "+" if r.passed else "!"
             click.echo(f"  [{icon}] {r.playbook.name}")
@@ -354,8 +355,6 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
                 click.echo(f"        [{step_icon}] {step.name}: {result.value}")
 
             click.echo()
-            if not r.passed:
-                overall_pass = False
 
         click.echo(f"  {'─'*56}")
         total = len(results)
@@ -363,7 +362,7 @@ def attack(target: str, playbook_id: Optional[str], output_json: bool, threshold
         click.echo(f"  Results: {passed_count}/{total} playbooks passed")
         click.echo(f"  Overall: {'PASS' if overall_pass else 'FAIL'}\n")
 
-    if not all(r.resilience_score >= threshold for r in results):
+    if not overall_pass:
         raise SystemExit(1)
 
 


### PR DESCRIPTION
Fixes #3237

## Problem
The red-team CLI used two different criteria for the same outcome:
- **Verdict/report**: `r.passed` (lines 317, 345–364)
- **Process exit code**: `r.resilience_score >= threshold` (line 366)

When these diverged (e.g., a playbook with score ≥ threshold but `passed=False`), CI could exit 0 while the report printed FAIL — or exit 1 while it printed PASS.

## Fix
Compute `overall_pass = all(r.passed for r in results)` once after experiment completion, then use that single value for:
1. JSON output (`overall_passed`)
2. Text report (`Overall: PASS/FAIL`)
3. Process exit code (`SystemExit(1)`)

This also removes the redundant local `overall_pass` variable that was separately computed inside the text-output branch.

## Changes
- 1 file, +4/-5 lines (`red_team.py`)
- No behavioral change when `r.passed` is consistent with score-vs-threshold
- Fixes the reported divergence when they differ

## Testing
```
$ pytest tests/ -k red -v
42 passed, 1 skipped in 0.14s
```