### PR TITLE
refactor(agent-hypervisor)!: make session methods synchronous

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -5,6 +5,46 @@ entries appear first.
 
 ---
 
+## Hypervisor session lifecycle methods are synchronous
+
+**Date:** TBD
+
+**Affected**
+
+- `agent-hypervisor` (`hypervisor.Hypervisor`)
+- callers of `create_session`, `join_session`, `activate_session`,
+  `terminate_session`, `verify_behavior`, and `monitor_sessions`
+
+**What changed**
+
+The following `Hypervisor` methods are now synchronous:
+
+- `create_session`
+- `join_session`
+- `activate_session`
+- `terminate_session`
+- `verify_behavior`
+- `monitor_sessions`
+
+They previously returned coroutines despite having no internal await points.
+They now return their result directly.
+
+**How to migrate**
+
+Remove `await` when calling these methods:
+
+```python
+session = hv.create_session(config=config, creator_did="did:mesh:admin")
+ring = hv.join_session(session.sso.session_id, "did:mesh:agent", sigma_raw=0.85)
+hv.activate_session(session.sso.session_id)
+hash_root = hv.terminate_session(session.sso.session_id)
+```
+
+Keep awaiting unrelated async APIs such as `SagaOrchestrator.execute_step` and
+`SagaOrchestrator.compensate`.
+
+---
+
 ## `HostSession.post_tool_call` and `pre_model_call` emit the adapter snapshot shape
 
 **Date:** TBD

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -63,6 +63,46 @@ against a patched server, by design.
 
 ---
 
+## Hypervisor session lifecycle methods are synchronous
+
+**Date:** TBD
+
+**Affected**
+
+- `agent-hypervisor` (`hypervisor.Hypervisor`)
+- callers of `create_session`, `join_session`, `activate_session`,
+  `terminate_session`, `verify_behavior`, and `monitor_sessions`
+
+**What changed**
+
+The following `Hypervisor` methods are now synchronous:
+
+- `create_session`
+- `join_session`
+- `activate_session`
+- `terminate_session`
+- `verify_behavior`
+- `monitor_sessions`
+
+They previously returned coroutines despite having no internal await points.
+They now return their result directly.
+
+**How to migrate**
+
+Remove `await` when calling these methods:
+
+```python
+session = hv.create_session(config=config, creator_did="did:mesh:admin")
+ring = hv.join_session(session.sso.session_id, "did:mesh:agent", sigma_raw=0.85)
+hv.activate_session(session.sso.session_id)
+hash_root = hv.terminate_session(session.sso.session_id)
+```
+
+Keep awaiting unrelated async APIs such as `SagaOrchestrator.execute_step` and
+`SagaOrchestrator.compensate`.
+
+---
+
 ## `HostSession.post_tool_call` and `pre_model_call` emit the adapter snapshot shape
 
 **Date:** TBD

--- a/agent-governance-python/agent-compliance/examples/governed_agent.py
+++ b/agent-governance-python/agent-compliance/examples/governed_agent.py
@@ -57,7 +57,7 @@ async def main():
     # --- Layer 3: Agent Runtime ---
     if HAS_RUNTIME:
         runtime = AgentRuntime()
-        session = await runtime.create_session(
+        session = runtime.create_session(
             config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL),
             creator_did=identity.did,
         )

--- a/agent-governance-python/agent-hypervisor/README.md
+++ b/agent-governance-python/agent-hypervisor/README.md
@@ -49,13 +49,13 @@ from hypervisor import Hypervisor, SessionConfig, ConsistencyMode
 hv = Hypervisor()
 
 # Create an isolated session with governance
-session = await hv.create_session(
+session = hv.create_session(
     config=SessionConfig(enable_audit=True),
     creator_did="did:mesh:admin",
 )
 
 # Agent joins, ring assigned automatically by trust score
-ring = await hv.join_session(
+ring = hv.join_session(
     session.sso.session_id,
     "did:mesh:agent-1",
     sigma_raw=0.85,
@@ -63,7 +63,7 @@ ring = await hv.join_session(
 # RING_2_STANDARD (trusted agent)
 
 # Activate and run a governed saga
-await hv.activate_session(session.sso.session_id)
+hv.activate_session(session.sso.session_id)
 saga = session.saga.create_saga(session.sso.session_id)
 step = session.saga.add_step(
     saga.saga_id, "draft_email", "did:mesh:agent-1",
@@ -75,7 +75,7 @@ result = await session.saga.execute_step(
 )
 
 # Terminate, returns tamper-evident audit hash
-hash_root = await hv.terminate_session(session.sso.session_id)
+hash_root = hv.terminate_session(session.sso.session_id)
 ```
 
 ## Configuration
@@ -98,7 +98,7 @@ hv = Hypervisor(
 )
 
 # Create a session with resource limits
-session = await hv.create_session(
+session = hv.create_session(
     config=SessionConfig(
         consistency_mode=ConsistencyMode.EVENTUAL,  # or STRONG
         max_participants=10,           # 1-1000
@@ -110,7 +110,7 @@ session = await hv.create_session(
 )
 
 # Agent joins, ring assigned by trust score
-ring = await hv.join_session(
+ring = hv.join_session(
     session.sso.session_id,
     "did:mesh:agent-1",
     sigma_raw=0.85,   # Raw trust score [0.0-1.0]
@@ -164,8 +164,8 @@ config = SessionConfig(
     enable_audit=True,
 )
 
-session = await hv.create_session(config=config, creator_did="did:mesh:admin")
-await hv.activate_session(session.sso.session_id)
+session = hv.create_session(config=config, creator_did="did:mesh:admin")
+hv.activate_session(session.sso.session_id)
 
 # Session lifecycle: CREATED -> HANDSHAKING -> ACTIVE -> TERMINATING -> ARCHIVED
 ```

--- a/agent-governance-python/agent-hypervisor/benchmarks/bench_hypervisor.py
+++ b/agent-governance-python/agent-hypervisor/benchmarks/bench_hypervisor.py
@@ -212,10 +212,10 @@ def bench_chain_verify():
 @benchmark_async("session_lifecycle", iterations=5000)
 async def bench_session_lifecycle():
     hv = Hypervisor()
-    s = await hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
-    await hv.join_session(s.sso.session_id, "did:mesh:a", sigma_raw=0.8)
-    await hv.activate_session(s.sso.session_id)
-    await hv.terminate_session(s.sso.session_id)
+    s = hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+    hv.join_session(s.sso.session_id, "did:mesh:a", sigma_raw=0.8)
+    hv.activate_session(s.sso.session_id)
+    hv.terminate_session(s.sso.session_id)
 
 
 # ---------------------------------------------------------------------------
@@ -245,12 +245,12 @@ async def bench_saga_3_steps():
 @benchmark_async("full_governance_pipeline", iterations=2000)
 async def bench_full_pipeline():
     hv = Hypervisor()
-    s = await hv.create_session(
+    s = hv.create_session(
         config=SessionConfig(enable_audit=True), creator_did="did:mesh:admin"
     )
     sid = s.sso.session_id
-    await hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
-    await hv.activate_session(sid)
+    hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
+    hv.activate_session(sid)
 
     # Capture deltas
     for i in range(3):
@@ -264,7 +264,7 @@ async def bench_full_pipeline():
     step = s.saga.add_step(saga.saga_id, "action", "did:mesh:a", "/api/action")
     await s.saga.execute_step(saga.saga_id, step.step_id, executor=lambda: asyncio.sleep(0))
 
-    await hv.terminate_session(sid)
+    hv.terminate_session(sid)
 
 
 # ---------------------------------------------------------------------------
@@ -277,24 +277,24 @@ async def bench_monitor_sessions():
     hv = Hypervisor()
     # Create 50 sessions: 40 active (healthy), 10 terminated
     for i in range(50):
-        s = await hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
-        await hv.join_session(s.sso.session_id, f"did:mesh:a{i}", sigma_raw=0.8)
-        await hv.activate_session(s.sso.session_id)
+        s = hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        hv.join_session(s.sso.session_id, f"did:mesh:a{i}", sigma_raw=0.8)
+        hv.activate_session(s.sso.session_id)
         if i >= 40:
-            await hv.terminate_session(s.sso.session_id)
-    await hv.monitor_sessions()
+            hv.terminate_session(s.sso.session_id)
+    hv.monitor_sessions()
 
 
 @benchmark_async("active_sessions_100", iterations=5000)
 async def bench_active_sessions():
     hv = Hypervisor()
     for i in range(100):
-        s = await hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
-        await hv.join_session(s.sso.session_id, f"did:mesh:a{i}", sigma_raw=0.8)
-        await hv.activate_session(s.sso.session_id)
+        s = hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        hv.join_session(s.sso.session_id, f"did:mesh:a{i}", sigma_raw=0.8)
+        hv.activate_session(s.sso.session_id)
         # Terminate half
         if i % 2 == 0:
-            await hv.terminate_session(s.sso.session_id)
+            hv.terminate_session(s.sso.session_id)
     _ = hv.active_sessions
 
 

--- a/agent-governance-python/agent-hypervisor/docs/api-reference.md
+++ b/agent-governance-python/agent-hypervisor/docs/api-reference.md
@@ -687,11 +687,11 @@ config = SessionConfig(
     min_eff_score=0.60,
     enable_audit=True,
 )
-managed = await hv.create_session(config=config, creator_did="did:example:alice")
+managed = hv.create_session(config=config, creator_did="did:example:alice")
 session_id = managed.sso.session_id
 
 # Join agents
-ring = await hv.join_session(
+ring = hv.join_session(
     session_id=session_id,
     agent_did="did:example:bob",
     sigma_raw=0.72,
@@ -699,8 +699,8 @@ ring = await hv.join_session(
 print(ring)  # ExecutionRing.RING_2_STANDARD
 
 # Activate and later terminate
-await hv.activate_session(session_id)
-hash_root = await hv.terminate_session(session_id)
+hv.activate_session(session_id)
+hash_root = hv.terminate_session(session_id)
 ```
 
 **Constructor Parameters**

--- a/agent-governance-python/agent-hypervisor/examples/demo.py
+++ b/agent-governance-python/agent-hypervisor/examples/demo.py
@@ -71,25 +71,25 @@ async def demo_session_lifecycle() -> None:
         enable_audit=True,
         consistency_mode=ConsistencyMode.EVENTUAL,
     )
-    session = await hv.create_session(config, creator_did="did:mesh:admin")
+    session = hv.create_session(config, creator_did="did:mesh:admin")
     step(f"Session created: {session.sso.session_id[:16]}...")
 
     # Join agents with different trust scores
-    ring_high = await hv.join_session(
+    ring_high = hv.join_session(
         session.sso.session_id,
         "did:mesh:trusted-agent",
         sigma_raw=0.95,
     )
     step(f"Trusted agent -> {ring_high.name} (sigma=0.95)")
 
-    ring_mid = await hv.join_session(
+    ring_mid = hv.join_session(
         session.sso.session_id,
         "did:mesh:standard-agent",
         sigma_raw=0.65,
     )
     step(f"Standard agent -> {ring_mid.name} (sigma=0.65)")
 
-    ring_low = await hv.join_session(
+    ring_low = hv.join_session(
         session.sso.session_id,
         "did:mesh:sandbox-agent",
         sigma_raw=0.20,
@@ -97,7 +97,7 @@ async def demo_session_lifecycle() -> None:
     step(f"Sandbox agent -> {ring_low.name} (sigma=0.20)")
 
     # Activate
-    await hv.activate_session(session.sso.session_id)
+    hv.activate_session(session.sso.session_id)
     step(f"Session activated -- {len(session.sso.participants)} participants")
 
     # Capture some deltas for the audit trail
@@ -116,7 +116,7 @@ async def demo_session_lifecycle() -> None:
     step("Delta captured: /workspace/report.md")
 
     # Terminate and get the audit hash root
-    hash_chain_root = await hv.terminate_session(session.sso.session_id)
+    hash_chain_root = hv.terminate_session(session.sso.session_id)
     step(f"Session terminated -- audit log root: {hash_chain_root[:16]}...")
 
     print(f"\n  {BOLD}Ring assignments show trust-based isolation:{RESET}")
@@ -133,9 +133,9 @@ async def demo_saga() -> None:
 
     hv = Hypervisor()
     config = SessionConfig(enable_audit=True)
-    session = await hv.create_session(config, creator_did="did:mesh:admin")
-    await hv.join_session(session.sso.session_id, "did:mesh:worker", sigma_raw=0.85)
-    await hv.activate_session(session.sso.session_id)
+    session = hv.create_session(config, creator_did="did:mesh:admin")
+    hv.join_session(session.sso.session_id, "did:mesh:worker", sigma_raw=0.85)
+    hv.activate_session(session.sso.session_id)
 
     saga_orch = session.saga
 
@@ -193,10 +193,10 @@ async def demo_audit() -> None:
 
     hv = Hypervisor()
     config = SessionConfig(enable_audit=True)
-    session = await hv.create_session(config, creator_did="did:mesh:admin")
-    await hv.join_session(session.sso.session_id, "did:mesh:agent-a", sigma_raw=0.80)
-    await hv.join_session(session.sso.session_id, "did:mesh:agent-b", sigma_raw=0.75)
-    await hv.activate_session(session.sso.session_id)
+    session = hv.create_session(config, creator_did="did:mesh:admin")
+    hv.join_session(session.sso.session_id, "did:mesh:agent-a", sigma_raw=0.80)
+    hv.join_session(session.sso.session_id, "did:mesh:agent-b", sigma_raw=0.75)
+    hv.activate_session(session.sso.session_id)
 
     # Agents make changes
     changes = [
@@ -222,7 +222,7 @@ async def demo_audit() -> None:
 
     step(f"Total deltas: {session.delta_engine.turn_count}")
 
-    audit_log = await hv.terminate_session(session.sso.session_id)
+    audit_log = hv.terminate_session(session.sso.session_id)
     step(f"audit log root: {audit_log}")
 
     print(f"\n  {BOLD}Audit guarantees:{RESET}")
@@ -282,24 +282,24 @@ async def demo_integrations() -> None:
     hv = Hypervisor(nexus=nexus, policy_check=policy_check, iatp=iatp)
 
     config = SessionConfig(enable_audit=True)
-    session = await hv.create_session(config, creator_did="did:mesh:admin")
+    session = hv.create_session(config, creator_did="did:mesh:admin")
 
     # Join with Nexus auto-resolution
-    ring_verified = await hv.join_session(
+    ring_verified = hv.join_session(
         session.sso.session_id,
         "did:mesh:verified",
         agent_history={"tasks_completed": 500, "violations": 0},
     )
     step(f"Verified partner -> {ring_verified.name} (Nexus score: 920)")
 
-    ring_standard = await hv.join_session(
+    ring_standard = hv.join_session(
         session.sso.session_id,
         "did:mesh:standard",
         agent_history={"tasks_completed": 50, "violations": 2},
     )
     step(f"Standard agent -> {ring_standard.name} (Nexus score: 650)")
 
-    ring_unknown = await hv.join_session(
+    ring_unknown = hv.join_session(
         session.sso.session_id,
         "did:mesh:unknown",
     )
@@ -312,7 +312,7 @@ async def demo_integrations() -> None:
         "trust_level": "standard",
         "reversibility": {"write_file": "reversible", "execute_code": "non_reversible"},
     }
-    ring_manifest = await hv.join_session(
+    ring_manifest = hv.join_session(
         session.sso.session_id,
         "did:mesh:manifest-agent",
         manifest=manifest,

--- a/agent-governance-python/agent-hypervisor/examples/docker-compose/app/server.py
+++ b/agent-governance-python/agent-hypervisor/examples/docker-compose/app/server.py
@@ -129,7 +129,7 @@ async def lifespan(app: FastAPI):  # type: ignore[no-untyped-def]
         min_eff_score=hv_cfg.get("min_eff_score", 0.60),
         enable_audit=hv_cfg.get("enable_audit", True),
     )
-    managed = await _hypervisor.create_session(
+    managed = _hypervisor.create_session(
         config=session_config, creator_did="did:mesh:hypervisor"
     )
     _session_id = managed.sso.session_id
@@ -179,7 +179,7 @@ async def register_agent(req: RegisterAgentRequest) -> AgentInfo:
         raise HTTPException(status_code=503, detail="Hypervisor not initialized")
 
     try:
-        ring = await _hypervisor.join_session(
+        ring = _hypervisor.join_session(
             session_id=_session_id,
             agent_did=req.agent_did,
             sigma_raw=req.sigma_raw,

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/api/server.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/api/server.py
@@ -211,7 +211,7 @@ async def create_session(req: CreateSessionRequest) -> CreateSessionResponse:
         min_eff_score=req.min_eff_score,
         enable_audit=req.enable_audit,
     )
-    managed = await _hv().create_session(config=config, creator_did=req.creator_did)
+    managed = _hv().create_session(config=config, creator_did=req.creator_did)
     return CreateSessionResponse(
         session_id=managed.sso.session_id,
         state=managed.sso.state.value,
@@ -275,7 +275,7 @@ async def join_session(session_id: str, req: JoinSessionRequest) -> JoinSessionR
     if req.actions:
         actions = [ActionDescriptor(**a) for a in req.actions]
     try:
-        ring = await hv.join_session(
+        ring = hv.join_session(
             session_id=session_id,
             agent_did=req.agent_did,
             actions=actions,
@@ -298,7 +298,7 @@ async def join_session(session_id: str, req: JoinSessionRequest) -> JoinSessionR
 async def activate_session(session_id: str) -> dict[str, str]:
     """Activate a session after handshaking is complete."""
     try:
-        await _hv().activate_session(session_id)
+        _hv().activate_session(session_id)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:
@@ -311,7 +311,7 @@ async def activate_session(session_id: str) -> dict[str, str]:
 async def terminate_session(session_id: str) -> dict[str, Any]:
     """Terminate a session and commit audit trail."""
     try:
-        hash_chain_root = await _hv().terminate_session(session_id)
+        hash_chain_root = _hv().terminate_session(session_id)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/core.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/core.py
@@ -54,8 +54,8 @@ class Hypervisor:
 
     Usage (basic — sigma_raw passed directly):
         hv = Hypervisor()
-        session = await hv.create_session(config, creator_did="did:mesh:admin")
-        await hv.join_session(session.sso.session_id, "did:mesh:agent-1", sigma_raw=0.85)
+        session = hv.create_session(config, creator_did="did:mesh:admin")
+        hv.join_session(session.sso.session_id, "did:mesh:agent-1", sigma_raw=0.85)
 
     Usage (enriched — adapters resolve sigma and parse manifests):
         hv = Hypervisor(
@@ -89,7 +89,7 @@ class Hypervisor:
         # Index of session IDs still requiring monitoring (non-archived/terminating)
         self._active_ids: set[str] = set()
 
-    async def create_session(
+    def create_session(
         self,
         config: SessionConfig,
         creator_did: str,
@@ -102,7 +102,7 @@ class Hypervisor:
         self._active_ids.add(sso.session_id)
         return managed
 
-    async def join_session(
+    def join_session(
         self,
         session_id: str,
         agent_did: str,
@@ -183,12 +183,12 @@ class Hypervisor:
 
         return ring
 
-    async def activate_session(self, session_id: str) -> None:
+    def activate_session(self, session_id: str) -> None:
         """Activate a session after handshaking is complete."""
         managed = self._get_session(session_id)
         managed.sso.activate()
 
-    async def terminate_session(self, session_id: str) -> str | None:
+    def terminate_session(self, session_id: str) -> str | None:
         """
         Terminate a session and finalize the audit hash chain.
 
@@ -218,7 +218,7 @@ class Hypervisor:
     def get_session(self, session_id: str) -> ManagedSession | None:
         return self._sessions.get(session_id)
 
-    async def verify_behavior(
+    def verify_behavior(
         self,
         session_id: str,
         agent_did: str,
@@ -292,7 +292,7 @@ class Hypervisor:
             raise ValueError(f"Session {session_id} not found")
         return managed
 
-    async def monitor_sessions(
+    def monitor_sessions(
         self,
         drift_threshold: float = 0.5,
     ) -> list[dict[str, Any]]:

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
@@ -124,8 +124,11 @@ class SagaOrchestrator:
             step.retry_count = attempt
             step.transition(StepState.EXECUTING)
             try:
+                execution = executor()
+                self._ensure_awaitable(execution, "executor")
+
                 result = await asyncio.wait_for(
-                    executor(),
+                    execution,
                     timeout=step.timeout_seconds,
                 )
                 step.execute_result = result
@@ -190,8 +193,11 @@ class SagaOrchestrator:
 
             step.transition(StepState.COMPENSATING)
             try:
+                compensation = compensator(step)
+                self._ensure_awaitable(compensation, "compensator")
+
                 result = await asyncio.wait_for(
-                    compensator(step),
+                    compensation,
                     timeout=step.timeout_seconds,
                 )
                 step.compensation_result = result
@@ -228,6 +234,10 @@ class SagaOrchestrator:
             for s in self._sagas.values()
             if s.state in (SagaState.RUNNING, SagaState.COMPENSATING)
         ]
+
+    def _ensure_awaitable(self, result: Any, name: str) -> None:
+        if not asyncio.isfuture(result) and not asyncio.iscoroutine(result):
+            raise TypeError(f"{name} must return an awaitable")
 
     def _get_saga(self, saga_id: str) -> Saga:
         saga = self._sagas.get(saga_id)

--- a/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
+++ b/agent-governance-python/agent-hypervisor/src/hypervisor/saga/orchestrator.py
@@ -10,6 +10,7 @@ Sequential step execution with reverse-order compensation on failure.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -119,14 +120,16 @@ class SagaOrchestrator:
 
         last_error: Exception | None = None
         attempts = 1 + step.max_retries
+        execution = executor()
+        self._ensure_awaitable(execution, "executor")
 
         for attempt in range(attempts):
+            if attempt > 0:
+                execution = executor()
+                self._ensure_awaitable(execution, "executor")
             step.retry_count = attempt
             step.transition(StepState.EXECUTING)
             try:
-                execution = executor()
-                self._ensure_awaitable(execution, "executor")
-
                 result = await asyncio.wait_for(
                     execution,
                     timeout=step.timeout_seconds,
@@ -192,10 +195,9 @@ class SagaOrchestrator:
                 continue
 
             step.transition(StepState.COMPENSATING)
+            compensation = compensator(step)
+            self._ensure_awaitable(compensation, "compensator")
             try:
-                compensation = compensator(step)
-                self._ensure_awaitable(compensation, "compensator")
-
                 result = await asyncio.wait_for(
                     compensation,
                     timeout=step.timeout_seconds,
@@ -236,7 +238,7 @@ class SagaOrchestrator:
         ]
 
     def _ensure_awaitable(self, result: Any, name: str) -> None:
-        if not asyncio.isfuture(result) and not asyncio.iscoroutine(result):
+        if not inspect.isawaitable(result):
             raise TypeError(f"{name} must return an awaitable")
 
     def _get_saga(self, saga_id: str) -> Saga:

--- a/agent-governance-python/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
+++ b/agent-governance-python/agent-hypervisor/tests/integration/test_hypervisor_e2e.py
@@ -41,7 +41,7 @@ class TestFullLifecycle:
 
     async def test_complete_session_lifecycle(self):
         """Happy path: create, join two agents, activate, terminate with audit."""
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(
                 consistency_mode=ConsistencyMode.EVENTUAL,
                 max_participants=5,
@@ -53,13 +53,13 @@ class TestFullLifecycle:
         sid = session.sso.session_id
 
         # Join two agents
-        ring_a = await self.hv.join_session(sid, "did:mesh:agent-alpha", sigma_raw=0.85)
-        ring_b = await self.hv.join_session(sid, "did:mesh:agent-beta", sigma_raw=0.45)
+        ring_a = self.hv.join_session(sid, "did:mesh:agent-alpha", sigma_raw=0.85)
+        ring_b = self.hv.join_session(sid, "did:mesh:agent-beta", sigma_raw=0.45)
         assert ring_a == ExecutionRing.RING_2_STANDARD
         assert ring_b == ExecutionRing.RING_3_SANDBOX
 
         # Activate
-        await self.hv.activate_session(sid)
+        self.hv.activate_session(sid)
 
         # Capture some audit deltas
         session.delta_engine.capture(
@@ -72,29 +72,29 @@ class TestFullLifecycle:
         )
 
         # Terminate — should get audit log root
-        hash_chain_root = await self.hv.terminate_session(sid)
+        hash_chain_root = self.hv.terminate_session(sid)
         assert hash_chain_root is not None
         assert len(hash_chain_root) == 64  # SHA-256 hex
 
     async def test_session_without_audit(self):
         """Session with audit disabled returns None audit log root."""
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(enable_audit=False),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
-        await self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.7)
-        await self.hv.activate_session(sid)
-        hash_chain_root = await self.hv.terminate_session(sid)
+        self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.7)
+        self.hv.activate_session(sid)
+        hash_chain_root = self.hv.terminate_session(sid)
         assert hash_chain_root is None
 
     async def test_multiple_concurrent_sessions(self):
         """Multiple sessions can run independently."""
-        s1 = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
-        s2 = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        s1 = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        s2 = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
 
-        await self.hv.join_session(s1.sso.session_id, "did:mesh:a", sigma_raw=0.8)
-        await self.hv.join_session(s2.sso.session_id, "did:mesh:b", sigma_raw=0.9)
+        self.hv.join_session(s1.sso.session_id, "did:mesh:a", sigma_raw=0.8)
+        self.hv.join_session(s2.sso.session_id, "did:mesh:b", sigma_raw=0.9)
 
         assert len(self.hv.active_sessions) == 2
         assert s1.sso.session_id != s2.sso.session_id
@@ -114,18 +114,18 @@ class TestRingEnforcementIntegration:
         self.hv = Hypervisor()
 
     async def test_high_score_gets_standard_ring(self):
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
-        ring = await self.hv.join_session(session.sso.session_id, "did:mesh:expert", sigma_raw=0.85)
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        ring = self.hv.join_session(session.sso.session_id, "did:mesh:expert", sigma_raw=0.85)
         assert ring == ExecutionRing.RING_2_STANDARD
 
     async def test_low_score_gets_sandbox(self):
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
-        ring = await self.hv.join_session(session.sso.session_id, "did:mesh:newbie", sigma_raw=0.3)
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        ring = self.hv.join_session(session.sso.session_id, "did:mesh:newbie", sigma_raw=0.3)
         assert ring == ExecutionRing.RING_3_SANDBOX
 
     async def test_non_reversible_action_forces_strong_mode(self):
         """Joining with non-reversible actions forces STRONG consistency."""
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL),
             creator_did="did:mesh:admin",
         )
@@ -137,7 +137,7 @@ class TestRingEnforcementIntegration:
                 reversibility=ReversibilityLevel.NONE,
             )
         ]
-        await self.hv.join_session(
+        self.hv.join_session(
             session.sso.session_id,
             "did:mesh:agent",
             actions=actions,
@@ -163,7 +163,7 @@ class TestSagaIntegration:
 
     async def test_saga_happy_path(self):
         """Multi-step saga executes all steps successfully."""
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
         saga = session.saga.create_saga(session.sso.session_id)
 
         step1 = session.saga.add_step(
@@ -185,7 +185,7 @@ class TestSagaIntegration:
 
     async def test_saga_timeout_triggers_failure(self):
         """Step that exceeds timeout is marked as failed."""
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
         saga = session.saga.create_saga(session.sso.session_id)
 
         step = session.saga.add_step(
@@ -205,7 +205,7 @@ class TestSagaIntegration:
 
     async def test_saga_retry_on_failure(self):
         """Step retries on transient failure and eventually succeeds."""
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
         saga = session.saga.create_saga(session.sso.session_id)
 
         step = session.saga.add_step(
@@ -235,7 +235,7 @@ class TestSagaIntegration:
 
     async def test_saga_compensation_on_failure(self):
         """Failed step triggers compensation of all committed steps."""
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
         saga = session.saga.create_saga(session.sso.session_id)
 
         step1 = session.saga.add_step(
@@ -278,7 +278,7 @@ class TestSagaIntegration:
 
     async def test_saga_escalation_on_compensation_failure(self):
         """Failed compensation escalates for manual intervention."""
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
         saga = session.saga.create_saga(session.sso.session_id)
 
         step1 = session.saga.add_step(
@@ -315,13 +315,13 @@ class TestAuditTrailIntegration:
         self.hv = Hypervisor()
 
     async def test_audit_trail_captures_all_turns(self):
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(enable_audit=True),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
-        await self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
-        await self.hv.activate_session(sid)
+        self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
+        self.hv.activate_session(sid)
 
         # Capture 5 turns
         for i in range(5):
@@ -335,7 +335,7 @@ class TestAuditTrailIntegration:
 
     async def test_hash_chain_integrity(self):
         """Public Preview: no chain verification, always returns True."""
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
         for i in range(10):
             session.delta_engine.capture(
                 f"did:mesh:agent-{i % 3}",
@@ -352,7 +352,7 @@ class TestAuditTrailIntegration:
 
     async def test_hash_chain_root_deterministic(self):
         """Same session with same deltas produces consistent audit log roots."""
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
 
         # Capture deltas
         session.delta_engine.capture(
@@ -388,22 +388,22 @@ class TestEdgeCases:
 
     async def test_cannot_join_nonexistent_session(self):
         with pytest.raises(ValueError, match="not found"):
-            await self.hv.join_session("fake-session", "did:mesh:a", sigma_raw=0.8)
+            self.hv.join_session("fake-session", "did:mesh:a", sigma_raw=0.8)
 
     async def test_duplicate_agent_rejected(self):
-        session = await self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
+        session = self.hv.create_session(config=SessionConfig(), creator_did="did:mesh:admin")
         sid = session.sso.session_id
-        await self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
+        self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
         with pytest.raises(Exception):
-            await self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
+            self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
 
     async def test_max_participants_enforced(self):
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(max_participants=2),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
-        await self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
-        await self.hv.join_session(sid, "did:mesh:b", sigma_raw=0.7)
+        self.hv.join_session(sid, "did:mesh:a", sigma_raw=0.8)
+        self.hv.join_session(sid, "did:mesh:b", sigma_raw=0.7)
         with pytest.raises(Exception):
-            await self.hv.join_session(sid, "did:mesh:c", sigma_raw=0.6)
+            self.hv.join_session(sid, "did:mesh:c", sigma_raw=0.6)

--- a/agent-governance-python/agent-hypervisor/tests/integration/test_scenarios.py
+++ b/agent-governance-python/agent-hypervisor/tests/integration/test_scenarios.py
@@ -225,11 +225,11 @@ class TestIATPManifestOnboarding:
         assert sigma == 0.95  # 950 / 1000
 
         # Join session with Nexus-enriched sigma
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(max_participants=5),
             creator_did="did:mesh:admin",
         )
-        ring = await self.hv.join_session(
+        ring = self.hv.join_session(
             session.sso.session_id,
             "did:mesh:partner-agent",
             actions=analysis.actions,
@@ -266,11 +266,11 @@ class TestIATPManifestOnboarding:
         )
         assert sigma == 0.40
 
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(),
             creator_did="did:mesh:admin",
         )
-        ring = await self.hv.join_session(
+        ring = self.hv.join_session(
             session.sso.session_id,
             "did:mesh:new-agent",
             actions=analysis.actions,
@@ -299,11 +299,11 @@ class TestIATPManifestOnboarding:
         analysis = self.iatp.analyze_manifest_dict(manifest)
         assert analysis.has_non_reversible_actions is True
 
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL),
             creator_did="did:mesh:admin",
         )
-        await self.hv.join_session(
+        self.hv.join_session(
             session.sso.session_id,
             "did:mesh:admin-agent",
             actions=analysis.actions,
@@ -396,14 +396,14 @@ class TestFullGovernancePipeline:
             history=AgentHistory(agent_did),
         )
 
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(enable_audit=True),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
 
-        await self.hv.join_session(sid, agent_did, sigma_raw=sigma)
-        await self.hv.activate_session(sid)
+        self.hv.join_session(sid, agent_did, sigma_raw=sigma)
+        self.hv.activate_session(sid)
 
         # All verification checks pass
         for i in range(5):
@@ -435,7 +435,7 @@ class TestFullGovernancePipeline:
             ],
         )
 
-        hash_chain_root = await self.hv.terminate_session(sid)
+        hash_chain_root = self.hv.terminate_session(sid)
         assert hash_chain_root is not None
 
 
@@ -626,7 +626,7 @@ class TestWiredHypervisor:
 
     async def test_join_with_manifest_auto_parses(self):
         """Providing a manifest dict auto-parses actions and sigma."""
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(max_participants=5),
             creator_did="did:mesh:admin",
         )
@@ -648,7 +648,7 @@ class TestWiredHypervisor:
             "scopes": ["data"],
         }
 
-        ring = await self.hv.join_session(
+        ring = self.hv.join_session(
             sid,
             "did:mesh:alice",
             manifest=manifest,
@@ -661,13 +661,13 @@ class TestWiredHypervisor:
 
     async def test_nexus_auto_resolves_sigma_when_zero(self):
         """When sigma_raw=0 and no manifest, Nexus resolves sigma."""
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(max_participants=5),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
 
-        ring = await self.hv.join_session(
+        ring = self.hv.join_session(
             sid,
             "did:mesh:alice",
             agent_history=AgentHistory("did:mesh:alice"),
@@ -677,14 +677,14 @@ class TestWiredHypervisor:
 
     async def test_nexus_conservative_merge(self):
         """When both sigma_raw and Nexus are available, uses lower (conservative)."""
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(max_participants=5),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
 
         # sigma_raw=0.95, Nexus=0.85 → min=0.85
-        ring = await self.hv.join_session(
+        ring = self.hv.join_session(
             sid,
             "did:mesh:alice",
             sigma_raw=0.95,
@@ -694,17 +694,17 @@ class TestWiredHypervisor:
 
     async def test_verify_behavior_returns_clean_result(self):
         """verify_behavior() returns a passing result for clean output."""
-        session = await self.hv.create_session(
+        session = self.hv.create_session(
             config=SessionConfig(max_participants=5),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
 
-        await self.hv.join_session(sid, "did:mesh:alice", sigma_raw=0.85)
-        await self.hv.activate_session(sid)
+        self.hv.join_session(sid, "did:mesh:alice", sigma_raw=0.85)
+        self.hv.activate_session(sid)
 
         self.verification_backend.set_drift("did:mesh:alice", 0.02)
-        result = await self.hv.verify_behavior(
+        result = self.hv.verify_behavior(
             session_id=sid,
             agent_did="did:mesh:alice",
             claimed_embedding="did:mesh:alice",
@@ -717,15 +717,15 @@ class TestWiredHypervisor:
     async def test_verify_behavior_returns_none_without_verifier(self):
         """Without Verification adapter, verify_behavior returns None."""
         hv_no_verifier = Hypervisor()
-        session = await hv_no_verifier.create_session(
+        session = hv_no_verifier.create_session(
             config=SessionConfig(max_participants=5),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
-        await hv_no_verifier.join_session(sid, "did:mesh:alice", sigma_raw=0.85)
-        await hv_no_verifier.activate_session(sid)
+        hv_no_verifier.join_session(sid, "did:mesh:alice", sigma_raw=0.85)
+        hv_no_verifier.activate_session(sid)
 
-        result = await hv_no_verifier.verify_behavior(
+        result = hv_no_verifier.verify_behavior(
             session_id=sid,
             agent_did="did:mesh:alice",
             claimed_embedding="a",
@@ -736,13 +736,13 @@ class TestWiredHypervisor:
     async def test_backward_compat_no_adapters(self):
         """Hypervisor without adapters works exactly as before."""
         hv = Hypervisor()
-        session = await hv.create_session(
+        session = hv.create_session(
             config=SessionConfig(max_participants=5),
             creator_did="did:mesh:admin",
         )
         sid = session.sso.session_id
 
-        ring = await hv.join_session(sid, "did:mesh:alice", sigma_raw=0.85)
+        ring = hv.join_session(sid, "did:mesh:alice", sigma_raw=0.85)
         assert ring == ExecutionRing.RING_2_STANDARD
         assert hv.nexus is None
         assert hv.policy_check is None

--- a/agent-governance-python/agent-hypervisor/tests/test_agent_manager.py
+++ b/agent-governance-python/agent-hypervisor/tests/test_agent_manager.py
@@ -55,7 +55,7 @@ AGENT_2 = "did:mesh:agent-2"
 
 class TestManagedSession:
     async def test_managed_session_has_subsystems(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         assert managed.sso is not None
         assert managed.reversibility is not None
         assert managed.delta_engine is not None
@@ -69,18 +69,18 @@ class TestManagedSession:
 
 class TestCreateSession:
     async def test_creates_session(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         assert isinstance(managed, ManagedSession)
         assert managed.sso.state == SessionState.HANDSHAKING
         assert managed.sso.creator_did == CREATOR
 
     async def test_session_stored_internally(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         assert hypervisor.get_session(managed.sso.session_id) is managed
 
     async def test_create_multiple_sessions(self, hypervisor, config):
-        s1 = await hypervisor.create_session(config, creator_did=CREATOR)
-        s2 = await hypervisor.create_session(config, creator_did=CREATOR)
+        s1 = hypervisor.create_session(config, creator_did=CREATOR)
+        s2 = hypervisor.create_session(config, creator_did=CREATOR)
         assert s1.sso.session_id != s2.sso.session_id
         assert len(hypervisor._sessions) == 2
 
@@ -92,8 +92,8 @@ class TestCreateSession:
 
 class TestJoinSession:
     async def test_join_with_high_sigma(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        ring = await hypervisor.join_session(
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        ring = hypervisor.join_session(
             managed.sso.session_id,
             AGENT_1,
             sigma_raw=0.85,
@@ -102,8 +102,8 @@ class TestJoinSession:
         assert managed.sso.participant_count == 1
 
     async def test_join_with_low_sigma_gets_sandbox(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        ring = await hypervisor.join_session(
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        ring = hypervisor.join_session(
             managed.sso.session_id,
             AGENT_1,
             sigma_raw=0.30,
@@ -111,17 +111,17 @@ class TestJoinSession:
         assert ring == ExecutionRing.RING_3_SANDBOX
 
     async def test_join_multiple_agents(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_2, sigma_raw=0.70)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.join_session(managed.sso.session_id, AGENT_2, sigma_raw=0.70)
         assert managed.sso.participant_count == 2
 
     async def test_join_nonexistent_session_raises(self, hypervisor):
         with pytest.raises(ValueError, match="not found"):
-            await hypervisor.join_session("session:nonexistent", AGENT_1, sigma_raw=0.5)
+            hypervisor.join_session("session:nonexistent", AGENT_1, sigma_raw=0.5)
 
     async def test_join_with_non_reversible_actions_forces_strong(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         actions = [
             ActionDescriptor(
                 action_id="delete-db",
@@ -131,7 +131,7 @@ class TestJoinSession:
                 is_read_only=False,
             ),
         ]
-        await hypervisor.join_session(
+        hypervisor.join_session(
             managed.sso.session_id,
             AGENT_1,
             actions=actions,
@@ -140,7 +140,7 @@ class TestJoinSession:
         assert managed.sso.consistency_mode == ConsistencyMode.STRONG
 
     async def test_join_with_reversible_actions_keeps_eventual(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         actions = [
             ActionDescriptor(
                 action_id="update-rec",
@@ -150,7 +150,7 @@ class TestJoinSession:
                 reversibility=ReversibilityLevel.FULL,
             ),
         ]
-        await hypervisor.join_session(
+        hypervisor.join_session(
             managed.sso.session_id,
             AGENT_1,
             actions=actions,
@@ -160,8 +160,8 @@ class TestJoinSession:
 
     async def test_join_with_zero_sigma_no_nexus(self, hypervisor, config):
         """Zero sigma with no Nexus adapter → eff_score stays 0 → sandbox."""
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        ring = await hypervisor.join_session(
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        ring = hypervisor.join_session(
             managed.sso.session_id,
             AGENT_1,
             sigma_raw=0.0,
@@ -179,9 +179,9 @@ class TestJoinSessionWithAdapters:
         nexus = MagicMock()
         nexus.resolve_sigma.return_value = 0.90
         hv = Hypervisor(nexus=nexus)
-        managed = await hv.create_session(config, creator_did=CREATOR)
+        managed = hv.create_session(config, creator_did=CREATOR)
 
-        ring = await hv.join_session(
+        ring = hv.join_session(
             managed.sso.session_id,
             AGENT_1,
             sigma_raw=0.0,
@@ -194,9 +194,9 @@ class TestJoinSessionWithAdapters:
         nexus = MagicMock()
         nexus.resolve_sigma.return_value = 0.50  # lower than raw
         hv = Hypervisor(nexus=nexus)
-        managed = await hv.create_session(config, creator_did=CREATOR)
+        managed = hv.create_session(config, creator_did=CREATOR)
 
-        ring = await hv.join_session(
+        ring = hv.join_session(
             managed.sso.session_id,
             AGENT_1,
             sigma_raw=0.85,
@@ -220,8 +220,8 @@ class TestJoinSessionWithAdapters:
         iatp.analyze_manifest_dict.return_value = analysis
 
         hv = Hypervisor(iatp=iatp)
-        managed = await hv.create_session(config, creator_did=CREATOR)
-        ring = await hv.join_session(
+        managed = hv.create_session(config, creator_did=CREATOR)
+        ring = hv.join_session(
             managed.sso.session_id,
             AGENT_1,
             manifest={"cap": "test"},
@@ -240,8 +240,8 @@ class TestJoinSessionWithAdapters:
         manifest_obj = MagicMock()  # not a dict
 
         hv = Hypervisor(iatp=iatp)
-        managed = await hv.create_session(config, creator_did=CREATOR)
-        await hv.join_session(
+        managed = hv.create_session(config, creator_did=CREATOR)
+        hv.join_session(
             managed.sso.session_id,
             AGENT_1,
             manifest=manifest_obj,
@@ -257,19 +257,19 @@ class TestJoinSessionWithAdapters:
 
 class TestActivateSession:
     async def test_activate_after_join(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.activate_session(managed.sso.session_id)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.activate_session(managed.sso.session_id)
         assert managed.sso.state == SessionState.ACTIVE
 
     async def test_activate_nonexistent_raises(self, hypervisor):
         with pytest.raises(ValueError, match="not found"):
-            await hypervisor.activate_session("session:bogus")
+            hypervisor.activate_session("session:bogus")
 
     async def test_activate_without_participants_raises(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         with pytest.raises(Exception):
-            await hypervisor.activate_session(managed.sso.session_id)
+            hypervisor.activate_session(managed.sso.session_id)
 
 
 # ---------------------------------------------------------------------------
@@ -279,32 +279,32 @@ class TestActivateSession:
 
 class TestTerminateSession:
     async def _create_active_session(self, hv, cfg):
-        managed = await hv.create_session(cfg, creator_did=CREATOR)
-        await hv.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hv.activate_session(managed.sso.session_id)
+        managed = hv.create_session(cfg, creator_did=CREATOR)
+        hv.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hv.activate_session(managed.sso.session_id)
         return managed
 
     async def test_terminate_archives(self, hypervisor, config):
         managed = await self._create_active_session(hypervisor, config)
-        await hypervisor.terminate_session(managed.sso.session_id)
+        hypervisor.terminate_session(managed.sso.session_id)
         assert managed.sso.state == SessionState.ARCHIVED
 
     async def test_terminate_returns_hash_when_audit_enabled(self, hypervisor, config):
         managed = await self._create_active_session(hypervisor, config)
         # Record a delta so hash chain root is non-empty
         managed.delta_engine.capture(agent_did=AGENT_1, changes=[])
-        result = await hypervisor.terminate_session(managed.sso.session_id)
+        result = hypervisor.terminate_session(managed.sso.session_id)
         assert result is not None
         assert managed.sso.state == SessionState.ARCHIVED
 
     async def test_terminate_no_audit_returns_none(self, hypervisor, config_no_audit):
         managed = await self._create_active_session(hypervisor, config_no_audit)
-        result = await hypervisor.terminate_session(managed.sso.session_id)
+        result = hypervisor.terminate_session(managed.sso.session_id)
         assert result is None
 
     async def test_terminate_nonexistent_raises(self, hypervisor):
         with pytest.raises(ValueError, match="not found"):
-            await hypervisor.terminate_session("session:ghost")
+            hypervisor.terminate_session("session:ghost")
 
 # ---------------------------------------------------------------------------
 # get_session / _get_session
@@ -313,7 +313,7 @@ class TestTerminateSession:
 
 class TestGetSession:
     async def test_get_existing(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         assert hypervisor.get_session(managed.sso.session_id) is managed
 
     def test_get_nonexistent_returns_none(self, hypervisor):
@@ -334,23 +334,23 @@ class TestActiveSessions:
         assert hypervisor.active_sessions == []
 
     async def test_includes_handshaking(self, hypervisor, config):
-        await hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.create_session(config, creator_did=CREATOR)
         assert len(hypervisor.active_sessions) == 1
 
     async def test_excludes_archived(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.activate_session(managed.sso.session_id)
-        await hypervisor.terminate_session(managed.sso.session_id)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.activate_session(managed.sso.session_id)
+        hypervisor.terminate_session(managed.sso.session_id)
         assert len(hypervisor.active_sessions) == 0
 
     async def test_mixed_states(self, hypervisor, config):
-        s1 = await hypervisor.create_session(config, creator_did=CREATOR)
-        s2 = await hypervisor.create_session(config, creator_did=CREATOR)
+        s1 = hypervisor.create_session(config, creator_did=CREATOR)
+        s2 = hypervisor.create_session(config, creator_did=CREATOR)
         # Terminate s1
-        await hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.activate_session(s1.sso.session_id)
-        await hypervisor.terminate_session(s1.sso.session_id)
+        hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.activate_session(s1.sso.session_id)
+        hypervisor.terminate_session(s1.sso.session_id)
         # s2 still handshaking
         active = hypervisor.active_sessions
         assert len(active) == 1
@@ -374,11 +374,11 @@ class TestSessionsAccessor:
         assert hypervisor.sessions == []
 
     async def test_session_count_includes_terminated(self, hypervisor, config):
-        s1 = await hypervisor.create_session(config, creator_did=CREATOR)
-        s2 = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.activate_session(s1.sso.session_id)
-        await hypervisor.terminate_session(s1.sso.session_id)
+        s1 = hypervisor.create_session(config, creator_did=CREATOR)
+        s2 = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.activate_session(s1.sso.session_id)
+        hypervisor.terminate_session(s1.sso.session_id)
         # active_sessions drops s1; session_count keeps it.
         assert len(hypervisor.active_sessions) == 1
         assert hypervisor.session_count == 2
@@ -388,9 +388,9 @@ class TestSessionsAccessor:
         }
 
     async def test_sessions_returns_snapshot_not_live_view(self, hypervisor, config):
-        await hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.create_session(config, creator_did=CREATOR)
         snapshot = hypervisor.sessions
-        await hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.create_session(config, creator_did=CREATOR)
         # Snapshot taken before second create must not grow.
         assert len(snapshot) == 1
         assert hypervisor.session_count == 2
@@ -403,9 +403,9 @@ class TestSessionsAccessor:
 
 class TestVerifyBehavior:
     async def test_no_adapter_returns_none(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        result = await hypervisor.verify_behavior(
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        result = hypervisor.verify_behavior(
             managed.sso.session_id,
             AGENT_1,
             claimed_embedding=[1, 0],
@@ -421,11 +421,11 @@ class TestVerifyBehavior:
         policy_check.check_behavioral_drift.return_value = drift_result
 
         hv = Hypervisor(policy_check=policy_check)
-        managed = await hv.create_session(config, creator_did=CREATOR)
-        await hv.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hv.activate_session(managed.sso.session_id)
+        managed = hv.create_session(config, creator_did=CREATOR)
+        hv.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hv.activate_session(managed.sso.session_id)
 
-        result = await hv.verify_behavior(
+        result = hv.verify_behavior(
             managed.sso.session_id,
             AGENT_1,
             claimed_embedding=[1],
@@ -437,16 +437,16 @@ class TestVerifyBehavior:
 class TestEdgeCases:
     async def test_session_capacity_limit(self, hypervisor):
         cfg = SessionConfig(max_participants=1)
-        managed = await hypervisor.create_session(cfg, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        managed = hypervisor.create_session(cfg, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
         with pytest.raises(Exception):
-            await hypervisor.join_session(managed.sso.session_id, AGENT_2, sigma_raw=0.85)
+            hypervisor.join_session(managed.sso.session_id, AGENT_2, sigma_raw=0.85)
 
     async def test_duplicate_agent_join_raises(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
         with pytest.raises(Exception):
-            await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+            hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
 
     async def test_hypervisor_default_init(self):
         hv = Hypervisor()
@@ -457,16 +457,16 @@ class TestEdgeCases:
 
     async def test_full_lifecycle(self, hypervisor, config):
         """End-to-end: create → join → activate → terminate."""
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         assert managed.sso.state == SessionState.HANDSHAKING
 
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
         assert managed.sso.participant_count == 1
 
-        await hypervisor.activate_session(managed.sso.session_id)
+        hypervisor.activate_session(managed.sso.session_id)
         assert managed.sso.state == SessionState.ACTIVE
 
-        await hypervisor.terminate_session(managed.sso.session_id)
+        hypervisor.terminate_session(managed.sso.session_id)
         assert managed.sso.state == SessionState.ARCHIVED
 
 
@@ -477,22 +477,22 @@ class TestEdgeCases:
 
 class TestActiveIndex:
     async def test_active_ids_tracks_creation(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
         assert managed.sso.session_id in hypervisor._active_ids
 
     async def test_active_ids_removed_on_terminate(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.activate_session(managed.sso.session_id)
-        await hypervisor.terminate_session(managed.sso.session_id)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.activate_session(managed.sso.session_id)
+        hypervisor.terminate_session(managed.sso.session_id)
         assert managed.sso.session_id not in hypervisor._active_ids
 
     async def test_active_ids_consistent_with_active_sessions(self, hypervisor, config):
-        s1 = await hypervisor.create_session(config, creator_did=CREATOR)
-        s2 = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.activate_session(s1.sso.session_id)
-        await hypervisor.terminate_session(s1.sso.session_id)
+        s1 = hypervisor.create_session(config, creator_did=CREATOR)
+        s2 = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.activate_session(s1.sso.session_id)
+        hypervisor.terminate_session(s1.sso.session_id)
         active = hypervisor.active_sessions
         assert len(active) == 1
         assert active[0].sso.session_id == s2.sso.session_id
@@ -505,39 +505,39 @@ class TestActiveIndex:
 
 class TestMonitorSessions:
     async def test_monitor_empty(self, hypervisor):
-        issues = await hypervisor.monitor_sessions()
+        issues = hypervisor.monitor_sessions()
         assert issues == []
 
     async def test_monitor_healthy_agents(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.activate_session(managed.sso.session_id)
-        issues = await hypervisor.monitor_sessions(drift_threshold=0.5)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.activate_session(managed.sso.session_id)
+        issues = hypervisor.monitor_sessions(drift_threshold=0.5)
         assert issues == []
 
     async def test_monitor_flags_low_score(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.30)
-        await hypervisor.activate_session(managed.sso.session_id)
-        issues = await hypervisor.monitor_sessions(drift_threshold=0.5)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.30)
+        hypervisor.activate_session(managed.sso.session_id)
+        issues = hypervisor.monitor_sessions(drift_threshold=0.5)
         assert len(issues) == 1
         assert issues[0]["agent_did"] == AGENT_1
 
     async def test_monitor_skips_terminated(self, hypervisor, config):
-        managed = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.30)
-        await hypervisor.activate_session(managed.sso.session_id)
-        await hypervisor.terminate_session(managed.sso.session_id)
-        issues = await hypervisor.monitor_sessions(drift_threshold=0.5)
+        managed = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(managed.sso.session_id, AGENT_1, sigma_raw=0.30)
+        hypervisor.activate_session(managed.sso.session_id)
+        hypervisor.terminate_session(managed.sso.session_id)
+        issues = hypervisor.monitor_sessions(drift_threshold=0.5)
         assert issues == []
 
     async def test_monitor_multiple_sessions(self, hypervisor, config):
-        s1 = await hypervisor.create_session(config, creator_did=CREATOR)
-        s2 = await hypervisor.create_session(config, creator_did=CREATOR)
-        await hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
-        await hypervisor.join_session(s2.sso.session_id, AGENT_2, sigma_raw=0.30)
-        await hypervisor.activate_session(s1.sso.session_id)
-        await hypervisor.activate_session(s2.sso.session_id)
-        issues = await hypervisor.monitor_sessions(drift_threshold=0.5)
+        s1 = hypervisor.create_session(config, creator_did=CREATOR)
+        s2 = hypervisor.create_session(config, creator_did=CREATOR)
+        hypervisor.join_session(s1.sso.session_id, AGENT_1, sigma_raw=0.85)
+        hypervisor.join_session(s2.sso.session_id, AGENT_2, sigma_raw=0.30)
+        hypervisor.activate_session(s1.sso.session_id)
+        hypervisor.activate_session(s2.sso.session_id)
+        issues = hypervisor.monitor_sessions(drift_threshold=0.5)
         assert len(issues) == 1
         assert issues[0]["agent_did"] == AGENT_2

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_cli.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_cli.py
@@ -31,13 +31,13 @@ def hv() -> Hypervisor:
 @pytest.fixture
 async def session_hv(hv: Hypervisor):
     """Hypervisor with one active session containing two agents."""
-    session = await hv.create_session(
+    session = hv.create_session(
         config=SessionConfig(max_participants=5),
         creator_did="did:mesh:admin",
     )
-    await hv.join_session(session.sso.session_id, "did:mesh:agent-1", sigma_raw=0.75)
-    await hv.join_session(session.sso.session_id, "did:mesh:agent-2", sigma_raw=0.80)
-    await hv.activate_session(session.sso.session_id)
+    hv.join_session(session.sso.session_id, "did:mesh:agent-1", sigma_raw=0.75)
+    hv.join_session(session.sso.session_id, "did:mesh:agent-2", sigma_raw=0.80)
+    hv.activate_session(session.sso.session_id)
     return hv, session.sso.session_id
 
 

--- a/agent-governance-python/agent-hypervisor/tests/unit/test_saga.py
+++ b/agent-governance-python/agent-hypervisor/tests/unit/test_saga.py
@@ -134,6 +134,49 @@ class TestSagaOrchestrator:
         assert step.state == StepState.COMMITTED
 
     @pytest.mark.asyncio
+    async def test_execute_step_accepts_generic_awaitable(self):
+        saga = self.orchestrator.create_saga("session:1")
+        step = self.orchestrator.add_step(saga.saga_id, "a1", "did:a", "/api/exec")
+
+        class AwaitableResult:
+            def __await__(self):
+                async def _run():
+                    return "ok"
+
+                return _run().__await__()
+
+        result = await self.orchestrator.execute_step(
+            saga.saga_id,
+            step.step_id,
+            executor=lambda: AwaitableResult(),
+        )
+
+        assert result == "ok"
+        assert step.state == StepState.COMMITTED
+
+    @pytest.mark.asyncio
+    async def test_sync_executor_contract_error_is_not_retried(self):
+        saga = self.orchestrator.create_saga("session:1")
+        step = self.orchestrator.add_step(
+            saga.saga_id,
+            "a1",
+            "did:a",
+            "/api/exec",
+            max_retries=2,
+        )
+        calls = 0
+
+        def executor():
+            nonlocal calls
+            calls += 1
+            return "not-awaitable"
+
+        with pytest.raises(TypeError, match="executor must return an awaitable"):
+            await self.orchestrator.execute_step(saga.saga_id, step.step_id, executor=executor)
+
+        assert calls == 1
+
+    @pytest.mark.asyncio
     async def test_execute_step_failure(self):
         saga = self.orchestrator.create_saga("session:1")
         step = self.orchestrator.add_step(saga.saga_id, "a1", "did:a", "/api/exec")

--- a/agent-governance-python/agent-os/README.md
+++ b/agent-governance-python/agent-os/README.md
@@ -457,13 +457,13 @@ from runtime import Runtime, SessionConfig, ConsistencyMode
 rt = Runtime()
 
 # Create a governed multi-agent session
-session = await rt.create_session(
+session = rt.create_session(
     config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL, max_participants=5),
     creator_did="did:mesh:admin",
 )
 
 # Agents are automatically assigned privilege rings based on trust score
-ring = await rt.join_session(session.sso.session_id, "did:mesh:agent-alpha", sigma_raw=0.85)
+ring = rt.join_session(session.sso.session_id, "did:mesh:agent-alpha", sigma_raw=0.85)
 # → Ring 2 (Standard) — can execute reversible actions
 
 # Multi-step saga with automatic timeout and compensation
@@ -475,7 +475,7 @@ step = session.saga.add_step(
 )
 
 # Terminate — returns tamper-evident summary hash
-summary_hash = await rt.terminate_session(session.sso.session_id)
+summary_hash = rt.terminate_session(session.sso.session_id)
 ```
 
 📖 **[Full Runtime documentation →](https://github.com/microsoft/agent-governance-toolkit)**

--- a/agent-governance-python/agent-runtime/README.md
+++ b/agent-governance-python/agent-runtime/README.md
@@ -49,7 +49,8 @@ hv = Hypervisor()
 
 # Create a governed session
 session = hv.create_session(
-    config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL)
+    config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL),
+    creator_did="did:mesh:admin",
 )
 
 # Execute with privilege enforcement

--- a/agent-governance-python/agent-runtime/README.md
+++ b/agent-governance-python/agent-runtime/README.md
@@ -48,7 +48,7 @@ from hypervisor import Hypervisor, SessionConfig, ConsistencyMode
 hv = Hypervisor()
 
 # Create a governed session
-session = await hv.create_session(
+session = hv.create_session(
     config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL)
 )
 

--- a/docs/packages/agent-hypervisor.md
+++ b/docs/packages/agent-hypervisor.md
@@ -55,13 +55,13 @@ from hypervisor import Hypervisor, SessionConfig, ConsistencyMode
 hv = Hypervisor()
 
 # Create an isolated session with governance
-session = await hv.create_session(
+session = hv.create_session(
     config=SessionConfig(enable_audit=True),
     creator_did="did:mesh:admin",
 )
 
 # Agent joins, ring assigned automatically by trust score
-ring = await hv.join_session(
+ring = hv.join_session(
     session.sso.session_id,
     "did:mesh:agent-1",
     sigma_raw=0.85,
@@ -69,7 +69,7 @@ ring = await hv.join_session(
 # RING_2_STANDARD (trusted agent)
 
 # Activate and run a governed saga
-await hv.activate_session(session.sso.session_id)
+hv.activate_session(session.sso.session_id)
 saga = session.saga.create_saga(session.sso.session_id)
 step = session.saga.add_step(
     saga.saga_id, "draft_email", "did:mesh:agent-1",
@@ -81,7 +81,7 @@ result = await session.saga.execute_step(
 )
 
 # Terminate, returns tamper-evident audit hash
-hash_root = await hv.terminate_session(session.sso.session_id)
+hash_root = hv.terminate_session(session.sso.session_id)
 ```
 
 ## Configuration
@@ -104,7 +104,7 @@ hv = Hypervisor(
 )
 
 # Create a session with resource limits
-session = await hv.create_session(
+session = hv.create_session(
     config=SessionConfig(
         consistency_mode=ConsistencyMode.EVENTUAL,  # or STRONG
         max_participants=10,           # 1-1000
@@ -116,7 +116,7 @@ session = await hv.create_session(
 )
 
 # Agent joins, ring assigned by trust score
-ring = await hv.join_session(
+ring = hv.join_session(
     session.sso.session_id,
     "did:mesh:agent-1",
     sigma_raw=0.85,   # Raw trust score [0.0-1.0]
@@ -170,8 +170,8 @@ config = SessionConfig(
     enable_audit=True,
 )
 
-session = await hv.create_session(config=config, creator_did="did:mesh:admin")
-await hv.activate_session(session.sso.session_id)
+session = hv.create_session(config=config, creator_did="did:mesh:admin")
+hv.activate_session(session.sso.session_id)
 
 # Session lifecycle: CREATED -> HANDSHAKING -> ACTIVE -> TERMINATING -> ARCHIVED
 ```

--- a/docs/packages/agent-os.md
+++ b/docs/packages/agent-os.md
@@ -462,13 +462,13 @@ from runtime import Runtime, SessionConfig, ConsistencyMode
 rt = Runtime()
 
 # Create a governed multi-agent session
-session = await rt.create_session(
+session = rt.create_session(
     config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL, max_participants=5),
     creator_did="did:mesh:admin",
 )
 
 # Agents are automatically assigned privilege rings based on trust score
-ring = await rt.join_session(session.sso.session_id, "did:mesh:agent-alpha", sigma_raw=0.85)
+ring = rt.join_session(session.sso.session_id, "did:mesh:agent-alpha", sigma_raw=0.85)
 # → Ring 2 (Standard) — can execute reversible actions
 
 # Multi-step saga with automatic timeout and compensation
@@ -480,7 +480,7 @@ step = session.saga.add_step(
 )
 
 # Terminate — returns tamper-evident summary hash
-summary_hash = await rt.terminate_session(session.sso.session_id)
+summary_hash = rt.terminate_session(session.sso.session_id)
 ```
 
 📖 **[Full Runtime documentation →](https://github.com/microsoft/agent-governance-toolkit)**

--- a/docs/packages/agent-runtime.md
+++ b/docs/packages/agent-runtime.md
@@ -55,7 +55,8 @@ hv = Hypervisor()
 
 # Create a governed session
 session = hv.create_session(
-    config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL)
+    config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL),
+    creator_did="did:mesh:admin",
 )
 
 # Execute with privilege enforcement

--- a/docs/packages/agent-runtime.md
+++ b/docs/packages/agent-runtime.md
@@ -54,7 +54,7 @@ from hypervisor import Hypervisor, SessionConfig, ConsistencyMode
 hv = Hypervisor()
 
 # Create a governed session
-session = await hv.create_session(
+session = hv.create_session(
     config=SessionConfig(consistency_mode=ConsistencyMode.EVENTUAL)
 )
 


### PR DESCRIPTION
## Related Issue

Fixes #3178.

## Problem & Solution

The Hypervisor session surface mixed sync and async methods even though six methods had no internal await points.

This PR implements the maintainer-approved sync direction for:

- `create_session`
- `join_session`
- `activate_session`
- `terminate_session`
- `verify_behavior`
- `monitor_sessions`

Direct call sites were updated across the current repository. Unrelated same-name async APIs were left unchanged.

`SagaOrchestrator.execute_step` and `compensate` remain async, with a narrow runtime guard requiring executor/compensator results to be awaitable.

## Impact on Your Work

Removes the mixed sync/async Hypervisor API footgun and makes the session surface consistent with the existing synchronous helpers and callers.

## Timeline

None.

## Alternatives Considered

Keeping the six methods async was rejected because they contain no internal await points and the maintainer explicitly selected the synchronous direction in #3178.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected

**Core & runtime:**

- [ ] agent-governance-toolkit-core
- [ ] agent-primitives
- [ ] agent-os
- [ ] agent-mesh
- [x] agent-runtime
- [ ] agent-sre
- [x] agent-compliance

**Governance & security:**

- [ ] agent-mcp-governance
- [ ] agent-rag-governance
- [ ] agent-sandbox
- [ ] agent-discovery
- [ ] agt-policies
- [ ] policy-engine

**Platform & tooling:**

- [x] agent-hypervisor
- [ ] agent-lightning
- [ ] agent-marketplace
- [ ] agent-governance-toolkit-cli
- [ ] agent-governance-toolkit-integrations
- [ ] agent-governance-toolkit-protocols
- [ ] agentmesh-integrations (framework integrations)

**CLI plugins:**

- [ ] agent-governance CLI plugins (copilot-cli / claude-code / opencode / antigravity-cli)

**Shared / other:**

- [ ] schemas
- [ ] action (GitHub Action)
- [ ] examples
- [x] docs / root

## Testing

### Unit Testing

Focused Hypervisor test suite:

`102 passed, 5 skipped`

### Manual Testing

- `py_compile` passed for edited Python files
- `git diff --check` passed
- repo-wide search found zero stale awaited direct Hypervisor calls
- unrelated `mesh.create_session(...)` await remains intentionally unchanged

## Checklist

- [x] I have linked a related issue above, or completed "Problem & Solution", "Impact on Your Work", and "Alternatives Considered"
- [x] My code follows the project style guidelines (ruff check)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing focused tests pass (pytest)
- [x] I have updated documentation as needed
- [x] I have signed the Microsoft CLA

## Attribution & Prior Art

- [x] This contribution does not contain code copied or derived from other projects without attribution
- [x] Any external projects that inspired this design are credited in code comments or documentation
- [x] If this PR implements functionality similar to an existing open-source project, I have listed it below

**Prior art / related projects** (if any):

None.

## AI Assistance

- [x] I can explain every meaningful change in this PR: what it does, why, and what tradeoffs were considered
- [x] I have run tests and verification appropriate for this change
- [x] No part of this PR was autonomously submitted by an AI agent without my review
- [x] I have not used AI to generate review comments on others' PRs

If AI tools materially shaped this change, briefly note what was used:

AI-assisted code review and repository search were used during implementation; all changes were reviewed and validated manually before submission.

## IP, Patents, and Licensing

- [x] This contribution does not implement patent-pending or patent-encumbered techniques
- [x] This contribution does not require an NDA or licensing agreement to understand or use
- [x] Any AI tools used have terms compatible with the MIT License