### PR TITLE
fix(opencode): distinguish prompt defense scopes

### DIFF
--- a/agent-governance-opencode/lib/policy.mjs
+++ b/agent-governance-opencode/lib/policy.mjs
@@ -334,15 +334,21 @@ export async function getPolicyStatus(state) {
     bundledDefaultError: state.bundledDefaultError?.message,
     configuredPolicyError: state.configuredPolicyError?.message,
     configuredPolicyPath: state.configuredPolicyPath,
+    configuredPromptDefenseCoverage: state.configuredPromptDefenseReport.coverage,
+    configuredPromptDefenseGrade: state.configuredPromptDefenseReport.grade,
+    configuredPromptDefenseMissing: state.configuredPromptDefenseReport.missing,
+    configuredPromptDefenseScope: "operator-additional-context",
     denyOnPolicyError: state.policy.denyOnPolicyError,
     minimumPromptDefenseGrade: state.policy.minimumPromptDefenseGrade,
     mode: state.policy.mode,
     path: state.path,
     promptDefenseCoverage: state.promptDefenseReport.coverage,
     promptDefenseGrade: state.promptDefenseReport.grade,
+    promptDefenseScope: "effective-context",
     promptDefenseBlocking: state.promptDefenseReport.isBlocking(
       state.policy.minimumPromptDefenseGrade,
     ),
+    promptDefenseBlockingScope: "effective-context",
     promptDefenseMissing: state.promptDefenseReport.missing,
     schemaVersion: state.policy.schemaVersion,
     sdkPath: state.sdkPath,
@@ -355,6 +361,9 @@ export async function getPolicyStatus(state) {
 function createGovernanceRuntime(policy) {
   const promptDefenseEvaluator = new PromptDefenseEvaluator();
   const promptDefenseReport = promptDefenseEvaluator.evaluate(policy.additionalContext.join("\n"));
+  const configuredPromptDefenseReport = promptDefenseEvaluator.evaluate(
+    toStringArray(policy.raw?.additionalContext).join("\n"),
+  );
   const mcpScanner = new McpSecurityScanner();
   const policyEngine = new PolicyEngine(buildLegacyRules(policy));
 
@@ -368,6 +377,7 @@ function createGovernanceRuntime(policy) {
   policyEngine.registerBackend(createMcpInvocationBackend(policy, mcpScanner));
 
   return {
+    configuredPromptDefenseReport,
     mcpScanner,
     policyEngine,
     promptDefenseReport,
@@ -1360,4 +1370,3 @@ function redactSecretLikeContent(text, _findings) {
 function describeSecretFindings(findings) {
   return `matched ${findings.length} secret pattern(s): ${findings.join(", ")}`;
 }
-

--- a/agent-governance-opencode/lib/policy.mjs
+++ b/agent-governance-opencode/lib/policy.mjs
@@ -73,12 +73,14 @@ export async function loadPolicy({
 
   let bundledDefaultError;
   let configuredPolicyError;
+  let configuredAdditionalContext = [];
   let compiledPolicy;
   let source = "bundled-default";
 
   if (existsSync(configuredPolicyPath)) {
     try {
       compiledPolicy = compilePolicy(await readJsonFile(configuredPolicyPath));
+      configuredAdditionalContext = toStringArray(compiledPolicy.raw?.additionalContext);
       source = process.env[USER_POLICY_ENV] ? "env" : "user";
     } catch (error) {
       configuredPolicyError = error;
@@ -94,7 +96,7 @@ export async function loadPolicy({
     }
   }
 
-  const runtime = createGovernanceRuntime(compiledPolicy);
+  const runtime = createGovernanceRuntime(compiledPolicy, configuredAdditionalContext);
   return {
     auditPath: resolvedAuditPath,
     bundledDefaultError,
@@ -358,11 +360,11 @@ export async function getPolicyStatus(state) {
   };
 }
 
-function createGovernanceRuntime(policy) {
+function createGovernanceRuntime(policy, configuredAdditionalContext) {
   const promptDefenseEvaluator = new PromptDefenseEvaluator();
   const promptDefenseReport = promptDefenseEvaluator.evaluate(policy.additionalContext.join("\n"));
   const configuredPromptDefenseReport = promptDefenseEvaluator.evaluate(
-    toStringArray(policy.raw?.additionalContext).join("\n"),
+    configuredAdditionalContext.join("\n"),
   );
   const mcpScanner = new McpSecurityScanner();
   const policyEngine = new PolicyEngine(buildLegacyRules(policy));

--- a/agent-governance-opencode/src/index.mjs
+++ b/agent-governance-opencode/src/index.mjs
@@ -65,7 +65,9 @@ export const AgtGovernance = async (ctx) => {
               level: "info",
               message:
                 `[AGT] OpenCode governance active — mode=${status.mode} source=${status.source} ` +
-                `promptDefense=${status.promptDefenseGrade} audit=${status.auditEntries}`,
+                `promptDefenseEffective=${status.promptDefenseGrade} ` +
+                `promptDefenseConfigured=${status.configuredPromptDefenseGrade} ` +
+                `audit=${status.auditEntries}`,
             },
           });
         }

--- a/agent-governance-opencode/test/policy.test.mjs
+++ b/agent-governance-opencode/test/policy.test.mjs
@@ -54,6 +54,35 @@ test("evaluateOpenCodePrompt allows benign prompts", async () => {
   await rm(root, { recursive: true, force: true });
 });
 
+test("getPolicyStatus distinguishes effective defenses from configured context", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-defense-status-"));
+  const policyPath = join(root, "policy.json");
+  await writeFile(
+    policyPath,
+    JSON.stringify({
+      schemaVersion: 1,
+      version: 1,
+      minimumPromptDefenseGrade: "B",
+      additionalContext: [],
+      toolPolicies: { allowedTools: ["*"] },
+    }),
+    "utf8",
+  );
+  const state = await loadPolicy({ policyPath, auditPath: join(root, "audit.json") });
+
+  const status = await getPolicyStatus(state);
+
+  assert.equal(status.promptDefenseScope, "effective-context");
+  assert.equal(status.promptDefenseGrade, "A");
+  assert.equal(status.configuredPromptDefenseScope, "operator-additional-context");
+  assert.equal(status.configuredPromptDefenseGrade, "F");
+  assert.equal(status.configuredPromptDefenseCoverage, "0/12");
+  assert.equal(status.configuredPromptDefenseMissing.length, 12);
+  assert.equal(status.promptDefenseBlockingScope, "effective-context");
+
+  await rm(root, { recursive: true, force: true });
+});
+
 test("evaluateOpenCodeTool denies dangerous bash bootstrap and reviews persistence writes", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-opencode-tool-"));
   const state = await loadPolicy({ auditPath: join(root, "audit.json") });

--- a/agent-governance-opencode/test/policy.test.mjs
+++ b/agent-governance-opencode/test/policy.test.mjs
@@ -83,6 +83,66 @@ test("getPolicyStatus distinguishes effective defenses from configured context",
   await rm(root, { recursive: true, force: true });
 });
 
+for (const scenario of [
+  { name: "no operator policy", invalidOperator: false, invalidDefault: false },
+  { name: "invalid operator policy", invalidOperator: true, invalidDefault: false },
+  { name: "minimal fallback policy", invalidOperator: false, invalidDefault: true },
+  { name: "both policy files invalid", invalidOperator: true, invalidDefault: true },
+]) {
+  test(`getPolicyStatus reports empty configured context with ${scenario.name}`, async (t) => {
+    const root = await mkdtemp(join(tmpdir(), "agt-opencode-defense-fallback-"));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const policyPath = join(root, "policy.json");
+    const defaultPolicyPath = join(root, "default-policy.json");
+    if (scenario.invalidOperator) {
+      await writeFile(policyPath, "invalid JSON", "utf8");
+    }
+    if (scenario.invalidDefault) {
+      await writeFile(defaultPolicyPath, "invalid JSON", "utf8");
+    }
+    const state = await loadPolicy({
+      policyPath,
+      homeDirectory: root,
+      auditPath: join(root, "audit.json"),
+      ...(scenario.invalidDefault ? { defaultPolicyPath } : {}),
+    });
+    const status = await getPolicyStatus(state);
+
+    assert.equal(state.source, "bundled-default");
+    assert.equal(Boolean(state.configuredPolicyError), scenario.invalidOperator);
+    assert.equal(Boolean(state.bundledDefaultError), scenario.invalidDefault);
+    assert.equal(status.configuredPromptDefenseScope, "operator-additional-context");
+    assert.equal(status.configuredPromptDefenseGrade, "F");
+    assert.equal(status.configuredPromptDefenseCoverage, "0/12");
+    assert.equal(status.configuredPromptDefenseMissing.length, 12);
+    assert.equal(status.promptDefenseScope, "effective-context");
+    assert.equal(status.promptDefenseGrade, "A");
+    assert.equal(status.promptDefenseCoverage, "12/12");
+    assert.equal(status.promptDefenseBlockingScope, "effective-context");
+
+    if (scenario.invalidOperator || scenario.invalidDefault) {
+      const result = await evaluateOpenCodePrompt(state, { prompt: "Hello" });
+      assert.equal(result.effect, "deny");
+      assert.match(result.reason, /policy could not be loaded/i);
+    }
+  });
+}
+
+test("getPolicyStatus still grades nonempty operator context", async (t) => {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-defense-operator-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const policyPath = join(root, "policy.json");
+  const policy = await readFile(new URL("../config/default-policy.json", import.meta.url), "utf8");
+  await writeFile(policyPath, policy, "utf8");
+  const state = await loadPolicy({ policyPath, auditPath: join(root, "audit.json") });
+  const status = await getPolicyStatus(state);
+
+  assert.notEqual(state.source, "bundled-default");
+  assert.equal(status.configuredPromptDefenseGrade, "D");
+  assert.equal(status.configuredPromptDefenseCoverage, "4/12");
+  assert.equal(status.promptDefenseGrade, "A");
+});
+
 test("evaluateOpenCodeTool denies dangerous bash bootstrap and reviews persistence writes", async () => {
   const root = await mkdtemp(join(tmpdir(), "agt-opencode-tool-"));
   const state = await loadPolicy({ auditPath: join(root, "audit.json") });


### PR DESCRIPTION
## Summary

- report prompt-defense coverage separately for effective context and operator-configured additional context
- grade operator context only from a successfully loaded operator policy; bundled defaults and minimal fallback content report empty configured context (F, 0/12)
- add explicit scope metadata and show both grades in the OpenCode session initialization log
- preserve existing effective-context status fields, blocking semantics, and fail-closed policy-load behavior

## Root cause

The previous grade measured the fully compiled context, which includes bundled guardrails, but its name made it easy to interpret as a grade of operator-supplied policy content. The initial scope split also counted bundled policy content as operator context when no valid operator policy was loaded; the review follow-up corrects that attribution.

## Validation

- `cd agent-governance-opencode && npm run check` — 75/75 tests passed on Node 22.20.0 and 24.14.0 with main c63c51e8 integrated
- regression tests reproduced the incorrect grade before the fix for absent and invalid operator policies
- coverage includes bundled defaults, minimal fallback, both policy files invalid, empty and nonempty operator context, unchanged effective grading, and fail-closed load errors
- isolated runtime smoke: implicit absence allows benign input; explicit missing policy denies it; configured F/0 and effective A/12 remain distinct
- changed-line spelling and `git diff --check` passed

Closes #3664

## Review follow-up

- Rechecked the September 14 integration report after preserving upstream merge cecfc640. All 75 tests already passed with the existing fixture correction; the reported two failures do not reproduce on this base. Follow-up 3a8cc90c adds explicit assertions that implicit policy absence has no configuration error and allows benign input. Explicitly missing or invalid configuration continues to deny; no production behavior changed.

- Addressed the bundled-default/fallback grading request in fbebdaa5.
- Integrated main with a signed merge and corrected implicit-versus-explicit missing policy fixtures in 1a916b3d; reproduced the two integration failures first, then added explicit missing-file coverage. No production behavior change in this follow-up.
- Implementation and test evidence: https://github.com/microsoft/agent-governance-toolkit/pull/3677#discussion_r3970375987

## Tracking and related work

- Primary issue: #3664; the closure directive above remains authoritative.
- Related session-scoped state work in #3669 is intentionally not implemented here.