### PR TITLE
ci: exempt dependabot PRs from the semantic title check

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -3,7 +3,10 @@ name: PR Title Check
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+    # `labeled`/`unlabeled` are here because the exemption below is keyed on a
+    # label. Without them a PR labelled after it opened would keep the verdict
+    # from the run that saw no labels.
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -34,6 +37,16 @@ jobs:
             build
             revert
           requireScope: false
+          # Dependabot writes its own titles and there is no setting that makes
+          # them satisfy `subjectPattern`. It uses "bump <dep> from a to b" for a
+          # version bump and "Update <dep> requirement from x to y" for a
+          # requirement range, so roughly half of what it opens starts with a
+          # capital U and fails a rule the author cannot act on. The check exists
+          # to keep human titles consistent for the changelog; a bot that already
+          # writes a conventional prefix every time is not the thing it guards
+          # against.
+          ignoreLabels: |
+            dependencies
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |
             The PR title subject "{subject}" must not start with an uppercase letter.


### PR DESCRIPTION
## The problem

All 34 open dependabot PRs are currently red. For 19 of them the only real failure is `Validate PR title`, with `auto-merge` failing behind it:

`#3705 #3703 #3702 #3700 #3699 #3696 #3694 #3693 #3691 #3690 #3689 #3688 #3687 #3682 #3656 #3655 #3623 #3618 #3617`

## The cause

`pr-title-check.yml` sets `subjectPattern: ^(?![A-Z]).+$`, so the subject may not start with a capital.

Dependabot writes its own titles and uses two different verbs:

```
chore(deps): bump the codeql-action group with 4 updates          <- passes
chore(deps-dev): Update fastembed requirement from ... to ...     <- fails
```

It says "bump" for a version bump and "Update" for a requirement-range change. Which one it picks depends on the update type, not on anything configurable, and `commit-message` in `dependabot.yml` controls the prefix rather than the verb. So roughly half of what Dependabot opens fails a rule its author cannot act on, after having run full CI.

## The change

Adds `ignoreLabels: dependencies` to the action.

Keyed on the label rather than on `github.actor` for two reasons: it covers any bot configured to carry the label, not just Dependabot, and it lets the action itself exit successfully, so a required-check configuration still sees a passing check rather than a skipped job.

`labeled` and `unlabeled` join the trigger types because the exemption is now label-dependent. Without them, a PR labelled after it opened would keep the verdict from the run that saw no labels.

## What this does not change

Human PRs are unaffected: the pattern, the type list and the error message are all untouched. The check keeps doing what it is for, which is consistent human titles for the changelog. A bot that already emits a valid conventional prefix on every PR is not what it guards against.

## Verification

`pr-title-check.yml` parses, and the parsed trigger types and `ignoreLabels` value are as intended. `ignoreLabels` is a documented input of `amannn/action-semantic-pull-request` at the pinned v6.1.1.

The real test is the next dependabot PR, or a re-run on any of the 19 above.
