### PR TITLE
fix(security): pin emitted and tutorial GitHub Actions to commit SHAs

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -101,7 +101,8 @@
     "pwsh",
     "notlike",
     "sdists",
-    "shellcheck"
+    "shellcheck",
+    "clusterfuzzlite"
   ],
   "ignorePaths": [
     "**/node_modules/**",

--- a/agent-governance-python/agent-os/docs/tutorials/vscode-extension.md
+++ b/agent-governance-python/agent-os/docs/tutorials/vscode-extension.md
@@ -494,6 +494,9 @@ on:
 jobs:
   policy-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       

--- a/agent-governance-python/agent-os/docs/tutorials/vscode-extension.md
+++ b/agent-governance-python/agent-os/docs/tutorials/vscode-extension.md
@@ -495,10 +495,10 @@ jobs:
   policy-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
       
@@ -514,7 +514,7 @@ jobs:
         run: agent-os scan --path src/ --output sarif
       
       - name: Upload Results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: agentos-results.sarif
 ```

--- a/agent-governance-typescript/agent-os-vscode/src/enterprise/integration/cicdIntegration.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/enterprise/integration/cicdIntegration.ts
@@ -53,10 +53,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
           
@@ -69,7 +69,7 @@ jobs:
         continue-on-error: true
         
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif
           

--- a/agent-governance-typescript/agent-os-vscode/src/enterprise/integration/cicdIntegration.ts
+++ b/agent-governance-typescript/agent-os-vscode/src/enterprise/integration/cicdIntegration.ts
@@ -50,7 +50,10 @@ jobs:
   security-check:
     runs-on: ubuntu-latest
     name: Agent OS Policy Validation
-    
+    permissions:
+      contents: read
+      security-events: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/docs/tutorials/25-security-hardening.md
+++ b/docs/tutorials/25-security-hardening.md
@@ -233,6 +233,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     strategy:
       matrix:
@@ -354,6 +355,7 @@ jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       id-token: write
     steps:

--- a/docs/tutorials/25-security-hardening.md
+++ b/docs/tutorials/25-security-hardening.md
@@ -304,10 +304,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      - uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: python
-      - uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      - uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           fuzz-seconds: 300
           mode: code-change

--- a/docs/tutorials/25-security-hardening.md
+++ b/docs/tutorials/25-security-hardening.md
@@ -95,10 +95,10 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -236,13 +236,13 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        language: [python, javascript]
+        language: [python, javascript-typescript]
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 ```
 
 ### Custom Queries
@@ -303,7 +303,7 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: google/clusterfuzzlite/actions/build_fuzzers@v1
         with:
           language: python
@@ -357,12 +357,12 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: ossf/scorecard-action@v2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: scorecard-results.sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: scorecard-results.sarif
 ```
@@ -391,22 +391,22 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Generate SPDX SBOM
-      - uses: anchore/sbom-action@v0
+      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           output-file: sbom.spdx.json
           format: spdx-json
 
       # Generate CycloneDX SBOM
-      - uses: anchore/sbom-action@v0
+      - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           output-file: sbom.cdx.json
           format: cyclonedx-json
 
       # Attest SBOM to the release
-      - uses: actions/attest-sbom@v2
+      - uses: actions/attest-sbom@bd218ad0dbcb3e146bd073d1d9c6d78e08aa8a0b # v2.4.0
         with:
           subject-path: sbom.spdx.json
 ```


### PR DESCRIPTION
## Summary

The CI YAML the VS Code extension emits, and the security-hardening and vscode-extension tutorials, referenced GitHub Actions by floating tags. That is exactly the pattern this project's own supply-chain guidance tells users to avoid, and a Scorecard "Pinned-Dependencies" check on the emitted workflow flags it.

## Change

Pin every action reference in the touched snippets and the emitted workflow template to a commit SHA. Each pin was resolved from the action's release tag (annotated tags peeled to their target commit), verified against the action repository, and, where the repository's own `.github/workflows` already pin the same action, reuses the exact SHA the repository uses:

- `github/codeql-action` to `e4fba868` (v4.37.3, matches #3533)
- `actions/checkout` to `df4cb1c0` (v6.0.3)
- `actions/setup-python` to `a309ff8b` (v6.2.0)
- `ossf/scorecard-action` to `2d114668` (v2.4.4)
- `gitleaks/gitleaks-action` to `ff98106e` (v2.3.9)
- `google/clusterfuzzlite` (build_fuzzers and run_fuzzers) to `884713a6` (v1)
- `anchore/sbom-action` to `e22c3899` (v0.24.0)
- `actions/attest-sbom` to `bd218ad0` (v2.4.0)

One deliberate divergence: `actions/attest-sbom` is pinned at v2.4.0, the same major as the snippet's previous floating `@v2`, so the tutorial's behaviour is preserved. The repository's own workflows use v4.1.0; moving the tutorial across two major versions is a content change beyond the scope of a pinning fix, and can follow separately if wanted.

Also correct the CodeQL language matrix in the tutorial from `[python, javascript]` to `[python, javascript-typescript]`, matching the repository's own `codeql.yml`, and add a least-privilege `permissions` block (`contents: read`, `security-events: write`) to the two jobs that upload SARIF without one (the emitted template and the vscode-extension tutorial snippet), since the default read-only `GITHUB_TOKEN` would otherwise make the upload step fail.

With these changes, every `uses:` reference in the touched files is pinned to a full commit SHA with a trailing version comment, and each SHA has been re-verified in a second independent resolution pass.

Files:

- `agent-governance-typescript/agent-os-vscode/src/enterprise/integration/cicdIntegration.ts` (the emitted workflow, now fully pinned, plus the SARIF-upload permissions block)
- `docs/tutorials/25-security-hardening.md`
- `agent-governance-python/agent-os/docs/tutorials/vscode-extension.md`

## Notes

- The `codeql`, `checkout`, `setup-python`, `scorecard`, `sbom` and `clusterfuzzlite` SHAs match the pins the repository already uses in its own `.github/workflows`. The edit to the TypeScript is inside a template literal, so it is textual only.

Refs #3535
