### PR TITLE
fix(opencode): deny unenforceable review decisions

### DIFF
--- a/agent-governance-opencode/config/default-policy.json
+++ b/agent-governance-opencode/config/default-policy.json
@@ -40,7 +40,7 @@
       "effect": "deny",
       "commandPatterns": [
         {
-          "source": "\\brm\\b(?=[^\\n\\r]*(?:\\s-[a-z]*r[a-z]*(?=\\s|$)|\\s--recursive\\b))(?=[^\\n\\r]*(?:\\s-[a-z]*f[a-z]*(?=\\s|$)|\\s--force\\b))[^\\n\\r]*",
+          "source": "\\brm\\b[\\s\\S]*\\b-rf\\b",
           "flags": "i"
         }
       ]

--- a/agent-governance-opencode/config/default-policy.json
+++ b/agent-governance-opencode/config/default-policy.json
@@ -40,7 +40,7 @@
       "effect": "deny",
       "commandPatterns": [
         {
-          "source": "\\brm\\b[\\s\\S]*\\b-rf\\b",
+          "source": "\\brm\\b(?=[^\\n\\r]*(?:\\s-[a-z]*r[a-z]*(?=\\s|$)|\\s--recursive\\b))(?=[^\\n\\r]*(?:\\s-[a-z]*f[a-z]*(?=\\s|$)|\\s--force\\b))[^\\n\\r]*",
           "flags": "i"
         }
       ]

--- a/agent-governance-opencode/lib/policy.mjs
+++ b/agent-governance-opencode/lib/policy.mjs
@@ -1318,7 +1318,7 @@ function normalizeEffectForOpenCode(state, effectiveDecision) {
     return "deny";
   }
   if (effectiveDecision === "review") {
-    return state.policy.mode === "advisory" ? "review" : "review";
+    return state.policy.mode === "advisory" ? "review" : "deny";
   }
   return "allow";
 }
@@ -1360,4 +1360,3 @@ function redactSecretLikeContent(text, _findings) {
 function describeSecretFindings(findings) {
   return `matched ${findings.length} secret pattern(s): ${findings.join(", ")}`;
 }
-

--- a/agent-governance-opencode/test/plugin.test.mjs
+++ b/agent-governance-opencode/test/plugin.test.mjs
@@ -91,14 +91,17 @@ test("tool.execute.before allows safe read calls", async () => {
   }
 });
 
-test("tool.execute.before marks review tools with __agt_review_reason", async () => {
+test("tool.execute.before blocks enforce-mode review tools", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-opencode-plugin-review-"));
   try {
     const plugin = await loadPlugin(root);
     const output = { args: { file_path: join(root, "package.json"), content: "{}" } };
 
-    await plugin["tool.execute.before"]({ tool: "write", sessionID: "review-session" }, output);
-    assert.ok(typeof output.args.__agt_review_reason === "string");
+    await assert.rejects(
+      plugin["tool.execute.before"]({ tool: "write", sessionID: "review-session" }, output),
+      /review|required|AGT/i,
+    );
+    assert.equal(output.args.__agt_review_reason, undefined);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/agent-governance-opencode/test/policy.test.mjs
+++ b/agent-governance-opencode/test/policy.test.mjs
@@ -81,31 +81,6 @@ test("evaluateOpenCodeTool denies dangerous bash bootstrap and enforce-mode revi
   await rm(root, { recursive: true, force: true });
 });
 
-test("bundled policy denies recursive deletion flag variants", async () => {
-  const root = await mkdtemp(join(tmpdir(), "agt-opencode-rm-"));
-  const state = await loadPolicy({ auditPath: join(root, "audit.json") });
-
-  for (const command of [
-    "rm -rf /",
-    "rm -fr /",
-    "rm -r -f /",
-    "rm --recursive --force /",
-    "rm --force --recursive /",
-  ]) {
-    const result = await evaluateOpenCodeTool(state, {
-      tool: "bash",
-      args: { command },
-      sessionId: "recursive-delete-session",
-      cwd: root,
-    });
-
-    assert.equal(result.effect, "deny", command);
-    assert.match(result.reason, /recursive delete/i, command);
-  }
-
-  await rm(root, { recursive: true, force: true });
-});
-
 test("evaluateOpenCodeTool denies metadata URL fetches regardless of arg name", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-opencode-url-"));
   const state = await loadPolicy({ auditPath: join(root, "audit.json") });

--- a/agent-governance-opencode/test/policy.test.mjs
+++ b/agent-governance-opencode/test/policy.test.mjs
@@ -54,7 +54,7 @@ test("evaluateOpenCodePrompt allows benign prompts", async () => {
   await rm(root, { recursive: true, force: true });
 });
 
-test("evaluateOpenCodeTool denies dangerous bash bootstrap and reviews persistence writes", async () => {
+test("evaluateOpenCodeTool denies dangerous bash bootstrap and enforce-mode review tools", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-opencode-tool-"));
   const state = await loadPolicy({ auditPath: join(root, "audit.json") });
 
@@ -72,11 +72,36 @@ test("evaluateOpenCodeTool denies dangerous bash bootstrap and reviews persisten
     sessionId: "write-session",
     cwd: root,
   });
-  assert.equal(reviewResult.effect, "review");
+  assert.equal(reviewResult.effect, "deny");
 
   const status = await getPolicyStatus(state);
   assert.ok(status.auditEntries >= 2);
   assert.equal(status.auditValid, true);
+
+  await rm(root, { recursive: true, force: true });
+});
+
+test("bundled policy denies recursive deletion flag variants", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-rm-"));
+  const state = await loadPolicy({ auditPath: join(root, "audit.json") });
+
+  for (const command of [
+    "rm -rf /",
+    "rm -fr /",
+    "rm -r -f /",
+    "rm --recursive --force /",
+    "rm --force --recursive /",
+  ]) {
+    const result = await evaluateOpenCodeTool(state, {
+      tool: "bash",
+      args: { command },
+      sessionId: "recursive-delete-session",
+      cwd: root,
+    });
+
+    assert.equal(result.effect, "deny", command);
+    assert.match(result.reason, /recursive delete/i, command);
+  }
 
   await rm(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary

- fail closed when an enforce-mode OpenCode tool rule evaluates to `review`, because the adapter has no approval continuation
- retain non-blocking `review` behavior in advisory mode
- add regression coverage for policy evaluation and the plugin hook
- persist the normalized OpenCode effect in prompt/tool audit entries so enforced denials are recorded as `deny`

## Behavior change

In enforce mode, bundled policy rules that evaluate to `review` for `bash`, `webfetch`, `websearch`, `write`, `edit`, `patch`, or `multiedit` now deny the invocation. This is intentional: OpenCode has no continuation through which an operator can approve a review decision. Advisory mode continues to surface a non-blocking review result.

## Root cause

The adapter returned `review` in both policy modes. In enforce mode that allowed an invocation to proceed even though the requested approval could not occur.

## Scope and related work

- Related issue: #3662.
- Recursive-delete parsing is deliberately out of scope for this PR. #3251 owns the broader parser-based implementation across integrations, including recursive-without-force and PowerShell forms. This PR is limited to the independent fail-closed adapter behavior.

## Validation

- `cd agent-governance-opencode && npm run check` — 75/75 tests passed on Node 22.20.0 and 24.14.0, with main c63c51e8 integrated
- failing-first regression: enforce-mode prompt/tool and bundled-tool audits recorded `review` before the correction; both now pass
- coverage checks allow/review/deny in both modes, historical hash-chain compatibility, and unchanged audit fields
- direct plugin smoke verifies enforce-mode denial, advisory review, and matching persisted audit decisions; corrupt audits remain fail-closed
- changed-line spelling and whitespace checks passed

## Review follow-up

Audit correction: 45c7a334. Existing upstream merge 2ee21bb7 was preserved; no history rewriting, dependency changes, or audit-schema migration.