### PR TITLE
fix(agent-os): report a non-integer supervisor level instead of governing it

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -61,12 +61,34 @@ class SupervisorHierarchy:
         """Check hierarchy rules and return a list of violations (empty = valid).
 
         Rules:
+        - Every level MUST be a real integer.
         - No supervisor may sit above the root: levels MUST NOT be negative.
         - Level 0 MUST exist and MUST be deterministic (not an LLM agent).
         - Middle levels (1–N) may be agent-based.
         - Each level present must have at least one supervisor.
         """
         violations: list[str] = []
+
+        # Checked first, because every rule below compares or counts levels and
+        # a non-integer level slips past all of them. ``range(1, max_level + 1)``
+        # raises on a float, so a float that *is* the maximum crashed here — but
+        # under a higher integer level the gap scan never sees it, and the
+        # hierarchy was reported as valid: a supervisor at level 0.5 sits between
+        # the root and level 1, is governed by neither, and yields no violations.
+        # ``bool`` is a subclass of ``int`` and ``False == 0``, so it is excluded
+        # explicitly rather than read as the root level, matching
+        # ``TrustRoot.validate_supervisor``.
+        for s in self._supervisors:
+            if isinstance(s.level, bool) or not isinstance(s.level, int):
+                violations.append(
+                    f"Supervisor '{s.name}' has non-integer level {s.level!r}; "
+                    "levels must be integers"
+                )
+        if violations:
+            # Returning early keeps the rules below from comparing or ranging
+            # over a value they cannot handle, which would raise instead of
+            # reporting.
+            return violations
 
         # Checked before anything else: level 0 is the root, so a negative level
         # places a supervisor *above* the deterministic authority. The

--- a/agent-governance-python/agent-os/tests/test_trust_root.py
+++ b/agent-governance-python/agent-os/tests/test_trust_root.py
@@ -111,20 +111,72 @@ def test_negative_level_is_reported_even_without_a_level_0(level: int) -> None:
     assert any('negative level' in v for v in hierarchy.validate_hierarchy())
 
 @pytest.mark.parametrize('level', [0.0, 1.0, 2.5])
-def test_float_level_never_reached_a_working_hierarchy(level: float) -> None:
-    """Rejecting a float level takes nothing away that used to work.
+def test_a_float_level_is_reported_when_it_is_the_maximum(level: float) -> None:
+    """A lone float level used to raise ``TypeError`` out of the gap scan.
 
-    ``validate_supervisor`` accepted a float before this change, so on its own
-    the stricter check looks like a regression -- notably ``0.0`` with
-    ``is_agent=False``, which a YAML or JSON round-trip can produce for a
-    legitimate root. But nothing downstream could consume it: the gap scan in
-    ``validate_hierarchy`` computes ``range(1, max_level + 1)``, and a float
-    ``max_level`` raises. A config that got a float past ``validate_supervisor``
-    crashed at the next step rather than being governed, so the fix converts an
-    unhandled ``TypeError`` into a ``False`` -- it does not narrow the set of
-    hierarchies that ever validated.
+    ``validate_supervisor`` accepted a float, and ``range(1, max_level + 1)``
+    does not, so a config that got a float past the declaration check crashed at
+    the next step. It is now a violation, which is the same answer the rest of
+    this method gives for a level it will not govern.
     """
     hierarchy = SupervisorHierarchy(trust_root=_root())
     hierarchy.register_supervisor('root', level=level, is_agent=False)
-    with pytest.raises(TypeError, match='float'):
-        hierarchy.validate_hierarchy()
+    assert any('non-integer level' in v for v in hierarchy.validate_hierarchy())
+
+
+@pytest.mark.parametrize(
+    ('level', 'top'),
+    [(0.0, 1), (1.0, 2), (0.5, 1), (1.5, 2), (-1.0, 1)],
+)
+def test_a_float_level_under_an_integer_maximum_is_reported(
+    level: float, top: int
+) -> None:
+    """The case a float-is-always-fatal reading misses, and the reason for the check.
+
+    ``range(1, max_level + 1)`` only raises when the float *is* the maximum. Put
+    any higher integer level in the hierarchy and the gap scan never sees the
+    float, so none of the other rules apply to it either: ``level == 0`` is False
+    for ``0.0``'s neighbours, ``level < 0`` is False for ``0.5``, and the level is
+    absent from ``range``. Before the check these returned ``violations == []`` --
+    a supervisor at 0.5 sitting between the root and level 1, governed by
+    neither, reported as a valid hierarchy. ``-1.0`` is included because the
+    negative-level rule did fire for it, but on a value the hierarchy cannot
+    order; naming the type is the more accurate violation.
+    """
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('root', level=0, is_agent=False)
+    hierarchy.register_supervisor('drifted', level=level, is_agent=True)
+    hierarchy.register_supervisor('top', level=top, is_agent=True)
+
+    violations = hierarchy.validate_hierarchy()
+
+    assert any('non-integer level' in v and 'drifted' in v for v in violations)
+
+
+def test_a_string_level_is_reported_instead_of_raising() -> None:
+    # '0' == 0 is False, so a string level skipped the determinism rule and then
+    # raised out of the `level < 0` comparison. Same class of gap as the float.
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('root', level='0', is_agent=False)  # type: ignore[arg-type]
+    hierarchy.register_supervisor('top', level=1, is_agent=True)
+
+    assert any('non-integer level' in v for v in hierarchy.validate_hierarchy())
+
+
+def test_a_bool_level_is_reported_rather_than_read_as_a_level() -> None:
+    # bool subclasses int and False == 0, so `True` would otherwise be governed
+    # as level 1 and `False` as the deterministic root.
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('root', level=False, is_agent=False)  # type: ignore[arg-type]
+
+    assert any('non-integer level' in v for v in hierarchy.validate_hierarchy())
+
+
+def test_an_all_integer_hierarchy_is_unaffected() -> None:
+    # The check must not add a violation to a hierarchy that already validated.
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('root', level=0, is_agent=False)
+    hierarchy.register_supervisor('mid', level=1, is_agent=True)
+    hierarchy.register_supervisor('leaf', level=2, is_agent=True)
+
+    assert hierarchy.validate_hierarchy() == []

--- a/agent-governance-python/agent-os/tests/test_trust_root.py
+++ b/agent-governance-python/agent-os/tests/test_trust_root.py
@@ -180,3 +180,22 @@ def test_an_all_integer_hierarchy_is_unaffected() -> None:
     hierarchy.register_supervisor('leaf', level=2, is_agent=True)
 
     assert hierarchy.validate_hierarchy() == []
+
+
+@pytest.mark.parametrize('level', ['0', '1', 0.0, 1.5, [0], True, False])
+def test_the_two_layers_agree_about_a_non_integer_level(level: object) -> None:
+    """Neither layer may accept a level the other one rejects.
+
+    ``validate_supervisor`` is the declaration check and ``validate_hierarchy``
+    the whole-hierarchy check, and ``register_supervisor`` sits between them
+    without calling the first. A level rejected by one and governed by the other
+    is the gap both checks exist to close, so it is asserted directly on the same
+    parametrize list rather than left implicit in two separate tests.
+    """
+    assert _root().validate_supervisor({'name': 'sup', 'level': level, 'is_agent': True}) is False
+
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('sup', level=level, is_agent=True)  # type: ignore[arg-type]
+    hierarchy.register_supervisor('top', level=9, is_agent=True)
+
+    assert any('non-integer level' in v and 'sup' in v for v in hierarchy.validate_hierarchy())

--- a/agent-governance-python/agent-os/tests/test_trust_root.py
+++ b/agent-governance-python/agent-os/tests/test_trust_root.py
@@ -109,3 +109,22 @@ def test_negative_level_is_reported_even_without_a_level_0(level: int) -> None:
     hierarchy = SupervisorHierarchy(trust_root=_root())
     hierarchy.register_supervisor('only', level=level, is_agent=True)
     assert any('negative level' in v for v in hierarchy.validate_hierarchy())
+
+@pytest.mark.parametrize('level', [0.0, 1.0, 2.5])
+def test_float_level_never_reached_a_working_hierarchy(level: float) -> None:
+    """Rejecting a float level takes nothing away that used to work.
+
+    ``validate_supervisor`` accepted a float before this change, so on its own
+    the stricter check looks like a regression -- notably ``0.0`` with
+    ``is_agent=False``, which a YAML or JSON round-trip can produce for a
+    legitimate root. But nothing downstream could consume it: the gap scan in
+    ``validate_hierarchy`` computes ``range(1, max_level + 1)``, and a float
+    ``max_level`` raises. A config that got a float past ``validate_supervisor``
+    crashed at the next step rather than being governed, so the fix converts an
+    unhandled ``TypeError`` into a ``False`` -- it does not narrow the set of
+    hierarchies that ever validated.
+    """
+    hierarchy = SupervisorHierarchy(trust_root=_root())
+    hierarchy.register_supervisor('root', level=level, is_agent=False)
+    with pytest.raises(TypeError, match='float'):
+        hierarchy.validate_hierarchy()


### PR DESCRIPTION
## Problem

#3510 merged at `a1ba0eb5`, one commit before the correction I pushed for it. Two things were left behind.

**1. The merged commit message states something that was disproved during review.** `ec3f7661` in `main` says:

> Previously accepted configurations are unchanged: level 0 deterministic, and agent-based supervisors at levels 1..N.

That was my claim and it is wrong. @liamcrumm tested it instead of reading it and found the counterexample: `validate_supervisor` accepted `level=0.0, is_agent=False` on the old code and rejects it now, because `isinstance(level, int)` excludes floats. Checking after the merge, it is broader than the one case he named — *every* float level was accepted before:

```
BEFORE #3510, validate_supervisor:      AFTER (now in main):
  True   level=0.0, is_agent=False        False   <-- liamcrumm's case
  True   level=1.0, is_agent=True         False
  True   level=2.5, is_agent=True         False
  True   level=-1                         False   (the vulnerability #3510 closed)
  True   level='0'                        False
  True   level=True                       False
```

I can't rewrite merged history, so this PR is the place that record gets corrected.

**2. Nothing in the suite records why that narrowing is acceptable.** It is acceptable — but the reason is not obvious, and the next person to read `isinstance(level, int)` will see a type check that rejects `0.0` and reasonably wonder whether a YAML config that writes `level: 0.0` used to work.

## Why it never worked

A float level could never reach a working hierarchy. `validate_hierarchy`'s gap scan computes `range(1, max_level + 1)`, which does not accept a float:

```
$ # against main as merged, a lone level=0.0 root, is_agent=False
level=0.0: TypeError: 'float' object cannot be interpreted as an integer
level=1.0: TypeError: 'float' object cannot be interpreted as an integer
level=2.5: TypeError: 'float' object cannot be interpreted as an integer
```

So before #3510 a float got past `validate_supervisor` and then crashed at the next step; it was never governed. #3510 converted an unhandled `TypeError` into a `False`, which is a strictly better failure for the same input. It did not narrow the set of hierarchies that ever validated — which is the accurate version of the claim my commit message made.

## Change

This started as a test-only PR. @MohammadHaroonAbuomar's review turned it into a source fix, because the gap he named is wider than a missing type check — and it disproved this PR's own original premise.

`range(1, max_level + 1)` only raises when the float **is** the maximum, which was the only shape the first version's test covered. Register any higher integer level and the gap scan never sees the float, and no other rule reaches it either: `level == 0` is False for `0.0`'s neighbours, `level < 0` is False for `0.5`, and the level is absent from `range`. Measured against the pre-fix method:

```
root=0 (det) + drifted=1.0 + top=2   -> violations == []
root=0 (det) + drifted=0.5 + top=1   -> violations == []
root=False   (bool)                  -> violations == []
root='0'     (str)                   -> TypeError out of `level < 0`
```

The `0.5` case is the one that matters: a supervisor sits between the root and level 1, is governed by neither, and the hierarchy reports as valid.

So `validate_hierarchy` now checks the level type first and returns early, which also stops the later rules from comparing or ranging over a value they cannot handle. `bool` is excluded explicitly, matching the reasoning already in `TrustRoot.validate_supervisor` — it subclasses `int` and `False == 0`, so it would otherwise be read as the deterministic root.

`agent_os/supervisor.py` +22, `tests/test_trust_root.py` rewritten (+80/-14). The docstring that claimed a float "crashed at the next step rather than being governed" was generalising from the lone-float case, so the test now asserts the violation and a second parametrized case covers the shape that claim missed — the record is the measurement rather than the inference.

## If a YAML `0.0` should keep working

I'd argue the right place is coercion at the config-loading boundary — `int(level)` when `float(level).is_integer()`, rejecting otherwise — not a wider type check in the invariant, since the invariant's job is to name the malformed input and `range()` will refuse a float regardless. That is a different layer from #3510 and I have not done it here. Happy to open it separately if you want it.

## Verification

**Pre-fix, 10 of the 11 new assertions fail.** The eleventh is an all-integer hierarchy asserting `violations == []`, which passes either way on purpose: the check must not add a violation to a hierarchy that already validated.

`tests/test_trust_root.py` cannot be collected on my machine — `ImportError: cannot import name '_native' from partially initialized module 'agent_control_specification'`, a compiled extension I do not have. It fails identically on `main` with this branch's changes stashed, so it is environmental, but it does mean I have not run the file as a suite. The assertions above were measured by binding the real `validate_hierarchy` (before and after) to a stand-in holding the same `_supervisors` list.

`ruff check --select E,F,W --ignore E501` and `ruff format --check` clean on both files; cspell over the added lines reports 0 issues.

Thanks again to @liamcrumm for checking the claim rather than taking it.