### PR TITLE
fix(opencode): upgrade js-yaml to 4.3.1

### DIFF
--- a/agent-governance-opencode/package-lock.json
+++ b/agent-governance-opencode/package-lock.json
@@ -1,21 +1,18 @@
 {
-  "name": "@ax0l0tl/agent-governance-opencode",
-  "version": "4.0.4",
+  "name": "@microsoft/agent-governance-opencode",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ax0l0tl/agent-governance-opencode",
-      "version": "4.0.4",
+      "name": "@microsoft/agent-governance-opencode",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/agent-governance-sdk": "3.7.0"
       },
       "engines": {
         "node": ">=22.0.0"
-      },
-      "overrides": {
-        "js-yaml": "4.2.0"
       }
     },
     "node_modules/@microsoft/agent-governance-sdk": {
@@ -89,9 +86,19 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/agent-governance-opencode/package.json
+++ b/agent-governance-opencode/package.json
@@ -45,7 +45,7 @@
     "@microsoft/agent-governance-sdk": "3.7.0"
   },
   "overrides": {
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.1"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/docs/dependency-audits/2026-08-10-js-yaml-4.3.1-opencode.md
+++ b/docs/dependency-audits/2026-08-10-js-yaml-4.3.1-opencode.md
@@ -1,0 +1,53 @@
+---
+title: "Dependency Audit: js-yaml 4.3.1 for OpenCode"
+last_reviewed: 2026-08-10
+owner: agt-maintainers
+---
+
+# Dependency Audit: `js-yaml` 4.3.1 for OpenCode
+
+<!-- cspell:ignore xmqj omap -->
+
+## Scope
+
+The OpenCode governance package overrides the TypeScript SDK's transitive
+`js-yaml` dependency. This update raises that override from 4.2.0 to 4.3.1 and
+regenerates the package lockfile.
+
+| Dependency | Previous | Updated | Use |
+|---|---:|---:|---|
+| `js-yaml` | 4.2.0 | 4.3.1 | Transitive policy YAML parsing through `@microsoft/agent-governance-sdk` |
+
+## Security rationale
+
+Two high-severity quadratic-CPU advisories affect the previous version:
+
+- GHSA-52cp-r559-cp3m / CVE-2026-59869 affects `js-yaml` 4.x before 4.3.0
+  through merge-key chains.
+- GHSA-5p4m-2wfm-xmqj affects `js-yaml` 4.x before 4.3.1 through `!!omap`
+  resolution.
+
+The second advisory means 4.3.0 is not a sufficient floor. Version 4.3.1 is
+the first 4.x release patched for both findings.
+
+## Compatibility and validation
+
+The change remains within the 4.x API line and does not alter AGT's policy
+schema or public OpenCode interfaces.
+
+Validation performed from `agent-governance-opencode/`:
+
+```text
+npm ci --ignore-scripts
+npm run check
+npm audit --omit=dev
+```
+
+The production audit reports zero vulnerabilities after the override and
+lockfile update.
+
+## Rollback
+
+Reverting the package override and lockfile restores 4.2.0, but also restores
+both high-severity findings. Rollback should therefore only accompany removal
+of the affected YAML parsing path or another compensating dependency fix.


### PR DESCRIPTION
> Coordination update (2026-09-13): Draft and parked in favor of #3894, which covers these OpenCode dependency changes at the required 4.3.2 floor. Do not merge this historical 4.3.1 update. #3671 remains open for the acceptance items described there.

## Summary

- raise the OpenCode package's transitive `js-yaml` override from 4.2.0 to 4.3.1
- regenerate the lockfile and verify that production dependency audit findings are cleared
- add a dependency audit record with rationale, validation, compatibility, and rollback notes

## Security rationale

Version 4.3.0 addresses [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m), but remains affected by [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj). Version 4.3.1 is therefore the first 4.x release that resolves both high-severity quadratic-CPU advisories.

## Validation

- `cd agent-governance-opencode && npm run check` — 25/25 tests passed
- `cd agent-governance-opencode && npm audit --omit=dev` — 0 vulnerabilities
- documentation link and frontmatter checks passed
- changed-line spelling and whitespace checks passed

Refs #3671


## Tracking

- Primary issue: #3671. Active repository dependency PR: #3894; this PR is parked.