### PR TITLE
fix(approval): reject duplicate and negative stage indexes at chain construction

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_protocol/coordinator.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/governance/approval_protocol/coordinator.py
@@ -93,11 +93,37 @@ class ApprovalStage:
 
 @dataclass(frozen=True)
 class ApprovalChain:
-    """A versioned, immutable approval-chain configuration."""
+    """A versioned, immutable approval-chain configuration.
+
+    ``stage_index`` is the identity of a stage, not merely its position:
+    :meth:`stage` resolves an index to the first matching stage, while
+    :meth:`ApprovalCoordinator._maybe_resolve` collapses the chain to the *set*
+    of required indexes. A duplicated index therefore satisfies two stages with
+    one approval, and lets an identity permitted only on a loose duplicate
+    satisfy a strict one. Both are rejected at construction so a misconfigured
+    chain can never open a request (fail-closed).
+
+    Parity note: the Go port applies the same duplicate/negative rejection in
+    ``ApprovalCoordinator.validateConfig``
+    (``agent-governance-golang/packages/agentmesh/approval_coordinator.go``).
+    """
 
     chain_id: str
     version: str
     stages: tuple[ApprovalStage, ...]
+
+    def __post_init__(self) -> None:
+        seen: set[int] = set()
+        for stage in self.stages:
+            if stage.stage_index < 0:
+                raise ApprovalProtocolError(
+                    f"invalid_approval_chain: stage index {stage.stage_index} must not be negative"
+                )
+            if stage.stage_index in seen:
+                raise ApprovalProtocolError(
+                    f"invalid_approval_chain: stage index {stage.stage_index} is duplicated"
+                )
+            seen.add(stage.stage_index)
 
     def stage(self, stage_index: int) -> Optional[ApprovalStage]:
         for stage in self.stages:

--- a/agent-governance-python/agent-mesh/tests/test_approval_protocol.py
+++ b/agent-governance-python/agent-mesh/tests/test_approval_protocol.py
@@ -562,3 +562,72 @@ class TestChainIntegrity:
         )
         assert not verdict.allowed
         assert verdict.reason_code == ReasonCode.NOT_TERMINAL_ALLOW
+
+
+# --------------------------------------------------------------------------- #
+# Chain configuration validation
+# --------------------------------------------------------------------------- #
+
+
+class TestChainConfigValidation:
+    """A misconfigured chain must be rejected before it can open a request.
+
+    Ported from the Go parity port's ``validateConfig`` table
+    (``TestApprovalCoordinatorOpenRequestInvalidConfig``).
+    """
+
+    @pytest.mark.parametrize(
+        "stages",
+        [
+            pytest.param(
+                (
+                    ApprovalStage(0, allowed_identities=frozenset({ALICE})),
+                    ApprovalStage(0, allowed_roles=frozenset({"compliance"})),
+                ),
+                id="duplicate-stage-index",
+            ),
+            pytest.param(
+                (
+                    ApprovalStage(0, allowed_identities=frozenset({ALICE})),
+                    ApprovalStage(1, allowed_roles=frozenset({"compliance"})),
+                    ApprovalStage(0, allowed_identities=frozenset({BOB})),
+                ),
+                id="duplicate-stage-index-non-adjacent",
+            ),
+            pytest.param(
+                (ApprovalStage(-1, allowed_identities=frozenset({ALICE})),),
+                id="negative-stage-index",
+            ),
+        ],
+    )
+    def test_invalid_stage_indexes_rejected_at_construction(self, stages):
+        with pytest.raises(ApprovalProtocolError, match="invalid_approval_chain"):
+            ApprovalChain(chain_id="misconfigured", version="1", stages=stages)
+
+    def test_distinct_stage_indexes_accepted(self):
+        """The guard must not reject a well-formed chain, including out-of-order indexes."""
+        chain = ApprovalChain(
+            chain_id="ordered",
+            version="1",
+            stages=(
+                ApprovalStage(1, allowed_roles=frozenset({"compliance"})),
+                ApprovalStage(0, allowed_identities=frozenset({ALICE})),
+            ),
+        )
+        assert chain.stage(0) is not None
+        assert chain.stage(1) is not None
+
+    def test_loose_duplicate_cannot_satisfy_a_strict_stage(self):
+        """The bypass this guard closes: one approval satisfying two distinct stages.
+
+        Without construction-time rejection, ``stage()`` resolves index 0 to the
+        first (non-required, BOB-authorized) stage while ``_maybe_resolve``
+        collapses the required set to ``{0}``. BOB, who is not permitted on the
+        required stage, would then resolve the request ALLOW.
+        """
+        stages = (
+            ApprovalStage(0, allowed_identities=frozenset({BOB}), required=False),
+            ApprovalStage(0, allowed_identities=frozenset({ALICE}), required=True),
+        )
+        with pytest.raises(ApprovalProtocolError, match="duplicated"):
+            ApprovalChain(chain_id="bypass", version="1", stages=stages)


### PR DESCRIPTION
## Description

`stage_index` is the identity of a stage, not merely its position:
`ApprovalChain.stage()` resolves an index by **first match**, while
`ApprovalCoordinator._maybe_resolve` collapses the chain to the **set** of
required indexes. A duplicated index therefore satisfies two stages with one
approval, and lets an identity permitted only on a loose duplicate satisfy a
strict one. Nothing validated the chain at construction.

## Impact

Authorization bypass, confirmed end-to-end. Given a chain whose required stage 0
permits only ALICE, plus a non-required stage also at index 0 permitting BOB:

```
resolution outcome: Outcome.ALLOW
execution allowed: True | reason: ok
```

BOB is not permitted on the required stage. ALICE never approved.

## Fix

`ApprovalChain.__post_init__` rejects duplicate and negative `stage_index`,
raising `ApprovalProtocolError("invalid_approval_chain: ...")`. Construction-time
rejection means a misconfigured chain can never open a request. This matches the
fail-closed treatment already applied to a chain with zero required stages.

## Testing

New `TestChainConfigValidation`: duplicate (adjacent and non-adjacent), negative,
the concrete bypass case, and a negative control asserting a well-formed chain
with out-of-order indexes is still accepted.

Each new test was mutation-tested: with the guard disabled, 4 fail and the
negative control passes. Full `agent-mesh` suite run against pristine `main` and
against this branch — the failure set is identical (pre-existing, from optional
deps absent locally), with 5 additional passing tests. `ruff check` reports no
new findings.

## Prior art / related projects

The duplicate/negative rejection and its table-driven test cases are ported from
this repository's Go parity port, `ApprovalCoordinator.validateConfig` in
`agent-governance-golang/packages/agentmesh/approval_coordinator.go` (#3242,
currently open). Note that #3483 describes that fix as merged; it is not yet.

Fixes #3515
Refs #3483
