### PR TITLE
test(agt-policies): pin confidence advisory rendering

### DIFF
--- a/agent-governance-python/agt-policies/tests/test_migrate.py
+++ b/agent-governance-python/agt-policies/tests/test_migrate.py
@@ -515,6 +515,30 @@ policy = GovernancePolicy()
     assert "deny_if_low_confidence(0.8)" in rego
 
 
+def test_confidence_threshold_advisory_survives_write_once(tmp_path: Path) -> None:
+    """The inert confidence rule warning remains visible without duplication."""
+    src = tmp_path / "confidence_bot.py"
+    _write_source(
+        src,
+        "from agent_os.integrations.base import GovernancePolicy\n"
+        "policy = GovernancePolicy(confidence_threshold=0.65)\n",
+    )
+
+    dry_run = migrate_mod.migrate_project(tmp_path, write=False)
+    dry_finding = dry_run.governance_policies[0]
+    assert len(dry_finding.notes) == 1
+    note = dry_finding.notes[0]
+    assert "threshold is not enforced until you do" in note
+
+    written = migrate_mod.migrate_project(tmp_path, write=True)
+    written_finding = written.governance_policies[0]
+    assert written_finding.notes == [note]
+
+    rendered = migrate_mod.render_report(written)
+    assert "**Notes:**" in rendered
+    assert rendered.count(note) == 1
+
+
 def test_substring_patterns_stay_case_insensitive(tmp_path: Path) -> None:
     """v4 matched substrings with ``pat.lower() in text.lower()``.
 


### PR DESCRIPTION
Refs #3540, specifically the untested `notes` advisory path.

This adds a focused regression test around `GovernancePolicy(confidence_threshold=0.65)` that verifies:

- a dry run records the unenforced-threshold advisory exactly once;
- `--write` preserves the same advisory without duplication; and
- the rendered migration report includes the `Notes` section and the advisory exactly once.

There is no production-code change. The focused test passes against current `main` with the repository-local ACS Python SDK.

The broader `test_migrate.py` file has three unrelated local failures when neither OPA nor `google-re2` is available; the new test passes independently.
