### PR TITLE
docs: correct contributor-check comment link and published-output claims

### DIFF
--- a/docs/tutorials/53-contributor-governance.md
+++ b/docs/tutorials/53-contributor-governance.md
@@ -80,23 +80,26 @@ python scripts/contributor_check.py --username <github-handle>
 Example output for a clean contributor:
 
 ```
-Reputation Report: clean-developer
-Risk: LOW
+Contributor Check: clean-developer
+==================================================
+Risk: 🟢 LOW
+
 No signals detected.
 ```
 
 Example output for a suspicious account:
 
 ```
-Reputation Report: suspicious-account
-Risk: HIGH
+Contributor Check: suspicious-account
+==================================================
+Risk: 🔴 HIGH
 
 Signals:
-  [HIGH] recent_repo_burst: 41 repos created in last 90 days
-  [HIGH] cross_repo_spray: Issues filed in 72 repos within 7 days
-  [HIGH] self_promotion_spray: 15 issues promoting own repos across 12 orgs
-  [HIGH] thin_credibility: Repo 'my-project' (22d old, 0 stars) promoted across 28 orgs
-  [HIGH] coordinated_promotion: 8 thin repos promoted to overlapping org set
+  🚩 [HIGH] recent_repo_burst: 41 repos created in last 90 days
+  🚩 [HIGH] cross_repo_spray: Issues filed in 72 repos within 7 days
+  🚩 [HIGH] self_promotion_spray: 15 issues promoting own repos across 12 orgs
+  🚩 [HIGH] thin_credibility: Repo 'my-project' (22d old, 0 stars) promoted across 28 orgs
+  🚩 [HIGH] coordinated_promotion: 8 thin repos promoted to overlapping org set
 ```
 
 ### JSON Output
@@ -326,9 +329,28 @@ jobs:
 1. Extracts the PR/issue author's username
 2. Runs contributor_check.py with `--repo` set to the current repository
 3. Optionally runs credential_audit.py for deeper analysis
-4. Posts a collapsible comment with findings (MEDIUM or higher)
-5. Adds risk labels (`needs-review:MEDIUM` or `needs-review:HIGH`)
+4. Posts a comment with **risk levels only** (MEDIUM or higher)
+5. Adds a risk label (`needs-review:MEDIUM`, `needs-review:HIGH`, or
+   `needs-review:UNKNOWN`)
 6. Comments are idempotent: re-runs update instead of duplicating
+
+### What the Action Does Not Publish
+
+The per-signal detail. The comment carries the risk level for each check group
+and an overall level, and nothing else. Which signals fired, and with what
+numbers, is not posted as a comment, not written to the job summary, and not
+uploaded as an artifact. The job discards it.
+
+That is deliberate. Publishing a scored dossier about a named contributor on
+the issue they just opened is a worse outcome than the spam it defends against,
+and a public accusation is not reversible. Maintainers who want the detail run
+`contributor_check.py` themselves against the same handle: it reads only public
+API data, so any result can be reproduced or contested.
+
+Note also that on a **public** repository, Actions run logs, job summaries, and
+artifacts are readable by anyone. There is no maintainer-only output channel
+inside Actions on a public repo, which is why the detail is dropped rather than
+written somewhere nominally internal.
 
 ### Security Note
 

--- a/scripts/contributor_check_action.py
+++ b/scripts/contributor_check_action.py
@@ -148,7 +148,7 @@ def _build_comment(username: str, overall: str, profile_risk: str,
         "*Automated check by "
         "[AGT Contributor Check]"
         "(https://github.com/microsoft/agent-governance-toolkit"
-        "/tree/main/scripts#contributor-reputation-tools).*"
+        "/blob/main/docs/tutorials/53-contributor-governance.md).*"
     )
     return "\n".join(lines)
 


### PR DESCRIPTION
Three accuracy fixes to the contributor-check surface. No behaviour change.

### 1. The comment footer link is dead

Every contributor-check comment this repo posts ends with a link to
`.../tree/main/scripts#contributor-reputation-tools`. There is no
`scripts/README.md` on `main`, so that anchor resolves to nothing and the
reader lands on a directory listing.

Repointed at [Tutorial 53](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/tutorials/53-contributor-governance.md),
which is the actual documentation for these tools.

Downstream note: `agentrust-io/.github` rewrites this footer line entirely for
its own repos, so the dead link only ever affected comments posted here.

### 2. Tutorial 53 described output the action does not produce

| Doc said | Actually |
|---|---|
| "Posts a collapsible comment with findings" | Posts risk levels only. The per-signal detail is discarded. |
| Labels are `needs-review:MEDIUM` or `:HIGH` | `:UNKNOWN` is a third label |
| Sample output header `Reputation Report: <user>` | `format_report` emits `Contributor Check: <user>`, a rule line, and a risk icon |

The first row is the one that matters. A maintainer reading the tutorial would
expect the bot to show them which signals fired, deploy it, and then wonder
where the findings went.

### 3. Added: what the action deliberately does not publish

New short section recording the reasoning, so the next person does not "fix"
the missing detail by posting it. Publishing a scored dossier about a named
contributor on the issue they just opened is a worse outcome than the spam it
defends against, and a public accusation is not reversible.

It also records a constraint that is easy to get wrong: on a **public** repo,
Actions run logs, job summaries, and artifacts are readable by anyone. There is
no maintainer-only output channel inside Actions on a public repo, so detail
cannot be routed "internally" there.

### Testing

`scripts/tests/test_contributor_check_action.py` passes (13 passed). No test
asserted on the footer URL.

### Context

Found while writing up this control as an RFC for the CoSAI WS4 workstream
(`cosai-oasis/ws4-secure-design-agentic-systems#156`).