### PR TITLE
fix(supply-chain): size the npm packument fall-back for real packuments

### DIFF
--- a/scripts/check_release_age.py
+++ b/scripts/check_release_age.py
@@ -73,6 +73,9 @@ import _supply_chain_common as common
 
 DEFAULT_MAX_DEPS = 50
 DEFAULT_DEADLINE_SEC = 120
+# npm packuments for popular packages exceed the shared 5 MB fetch cap;
+# still bounded, just sized for real packuments (fail-closed above this).
+NPM_PACKUMENT_MAX_BYTES = 64 * 1024 * 1024
 MANIFEST_BASENAMES = [
     "package.json",
     "Cargo.toml",
@@ -388,9 +391,13 @@ def fetch_release_time(ecosystem: str, package: str, version: str) -> datetime |
         stamp = data.get("time") if isinstance(data.get("time"), str) else None
         if stamp:
             return _parse_iso(stamp)
-        # Fall back: packument with bounded read.
+        # Fall back: packument with bounded read. Long-lived packages
+        # routinely exceed the default 5 MB cap (@typescript-eslint/*
+        # packuments are >10 MB), which made this fall-back report
+        # "could not verify" and hard-fail the check for legitimately
+        # cooled versions. Keep the read bounded, just with headroom.
         packument_url = f"https://registry.npmjs.org/{common.safe_url_path(package)}"
-        pack = common.fetch_json(packument_url)
+        pack = common.fetch_json(packument_url, max_bytes=NPM_PACKUMENT_MAX_BYTES)
         if pack is None:
             return None
         times = pack.get("time") or {}

--- a/scripts/tests/test_check_release_age.py
+++ b/scripts/tests/test_check_release_age.py
@@ -536,3 +536,24 @@ def test_main_deadline_unscanned_becomes_finding():
          patch.object(common.Deadline, "expired", return_value=True):
         rc = cra.main_with_args(["--max-deps", "0", "--total-deadline-sec", "60"])
     assert rc == 1
+
+
+def test_fetch_release_time_npm_packument_fallback_uses_large_cap(monkeypatch):
+    """Packuments for long-lived npm packages exceed the 5 MB default cap;
+    the fall-back fetch must pass the packument-sized bound (a 10 MB+
+    packument previously returned None and hard-failed the check)."""
+    calls = []
+
+    def fake_fetch_json(url, *, max_bytes=cra.common.MAX_RESPONSE_BYTES):
+        calls.append((url, max_bytes))
+        if url.endswith("/9.9.9"):
+            return {}  # per-version doc without a time field
+        return {"time": {"9.9.9": "2026-07-20T17:39:25.625Z"}}
+
+    monkeypatch.setattr(cra.common, "fetch_json", fake_fetch_json)
+    out = cra.fetch_release_time("npm", "big-packument-pkg", "9.9.9")
+    assert out is not None and out.year == 2026
+    packument_calls = [c for c in calls if not c[0].endswith("/9.9.9")]
+    assert packument_calls, "packument fall-back was not exercised"
+    assert packument_calls[0][1] == cra.NPM_PACKUMENT_MAX_BYTES
+    assert cra.NPM_PACKUMENT_MAX_BYTES > cra.common.MAX_RESPONSE_BYTES


### PR DESCRIPTION
## Summary

The 7-day cooling-off check's npm path falls back to the full packument when the per-version doc carries no `time` field. Packuments for long-lived packages exceed the shared 5 MB `fetch_json` cap (`@typescript-eslint/eslint-plugin` is >10 MB), so the fetch returned `None`, the check printed `Registry response unparseable ... could not verify`, and legitimately cooled bumps hard-failed — currently blocking #3386/#3389 and most of the rebased dependabot batch.

## Change

- `scripts/check_release_age.py`: the packument fall-back fetch gets its own `NPM_PACKUMENT_MAX_BYTES = 64 MB` bound. Still fail-closed above the cap; sized for real packuments below it. Per-version endpoint remains the first choice with the default cap.
- Regression test pinning that the fall-back passes the larger bound.

## Verification

- `scripts/tests/test_check_release_age.py`: 58 passed (was 57).
- Live: `fetch_release_time('npm', '@typescript-eslint/eslint-plugin', '8.65.0')` now returns `2026-07-20T17:39:25Z` (was None).

Scripts-only change; no dependency manifests touched (scanner-trip-wire safe).