### PR TITLE
chore(ci): add cooldown to the cspell repo terms

### DIFF
--- a/.cspell-repo-terms.txt
+++ b/.cspell-repo-terms.txt
@@ -1023,11 +1023,12 @@ zerovec
 zoneinfo
 
 # --- Documentation site and ACS integration terms ---
-AgentRateLimiter
 AEDT
+AgentRateLimiter
 anthonyonazure
 Bigspin
 Clendenen
+cooldown
 Ecommerce
 externalidentity
 fnmatchcase


### PR DESCRIPTION
## Summary

Adds `cooldown` to `.cspell-repo-terms.txt`.

## Problem

#3593 introduced a `cooldown:` key in `.github/dependabot.yml` without adding the word to the spell-check dictionary. Any PR that touches that block now fails `Spell-check changed files` on the word itself. #3648, which applies the cooldown to the remaining eleven ecosystems, is blocked by exactly this.

## Changes

| File | What changed |
|------|-------------|
| `.cspell-repo-terms.txt` | Added `cooldown` to the documentation/integration terms section |

## Testing

Verified `cooldown` was absent from both `.cspell-repo-terms.txt` and `.cspell.json` on main, and confirmed the failing job on #3648 reports `Unknown word (cooldown)`.
