### PR TITLE
fix(sandbox): honour configured timeoutSeconds in DockerSandboxProvider.executeCode

### DIFF
--- a/agent-governance-typescript/src/sandbox.ts
+++ b/agent-governance-typescript/src/sandbox.ts
@@ -131,6 +131,7 @@ function validateResourceName(value: string, label: string): void {
 export class DockerSandboxProvider implements SandboxProvider {
   private readonly image: string;
   private readonly containers = new Map<string, string>(); // sessionId -> containerId
+  private readonly sessionTimeoutsMs = new Map<string, number>(); // sessionId -> exec timeout (ms)
 
   constructor(image: string = 'python:3.11-slim') {
     this.image = image;
@@ -189,6 +190,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         .trim();
 
       this.containers.set(sessionId, containerId);
+      this.sessionTimeoutsMs.set(sessionId, cfg.timeoutSeconds * 1000);
 
       return {
         agentId,
@@ -216,6 +218,13 @@ export class DockerSandboxProvider implements SandboxProvider {
     const executionId = randomUUID();
     const startTime = Date.now();
 
+    // Honour the timeout configured for this session (createSession), falling
+    // back to the default only when the session predates timeout tracking.
+    // Previously this was hard-coded to 60_000 ms, so a custom timeoutSeconds
+    // was silently ignored and the sandbox ran longer than the caller allowed.
+    const timeoutMs =
+      this.sessionTimeoutsMs.get(sessionId) ?? defaultSandboxConfig().timeoutSeconds * 1000;
+
     return new Promise<ExecutionHandle>((resolve) => {
       const encoded = Buffer.from(code).toString('base64');
       const execArgs = [
@@ -223,7 +232,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         `import base64; exec(base64.b64decode('${encoded}').decode())`,
       ];
 
-      execFile('docker', execArgs, { timeout: 60_000 }, (error, stdout, stderr) => {
+      execFile('docker', execArgs, { timeout: timeoutMs }, (error, stdout, stderr) => {
         const durationSeconds = (Date.now() - startTime) / 1000.0;
         // Node's ExecException.code can be: a numeric exit code (child exited
         // non-zero), `null` (child killed by a signal — `error.signal` is set
@@ -265,6 +274,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     const containerId = this.containers.get(sessionId);
     if (!containerId) {
+      this.sessionTimeoutsMs.delete(sessionId);
       return; // already destroyed or never existed
     }
 
@@ -275,6 +285,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       });
     } finally {
       this.containers.delete(sessionId);
+      this.sessionTimeoutsMs.delete(sessionId);
     }
   }
 }

--- a/agent-governance-typescript/src/sandbox.ts
+++ b/agent-governance-typescript/src/sandbox.ts
@@ -76,6 +76,20 @@ export function defaultSandboxConfig(): SandboxConfig {
   };
 }
 
+// resolveTimeoutMs converts a configured timeoutSeconds into an exec timeout in
+// milliseconds, falling back to the default when the value is not a positive,
+// finite number. This is a safety control: Node's execFile treats timeout: 0
+// (or NaN) as "no timeout", so a degenerate config (e.g. a value that arrived
+// via `any`, or a non-positive operator input) must not be allowed to silently
+// disable the sandbox timeout.
+function resolveTimeoutMs(timeoutSeconds: number): number {
+  const seconds =
+    Number.isFinite(timeoutSeconds) && timeoutSeconds > 0
+      ? timeoutSeconds
+      : defaultSandboxConfig().timeoutSeconds;
+  return seconds * 1000;
+}
+
 // ---------------------------------------------------------------------------
 // Abstract interface
 // ---------------------------------------------------------------------------
@@ -190,7 +204,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         .trim();
 
       this.containers.set(sessionId, containerId);
-      this.sessionTimeoutsMs.set(sessionId, cfg.timeoutSeconds * 1000);
+      this.sessionTimeoutsMs.set(sessionId, resolveTimeoutMs(cfg.timeoutSeconds));
 
       return {
         agentId,
@@ -223,7 +237,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // Previously this was hard-coded to 60_000 ms, so a custom timeoutSeconds
     // was silently ignored and the sandbox ran longer than the caller allowed.
     const timeoutMs =
-      this.sessionTimeoutsMs.get(sessionId) ?? defaultSandboxConfig().timeoutSeconds * 1000;
+      this.sessionTimeoutsMs.get(sessionId) ?? resolveTimeoutMs(defaultSandboxConfig().timeoutSeconds);
 
     return new Promise<ExecutionHandle>((resolve) => {
       const encoded = Buffer.from(code).toString('base64');

--- a/agent-governance-typescript/tests/sandbox-timeout.test.ts
+++ b/agent-governance-typescript/tests/sandbox-timeout.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+// Regression tests for issue #3118: DockerSandboxProvider.executeCode() must
+// honour the session's configured timeoutSeconds rather than a hard-coded
+// 60_000 ms. child_process is mocked so these run without Docker.
+
+import { execFile, execFileSync } from 'child_process';
+import { DockerSandboxProvider, defaultSandboxConfig } from '../src/sandbox';
+
+jest.mock('child_process');
+
+const mockedExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
+const mockedExecFile = execFile as unknown as jest.Mock;
+
+describe('DockerSandboxProvider executeCode timeout (issue #3118)', () => {
+  let capturedTimeoutMs: number | undefined;
+
+  beforeEach(() => {
+    capturedTimeoutMs = undefined;
+    // createSession -> execFileSync('docker', ['run', ...]) returns the container id.
+    mockedExecFileSync.mockReturnValue(Buffer.from('fake-container-id'));
+    // executeCode -> execFile('docker', ['exec', ...], options, cb). Capture the
+    // timeout and report a clean, successful execution.
+    mockedExecFile.mockImplementation(
+      (
+        _file: string,
+        _args: string[],
+        options: { timeout?: number },
+        cb: (error: null, stdout: string, stderr: string) => void,
+      ) => {
+        capturedTimeoutMs = options.timeout;
+        cb(null, '', '');
+        return {} as never;
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses the session-configured timeoutSeconds', async () => {
+    const provider = new DockerSandboxProvider();
+    const config = { ...defaultSandboxConfig(), timeoutSeconds: 2 };
+    const session = await provider.createSession('agent', config);
+
+    await provider.executeCode('agent', session.sessionId, 'print("hi")');
+
+    expect(capturedTimeoutMs).toBe(2000);
+  });
+
+  it('does not hard-code 60_000 ms for a custom timeout', async () => {
+    const provider = new DockerSandboxProvider();
+    const config = { ...defaultSandboxConfig(), timeoutSeconds: 5 };
+    const session = await provider.createSession('agent', config);
+
+    await provider.executeCode('agent', session.sessionId, 'print("hi")');
+
+    expect(capturedTimeoutMs).toBe(5000);
+    expect(capturedTimeoutMs).not.toBe(60_000);
+  });
+
+  it('falls back to the default timeout when no config is provided', async () => {
+    const provider = new DockerSandboxProvider();
+    const session = await provider.createSession('agent');
+
+    await provider.executeCode('agent', session.sessionId, 'print("hi")');
+
+    expect(capturedTimeoutMs).toBe(defaultSandboxConfig().timeoutSeconds * 1000);
+  });
+});

--- a/agent-governance-typescript/tests/sandbox-timeout.test.ts
+++ b/agent-governance-typescript/tests/sandbox-timeout.test.ts
@@ -1,4 +1,5 @@
-// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 // Regression tests for issue #3118: DockerSandboxProvider.executeCode() must
 // honour the session's configured timeoutSeconds rather than a hard-coded
@@ -67,5 +68,30 @@ describe('DockerSandboxProvider executeCode timeout (issue #3118)', () => {
     await provider.executeCode('agent', session.sessionId, 'print("hi")');
 
     expect(capturedTimeoutMs).toBe(defaultSandboxConfig().timeoutSeconds * 1000);
+  });
+
+  // A non-positive timeoutSeconds must not become `timeout: 0`, which Node's
+  // execFile treats as "no timeout" and would disable the sandbox safety cap.
+  it('clamps a non-positive timeoutSeconds to the default', async () => {
+    const provider = new DockerSandboxProvider();
+    const config = { ...defaultSandboxConfig(), timeoutSeconds: 0 };
+    const session = await provider.createSession('agent', config);
+
+    await provider.executeCode('agent', session.sessionId, 'print("hi")');
+
+    expect(capturedTimeoutMs).toBe(defaultSandboxConfig().timeoutSeconds * 1000);
+    expect(capturedTimeoutMs).not.toBe(0);
+  });
+
+  it('clamps a non-finite timeoutSeconds to the default', async () => {
+    const provider = new DockerSandboxProvider();
+    // Simulate a value that arrived via `any` and bypassed static typing.
+    const config = { ...defaultSandboxConfig(), timeoutSeconds: NaN as number };
+    const session = await provider.createSession('agent', config);
+
+    await provider.executeCode('agent', session.sessionId, 'print("hi")');
+
+    expect(capturedTimeoutMs).toBe(defaultSandboxConfig().timeoutSeconds * 1000);
+    expect(Number.isFinite(capturedTimeoutMs)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`DockerSandboxProvider.executeCode()` always passed `{ timeout: 60_000 }` to `execFile`, ignoring the `timeoutSeconds` a caller supplied to `createSession`. Someone who set e.g. `timeoutSeconds: 2` to bound how long agent-generated code may run actually got 60 seconds — a silently weakened sandbox safety control. Since timeouts are part of the sandbox's safety envelope, this can cause unexpected resource usage and gives a false sense of containment.

Fixes #3118

## Change

- Record each session's timeout (`timeoutSeconds * 1000`) in a `sessionId -> ms` map when the session is created.
- Use that value in `executeCode` instead of the hard-coded `60_000`, falling back to `defaultSandboxConfig().timeoutSeconds * 1000` only for sessions created before the timeout was tracked.
- Clean up the per-session entry in `destroySession`, alongside the existing container mapping, so the map does not leak.

## Testing

Added `tests/sandbox-timeout.test.ts` (mocks `child_process`, so it runs without Docker):
- `executeCode` uses the session-configured `timeoutSeconds` (`2` → `2000` ms).
- A custom timeout is not hard-coded to `60_000` (`5` → `5000` ms).
- Falls back to the default (`60_000` ms) when no config is provided.

Verified the tests **fail on the pre-fix code** (`Expected: 2000 / Received: 60000`) and **pass with the fix**. `tsc` build is clean, `eslint` is clean on the changed files, and the full jest suite passes (the one unrelated failure is the pre-existing Docker *lifecycle* test, which fails identically on `main` in an environment without a working Docker daemon and otherwise skips).