### PR TITLE
docs(opencode): fix workspace install path and stale hook references

### DIFF
--- a/agent-governance-opencode/README.md
+++ b/agent-governance-opencode/README.md
@@ -45,15 +45,14 @@ governance tools from external workflows.
 
 ## Current scope
 
-This initial package enforces:
+This package enforces:
 
-- `session.start`           — injects AGT governance context into the session
-- `event` (chat-style)      — scans submitted prompts; throws to block
+- `session.created`         — logs AGT governance status at session start
+- `event`                   — scans prompt-bearing events; throws to block
 - `tool.execute.before`     — allow / review / deny tool calls
 - `tool.execute.after`      — scans tool output and redacts known secret
                               patterns (AWS, GitHub PAT, OpenAI, JWT, PEM
                               private keys, Azure storage keys)
-- `tool.execute.error`      — records audit entry for failed tool calls
 
 It also exposes two custom tools (in-process **and** via the stdio MCP server):
 
@@ -76,10 +75,15 @@ npm run check
 OpenCode loads plugins from:
 
 1. `opencode.json` `plugin` entries (npm specifiers)
-2. `~/.config/opencode/plugins/*.{ts,js,mjs}` (user-global)
-3. `.opencode/plugins/*.{ts,js,mjs}` (workspace-local)
+2. `~/.config/opencode/plugin/*.{ts,js}` or `~/.config/opencode/plugins/*.{ts,js}`
+   (user-global)
+3. `.opencode/plugin/*.{ts,js}` or `.opencode/plugins/*.{ts,js}`
+   (workspace-local)
 
-### Option A — workspace `opencode.json`
+OpenCode 1.18.x auto-discovers only `.ts` and `.js` workspace plugin files —
+`.mjs` shims are not discovered.
+
+### Option A — workspace `opencode.json` (recommended)
 
 ```json
 {
@@ -88,9 +92,11 @@ OpenCode loads plugins from:
 }
 ```
 
-### Option B — workspace plugin file (no install required)
+### Option B — workspace plugin file (repo-local development)
 
-Create `.opencode/plugins/agt.mjs`:
+Create `.opencode/plugins/agt.js`. The re-export below resolves against an
+AGT monorepo checkout, so this option is intended for developing the plugin
+from this repository — it is not installation-free for general consumers:
 
 ```js
 export { default } from "../../agent-governance-opencode/src/index.mjs";

--- a/docs/packages/opencode-governance.md
+++ b/docs/packages/opencode-governance.md
@@ -1,5 +1,5 @@
 ---
-last_reviewed: 2026-05-29
+last_reviewed: 2026-08-19
 owner: agt-maintainers
 title: OpenCode CLI governance package
 description: AGT in-process plugin for the OpenCode CLI — enforce policy on prompts, tools, and tool output.
@@ -30,11 +30,10 @@ That model lets this package:
 
 | OpenCode hook | AGT behavior |
 |---|---|
-| `session.start` | Injects governance context describing the active policy and mode. |
-| `event` (chat-style) | Scans the submitted prompt with the AGT prompt-defense backend. Throws on `deny`. |
+| `session.created` | Logs AGT governance status at session start (best-effort; does not inject session context). |
+| `event` | Scans prompt-bearing events (`message.part.updated` text parts) with the AGT prompt-defense backend. Throws on `deny`. |
 | `tool.execute.before` | Runs `evaluateOpenCodeTool`. Throws on `deny`; marks args on `review`. |
 | `tool.execute.after` | Scans tool output for AWS keys, GitHub PATs, OpenAI keys, Azure storage keys, JWTs, and PEM private keys. Redacts in enforce mode. |
-| `tool.execute.error` | Records an audit entry without re-running policy. |
 
 It also publishes a stdio MCP server (`server/agt-mcp.mjs`) for operators who
 want to invoke `agt_policy_status` or `agt_policy_check_text` from external


### PR DESCRIPTION
## Summary

Fixes #3707: the documented workspace-file install path for the OpenCode governance plugin is silently never loaded. OpenCode 1.18.x auto-discovers only `{plugin,plugins}/*.{ts,js}` workspace files, so following the README's `.opencode/plugins/agt.mjs` instruction starts OpenCode with no AGT hooks, no warning, and no governance — even with a valid enforce-mode policy on disk.

Changes:
- Recommend the npm-specifier `opencode.json` path as the primary install.
- Correct the auto-discovery globs (`.ts`/`.js` only, both `plugin` and `plugins` directories) and state explicitly that `.mjs` shims are not discovered.
- Mark the workspace-file option as repo-local development: the relative re-export resolves against an AGT monorepo checkout, not an ordinary package install.
- Replace the removed `session.start` / `tool.execute.error` hook rows with the shipped contract (`session.created` status logging — no context injection; `event` prompt scanning; `tool.execute.before/after`).

## Testing

- Docs-only change; verified the shipped hook keys in `src/index.mjs` (`session.created`, `event`, `tool.execute.before`, `tool.execute.after`) and the discovery glob in OpenCode 1.18.16 source (`{plugin,plugins}/*.{ts,js}`) before editing.
- `grep` confirms no remaining `session.start` / `tool.execute.error` / `.mjs`-glob claims in the two touched files.
