### PR TITLE
fix(agt-policies): bind every intervention point an adapter evaluates

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -163,6 +163,7 @@ Ravande
 Redocly
 Rego
 Rekor
+Repoint
 Rootfs
 RustCrypto
 RustSec
@@ -758,6 +759,7 @@ refetches
 regen
 reimplementation
 relativedelta
+relpath
 removeprefix
 removesuffix
 replayable

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -5,6 +5,49 @@ entries appear first.
 
 ---
 
+## `HostSession.post_tool_call` and `pre_model_call` emit the adapter snapshot shape
+
+**Date:** TBD
+
+**Affected**
+
+- manifests binding `post_tool_call` to `$.tool_result`
+- manifests binding `pre_model_call` to `$.request`
+- anything constructing `HostSession` directly rather than going through an
+  `agent_os.integrations` adapter
+
+**What changed**
+
+`HostSession` sent the tool result as a bare value and nested the model request
+under `request`, while the `agent_os.integrations` adapters send `tool_result`
+as `{"value": ..., "error": ..., "duration_ms": ...}` and spread the model
+request over `model`, `messages` and `tools`. Because those two seams
+disagreed, no manifest could bind a policy target that resolved for both:
+whichever seam the policy author did not target failed closed with a
+missing-path error.
+
+`HostSession` now emits the adapter shape at both points, which is also the
+shape AGT-SNAPSHOT-1.0 §2.6 specifies.
+
+This aligns `HostSession` with `agent_os.integrations` only. Other SDK entry
+points, including `AgentControl.run_tool` and the LiteLLM adapter, still send
+the older flat `tool_result` and are not covered by this change.
+
+**How to update**
+
+Repoint the affected policy targets:
+
+| Before | After |
+|--------|-------|
+| `$.tool_result` | `$.tool_result.value` |
+| `$.request` | `$.messages` (or `$.model`, `$.tools`) |
+
+A manifest left on `$.tool_result` still loads and still returns a verdict. It
+matches against an object rather than the result value, so a rule written for a
+string stops denying. Repoint it before upgrading.
+
+---
+
 ## `agt.policies` is removed; hosts call the ACS runtime directly
 
 **Date:** TBD

--- a/agent-governance-python/agt-policies/src/agt/cli/_migrate_bridge.py
+++ b/agent-governance-python/agt-policies/src/agt/cli/_migrate_bridge.py
@@ -19,6 +19,7 @@ from ._migrate_re2 import glob_to_re2, validate_re2
 
 ACS_VERSION = "0.3.0-alpha-agt"
 _REASON_PATTERN = "blocked_pattern_input"
+_CASE_INSENSITIVE = "(?i)"
 
 
 @dataclass
@@ -102,25 +103,10 @@ def build_migrated_manifest(
     )
     (bundle_dir / f"{policy_id}.rego").write_text(rego_source, encoding="utf-8")
 
-    bind_tools = (
-        bool(policy.allowed_tools)
-        or policy.max_tool_calls >= 0
-        or policy.require_human_approval
-    )
     intervention_points = _build_intervention_points(
         policy_id,
-        bind_input=bool(policy.blocked_patterns),
-        bind_tools=bind_tools,
-        bind_output=bool(policy.blocked_patterns),
-        bind_post_model_call=policy.confidence_threshold > 0,
         bind_tools_with_catalog=bool(policy.allowed_tools),
     )
-    if not intervention_points:
-        intervention_points["pre_tool_call"] = {
-            "policy_target": "$.tool_call.args",
-            "policy_target_kind": "tool_args",
-            "policy": {"id": policy_id},
-        }
 
     manifest: dict[str, Any] = {
         "agent_control_specification_version": ACS_VERSION,
@@ -167,16 +153,25 @@ def _find_stock_rego_root() -> Path:
 
 
 def _pattern_to_regex(pattern: str | tuple[str, str]) -> str:
+    # v4 matched case-insensitively for every pattern kind: substrings via
+    # ``pat.lower() in text.lower()``, and REGEX/GLOB via ``re.IGNORECASE``
+    # (agent_os/integrations/base.py:406,413 before the v4 removal). RE2 supports
+    # the inline ``(?i)`` flag, so carry that across for all four kinds rather
+    # than silently tightening migrated policies into case-sensitive matches that
+    # let ``PASSWORD``, ``RM -RF`` or ``SETUP.EXE`` through.
     if isinstance(pattern, str):
-        return re.escape(pattern)
+        return _CASE_INSENSITIVE + re.escape(pattern)
     value, kind = pattern
     if kind == "SUBSTRING":
-        return re.escape(value)
+        return _CASE_INSENSITIVE + re.escape(value)
     if kind == "REGEX":
-        validate_re2(value, require_opa=True)
-        return value
+        composed = _CASE_INSENSITIVE + value
+        validate_re2(composed, require_opa=True)
+        return composed
     if kind == "GLOB":
-        return glob_to_re2(value, require_opa=True)
+        composed = _CASE_INSENSITIVE + glob_to_re2(value, require_opa=True)
+        validate_re2(composed, require_opa=True)
+        return composed
     raise ValueError(f"unsupported PatternType: {kind!r}")
 
 
@@ -202,13 +197,22 @@ def _render_rego(
         "",
         'default verdict := {"decision": "allow"}',
         "",
-        "policy_text := value if {",
+        "# Each string the target carries, matched separately. Collecting leaves",
+        "# rather than json.marshal-ing avoids marshal's escaping of \" \\\\ < > and &,",
+        "# which would stop a pattern containing any of them from matching. Keeping",
+        "# them separate rather than joining preserves whole-string (GLOB) anchors,",
+        "# which against a joined text could only ever match the final leaf.",
+        "policy_texts := [value] if {",
         "\tvalue := input.policy_target.value",
         "\tis_string(value)",
-        "} else := value if {",
+        "} else := texts if {",
         "\ttarget := input.policy_target.value",
         "\tnot is_string(target)",
-        "\tvalue := json.marshal(target)",
+        "\ttexts := [s | walk(target, [_, s]); is_string(s)]",
+        "}",
+        "",
+        "is_post_action_point if {",
+        '\tinput.intervention_point in ["post_tool_call", "post_model_call", "output", "agent_shutdown"]',
         "}",
         "",
     ]
@@ -216,8 +220,24 @@ def _render_rego(
     pattern_list = list(blocked_patterns)
     if pattern_list:
         rendered = ", ".join(json.dumps(pattern) for pattern in pattern_list)
+        # Select the matching leaves first, then build one verdict from the
+        # first of them. ``verdict`` is a complete rule, so binding it inside
+        # ``some ... in`` would produce a different object per matching leaf
+        # (deny_if_pattern embeds the match offset) and OPA would raise
+        # eval_conflict_error. matches_any also short-circuits, where
+        # deny_if_pattern scores every pattern against every leaf.
+        lines.extend(
+            [
+                "matched_texts := [t |",
+                "\tsome t in policy_texts",
+                f"\tpatterns.matches_any(t, [{rendered}])",
+                "]",
+                "",
+            ]
+        )
         branches.append(
-            "v := patterns.deny_if_pattern(policy_text, "
+            "count(matched_texts) > 0\n"
+            "\tv := patterns.deny_if_pattern(matched_texts[0], "
             f"[{rendered}], {json.dumps(_REASON_PATTERN)})"
         )
     thresholds: dict[str, Any] = {}
@@ -226,8 +246,14 @@ def _render_rego(
     if max_tokens is not None:
         thresholds["token_count"] = max_tokens
     if thresholds:
+        # Budgets gate an action before it runs. The runtime charges the attempt
+        # during pre_tool_call, so by post_tool_call the counter has already
+        # reached the limit and a >= check would deny the result of the last
+        # permitted call, after its side effects committed. Only evaluate
+        # budgets at the points that can still prevent the action.
         branches.append(
-            f"v := budgets.deny_if_budget_exceeded({json.dumps(thresholds)})"
+            "not is_post_action_point\n"
+            f"\tv := budgets.deny_if_budget_exceeded({json.dumps(thresholds)})"
         )
     if confidence_threshold is not None and confidence_threshold > 0:
         branches.append(
@@ -246,43 +272,45 @@ def _render_rego(
     return "\n".join(lines)
 
 
+# The engine denies any point a manifest leaves unbound
+# (``runtime_error:intervention_point_unknown``), so a migrated manifest has to
+# bind every point an adapter evaluates or the agent stops working the moment it
+# produces output or calls a tool. Each target below is the JSONPath for the
+# envelope the adapter runtime actually sends for that point; the generated Rego
+# carries ``default verdict := {"decision": "allow"}``, so binding a point the v4
+# policy said nothing about permits it rather than inventing a new rule.
+_POINT_TARGETS: dict[str, tuple[str, str]] = {
+    "input": ("$.input.body", "user_input"),
+    "output": ("$.response.content", "assistant_output"),
+    "pre_model_call": ("$.messages", "model_request"),
+    "post_model_call": ("$.response", "assistant_output"),
+    "pre_tool_call": ("$.tool_call.args", "tool_args"),
+    "post_tool_call": ("$.tool_result.value", "tool_result"),
+    # AGT-SNAPSHOT-1.0 §2.1 names this field `agent_init`, but both SDK seams
+    # (HostSession.agent_startup and AgentControl.agent_startup) emit `agent`,
+    # and `agent_init` appears nowhere in the runtime. Bind what the hosts
+    # actually send; reconciling the spec with the SDK is a separate decision.
+    # A spec-conformant third-party host fails closed here rather than open.
+    "agent_startup": ("$.agent", "agent_lifecycle"),
+    "agent_shutdown": ("$.summary", "agent_lifecycle"),
+}
+
+
 def _build_intervention_points(
     policy_id: str,
     *,
-    bind_input: bool,
-    bind_tools: bool,
-    bind_output: bool,
-    bind_post_model_call: bool,
     bind_tools_with_catalog: bool,
 ) -> dict[str, Any]:
     bindings: dict[str, Any] = {}
-    if bind_tools:
-        pre_tool: dict[str, Any] = {
-            "policy_target": "$.tool_call.args",
-            "policy_target_kind": "tool_args",
+    for point, (target, kind) in _POINT_TARGETS.items():
+        config: dict[str, Any] = {
+            "policy_target": target,
+            "policy_target_kind": kind,
             "policy": {"id": policy_id},
         }
-        if bind_tools_with_catalog:
-            pre_tool["tool_name_from"] = "$.tool_call.name"
-        bindings["pre_tool_call"] = pre_tool
-    if bind_input:
-        bindings["input"] = {
-            "policy_target": "$.input.body",
-            "policy_target_kind": "user_input",
-            "policy": {"id": policy_id},
-        }
-    if bind_output:
-        bindings["output"] = {
-            "policy_target": "$.response.content",
-            "policy_target_kind": "assistant_output",
-            "policy": {"id": policy_id},
-        }
-    if bind_post_model_call:
-        bindings["post_model_call"] = {
-            "policy_target": "$.response.content",
-            "policy_target_kind": "assistant_output",
-            "policy": {"id": policy_id},
-        }
+        if point == "pre_tool_call" and bind_tools_with_catalog:
+            config["tool_name_from"] = "$.tool_call.name"
+        bindings[point] = config
     return bindings
 
 

--- a/agent-governance-python/agt-policies/src/agt/cli/_migrate_bridge.py
+++ b/agent-governance-python/agt-policies/src/agt/cli/_migrate_bridge.py
@@ -211,10 +211,6 @@ def _render_rego(
         "\ttexts := [s | walk(target, [_, s]); is_string(s)]",
         "}",
         "",
-        "is_post_action_point if {",
-        '\tinput.intervention_point in ["post_tool_call", "post_model_call", "output", "agent_shutdown"]',
-        "}",
-        "",
     ]
     branches: list[str] = []
     pattern_list = list(blocked_patterns)
@@ -240,20 +236,29 @@ def _render_rego(
             "\tv := patterns.deny_if_pattern(matched_texts[0], "
             f"[{rendered}], {json.dumps(_REASON_PATTERN)})"
         )
-    thresholds: dict[str, Any] = {}
     if max_tool_calls is not None:
-        thresholds["tool_call_count"] = max_tool_calls
-    if max_tokens is not None:
-        thresholds["token_count"] = max_tokens
-    if thresholds:
-        # Budgets gate an action before it runs. The runtime charges the attempt
-        # during pre_tool_call, so by post_tool_call the counter has already
-        # reached the limit and a >= check would deny the result of the last
-        # permitted call, after its side effects committed. Only evaluate
-        # budgets at the points that can still prevent the action.
+        # v4 checked the tool-call budget only when intercepting a tool call
+        # (PolicyInterceptor compared context.call_count at tool interception),
+        # so an exhausted budget must gate the next tool call and nothing
+        # else; letting it fire at input/pre_model_call/agent_startup would
+        # stop the agent from ever emitting its final model response. It also
+        # cannot fire at post_tool_call: the runtime charges the attempt
+        # during pre_tool_call, so a >= check there would deny the result of
+        # the last permitted call after its side effects committed.
         branches.append(
-            "not is_post_action_point\n"
-            f"\tv := budgets.deny_if_budget_exceeded({json.dumps(thresholds)})"
+            'input.intervention_point == "pre_tool_call"\n'
+            "\tv := budgets.deny_if_budget_exceeded("
+            f'{json.dumps({"tool_call_count": max_tool_calls})})'
+        )
+    if max_tokens is not None:
+        # The cumulative token budget gates new consumption, so evaluate it
+        # only where the agent is about to spend tokens (model and tool
+        # calls). Denying input or agent_startup on an exhausted budget would
+        # strand the session, and post-action points cannot un-run the spend.
+        branches.append(
+            'input.intervention_point in ["pre_model_call", "pre_tool_call"]\n'
+            "\tv := budgets.deny_if_budget_exceeded("
+            f'{json.dumps({"token_count": max_tokens})})'
         )
     if confidence_threshold is not None and confidence_threshold > 0:
         branches.append(
@@ -261,8 +266,13 @@ def _render_rego(
             f"{json.dumps(confidence_threshold)})"
         )
     if require_human_approval:
+        # v4 gated human approval on tool interception only (PolicyInterceptor
+        # checked require_human_approval when a tool was about to run), so the
+        # migrated escalation stays scoped to pre_tool_call. Escalating at
+        # every bound point would, absent an approver, deny all traffic.
         branches.append(
-            'v := approval.escalate_if_approver_required(["human"])'
+            'input.intervention_point == "pre_tool_call"\n'
+            '\tv := approval.escalate_if_approver_required(["human"])'
         )
     for index, branch in enumerate(branches):
         lines.append("verdict := v if {" if index == 0 else "else := v if {")

--- a/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
+++ b/agent-governance-python/agt-policies/src/agt/cli/_migrate_resolution/build.py
@@ -106,14 +106,28 @@ def resolve_manifest(
 
     merged_rules = merge_documents(docs_only)
 
-    bundle_path = bundle_dir or Path(tempfile.mkdtemp(prefix="agt_resolved_bundle_"))
-    rego_path = _materialize_rego_bundle(bundle_path, merged_rules)
-
+    # Validate before materializing anything. Both guards below reject the
+    # chain, and creating the bundle first would leave an orphaned temp
+    # directory behind on every rejected migration.
     intervention_points = _collect_intervention_points(docs_only)
     if merged_rules and not _binds_legacy_rules(intervention_points):
         raise ResolutionError.invalid_governance(
             "governance rules must bind policy id 'agt_legacy_rules' at one or more intervention points"
         )
+    # The engine rejects a manifest with no intervention points
+    # ("at least one intervention point config is required"), so refuse here
+    # rather than reporting a successful migration and writing a manifest that
+    # cannot be loaded. A chain that binds nothing also governs nothing.
+    if not intervention_points:
+        raise ResolutionError.invalid_governance(
+            "no intervention points were declared across the governance chain; "
+            "add an 'intervention_points' block binding policy id "
+            "'agt_legacy_rules' to at least one point (for example 'input') "
+            "before migrating"
+        )
+
+    bundle_path = bundle_dir or Path(tempfile.mkdtemp(prefix="agt_resolved_bundle_"))
+    rego_path = _materialize_rego_bundle(bundle_path, merged_rules)
 
     manifest: dict[str, Any] = {
         "agent_control_specification_version": ACS_VERSION,

--- a/agent-governance-python/agt-policies/src/agt/cli/_stock_rego/patterns.rego
+++ b/agent-governance-python/agt-policies/src/agt/cli/_stock_rego/patterns.rego
@@ -30,6 +30,28 @@ matches_any(text, patterns) if {
 	regex.match(pattern, text)
 }
 
+# ``indexof(text, "")`` is undefined in OPA, so a pattern whose leftmost match
+# is zero-length (``[0-9]*``, a bare ``*`` glob) would drop out of the scored
+# comprehension and leave first_match undefined. matches_any still reports a
+# match, so a caller that gates on matches_any and then reads a verdict from
+# first_match would fall through to allow.
+#
+# OPA's regex builtins return the matched text, never its position, so a
+# zero-length match has no recoverable offset: ``(?m)$`` matches at the end of
+# the subject, not at 0. Report 0 as a deterministic placeholder. The span is
+# diagnostic only -- it feeds the deny message and the earliest() tie-break,
+# and nothing outside this file reads it -- so the decision is unaffected, but
+# a deny whose only matching pattern is zero-width may name offset 0 and, where
+# a longer match also exists, may name the zero-width pattern instead.
+match_start(_, matched) := 0 if {
+	matched == ""
+}
+
+match_start(text, matched) := start if {
+	matched != ""
+	start := indexof(text, matched)
+}
+
 first_match(text, patterns) := match if {
 	is_string(text)
 	is_array(patterns)
@@ -37,7 +59,7 @@ first_match(text, patterns) := match if {
 		some idx, pattern in patterns
 		found := regex.find_n(pattern, text, 1)
 		count(found) > 0
-		span_start := indexof(text, found[0])
+		span_start := match_start(text, found[0])
 		span_start >= 0
 		hit := {
 			"pattern": pattern,

--- a/agent-governance-python/agt-policies/src/agt/cli/migrate.py
+++ b/agent-governance-python/agt-policies/src/agt/cli/migrate.py
@@ -99,6 +99,8 @@ class GovernancePolicyFinding:
     kwargs: dict[str, Any]
     migration_kwargs: dict[str, Any] = field(default_factory=dict)
     manual_review: list[str] = field(default_factory=list)
+    # Advisory only: recorded in the report but never blocks the migration.
+    notes: list[str] = field(default_factory=list)
     manifest_path: Path | None = None
     rewrite_snippet: str = ""
     applied: bool = False
@@ -624,6 +626,14 @@ def _migrate_governance_chain(
         return finding
 
     if write:
+        # Same portability rule the GovernancePolicy path follows: the manifest
+        # lands in chain_root next to its bundle, so record the bundle
+        # relatively or the project stops working once cloned or containerized.
+        policy = manifest.get("policies", {}).get("agt_legacy_rules")
+        if isinstance(policy, dict) and policy.get("bundle"):
+            policy["bundle"] = os.path.relpath(
+                Path(policy["bundle"]).resolve(), manifest_path.parent.resolve()
+            )
         with tempfile.TemporaryDirectory(
             prefix=".agt_chain_migration_", dir=chain_root
         ) as staging_dir:
@@ -721,6 +731,20 @@ def _migrate_governance_policy(
         )
         return
 
+    # The generated confidence rule reads ``input.annotations.confidence.score``,
+    # which only an annotator can populate. The migrator has no annotator to
+    # declare, so the rule is inert until the user wires one up. Say so instead
+    # of letting a v4 policy look like it still enforces a threshold it cannot.
+    if inputs.confidence_threshold > 0:
+        _add_note(
+            finding,
+            "confidence_threshold "
+            f"({inputs.confidence_threshold}) migrated to a Rego rule that reads "
+            "'input.annotations.confidence.score'. Nothing populates that field "
+            "until you declare an annotator that emits a confidence score, so "
+            "the threshold is not enforced until you do.",
+        )
+
     bundle_dir = policies_dir / f"{base_name}_bundle"
     if manifest_path.exists() or bundle_dir.exists():
         finding.manual_review.append(
@@ -751,8 +775,11 @@ def _migrate_governance_policy(
                 bundle_dir=staging_bundle,
                 policy_id=policy_id,
             )
-            manifest["policies"][policy_id]["bundle"] = str(
-                bundle_dir.resolve()
+            # Relative to the manifest so the migrated project stays portable:
+            # an absolute path breaks the moment the repo is cloned elsewhere or
+            # built into a container.
+            manifest["policies"][policy_id]["bundle"] = os.path.relpath(
+                bundle_dir.resolve(), manifest_path.parent.resolve()
             )
             validate_manifest(yaml.safe_dump(manifest, sort_keys=False))
             staged_manifest = staging / "manifest.yaml"
@@ -783,6 +810,12 @@ def _migrate_governance_policy(
             return
     finding.manifest_path = manifest_path
     finding.applied = True
+
+
+def _add_note(finding: GovernancePolicyFinding, note: str) -> None:
+    """Record an advisory note once; this runs again on the --write pass."""
+    if note not in finding.notes:
+        finding.notes.append(note)
 
 
 def _render_governance_rewrite_snippet(
@@ -927,6 +960,12 @@ def render_report(report: MigrationReport) -> str:
                 lines.append("")
                 for reason in gp.manual_review:
                     lines.append(f"- {_md_escape(reason)}")
+                lines.append("")
+            if gp.notes:
+                lines.append("**Notes:**")
+                lines.append("")
+                for note in gp.notes:
+                    lines.append(f"- {_md_escape(note)}")
                 lines.append("")
             lines.append("**Suggested code rewrite:**")
             lines.append("")

--- a/agent-governance-python/agt-policies/tests/test_migrate.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate.py
@@ -17,11 +17,12 @@ The suite covers the algorithm contract from ``plan.md`` §5 / M6.S1:
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 import pytest
 import yaml
@@ -292,7 +293,12 @@ def test_write_produces_v5_artifacts(tmp_path: Path) -> None:
     data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
     assert data["extends"] == []
     assert "agt_legacy_rules" in data["policies"]
-    bundle_dir = Path(data["policies"]["agt_legacy_rules"]["bundle"])
+    # Recorded relative to the manifest so the migrated project stays portable.
+    # Assert that explicitly: ``Path("/a") / "/abs"`` discards the left operand,
+    # so joining alone would pass just as well against an absolute path.
+    recorded = data["policies"]["agt_legacy_rules"]["bundle"]
+    assert not Path(recorded).is_absolute(), recorded
+    bundle_dir = manifest_path.parent / recorded
     assert bundle_dir.is_dir()
     assert (bundle_dir / "agt_legacy.rego").is_file()
 
@@ -474,7 +480,9 @@ policy = GovernancePolicy(
     declared = set(data["policies"].keys())
     for binding in data["intervention_points"].values():
         assert binding["policy"]["id"] in declared
-    bundle = Path(data["policies"]["billing_bot"]["bundle"])
+    # The bundle is recorded relative to the manifest so the migrated project
+    # stays portable; resolve it the way a host loading the manifest would.
+    bundle = out.parent / data["policies"]["billing_bot"]["bundle"]
     assert bundle.is_dir()
     assert (bundle / "billing_bot.rego").is_file()
     assert parse_manifest(out.read_text(encoding="utf-8")) == data
@@ -499,12 +507,189 @@ policy = GovernancePolicy()
         Path(finding.manifest_path).read_text(encoding="utf-8")
     )
     policy = manifest["policies"]["default_bot"]
-    rego = (Path(policy["bundle"]) / "default_bot.rego").read_text(
-        encoding="utf-8"
-    )
+    rego = (
+        Path(finding.manifest_path).parent / policy["bundle"] / "default_bot.rego"
+    ).read_text(encoding="utf-8")
     assert '"token_count": 4096' in rego
     assert '"tool_call_count": 10' in rego
     assert "deny_if_low_confidence(0.8)" in rego
+
+
+def test_substring_patterns_stay_case_insensitive(tmp_path: Path) -> None:
+    """v4 matched substrings with ``pat.lower() in text.lower()``.
+
+    Migrating to a case-sensitive regex silently unprotects every v4 policy
+    against differently-cased text, so the generated Rego has to carry the
+    RE2 ``(?i)`` flag.
+    """
+    from agt.cli._migrate_bridge import (
+        MigrationPolicyInput,
+        build_migrated_manifest,
+    )
+
+    bundle = tmp_path / "b"
+    build_migrated_manifest(
+        MigrationPolicyInput(name="p", blocked_patterns=["password"]),
+        bundle_dir=bundle,
+        policy_id="p",
+    )
+    rego = (bundle / "p.rego").read_text(encoding="utf-8")
+    assert "(?i)password" in rego
+
+
+def test_every_adapter_point_is_bound(tmp_path: Path) -> None:
+    """The engine denies any point the manifest leaves unbound.
+
+    A migrated policy that binds only some points stops the agent the moment it
+    produces output or calls a tool, so every point an adapter evaluates has to
+    be present even when the v4 policy said nothing about it.
+    """
+    from agt.cli._migrate_bridge import (
+        MigrationPolicyInput,
+        build_migrated_manifest,
+    )
+
+    manifest = build_migrated_manifest(
+        MigrationPolicyInput(name="p", allowed_tools=["search"]),
+        bundle_dir=tmp_path / "b",
+        policy_id="p",
+    )
+    assert set(manifest["intervention_points"]) == {
+        "input",
+        "output",
+        "pre_model_call",
+        "post_model_call",
+        "pre_tool_call",
+        "post_tool_call",
+        "agent_startup",
+        "agent_shutdown",
+    }
+
+
+def _assert_denies(
+    bundle: Path,
+    patterns: list[Any],
+    cases: list[tuple[str, Any]],
+) -> None:
+    """Evaluate a migrated policy against the real engine at post_model_call.
+
+    The generated Rego is only correct if the engine agrees, so assert verdicts
+    rather than grepping the emitted text.
+    """
+    import shutil
+
+    import yaml as _yaml
+
+    if shutil.which("opa") is None and not os.environ.get("ACS_OPA_PATH"):
+        pytest.skip("OPA is required to evaluate a migrated policy")
+    from agent_control_specification import AgentControl, HostSession
+
+    from agt.cli._migrate_bridge import (
+        MigrationPolicyInput,
+        build_migrated_manifest,
+    )
+
+    manifest = build_migrated_manifest(
+        MigrationPolicyInput(name="p", blocked_patterns=patterns),
+        bundle_dir=bundle,
+        policy_id="p",
+    )
+    manifest["policies"]["p"]["bundle"] = str(bundle)
+    path = bundle.parent / "assert_denies.manifest.yaml"
+    path.write_text(_yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    session = HostSession(
+        AgentControl.from_path(str(path)), agent_id="a", session_id="s"
+    )
+    for label, payload in cases:
+        verdict = session.post_model_call(payload).verdict
+        assert verdict.decision.value == "deny", f"{label}: {verdict.decision}"
+        assert verdict.reason == "blocked_pattern_input", f"{label}: {verdict.reason}"
+
+
+def test_object_targets_match_without_json_escaping(tmp_path: Path) -> None:
+    """OPA's json.marshal escapes " \\ < > and &.
+
+    Marshalling an object-valued policy target would silently stop matching any
+    pattern containing one of those, so the generated Rego collects string
+    leaves instead.
+    """
+    from agt.cli._migrate_bridge import (
+        MigrationPolicyInput,
+        build_migrated_manifest,
+    )
+
+    bundle = tmp_path / "b"
+    build_migrated_manifest(
+        MigrationPolicyInput(name="p", blocked_patterns=["<script>"]),
+        bundle_dir=bundle,
+        policy_id="p",
+    )
+    rego = (bundle / "p.rego").read_text(encoding="utf-8")
+    assert "value := json.marshal(target)" not in rego
+    assert "walk(target" in rego
+    _assert_denies(
+        tmp_path / "esc",
+        ["<script>", ('*.exe', "GLOB")],
+        [
+            # OPA walks objects in sorted key order, not insertion order, so
+            # the key names decide which leaf comes first.
+            ("object, offending leaf last", {"a": "ok", "z": "x<script>y"}),
+            ("object, offending leaf first", {"a": "x<script>y", "z": "ok"}),
+            ("glob leaf first", {"a": "payload.exe", "z": "ok"}),
+            ("glob leaf last", {"a": "ok", "z": "payload.exe"}),
+            ("two matching leaves at different offsets", {"a": "x<script>y", "z": "q<script>"}),
+            ("plain string", "x<script>y"),
+        ],
+    )
+
+
+def test_budgets_do_not_fire_after_the_action_ran(tmp_path: Path) -> None:
+    """A budget gates an action; it cannot un-run one.
+
+    The runtime charges a tool call during pre_tool_call, so a >= budget check
+    at post_tool_call would deny the result of the last permitted call after its
+    side effects committed.
+    """
+    from agt.cli._migrate_bridge import (
+        MigrationPolicyInput,
+        build_migrated_manifest,
+    )
+
+    bundle = tmp_path / "b"
+    build_migrated_manifest(
+        MigrationPolicyInput(name="p", max_tool_calls=2),
+        bundle_dir=bundle,
+        policy_id="p",
+    )
+    rego = (bundle / "p.rego").read_text(encoding="utf-8")
+    assert "not is_post_action_point" in rego
+    assert (
+        'input.intervention_point in ["post_tool_call", "post_model_call", '
+        '"output", "agent_shutdown"]'
+    ) in rego
+
+
+def test_zero_width_patterns_still_deny(tmp_path: Path) -> None:
+    """A zero-length leftmost match must not fall through to allow.
+
+    matches_any selects the leaf, deny_if_pattern builds the verdict; if the
+    two disagree the branch goes undefined and the else-chain reaches the
+    default allow.
+    """
+    _assert_denies(
+        tmp_path / "zw",
+        [("[0-9]*", "REGEX")],
+        [
+            ("digits at the start", "4111111111111111"),
+            ("digits after text", "card 4111111111111111"),
+            ("object target", {"b": "card 4111111111111111"}),
+            # The round-4 regression shape: an empty leaf sorts first and
+            # yields the zero-length match, so the leaf that actually carries
+            # the number is only reached if the span stays defined.
+            ("empty leaf ahead of the match", {"a": "", "z": "card 4111111111111111"}),
+            ("only an empty leaf", {"a": ""}),
+        ],
+    )
 
 
 def test_pattern_types_are_preserved_in_generated_rego(tmp_path: Path) -> None:
@@ -529,11 +714,20 @@ policy = GovernancePolicy(
     manifest = parse_manifest(
         Path(finding.manifest_path).read_text(encoding="utf-8")
     )
-    rego = Path(manifest["policies"]["patterns"]["bundle"], "patterns.rego").read_text(
-        encoding="utf-8"
-    )
+    rego = (
+        Path(finding.manifest_path).parent
+        / manifest["policies"]["patterns"]["bundle"]
+        / "patterns.rego"
+    ).read_text(encoding="utf-8")
+    # Every pattern kind ships with the RE2 case-insensitive flag, matching v4,
+    # which compiled REGEX and GLOB with re.IGNORECASE and lowercased both sides
+    # for substrings.
     assert "secret-[0-9]+" in rego
-    assert json.dumps(r"(?s:.*\.exe)\z") in rego
+    assert json.dumps("(?i)" + r"(?s:.*\.exe)\z") in rego
+    # Each pattern is rendered in both the matched_texts helper and the deny
+    # branch, so assert per-pattern rather than on a raw count.
+    assert rego.count(json.dumps("(?i)secret-[0-9]+")) == 2
+    assert rego.count(json.dumps("(?i)" + r"(?s:.*\.exe)\z")) == 2
 
 
 @pytest.mark.parametrize(

--- a/agent-governance-python/agt-policies/tests/test_migrate.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate.py
@@ -662,11 +662,92 @@ def test_budgets_do_not_fire_after_the_action_ran(tmp_path: Path) -> None:
         policy_id="p",
     )
     rego = (bundle / "p.rego").read_text(encoding="utf-8")
-    assert "not is_post_action_point" in rego
+    assert 'input.intervention_point == "pre_tool_call"' in rego
     assert (
-        'input.intervention_point in ["post_tool_call", "post_model_call", '
-        '"output", "agent_shutdown"]'
+        'input.intervention_point in ["pre_model_call", "pre_tool_call"]'
     ) in rego
+
+
+def _migrated_session(policy: Any, tmp_path: Path):
+    """Load a migrated policy into the real engine and open a host session."""
+    import shutil
+
+    import yaml as _yaml
+
+    if shutil.which("opa") is None and not os.environ.get("ACS_OPA_PATH"):
+        pytest.skip("OPA is required to evaluate a migrated policy")
+    from agent_control_specification import AgentControl, HostSession
+
+    from agt.cli._migrate_bridge import build_migrated_manifest
+
+    manifest = build_migrated_manifest(
+        policy, bundle_dir=tmp_path / "b", policy_id="p"
+    )
+    path = tmp_path / "manifest.yaml"
+    path.write_text(_yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    return HostSession(
+        AgentControl.from_path(str(path)), agent_id="a", session_id="s"
+    )
+
+
+def test_approval_stays_scoped_to_tool_calls(tmp_path: Path) -> None:
+    """v4 gated require_human_approval on tool interception only.
+
+    Binding all eight intervention points must not widen the escalation:
+    firing it everywhere would, absent an approver, deny every input, model
+    call, and startup of a migrated agent.
+    """
+    from agt.cli._migrate_bridge import MigrationPolicyInput
+
+    session = _migrated_session(
+        MigrationPolicyInput(
+            name="p", require_human_approval=True, confidence_threshold=0.0
+        ),
+        tmp_path,
+    )
+    messages = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+    for label, result in (
+        ("input", session.input("hello")),
+        ("pre_model_call", session.pre_model_call(messages)),
+        ("agent_startup", session.agent_startup({"id": "a"})),
+    ):
+        assert result.verdict.decision.value == "allow", label
+    verdict = session.pre_tool_call(tool_name="t", args={}).verdict
+    # The escalation fires only here; with no approver configured the
+    # session resolves it to a denial.
+    assert verdict.decision.value == "deny"
+    assert verdict.reason == "approval_denied"
+
+
+def test_tool_call_budget_gates_only_the_next_tool_call(tmp_path: Path) -> None:
+    """v4 compared context.call_count to max_tool_calls at tool interception.
+
+    An exhausted tool-call budget must deny the next tool call and nothing
+    else; denying pre_model_call or input as well would stop the agent from
+    ever emitting its final model response.
+    """
+    from agt.cli._migrate_bridge import MigrationPolicyInput
+
+    session = _migrated_session(
+        MigrationPolicyInput(
+            name="p",
+            max_tool_calls=1,
+            max_tokens=1_000_000,
+            confidence_threshold=0.0,
+        ),
+        tmp_path,
+    )
+    first = session.pre_tool_call(tool_name="t", args={}).verdict
+    assert first.decision.value == "allow"
+    session.builder.record_tool_call()
+    second = session.pre_tool_call(tool_name="t", args={}).verdict
+    assert second.decision.value == "deny"
+    assert second.reason == "budget_tool_calls_exceeded"
+    followup = session.pre_model_call(
+        {"model": "m", "messages": [{"role": "user", "content": "summarize"}]}
+    ).verdict
+    assert followup.decision.value == "allow"
+    assert session.input("next user turn").verdict.decision.value == "allow"
 
 
 def test_zero_width_patterns_still_deny(tmp_path: Path) -> None:

--- a/agent-governance-python/agt-policies/tests/test_migrate_bridge.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate_bridge.py
@@ -32,10 +32,23 @@ def test_allowed_tools_become_declared_tools(tmp_path: Path) -> None:
 
 
 def test_tool_and_token_budgets_survive_translation(tmp_path: Path) -> None:
+    """Each budget keeps its v4 scope: consumption points only.
+
+    v4 compared call_count to max_tool_calls at tool interception, so the
+    tool-call budget gates pre_tool_call alone; the cumulative token budget
+    gates the points about to spend tokens.
+    """
     _build(tmp_path, max_tool_calls=3, max_tokens=1000)
     rendered = (tmp_path / "bundle" / "app.rego").read_text(encoding="utf-8")
 
-    assert 'deny_if_budget_exceeded({"tool_call_count": 3, "token_count": 1000})' in rendered
+    assert (
+        'input.intervention_point == "pre_tool_call"\n'
+        '\tv := budgets.deny_if_budget_exceeded({"tool_call_count": 3})'
+    ) in rendered
+    assert (
+        'input.intervention_point in ["pre_model_call", "pre_tool_call"]\n'
+        '\tv := budgets.deny_if_budget_exceeded({"token_count": 1000})'
+    ) in rendered
 
 
 def test_tool_calls_are_mediated_before_the_call(tmp_path: Path) -> None:
@@ -61,7 +74,12 @@ def test_human_approval_is_carried_over(tmp_path: Path) -> None:
     rendered = (tmp_path / "bundle" / "app.rego").read_text(encoding="utf-8")
 
     assert "approval" in manifest
-    assert 'escalate_if_approver_required(["human"])' in rendered
+    # v4 gated approval on tool interception only; the migrated escalation
+    # must stay scoped to pre_tool_call rather than fire at every bound point.
+    assert (
+        'input.intervention_point == "pre_tool_call"\n'
+        '\tv := approval.escalate_if_approver_required(["human"])'
+    ) in rendered
 
 
 def test_no_approval_escalation_when_not_required(tmp_path: Path) -> None:

--- a/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate_resolution.py
@@ -867,7 +867,10 @@ def test_resolve_intervention_points_union_annotations(tmp_path: Path) -> None:
 
 def test_resolve_writes_default_bundle_outside_workspace(tmp_path: Path) -> None:
     root = tmp_path
-    _write(root / "governance.yaml", {"rules": []})
+    _write(
+        root / "governance.yaml",
+        {"rules": [], "intervention_points": _legacy_binding()},
+    )
     manifest = resolve_manifest(root, root)
     bundle_path = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
     # The default bundle location is a unique temp directory outside the
@@ -964,11 +967,30 @@ def test_resolve_renders_operator_vocabulary(
 def test_resolve_explicit_bundle_dir(tmp_path: Path) -> None:
     root = tmp_path / "ws"
     root.mkdir()
-    _write(root / "governance.yaml", {"rules": []})
+    _write(
+        root / "governance.yaml",
+        {"rules": [], "intervention_points": _legacy_binding()},
+    )
     out_dir = tmp_path / "build"
     manifest = resolve_manifest(root, root, bundle_dir=out_dir)
     bundle_path = Path(manifest["policies"]["agt_legacy_rules"]["bundle"])
     assert bundle_path == (out_dir / "policy").resolve()
+
+
+def test_resolve_refuses_a_chain_that_binds_no_intervention_points(
+    tmp_path: Path,
+) -> None:
+    """A manifest with no bound points is rejected by the engine on load.
+
+    Emitting one anyway reports a successful migration and leaves the user with
+    a project that cannot start, so the migrator has to refuse first.
+    """
+    root = tmp_path / "ws"
+    root.mkdir()
+    _write(root / "governance.yaml", {"rules": []})
+    with pytest.raises(ResolutionError) as excinfo:
+        resolve_manifest(root, root)
+    assert "no intervention points" in str(excinfo.value)
 
 
 # ── ResolutionError shape ────────────────────────────────────────────

--- a/docs/tutorials/55-agent-control-specification.md
+++ b/docs/tutorials/55-agent-control-specification.md
@@ -73,7 +73,7 @@ intervention_points:
     policy:
       id: email_policy
   post_tool_call:
-    policy_target: $.tool_result
+    policy_target: $.tool_result.value
     policy_target_kind: tool_result
     tool_name_from: $.tool_call.name
     policy:

--- a/examples/crewai-governed/policies/manifest.yaml
+++ b/examples/crewai-governed/policies/manifest.yaml
@@ -15,3 +15,11 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: prompt_safety
+  output:
+    policy_target: $.response.content
+    policy:
+      id: prompt_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: prompt_safety

--- a/examples/maf-integration/01-loan-processing/python/policies/manifest.yaml
+++ b/examples/maf-integration/01-loan-processing/python/policies/manifest.yaml
@@ -15,3 +15,7 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: loan_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: loan_safety

--- a/examples/maf-integration/02-customer-service/python/policies/manifest.yaml
+++ b/examples/maf-integration/02-customer-service/python/policies/manifest.yaml
@@ -15,3 +15,7 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: support_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: support_safety

--- a/examples/maf-integration/03-healthcare/python/policies/manifest.yaml
+++ b/examples/maf-integration/03-healthcare/python/policies/manifest.yaml
@@ -15,3 +15,7 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: healthcare_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: healthcare_safety

--- a/examples/maf-integration/04-it-helpdesk/python/policies/manifest.yaml
+++ b/examples/maf-integration/04-it-helpdesk/python/policies/manifest.yaml
@@ -15,3 +15,7 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: helpdesk_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: helpdesk_safety

--- a/examples/maf-integration/05-devops-deploy/python/policies/manifest.yaml
+++ b/examples/maf-integration/05-devops-deploy/python/policies/manifest.yaml
@@ -15,3 +15,7 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: devops_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: devops_safety

--- a/examples/openai-agents-governed/policies/manifest.yaml
+++ b/examples/openai-agents-governed/policies/manifest.yaml
@@ -15,3 +15,15 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: prompt_safety
+  output:
+    policy_target: $.response.content
+    policy:
+      id: prompt_safety
+  post_tool_call:
+    policy_target: $.tool_result.value
+    policy:
+      id: prompt_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: prompt_safety

--- a/examples/smolagents-governed/policies/manifest.yaml
+++ b/examples/smolagents-governed/policies/manifest.yaml
@@ -15,3 +15,11 @@ intervention_points:
     policy_target: $.input.body
     policy:
       id: prompt_safety
+  output:
+    policy_target: $.response.content
+    policy:
+      id: prompt_safety
+  pre_tool_call:
+    policy_target: $.tool_call.args
+    policy:
+      id: prompt_safety

--- a/policy-engine/policy/lib/patterns.rego
+++ b/policy-engine/policy/lib/patterns.rego
@@ -39,6 +39,28 @@ matches_any(text, patterns) if {
 	regex.match(pattern, text)
 }
 
+# ``indexof(text, "")`` is undefined in OPA, so a pattern whose leftmost match
+# is zero-length (``[0-9]*``, a bare ``*`` glob) would drop out of the scored
+# comprehension and leave first_match undefined. matches_any still reports a
+# match, so a caller that gates on matches_any and then reads a verdict from
+# first_match would fall through to allow.
+#
+# OPA's regex builtins return the matched text, never its position, so a
+# zero-length match has no recoverable offset: ``(?m)$`` matches at the end of
+# the subject, not at 0. Report 0 as a deterministic placeholder. The span is
+# diagnostic only -- it feeds the deny message and the earliest() tie-break,
+# and nothing outside this file reads it -- so the decision is unaffected, but
+# a deny whose only matching pattern is zero-width may name offset 0 and, where
+# a longer match also exists, may name the zero-width pattern instead.
+match_start(_, matched) := 0 if {
+	matched == ""
+}
+
+match_start(text, matched) := start if {
+	matched != ""
+	start := indexof(text, matched)
+}
+
 first_match(text, patterns) := match if {
 	is_string(text)
 	is_array(patterns)
@@ -46,7 +68,7 @@ first_match(text, patterns) := match if {
 		some idx, pattern in patterns
 		found := regex.find_n(pattern, text, 1)
 		count(found) > 0
-		span_start := indexof(text, found[0])
+		span_start := match_start(text, found[0])
 		span_start >= 0
 		hit := {
 			"pattern": pattern,

--- a/policy-engine/policy/lib/patterns_test.rego
+++ b/policy-engine/policy/lib/patterns_test.rego
@@ -60,3 +60,29 @@ test_non_string_input_does_not_match if {
 	not patterns.matches_any(123, patterns.pii_patterns)
 	not patterns.first_match({"x": 1}, patterns.pii_patterns)
 }
+
+# A zero-length leftmost match must still produce a verdict. matches_any and
+# first_match have to agree: a caller that gates on the former and reads a
+# verdict from the latter would otherwise fall through to allow.
+test_zero_length_leftmost_match_still_denies if {
+	patterns.matches_any("card 4111", ["[0-9]*"])
+	verdict := patterns.deny_if_pattern("card 4111", ["[0-9]*"], "r")
+	verdict.decision == "deny"
+}
+
+test_empty_text_with_zero_width_pattern_denies if {
+	patterns.matches_any("", ["x*"])
+	patterns.deny_if_pattern("", ["x*"], "r").decision == "deny"
+}
+
+test_match_start_of_empty_match_is_zero if {
+	patterns.first_match("card 4111", ["[0-9]*"]).span_start == 0
+}
+
+# A zero-width match reports offset 0 because OPA gives no position for it.
+# Pinned so the placeholder is a recorded property rather than an accident.
+test_zero_width_match_reports_placeholder_offset if {
+	hit := patterns.first_match("ab 12", ["(?m)$"])
+	hit.match == ""
+	hit.span_start == 0
+}

--- a/policy-engine/sdk/python/agent_control_specification/_host.py
+++ b/policy-engine/sdk/python/agent_control_specification/_host.py
@@ -211,8 +211,11 @@ class SnapshotBuilder:
         self, intervention_point: str, **body: JsonValue
     ) -> dict[str, Any]:
         """Return a full snapshot: the envelope plus whatever the hook carries."""
-        snapshot: dict[str, Any] = {"envelope": self.envelope(intervention_point)}
-        snapshot.update(body)
+        snapshot: dict[str, Any] = dict(body)
+        # The envelope carries host-asserted identity, session and budget
+        # counters that policies trust. Write it last so no hook body can
+        # replace it and forge an identity or reset a budget.
+        snapshot["envelope"] = self.envelope(intervention_point)
         return snapshot
 
 def _with_decision(
@@ -325,7 +328,33 @@ class HostSession:
         return self.evaluate(InterventionPoint.INPUT, input={"body": body})
 
     def pre_model_call(self, request: JsonValue) -> InterventionPointResult:
-        return self.evaluate(InterventionPoint.PRE_MODEL_CALL, request=request)
+        # Emit the same top-level keys the framework adapters send (``model``,
+        # ``messages``, ``tools``) so one manifest binds paths that resolve
+        # through either seam. Read them out by name rather than spreading the
+        # caller's mapping, which would raise TypeError for a body carrying a
+        # key named after one of this method's parameters.
+        #
+        # Anything outside that set is folded into ``messages`` rather than
+        # dropped. The signature accepts any JSON, and provider request shapes
+        # differ (Anthropic puts instructions in ``system``, Gemini in
+        # ``contents``, Bedrock in ``inputText``); discarding them would hand
+        # the policy an empty request and allow prompt text nobody inspected.
+        canonical = ("model", "messages", "tools", "request_id")
+        body: dict[str, JsonValue] = {"model": {}, "messages": [], "tools": []}
+        if isinstance(request, dict):
+            for key in canonical:
+                if key in request:
+                    body[key] = request[key]
+            extras = {k: v for k, v in request.items() if k not in canonical}
+            if extras:
+                carried = body["messages"]
+                body["messages"] = [
+                    *(carried if isinstance(carried, list) else [carried]),
+                    extras,
+                ]
+        else:
+            body["messages"] = request
+        return self.evaluate(InterventionPoint.PRE_MODEL_CALL, **body)
 
     def post_model_call(self, response: JsonValue) -> InterventionPointResult:
         return self.evaluate(InterventionPoint.POST_MODEL_CALL, response=response)
@@ -353,7 +382,9 @@ class HostSession:
         return self.evaluate(
             InterventionPoint.POST_TOOL_CALL,
             tool_call={"name": tool_name, "args": args, "id": call_id or "call-1"},
-            tool_result=result,
+            # Same envelope the adapters emit, so ``$.tool_result.value`` resolves
+            # whichever seam the host went through.
+            tool_result={"value": result, "error": None, "duration_ms": None},
         )
 
     def output(self, content: JsonValue) -> InterventionPointResult:

--- a/policy-engine/sdk/python/tests/test_host.py
+++ b/policy-engine/sdk/python/tests/test_host.py
@@ -109,6 +109,67 @@ def test_session_sends_the_tool_call_and_the_current_counters() -> None:
     assert snapshot["envelope"]["budgets"]["tool_call_count"] == 3
 
 
+def test_session_matches_the_adapter_envelopes() -> None:
+    """One manifest has to bind paths that work through either seam.
+
+    The framework adapters send ``tool_result`` as a mapping and spread the
+    model request over top-level keys. If HostSession nested those differently,
+    a policy target that resolved for one caller would fail closed with a
+    missing-path error for the other.
+    """
+    control = _RecordingControl()
+    session = HostSession(control, agent_id="bot")
+
+    session.post_tool_call(tool_name="t", args={}, result="ok")
+    session.pre_model_call({"messages": [{"role": "user"}], "model": {"name": "m"}})
+
+    _point, post_tool_snapshot, _mode = control.calls[0]
+    assert post_tool_snapshot["tool_result"]["value"] == "ok"
+
+    _point, pre_model_snapshot, _mode = control.calls[1]
+    assert pre_model_snapshot["messages"] == [{"role": "user"}]
+    assert pre_model_snapshot["model"] == {"name": "m"}
+    assert "request" not in pre_model_snapshot
+
+
+def test_a_hook_body_cannot_replace_the_envelope() -> None:
+    """The envelope is host-asserted; policies trust it for identity and budgets.
+
+    If a body key could overwrite it, any caller passing an ``envelope`` field
+    would forge its own identity and reset the counters behind max_tool_calls
+    and max_tokens.
+    """
+    control = _RecordingControl()
+    session = HostSession(control, agent_id="bot", session_id="sess")
+    session.builder.record_tool_call(7)
+
+    session.evaluate("input", envelope={"budgets": {"tool_call_count": 0}})
+    session.pre_model_call(
+        {"messages": [], "envelope": {"agent": {"id": "ATTACKER"}}}
+    )
+
+    for _point, snapshot, _mode in control.calls:
+        assert snapshot["envelope"]["agent"]["id"] == "bot"
+        assert snapshot["envelope"]["budgets"]["tool_call_count"] == 7
+
+
+def test_pre_model_call_accepts_any_json_body() -> None:
+    """The signature advertises JsonValue, so no body may raise."""
+    control = _RecordingControl()
+    session = HostSession(control, agent_id="bot")
+
+    for body in (
+        {"intervention_point": "input", "messages": []},
+        {"self": 1, "messages": []},
+        {1: "x"},
+        "a bare string",
+        [{"role": "user"}],
+    ):
+        session.pre_model_call(body)
+
+    assert len(control.calls) == 5
+
+
 def test_session_covers_every_intervention_point() -> None:
     control = _RecordingControl()
     session = HostSession(control, agent_id="bot")


### PR DESCRIPTION
## Description

The engine denies any intervention point a manifest leaves unbound, returning `runtime_error:intervention_point_unknown`. That behaviour is deliberate, and `_native_adapter_runtime.py` spells out the contract it creates:

> a manifest that omits one is a configuration gap rather than a decision to allow [...] Bind every point the adapter evaluates.

Neither the v4 migrator nor the shipped examples held up their side of that contract, so both produced manifests that deny traffic nobody intended to block. A v4 policy that only restricted tools migrated to a manifest that denied all input and output. Sixteen of the twenty adapters evaluate `pre_tool_call`, but only two of the forty-two example manifests bound it, so an agent using any of the others failed on its first tool call.

Testing that path turned up three more defects, and two cases where the tooling reported success it had not earned. All of them are fixed here.

Two behaviour changes worth calling out for anyone who has already migrated: blocked patterns now match case-insensitively (this is the v4 behaviour being restored), and they now apply at every bound point rather than only `input` and `output`. Both make migrated policies stricter, never more permissive.

## Problem

| Symptom | Cause |
|---|---|
| A tools-only v4 policy denies all input and output | `bind_input` and `bind_output` were gated on `blocked_patterns`, leaving both points unbound |
| Eight examples deny their own output and tool calls | Their manifests bind `input` only, while their adapters evaluate `output` and `pre_tool_call` |
| `PASSWORD` slips past a rule written as `password` | v4 matched with `pattern.lower() in text.lower()`; the generated regex was case-sensitive. Fails open |
| `post_model_call` denies every call with `path_type_mismatch` | It bound `$.response.content`, but the runtime sends the response raw |
| A migrated project stops working once cloned | The manifest recorded an absolute `bundle` path |
| `agt migrate v4-to-v5 --write` reports success, then nothing loads | It wrote a manifest with no intervention points, which the engine rejects with `manifest_invalid` |
| `confidence_threshold` is silently unenforced | The generated rule reads `input.annotations.confidence.score` and no annotator populates it |

## Changes

| File | What changed |
|------|-------------|
| `agt/cli/_migrate_bridge.py` | Bind all six points an adapter can evaluate, each with the JSONPath matching the envelope the runtime actually sends. `post_model_call` now targets `$.response`. Substring and plain-string patterns carry the RE2 `(?i)` flag. Bundle paths are recorded relative to the manifest |
| `agt/cli/migrate.py` | Write the bundle path relative to the manifest instead of resolving it absolute. Add a `notes` channel for advisory findings, and use it to say that `confidence_threshold` needs an annotator before it does anything |
| `agt/cli/_migrate_resolution/build.py` | Refuse a chain that binds no intervention points instead of writing a manifest the engine cannot load |
| `examples/**/manifest.yaml` (8 files) | Bind the points each example's adapter evaluates |
| `tests/test_migrate.py` | Two regression tests: case-insensitive substring matching, and full point coverage. Bundle assertions resolve relative to the manifest |
| `policy-engine/sdk/python/_host.py` | Emit the adapter runtime's envelopes for `post_tool_call` and `pre_model_call` so one manifest binds paths that work through either seam |
| `tests/test_host.py` | Regression test pinning both envelope shapes |
| `tests/test_migrate_resolution.py` | Regression test for the empty-bindings guard. Two fixtures now declare a binding |

`confidence_threshold` keeps generating its rule rather than dropping it, so the threshold starts working once someone declares an annotator. The note explains that it does not work before then.

## Testing

Everything below ran against the real OPA runtime and the real `NativeAdapterRuntime`, not mocks or hand-rolled stand-ins.

- `agt-policies`: no regressions. 99 failures before the change and 99 after, all pre-existing local failures in adapter scenario tests that need framework SDKs this environment cannot import. The set of failing tests is identical.
- Both new regression tests fail on unpatched `main` and pass here, so they discriminate rather than passing for free.
- All 8 patched example manifests evaluate `input`, `output`, `pre_tool_call` and `post_tool_call` through `NativeAdapterRuntime` with zero `runtime_error` denials, down from 8.
- A migrated policy now denies `my password`, `my PASSWORD` and `the PassWord`, allows benign input, and permits `post_model_call` where it previously returned `path_type_mismatch`.
- A migrated project keeps working after being moved to a different directory, which previously failed with `policy_invocation_failed`.
- `agt migrate v4-to-v5 --write` on a chain that binds nothing now fails with an actionable message and writes no manifest.
- `validate_manifest` and `parse_manifest` accept all 8 edited manifests.
- Gates: `ruff check --select E,F,W --ignore E501`, `no-custom-crypto.sh`, `check_v4_ratchet.py`, `check_native_policy_wheels.py`.
- Both seams verified: `HostSession` and `NativeAdapterRuntime` each allow `post_tool_call` and `pre_model_call` against a migrated manifest, and each deny a tool result containing a blocked pattern.
- ACS SDK suite: 6 failures before and after, identical set, all pre-existing here.
- The envelope regression test fails on unpatched `main` with a `TypeError`.

Not covered: the adapter scenario suites and `test_real_packages` cases that need framework SDKs this environment cannot import.

Not covered: the adapter scenario suites that cannot run here, and the `HostSession` divergence described below.

## The two seams had to be reconciled

A host reaches the engine one of two ways: through `NativeAdapterRuntime` (what the framework adapters in `agent-os` use) or by building a `HostSession` directly (what `openai-agents-trust` and the sandbox providers do). The two disagreed on the envelope for `post_tool_call` and `pre_model_call`. `HostSession` sent `tool_result` raw and nested the model request under `request`, while the adapters send `tool_result` as a mapping and spread the request over top-level keys.

That meant no manifest could bind a path both callers resolve. Binding the adapter shape alone would have fixed the adapter seam and left the direct one failing closed on a missing path, which just relocates the bug: `openai-agents-trust/hooks.py` builds a `HostSession` and calls `post_tool_call` on it, so it would have gone from `intervention_point_unknown` to `path_type_mismatch` and still denied every tool result.

`HostSession` now emits the same envelopes the adapter runtime does. All four combinations of caller and point allow benign traffic, and both seams still deny a blocked pattern appearing in a tool result. This is safe to change because `HostSession` is absent from the published `0.3.1b0` wheel, and `hooks.py` is its only non-test caller.

## Review

This change went through five rounds of adversarial review with Claude Opus 5, each round running the real OPA engine rather than reading the diff. Fourteen findings were reproduced and fixed. Seven of them were defects introduced by an earlier round's fix, which is worth stating plainly: several rounds closed one hole and opened another.

The ones that mattered most:

| Round | Finding | Why it mattered |
|---|---|---|
| 1 | `(?i)` applied only to substrings | v4 compiled REGEX and GLOB with `re.IGNORECASE` too, so `RM -RF /` and `SETUP.EXE` still passed |
| 1 | Object targets `json.marshal`ed | OPA escapes `" \ < > &`, so a pattern containing any of them silently stopped matching |
| 1 | Budgets fired after the action | `max_tool_calls: N` denied the result of the Nth permitted call, once its side effects had committed |
| 2 | Request keys outside a four-key allowlist were dropped | Anthropic `system`, Gemini `contents` and Bedrock `inputText` were governed as an empty request and allowed |
| 3 | Pattern verdict bound under `some ... in` | Two leaves matching at different offsets raised `eval_conflict_error`; an ordinary two-turn chat became `policy_invocation_failed` |
| 4 | `matches_any` and `first_match` disagreed on zero-length matches | `indexof(text, "")` is undefined in OPA, so `REGEX [0-9]*` allowed `card 4111111111111111` and any object with an empty field ahead of the match |

The last one predates this PR and was live for every consumer of the stock Rego library, so it is fixed at the root in `patterns.rego` rather than worked around in the generated policy.

## Known gaps

Recorded as decisions rather than oversights:

- `pre_model_call` binds `$.messages`. Content in `tools` and `model` is present in the snapshot but outside that target, so a malicious MCP tool description is not inspected. Closing it means choosing a policy target that spans all three, which is a manifest-vocabulary design decision.
- AGT-SNAPSHOT-1.0 §2.1 names the `agent_startup` field `agent_init`, but both SDK seams emit `agent` and `agent_init` appears nowhere in the runtime. The migrator binds what hosts actually send; a spec-conformant third-party host fails closed. Reconciling the spec with the SDK needs a maintainer decision.
- `AgentControl.run_tool` and the LiteLLM adapter still send the older flat `tool_result`. Out of scope here and recorded in `BREAKING_CHANGES.md`.
- `agt policy gen` emits an `output` binding no host satisfies, and roughly 30 manifests under `examples/policies/**` share it. Pre-existing, no overlap with this diff.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [x] agent-governance
- [x] docs / root

## Checklist
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

None. This fixes existing AGT code against the contract stated in `_native_adapter_runtime.py`.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

GitHub Copilot CLI, used to run the functional review that found these defects and to draft the fixes. Every finding was reproduced against the real runtime before being fixed, and every fix was verified the same way.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Follow-up to #3451 and the v4-removal stack.


