### PR TITLE
docs: install agent-hypervisor before agent-mesh, and say why

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ source .venv/bin/activate        # Linux/macOS
 # (Required for all local development to ensure you test against local core changes)
 pip install --no-cache-dir --no-deps -e agent-governance-toolkit-core
 
+# Required before agent-mesh: its dev extra pins agent_hypervisor>=5.0.0, and
+# PyPI tops out at the pre-consolidation 3.7.0 wheel, so pip cannot resolve it.
+# Install the local dep-only stub first. Do not work around this by installing
+# agent-hypervisor from PyPI: 3.7.0 ships real code in the top-level
+# `hypervisor` package that collides with the copy -core force-includes, and
+# the resulting breakage shows up later at import time rather than here.
+pip install --no-cache-dir --no-deps -e agent-hypervisor
+
 # Install the package you are working on in editable mode
 pip install -e "agent-os[dev]"       # Policy engine
 pip install -e "agent-mesh[dev]"     # Identity/trust layer
@@ -300,6 +308,11 @@ cd agent-governance-toolkit
 # Install the core package from the local source to avoid dependency conflicts
 pip install --no-cache-dir --no-deps -e "agent-governance-python/agent-governance-toolkit-core"
 
+# agent-hypervisor comes first: agent-mesh's dev extra pins
+# agent_hypervisor>=5.0.0 and PyPI tops out at 3.7.0, so installing agent-mesh
+# before it fails to resolve. See the note in the Python setup section above.
+pip install -e "agent-governance-python/agent-hypervisor[dev]"
+
 pip install -e "agent-governance-python/agent-primitives[dev]"
 pip install -e "agent-governance-python/agent-mcp-governance[dev]"
 pip install -e "agent-governance-python/agent-os[dev]"
@@ -309,7 +322,6 @@ pip install -e "agent-governance-python/agent-sre[dev]"
 pip install -e "agent-governance-python/agent-compliance[dev]"
 pip install -e "agent-governance-python/agent-marketplace[dev]"  # installs agentmesh-marketplace
 pip install -e "agent-governance-python/agent-lightning[dev]"
-pip install -e "agent-governance-python/agent-hypervisor[dev]"
 pip install -e "agent-governance-python/agentmesh-integrations[dev]"
 
 # Restore the standalone .NET SDK when working in that path


### PR DESCRIPTION
Closes #3733.

`pip install -e "agent-mesh[dev]"`, as `CONTRIBUTING.md` documents it, cannot resolve:

```
ERROR: Could not find a version that satisfies the requirement
agent-hypervisor<6.0,>=5.0.0; extra == "dev" (from agentmesh-platform[dev])
(from versions: 2.0.0, ..., 3.6.0, 3.7.0)
```

CI already handles this by pre-installing the local dep-only stub, and `ci.yml` carries a comment explaining exactly why. That comment is the right explanation in the wrong place: somebody following `CONTRIBUTING.md` never sees it, and the documented command fails before they get there.

## Changes

**Python setup section.** Adds the stub install with its reason, in the same shape as the `-core` line directly above it, which already exists for a comparable reason.

**Development Setup section.** Moves `agent-hypervisor` above `agent-mesh`. That block listed them in the failing order, so this is a reorder rather than an addition.

The note explicitly warns against working around this by taking `agent-hypervisor` from PyPI. Per the `ci.yml` comment, 3.7.0 ships real code in the top-level `hypervisor` package that collides with the copy `-core` force-includes, so the obvious fix produces confusing breakage at import time instead of a clear failure at install time. An install error that teaches you the wrong fix costs more than one that just stops.

## Verification

Two clean virtualenvs, not assumed:

| | Result |
|---|---|
| Documented order | all three installs exit 0; `pytest tests/governance/test_audit_backends.py` → **25 passed** |
| Skipping the new step | reproduces the resolver error exactly |

So the added line is necessary, not merely sufficient.

## Scope

Docs only. I checked every `pyproject.toml` under `agent-governance-python/` and `agent-mesh` is the only package pinning a monorepo sibling at a version PyPI cannot satisfy, so no other section needs the same treatment. #3733 lists two larger alternatives (a bootstrap target, or moving the pin out of the published extra); this is the smallest change that makes the documented path work, and I have not assumed which of the others maintainers would prefer.