### PR TITLE
fix(agent-os): bound email and basic auth scan complexity

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -159,8 +159,17 @@ class CredentialRedactor:
     PII_PATTERNS: tuple[CredentialPattern, ...] = (
         CredentialPattern(
             name="Email address",
+            # RFC 5321 limits the local part to 64 octets. The character class
+            # below is ASCII-only, so the same limit also bounds regex work at
+            # every candidate start. Without it, separator-dense input that
+            # contains no ``@`` makes the greedy local part scan the remaining
+            # string from each word boundary, producing quadratic behavior.
+            # Keep the word boundary fail-closed: punctuation such as ``-`` or
+            # ``.`` must not let untrusted output hide a readable email suffix.
+            # An uninterrupted local part over the RFC limit is intentionally
+            # out of scope; a separator-delimited suffix may still be reported.
             pattern=re.compile(
-                r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
+                r"\b[A-Za-z0-9._%+\-]{1,64}@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
             ),
         ),
         CredentialPattern(

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -119,8 +119,15 @@ class CredentialRedactor:
         ),
         CredentialPattern(
             name="Basic auth secret",
+            # Bound the scheme-like scan at every candidate start. Without this
+            # limit, separator-dense input with no ``://`` makes the unbounded
+            # scheme class scan overlapping suffixes repeatedly. Allow any
+            # scheme character to start the bounded suffix: a long valid scheme
+            # may have only digits or punctuation in its final 64 characters,
+            # but its username/password must still be redacted fail-closed.
             pattern=re.compile(
-                r"(?i)(?:\bBasic\s+[A-Za-z0-9+/=]{8,}\b|\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^@\s/]+@)"
+                r"(?i)(?:\bBasic\s+[A-Za-z0-9+/=]{8,}\b|"
+                r"[a-z0-9+.-]{1,64}://[^/\s:@]+:[^@\s/]+@)"
             ),
         ),
         CredentialPattern(
@@ -164,13 +171,12 @@ class CredentialRedactor:
             # every candidate start. Without it, separator-dense input that
             # contains no ``@`` makes the greedy local part scan overlapping
             # suffixes from many candidate starts, producing quadratic behavior.
-            # Deliberately omit a leading word boundary. This is a fail-closed
-            # egress detector, not an RFC validator: if untrusted output pads a
-            # readable address with an uninterrupted word-character prefix, the
-            # engine must be able to report a bounded suffix instead of missing
-            # the address entirely.
+            # Deliberately omit word boundaries around the pattern. This is a
+            # fail-closed egress detector, not an RFC validator: if untrusted
+            # output pads a readable address with uninterrupted word characters,
+            # the engine must report a bounded match instead of missing it.
             pattern=re.compile(
-                r"[A-Za-z0-9._%+\-]{1,64}@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
+                r"[A-Za-z0-9._%+\-]{1,64}@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"
             ),
         ),
         CredentialPattern(

--- a/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
+++ b/agent-governance-python/agent-os/src/agent_os/credential_redactor.py
@@ -162,14 +162,15 @@ class CredentialRedactor:
             # RFC 5321 limits the local part to 64 octets. The character class
             # below is ASCII-only, so the same limit also bounds regex work at
             # every candidate start. Without it, separator-dense input that
-            # contains no ``@`` makes the greedy local part scan the remaining
-            # string from each word boundary, producing quadratic behavior.
-            # Keep the word boundary fail-closed: punctuation such as ``-`` or
-            # ``.`` must not let untrusted output hide a readable email suffix.
-            # An uninterrupted local part over the RFC limit is intentionally
-            # out of scope; a separator-delimited suffix may still be reported.
+            # contains no ``@`` makes the greedy local part scan overlapping
+            # suffixes from many candidate starts, producing quadratic behavior.
+            # Deliberately omit a leading word boundary. This is a fail-closed
+            # egress detector, not an RFC validator: if untrusted output pads a
+            # readable address with an uninterrupted word-character prefix, the
+            # engine must be able to report a bounded suffix instead of missing
+            # the address entirely.
             pattern=re.compile(
-                r"\b[A-Za-z0-9._%+\-]{1,64}@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
+                r"[A-Za-z0-9._%+\-]{1,64}@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
             ),
         ),
         CredentialPattern(

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -8,7 +8,7 @@ import time
 
 import pytest
 
-from agent_os.credential_redactor import CredentialRedactor, REDACTED_PLACEHOLDER
+from agent_os.credential_redactor import REDACTED_PLACEHOLDER, CredentialRedactor
 
 
 def _fake_github_token(prefix: str) -> str:
@@ -274,6 +274,46 @@ def test_azure_sas_pattern_has_no_quadratic_backtracking():
     assert elapsed < 1.0
 
 
+@pytest.mark.parametrize(
+    "scheme",
+    [
+        "1.https",
+        ("Z" * 65) + "https",
+        ("a." * 65) + "https",
+        "a" + ("1" * 100),
+        "a" + ("." * 100),
+    ],
+    ids=[
+        "punctuation-prefix",
+        "long-word-prefix",
+        "separator-dense-prefix",
+        "long-numeric-tail",
+        "long-punctuation-tail",
+    ],
+)
+def test_basic_auth_uri_remains_fail_closed_with_padded_scheme(scheme: str):
+    secret = "user:pass123"
+    url = f"{scheme}://{secret}@example.com/resource"
+
+    redacted, types = CredentialRedactor.scan_and_redact(url)
+
+    assert "Basic auth secret" in types
+    assert REDACTED_PLACEHOLDER in redacted
+    assert secret not in redacted
+
+
+def test_basic_auth_scan_and_redact_handles_separator_dense_input_quickly():
+    text = "a." * 24_000
+
+    start = time.perf_counter()
+    redacted, types = CredentialRedactor.scan_and_redact(text)
+    elapsed = time.perf_counter() - start
+
+    assert redacted == text
+    assert "Basic auth secret" not in types
+    assert elapsed < 1.0
+
+
 def test_slack_token_fully_redacted_when_followed_by_word_char():
     # Regression: the "-" in the token class let a trailing word boundary
     # backtrack and redact only a prefix, leaking the final secret segment.
@@ -424,6 +464,25 @@ def test_email_detection_remains_fail_closed_next_to_punctuation(
 def test_email_detection_remains_fail_closed_with_uninterrupted_prefix():
     readable_email = "john@corp.com"
     attacker_controlled_text = f"{'Z' * 61}{readable_email}"
+
+    assert CredentialRedactor.contains_pii(attacker_controlled_text)
+
+    matches = CredentialRedactor.find_pii_matches(attacker_controlled_text)
+
+    assert any(
+        match.name == "Email address" and readable_email in match.matched_text
+        for match in matches
+    )
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    ["1", "_", "\N{CYRILLIC SMALL LETTER YA}"],
+    ids=["digit", "underscore", "unicode-word-character"],
+)
+def test_email_detection_remains_fail_closed_with_uninterrupted_suffix(suffix: str):
+    readable_email = "john@corp.com"
+    attacker_controlled_text = f"{readable_email}{suffix}"
 
     assert CredentialRedactor.contains_pii(attacker_controlled_text)
 

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -397,3 +397,69 @@ def test_ssn_pattern_rejects_bare_nine_digit_forms(text: str):
     assert not any(
         m.name == "US SSN" for m in CredentialRedactor.find_pii_matches(text)
     )
+
+
+def test_email_local_part_respects_rfc_5321_length_limit():
+    valid_email = f"{'a' * 64}@example.com"
+    overlong_email = f"{'a' * 65}@example.com"
+
+    valid_matches = CredentialRedactor.find_pii_matches(valid_email)
+    overlong_matches = CredentialRedactor.find_pii_matches(overlong_email)
+
+    assert any(
+        match.name == "Email address" and match.matched_text == valid_email
+        for match in valid_matches
+    )
+    assert not any(match.name == "Email address" for match in overlong_matches)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_email"),
+    [
+        ("Contact john.doe@corp.com", "john.doe@corp.com"),
+        ("Contact -john.doe@corp.com", "john.doe@corp.com"),
+        ("Contact +tag@example.com", "tag@example.com"),
+        ("Contact .john.doe@corp.com", "john.doe@corp.com"),
+        ("Contact %john.doe@corp.com", "john.doe@corp.com"),
+        ("Contact:-jane.roe@contoso.com", "jane.roe@contoso.com"),
+    ],
+)
+def test_email_detection_remains_fail_closed_next_to_punctuation(
+    text: str, expected_email: str
+):
+    matches = CredentialRedactor.find_pii_matches(text)
+
+    assert any(
+        match.name == "Email address" and match.matched_text == expected_email
+        for match in matches
+    )
+
+
+def test_email_detection_prefers_bounded_suffix_match_to_punctuation_bypass():
+    bounded_suffix = f"{'a' * 64}@example.com"
+    invalid_overlong_email = f"x.{bounded_suffix}"
+
+    matches = CredentialRedactor.find_pii_matches(invalid_overlong_email)
+
+    assert any(
+        match.name == "Email address" and match.matched_text == bounded_suffix
+        for match in matches
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "1.1.1." * 8_000,
+        "123-45-" * 8_000,
+        "a." * 24_000,
+    ],
+    ids=["ipv4-shaped", "ssn-shaped", "email-dots"],
+)
+def test_pii_scan_handles_separator_dense_input_quickly(text: str):
+    start = time.perf_counter()
+    matches = CredentialRedactor.find_pii_matches(text)
+    elapsed = time.perf_counter() - start
+
+    assert not any(match.name == "Email address" for match in matches)
+    assert elapsed < 1.0

--- a/agent-governance-python/agent-os/tests/test_credential_redactor.py
+++ b/agent-governance-python/agent-os/tests/test_credential_redactor.py
@@ -399,20 +399,6 @@ def test_ssn_pattern_rejects_bare_nine_digit_forms(text: str):
     )
 
 
-def test_email_local_part_respects_rfc_5321_length_limit():
-    valid_email = f"{'a' * 64}@example.com"
-    overlong_email = f"{'a' * 65}@example.com"
-
-    valid_matches = CredentialRedactor.find_pii_matches(valid_email)
-    overlong_matches = CredentialRedactor.find_pii_matches(overlong_email)
-
-    assert any(
-        match.name == "Email address" and match.matched_text == valid_email
-        for match in valid_matches
-    )
-    assert not any(match.name == "Email address" for match in overlong_matches)
-
-
 @pytest.mark.parametrize(
     ("text", "expected_email"),
     [
@@ -430,7 +416,21 @@ def test_email_detection_remains_fail_closed_next_to_punctuation(
     matches = CredentialRedactor.find_pii_matches(text)
 
     assert any(
-        match.name == "Email address" and match.matched_text == expected_email
+        match.name == "Email address" and expected_email in match.matched_text
+        for match in matches
+    )
+
+
+def test_email_detection_remains_fail_closed_with_uninterrupted_prefix():
+    readable_email = "john@corp.com"
+    attacker_controlled_text = f"{'Z' * 61}{readable_email}"
+
+    assert CredentialRedactor.contains_pii(attacker_controlled_text)
+
+    matches = CredentialRedactor.find_pii_matches(attacker_controlled_text)
+
+    assert any(
+        match.name == "Email address" and readable_email in match.matched_text
         for match in matches
     )
 


### PR DESCRIPTION
## Description

The email PII pattern and the Basic auth URI pattern could perform unbounded
scans from many candidate positions on separator-dense input, producing
quadratic behavior.

This change:

- bounds each attempted ASCII email local-part match to 64 characters;
- omits email word boundaries so attacker-controlled prefix or suffix padding cannot hide a readable address;
- bounds the Basic auth URI scheme-like suffix to 64 characters per candidate start;
- preserves fail-closed redaction for long schemes whose bounded suffix begins with a digit or punctuation;
- adds correctness and performance regressions for email and Basic auth padding and near-miss inputs;
- retains coverage for the IPv4-, SSN-, and email-shaped inputs discussed in #3566.

For overlong or padded values, the detector may report a bounded suffix. This
is intentional fail-closed behavior for an egress security gate: over-detection
is safer than allowing attacker-controlled padding to hide readable sensitive
data.

On the local Python 3.13 run, the affected email matcher improved from roughly
1.95–2.55 seconds to 0.005–0.008 seconds for the 48–56 KB adversarial cases.
The newly covered 48 KB Basic auth near-miss cases complete in under 0.1 seconds.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [x] Security fix

## Package(s) Affected

- [x] agent-os-kernel
- [ ] agent-mesh
- [ ] agent-runtime
- [ ] agent-sre
- [ ] agent-governance
- [ ] docs / root

## Checklist

- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the [Microsoft CLA](https://cla.opensource.microsoft.com/)

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects**:

The bounded local-part approach follows the discussion in #3566 and the
RFC 5321 local-part length limit. No external code was copied.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

OpenAI Codex assisted with root-cause analysis, implementation drafting,
regression-test design, and local verification. I reviewed the resulting diff
and can explain the change and its fail-closed tradeoff.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [ ] Any AI tools used have terms compatible with the MIT License

## Related Issues

Fixes #3566