### PR TITLE
feat: add IResponseSanitizer seam for pluggable MCP response sanitization

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance.Extensions.ModelContextProtocol/AgentGovernanceMcpServerBuilderExtensions.cs
+++ b/agent-governance-dotnet/src/AgentGovernance.Extensions.ModelContextProtocol/AgentGovernanceMcpServerBuilderExtensions.cs
@@ -34,6 +34,7 @@ public static class AgentGovernanceMcpServerBuilderExtensions
         builder.Services.TryAddSingleton(static serviceProvider =>
             new GovernanceKernel(serviceProvider.GetRequiredService<IOptions<McpGovernanceOptions>>().Value.ToGovernanceOptions()));
         builder.Services.TryAddSingleton<McpResponseSanitizer>();
+        builder.Services.TryAddSingleton<IResponseSanitizer>(sp => sp.GetRequiredService<McpResponseSanitizer>());
         builder.Services.TryAddSingleton<McpSecurityScanner>();
         builder.Services.TryAddSingleton<McpGovernanceRuntime>();
         builder.Services.TryAddEnumerable(

--- a/agent-governance-dotnet/src/AgentGovernance.Extensions.ModelContextProtocol/McpGovernanceRuntime.cs
+++ b/agent-governance-dotnet/src/AgentGovernance.Extensions.ModelContextProtocol/McpGovernanceRuntime.cs
@@ -12,12 +12,12 @@ namespace AgentGovernance.Extensions.ModelContextProtocol;
 internal sealed class McpGovernanceRuntime
 {
     private readonly GovernanceKernel _kernel;
-    private readonly McpResponseSanitizer _sanitizer;
+    private readonly IResponseSanitizer _sanitizer;
     private readonly McpGovernanceOptions _options;
 
     public McpGovernanceRuntime(
         GovernanceKernel kernel,
-        McpResponseSanitizer sanitizer,
+        IResponseSanitizer sanitizer,
         IOptions<McpGovernanceOptions> options)
     {
         _kernel = kernel ?? throw new ArgumentNullException(nameof(kernel));

--- a/agent-governance-dotnet/src/AgentGovernance/Mcp/IResponseSanitizer.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Mcp/IResponseSanitizer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+namespace AgentGovernance.Mcp;
+
+/// <summary>
+/// Scans and sanitizes MCP tool output before it reaches an LLM. Implemented by
+/// <see cref="McpResponseSanitizer"/> and resolved from DI so consumers can replace or extend
+/// response sanitization with their own implementation.
+/// </summary>
+public interface IResponseSanitizer
+{
+    /// <summary>Scans text for threats and returns a sanitized version.</summary>
+    McpSanitizedResponse ScanText(string text);
+}

--- a/agent-governance-dotnet/src/AgentGovernance/Mcp/McpResponseSanitizer.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Mcp/McpResponseSanitizer.cs
@@ -61,7 +61,7 @@ public sealed class McpSanitizedResponse
 /// Detects prompt injection tags, imperative override phrasing,
 /// credential leakage, and data exfiltration URLs. Thread-safe.
 /// </summary>
-public sealed class McpResponseSanitizer
+public sealed class McpResponseSanitizer : IResponseSanitizer
 {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(200);
 

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/McpGovernanceExtensionsTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/McpGovernanceExtensionsTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using AgentGovernance.Extensions.ModelContextProtocol;
+using AgentGovernance.Mcp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ModelContextProtocol;
@@ -157,6 +158,35 @@ public sealed class McpGovernanceExtensionsTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => _ = options.Value);
         Assert.Contains("Unsafe MCP tool definition", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WithGovernance_ResolvesDefaultResponseSanitizer()
+    {
+        var services = new ServiceCollection();
+        services.AddMcpServer().WithGovernance();
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.IsType<McpResponseSanitizer>(serviceProvider.GetRequiredService<IResponseSanitizer>());
+    }
+
+    [Fact]
+    public void WithGovernance_AllowsCustomResponseSanitizer()
+    {
+        var services = new ServiceCollection();
+        // Registered before WithGovernance; TryAdd must not overwrite it.
+        services.AddSingleton<IResponseSanitizer, CustomResponseSanitizer>();
+        services.AddMcpServer().WithGovernance();
+
+        using var serviceProvider = services.BuildServiceProvider();
+
+        Assert.IsType<CustomResponseSanitizer>(serviceProvider.GetRequiredService<IResponseSanitizer>());
+    }
+
+    private sealed class CustomResponseSanitizer : IResponseSanitizer
+    {
+        public McpSanitizedResponse ScanText(string text) => new McpResponseSanitizer().ScanText(text);
     }
 
     [Fact]


### PR DESCRIPTION
Draft implementation for #3776.

## Problem
`McpResponseSanitizer` is `sealed` with no interface and `McpGovernanceRuntime` depends on the concrete type, so response sanitization can't be replaced or extended.

## Change
- Add `IResponseSanitizer` (`ScanText`) in `AgentGovernance.Mcp`; `McpResponseSanitizer` implements it (no behavior change).
- `McpGovernanceRuntime` depends on `IResponseSanitizer`.
- `WithGovernance` registers the default behind the interface via `TryAddSingleton`, so a consumer can register their own `IResponseSanitizer` before `WithGovernance` and it wins.

## Tests
Adds coverage for default resolution and custom replacement. All existing MCP tests pass (82 total).

Draft: opening to align on the API shape (interface surface, optional composition of multiple sanitizers) before finalizing. Happy to iterate.