### PR TITLE
fix(opencode): surface prompt denials

### DIFF
--- a/agent-governance-opencode/lib/policy.mjs
+++ b/agent-governance-opencode/lib/policy.mjs
@@ -83,6 +83,8 @@ export async function loadPolicy({
     } catch (error) {
       configuredPolicyError = error;
     }
+  } else if (policyPath) {
+    configuredPolicyError = new Error(`Configured policy file not found: ${configuredPolicyPath}`);
   }
 
   if (!compiledPolicy) {
@@ -1360,4 +1362,3 @@ function redactSecretLikeContent(text, _findings) {
 function describeSecretFindings(findings) {
   return `matched ${findings.length} secret pattern(s): ${findings.join(", ")}`;
 }
-

--- a/agent-governance-opencode/src/index.mjs
+++ b/agent-governance-opencode/src/index.mjs
@@ -53,6 +53,12 @@ export const AgtGovernance = async (ctx) => {
     }
   }
 
+  const initialState = await getState();
+  const initializationError = getPolicyInitializationError(initialState);
+  if (initializationError && initialState.policy.denyOnPolicyError) {
+    throw new Error(initializationError);
+  }
+
   return {
     "session.created": async () => {
       try {
@@ -89,8 +95,9 @@ export const AgtGovernance = async (ctx) => {
       });
 
       if (result.effect === "deny") {
-        // throwing here silently breaks the OpenCode session. Exception message is never displayed to the user, this is not the way to go...       
-        throw new Error(result.reason || "AGT governance blocked the submitted prompt.");
+        const reason = result.reason || "AGT governance blocked the submitted prompt.";
+        await surfaceGovernanceDenial(ctx, reason);
+        throw new Error(reason);
       }
     },
     "tool.execute.before": async (input, output) => {
@@ -163,6 +170,43 @@ export const AgtGovernance = async (ctx) => {
     },
   };
 };
+
+function getPolicyInitializationError(state) {
+  if (state.configuredPolicyError) {
+    return `AGT policy could not be loaded from ${state.configuredPolicyPath}: ${state.configuredPolicyError.message}`;
+  }
+  if (state.bundledDefaultError) {
+    return `AGT bundled default policy could not be loaded from ${state.path}: ${state.bundledDefaultError.message}`;
+  }
+  return "";
+}
+
+async function surfaceGovernanceDenial(ctx, reason) {
+  const notifications = [];
+  if (typeof ctx?.client?.tui?.showToast === "function") {
+    notifications.push(
+      ctx.client.tui.showToast({
+        body: {
+          title: "AGT governance blocked the prompt",
+          message: reason,
+          variant: "error",
+        },
+      }),
+    );
+  }
+  if (typeof ctx?.client?.app?.log === "function") {
+    notifications.push(
+      ctx.client.app.log({
+        body: {
+          service: "agt-governance",
+          level: "warn",
+          message: `[AGT] Prompt denied: ${reason}`,
+        },
+      }),
+    );
+  }
+  await Promise.allSettled(notifications);
+}
 
 export default AgtGovernance;
 

--- a/agent-governance-opencode/test/plugin.test.mjs
+++ b/agent-governance-opencode/test/plugin.test.mjs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -16,7 +16,7 @@ const injectionFixture = Buffer.from(
   "base64",
 ).toString("utf8");
 
-async function loadPlugin(directory) {
+async function loadPlugin(directory, { client, policyPath } = {}) {
   // Force the plugin to read its policy from an isolated path so tests do
   // not collide with the user's real ~/.config/opencode/agt config. We do
   // this by setting AGT_OPENCODE_AUDIT_PATH and AGT_OPENCODE_POLICY_PATH
@@ -24,13 +24,17 @@ async function loadPlugin(directory) {
   const previousAudit = process.env.AGT_OPENCODE_AUDIT_PATH;
   const previousPolicy = process.env.AGT_OPENCODE_POLICY_PATH;
   process.env.AGT_OPENCODE_AUDIT_PATH = join(directory, "audit.json");
-  delete process.env.AGT_OPENCODE_POLICY_PATH;
+  if (policyPath) {
+    process.env.AGT_OPENCODE_POLICY_PATH = policyPath;
+  } else {
+    delete process.env.AGT_OPENCODE_POLICY_PATH;
+  }
 
   try {
     const plugin = await AgtGovernance({
       directory,
       worktree: directory,
-      client: { app: { log: async () => {} } },
+      client: client ?? { app: { log: async () => {} } },
     });
     return plugin;
   } finally {
@@ -39,7 +43,9 @@ async function loadPlugin(directory) {
     } else {
       process.env.AGT_OPENCODE_AUDIT_PATH = previousAudit;
     }
-    if (previousPolicy !== undefined) {
+    if (previousPolicy === undefined) {
+      delete process.env.AGT_OPENCODE_POLICY_PATH;
+    } else {
       process.env.AGT_OPENCODE_POLICY_PATH = previousPolicy;
     }
   }
@@ -56,6 +62,29 @@ test("plugin exports the expected OpenCode contract surface", async () => {
     assert.equal(typeof plugin["tool.execute.after"], "function");
     assert.equal(typeof plugin.tool.agt_policy_status.execute, "function");
     assert.equal(typeof plugin.tool.agt_policy_check_text.execute, "function");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("plugin initialization fails loudly for an invalid configured policy", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-plugin-policy-error-"));
+  try {
+    const policyPath = join(root, "invalid-policy.json");
+    await writeFile(policyPath, "{invalid json}\n", "utf8");
+
+    await assert.rejects(loadPlugin(root, { policyPath }), /policy could not be loaded|JSON/i);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("plugin initialization fails loudly for a missing configured policy", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-plugin-policy-missing-"));
+  try {
+    const policyPath = join(root, "missing-policy.json");
+
+    await assert.rejects(loadPlugin(root, { policyPath }), /policy could not be loaded|not found/i);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -133,6 +162,40 @@ test("event hook blocks prompt-injection messages", async () => {
       }),
       /prompt injection|poisoning|inject|reveal/i,
     );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("event hook surfaces prompt denials before failing closed", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-plugin-event-visible-"));
+  const toasts = [];
+  const logs = [];
+  try {
+    const plugin = await loadPlugin(root, {
+      client: {
+        app: { log: async (entry) => logs.push(entry) },
+        tui: { showToast: async (toast) => toasts.push(toast) },
+      },
+    });
+
+    await assert.rejects(
+      plugin.event({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            sessionID: "visible-denial-session",
+            part: { type: "text", text: injectionFixture },
+          },
+        },
+      }),
+      /prompt injection|poisoning|inject|reveal/i,
+    );
+
+    assert.equal(toasts.length, 1);
+    assert.equal(toasts[0].body.variant, "error");
+    assert.match(toasts[0].body.message, /prompt injection|poisoning|inject|reveal/i);
+    assert.ok(logs.some((entry) => entry.body.level === "warn"));
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- surface prompt denials through an OpenCode error toast and warning log before blocking the request
- eagerly validate policy state during plugin initialization when fail-closed behavior is configured
- treat a missing explicitly configured policy file as an initialization error
- add regression tests for invalid policies, missing policies, and visible denial notifications

## Root cause

Prompt denials were represented only by a thrown exception, and explicit policy load failures could remain latent until a later hook. The adapter now uses OpenCode's supported toast/log APIs to make the denial visible while retaining the exception required to stop execution.

## Validation

- `cd agent-governance-opencode && npm run check` — 28/28 tests passed
- changed-line spelling and whitespace checks passed

Closes #3663


## Tracking and related work

- Primary issue: #3663; the closure directive above remains authoritative.
- Related session-scoped state work in #3669 is intentionally not implemented here.