### PR TITLE
fix(supervisor): return a deny decision instead of crashing at max escalation depth

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -142,8 +142,9 @@ class SupervisorHierarchy:
                 return TrustDecision(
                     allowed=False,
                     reason="Max escalation depth exceeded",
-                    policy_name="escalation_limit",
+                    authority="supervisor",
                 )
 
-        # Final decision always comes from the deterministic trust root
+        # Below the escalation-depth cap, the final decision comes from the
+        # deterministic trust root
         return self.trust_root.validate_action(action)

--- a/agent-governance-python/agent-os/tests/test_supervisor_escalation_depth.py
+++ b/agent-governance-python/agent-os/tests/test_supervisor_escalation_depth.py
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Regression test for the escalation-depth cap in ``SupervisorHierarchy``.
+
+When an escalation chain exceeded ``max_escalation_depth`` the cap branch built a
+``TrustDecision`` with a ``policy_name`` keyword the dataclass never defined and
+without the required ``authority`` field, so the guard raised ``TypeError``
+instead of returning a deny decision (issue #3539).
+"""
+from __future__ import annotations
+
+from agent_os.supervisor import SupervisorHierarchy
+from agent_os.trust_root import TrustDecision
+
+
+class _StubTrustRoot:
+    """Minimal trust root: only the escalation-depth guard is exercised here."""
+
+    def __init__(self, max_escalation_depth: int) -> None:
+        self.max_escalation_depth = max_escalation_depth
+
+    def validate_action(self, action: dict) -> TrustDecision:
+        # Reached only when the depth cap is NOT hit.
+        return TrustDecision(
+            allowed=True, reason="stub allow", authority="native-runtime"
+        )
+
+
+def _hierarchy_exceeding_depth() -> SupervisorHierarchy:
+    """A chain whose distinct levels below ``from_level`` exceed the cap."""
+    hierarchy = SupervisorHierarchy(trust_root=_StubTrustRoot(max_escalation_depth=2))
+    # Levels 0, 1, 2, 3 -> four distinct levels above from_level=4.
+    for level in range(4):
+        hierarchy.register_supervisor(
+            f"sup-{level}", level=level, is_agent=level != 0
+        )
+    return hierarchy
+
+
+def test_escalation_depth_cap_returns_well_formed_decision() -> None:
+    """Past the cap the guard must deny, not raise ``TypeError``."""
+    decision = _hierarchy_exceeding_depth().escalate(
+        {"tool": "x", "arguments": {}}, from_level=4
+    )
+    assert isinstance(decision, TrustDecision)
+    assert not decision.allowed
+    assert "Max escalation depth" in decision.reason
+    assert decision.authority == "supervisor"
+    assert decision.deterministic
+
+
+def test_escalation_below_the_cap_still_reaches_the_trust_root() -> None:
+    """Under the cap the decision still flows through to the trust root."""
+    hierarchy = SupervisorHierarchy(trust_root=_StubTrustRoot(max_escalation_depth=5))
+    hierarchy.register_supervisor("root", level=0, is_agent=False)
+    hierarchy.register_supervisor("worker", level=1, is_agent=True)
+    decision = hierarchy.escalate({"tool": "x", "arguments": {}}, from_level=1)
+    assert decision.allowed


### PR DESCRIPTION
## Summary

At the escalation-depth cap in `SupervisorHierarchy.escalate()`, the guard built its decision as:

```python
TrustDecision(allowed=False, reason="Max escalation depth exceeded", policy_name="escalation_limit")
```

but `TrustDecision` (`trust_root.py`) is a dataclass defining only `allowed`, `reason`, `authority`, `deterministic`. So the call raises `TypeError` two ways: an unexpected `policy_name` keyword, and a missing required `authority`. The branch meant to cap runaway escalation instead crashes the caller, and if an outer layer swallows the exception it becomes a fail-open at exactly the point the limiter should engage.

## Change

Construct the decision with the fields the dataclass defines, using `authority="supervisor"` (the depth cap is enforced by `SupervisorHierarchy`; the only other authority literal in the tree is `"native-runtime"`). The cap now returns a well-formed deny.

## Tests

Adds `tests/test_supervisor_escalation_depth.py`: one test drives an escalation chain past `max_escalation_depth` and asserts a well-formed limiting `TrustDecision(allowed=False, ...)` with no `TypeError`; one asserts below-cap escalation still flows to the trust root. Both pass, and the existing `test_trust_root`, `test_escalation`, and `test_escalation_and_reversibility` suites still pass.

Refs #3539
