### PR TITLE
fix(engine-api): signal placeholder backends

### DIFF
--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/agents.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/agents.py
@@ -10,7 +10,7 @@ A later epic wires this to the agent registry to return persisted
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 
 from agentmesh.engine_api.capabilities import capability_flags
 from agentmesh.engine_api.models import AgentListResponse
@@ -30,8 +30,10 @@ router = APIRouter()
 @capability_flags(runtime_mutating=False, user_intent_required=False, read_only_surface=True)
 async def list_agents(
     request: Request,
+    response: Response,
     pagination: PaginationParams = Depends(),
 ) -> AgentListResponse:
     """Return registered agents (empty until the agent registry ships)."""
+    response.headers["X-AGT-Backend-Status"] = "placeholder"
     items, page = paginate([], pagination)
     return AgentListResponse(items=items, pagination=page)

--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/audit.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/audit.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from agentmesh.engine_api.capabilities import capability_flags
 from agentmesh.engine_api.models import AuditLogResponse
@@ -34,6 +34,7 @@ router = APIRouter()
 @capability_flags(runtime_mutating=False, user_intent_required=False, read_only_surface=True)
 async def get_audit_log(
     request: Request,
+    response: Response,
     pagination: PaginationParams = Depends(),
     agent_did: str | None = Query(None, description="Filter by acting agent DID"),
     from_: datetime | None = Query(
@@ -42,5 +43,6 @@ async def get_audit_log(
     to: datetime | None = Query(None, description="End of time range (date-time)"),
 ) -> AuditLogResponse:
     """Return audit log entries (empty until the audit backend ships)."""
+    response.headers["X-AGT-Backend-Status"] = "placeholder"
     items, page = paginate([], pagination)
     return AuditLogResponse(items=items, pagination=page)

--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/decisions.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/decisions.py
@@ -10,7 +10,7 @@ A later epic wires this to the decision log to return persisted
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from agentmesh.engine_api.capabilities import capability_flags
 from agentmesh.engine_api.models import DecisionListResponse, Verdict
@@ -30,10 +30,12 @@ router = APIRouter()
 @capability_flags(runtime_mutating=False, user_intent_required=False, read_only_surface=True)
 async def list_decisions(
     request: Request,
+    response: Response,
     pagination: PaginationParams = Depends(),
     agent_did: str | None = Query(None, description="Filter by agent DID"),
     verdict: Verdict | None = Query(None, description="Filter by decision verdict"),
 ) -> DecisionListResponse:
     """Return recent policy decisions (empty until the decision log ships)."""
+    response.headers["X-AGT-Backend-Status"] = "placeholder"
     items, page = paginate([], pagination)
     return DecisionListResponse(items=items, pagination=page)

--- a/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/trust.py
+++ b/agent-governance-python/agent-mesh/src/agentmesh/engine_api/routes/trust.py
@@ -12,7 +12,7 @@ the delegation and sponsorship relationships).
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, Query, Request, Response
 
 from agentmesh.engine_api.capabilities import capability_flags
 from agentmesh.engine_api.models import TrustGraph, TrustScoreListResponse
@@ -32,10 +32,12 @@ router = APIRouter()
 @capability_flags(runtime_mutating=False, user_intent_required=False, read_only_surface=True)
 async def get_trust_scores(
     request: Request,
+    response: Response,
     pagination: PaginationParams = Depends(),
     agent_did: str | None = Query(None, description="Filter by agent DID"),
 ) -> TrustScoreListResponse:
     """Return per-agent trust scores (empty until the trust backend ships)."""
+    response.headers["X-AGT-Backend-Status"] = "placeholder"
     items, page = paginate([], pagination)
     return TrustScoreListResponse(items=items, pagination=page)
 
@@ -47,6 +49,7 @@ async def get_trust_scores(
     response_model=TrustGraph,
 )
 @capability_flags(runtime_mutating=False, user_intent_required=False, read_only_surface=True)
-async def get_trust_graph(request: Request) -> TrustGraph:
+async def get_trust_graph(request: Request, response: Response) -> TrustGraph:
     """Return the trust relationship graph (empty until the trust backend ships)."""
+    response.headers["X-AGT-Backend-Status"] = "placeholder"
     return TrustGraph(nodes=[], edges=[])

--- a/agent-governance-python/agent-mesh/tests/engine_api/test_placeholder_backend_status.py
+++ b/agent-governance-python/agent-mesh/tests/engine_api/test_placeholder_backend_status.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""Regression tests for placeholder Engine API backend signalling."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/agents",
+        "/api/v1/audit/log",
+        "/api/v1/decisions",
+        "/api/v1/trust/scores",
+        "/api/v1/trust/graph",
+    ],
+)
+def test_placeholder_routes_signal_backend_status(client, path: str) -> None:
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.headers["X-AGT-Backend-Status"] == "placeholder"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/health",
+        "/api/v1/policies",
+    ],
+)
+def test_non_placeholder_routes_do_not_signal_placeholder_status(client, path: str) -> None:
+    response = client.get(path)
+
+    assert response.status_code == 200
+    assert "X-AGT-Backend-Status" not in response.headers


### PR DESCRIPTION
## Summary

Expose a machine-readable signal on Engine API endpoints whose backends are still placeholders.

## Problem

The agents, audit, decisions, and trust routes intentionally return contract-conformant `200 OK` responses with empty payloads until their real backends ship.

Without an explicit signal, clients cannot distinguish a genuinely empty result from a route that is still backed only by a placeholder implementation.

## Changes

- add `X-AGT-Backend-Status: placeholder` to the placeholder agents route
- add the header to the placeholder audit route
- add the header to the placeholder decisions route
- add the header to both placeholder trust routes
- leave implemented Engine API routes unchanged
- add regression coverage for all placeholder routes and negative controls

## Testing

Added focused regression coverage in:

`agent-governance-python/agent-mesh/tests/engine_api/test_placeholder_backend_status.py`

The coverage checks all five placeholder endpoints and verifies implemented health and policy endpoints do not emit the placeholder header.

The branch is based on upstream `main` at `7d0cef5d`.

Closes #3092.