### PR TITLE
fix(agent-os): stop the adapter SSN pattern hard-blocking bare nine-digit numbers

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -30,10 +30,11 @@ PII_PATTERNS: tuple[re.Pattern[str], ...] = (
     # (``employee_123-45-6789``) is still detected.
     # NOT yet in step with the two Rego copies, which still carry the loose
     # form: policy-engine/policy/lib/patterns.rego and agt-policies
-    # .../cli/_stock_rego/patterns.rego. Both declare that they track this
-    # constant, and the first is reachable as a hard block through
+    # .../cli/_stock_rego/patterns.rego. The first declares that it tracks
+    # this constant and is reachable as a hard block through
     # patterns.deny_if_pattern (agt_default.rego), so the same over-block
-    # survives on the OPA path. They cannot take this pattern verbatim: RE2
+    # survives on the OPA path; the wheel-shipped copy carries the pattern
+    # with no such note. They cannot take this pattern verbatim: RE2
     # has no lookarounds, so an equivalent has to anchor with
     # ``(^|[^A-Za-z0-9])`` / ``([^A-Za-z0-9]|$)``, which consumes a character
     # and shifts the span offset that deny_if_pattern reports.

--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -28,8 +28,15 @@ PII_PATTERNS: tuple[re.Pattern[str], ...] = (
     # gateway-DoS on the MCP path; issue #3532 tracks this adapter-side copy.
     # Lookarounds rather than ``\b`` so an SSN glued to ``_``
     # (``employee_123-45-6789``) is still detected.
-    # policy-engine/policy/lib/patterns.rego keeps the looser form on purpose:
-    # that path is detection-only reporting, not a hard block.
+    # NOT yet in step with the two Rego copies, which still carry the loose
+    # form: policy-engine/policy/lib/patterns.rego and agt-policies
+    # .../cli/_stock_rego/patterns.rego. Both declare that they track this
+    # constant, and the first is reachable as a hard block through
+    # patterns.deny_if_pattern (agt_default.rego), so the same over-block
+    # survives on the OPA path. They cannot take this pattern verbatim: RE2
+    # has no lookarounds, so an equivalent has to anchor with
+    # ``(^|[^A-Za-z0-9])`` / ``([^A-Za-z0-9]|$)``, which consumes a character
+    # and shifts the span offset that deny_if_pattern reports.
     re.compile(r"(?<![A-Za-z0-9])\d{3}[\s.-]\d{2}[\s.-]\d{4}(?![A-Za-z0-9])"),
     re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
     re.compile(r"\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14})\b"),

--- a/agent-governance-python/agent-os/src/agent_os/integrations/base.py
+++ b/agent-governance-python/agent-os/src/agent_os/integrations/base.py
@@ -19,7 +19,18 @@ logger = logging.getLogger(__name__)
 
 
 PII_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b"),
+    # US SSN. A separator is REQUIRED: these patterns drive blocking paths
+    # (autogen_adapter DropMessage, PolicyViolationError on state updates,
+    # bedrock_adapter), so an optional separator matched any bare nine-digit
+    # run and hard-denied ordinary traffic carrying a tracking number, ABA
+    # routing number, or ZIP+4. Ported from the gateway-side fix in #3531
+    # (agent_os/credential_redactor.py, "US SSN"), which closed the same
+    # gateway-DoS on the MCP path; issue #3532 tracks this adapter-side copy.
+    # Lookarounds rather than ``\b`` so an SSN glued to ``_``
+    # (``employee_123-45-6789``) is still detected.
+    # policy-engine/policy/lib/patterns.rego keeps the looser form on purpose:
+    # that path is detection-only reporting, not a hard block.
+    re.compile(r"(?<![A-Za-z0-9])\d{3}[\s.-]\d{2}[\s.-]\d{4}(?![A-Za-z0-9])"),
     re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"),
     re.compile(r"\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14})\b"),
     re.compile(

--- a/agent-governance-python/agent-os/tests/test_pii_patterns.py
+++ b/agent-governance-python/agent-os/tests/test_pii_patterns.py
@@ -5,11 +5,11 @@
 The dashed-only SSN regex (``\\b\\d{3}-\\d{2}-\\d{4}\\b``) that used to be
 duplicated across each framework adapter was trivially bypassed by SSNs
 formatted with spaces or dots (#2635).  Widening it also made the separator
-optional, so it matched any bare nine-digit run.  That is safe for a
-detection-only path but not here: these patterns drive blocking call sites
-(``autogen_adapter`` ``DropMessage``, ``PolicyViolationError`` on state
-updates, ``bedrock_adapter``), where a tracking number, ABA routing number,
-or ZIP+4 in ordinary content became a hard deny (#3532).
+optional, so it matched any bare nine-digit run.  These patterns drive
+blocking call sites (``autogen_adapter`` ``DropMessage``,
+``PolicyViolationError`` on state updates, ``bedrock_adapter``), so a
+tracking number, ABA routing number, or ZIP+4 in ordinary content became a
+hard deny (#3532).
 
 #3531 resolved the same tension on the MCP gateway copy of this pattern by
 requiring a separator while keeping the space and dot forms.  This module

--- a/agent-governance-python/agent-os/tests/test_pii_patterns.py
+++ b/agent-governance-python/agent-os/tests/test_pii_patterns.py
@@ -20,9 +20,10 @@ holds the adapter-side copy to that same contract:
 2. It does not match bare nine-digit runs, which are not SSNs.
 3. Adapters that retain local PII scanning share the same regex objects.
 
-For the two adapters whose PII enforcement path can be exercised without
-optional third-party SDKs, we also drive a live boundary test through the
-real call site to verify the regex behaves the same end-to-end.
+Bedrock's PII path can be exercised without optional third-party SDKs, so it
+also gets a live boundary test through ``bedrock_adapter._scan_pii`` to
+verify the regex behaves the same end-to-end.  The autogen adapter is only
+checked for sharing the same regex objects, not driven at its call site.
 """
 from __future__ import annotations
 import pytest

--- a/agent-governance-python/agent-os/tests/test_pii_patterns.py
+++ b/agent-governance-python/agent-os/tests/test_pii_patterns.py
@@ -31,7 +31,8 @@ from agent_os.integrations import autogen_adapter, bedrock_adapter
 from agent_os.integrations.base import PII_PATTERNS
 _SSN_VARIANTS = ('123-45-6789', '123 45 6789', '123.45.6789')
 _SSN_NON_MATCHES = ('', 'no digits in dashed positions', '12-345-6789', '1234-56-7890', 'no digits at all')
-# Nine-digit content that a blocking path must let through (#3532).
+# Content a blocking path must let through (#3532): bare nine-digit runs, plus
+# neighbouring digit groupings that must not start matching either.
 _SSN_FALSE_POSITIVES = ('Tracking: 123456789', 'order_123456789', 'ZIP 12345-6789', 'ABA 021000021', 'order 1234567890 shipped', 'build 12-34-5678 tagged')
 
 def _ssn_pattern():

--- a/agent-governance-python/agent-os/tests/test_pii_patterns.py
+++ b/agent-governance-python/agent-os/tests/test_pii_patterns.py
@@ -1,28 +1,38 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-"""Regression tests for the shared ``PII_PATTERNS`` constant (issue #2635).
+"""Regression tests for the shared ``PII_PATTERNS`` constant (issues #2635, #3532).
 
 The dashed-only SSN regex (``\\b\\d{3}-\\d{2}-\\d{4}\\b``) that used to be
 duplicated across each framework adapter was trivially bypassed by SSNs
-formatted with spaces, dots, or no separator at all.  This module guards
-two invariants going forward:
+formatted with spaces or dots (#2635).  Widening it also made the separator
+optional, so it matched any bare nine-digit run.  That is safe for a
+detection-only path but not here: these patterns drive blocking call sites
+(``autogen_adapter`` ``DropMessage``, ``PolicyViolationError`` on state
+updates, ``bedrock_adapter``), where a tracking number, ABA routing number,
+or ZIP+4 in ordinary content became a hard deny (#3532).
+
+#3531 resolved the same tension on the MCP gateway copy of this pattern by
+requiring a separator while keeping the space and dot forms.  This module
+holds the adapter-side copy to that same contract:
 
 1. The shared SSN regex in :mod:`agent_os.integrations.base` matches every
-   common separator variant (dash, space, dot, none).
-2. Adapters that retain local PII scanning share the same regex objects.
+   *separated* variant (dash, space, dot), including one glued to ``_``.
+2. It does not match bare nine-digit runs, which are not SSNs.
+3. Adapters that retain local PII scanning share the same regex objects.
 
 For the two adapters whose PII enforcement path can be exercised without
 optional third-party SDKs, we also drive a live boundary test through the
-real call site to verify the broadened SSN regex actually blocks every
-variant end-to-end.
+real call site to verify the regex behaves the same end-to-end.
 """
 from __future__ import annotations
 import pytest
 from agent_os.integrations import base as _base
 from agent_os.integrations import autogen_adapter, bedrock_adapter
 from agent_os.integrations.base import PII_PATTERNS
-_SSN_VARIANTS = ('123-45-6789', '123 45 6789', '123.45.6789', '123456789')
+_SSN_VARIANTS = ('123-45-6789', '123 45 6789', '123.45.6789')
 _SSN_NON_MATCHES = ('', 'no digits in dashed positions', '12-345-6789', '1234-56-7890', 'no digits at all')
+# Nine-digit content that a blocking path must let through (#3532).
+_SSN_FALSE_POSITIVES = ('Tracking: 123456789', 'order_123456789', 'ZIP 12345-6789', 'ABA 021000021', 'order 1234567890 shipped', 'build 12-34-5678 tagged')
 
 def _ssn_pattern():
     """Return the SSN regex from the shared ``PII_PATTERNS`` tuple."""
@@ -43,9 +53,26 @@ def test_shared_ssn_regex_matches_variant_in_sentence(variant: str) -> None:
 
 @pytest.mark.parametrize('non_match', _SSN_NON_MATCHES)
 def test_shared_ssn_regex_rejects_obvious_non_ssn(non_match: str) -> None:
-    """Sanity check that the broadened regex still rejects clear non-SSNs."""
+    """Sanity check that the regex still rejects clear non-SSNs."""
     ssn = _ssn_pattern()
     assert ssn.search(non_match) is None, f'shared SSN regex {ssn.pattern!r} unexpectedly matched {non_match!r}'
+
+@pytest.mark.parametrize('text', _SSN_FALSE_POSITIVES)
+def test_shared_ssn_regex_rejects_bare_nine_digit_forms(text: str) -> None:
+    """These patterns gate blocking paths, so a separator is required (#3532).
+
+    Without it, a bare nine-digit run hard-denies ordinary content carrying a
+    tracking number, routing number, or ZIP+4.
+    """
+    ssn = _ssn_pattern()
+    assert ssn.search(text) is None, f'shared SSN regex {ssn.pattern!r} would hard-block {text!r}'
+
+def test_shared_ssn_regex_detects_ssn_glued_to_underscore() -> None:
+    """``\\b`` treats ``_`` as a word character, so a glued SSN escaped detection.
+
+    The lookaround anchors ported from #3531 catch it.
+    """
+    assert _ssn_pattern().search('employee_123-45-6789') is not None
 
 def test_shared_pii_patterns_is_immutable_tuple() -> None:
     """The shared constant is a tuple so adapters cannot mutate it in place."""

--- a/agent-governance-python/agent-os/tests/test_pii_patterns.py
+++ b/agent-governance-python/agent-os/tests/test_pii_patterns.py
@@ -58,11 +58,13 @@ def test_shared_ssn_regex_rejects_obvious_non_ssn(non_match: str) -> None:
     assert ssn.search(non_match) is None, f'shared SSN regex {ssn.pattern!r} unexpectedly matched {non_match!r}'
 
 @pytest.mark.parametrize('text', _SSN_FALSE_POSITIVES)
-def test_shared_ssn_regex_rejects_bare_nine_digit_forms(text: str) -> None:
+def test_shared_ssn_regex_rejects_common_false_positives(text: str) -> None:
     """These patterns gate blocking paths, so a separator is required (#3532).
 
     Without it, a bare nine-digit run hard-denies ordinary content carrying a
-    tracking number, routing number, or ZIP+4.
+    tracking number or routing number. The remaining cases (ZIP+4, ten-digit
+    runs, an eight-digit build tag) guard the digit grouping itself, which the
+    separator requirement must not loosen.
     """
     ssn = _ssn_pattern()
     assert ssn.search(text) is None, f'shared SSN regex {ssn.pattern!r} would hard-block {text!r}'


### PR DESCRIPTION
## Description

`PII_PATTERNS[0]` in `agent_os/integrations/base.py` was
`\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b` — the separator is optional, so it matched
any bare nine-digit run. Unlike the detection-only Rego pattern, this constant
drives **blocking** call sites: `autogen_adapter` `DropMessage`,
`PolicyViolationError` on state updates, and `bedrock_adapter` (which aliases
the same tuple through `_PII_RE`). A tracking number, ABA routing number, or
ZIP+4 in ordinary message content produced a hard deny.

This is the adapter-side residual of the gateway-DoS that #3531 fixed on the MCP
path, tracked as #3532.

## Fix

Ports #3531's pattern: `(?<![A-Za-z0-9])\d{3}[\s.-]\d{2}[\s.-]\d{4}(?![A-Za-z0-9])`.
A separator is required, and lookarounds replace `\b` so an SSN glued to `_`
(`employee_123-45-6789`) is still detected. `bedrock_adapter._PII_RE` already
aliases `PII_PATTERNS`, so one change covers both copies.

## Note on #2635

This intentionally narrows the pattern that #2635 broadened. The space and dot
forms that change was about are retained; only the no-separator form is dropped,
and only on this blocking path. `policy-engine/policy/lib/patterns.rego` keeps
the looser form, which is correct there — that path reports rather than blocks.
Two assertions in `test_pii_patterns.py` that required the bare form to match
are updated accordingly, and the module docstring now records the tradeoff.

## Testing

Added both-direction coverage per the issue: separated forms and the
underscore-glued form must match; `Tracking: 123456789`, `ZIP 12345-6789`,
`ABA 021000021`, and ten-digit runs must not.

Mutation-tested: restoring the loose pattern fails 4 of the new tests. Full
`agent-os` suite run against pristine `main` and this branch — failure sets are
identical (pre-existing, from optional deps and an `agent_control_specification`
version mismatch locally), with 4 additional passing tests. `ruff check` reports
no new findings.

## Prior art / related projects

Pattern and test structure ported from #3531 (`agent_os/credential_redactor.py`,
"US SSN") in this repository.

Fixes #3532
