### PR TITLE
fix(cli): widen mcp extra cryptography upper bound to <51.0

### DIFF
--- a/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 docker = ["docker>=7.1.0,<8.0"]
 hyperlight = ["hyperlight-sandbox>=0.4.0,<0.5"]
 policy = ["agent-governance-toolkit-core>=5.0.0,<6.0"]
-mcp = ["mcp>=1.0.0,<2.0", "cryptography>=46.0.7,<49.0"]
+mcp = ["mcp>=1.0.0,<2.0", "cryptography>=46.0.7,<51.0"]
 api = ["fastapi>=0.115.0,<1.0", "uvicorn>=0.27.0,<1.0"]
 otel = ["opentelemetry-exporter-otlp>=1.20,<2.0"]
 langfuse = ["langfuse>=2.0,<5.0"]


### PR DESCRIPTION
Summary

The mcp extra in agent-governance-toolkit-cli still pinned cryptography below 49.0. That range is disjoint from the bound now required by agent mesh and agent os, which was raised to below 51.0 in pull request 3615 and pull request 3621. Installing the cli mcp extra together with agent mesh or agent os in one environment asked pip to satisfy cryptography below 49.0 and cryptography 50.0 or higher at the same time, which has no solution.

Change

One line in agent-governance-python/agent-governance-toolkit-cli/pyproject.toml, raising the mcp extra bound from cryptography>=46.0.7,<49.0 to cryptography>=46.0.7,<51.0, matching the core package bound.

Fixes #3651