### PR TITLE
fix(ci): scope markdown-link-check to the PR's merge base

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -550,6 +550,7 @@ levelname
 liamcrumm
 libagent
 libc
+linkbase
 linkcheck
 linkified
 linkpkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -992,6 +992,31 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+      # `check-modified-files-only` runs `git diff --name-only <base-branch>`, a
+      # two-dot diff against the base *tip*. On a branch that has fallen behind,
+      # every commit that landed on the base since the branch point is reported
+      # as modified, so the job checks hundreds of files the PR never touched and
+      # fails on links that were already fixed upstream. Resolving the base to
+      # its merge base with HEAD restores the intended "files this PR changed"
+      # scope.
+      - name: Resolve merge base for changed-file scoping
+        id: linkbase
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -e
+          if [ -z "$BASE_REF" ]; then
+            # Not a pull request (schedule/push): keep the previous behaviour.
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --no-tags origin "$BASE_REF"
+          if BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD); then
+            echo "ref=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::cannot resolve merge base with $BASE_REF; using its tip"
+            echo "ref=origin/$BASE_REF" >> "$GITHUB_OUTPUT"
+          fi
       - name: Markdown link check
         uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         with:
@@ -1001,7 +1026,7 @@ jobs:
           # Only check links in files changed by the PR/push to avoid
           # pre-existing broken links blocking unrelated work.
           check-modified-files-only: 'yes'
-          base-branch: main
+          base-branch: ${{ steps.linkbase.outputs.ref }}
 
   # ── Workflow security audit (only when workflows change) ─────────────
   workflow-security:


### PR DESCRIPTION
## Summary

Scope `markdown-link-check` to the files a PR actually changed, instead of every file that changed on `main` since the branch point.

## Problem

The job sets `check-modified-files-only: 'yes'` with `base-branch: main`. That action runs `git diff --name-only main`, a two-dot diff against the base *tip*, so on a branch that has fallen behind, every commit that landed on `main` since the branch point is reported as modified.

The job then checks those files as they exist on the stale branch, and fails on links that were already fixed upstream.

Measured on #3450, which is 55 commits behind and changes exactly one markdown file:

```
files checked by the job : 255
markdown files in the PR : 1
```

It failed on four links, all of which #3352 had already fixed on `main` before that run executed.

Every PR currently failing this check is behind `main`:

| PR | commits behind |
|----|----------------|
| #3612 | 269 |
| #3342 | 65 |
| #3523 | 61 |
| #3254 | 59 |
| #3450 | 55 |
| #3574, #3508, #3251 | 37 |
| #3255 | 23 |
| #3409 | 14 |

The job's own comment states the intent ("Only check links in files changed by the PR/push to avoid pre-existing broken links blocking unrelated work"), which the two-dot diff defeats.

`ci-complete` lists `markdown-link-check` in its `needs`, so each of these also fails `ci-complete`.

## Changes

| File | What changed |
|------|-------------|
| `.github/workflows/ci.yml` | Resolve `base-branch` to `git merge-base origin/$BASE_REF HEAD` before invoking the action |

Non-pull-request events (schedule, push) keep the previous behaviour. If `merge-base` cannot be resolved, the step warns and falls back to the base tip, which is exactly today's behaviour.

## Testing

`python3 scripts/ci/generate_workflows.py --check` passes, and the YAML parses with `yaml.safe_load`. This PR's own `markdown-link-check` run exercises the change.
