### PR TITLE
fix(audit): serialize concurrent audit log writes and use unique temp file paths

### DIFF
--- a/agent-governance-claude-code/lib/audit.mjs
+++ b/agent-governance-claude-code/lib/audit.mjs
@@ -9,7 +9,22 @@ import { dirname } from "node:path";
 const GENESIS_HASH = "0".repeat(64);
 const MAX_ENTRIES = 10000;
 
+let writeQueue = Promise.resolve();
+
 export async function appendAuditEntry(auditPath, entry) {
+  return new Promise((resolve, reject) => {
+    writeQueue = writeQueue
+      .then(async () => {
+        const result = await _appendAuditEntryInternal(auditPath, entry);
+        resolve(result);
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
+}
+
+async function _appendAuditEntryInternal(auditPath, entry) {
   const entries = await loadAuditEntries(auditPath);
   if (!verifyAuditEntries(entries)) {
     throw new Error(`Audit log at ${auditPath} failed hash-chain verification.`);
@@ -62,7 +77,11 @@ export async function loadAuditEntries(auditPath) {
   }
 
   try {
-    const text = await readFile(auditPath, "utf8");
+    const raw = await readFile(auditPath, "utf8");
+    const text = raw.replace(/\0/g, "").trim();
+    if (!text) {
+      return [];
+    }
     const value = JSON.parse(text);
     if (!Array.isArray(value)) {
       throw new Error(`Audit log at ${auditPath} is not a JSON array.`);
@@ -105,7 +124,8 @@ export function verifyAuditEntries(entries) {
 
 async function writeAuditEntries(auditPath, entries) {
   await mkdir(dirname(auditPath), { recursive: true });
-  const tempPath = `${auditPath}.tmp-${process.pid}`;
+  const uniqueId = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tempPath = `${auditPath}.tmp-${uniqueId}`;
   await writeFile(tempPath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
   await rename(tempPath, auditPath);
 }

--- a/agent-governance-opencode/lib/audit.mjs
+++ b/agent-governance-opencode/lib/audit.mjs
@@ -9,7 +9,22 @@ import { dirname } from "node:path";
 const GENESIS_HASH = "0".repeat(64);
 const MAX_ENTRIES = 10000;
 
+let writeQueue = Promise.resolve();
+
 export async function appendAuditEntry(auditPath, entry) {
+  return new Promise((resolve, reject) => {
+    writeQueue = writeQueue
+      .then(async () => {
+        const result = await _appendAuditEntryInternal(auditPath, entry);
+        resolve(result);
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
+}
+
+async function _appendAuditEntryInternal(auditPath, entry) {
   const entries = await loadAuditEntries(auditPath);
   if (!verifyAuditEntries(entries)) {
     throw new Error(`Audit log at ${auditPath} failed hash-chain verification.`);
@@ -62,7 +77,11 @@ export async function loadAuditEntries(auditPath) {
   }
 
   try {
-    const text = await readFile(auditPath, "utf8");
+    const raw = await readFile(auditPath, "utf8");
+    const text = raw.replace(/\0/g, "").trim();
+    if (!text) {
+      return [];
+    }
     const value = JSON.parse(text);
     if (!Array.isArray(value)) {
       throw new Error(`Audit log at ${auditPath} is not a JSON array.`);
@@ -105,7 +124,8 @@ export function verifyAuditEntries(entries) {
 
 async function writeAuditEntries(auditPath, entries) {
   await mkdir(dirname(auditPath), { recursive: true });
-  const tempPath = `${auditPath}.tmp-${process.pid}`;
+  const uniqueId = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tempPath = `${auditPath}.tmp-${uniqueId}`;
   await writeFile(tempPath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
   await rename(tempPath, auditPath);
 }

--- a/agent-governance-opencode/test/policy.test.mjs
+++ b/agent-governance-opencode/test/policy.test.mjs
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
+import { appendAuditEntry } from "../lib/audit.mjs";
 import {
   checkArbitraryText,
   evaluateOpenCodePrompt,
@@ -183,6 +184,29 @@ test("corrupt audit logs are reported invalid and fail closed on new decisions",
 
   assert.equal(result.effect, "deny");
   assert.match(result.reason, /failed closed/i);
+
+  await rm(root, { recursive: true, force: true });
+});
+
+test("concurrent appendAuditEntry calls serialize and maintain valid hash chain", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agt-opencode-concurrent-"));
+  const auditPath = join(root, "audit.json");
+  const state = await loadPolicy({ auditPath });
+
+  await Promise.all(
+    Array.from({ length: 15 }, (_, i) =>
+      appendAuditEntry(auditPath, {
+        agentId: `test-agent-${i}`,
+        action: `tool.test_${i}`,
+        decision: "allow",
+      }),
+    ),
+  );
+
+  const status = await getPolicyStatus(state);
+  assert.equal(status.auditValid, true);
+  assert.equal(status.auditEntries, 15);
+  assert.equal(status.auditError, undefined);
 
   await rm(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary

Fixes a race condition in `appendAuditEntry` across `agent-governance-opencode` and `agent-governance-claude-code` where concurrent async tool executions within the same Node process (same `process.pid`) corrupt `audit-log.json`.

## Problem

When multiple tool evaluations or hooks execute concurrently in an agent harness:
1. In `writeAuditEntries`, the temporary file path was constructed using `const tempPath = `${auditPath}.tmp-${process.pid}``.
2. Because concurrent promises share the same PID, multiple writes collide on the exact same temp file simultaneously.
3. This causes overlapping writes, `rename()` race conditions (`ENOENT: no such file or directory`), and corrupted target JSON with trailing `\0` (NUL) bytes or truncated content (`Unterminated string`).
4. Subsequent evaluations fail to parse `audit-log.json` and fail closed on governance checks.

## Solution

1. **In-Process Mutex Queue**: Serialized `appendAuditEntry()` operations using a promise queue (`writeQueue`) to ensure atomic sequence and valid SHA-256 hash chaining.
2. **Unique Temp File Descriptors**: Added a unique timestamp and random identifier to temporary file paths (`.tmp-${process.pid}-${Date.now()}-${random}`).
3. **Resilient Sanitization**: Stripped `\0` null bytes before `JSON.parse` in `loadAuditEntries()` to recover safely from any existing corrupted buffers.
4. **Unit Test**: Added a concurrent audit write test asserting that 15 parallel `appendAuditEntry()` calls serialize cleanly and maintain valid hash verification.

## Testing

- Ran `npm test` in `agent-governance-opencode` (26/26 tests passed including new concurrency test).
- Ran `npm test` in `agent-governance-claude-code` (17/17 tests passed).