### PR TITLE
fix(agent-os): detect separated SSN forms without matching bare nine digits

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -171,7 +171,17 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="US SSN",
-            pattern=re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+            # Accept the space and dot separated forms the dash-only pattern
+            # missed (issue #3239). A separator is required: this module feeds
+            # the MCP gateway, where pii_leak is a hard-block category, so a
+            # bare nine-digit match would deny any request carrying a tracking
+            # number, ZIP+4, or ABA routing number. policy/lib/patterns.rego
+            # keeps the looser form for detection-only reporting.
+            # Use the lookaround idiom documented above rather than ``\b`` so an
+            # SSN adjacent to ``_`` (``employee_123-45-6789``) is still detected.
+            pattern=re.compile(
+                r"(?<![A-Za-z0-9])\d{3}[\s.-]\d{2}[\s.-]\d{4}(?![A-Za-z0-9])"
+            ),
         ),
         CredentialPattern(
             name="Credit card number",

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -356,3 +356,44 @@ def test_scan_and_redact_reports_types_without_raw_secret():
 def test_scan_and_redact_empty_input():
     assert CredentialRedactor.scan_and_redact(None) == ("", [])
     assert CredentialRedactor.scan_and_redact("") == ("", [])
+
+
+@pytest.mark.parametrize(
+    "ssn",
+    [
+        "123-45-6789",   # dash
+        "123 45 6789",   # space
+        "123.45.6789",   # dot
+    ],
+)
+def test_ssn_detected_across_separators(ssn: str):
+    """The dash-only pattern missed the space and dot forms used elsewhere in the
+    codebase. Regression for issue #3239."""
+    matches = CredentialRedactor.find_pii_matches(f"employee ssn {ssn} on file")
+    assert any(m.name == "US SSN" and m.matched_text == ssn for m in matches)
+
+
+def test_ssn_glued_to_a_word_character_is_detected():
+    """A word boundary treats ``_`` as a word character, so an SSN glued to one
+    escaped detection. The lookaround anchor catches it."""
+    matches = CredentialRedactor.find_pii_matches("employee_123-45-6789")
+    assert any(m.name == "US SSN" for m in matches)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Tracking: 123456789",       # bare nine digits, not an SSN
+        "order_123456789",           # nine-digit id glued to an underscore
+        "ZIP 12345-6789",            # ZIP+4
+        "ABA 021000021",             # routing number
+        "order 1234567890 shipped",  # ten digits
+        "build 12-34-5678 tagged",   # wrong digit grouping
+    ],
+)
+def test_ssn_pattern_rejects_bare_nine_digit_forms(text: str):
+    """pii_leak is a hard-block category in the MCP gateway, so a bare nine-digit
+    match would deny ordinary traffic. A separator is required here."""
+    assert not any(
+        m.name == "US SSN" for m in CredentialRedactor.find_pii_matches(text)
+    )


### PR DESCRIPTION
## Problem

`credential_redactor` matched only the dash form `123-45-6789`. The space and dot separated variants used elsewhere in the codebase (`policy/lib/patterns.rego` `pii_ssn`, the YAML policy packs) went undetected, so the same SSN was caught on one path and missed on another. Issue #3239.

## Change

- Accept the space and dot separated forms.
- Use the `(?<![A-Za-z0-9])` / `(?![A-Za-z0-9])` idiom this file already documents (lines 54 to 59) rather than `\b`. `\b` treats `_` as a word character, so `employee_123-45-6789` escaped detection.
- Require a separator, deliberately diverging from the looser policy-lib pattern.

## Why a separator is required

This module feeds the MCP gateway, where `pii_leak` is a hard-block category, blocked even under SANITIZE and a request-deny in stateless. Accepting a bare nine digits would deny ordinary traffic:

| input | dash-only (main) | optional separator | this PR |
|---|---|---|---|
| `Tracking: 123456789` | no match | match | no match |
| `order_123456789` | no match | match | no match |
| `ZIP 12345-6789` | no match | match | no match |
| `ABA 021000021` | no match | match | no match |
| `ssn 123-45-6789` | match | match | match |
| `ssn 123 45 6789` | no match | match | match |
| `ssn 123.45.6789` | no match | match | match |
| `employee_123-45-6789` | no match | match | match |

`policy/lib/patterns.rego` keeps the looser form for detection-only reporting, where a false positive costs a report line rather than a denied request.

## Tests

Positive coverage per separator, a glued-input regression, and a rejection matrix for the bare nine-digit classes: tracking number, underscore-prefixed id, ZIP+4, ABA routing, ten digits, and wrong digit grouping.

## Supersedes #3353

That branch took the optional-separator approach and accumulated a merge commit and two autofix commits. The false-positive surface @MohammadHaroonAbuomar identified there is exactly why a separator is required here. This branch is one signed commit off current main.
