### PR TITLE
chore: add prayagupa as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 #
 # Only the project lead can bypass this requirement or push without a PR.
 
-* @MohammadHaroonAbuomar @liamcrumm
+* @MohammadHaroonAbuomar @liamcrumm @prayagupa


### PR DESCRIPTION
Adds @prayagupa to the `*` code-owner line so their approvals satisfy the require_code_owner_review gate, alongside @MohammadHaroonAbuomar and @liamcrumm — per maintainer decision so Prayag and Liam can both review and merge, including each other's PRs.

Pairs with the repository permission grant (Maintain) done in settings; the CODEOWNERS entry has no effect until that grant exists.