### PR TITLE
feat: add PolicyEngine.EvaluateAsync so external backends aren't forced into sync-over-async

### DIFF
--- a/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
+++ b/agent-governance-dotnet/src/AgentGovernance/Policy/PolicyEngine.cs
@@ -158,6 +158,58 @@ public sealed class PolicyEngine
     /// </summary>
     public PolicyDecision Evaluate(string agentDid, Dictionary<string, object> context)
     {
+        var prep = Prepare(agentDid, context);
+        if (prep.ExternalBackends.Count == 0)
+        {
+            return CloneDecision(
+                prep.Internal.Decision,
+                prep.Stopwatch.Elapsed.TotalMilliseconds,
+                prep.Internal.Decision.Metadata);
+        }
+
+        var externalDecisions = prep.ExternalBackends
+            .Select(backend => backend.Evaluate(prep.EvalContext))
+            .ToList();
+
+        return Combine(prep, externalDecisions);
+    }
+
+    /// <summary>
+    /// Asynchronously evaluates an agent request against all loaded policies, awaiting external backends
+    /// via <see cref="IExternalPolicyBackend.EvaluateAsync"/> instead of blocking on the synchronous
+    /// path. Internal (in-memory) policy evaluation and the fail-closed resolution are identical to
+    /// <see cref="Evaluate"/>.
+    /// </summary>
+    public async Task<PolicyDecision> EvaluateAsync(
+        string agentDid,
+        Dictionary<string, object> context,
+        CancellationToken cancellationToken = default)
+    {
+        var prep = Prepare(agentDid, context);
+        if (prep.ExternalBackends.Count == 0)
+        {
+            return CloneDecision(
+                prep.Internal.Decision,
+                prep.Stopwatch.Elapsed.TotalMilliseconds,
+                prep.Internal.Decision.Metadata);
+        }
+
+        // Evaluate external backends sequentially to preserve ordering and avoid assuming backends are
+        // safe to invoke concurrently.
+        var externalDecisions = new List<ExternalPolicyDecision>(prep.ExternalBackends.Count);
+        foreach (var backend in prep.ExternalBackends)
+        {
+            externalDecisions.Add(await backend.EvaluateAsync(prep.EvalContext, cancellationToken).ConfigureAwait(false));
+        }
+
+        return Combine(prep, externalDecisions);
+    }
+
+    // Shared prologue for Evaluate/EvaluateAsync: validate, normalize the DID, snapshot policies and
+    // backends, build the evaluation context, and run the in-memory policies. The stopwatch is stopped
+    // after internal evaluation so external time is accounted separately (via each decision's EvaluationMs).
+    private EvaluationPrep Prepare(string agentDid, Dictionary<string, object> context)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(agentDid);
         ArgumentNullException.ThrowIfNull(context);
 
@@ -191,19 +243,14 @@ public sealed class PolicyEngine
         var internalEvaluation = EvaluateInternalPolicies(snapshot, evalContext, evaluatedAt, sw);
         sw.Stop();
 
-        if (externalSnapshot.Count == 0)
-        {
-            return CloneDecision(
-                internalEvaluation.Decision,
-                sw.Elapsed.TotalMilliseconds,
-                internalEvaluation.Decision.Metadata);
-        }
+        return new EvaluationPrep(evalContext, internalEvaluation, externalSnapshot, evaluatedAt, sw);
+    }
 
-        var externalDecisions = externalSnapshot
-            .Select(backend => backend.Evaluate(evalContext))
-            .ToList();
-
-        var metadata = CreateExternalMetadata(internalEvaluation.Decision.Metadata, externalDecisions);
+    // Combines the internal decision with the external backend decisions. Fail-closed: any backend with a
+    // non-empty Error or a deny fails the whole request.
+    private PolicyDecision Combine(EvaluationPrep prep, List<ExternalPolicyDecision> externalDecisions)
+    {
+        var metadata = CreateExternalMetadata(prep.Internal.Decision.Metadata, externalDecisions);
         var failingDecision = externalDecisions.FirstOrDefault(decision => !string.IsNullOrWhiteSpace(decision.Error) || !decision.Allowed);
 
         if (failingDecision is not null)
@@ -212,25 +259,25 @@ public sealed class PolicyEngine
             {
                 Allowed = false,
                 Action = "deny",
-                MatchedRule = internalEvaluation.Decision.MatchedRule,
-                PolicyName = internalEvaluation.Decision.PolicyName,
+                MatchedRule = prep.Internal.Decision.MatchedRule,
+                PolicyName = prep.Internal.Decision.PolicyName,
                 Reason = string.IsNullOrWhiteSpace(failingDecision.Error)
                     ? $"External policy backend '{failingDecision.Backend}' denied the request."
                     : $"External policy backend '{failingDecision.Backend}' failed: {failingDecision.Error}",
-                Approvers = internalEvaluation.Decision.Approvers,
-                RateLimited = internalEvaluation.Decision.RateLimited,
-                RateLimitReset = internalEvaluation.Decision.RateLimitReset,
-                EvaluatedAt = evaluatedAt,
-                EvaluationMs = sw.Elapsed.TotalMilliseconds + externalDecisions.Sum(decision => decision.EvaluationMs),
+                Approvers = prep.Internal.Decision.Approvers,
+                RateLimited = prep.Internal.Decision.RateLimited,
+                RateLimitReset = prep.Internal.Decision.RateLimitReset,
+                EvaluatedAt = prep.EvaluatedAt,
+                EvaluationMs = prep.Stopwatch.Elapsed.TotalMilliseconds + externalDecisions.Sum(decision => decision.EvaluationMs),
                 Metadata = metadata
             };
         }
 
-        if (internalEvaluation.HadMatches)
+        if (prep.Internal.HadMatches)
         {
             return CloneDecision(
-                internalEvaluation.Decision,
-                sw.Elapsed.TotalMilliseconds + externalDecisions.Sum(decision => decision.EvaluationMs),
+                prep.Internal.Decision,
+                prep.Stopwatch.Elapsed.TotalMilliseconds + externalDecisions.Sum(decision => decision.EvaluationMs),
                 metadata);
         }
 
@@ -242,17 +289,25 @@ public sealed class PolicyEngine
                 Allowed = true,
                 Action = "allow",
                 Reason = $"Allowed by external policy backend(s): {string.Join(", ", externalDecisions.Select(decision => decision.Backend).Distinct(StringComparer.Ordinal))}.",
-                EvaluatedAt = evaluatedAt,
-                EvaluationMs = sw.Elapsed.TotalMilliseconds + externalDecisions.Sum(decision => decision.EvaluationMs),
+                EvaluatedAt = prep.EvaluatedAt,
+                EvaluationMs = prep.Stopwatch.Elapsed.TotalMilliseconds + externalDecisions.Sum(decision => decision.EvaluationMs),
                 Metadata = metadata
             };
         }
 
         return CloneDecision(
-            internalEvaluation.Decision,
-            sw.Elapsed.TotalMilliseconds,
+            prep.Internal.Decision,
+            prep.Stopwatch.Elapsed.TotalMilliseconds,
             metadata);
     }
+
+    // Shared state captured by Prepare and consumed by Combine.
+    private sealed record EvaluationPrep(
+        Dictionary<string, object> EvalContext,
+        InternalEvaluation Internal,
+        List<IExternalPolicyBackend> ExternalBackends,
+        DateTime EvaluatedAt,
+        Stopwatch Stopwatch);
 
     private static Dictionary<string, object> CreateExternalMetadata(
         Dictionary<string, object>? existingMetadata,

--- a/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceClientAndPolicyEvaluationTests.cs
+++ b/agent-governance-dotnet/tests/AgentGovernance.Tests/GovernanceClientAndPolicyEvaluationTests.cs
@@ -486,4 +486,89 @@ rules:
         Assert.False(decision.Allowed);
         Assert.Equal("deny-write", decision.MatchedRule);
     }
+
+    /// <summary>Records whether the sync or async path was invoked.</summary>
+    private sealed class AsyncTrackingBackend : IExternalPolicyBackend
+    {
+        public string Name => "async-tracking";
+
+        public int SyncCalls { get; private set; }
+
+        public int AsyncCalls { get; private set; }
+
+        public ExternalPolicyDecision Evaluate(IReadOnlyDictionary<string, object> context)
+        {
+            SyncCalls++;
+            return Decision();
+        }
+
+        public Task<ExternalPolicyDecision> EvaluateAsync(IReadOnlyDictionary<string, object> context, CancellationToken cancellationToken = default)
+        {
+            AsyncCalls++;
+            return Task.FromResult(Decision());
+        }
+
+        private ExternalPolicyDecision Decision() => new()
+        {
+            Backend = Name,
+            Allowed = true,
+            Reason = "ok"
+        };
+    }
+
+    [Fact]
+    public async Task PolicyEngine_EvaluateAsync_UsesBackendAsyncPath()
+    {
+        var backend = new AsyncTrackingBackend();
+        var engine = new PolicyEngine();
+        engine.AddExternalBackend(backend);
+
+        var decision = await engine.EvaluateAsync("did:agentmesh:test", new Dictionary<string, object>
+        {
+            ["tool_name"] = "anything"
+        });
+
+        Assert.True(decision.Allowed);
+        Assert.Equal(1, backend.AsyncCalls);
+        Assert.Equal(0, backend.SyncCalls);
+    }
+
+    [Fact]
+    public void PolicyEngine_Evaluate_UsesBackendSyncPath()
+    {
+        var backend = new AsyncTrackingBackend();
+        var engine = new PolicyEngine();
+        engine.AddExternalBackend(backend);
+
+        var decision = engine.Evaluate("did:agentmesh:test", new Dictionary<string, object>
+        {
+            ["tool_name"] = "anything"
+        });
+
+        Assert.True(decision.Allowed);
+        Assert.Equal(1, backend.SyncCalls);
+        Assert.Equal(0, backend.AsyncCalls);
+    }
+
+    [Fact]
+    public async Task PolicyEngine_EvaluateAsync_FailsClosedOnBackendError()
+    {
+        var stub = new StubExternalBackend("stub-error", _ => new ExternalPolicyDecision
+        {
+            Backend = "stub-error",
+            Allowed = true, // even if the backend says allow, a non-empty Error must fail closed
+            Reason = "transport failure",
+            Error = "connection refused"
+        });
+
+        var engine = new PolicyEngine();
+        engine.AddExternalBackend(stub);
+
+        var decision = await engine.EvaluateAsync("did:agentmesh:test", new Dictionary<string, object>
+        {
+            ["tool_name"] = "anything"
+        });
+
+        Assert.False(decision.Allowed);
+    }
 }


### PR DESCRIPTION
Draft implementation for #3775.

## Problem
`PolicyEngine` only exposes a synchronous `Evaluate` that calls `IExternalPolicyBackend.Evaluate`. A backend whose decision requires a network call (an async-only SDK) has to block a thread with `.GetAwaiter().GetResult()`, which pressures the thread pool under load.

## Change
- Extract the shared prologue (`Prepare`: validate, snapshot, build context, run in-memory policies) and result combination (`Combine`: fail-closed resolution) out of `Evaluate`.
- Add `PolicyEngine.EvaluateAsync(agentDid, context, ct)` that awaits each backend's `EvaluateAsync`. External backends run sequentially to preserve ordering and avoid assuming they're concurrency-safe.
- Sync `Evaluate` keeps its exact previous behavior; internal policy evaluation and fail-closed semantics are unchanged.

## Tests
Adds coverage that `EvaluateAsync` uses the backend async path, `Evaluate` uses the sync path, and `EvaluateAsync` still fails closed on a backend error. All existing policy tests pass (146 total).

## Open questions for maintainers
- Should the async path extend up through `GovernanceKernel.EvaluateToolCall` (and the MCP decorator, which is already `async`)? Kept this PR to the engine to stay focused; happy to follow up.
- Sequential vs. concurrent backend evaluation — went sequential to match current semantics.

Draft: opening to align on shape before finalizing.