### PR TITLE
fix(agent-os): report invalid supervisor levels

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/supervisor.py
+++ b/agent-governance-python/agent-os/src/agent_os/supervisor.py
@@ -61,12 +61,23 @@ class SupervisorHierarchy:
         """Check hierarchy rules and return a list of violations (empty = valid).
 
         Rules:
+        - Supervisor levels must be integers (``bool`` is not accepted as a level).
         - No supervisor may sit above the root: levels MUST NOT be negative.
         - Level 0 MUST exist and MUST be deterministic (not an LLM agent).
         - Middle levels (1–N) may be agent-based.
         - Each level present must have at least one supervisor.
         """
         violations: list[str] = []
+
+        valid_supervisors: list[_Supervisor] = []
+        for s in self._supervisors:
+            if not isinstance(s.level, int) or isinstance(s.level, bool):
+                violations.append(
+                    f"Supervisor '{s.name}' has non-integer level {s.level!r}; "
+                    "levels must be integers"
+                )
+                continue
+            valid_supervisors.append(s)
 
         # Checked before anything else: level 0 is the root, so a negative level
         # places a supervisor *above* the deterministic authority. The
@@ -75,14 +86,14 @@ class SupervisorHierarchy:
         # negative level was invisible to both — an agent registered at level -1
         # produced no violations at all while ranking ahead of the trust root in
         # ``get_authority_chain``.
-        for s in self._supervisors:
+        for s in valid_supervisors:
             if s.level < 0:
                 violations.append(
                     f"Supervisor '{s.name}' has negative level {s.level}; level 0 is the "
                     "root and nothing may sit above it"
                 )
 
-        level_0 = [s for s in self._supervisors if s.level == 0]
+        level_0 = [s for s in valid_supervisors if s.level == 0]
         if not level_0:
             violations.append("Level 0 (root) has no registered supervisor")
         else:
@@ -93,10 +104,10 @@ class SupervisorHierarchy:
                     )
 
         # Ensure no gaps in levels (every level between 0 and max has a supervisor)
-        if self._supervisors:
-            max_level = max(s.level for s in self._supervisors)
+        if valid_supervisors:
+            max_level = max(s.level for s in valid_supervisors)
             for lvl in range(1, max_level + 1):
-                if not any(s.level == lvl for s in self._supervisors):
+                if not any(s.level == lvl for s in valid_supervisors):
                     violations.append(f"Level {lvl} has no registered supervisor")
 
         return violations

--- a/agent-governance-python/agent-os/tests/test_supervisor_hierarchy_validation.py
+++ b/agent-governance-python/agent-os/tests/test_supervisor_hierarchy_validation.py
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Regression tests for supervisor hierarchy validation."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from agent_os.supervisor import SupervisorHierarchy
+from agent_os.trust_root import TrustRoot
+
+
+def _hierarchy() -> SupervisorHierarchy:
+    # validate_hierarchy() does not consult the trust root; a typed placeholder
+    # keeps this test focused on registration metadata only.
+    return SupervisorHierarchy(cast(TrustRoot, object()))
+
+
+@pytest.mark.parametrize("level", ["1", 1.0, None, True, False])
+def test_validate_hierarchy_reports_non_integer_level_without_crashing(level: Any) -> None:
+    hierarchy = _hierarchy()
+    hierarchy.register_supervisor("trust-root", level=0, is_agent=False)
+    hierarchy.register_supervisor("invalid", level=level, is_agent=True)
+
+    violations = hierarchy.validate_hierarchy()
+
+    assert any("invalid" in violation and "non-integer level" in violation for violation in violations)
+
+
+def test_invalid_false_level_does_not_satisfy_root_requirement() -> None:
+    hierarchy = _hierarchy()
+    hierarchy.register_supervisor("boolean-root", level=False, is_agent=False)
+
+    violations = hierarchy.validate_hierarchy()
+
+    assert any("non-integer level" in violation for violation in violations)
+    assert "Level 0 (root) has no registered supervisor" in violations
+
+
+def test_valid_integer_hierarchy_contract_is_unchanged() -> None:
+    hierarchy = _hierarchy()
+    hierarchy.register_supervisor("trust-root", level=0, is_agent=False)
+    hierarchy.register_supervisor("worker", level=1, is_agent=True)
+
+    assert hierarchy.validate_hierarchy() == []


### PR DESCRIPTION
## Summary

Make `SupervisorHierarchy.validate_hierarchy()` report malformed supervisor levels as validation violations instead of raising `TypeError`.

## Problem

`register_supervisor()` is type-annotated with `level: int`, but runtime callers can still supply malformed values.

`validate_hierarchy()` currently performs numeric comparison, `max()`, and `range()` operations directly on registered levels. Values such as strings, floats, `None`, or booleans can therefore make validation itself crash or be interpreted incorrectly.

A validation function should report an invalid hierarchy rather than fail while inspecting it.

## Changes

- explicitly identify supervisor levels that are not real integers
- report each invalid level as a hierarchy violation
- exclude invalid levels from numeric root/gap checks
- preserve the existing advisory registration model
- keep valid integer hierarchy behaviour unchanged
- add regression coverage for malformed and valid levels

## Testing

Added focused regression tests in:

`agent-governance-python/agent-os/tests/test_supervisor_hierarchy_validation.py`

The tests cover invalid string, float, boolean and null-like levels together with valid integer hierarchies.

The branch is based on upstream `main` at `7d0cef5d`.

Addresses the supervisor-level validation follow-up in #3513.