### PR TITLE
fix: raise cli mcp cryptography ceiling to match agent-os and agent-mesh

### DIFF
--- a/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
+++ b/agent-governance-python/agent-governance-toolkit-cli/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 docker = ["docker>=7.1.0,<8.0"]
 hyperlight = ["hyperlight-sandbox>=0.4.0,<0.5"]
 policy = ["agent-governance-toolkit-core>=5.0.0,<6.0"]
-mcp = ["mcp>=1.0.0,<2.0", "cryptography>=46.0.7,<49.0"]
+mcp = ["mcp>=1.0.0,<2.0", "cryptography>=50.0.0,<51.0"]
 api = ["fastapi>=0.115.0,<1.0", "uvicorn>=0.27.0,<1.0"]
 otel = ["opentelemetry-exporter-otlp>=1.20,<2.0"]
 langfuse = ["langfuse>=2.0,<5.0"]


### PR DESCRIPTION
## Problem

The toolkit-cli `mcp` extra still pinned `cryptography>=46.0.7,<49.0` while agent-os and agent-mesh were raised to `cryptography>=50.0.0,<51.0` (#3615, #3621). Installing the CLI with the mcp extra in the same environment as agent-os or agent-mesh fails pip resolution: no cryptography version satisfies both ranges.

Fixes #3651.

## Fix

Raised the cli `mcp` extra range to `cryptography>=50.0.0,<51.0`, matching the other packages.

## Validation

```
pip install --dry-run "cryptography>=50.0.0,<51.0" "mcp>=1.0.0,<2.0"
# resolves successfully; the previously-conflicting agent-os/agent-mesh range now overlaps
```

DCO signoff included.
