### PR TITLE
fix(ci): bump all codeql-action pins together and group future bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -177,3 +177,12 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    groups:
+      # codeql-action's init, autobuild and analyze steps must run the same
+      # version: init writes a config stamped with its version and analyze
+      # refuses to load a config from a different one ("Loaded a configuration
+      # file for version X, but running version Y"). Bumping them in separate
+      # PRs leaves every one of them red, so they are grouped into a single PR.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,7 +652,7 @@ jobs:
             --output binskim-results.sarif
       - name: Upload BinSkim SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: agent-governance-dotnet/binskim-results.sarif
           category: binskim

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,12 +33,12 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
 
-      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
 
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,12 +33,12 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
 
-      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+      - uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+      - uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Bump all five `github/codeql-action` pins to v4.37.3 in one change, and group future bumps so they cannot drift apart again.

## Problem

`github/codeql-action` requires `init`, `autobuild
 and `analyze` to run the same version. `init` writes a config file stamped with its version, and `analyze` refuses to load a config from a different one:

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.37.3'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.36.2', but running version '4.37.3'
```

Dependabot opened #3456 (`init`) and #3458 (`analyze`) as separate PRs. Each bumped one step and left the others at 4.36.2, so both failed `Analyze (javascript-typescript)` and `Analyze (python)` and neither could go green on its own. CodeQL scanning has been red on those PRs since 2026-07-28.

## Changes

| File | What changed |
|------|-------------|
| `.github/workflows/codeql.yml` | `init`, `autobuild`, `analyze` bumped to `e4fba86` (v4.37.3) |
| `.github/workflows/ci.yml` | `upload-sarif` bumped to `e4fba86`, stale `# v4.36.2` comment corrected |
| `.github/workflows/scorecard.yml` | `upload-sarif` bumped to `e4fba86` |
| `.github/dependabot.yml` | Added a `codeql-action` group matching `github/codeql-action*` |

`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` is the upstream commit tagged `v4.37.3`, published 2026-07-22, so it also satisfies the repo's 7-day cooling-off rule.

## Testing

All four YAML files parse with `yaml.safe_load`. The CodeQL workflow on this branch exercises the change directly: if the pins are consistent, `Analyze` passes.

Supersedes #3456 and #3458.
