### PR TITLE
fix(agent-os): warn when TLS config has no URL

### DIFF
--- a/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
+++ b/agent-governance-python/agent-os/src/agent_os/mcp_auth_enforcement.py
@@ -225,11 +225,19 @@ class McpAuthPolicy:
 
         servers = []
         for s in policy_data.get("servers", []):
+            url = s.get("url", "")
+            require_tls = s.get("require_tls", True)
+            if require_tls and (not isinstance(url, str) or not url.strip()):
+                logger.warning(
+                    "MCP server '%s' requires TLS but has no URL configured; "
+                    "TLS cannot be validated until a URL is supplied at check time",
+                    s.get("name", "<unnamed>"),
+                )
             servers.append(McpServerEntry(
                 name=s["name"],
-                url=s.get("url", ""),
+                url=url,
                 allowed_auth_methods=s.get("allowed_auth_methods", ["oauth2", "mtls", "bearer"]),
-                require_tls=s.get("require_tls", True),
+                require_tls=require_tls,
                 min_tls_version=s.get("min_tls_version", "1.2"),
             ))
 

--- a/agent-governance-python/agent-os/tests/test_mcp_auth_config_warnings.py
+++ b/agent-governance-python/agent-os/tests/test_mcp_auth_config_warnings.py
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Configuration diagnostics for MCP authentication policy loading."""
+
+import logging
+
+from agent_os.mcp_auth_enforcement import McpAuthPolicy, McpServerEntry
+
+
+def test_yaml_warns_when_tls_is_required_without_a_url(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="agent_os.mcp_auth_enforcement"):
+        McpAuthPolicy.from_yaml("""
+mcp_auth_policy:
+  servers:
+    - name: finance-tools
+      allowed_auth_methods: [mtls]
+      require_tls: true
+""")
+
+    assert "finance-tools" in caplog.text
+    assert "requires TLS but has no URL configured" in caplog.text
+
+
+def test_yaml_with_tls_url_does_not_emit_missing_url_warning(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="agent_os.mcp_auth_enforcement"):
+        McpAuthPolicy.from_yaml("""
+mcp_auth_policy:
+  servers:
+    - name: finance-tools
+      url: https://mcp.internal/finance
+      allowed_auth_methods: [mtls]
+      require_tls: true
+""")
+
+    assert "requires TLS but has no URL configured" not in caplog.text
+
+
+def test_programmatic_entry_without_url_remains_allowed(caplog) -> None:
+    """The config warning must not change the S10.12 programmatic path."""
+    with caplog.at_level(logging.WARNING, logger="agent_os.mcp_auth_enforcement"):
+        policy = McpAuthPolicy(
+            servers=[McpServerEntry(name="dynamic", allowed_auth_methods=["mtls"])]
+        )
+
+    assert "requires TLS but has no URL configured" not in caplog.text
+    assert policy.check("dynamic", auth_method="mtls").allowed


### PR DESCRIPTION
## Summary

Surface an actionable configuration warning when an MCP server loaded from YAML requires TLS but has no usable URL configured.

## Problem

`McpServerEntry` defaults to `require_tls=True`, but an empty URL deliberately remains permitted because callers may supply the connection URL later at check time.

That behaviour is required for the programmatic path, but in YAML configuration it can hide a likely misconfiguration: the operator has explicitly required TLS while providing no URL against which the TLS requirement can be validated.

## Changes

- warn during `McpAuthPolicy.from_yaml()` when `require_tls: true` is combined with an empty or unusable URL
- identify the affected server in the warning
- preserve the existing programmatic empty-URL behaviour
- preserve all runtime allow/deny semantics
- add regression coverage for warning and non-warning cases

## Testing

Added focused regression coverage in:

`agent-governance-python/agent-os/tests/test_mcp_auth_config_warnings.py`

The coverage checks:

- YAML TLS configuration without a URL emits the warning
- YAML configuration with a TLS URL does not emit it
- programmatic registration without a URL remains permitted and does not emit the configuration warning

No runtime enforcement behaviour is changed.

The branch is based on upstream `main` at `7d0cef5d`.

Addresses the `require_tls` empty-URL configuration-lint follow-up in #3513.