### PR TITLE
feat(mcp): make bundled servers stateless-first

### DIFF
--- a/agent-governance-antigravity-cli/assets/extensions/agt-global-policy/mcp/server.mjs
+++ b/agent-governance-antigravity-cli/assets/extensions/agt-global-policy/mcp/server.mjs
@@ -10,6 +10,7 @@ const SERVER_INFO = {
   version: "3.3.0",
 };
 const PROTOCOL_VERSION = "2024-11-05";
+const STATELESS_PROTOCOL_VERSION = "2026-07-28";
 const JSONRPC_VERSION = "2.0";
 const HEADER_SEPARATOR = Buffer.from("\r\n\r\n", "utf8");
 const extensionRoot = fileURLToPath(new URL("..", import.meta.url));
@@ -107,6 +108,18 @@ async function handleMessage(message) {
   }
 
   try {
+    if (message.method === "server/discover") {
+      writeResult(message.id, {
+        protocolVersion: STATELESS_PROTOCOL_VERSION,
+        capabilities: {
+          tools: {},
+        },
+        serverInfo: SERVER_INFO,
+        tools,
+      });
+      return;
+    }
+
     if (message.method === "initialize") {
       writeResult(message.id, {
         protocolVersion: PROTOCOL_VERSION,
@@ -123,13 +136,29 @@ async function handleMessage(message) {
       return;
     }
 
+    const requestMeta =
+      message.method === "tools/list" || message.method === "tools/call"
+        ? validateStatelessRequestMeta(message)
+        : undefined;
+    if (requestMeta === null) {
+      writeError(
+        message.id ?? null,
+        -32001,
+        "Invalid stateless request metadata: _meta.clientInfo requires non-empty name and version, and _meta.capabilities must be an object.",
+      );
+      return;
+    }
+
     if (message.method === "tools/list") {
       writeResult(message.id, { tools });
       return;
     }
 
     if (message.method === "tools/call") {
-      writeResult(message.id, await callTool(message.params ?? {}));
+      writeResult(
+        message.id,
+        withRequestMeta(await callTool(message.params ?? {}), requestMeta),
+      );
       return;
     }
 
@@ -194,6 +223,49 @@ async function callTool(params) {
     ],
     isError: true,
   };
+}
+
+function validateStatelessRequestMeta(request) {
+  if (!Object.prototype.hasOwnProperty.call(request, "_meta")) {
+    return undefined;
+  }
+
+  const meta = request._meta;
+  if (
+    !isObject(meta) ||
+    !isObject(meta.clientInfo) ||
+    !isNonEmptyString(meta.clientInfo.name) ||
+    !isNonEmptyString(meta.clientInfo.version) ||
+    !isObject(meta.capabilities)
+  ) {
+    return null;
+  }
+
+  return {
+    clientInfo: {
+      name: meta.clientInfo.name,
+      version: meta.clientInfo.version,
+    },
+    capabilities: meta.capabilities,
+  };
+}
+
+function withRequestMeta(result, requestMeta) {
+  if (requestMeta === undefined) {
+    return result;
+  }
+  return {
+    ...result,
+    _meta: requestMeta,
+  };
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function writeResult(id, result) {

--- a/agent-governance-antigravity-cli/test/mcp-server.test.mjs
+++ b/agent-governance-antigravity-cli/test/mcp-server.test.mjs
@@ -12,6 +12,13 @@ import { fileURLToPath } from "node:url";
 import { installPackage } from "../lib/cli.mjs";
 
 const PACKAGE_ROOT = dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const STATELESS_META = {
+  clientInfo: {
+    name: "agt-parity-test",
+    version: "1.0.0",
+  },
+  capabilities: {},
+};
 
 test("bundled MCP server handles initialize, tools/list, and tools/call over stdio", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-antigravity-mcp-server-"));
@@ -86,6 +93,175 @@ test("bundled MCP server handles initialize, tools/list, and tools/call over std
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test("server/discover matches legacy capability and tool declarations over stdio", async () => {
+  await withServer("agt-antigravity-mcp-discover-", async (child) => {
+    const initialize = await request(child, {
+      jsonrpc: "2.0",
+      id: 10,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05" },
+    });
+    const listTools = await request(child, {
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/list",
+      params: {},
+    });
+    const discover = await request(child, {
+      jsonrpc: "2.0",
+      id: 12,
+      method: "server/discover",
+      params: {},
+      _meta: STATELESS_META,
+    });
+
+    assert.equal(initialize.result.protocolVersion, "2024-11-05");
+    assert.equal(discover.result.protocolVersion, "2026-07-28");
+    assert.deepEqual(discover.result.capabilities, initialize.result.capabilities);
+    assert.deepEqual(discover.result.serverInfo, initialize.result.serverInfo);
+    assert.deepEqual(discover.result.tools, listTools.result.tools);
+    assert.equal("sessionId" in discover.result, false);
+  });
+});
+
+test("stateless tools/list validates per-request _meta over stdio", async () => {
+  await withServer("agt-antigravity-mcp-meta-list-", async (child) => {
+    const accepted = await request(child, {
+      jsonrpc: "2.0",
+      id: 13,
+      method: "tools/list",
+      params: {},
+      _meta: STATELESS_META,
+    });
+    const rejected = await request(child, {
+      jsonrpc: "2.0",
+      id: 14,
+      method: "tools/list",
+      params: {},
+      _meta: { capabilities: {} },
+    });
+
+    assert.deepEqual(accepted.result.tools.map(({ name }) => name), [
+      "agt_policy_status",
+      "agt_policy_check_text",
+    ]);
+    assert.equal(rejected.error.code, -32001);
+  });
+});
+
+test("stateless tools/call rejects missing caller identity after discovery over stdio", async () => {
+  await withServer("agt-antigravity-mcp-meta-deny-", async (child) => {
+    const discover = await request(child, {
+      jsonrpc: "2.0",
+      id: 15,
+      method: "server/discover",
+      params: {},
+      _meta: STATELESS_META,
+    });
+    const rejected = await request(child, {
+      jsonrpc: "2.0",
+      id: 16,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: { capabilities: {} },
+    });
+
+    assert.equal(discover.result.protocolVersion, "2026-07-28");
+    assert.equal(rejected.error.code, -32001);
+    assert.equal("result" in rejected, false);
+  });
+});
+
+test("stateless tools/call preserves caller context over stdio", async () => {
+  await withServer("agt-antigravity-mcp-meta-call-", async (child) => {
+    const response = await request(child, {
+      jsonrpc: "2.0",
+      id: 17,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: STATELESS_META,
+    });
+
+    assert.deepEqual(response.result._meta, STATELESS_META);
+    assert.equal(response.result.isError, undefined);
+  });
+});
+
+test("legacy lifecycle remains compatible and terminal outcomes stay distinct over stdio", async () => {
+  await withServer("agt-antigravity-mcp-compat-", async (child) => {
+    const initialize = await request(child, {
+      jsonrpc: "2.0",
+      id: 18,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05" },
+    });
+    child.stdin.write(encodeMessage({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    }));
+    const compatibilityFallback = await request(child, {
+      jsonrpc: "2.0",
+      id: 19,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+    });
+    const allow = await request(child, {
+      jsonrpc: "2.0",
+      id: 20,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: STATELESS_META,
+    });
+    const deny = await request(child, {
+      jsonrpc: "2.0",
+      id: 21,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: { capabilities: {} },
+    });
+
+    assert.equal(initialize.result.protocolVersion, "2024-11-05");
+    assert.equal(compatibilityFallback.result.isError, undefined);
+    assert.notDeepEqual(allow.result, deny.error ?? deny.result);
+    assert.notDeepEqual(allow.result, compatibilityFallback.result);
+    assert.notDeepEqual(deny.error ?? deny.result, compatibilityFallback.result);
+  });
+});
+
+async function withServer(prefix, callback) {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  const antigravityHome = join(root, ".antigravity");
+
+  await installPackage({ antigravityHome, packageRoot: PACKAGE_ROOT });
+  const serverPath = join(antigravityHome, "extensions", "agt-global-policy", "mcp", "server.mjs");
+  const child = spawn(process.execPath, [serverPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  try {
+    await callback(child);
+  } finally {
+    child.kill();
+    await rm(root, { recursive: true, force: true });
+  }
+}
 
 function request(child, payload) {
   return new Promise((resolve, reject) => {

--- a/agent-governance-claude-code/server/agt-mcp.mjs
+++ b/agent-governance-claude-code/server/agt-mcp.mjs
@@ -8,6 +8,7 @@ import { checkArbitraryText, getPolicyStatus, loadPolicy } from "../lib/policy.m
 
 const VERSION = "3.6.0";
 const PROTOCOL_VERSION = "2024-11-05";
+const STATELESS_PROTOCOL_VERSION = "2026-07-28";
 const TOOL_DEFINITIONS = [
   {
     name: "agt_policy_status",
@@ -46,6 +47,20 @@ export async function handleJsonRpcRequest(state, request) {
     return jsonRpcError(id, -32600, "Invalid Request");
   }
 
+  if (method === "server/discover") {
+    return jsonRpcResult(id, {
+      protocolVersion: STATELESS_PROTOCOL_VERSION,
+      capabilities: {
+        tools: {},
+      },
+      serverInfo: {
+        name: "agt-governance",
+        version: VERSION,
+      },
+      tools: TOOL_DEFINITIONS,
+    });
+  }
+
   if (method === "initialize") {
     const protocolVersion =
       typeof params.protocolVersion === "string" ? params.protocolVersion : PROTOCOL_VERSION;
@@ -70,12 +85,24 @@ export async function handleJsonRpcRequest(state, request) {
     return jsonRpcResult(id, {});
   }
 
+  const requestMeta =
+    method === "tools/list" || method === "tools/call"
+      ? validateStatelessRequestMeta(request)
+      : undefined;
+  if (requestMeta === null) {
+    return jsonRpcError(
+      id,
+      -32001,
+      "Invalid stateless request metadata: _meta.clientInfo requires non-empty name and version, and _meta.capabilities must be an object.",
+    );
+  }
+
   if (method === "tools/list") {
     return jsonRpcResult(id, { tools: TOOL_DEFINITIONS });
   }
 
   if (method === "tools/call") {
-    return jsonRpcResult(id, await callTool(state, params));
+    return jsonRpcResult(id, withRequestMeta(await callTool(state, params), requestMeta));
   }
 
   return jsonRpcError(id, -32601, `Method not found: ${method}`);
@@ -103,6 +130,49 @@ async function callTool(state, params) {
   }
 
   return asJsonError(`Unknown tool: ${String(name)}`);
+}
+
+function validateStatelessRequestMeta(request) {
+  if (!Object.prototype.hasOwnProperty.call(request, "_meta")) {
+    return undefined;
+  }
+
+  const meta = request._meta;
+  if (
+    !isObject(meta) ||
+    !isObject(meta.clientInfo) ||
+    !isNonEmptyString(meta.clientInfo.name) ||
+    !isNonEmptyString(meta.clientInfo.version) ||
+    !isObject(meta.capabilities)
+  ) {
+    return null;
+  }
+
+  return {
+    clientInfo: {
+      name: meta.clientInfo.name,
+      version: meta.clientInfo.version,
+    },
+    capabilities: meta.capabilities,
+  };
+}
+
+function withRequestMeta(result, requestMeta) {
+  if (requestMeta === undefined) {
+    return result;
+  }
+  return {
+    ...result,
+    _meta: requestMeta,
+  };
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function asJsonContent(value) {

--- a/agent-governance-claude-code/test/mcp-server.test.mjs
+++ b/agent-governance-claude-code/test/mcp-server.test.mjs
@@ -9,6 +9,13 @@ import { encodeJsonRpcMessage, handleJsonRpcRequest } from "../server/agt-mcp.mj
 import { loadPolicy } from "../lib/policy.mjs";
 
 const state = await loadPolicy();
+const STATELESS_META = {
+  clientInfo: {
+    name: "agt-parity-test",
+    version: "1.0.0",
+  },
+  capabilities: {},
+};
 
 test("initialize returns MCP server metadata", async () => {
   const response = await handleJsonRpcRequest(state, {
@@ -63,4 +70,146 @@ test("encoded JSON-RPC messages include a content-length header", () => {
 
   assert.match(encoded, /^Content-Length: \d+\r\n\r\n/);
   assert.match(encoded, /"ok":true/);
+});
+
+test("server/discover matches legacy capability and tool declarations", async () => {
+  const initialize = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 10,
+    method: "initialize",
+    params: { protocolVersion: "2024-11-05" },
+  });
+  const listTools = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 11,
+    method: "tools/list",
+    params: {},
+  });
+  const discover = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 12,
+    method: "server/discover",
+    params: {},
+    _meta: STATELESS_META,
+  });
+
+  assert.equal(initialize.result.protocolVersion, "2024-11-05");
+  assert.equal(discover.result.protocolVersion, "2026-07-28");
+  assert.deepEqual(discover.result.capabilities, initialize.result.capabilities);
+  assert.deepEqual(discover.result.serverInfo, initialize.result.serverInfo);
+  assert.deepEqual(discover.result.tools, listTools.result.tools);
+  assert.equal("sessionId" in discover.result, false);
+});
+
+test("stateless tools/list validates per-request _meta", async () => {
+  const accepted = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 13,
+    method: "tools/list",
+    params: {},
+    _meta: STATELESS_META,
+  });
+  const rejected = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 14,
+    method: "tools/list",
+    params: {},
+    _meta: { capabilities: {} },
+  });
+
+  assert.deepEqual(accepted.result.tools.map(({ name }) => name), [
+    "agt_policy_status",
+    "agt_policy_check_text",
+  ]);
+  assert.equal(rejected.error.code, -32001);
+});
+
+test("stateless tools/call rejects missing caller identity after discovery", async () => {
+  const discover = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 15,
+    method: "server/discover",
+    params: {},
+    _meta: STATELESS_META,
+  });
+  const rejected = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 16,
+    method: "tools/call",
+    params: {
+      name: "agt_policy_status",
+      arguments: {},
+    },
+    _meta: { capabilities: {} },
+  });
+
+  assert.equal(discover.result.protocolVersion, "2026-07-28");
+  assert.equal(rejected.error.code, -32001);
+  assert.equal("result" in rejected, false);
+});
+
+test("stateless tools/call preserves caller context", async () => {
+  const response = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 17,
+    method: "tools/call",
+    params: {
+      name: "agt_policy_status",
+      arguments: {},
+    },
+    _meta: STATELESS_META,
+  });
+
+  assert.deepEqual(response.result._meta, STATELESS_META);
+  assert.equal(response.result.isError, undefined);
+});
+
+test("legacy lifecycle remains compatible and terminal outcomes stay distinct", async () => {
+  const initialize = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 18,
+    method: "initialize",
+    params: { protocolVersion: "2024-11-05" },
+  });
+  const initialized = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+    params: {},
+  });
+  const compatibilityFallback = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 19,
+    method: "tools/call",
+    params: {
+      name: "agt_policy_status",
+      arguments: {},
+    },
+  });
+  const allow = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 20,
+    method: "tools/call",
+    params: {
+      name: "agt_policy_status",
+      arguments: {},
+    },
+    _meta: STATELESS_META,
+  });
+  const deny = await handleJsonRpcRequest(state, {
+    jsonrpc: "2.0",
+    id: 21,
+    method: "tools/call",
+    params: {
+      name: "agt_policy_status",
+      arguments: {},
+    },
+    _meta: { capabilities: {} },
+  });
+
+  assert.equal(initialize.result.protocolVersion, "2024-11-05");
+  assert.equal(initialized, null);
+  assert.equal(compatibilityFallback.result.isError, undefined);
+  assert.notDeepEqual(allow.result, deny.error ?? deny.result);
+  assert.notDeepEqual(allow.result, compatibilityFallback.result);
+  assert.notDeepEqual(deny.error ?? deny.result, compatibilityFallback.result);
 });

--- a/agent-governance-opencode/server/agt-mcp.mjs
+++ b/agent-governance-opencode/server/agt-mcp.mjs
@@ -8,6 +8,7 @@ import { checkArbitraryText, getPolicyStatus, loadPolicy } from "../lib/policy.m
 
 const VERSION = "3.6.0";
 const PROTOCOL_VERSION = "2024-11-05";
+const STATELESS_PROTOCOL_VERSION = "2026-07-28";
 const TOOL_DEFINITIONS = [
   {
     name: "agt_policy_status",
@@ -46,6 +47,20 @@ export async function handleJsonRpcRequest(state, request) {
     return jsonRpcError(id, -32600, "Invalid Request");
   }
 
+  if (method === "server/discover") {
+    return jsonRpcResult(id, {
+      protocolVersion: STATELESS_PROTOCOL_VERSION,
+      capabilities: {
+        tools: {},
+      },
+      serverInfo: {
+        name: "agt-governance",
+        version: VERSION,
+      },
+      tools: TOOL_DEFINITIONS,
+    });
+  }
+
   if (method === "initialize") {
     const protocolVersion =
       typeof params.protocolVersion === "string" ? params.protocolVersion : PROTOCOL_VERSION;
@@ -70,12 +85,24 @@ export async function handleJsonRpcRequest(state, request) {
     return jsonRpcResult(id, {});
   }
 
+  const requestMeta =
+    method === "tools/list" || method === "tools/call"
+      ? validateStatelessRequestMeta(request)
+      : undefined;
+  if (requestMeta === null) {
+    return jsonRpcError(
+      id,
+      -32001,
+      "Invalid stateless request metadata: _meta.clientInfo requires non-empty name and version, and _meta.capabilities must be an object.",
+    );
+  }
+
   if (method === "tools/list") {
     return jsonRpcResult(id, { tools: TOOL_DEFINITIONS });
   }
 
   if (method === "tools/call") {
-    return jsonRpcResult(id, await callTool(state, params));
+    return jsonRpcResult(id, withRequestMeta(await callTool(state, params), requestMeta));
   }
 
   return jsonRpcError(id, -32601, `Method not found: ${method}`);
@@ -103,6 +130,49 @@ async function callTool(state, params) {
   }
 
   return asJsonError(`Unknown tool: ${String(name)}`);
+}
+
+function validateStatelessRequestMeta(request) {
+  if (!Object.prototype.hasOwnProperty.call(request, "_meta")) {
+    return undefined;
+  }
+
+  const meta = request._meta;
+  if (
+    !isObject(meta) ||
+    !isObject(meta.clientInfo) ||
+    !isNonEmptyString(meta.clientInfo.name) ||
+    !isNonEmptyString(meta.clientInfo.version) ||
+    !isObject(meta.capabilities)
+  ) {
+    return null;
+  }
+
+  return {
+    clientInfo: {
+      name: meta.clientInfo.name,
+      version: meta.clientInfo.version,
+    },
+    capabilities: meta.capabilities,
+  };
+}
+
+function withRequestMeta(result, requestMeta) {
+  if (requestMeta === undefined) {
+    return result;
+  }
+  return {
+    ...result,
+    _meta: requestMeta,
+  };
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function asJsonContent(value) {

--- a/agent-governance-opencode/test/mcp-server.test.mjs
+++ b/agent-governance-opencode/test/mcp-server.test.mjs
@@ -10,6 +10,14 @@ import test from "node:test";
 import { loadPolicy } from "../lib/policy.mjs";
 import { encodeJsonRpcMessage, handleJsonRpcRequest } from "../server/agt-mcp.mjs";
 
+const STATELESS_META = {
+  clientInfo: {
+    name: "agt-parity-test",
+    version: "1.0.0",
+  },
+  capabilities: {},
+};
+
 test("handleJsonRpcRequest responds to initialize with serverInfo", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-opencode-mcp-init-"));
   const state = await loadPolicy({ auditPath: join(root, "audit.json") });
@@ -78,3 +86,165 @@ test("handleJsonRpcRequest rejects invalid requests", async () => {
 
   await rm(root, { recursive: true, force: true });
 });
+
+test("server/discover matches legacy capability and tool declarations", async () => {
+  await withState("agt-opencode-mcp-discover-", async (state) => {
+    const initialize = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 10,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05" },
+    });
+    const listTools = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 11,
+      method: "tools/list",
+      params: {},
+    });
+    const discover = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 12,
+      method: "server/discover",
+      params: {},
+      _meta: STATELESS_META,
+    });
+
+    assert.equal(initialize.result.protocolVersion, "2024-11-05");
+    assert.equal(discover.result.protocolVersion, "2026-07-28");
+    assert.deepEqual(discover.result.capabilities, initialize.result.capabilities);
+    assert.deepEqual(discover.result.serverInfo, initialize.result.serverInfo);
+    assert.deepEqual(discover.result.tools, listTools.result.tools);
+    assert.equal("sessionId" in discover.result, false);
+  });
+});
+
+test("stateless tools/list validates per-request _meta", async () => {
+  await withState("agt-opencode-mcp-meta-list-", async (state) => {
+    const accepted = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 13,
+      method: "tools/list",
+      params: {},
+      _meta: STATELESS_META,
+    });
+    const rejected = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 14,
+      method: "tools/list",
+      params: {},
+      _meta: { capabilities: {} },
+    });
+
+    assert.deepEqual(accepted.result.tools.map(({ name }) => name), [
+      "agt_policy_status",
+      "agt_policy_check_text",
+    ]);
+    assert.equal(rejected.error.code, -32001);
+  });
+});
+
+test("stateless tools/call rejects missing caller identity after discovery", async () => {
+  await withState("agt-opencode-mcp-meta-deny-", async (state) => {
+    const discover = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 15,
+      method: "server/discover",
+      params: {},
+      _meta: STATELESS_META,
+    });
+    const rejected = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 16,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: { capabilities: {} },
+    });
+
+    assert.equal(discover.result.protocolVersion, "2026-07-28");
+    assert.equal(rejected.error.code, -32001);
+    assert.equal("result" in rejected, false);
+  });
+});
+
+test("stateless tools/call preserves caller context", async () => {
+  await withState("agt-opencode-mcp-meta-call-", async (state) => {
+    const response = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 17,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: STATELESS_META,
+    });
+
+    assert.deepEqual(response.result._meta, STATELESS_META);
+    assert.equal(response.result.isError, undefined);
+  });
+});
+
+test("legacy lifecycle remains compatible and terminal outcomes stay distinct", async () => {
+  await withState("agt-opencode-mcp-compat-", async (state) => {
+    const initialize = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 18,
+      method: "initialize",
+      params: { protocolVersion: "2024-11-05" },
+    });
+    const initialized = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    });
+    const compatibilityFallback = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 19,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+    });
+    const allow = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 20,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: STATELESS_META,
+    });
+    const deny = await handleJsonRpcRequest(state, {
+      jsonrpc: "2.0",
+      id: 21,
+      method: "tools/call",
+      params: {
+        name: "agt_policy_status",
+        arguments: {},
+      },
+      _meta: { capabilities: {} },
+    });
+
+    assert.equal(initialize.result.protocolVersion, "2024-11-05");
+    assert.equal(initialized, null);
+    assert.equal(compatibilityFallback.result.isError, undefined);
+    assert.notDeepEqual(allow.result, deny.error ?? deny.result);
+    assert.notDeepEqual(allow.result, compatibilityFallback.result);
+    assert.notDeepEqual(deny.error ?? deny.result, compatibilityFallback.result);
+  });
+});
+
+async function withState(prefix, callback) {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    const state = await loadPolicy({ auditPath: join(root, "audit.json") });
+    await callback(state);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
RFC #2597 is the scope authority for making the Claude Code, OpenCode, and Antigravity MCP servers stateless-first while preserving the legacy lifecycle.

This adds `server/discover` with the same capabilities, `serverInfo`, and full tool declaration as `initialize` plus `tools/list`, while `initialize` and `notifications/initialized` stay unchanged as compatibility paths.

The RFC answers my July scoping question: `_meta` is per-request across list/read/call, so these tool-only servers validate client info and capabilities on list/call, reject invalid stateless calls, and preserve valid caller context in the result.

One boundary worth naming: ADR 0027 identifies a stateless peer by the `MCP-Protocol-Version: 2026-07-28` transport header, and stdio has no equivalent, so these servers treat absent `_meta` as legacy and reject only `_meta` that is present and malformed — which is what this issue asks for, accepting stateless requests that carry `_meta`. Rejecting absent `_meta` would need a server-level stateless-only mode; say the word if you want that as a follow-up.

Each package keeps its own test idiom and its native gates pass: `npm run check` and `npm test` are green at 22, 30, and 27 tests for Claude Code, OpenCode, and Antigravity.

No protocol session state or identifier is added.

Closes #3131
