### PR TITLE
fix(agent-os): stop escalate() crashing at max escalation depth

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -142,7 +142,7 @@ class SupervisorHierarchy:
                 return TrustDecision(
                     allowed=False,
                     reason="Max escalation depth exceeded",
-                    policy_name="escalation_limit",
+                    authority="trust_root",
                 )
 
         # Final decision always comes from the deterministic trust root

--- a/agent-governance-python/agent-os/tests/test_supervisor_escalation.py
+++ b/agent-governance-python/agent-os/tests/test_supervisor_escalation.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Tests for SupervisorHierarchy.escalate depth limiting."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_os.supervisor import SupervisorHierarchy
+from agent_os.trust_root import TrustDecision, TrustRoot
+
+
+def _hierarchy(max_escalation_depth: int) -> SupervisorHierarchy:
+    # The runtime is only consulted by validate_action, which the max-depth
+    # branch never reaches, so a non-None sentinel is sufficient here.
+    trust_root = TrustRoot(runtime=object(), max_escalation_depth=max_escalation_depth)
+    hierarchy = SupervisorHierarchy(trust_root)
+    hierarchy.register_supervisor("root", level=0)
+    hierarchy.register_supervisor("mid", level=1)
+    hierarchy.register_supervisor("near", level=2)
+    return hierarchy
+
+
+@pytest.mark.parametrize("max_depth", [0, 1, 2])
+def test_escalate_past_max_depth_returns_well_formed_deny(max_depth: int) -> None:
+    """Regression for #3539: escalating past max_escalation_depth must return a
+    limiting TrustDecision, not raise TypeError.
+
+    The hierarchy has three levels (0, 1, 2) below ``from_level=3``, so every
+    ``max_depth`` here is exceeded and the depth guard trips. Before the fix the
+    guard constructed ``TrustDecision(..., policy_name=...)``, which raised
+    ``TypeError`` because the dataclass has no ``policy_name`` field (and no
+    ``authority`` was supplied)."""
+    hierarchy = _hierarchy(max_escalation_depth=max_depth)
+
+    decision = hierarchy.escalate({"tool": "x", "arguments": {}}, from_level=3)
+
+    assert isinstance(decision, TrustDecision)
+    assert decision.allowed is False
+    assert "max escalation depth" in decision.reason.lower()
+    assert decision.authority == "trust_root"
+    assert decision.deterministic is True


### PR DESCRIPTION
## Summary

`SupervisorHierarchy.escalate()` builds its depth-limit decision as:

```python
TrustDecision(..., policy_name="escalation_limit")
```

but `TrustDecision` (`trust_root.py`) defines only `allowed`, `reason`, `authority`, `deterministic` — there is no `policy_name` field, and `authority` is required with no default. So the moment an escalation chain exceeds `max_escalation_depth`, the constructor raises:

```
TypeError: TrustDecision.__init__() got an unexpected keyword argument 'policy_name'
```

The path meant to cap runaway escalations instead crashes the caller — and if some layer above swallows the exception, it becomes a potential fail-open at exactly the point the limiter should engage.

Fixes #3539

## Change

Construct the limiting decision with the fields the dataclass actually defines: `authority="trust_root"` (this is the trust root's escalation cap being enforced — consistent with the method docstring, "TrustDecision from the trust root") and the existing `reason`; `deterministic` defaults to `True`.

## Testing

Added `tests/test_supervisor_escalation.py`, which drives an escalation chain past several `max_escalation_depth` settings (0, 1, 2) and asserts a well-formed limiting `TrustDecision` (`allowed=False`, reason mentions max depth, `authority="trust_root"`, `deterministic=True`).

Verified the test **fails on the pre-fix code** (all cases raise `TypeError: ... unexpected keyword argument 'policy_name'`) and **passes with the fix**. Ruff lint/format clean on the changed files.