### PR TITLE
fix(supply-chain): age-check `=`-pinned cargo dependencies

### DIFF
--- a/scripts/check_release_age.py
+++ b/scripts/check_release_age.py
@@ -162,6 +162,16 @@ def _resolve_cargo_deps(tree: dict | None) -> dict[str, str]:
                     ver = raw.strip()
             if not ver:
                 continue
+            # Cargo's explicit exact-pin operator: ``=1.2.3`` (optionally
+            # ``= 1.2.3``). Strip a single leading ``=`` so exact pins are
+            # resolved and age-checked like bare pins; without this the
+            # version fails SAFE_VERSION_RE below and the dep is silently
+            # skipped. A double ``==`` is not valid Cargo syntax and still
+            # fails the safe-version check after one strip.
+            if ver.startswith("="):
+                ver = ver[1:].strip()
+            if not ver:
+                continue
             # Cargo allows ^1.0 as the implicit form; only treat as exact-pin
             # when it strictly looks like a pin (no ^ ~ >= <= * inside).
             if any(c in ver for c in ("^", "~", ">", "<", "*", " ", ",")):

--- a/scripts/tests/test_check_release_age.py
+++ b/scripts/tests/test_check_release_age.py
@@ -309,7 +309,7 @@ def test_main_too_young_exact_pinned_crate_fails():
     """End-to-end: a fresh ``=``-pinned crate must fail the age check."""
     toml_map = {
         ("origin/main", "Cargo.toml"): {"dependencies": {}},
-        ("HEAD", "Cargo.toml"): {"dependencies": {"newcrate": "=1.2.3"}},
+        ("HEAD", "Cargo.toml"): {"dependencies": {"new-crate": "=1.2.3"}},
     }
     fresh = datetime.now(timezone.utc) - timedelta(days=2)
     with _mock_changed(["Cargo.toml"]), \
@@ -317,7 +317,7 @@ def test_main_too_young_exact_pinned_crate_fails():
          patch.object(cra, "fetch_release_time", return_value=fresh) as fetch:
         rc = cra.main_with_args(["--base", "origin/main", "--min-age-days", "7"])
     assert rc == 1
-    fetch.assert_called_once_with("cargo", "newcrate", "1.2.3")
+    fetch.assert_called_once_with("cargo", "new-crate", "1.2.3")
 
 
 def test_collect_candidates_pyproject_pep621():

--- a/scripts/tests/test_check_release_age.py
+++ b/scripts/tests/test_check_release_age.py
@@ -112,6 +112,33 @@ def test_cargo_skips_range_specifiers():
     assert cra._resolve_cargo_deps(tree) == {}
 
 
+def test_cargo_resolves_exact_pin_operator():
+    """Regression: ``=``-pinned deps must be checked, not silently skipped.
+
+    ``agent-control-spec = "=0.4.0-alpha.1"`` previously fell through:
+    the leading ``=`` failed SAFE_VERSION_RE and the dep dropped out of
+    the candidate set without any finding.
+    """
+    tree = {
+        "dependencies": {
+            "agent-control-spec": "=0.4.0-alpha.1",
+            "spaced": "= 1.2.3",
+            "tabled": {"version": "=1.40.0", "features": ["full"]},
+        },
+    }
+    assert cra._resolve_cargo_deps(tree) == {
+        "agent-control-spec": "0.4.0-alpha.1",
+        "spaced": "1.2.3",
+        "tabled": "1.40.0",
+    }
+
+
+def test_cargo_skips_invalid_equals_forms():
+    """``==`` is not Cargo syntax and a bare ``=`` has no version."""
+    tree = {"dependencies": {"dbl": "==1.2.3", "bare": "="}}
+    assert cra._resolve_cargo_deps(tree) == {}
+
+
 def test_cargo_includes_dev_and_build_deps():
     tree = {
         "dev-dependencies": {"pretty_assertions": "1.4.0"},
@@ -264,6 +291,33 @@ def test_collect_candidates_cargo_dotted_table():
          _mock_loaders({}, toml_map)[0], _mock_loaders({}, toml_map)[1], _mock_loaders({}, toml_map)[2]:
         out = cra.collect_candidates("origin/main")
     assert out == [("cargo", "tokio", "1.40.0", "Cargo.toml")]
+
+
+def test_collect_candidates_cargo_exact_pin_operator():
+    """``=``-pinned Cargo deps become candidates (regression coverage)."""
+    toml_map = {
+        ("origin/main", "Cargo.toml"): {"dependencies": {}},
+        ("HEAD", "Cargo.toml"): {"dependencies": {"agent-control-spec": "=0.4.0-alpha.1"}},
+    }
+    with _mock_changed(["Cargo.toml"]), \
+         _mock_loaders({}, toml_map)[0], _mock_loaders({}, toml_map)[1], _mock_loaders({}, toml_map)[2]:
+        out = cra.collect_candidates("origin/main")
+    assert out == [("cargo", "agent-control-spec", "0.4.0-alpha.1", "Cargo.toml")]
+
+
+def test_main_too_young_exact_pinned_crate_fails():
+    """End-to-end: a fresh ``=``-pinned crate must fail the age check."""
+    toml_map = {
+        ("origin/main", "Cargo.toml"): {"dependencies": {}},
+        ("HEAD", "Cargo.toml"): {"dependencies": {"newcrate": "=1.2.3"}},
+    }
+    fresh = datetime.now(timezone.utc) - timedelta(days=2)
+    with _mock_changed(["Cargo.toml"]), \
+         _mock_loaders({}, toml_map)[0], _mock_loaders({}, toml_map)[1], _mock_loaders({}, toml_map)[2], \
+         patch.object(cra, "fetch_release_time", return_value=fresh) as fetch:
+        rc = cra.main_with_args(["--base", "origin/main", "--min-age-days", "7"])
+    assert rc == 1
+    fetch.assert_called_once_with("cargo", "newcrate", "1.2.3")
 
 
 def test_collect_candidates_pyproject_pep621():


### PR DESCRIPTION
## Description

The 7-day cooling-off scanner skipped any cargo dependency written with the explicit exact-pin operator. `=0.4.0-alpha.1` fails `SAFE_VERSION_RE`, which requires a leading alphanumeric character, so `_resolve_cargo_deps` dropped the dependency instead of age-checking it. Exact pinning is the form this repository's own version-selection guidance asks for, which left the rule blindest exactly where it was meant to be strictest.

The fix strips one leading `=`, plus any whitespace after it, before the safe-version check. `==` is not valid cargo syntax and still fails after a single strip.

The scanner change is authored by @MohammadHaroonAbuomar. It is split out here because the Scanner trip-wire rejects any PR that touches scanner code and dependency manifests together, and asks for scanner updates to land first.

### What the corrected scanner finds

Run against #3561, which retargets the policy engine onto published crates, it reported four things the previous version passed in silence:

| Finding | Detail |
| --- | --- |
| `serde_yaml = "=0.9.34"` | 404s on crates.io. The release is published as `0.9.34+deprecated`, and cargo ignores build metadata when matching, so the pin resolved locally while naming a version the registry does not have |
| `agent-hooks-sdk 0.1.0-alpha.4` | Published 1 day earlier, well inside the window |
| `agent-control-spec 0.4.0-alpha.1` | Published 6 days earlier |
| Two path dependencies | Named versions that exist only in the working tree |

The last row is worth a note for whoever tunes this next. A `path` dependency is never fetched from a registry, so its version requirement means nothing unless the depending crate is published. The scanner resolves it anyway. In #3561 that was resolved by dropping the requirement from crates marked `publish = false`, which is correct on its own terms, but a future change could skip path dependencies whose parent sets `publish = false`.

### Tests

`scripts/tests/test_check_release_age.py` gains cases for the string, spaced, and inline-table `=` forms, the invalid `==` and bare `=` forms, candidate collection, and an end-to-end run where a too-young `=`-pinned crate fails the check. 57 tests pass.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected
- [ ] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [x] docs / root

Repository tooling only: `scripts/check_release_age.py` and its tests. No dependency manifest is touched, so the Scanner trip-wire does not fire.

## Checklist
- [x] My code follows the project style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] I have updated documentation as needed
- [ ] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art
- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation

The scanner fix is @MohammadHaroonAbuomar's work, carried here with authorship and sign-off intact. The follow-up commit only renames a test placeholder that the spell-check gate rejected.

## AI Assistance
- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

Written with GitHub Copilot CLI.

## IP, Patents, and Licensing
- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License

## Related Issues

Unblocks #3561, which cannot go green while the scanner change and the dependency manifests share a branch.
