### PR TITLE
fix(ci): allow capitalized Dependabot PR titlesUpdate pr-title-check.yml

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,4 +1,5 @@
 # Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
 name: PR Title Check
 
 on:
@@ -14,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read    # amannn/action-semantic-pull-request reads the PR title/body
+      pull-requests: read # amannn/action-semantic-pull-request reads the PR title/body
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
@@ -34,7 +35,7 @@ jobs:
             build
             revert
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
+          subjectPattern: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && '.+' || '^(?![A-Z]).+$' }}
           subjectPatternError: |
             The PR title subject "{subject}" must not start with an uppercase letter.
             Use lowercase: "feat: add foo" not "feat: Add foo".


### PR DESCRIPTION
## Related Issue

Fixes #3559

## Problem & Solution

Dependabot PRs can use capitalized subjects such as `Bump` and `Update`, which currently fail the `Validate PR title` check because the validator requires the subject to start with a lowercase letter.

This change allows capitalized subjects for Dependabot PRs while keeping the existing lowercase subject requirement for other contributors.

## Impact on Your Work

This removes the need to manually retitle Dependabot PRs before they can pass the PR title validation check.

## Timeline

None

## Alternatives Considered

The issue suggested either relaxing the validator for Dependabot or automatically retitling Dependabot PRs. I chose to adjust the validator so valid Dependabot titles are accepted without modifying the PR title.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Maintenance (dependency updates, CI/CD, refactoring)
- [ ] Security fix

## Package(s) Affected

- [x] action (GitHub Action)

## Testing

### Unit Testing

No unit tests were added because this change modifies GitHub Actions workflow configuration.

### Manual Testing

Verified the workflow change and confirmed that the existing lowercase subject rule remains in place for non-Dependabot PRs while Dependabot PRs can use capitalized subjects.

## Checklist

- [x] I have linked a related issue above
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass
- [ ] I have updated documentation as needed
- [ ] I have signed the Microsoft CLA

## Attribution & Prior Art

No external code was copied or derived for this change.

## AI Assistance

AI assistance was used to help identify the relevant workflow and draft the configuration change. I reviewed the resulting change before submission.

## IP, Patents, and Licensing

This contribution does not knowingly implement patent-pending or patent-encumbered techniques and does not require an NDA or additional licensing agreement.
