### PR TITLE
chore(deps): apply the 7-day dependabot cooldown to every ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,8 @@ updates:
       - "/agent-governance-python/agent-sandbox"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -53,6 +55,8 @@ updates:
     directory: "/agent-governance-python/agent-os/extensions/mcp-server"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -64,6 +68,8 @@ updates:
     directory: "/agent-governance-python/agent-os/extensions/copilot"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -75,6 +81,8 @@ updates:
     directory: "/agent-governance-copilot-cli"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -86,6 +94,8 @@ updates:
     directory: "/agent-governance-claude-code"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -97,6 +107,8 @@ updates:
     directory: "/agent-governance-typescript"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -108,6 +120,8 @@ updates:
     directory: "/agent-governance-antigravity-cli"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -120,6 +134,8 @@ updates:
     directory: "/agent-governance-dotnet"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -135,6 +151,8 @@ updates:
     directory: "/agent-governance-rust"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -147,6 +165,8 @@ updates:
     directory: "/agent-governance-golang"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -159,6 +179,8 @@ updates:
     directory: "/agent-governance-python/agent-os"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     labels:
       - "dependencies"


### PR DESCRIPTION
## Related Issue
Follows #3593 (which added the native cooldown to the github-actions block only).

## Problem & Solution
Problem: npm/pip/cargo/nuget/gomod/docker dependabot bumps still propose releases younger than the repo's 7-day cooling policy, so the CI cooling check correctly rejects them — and every `@dependabot rebase` picks up an even fresher version, restarting the clock (the typescript-eslint batch has chased the window for a week: 8.65.0 cooled, rebase brought 8.66.0 at 4 days).
Solution: `cooldown: default-days: 7` on all 12 update blocks, so dependabot itself waits and proposed versions arrive already cooled. The CI check stays as the enforcement backstop.

## Impact on Your Work
Ends the rebase-chases-cooling loop and most cooling-check babysitting.

## Timeline
None.

## Alternatives Considered
Keeping CI-only cooling (the current chase loop); scanner-side allowlists (weaker control).