### PR TITLE
fix: relax cryptography constraint for MCP extra

### DIFF
--- a/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 docker = ["docker>=7.1.0,<8.0"]
 hyperlight = ["hyperlight-sandbox>=0.4.0,<0.5"]
 policy = ["agent-governance-toolkit-core>=5.0.0,<6.0"]
-mcp = ["mcp>=1.0.0,<2.0", "cryptography>=46.0.7,<49.0"]
+mcp = ["mcp>=1.0.0,<2.0", "cryptography>=46.0.7,<51.0"]
 api = ["fastapi>=0.115.0,<1.0", "uvicorn>=0.27.0,<1.0"]
 otel = ["opentelemetry-exporter-otlp>=1.20,<2.0"]
 langfuse = ["langfuse>=2.0,<5.0"]


### PR DESCRIPTION
## Problem

The MCP optional dependency in `agent-governance-toolkit-cli` constrained
`cryptography` to `<49.0`.

This conflicts with Agent Mesh / Agent OS components that require
`cryptography>=50.0.0,<51.0`, making the dependency requirements
unresolvable.

Related issue: #3651

## Fix

Updated the MCP optional dependency from:

`cryptography>=46.0.7,<49.0`

to:

`cryptography>=46.0.7,<51.0`

This allows compatible `cryptography` 50.x releases.

## Verification

Verified the dependency conflict using pip's resolver:

### Before

`cryptography>=46.0.7,<49.0` combined with
`cryptography>=50.0.0,<51.0` resulted in `ResolutionImpossible`.

### After

`cryptography>=46.0.7,<51.0` combined with
`cryptography>=50.0.0,<51.0` resolved successfully.

Also verified that the modified CLI package can be built and installed
with the MCP extra.

## Files Changed

- `agent-governance-python/agent-governance-toolkit-cli/pyproject.toml`